### PR TITLE
ConnectId User ID Module: Support Publisher-supplied user identifier

### DIFF
--- a/modules/connectIdSystem.md
+++ b/modules/connectIdSystem.md
@@ -29,5 +29,6 @@ The below parameters apply only to the Yahoo ConnectID user ID Module.
 | --- | --- | --- | --- | --- |
 | name | Required | String | ID value for the Yahoo ConnectID module - `"connectId"` | `"connectId"` |
 | params | Required | Object | Data for Yahoo ConnectID initialization. | |
-| params.pixelId | Required | Number | The Yahoo supplied publisher specific pixel Id  | `8976` |
-| params.he | Required | String | The SHA-256 hashed user email address | `"529cb86de31e9547a712d9f380146e98bbd39beec"` |
+| params.pixelId | Required | Number | The Yahoo supplied publisher specific pixel Id.  | `8976` |
+| params.he | Optional | String | The SHA-256 hashed user email address. One of either the `he` parameter or the `puid` parameter must be supplied. | `"529cb86de31e9547a712d9f380146e98bbd39beec"` |
+| params.puid | Optional | String | The publisher-supplied user identifier. One of either the `he` parameter or the `puid` parameter must be supplied. | `"P-975484817"` |

--- a/test/spec/modules/connectIdSystem_spec.js
+++ b/test/spec/modules/connectIdSystem_spec.js
@@ -4,6 +4,7 @@ import {connectIdSubmodule} from 'modules/connectIdSystem.js';
 
 describe('Yahoo ConnectID Submodule', () => {
   const HASHED_EMAIL = '6bda6f2fa268bf0438b5423a9861a2cedaa5dec163c03f743cfe05c08a8397b2';
+  const PUBLISHER_USER_ID = '975484817';
   const PIXEL_ID = '1234';
   const PROD_ENDPOINT = `https://ups.analytics.yahoo.com/ups/${PIXEL_ID}/fed`;
   const OVERRIDE_ENDPOINT = 'https://foo/bar';
@@ -48,28 +49,76 @@ describe('Yahoo ConnectID Submodule', () => {
       return result;
     }
 
-    it('returns undefined if he and pixelId params are not passed', () => {
+    it('returns undefined if he, pixelId and puid params are not passed', () => {
       expect(invokeGetIdAPI({}, consentData)).to.be.undefined;
       expect(ajaxStub.callCount).to.equal(0);
     });
 
     it('returns undefined if the pixelId param is not passed', () => {
       expect(invokeGetIdAPI({
-        he: HASHED_EMAIL
+        he: HASHED_EMAIL,
+        puid: PUBLISHER_USER_ID
       }, consentData)).to.be.undefined;
       expect(ajaxStub.callCount).to.equal(0);
     });
 
-    it('returns undefined if the he param is not passed', () => {
+    it('returns undefined if the pixelId param is passed, but the he and puid param are not passed', () => {
       expect(invokeGetIdAPI({
         pixelId: PIXEL_ID
       }, consentData)).to.be.undefined;
       expect(ajaxStub.callCount).to.equal(0);
     });
 
-    it('returns an object with the callback function if the correct params are passed', () => {
+    it('returns an object with the callback function if the endpoint override param and the he params are passed', () => {
       let result = invokeGetIdAPI({
         he: HASHED_EMAIL,
+        endpoint: OVERRIDE_ENDPOINT
+      }, consentData);
+      expect(result).to.be.an('object').that.has.all.keys('callback');
+      expect(result.callback).to.be.a('function');
+    });
+
+    it('returns an object with the callback function if the endpoint override param and the puid params are passed', () => {
+      let result = invokeGetIdAPI({
+        puid: PUBLISHER_USER_ID,
+        endpoint: OVERRIDE_ENDPOINT
+      }, consentData);
+      expect(result).to.be.an('object').that.has.all.keys('callback');
+      expect(result.callback).to.be.a('function');
+    });
+
+    it('returns an object with the callback function if the endpoint override param and the puid and he params are passed', () => {
+      let result = invokeGetIdAPI({
+        he: HASHED_EMAIL,
+        puid: PUBLISHER_USER_ID,
+        endpoint: OVERRIDE_ENDPOINT
+      }, consentData);
+      expect(result).to.be.an('object').that.has.all.keys('callback');
+      expect(result.callback).to.be.a('function');
+    });
+
+    it('returns an object with the callback function if the pixelId and he params are passed', () => {
+      let result = invokeGetIdAPI({
+        he: HASHED_EMAIL,
+        pixelId: PIXEL_ID
+      }, consentData);
+      expect(result).to.be.an('object').that.has.all.keys('callback');
+      expect(result.callback).to.be.a('function');
+    });
+
+    it('returns an object with the callback function if the pixelId and puid params are passed', () => {
+      let result = invokeGetIdAPI({
+        puid: PUBLISHER_USER_ID,
+        pixelId: PIXEL_ID
+      }, consentData);
+      expect(result).to.be.an('object').that.has.all.keys('callback');
+      expect(result.callback).to.be.a('function');
+    });
+
+    it('returns an object with the callback function if the pixelId, he and puid params are passed', () => {
+      let result = invokeGetIdAPI({
+        he: HASHED_EMAIL,
+        puid: PUBLISHER_USER_ID,
         pixelId: PIXEL_ID
       }, consentData);
       expect(result).to.be.an('object').that.has.all.keys('callback');
@@ -96,13 +145,57 @@ describe('Yahoo ConnectID Submodule', () => {
       localStorage.removeItem('connectIdOptOut');
     });
 
-    it('Makes an ajax GET request to the production API endpoint with query params', () => {
+    it('Makes an ajax GET request to the production API endpoint with pixelId and he query params', () => {
       invokeGetIdAPI({
         he: HASHED_EMAIL,
         pixelId: PIXEL_ID
       }, consentData);
 
       const expectedParams = {
+        he: HASHED_EMAIL,
+        pixelId: PIXEL_ID,
+        '1p': '0',
+        gdpr: '1',
+        gdpr_consent: consentData.gdpr.consentString,
+        us_privacy: consentData.uspConsent
+      };
+      const requestQueryParams = parseQS(ajaxStub.firstCall.args[0].split('?')[1]);
+
+      expect(ajaxStub.firstCall.args[0].indexOf(`${PROD_ENDPOINT}?`)).to.equal(0);
+      expect(requestQueryParams).to.deep.equal(expectedParams);
+      expect(ajaxStub.firstCall.args[3]).to.deep.equal({method: 'GET', withCredentials: true});
+    });
+
+    it('Makes an ajax GET request to the production API endpoint with pixelId and puid query params', () => {
+      invokeGetIdAPI({
+        puid: PUBLISHER_USER_ID,
+        pixelId: PIXEL_ID
+      }, consentData);
+
+      const expectedParams = {
+        puid: PUBLISHER_USER_ID,
+        pixelId: PIXEL_ID,
+        '1p': '0',
+        gdpr: '1',
+        gdpr_consent: consentData.gdpr.consentString,
+        us_privacy: consentData.uspConsent
+      };
+      const requestQueryParams = parseQS(ajaxStub.firstCall.args[0].split('?')[1]);
+
+      expect(ajaxStub.firstCall.args[0].indexOf(`${PROD_ENDPOINT}?`)).to.equal(0);
+      expect(requestQueryParams).to.deep.equal(expectedParams);
+      expect(ajaxStub.firstCall.args[3]).to.deep.equal({method: 'GET', withCredentials: true});
+    });
+
+    it('Makes an ajax GET request to the production API endpoint with pixelId, puid and he query params', () => {
+      invokeGetIdAPI({
+        puid: PUBLISHER_USER_ID,
+        he: HASHED_EMAIL,
+        pixelId: PIXEL_ID
+      }, consentData);
+
+      const expectedParams = {
+        puid: PUBLISHER_USER_ID,
         he: HASHED_EMAIL,
         pixelId: PIXEL_ID,
         '1p': '0',


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
The ConnectID User Identity module has been extended to support a publisher-supplied user identifier as an optional input parameter that can be used to help to generate a ConnectID. 


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Documentation PR: https://github.com/prebid/prebid.github.io/pull/4080