### PR TITLE
AMX bid adapter: update refererInfo for Prebid 7

### DIFF
--- a/modules/amxBidAdapter.js
+++ b/modules/amxBidAdapter.js
@@ -1,37 +1,46 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
-import { parseUrl, deepAccess, _each, formatQS, getUniqueIdentifierStr, triggerPixel, isFn, logError } from '../src/utils.js';
+import {
+  parseUrl,
+  deepAccess,
+  _each,
+  formatQS,
+  getUniqueIdentifierStr,
+  triggerPixel,
+  isFn,
+  logError,
+} from '../src/utils.js';
 import { config } from '../src/config.js';
 import { getStorageManager } from '../src/storageManager.js';
 
 const BIDDER_CODE = 'amx';
-const storage = getStorageManager({gvlid: 737, bidderCode: BIDDER_CODE});
+const storage = getStorageManager({ gvlid: 737, bidderCode: BIDDER_CODE });
 const SIMPLE_TLD_TEST = /\.com?\.\w{2,4}$/;
 const DEFAULT_ENDPOINT = 'https://prebid.a-mo.net/a/c';
-const VERSION = 'pba1.3.1';
+const VERSION = 'pba1.3.2';
 const VAST_RXP = /^\s*<\??(?:vast|xml)/i;
 const TRACKING_ENDPOINT = 'https://1x1.a-mo.net/hbx/';
 const AMUID_KEY = '__amuidpb';
 
 function getLocation(request) {
-  // TODO: does it make sense to fall back to window.location?
-  return parseUrl(request.refererInfo?.topmostLocation || window.location.href)
-};
+  return parseUrl(request.refererInfo?.topmostLocation || window.location.href);
+}
 
 const largestSize = (sizes, mediaTypes) => {
   const allSizes = sizes
     .concat(deepAccess(mediaTypes, `${BANNER}.sizes`, []) || [])
-    .concat(deepAccess(mediaTypes, `${VIDEO}.sizes`, []) || [])
+    .concat(deepAccess(mediaTypes, `${VIDEO}.sizes`, []) || []);
 
-  return allSizes.sort((a, b) => (b[0] * b[1]) - (a[0] * a[1]))[0];
-}
+  return allSizes.sort((a, b) => b[0] * b[1] - a[0] * a[1])[0];
+};
 
 function flatMap(input, mapFn) {
   if (input == null) {
-    return []
+    return [];
   }
-  return input.map(mapFn)
-    .reduce((acc, item) => item != null && acc.concat(item), [])
+  return input
+    .map(mapFn)
+    .reduce((acc, item) => item != null && acc.concat(item), []);
 }
 
 const isVideoADM = (html) => html != null && VAST_RXP.test(html);
@@ -44,14 +53,13 @@ function getMediaType(bid) {
   return BANNER;
 }
 
-const nullOrType = (value, type) =>
-  value == null || (typeof value) === type // eslint-disable-line valid-typeof
+const nullOrType = (value, type) => value == null || typeof value === type; // eslint-disable-line valid-typeof
 
 function getID(loc) {
   const host = loc.hostname.split('.');
-  const short = host.slice(
-    host.length - (SIMPLE_TLD_TEST.test(loc.hostname) ? 3 : 2)
-  ).join('.');
+  const short = host
+    .slice(host.length - (SIMPLE_TLD_TEST.test(loc.hostname) ? 3 : 2))
+    .join('.');
   return btoa(short).replace(/=+$/, '');
 }
 
@@ -59,21 +67,21 @@ const enc = encodeURIComponent;
 
 function getUIDSafe() {
   try {
-    return storage.getDataFromLocalStorage(AMUID_KEY)
+    return storage.getDataFromLocalStorage(AMUID_KEY);
   } catch (e) {
-    return null
+    return null;
   }
 }
 
 function setUIDSafe(uid) {
   try {
-    storage.setDataInLocalStorage(AMUID_KEY, uid)
+    storage.setDataInLocalStorage(AMUID_KEY, uid);
   } catch (e) {
     // do nothing
   }
 }
 
