### PR TITLE
Prebid Core : fix issue of mergeConfig

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -386,7 +386,11 @@ export function newConfig() {
         option = Object.assign({}, defaults[topic], option);
       }
 
-      topicalConfig[topic] = config[topic] = option;
+      try {
+        topicalConfig[topic] = config[topic] = option;
+      } catch (e) {
+        logWarn(`Cannot set config for property ${topic} : `, e)
+      }
     });
 
     callSubscribers(topicalConfig);
@@ -525,11 +529,7 @@ export function newConfig() {
       return;
     }
 
-    const mergedConfig = Object.keys(obj).reduce((accum, key) => {
-      const prevConf = _getConfig()[key] || {};
-      accum[key] = mergeDeep(prevConf, obj[key]);
-      return accum;
-    }, {});
+    const mergedConfig = mergeDeep(_getConfig(), obj);
 
     setConfig({ ...mergedConfig });
     return mergedConfig;

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -596,6 +596,7 @@ describe('config API', function () {
     }
 
     setConfig({
+      bidderTimeout: 2000,
       ortb2: {
         user: {
           data: [userObj1, userObj2]
@@ -609,6 +610,7 @@ describe('config API', function () {
     });
 
     const rtd = {
+      bidderTimeout: 3000,
       ortb2: {
         user: {
           data: [userObj1]
@@ -623,11 +625,13 @@ describe('config API', function () {
     mergeConfig(rtd);
 
     let ortb2Config = getConfig('ortb2');
+    let bidderTimeout = getConfig('bidderTimeout');
 
     expect(ortb2Config.user.data).to.deep.include.members([userObj1, userObj2]);
     expect(ortb2Config.site.content.data).to.deep.include.members([siteObj1]);
     expect(ortb2Config.user.data).to.have.lengthOf(2);
     expect(ortb2Config.site.content.data).to.have.lengthOf(1);
+    expect(bidderTimeout).to.equal(3000);
   });
 
   it('should not corrupt global configuration with bidder configuration', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
We have observed following behaviour during our testing.
When `mergeConfig` is used after `setConfig`, all the properties which have object as value in the config are merged or get the latest value but the properties which are non-object, are not merged or does not get the latest value.
e.g:
```
pbjs.setConfig({
  testProp: 2000,
  testObj: {
     a1: 1
  }
});

pbjs.mergeConfig({
  testProp: 3000,
  testObj: {
     a1: 2,
     a2: 3
  }
});
```
After the above statements execution, the value of config object becomes
```
testProp: 2000,
testObj: {
  a1: 2,
  a2: 3
}
```
Here the value of `testObj` is merged but `testProp` isn't.
The reason being, when we call `mergeConfig`, it calls `mergeDeep` internally on the conflicting properties.
Since `mergeDeep` only works for object, we get above behaviour.

**Solution:**
Instead of using a `mergeDeep` on conflicting properties, we have used it on complete object.