### PR TITLE
Prebid core: fix bug with native adUnits generating invalid PBS requests

### DIFF
--- a/src/constants.json
+++ b/src/constants.json
@@ -152,6 +152,8 @@
     "MAIN": 3
   },
   "NATIVE_KEYS_THAT_ARE_NOT_ASSETS": [
+    "privacyLink",
+    "clickUrl",
     "sendTargetingKeys",
     "adTemplate",
     "rendererUrl",

--- a/src/native.js
+++ b/src/native.js
@@ -80,7 +80,7 @@ const SUPPORTED_TYPES = {
   image: IMAGE
 };
 
-const { NATIVE_ASSET_TYPES, NATIVE_IMAGE_TYPES, PREBID_NATIVE_DATA_KEYS_TO_ORTB, NATIVE_KEYS_THAT_ARE_NOT_ASSETS } = CONSTANTS;
+const { NATIVE_ASSET_TYPES, NATIVE_IMAGE_TYPES, PREBID_NATIVE_DATA_KEYS_TO_ORTB, NATIVE_KEYS_THAT_ARE_NOT_ASSETS, NATIVE_KEYS } = CONSTANTS;
 
 // inverse native maps useful for converting to legacy
 const PREBID_NATIVE_DATA_KEYS_TO_ORTB_INVERSE = inverse(PREBID_NATIVE_DATA_KEYS_TO_ORTB);
@@ -488,6 +488,10 @@ export function toOrtbNativeRequest(legacyNativeAssets) {
   for (let key in legacyNativeAssets) {
     // skip conversion for non-asset keys
     if (NATIVE_KEYS_THAT_ARE_NOT_ASSETS.includes(key)) continue;
+    if (!NATIVE_KEYS.hasOwnProperty(key)) {
+      logError(`Unrecognized native asset code: ${key}. Asset will be ignored.`);
+      continue;
+    }
 
     const asset = legacyNativeAssets[key];
     let required = 0;
@@ -560,7 +564,6 @@ export function toOrtbNativeRequest(legacyNativeAssets) {
       // in `ext` case, required field is not needed
       delete ortbAsset.required;
     }
-
     ortb.assets.push(ortbAsset);
   }
   return ortb;

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -877,6 +877,17 @@ describe('validate native', function () {
     });
   });
 
+  ['bogusKey', 'clickUrl', 'privacyLink'].forEach(nativeKey => {
+    it(`should not generate an empty asset for key ${nativeKey}`, () => {
+      const ortbReq = toOrtbNativeRequest({
+        [nativeKey]: {
+          required: true
+        }
+      });
+      expect(ortbReq.assets.length).to.equal(0);
+    });
+  })
+
   it('should convert from ortb to old-style native request', () => {
     const openRTBRequest = {
       'ver': '1.2',


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fix a bug introduced by the migration of native to ortb (#8086, #8748): the logic incorrectly tries to generate asset requests for `clickUrl` and `privacyLink`, which then get rejected by PBS (#8974).

## Other information

Fixes #8974

