### PR TITLE
Yahoossp and Aol Bid Adapters:  Added epsilon.com user id source

### DIFF
--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -31,16 +31,38 @@ const SYNC_TYPES = {
 };
 
 const SUPPORTED_USER_ID_SOURCES = [
+  'admixer.net',
   'adserver.org',
+  'adtelligent.com',
+  'akamai.com',
+  'amxrtb.com',
+  'audigent.com',
+  'britepool.com',
   'criteo.com',
+  'crwdcntrl.net',
+  'deepintent.com',
   'epsilon.com',
+  'hcn.health',
   'id5-sync.com',
+  'idx.lat',
   'intentiq.com',
+  'intimatemerger.com',
   'liveintent.com',
-  'quantcast.com',
-  'verizonmedia.com',
   'liveramp.com',
-  'yahoo.com'
+  'mediawallahscript.com',
+  'merkleinc.com',
+  'netid.de',
+  'neustar.biz',
+  'nextroll.com',
+  'novatiq.com',
+  'parrable.com',
+  'pubcid.org',
+  'quantcast.com',
+  'tapad.com',
+  'uidapi.com',
+  'verizonmedia.com',
+  'yahoo.com',
+  'zeotap.com'
 ];
 
 const pubapiTemplate = template`${'host'}/pubapi/3.0/${'network'}/${'placement'}/${'pageid'}/${'sizeid'}/ADTECH;v=2;cmd=bid;cors=yes;alias=${'alias'};misc=${'misc'};${'dynamicParams'}`;

