### PR TITLE
Clear currency conversionCache after rate file has been downloaded

### DIFF
--- a/modules/currency.js
+++ b/modules/currency.js
@@ -146,6 +146,7 @@ function initCurrency(url) {
           try {
             currencyRates = JSON.parse(response);
             logInfo('currencyRates set to ' + JSON.stringify(currencyRates));
+            conversionCache = {};
             currencyRatesLoaded = true;
             processBidResponseQueue();
             ready.done();

--- a/test/spec/modules/currency_spec.js
+++ b/test/spec/modules/currency_spec.js
@@ -169,6 +169,28 @@ describe('currency', function () {
       expect(getGlobal().convertCurrency(1.0, 'USD', 'EUR')).to.equal(4);
       expect(getGlobal().convertCurrency(1.0, 'USD', 'JPY')).to.equal(200);
     });
+    it('uses default rates until currency file is loaded', function () {
+      setConfig({
+        adServerCurrency: 'USD',
+        defaultRates: {
+          USD: {
+            JPY: 100
+          }
+        }
+      });
+
+      // Race condition where a bid is converted before the file has been loaded
+      expect(getGlobal().convertCurrency(1.0, 'USD', 'JPY')).to.equal(100);
+
+      fakeCurrencyFileServer.respondWith(JSON.stringify({
+        'dataAsOf': '2017-04-25',
+        'conversions': {
+          'USD': { JPY: 200 }
+        }
+      }));
+      fakeCurrencyFileServer.respond();
+      expect(getGlobal().convertCurrency(1.0, 'USD', 'JPY')).to.equal(200);
+    });
   });
   describe('bidder override', function () {
     it('allows setConfig to set bidder currency', function () {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Clears the conversionCache after loading the rate file. It fixes a race-condition observed in production where stale conversion data is used. This issue explains it further detail: https://github.com/prebid/Prebid.js/issues/8916

