### PR TITLE
AdagioBidAdapter: Native multiple js trackers + fix FPD handling 

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -532,7 +532,12 @@ function _parseNativeBidResponse(bid) {
           native.impressionTrackers.push(tracker.url);
           break;
         case 2:
-          native.javascriptTrackers = `<script src=\"${tracker.url}\"></script>`;
+          const script = `<script async src=\"${tracker.url}\"></script>`;
+          if (!native.javascriptTrackers) {
+            native.javascriptTrackers = script;
+          } else {
+            native.javascriptTrackers += `\n${script}`;
+          }
           break;
       }
     });

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -628,7 +628,16 @@ export function setExtraParam(bid, paramName) {
 
   const detected = adgGlobalConf[paramName] || deepAccess(ortb2Conf, `site.ext.data.${paramName}`, null);
   if (detected) {
-    bid.params[paramName] = detected;
+    // First Party Data can be an array.
+    // As we consider that params detected from FPD are fallbacks, we just keep the 1st value.
+    if (Array.isArray(detected)) {
+      if (detected.length) {
+        bid.params[paramName] = detected[0].toString();
+      }
+      return;
+    }
+
+    bid.params[paramName] = detected.toString();
   }
 }
 

--- a/modules/adagioBidAdapter.md
+++ b/modules/adagioBidAdapter.md
@@ -10,7 +10,7 @@ Connects to Adagio demand source to fetch bids.
 
 ## Configuration
 
-Adagio require several params. These params must be set at Prebid.js global config level or at adUnit level.
+Adagio require several params. These params must be set at Prebid.js BidderConfig config level or at adUnit level.
 
 Below, the list of Adagio params and where they can be set.
 
@@ -57,6 +57,16 @@ pbjs.setConfig({
   },
 });
 ```
+
+#### Note on FPD support
+
+Adagio will use FPD data as fallback for the params below:
+- pagetype
+- environment
+- category
+- subcategory
+
+If the FPD value is an array, the 1st value of this array will be used.
 
 ### adUnit configuration
 

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -150,7 +150,9 @@ describe('Adagio bid adapter', () => {
           ext: {
             data: {
               environment: 'desktop',
-              pagetype: 'abc'
+              pagetype: 'abc',
+              category: ['cat1', 'cat2', 'cat3'],
+              subcategory: []
             }
           }
         }
@@ -170,6 +172,12 @@ describe('Adagio bid adapter', () => {
 
       setExtraParam(bid, 'pagetype')
       expect(bid.params.pagetype).to.equal('article');
+
+      setExtraParam(bid, 'category');
+      expect(bid.params.category).to.equal('cat1'); // Only the first value is kept
+
+      setExtraParam(bid, 'subcategory');
+      expect(bid.params.subcategory).to.be.undefined;
     });
 
     it('should use the adUnit param unit if defined', function() {

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -1081,7 +1081,7 @@ describe('Adagio bid adapter', () => {
           impressionTrackers: [
             'https://eventrack.local/impression'
           ],
-          javascriptTrackers: '<script src=\"https://eventrack.local/impression\"></script>',
+          javascriptTrackers: '<script async src=\"https://eventrack.local/impression\"></script>',
           clickTrackers: [
             'https://i.am.a.clicktracker.url'
           ],
@@ -1103,6 +1103,19 @@ describe('Adagio bid adapter', () => {
         expect(r[0].mediaType).to.equal(NATIVE);
         expect(r[0].native).ok;
         expect(r[0].native).to.deep.equal(expected);
+      });
+
+      it('Should handle multiple javascriptTrackers in one single string', () => {
+        const serverResponseWithNativeCopy = utils.deepClone(serverResponseWithNative);
+        serverResponseWithNativeCopy.body.bids[0].admNative.eventtrackers.push(
+          {
+            event: 1,
+            method: 2,
+            url: 'https://eventrack.local/impression-2'
+          },)
+        const r = spec.interpretResponse(serverResponseWithNativeCopy, bidRequestNative);
+        const expected = '<script async src=\"https://eventrack.local/impression\"></script>\n<script async src=\"https://eventrack.local/impression-2\"></script>';
+        expect(r[0].native.javascriptTrackers).to.equal(expected);
       });
     });
   });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change

- Update Native response handling to support multiple js trackers (`native.javascriptTrackers`)
- Fix params auto detection when FPD value is an array 

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Public doc MR: https://github.com/prebid/prebid.github.io/pull/4025