### PR TITLE
Multiple bid adapters: use auctionId for `source.tid`

### DIFF
--- a/modules/adfBidAdapter.js
+++ b/modules/adfBidAdapter.js
@@ -93,7 +93,7 @@ export const spec = {
     const adxDomain = setOnAny(validBidRequests, 'params.adxDomain') || 'adx.adform.net';
 
     const pt = setOnAny(validBidRequests, 'params.pt') || setOnAny(validBidRequests, 'params.priceType') || 'net';
-    const tid = validBidRequests[0].transactionId;
+    const tid = bidderRequest.auctionId;
     const test = setOnAny(validBidRequests, 'params.test');
     const currency = getConfig('currency.adServerCurrency');
     const cur = currency && [ currency ];

--- a/modules/adkernelAdnBidAdapter.js
+++ b/modules/adkernelAdnBidAdapter.js
@@ -61,6 +61,7 @@ function buildRequestParams(tags, bidderRequest) {
   let {auctionId, gdprConsent, uspConsent, transactionId, refererInfo} = bidderRequest;
   let req = {
     id: auctionId,
+    // TODO: transactionId is undefined here, should this be auctionId? see #8573
     tid: transactionId,
     site: buildSite(refererInfo),
     imp: tags

--- a/modules/adxcgBidAdapter.js
+++ b/modules/adxcgBidAdapter.js
@@ -98,7 +98,7 @@ export const spec = {
     device.dnt = getDNT() ? 1 : 0;
     device.language = (navigator && navigator.language) ? navigator.language.split('-')[0] : '';
 
-    const tid = validBidRequests[0].transactionId;
+    const tid = bidderRequest.auctionId;
     const test = setOnAny(validBidRequests, 'params.test');
     const currency = getConfig('currency.adServerCurrency');
     const cur = currency && [ currency ];

--- a/modules/dianomiBidAdapter.js
+++ b/modules/dianomiBidAdapter.js
@@ -112,7 +112,7 @@ export const spec = {
       setOnAny(validBidRequests, 'params.pt') ||
       setOnAny(validBidRequests, 'params.priceType') ||
       'net';
-    const tid = validBidRequests[0].transactionId;
+    const tid = bidderRequest.auctionId;
     const currency = getConfig('currency.adServerCurrency');
     const cur = currency && [currency];
     const eids = setOnAny(validBidRequests, 'userIdAsEids');

--- a/modules/finativeBidAdapter.js
+++ b/modules/finativeBidAdapter.js
@@ -63,7 +63,7 @@ export const spec = {
     // convert Native ORTB definition to old-style prebid native definition
     validBidRequests = convertOrtbRequestToProprietaryNative(validBidRequests);
     const pt = setOnAny(validBidRequests, 'params.pt') || setOnAny(validBidRequests, 'params.priceType') || 'net';
-    const tid = validBidRequests[0].transactionId;
+    const tid = bidderRequest.auctionId;
     const cur = [config.getConfig('currency.adServerCurrency') || DEFAULT_CUR];
     let url = bidderRequest.refererInfo.referer;
 

--- a/modules/improvedigitalBidAdapter.js
+++ b/modules/improvedigitalBidAdapter.js
@@ -307,10 +307,10 @@ const ID_REQUEST = {
     }
     // In the single request mode, split imps between those going to the ad server and those going to extend server
     if (extendImps.length) {
-      requests.push(formatRequest(extendImps, null, true));
+      requests.push(formatRequest(extendImps, bidderRequest.auctionId, true));
     }
     if (adServerImps.length) {
-      requests.push(formatRequest(adServerImps, null, false));
+      requests.push(formatRequest(adServerImps, bidderRequest.auctionId, false));
     }
 
     return requests;

--- a/modules/readpeakBidAdapter.js
+++ b/modules/readpeakBidAdapter.js
@@ -41,7 +41,7 @@ export const spec = {
       cur: [currency],
       source: {
         fd: 1,
-        tid: bidRequests[0].transactionId,
+        tid: bidderRequest.auctionId,
         ext: {
           prebid: '$prebid.version$'
         }

--- a/modules/seedingAllianceBidAdapter.js
+++ b/modules/seedingAllianceBidAdapter.js
@@ -67,7 +67,7 @@ export const spec = {
     validBidRequests = convertOrtbRequestToProprietaryNative(validBidRequests);
 
     const pt = setOnAny(validBidRequests, 'params.pt') || setOnAny(validBidRequests, 'params.priceType') || 'net';
-    const tid = validBidRequests[0].transactionId;
+    const tid = bidderRequest.auctionId;
     const cur = [config.getConfig('currency.adServerCurrency') || DEFAULT_CUR];
     let url = bidderRequest.refererInfo.page;
 

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -52,7 +52,7 @@ export const sharethroughAdapterSpec = {
         ext: {},
       },
       source: {
-        tid: bidRequests[0].transactionId,
+        tid: bidderRequest.auctionId,
         ext: {
           version: '$prebid.version$',
           str: VERSION,

--- a/modules/talkadsBidAdapter.js
+++ b/modules/talkadsBidAdapter.js
@@ -63,6 +63,7 @@ export const spec = {
       cur: CURRENCY,
       timeout: poBidderRequest.timeout,
       auction_id: paValidBidRequests[0].auctionId,
+      // TODO: should this use auctionId? see #8573
       transaction_id: paValidBidRequests[0].transactionId,
       bids: laBids,
       gdpr: { applies: false, consent: false },

--- a/modules/truereachBidAdapter.js
+++ b/modules/truereachBidAdapter.js
@@ -25,6 +25,7 @@ export const spec = {
 
     let siteId = deepAccess(validBidRequests[0], 'params.site_id');
 
+    // TODO: should this use auctionId? see #8573
     let url = BIDDER_URL + siteId + '?hb=1&transactionId=' + validBidRequests[0].transactionId;
 
     return {

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -59,7 +59,7 @@ function getBidFloor(bid) {
 
 function getSource(validBidRequests) {
   let source = {
-    tid: validBidRequests[0].transactionId
+    tid: validBidRequests[0].auctionId
   };
   if (validBidRequests[0].schain) {
     utils.deepSetValue(source, 'ext.schain', validBidRequests[0].schain);

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "prebid.js",
-      "version": "7.16.0-pre",
+      "version": "7.19.0-pre",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.7",

--- a/test/spec/modules/adfBidAdapter_spec.js
+++ b/test/spec/modules/adfBidAdapter_spec.js
@@ -170,11 +170,10 @@ describe('Adf adapter', function () {
       let validBidRequests = [{
         bidId: 'bidId',
         params: { siteId: 'siteId' },
-        transactionId: 'transactionId'
       }];
-      let request = JSON.parse(spec.buildRequests(validBidRequests, { refererInfo: { page: 'page' } }).data);
+      let request = JSON.parse(spec.buildRequests(validBidRequests, { refererInfo: { page: 'page' }, auctionId: 'tid' }).data);
 
-      assert.equal(request.source.tid, validBidRequests[0].transactionId);
+      assert.equal(request.source.tid, 'tid');
       assert.equal(request.source.fd, 1);
     });
 

--- a/test/spec/modules/adxcgBidAdapter_spec.js
+++ b/test/spec/modules/adxcgBidAdapter_spec.js
@@ -164,11 +164,10 @@ describe('Adxcg adapter', function () {
       let validBidRequests = [{
         bidId: 'bidId',
         params: {siteId: 'siteId'},
-        transactionId: 'transactionId'
       }];
-      let request = JSON.parse(spec.buildRequests(validBidRequests, {refererInfo: {referer: 'page'}}).data);
+      let request = JSON.parse(spec.buildRequests(validBidRequests, {refererInfo: {referer: 'page'}, auctionId: 'tid'}).data);
 
-      assert.equal(request.source.tid, validBidRequests[0].transactionId);
+      assert.equal(request.source.tid, 'tid');
       assert.equal(request.source.fd, 1);
     });
 

--- a/test/spec/modules/dianomiBidAdapter_spec.js
+++ b/test/spec/modules/dianomiBidAdapter_spec.js
@@ -159,14 +159,13 @@ describe('Dianomi adapter', () => {
         {
           bidId: 'bidId',
           params: { smartadId: 1234 },
-          transactionId: 'transactionId',
         },
       ];
       let request = JSON.parse(
-        spec.buildRequests(validBidRequests, { refererInfo: { page: 'page' } }).data
+        spec.buildRequests(validBidRequests, { refererInfo: { page: 'page' }, auctionId: 'tid' }).data
       );
 
-      assert.equal(request.source.tid, validBidRequests[0].transactionId);
+      assert.equal(request.source.tid, 'tid');
       assert.equal(request.source.fd, 1);
     });
 

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -172,6 +172,7 @@ describe('sharethrough adapter spec', function () {
         refererInfo: {
           ref: 'https://referer.com',
         },
+        auctionId: 'auction-id'
       };
     });
 
@@ -233,7 +234,7 @@ describe('sharethrough adapter spec', function () {
             expect(openRtbReq.device.ua).to.equal(navigator.userAgent);
             expect(openRtbReq.regs.coppa).to.equal(1);
 
-            expect(openRtbReq.source.tid).to.equal(bidRequests[0].transactionId);
+            expect(openRtbReq.source.tid).to.equal(bidderRequest.auctionId);
             expect(openRtbReq.source.ext.version).not.to.be.undefined;
             expect(openRtbReq.source.ext.str).not.to.be.undefined;
             expect(openRtbReq.source.ext.schain).to.deep.equal(bidRequests[0].schain);

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -272,10 +272,10 @@ describe('ttdBidAdapter', function () {
       expect(requestBody.imp[0].ext.gpid).to.equal(gpid);
     });
 
-    it('sends transaction id in source.tid', function () {
+    it('sends auction id in source.tid', function () {
       const requestBody = testBuildRequests(baseBannerBidRequests, baseBidderRequest).data;
       expect(requestBody.source).to.be.not.null;
-      expect(requestBody.source.tid).to.equal('1111474f-58b1-4368-b812-84f8c937a099');
+      expect(requestBody.source.tid).to.equal(baseBidderRequest.auctionId);
     });
 
     it('includes the ad size in the bid request', function () {
@@ -557,7 +557,7 @@ describe('ttdBidAdapter', function () {
       const requestBody = testBuildRequests(baseBannerMultipleBidRequests, baseBidderRequest).data;
       expect(requestBody.imp.length).to.equal(2);
       expect(requestBody.source).to.be.not.null;
-      expect(requestBody.source.tid).to.equal('1111474f-58b1-4368-b812-84f8c937a099');
+      expect(requestBody.source.tid).to.equal(baseBidderRequest.auctionId);
       expect(requestBody.imp[0].ext).to.be.not.null;
       expect(requestBody.imp[0].ext.tid).to.equal('8651474f-58b1-4368-b812-84f8c937a099');
       expect(requestBody.imp[1].ext).to.be.not.null;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

This changes bid adapters that were setting `source.tid = bidRequests[0].transactionId` to use `auctionId` instead. This is _not_ exhaustive - I just touched the adapters that were easy to grep for.

Part of https://github.com/prebid/Prebid.js/issues/8573

