### PR TITLE
Adkernel Bid Adapter: Add impression-level FPD support

### DIFF
--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -14,11 +14,12 @@ import {
   isPlainObject,
   isStr,
   mergeDeep,
-  parseGPTSingleSizeArrayToRtbSize
+  parseGPTSingleSizeArrayToRtbSize,
+  getDefinedParams
 } from '../src/utils.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
-import {find, includes} from '../src/polyfill.js';
+import {find} from '../src/polyfill.js';
 import {config} from '../src/config.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 
@@ -28,10 +29,11 @@ import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
  *
  * Please contact prebid@adkernel.com and we'll add your adapter as an alias.
  */
-
-const VIDEO_TARGETING = Object.freeze(['mimes', 'minduration', 'maxduration', 'protocols',
-  'startdelay', 'linearity', 'boxingallowed', 'playbackmethod', 'delivery',
-  'pos', 'api', 'ext']);
+const VIDEO_PARAMS = ['pos', 'context', 'placement', 'api', 'mimes', 'protocols', 'playbackmethod', 'minduration', 'maxduration',
+  'startdelay', 'linearity', 'skip', 'skipmin', 'skipafter', 'minbitrate', 'maxbitrate', 'delivery', 'playbackend', 'boxingallowed'];
+const VIDEO_FPD = ['battr', 'pos'];
+const NATIVE_FPD = ['battr', 'api'];
+const BANNER_FPD = ['btype', 'battr', 'pos', 'api'];
 const VERSION = '1.6';
 const SYNC_IFRAME = 1;
 const SYNC_IMAGE = 2;
@@ -274,18 +276,18 @@ function buildImp(bidRequest, secure) {
       format: sizes.map(wh => parseGPTSingleSizeArrayToRtbSize(wh)),
       topframe: 0
     };
+    populateImpFpd(imp.banner, bidRequest, BANNER_FPD);
     mediaType = BANNER;
   } else if (deepAccess(bidRequest, 'mediaTypes.video')) {
     let video = deepAccess(bidRequest, 'mediaTypes.video');
-    imp.video = {};
+    imp.video = getDefinedParams(video, VIDEO_PARAMS);
+    populateImpFpd(imp.video, bidRequest, VIDEO_FPD);
     if (video.playerSize) {
       sizes = video.playerSize[0];
       imp.video = Object.assign(imp.video, parseGPTSingleSizeArrayToRtbSize(sizes) || {});
-    }
-    if (bidRequest.params.video) {
-      Object.keys(bidRequest.params.video)
-        .filter(key => includes(VIDEO_TARGETING, key))
-        .forEach(key => imp.video[key] = bidRequest.params.video[key]);
+    } else if (video.w && video.h) {
+      imp.video.w = video.w;
+      imp.video.h = video.h;
     }
     mediaType = VIDEO;
   } else if (deepAccess(bidRequest, 'mediaTypes.native')) {
@@ -294,6 +296,7 @@ function buildImp(bidRequest, secure) {
       ver: '1.1',
       request: JSON.stringify(nativeRequest)
     };
+    populateImpFpd(imp.native, bidRequest, NATIVE_FPD);
     mediaType = NATIVE;
   } else {
     throw new Error('Unsupported bid received');
@@ -335,6 +338,19 @@ function buildNativeRequest(nativeReq) {
     request.assets.push(assetRoot);
   }
   return request;
+}
+
+/**
+ * Populate impression-level FPD from bid request
+ * @param target {Object}
+ * @param bidRequest {BidRequest}
+ * @param props {String[]}
+ */
+function populateImpFpd(target, bidRequest, props) {
+  if (bidRequest.ortb2Imp === undefined) {
+    return;
+  }
+  Object.assign(target, getDefinedParams(bidRequest.ortb2Imp, props));
 }
 
 /**

--- a/test/spec/modules/adkernelBidAdapter_spec.js
+++ b/test/spec/modules/adkernelBidAdapter_spec.js
@@ -17,6 +17,9 @@ describe('Adkernel adapter', function () {
         banner: {
           sizes: [[300, 250], [300, 200]]
         }
+      },
+      ortb2Imp: {
+        battr: [6, 7, 9]
       }
     }, bid2_zone2 = {
       bidder: 'adkernel',
@@ -95,12 +98,12 @@ describe('Adkernel adapter', function () {
       params: {
         zoneId: 1,
         host: 'rtb.adkernel.com',
-        video: {api: [1, 2]}
       },
       mediaTypes: {
         video: {
           context: 'instream',
-          playerSize: [[640, 480]]
+          playerSize: [[640, 480]],
+          api: [1, 2]
         }
       },
       adUnitCode: 'ad-unit-1'
@@ -293,6 +296,7 @@ describe('Adkernel adapter', function () {
 
   describe('banner request building', function () {
     let bidRequest, bidRequests, _;
+
     before(function () {
       [_, bidRequests] = buildRequest([bid1_zone1]);
       bidRequest = bidRequests[0];
@@ -335,6 +339,11 @@ describe('Adkernel adapter', function () {
       expect(bidRequest.device).to.have.property('ipv6', 'caller');
       expect(bidRequest.device).to.have.property('ua', 'caller');
       expect(bidRequest.device).to.have.property('dnt', 1);
+    });
+
+    it('should copy FPD to imp.banner', function() {
+      expect(bidRequest.imp[0].banner).to.have.property('battr');
+      expect(bidRequest.imp[0].banner.battr).to.be.eql([6, 7, 9]);
     });
 
     it('shouldn\'t contain gdpr nor ccpa information for default request', function () {


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change

Added impression-level fpd data support for complete **ortb_blocking_supported** support



- prebid-dev@adkernel.com
- [x] official adapter submission