### PR TITLE
openxOrtb: minor bugfix - handle response with missing seatbid and no nbr

### DIFF
--- a/modules/openxOrtbBidAdapter.js
+++ b/modules/openxOrtbBidAdapter.js
@@ -275,7 +275,7 @@ function interpretOrtbResponse(resp, req) {
   }
 
   const respBody = resp.body;
-  if (!respBody || 'nbr' in respBody) {
+  if (!respBody || 'nbr' in respBody || !Array.isArray(respBody.seatbid)) {
     return [];
   }
 

--- a/test/spec/modules/openxOrtbBidAdapter_spec.js
+++ b/test/spec/modules/openxOrtbBidAdapter_spec.js
@@ -1019,6 +1019,37 @@ describe('OpenxRtbAdapter', function () {
       });
     });
 
+    context('when no seatbid in response', function () {
+      let bids;
+      beforeEach(function () {
+        bidRequestConfigs = [{
+          bidder: 'openx',
+          params: {
+            unit: '12345678',
+            delDomain: 'test-del-domain'
+          },
+          adUnitCode: 'adunit-code',
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250], [300, 600]],
+            },
+          },
+          bidId: 'test-bid-id',
+          bidderRequestId: 'test-bidder-request-id',
+          auctionId: 'test-auction-id'
+        }];
+
+        bidRequest = spec.buildRequests(bidRequestConfigs, {refererInfo: {}})[0];
+
+        bidResponse = {ext: {}, id: 'test-bid-id'};
+        bids = spec.interpretResponse({body: bidResponse}, bidRequest);
+      });
+
+      it('should not return any bids', function () {
+        expect(bids.length).to.equal(0);
+      });
+    });
+
     context('when there is no response', function () {
       let bids;
       beforeEach(function () {


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Address a rare case where the adapter receives a response from openx with no bids and `nbr` ("no-bid reason") is also missing, which causes it to error out and throw away an eventual fledge config that might have been present in the response.

## Other information
@kenan-gillet @luigi-sayson 
