### PR TITLE
Adnuntius Bid Adapter: allow Adnuntius to read dimensions

### DIFF
--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -90,7 +90,7 @@ export const spec = {
       if (bidderRequest && bidderRequest.refererInfo) networks[network].context = bidderRequest.refererInfo.page;
       if (adnMeta) networks[network].metaData = adnMeta;
       const adUnit = { ...targeting, auId: bid.params.auId, targetId: bid.bidId }
-      if (bid.mediaTypes.banner && bid.mediaTypes.banner.sizes) adUnit.dimensions = bid.mediaTypes.banner.sizes
+      if (bid.mediaTypes && bid.mediaTypes.banner && bid.mediaTypes.banner.sizes) adUnit.dimensions = bid.mediaTypes.banner.sizes
       networks[network].adUnits.push(adUnit);
     }
 

--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -89,7 +89,9 @@ export const spec = {
       networks[network].adUnits = networks[network].adUnits || [];
       if (bidderRequest && bidderRequest.refererInfo) networks[network].context = bidderRequest.refererInfo.page;
       if (adnMeta) networks[network].metaData = adnMeta;
-      networks[network].adUnits.push({ ...targeting, auId: bid.params.auId, targetId: bid.bidId });
+      const adUnit = { ...targeting, auId: bid.params.auId, targetId: bid.bidId }
+      if (bid.mediaTypes.banner && bid.mediaTypes.banner.sizes) adUnit.dimensions = bid.mediaTypes.banner.sizes
+      networks[network].adUnits.push(adUnit);
     }
 
     const networkKeys = Object.keys(networks)

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -11,8 +11,11 @@ describe('adnuntiusBidAdapter', function () {
   const GVLID = 855;
   const usi = utils.generateUUID()
   const meta = [{ key: 'usi', value: usi }]
-  const storage = getStorageManager({ gvlid: GVLID, moduleName: 'adnuntius' })
-  storage.setDataInLocalStorage('adn.metaData', JSON.stringify(meta))
+
+  before(() => {
+    const storage = getStorageManager({ gvlid: GVLID, moduleName: 'adnuntius' })
+    storage.setDataInLocalStorage('adn.metaData', JSON.stringify(meta))
+  });
 
   beforeEach(function () {
     $$PREBID_GLOBAL$$.bidderSettings = {

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -11,11 +11,8 @@ describe('adnuntiusBidAdapter', function () {
   const GVLID = 855;
   const usi = utils.generateUUID()
   const meta = [{ key: 'usi', value: usi }]
-
-  before(() => {
-    const storage = getStorageManager({gvlid: GVLID, moduleName: 'adnuntius'})
-    storage.setDataInLocalStorage('adn.metaData', JSON.stringify(meta))
-  });
+  const storage = getStorageManager({ gvlid: GVLID, moduleName: 'adnuntius' })
+  storage.setDataInLocalStorage('adn.metaData', JSON.stringify(meta))
 
   beforeEach(function () {
     $$PREBID_GLOBAL$$.bidderSettings = {
@@ -46,7 +43,11 @@ describe('adnuntiusBidAdapter', function () {
         auId: '8b6bc',
         network: 'adnuntius',
       },
-
+      mediaTypes: {
+        banner: {
+          sizes: [[640, 480], [600, 400]],
+        }
+      },
     }
   ]
 
@@ -228,7 +229,7 @@ describe('adnuntiusBidAdapter', function () {
       expect(request[0]).to.have.property('url');
       expect(request[0].url).to.equal(ENDPOINT_URL);
       expect(request[0]).to.have.property('data');
-      expect(request[0].data).to.equal('{\"adUnits\":[{\"auId\":\"8b6bc\",\"targetId\":\"123\"}],\"metaData\":{\"usi\":\"' + usi + '\"}}');
+      expect(request[0].data).to.equal('{\"adUnits\":[{\"auId\":\"8b6bc\",\"targetId\":\"123\",\"dimensions\":[[640,480],[600,400]]}],\"metaData\":{\"usi\":\"' + usi + '\"}}');
     });
 
     it('Test Video requests', function () {


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Allow Adnuntius to read the dimensions from the incoming request and pass them onto the ad server request. This is to ensure that the correct ad sizes are delivered back. Previously we could not do this in the ad server. 


- contact email of the adapter’s maintainer: prebid@adnuntius.com
- [x] official adapter submission
