### PR TITLE
openxOrtb bid adapter: support 204 response, small bug fix

### DIFF
--- a/modules/openxOrtbBidAdapter.js
+++ b/modules/openxOrtbBidAdapter.js
@@ -252,6 +252,10 @@ function getFloor(bid, mediaType) {
 }
 
 function interpretResponse(resp, req) {
+  if (!resp.body) {
+    resp.body = {nbr: 0};
+  }
+
   // pass these from request to the responses for use in userSync
   if (req.data.ext) {
     if (req.data.ext.delDomain) {
@@ -301,7 +305,7 @@ function interpretResponse(resp, req) {
       }
 
       if (respBody.ext && respBody.ext.paf) {
-        response.meta.paf = respBody.ext.paf;
+        response.meta.paf = Object.assign({}, respBody.ext.paf);
         response.meta.paf.content_id = utils.deepAccess(bid, 'ext.paf.content_id');
       }
 

--- a/test/spec/modules/openxOrtbBidAdapter_spec.js
+++ b/test/spec/modules/openxOrtbBidAdapter_spec.js
@@ -952,7 +952,7 @@ describe('OpenxRtbAdapter', function () {
     let bidResponse;
     let bid;
 
-    context('when there is no response', function () {
+    context('when there is an nbr response', function () {
       let bids;
       beforeEach(function () {
         bidRequestConfigs = [{
@@ -975,6 +975,37 @@ describe('OpenxRtbAdapter', function () {
         bidRequest = spec.buildRequests(bidRequestConfigs, {refererInfo: {}})[0];
 
         bidResponse = {nbr: 0}; // Unknown error
+        bids = spec.interpretResponse({body: bidResponse}, bidRequest);
+      });
+
+      it('should not return any bids', function () {
+        expect(bids.length).to.equal(0);
+      });
+    });
+
+    context('when there is no response', function () {
+      let bids;
+      beforeEach(function () {
+        bidRequestConfigs = [{
+          bidder: 'openx',
+          params: {
+            unit: '12345678',
+            delDomain: 'test-del-domain'
+          },
+          adUnitCode: 'adunit-code',
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250], [300, 600]],
+            },
+          },
+          bidId: 'test-bid-id',
+          bidderRequestId: 'test-bidder-request-id',
+          auctionId: 'test-auction-id'
+        }];
+
+        bidRequest = spec.buildRequests(bidRequestConfigs, {refererInfo: {}})[0];
+
+        bidResponse = ''; // Unknown error
         bids = spec.interpretResponse({body: bidResponse}, bidRequest);
       });
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Small fix to support 204 no content responses.
Small fix described here https://github.com/prebid/Prebid.js/pull/8738/commits/cb7f78021980e6dd5b15b3b6b7ecfa5f271aff35#diff-8d063d37151ad27b5e19dc9a5feb045afb60a443291fc570d5d9669172afd20aL86-L87