### PR TITLE
Adkernel Bid Adapter: DisplayIo alias

### DIFF
--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -94,7 +94,8 @@ export const spec = {
     {code: 'turktelekom'},
     {code: 'felixads'},
     {code: 'motionspots'},
-    {code: 'sonic_twist'}
+    {code: 'sonic_twist'},
+    {code: 'displayioads'}
   ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change

Adaptor alias for DisplayIo network

- prebid-dev@adkernel.com
- [x] official adapter submission