### PR TITLE
Ogury Bid Adapter: Add xandr sync

### DIFF
--- a/modules/oguryBidAdapter.js
+++ b/modules/oguryBidAdapter.js
@@ -11,7 +11,7 @@ const DEFAULT_TIMEOUT = 1000;
 const BID_HOST = 'https://mweb-hb.presage.io/api/header-bidding-request';
 const TIMEOUT_MONITORING_HOST = 'https://ms-ads-monitoring-events.presage.io';
 const MS_COOKIE_SYNC_DOMAIN = 'https://ms-cookie-sync.presage.io';
-const ADAPTER_VERSION = '1.2.13';
+const ADAPTER_VERSION = '1.3.0';
 
 function getClientWidth() {
   const documentElementClientWidth = window.top.document.documentElement.clientWidth
@@ -56,6 +56,10 @@ function getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent) {
     {
       type: 'image',
       url: `${MS_COOKIE_SYNC_DOMAIN}/ttd/init-sync?iab_string=${(gdprConsent && gdprConsent.consentString) || ''}&source=prebid`
+    },
+    {
+      type: 'image',
+      url: `${MS_COOKIE_SYNC_DOMAIN}/xandr/init-sync?iab_string=${(gdprConsent && gdprConsent.consentString) || ''}&source=prebid`
     }
   ]
 }
@@ -209,6 +213,6 @@ export const spec = {
   onBidWon,
   getWindowContext,
   onTimeout
-};
+}
 
 registerBidder(spec);

--- a/test/spec/modules/oguryBidAdapter_spec.js
+++ b/test/spec/modules/oguryBidAdapter_spec.js
@@ -119,26 +119,30 @@ describe('OguryBidAdapter', function () {
       };
     });
 
