### PR TITLE
USP consent management module: fix bug with zero-conf not being enabled on first auction

### DIFF
--- a/modules/consentManagementUsp.js
+++ b/modules/consentManagementUsp.js
@@ -4,11 +4,11 @@
  * information and make it available for any USP (CCPA) supported adapters to
  * read/pass this information to their system.
  */
-import { isFn, logInfo, logWarn, isStr, isNumber, isPlainObject, logError } from '../src/utils.js';
-import { config } from '../src/config.js';
-import { uspDataHandler } from '../src/adapterManager.js';
-import {getGlobal} from '../src/prebidGlobal.js';
+import {isFn, isNumber, isPlainObject, isStr, logError, logInfo, logWarn} from '../src/utils.js';
+import {config} from '../src/config.js';
+import {uspDataHandler} from '../src/adapterManager.js';
 import {timedAuctionHook} from '../src/utils/perfMetrics.js';
+import {getHook} from '../src/hook.js';
 
 const DEFAULT_CONSENT_API = 'iab';
 const DEFAULT_CONSENT_TIMEOUT = 50;
@@ -19,7 +19,7 @@ export let consentTimeout = DEFAULT_CONSENT_TIMEOUT;
 export let staticConsentData;
 
 let consentData;
-let addedConsentHook = false;
+let enabled = false;
 
 // consent APIs
 const uspCallMap = {
@@ -213,6 +213,9 @@ function loadConsentData(cb) {
  * @param {function} fn required; The next function in the chain, used by hook.js
  */
 export const requestBidsHook = timedAuctionHook('usp', function requestBidsHook(fn, reqBidsConfigObj) {
+  if (!enabled) {
+    enableConsentManagement();
+  }
   loadConsentData((errMsg, ...extraArgs) => {
     if (errMsg != null) {
       logWarn(errMsg, ...extraArgs);
@@ -258,8 +261,7 @@ export function resetConsentData() {
   consentAPI = undefined;
   consentTimeout = undefined;
   uspDataHandler.reset();
-  getGlobal().requestBids.getHooks({hook: requestBidsHook}).remove();
-  addedConsentHook = false;
+  enabled = false;
 }
 
 /**
@@ -296,13 +298,13 @@ export function setConsentConfig(config) {
 }
 
 function enableConsentManagement(configFromUser = false) {
-  if (!addedConsentHook) {
+  if (!enabled) {
     logInfo(`USPAPI consentManagement module has been activated${configFromUser ? '' : ` using default values (api: '${consentAPI}', timeout: ${consentTimeout}ms)`}`);
-    getGlobal().requestBids.before(requestBidsHook, 50);
+    enabled = true;
+    uspDataHandler.enable();
   }
-  addedConsentHook = true;
-  uspDataHandler.enable();
   loadConsentData(); // immediately look up consent data to make it available without requiring an auction
 }
 config.getConfig('consentManagement', config => setConsentConfig(config.consentManagement));
-setTimeout(() => !addedConsentHook && enableConsentManagement());
+
+getHook('requestBids').before(requestBidsHook, 50);

--- a/test/spec/modules/consentManagementUsp_spec.js
+++ b/test/spec/modules/consentManagementUsp_spec.js
@@ -23,8 +23,12 @@ function createIFrameMarker() {
 }
 
 describe('consentManagement', function () {
-  it('should be enabled by default', () => {
-    expect(uspDataHandler.enabled).to.be.true;
+  it('should enable itself on requestBids using default values', (done) => {
+    requestBidsHook(() => {
+      expect(uspDataHandler.enabled).to.be.true;
+      expect(consentAPI).to.eql('iab');
+      done();
+    }, {});
   });
   it('should respect configuration set after activation', () => {
     setConsentConfig({


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Since v7, the USP module automatically enables itself without requiring any config from the user. However, after (I believe) #8626 the timing of when auction hooks run changed so that the USP module incorrectly enables itself _after_ the first auction has already started. This bugfix makes sure USP enables itself in time.

