### PR TITLE
PBjs Core (Native): ortb tracker support

### DIFF
--- a/src/native.js
+++ b/src/native.js
@@ -272,7 +272,7 @@ export function fireNativeTrackers(message, bidResponse) {
   const nativeResponse = bidResponse.native.ortb || legacyPropertiesToOrtbNative(bidResponse.native);
 
   if (message.action === 'click') {
-    fireClickTrackers(nativeResponse, {assetId: message?.assetId});
+    fireClickTrackers(nativeResponse, message?.assetId);
   } else {
     fireImpressionTrackers(nativeResponse);
   }
@@ -305,7 +305,7 @@ export function fireImpressionTrackers(nativeResponse, {runMarkup = (mkup) => in
   }
 }
 
-export function fireClickTrackers(nativeResponse, {fetchURL = triggerPixel, assetId} = {}) {
+export function fireClickTrackers(nativeResponse, assetId = null, {fetchURL = triggerPixel} = {}) {
   // legacy click tracker
   if (!assetId) {
     (nativeResponse.link?.clicktrackers || []).forEach(url => fetchURL(url));

--- a/src/native.js
+++ b/src/native.js
@@ -272,7 +272,7 @@ export function fireNativeTrackers(message, bidResponse) {
   const nativeResponse = bidResponse.native.ortb || legacyPropertiesToOrtbNative(bidResponse.native);
 
   if (message.action === 'click') {
-    fireClickTrackers(nativeResponse, message);
+    fireClickTrackers(nativeResponse, {assetId: message?.assetId});
   } else {
     fireImpressionTrackers(nativeResponse);
   }
@@ -305,21 +305,20 @@ export function fireImpressionTrackers(nativeResponse, {runMarkup = (mkup) => in
   }
 }
 
-export function fireClickTrackers(nativeResponse, message, {fetchURL = triggerPixel} = {}) {
+export function fireClickTrackers(nativeResponse, {fetchURL = triggerPixel, assetId} = {}) {
   // legacy click tracker
-  if (!message) {
+  if (!assetId) {
     (nativeResponse.link?.clicktrackers || []).forEach(url => fetchURL(url));
   } else {
     // ortb click tracker. This will try to call the clicktracker associated with the asset;
     // will fallback to the link if none is found.
-    const assetIdLinkMap = nativeResponse.assets
+    const assetIdLinkMap = (nativeResponse.assets || [])
       .filter(a => a.link)
       .reduce((map, asset) => {
         map[asset.id] = asset.link;
         return map
       }, {});
     const masterClickTrackers = nativeResponse.link?.clicktrackers || [];
-    const assetId = message.assetId;
     let assetLink = assetIdLinkMap[assetId];
     let clickTrackers = masterClickTrackers;
     if (assetLink) {

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -1212,8 +1212,8 @@ describe('fireClickTrackers', () => {
     fetchURL = sinon.stub();
   });
 
-  function runTrackers(resp) {
-    fireClickTrackers(resp, {fetchURL});
+  function runTrackers(resp, args) {
+    fireClickTrackers(resp, {...args, fetchURL});
   }
 
   it('should load each URL in link.clicktrackers', () => {
@@ -1223,6 +1223,21 @@ describe('fireClickTrackers', () => {
         clicktrackers: urls
       }
     });
+    urls.forEach(url => sinon.assert.calledWith(fetchURL, url));
+  })
+
+  it('should load each URL in asset.link.clicktrackers, when response is ORTB', () => {
+    const urls = ['asset_url1', 'asset_url2'];
+    runTrackers({
+      assets: [
+        {
+          id: 1,
+          link: {
+            clicktrackers: urls
+          }
+        }
+      ],
+    }, {assetId: '1'});
     urls.forEach(url => sinon.assert.calledWith(fetchURL, url));
   })
 })

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -1212,8 +1212,8 @@ describe('fireClickTrackers', () => {
     fetchURL = sinon.stub();
   });
 
-  function runTrackers(resp, args) {
-    fireClickTrackers(resp, {...args, fetchURL});
+  function runTrackers(resp, assetId = null) {
+    fireClickTrackers(resp, assetId, {fetchURL});
   }
 
   it('should load each URL in link.clicktrackers', () => {
@@ -1237,7 +1237,7 @@ describe('fireClickTrackers', () => {
           }
         }
       ],
-    }, {assetId: '1'});
+    }, 1);
     urls.forEach(url => sinon.assert.calledWith(fetchURL, url));
   })
 })


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->

- [ x ] Feature

## Description of change
Native ORTB spec allows clicktrackers to be defined on individual assets; this PR adds this feature, together with PUC [#150](https://github.com/prebid/prebid-universal-creative/pull/150). 

## Other information
Accompaining with https://github.com/prebid/prebid-universal-creative/pull/150  
