### PR TITLE
BetweenBidAdapter: default value for the cur parameter

### DIFF
--- a/modules/betweenBidAdapter.js
+++ b/modules/betweenBidAdapter.js
@@ -59,9 +59,9 @@ export const spec = {
       if (i.params.itu !== undefined) {
         params.itu = i.params.itu;
       }
-      if (i.params.cur !== undefined) {
-        params.cur = i.params.cur;
-      }
+
+      params.cur = i.params.cur || 'USD';
+
       if (i.params.subid !== undefined) {
         params.subid = i.params.subid;
       }

--- a/test/spec/modules/betweenBidAdapter_spec.js
+++ b/test/spec/modules/betweenBidAdapter_spec.js
@@ -86,7 +86,7 @@ describe('betweenBidAdapterTests', function () {
     expect(req_data.cur).to.equal('THX');
   });
   it('validate default cur USD', function() {
-    let bidRequestData =[{
+    let bidRequestData = [{
       bidId: 'bid1234',
       bidder: 'between',
       params: {

--- a/test/spec/modules/betweenBidAdapter_spec.js
+++ b/test/spec/modules/betweenBidAdapter_spec.js
@@ -85,6 +85,23 @@ describe('betweenBidAdapterTests', function () {
 
     expect(req_data.cur).to.equal('THX');
   });
+  it('validate default cur USD', function() {
+    let bidRequestData =[{
+      bidId: 'bid1234',
+      bidder: 'between',
+      params: {
+        w: 240,
+        h: 400,
+        s: 1112
+      },
+      sizes: [[240, 400]]
+    }];
+
+    let request = spec.buildRequests(bidRequestData);
+    let req_data = JSON.parse(request.data)[0].data;
+
+    expect(req_data.cur).to.equal('USD');
+  });
   it('validate subid param', function() {
     let bidRequestData = [{
       bidId: 'bid1234',


### PR DESCRIPTION

## Type of change
- [x] Other

## Description of change
If the 'cur' parameter is not passed, the default setting is 'USD'.

- contact email of the adapter’s maintainer: khaylov@betweenx.com
- [x] official adapter submission
