### PR TITLE
Prebid core: optimize sizeMapping to reduce computation when not in use

### DIFF
--- a/src/sizeMapping.js
+++ b/src/sizeMapping.js
@@ -1,6 +1,7 @@
 import { config } from './config.js';
 import {logWarn, logInfo, isPlainObject, deepAccess, deepClone, getWindowTop} from './utils.js';
 import {includes} from './polyfill.js';
+import {BANNER} from './mediaTypes.js';
 
 let sizeConfig = [];
 
@@ -75,22 +76,19 @@ export function resolveStatus({labels = [], labelAll = false, activeLabels = []}
     } else {
       mediaTypes = {};
     }
-  } else {
-    mediaTypes = deepClone(mediaTypes);
   }
 
   let oldSizes = deepAccess(mediaTypes, 'banner.sizes');
   if (maps.shouldFilter && oldSizes) {
+    mediaTypes = deepClone(mediaTypes);
     mediaTypes.banner.sizes = oldSizes.filter(size => maps.sizesSupported[size]);
   }
 
-  let allMediaTypes = Object.keys(mediaTypes);
-
   let results = {
     active: (
-      allMediaTypes.every(type => type !== 'banner')
+      !mediaTypes.hasOwnProperty(BANNER)
     ) || (
-      allMediaTypes.some(type => type === 'banner') && deepAccess(mediaTypes, 'banner.sizes.length') > 0 && (
+      deepAccess(mediaTypes, 'banner.sizes.length') > 0 && (
         labels.length === 0 || (
           (!labelAll && (
             labels.some(label => maps.labels[label]) ||


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Refactoring (no functional changes, no api changes)

## Description of change

Refactor sizeMapping (v1) logic to optimize for the case when it's not being used. Profiler runs show this to be relatively expensive on a page without any sizeMapping configuration.

