### PR TITLE
Adagio Adapter: set back to the original style after getSlotPosition

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -794,9 +794,10 @@ function getSlotPosition(adUnitElementId) {
 
     if (mustDisplayElement) {
       domElement.style = domElement.style || {};
+      const originalDisplay = domElement.style.display;
       domElement.style.display = 'block';
       box = domElement.getBoundingClientRect();
-      domElement.style.display = elComputedDisplay;
+      domElement.style.display = originalDisplay || null;
     }
     position.x = Math.round(box.left + scrollLeft - clientLeft);
     position.y = Math.round(box.top + scrollTop - clientTop);

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -1265,6 +1265,29 @@ describe('Adagio bid adapter', () => {
       expect(result.dom_loading).to.be.a('String');
       expect(result.user_timestamp).to.be.a('String');
     });
+
+    it('should return `adunit_position` feature when the slot is hidden', function () {
+      const elem = fixtures.getElementById();
+      sandbox.stub(window.top.document, 'getElementById').returns(elem);
+      sandbox.stub(window.top, 'getComputedStyle').returns({ display: 'none' });
+      sandbox.stub(utils, 'inIframe').returns(false);
+
+      const bidRequest = new BidRequestBuilder({
+        mediaTypes: {
+          banner: { sizes: [[300, 250]] },
+        },
+      })
+        .withParams()
+        .build();
+
+      const bidderRequest = new BidderRequestBuilder().build();
+
+      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const result = requests[0].data.adUnits[0].features;
+
+      expect(result.adunit_position).to.match(/^[\d]+x[\d]+$/);
+      expect(elem.style.display).to.equal(null); // set null to reset style
+    });
   });
 
   describe('Adagio features when prebid in Safeframe', function() {


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description of change

The Adagio adapter revert to the previous style of the element itself, rather than computed style.

Details is the issue #9035.

Resolves #9035


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
