### PR TITLE
Nativo Bid Adapter: fix floors bug

### DIFF
--- a/modules/nativoBidAdapter.js
+++ b/modules/nativoBidAdapter.js
@@ -465,8 +465,9 @@ export function parseFloorPriceData(bidRequest) {
     // Setup price floor data per media type
     let mediaTypeData = bidMediaTypes[mediaType]
     let mediaTypeFloorPriceData = {}
+    let mediaTypeSizes = mediaTypeData.sizes || mediaTypeData.playerSize || [];
     // Step through each size of the media type so we can get floor data for each size per media type
-    mediaTypeData.sizes.forEach((size) => {
+    mediaTypeSizes.forEach((size) => {
       // Get floor price data per the getFloor method and respective media type / size combination
       const priceFloorData = bidRequest.getFloor({
         currency: FLOOR_PRICE_CURRENCY,


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Nativo adapter currently looks for sizes on all mediaTypes which throws an error for video as sizes is not defined. Adding a fix to look in both locations and default to an empty array to avoid error.