### PR TITLE
Appnexus Bid Adapter: update logic of native viewability script

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -10,6 +10,7 @@ import {
   getMaxValueFromArray,
   getMinValueFromArray,
   getParameterByName,
+  getUniqueIdentifierStr,
   isArray,
   isArrayOfNums,
   isEmpty,
@@ -444,16 +445,6 @@ export const spec = {
     }
 
     return params;
-  },
-
-  /**
-   * Add element selector to javascript tracker to improve native viewability
-   * @param {Bid} bid
-   */
-  onBidWon: function (bid) {
-    if (FEATURES.NATIVE && bid.native) {
-      reloadViewabilityScriptWithCorrectParameters(bid);
-    }
   }
 };
 
@@ -467,58 +458,9 @@ function deleteValues(keyPairObj) {
   }
 }
 
-function reloadViewabilityScriptWithCorrectParameters(bid) {
-  let viewJsPayload = getAppnexusViewabilityScriptFromJsTrackers(bid.native.javascriptTrackers);
-
-  if (viewJsPayload) {
-    let prebidParams = 'pbjs_adid=' + bid.adId + ';pbjs_auc=' + bid.adUnitCode;
-
-    let jsTrackerSrc = getViewabilityScriptUrlFromPayload(viewJsPayload);
-
-    let newJsTrackerSrc = jsTrackerSrc.replace('dom_id=%native_dom_id%', prebidParams);
-
-    // find iframe containing script tag
-    let frameArray = document.getElementsByTagName('iframe');
-
-    // boolean var to modify only one script. That way if there are muliple scripts,
-    // they won't all point to the same creative.
-    let modifiedAScript = false;
-
-    // first, loop on all ifames
-    for (let i = 0; i < frameArray.length && !modifiedAScript; i++) {
-      let currentFrame = frameArray[i];
-      try {
-        // IE-compatible, see https://stackoverflow.com/a/3999191/2112089
-        let nestedDoc = currentFrame.contentDocument || currentFrame.contentWindow.document;
-
-        if (nestedDoc) {
-          // if the doc is present, we look for our jstracker
-          let scriptArray = nestedDoc.getElementsByTagName('script');
-          for (let j = 0; j < scriptArray.length && !modifiedAScript; j++) {
-            let currentScript = scriptArray[j];
-            if (currentScript.getAttribute('data-src') == jsTrackerSrc) {
-              currentScript.setAttribute('src', newJsTrackerSrc);
-              currentScript.setAttribute('data-src', '');
-              if (currentScript.removeAttribute) {
-                currentScript.removeAttribute('data-src');
-              }
-              modifiedAScript = true;
-            }
-          }
-        }
-      } catch (exception) {
-        // trying to access a cross-domain iframe raises a SecurityError
-        // this is expected and ignored
-        if (!(exception instanceof DOMException && exception.name === 'SecurityError')) {
-          // all other cases are raised again to be treated by the calling function
-          throw exception;
-        }
-      }
-    }
-  }
-}
-
 function strIsAppnexusViewabilityScript(str) {
+  if (!str || str === '') return false;
+
   let regexMatchUrlStart = str.match(VIEWABILITY_URL_START);
   let viewUrlStartInStr = regexMatchUrlStart != null && regexMatchUrlStart.length >= 1;
 
@@ -526,30 +468,6 @@ function strIsAppnexusViewabilityScript(str) {
   let fileNameInStr = regexMatchFileName != null && regexMatchFileName.length >= 1;
 
   return str.startsWith(SCRIPT_TAG_START) && fileNameInStr && viewUrlStartInStr;
-}
-
-function getAppnexusViewabilityScriptFromJsTrackers(jsTrackerArray) {
-  let viewJsPayload;
-  if (isStr(jsTrackerArray) && strIsAppnexusViewabilityScript(jsTrackerArray)) {
-    viewJsPayload = jsTrackerArray;
-  } else if (isArray(jsTrackerArray)) {
-    for (let i = 0; i < jsTrackerArray.length; i++) {
-      let currentJsTracker = jsTrackerArray[i];
-      if (strIsAppnexusViewabilityScript(currentJsTracker)) {
-        viewJsPayload = currentJsTracker;
-      }
-    }
-  }
-  return viewJsPayload;
-}
-
-function getViewabilityScriptUrlFromPayload(viewJsPayload) {
-  // extracting the content of the src attribute
-  // -> substring between src=" and "
-  let indexOfFirstQuote = viewJsPayload.indexOf('src="') + 5; // offset of 5: the length of 'src=' + 1
-  let indexOfSecondQuote = viewJsPayload.indexOf('"', indexOfFirstQuote);
-  let jsTrackerSrc = viewJsPayload.substring(indexOfFirstQuote, indexOfSecondQuote);
-  return jsTrackerSrc;
 }
 
 function formatRequest(payload, bidderRequest) {
@@ -633,7 +551,9 @@ function newRenderer(adUnitCode, rtbBid, rendererOptions = {}) {
  */
 function newBid(serverBid, rtbBid, bidderRequest) {
   const bidRequest = getBidRequest(serverBid.uuid, [bidderRequest]);
+  const adId = getUniqueIdentifierStr();
   const bid = {
+    adId: adId,
     requestId: serverBid.uuid,
     cpm: rtbBid.cpm,
     creativeId: rtbBid.creative_id,
@@ -721,20 +641,20 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     }
   } else if (FEATURES.NATIVE && rtbBid.rtb[NATIVE]) {
     const nativeAd = rtbBid.rtb[NATIVE];
+    let viewScript;
 
-    // setting up the jsTracker:
-    // we put it as a data-src attribute so that the tracker isn't called
-    // until we have the adId (see onBidWon)
-    let jsTrackerDisarmed = rtbBid.viewability.config.replace('src=', 'data-src=');
+    if (strIsAppnexusViewabilityScript(rtbBid.viewability.config)) {
+      let prebidParams = 'pbjs_adid=' + adId + ';pbjs_auc=' + bidRequest.adUnitCode;
+      viewScript = rtbBid.viewability.config.replace('dom_id=%native_dom_id%', prebidParams);
+    }
 
     let jsTrackers = nativeAd.javascript_trackers;
-
     if (jsTrackers == undefined) {
-      jsTrackers = jsTrackerDisarmed;
+      jsTrackers = viewScript;
     } else if (isStr(jsTrackers)) {
-      jsTrackers = [jsTrackers, jsTrackerDisarmed];
+      jsTrackers = [jsTrackers, viewScript];
     } else {
-      jsTrackers.push(jsTrackerDisarmed);
+      jsTrackers.push(viewScript);
     }
 
     bid[NATIVE] = {

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -1195,6 +1195,7 @@ describe('AppNexusAdapter', function () {
     it('should get correct bid response', function () {
       let expectedResponse = [
         {
+          'adId': '3a1f23123e',
           'requestId': '3db3773286ee59',
           'cpm': 0.5,
           'creativeId': 29681110,

--- a/test/spec/modules/big-richmediaBidAdapter_spec.js
+++ b/test/spec/modules/big-richmediaBidAdapter_spec.js
@@ -190,6 +190,7 @@ describe('bigRichMediaAdapterTests', function () {
     it('should get correct bid response', function () {
       const expectedResponse = [
         {
+          'adId': '3a1f23123e',
           'requestId': '3db3773286ee59',
           'cpm': 0.5,
           'creativeId': 29681110,


### PR DESCRIPTION

## Type of change
- [x] Bugfix

## Description of change
Since the introduction to the #8086 in 7.8.0, there was an issue accidentally introduced that prevented the appnexus native viewability script from properly executing.  This PR rewrites the overall logic we had for the appnexus native viewability script to have it properly execute again.

**Some historical context**
There was custom logic implemented some years ago to initially suppress the native script, wait for the onBidWon trigger to execute, replace the native script's placeholders with values derived from the bid, and then activate the script on the page (see #4022 for details and the original logic).  

One of the values that was needed to go into the script was the bid's `adId`.  This value is normally created by prebid core (in the bidfactory.js) after the bid adapter creates the initial bid object (in the interpretResponse function) and passes it to the bidderFactory for further processing.  So we previously waited for this `adId` value via the onBidWon trigger, when we knew it was made and available to be read.  

**Behavior of the issue**
As part of the changes made with #8086, it shifted the location of the addWinningBid function call to occur separately (during the first Native Request postMessage call) instead of during the fireNativeTrackers postMessage call (https://github.com/prebid/Prebid.js/blame/master/src/secureCreatives.js#L118).  This change was done to ensure that the  native bid would always be marked as a winning bid from prebid.js' perspective (as there were certain use-cases with `allAssetRequest` in PUC that would not call Prebid.js to fire native trackers and have PUC take care of it).

Our native script was written to the page as part of the native javascriptTrackers process, which is triggered with the fireNativeTrackers function.  The onBidWon trigger (that activated our script) is part of the addWinningBid function's process.  

Prior to #8086, the fireNativeTracker was specifically called before the addWinningBid, which guaranteed the native script would be written (but not activated) onto the page and then the onBidWon would find the script, do the changes, and then activate it on the page.  With the PR, this order of events basically got flipped and the onBidWon call never found the script on the page because it was written later in sequence (and remained inactive).

**Fix**
Thanks to the evolving nature of Prebid.js, now we're able to create the bid's `adId` in our adapter and have it be respected/used by prebid-core.  This change enables use to remove the majority of the custom code and simply replace the script's placeholder values immediately when we receive the bid response (leaving the script in an active state that doesn't need further modifications during the onBidWon trigger).

I have ran some tests with the old native rendering (native-trk.js) and updated native rendering (native-render.js) and both seem to work with these changes.

PS: When I was updating the unit tests, I noticed that the big-richmedia adapter appears to be directly importing the spec object from the appnexusBidAdapter file.  As a result, I needed to update their unit test that was impacted by this PR.