### PR TITLE
yahoossp bid adapter: Update outstream renderer CDN location update

### DIFF
--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -488,7 +488,7 @@ function generateServerRequest({payload, requestOptions, bidderRequest}) {
 
 function createRenderer(bidderRequest, bidResponse) {
   const renderer = Renderer.install({
-    url: 'https://cdn.vidible.tv/prod/hb-outstream-renderer/renderer.js',
+    url: 'https://s.yimg.com/kp/prebid-outstream-renderer/renderer.js',
     loaded: false,
     adUnitCode: bidderRequest.adUnitCode
   })


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
New location for outstream renderer script onto main Yahoo static CDN host. Old script simply copied over.