### PR TITLE
IX Bid Adapter: deprecate detecMissingSize config

### DIFF
--- a/modules/ixBidAdapter.md
+++ b/modules/ixBidAdapter.md
@@ -362,25 +362,7 @@ pbjs.setConfig({
 });
 ```
 #### The **detectMissingSizes** feature
-By default, the IX bidding adapter bids on all banner sizes available in the ad unit when configured to at least one banner size. If you want the IX bidding adapter to only bid on the banner size it’s configured to, switch off this feature using `detectMissingSizes`.
-```
-pbjs.setConfig({
-    ix: {
-        detectMissingSizes: false
-    }
-});
-```
-OR
-```
-pbjs.setBidderConfig({
-    bidders: ["ix"],
-    config: {
-        ix: {
-            detectMissingSizes: false
-        }
-    }
-});
-```
+`detectMissingSize` config is now deprecated and IX bidding adapter bids on all banner sizes available in the ad unit when configured to at least one banner size. 
 
 **Native**
 

--- a/modules/ixBidAdapter.md
+++ b/modules/ixBidAdapter.md
@@ -362,7 +362,7 @@ pbjs.setConfig({
 });
 ```
 #### The **detectMissingSizes** feature
-`detectMissingSize` config is now deprecated and IX bidding adapter bids on all banner sizes available in the ad unit when configured to at least one banner size. 
+`detectMissingSize` config is now deprecated and IX bidding adapter bids on all banner sizes available in the ad unit when configured to at least one banner size.
 
 **Native**
 

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -2323,15 +2323,7 @@ describe('IndexexchangeAdapter', function () {
     });
 
     describe('detect missing sizes', function () {
-      beforeEach(function () {
-        config.setConfig({
-          ix: {
-            detectMissingSizes: false
-          }
-        });
-      })
-
-      it('request should not contain missing sizes if detectMissingSizes = false', function () {
+      it('request should always contain missing sizes', function () {
         const bid1 = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
         bid1.mediaTypes.banner.sizes = LARGE_SET_OF_SIZES;
 
@@ -2688,15 +2680,6 @@ describe('IndexexchangeAdapter', function () {
         expect(videoImp.id).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].bidId);
         expect(videoImp.video.w).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].params.size[0]);
         expect(videoImp.video.h).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].params.size[1]);
-      });
-
-      it('should get missing sizes count 0 when params.size not used', function () {
-        const bid = utils.deepClone(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]);
-        delete bid.params.size;
-        const request = spec.buildRequests([bid], {});
-        const diagObj = JSON.parse(request[0].data.r).ext.ixdiag;
-        expect(diagObj.msd).to.equal(0);
-        expect(diagObj.msi).to.equal(0);
       });
     });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
`detectMissingSize` config is now deprecated and IX bidding adapter bids on all banner sizes available in the ad unit when configured to at least one banner size.

- contact shahin.rahbariasl@indexexchange.com for more info.

For any changes that affect user-facing APIs or example code documented on http://prebid.org, please provide:

- link to a PR on the docs repo: https://github.com/prebid/prebid.github.io/pull/3981

