### PR TITLE
Prebid core: accept pub-defined transactionId from `ortb2Imp.ext.tid`

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -662,10 +662,10 @@ export const startAuction = hook('async', function ({ bidsBackHandler, timeout: 
 
     const bidders = allBidders.filter(bidder => !s2sBidders.has(bidder));
 
-    adUnit.transactionId = generateUUID();
-
+    const tid = adUnit.ortb2Imp?.ext?.tid || generateUUID();
+    adUnit.transactionId = tid;
     // Populate ortb2Imp.ext.tid with transactionId. Specifying a transaction ID per item in the ortb impression array, lets multiple transaction IDs be transmitted in a single bid request.
-    deepSetValue(adUnit, 'ortb2Imp.ext.tid', adUnit.transactionId)
+    deepSetValue(adUnit, 'ortb2Imp.ext.tid', tid);
 
     bidders.forEach(bidder => {
       const adapter = bidderRegistry[bidder];

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1841,6 +1841,50 @@ describe('Unit: Prebid Module', function () {
           .and.to.match(/[a-f0-9\-]{36}/i);
       });
 
+      describe('transactionId', () => {
+        let adUnit;
+        beforeEach(() => {
+          adUnit = {
+            code: 'adUnit',
+            mediaTypes: {
+              banner: {
+                sizes: [300, 250]
+              }
+            },
+            bids: [
+              {
+                bidder: 'mock-bidder',
+              }
+            ]
+          };
+        });
+        it('should be set to ortb2Imp.ext.tid, if specified', () => {
+          $$PREBID_GLOBAL$$.requestBids({
+            adUnits: [
+              {...adUnit, ortb2Imp: {ext: {tid: 'custom-tid'}}}
+            ]
+          });
+          sinon.assert.match(auctionArgs.adUnits[0], {
+            transactionId: 'custom-tid',
+            ortb2Imp: {
+              ext: {
+                tid: 'custom-tid'
+              }
+            }
+          })
+        });
+        it('should be copied to ortb2Imp.ext.tid, if not specified', () => {
+          $$PREBID_GLOBAL$$.requestBids({
+            adUnits: [
+              adUnit
+            ]
+          });
+          const tid = auctionArgs.adUnits[0].transactionId;
+          expect(tid).to.exist;
+          expect(auctionArgs.adUnits[0].ortb2Imp.ext.tid).to.eql(tid);
+        });
+      });
+
       it('should always set ortb2.ext.tid same as transactionId in adUnits', function () {
         $$PREBID_GLOBAL$$.requestBids({
           adUnits: [


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

This change unifies `adUnit.transactionId` with `adUnit.ortb2Imp.ext.tid`: if the publisher specifies the latter, it will be copied to the former; otherwise both resolve to the same UUID.

## Other information
Addresses https://github.com/prebid/Prebid.js/issues/8807

