### PR TITLE
Debugging module: graceful handling of missing sessionStorage

### DIFF
--- a/modules/debugging/debugging.js
+++ b/modules/debugging/debugging.js
@@ -49,9 +49,17 @@ function saveDebuggingConfig(debugConfig, {sessionStorage = window.sessionStorag
   }
 }
 
-export function getConfig(debugging, {sessionStorage = window.sessionStorage, DEBUG_KEY, config, hook, logger} = {}) {
+export function getConfig(debugging, {getStorage = () => window.sessionStorage, DEBUG_KEY, config, hook, logger} = {}) {
   if (debugging == null) return;
-  saveDebuggingConfig(debugging, {sessionStorage, DEBUG_KEY});
+  let sessionStorage;
+  try {
+    sessionStorage = getStorage();
+  } catch (e) {
+    logger.logError(`sessionStorage is not available: debugging configuration will not persist on page reload`, e);
+  }
+  if (sessionStorage != null) {
+    saveDebuggingConfig(debugging, {sessionStorage, DEBUG_KEY});
+  }
   if (!debugging.enabled) {
     disableDebugging({hook, logger});
   } else {

--- a/test/spec/modules/debugging_mod_spec.js
+++ b/test/spec/modules/debugging_mod_spec.js
@@ -273,6 +273,15 @@ describe('bid interceptor', () => {
   });
 });
 
+describe('Debugging config', () => {
+  it('should behave gracefully when sessionStorage throws', () => {
+    const logError = sinon.stub();
+    const getStorage = () => { throw new Error() };
+    getConfig({enabled: false}, {getStorage, logger: {logError}, hook});
+    expect(logError.called).to.be.true;
+  });
+});
+
 describe('bidderBidInterceptor', () => {
   let next, interceptBids, onCompletion, interceptResult, done, addBid;
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fix an issue with the debugging module throwing if `sessionStorage` is not available

Related: https://github.com/prebid/Prebid.js/issues/8934, https://github.com/prebid/Prebid.js/pull/8935
