### PR TITLE
Invibes Bid Adapter: distinguish between first and subsequent event; disable userSyncs

### DIFF
--- a/modules/invibesBidAdapter.js
+++ b/modules/invibesBidAdapter.js
@@ -9,11 +9,12 @@ const CONSTANTS = {
   SYNC_ENDPOINT: 'https://k.r66net.com/GetUserSync',
   TIME_TO_LIVE: 300,
   DEFAULT_CURRENCY: 'EUR',
-  PREBID_VERSION: 8,
+  PREBID_VERSION: 9,
   METHOD: 'GET',
   INVIBES_VENDOR_ID: 436,
   USERID_PROVIDERS: ['pubcid', 'pubProvidedId', 'uid2', 'zeotapIdPlus', 'id5id'],
-  META_TAXONOMY: ['networkId', 'networkName', 'agencyId', 'agencyName', 'advertiserId', 'advertiserName', 'advertiserDomains', 'brandId', 'brandName', 'primaryCatId', 'secondaryCatIds', 'mediaType']
+  META_TAXONOMY: ['networkId', 'networkName', 'agencyId', 'agencyName', 'advertiserId', 'advertiserName', 'advertiserDomains', 'brandId', 'brandName', 'primaryCatId', 'secondaryCatIds', 'mediaType'],
+  DISABLE_USER_SYNC: true
 };
 
 const storage = getStorageManager({gvlid: CONSTANTS.INVIBES_VENDOR_ID, bidderCode: CONSTANTS.BIDDER_CODE});
@@ -40,15 +41,7 @@ export const spec = {
   interpretResponse: function (responseObj, requestParams) {
     return handleResponse(responseObj, requestParams != null ? requestParams.bidRequests : null);
   },
-  getUserSyncs: function (syncOptions) {
-    if (syncOptions.iframeEnabled) {
-      const syncUrl = buildSyncUrl();
-      return {
-        type: 'iframe',
-        url: syncUrl
-      };
-    }
-  }
+  getUserSyncs: getUserSync,
 };
 
 registerBidder(spec);
