### PR TITLE
Prebid core: optimize getRefererInfo to run only once per page

### DIFF
--- a/src/refererDetection.js
+++ b/src/refererDetection.js
@@ -11,6 +11,8 @@
 import { config } from './config.js';
 import {logWarn} from './utils.js';
 
+let RI = new WeakMap();
+
 /**
  * Prepend a URL with the page's protocol (http/https), if necessary.
  */
@@ -252,10 +254,19 @@ export function detectReferer(win) {
     };
   }
 
-  return refererInfo;
+  return function() {
+    if (!RI.has(win)) {
+      RI.set(win, Object.freeze(refererInfo()));
+    }
+    return RI.get(win);
+  }
 }
 
 /**
  * @type {function(): refererInfo}
  */
 export const getRefererInfo = detectReferer(window);
+
+export function resetRefererInfo() {
+  RI = new WeakMap();
+}

--- a/test/spec/modules/enrichmentFpdModule_spec.js
+++ b/test/spec/modules/enrichmentFpdModule_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { getRefererInfo } from 'src/refererDetection.js';
+import {getRefererInfo, resetRefererInfo} from 'src/refererDetection.js';
 import { processFpd, coreStorage } from 'modules/enrichmentFpdModule.js';
 
 describe('the first party data enrichment module', function() {
@@ -20,6 +20,7 @@ describe('the first party data enrichment module', function() {
   });
 
   beforeEach(function() {
+    resetRefererInfo();
     querySelectorStub = sinon.stub(window.top.document, 'querySelector');
     querySelectorStub.withArgs("link[rel='canonical']").returns(canonical);
     querySelectorStub.withArgs("meta[name='keywords']").returns(keywords);

--- a/test/spec/modules/fpdModule_spec.js
+++ b/test/spec/modules/fpdModule_spec.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import {config} from 'src/config.js';
-import {getRefererInfo} from 'src/refererDetection.js';
+import {getRefererInfo, resetRefererInfo} from 'src/refererDetection.js';
 import {processFpd, registerSubmodules, startAuctionHook, reset} from 'modules/fpdModule/index.js';
 import * as enrichmentModule from 'modules/enrichmentFpdModule.js';
 import * as validationModule from 'modules/validationFpdModule/index.js';
@@ -70,6 +70,7 @@ describe('the first party data module', function () {
     });
 
     beforeEach(function() {
+      resetRefererInfo();
       querySelectorStub = sinon.stub(window.top.document, 'querySelector');
       querySelectorStub.withArgs("link[rel='canonical']").returns(canonical);
       querySelectorStub.withArgs("meta[name='keywords']").returns(keywords);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Refactoring (no functional changes, no api changes)

## Description of change

Refactor getRefererInfo to do the heavy lifting only once; profiler data shows this to be one of the more expensive pieces of logic in core.

