### PR TITLE
Medianet Bid Adapter: added AAX bidder alias

### DIFF
--- a/modules/medianetBidAdapter.js
+++ b/modules/medianetBidAdapter.js
@@ -47,6 +47,10 @@ mnData.urlData = {
   isTop: refererInfo.reachedTop
 };
 
+const aliases = [
+  { code: 'aax', gvlid: 720 },
+];
+
 $$PREBID_GLOBAL$$.medianetGlobals = $$PREBID_GLOBAL$$.medianetGlobals || {};
 
 function getTopWindowReferrer() {
@@ -418,7 +422,7 @@ export const spec = {
 
   code: BIDDER_CODE,
   gvlid: 142,
-
+  aliases,
   supportedMediaTypes: [BANNER, NATIVE, VIDEO],
 
   /**


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
Adapter alias for AAX network.

---
contact email of the adapter’s maintainer: [prebid-support@media.net](mailto:prebid-support@media.net)
- [x] official adapter submission
