### PR TITLE
1plusX RTD Module: Send GDPR info to PAPI

### DIFF
--- a/modules/1plusXRtdProvider.js
+++ b/modules/1plusXRtdProvider.js
@@ -57,15 +57,15 @@ export const extractConfig = (moduleConfig, reqBidsConfigObj) => {
   return { customerId, timeout, bidders };
 }
 
-export const extractConsent = (consent) => {
-  if (!consent || !consent.vendorData) {
+export const extractConsent = ({ gdprApplies, vendorData }) => {
+  if (!vendorData && (gdprApplies === null || gdprApplies === undefined)) {
     return null
   }
   const result = {
-    'gdpr_applies': consent.gdprApplies,
-    'consent_string': consent.vendorData.tcString
+    'gdpr_applies': gdprApplies,
+    'consent_string': vendorData.tcString
   }
-  if (result && Object.values(result).some(v => !v)) {
+  if (Object.values(result).some(v => (v === null || v === undefined))) {
     throw 'TCF Consent: gdprApplies and tcString both have to be defined'
   }
   return result
@@ -242,7 +242,7 @@ const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, userConsent
     // Get the required config
     const { customerId, bidders } = extractConfig(moduleConfig, reqBidsConfigObj);
     // Get PAPI URL
-    const papiUrl = getPapiUrl(customerId, extractConsent(userConsent))
+    const papiUrl = getPapiUrl(customerId, extractConsent(userConsent) || {})
     // Call PAPI
     getTargetingDataFromPapi(papiUrl)
       .then((papiResponse) => {

--- a/modules/1plusXRtdProvider.js
+++ b/modules/1plusXRtdProvider.js
@@ -61,9 +61,9 @@ export const extractConsent = (consent) => {
   if (!consent || !consent.vendorData) {
     return null
   }
-  const result = { 
-    'gdpr_applies': consent.gdprApplies, 
-    'consent_string': consent.vendorData.tcString 
+  const result = {
+    'gdpr_applies': consent.gdprApplies,
+    'consent_string': consent.vendorData.tcString
   }
   if (result && Object.values(result).some(v => !v)) {
     throw 'TCF Consent: gdprApplies and tcString both have to be defined'

--- a/modules/1plusXRtdProvider.js
+++ b/modules/1plusXRtdProvider.js
@@ -6,7 +6,6 @@ import {
   deepAccess, mergeDeep,
   isNumber, isArray, deepSetValue
 } from '../src/utils.js';
-import { json } from 'body-parser';
 
 // Constants
 const REAL_TIME_MODULE = 'realTimeData';
@@ -60,12 +59,12 @@ export const extractConfig = (moduleConfig, reqBidsConfigObj) => {
 
 export const extractConsent = (consent) => {
   if (!consent || !consent.vendorData) {
-    return null 
+    return null
   }
-  const result = {
-    'gdpr_applies': consent.gdprApplies,
+  const result = { 
+    'gdpr_applies': consent.gdprApplies, 
     'consent_string': consent.vendorData.tcString 
-  } 
+  }
   if (result && Object.values(result).some(v => !v)) {
     throw 'TCF Consent: gdprApplies and tcString both have to be defined'
   }
@@ -82,7 +81,6 @@ export const getPapiUrl = (customerId, consent) => {
   const currentUrl = encodeURIComponent(window.location.href);
   var papiUrl = `https://${customerId}.profiles.tagger.opecloud.com/${PAPI_VERSION}/targeting?url=${currentUrl}`;
   if (consent) {
-    console.log("entering consent if")
     Object.entries(consent).forEach(([key, value]) => {
       papiUrl += `&${key}=${value}`
     })

--- a/modules/1plusXRtdProvider.js
+++ b/modules/1plusXRtdProvider.js
@@ -57,16 +57,20 @@ export const extractConfig = (moduleConfig, reqBidsConfigObj) => {
   return { customerId, timeout, bidders };
 }
 
-export const extractConsent = ({ gdprApplies, vendorData }) => {
-  if (!vendorData && (gdprApplies === null || gdprApplies === undefined)) {
+export const extractConsent = ({ gdpr }) => {
+  if (!gdpr) {
     return null
+  }
+  const { gdprApplies, consentString } = gdpr
+  if (!(gdprApplies == '0' || gdprApplies == '1')) {
+    throw 'TCF Consent: gdprApplies has wrong format'
+  }
+  if (!(typeof consentString === 'string')) {
+    throw 'TCF Consent: consentString is not string'
   }
   const result = {
     'gdpr_applies': gdprApplies,
-    'consent_string': vendorData.tcString
-  }
-  if (Object.values(result).some(v => (v === null || v === undefined))) {
-    throw 'TCF Consent: gdprApplies and tcString both have to be defined'
+    'consent_string': consentString
   }
   return result
 }

--- a/test/spec/modules/1plusXRtdProvider_spec.js
+++ b/test/spec/modules/1plusXRtdProvider_spec.js
@@ -312,13 +312,10 @@ describe('1plusXRtdProvider', () => {
     }
 
     it('correctly builds URLs based on consent', () => {
-      const url1 = getPapiUrl(customer )
-      const url2 = getPapiUrl(customer,extractConsent(consent))
-      console.log(url1)
-      console.log(url2)
+      const url1 = getPapiUrl(customer)
+      const url2 = getPapiUrl(customer, extractConsent(consent))
       expect(['&consent_string=myConsent&gdpr_applies=1', '&gdpr_applies=1&consent_string=myConsent']).to.contain(url2.replace(url1, ''))
     })
-    
   })
 
   describe('updateBidderConfig', () => {

--- a/test/spec/modules/1plusXRtdProvider_spec.js
+++ b/test/spec/modules/1plusXRtdProvider_spec.js
@@ -273,8 +273,8 @@ describe('1plusXRtdProvider', () => {
       const consent1 = null
       const consent2 = undefined
 
-      expect(extractConsent(consent1) === null)
-      expect(extractConsent(consent2) === null)
+      expect(extractConsent(consent1)).to.equal(null)
+      expect(extractConsent(consent2)).to.equal(null)
     })
 
     it('throws an error if the consent is malformed', () => {
@@ -297,7 +297,7 @@ describe('1plusXRtdProvider', () => {
         try {
           extractConsent(consent)
           assert(false, 'Should be throwing an exception')
-        } catch (e) {}
+        } catch (e) { }
       }
     })
   })
@@ -311,11 +311,14 @@ describe('1plusXRtdProvider', () => {
       }
     }
 
-    it('correctly builds URLs distinguishing if consent is present or null', () => {
-      const url1 = getPapiUrl({ customerId: customer })
-      const url2 = getPapiUrl({ customerId: customer, consent: consent })
-      expect(url2.replace(url1, '')).to.equal('&consent_string=myConsent&gdpr_applies=1')
+    it('correctly builds URLs based on consent', () => {
+      const url1 = getPapiUrl(customer )
+      const url2 = getPapiUrl(customer,extractConsent(consent))
+      console.log(url1)
+      console.log(url2)
+      expect(['&consent_string=myConsent&gdpr_applies=1', '&gdpr_applies=1&consent_string=myConsent']).to.contain(url2.replace(url1, ''))
     })
+    
   })
 
   describe('updateBidderConfig', () => {

--- a/test/spec/modules/1plusXRtdProvider_spec.js
+++ b/test/spec/modules/1plusXRtdProvider_spec.js
@@ -270,11 +270,8 @@ describe('1plusXRtdProvider', () => {
       expect(output).to.deep.include(expectedOutput)
     })
     it('extracts null if not given at all', () => {
-      const consent1 = null
-      const consent2 = undefined
-
+      const consent1 = {}
       expect(extractConsent(consent1)).to.equal(null)
-      expect(extractConsent(consent2)).to.equal(null)
     })
 
     it('throws an error if the consent is malformed', () => {

--- a/test/spec/modules/1plusXRtdProvider_spec.js
+++ b/test/spec/modules/1plusXRtdProvider_spec.js
@@ -256,9 +256,9 @@ describe('1plusXRtdProvider', () => {
   describe('extractConsent', () => {
     it('extracts consent strings correctly if given', () => {
       const consent = {
-        gdprApplies: 1,
-        vendorData: {
-          tcString: 'myConsent'
+        gdpr: {
+          gdprApplies: 1,
+          consentString: 'myConsent'
         }
       }
       const output = extractConsent(consent)
@@ -269,28 +269,40 @@ describe('1plusXRtdProvider', () => {
       expect(expectedOutput).to.deep.include(output)
       expect(output).to.deep.include(expectedOutput)
     })
-    it('extracts null if not given at all', () => {
+    it('extracts null if consent object is empty', () => {
       const consent1 = {}
       expect(extractConsent(consent1)).to.equal(null)
     })
 
     it('throws an error if the consent is malformed', () => {
       const consent1 = {
-        gdprApplies: 1
+        gdpr: {
+          gdprApplies: 1
+        }
       }
       const consent2 = {
-        vendorData: {
-          tcString: 'myConsent'
+        gdpr: {
+          consentString: 'myConsent'
         }
       }
       const consent3 = {
-        gdprApplies: 1,
-        vendorData: {
-          other: 'test'
+        gdpr: {
+          gdprApplies: 1,
+          consentString: 3
         }
       }
+      const consent4 = {
+        gdpr: {
+          gdprApplies: 'yes',
+          consentString: 'myConsent'
+        }
+      }
+      const consent5 = {
+        gdprApplies: 1,
+        consentString: 'myConsent'
+      }
 
-      for (const consent in [consent1, consent2, consent3]) {
+      for (const consent in [consent1, consent2, consent3, consent4, consent5]) {
         try {
           extractConsent(consent)
           assert(false, 'Should be throwing an exception')
@@ -302,9 +314,9 @@ describe('1plusXRtdProvider', () => {
   describe('getPapiUrl', () => {
     const customer = 'acme'
     const consent = {
-      gdprApplies: 1,
-      vendorData: {
-        tcString: 'myConsent'
+      gdpr: {
+        gdprApplies: 1,
+        consentString: 'myConsent'
       }
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Before calling our Profile API, we want to extract TCF consent and, if available, attach it as query parameters to our call. 

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
