### PR TITLE
Lotame Panorama Id System: bug fixes

### DIFF
--- a/modules/lotamePanoramaIdSystem.js
+++ b/modules/lotamePanoramaIdSystem.js
@@ -28,6 +28,7 @@ const DAYS_TO_CACHE = 7;
 const DAY_MS = 60 * 60 * 24 * 1000;
 const MISSING_CORE_CONSENT = 111;
 const GVLID = 95;
+const ID_HOST = 'id.crwdcntrl.net';
 
 export const storage = getStorageManager({gvlid: GVLID, moduleName: MODULE_NAME});
 let cookieDomain;
@@ -57,12 +58,14 @@ function setProfileId(profileId) {
  * Get the Lotame profile id by checking cookies first and then local storage
  */
 function getProfileId() {
+  let profileId;
   if (storage.cookiesAreEnabled()) {
-    return storage.getCookie(KEY_PROFILE, undefined);
+    profileId = storage.getCookie(KEY_PROFILE, undefined);
   }
-  if (storage.hasLocalStorage()) {
-    return storage.getDataFromLocalStorage(KEY_PROFILE, undefined);
+  if (!profileId && storage.hasLocalStorage()) {
+    profileId = storage.getDataFromLocalStorage(KEY_PROFILE, undefined);
   }
+  return profileId;
 }
 
 /**
@@ -78,10 +81,11 @@ function getFromStorage(key) {
     const storedValueExp = storage.getDataFromLocalStorage(
       `${key}_exp`, undefined
     );
-    if (storedValueExp === '') {
+
+    if (storedValueExp === '' || storedValueExp === null) {
       value = storage.getDataFromLocalStorage(key, undefined);
     } else if (storedValueExp) {
-      if ((new Date(storedValueExp)).getTime() - Date.now() > 0) {
+      if ((new Date(parseInt(storedValueExp, 10))).getTime() - Date.now() > 0) {
         value = storage.getDataFromLocalStorage(key, undefined);
       }
     }
@@ -284,7 +288,7 @@ export const lotamePanoramaIdSubmodule = {
 
       const url = buildUrl({
         protocol: 'https',
-        host: `id.crwdcntrl.net`,
+        host: ID_HOST,
         pathname: '/id',
         search: isEmpty(queryParams) ? undefined : queryParams,
       });

--- a/test/spec/modules/lotamePanoramaIdSystem_spec.js
+++ b/test/spec/modules/lotamePanoramaIdSystem_spec.js
@@ -70,7 +70,7 @@ describe('LotameId', function() {
 
     it('should call the remote server when getId is called', function () {
       expect(request.url).to.be.eq('https://id.crwdcntrl.net/id');
-
+      
       expect(callBackSpy.calledOnce).to.be.true;
     });
 

--- a/test/spec/modules/lotamePanoramaIdSystem_spec.js
+++ b/test/spec/modules/lotamePanoramaIdSystem_spec.js
@@ -70,7 +70,6 @@ describe('LotameId', function() {
 
     it('should call the remote server when getId is called', function () {
       expect(request.url).to.be.eq('https://id.crwdcntrl.net/id');
-      
       expect(callBackSpy.calledOnce).to.be.true;
     });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

Does this change affect user-facing APIs or examples documented on http://prebid.org? No

## Description of change
Contains a couple of fixes to bugs recently identified in the lotamePanoramaIdSystem module:

1. In getProfileId, it wasn’t testing a cookie value for being empty before returning. It should look to localStorage in this case. 
2. In getFromStorage, it should check for null values, and also needs to convert a stored timestamp from a string to an integer before applying.