### PR TITLE
Appnexus Bid Adapter: fix undefined state with adunit ortb keywords

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -250,10 +250,10 @@ export const spec = {
     // need to convert the string values into array of strings, to properly merge values with other existing keys later
     Object.keys(anAuctionKeywords).forEach(k => { if (isStr(anAuctionKeywords[k]) || isNumber(anAuctionKeywords[k])) anAuctionKeywords[k] = [anAuctionKeywords[k]] });
     // combine all sources of keywords (converted from string comma list to object format) into one object (that combines the values for shared keys)
-    let mergedAuctionKeywrds = mergeDeep({}, anAuctionKeywords, ...ortb2KeywordsObjList);
+    let mergedAuctionKeywords = mergeDeep({}, anAuctionKeywords, ...ortb2KeywordsObjList);
 
     // convert to final format used by adserver
-    let auctionKeywords = transformBidderParamKeywords(mergedAuctionKeywrds);
+    let auctionKeywords = transformBidderParamKeywords(mergedAuctionKeywords);
     if (auctionKeywords.length > 0) {
       auctionKeywords.forEach(deleteValues);
       payload.keywords = auctionKeywords;
@@ -1202,28 +1202,30 @@ function convertKeywordsToString(keywords) {
 function convertStringToKeywordsObj(keyStr) {
   let result = {};
 
-  // will split based on commas and will eat white space before/after the comma
-  let keywordList = keyStr.split(/\s*(?:,)\s*/);
-  keywordList.forEach(kw => {
-    // if = exists, then split
-    if (kw.indexOf('=') !== -1) {
-      let kwPair = kw.split('=');
-      let key = kwPair[0];
-      let val = kwPair[1];
+  if (isStr(keyStr) && keyStr !== '') {
+    // will split based on commas and will eat white space before/after the comma
+    let keywordList = keyStr.split(/\s*(?:,)\s*/);
+    keywordList.forEach(kw => {
+      // if = exists, then split
+      if (kw.indexOf('=') !== -1) {
+        let kwPair = kw.split('=');
+        let key = kwPair[0];
+        let val = kwPair[1];
 
-      // then check for existing key in result > if so add value to the array > if not, add new key and create value array
-      if (result.hasOwnProperty(key)) {
-        result[key].push(val);
+        // then check for existing key in result > if so add value to the array > if not, add new key and create value array
+        if (result.hasOwnProperty(key)) {
+          result[key].push(val);
+        } else {
+          result[key] = [val];
+        }
       } else {
-        result[key] = [val];
+        // make a key with '' value; if key already exists > don't add
+        if (!result.hasOwnProperty(kw)) {
+          result[kw] = [''];
+        }
       }
-    } else {
-      // make a key with '' value; if key already exists > don't add
-      if (!result.hasOwnProperty(kw)) {
-        result[kw] = [''];
-      }
-    }
-  });
+    });
+  }
 
   return result;
 }

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -757,6 +757,82 @@ describe('AppNexusAdapter', function () {
       });
     }
 
+    it('should convert keyword params (when there are no ortb keywords) to proper form and attaches to request', function () {
+      let bidRequest = Object.assign({},
+        bidRequests[0],
+        {
+          params: {
+            placementId: '10433394',
+            keywords: {
+              single: 'val',
+              singleArr: ['val'],
+              singleArrNum: [5],
+              multiValMixed: ['value1', 2, 'value3'],
+              singleValNum: 123,
+              emptyStr: '',
+              emptyArr: [''],
+              badValue: { 'foo': 'bar' } // should be dropped
+            }
+          }
+        }
+      );
+
+      const request = spec.buildRequests([bidRequest]);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.tags[0].keywords).to.deep.equal([{
+        'key': 'single',
+        'value': ['val']
+      }, {
+        'key': 'singleArr',
+        'value': ['val']
+      }, {
+        'key': 'singleArrNum',
+        'value': ['5']
+      }, {
+        'key': 'multiValMixed',
+        'value': ['value1', '2', 'value3']
+      }, {
+        'key': 'singleValNum',
+        'value': ['123']
+      }, {
+        'key': 'emptyStr'
+      }, {
+        'key': 'emptyArr'
+      }]);
+    });
+
+    it('should convert adUnit ortb2 keywords (when there are no bid param keywords) to proper form and attaches to request', function () {
+      let bidRequest = Object.assign({},
+        bidRequests[0],
+        {
+          ortb2Imp: {
+            ext: {
+              data: {
+                keywords: 'ortb2=yes,ortb2test, multiValMixed=4, singleValNum=456'
+              }
+            }
+          }
+        }
+      );
+
+      const request = spec.buildRequests([bidRequest]);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.tags[0].keywords).to.deep.equal([{
+        'key': 'ortb2',
+        'value': ['yes']
+      }, {
+        'key': 'ortb2test'
+      }, {
+        'key': 'multiValMixed',
+        'value': ['4']
+      }, {
+        'key': 'singleValNum',
+        'value': ['456']
+      }]);
+    });
+
     it('should convert keyword params and adUnit ortb2 keywords to proper form and attaches to request', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix


## Description of change
Fixes #9006 

Fixes a case where the undefined state of ortb keywords in the adunit wasn't properly caught and handled.  