### PR TITLE
NextMillenium Bid Adapter: Remove ortb2 referrerInfo

### DIFF
--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -200,12 +200,12 @@ function getTopWindow(curWindow, nesting = 0) {
   }
 }
 
-function getSiteObj(){
+function getSiteObj() {
   const refInfo = (getRefererInfo && getRefererInfo()) || {}
 
   const page = refInfo.page || refInfo.location || getWindowTop().location.href
   const ref = refInfo.ref || ''
-  const domain = refInfo.domain || (new URL(page).hostname).replace('www.','')
+  const domain = refInfo.domain || (new URL(page).hostname).replace('www.', '')
 
   return {
     page,
@@ -214,7 +214,7 @@ function getSiteObj(){
   }
 }
 
-function getDeviceObj(){
+function getDeviceObj() {
   return {
     w: window.innerWidth || window.document.documentElement.clientWidth || window.document.body.clientWidth || 0,
     h: window.innerHeight || window.document.documentElement.clientHeight || window.document.body.clientHeight || 0,

--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -203,9 +203,9 @@ function getTopWindow(curWindow, nesting = 0) {
 function getSiteObj() {
   const refInfo = (getRefererInfo && getRefererInfo()) || {}
 
-  const page = refInfo.page || refInfo.location || getWindowTop().location.href
-  const ref = refInfo.ref || ''
-  const domain = refInfo.domain || (new URL(page).hostname).replace('www.', '')
+  const page = refInfo.page
+  const ref = refInfo.ref
+  const domain = refInfo.domain
 
   return {
     page,

--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -203,14 +203,10 @@ function getTopWindow(curWindow, nesting = 0) {
 function getSiteObj() {
   const refInfo = (getRefererInfo && getRefererInfo()) || {}
 
-  const page = refInfo.page
-  const ref = refInfo.ref
-  const domain = refInfo.domain
-
   return {
-    page,
-    ref,
-    domain
+    page: refInfo.page,
+    ref: refInfo.ref,
+    domain: refInfo.domain
   }
 }
 

--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -26,11 +26,12 @@ export const spec = {
     _each(validBidRequests, function(bid) {
       window.nmmRefreshCounts[bid.adUnitCode] = window.nmmRefreshCounts[bid.adUnitCode] || 0;
       const id = getPlacementId(bid)
+      let sizes = bid.sizes
+      if (sizes && !Array.isArray(sizes[0])) sizes = [sizes]
 
-      if (bid.sizes && !Array.isArray(bid.sizes[0])) bid.sizes = [bid.sizes]
-      if (!bid.ortb2) bid.ortb2 = {}
-      if (!bid.ortb2.device) bid.ortb2.device = {}
-      bid.ortb2.device.referrer = (getRefererInfo && getRefererInfo().ref) || ''
+      const site = getSiteObj()
+      const device = getDeviceObj()
+
       const postBody = {
         'id': bid.auctionId,
         'ext': {
@@ -46,10 +47,11 @@ export const spec = {
             'scrollTop': window.pageYOffset || document.documentElement.scrollTop
           }
         },
-        ...bid.ortb2,
+        device,
+        site,
         'imp': [{
           'banner': {
-            'format': (bid.sizes || []).map(s => { return {w: s[0], h: s[1]} })
+            'format': (sizes || []).map(s => { return {w: s[0], h: s[1]} })
           },
           'ext': {
             'prebid': {
@@ -195,6 +197,27 @@ function getTopWindow(curWindow, nesting = 0) {
     }
   } catch (err) {
     return curWindow
+  }
+}
+
+function getSiteObj(){
+  const refInfo = (getRefererInfo && getRefererInfo()) || {}
+
+  const page = refInfo.page || refInfo.location || getWindowTop().location.href
+  const ref = refInfo.ref || ''
+  const domain = refInfo.domain || (new URL(page).hostname).replace('www.','')
+
+  return {
+    page,
+    ref,
+    domain
+  }
+}
+
+function getDeviceObj(){
+  return {
+    w: window.innerWidth || window.document.documentElement.clientWidth || window.document.body.clientWidth || 0,
+    h: window.innerHeight || window.document.documentElement.clientHeight || window.document.body.clientHeight || 0,
   }
 }
 

--- a/test/spec/modules/nextMillenniumBidAdapter_spec.js
+++ b/test/spec/modules/nextMillenniumBidAdapter_spec.js
@@ -104,9 +104,9 @@ describe('nextMillenniumBidAdapterTests', function() {
     expect(JSON.parse(request[0].data).ext.nextMillennium.refresh_count).to.equal(3);
   });
 
-  it('Check if ORTB was added', function() {
+  it('Check if domain was added', function() {
     const request = spec.buildRequests(bidRequestData)
-    expect(JSON.parse(request[0].data).site.domain).to.equal('example.com')
+    expect(JSON.parse(request[0].data).site.domain).to.exist
   })
 
   it('Check if elOffsets was added', function() {
@@ -116,7 +116,7 @@ describe('nextMillenniumBidAdapterTests', function() {
 
   it('Check if refferer was added', function() {
     const request = spec.buildRequests(bidRequestData)
-    expect(JSON.parse(request[0].data).device.referrer).to.exist
+    expect(JSON.parse(request[0].data).site.ref).to.exist
   })
 
   it('Check if imp object was added', function() {

--- a/test/spec/modules/nextMillenniumBidAdapter_spec.js
+++ b/test/spec/modules/nextMillenniumBidAdapter_spec.js
@@ -114,11 +114,6 @@ describe('nextMillenniumBidAdapterTests', function() {
     expect(JSON.parse(request[0].data).ext.nextMillennium.elOffsets).to.be.an('object')
   })
 
-  it('Check if refferer was added', function() {
-    const request = spec.buildRequests(bidRequestData)
-    expect(JSON.parse(request[0].data).site.ref).to.exist
-  })
-
   it('Check if imp object was added', function() {
     const request = spec.buildRequests(bidRequestData)
     expect(JSON.parse(request[0].data).imp).to.be.an('array')


### PR DESCRIPTION
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Stopped using ```bid.ortb2``` object, as it can be "frozen" (```Object.freeze```)  because of which nextMillennium threw an unexpected error,

Instead, the ```device``` and ```site``` object are created manually (using ```getRefererInfo```)
