### PR TITLE
FTRACK USER ID MODULE: tweaking the createEidsArray() method to accept two schema patterns

### DIFF
--- a/modules/ftrackIdSystem.js
+++ b/modules/ftrackIdSystem.js
@@ -48,20 +48,36 @@ export const ftrackIdSubmodule = {
    *   similar to the module name and ending in id or Id
    */
   decode (value, config) {
-    if (!value) { return }
-    const ext = {}
-
-    for (var key in value) {
-      /** unpack the strings from the arrays */
-      ext[key] = value[key][0]
-    }
-
-    return {
+    value = value || {};
+    const DECODE_RESPONSE = {
       ftrackId: {
-        uid: value.DeviceID && value.DeviceID[0],
-        ext
+        uid: '',
+        ext: {}
       }
     }
+
+    // Loop over the value's properties:
+    // -- if string, assign value as is.
+    // -- if array, convert to string then assign value.
+    // -- If neither type, assign value as empty string
+    for (var key in value) {
+      let keyValue = value[key];
+      if (Array.isArray(keyValue)) {
+        keyValue = keyValue.join('|');
+      } else if (typeof value[key] !== 'string') {
+        // Unexpected value type, should be string or array
+        keyValue = '';
+      }
+
+      DECODE_RESPONSE.ftrackId.ext[key] = keyValue;
+    }
+
+    // If we have DeviceId value, assign it to the uid property
+    if (DECODE_RESPONSE.ftrackId.ext.hasOwnProperty('DeviceID')) {
+      DECODE_RESPONSE.ftrackId.uid = DECODE_RESPONSE.ftrackId.ext.DeviceID;
+    }
+
+    return DECODE_RESPONSE;
   },
 
   /**

--- a/modules/ftrackIdSystem.js
+++ b/modules/ftrackIdSystem.js
@@ -48,7 +48,10 @@ export const ftrackIdSubmodule = {
    *   similar to the module name and ending in id or Id
    */
   decode (value, config) {
-    value = value || {};
+    if (!value) {
+      return;
+    };
+
     const DECODE_RESPONSE = {
       ftrackId: {
         uid: '',

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -420,16 +420,26 @@ export function createEidsArray(bidRequestUserId) {
         eids = eids.concat(bidRequestUserId['pubProvidedId']);
       } else if (subModuleKey === 'ftrackId') {
         // ftrack has multiple IDs so we add each one that exists
-        let eid = {
+        const E_ID = {
           'atype': 1,
-          'id': (bidRequestUserId.ftrackId.DeviceID || []).join('|'),
           'ext': {}
-        }
-        for (let id in bidRequestUserId.ftrackId) {
-          eid.ext[id] = (bidRequestUserId.ftrackId[id] || []).join('|');
+        };
+        const IDS = bidRequestUserId.ftrackId.hasOwnProperty('ext') ? bidRequestUserId.ftrackId.ext : bidRequestUserId.ftrackId;
+
+        for (let id in IDS) {
+          if (typeof IDS[id] === 'string') {
+            E_ID.ext[id] = IDS[id];
+          } else if (Array.isArray(IDS[id])) {
+            E_ID.ext[id] = IDS[id].join('|');
+          } else {
+            // Unexpected value type
+            E_ID.ext[id] = '';
+          }
         }
 
-        eids.push(eid);
+        E_ID.id = E_ID.ext.DeviceID || '';
+
+        eids.push(E_ID);
       } else if (Array.isArray(bidRequestUserId[subModuleKey])) {
         bidRequestUserId[subModuleKey].forEach((config, index, arr) => {
           const eid = createEidObject(config, subModuleKey);

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -419,27 +419,12 @@ export function createEidsArray(bidRequestUserId) {
       if (subModuleKey === 'pubProvidedId') {
         eids = eids.concat(bidRequestUserId['pubProvidedId']);
       } else if (subModuleKey === 'ftrackId') {
-        // ftrack has multiple IDs so we add each one that exists
-        const E_ID = {
-          'atype': 1,
-          'ext': {}
-        };
-        const IDS = bidRequestUserId.ftrackId.hasOwnProperty('ext') ? bidRequestUserId.ftrackId.ext : bidRequestUserId.ftrackId;
-
-        for (let id in IDS) {
-          if (typeof IDS[id] === 'string') {
-            E_ID.ext[id] = IDS[id];
-          } else if (Array.isArray(IDS[id])) {
-            E_ID.ext[id] = IDS[id].join('|');
-          } else {
-            // Unexpected value type
-            E_ID.ext[id] = '';
-          }
-        }
-
-        E_ID.id = E_ID.ext.DeviceID || '';
-
-        eids.push(E_ID);
+        // Schema based on the return value of ftrack decode() method
+        eids.push({
+          atype: 1,
+          ext: bidRequestUserId.ftrackId.ext,
+          id: bidRequestUserId.ftrackId.uid
+        });
       } else if (Array.isArray(bidRequestUserId[subModuleKey])) {
         bidRequestUserId[subModuleKey].forEach((config, index, arr) => {
           const eid = createEidObject(config, subModuleKey);
@@ -456,6 +441,7 @@ export function createEidsArray(bidRequestUserId) {
       }
     }
   }
+
   return eids;
 }
 

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -444,11 +444,15 @@ describe('eids array generation for known sub-modules', function() {
 
   describe('ftrackId', () => {
     it('should return the correct EID schema', () => {
+      // This is the schema returned from the ftrack decode() method
       expect(createEidsArray({
         ftrackId: {
-          DeviceID: ['aaa', 'bbb'],
-          SingleDeviceID: ['ccc', 'ddd'],
-          HHID: ['eee', 'fff']
+          uid: 'test-device-id',
+          ext: {
+            DeviceID: 'test-device-id',
+            SingleDeviceID: 'test-single-device-id',
+            HHID: 'test-household-id'
+          }
         },
         foo: {
           bar: 'baz'
@@ -458,11 +462,11 @@ describe('eids array generation for known sub-modules', function() {
         }
       })).to.deep.equal([{
         atype: 1,
-        id: 'aaa|bbb',
+        id: 'test-device-id',
         ext: {
-          DeviceID: 'aaa|bbb',
-          SingleDeviceID: 'ccc|ddd',
-          HHID: 'eee|fff'
+          DeviceID: 'test-device-id',
+          SingleDeviceID: 'test-single-device-id',
+          HHID: 'test-household-id'
         }
       }]);
     });

--- a/test/spec/modules/ftrackIdSystem_spec.js
+++ b/test/spec/modules/ftrackIdSystem_spec.js
@@ -327,6 +327,25 @@ describe('FTRACK ID System', () => {
         }]
       }
     };
+    // The full config mock alternate version
+    const USER_SYNC_CONFIG_ALTERNATE_MOCK = {
+      userSync: {
+        auctionDelay: 10,
+        userIds: [{
+          name: 'ftrack',
+          value: {
+            ftrackId: {
+              uid: 'device_test_id',
+              ext: {
+                HHID: 'household_test_id',
+                DeviceID: 'device_test_id',
+                SingleDeviceID: 'single_device_test_id'
+              }
+            }
+          }
+        }]
+      }
+    };
     // The full eids response
     let expectedEids = [{
       id: 'device_test_id',
@@ -353,7 +372,7 @@ describe('FTRACK ID System', () => {
     });
 
     describe('pbjs.getUserIdsAsync()', () => {
-      it('should return the IDs in the correct schema', () => {
+      it('should return the IDs in the correct schema - flat schema', () => {
         config.setConfig(userSyncConfigMock);
 
         getGlobal().getUserIdsAsync().then(ids => {
@@ -375,8 +394,16 @@ describe('FTRACK ID System', () => {
     });
 
     describe('pbjs.getUserIdsAsEids()', () => {
-      it('should return the correct EIDs schema', () => {
+      it('should return the correct EIDs schema - original schema', () => {
         let userSyncConfig = Object.assign({}, userSyncConfigMock);
+
+        config.setConfig(userSyncConfig);
+
+        expect(getGlobal().getUserIdsAsEids()).to.deep.equal(expectedEids);
+      });
+
+      it('should return the correct EIDs schema - alternate schema', () => {
+        let userSyncConfig = Object.assign({}, USER_SYNC_CONFIG_ALTERNATE_MOCK);
 
         config.setConfig(userSyncConfig);
 

--- a/test/spec/modules/ftrackIdSystem_spec.js
+++ b/test/spec/modules/ftrackIdSystem_spec.js
@@ -275,10 +275,55 @@ describe('FTRACK ID System', () => {
 
   describe(`decode() method`, () => {
     it(`should respond with an object with the key 'ftrackId'`, () => {
-      expect(ftrackIdSubmodule.decode('value', configMock)).to.deep.equal({
+      const MOCK_VALUE_STRINGS = {
+          HHID: 'household_test_id',
+          DeviceID: 'device_test_id',
+          SingleDeviceID: 'single_device_test_id'
+        },
+        MOCK_VALUE_ARRAYS = {
+          HHID: ['household_test_id', 'a', 'b'],
+          DeviceID: ['device_test_id', 'c', 'd'],
+          SingleDeviceID: ['single_device_test_id', 'e', 'f']
+        },
+        MOCK_VALUE_BOTH = {
+          foo: ['foo', 'a', 'b'],
+          bar: 'bar',
+          baz: ['baz', 'baz', 'baz']
+        };
+
+      // strings are just passed through
+      expect(ftrackIdSubmodule.decode(MOCK_VALUE_STRINGS, configMock)).to.deep.equal({
         ftrackId: {
-          ext: { 0: 'v', 1: 'a', 2: 'l', 3: 'u', 4: 'e' },
-          uid: undefined,
+          ext: {
+            HHID: 'household_test_id',
+            DeviceID: 'device_test_id',
+            SingleDeviceID: 'single_device_test_id'
+          },
+          uid: 'device_test_id',
+        },
+      });
+
+      // arrays are converted to strings
+      expect(ftrackIdSubmodule.decode(MOCK_VALUE_ARRAYS, configMock)).to.deep.equal({
+        ftrackId: {
+          ext: {
+            HHID: 'household_test_id|a|b',
+            DeviceID: 'device_test_id|c|d',
+            SingleDeviceID: 'single_device_test_id|e|f'
+          },
+          uid: 'device_test_id|c|d',
+        },
+      });
+
+      // mix of both but uid should be empty string because DeviceId is not defined
+      expect(ftrackIdSubmodule.decode(MOCK_VALUE_BOTH, configMock)).to.deep.equal({
+        ftrackId: {
+          ext: {
+            foo: 'foo|a|b',
+            bar: 'bar',
+            baz: 'baz|baz|baz'
+          },
+          uid: '',
         },
       });
     });
@@ -309,75 +354,40 @@ describe('FTRACK ID System', () => {
   });
 
   describe('pbjs "get id" methods', () => {
-    // The full set of ftrack IDs to test against
-    let expectedIds = {
-      HHID: ['household_test_id'],
-      DeviceID: ['device_test_id'],
-      SingleDeviceID: ['single_device_test_id']
-    };
-    // The full config mock
-    let userSyncConfigMock = {
-      userSync: {
-        auctionDelay: 10,
-        userIds: [{
-          name: 'ftrack',
-          value: {
-            ftrackId: expectedIds
-          }
-        }]
-      }
-    };
-    // The full config mock alternate version
-    const USER_SYNC_CONFIG_ALTERNATE_MOCK = {
-      userSync: {
-        auctionDelay: 10,
-        userIds: [{
-          name: 'ftrack',
-          value: {
-            ftrackId: {
-              uid: 'device_test_id',
-              ext: {
-                HHID: 'household_test_id',
-                DeviceID: 'device_test_id',
-                SingleDeviceID: 'single_device_test_id'
-              }
-            }
-          }
-        }]
-      }
-    };
-    // The full eids response
-    let expectedEids = [{
-      id: 'device_test_id',
-      atype: 1,
-      ext: {
-        HHID: expectedIds.HHID.join('|'),
-        DeviceID: expectedIds.DeviceID.join('|'),
-        SingleDeviceID: expectedIds.SingleDeviceID.join('|')
-      }
-    }];
-
     beforeEach(() => {
       init(config);
       setSubmoduleRegistry([ftrackIdSubmodule]);
     });
 
-    afterEach(() => {
-      // Reset expectedIds to the default values because some tests overwrite them
-      expectedIds = {
-        HHID: ['household_test_id'],
-        DeviceID: ['device_test_id'],
-        SingleDeviceID: ['single_device_test_id']
-      };
-    });
-
     describe('pbjs.getUserIdsAsync()', () => {
       it('should return the IDs in the correct schema - flat schema', () => {
-        config.setConfig(userSyncConfigMock);
+        config.setConfig({
+          userSync: {
+            auctionDelay: 10,
+            userIds: [{
+              name: 'ftrack',
+              value: {
+                ftrackId: {
+                  uid: 'device_test_id',
+                  ext: {
+                    HHID: 'household_test_id',
+                    DeviceID: 'device_test_id',
+                    SingleDeviceID: 'single_device_test_id'
+                  }
+                }
+              }
+            }]
+          }
+        });
 
         getGlobal().getUserIdsAsync().then(ids => {
           expect(ids).to.deep.equal({
-            ftrackId: expectedIds
+            uid: 'device_test_id',
+            ftrackId: {
+              HHID: 'household_test_id',
+              DeviceID: 'device_test_id',
+              SingleDeviceID: 'single_device_test_id'
+            }
           });
         });
       });
@@ -385,81 +395,154 @@ describe('FTRACK ID System', () => {
 
     describe('pbjs.getUserIds()', () => {
       it('should return the IDs in the correct schema', () => {
-        config.setConfig(userSyncConfigMock);
+        config.setConfig({
+          userSync: {
+            auctionDelay: 10,
+            userIds: [{
+              name: 'ftrack',
+              value: {
+                ftrackId: {
+                  uid: 'device_test_id',
+                  ext: {
+                    HHID: 'household_test_id',
+                    DeviceID: 'device_test_id',
+                    SingleDeviceID: 'single_device_test_id'
+                  }
+                }
+              }
+            }]
+          }
+        });
 
         expect(getGlobal().getUserIds()).to.deep.equal({
-          'ftrackId': expectedIds
+          ftrackId: {
+            uid: 'device_test_id',
+            ext: {
+              HHID: 'household_test_id',
+              DeviceID: 'device_test_id',
+              SingleDeviceID: 'single_device_test_id'
+            }
+          }
         });
       });
     });
 
     describe('pbjs.getUserIdsAsEids()', () => {
-      it('should return the correct EIDs schema - original schema', () => {
-        let userSyncConfig = Object.assign({}, userSyncConfigMock);
+      it('should return the correct EIDs schema ', () => {
+        // Pass all three IDs
+        config.setConfig({
+          userSync: {
+            auctionDelay: 10,
+            userIds: [{
+              name: 'ftrack',
+              value: {
+                ftrackId: {
+                  uid: 'device_test_id',
+                  ext: {
+                    HHID: 'household_test_id',
+                    DeviceID: 'device_test_id',
+                    SingleDeviceID: 'single_device_test_id'
+                  }
+                }
+              }
+            }]
+          }
+        });
 
-        config.setConfig(userSyncConfig);
-
-        expect(getGlobal().getUserIdsAsEids()).to.deep.equal(expectedEids);
-      });
-
-      it('should return the correct EIDs schema - alternate schema', () => {
-        let userSyncConfig = Object.assign({}, USER_SYNC_CONFIG_ALTERNATE_MOCK);
-
-        config.setConfig(userSyncConfig);
-
-        expect(getGlobal().getUserIdsAsEids()).to.deep.equal(expectedEids);
+        expect(getGlobal().getUserIdsAsEids()).to.deep.equal([{
+          id: 'device_test_id',
+          atype: 1,
+          ext: {
+            HHID: 'household_test_id',
+            DeviceID: 'device_test_id',
+            SingleDeviceID: 'single_device_test_id'
+          }
+        }]);
       });
 
       describe('by ID type:', () => {
         it('- DeviceID', () => {
-          let userSyncConfig = Object.assign({}, userSyncConfigMock);
+          // Pass DeviceID only
+          config.setConfig({
+            userSync: {
+              auctionDelay: 10,
+              userIds: [{
+                name: 'ftrack',
+                value: {
+                  ftrackId: {
+                    uid: 'device_test_id',
+                    ext: {
+                      DeviceID: 'device_test_id',
+                    }
+                  }
+                }
+              }]
+            }
+          });
 
-          userSyncConfig.userSync.userIds[0].value.ftrackId = {
-            DeviceID: ['device_test_id']
-          };
-
-          let expectedEidsClone = expectedEids.slice();
-          expectedEidsClone[0].ext = {
-            DeviceID: expectedIds.DeviceID.join('|')
-          };
-
-          config.setConfig(userSyncConfig);
-
-          expect(getGlobal().getUserIdsAsEids()).to.deep.equal(expectedEidsClone);
+          expect(getGlobal().getUserIdsAsEids()).to.deep.equal([{
+            id: 'device_test_id',
+            atype: 1,
+            ext: {
+              DeviceID: 'device_test_id'
+            }
+          }]);
         });
 
         it('- HHID', () => {
-          let userSyncConfig = Object.assign({}, userSyncConfigMock);
-          userSyncConfig.userSync.userIds[0].value.ftrackId = {
-            HHID: ['household_test_id']
-          };
+          // Pass HHID only
+          config.setConfig({
+            userSync: {
+              auctionDelay: 10,
+              userIds: [{
+                name: 'ftrack',
+                value: {
+                  ftrackId: {
+                    uid: '',
+                    ext: {
+                      HHID: 'household_test_id'
+                    }
+                  }
+                }
+              }]
+            }
+          });
 
-          let expectedEidsClone = expectedEids.slice();
-          expectedEidsClone[0].id = '';
-          expectedEidsClone[0].ext = {
-            HHID: expectedIds.HHID.join('|')
-          };
-
-          config.setConfig(userSyncConfig);
-
-          expect(getGlobal().getUserIdsAsEids()).to.deep.equal(expectedEidsClone);
+          expect(getGlobal().getUserIdsAsEids()).to.deep.equal([{
+            id: '',
+            atype: 1,
+            ext: {
+              HHID: 'household_test_id'
+            }
+          }]);
         });
 
         it('- SingleDeviceID', () => {
-          let userSyncConfig = Object.assign({}, userSyncConfigMock);
-          userSyncConfig.userSync.userIds[0].value.ftrackId = {
-            SingleDeviceID: ['single_device_test_id']
-          };
+          // Pass SingleDeviceID only
+          config.setConfig({
+            userSync: {
+              auctionDelay: 10,
+              userIds: [{
+                name: 'ftrack',
+                value: {
+                  ftrackId: {
+                    uid: '',
+                    ext: {
+                      SingleDeviceID: 'single_device_test_id'
+                    }
+                  }
+                }
+              }]
+            }
+          });
 
-          let expectedEidsClone = expectedEids.slice();
-          expectedEidsClone[0].id = '';
-          expectedEidsClone[0].ext = {
-            SingleDeviceID: expectedIds.SingleDeviceID.join('|')
-          };
-
-          config.setConfig(userSyncConfig);
-
-          expect(getGlobal().getUserIdsAsEids()).to.deep.equal(expectedEidsClone);
+          expect(getGlobal().getUserIdsAsEids()).to.deep.equal([{
+            id: '',
+            atype: 1,
+            ext: {
+              SingleDeviceID: 'single_device_test_id'
+            }
+          }]);
         });
       });
     });


### PR DESCRIPTION
## Type of change
- [X] Bugfix
- [X] Refactoring (no functional changes, no api changes)

## Description of change
A partner was attempting to use the FTRACK User ID module and they were getting errors in the `createEidsArray` method. The issue was the JSON schema being passed into the method did not match the schema we wrote the code for. The change this PR addresses is the JSON parsing logic was tweaked to accept both schema patterns while also checking value type (string|array) before pushing to the `eids` array that is returned