### PR TITLE
Criteo Bid Adapter: add support for banner+native multiformat ad unit

### DIFF
--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -13,7 +13,7 @@ import * as utils from 'src/utils.js';
 import * as refererDetection from 'src/refererDetection.js';
 import { config } from '../../../src/config.js';
 import * as storageManager from 'src/storageManager.js';
-import {BANNER, NATIVE, VIDEO} from '../../../src/mediaTypes.js';
+import { BANNER, NATIVE, VIDEO } from '../../../src/mediaTypes.js';
 
 describe('The Criteo bidding adapter', function () {
   let utilsMock, sandbox;
@@ -707,7 +707,7 @@ describe('The Criteo bidding adapter', function () {
       expect(ortbRequest.slots[0].sizes[0]).to.equal('undefinedxundefined');
     });
 
-    it('should properly detect and get sizes of native sizeless banner', function () {
+    it('should properly detect and forward native flag', function () {
       const bidRequests = [
         {
           mediaTypes: {
@@ -722,11 +722,10 @@ describe('The Criteo bidding adapter', function () {
       ];
       const request = spec.buildRequests(bidRequests, bidderRequest);
       const ortbRequest = request.data;
-      expect(ortbRequest.slots[0].sizes).to.have.lengthOf(1);
-      expect(ortbRequest.slots[0].sizes[0]).to.equal('2x2');
+      expect(ortbRequest.slots[0].native).to.equal(true);
     });
 
-    it('should properly detect and get size of native sizeless banner', function () {
+    it('should properly detect and forward native flag', function () {
       const bidRequests = [
         {
           mediaTypes: {
@@ -741,8 +740,7 @@ describe('The Criteo bidding adapter', function () {
       ];
       const request = spec.buildRequests(bidRequests, bidderRequest);
       const ortbRequest = request.data;
-      expect(ortbRequest.slots[0].sizes).to.have.lengthOf(1);
-      expect(ortbRequest.slots[0].sizes[0]).to.equal('2x2');
+      expect(ortbRequest.slots[0].native).to.equal(true);
     });
 
     it('should properly build a networkId request', function () {
@@ -1258,11 +1256,13 @@ describe('The Criteo bidding adapter', function () {
             if (inputParams.mediaType === BANNER && inputParams.size[0] === 300 && inputParams.size[1] === 250) {
               return {
                 currency: 'USD',
-                floor: 1.0};
+                floor: 1.0
+              };
             } else if (inputParams.mediaType === BANNER && inputParams.size[0] === 728 && inputParams.size[1] === 90) {
               return {
                 currency: 'USD',
-                floor: 2.0};
+                floor: 2.0
+              };
             } else {
               return {}
             }
@@ -1273,9 +1273,10 @@ describe('The Criteo bidding adapter', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.slots[0].ext.floors).to.deep.equal({
         'banner': {
-          '300x250': {'currency': 'USD', 'floor': 1},
-          '728x90': {'currency': 'USD', 'floor': 2}
-        }});
+          '300x250': { 'currency': 'USD', 'floor': 1 },
+          '728x90': { 'currency': 'USD', 'floor': 2 }
+        }
+      });
     });
 
     it('should properly build a video request with several player sizes with floors', function () {
@@ -1297,11 +1298,13 @@ describe('The Criteo bidding adapter', function () {
             if (inputParams.mediaType === VIDEO && inputParams.size[0] === 300 && inputParams.size[1] === 250) {
               return {
                 currency: 'USD',
-                floor: 1.0};
+                floor: 1.0
+              };
             } else if (inputParams.mediaType === VIDEO && inputParams.size[0] === 728 && inputParams.size[1] === 90) {
               return {
                 currency: 'USD',
-                floor: 2.0};
+                floor: 2.0
+              };
             } else {
               return {}
             }
@@ -1312,9 +1315,10 @@ describe('The Criteo bidding adapter', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.slots[0].ext.floors).to.deep.equal({
         'video': {
-          '300x250': {'currency': 'USD', 'floor': 1},
-          '728x90': {'currency': 'USD', 'floor': 2}
-        }});
+          '300x250': { 'currency': 'USD', 'floor': 1 },
+          '728x90': { 'currency': 'USD', 'floor': 2 }
+        }
+      });
     });
 
     it('should properly build a multi format request with floors', function () {
@@ -1347,19 +1351,23 @@ describe('The Criteo bidding adapter', function () {
             if (inputParams.mediaType === BANNER && inputParams.size[0] === 300 && inputParams.size[1] === 250) {
               return {
                 currency: 'USD',
-                floor: 1.0};
+                floor: 1.0
+              };
             } else if (inputParams.mediaType === BANNER && inputParams.size[0] === 728 && inputParams.size[1] === 90) {
               return {
                 currency: 'USD',
-                floor: 2.0};
+                floor: 2.0
+              };
             } else if (inputParams.mediaType === VIDEO && inputParams.size[0] === 640 && inputParams.size[1] === 480) {
               return {
                 currency: 'EUR',
-                floor: 3.2};
+                floor: 3.2
+              };
             } else if (inputParams.mediaType === NATIVE && inputParams.size === '*') {
               return {
                 currency: 'YEN',
-                floor: 4.99};
+                floor: 4.99
+              };
             } else {
               return {}
             }
@@ -1371,15 +1379,16 @@ describe('The Criteo bidding adapter', function () {
       expect(request.data.slots[0].ext.data.someContextAttribute).to.deep.equal('abc');
       expect(request.data.slots[0].ext.floors).to.deep.equal({
         'banner': {
-          '300x250': {'currency': 'USD', 'floor': 1},
-          '728x90': {'currency': 'USD', 'floor': 2}
+          '300x250': { 'currency': 'USD', 'floor': 1 },
+          '728x90': { 'currency': 'USD', 'floor': 2 }
         },
         'video': {
-          '640x480': {'currency': 'EUR', 'floor': 3.2}
+          '640x480': { 'currency': 'EUR', 'floor': 3.2 }
         },
         'native': {
-          '*': {'currency': 'YEN', 'floor': 4.99}
-        }});
+          '*': { 'currency': 'YEN', 'floor': 4.99 }
+        }
+      });
     });
   });
 


### PR DESCRIPTION
## Type of change
- [X] Feature


## Description of change
Previously, the use of a native adunit was exclusive with the banner type.