-    it('should return syncs array with two elements of type image', () => {
+    it('should return syncs array with three elements of type image', () => {
       const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
 
-      expect(userSyncs).to.have.lengthOf(2);
+      expect(userSyncs).to.have.lengthOf(3);
       expect(userSyncs[0].type).to.equal('image');
       expect(userSyncs[0].url).to.contain('https://ms-cookie-sync.presage.io/v1/init-sync/bid-switch');
       expect(userSyncs[1].type).to.equal('image');
       expect(userSyncs[1].url).to.contain('https://ms-cookie-sync.presage.io/ttd/init-sync');
+      expect(userSyncs[2].type).to.equal('image');
+      expect(userSyncs[2].url).to.contain('https://ms-cookie-sync.presage.io/xandr/init-sync');
     });
 
     it('should set the source as query param', () => {
       const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
       expect(userSyncs[0].url).to.contain('source=prebid');
       expect(userSyncs[1].url).to.contain('source=prebid');
+      expect(userSyncs[2].url).to.contain('source=prebid');
     });
 
     it('should set the tcString as query param', () => {
       const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
       expect(userSyncs[0].url).to.contain(`iab_string=${gdprConsent.consentString}`);
       expect(userSyncs[1].url).to.contain(`iab_string=${gdprConsent.consentString}`);
+      expect(userSyncs[2].url).to.contain(`iab_string=${gdprConsent.consentString}`);
     });
 
     it('should return an empty array when pixel is disable', () => {
@@ -146,82 +150,94 @@ describe('OguryBidAdapter', function () {
       expect(spec.getUserSyncs(syncOptions, [], gdprConsent)).to.have.lengthOf(0);
     });
 
-    it('should return syncs array with two elements of type image when consentString is undefined', () => {
+    it('should return syncs array with three elements of type image when consentString is undefined', () => {
       gdprConsent = {
         gdprApplies: true,
         consentString: undefined
       };
 
       const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
-      expect(userSyncs).to.have.lengthOf(2);
+      expect(userSyncs).to.have.lengthOf(3);
       expect(userSyncs[0].type).to.equal('image');
       expect(userSyncs[0].url).to.equal('https://ms-cookie-sync.presage.io/v1/init-sync/bid-switch?iab_string=&source=prebid')
       expect(userSyncs[1].type).to.equal('image');
       expect(userSyncs[1].url).to.equal('https://ms-cookie-sync.presage.io/ttd/init-sync?iab_string=&source=prebid')
+      expect(userSyncs[2].type).to.equal('image');
+      expect(userSyncs[2].url).to.equal('https://ms-cookie-sync.presage.io/xandr/init-sync?iab_string=&source=prebid')
     });
 
-    it('should return syncs array with two elements of type image when consentString is null', () => {
+    it('should return syncs array with three elements of type image when consentString is null', () => {
       gdprConsent = {
         gdprApplies: true,
         consentString: null
       };
 
       const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
-      expect(userSyncs).to.have.lengthOf(2);
+      expect(userSyncs).to.have.lengthOf(3);
       expect(userSyncs[0].type).to.equal('image');
       expect(userSyncs[0].url).to.equal('https://ms-cookie-sync.presage.io/v1/init-sync/bid-switch?iab_string=&source=prebid')
       expect(userSyncs[1].type).to.equal('image');
       expect(userSyncs[1].url).to.equal('https://ms-cookie-sync.presage.io/ttd/init-sync?iab_string=&source=prebid')
+      expect(userSyncs[2].type).to.equal('image');
+      expect(userSyncs[2].url).to.equal('https://ms-cookie-sync.presage.io/xandr/init-sync?iab_string=&source=prebid')
     });
 
-    it('should return syncs array with two elements of type image when gdprConsent is undefined', () => {
+    it('should return syncs array with three elements of type image when gdprConsent is undefined', () => {
       gdprConsent = undefined;
 
       const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
-      expect(userSyncs).to.have.lengthOf(2);
+      expect(userSyncs).to.have.lengthOf(3);
       expect(userSyncs[0].type).to.equal('image');
       expect(userSyncs[0].url).to.equal('https://ms-cookie-sync.presage.io/v1/init-sync/bid-switch?iab_string=&source=prebid')
       expect(userSyncs[1].type).to.equal('image');
       expect(userSyncs[1].url).to.equal('https://ms-cookie-sync.presage.io/ttd/init-sync?iab_string=&source=prebid')
+      expect(userSyncs[2].type).to.equal('image');
+      expect(userSyncs[2].url).to.equal('https://ms-cookie-sync.presage.io/xandr/init-sync?iab_string=&source=prebid')
     });
 
-    it('should return syncs array with two elements of type image when gdprConsent is null', () => {
+    it('should return syncs array with three elements of type image when gdprConsent is null', () => {
       gdprConsent = null;
 
       const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
-      expect(userSyncs).to.have.lengthOf(2);
+      expect(userSyncs).to.have.lengthOf(3);
       expect(userSyncs[0].type).to.equal('image');
       expect(userSyncs[0].url).to.equal('https://ms-cookie-sync.presage.io/v1/init-sync/bid-switch?iab_string=&source=prebid')
       expect(userSyncs[1].type).to.equal('image');
       expect(userSyncs[1].url).to.equal('https://ms-cookie-sync.presage.io/ttd/init-sync?iab_string=&source=prebid')
+      expect(userSyncs[2].type).to.equal('image');
+      expect(userSyncs[2].url).to.equal('https://ms-cookie-sync.presage.io/xandr/init-sync?iab_string=&source=prebid')
     });
 
-    it('should return syncs array with two elements of type image when gdprConsent is null and gdprApplies is false', () => {
+    it('should return syncs array with three elements of type image when gdprConsent is null and gdprApplies is false', () => {
       gdprConsent = {
         gdprApplies: false,
         consentString: null
       };
 
       const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
-      expect(userSyncs).to.have.lengthOf(2);
+      expect(userSyncs).to.have.lengthOf(3);
       expect(userSyncs[0].type).to.equal('image');
       expect(userSyncs[0].url).to.equal('https://ms-cookie-sync.presage.io/v1/init-sync/bid-switch?iab_string=&source=prebid')
       expect(userSyncs[1].type).to.equal('image');
       expect(userSyncs[1].url).to.equal('https://ms-cookie-sync.presage.io/ttd/init-sync?iab_string=&source=prebid')
+      expect(userSyncs[2].type).to.equal('image');
+      expect(userSyncs[2].url).to.equal('https://ms-cookie-sync.presage.io/xandr/init-sync?iab_string=&source=prebid')
     });
 
-    it('should return syncs array with two elements of type image when gdprConsent is empty string and gdprApplies is false', () => {
+    it('should return syncs array with three elements of type image when gdprConsent is empty string and gdprApplies is false', () => {
       gdprConsent = {
         gdprApplies: false,
         consentString: ''
       };
 
       const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
-      expect(userSyncs).to.have.lengthOf(2);
+      expect(userSyncs).to.have.lengthOf(3);
       expect(userSyncs[0].type).to.equal('image');
       expect(userSyncs[0].url).to.equal('https://ms-cookie-sync.presage.io/v1/init-sync/bid-switch?iab_string=&source=prebid')
       expect(userSyncs[1].type).to.equal('image');
       expect(userSyncs[1].url).to.equal('https://ms-cookie-sync.presage.io/ttd/init-sync?iab_string=&source=prebid')
+      expect(userSyncs[2].type).to.equal('image');
+      expect(userSyncs[2].url).to.equal('https://ms-cookie-sync.presage.io/xandr/init-sync?iab_string=&source=prebid')
     });
   });
 
@@ -279,7 +295,7 @@ describe('OguryBidAdapter', function () {
       },
       ext: {
         prebidversion: '$prebid.version$',
-        adapterversion: '1.2.13'
+        adapterversion: '1.3.0'
       },
       device: {
         w: stubbedWidth,
@@ -659,7 +675,7 @@ describe('OguryBidAdapter', function () {
           advertiserDomains: openRtbBidResponse.body.seatbid[0].bid[0].adomain
         },
         nurl: openRtbBidResponse.body.seatbid[0].bid[0].nurl,
-        adapterVersion: '1.2.13',
+        adapterVersion: '1.3.0',
         prebidVersion: '$prebid.version$'
       }, {
         requestId: openRtbBidResponse.body.seatbid[0].bid[1].impid,
@@ -676,7 +692,7 @@ describe('OguryBidAdapter', function () {
           advertiserDomains: openRtbBidResponse.body.seatbid[0].bid[1].adomain
         },
         nurl: openRtbBidResponse.body.seatbid[0].bid[1].nurl,
-        adapterVersion: '1.2.13',
+        adapterVersion: '1.3.0',
         prebidVersion: '$prebid.version$'
       }]
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
We are adding a call to synchronize our users with Xandr one.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