@@ -60,7 +53,9 @@ invibes.purposes = invibes.purposes || [false, false, false, false, false, false
 invibes.legitimateInterests = invibes.legitimateInterests || [false, false, false, false, false, false, false, false, false, false];
 invibes.placementBids = invibes.placementBids || [];
 invibes.pushedCids = invibes.pushedCids || {};
+let preventPageViewEvent = false;
 let _customUserSync;
+let _disableUserSyncs;
 
 function isBidRequestValid(bid) {
   if (typeof bid.params !== 'object') {
@@ -73,6 +68,18 @@ function isBidRequestValid(bid) {
   }
 
   return true;
+}
+
+function getUserSync(syncOptions) {
+  if (syncOptions.iframeEnabled) {
+    if (!(_disableUserSyncs == null || _disableUserSyncs == undefined ? CONSTANTS.DISABLE_USER_SYNC : _disableUserSyncs)) {
+      const syncUrl = buildSyncUrl();
+      return {
+        type: 'iframe',
+        url: syncUrl
+      };
+    }
+  }
 }
 
 function buildRequest(bidRequests, bidderRequest) {
@@ -89,6 +96,7 @@ function buildRequest(bidRequests, bidderRequest) {
     _domainId = _domainId || bidRequest.params.domainId;
     _customEndpoint = _customEndpoint || bidRequest.params.customEndpoint;
     _customUserSync = _customUserSync || bidRequest.params.customUserSync;
+    _disableUserSyncs = bidRequest?.params?.disableUserSyncs;
     _userId = _userId || bidRequest.userId;
   });
 
@@ -129,6 +137,7 @@ function buildRequest(bidRequests, bidderRequest) {
 
     tc: invibes.gdpr_consent,
     isLocalStorageEnabled: storage.hasLocalStorage(),
+    preventPageViewEvent: preventPageViewEvent,
   };
 
   let lid = readFromLocalStorage('ivbsdid');
@@ -157,6 +166,8 @@ function buildRequest(bidRequests, bidderRequest) {
   }
 
   let endpoint = createEndpoint(_customEndpoint, _domainId, _placementIds);
+
+  preventPageViewEvent = true;
 
   return {
     method: CONSTANTS.METHOD,

--- a/test/spec/modules/invibesBidAdapter_spec.js
+++ b/test/spec/modules/invibesBidAdapter_spec.js
@@ -14,7 +14,9 @@ describe('invibesBidAdapter:', function () {
       bidder: BIDDER_CODE,
       bidderRequestId: 'r1',
       params: {
-        placementId: PLACEMENT_ID
+        placementId: PLACEMENT_ID,
+        disableUserSyncs: false
+
       },
       adUnitCode: 'test-div1',
       auctionId: 'a1',
@@ -29,7 +31,8 @@ describe('invibesBidAdapter:', function () {
       bidder: BIDDER_CODE,
       bidderRequestId: 'r2',
       params: {
-        placementId: 'abcde'
+        placementId: 'abcde',
+        disableUserSyncs: false
       },
       adUnitCode: 'test-div2',
       auctionId: 'a2',
@@ -170,6 +173,16 @@ describe('invibesBidAdapter:', function () {
   });
 
   describe('buildRequests', function () {
+    it('sends preventPageViewEvent as false on first call', function () {
+      let request = spec.buildRequests(bidRequests);
+      expect(request.data.preventPageViewEvent).to.be.false;
+    });
+
+    it('sends preventPageViewEvent as true on 2nd call', function () {
+      let request = spec.buildRequests(bidRequests);
+      expect(request.data.preventPageViewEvent).to.be.true;
+    });
+
     it('sends bid request to ENDPOINT via GET', function () {
       const request = spec.buildRequests(bidRequests);
       expect(request.url).to.equal(ENDPOINT);
@@ -1200,7 +1213,15 @@ describe('invibesBidAdapter:', function () {
   });
 
   describe('getUserSyncs', function () {
+    it('returns undefined if disableUserSyncs not passed as bid request param ', function () {
+      spec.buildRequests(bidRequestsWithUserId);
+      let response = spec.getUserSyncs({iframeEnabled: true});
+      expect(response).to.equal(undefined);
+    });
+
     it('returns an iframe if enabled', function () {
+      spec.buildRequests(bidRequests);
+
       let response = spec.getUserSyncs({iframeEnabled: true});
       expect(response.type).to.equal('iframe');
       expect(response.url).to.include(SYNC_ENDPOINT);
@@ -1208,6 +1229,8 @@ describe('invibesBidAdapter:', function () {
 
     it('returns an iframe with params if enabled', function () {
       top.window.invibes.optIn = 1;
+      spec.buildRequests(bidRequests);
+
       let response = spec.getUserSyncs({iframeEnabled: true});
       expect(response.type).to.equal('iframe');
       expect(response.url).to.include(SYNC_ENDPOINT);
@@ -1216,6 +1239,8 @@ describe('invibesBidAdapter:', function () {
 
     it('returns an iframe with params including if enabled', function () {
       top.window.invibes.optIn = 1;
+      spec.buildRequests(bidRequests);
+
       global.document.cookie = 'ivbsdid={"id":"dvdjkams6nkq","cr":' + Date.now() + ',"hc":0}';
       SetBidderAccess();
 
@@ -1227,7 +1252,9 @@ describe('invibesBidAdapter:', function () {
     });
 
     it('returns an iframe with params including if enabled read from LocalStorage', function () {
+      spec.buildRequests(bidRequests);
       top.window.invibes.optIn = 1;
+
       localStorage.ivbsdid = 'dvdjkams6nkq';
       SetBidderAccess();
 
@@ -1239,6 +1266,8 @@ describe('invibesBidAdapter:', function () {
     });
 
     it('returns undefined if iframe not enabled ', function () {
+      spec.buildRequests(bidRequests);
+
       let response = spec.getUserSyncs({iframeEnabled: false});
       expect(response).to.equal(undefined);
     });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Distinguish between first and subsequent event and disable userSyncs as default, configurable on bidRequests params.
