### PR TITLE
Fix get host info added new regex

### DIFF
--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -483,19 +483,20 @@ export function _getHostInfo(validBidRequests) {
 
   domainInfo.domain = hostParam.split('/', 1)[0];
 
+  let regexHostParam = new RegExp(`^(https:\\||http:\\)`);
   let regexNewEndpoints = new RegExp(`^(vz.*|zz.*)\\.[a-z]{3}\\.tappx\\.com$`, 'i');
   let regexClassicEndpoints = new RegExp(`^([a-z]{3}|testing)\\.[a-z]{3}\\.tappx\\.com$`, 'i');
-
-  if (regexNewEndpoints.test(domainInfo.domain)) {
-    domainInfo.newEndpoint = true;
-    domainInfo.endpoint = domainInfo.domain.split('.', 1)[0]
-    domainInfo.url = `https://${hostParam}`
-  } else if (regexClassicEndpoints.test(domainInfo.domain)) {
-    domainInfo.newEndpoint = false;
-    domainInfo.endpoint = endpoint
-    domainInfo.url = `https://${hostParam}${endpoint}`
+  if (regexHostParam.test(hostParam)) {
+    if (regexNewEndpoints.test(domainInfo.domain)) {
+      domainInfo.newEndpoint = true;
+      domainInfo.endpoint = domainInfo.domain.split('.', 1)[0]
+      domainInfo.url = `https://${hostParam}`
+    } else if (regexClassicEndpoints.test(domainInfo.domain)) {
+      domainInfo.newEndpoint = false;
+      domainInfo.endpoint = endpoint
+      domainInfo.url = `https://${hostParam}${endpoint}`
+    }
   }
-
   return domainInfo;
 }
 

--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -486,7 +486,7 @@ export function _getHostInfo(validBidRequests) {
   let regexHostParam = new RegExp(`^(https:\\||http:\\)`);
   let regexNewEndpoints = new RegExp(`^(vz.*|zz.*)\\.[a-z]{3}\\.tappx\\.com$`, 'i');
   let regexClassicEndpoints = new RegExp(`^([a-z]{3}|testing)\\.[a-z]{3}\\.tappx\\.com$`, 'i');
-  if (regexHostParam.test(hostParam)) {
+  if (!regexHostParam.test(hostParam)) {
     if (regexNewEndpoints.test(domainInfo.domain)) {
       domainInfo.newEndpoint = true;
       domainInfo.endpoint = domainInfo.domain.split('.', 1)[0]

--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -483,8 +483,8 @@ export function _getHostInfo(validBidRequests) {
 
   domainInfo.domain = hostParam.split('/', 1)[0];
 
-  let regexHostParamHttps = new RegExp(`^https:\\`);
-  let regexHostParamHttp = new RegExp(`^http:\\`);
+  let regexHostParamHttps = new RegExp(`^https:\\\\`);
+  let regexHostParamHttp = new RegExp(`^http:\\\\`);
 
   let regexNewEndpoints = new RegExp(`^(vz.*|zz.*)\\.[a-z]{3}\\.tappx\\.com$`, 'i');
   let regexClassicEndpoints = new RegExp(`^([a-z]{3}|testing)\\.[a-z]{3}\\.tappx\\.com$`, 'i');

--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -483,20 +483,28 @@ export function _getHostInfo(validBidRequests) {
 
   domainInfo.domain = hostParam.split('/', 1)[0];
 
-  let regexHostParam = new RegExp(`^(https:\\||http:\\)`);
+  let regexHostParamHttps = new RegExp(`^https:\\`);
+  let regexHostParamHttp = new RegExp(`^http:\\`);
+
   let regexNewEndpoints = new RegExp(`^(vz.*|zz.*)\\.[a-z]{3}\\.tappx\\.com$`, 'i');
   let regexClassicEndpoints = new RegExp(`^([a-z]{3}|testing)\\.[a-z]{3}\\.tappx\\.com$`, 'i');
-  if (!regexHostParam.test(hostParam)) {
-    if (regexNewEndpoints.test(domainInfo.domain)) {
-      domainInfo.newEndpoint = true;
-      domainInfo.endpoint = domainInfo.domain.split('.', 1)[0]
-      domainInfo.url = `https://${hostParam}`
-    } else if (regexClassicEndpoints.test(domainInfo.domain)) {
-      domainInfo.newEndpoint = false;
-      domainInfo.endpoint = endpoint
-      domainInfo.url = `https://${hostParam}${endpoint}`
-    }
+
+  if (regexHostParamHttps.test(hostParam)) {
+    hostParam = hostParam.replace("https:\\", "");
+  } else if (regexHostParamHttp.test(hostParam)) {
+    hostParam = hostParam.replace("http:\\", "");
   }
+
+  if (regexNewEndpoints.test(domainInfo.domain)) {
+     domainInfo.newEndpoint = true;
+     domainInfo.endpoint = domainInfo.domain.split('.', 1)[0]
+     domainInfo.url = `https://${hostParam}`
+  } else if (regexClassicEndpoints.test(domainInfo.domain)) {
+     domainInfo.newEndpoint = false;
+     domainInfo.endpoint = endpoint
+     domainInfo.url = `https://${hostParam}${endpoint}`
+  }
+  
   return domainInfo;
 }
 


### PR DESCRIPTION
We have added a regex filter to avoid incorrect input of the hostParam parameter. The regex consists of two parameters that could be entered such as https or http. With this we prevent errors from occurring.
![image](https://user-images.githubusercontent.com/77485538/186349781-6d0aae46-3c07-4cc2-b4b6-b0146b54c72c.png)
