### PR TITLE
Revert "Prebid core: optimize getRefererInfo to run only once per pag…

### DIFF
--- a/src/refererDetection.js
+++ b/src/refererDetection.js
@@ -11,8 +11,6 @@
 import { config } from './config.js';
 import {logWarn} from './utils.js';
 
-let RI = new WeakMap();
-
 /**
  * Prepend a URL with the page's protocol (http/https), if necessary.
  */
@@ -254,19 +252,10 @@ export function detectReferer(win) {
     };
   }
 
-  return function() {
-    if (!RI.has(win)) {
-      RI.set(win, Object.freeze(refererInfo()));
-    }
-    return RI.get(win);
-  }
+  return refererInfo;
 }
 
 /**
  * @type {function(): refererInfo}
  */
 export const getRefererInfo = detectReferer(window);
-
-export function resetRefererInfo() {
-  RI = new WeakMap();
-}

--- a/test/spec/modules/enrichmentFpdModule_spec.js
+++ b/test/spec/modules/enrichmentFpdModule_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import {getRefererInfo, resetRefererInfo} from 'src/refererDetection.js';
+import { getRefererInfo } from 'src/refererDetection.js';
 import { processFpd, coreStorage } from 'modules/enrichmentFpdModule.js';
 
 describe('the first party data enrichment module', function() {
@@ -20,7 +20,6 @@ describe('the first party data enrichment module', function() {
   });
 
   beforeEach(function() {
-    resetRefererInfo();
     querySelectorStub = sinon.stub(window.top.document, 'querySelector');
     querySelectorStub.withArgs("link[rel='canonical']").returns(canonical);
     querySelectorStub.withArgs("meta[name='keywords']").returns(keywords);

--- a/test/spec/modules/fpdModule_spec.js
+++ b/test/spec/modules/fpdModule_spec.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import {config} from 'src/config.js';
-import {getRefererInfo, resetRefererInfo} from 'src/refererDetection.js';
+import {getRefererInfo} from 'src/refererDetection.js';
 import {processFpd, registerSubmodules, startAuctionHook, reset} from 'modules/fpdModule/index.js';
 import * as enrichmentModule from 'modules/enrichmentFpdModule.js';
 import * as validationModule from 'modules/validationFpdModule/index.js';
@@ -70,7 +70,6 @@ describe('the first party data module', function () {
     });
 
     beforeEach(function() {
-      resetRefererInfo();
       querySelectorStub = sinon.stub(window.top.document, 'querySelector');
       querySelectorStub.withArgs("link[rel='canonical']").returns(canonical);
       querySelectorStub.withArgs("meta[name='keywords']").returns(keywords);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

With #8864 the `refererInfo` object is calculated only once per page; this is incorrect when the location is updated via browser history API. If pubs pair that with updating `pageUrl` or `<link rel="canonical">` APIs, it's not trivial to detect whether `refererInfo` should be recalculated; for now this "fixes" the problem by reverting.

## Other information
Fixes https://github.com/prebid/Prebid.js/issues/8940

<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->


