### PR TITLE
AMX: Ignore empty "adUnitId" parameter

### DIFF
--- a/modules/amxBidAdapter.js
+++ b/modules/amxBidAdapter.js
@@ -147,7 +147,7 @@ function convertRequest(bid) {
   const tid = deepAccess(bid, 'params.tagId');
 
   const au =
-    bid.params != null && typeof bid.params.adUnitId === 'string'
+    bid.params != null && typeof bid.params.adUnitId === 'string' && bid.params.adUnitId !== ''
       ? bid.params.adUnitId
       : bid.adUnitCode;
 

--- a/test/spec/modules/amxBidAdapter_spec.js
+++ b/test/spec/modules/amxBidAdapter_spec.js
@@ -359,6 +359,7 @@ describe('AmxBidAdapter', () => {
             bidId: sampleRequestId + '_2',
             params: {
               ...sampleBidRequestBase.params,
+              adUnitId: '',
               tagId: 'example',
             },
           },
@@ -404,12 +405,12 @@ describe('AmxBidAdapter', () => {
 
     it('can build a video request', () => {
       const { data } = spec.buildRequests(
-        [sampleBidRequestVideo],
+        [{...sampleBidRequestVideo, params: { ...sampleBidRequestVideo.params, adUnitId: 'custom-auid' }}],
         sampleBidderRequest
       );
       expect(Object.keys(data.m).length).to.equal(1);
       expect(data.m[sampleRequestId + '_video']).to.deep.equal({
-        au: 'div-gpt-ad-example',
+        au: 'custom-auid',
         ms: [[[300, 150]], [], [[360, 250]]],
         av: true,
         aw: 360,


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## Description of change

The amxBidAdapter takes an optional "adUnitId" parameter, defaulting to the bid request "adUnitCode". Because some wrappers send an empty string when the publisher intends to send an empty/nonexistent value (e.g. use the default), we should treat the empty string as non-existent/default to adUnitCode.
