### PR TITLE
dgkeywordRtdProvider submodule: support 1plusX SDK

### DIFF
--- a/modules/dgkeywordRtdProvider.js
+++ b/modules/dgkeywordRtdProvider.js
@@ -41,7 +41,7 @@ export function getDgKeywordsAndSet(reqBidsConfigObj, callback, moduleConfig, us
   } else {
     logMessage('[dgkeyword sub module] dgkeyword targets:', setKeywordTargetBidders);
     logMessage('[dgkeyword sub module] get targets from profile api start.');
-    ajax(getProfileApiUrl(moduleConfig?.params?.url), {
+    ajax(getProfileApiUrl(moduleConfig?.params?.url, moduleConfig?.params?.disableReadFpid), {
       success: function(response) {
         const res = JSON.parse(response);
         if (!isFinish) {
@@ -96,9 +96,9 @@ export function getDgKeywordsAndSet(reqBidsConfigObj, callback, moduleConfig, us
   }
 }
 
-export function getProfileApiUrl(customeUrl) {
+export function getProfileApiUrl(customeUrl, disableReadFpid) {
   const URL = 'https://mediaconsortium.profiles.tagger.opecloud.com/api/v1';
-  const fpid = readFpidFromLocalStrage();
+  const fpid = (disableReadFpid) ? '' : readFpidFromLocalStrage();
   let url = customeUrl || URL;
   url = url + '?url=' + encodeURIComponent(window.location.href) + ((fpid) ? `&fpid=${fpid}` : '');
   return url;

--- a/modules/dgkeywordRtdProvider.js
+++ b/modules/dgkeywordRtdProvider.js
@@ -20,10 +20,8 @@ import { getGlobal } from '../src/prebidGlobal.js';
  * @param {Object} userConsent
  */
 export function getDgKeywordsAndSet(reqBidsConfigObj, callback, moduleConfig, userConsent) {
-  const URL = 'https://mediaconsortium.profiles.tagger.opecloud.com/api/v1?url=';
   const PROFILE_TIMEOUT_MS = 1000;
   const timeout = (moduleConfig && moduleConfig.params && moduleConfig.params.timeout && Number(moduleConfig.params.timeout) > 0) ? Number(moduleConfig.params.timeout) : PROFILE_TIMEOUT_MS;
-  const url = (moduleConfig && moduleConfig.params && moduleConfig.params.url) ? moduleConfig.params.url : URL + encodeURIComponent(window.location.href);
   const adUnits = reqBidsConfigObj.adUnits || getGlobal().adUnits;
   callback = (function(cb) {
     let done = false;
@@ -43,7 +41,7 @@ export function getDgKeywordsAndSet(reqBidsConfigObj, callback, moduleConfig, us
   } else {
     logMessage('[dgkeyword sub module] dgkeyword targets:', setKeywordTargetBidders);
     logMessage('[dgkeyword sub module] get targets from profile api start.');
-    ajax(url, {
+    ajax(getProfileApiUrl(moduleConfig?.params?.url), {
       success: function(response) {
         const res = JSON.parse(response);
         if (!isFinish) {
@@ -95,6 +93,26 @@ export function getDgKeywordsAndSet(reqBidsConfigObj, callback, moduleConfig, us
       }
       callback();
     }, timeout);
+  }
+}
+
+export function getProfileApiUrl(customeUrl) {
+  const URL = 'https://mediaconsortium.profiles.tagger.opecloud.com/api/v1';
+  const fpid = readFpidFromLocalStrage();
+  let url = customeUrl || URL;
+  url = url + '?url=' + encodeURIComponent(window.location.href) + ((fpid) ? `&fpid=${fpid}` : '');
+  return url;
+}
+
+export function readFpidFromLocalStrage() {
+  try {
+    const fpid = window.localStorage.getItem('ope_fpid');
+    if (fpid) {
+      return fpid;
+    }
+    return null;
+  } catch (error) {
+    return null;
   }
 }
 

--- a/test/spec/modules/dgkeywordRtdProvider_spec.js
+++ b/test/spec/modules/dgkeywordRtdProvider_spec.js
@@ -401,5 +401,33 @@ describe('Digital Garage Keyword Module', function () {
         JSON.stringify(DUMMY_RESPONSE)
       );
     });
+    it('disable fpid stored in local strage.', function (done) {
+      const uuid = 'uuid_abcdefghijklmnopqrstuvwxyz';
+      let pbjs = cloneDeep(config);
+      pbjs.adUnits = cloneDeep(AD_UNITS);
+      if (IGNORE_SET_ORTB2) {
+        pbjs._ignoreSetOrtb2 = true;
+      }
+      let moduleConfig = cloneDeep(DEF_CONFIG);
+      window.localStorage.setItem('ope_fpid', uuid);
+      moduleConfig.params.disableReadFpid = true;
+      dgRtd.getDgKeywordsAndSet(
+        pbjs,
+        () => {
+          const url = dgRtd.getProfileApiUrl(null, moduleConfig.params.disableReadFpid);
+          expect(url.indexOf(uuid) > 0).to.equal(false);
+          expect(url).to.equal(server.requests[0].url);
+          done();
+        },
+        moduleConfig,
+        null
+      );
+      const request = server.requests[0];
+      request.respond(
+        200,
+        DUMMY_RESPONSE_HEADER,
+        JSON.stringify(DUMMY_RESPONSE)
+      );
+    });
   });
 });

--- a/test/spec/modules/dgkeywordRtdProvider_spec.js
+++ b/test/spec/modules/dgkeywordRtdProvider_spec.js
@@ -302,7 +302,7 @@ describe('Digital Garage Keyword Module', function () {
             JSON.stringify(DUMMY_RESPONSE)
           );
         }
-      }, 1000);
+      }, 50);
     });
     it('should get profiles ok(200).', function (done) {
       let pbjs = cloneDeep(config);
@@ -335,6 +335,60 @@ describe('Digital Garage Keyword Module', function () {
               dg: SUCCESS_ORTB2,
             });
           }
+          done();
+        },
+        moduleConfig,
+        null
+      );
+      const request = server.requests[0];
+      request.respond(
+        200,
+        DUMMY_RESPONSE_HEADER,
+        JSON.stringify(DUMMY_RESPONSE)
+      );
+    });
+    it('change url.', function (done) {
+      const dummyUrl = 'https://www.test.com/test'
+      let pbjs = cloneDeep(config);
+      pbjs.adUnits = cloneDeep(AD_UNITS);
+      if (IGNORE_SET_ORTB2) {
+        pbjs._ignoreSetOrtb2 = true;
+      }
+      let moduleConfig = cloneDeep(DEF_CONFIG);
+      moduleConfig.params.url = dummyUrl;
+      dgRtd.getDgKeywordsAndSet(
+        pbjs,
+        () => {
+          const url = dgRtd.getProfileApiUrl(dummyUrl);
+          expect(url.indexOf('?fpid=') === -1).to.equal(true);
+          expect(url).to.equal(server.requests[0].url);
+          done();
+        },
+        moduleConfig,
+        null
+      );
+      const request = server.requests[0];
+      request.respond(
+        200,
+        DUMMY_RESPONSE_HEADER,
+        JSON.stringify(DUMMY_RESPONSE)
+      );
+    });
+    it('add fpid stored in local strage.', function (done) {
+      const uuid = 'uuid_abcdefghijklmnopqrstuvwxyz';
+      let pbjs = cloneDeep(config);
+      pbjs.adUnits = cloneDeep(AD_UNITS);
+      if (IGNORE_SET_ORTB2) {
+        pbjs._ignoreSetOrtb2 = true;
+      }
+      let moduleConfig = cloneDeep(DEF_CONFIG);
+      window.localStorage.setItem('ope_fpid', uuid);
+      dgRtd.getDgKeywordsAndSet(
+        pbjs,
+        () => {
+          const url = dgRtd.getProfileApiUrl(null);
+          expect(url.indexOf(uuid) > 0).to.equal(true);
+          expect(url).to.equal(server.requests[0].url);
           done();
         },
         moduleConfig,


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->
added support for `fpid` param in LocalStorage: suit for 1plusX spec

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
