### PR TITLE
Adtelligent Bid Adapter: add VidCrunch LLC alias

### DIFF
--- a/modules/adtelligentBidAdapter.js
+++ b/modules/adtelligentBidAdapter.js
@@ -23,6 +23,7 @@ const HOST_GETTERS = {
   janet: () => 'ghb.bidder.jmgads.com',
   pgam: () => 'ghb.pgamssp.com',
   ocm: () => 'ghb.cenarius.orangeclickmedia.com',
+  vidcrunchllc: () => 'ghb.platform.vidcrunch.com',
 }
 const getUri = function (bidderCode) {
   let bidderWithoutSuffix = bidderCode.split('_')[0];
@@ -43,6 +44,7 @@ export const spec = {
     { code: 'navelix', gvlid: 380 },
     'pgam',
     'ocm',
+    { code: 'vidcrunchllc', gvlid: 1145 },
   ],
   supportedMediaTypes: [VIDEO, BANNER],
   isBidRequestValid: function (bid) {

--- a/test/spec/modules/adtelligentBidAdapter_spec.js
+++ b/test/spec/modules/adtelligentBidAdapter_spec.js
@@ -20,6 +20,7 @@ const aliasEP = {
   janet: 'https://ghb.bidder.jmgads.com/v2/auction/',
   pgam: 'https://ghb.pgamssp.com/v2/auction/',
   ocm: 'https://ghb.cenarius.orangeclickmedia.com/v2/auction/',
+  vidcrunchllc: 'https://ghb.platform.vidcrunch.com/v2/auction/',
 };
 
 const DEFAULT_ADATPER_REQ = { bidderCode: 'adtelligent' };


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter 

## Description of change
Add new bidder for VidCrunch LLC
- test parameters for validating bids
```
{
  bidder: 'vidcrunchllc',
  params: {
    aid: 529814
  }
}
```

- g.moroz@adtelligent.com
- [x] official adapter submission

- [A link to a PR on the docs repo](https://github.com/prebid/prebid.github.io/pull/3968)
