### PR TITLE
Vrtcal Bid Adapter: added support for 3rd party user IDs

### DIFF
--- a/modules/vrtcalBidAdapter.js
+++ b/modules/vrtcalBidAdapter.js
@@ -27,6 +27,11 @@ export const spec = {
       let ccpa = '';
       let coppa = 0;
       let tmax = 0;
+      let eids = [];
+
+      if (bidRequests[0].userIdAsEids && bidRequests[0].userIdAsEids.length > 0) {
+        eids = bidRequests[0].userIdAsEids;
+      }
 
       if (bid && bid.gdprConsent) {
         gdprApplies = bid.gdprConsent.gdprApplies ? 1 : 0;
@@ -74,7 +79,8 @@ export const spec = {
         },
         user: {
           ext: {
-            consent: gdprConsent
+            consent: gdprConsent,
+            eids: eids
           }
         }
       };

--- a/test/spec/modules/vrtcalBidAdapter_spec.js
+++ b/test/spec/modules/vrtcalBidAdapter_spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai'
 import { spec } from 'modules/vrtcalBidAdapter'
 import { newBidder } from 'src/adapters/bidderFactory'
 import { config } from 'src/config.js';
+import { createEidsArray } from 'modules/userId/eids.js';
 
 describe('vrtcalBidAdapter', function () {
   const adapter = newBidder(spec)
@@ -27,6 +28,7 @@ describe('vrtcalBidAdapter', function () {
         'bidId': 'bidID0001',
         'bidderRequestId': 'br0001',
         'auctionId': 'auction0001',
+        'userIdAsEids': {}
       }
     ];
 
@@ -58,7 +60,7 @@ describe('vrtcalBidAdapter', function () {
       config.setConfig({ coppa: false });
 
       request = spec.buildRequests(bidRequests);
-      expect(request[0].data).to.match(/"user":{"ext":{"consent":"gdpr-consent-string"}}/);
+      expect(request[0].data).to.match(/"user":{"ext":{"consent":"gdpr-consent-string"/);
       expect(request[0].data).to.match(/"regs":{"coppa":0,"ext":{"gdpr":1,"us_privacy":"ccpa-consent-string"}}/);
     });
 
@@ -66,6 +68,15 @@ describe('vrtcalBidAdapter', function () {
       config.setConfig({ bidderTimeout: 435 });
       request = spec.buildRequests(bidRequests);
       expect(request[0].data).to.match(/"tmax":435/);
+    });
+
+    it('pass 3rd party IDs with the request when present', function () {
+      bidRequests[0].userIdAsEids = createEidsArray({
+        tdid: 'TTD_ID_FROM_USER_ID_MODULE'
+      });
+
+      request = spec.buildRequests(bidRequests);
+      expect(request[0].data).to.include(JSON.stringify({ext: {consent: 'gdpr-consent-string', eids: [{source: 'adserver.org', uids: [{id: 'TTD_ID_FROM_USER_ID_MODULE', atype: 1, ext: {rtiPartner: 'TDID'}}]}]}}));
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
