### PR TITLE
Prebid core: fix bug with refererInfo not updating after location change

### DIFF
--- a/src/refererDetection.js
+++ b/src/refererDetection.js
@@ -254,9 +254,12 @@ export function detectReferer(win) {
     };
   }
 
+  let cacheRef = win.location.href;
+
   return function() {
-    if (!RI.has(win)) {
+    if (!RI.has(win) || cacheRef !== win.location.href) {
       RI.set(win, Object.freeze(refererInfo()));
+      cacheRef = win.location.href;
     }
     return RI.get(win);
   }

--- a/test/spec/refererDetection_spec.js
+++ b/test/spec/refererDetection_spec.js
@@ -96,6 +96,27 @@ describe('Referer detection', () => {
     config.resetConfig();
   });
 
+  describe('result caching', () => {
+    it('does not return cached result if location changes', () => {
+      const startPage = 'https://www.example.com'
+      const w = buildWindowTree([startPage]);
+      const detect = detectReferer(w);
+      detect();
+      w.location.href = `${startPage}/subpage`
+      w.document.referrer = startPage
+      sinon.assert.match(detect(), {
+        ref: w.document.referrer,
+        page: w.location.href
+      });
+      w.document.referrer = w.location.href;
+      w.location.href = `${startPage}/otherpage`
+      sinon.assert.match(detect(), {
+        ref: w.document.referrer,
+        page: w.location.href
+      })
+    });
+  });
+
   describe('Non cross-origin scenarios', () => {
     describe('No iframes', () => {
       it('Should return the current window location and no canonical URL', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

With #8864 the `refererInfo` object is calculated only once per page; this is incorrect when the location is updated via browser history API. This addresses the problem by recalculating when `window.location.href` changes.

## Other information
Fixes https://github.com/prebid/Prebid.js/issues/8940

<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
