### PR TITLE
ID5 User ID Module - refactor fetch and add server-side config options

### DIFF
--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -7,19 +7,19 @@
 
 import {
   deepAccess,
-  logInfo,
   deepSetValue,
-  logError,
   isEmpty,
   isEmptyStr,
+  logError,
+  logInfo,
   logWarn,
   safeJSONParse
 } from '../src/utils.js';
-import { ajax } from '../src/ajax.js';
-import { submodule } from '../src/hook.js';
-import { getRefererInfo } from '../src/refererDetection.js';
-import { getStorageManager } from '../src/storageManager.js';
-import { uspDataHandler } from '../src/adapterManager.js';
+import {ajax} from '../src/ajax.js';
+import {submodule} from '../src/hook.js';
+import {getRefererInfo} from '../src/refererDetection.js';
+import {getStorageManager} from '../src/storageManager.js';
+import {uspDataHandler} from '../src/adapterManager.js';
 
 const MODULE_NAME = 'id5Id';
 const GVLID = 131;
@@ -28,10 +28,11 @@ export const ID5_STORAGE_NAME = 'id5id';
 export const ID5_PRIVACY_STORAGE_NAME = `${ID5_STORAGE_NAME}_privacy`;
 const LOCAL_STORAGE = 'html5';
 const LOG_PREFIX = 'User ID - ID5 submodule: ';
+const ID5_API_CONFIG_URL = 'https://id5-sync.com/api/config/prebid'
 
 // order the legacy cookie names in reverse priority order so the last
 // cookie in the array is the most preferred to use
-const LEGACY_COOKIE_NAMES = [ 'pbjs-id5id', 'id5id.1st', 'id5id' ];
+const LEGACY_COOKIE_NAMES = ['pbjs-id5id', 'id5id.1st', 'id5id'];
 
 export const storage = getStorageManager({gvlid: GVLID, moduleName: MODULE_NAME});
 
