### PR TITLE
Core & multiple modules: introduce new `bidRejected` event, and refactor bid rejection logic

### DIFF
--- a/modules/categoryTranslation.js
+++ b/modules/categoryTranslation.js
@@ -34,13 +34,13 @@ export const registerAdserver = hook('async', function(adServer) {
 }, 'registerAdserver');
 registerAdserver();
 
-export const getAdserverCategoryHook = timedBidResponseHook('categoryTranslation', function getAdserverCategoryHook(fn, adUnitCode, bid) {
+export const getAdserverCategoryHook = timedBidResponseHook('categoryTranslation', function getAdserverCategoryHook(fn, adUnitCode, bid, reject) {
   if (!bid) {
-    return fn.call(this, adUnitCode); // if no bid, call original and let it display warnings
+    return fn.call(this, adUnitCode, bid, reject); // if no bid, call original and let it display warnings
   }
 
   if (!config.getConfig('adpod.brandCategoryExclusion')) {
-    return fn.call(this, adUnitCode, bid);
+    return fn.call(this, adUnitCode, bid, reject);
   }
 
   let localStorageKey = (config.getConfig('brandCategoryTranslation.translationFile')) ? DEFAULT_IAB_TO_FW_MAPPING_KEY_PUB : DEFAULT_IAB_TO_FW_MAPPING_KEY;
@@ -63,7 +63,7 @@ export const getAdserverCategoryHook = timedBidResponseHook('categoryTranslation
       logError('Translation mapping data not found in local storage');
     }
   }
-  fn.call(this, adUnitCode, bid);
+  fn.call(this, adUnitCode, bid, reject);
 });
 
 export function initTranslation(url, localStorageKey) {

--- a/modules/currency.js
+++ b/modules/currency.js
@@ -181,9 +181,9 @@ function resetCurrency() {
   bidderCurrencyDefault = {};
 }
 
-export const addBidResponseHook = timedBidResponseHook('currency', function addBidResponseHook(fn, adUnitCode, bid) {
+export const addBidResponseHook = timedBidResponseHook('currency', function addBidResponseHook(fn, adUnitCode, bid, reject) {
   if (!bid) {
-    return fn.call(this, adUnitCode); // if no bid, call original and let it display warnings
+    return fn.call(this, adUnitCode, bid, reject); // if no bid, call original and let it display warnings
   }
 
   let bidder = bid.bidderCode || bid.bidder;
@@ -209,10 +209,10 @@ export const addBidResponseHook = timedBidResponseHook('currency', function addB
 
   // execute immediately if the bid is already in the desired currency
   if (bid.currency === adServerCurrency) {
-    return fn.call(this, adUnitCode, bid);
+    return fn.call(this, adUnitCode, bid, reject);
   }
 
-  bidResponseQueue.push(wrapFunction(fn, this, [adUnitCode, bid]));
+  bidResponseQueue.push(wrapFunction(fn, this, [adUnitCode, bid, reject]));
   if (!currencySupportEnabled || currencyRatesLoaded) {
     processBidResponseQueue();
   } else {
@@ -239,7 +239,8 @@ function wrapFunction(fn, context, params) {
         }
       } catch (e) {
         logWarn('Returning NO_BID, getCurrencyConversion threw error: ', e);
-        params[1] = createBid(CONSTANTS.STATUS.NO_BID, bid.getIdentifiers());
+        // TODO: in v8, this should not continue with a "NO_BID"
+        params[1] = params[2](CONSTANTS.REJECTION_REASON.CANNOT_CONVERT_CURRENCY);
       }
     }
     return fn.apply(context, params);

--- a/modules/currency.js
+++ b/modules/currency.js
@@ -1,10 +1,9 @@
-import { logInfo, logWarn, logError, logMessage } from '../src/utils.js';
-import { getGlobal } from '../src/prebidGlobal.js';
-import { createBid } from '../src/bidfactory.js';
+import {logError, logInfo, logMessage, logWarn} from '../src/utils.js';
+import {getGlobal} from '../src/prebidGlobal.js';
 import CONSTANTS from '../src/constants.json';
-import { ajax } from '../src/ajax.js';
-import { config } from '../src/config.js';
-import { getHook } from '../src/hook.js';
+import {ajax} from '../src/ajax.js';
+import {config} from '../src/config.js';
+import {getHook} from '../src/hook.js';
 import {defer} from '../src/utils/promise.js';
 import {timedBidResponseHook} from '../src/utils/perfMetrics.js';
 

--- a/modules/dchain.js
+++ b/modules/dchain.js
@@ -109,7 +109,7 @@ function isValidDchain(bid) {
   }
 }
 
-export const addBidResponseHook = timedBidResponseHook('dchain', function addBidResponseHook(fn, adUnitCode, bid) {
+export const addBidResponseHook = timedBidResponseHook('dchain', function addBidResponseHook(fn, adUnitCode, bid, reject) {
   const basicDchain = {
     ver: '1.0',
     complete: 0,
@@ -140,7 +140,7 @@ export const addBidResponseHook = timedBidResponseHook('dchain', function addBid
     bid.meta.dchain = basicDchain;
   }
 
-  fn(adUnitCode, bid);
+  fn(adUnitCode, bid,  reject);
 });
 
 export function init() {

--- a/modules/dchain.js
+++ b/modules/dchain.js
@@ -140,7 +140,7 @@ export const addBidResponseHook = timedBidResponseHook('dchain', function addBid
     bid.meta.dchain = basicDchain;
   }
 
-  fn(adUnitCode, bid,  reject);
+  fn(adUnitCode, bid, reject);
 });
 
 export function init() {

--- a/modules/debugging/legacy.js
+++ b/modules/debugging/legacy.js
@@ -54,7 +54,7 @@ export function applyBidOverrides(overrideObj, bidObj, bidType, logger) {
   }, bidObj);
 }
 
-export function addBidResponseHook(next, adUnitCode, bid) {
+export function addBidResponseHook(next, adUnitCode, bid, reject) {
   const {overrides, logger} = this;
 
   if (bidderExcluded(overrides.bidders, bid.bidderCode)) {
@@ -70,7 +70,7 @@ export function addBidResponseHook(next, adUnitCode, bid) {
     });
   }
 
-  next(adUnitCode, bid);
+  next(adUnitCode, bid, reject);
 }
 
 export function addBidderRequestsHook(next, bidderRequests) {

--- a/modules/mass.js
+++ b/modules/mass.js
@@ -78,7 +78,7 @@ export function updateRenderers() {
 /**
  * Before hook for 'addBidResponse'.
  */
-export const addBidResponseHook = timedBidResponseHook('mass', function addBidResponseHook(next, adUnitCode, bid, {index = auctionManager.index} = {}) {
+export const addBidResponseHook = timedBidResponseHook('mass', function addBidResponseHook(next, adUnitCode, bid, reject, {index = auctionManager.index} = {}) {
   let renderer;
   for (let i = 0; i < renderers.length; i++) {
     if (renderers[i].match(bid)) {

--- a/modules/mass.js
+++ b/modules/mass.js
@@ -104,7 +104,7 @@ export const addBidResponseHook = timedBidResponseHook('mass', function addBidRe
     addListenerOnce();
   }
 
-  next(adUnitCode, bid);
+  next(adUnitCode, bid, reject);
 });
 
 /**

--- a/modules/multibid/index.js
+++ b/modules/multibid/index.js
@@ -99,7 +99,7 @@ export function adjustBidderRequestsHook(fn, bidderRequests) {
    * @param {String} ad unit code for bid
    * @param {Object} bid object
 */
-export const addBidResponseHook = timedBidResponseHook('multibid', function addBidResponseHook(fn, adUnitCode, bid) {
+export const addBidResponseHook = timedBidResponseHook('multibid', function addBidResponseHook(fn, adUnitCode, bid, reject) {
   let floor = deepAccess(bid, 'floorData.floorValue');
 
   if (!config.getConfig('multibid')) resetMultiConfig();
@@ -107,7 +107,7 @@ export const addBidResponseHook = timedBidResponseHook('multibid', function addB
   // Else checks if multiconfig exists and bid bidderCode exists within config
   // Else continue with no modifications
   if (hasMultibid && multiConfig[bid.bidderCode] && deepAccess(bid, 'video.context') === 'adpod') {
-    fn.call(this, adUnitCode, bid);
+    fn.call(this, adUnitCode, bid, reject);
   } else if (hasMultibid && multiConfig[bid.bidderCode]) {
     // Set property multibidPrefix on bid
     if (multiConfig[bid.bidderCode].prefix) bid.multibidPrefix = multiConfig[bid.bidderCode].prefix;
@@ -127,7 +127,7 @@ export const addBidResponseHook = timedBidResponseHook('multibid', function addB
         if (multiConfig[bid.bidderCode].prefix) bid.targetingBidder = multiConfig[bid.bidderCode].prefix + length;
         if (length === multiConfig[bid.bidderCode].maxbids) multibidUnits[adUnitCode][bid.bidderCode].maxReached = true;
 
-        fn.call(this, adUnitCode, bid);
+        fn.call(this, adUnitCode, bid, reject);
       } else {
         logWarn(`Filtering multibid received from bidder ${bid.bidderCode}: ` + ((multibidUnits[adUnitCode][bid.bidderCode].maxReached) ? `Maximum bid limit reached for ad unit code ${adUnitCode}` : 'Bid cpm under floors value.'));
       }
@@ -137,10 +137,10 @@ export const addBidResponseHook = timedBidResponseHook('multibid', function addB
       deepSetValue(multibidUnits, [adUnitCode, bid.bidderCode], {ads: [bid]});
       if (multibidUnits[adUnitCode][bid.bidderCode].ads.length === multiConfig[bid.bidderCode].maxbids) multibidUnits[adUnitCode][bid.bidderCode].maxReached = true;
 
-      fn.call(this, adUnitCode, bid);
+      fn.call(this, adUnitCode, bid, reject);
     }
   } else {
-    fn.call(this, adUnitCode, bid);
+    fn.call(this, adUnitCode, bid, reject);
   }
 });
 

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -933,6 +933,7 @@ Object.assign(ORTB2.prototype, {
             transactionId: this.adUnitsByImp[bid.impid].transactionId,
             auctionId: this.auctionId,
           });
+          bidObject.requestBidder = bidRequest?.bidder;
           bidObject.requestTimestamp = this.requestTimestamp;
           bidObject.cpm = cpm;
           if (bid?.ext?.prebid?.meta?.adaptercode) {
@@ -1123,8 +1124,7 @@ export function PrebidServer() {
         onBid: function ({adUnit, bid}) {
           const metrics = bid.metrics = s2sBidRequest.metrics.fork().renameWith();
           metrics.checkpoint('addBidResponse');
-
-          if (bid.requestId == null && !s2sBidRequest.s2sConfig.allowUnknownBidderCodes) {
+          if ((bid.requestId == null || bid.requestBidder == null) && !s2sBidRequest.s2sConfig.allowUnknownBidderCodes) {
             logWarn(`PBS adapter received bid from unknown bidder (${bid.bidder}), but 's2sConfig.allowUnknownBidderCodes' is not set. Ignoring bid.`);
             addBidResponse.reject(adUnit, bid, CONSTANTS.REJECTION_REASON.BIDDER_DISALLOWED);
           } else {

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -1129,6 +1129,8 @@ export function PrebidServer() {
           metrics.checkpoint('addBidResponse');
           if (metrics.measureTime('addBidResponse.validate', () => isValid(adUnit, bid))) {
             addBidResponse(adUnit, bid);
+          } else {
+            addBidResponse.reject(adUnit, bid, CONSTANTS.REJECTION_REASON.INVALID);
           }
         }
       })

--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -698,7 +698,7 @@ export const addBidResponseHook = timedBidResponseHook('priceFloors', function a
   let floorData = _floorDataForAuction[bid.auctionId];
   // if no floor data then bail
   if (!floorData || !bid || floorData.skipped) {
-    return fn.call(this, adUnitCode, bid);
+    return fn.call(this, adUnitCode, bid, reject);
   }
 
   const matchingBidRequest = auctionManager.index.getBidRequest(bid);
@@ -708,7 +708,7 @@ export const addBidResponseHook = timedBidResponseHook('priceFloors', function a
 
   if (!floorInfo.matchingFloor) {
     logWarn(`${MODULE_NAME}: unable to determine a matching price floor for bidResponse`, bid);
-    return fn.call(this, adUnitCode, bid);
+    return fn.call(this, adUnitCode, bid, reject);
   }
 
   // determine the base cpm to use based on if the currency matches the floor currency
@@ -724,7 +724,7 @@ export const addBidResponseHook = timedBidResponseHook('priceFloors', function a
       adjustedCpm = getGlobal().convertCurrency(bid.cpm, bidResponseCurrency.toUpperCase(), floorCurrency);
     } catch (err) {
       logError(`${MODULE_NAME}: Unable do get currency conversion for bidResponse to Floor Currency. Do you have Currency module enabled? ${bid}`);
-      return fn.call(this, adUnitCode, bid);
+      return fn.call(this, adUnitCode, bid, reject);
     }
   }
 
@@ -742,7 +742,7 @@ export const addBidResponseHook = timedBidResponseHook('priceFloors', function a
     logWarn(`${MODULE_NAME}: ${flooredBid.bidderCode}'s Bid Response for ${adUnitCode} was rejected due to floor not met (adjusted cpm: ${bid?.floorData?.cpmAfterAdjustments}, floor: ${floorInfo?.matchingFloor})`, bid);
     return fn.call(this, adUnitCode, flooredBid, reject);
   }
-  return fn.call(this, adUnitCode, bid);
+  return fn.call(this, adUnitCode, bid, reject);
 });
 
 config.getConfig('floors', config => handleSetFloorsConfig(config.floors));

--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -20,7 +20,6 @@ import {ajaxBuilder} from '../src/ajax.js';
 import * as events from '../src/events.js';
 import CONSTANTS from '../src/constants.json';
 import {getHook} from '../src/hook.js';
-import {createBid} from '../src/bidfactory.js';
 import {find} from '../src/polyfill.js';
 import {getRefererInfo} from '../src/refererDetection.js';
 import {bidderSettings} from '../src/bidderSettings.js';

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -202,6 +202,8 @@ export function newBidder(spec) {
         adUnitCodesHandled[adUnitCode] = true;
         if (metrics.measureTime('addBidResponse.validate', () => isValid(adUnitCode, bid))) {
           addBidResponse(adUnitCode, bid);
+        } else {
+          addBidResponse.reject(adUnitCode, bid, 'Bid is invalid')
         }
       }
 
@@ -261,7 +263,9 @@ export function newBidder(spec) {
           if (bidRequest) {
             bid.adapterCode = bidRequest.bidder;
             if (isInvalidAlternateBidder(bid.bidderCode, bidRequest.bidder)) {
-              logWarn(`${bid.bidderCode} is not a registered partner or known bidder of ${bidRequest.bidder}, hence continuing without bid. If you wish to support this bidder, please mark allowAlternateBidderCodes as true in bidderSettings.`);
+              const rejectionReason = `${bid.bidderCode} is not a registered partner or known bidder of ${bidRequest.bidder}`;
+              logWarn(`${rejectionReason}, hence continuing without bid. If you wish to support this bidder, please mark allowAlternateBidderCodes as true in bidderSettings.`);
+              addBidResponse.reject(bidRequest.adUnitCode, bid, rejectionReason)
               return;
             }
             // creating a copy of original values as cpm and currency are modified later
@@ -272,6 +276,7 @@ export function newBidder(spec) {
             addBidWithCode(bidRequest.adUnitCode, prebidBid);
           } else {
             logWarn(`Bidder ${spec.code} made bid for unknown request ID: ${bid.requestId}. Ignoring.`);
+            addBidResponse.reject(null, bid, 'Invalid request ID');
           }
         },
         onCompletion: afterAllResponses,

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -203,7 +203,7 @@ export function newBidder(spec) {
         if (metrics.measureTime('addBidResponse.validate', () => isValid(adUnitCode, bid))) {
           addBidResponse(adUnitCode, bid);
         } else {
-          addBidResponse.reject(adUnitCode, bid, 'Bid is invalid')
+          addBidResponse.reject(adUnitCode, bid, CONSTANTS.REJECTION_REASON.INVALID)
         }
       }
 
@@ -263,9 +263,8 @@ export function newBidder(spec) {
           if (bidRequest) {
             bid.adapterCode = bidRequest.bidder;
             if (isInvalidAlternateBidder(bid.bidderCode, bidRequest.bidder)) {
-              const rejectionReason = `${bid.bidderCode} is not a registered partner or known bidder of ${bidRequest.bidder}`;
-              logWarn(`${rejectionReason}, hence continuing without bid. If you wish to support this bidder, please mark allowAlternateBidderCodes as true in bidderSettings.`);
-              addBidResponse.reject(bidRequest.adUnitCode, bid, rejectionReason)
+              logWarn(`${bid.bidderCode} is not a registered partner or known bidder of ${bidRequest.bidder}, hence continuing without bid. If you wish to support this bidder, please mark allowAlternateBidderCodes as true in bidderSettings.`);
+              addBidResponse.reject(bidRequest.adUnitCode, bid, CONSTANTS.REJECTION_REASON.DISALLOWED_ALTERNATE)
               return;
             }
             // creating a copy of original values as cpm and currency are modified later
@@ -276,7 +275,7 @@ export function newBidder(spec) {
             addBidWithCode(bidRequest.adUnitCode, prebidBid);
           } else {
             logWarn(`Bidder ${spec.code} made bid for unknown request ID: ${bid.requestId}. Ignoring.`);
-            addBidResponse.reject(null, bid, 'Invalid request ID');
+            addBidResponse.reject(null, bid, CONSTANTS.REJECTION_REASON.INVALID_REQUEST_ID);
           }
         },
         onCompletion: afterAllResponses,

--- a/src/auction.js
+++ b/src/auction.js
@@ -58,22 +58,36 @@
  */
 
 import {
-  flatten, timestamp, adUnitsFilter, deepAccess, getValue, parseUrl, generateUUID,
-  logMessage, bind, logError, logInfo, logWarn, isEmpty, _each, isFn, isEmptyStr, pick
+  _each,
+  adUnitsFilter,
+  bind,
+  deepAccess,
+  flatten,
+  generateUUID,
+  getValue,
+  isEmpty,
+  isEmptyStr,
+  isFn,
+  logError,
+  logInfo,
+  logMessage,
+  logWarn,
+  parseUrl,
+  timestamp
 } from './utils.js';
-import { getPriceBucketString } from './cpmBucketManager.js';
-import { getNativeTargeting } from './native.js';
-import { getCacheUrl, store } from './videoCache.js';
-import { Renderer } from './Renderer.js';
-import { config } from './config.js';
-import { userSync } from './userSync.js';
-import { hook } from './hook.js';
+import {getPriceBucketString} from './cpmBucketManager.js';
+import {getNativeTargeting} from './native.js';
+import {getCacheUrl, store} from './videoCache.js';
+import {Renderer} from './Renderer.js';
+import {config} from './config.js';
+import {userSync} from './userSync.js';
+import {hook} from './hook.js';
 import {find, includes} from './polyfill.js';
-import { OUTSTREAM } from './video.js';
-import { VIDEO } from './mediaTypes.js';
+import {OUTSTREAM} from './video.js';
+import {VIDEO} from './mediaTypes.js';
 import {auctionManager} from './auctionManager.js';
 import {bidderSettings} from './bidderSettings.js';
-import * as events from './events.js'
+import * as events from './events.js';
 import adapterManager from './adapterManager.js';
 import CONSTANTS from './constants.json';
 import {GreedyPromise} from './utils/promise.js';
@@ -645,7 +659,6 @@ const batchAndStore = batchingCache();
 export const callPrebidCache = hook('async', function(auctionInstance, bidResponse, afterBidAdded, videoMediaType) {
   batchAndStore(auctionInstance, bidResponse, afterBidAdded);
 }, 'callPrebidCache');
-
 
 /**
  * Augment `bidResponse` with properties that are common across all bids - including rejected bids.

--- a/src/auction.js
+++ b/src/auction.js
@@ -466,6 +466,7 @@ export function auctionCallbacks(auctionDone, auctionInstance, {index = auctionM
       noBid.cpm = 0;
 
       bid.rejectionReason = reason;
+      logWarn(`Bid from ${bid.bidder || 'unknown bidder'} was rejected: ${reason}`, bid)
       events.emit(CONSTANTS.EVENTS.BID_REJECTED, bid);
       auctionInstance.addBidRejected(bid);
       done();

--- a/src/constants.json
+++ b/src/constants.json
@@ -123,7 +123,8 @@
   "REJECTION_REASON": {
     "INVALID": "Bid has missing or invalid properties",
     "INVALID_REQUEST_ID": "Invalid request ID",
-    "BIDDER_DISALLOWED": "Bidder code is not allowed by allowedAlternateBidderCodes / allowUnknownBidderCodes"
+    "BIDDER_DISALLOWED": "Bidder code is not allowed by allowedAlternateBidderCodes / allowUnknownBidderCodes",
+    "FLOOR_NOT_MET": "Bid does not meet price floor"
   },
   "PREBID_NATIVE_DATA_KEYS_TO_ORTB": {
     "body": "desc",

--- a/src/constants.json
+++ b/src/constants.json
@@ -29,6 +29,7 @@
     "BID_TIMEOUT": "bidTimeout",
     "BID_REQUESTED": "bidRequested",
     "BID_RESPONSE": "bidResponse",
+    "BID_REJECTED": "bidRejected",
     "NO_BID": "noBid",
     "BID_WON": "bidWon",
     "BIDDER_DONE": "bidderDone",

--- a/src/constants.json
+++ b/src/constants.json
@@ -121,9 +121,9 @@
     "BID_REJECTED": "bidRejected"
   },
   "REJECTION_REASON": {
-    "INVALID": "Bid is invalid",
+    "INVALID": "Bid has missing or invalid properties",
     "INVALID_REQUEST_ID": "Invalid request ID",
-    "BIDDER_DISALLOWED": "Bidder code is not allowed by allowedAlternateBidderCodes"
+    "BIDDER_DISALLOWED": "Bidder code is not allowed by allowedAlternateBidderCodes / allowUnknownBidderCodes"
   },
   "PREBID_NATIVE_DATA_KEYS_TO_ORTB": {
     "body": "desc",

--- a/src/constants.json
+++ b/src/constants.json
@@ -124,7 +124,8 @@
     "INVALID": "Bid has missing or invalid properties",
     "INVALID_REQUEST_ID": "Invalid request ID",
     "BIDDER_DISALLOWED": "Bidder code is not allowed by allowedAlternateBidderCodes / allowUnknownBidderCodes",
-    "FLOOR_NOT_MET": "Bid does not meet price floor"
+    "FLOOR_NOT_MET": "Bid does not meet price floor",
+    "CANNOT_CONVERT_CURRENCY": "Unable to convert currency"
   },
   "PREBID_NATIVE_DATA_KEYS_TO_ORTB": {
     "body": "desc",

--- a/src/constants.json
+++ b/src/constants.json
@@ -120,6 +120,11 @@
     "RENDERED": "rendered",
     "BID_REJECTED": "bidRejected"
   },
+  "REJECTION_REASON": {
+    "INVALID": "Bid is invalid",
+    "INVALID_REQUEST_ID": "Invalid request ID",
+    "BIDDER_DISALLOWED": "Bidder code is not allowed by allowedAlternateBidderCodes"
+  },
   "PREBID_NATIVE_DATA_KEYS_TO_ORTB": {
     "body": "desc",
     "body2": "desc2",

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -36,7 +36,7 @@ import {listenMessagesFromCreative} from './secureCreatives.js';
 import {userSync} from './userSync.js';
 import {config} from './config.js';
 import {auctionManager} from './auctionManager.js';
-import {filters, targeting} from './targeting.js';
+import {filters, isBidUsable, targeting} from './targeting.js';
 import {hook, wrapHook} from './hook.js';
 import {loadSession} from './debugging.js';
 import {includes} from './polyfill.js';
@@ -296,8 +296,7 @@ $$PREBID_GLOBAL$$.getAdserverTargetingForAdUnitCodeStr = function (adunitCode) {
 $$PREBID_GLOBAL$$.getHighestUnusedBidResponseForAdUnitCode = function (adunitCode) {
   if (adunitCode) {
     const bid = auctionManager.getAllBidsForAdUnitCode(adunitCode)
-      .filter(filters.isUnusedBid)
-      .filter(filters.isBidNotExpired)
+      .filter(isBidUsable)
 
     return bid.length ? bid.reduce(getHighestCpm) : {}
   } else {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -36,7 +36,7 @@ import {listenMessagesFromCreative} from './secureCreatives.js';
 import {userSync} from './userSync.js';
 import {config} from './config.js';
 import {auctionManager} from './auctionManager.js';
-import {filters, isBidUsable, targeting} from './targeting.js';
+import {isBidUsable, targeting} from './targeting.js';
 import {hook, wrapHook} from './hook.js';
 import {loadSession} from './debugging.js';
 import {includes} from './polyfill.js';

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -1,15 +1,28 @@
 import {
-  uniques, isGptPubadsDefined, getHighestCpm, getOldestHighestCpmBid, groupBy, isAdUnitCodeMatchingSlot, timestamp,
-  deepAccess, deepClone, logError, logWarn, logInfo, isFn, isArray, logMessage, isStr,
+  deepAccess,
+  deepClone,
+  getHighestCpm,
+  getOldestHighestCpmBid,
+  groupBy,
+  isAdUnitCodeMatchingSlot,
+  isArray,
+  isFn,
+  isGptPubadsDefined,
+  isStr,
+  logError,
+  logInfo,
+  logMessage,
+  logWarn,
+  timestamp,
+  uniques,
 } from './utils.js';
-import { config } from './config.js';
-import { NATIVE_TARGETING_KEYS } from './native.js';
-import { auctionManager } from './auctionManager.js';
-import { sizeSupported } from './sizeMapping.js';
-import { ADPOD } from './mediaTypes.js';
-import { hook } from './hook.js';
-import { bidderSettings } from './bidderSettings.js';
-import {includes, find} from './polyfill.js';
+import {config} from './config.js';
+import {NATIVE_TARGETING_KEYS} from './native.js';
+import {auctionManager} from './auctionManager.js';
+import {ADPOD} from './mediaTypes.js';
+import {hook} from './hook.js';
+import {bidderSettings} from './bidderSettings.js';
+import {find, includes} from './polyfill.js';
 import CONSTANTS from './constants.json';
 
 var pbTargetingKeys = [];

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -1,5 +1,6 @@
 // jscs:disable
 import CONSTANTS from 'src/constants.json';
+import {createBid} from '../../src/bidfactory.js';
 const utils = require('src/utils.js');
 
 function convertTargetingsFromOldToNew(targetings) {
@@ -1268,7 +1269,7 @@ export function createBidReceived({bidder, cpm, auctionId, responseTimestamp, ad
   if (typeof status !== 'undefined') {
     bid.status = status;
   }
-  return bid;
+  return Object.assign(createBid(CONSTANTS.STATUS.GOOD), bid);
 }
 
 export function getServerTestingsAds() {

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -21,6 +21,7 @@ import {auctionManager} from '../../src/auctionManager.js';
 import 'modules/debugging/index.js' // some tests look for debugging side effects
 import {AuctionIndex} from '../../src/auctionIndex.js';
 import {expect} from 'chai';
+import {deepClone} from '../../src/utils.js';
 
 var assert = require('assert');
 
@@ -57,7 +58,16 @@ function mockBid(opts) {
     'currency': 'USD',
     'netRevenue': true,
     'ttl': 360,
-    getSize: () => '300x250'
+    getSize: () => '300x250',
+    getIdentifiers() {
+      return {
+        src: this.source,
+        bidder: this.bidderCode,
+        bidId: this.requestId,
+        transactionId: this.transactionId,
+        auctionId: this.auctionId
+      }
+    }
   };
 }
 
@@ -1323,6 +1333,7 @@ describe('auctionmanager.js', function () {
       getAdUnits: () => getBidRequests().flatMap(br => br.bids).map(br => ({ code: br.adUnitCode, transactionId: br.transactionId, mediaTypes: br.mediaTypes })),
       getAuctionId: () => '1',
       addBidReceived: () => true,
+      addBidRejected: () => true,
       getTimeout: () => 1000,
       getAuctionStart: () => start,
     }
@@ -1382,26 +1393,31 @@ describe('auctionmanager.js', function () {
       bidRequests = null;
     });
 
-    it('should call auction done after bid is added to auction for mediaType banner', function () {
-      let ADUNIT_CODE2 = 'adUnitCode2';
-      let BIDDER_CODE2 = 'sampleBidder2';
+    Object.entries({
+      'added to': 'addBidResponse',
+      'rejected from': 'rejectBidResponse'
+    }).forEach(([t, method]) => {
+      it(`should call auction done after bid is ${t} auction for mediaType banner`, function () {
+        let ADUNIT_CODE2 = 'adUnitCode2';
+        let BIDDER_CODE2 = 'sampleBidder2';
 
-      let bids1 = [mockBid({ bidderCode: BIDDER_CODE1, transactionId: ADUNIT_CODE1 })];
-      let bids2 = [mockBid({ bidderCode: BIDDER_CODE2, transactionId: ADUNIT_CODE2 })];
-      bidRequests = [
-        mockBidRequest(bids[0]),
-        mockBidRequest(bids1[0], { adUnitCode: ADUNIT_CODE1 }),
-        mockBidRequest(bids2[0], { adUnitCode: ADUNIT_CODE2 })
-      ];
-      let cbs = auctionCallbacks(doneSpy, auction);
-      cbs.addBidResponse.call(bidRequests[0], ADUNIT_CODE, bids[0]);
-      cbs.adapterDone.call(bidRequests[0]);
-      cbs.addBidResponse.call(bidRequests[1], ADUNIT_CODE1, bids1[0]);
-      cbs.adapterDone.call(bidRequests[1]);
-      cbs.addBidResponse.call(bidRequests[2], ADUNIT_CODE2, bids2[0]);
-      cbs.adapterDone.call(bidRequests[2]);
-      assert.equal(doneSpy.callCount, 1);
-    });
+        let bids1 = [mockBid({ bidderCode: BIDDER_CODE1, transactionId: ADUNIT_CODE1 })];
+        let bids2 = [mockBid({ bidderCode: BIDDER_CODE2, transactionId: ADUNIT_CODE2 })];
+        bidRequests = [
+          mockBidRequest(bids[0]),
+          mockBidRequest(bids1[0], { adUnitCode: ADUNIT_CODE1 }),
+          mockBidRequest(bids2[0], { adUnitCode: ADUNIT_CODE2 })
+        ];
+        let cbs = auctionCallbacks(doneSpy, auction);
+        cbs[method](ADUNIT_CODE, bids[0]);
+        cbs.adapterDone.call(bidRequests[0]);
+        cbs[method](ADUNIT_CODE1, bids1[0]);
+        cbs.adapterDone.call(bidRequests[1]);
+        cbs[method](ADUNIT_CODE2, bids2[0]);
+        cbs.adapterDone.call(bidRequests[2]);
+        assert.equal(doneSpy.callCount, 1);
+      });
+    })
 
     it('should call auction done after prebid cache is complete for mediaType video', function() {
       bids[0].mediaType = 'video';
@@ -1543,6 +1559,75 @@ describe('auctionmanager.js', function () {
         });
       })
     });
+
+    describe('when bids are rejected', () => {
+      let cbs, bid, expectedRejection;
+      const onBidRejected = sinon.stub();
+      const REJECTION_REASON = 'Bid rejected';
+      const AU_CODE = 'au';
+
+      function rejectHook(fn, adUnitCode, bid, reject) {
+        reject(REJECTION_REASON);
+      }
+
+      before(() => {
+        addBidResponse.before(rejectHook, 999);
+        events.on(CONSTANTS.EVENTS.BID_REJECTED, onBidRejected);
+      });
+
+      after(() => {
+        addBidResponse.getHooks({hook: rejectHook}).remove();
+        events.off(CONSTANTS.EVENTS.BID_REJECTED, onBidRejected);
+      });
+
+      beforeEach(() => {
+        onBidRejected.reset();
+        bid = mockBid({bidderCode: BIDDER_CODE});
+        bidRequests = [
+          mockBidRequest(bid),
+        ];
+        cbs = auctionCallbacks(doneSpy, auction);
+        expectedRejection = sinon.match(Object.assign({}, bid, {
+          rejectionReason: REJECTION_REASON,
+          adUnitCode: AU_CODE
+        }));
+      });
+
+      Object.entries({
+        'through rejectBidResponse': () => cbs.rejectBidResponse(AU_CODE, deepClone(bid), REJECTION_REASON),
+        'from addBidResponse hooks': () => cbs.addBidResponse(AU_CODE, deepClone(bid))
+      }).forEach(([t, rejectBid]) => {
+        describe(t, () => {
+          it('should emit a BID_REJECTED event', () => {
+            rejectBid();
+            sinon.assert.calledWith(onBidRejected, expectedRejection);
+          });
+
+          it('should pass bid to auction.addBidRejected', () => {
+            auction.addBidRejected = sinon.stub();
+            rejectBid();
+            sinon.assert.calledWith(auction.addBidRejected, expectedRejection);
+          });
+
+          it('should add a NO_BID bid to the auction', () => {
+            auction.addBidReceived = sinon.stub();
+            rejectBid();
+            const noBid = auction.addBidReceived.args[0][0];
+            sinon.assert.match(noBid, {
+              cpm: 0,
+              ad: undefined,
+              adUrl: undefined,
+              vastUrl: undefined,
+              vastXml: undefined,
+              requestId: bid.requestId,
+              auctionId: bid.auctionId,
+              adUnitCode: AU_CODE,
+              rejectionReason: undefined,
+            })
+          });
+        })
+      })
+    })
   });
 
   describe('auctionOptions', function() {

--- a/test/spec/modules/currency_spec.js
+++ b/test/spec/modules/currency_spec.js
@@ -351,6 +351,11 @@ describe('currency', function () {
   });
 
   describe('currency.addBidResponseDecorator', function () {
+    let reject;
+    beforeEach(() => {
+      reject = sinon.stub().returns({status: 'rejected'});
+    });
+
     it('should leave bid at 1 when currency support is not enabled and fromCurrency is USD', function () {
       setConfig({});
       var bid = makeBid({ 'cpm': 1, 'currency': 'USD' });
@@ -368,8 +373,9 @@ describe('currency', function () {
       var innerBid;
       addBidResponseHook(function(adCodeId, bid) {
         innerBid = bid;
-      }, 'elementId', bid);
-      expect(innerBid.statusMessage).to.equal('Bid returned empty or error response');
+      }, 'elementId', bid, reject);
+      expect(innerBid.status).to.equal('rejected');
+      expect(reject.calledOnce).to.be.true;
     });
 
     it('should not buffer bid when currency is already in desired currency', function () {
@@ -395,8 +401,9 @@ describe('currency', function () {
       var innerBid;
       addBidResponseHook(function(adCodeId, bid) {
         innerBid = bid;
-      }, 'elementId', bid);
-      expect(innerBid.statusMessage).to.equal('Bid returned empty or error response');
+      }, 'elementId', bid, reject);
+      expect(innerBid.status).to.equal('rejected');
+      expect(reject.calledOnce).to.be.true;
     });
 
     it('should result in NO_BID when adServerCurrency is not supported in file', function () {
@@ -407,8 +414,9 @@ describe('currency', function () {
       var innerBid;
       addBidResponseHook(function(adCodeId, bid) {
         innerBid = bid;
-      }, 'elementId', bid);
-      expect(innerBid.statusMessage).to.equal('Bid returned empty or error response');
+      }, 'elementId', bid, reject);
+      expect(innerBid.status).to.equal('rejected');
+      expect(reject.calledOnce).to.be.true;
     });
 
     it('should return 1 when currency support is enabled and same currency code is requested as is set to adServerCurrency', function () {

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -1665,7 +1665,7 @@ describe('the price floors module', function () {
   });
   describe('bidResponseHook tests', function () {
     const AUCTION_ID = '123456';
-    let returnedBidResponse, indexStub;
+    let returnedBidResponse, indexStub, reject;
     let adUnit = {
       transactionId: 'au',
       code: 'test_div_1'
@@ -1681,6 +1681,7 @@ describe('the price floors module', function () {
     };
     beforeEach(function () {
       returnedBidResponse = {};
+      reject = sinon.stub().returns({status: CONSTANTS.BID_STATUS.BID_REJECTED});
       indexStub = sinon.stub(auctionManager, 'index');
       indexStub.get(() => stubAuctionIndex({adUnits: [adUnit]}));
     });
@@ -1693,7 +1694,7 @@ describe('the price floors module', function () {
       let next = (adUnitCode, bid) => {
         returnedBidResponse = bid;
       };
-      addBidResponseHook(next, bidResp.adUnitCode, Object.assign(createBid(CONSTANTS.STATUS.GOOD, {auctionId: AUCTION_ID}), bidResp));
+      addBidResponseHook(next, bidResp.adUnitCode, Object.assign(createBid(CONSTANTS.STATUS.GOOD, {auctionId: AUCTION_ID}), bidResp), reject);
     };
     it('continues with the auction if not floors data is present without any flooring', function () {
       runBidResponse();
@@ -1710,9 +1711,8 @@ describe('the price floors module', function () {
       _floorDataForAuction[AUCTION_ID] = utils.deepClone(basicFloorConfig);
       _floorDataForAuction[AUCTION_ID].data.values = { 'banner': 1.0 };
       runBidResponse();
-      expect(returnedBidResponse).to.haveOwnProperty('floorData');
+      expect(reject.calledOnce).to.be.true;
       expect(returnedBidResponse.status).to.equal(CONSTANTS.BID_STATUS.BID_REJECTED);
-      expect(returnedBidResponse.cpm).to.equal(0);
     });
     it('if it finds a rule and does not floor should update the bid accordingly', function () {
       _floorDataForAuction[AUCTION_ID] = utils.deepClone(basicFloorConfig);

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -1681,7 +1681,7 @@ describe('the price floors module', function () {
     };
     beforeEach(function () {
       returnedBidResponse = {};
-      reject = sinon.stub().returns({status: CONSTANTS.BID_STATUS.BID_REJECTED});
+      reject = sinon.stub().returns({status: 'rejected'});
       indexStub = sinon.stub(auctionManager, 'index');
       indexStub.get(() => stubAuctionIndex({adUnits: [adUnit]}));
     });
@@ -1712,7 +1712,7 @@ describe('the price floors module', function () {
       _floorDataForAuction[AUCTION_ID].data.values = { 'banner': 1.0 };
       runBidResponse();
       expect(reject.calledOnce).to.be.true;
-      expect(returnedBidResponse.status).to.equal(CONSTANTS.BID_STATUS.BID_REJECTED);
+      expect(returnedBidResponse.status).to.equal('rejected');
     });
     it('if it finds a rule and does not floor should update the bid accordingly', function () {
       _floorDataForAuction[AUCTION_ID] = utils.deepClone(basicFloorConfig);

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -62,6 +62,7 @@ describe('bidders created by newBidder', function () {
     };
 
     addBidResponseStub = sinon.stub();
+    addBidResponseStub.reject = sinon.stub();
     doneStub = sinon.stub();
   });
 
@@ -508,7 +509,7 @@ describe('bidders created by newBidder', function () {
       expect(userSyncStub.firstCall.args[2]).to.equal('usersync.com');
     });
 
-    it('should logError when required bid response params are missing', function () {
+    it('should logError and reject bid when required bid response params are missing', function () {
       const bidder = newBidder(spec);
 
       const bid = {
@@ -532,9 +533,10 @@ describe('bidders created by newBidder', function () {
       bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(logErrorSpy.calledOnce).to.equal(true);
+      expect(addBidResponseStub.reject.calledOnce).to.be.true;
     });
 
-    it('should logError when required bid response params are undefined', function () {
+    it('should logError and reject bid when required response params are undefined', function () {
       const bidder = newBidder(spec);
 
       const bid = {
@@ -562,6 +564,7 @@ describe('bidders created by newBidder', function () {
       bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(logErrorSpy.calledOnce).to.equal(true);
+      expect(addBidResponseStub.reject.calledOnce).to.be.true;
     });
 
     it('should require requestId from interpretResponse', () => {
@@ -586,6 +589,7 @@ describe('bidders created by newBidder', function () {
       bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
       expect(addBidResponseStub.called).to.be.false;
+      expect(addBidResponseStub.reject.calledOnce).to.be.true;
     });
   });
 
@@ -856,6 +860,7 @@ describe('validate bid response: ', function () {
     });
 
     addBidResponseStub = sinon.stub();
+    addBidResponseStub.reject = sinon.stub();
     doneStub = sinon.stub();
     ajaxStub = sinon.stub(ajax, 'ajax').callsFake(function(url, callbacks) {
       const fakeResponse = sinon.stub();
@@ -954,7 +959,8 @@ describe('validate bid response: ', function () {
       spec.interpretResponse.returns(bids1);
       bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
-      expect(addBidResponseStub.calledOnce).to.equal(false);
+      expect(addBidResponseStub.called).to.equal(false);
+      expect(addBidResponseStub.reject.calledOnce).to.be.true;
       expect(logErrorSpy.calledWithMatch('Ignoring bid: Native bid missing some required properties.')).to.equal(true);
     });
   }
@@ -1074,7 +1080,8 @@ describe('validate bid response: ', function () {
       spec.interpretResponse.returns(bids1);
       bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
-      expect(addBidResponseStub.calledOnce).to.equal(false);
+      expect(addBidResponseStub.called).to.equal(false);
+      expect(addBidResponseStub.reject.calledOnce).to.be.true;
       expect(logWarnSpy.callCount).to.equal(1);
     });
 
@@ -1085,7 +1092,8 @@ describe('validate bid response: ', function () {
       spec.interpretResponse.returns(bids1);
       bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
-      expect(addBidResponseStub.calledOnce).to.equal(false);
+      expect(addBidResponseStub.called).to.equal(false);
+      expect(addBidResponseStub.reject.calledOnce).to.be.true;
     });
 
     it('should log warning when the particular bidder is not specified in allowedAlternateBidderCodes and allowAlternateBidderCodes flag is true', function () {
@@ -1096,7 +1104,8 @@ describe('validate bid response: ', function () {
       spec.interpretResponse.returns(bids1);
       bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
-      expect(addBidResponseStub.calledOnce).to.equal(false);
+      expect(addBidResponseStub.called).to.equal(false);
+      expect(addBidResponseStub.reject.calledOnce).to.be.true;
       expect(logWarnSpy.callCount).to.equal(1);
     });
 
@@ -1147,7 +1156,8 @@ describe('validate bid response: ', function () {
       spec.interpretResponse.returns(bids1);
       bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
-      expect(addBidResponseStub.calledOnce).to.equal(false);
+      expect(addBidResponseStub.called).to.equal(false);
+      expect(addBidResponseStub.reject.calledOnce).to.be.true;
       expect(logWarnSpy.callCount).to.equal(1);
     });
 
@@ -1159,7 +1169,7 @@ describe('validate bid response: ', function () {
       spec.interpretResponse.returns(bids1);
       bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
-      expect(addBidResponseStub.calledOnce).to.equal(true);
+      expect(addBidResponseStub.called).to.equal(true);
       expect(logWarnSpy.callCount).to.equal(0);
       expect(logErrorSpy.callCount).to.equal(0);
     });
@@ -1172,8 +1182,9 @@ describe('validate bid response: ', function () {
       spec.interpretResponse.returns(bids1);
       bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
-      expect(addBidResponseStub.calledOnce).to.equal(false);
+      expect(addBidResponseStub.called).to.equal(false);
       expect(logWarnSpy.callCount).to.equal(1);
+      expect(addBidResponseStub.reject.calledOnce).to.be.true;
     });
 
     it('should not accept the bid, when bidderSetting is missing for the bidder. It should fallback to standard setting and reject the bid', function () {
@@ -1183,7 +1194,8 @@ describe('validate bid response: ', function () {
       spec.interpretResponse.returns(bids1);
       bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
-      expect(addBidResponseStub.calledOnce).to.equal(false);
+      expect(addBidResponseStub.called).to.equal(false);
+      expect(addBidResponseStub.reject.calledOnce).to.be.true;
       expect(logWarnSpy.callCount).to.equal(1);
     });
   });

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -6,8 +6,14 @@ import CONSTANTS from 'src/constants.json';
 import { auctionManager } from 'src/auctionManager.js';
 import * as utils from 'src/utils.js';
 import {deepClone} from 'src/utils.js';
+import {createBid} from '../../../../src/bidfactory.js';
+import {hook} from '../../../../src/hook.js';
 
-const bid1 = {
+function mkBid(bid, status = CONSTANTS.STATUS.GOOD) {
+  return Object.assign(createBid(status), bid);
+}
+
+const sampleBid = {
   'bidderCode': 'rubicon',
   'width': '300',
   'height': '250',
@@ -39,7 +45,9 @@ const bid1 = {
   'ttl': 300
 };
 
-const bid2 = {
+const bid1 = mkBid(sampleBid);
+
+const bid2 = mkBid({
   'bidderCode': 'rubicon',
   'width': '300',
   'height': '250',
@@ -67,9 +75,9 @@ const bid2 = {
   'netRevenue': true,
   'currency': 'USD',
   'ttl': 300
-};
+});
 
-const bid3 = {
+const bid3 = mkBid({
   'bidderCode': 'rubicon',
   'width': '300',
   'height': '600',
@@ -97,9 +105,9 @@ const bid3 = {
   'netRevenue': true,
   'currency': 'USD',
   'ttl': 300
-};
+});
 
-const nativeBid1 = {
+const nativeBid1 = mkBid({
   'bidderCode': 'appnexus',
   'width': 0,
   'height': 0,
@@ -165,8 +173,9 @@ const nativeBid1 = {
     [CONSTANTS.NATIVE_KEYS.image]: 'http://vcdn.adnxs.com/p/creative-image/94/22/cd/0f/9422cd0f-f400-45d3-80f5-2b92629d9257.jpg',
     [CONSTANTS.NATIVE_KEYS.icon]: 'http://vcdn.adnxs.com/p/creative-image/bd/59/a6/c6/bd59a6c6-0851-411d-a16d-031475a51312.png'
   }
-};
-const nativeBid2 = {
+});
+
+const nativeBid2 = mkBid({
   'bidderCode': 'dgads',
   'width': 0,
   'height': 0,
@@ -222,7 +231,7 @@ const nativeBid2 = {
     [CONSTANTS.NATIVE_KEYS.sponsoredBy]: 'test.com',
     [CONSTANTS.NATIVE_KEYS.clickUrl]: 'http://prebid.org/'
   }
-};
+});
 
 describe('targeting tests', function () {
   let sandbox;
@@ -230,6 +239,10 @@ describe('targeting tests', function () {
   let useBidCache;
   let bidCacheFilterFunction;
   let undef;
+
+  before(() => {
+    hook.ready();
+  });
 
   beforeEach(function() {
     sandbox = sinon.sandbox.create();
@@ -285,6 +298,12 @@ describe('targeting tests', function () {
       amBidsReceivedStub.restore();
       amGetAdUnitsStub.restore();
       bidExpiryStub.restore();
+    });
+
+    it('should filter out NO_BID bids', () => {
+      bidsReceived = [mkBid(sampleBid, CONSTANTS.STATUS.NO_BID)];
+      const tg = targetingInstance.getAllTargeting();
+      expect(tg[bidsReceived[0].adUnitCode]).to.eql({});
     });
 
     describe('when handling different adunit targeting value types', function () {

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -200,6 +200,7 @@ describe('Unit: Prebid Module', function () {
     hook.ready();
     $$PREBID_GLOBAL$$.requestBids.getHooks().remove();
     resetDebugging();
+    sinon.stub(filters, 'isActualBid').returns(true); // stub this out so that we can use vanilla objects as bids
   });
 
   beforeEach(function () {
@@ -216,6 +217,7 @@ describe('Unit: Prebid Module', function () {
 
   after(function() {
     auctionManager.clearAllAuctions();
+    filters.isActualBid.restore();
   });
 
   describe('and global adUnits', () => {
@@ -504,8 +506,8 @@ describe('Unit: Prebid Module', function () {
           'client_initiated_ad_counting': true,
           'rtb': {
             'banner': {
-              'width': 728,
-              'height': 90,
+              'width': 300,
+              'height': 250,
               'content': '<!-- Creative -->'
             },
             'trackers': [{


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature

## Description of change

This: 
 - introduces a new `bidRejected` event, emitted when an adapter returns a bid response that core decides should not be used
 - normalizes the "NO_BID" rejections done by priceFloors and currency. Unlike the proposal in https://github.com/prebid/Prebid.js/issues/8956, I decided to _not_ generate these bids outside of those cases, because they don't always work well through the usual bid response flow (for example, sometimes we do not know which bidder it came from, or which adUnit it refers to). 
 - the above means that apart from the new 'bidRejected' event, the current behavior is left unchanged, except that:
 - banner bid responses whose size does not match any of the sizes in the request are now rejected (see https://github.com/prebid/Prebid.js/issues/8887)
 - targeting logic now does not check for bid size, but does exclude NO_BID bids


## Other information

Closes https://github.com/prebid/Prebid.js/issues/8956
Closes https://github.com/prebid/Prebid.js/issues/8887
