### PR TITLE
bidWatch Analytics Adapter : 6.x code refactory + add creative endpoint

### DIFF
--- a/modules/bidwatchAnalyticsAdapter.js
+++ b/modules/bidwatchAnalyticsAdapter.js
@@ -10,50 +10,153 @@ const {
   EVENTS: {
     AUCTION_END,
     BID_WON,
+    BID_RESPONSE,
+    BID_REQUESTED,
+    BID_TIMEOUT,
   }
 } = CONSTANTS;
 
+let saveEvents = {}
 let allEvents = {}
+let auctionEnd = {}
 let initOptions = {}
 let endpoint = 'https://default'
-let objectToSearchForBidderCode = ['bidderRequests', 'bidsReceived', 'noBids']
+let requestsAttributes = ['adUnitCode', 'auctionId', 'bidder', 'bidderCode', 'bidId', 'cpm', 'creativeId', 'currency', 'width', 'height', 'mediaType', 'netRevenue', 'originalCpm', 'originalCurrency', 'requestId', 'size', 'source', 'status', 'timeToRespond', 'transactionId', 'ttl', 'sizes', 'mediaTypes', 'src', 'params', 'userId', 'labelAny', 'bids'];
 
 function getAdapterNameForAlias(aliasName) {
   return adapterManager.aliasRegistry[aliasName] || aliasName;
 }
 
