### PR TITLE
Prebid Core: Improve Native ad robustness to null values

### DIFF
--- a/src/native.js
+++ b/src/native.js
@@ -449,6 +449,9 @@ export function getAllAssetsMessage(data, adObject, {getNativeReq = getNativeReq
  * appropriate for sending in adserver targeting or placeholder replacement.
  */
 function getAssetValue(value) {
+  // as typeof null is 'object' this case is problematic in the next condition
+  if (value === null) value = '';
+
   if (typeof value === 'object' && value.url) {
     return value.url;
   }

--- a/src/native.js
+++ b/src/native.js
@@ -449,14 +449,7 @@ export function getAllAssetsMessage(data, adObject, {getNativeReq = getNativeReq
  * appropriate for sending in adserver targeting or placeholder replacement.
  */
 function getAssetValue(value) {
-  // as typeof null is 'object' this case is problematic in the next condition
-  if (value === null) value = '';
-
-  if (typeof value === 'object' && value.url) {
-    return value.url;
-  }
-
-  return value;
+  return value?.url || value;
 }
 
 function getNativeKeys(adUnit) {

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -190,6 +190,11 @@ describe('native.js', function () {
     expect(targeting.hb_native_foo).to.equal(bid.native.foo);
   });
 
+  it('can get targeting from null native keys', () => {
+    const targeting = getNativeTargeting({...bid, native: {...bid.native, displayUrl: null}});
+    expect(targeting.hb_native_displayurl).to.not.be.ok;
+  })
+
   it('sends placeholders for configured assets', function () {
     const adUnit = {
       transactionId: 'au',


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [*] Bugfix

## Description of change

add robustness to null values in native response format.
when receiving those non mandatory null values:
        {
                ...
                "clickUrl": "https://tracking-preprod.omnitagjs.com/tracking/ar?...3D10",
		"displayUrl": null,
		...
		"privacyIcon": null,
		"privacyLink": null,
		"salePrice": null
	}

we can see this error in console:
`Cannot read properties of null (reading 'url')`

You can see it on this page : 
[native bug example](https://adyoulike.github.io/Tag/prebid/prebid_native.html?env=preprod)

