### PR TITLE
Prebid Core: Native Privacy Link Solution 

### DIFF
--- a/src/native.js
+++ b/src/native.js
@@ -740,6 +740,7 @@ function toLegacyResponse(ortbResponse, ortbRequest) {
   const legacyResponse = {};
   const requestAssets = ortbRequest?.assets || [];
   legacyResponse.clickUrl = ortbResponse.link.url;
+  legacyResponse.privacyLink = ortbResponse.privacy;
   for (const asset of ortbResponse?.assets || []) {
     const requestAsset = requestAssets.find(reqAsset => asset.id === reqAsset.id);
     if (asset.title) {

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -44,6 +44,106 @@ const bid = {
   },
 };
 
+const ortbBid = {
+  adId: '123',
+  transactionId: 'au',
+  native: {
+    ortb: {
+      assets: [
+        {
+          id: 0,
+          title: {
+            text: 'Native Creative'
+          }
+        },
+        {
+          id: 1,
+          data: {
+            value: 'Cool description great stuff'
+          }
+        },
+        {
+          id: 2,
+          data: {
+            value: 'Do it'
+          }
+        },
+        {
+          id: 3,
+          img: {
+            url: 'http://cdn.example.com/p/creative-image/image.png',
+            h: 83,
+            w: 127
+          }
+        },
+        {
+          id: 4,
+          img: {
+            url: 'http://cdn.example.com/p/creative-image/icon.jpg',
+            h: 742,
+            w: 989
+          }
+        },
+        {
+          id: 5,
+          data: {
+            value: 'AppNexus',
+            type: 1
+          }
+        }
+      ],
+      link: {
+        url: 'https://www.link.example'
+      },
+      privacy: 'https://privacy-link.example',
+      ver: '1.2'
+    }
+  },
+};
+
+const ortbRequest = {
+  assets: [
+    {
+      id: 0,
+      required: 0,
+      title: {
+        len: 140
+      }
+    }, {
+      id: 1,
+      required: 0,
+      data: {
+        type: 2
+      }
+    }, {
+      id: 2,
+      required: 0,
+      data: {
+        type: 12
+      }
+    }, {
+      id: 3,
+      required: 0,
+      img: {
+        type: 3
+      }
+    }, {
+      id: 4,
+      required: 0,
+      img: {
+        type: 1
+      }
+    }, {
+      id: 5,
+      required: 0,
+      data: {
+        type: 1
+      }
+    }
+  ],
+  ver: '1.2'
+}
+
 const bidWithUndefinedFields = {
   transactionId: 'au',
   native: {
@@ -398,6 +498,50 @@ describe('native.js', function () {
     expect(message.assets).to.deep.include({
       key: 'foo',
       value: bid.native.ext.foo,
+    });
+  });
+
+  it('creates native all asset message with OpenRTB format', function () {
+    const messageRequest = {
+      message: 'Prebid Native',
+      action: 'allAssetRequest',
+      adId: '123',
+    };
+
+    const message = getAllAssetsMessage(messageRequest, ortbBid, {getNativeReq: () => ortbRequest});
+
+    expect(message.assets.length).to.equal(8);
+    expect(message.assets).to.deep.include({
+      key: 'body',
+      value: bid.native.body,
+    });
+    expect(message.assets).to.deep.include({
+      key: 'image',
+      value: bid.native.image.url,
+    });
+    expect(message.assets).to.deep.include({
+      key: 'clickUrl',
+      value: bid.native.clickUrl,
+    });
+    expect(message.assets).to.deep.include({
+      key: 'title',
+      value: bid.native.title,
+    });
+    expect(message.assets).to.deep.include({
+      key: 'icon',
+      value: bid.native.icon.url,
+    });
+    expect(message.assets).to.deep.include({
+      key: 'cta',
+      value: bid.native.cta,
+    });
+    expect(message.assets).to.deep.include({
+      key: 'sponsoredBy',
+      value: bid.native.sponsoredBy,
+    });
+    expect(message.assets).to.deep.include({
+      key: 'privacyLink',
+      value: ortbBid.native.ortb.privacy,
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
When an adapter responds with an openRTB native response. The `privacyLink` is ignored during the conversion to the legacy response (in the toLegacyResponse function). This PR is a potential fix to the issue:  https://github.com/prebid/Prebid.js/issues/8839


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Contact [love.sharma@indexexchange.com](mailto:love.sharma@indexexchange.com) for more information.