### PR TITLE
Consumable Bid Adapter: remove impressionUrl

### DIFF
--- a/modules/consumableBidAdapter.js
+++ b/modules/consumableBidAdapter.js
@@ -1,4 +1,4 @@
-import { logWarn, createTrackPixelHtml, deepAccess, isArray, deepSetValue } from '../src/utils.js';
+import { logWarn, deepAccess, isArray, deepSetValue } from '../src/utils.js';
 import {config} from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
@@ -255,7 +255,7 @@ function getSize(sizes) {
 function retrieveAd(decision, unitId, unitName) {
   let ad;
   if (decision.contents && decision.contents[0]) {
-    ad = decision.contents[0].body + createTrackPixelHtml(decision.impressionUrl);
+    ad = decision.contents[0].body;
   }
   if (decision.vastXml) {
     ad = decision.vastXml;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Removes unused impressionUrl pixel
