### PR TITLE
Prebid core: accept custom Promise constructor

### DIFF
--- a/src/utils/promise.js
+++ b/src/utils/promise.js
@@ -1,10 +1,12 @@
+import {getGlobal} from '../prebidGlobal.js';
+
 const SUCCESS = 0;
 const FAIL = 1;
 
 /**
  * A version of Promise that runs callbacks synchronously when it can (i.e. after it's been fulfilled or rejected).
  */
-export class GreedyPromise extends Promise {
+export class GreedyPromise extends (getGlobal().Promise || Promise) {
   #result;
   #callbacks;
   #parent = null;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

Allow publishers to provide the Promise constructor as  `pbjs.Promise` to help compatibility with libraries such as bluebirdjs  that monkey-patch the global `Promise`.

## Other information
Closes https://github.com/prebid/Prebid.js/issues/8903
