### PR TITLE
removed localstorage from  adqueryIdSystem module

### DIFF
--- a/modules/adqueryIdSystem.js
+++ b/modules/adqueryIdSystem.js
@@ -50,10 +50,6 @@ export const adqueryIdSubmodule = {
    * @returns {{qid:Object}}
    */
   decode(value) {
-    let qid = storage.getDataFromLocalStorage('qid');
-    if (utils.isStr(qid)) {
-      return {qid: qid};
-    }
     return (value && typeof value['qid'] === 'string') ? { 'qid': value['qid'] } : undefined;
   },
   /**
@@ -71,30 +67,24 @@ export const adqueryIdSubmodule = {
       config.params.urlArg);
 
     const resp = function (callback) {
-      let qid = storage.getDataFromLocalStorage('qid');
-      if (utils.isStr(qid)) {
-        const responseObj = {qid: qid};
-        callback(responseObj);
-      } else {
-        const callbacks = {
-          success: response => {
-            let responseObj;
-            if (response) {
-              try {
-                responseObj = JSON.parse(response);
-              } catch (error) {
-                utils.logError(error);
-              }
+      const callbacks = {
+        success: response => {
+          let responseObj;
+          if (response) {
+            try {
+              responseObj = JSON.parse(response);
+            } catch (error) {
+              utils.logError(error);
             }
-            callback(responseObj);
-          },
-          error: error => {
-            utils.logError(`${MODULE_NAME}: ID fetch encountered an error`, error);
-            callback();
           }
-        };
-        ajax(url, callbacks, undefined, {method: 'GET'});
-      }
+          callback(responseObj);
+        },
+        error: error => {
+          utils.logError(`${MODULE_NAME}: ID fetch encountered an error`, error);
+          callback();
+        }
+      };
+      ajax(url, callbacks, undefined, {method: 'GET'});
     };
     return {callback: resp};
   }

--- a/test/spec/modules/adqueryIdSystem_spec.js
+++ b/test/spec/modules/adqueryIdSystem_spec.js
@@ -1,13 +1,5 @@
-import { adqueryIdSubmodule, storage } from 'modules/adqueryIdSystem.js';
+import { adqueryIdSubmodule } from 'modules/adqueryIdSystem.js';
 import { server } from 'test/mocks/xhr.js';
-import {amxIdSubmodule} from '../../../modules/amxIdSystem';
-import * as utils from '../../../src/utils';
-
-const config = {
-  storage: {
-    type: 'html5',
-  },
-};
 
 describe('AdqueryIdSystem', function () {
   describe('qid submodule', () => {
@@ -21,16 +13,6 @@ describe('AdqueryIdSystem', function () {
   });
 
   describe('getId', function() {
-    let getDataFromLocalStorageStub;
-
-    beforeEach(function() {
-      getDataFromLocalStorageStub = sinon.stub(storage, 'getDataFromLocalStorage');
-    });
-
-    afterEach(function () {
-      getDataFromLocalStorageStub.restore();
-    });
-
     it('gets a adqueryId', function() {
       const config = {
         params: {}
@@ -43,19 +25,6 @@ describe('AdqueryIdSystem', function () {
       request.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify({ qid: 'qid' }));
       expect(callbackSpy.lastCall.lastArg).to.deep.equal({qid: 'qid'});
     });
-
-    it('gets a cached adqueryId', function() {
-      const config = {
-        params: {}
-      };
-      getDataFromLocalStorageStub.withArgs('qid').returns('qid');
-
-      const callbackSpy = sinon.spy();
-      const callback = adqueryIdSubmodule.getId(config).callback;
-      callback(callbackSpy);
-      expect(callbackSpy.lastCall.lastArg).to.deep.equal({qid: 'qid'});
-    });
-
     it('allows configurable id url', function() {
       const config = {
         params: {


### PR DESCRIPTION

## Type of change
- [ x] Bugfix

## Description of change
We gave up on storing the id in localstorage because this caused duplicate qid
