### PR TITLE
AdagioBidAdapter: fix domain/page detection via refererInfo (keep `topmostLocation`  information only)

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -271,9 +271,8 @@ function getDevice() {
 function getSite(bidderRequest) {
   const { refererInfo } = bidderRequest;
   return {
-    // TODO: do these fallbacks make sense?
-    domain: refererInfo.domain || parseDomain(refererInfo.topmostLocation) || '',
-    page: refererInfo.page || refererInfo.topmostLocation || '',
+    domain: parseDomain(refererInfo.topmostLocation) || '',
+    page: refererInfo.topmostLocation || '',
     referrer: refererInfo.ref || getWindowSelf().document.referrer || '',
     top: refererInfo.reachedTop
   };

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -1391,6 +1391,7 @@ describe('Adagio bid adapter', () => {
         refererInfo: {
           numIframes: 0,
           reachedTop: true,
+          topmostLocation: 'https://test.io/article/a.html',
           page: 'https://test.io/article/a.html',
           domain: 'test.io',
           ref: 'https://google.com'
@@ -1417,6 +1418,7 @@ describe('Adagio bid adapter', () => {
         numIframes: 0,
         reachedTop: true,
         page: 'http://level.io/',
+        topmostLocation: 'http://level.io/',
         stack: [
           'http://level.io/',
           'http://example.com/iframe1.html',


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
This PR fix a bug introduced in v 7 regarding how we expect to send current domain/page to our endpoint.


- contact email of the adapter’s maintainer: dev@adagio.io
- [x] official adapter submission

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Related to #8450