@@ -102,92 +103,27 @@ export const id5IdSubmodule = {
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function getId
-   * @param {SubmoduleConfig} config
+   * @param {SubmoduleConfig} submoduleConfig
    * @param {ConsentData} consentData
    * @param {(Object|undefined)} cacheIdObj
    * @returns {IdResponse|undefined}
    */
-  getId(config, consentData, cacheIdObj) {
-    if (!hasRequiredConfig(config)) {
+  getId(submoduleConfig, consentData, cacheIdObj) {
+    if (!hasRequiredConfig(submoduleConfig)) {
       return undefined;
     }
 
-    const url = `https://id5-sync.com/g/v2/${config.params.partner}.json`;
-    const hasGdpr = (consentData && typeof consentData.gdprApplies === 'boolean' && consentData.gdprApplies) ? 1 : 0;
-    const usp = uspDataHandler.getConsentData();
-    const referer = getRefererInfo();
-    const signature = (cacheIdObj && cacheIdObj.signature) ? cacheIdObj.signature : getLegacyCookieSignature();
-    const data = {
-      'partner': config.params.partner,
-      'gdpr': hasGdpr,
-      'nbPage': incrementNb(config.params.partner),
-      'o': 'pbjs',
-      'rf': referer.topmostLocation,
-      'top': referer.reachedTop ? 1 : 0,
-      'u': referer.stack[0] || window.location.href,
-      'v': '$prebid.version$'
-    };
-
-    // pass in optional data, but only if populated
-    if (hasGdpr && typeof consentData.consentString !== 'undefined' && !isEmpty(consentData.consentString) && !isEmptyStr(consentData.consentString)) {
-      data.gdpr_consent = consentData.consentString;
-    }
-    if (typeof usp !== 'undefined' && !isEmpty(usp) && !isEmptyStr(usp)) {
-      data.us_privacy = usp;
-    }
-    if (typeof signature !== 'undefined' && !isEmptyStr(signature)) {
-      data.s = signature;
-    }
-    if (typeof config.params.pd !== 'undefined' && !isEmptyStr(config.params.pd)) {
-      data.pd = config.params.pd;
-    }
-    if (typeof config.params.provider !== 'undefined' && !isEmptyStr(config.params.provider)) {
-      data.provider = config.params.provider;
-    }
-
-    const abTestingConfig = getAbTestingConfig(config);
-    if (abTestingConfig.enabled === true) {
-      data.ab_testing = {
-        enabled: true,
-        control_group_pct: abTestingConfig.controlGroupPct // The server validates
-      };
-    }
-
-    const resp = function (callback) {
-      const callbacks = {
-        success: response => {
-          let responseObj;
-          if (response) {
-            try {
-              responseObj = JSON.parse(response);
-              logInfo(LOG_PREFIX + 'response received from the server', responseObj);
-
-              resetNb(config.params.partner);
-
-              if (responseObj.privacy) {
-                storeInLocalStorage(ID5_PRIVACY_STORAGE_NAME, JSON.stringify(responseObj.privacy), NB_EXP_DAYS);
-              }
-
-              // TODO: remove after requiring publishers to use localstorage and
-              // all publishers have upgraded
-              if (config.storage.type === LOCAL_STORAGE) {
-                removeLegacyCookies(config.params.partner);
-              }
-            } catch (error) {
-              logError(LOG_PREFIX + error);
-            }
-          }
-          callback(responseObj);
-        },
-        error: error => {
+    const resp = function (cbFunction) {
+      new IdFetchFlow(submoduleConfig, consentData, cacheIdObj, uspDataHandler.getConsentData()).execute()
+        .then(response => {
+          cbFunction(response)
+        })
+        .catch(error => {
           logError(LOG_PREFIX + 'getId fetch encountered an error', error);
-          callback();
-        }
-      };
-      logInfo(LOG_PREFIX + 'requesting an ID from the server', data);
-      ajax(url, callbacks, JSON.stringify(data), { method: 'POST', withCredentials: true });
+          cbFunction();
+        });
     };
-    return { callback: resp };
+    return {callback: resp};
   },
 
   /**
@@ -211,6 +147,139 @@ export const id5IdSubmodule = {
     return cacheIdObj;
   }
 };
+
+class IdFetchFlow {
+  constructor(submoduleConfig, gdprConsentData, cacheIdObj, usPrivacyData) {
+    this.submoduleConfig = submoduleConfig
+    this.gdprConsentData = gdprConsentData
+    this.cacheIdObj = cacheIdObj
+    this.usPrivacyData = usPrivacyData
+  }
+
+  execute() {
+    return this.#callForConfig(this.submoduleConfig)
+      .then(fetchFlowConfig => {
+        return this.#callForExtensions(fetchFlowConfig.extensionsCall)
+          .then(extensionsData => {
+            return this.#callId5Fetch(fetchFlowConfig.fetchCall, extensionsData)
+          })
+      })
+      .then(fetchCallResponse => {
+        try {
+          resetNb(this.submoduleConfig.params.partner);
+          if (fetchCallResponse.privacy) {
+            storeInLocalStorage(ID5_PRIVACY_STORAGE_NAME, JSON.stringify(fetchCallResponse.privacy), NB_EXP_DAYS);
+          }
+        } catch (error) {
+          logError(LOG_PREFIX + error);
+        }
+        return fetchCallResponse;
+      })
+  }
+
+  #ajaxPromise(url, data, options) {
+    return new Promise((resolve, reject) => {
+      ajax(url,
+        {
+          success: function (res) {
+            resolve(res)
+          },
+          error: function (err) {
+            reject(err)
+          }
+        }, data, options)
+    })
+  }
+
+  // eslint-disable-next-line no-dupe-class-members
+  #callForConfig(submoduleConfig) {
+    let url = submoduleConfig.params.configUrl || ID5_API_CONFIG_URL; // override for debug/test purposes only
+    return this.#ajaxPromise(url, JSON.stringify(submoduleConfig), {method: 'POST'})
+      .then(response => {
+        let responseObj = JSON.parse(response);
+        logInfo(LOG_PREFIX + 'config response received from the server', responseObj);
+        return responseObj;
+      });
+  }
+
+  // eslint-disable-next-line no-dupe-class-members
+  #callForExtensions(extensionsCallConfig) {
+    if (extensionsCallConfig === undefined) {
+      return Promise.resolve(undefined)
+    }
+    let extensionsUrl = extensionsCallConfig.url
+    let method = extensionsCallConfig.method || 'GET'
+    let data = method === 'GET' ? undefined : JSON.stringify(extensionsCallConfig.body || {})
+    return this.#ajaxPromise(extensionsUrl, data, {'method': method})
+      .then(response => {
+        let responseObj = JSON.parse(response);
+        logInfo(LOG_PREFIX + 'extensions response received from the server', responseObj);
+        return responseObj;
+      })
+  }
+
+  // eslint-disable-next-line no-dupe-class-members
+  #callId5Fetch(fetchCallConfig, extensionsData) {
+    let url = fetchCallConfig.url;
+    let additionalData = fetchCallConfig.overrides || {};
+    let data = {
+      ...this.#createFetchRequestData(),
+      ...additionalData,
+      extensions: extensionsData
+    };
+    return this.#ajaxPromise(url, JSON.stringify(data), {method: 'POST', withCredentials: true})
+      .then(response => {
+        let responseObj = JSON.parse(response);
+        logInfo(LOG_PREFIX + 'fetch response received from the server', responseObj);
+        return responseObj;
+      });
+  }
+
+  // eslint-disable-next-line no-dupe-class-members
+  #createFetchRequestData() {
+    const params = this.submoduleConfig.params;
+    const hasGdpr = (this.gdprConsentData && typeof this.gdprConsentData.gdprApplies === 'boolean' && this.gdprConsentData.gdprApplies) ? 1 : 0;
+    const referer = getRefererInfo();
+    const signature = (this.cacheIdObj && this.cacheIdObj.signature) ? this.cacheIdObj.signature : getLegacyCookieSignature();
+    const nbPage = incrementNb(params.partner);
+    const data = {
+      'partner': params.partner,
+      'gdpr': hasGdpr,
+      'nbPage': nbPage,
+      'o': 'pbjs',
+      'rf': referer.topmostLocation,
+      'top': referer.reachedTop ? 1 : 0,
+      'u': referer.stack[0] || window.location.href,
+      'v': '$prebid.version$',
+      'storage': this.submoduleConfig.storage
+    };
+
+    // pass in optional data, but only if populated
+    if (hasGdpr && this.gdprConsentData.consentString !== undefined && !isEmpty(this.gdprConsentData.consentString) && !isEmptyStr(this.gdprConsentData.consentString)) {
+      data.gdpr_consent = this.gdprConsentData.consentString;
+    }
+    if (this.usPrivacyData !== undefined && !isEmpty(this.usPrivacyData) && !isEmptyStr(this.usPrivacyData)) {
+      data.us_privacy = this.usPrivacyData;
+    }
+    if (signature !== undefined && !isEmptyStr(signature)) {
+      data.s = signature;
+    }
+    if (params.pd !== undefined && !isEmptyStr(params.pd)) {
+      data.pd = params.pd;
+    }
+    if (params.provider !== undefined && !isEmptyStr(params.provider)) {
+      data.provider = params.provider;
+    }
+    const abTestingConfig = params.abTesting || {enabled: false};
+
+    if (abTestingConfig.enabled) {
+      data.ab_testing = {
+        enabled: true, control_group_pct: abTestingConfig.controlGroupPct // The server validates
+      };
+    }
+    return data
+  }
+}
 
 function hasRequiredConfig(config) {
   if (!config || !config.params || !config.params.partner || typeof config.params.partner !== 'number') {
@@ -242,45 +311,34 @@ export function expDaysStr(expDays) {
 export function nbCacheName(partnerId) {
   return `${ID5_STORAGE_NAME}_${partnerId}_nb`;
 }
+
 export function storeNbInCache(partnerId, nb) {
   storeInLocalStorage(nbCacheName(partnerId), nb, NB_EXP_DAYS);
 }
+
 export function getNbFromCache(partnerId) {
   let cacheNb = getFromLocalStorage(nbCacheName(partnerId));
   return (cacheNb) ? parseInt(cacheNb) : 0;
 }
+
 function incrementNb(partnerId) {
   const nb = (getNbFromCache(partnerId) + 1);
   storeNbInCache(partnerId, nb);
   return nb;
 }
+
 function resetNb(partnerId) {
   storeNbInCache(partnerId, 0);
 }
 
 function getLegacyCookieSignature() {
   let legacyStoredValue;
-  LEGACY_COOKIE_NAMES.forEach(function(cookie) {
+  LEGACY_COOKIE_NAMES.forEach(function (cookie) {
     if (storage.getCookie(cookie)) {
       legacyStoredValue = safeJSONParse(storage.getCookie(cookie)) || legacyStoredValue;
     }
   });
   return (legacyStoredValue && legacyStoredValue.signature) || '';
-}
-
-/**
- * Remove our legacy cookie values. Needed until we move all publishers
- * to html5 storage in a future release
- * @param {integer} partnerId
- */
-function removeLegacyCookies(partnerId) {
-  logInfo(LOG_PREFIX + 'removing legacy cookies');
-  LEGACY_COOKIE_NAMES.forEach(function(cookie) {
-    storage.setCookie(`${cookie}`, ' ', expDaysStr(-1));
-    storage.setCookie(`${cookie}_nb`, ' ', expDaysStr(-1));
-    storage.setCookie(`${cookie}_${partnerId}_nb`, ' ', expDaysStr(-1));
-    storage.setCookie(`${cookie}_last`, ' ', expDaysStr(-1));
-  });
 }
 
 /**
@@ -303,6 +361,7 @@ export function getFromLocalStorage(key) {
   storage.removeDataFromLocalStorage(key);
   return null;
 }
+
 /**
  * Ensure that we always set an expiration in local storage since
  * by default it's not required
@@ -313,16 +372,6 @@ export function getFromLocalStorage(key) {
 export function storeInLocalStorage(key, value, expDays) {
   storage.setDataInLocalStorage(`${key}_exp`, expDaysStr(expDays));
   storage.setDataInLocalStorage(`${key}`, value);
-}
-
-/**
- * gets the existing abTesting config or generates a default config with abTesting off
- *
- * @param {SubmoduleConfig|undefined} config
- * @returns {Object} an object which always contains at least the property "enabled"
- */
-function getAbTestingConfig(config) {
-  return deepAccess(config, 'params.abTesting', { enabled: false });
 }
 
 submodule('userId', id5IdSubmodule);

--- a/modules/id5IdSystem.md
+++ b/modules/id5IdSystem.md
@@ -29,7 +29,8 @@ pbjs.setConfig({
         abTesting: {             // optional
           enabled: true,         // false by default
           controlGroupPct: 0.1   // valid values are 0.0 - 1.0 (inclusive)
-        }
+        }, 
+        disableExtensions: false // optional
       },
       storage: {
         type: 'html5',           // "html5" is the required storage type
@@ -43,21 +44,22 @@ pbjs.setConfig({
 });
 ```
 
-| Param under userSync.userIds[] | Scope | Type | Description | Example |
+| Param under userSync.userIds[] | Scope | Type | Description                                                                                                                                                                                                                                                                    | Example |
 | --- | --- | --- | --- | --- |
-| name | Required | String | The name of this module: `"id5Id"` | `"id5Id"` |
-| params | Required | Object | Details for the ID5 ID. | |
-| params.partner | Required | Number | This is the ID5 Partner Number obtained from registering with ID5. | `173` |
-| params.pd | Optional | String | Partner-supplied data used for linking ID5 IDs across domains. See [our documentation](https://support.id5.io/portal/en/kb/articles/passing-partner-data-to-id5) for details on generating the string. Omit the parameter or leave as an empty string if no data to supply | `"MT1iNTBjY..."` |
-| params.provider | Optional | String | An identifier provided by ID5 to technology partners who manage Prebid setups on behalf of publishers. Reach out to [ID5](mailto:prebid@id5.io) if you have questions about this parameter  | `pubmatic-identity-hub` |
-| params.abTesting | Optional | Object | Allows publishers to easily run an A/B Test. If enabled and the user is in the Control Group, the ID5 ID will NOT be exposed to bid adapters for that request | Disabled by default |
-| params.abTesting.enabled | Optional | Boolean | Set this to `true` to turn on this feature | `true` or `false` |
+| name | Required | String | The name of this module: `"id5Id"`                                                                                                                                                                                                                                             | `"id5Id"` |
+| params | Required | Object | Details for the ID5 ID.                                                                                                                                                                                                                                                        | |
+| params.partner | Required | Number | This is the ID5 Partner Number obtained from registering with ID5.                                                                                                                                                                                                             | `173` |
+| params.pd | Optional | String | Partner-supplied data used for linking ID5 IDs across domains. See [our documentation](https://support.id5.io/portal/en/kb/articles/passing-partner-data-to-id5) for details on generating the string. Omit the parameter or leave as an empty string if no data to supply     | `"MT1iNTBjY..."` |
+| params.provider | Optional | String | An identifier provided by ID5 to technology partners who manage Prebid setups on behalf of publishers. Reach out to [ID5](mailto:prebid@id5.io) if you have questions about this parameter                                                                                     | `pubmatic-identity-hub` |
+| params.abTesting | Optional | Object | Allows publishers to easily run an A/B Test. If enabled and the user is in the Control Group, the ID5 ID will NOT be exposed to bid adapters for that request                                                                                                                  | Disabled by default |
+| params.abTesting.enabled | Optional | Boolean | Set this to `true` to turn on this feature                                                                                                                                                                                                                                     | `true` or `false` |
 | params.abTesting.controlGroupPct | Optional | Number | Must be a number between `0.0` and `1.0` (inclusive) and is used to determine the percentage of requests that fall into the control group (and thus not exposing the ID5 ID). For example, a value of `0.20` will result in 20% of requests without an ID5 ID and 80% with an ID. | `0.1` |
-| storage | Required | Object | Storage settings for how the User ID module will cache the ID5 ID locally | |
-| storage.type | Required | String | This is where the results of the user ID will be stored. ID5 **requires** `"html5"`. | `"html5"` |
-| storage.name | Required | String | The name of the local storage where the user ID will be stored. ID5 **requires** `"id5id"`. | `"id5id"` |
-| storage.expires | Optional | Integer | How long (in days) the user ID information will be stored. ID5 recommends `90`. | `90` |
-| storage.refreshInSeconds | Optional | Integer | How many seconds until the ID5 ID will be refreshed. ID5 strongly recommends 8 hours between refreshes | `8*3600` |
+| params.disableExtensions | Optional | Boolean | Set this to `true` to force turn off extensions call. Default `false`                                                                                                                                                                                                          | `true` or `false` |
+| storage | Required | Object | Storage settings for how the User ID module will cache the ID5 ID locally                                                                                                                                                                                                      | |
+| storage.type | Required | String | This is where the results of the user ID will be stored. ID5 **requires** `"html5"`.                                                                                                                                                                                           | `"html5"` |
+| storage.name | Required | String | The name of the local storage where the user ID will be stored. ID5 **requires** `"id5id"`.                                                                                                                                                                                    | `"id5id"` |
+| storage.expires | Optional | Integer | How long (in days) the user ID information will be stored. ID5 recommends `90`.                                                                                                                                                                                                | `90` |
+| storage.refreshInSeconds | Optional | Integer | How many seconds until the ID5 ID will be refreshed. ID5 strongly recommends 8 hours between refreshes                                                                                                                                                                         | `8*3600` |
 
 **ATTENTION:** As of Prebid.js v4.14.0, ID5 requires `storage.type` to be `"html5"` and `storage.name` to be `"id5id"`. Using other values will display a warning today, but in an upcoming release, it will prevent the ID5 module from loading. This change is to ensure the ID5 module in Prebid.js interoperates properly with the [ID5 API](https://github.com/id5io/id5-api.js) and to reduce the size of publishers' first-party cookies that are sent to their web servers. If you have any questions, please reach out to us at [prebid@id5.io](mailto:prebid@id5.io).
 

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -5,28 +5,36 @@ import {
   ID5_PRIVACY_STORAGE_NAME,
   ID5_STORAGE_NAME,
   id5IdSubmodule,
-  nbCacheName, storage,
+  nbCacheName,
+  storage,
   storeInLocalStorage,
   storeNbInCache,
 } from 'modules/id5IdSystem.js';
 import {coreStorage, init, requestBidsHook, setSubmoduleRegistry} from 'modules/userId/index.js';
 import {config} from 'src/config.js';
-import {server} from 'test/mocks/xhr.js';
 import * as events from 'src/events.js';
 import CONSTANTS from 'src/constants.json';
 import * as utils from 'src/utils.js';
+import {uspDataHandler} from 'src/adapterManager.js';
 import 'src/prebid.js';
 import {hook} from '../../../src/hook.js';
 import {mockGdprConsent} from '../../helpers/consentData.js';
 
 let expect = require('chai').expect;
 
-describe('ID5 ID System', function() {
+describe('ID5 ID System', function () {
   const ID5_MODULE_NAME = 'id5Id';
   const ID5_EIDS_NAME = ID5_MODULE_NAME.toLowerCase();
   const ID5_SOURCE = 'id5-sync.com';
   const ID5_TEST_PARTNER_ID = 173;
   const ID5_ENDPOINT = `https://id5-sync.com/g/v2/${ID5_TEST_PARTNER_ID}.json`;
+  const ID5_API_CONFIG_URL = `https://id5-sync.com/api/config/prebid`;
+  const ID5_EXTENSIONS_ENDPOINT = 'https://extensions.id5-sync.com/test';
+  const ID5_API_CONFIG = {
+    fetchCall: {
+      url: ID5_ENDPOINT
+    }
+  };
   const ID5_NB_STORAGE_NAME = nbCacheName(ID5_TEST_PARTNER_ID);
   const ID5_STORED_ID = 'storedid5id';
   const ID5_STORED_SIGNATURE = '123456';
@@ -58,6 +66,7 @@ describe('ID5 ID System', function() {
       }
     }
   }
+
   function getId5ValueConfig(value) {
     return {
       name: ID5_MODULE_NAME,
@@ -68,6 +77,7 @@ describe('ID5 ID System', function() {
       }
     }
   }
+
   function getUserSyncConfig(userIds) {
     return {
       userSync: {
@@ -76,12 +86,15 @@ describe('ID5 ID System', function() {
       }
     }
   }
+
   function getFetchLocalStorageConfig() {
     return getUserSyncConfig([getId5FetchConfig(ID5_STORAGE_NAME, 'html5')]);
   }
+
   function getValueConfig(value) {
     return getUserSyncConfig([getId5ValueConfig(value)]);
   }
+
   function getAdUnitMock(code = 'adUnit-code') {
     return {
       code,
@@ -91,15 +104,81 @@ describe('ID5 ID System', function() {
     };
   }
 
+  function callSubmoduleGetId(config, consentData, cacheIdObj) {
+    return new Promise((resolve) => {
+      id5IdSubmodule.getId(config, consentData, cacheIdObj).callback((response) => {
+        resolve(response)
+      })
+    });
+  }
+
+  class XhrServerMock {
+    constructor(server) {
+      this.currentRequestIdx = 0
+      this.server = server
+    }
+
+    expectFirstRequest() {
+      return this.#expectRequest(0);
+    }
+
+    expectNextRequest() {
+      return this.#expectRequest(++this.currentRequestIdx)
+    }
+
+    expectConfigRequest() {
+      return this.expectFirstRequest()
+        .then(configRequest => {
+          expect(configRequest.url).is.eq(ID5_API_CONFIG_URL);
+          expect(configRequest.method).is.eq('POST');
+          return configRequest;
+        })
+    }
+
+    respondWithConfigAndExpectNext(configRequest, config = ID5_API_CONFIG) {
+      configRequest.respond(200, {'Content-Type': 'application/json'}, JSON.stringify(config));
+      return this.expectNextRequest()
+    }
+
+    expectFetchRequest() {
+      return this.expectConfigRequest()
+        .then(configRequest => {
+          return this.respondWithConfigAndExpectNext(configRequest, ID5_API_CONFIG);
+        }).then(request => {
+          expect(request.url).is.eq(ID5_API_CONFIG.fetchCall.url);
+          expect(request.method).is.eq('POST');
+          return request;
+        })
+    }
+
+    #expectRequest(index) {
+      let server = this.server
+      return new Promise(function (resolve) {
+        (function waitForCondition() {
+          if (server.requests && server.requests.length > index) return resolve(server.requests[index]);
+          setTimeout(waitForCondition, 30);
+        })();
+      })
+        .then(request => {
+          return request
+        });
+    }
+
+    hasReceivedAnyRequest() {
+      let requests = this.server.requests;
+      return requests && requests.length > 0;
+    }
+  }
+
   before(() => {
     hook.ready();
   });
 
-  describe('Check for valid publisher config', function() {
-    it('should fail with invalid config', function() {
+  describe('Check for valid publisher config', function () {
+    it('should fail with invalid config', function () {
       // no config
-      expect(id5IdSubmodule.getId()).to.be.eq(undefined);
-      expect(id5IdSubmodule.getId({ })).to.be.eq(undefined);
+      expect(id5IdSubmodule.getId()).is.eq(undefined);
+      expect(id5IdSubmodule.getId({})).is.eq(undefined);
 
       // valid params, invalid storage
       expect(id5IdSubmodule.getId({ params: { partner: 123 } })).to.be.eq(undefined);
@@ -113,7 +192,7 @@ describe('ID5 ID System', function() {
       expect(id5IdSubmodule.getId({ storage: { name: 'name', type: 'html5', }, params: { partner: 'abc' } })).to.be.eq(undefined);
     });
 
-    it('should warn with non-recommended storage params', function() {
+    it('should warn with non-recommended storage params', function () {
       let logWarnStub = sinon.stub(utils, 'logWarn');
 
       id5IdSubmodule.getId({ storage: { name: 'name', type: 'html5', }, params: { partner: 123 } });
@@ -126,189 +205,457 @@ describe('ID5 ID System', function() {
     });
   });
 
-  describe('Xhr Requests from getId()', function() {
-    const responseHeader = { 'Content-Type': 'application/json' };
-    let callbackSpy = sinon.spy();
+  describe('Xhr Requests from getId()', function () {
+    const responseHeader = {'Content-Type': 'application/json'};
 
-    beforeEach(function() {
-      callbackSpy.resetHistory();
+    beforeEach(function () {
     });
-    afterEach(function () {
 
+    afterEach(function () {
+      uspDataHandler.reset()
     });
 
     it('should call the ID5 server and handle a valid response', function () {
-      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig(), undefined, undefined).callback;
-      submoduleCallback(callbackSpy);
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
+      let config = getId5FetchConfig();
+      let submoduleResponse = callSubmoduleGetId(config, undefined, undefined);
 
-      let request = server.requests[0];
-      let requestBody = JSON.parse(request.requestBody);
-      expect(request.url).to.contain(ID5_ENDPOINT);
-      expect(request.withCredentials).to.be.true;
-      expect(requestBody.partner).to.eq(ID5_TEST_PARTNER_ID);
-      expect(requestBody.o).to.eq('pbjs');
-      expect(requestBody.pd).to.be.undefined;
-      expect(requestBody.s).to.be.undefined;
-      expect(requestBody.provider).to.be.undefined
-      expect(requestBody.v).to.eq('$prebid.version$');
-      expect(requestBody.gdpr).to.exist;
-      expect(requestBody.gdpr_consent).to.be.undefined;
-      expect(requestBody.us_privacy).to.be.undefined;
+      return xhrServerMock.expectFetchRequest()
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(fetchRequest.url).to.contain(ID5_ENDPOINT);
+          expect(fetchRequest.withCredentials).is.true;
+          expect(requestBody.partner).is.eq(ID5_TEST_PARTNER_ID);
+          expect(requestBody.o).is.eq('pbjs');
+          expect(requestBody.pd).is.undefined;
+          expect(requestBody.s).is.undefined;
+          expect(requestBody.provider).is.undefined
+          expect(requestBody.v).is.eq('$prebid.version$');
+          expect(requestBody.gdpr).is.eq(0);
+          expect(requestBody.gdpr_consent).is.undefined;
+          expect(requestBody.us_privacy).is.undefined;
+          expect(requestBody.storage).is.deep.eq(config.storage)
 
-      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
-      expect(callbackSpy.calledOnce).to.be.true;
-      expect(callbackSpy.lastCall.lastArg).to.deep.equal(ID5_JSON_RESPONSE);
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse
+        })
+        .then(submoduleResponse => {
+          expect(submoduleResponse).is.deep.equal(ID5_JSON_RESPONSE);
+        });
+    });
+
+    it('should call the ID5 server with gdpr data ', function () {
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
+      let consentData = {
+        gdprApplies: true,
+        consentString: 'consentString'
+      }
+
+      let submoduleResponse = callSubmoduleGetId(getId5FetchConfig(), consentData, undefined);
+
+      return xhrServerMock.expectFetchRequest()
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(requestBody.partner).is.eq(ID5_TEST_PARTNER_ID);
+          expect(requestBody.gdpr).to.eq(1);
+          expect(requestBody.gdpr_consent).is.eq(consentData.consentString);
+
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse
+        })
+        .then(submoduleResponse => {
+          expect(submoduleResponse).is.deep.equal(ID5_JSON_RESPONSE);
+        });
+    });
+
+    it('should call the ID5 server without gdpr data when gdpr not applies ', function () {
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
+      let consentData = {
+        gdprApplies: false,
+        consentString: 'consentString'
+      }
+
+      let submoduleResponse = callSubmoduleGetId(getId5FetchConfig(), consentData, undefined);
+
+      return xhrServerMock.expectFetchRequest()
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(requestBody.gdpr).to.eq(0);
+          expect(requestBody.gdpr_consent).is.undefined
+
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse
+        })
+        .then(submoduleResponse => {
+          expect(submoduleResponse).is.deep.equal(ID5_JSON_RESPONSE);
+        });
+    });
+
+    it('should call the ID5 server with us privacy consent', function () {
+      let usPrivacyString = '1YN-';
+      uspDataHandler.setConsentData(usPrivacyString)
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
+      let consentData = {
+        gdprApplies: true,
+        consentString: 'consentString'
+      }
+
+      let submoduleResponse = callSubmoduleGetId(getId5FetchConfig(), consentData, undefined);
+
+      return xhrServerMock.expectFetchRequest()
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(requestBody.partner).is.eq(ID5_TEST_PARTNER_ID);
+          expect(requestBody.us_privacy).to.eq(usPrivacyString);
+
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse
+        })
+        .then(submoduleResponse => {
+          expect(submoduleResponse).is.deep.equal(ID5_JSON_RESPONSE);
+        });
     });
 
     it('should call the ID5 server with no signature field when no stored object', function () {
-      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig(), undefined, undefined).callback;
-      submoduleCallback(callbackSpy);
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
+      let submoduleResponse = callSubmoduleGetId(getId5FetchConfig(), undefined, undefined);
 
-      let request = server.requests[0];
-      let requestBody = JSON.parse(request.requestBody);
-      expect(requestBody.s).to.be.undefined;
+      return xhrServerMock.expectFetchRequest()
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(requestBody.s).is.undefined;
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse
+        })
+    });
 
-      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+    it('should call the ID5 server for config with submodule config object', function () {
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
+      let id5FetchConfig = getId5FetchConfig();
+      id5FetchConfig.params.extraParam = {
+        x: 'X',
+        y: {
+          a: 1,
+          b: '3'
+        }
+      }
+      let submoduleResponse = callSubmoduleGetId(id5FetchConfig, undefined, undefined);
+
+      return xhrServerMock.expectConfigRequest()
+        .then(configRequest => {
+          let requestBody = JSON.parse(configRequest.requestBody)
+          expect(requestBody).is.deep.eq(id5FetchConfig)
+          return xhrServerMock.respondWithConfigAndExpectNext(configRequest)
+        })
+        .then(fetchRequest => {
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse
+        })
+    });
+
+    it('should call the ID5 server for config with overridden url', function () {
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
+      let id5FetchConfig = getId5FetchConfig();
+      id5FetchConfig.params.configUrl = 'http://localhost/x/y/z'
+
+      let submoduleResponse = callSubmoduleGetId(id5FetchConfig, undefined, undefined);
+
+      return xhrServerMock.expectFirstRequest()
+        .then(configRequest => {
+          expect(configRequest.url).is.eq('http://localhost/x/y/z')
+          return xhrServerMock.respondWithConfigAndExpectNext(configRequest)
+        })
+        .then(fetchRequest => {
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse
+        })
+    });
+
+    it('should call the ID5 server with additional data when provided', function () {
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
+      let submoduleResponse = callSubmoduleGetId(getId5FetchConfig(), undefined, undefined);
+
+      return xhrServerMock.expectConfigRequest()
+        .then(configRequest => {
+          return xhrServerMock.respondWithConfigAndExpectNext(configRequest, {
+            fetchCall: {
+              url: ID5_ENDPOINT,
+              overrides: {
+                arg1: '123',
+                arg2: {
+                  x: '1',
+                  y: 2
+                }
+              }
+            }
+          });
+        })
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(requestBody.partner).is.eq(ID5_TEST_PARTNER_ID);
+          expect(requestBody.o).is.eq('pbjs');
+          expect(requestBody.v).is.eq('$prebid.version$');
+          expect(requestBody.arg1).is.eq('123')
+          expect(requestBody.arg2).is.deep.eq({
+            x: '1',
+            y: 2
+          })
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse
+        })
+    });
+
+    it('should call the ID5 server with extensions', function () {
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
+      let submoduleResponse = callSubmoduleGetId(getId5FetchConfig(), undefined, undefined);
+
+      return xhrServerMock.expectConfigRequest()
+        .then(configRequest => {
+          return xhrServerMock.respondWithConfigAndExpectNext(configRequest, {
+            fetchCall: {
+              url: ID5_ENDPOINT
+            },
+            extensionsCall: {
+              url: ID5_EXTENSIONS_ENDPOINT,
+              method: 'GET'
+            }
+          });
+        })
+        .then(extensionsRequest => {
+          expect(extensionsRequest.url).is.eq(ID5_EXTENSIONS_ENDPOINT)
+          expect(extensionsRequest.method).is.eq('GET')
+          extensionsRequest.respond(200, responseHeader, JSON.stringify({
+            lb: 'ex'
+          }))
+          return xhrServerMock.expectNextRequest();
+        })
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(requestBody.partner).is.eq(ID5_TEST_PARTNER_ID);
+          expect(requestBody.o).is.eq('pbjs');
+          expect(requestBody.v).is.eq('$prebid.version$');
+          expect(requestBody.extensions).is.deep.eq({
+            lb: 'ex'
+          })
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse
+        })
+    });
+
+    it('should call the ID5 server with extensions fetched with POST', function () {
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
+      let submoduleResponse = callSubmoduleGetId(getId5FetchConfig(), undefined, undefined);
+
+      return xhrServerMock.expectConfigRequest()
+        .then(configRequest => {
+          return xhrServerMock.respondWithConfigAndExpectNext(configRequest, {
+            fetchCall: {
+              url: ID5_ENDPOINT
+            },
+            extensionsCall: {
+              url: ID5_EXTENSIONS_ENDPOINT,
+              method: 'POST',
+              body: {
+                x: '1',
+                y: 2
+              }
+            }
+          });
+        })
+        .then(extensionsRequest => {
+          expect(extensionsRequest.url).is.eq(ID5_EXTENSIONS_ENDPOINT)
+          expect(extensionsRequest.method).is.eq('POST')
+          let requestBody = JSON.parse(extensionsRequest.requestBody)
+          expect(requestBody).is.deep.eq({
+            x: '1',
+            y: 2
+          })
+          extensionsRequest.respond(200, responseHeader, JSON.stringify({
+            lb: 'post',
+          }))
+          return xhrServerMock.expectNextRequest();
+        })
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(requestBody.partner).is.eq(ID5_TEST_PARTNER_ID);
+          expect(requestBody.o).is.eq('pbjs');
+          expect(requestBody.v).is.eq('$prebid.version$');
+          expect(requestBody.extensions).is.deep.eq({
+            lb: 'post'
+          })
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse
+        })
     });
 
     it('should call the ID5 server with signature field from stored object', function () {
-      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig(), undefined, ID5_STORED_OBJ).callback;
-      submoduleCallback(callbackSpy);
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
+      let submoduleResponse = callSubmoduleGetId(getId5FetchConfig(), undefined, ID5_STORED_OBJ);
 
-      let request = server.requests[0];
-      let requestBody = JSON.parse(request.requestBody);
-      expect(requestBody.s).to.eq(ID5_STORED_SIGNATURE);
-
-      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+      return xhrServerMock.expectFetchRequest()
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(requestBody.s).is.eq(ID5_STORED_SIGNATURE);
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse
+        })
     });
 
     it('should call the ID5 server with pd field when pd config is set', function () {
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
       const pubData = 'b50ca08271795a8e7e4012813f23d505193d75c0f2e2bb99baa63aa822f66ed3';
 
       let id5Config = getId5FetchConfig();
       id5Config.params.pd = pubData;
 
-      let submoduleCallback = id5IdSubmodule.getId(id5Config, undefined, ID5_STORED_OBJ).callback;
-      submoduleCallback(callbackSpy);
+      let submoduleResponse = callSubmoduleGetId(id5Config, undefined, ID5_STORED_OBJ);
 
-      let request = server.requests[0];
-      let requestBody = JSON.parse(request.requestBody);
-      expect(requestBody.pd).to.eq(pubData);
-
-      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+      return xhrServerMock.expectFetchRequest()
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(requestBody.pd).is.eq(pubData);
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse;
+        })
     });
 
     it('should call the ID5 server with no pd field when pd config is not set', function () {
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
       let id5Config = getId5FetchConfig();
       id5Config.params.pd = undefined;
 
-      let submoduleCallback = id5IdSubmodule.getId(id5Config, undefined, ID5_STORED_OBJ).callback;
-      submoduleCallback(callbackSpy);
+      let submoduleResponse = callSubmoduleGetId(id5Config, undefined, ID5_STORED_OBJ);
 
-      let request = server.requests[0];
-      let requestBody = JSON.parse(request.requestBody);
-      expect(requestBody.pd).to.be.undefined;
-
-      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+      return xhrServerMock.expectFetchRequest()
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(requestBody.pd).is.undefined;
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse;
+        })
     });
 
     it('should call the ID5 server with nb=1 when no stored value exists and reset after', function () {
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
       coreStorage.removeDataFromLocalStorage(ID5_NB_STORAGE_NAME);
 
-      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig(), undefined, ID5_STORED_OBJ).callback;
-      submoduleCallback(callbackSpy);
+      let submoduleResponse = callSubmoduleGetId(getId5FetchConfig(), undefined, ID5_STORED_OBJ);
 
-      let request = server.requests[0];
-      let requestBody = JSON.parse(request.requestBody);
-      expect(requestBody.nbPage).to.eq(1);
-
-      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
-
-      expect(getNbFromCache(ID5_TEST_PARTNER_ID)).to.be.eq(0);
+      return xhrServerMock.expectFetchRequest()
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(requestBody.nbPage).is.eq(1);
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse
+        })
+        .then(() => {
+          expect(getNbFromCache(ID5_TEST_PARTNER_ID)).is.eq(0);
+        })
     });
 
     it('should call the ID5 server with incremented nb when stored value exists and reset after', function () {
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
       storeNbInCache(ID5_TEST_PARTNER_ID, 1);
 
-      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig(), undefined, ID5_STORED_OBJ).callback;
-      submoduleCallback(callbackSpy);
+      let submoduleResponse = callSubmoduleGetId(getId5FetchConfig(), undefined, ID5_STORED_OBJ);
 
-      let request = server.requests[0];
-      let requestBody = JSON.parse(request.requestBody);
-      expect(requestBody.nbPage).to.eq(2);
-
-      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
-
-      expect(getNbFromCache(ID5_TEST_PARTNER_ID)).to.be.eq(0);
+      return xhrServerMock.expectFetchRequest()
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(requestBody.nbPage).is.eq(2);
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse
+        })
+        .then(() => {
+          expect(getNbFromCache(ID5_TEST_PARTNER_ID)).is.eq(0);
+        })
     });
 
     it('should call the ID5 server with ab_testing object when abTesting is turned on', function () {
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
       let id5Config = getId5FetchConfig();
-      id5Config.params.abTesting = { enabled: true, controlGroupPct: 0.234 }
+      id5Config.params.abTesting = {enabled: true, controlGroupPct: 0.234}
 
-      let submoduleCallback = id5IdSubmodule.getId(id5Config, undefined, ID5_STORED_OBJ).callback;
-      submoduleCallback(callbackSpy);
+      let submoduleResponse = callSubmoduleGetId(id5Config, undefined, ID5_STORED_OBJ);
 
-      let request = server.requests[0];
-      let requestBody = JSON.parse(request.requestBody);
-      expect(requestBody.ab_testing.enabled).to.eq(true);
-      expect(requestBody.ab_testing.control_group_pct).to.eq(0.234);
-
-      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+      return xhrServerMock.expectFetchRequest()
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(requestBody.ab_testing.enabled).is.eq(true);
+          expect(requestBody.ab_testing.control_group_pct).is.eq(0.234);
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse;
+        });
     });
 
     it('should call the ID5 server without ab_testing object when abTesting is turned off', function () {
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
       let id5Config = getId5FetchConfig();
-      id5Config.params.abTesting = { enabled: false, controlGroupPct: 0.55 }
+      id5Config.params.abTesting = {enabled: false, controlGroupPct: 0.55}
 
-      let submoduleCallback = id5IdSubmodule.getId(id5Config, undefined, ID5_STORED_OBJ).callback;
-      submoduleCallback(callbackSpy);
+      let submoduleResponse = callSubmoduleGetId(id5Config, undefined, ID5_STORED_OBJ);
 
-      let request = server.requests[0];
-      let requestBody = JSON.parse(request.requestBody);
-      expect(requestBody.ab_testing).to.be.undefined;
-
-      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+      return xhrServerMock.expectFetchRequest()
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(requestBody.ab_testing).is.undefined;
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse
+        });
     });
 
     it('should call the ID5 server without ab_testing when when abTesting is not set', function () {
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
       let id5Config = getId5FetchConfig();
 
-      let submoduleCallback = id5IdSubmodule.getId(id5Config, undefined, ID5_STORED_OBJ).callback;
-      submoduleCallback(callbackSpy);
+      let submoduleResponse = callSubmoduleGetId(id5Config, undefined, ID5_STORED_OBJ);
 
-      let request = server.requests[0];
-      let requestBody = JSON.parse(request.requestBody);
-      expect(requestBody.ab_testing).to.be.undefined;
-
-      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+      return xhrServerMock.expectFetchRequest()
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(requestBody.ab_testing).is.undefined;
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse
+        });
     });
 
     it('should store the privacy object from the ID5 server response', function () {
-      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig(), undefined, ID5_STORED_OBJ).callback;
-      submoduleCallback(callbackSpy);
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
+      let submoduleResponse = callSubmoduleGetId(getId5FetchConfig(), undefined, ID5_STORED_OBJ);
 
-      let request = server.requests[0];
-
-      let responseObject = utils.deepClone(ID5_JSON_RESPONSE);
-      responseObject.privacy = {
+      const privacy = {
         jurisdiction: 'gdpr',
         id5_consent: true
       };
-      request.respond(200, responseHeader, JSON.stringify(responseObject));
-      expect(getFromLocalStorage(ID5_PRIVACY_STORAGE_NAME)).to.be.eq(JSON.stringify(responseObject.privacy));
-      coreStorage.removeDataFromLocalStorage(ID5_PRIVACY_STORAGE_NAME);
+
+      return xhrServerMock.expectFetchRequest()
+        .then(request => {
+          let responseObject = utils.deepClone(ID5_JSON_RESPONSE);
+          responseObject.privacy = privacy;
+          request.respond(200, responseHeader, JSON.stringify(responseObject));
+          return submoduleResponse
+        })
+        .then(() => {
+          expect(getFromLocalStorage(ID5_PRIVACY_STORAGE_NAME)).is.eq(JSON.stringify(privacy));
+          coreStorage.removeDataFromLocalStorage(ID5_PRIVACY_STORAGE_NAME);
+        })
     });
 
     it('should not store a privacy object if not part of ID5 server response', function () {
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
       coreStorage.removeDataFromLocalStorage(ID5_PRIVACY_STORAGE_NAME);
-      let submoduleCallback = id5IdSubmodule.getId(getId5FetchConfig(), undefined, ID5_STORED_OBJ).callback;
-      submoduleCallback(callbackSpy);
+      let submoduleResponse = callSubmoduleGetId(getId5FetchConfig(), undefined, ID5_STORED_OBJ);
 
-      let request = server.requests[0];
-
-      request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
-      expect(getFromLocalStorage(ID5_PRIVACY_STORAGE_NAME)).to.be.null;
+      return xhrServerMock.expectFetchRequest()
+        .then(request => {
+          let responseObject = utils.deepClone(ID5_JSON_RESPONSE);
+          responseObject.privacy = undefined;
+          request.respond(200, responseHeader, JSON.stringify(responseObject));
+          return submoduleResponse
+        })
+        .then(() => {
+          expect(getFromLocalStorage(ID5_PRIVACY_STORAGE_NAME)).is.null;
+        });
     });
 
     describe('when legacy cookies are set', () => {
@@ -327,11 +674,11 @@ describe('ID5 ID System', function() {
     })
   });
 