--- a/modules/aolBidAdapter.js
+++ b/modules/aolBidAdapter.js
@@ -33,6 +33,7 @@ const SYNC_TYPES = {
 const SUPPORTED_USER_ID_SOURCES = [
   'adserver.org',
   'criteo.com',
+  'epsilon.com',
   'id5-sync.com',
   'intentiq.com',
   'liveintent.com',

--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -30,6 +30,7 @@ const SUPPORTED_USER_ID_SOURCES = [
   'criteo.com',
   'crwdcntrl.net',
   'deepintent.com',
+  'epsilon.com',
   'hcn.health',
   'id5-sync.com',
   'idx.lat',

--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -47,7 +47,6 @@ const SUPPORTED_USER_ID_SOURCES = [
   'parrable.com',
   'pubcid.org',
   'quantcast.com',
-  'quantcast.com',
   'tapad.com',
   'uidapi.com',
   'verizonmedia.com',

--- a/test/spec/modules/aolBidAdapter_spec.js
+++ b/test/spec/modules/aolBidAdapter_spec.js
@@ -81,20 +81,46 @@ describe('AolAdapter', function () {
   const ONE_DISPLAY_TTL = 60;
   const ONE_MOBILE_TTL = 3600;
   const SUPPORTED_USER_ID_SOURCES = {
-    'adserver.org': '100',
-    'criteo.com': '200',
-    'id5-sync.com': '300',
-    'intentiq.com': '400',
-    'liveintent.com': '500',
-    'quantcast.com': '600',
-    'verizonmedia.com': '700',
-    'liveramp.com': '800'
+    'admixer.net': '100',
+    'adserver.org': '200',
+    'adtelligent.com': '300',
+    'amxrtb.com': '500',
+    'audigent.com': '600',
+    'britepool.com': '700',
+    'criteo.com': '800',
+    'crwdcntrl.net': '900',
+    'deepintent.com': '1000',
+    'epsilon.com': '1100',
+    'hcn.health': '1200',
+    'id5-sync.com': '1300',
+    'idx.lat': '1400',
+    'intentiq.com': '1500',
+    'intimatemerger.com': '1600',
+    'liveintent.com': '1700',
+    'liveramp.com': '1800',
+    'mediawallahscript.com': '1900',
+    'netid.de': '2100',
+    'neustar.biz': '2200',
+    'pubcid.org': '2600',
+    'quantcast.com': '2700',
+    'tapad.com': '2800',
+    'zeotap.com': '3200'
   };
 
   const USER_ID_DATA = {
+    admixerId: SUPPORTED_USER_ID_SOURCES['admixer.net'],
+    adtelligentId: SUPPORTED_USER_ID_SOURCES['adtelligent.com'],
+    amxId: SUPPORTED_USER_ID_SOURCES['amxrtb.com'],
+    britepoolid: SUPPORTED_USER_ID_SOURCES['britepool.com'],
     criteoId: SUPPORTED_USER_ID_SOURCES['criteo.com'],
     connectid: SUPPORTED_USER_ID_SOURCES['verizonmedia.com'],
+    dmdId: SUPPORTED_USER_ID_SOURCES['hcn.health'],
+    hadronId: SUPPORTED_USER_ID_SOURCES['audigent.com'],
+    lotamePanoramaId: SUPPORTED_USER_ID_SOURCES['crwdcntrl.net'],
+    deepintentId: SUPPORTED_USER_ID_SOURCES['deepintent.com'],
+    fabrickId: SUPPORTED_USER_ID_SOURCES['neustar.biz'],
     idl_env: SUPPORTED_USER_ID_SOURCES['liveramp.com'],
+    IDP: SUPPORTED_USER_ID_SOURCES['zeotap.com'],
     lipb: {
       lipbid: SUPPORTED_USER_ID_SOURCES['liveintent.com'],
       segments: ['100', '200']
@@ -104,8 +130,15 @@ describe('AolAdapter', function () {
       uid: SUPPORTED_USER_ID_SOURCES['id5-sync.com'],
       ext: {foo: 'bar'}
     },
+    idx: SUPPORTED_USER_ID_SOURCES['idx.lat'],
+    imuid: SUPPORTED_USER_ID_SOURCES['intimatemerger.com'],
     intentIqId: SUPPORTED_USER_ID_SOURCES['intentiq.com'],
-    quantcastId: SUPPORTED_USER_ID_SOURCES['quantcast.com']
+    mwOpenLinkId: SUPPORTED_USER_ID_SOURCES['mediawallahscript.com'],
+    netId: SUPPORTED_USER_ID_SOURCES['netid.de'],
+    quantcastId: SUPPORTED_USER_ID_SOURCES['quantcast.com'],
+    publinkId: SUPPORTED_USER_ID_SOURCES['epsilon.com'],
+    pubcid: SUPPORTED_USER_ID_SOURCES['pubcid.org'],
+    tapadId: SUPPORTED_USER_ID_SOURCES['tapad.com']
   };
 
   function createCustomBidRequest({bids, params} = {}) {

--- a/test/spec/modules/yahoosspBidAdapter_spec.js
+++ b/test/spec/modules/yahoosspBidAdapter_spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { config } from 'src/config.js';
 import { BANNER, VIDEO } from 'src/mediaTypes.js';
 import { spec } from 'modules/yahoosspBidAdapter.js';
+import {createEidsArray} from '../../../modules/userId/eids';
 
 const DEFAULT_BID_ID = '84ab500420319d';
 const DEFAULT_BID_DCN = '2093845709823475';
@@ -832,6 +833,50 @@ describe('YahooSSP Bid Adapter:', () => {
           },
           withCredentials: true
         });
+    });
+  });
+
+  describe('User data', () => {
+    it('should set the allowed sources user eids', () => {
+      const { validBidRequests, bidderRequest } = generateBuildRequestMock({});
+      validBidRequests[0].userIdAsEids = createEidsArray({
+        admixerId: 'admixerId_FROM_USER_ID_MODULE',
+        adtelligentId: 'adtelligentId_FROM_USER_ID_MODULE',
+        amxId: 'amxId_FROM_USER_ID_MODULE',
+        britepoolid: 'britepoolid_FROM_USER_ID_MODULE',
+        deepintentId: 'deepintentId_FROM_USER_ID_MODULE',
+        publinkId: 'publinkId_FROM_USER_ID_MODULE',
+        intentIqId: 'intentIqId_FROM_USER_ID_MODULE',
+        idl_env: 'idl_env_FROM_USER_ID_MODULE',
+        imuid: 'imuid_FROM_USER_ID_MODULE',
+        criteoId: 'criteoId_FROM_USER_ID_MODULE',
+        fabrickId: 'fabrickId_FROM_USER_ID_MODULE',
+      });
+      const data = spec.buildRequests(validBidRequests, bidderRequest).data;
+
+      expect(data.user.ext.eids).to.deep.equal([
+        {source: 'admixer.net', uids: [{id: 'admixerId_FROM_USER_ID_MODULE', atype: 3}]},
+        {source: 'adtelligent.com', uids: [{id: 'adtelligentId_FROM_USER_ID_MODULE', atype: 3}]},
+        {source: 'amxrtb.com', uids: [{id: 'amxId_FROM_USER_ID_MODULE', atype: 1}]},
+        {source: 'britepool.com', uids: [{id: 'britepoolid_FROM_USER_ID_MODULE', atype: 3}]},
+        {source: 'deepintent.com', uids: [{id: 'deepintentId_FROM_USER_ID_MODULE', atype: 3}]},
+        {source: 'epsilon.com', uids: [{id: 'publinkId_FROM_USER_ID_MODULE', atype: 3}]},
+        {source: 'intentiq.com', uids: [{id: 'intentIqId_FROM_USER_ID_MODULE', atype: 1}]},
+        {source: 'liveramp.com', uids: [{id: 'idl_env_FROM_USER_ID_MODULE', atype: 3}]},
+        {source: 'intimatemerger.com', uids: [{id: 'imuid_FROM_USER_ID_MODULE', atype: 1}]},
+        {source: 'criteo.com', uids: [{id: 'criteoId_FROM_USER_ID_MODULE', atype: 1}]},
+        {source: 'neustar.biz', uids: [{id: 'fabrickId_FROM_USER_ID_MODULE', atype: 1}]}
+      ]);
+    });
+
+    it('should not set not allowed user eids sources', () => {
+      const { validBidRequests, bidderRequest } = generateBuildRequestMock({});
+      validBidRequests[0].userIdAsEids = createEidsArray({
+        justId: 'justId_FROM_USER_ID_MODULE'
+      });
+      const data = spec.buildRequests(validBidRequests, bidderRequest).data;
+
+      expect(data.user.ext.eids).to.deep.equal([]);
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
