### PR TITLE
Prebid core: fix bug with some native assets being lost from ortb native responses

### DIFF
--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -400,6 +400,66 @@ describe('native.js', function () {
       value: bid.native.ext.foo,
     });
   });
+
+  const SAMPLE_ORTB_REQUEST = toOrtbNativeRequest({
+    title: 'vtitle',
+    body: 'vbody'
+  });
+  const SAMPLE_ORTB_RESPONSE = {
+    native: {
+      ortb: {
+        link: {
+          url: 'url'
+        },
+        assets: [
+          {
+            id: 0,
+            title: {
+              text: 'vtitle'
+            }
+          },
+          {
+            id: 1,
+            data: {
+              value: 'vbody'
+            }
+          }
+        ]
+      }
+    }
+  }
+  describe('getAllAssetsMessage', () => {
+    it('returns assets in legacy format for ortb responses', () => {
+      const actual = getAllAssetsMessage({}, SAMPLE_ORTB_RESPONSE, {getNativeReq: () => SAMPLE_ORTB_REQUEST});
+      expect(actual.assets).to.eql([
+        {
+          key: 'clickUrl',
+          value: 'url'
+        },
+        {
+          key: 'title',
+          value: 'vtitle'
+        },
+        {
+          key: 'body',
+          value: 'vbody'
+        },
+      ])
+    });
+  });
+  describe('getAssetsMessage', () => {
+    Object.entries({
+      'hb_native_title': {key: 'title', value: 'vtitle'},
+      'hb_native_body': {key: 'body', value: 'vbody'}
+    }).forEach(([tkey, assetVal]) => {
+      it(`returns ${tkey} asset in legacy format for ortb responses`, () => {
+        const actual = getAssetMessage({
+          assets: [tkey]
+        }, SAMPLE_ORTB_RESPONSE, {getNativeReq: () => SAMPLE_ORTB_REQUEST})
+        expect(actual.assets).to.eql([assetVal])
+      })
+    })
+  })
 });
 
 describe('validate native openRTB', function () {

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -1082,3 +1082,39 @@ describe('fireClickTrackers', () => {
     urls.forEach(url => sinon.assert.calledWith(fetchURL, url));
   })
 })
+
+describe('toOrtbNativeResponse', () => {
+  it('should work when there are unrequested assets in the response', () => {
+    const legacyResponse = {
+      'title': 'vtitle',
+      'body': 'vbody'
+    }
+    const request = toOrtbNativeRequest({
+      title: {
+        required: 'true'
+      },
+
+    });
+    const ortbResponse = toOrtbNativeResponse(legacyResponse, request);
+    expect(ortbResponse.assets.length).to.eql(1);
+  });
+
+  it('should not modify the request', () => {
+    const legacyResponse = {
+      title: 'vtitle'
+    }
+    const request = toOrtbNativeRequest({
+      title: {
+        required: true
+      }
+    });
+    const requestCopy = JSON.parse(JSON.stringify(request));
+    const response = toOrtbNativeResponse(legacyResponse, request);
+    expect(request).to.eql(requestCopy);
+    sinon.assert.match(response.assets[0], {
+      title: {
+        text: 'vtitle'
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

For reasons that I don't understand, there are two ways native assets can be retrieved for rendering - `getAssetMessage` and `getAllAssetsMessage`. https://github.com/prebid/Prebid.js/pull/8086 only updated one of them, this PR brings the other in line.

It's unclear to me what the impact of this is, except that it currently can only affect bids coming from the Prebid Server adapter (because it's the only one using ortb in native bid responses). I am not sure how many creatives use one way over the other.