-  describe('Request Bids Hook', function() {
+  describe('Request Bids Hook', function () {
     let adUnits;
     let sandbox;
 
-    beforeEach(function() {
+    beforeEach(function () {
       sandbox = sinon.sandbox.create();
       mockGdprConsent(sandbox);
       sinon.stub(events, 'getEvents').returns([]);
@@ -340,7 +687,7 @@ describe('ID5 ID System', function() {
       coreStorage.removeDataFromLocalStorage(ID5_NB_STORAGE_NAME);
       adUnits = [getAdUnitMock()];
     });
-    afterEach(function() {
+    afterEach(function () {
       events.getEvents.restore();
       coreStorage.removeDataFromLocalStorage(ID5_STORAGE_NAME);
       coreStorage.removeDataFromLocalStorage(`${ID5_STORAGE_NAME}_last`);
@@ -359,8 +706,8 @@ describe('ID5 ID System', function() {
         adUnits.forEach(unit => {
           unit.bids.forEach(bid => {
             expect(bid).to.have.deep.nested.property(`userId.${ID5_EIDS_NAME}`);
-            expect(bid.userId.id5id.uid).to.equal(ID5_STORED_ID);
-            expect(bid.userIdAsEids[0]).to.deep.equal({
+            expect(bid.userId.id5id.uid).is.equal(ID5_STORED_ID);
+            expect(bid.userIdAsEids[0]).is.deep.equal({
               source: ID5_SOURCE,
               uids: [{
                 id: ID5_STORED_ID,
@@ -373,7 +720,7 @@ describe('ID5 ID System', function() {
           });
         });
         done();
-      }, { adUnits });
+      }, {adUnits});
     });
 
     it('should add config value ID to bids', function (done) {
@@ -385,15 +732,15 @@ describe('ID5 ID System', function() {
         adUnits.forEach(unit => {
           unit.bids.forEach(bid => {
             expect(bid).to.have.deep.nested.property(`userId.${ID5_EIDS_NAME}`);
-            expect(bid.userId.id5id.uid).to.equal(ID5_STORED_ID);
-            expect(bid.userIdAsEids[0]).to.deep.equal({
+            expect(bid.userId.id5id.uid).is.equal(ID5_STORED_ID);
+            expect(bid.userIdAsEids[0]).is.deep.equal({
               source: ID5_SOURCE,
-              uids: [{ id: ID5_STORED_ID, atype: 1 }]
+              uids: [{id: ID5_STORED_ID, atype: 1}]
             });
           });
         });
         done();
-      }, { adUnits });
+      }, {adUnits});
     });
 
     it('should set nb=1 in cache when no stored nb value exists and cached ID', function (done) {
@@ -405,7 +752,7 @@ describe('ID5 ID System', function() {
       config.setConfig(getFetchLocalStorageConfig());
 
       requestBidsHook((adUnitConfig) => {
-        expect(getNbFromCache(ID5_TEST_PARTNER_ID)).to.be.eq(1);
+        expect(getNbFromCache(ID5_TEST_PARTNER_ID)).is.eq(1);
         done()
       }, {adUnits});
     });
@@ -419,19 +766,20 @@ describe('ID5 ID System', function() {
       config.setConfig(getFetchLocalStorageConfig());
 
       requestBidsHook(() => {
-        expect(getNbFromCache(ID5_TEST_PARTNER_ID)).to.be.eq(2);
+        expect(getNbFromCache(ID5_TEST_PARTNER_ID)).is.eq(2);
         done()
       }, {adUnits});
     });
 
     it('should call ID5 servers with signature and incremented nb post auction if refresh needed', function () {
-      storeInLocalStorage(ID5_STORAGE_NAME, JSON.stringify(ID5_STORED_OBJ), 1);
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
+      let initialLocalStorageValue = JSON.stringify(ID5_STORED_OBJ);
+      storeInLocalStorage(ID5_STORAGE_NAME, initialLocalStorageValue, 1);
       storeInLocalStorage(`${ID5_STORAGE_NAME}_last`, expDaysStr(-1), 1);
-      storeNbInCache(ID5_TEST_PARTNER_ID, 1);
 
+      storeNbInCache(ID5_TEST_PARTNER_ID, 1);
       let id5Config = getFetchLocalStorageConfig();
       id5Config.userSync.userIds[0].storage.refreshInSeconds = 2;
-
       init(config);
       setSubmoduleRegistry([id5IdSubmodule]);
       config.setConfig(id5Config);
@@ -441,53 +789,62 @@ describe('ID5 ID System', function() {
           resolve()
         }, {adUnits});
       }).then(() => {
-        expect(getNbFromCache(ID5_TEST_PARTNER_ID)).to.be.eq(2);
-        expect(server.requests).to.be.empty;
+        expect(xhrServerMock.hasReceivedAnyRequest()).is.false;
         events.emit(CONSTANTS.EVENTS.AUCTION_END, {});
-        return new Promise((resolve) => setTimeout(resolve))
-      }).then(() => {
-        let request = server.requests[0];
+        return xhrServerMock.expectFetchRequest()
+      }).then(request => {
         let requestBody = JSON.parse(request.requestBody);
-        expect(request.url).to.contain(ID5_ENDPOINT);
-        expect(requestBody.s).to.eq(ID5_STORED_SIGNATURE);
-        expect(requestBody.nbPage).to.eq(2);
-
-        const responseHeader = { 'Content-Type': 'application/json' };
+        expect(requestBody.s).is.eq(ID5_STORED_SIGNATURE);
+        expect(requestBody.nbPage).is.eq(2);
+        expect(getNbFromCache(ID5_TEST_PARTNER_ID)).is.eq(2);
+        const responseHeader = {'Content-Type': 'application/json'};
         request.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
 
-        expect(decodeURIComponent(getFromLocalStorage(ID5_STORAGE_NAME))).to.be.eq(JSON.stringify(ID5_JSON_RESPONSE));
-        expect(getNbFromCache(ID5_TEST_PARTNER_ID)).to.be.eq(0);
+        return new Promise(function (resolve) {
+          (function waitForCondition() {
+            if (getFromLocalStorage(ID5_STORAGE_NAME) !== initialLocalStorageValue) return resolve();
+            setTimeout(waitForCondition, 30);
+          })();
+        })
+      }).then(() => {
+        expect(decodeURIComponent(getFromLocalStorage(ID5_STORAGE_NAME))).is.eq(JSON.stringify(ID5_JSON_RESPONSE));
+        expect(getNbFromCache(ID5_TEST_PARTNER_ID)).is.eq(0);
       })
     });
   });
 
-  describe('Decode stored object', function() {
-    const expectedDecodedObject = { id5id: { uid: ID5_STORED_ID, ext: { linkType: ID5_STORED_LINK_TYPE } } };
+  describe('Decode stored object', function () {
+    const expectedDecodedObject = {id5id: {uid: ID5_STORED_ID, ext: {linkType: ID5_STORED_LINK_TYPE}}};
 
-    it('should properly decode from a stored object', function() {
-      expect(id5IdSubmodule.decode(ID5_STORED_OBJ, getId5FetchConfig())).to.deep.equal(expectedDecodedObject);
+    it('should properly decode from a stored object', function () {
+      expect(id5IdSubmodule.decode(ID5_STORED_OBJ, getId5FetchConfig())).is.deep.equal(expectedDecodedObject);
     });
-    it('should return undefined if passed a string', function() {
-      expect(id5IdSubmodule.decode('somestring', getId5FetchConfig())).to.eq(undefined);
+    it('should return undefined if passed a string', function () {
+      expect(id5IdSubmodule.decode('somestring', getId5FetchConfig())).is.eq(undefined);
     });
   });
 
-  describe('A/B Testing', function() {
-    const expectedDecodedObjectWithIdAbOff = { id5id: { uid: ID5_STORED_ID, ext: { linkType: ID5_STORED_LINK_TYPE } } };
-    const expectedDecodedObjectWithIdAbOn = { id5id: { uid: ID5_STORED_ID, ext: { linkType: ID5_STORED_LINK_TYPE, abTestingControlGroup: false } } };
-    const expectedDecodedObjectWithoutIdAbOn = { id5id: { uid: '', ext: { linkType: 0, abTestingControlGroup: true } } };
+  describe('A/B Testing', function () {
+    const expectedDecodedObjectWithIdAbOff = {id5id: {uid: ID5_STORED_ID, ext: {linkType: ID5_STORED_LINK_TYPE}}};
+    const expectedDecodedObjectWithIdAbOn = {
+      id5id: {
+        uid: ID5_STORED_ID,
+        ext: {linkType: ID5_STORED_LINK_TYPE, abTestingControlGroup: false}
+      }
+    };
+    const expectedDecodedObjectWithoutIdAbOn = {id5id: {uid: '', ext: {linkType: 0, abTestingControlGroup: true}}};
     let testConfig, storedObject;
 
-    beforeEach(function() {
+    beforeEach(function () {
       testConfig = getId5FetchConfig();
       storedObject = utils.deepClone(ID5_STORED_OBJ);
     });
 
-    describe('A/B Testing Config is Set', function() {
+    describe('A/B Testing Config is Set', function () {
       let randStub;
 
-      beforeEach(function() {
-        randStub = sinon.stub(Math, 'random').callsFake(function() {
+      beforeEach(function () {
+        randStub = sinon.stub(Math, 'random').callsFake(function () {
           return 0.25;
         });
       });
@@ -495,39 +852,39 @@ describe('ID5 ID System', function() {
         randStub.restore();
       });
 
-      describe('Decode', function() {
+      describe('Decode', function () {
         let logErrorSpy;
 
-        beforeEach(function() {
+        beforeEach(function () {
           logErrorSpy = sinon.spy(utils, 'logError');
         });
-        afterEach(function() {
+        afterEach(function () {
           logErrorSpy.restore();
         });
 
         it('should not set abTestingControlGroup extension when A/B testing is off', function () {
           let decoded = id5IdSubmodule.decode(storedObject, testConfig);
-          expect(decoded).to.deep.equal(expectedDecodedObjectWithIdAbOff);
+          expect(decoded).is.deep.equal(expectedDecodedObjectWithIdAbOff);
         });
 
         it('should set abTestingControlGroup to false when A/B testing is on but in normal group', function () {
-          storedObject.ab_testing = { result: 'normal' };
+          storedObject.ab_testing = {result: 'normal'};
           let decoded = id5IdSubmodule.decode(storedObject, testConfig);
-          expect(decoded).to.deep.equal(expectedDecodedObjectWithIdAbOn);
+          expect(decoded).is.deep.equal(expectedDecodedObjectWithIdAbOn);
         });
 
         it('should not expose ID when everyone is in control group', function () {
-          storedObject.ab_testing = { result: 'control' };
+          storedObject.ab_testing = {result: 'control'};
           storedObject.universal_uid = '';
           storedObject.link_type = 0;
           let decoded = id5IdSubmodule.decode(storedObject, testConfig);
-          expect(decoded).to.deep.equal(expectedDecodedObjectWithoutIdAbOn);
+          expect(decoded).is.deep.equal(expectedDecodedObjectWithoutIdAbOn);
         });
 
         it('should log A/B testing errors', function () {
-          storedObject.ab_testing = { result: 'error' };
+          storedObject.ab_testing = {result: 'error'};
           let decoded = id5IdSubmodule.decode(storedObject, testConfig);
-          expect(decoded).to.deep.equal(expectedDecodedObjectWithIdAbOff);
+          expect(decoded).is.deep.equal(expectedDecodedObjectWithIdAbOff);
           sinon.assert.calledOnce(logErrorSpy);
         });
       });


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)

This PR mostly refactors the process to request an ID5 ID from our servers, utilizing promises and better organizing the code. In doing so, we've also added a feature to allow config to be pulled down from our server (so publishers don't have to make changes to their website when they want to add features) and an optional ability to add extensions that get passed into the request for an ID5 ID that are used when determining the ID5 ID to provide back to the publisher.

- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
   - https://github.com/prebid/prebid.github.io/pull/3944