-function setOriginalBidder(arg) {
-  Object.keys(arg).forEach(key => {
-    arg[key]['originalBidder'] = getAdapterNameForAlias(arg[key]['bidderCode']);
-    if (typeof arg[key]['creativeId'] == 'number') { arg[key]['creativeId'] = arg[key]['creativeId'].toString(); }
-  });
-  return arg
-}
-
-function checkBidderCode(args) {
-  if (typeof args == 'object') {
-    for (let i = 0; i < objectToSearchForBidderCode.length; i++) {
-      if (typeof args[objectToSearchForBidderCode[i]] == 'object') { args[objectToSearchForBidderCode[i]] = setOriginalBidder(args[objectToSearchForBidderCode[i]]) }
+function filterAttributes(arg, removead) {
+  let response = {};
+  if (typeof arg == 'object') {
+    if (typeof arg['bidderCode'] == 'string') {
+      response['originalBidder'] = getAdapterNameForAlias(arg['bidderCode']);
+    } else if (typeof arg['bidder'] == 'string') {
+      response['originalBidder'] = getAdapterNameForAlias(arg['bidder']);
     }
+    if (!removead && typeof arg['ad'] != 'undefined') {
+      response['ad'] = arg['ad'];
+    }
+    if (typeof arg['gdprConsent'] != 'undefined') {
+      response['gdprConsent'] = {};
+      if (typeof arg['gdprConsent']['consentString'] != 'undefined') { response['gdprConsent']['consentString'] = arg['gdprConsent']['consentString']; }
+    }
+    requestsAttributes.forEach((attr) => {
+      if (typeof arg[attr] != 'undefined') { response[attr] = arg[attr]; }
+    });
+    if (typeof response['creativeId'] == 'number') { response['creativeId'] = response['creativeId'].toString(); }
   }
-  if (typeof args['bidderCode'] == 'string') { args['originalBidder'] = getAdapterNameForAlias(args['bidderCode']); } else if (typeof args['bidder'] == 'string') { args['originalBidder'] = getAdapterNameForAlias(args['bidder']); }
-  if (typeof args['creativeId'] == 'number') { args['creativeId'] = args['creativeId'].toString(); }
-  return args
+  return response;
 }
 
-function addEvent(eventType, args) {
+function cleanAuctionEnd(args) {
+  let response = {};
+  let filteredObj;
+  let objects = ['bidderRequests', 'bidsReceived', 'noBids'];
+  objects.forEach((attr) => {
+    if (Array.isArray(args[attr])) {
+      response[attr] = [];
+      args[attr].forEach((obj) => {
+        filteredObj = filterAttributes(obj, true);
+        if (typeof obj['bids'] == 'object') {
+          filteredObj['bids'] = [];
+          obj['bids'].forEach((bid) => {
+            filteredObj['bids'].push(filterAttributes(bid, true));
+          });
+        }
+        response[attr].push(filteredObj);
+      });
+    }
+  });
+  return response;
+}
+
+function cleanCreatives(args) {
+  return filterAttributes(args, false);
+}
+
+function enhanceMediaType(arg) {
+  saveEvents['bidRequested'].forEach((bidRequested) => {
+    if (bidRequested['auctionId'] == arg['auctionId'] && Array.isArray(bidRequested['bids'])) {
+      bidRequested['bids'].forEach((bid) => {
+        if (bid['transactionId'] == arg['transactionId'] && bid['bidId'] == arg['requestId']) { arg['mediaTypes'] = bid['mediaTypes']; }
+      });
+    }
+  });
+  return arg;
+}
+
+function addBidResponse(args) {
+  let eventType = BID_RESPONSE;
+  let argsCleaned = cleanCreatives(JSON.parse(JSON.stringify(args))); ;
   if (allEvents[eventType] == undefined) { allEvents[eventType] = [] }
-  if (eventType && args) { args = checkBidderCode(args); }
-  allEvents[eventType].push(args);
+  allEvents[eventType].push(argsCleaned);
+}
+
+function addBidRequested(args) {
+  let eventType = BID_REQUESTED;
+  let argsCleaned = filterAttributes(args, true);
+  if (saveEvents[eventType] == undefined) { saveEvents[eventType] = [] }
+  saveEvents[eventType].push(argsCleaned);
+}
+
+function addTimeout(args) {
+  let eventType = BID_TIMEOUT;
+  if (saveEvents[eventType] == undefined) { saveEvents[eventType] = [] }
+  saveEvents[eventType].push(args);
+  let argsCleaned = [];
+  let argsDereferenced = JSON.parse(JSON.stringify(args));
+  argsDereferenced.forEach((attr) => {
+    argsCleaned.push(filterAttributes(JSON.parse(JSON.stringify(attr)), false));
+  });
+  if (auctionEnd[eventType] == undefined) { auctionEnd[eventType] = [] }
+  auctionEnd[eventType].push(argsCleaned);
+}
+
+function addAuctionEnd(args) {
+  let eventType = AUCTION_END;
+  if (saveEvents[eventType] == undefined) { saveEvents[eventType] = [] }
+  saveEvents[eventType].push(args);
+  let argsCleaned = cleanAuctionEnd(JSON.parse(JSON.stringify(args)));
+  if (auctionEnd[eventType] == undefined) { auctionEnd[eventType] = [] }
+  auctionEnd[eventType].push(argsCleaned);
 }
 
 function handleBidWon(args) {
-  if (typeof allEvents.bidRequested == 'object' && allEvents.bidRequested.length > 0 && allEvents.bidRequested[0].gdprConsent) { args.gdpr = allEvents.bidRequested[0].gdprConsent; }
+  args = enhanceMediaType(filterAttributes(JSON.parse(JSON.stringify(args)), true));
+  let increment = args['cpm'];
+  if (typeof saveEvents['auctionEnd'] == 'object') {
+    saveEvents['auctionEnd'].forEach((auction) => {
+      if (auction['auctionId'] == args['auctionId'] && typeof auction['bidsReceived'] == 'object') {
+        auction['bidsReceived'].forEach((bid) => {
+          if (bid['transactionId'] == args['transactionId'] && bid['adId'] != args['adId']) {
+            if (args['cpm'] < bid['cpm']) {
+              increment = 0;
+            } else if (increment > args['cpm'] - bid['cpm']) {
+              increment = args['cpm'] - bid['cpm'];
+            }
+          }
+        });
+      }
+    });
+  }
+  args['cpmIncrement'] = increment;
+  if (typeof saveEvents.bidRequested == 'object' && saveEvents.bidRequested.length > 0 && saveEvents.bidRequested[0].gdprConsent) { args.gdpr = saveEvents.bidRequested[0].gdprConsent; }
   ajax(endpoint + '.bidwatch.io/analytics/bid_won', null, JSON.stringify(args), {method: 'POST', withCredentials: true});
 }
 
 function handleAuctionEnd() {
-  ajax(endpoint + '.bidwatch.io/analytics/auctions', null, JSON.stringify(allEvents), {method: 'POST', withCredentials: true});
+  ajax(endpoint + '.bidwatch.io/analytics/auctions', function (data) {
+    let list = JSON.parse(data);
+    if (Array.isArray(list) && typeof allEvents['bidResponse'] != 'undefined') {
+      allEvents['bidResponse'].forEach((bidResponse) => {
+        if (list.includes(bidResponse['originalBidder'] + '_' + bidResponse['creativeId'])) { ajax(endpoint + '.bidwatch.io/analytics/creatives', null, JSON.stringify(bidResponse), {method: 'POST', withCredentials: true}); }
+      });
+    }
+    allEvents = {};
+  }, JSON.stringify(auctionEnd), {method: 'POST', withCredentials: true});
+  auctionEnd = {};
 }
 
 let bidwatchAnalytics = Object.assign(adapter({url, analyticsType}), {
@@ -61,13 +164,22 @@ let bidwatchAnalytics = Object.assign(adapter({url, analyticsType}), {
     eventType,
     args
   }) {
-    addEvent(eventType, args);
     switch (eventType) {
       case AUCTION_END:
+        addAuctionEnd(args);
         handleAuctionEnd();
         break;
       case BID_WON:
         handleBidWon(args);
+        break;
+      case BID_RESPONSE:
+        addBidResponse(args);
+        break;
+      case BID_REQUESTED:
+        addBidRequested(args);
+        break;
+      case BID_TIMEOUT:
+        addTimeout(args);
         break;
     }
   }});

--- a/test/spec/modules/bidwatchAnalyticsAdapter_spec.js
+++ b/test/spec/modules/bidwatchAnalyticsAdapter_spec.js
@@ -106,7 +106,8 @@ describe('BidWatch Analytics', function () {
         'gdprConsent': {
           'consentString': 'CONSENT',
           'gdprApplies': true,
-          'apiVersion': 2
+          'apiVersion': 2,
+          'vendorData': 'a lot of borring stuff',
         },
         'start': 1647424261189
       },
@@ -259,15 +260,16 @@ describe('BidWatch Analytics', function () {
   describe('main test flow', function () {
     beforeEach(function () {
       sinon.stub(events, 'getEvents').returns([]);
+      sinon.spy(bidwatchAnalytics, 'track');
     });
 
     afterEach(function () {
       events.getEvents.restore();
+      bidwatchAnalytics.disableAnalytics();
+      bidwatchAnalytics.track.restore();
     });
 
-    it('should catch events of interest', function () {
-      sinon.spy(bidwatchAnalytics, 'track');
-
+    it('test auctionEnd', function () {
       adapterManager.registerAnalyticsAdapter({
         code: 'bidwatch',
         adapter: bidwatchAnalytics
@@ -279,10 +281,40 @@ describe('BidWatch Analytics', function () {
           domain: 'test'
         }
       });
+
+      events.emit(constants.EVENTS.BID_REQUESTED, auctionEnd['bidderRequests'][0]);
+      events.emit(constants.EVENTS.BID_RESPONSE, auctionEnd['bidsReceived'][0]);
       events.emit(constants.EVENTS.BID_TIMEOUT, bidTimeout);
       events.emit(constants.EVENTS.AUCTION_END, auctionEnd);
+      expect(server.requests.length).to.equal(1);
+      let message = JSON.parse(server.requests[0].requestBody);
+      expect(message).to.have.property('auctionEnd').exist;
+      expect(message.auctionEnd).to.have.lengthOf(1);
+      expect(message.auctionEnd[0]).to.have.property('bidsReceived').and.to.have.lengthOf(1);
+      expect(message.auctionEnd[0].bidsReceived[0]).not.to.have.property('ad');
+      expect(message.auctionEnd[0]).to.have.property('bidderRequests').and.to.have.lengthOf(1);
+      expect(message.auctionEnd[0].bidderRequests[0]).to.have.property('gdprConsent');
+      expect(message.auctionEnd[0].bidderRequests[0].gdprConsent).not.to.have.property('vendorData');
+      sinon.assert.callCount(bidwatchAnalytics.track, 4);
+    });
+    it('test bidWon', function() {
+      adapterManager.registerAnalyticsAdapter({
+        code: 'bidwatch',
+        adapter: bidwatchAnalytics
+      });
+
+      adapterManager.enableAnalytics({
+        provider: 'bidwatch',
+        options: {
+          domain: 'test'
+        }
+      });
       events.emit(constants.EVENTS.BID_WON, bidWon);
-      sinon.assert.callCount(bidwatchAnalytics.track, 3);
+      expect(server.requests.length).to.equal(1);
+      let message = JSON.parse(server.requests[0].requestBody);
+      expect(message).not.to.have.property('ad');
+      expect(message).to.have.property('cpmIncrement').and.to.equal(27.4276);
+      sinon.assert.callCount(bidwatchAnalytics.track, 1);
     });
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other

## Description of change

- Makes a dereferenced copy of events received in order to be able to modify them without altering ad delivery
- Remove ad creative code from the payload send to our endpoint to minimize its size
- Remove gdpr vendor data for the same reason (not needed as long as we have the consent string)
- Add a new endpoint call dedicated to creatives which each bid response sent individually.
- Compute cpm increment for a bid won (difference between the bid won cpm and the second best price in the same transaction)
- Call endpoint creatives only when needed based on another previous call response. This should avoid useless calls to be done.
- Code was cleaned as per advices in PR #8710 
