### PR TITLE
dgkeyword RTD provider: fix tests causing ID5 test failures

### DIFF
--- a/modules/dgkeywordRtdProvider.js
+++ b/modules/dgkeywordRtdProvider.js
@@ -25,6 +25,15 @@ export function getDgKeywordsAndSet(reqBidsConfigObj, callback, moduleConfig, us
   const timeout = (moduleConfig && moduleConfig.params && moduleConfig.params.timeout && Number(moduleConfig.params.timeout) > 0) ? Number(moduleConfig.params.timeout) : PROFILE_TIMEOUT_MS;
   const url = (moduleConfig && moduleConfig.params && moduleConfig.params.url) ? moduleConfig.params.url : URL + encodeURIComponent(window.location.href);
   const adUnits = reqBidsConfigObj.adUnits || getGlobal().adUnits;
+  callback = (function(cb) {
+    let done = false;
+    return function () {
+      if (!done) {
+        done = true;
+        return cb.apply(this, arguments);
+      }
+    }
+  })(callback);
   let isFinish = false;
   logMessage('[dgkeyword sub module]', adUnits, timeout);
   let setKeywordTargetBidders = getTargetBidderOfDgKeywords(adUnits);

--- a/test/spec/modules/dgkeywordRtdProvider_spec.js
+++ b/test/spec/modules/dgkeywordRtdProvider_spec.js
@@ -293,8 +293,8 @@ describe('Digital Garage Keyword Module', function () {
         moduleConfig,
         null
       );
+      const request = server.requests[0];
       setTimeout(() => {
-        const request = server.requests[0];
         if (request) {
           request.respond(
             200,


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

dgkeyword RTD provider tests sometimes respond to the wrong XHR mock, which seems to affect mostly an unrelated ID5 test, causing it to fail.

