### PR TITLE
PBS Bid Adapter: alias Fix

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -558,7 +558,7 @@ Object.assign(ORTB2.prototype, {
           const bidder = adapterManager.bidderRegistry[bid.bidder];
           // adding alias only if alias source bidder exists and alias isn't configured to be standalone
           // pbs adapter
-          if (bidder && !bidder.getSpec().skipPbsAliasing) {
+          if (!bidder || !bidder.getSpec().skipPbsAliasing) {
             aliases[bid.bidder] = adapterManager.aliasRegistry[bid.bidder];
           }
         }

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -19,7 +19,6 @@ import { auctionManager } from '../../../src/auctionManager.js';
 import { stubAuctionIndex } from '../../helpers/indexStub.js';
 import { registerBidder } from 'src/adapters/bidderFactory.js';
 import {getGlobal} from '../../../src/prebidGlobal.js';
-import { hasConsoleLogger } from '../../../src/utils.js';
 
 let CONFIG = {
   accountId: '1',


### PR DESCRIPTION
Issue is here:
https://github.com/prebid/Prebid.js/issues/8831

## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Code doesn't need a bid adapter to be available to setAlias
