### PR TITLE
Permutive RTD Module: merge external submodule params

### DIFF
--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -59,7 +59,7 @@ let cachedPermutiveModuleConfig = {}
  * not initialised before this submodule is initialised.
  */
 function readPermutiveModuleConfigFromCache() {
-  const params = safeJSONParse(window.localStorage.getItem(PERMUTIVE_SUBMODULE_CONFIG_KEY))
+  const params = safeJSONParse(storage.getDataFromLocalStorage(PERMUTIVE_SUBMODULE_CONFIG_KEY))
   return cachedPermutiveModuleConfig = liftIntoParams(params)
 }
 

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -8,14 +8,18 @@
 import {getGlobal} from '../src/prebidGlobal.js';
 import {submodule} from '../src/hook.js';
 import {getStorageManager} from '../src/storageManager.js';
-import {deepAccess, deepSetValue, isFn, logError, mergeDeep} from '../src/utils.js';
+import {deepAccess, deepSetValue, isFn, logError, mergeDeep, isPlainObject, safeJSONParse} from '../src/utils.js';
 import {includes} from '../src/polyfill.js';
 
 const MODULE_NAME = 'permutive'
 
+export const PERMUTIVE_SUBMODULE_CONFIG_KEY = 'permutive-prebid-rtd'
+
 export const storage = getStorageManager({gvlid: null, moduleName: MODULE_NAME})
 
-function init (moduleConfig, userConsent) {
+function init(moduleConfig, userConsent) {
+  readPermutiveModuleConfigFromCache()
+
   return true
 }
 
@@ -43,20 +47,63 @@ export function initSegments (reqBidsConfigObj, callback, customModuleConfig) {
   }
 }
 
+function liftIntoParams(params) {
+  return isPlainObject(params) ? { params } : {}
+}
+
+let cachedPermutiveModuleConfig = {}
+
 /**
- * Merges segments into existing bidder config
- * @param {Object} customModuleConfig - Publisher config for module
- * @return {Object} Merged defatul and custom config
+ * Access the submodules RTD params that are cached to LocalStorage by the Permutive SDK. This lets the RTD submodule
+ * apply publisher defined params set in the Permutive platform, so they may still be applied if the Permutive SDK has
+ * not initialised before this submodule is initialised.
  */
-function getModuleConfig (customModuleConfig) {
+function readPermutiveModuleConfigFromCache() {
+  const params = safeJSONParse(window.localStorage.getItem(PERMUTIVE_SUBMODULE_CONFIG_KEY))
+  return cachedPermutiveModuleConfig = liftIntoParams(params)
+}
+
+/**
+ * Access the submodules RTD params attached to the Permutive SDK.
+ *
+ * @return The Permutive config available by the Permutive SDK or null if the operation errors.
+ */
+function getParamsFromPermutive() {
+  try {
+    return liftIntoParams(window.permutive.addons.prebid.getPermutiveRtdConfig())
+  } catch (e) {
+    return null
+  }
+}
+
+/**
+ * Merges segments into existing bidder config in reverse priority order. The highest priority is 1.
+ *
+ *   1. customModuleConfig <- set by publisher with pbjs.setConfig
+ *   2. permutiveRtdConfig <- set by the publisher using the Permutive platform
+ *   3. defaultConfig
+ *
+ * As items with a higher priority will be deeply merged into the previous config, deep merges are performed by
+ * reversing the priority order.
+ *
+ * @param {Object} customModuleConfig - Publisher config for module
+ * @return {Object} Deep merges of the default, Permutive and custom config.
+ */
+export function getModuleConfig(customModuleConfig) {
+  // Use the params from Permutive if available, otherwise fallback to the cached value set by Permutive.
+  const permutiveModuleConfig = getParamsFromPermutive() || cachedPermutiveModuleConfig
+
   return mergeDeep({
     waitForIt: false,
     params: {
       maxSegs: 500,
       acBidders: [],
-      overwrites: {}
-    }
-  }, customModuleConfig)
+      overwrites: {},
+    },
+  },
+  permutiveModuleConfig,
+  customModuleConfig,
+  )
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Cohort activation within [Permutive's RTD module](https://docs.prebid.org/dev-docs/modules/permutiveRtdProvider.html#cohort-activation-with-permutive-rtd-module) is failing to be applied with [option 1](https://docs.prebid.org/dev-docs/modules/permutiveRtdProvider.html#option-1---automated), which let publishers set `acBidders` through Permutive's platform. We require this fix where the RTD module attempts to retrieve this config from LS or our Permutive SDK. This lets publishers modify their `Permutive <-> Prebid` integration without code changes.

We read from LS on initialisation in the event that the Permutive SDK has not initialised before the config is required. Every call to retrieve our config will attempt to interact with Permutive's prebid addon which will have this config available in memory, otherwise fallback to cache.

### Config Priority

  1. customModuleConfig <- set by publisher with pbjs.setConfig
  2. permutiveRtdConfig <- set by the publisher using the Permutive platform
  3. defaultConfig

The configuration module is deeply merged in reverse priority order. This means that the highest priority config (`customModuleConfig`) defined by `.setConfig` within Prebid will be merged last and overwrite other configurations.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
N/A
