### PR TITLE
bidWatch Analytics Adapter : minor fixes

### DIFF
--- a/modules/bidwatchAnalyticsAdapter.js
+++ b/modules/bidwatchAnalyticsAdapter.js
@@ -196,7 +196,9 @@ bidwatchAnalytics.originEnableAnalytics = bidwatchAnalytics.enableAnalytics;
 bidwatchAnalytics.enableAnalytics = function (config) {
   bidwatchAnalytics.originEnableAnalytics(config); // call the base class function
   initOptions = config.options;
-  if (initOptions.domain) { endpoint = 'https://' + initOptions.domain; }
+  if (initOptions.domain) {
+    endpoint = 'https://' + initOptions.domain;
+  }
 };
 
 adapterManager.registerAnalyticsAdapter({


### PR DESCRIPTION

## Type of change
- [x ] Bugfix
- [x] Other

## Description of change
- send AdUnits
- avoid to make multiple calls for the same creative id.