### PR TITLE
Adtelligent Bid Adapter: add OCM alias

### DIFF
--- a/modules/adtelligentBidAdapter.js
+++ b/modules/adtelligentBidAdapter.js
@@ -22,6 +22,7 @@ const HOST_GETTERS = {
   streamkey: () => 'ghb.hb.streamkey.net',
   janet: () => 'ghb.bidder.jmgads.com',
   pgam: () => 'ghb.pgamssp.com',
+  ocm: () => 'ghb.cenarius.orangeclickmedia.com',
 }
 const getUri = function (bidderCode) {
   let bidderWithoutSuffix = bidderCode.split('_')[0];
@@ -40,7 +41,8 @@ export const spec = {
   aliases: ['onefiftytwomedia', 'appaloosa', 'bidsxchange', 'streamkey', 'janet',
     { code: 'selectmedia', gvlid: 775 },
     { code: 'navelix', gvlid: 380 },
-    'pgam'
+    'pgam',
+    'ocm',
   ],
   supportedMediaTypes: [VIDEO, BANNER],
   isBidRequestValid: function (bid) {

--- a/test/spec/modules/adtelligentBidAdapter_spec.js
+++ b/test/spec/modules/adtelligentBidAdapter_spec.js
@@ -19,6 +19,7 @@ const aliasEP = {
   streamkey: 'https://ghb.hb.streamkey.net/v2/auction/',
   janet: 'https://ghb.bidder.jmgads.com/v2/auction/',
   pgam: 'https://ghb.pgamssp.com/v2/auction/',
+  ocm: 'https://ghb.cenarius.orangeclickmedia.com/v2/auction/',
 };
 
 const DEFAULT_ADATPER_REQ = { bidderCode: 'adtelligent' };


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter 

## Description of change
Add new bidder alias OCM
- test parameters for validating bids
```
{
  bidder: 'ocm',
  params: {
    aid: 529814
  }
}
```

- g.moroz@adtelligent.com
- [x] official adapter submission

- [A link to a PR on the docs repo](https://github.com/prebid/prebid.github.io/pull/3955)
