### PR TITLE
Prebid Core Referer Detection: Allow for configurable referrer detection frequency

### DIFF
--- a/test/spec/modules/enrichmentFpdModule_spec.js
+++ b/test/spec/modules/enrichmentFpdModule_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { getRefererInfo } from 'src/refererDetection.js';
+import { getRefererInfo, resetRefererInfo } from 'src/refererDetection.js';
 import { processFpd, coreStorage } from 'modules/enrichmentFpdModule.js';
 
 describe('the first party data enrichment module', function() {
@@ -20,6 +20,7 @@ describe('the first party data enrichment module', function() {
   });
 
   beforeEach(function() {
+    resetRefererInfo();
     querySelectorStub = sinon.stub(window.top.document, 'querySelector');
     querySelectorStub.withArgs("link[rel='canonical']").returns(canonical);
     querySelectorStub.withArgs("meta[name='keywords']").returns(keywords);

--- a/test/spec/modules/fpdModule_spec.js
+++ b/test/spec/modules/fpdModule_spec.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import {config} from 'src/config.js';
-import {getRefererInfo} from 'src/refererDetection.js';
+import {getRefererInfo, resetRefererInfo} from 'src/refererDetection.js';
 import {processFpd, registerSubmodules, startAuctionHook, reset} from 'modules/fpdModule/index.js';
 import * as enrichmentModule from 'modules/enrichmentFpdModule.js';
 import * as validationModule from 'modules/validationFpdModule/index.js';
@@ -70,6 +70,7 @@ describe('the first party data module', function () {
     });
 
     beforeEach(function() {
+      resetRefererInfo();
       querySelectorStub = sinon.stub(window.top.document, 'querySelector');
       querySelectorStub.withArgs("link[rel='canonical']").returns(canonical);
       querySelectorStub.withArgs("meta[name='keywords']").returns(keywords);

--- a/test/spec/refererDetection_spec.js
+++ b/test/spec/refererDetection_spec.js
@@ -1,4 +1,5 @@
 import {detectReferer, ensureProtocol, parseDomain} from 'src/refererDetection.js';
+import * as refererDetection from 'src/refererDetection.js';
 import {config} from 'src/config.js';
 import {expect} from 'chai';
 
@@ -132,6 +133,19 @@ describe('Referer detection', () => {
           ref: 'https://othersite.com/',
           domain: 'example.com'
         });
+      });
+
+      it('Should allow configuration for referer detection frequency', () => {
+        const spy = sinon.spy(refererDetection, 'resetRefererInfo');
+        config.getConfig('refDetectionFreq', (config) => {
+          if (config.refDetectionFreq === 'ongoing') {
+            sinon.assert.calledOnce(spy);
+          }
+        });
+
+        const testWindow = buildWindowTree(['https://example.com/some/page'], 'https://othersite.com/', 'https://example.com/canonical/page');
+        detectReferer(testWindow)();
+        config.setConfig({'refDetectionFreq': 'ongoing'});
       });
     });
 


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
This PR introduces new logic to support configurable referrer detection frequency.  New logic is as follows:
- By default referrer detection will occur only once
- Optionally, if the following is passed into the setConfig func, then the referrer frequency detection will be continuous:
`pbjs.setConfig({refDetectionFreq: 'ongoing'});`

## Other information
Relates to https://github.com/prebid/Prebid.js/issues/8955
@dgirardi can you review?