### PR TITLE
1plusX Rtd Module: Add FPID support for PAPI and Fix Test Bug

### DIFF
--- a/test/spec/modules/1plusXRtdProvider_spec.js
+++ b/test/spec/modules/1plusXRtdProvider_spec.js
@@ -9,6 +9,8 @@ import {
   extractConsent,
   getPapiUrl
 } from 'modules/1plusXRtdProvider';
+import assert from 'assert';
+import { extractFpid } from '../../../modules/1plusXRtdProvider';
 
 describe('1plusXRtdProvider', () => {
   // Fake server config
@@ -277,37 +279,46 @@ describe('1plusXRtdProvider', () => {
     it('throws an error if the consent is malformed', () => {
       const consent1 = {
         gdpr: {
-          gdprApplies: 1
-        }
-      }
-      const consent2 = {
-        gdpr: {
           consentString: 'myConsent'
         }
       }
-      const consent3 = {
+      const consent2 = {
         gdpr: {
           gdprApplies: 1,
           consentString: 3
         }
       }
-      const consent4 = {
+      const consent3 = {
         gdpr: {
           gdprApplies: 'yes',
           consentString: 'myConsent'
         }
       }
-      const consent5 = {
-        gdprApplies: 1,
-        consentString: 'myConsent'
+      const consent4 = {
+        gdpr: {}
       }
 
-      for (const consent in [consent1, consent2, consent3, consent4, consent5]) {
+      for (const consent of [consent1, consent2, consent3, consent4]) {
+        var failed = false;
         try {
           extractConsent(consent)
-          assert(false, 'Should be throwing an exception')
-        } catch (e) { }
+        } catch (e) {
+          failed = true;
+        } finally {
+          assert(failed, 'Should be throwing an exception')
+        }
       }
+    })
+  })
+
+  describe('extractFpid', () => {
+    it('correctly extracts an ope fpid if present', () => {
+      window.localStorage.setItem('ope_fpid', 'oneplusx_test_key')
+      const id1 = extractFpid()
+      window.localStorage.removeItem('ope_fpid')
+      const id2 = extractFpid()
+      expect(id1).to.equal('oneplusx_test_key')
+      expect(id2).to.equal(null)
     })
   })
 
@@ -320,11 +331,16 @@ describe('1plusXRtdProvider', () => {
       }
     }
 
-    it('correctly builds URLs based on consent', () => {
+    it('correctly builds URLs if gdpr parameters are present', () => {
       const url1 = getPapiUrl(customer)
       const url2 = getPapiUrl(customer, extractConsent(consent))
       expect(['&consent_string=myConsent&gdpr_applies=1', '&gdpr_applies=1&consent_string=myConsent']).to.contain(url2.replace(url1, ''))
     })
+
+    it('correctly builds URLs if fpid parameters are present')
+    const url1 = getPapiUrl(customer)
+    const url2 = getPapiUrl(customer, {}, 'my_first_party_id')
+    expect(url2.replace(url1, '')).to.equal('&fpid=my_first_party_id')
   })
 
   describe('updateBidderConfig', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
- Extract 1plusX first party id and attach it to our profile API call in case it is present
- Slightly relax the conditions of the gdpr consent object -- the consent string doesn't have to be defined anymore (e.g. if gdpr does not apply)
- Fix a bug in a previous test case that made the test go green no matter what

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
