### PR TITLE
Pubmatic bid adapter: improved site object handling

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -391,6 +391,15 @@ function _appendSiteAppDevice(request, pageUrl, accountId) {
   }
 }
 
+function getSiteObj(objToAddProp, checkObj, sitePropList) {
+  sitePropList.forEach((prop) => {
+    // will delete property if it is overrided by ortb2 config
+    if (objToAddProp?.[prop]) delete objToAddProp?.[prop];
+    if (checkObj?.[propName]) objToAddProp[propName] = checkObj[propName];
+  });
+  return objToAddProp;
+}
+
 function addBidderFirstPartyDataToRequest(request, bidderFpd) {
   const fpdConfigs = Object.entries(bidderFpd).reduce((acc, [bidder, bidderOrtb2]) => {
     const ortb2 = mergeDeep({}, bidderOrtb2);
@@ -980,8 +989,11 @@ Object.assign(ORTB2.prototype, {
       deepSetValue(request, 'regs.coppa', 1);
     }
 
+    const sitePropList = ['page', 'domain', 'ref'];
+    const siteObj = getSiteObj({}, request.site, sitePropList);
     const commonFpd = s2sBidRequest.ortb2Fragments?.global || {};
     mergeDeep(request, commonFpd);
+    request.site = getSiteObj(request.site, siteObj, sitePropList);
 
     addBidderFirstPartyDataToRequest(request, s2sBidRequest.ortb2Fragments?.bidder || {});
 

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -391,15 +391,6 @@ function _appendSiteAppDevice(request, pageUrl, accountId) {
   }
 }
 
-function getSiteObj(objToAddProp, referObj, sitePropList) {
-  sitePropList.forEach((prop) => {
-    // will delete property if it is overrided by ortb2 config
-    if (objToAddProp?.[prop]) delete objToAddProp?.[prop];
-    if (referObj?.[propName]) objToAddProp[propName] = referObj[propName];
-  });
-  return objToAddProp;
-}
-
 function addBidderFirstPartyDataToRequest(request, bidderFpd) {
   const fpdConfigs = Object.entries(bidderFpd).reduce((acc, [bidder, bidderOrtb2]) => {
     const ortb2 = mergeDeep({}, bidderOrtb2);
@@ -989,11 +980,8 @@ Object.assign(ORTB2.prototype, {
       deepSetValue(request, 'regs.coppa', 1);
     }
 
-    const sitePropList = ['page', 'domain', 'ref'];
-    const siteObj = getSiteObj({}, request.site, sitePropList);
     const commonFpd = s2sBidRequest.ortb2Fragments?.global || {};
     mergeDeep(request, commonFpd);
-    request.site = getSiteObj(request.site, siteObj, sitePropList);
 
     addBidderFirstPartyDataToRequest(request, s2sBidRequest.ortb2Fragments?.bidder || {});
 

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -391,11 +391,11 @@ function _appendSiteAppDevice(request, pageUrl, accountId) {
   }
 }
 
-function getSiteObj(objToAddProp, checkObj, sitePropList) {
+function getSiteObj(objToAddProp, referObj, sitePropList) {
   sitePropList.forEach((prop) => {
     // will delete property if it is overrided by ortb2 config
     if (objToAddProp?.[prop]) delete objToAddProp?.[prop];
-    if (checkObj?.[propName]) objToAddProp[propName] = checkObj[propName];
+    if (referObj?.[propName]) objToAddProp[propName] = referObj[propName];
   });
   return objToAddProp;
 }

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -183,7 +183,7 @@ _each(NATIVE_ASSETS, anAsset => { NATIVE_ASSET_ID_TO_KEY_MAP[anAsset.ID] = anAss
 // loading NATIVE_ASSET_KEY_TO_ASSET_MAP
 _each(NATIVE_ASSETS, anAsset => { NATIVE_ASSET_KEY_TO_ASSET_MAP[anAsset.KEY] = anAsset });
 
-function _getDomainFromURL(url) {
+export function _getDomainFromURL(url) {
   let anchor = document.createElement('a');
   anchor.href = url;
   return anchor.hostname;

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -1146,7 +1146,11 @@ export const spec = {
     // First Party Data
     const commonFpd = (bidderRequest && bidderRequest.ortb2) || {};
     if (commonFpd.site) {
+      const { page, domain, ref } = payload.site;
       mergeDeep(payload, {site: commonFpd.site});
+      payload.site.page = page;
+      payload.site.domain = domain;
+      payload.site.ref = ref;
     }
     if (commonFpd.user) {
       mergeDeep(payload, {user: commonFpd.user});

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -1631,17 +1631,15 @@ describe('PubMatic adapter', function () {
       describe('FPD', function() {
         let newRequest;
 
-        it('ortb2.site should be merged in the request', function() {
+        it('ortb2.site should be merged except page, domain & ref in the request', function() {
           const ortb2 = {
             site: {
-              domain: 'page.example.com',
               cat: ['IAB2'],
               sectioncat: ['IAB2-2']
             }
           };
           const request = spec.buildRequests(bidRequests, {ortb2});
           let data = JSON.parse(request.data);
-          expect(data.site.domain).to.equal('page.example.com');
           expect(data.site.cat).to.deep.equal(['IAB2']);
           expect(data.site.sectioncat).to.deep.equal(['IAB2-2']);
         });

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {spec, checkVideoPlacement} from 'modules/pubmaticBidAdapter.js';
+import {spec, checkVideoPlacement, _getDomainFromURL} from 'modules/pubmaticBidAdapter.js';
 import * as utils from 'src/utils.js';
 import {config} from 'src/config.js';
 import { createEidsArray } from 'modules/userId/eids.js';
@@ -1630,6 +1630,57 @@ describe('PubMatic adapter', function () {
 
       describe('FPD', function() {
         let newRequest;
+
+        describe('ortb2.site should not override page, domain & ref values', function() {
+          it('When above properties are present in ortb2.site', function() {
+            const ortb2 = {
+              site: {
+                domain: 'page.example.com',
+                page: 'https://page.example.com/here.html',
+                ref: 'https://page.example.com/here.html'
+              }
+            };
+            const request = spec.buildRequests(bidRequests, {ortb2});
+            let data = JSON.parse(request.data);
+            expect(data.site.domain).not.equal('page.example.com');
+            expect(data.site.page).not.equal('https://page.example.com/here.html');
+            expect(data.site.ref).not.equal('https://page.example.com/here.html');
+          });
+
+          it('When above properties are absent in ortb2.site', function () {
+            const ortb2 = {
+              site: {}
+            };
+            let request = spec.buildRequests(bidRequests, {
+              auctionId: 'new-auction-id',
+              ortb2
+            });
+            let data = JSON.parse(request.data);
+            let response = spec.interpretResponse(bidResponses, request);
+            expect(data.site.page).to.equal(bidRequests[0].params.kadpageurl);
+            expect(data.site.domain).to.equal(_getDomainFromURL(data.site.page));
+            expect(response[0].referrer).to.equal(data.site.ref);
+          });
+
+          it('With some extra properties in ortb2.site', function() {
+            const ortb2 = {
+              site: {
+                domain: 'page.example.com',
+                page: 'https://page.example.com/here.html',
+                ref: 'https://page.example.com/here.html',
+                cat: ['IAB2'],
+                sectioncat: ['IAB2-2']
+              }
+            };
+            const request = spec.buildRequests(bidRequests, {ortb2});
+            let data = JSON.parse(request.data);
+            expect(data.site.domain).not.equal('page.example.com');
+            expect(data.site.page).not.equal('https://page.example.com/here.html');
+            expect(data.site.ref).not.equal('https://page.example.com/here.html');
+            expect(data.site.cat).to.deep.equal(['IAB2']);
+            expect(data.site.sectioncat).to.deep.equal(['IAB2-2']);
+          });
+        });
 
         it('ortb2.site should be merged except page, domain & ref in the request', function() {
           const ortb2 = {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
- Now, site.page, site.domain and site.ref can not be overwritten by the publisher in the **ortb2** object by setting the config.