-function nestedQs (qsData) {
+function nestedQs(qsData) {
   const out = [];
   Object.keys(qsData || {}).forEach((key) => {
     out.push(enc(key) + '=' + enc(String(qsData[key])));
@@ -85,23 +93,28 @@ function nestedQs (qsData) {
 function createBidMap(bids) {
   const out = {};
   _each(bids, (bid) => {
-    out[bid.bidId] = convertRequest(bid)
-  })
+    out[bid.bidId] = convertRequest(bid);
+  });
   return out;
 }
 
 const trackEvent = (eventName, data) =>
-  triggerPixel(`${TRACKING_ENDPOINT}g_${eventName}?${formatQS({
-    ...data,
-    ts: Date.now(),
-    eid: getUniqueIdentifierStr(),
-  })}`);
+  triggerPixel(
+    `${TRACKING_ENDPOINT}g_${eventName}?${formatQS({
+      ...data,
+      ts: Date.now(),
+      eid: getUniqueIdentifierStr(),
+    })}`
+  );
 
 const DEFAULT_MIN_FLOOR = 0;
 
 function ensureFloor(floorValue) {
-  return typeof floorValue === 'number' && isFinite(floorValue) && floorValue > 0.0
-    ? floorValue : DEFAULT_MIN_FLOOR;
+  return typeof floorValue === 'number' &&
+    isFinite(floorValue) &&
+    floorValue > 0.0
+    ? floorValue
+    : DEFAULT_MIN_FLOOR;
 }
 
 function getFloor(bid) {
@@ -114,7 +127,7 @@ function getFloor(bid) {
       currency: 'USD',
       mediaType: '*',
       size: '*',
-      bidRequest: bid
+      bidRequest: bid,
     });
     return floor.floor;
   } catch (e) {
@@ -123,14 +136,20 @@ function getFloor(bid) {
   }
 }
 
+function refInfo(bidderRequest, subKey, defaultValue) {
+  return deepAccess(bidderRequest, 'refererInfo.' + subKey, defaultValue);
+}
+
 function convertRequest(bid) {
   const size = largestSize(bid.sizes, bid.mediaTypes) || [0, 0];
-  const isVideoBid = bid.mediaType === VIDEO || VIDEO in bid.mediaTypes
+  const isVideoBid = bid.mediaType === VIDEO || VIDEO in bid.mediaTypes;
   const av = isVideoBid || size[1] > 100;
-  const tid = deepAccess(bid, 'params.tagId')
+  const tid = deepAccess(bid, 'params.tagId');
 
-  const au = bid.params != null && typeof bid.params.adUnitId === 'string'
-    ? bid.params.adUnitId : bid.adUnitCode;
+  const au =
+    bid.params != null && typeof bid.params.adUnitId === 'string'
+      ? bid.params.adUnitId
+      : bid.adUnitCode;
 
   const multiSizes = [
     bid.sizes,
@@ -150,22 +169,14 @@ function convertRequest(bid) {
     ah: size[1],
     tf: 0,
     sc: bid.schain || {},
-    f: ensureFloor(getFloor(bid))
+    f: ensureFloor(getFloor(bid)),
+    rtb: bid.ortb2Imp,
   };
 
   if (typeof tid === 'string' && tid.length > 0) {
     params.i = tid;
   }
   return params;
-}
-
-function decorateADM(bid) {
-  const impressions = deepAccess(bid, 'ext.himp', [])
-    .concat(bid.nurl != null ? [bid.nurl] : [])
-    .filter((imp) => imp != null && imp.length > 0)
-    .map((src) => `<img src="${src}" width="0" height="0"/>`)
-    .join('');
-  return bid.adm + impressions;
 }
 
 function resolveSize(bid, request, bidId) {
@@ -183,11 +194,11 @@ function resolveSize(bid, request, bidId) {
 
 function values(source) {
   if (Object.values != null) {
-    return Object.values(source)
+    return Object.values(source);
   }
 
   return Object.keys(source).map((key) => {
-    return source[key]
+    return source[key];
   });
 }
 
@@ -199,19 +210,24 @@ export const spec = {
   supportedMediaTypes: [BANNER, VIDEO],
 
   isBidRequestValid(bid) {
-    return nullOrType(deepAccess(bid, 'params.endpoint', null), 'string') &&
+    return (
+      nullOrType(deepAccess(bid, 'params.endpoint', null), 'string') &&
       nullOrType(deepAccess(bid, 'params.tagId', null), 'string')
+    );
   },
 
   buildRequests(bidRequests, bidderRequest) {
     const loc = getLocation(bidderRequest);
     const tagId = deepAccess(bidRequests[0], 'params.tagId', null);
     const testMode = deepAccess(bidRequests[0], 'params.testMode', 0);
-    const fbid = bidRequests[0] != null ? bidRequests[0] : {
-      bidderRequestsCount: 0,
-      bidderWinsCount: 0,
-      bidRequestsCount: 0
-    }
+    const fbid =
+      bidRequests[0] != null
+        ? bidRequests[0]
+        : {
+          bidderRequestsCount: 0,
+          bidderWinsCount: 0,
+          bidRequestsCount: 0,
+        };
 
     const payload = {
       a: bidderRequest.auctionId,
@@ -223,7 +239,7 @@ export const spec = {
       tm: isTrue(testMode),
       V: '$prebid.version$',
       vg: '$$PREBID_GLOBAL$$',
-      i: (testMode && tagId != null) ? tagId : getID(loc),
+      i: testMode && tagId != null ? tagId : getID(loc),
       l: {},
       f: 0.01,
       cv: VERSION,
@@ -232,10 +248,9 @@ export const spec = {
       w: screen.width,
       gs: deepAccess(bidderRequest, 'gdprConsent.gdprApplies', ''),
       gc: deepAccess(bidderRequest, 'gdprConsent.consentString', ''),
-      u: deepAccess(bidderRequest, 'refererInfo.canonicalUrl', loc.href),
-      // TODO: are these referer values correct?
-      do: loc.hostname,
-      re: deepAccess(bidderRequest, 'refererInfo.ref'),
+      u: refInfo(bidderRequest, 'page', loc.href),
+      do: refInfo(bidderRequest, 'site', loc.hostname),
+      re: refInfo(bidderRequest, 'ref'),
       am: getUIDSafe(),
       usp: bidderRequest.uspConsent || '1---',
       smt: 1,
@@ -244,20 +259,23 @@ export const spec = {
       cpp: config.getConfig('coppa') ? 1 : 0,
       fpd2: bidderRequest.ortb2,
       tmax: config.getConfig('bidderTimeout'),
-      eids: values(bidRequests.reduce((all, bid) => {
-        // we only want unique ones in here
-        if (bid == null || bid.userIdAsEids == null) {
-          return all
-        }
-
-        _each(bid.userIdAsEids, (value) => {
-          if (value == null) {
-            return;
+      amp: refInfo(bidderRequest, 'isAmp', null),
+      eids: values(
+        bidRequests.reduce((all, bid) => {
+          // we only want unique ones in here
+          if (bid == null || bid.userIdAsEids == null) {
+            return all;
           }
-          all[value.source] = value
-        });
-        return all;
-      }, {})),
+
+          _each(bid.userIdAsEids, (value) => {
+            if (value == null) {
+              return;
+            }
+            all[value.source] = value;
+          });
+          return all;
+        }, {})
+      ),
     };
 
     return {
@@ -270,13 +288,14 @@ export const spec = {
 
   getUserSyncs(syncOptions, serverResponses) {
     if (serverResponses == null || serverResponses.length === 0) {
-      return []
+      return [];
     }
-    const output = []
+    const output = [];
     _each(serverResponses, function ({ body: response }) {
       if (response != null && response.p != null && response.p.hreq) {
         _each(response.p.hreq, function (syncPixel) {
-          const pixelType = syncPixel.indexOf('__st=iframe') !== -1 ? 'iframe' : 'image';
+          const pixelType =
+            syncPixel.indexOf('__st=iframe') !== -1 ? 'iframe' : 'image';
           if (syncOptions.iframeEnabled || pixelType === 'image') {
             output.push({
               url: syncPixel,
@@ -303,7 +322,7 @@ export const spec = {
       return flatMap(response.r[bidID], (siteBid) =>
         siteBid.b.map((bid) => {
           const mediaType = getMediaType(bid);
-          const ad = mediaType === BANNER ? decorateADM(bid) : bid.adm;
+          const ad = bid.adm;
 
           if (ad == null) {
             return null;
@@ -312,7 +331,7 @@ export const spec = {
           const size = resolveSize(bid, request.data, bidID);
           const defaultExpiration = mediaType === BANNER ? 240 : 300;
 
-          return ({
+          return {
             requestId: bidID,
             cpm: bid.price,
             width: size[0],
@@ -327,8 +346,9 @@ export const spec = {
             },
             mediaType,
             ttl: typeof bid.exp === 'number' ? bid.exp : defaultExpiration,
-          });
-        })).filter((possibleBid) => possibleBid != null);
+          };
+        })
+      ).filter((possibleBid) => possibleBid != null);
     });
   },
 

--- a/test/spec/modules/amxBidAdapter_spec.js
+++ b/test/spec/modules/amxBidAdapter_spec.js
@@ -1,50 +1,52 @@
-import * as utils from 'src/utils.js';
-import { createEidsArray } from 'modules/userId/eids.js';
 import { expect } from 'chai';
 import { spec } from 'modules/amxBidAdapter.js';
+import { createEidsArray } from 'modules/userId/eids.js';
 import { BANNER, VIDEO } from 'src/mediaTypes.js';
-import { config } from 'src/config.js';
+import * as utils from 'src/utils.js';
 
 const sampleRequestId = '82c91e127a9b93e';
-const sampleDisplayAd = (additionalImpressions) => `<script src='https://assets.a-mo.net/tmode.v1.js'></script>${additionalImpressions}`;
+const sampleDisplayAd = `<script src='https://assets.a-mo.net/tmode.v1.js'></script>`;
 const sampleDisplayCRID = '78827819';
 // minimal example vast
-const sampleVideoAd = (addlImpression) => `
+const sampleVideoAd = (addlImpression) =>
+  `
 <?xml version="1.0" encoding="UTF-8" ?><VAST version="2.0"><Ad id="128a6.44d74.46b3"><InLine><Error><![CDATA[http://example.net/hbx/verr?e=]]></Error><Impression><![CDATA[http://example.net/hbx/vimp?lid=test&aid=testapp]]></Impression><Creatives><Creative sequence="1"><Linear><Duration>00:00:15</Duration><TrackingEvents><Tracking event="firstQuartile"><![CDATA[https://example.com?event=first_quartile]]></Tracking></TrackingEvents><VideoClicks><ClickThrough><![CDATA[http://example.com]]></ClickThrough></VideoClicks><MediaFiles><MediaFile delivery="progressive" width="16" height="9" type="video/mp4" bitrate="800"><![CDATA[https://example.com/media.mp4]]></MediaFile></MediaFiles></Linear></Creative></Creatives>${addlImpression}</InLine></Ad></VAST>
-`.replace(/\n+/g, '')
-
-const embeddedTrackingPixel = `https://1x1.a-mo.net/hbx/g_impression?A=sample&B=20903`;
-const sampleNurl = 'https://example.exchange/nurl';
+`.replace(/\n+/g, '');
 
 const sampleFPD = {
   site: {
     keywords: 'sample keywords',
     ext: {
       data: {
-        pageType: 'article'
-      }
-    }
+        pageType: 'article',
+      },
+    },
   },
   user: {
     gender: 'O',
     yob: 1982,
-  }
+  },
 };
 
 const sampleBidderRequest = {
   gdprConsent: {
     gdprApplies: true,
     consentString: utils.getUniqueIdentifierStr(),
-    vendorData: {}
+    vendorData: {},
   },
   auctionId: utils.getUniqueIdentifierStr(),
   uspConsent: '1YYY',
   refererInfo: {
     location: 'https://www.prebid.org',
+    site: 'prebid.org',
     topmostLocation: 'https://www.prebid.org',
-    canonicalUrl: 'https://www.prebid.org/the/link/to/the/page'
+    page: 'https://www.prebid.org/the/link/to/the/page',
   },
-  ortb2: sampleFPD
+  ortb2: sampleFPD,
+};
+
+const sampleImpExt = {
+  testKey: 'testValue',
 };
 
 const sampleBidRequestBase = {
@@ -52,20 +54,29 @@ const sampleBidRequestBase = {
   params: {
     endpoint: 'https://httpbin.org/post',
   },
+  ortb2Imp: {
+    ext: sampleImpExt,
+  },
   sizes: [[320, 50]],
   getFloor(params) {
-    if (params.size == null || params.currency == null || params.mediaType == null) {
-      throw new Error(`getFloor called with incomplete params: ${JSON.stringify(params)}`)
+    if (
+      params.size == null ||
+      params.currency == null ||
+      params.mediaType == null
+    ) {
+      throw new Error(
+        `getFloor called with incomplete params: ${JSON.stringify(params)}`
+      );
     }
     return {
       floor: 0.5,
-      currency: 'USD'
-    }
+      currency: 'USD',
+    };
   },
   mediaTypes: {
     [BANNER]: {
-      sizes: [[300, 250]]
-    }
+      sizes: [[300, 250]],
+    },
   },
   adUnitCode: 'div-gpt-ad-example',
   transactionId: utils.getUniqueIdentifierStr(),
@@ -75,13 +86,15 @@ const sampleBidRequestBase = {
 
 const schainConfig = {
   ver: '1.0',
-  nodes: [{
-    asi: 'greatnetwork.exchange',
-    sid: '000001',
-    hp: 1,
-    rid: 'bid_request_1',
-    domain: 'publisher.com'
-  }]
+  nodes: [
+    {
+      asi: 'greatnetwork.exchange',
+      sid: '000001',
+      hp: 1,
+      rid: 'bid_request_1',
+      domain: 'publisher.com',
+    },
+  ],
 };
 
 const sampleBidRequestVideo = {
@@ -94,89 +107,93 @@ const sampleBidRequestVideo = {
       sizes: [[360, 250]],
       context: 'adpod',
       adPodDurationSec: 90,
-      contentMode: 'live'
-    }
-  }
+      contentMode: 'live',
+    },
+  },
 };
 
 const sampleServerResponse = {
-  'p': {
-    'hreq': ['https://1x1.a-mo.net/hbx/g_sync?partner=test', 'https://1x1.a-mo.net/hbx/g_syncf?__st=iframe']
+  p: {
+    hreq: [
+      'https://1x1.a-mo.net/hbx/g_sync?partner=test',
+      'https://1x1.a-mo.net/hbx/g_syncf?__st=iframe',
+    ],
   },
-  'r': {
+  r: {
     [sampleRequestId]: [
       {
-        'b': [
+        b: [
           {
-            'adid': '78827819',
-            'adm': sampleDisplayAd(''),
-            'adomain': [
-              'example.com'
-            ],
-            'crid': sampleDisplayCRID,
-            'ext': {
-              'himp': [
-                embeddedTrackingPixel
-              ],
-            },
-            'nurl': sampleNurl,
-            'h': 600,
-            'id': '2014691335735134254',
-            'impid': '1',
-            'exp': 90,
-            'price': 0.25,
-            'w': 300
+            adid: '78827819',
+            adm: sampleDisplayAd,
+            adomain: ['example.com'],
+            crid: sampleDisplayCRID,
+            h: 600,
+            id: '2014691335735134254',
+            impid: '1',
+            exp: 90,
+            price: 0.25,
+            w: 300,
           },
           {
-            'adid': '222976952',
-            'adm': sampleVideoAd(''),
-            'adomain': [
-              'example.com'
-            ],
-            'crid': sampleDisplayCRID,
-            'ext': {
-              'himp': [
-                embeddedTrackingPixel
-              ],
-            },
-            'nurl': sampleNurl,
-            'h': 1,
-            'id': '7735706981389902829',
-            'impid': '1',
-            'exp': 90,
-            'price': 0.25,
-            'w': 1
+            adid: '222976952',
+            adm: sampleVideoAd(''),
+            adomain: ['example.com'],
+            crid: sampleDisplayCRID,
+            ext: {},
+            h: 1,
+            id: '7735706981389902829',
+            impid: '1',
+            exp: 90,
+            price: 0.25,
+            w: 1,
           },
         ],
-      }
-    ]
+      },
+    ],
   },
-}
+};
 
 describe('AmxBidAdapter', () => {
   describe('isBidRequestValid', () => {
     it('endpoint must be an optional string', () => {
-      expect(spec.isBidRequestValid({params: { endpoint: 1 }})).to.equal(false)
-      expect(spec.isBidRequestValid({params: { endpoint: 'test' }})).to.equal(true)
+      expect(spec.isBidRequestValid({ params: { endpoint: 1 } })).to.equal(
+        false
+      );
+      expect(spec.isBidRequestValid({ params: { endpoint: 'test' } })).to.equal(
+        true
+      );
     });
 
     it('tagId is an optional string', () => {
-      expect(spec.isBidRequestValid({params: { tagId: 1 }})).to.equal(false)
-      expect(spec.isBidRequestValid({params: { tagId: 'test' }})).to.equal(true)
+      expect(spec.isBidRequestValid({ params: { tagId: 1 } })).to.equal(false);
+      expect(spec.isBidRequestValid({ params: { tagId: 'test' } })).to.equal(
+        true
+      );
     });
 
     it('testMode is an optional truthy value', () => {
-      expect(spec.isBidRequestValid({params: { testMode: 1 }})).to.equal(true)
-      expect(spec.isBidRequestValid({params: { testMode: 'true' }})).to.equal(true)
+      expect(spec.isBidRequestValid({ params: { testMode: 1 } })).to.equal(
+        true
+      );
+      expect(spec.isBidRequestValid({ params: { testMode: 'true' } })).to.equal(
+        true
+      );
       // ignore invalid values (falsy)
-      expect(spec.isBidRequestValid({params: { testMode: 'non-truthy-invalid-value' }})).to.equal(true)
-      expect(spec.isBidRequestValid({params: { testMode: false }})).to.equal(true)
+      expect(
+        spec.isBidRequestValid({
+          params: { testMode: 'non-truthy-invalid-value' },
+        })
+      ).to.equal(true);
+      expect(spec.isBidRequestValid({ params: { testMode: false } })).to.equal(
+        true
+      );
     });
 
     it('none of the params are required', () => {
-      expect(spec.isBidRequestValid({})).to.equal(true)
+      expect(spec.isBidRequestValid({})).to.equal(true);
     });
-  })
+  });
   describe('getUserSync', () => {
     it('will only sync from valid server responses', () => {
       const syncs = spec.getUserSyncs({ iframeEnabled: true });
@@ -184,43 +201,62 @@ describe('AmxBidAdapter', () => {
     });
 
     it('will return valid syncs from a server response', () => {
-      const syncs = spec.getUserSyncs({ iframeEnabled: true }, [{body: sampleServerResponse}]);
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, [
+        { body: sampleServerResponse },
+      ]);
       expect(syncs.length).to.equal(2);
       expect(syncs[0].type).to.equal('image');
       expect(syncs[1].type).to.equal('iframe');
     });
 
     it('will filter out iframe syncs based on options', () => {
-      const syncs = spec.getUserSyncs({ iframeEnabled: false }, [{body: sampleServerResponse}, {body: sampleServerResponse}]);
+      const syncs = spec.getUserSyncs({ iframeEnabled: false }, [
+        { body: sampleServerResponse },
+        { body: sampleServerResponse },
+      ]);
       expect(syncs.length).to.equal(2);
-      expect(syncs).to.satisfy((allSyncs) => allSyncs.every((sync) => sync.type === 'image'))
+      expect(syncs).to.satisfy((allSyncs) =>
+        allSyncs.every((sync) => sync.type === 'image')
+      );
     });
   });
 
   describe('buildRequests', () => {
     it('will default to prebid.a-mo.net endpoint', () => {
       const { url } = spec.buildRequests([], sampleBidderRequest);
-      expect(url).to.equal('https://prebid.a-mo.net/a/c')
+      expect(url).to.equal('https://prebid.a-mo.net/a/c');
     });
 
     it('will read the prebid version & global', () => {
-      const { data: { V: prebidVersion, vg: prebidGlobal } } = spec.buildRequests([{
-        ...sampleBidRequestBase,
-        params: {
-          testMode: true
-        }
-      }], sampleBidderRequest);
-      expect(prebidVersion).to.equal('$prebid.version$')
-      expect(prebidGlobal).to.equal('$$PREBID_GLOBAL$$')
+      const {
+        data: { V: prebidVersion, vg: prebidGlobal },
+      } = spec.buildRequests(
+        [
+          {
+            ...sampleBidRequestBase,
+            params: {
+              testMode: true,
+            },
+          },
+        ],
+        sampleBidderRequest
+      );
+      expect(prebidVersion).to.equal('$prebid.version$');
+      expect(prebidGlobal).to.equal('$$PREBID_GLOBAL$$');
     });
 
     it('reads test mode from the first bid request', () => {
-      const { data } = spec.buildRequests([{
-        ...sampleBidRequestBase,
-        params: {
-          testMode: true
-        }
-      }], sampleBidderRequest);
+      const { data } = spec.buildRequests(
+        [
+          {
+            ...sampleBidRequestBase,
+            params: {
+              testMode: true,
+            },
+          },
+        ],
+        sampleBidderRequest
+      );
       expect(data.tm).to.equal(true);
     });
 
@@ -231,9 +267,9 @@ describe('AmxBidAdapter', () => {
           location: null,
           topmostLocation: null,
           ref: 'http://search-traffic-source.com',
-        }
+        },
       });
-      expect(data.do).to.equal('localhost')
+      expect(data.do).to.equal('localhost');
       expect(data.re).to.equal('http://search-traffic-source.com');
     });
 
@@ -244,48 +280,59 @@ describe('AmxBidAdapter', () => {
           location: null,
           topmostLocation: 'http://top-site.com',
           ref: 'http://search-traffic-source.com',
-        }
+        },
       });
       expect(data.do).to.equal('top-site.com');
       expect(data.re).to.equal('http://search-traffic-source.com');
     });
 
     it('handles referer data and GDPR, USP Consent, COPPA', () => {
-      const { data } = spec.buildRequests([sampleBidRequestBase], sampleBidderRequest);
+      const { data } = spec.buildRequests(
+        [sampleBidRequestBase],
+        sampleBidderRequest
+      );
       delete data.m; // don't deal with "m" in this test
-      expect(data.gs).to.equal(sampleBidderRequest.gdprConsent.gdprApplies)
-      expect(data.gc).to.equal(sampleBidderRequest.gdprConsent.consentString)
-      expect(data.usp).to.equal(sampleBidderRequest.uspConsent)
-      expect(data.cpp).to.equal(0)
+      expect(data.gs).to.equal(sampleBidderRequest.gdprConsent.gdprApplies);
+      expect(data.gc).to.equal(sampleBidderRequest.gdprConsent.consentString);
+      expect(data.usp).to.equal(sampleBidderRequest.uspConsent);
+      expect(data.cpp).to.equal(0);
     });
 
     it('will forward bid request count & wins count data', () => {
-      const bidderRequestsCount = Math.floor(Math.random() * 100)
-      const bidderWinsCount = Math.floor(Math.random() * 100)
-      const { data } = spec.buildRequests([{
-        ...sampleBidRequestBase,
-        bidderRequestsCount,
-        bidderWinsCount
-      }], sampleBidderRequest);
+      const bidderRequestsCount = Math.floor(Math.random() * 100);
+      const bidderWinsCount = Math.floor(Math.random() * 100);
+      const { data } = spec.buildRequests(
+        [
+          {
+            ...sampleBidRequestBase,
+            bidderRequestsCount,
+            bidderWinsCount,
+          },
+        ],
+        sampleBidderRequest
+      );
 
-      expect(data.brc).to.equal(bidderRequestsCount)
-      expect(data.bwc).to.equal(bidderWinsCount)
-      expect(data.trc).to.equal(0)
+      expect(data.brc).to.equal(bidderRequestsCount);
+      expect(data.bwc).to.equal(bidderWinsCount);
+      expect(data.trc).to.equal(0);
     });
     it('will forward first-party data', () => {
-      const { data } = spec.buildRequests([sampleBidRequestBase], sampleBidderRequest);
-      expect(data.fpd2).to.deep.equal(sampleFPD)
+      const { data } = spec.buildRequests(
+        [sampleBidRequestBase],
+        sampleBidderRequest
+      );
+      expect(data.fpd2).to.deep.equal(sampleFPD);
     });
 
     it('will collect & forward RTI user IDs', () => {
-      const randomRTI = `greatRTI${Math.floor(Math.random() * 100)}`
+      const randomRTI = `greatRTI${Math.floor(Math.random() * 100)}`;
       const userId = {
         britepoolid: 'sample-britepool',
         criteoId: 'sample-criteo',
-        digitrustid: {data: {id: 'sample-digitrust'}},
-        id5id: {uid: 'sample-id5'},
+        digitrustid: { data: { id: 'sample-digitrust' } },
+        id5id: { uid: 'sample-id5' },
         idl_env: 'sample-liveramp',
-        lipb: {lipbid: 'sample-liveintent'},
+        lipb: { lipbid: 'sample-liveintent' },
         netId: 'sample-netid',
         parrableId: { eid: 'sample-parrable' },
         pubcid: 'sample-pubcid',
@@ -296,71 +343,74 @@ describe('AmxBidAdapter', () => {
       const eids = createEidsArray(userId);
       const bid = {
         ...sampleBidRequestBase,
-        userIdAsEids: eids
+        userIdAsEids: eids,
       };
 
       const { data } = spec.buildRequests([bid, bid], sampleBidderRequest);
-      expect(data.eids).to.deep.equal(eids)
+      expect(data.eids).to.deep.equal(eids);
     });
 
     it('can build a banner request', () => {
-      const { method, url, data } = spec.buildRequests([sampleBidRequestBase, {
-        ...sampleBidRequestBase,
-        bidId: sampleRequestId + '_2',
-        params: {
-          ...sampleBidRequestBase.params,
-          tagId: 'example'
-        }
-      }], sampleBidderRequest)
+      const { method, url, data } = spec.buildRequests(
+        [
+          sampleBidRequestBase,
+          {
+            ...sampleBidRequestBase,
+            bidId: sampleRequestId + '_2',
+            params: {
+              ...sampleBidRequestBase.params,
+              tagId: 'example',
+            },
+          },
+        ],
+        sampleBidderRequest
+      );
 
-      expect(url).to.equal(sampleBidRequestBase.params.endpoint)
+      expect(url).to.equal(sampleBidRequestBase.params.endpoint);
       expect(method).to.equal('POST');
       expect(Object.keys(data.m).length).to.equal(2);
       expect(data.m[sampleRequestId]).to.deep.equal({
         av: true,
         au: 'div-gpt-ad-example',
         vd: {},
-        ms: [
-          [[320, 50]],
-          [[300, 250]],
-          []
-        ],
+        ms: [[[320, 50]], [[300, 250]], []],
         aw: 300,
         sc: {},
         ah: 250,
         tf: 0,
         f: 0.5,
-        vr: false
+        vr: false,
+        rtb: {
+          ext: sampleImpExt,
+        },
       });
       expect(data.m[sampleRequestId + '_2']).to.deep.equal({
         av: true,
         aw: 300,
         au: 'div-gpt-ad-example',
         sc: {},
-        ms: [
-          [[320, 50]],
-          [[300, 250]],
-          []
-        ],
+        ms: [[[320, 50]], [[300, 250]], []],
         i: 'example',
         ah: 250,
         vd: {},
         tf: 0,
         f: 0.5,
         vr: false,
+        rtb: {
+          ext: sampleImpExt,
+        },
       });
     });
 
     it('can build a video request', () => {
-      const { data } = spec.buildRequests([sampleBidRequestVideo], sampleBidderRequest);
+      const { data } = spec.buildRequests(
+        [sampleBidRequestVideo],
+        sampleBidderRequest
+      );
       expect(Object.keys(data.m).length).to.equal(1);
       expect(data.m[sampleRequestId + '_video']).to.deep.equal({
         au: 'div-gpt-ad-example',
-        ms: [
-          [[300, 150]],
-          [],
-          [[360, 250]]
-        ],
+        ms: [[[300, 150]], [], [[360, 250]]],
         av: true,
         aw: 360,
         ah: 250,
@@ -369,11 +419,14 @@ describe('AmxBidAdapter', () => {
           sizes: [[360, 250]],
           context: 'adpod',
           adPodDurationSec: 90,
-          contentMode: 'live'
+          contentMode: 'live',
         },
         tf: 0,
         f: 0.5,
-        vr: true
+        rtb: {
+          ext: sampleImpExt,
+        },
+        vr: true,
       });
     });
   });
@@ -397,18 +450,21 @@ describe('AmxBidAdapter', () => {
             aw: 300,
             ah: 250,
           },
-        }
-      }
+        },
+      },
     };
 
     it('will handle a nobid response', () => {
-      const parsed = spec.interpretResponse({ body: '' }, baseRequest)
-      expect(parsed).to.eql([])
+      const parsed = spec.interpretResponse({ body: '' }, baseRequest);
+      expect(parsed).to.eql([]);
     });
 
     it('can parse a display ad', () => {
-      const parsed = spec.interpretResponse({ body: sampleServerResponse }, baseRequest)
-      expect(parsed.length).to.equal(2)
+      const parsed = spec.interpretResponse(
+        { body: sampleServerResponse },
+        baseRequest
+      );
+      expect(parsed.length).to.equal(2);
 
       // we should have display, video, display
       expect(parsed[0]).to.deep.equal({
@@ -421,16 +477,16 @@ describe('AmxBidAdapter', () => {
         width: 300,
         height: 600, // from the bid itself
         ttl: 90,
-        ad: sampleDisplayAd(
-          `<img src="${embeddedTrackingPixel}" width="0" height="0"/>` +
-          `<img src="${sampleNurl}" width="0" height="0"/>`
-        ),
+        ad: sampleDisplayAd,
       });
     });
 
     it('can parse a video ad', () => {
-      const parsed = spec.interpretResponse({ body: sampleServerResponse }, baseRequest)
-      expect(parsed.length).to.equal(2)
+      const parsed = spec.interpretResponse(
+        { body: sampleServerResponse },
+        baseRequest
+      );
+      expect(parsed.length).to.equal(2);
       expect(parsed[1]).to.deep.equal({
         ...baseBidResponse,
         meta: {
@@ -453,9 +509,9 @@ describe('AmxBidAdapter', () => {
       _Image = window.Image;
       window.Image = class FakeImage {
         set src(value) {
-          firedPixels.push(value)
+          firedPixels.push(value);
         }
-      }
+      };
     });
 
     beforeEach(() => {
@@ -479,24 +535,26 @@ describe('AmxBidAdapter', () => {
         adserverTargeting: {
           hb_pb: '1.23',
           hb_adid: 'ad-id',
-          hb_bidder: 'example'
-        }
+          hb_bidder: 'example',
+        },
       });
-      expect(firedPixels.length).to.equal(1)
-      expect(firedPixels[0]).to.match(/\/hbx\/g_pbst/)
+      expect(firedPixels.length).to.equal(1);
+      expect(firedPixels[0]).to.match(/\/hbx\/g_pbst/);
       try {
         const parsed = new URL(firedPixels[0]);
         const nestedData = parsed.searchParams.get('c2');
-        expect(nestedData).to.equal(utils.formatQS({
-          hb_pb: '1.23',
-          hb_adid: 'ad-id',
-          hb_bidder: 'example'
-        }));
+        expect(nestedData).to.equal(
+          utils.formatQS({
+            hb_pb: '1.23',
+            hb_adid: 'ad-id',
+            hb_bidder: 'example',
+          })
+        );
       } catch (e) {
         // unsupported browser; try testing for string
         const pixel = firedPixels[0];
-        expect(pixel).to.have.string(encodeURIComponent('hb_pb=1.23'))
-        expect(pixel).to.have.string(encodeURIComponent('hb_adid=ad-id'))
+        expect(pixel).to.have.string(encodeURIComponent('hb_pb=1.23'));
+        expect(pixel).to.have.string(encodeURIComponent('hb_adid=ad-id'));
       }
     });
 
@@ -506,10 +564,10 @@ describe('AmxBidAdapter', () => {
         bidId: 'test-bid-id',
         adUnitCode: 'div-gpt-ad',
         timeout: 300,
-        auctionId: utils.getUniqueIdentifierStr()
+        auctionId: utils.getUniqueIdentifierStr(),
       });
-      expect(firedPixels.length).to.equal(1)
-      expect(firedPixels[0]).to.match(/\/hbx\/g_pbto/)
+      expect(firedPixels.length).to.equal(1);
+      expect(firedPixels[0]).to.match(/\/hbx\/g_pbto/);
     });
 
     it('will log an event for prebid win', () => {
@@ -522,19 +580,19 @@ describe('AmxBidAdapter', () => {
         cpm: 1.34,
         adUnitCode: 'div-gpt-ad',
         timeout: 300,
-        auctionId: utils.getUniqueIdentifierStr()
+        auctionId: utils.getUniqueIdentifierStr(),
       });
-      expect(firedPixels.length).to.equal(1)
-      expect(firedPixels[0]).to.match(/\/hbx\/g_pbwin/)
+      expect(firedPixels.length).to.equal(1);
+      expect(firedPixels[0]).to.match(/\/hbx\/g_pbwin/);
 
       const pixel = firedPixels[0];
       try {
         const url = new URL(pixel);
-        expect(url.searchParams.get('C')).to.equal('1')
-        expect(url.searchParams.get('np')).to.equal('1.34')
+        expect(url.searchParams.get('C')).to.equal('1');
+        expect(url.searchParams.get('np')).to.equal('1.34');
       } catch (e) {
-        expect(pixel).to.have.string('C=1')
-        expect(pixel).to.have.string('np=1.34')
+        expect(pixel).to.have.string('C=1');
+        expect(pixel).to.have.string('np=1.34');
       }
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature


## Description of change
Update amxBidAdapter to use the correct "refererInfo" fields for prebid 7, e.g. `site` and `page`. Remove legacy "decorateAdm" code. Adding ortb2Imp as part of data sent to server.
