### PR TITLE
Prebid core: restore bid-level `renderer`

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -690,7 +690,7 @@ function getPreparedBidForAuction(bid, {index = auctionManager.index} = {}) {
   events.emit(CONSTANTS.EVENTS.BID_ADJUSTMENT, bid);
 
   // a publisher-defined renderer can be used to render bids
-  const adUnitRenderer = index.getAdUnit(bid).renderer;
+  const bidRenderer = index.getBidRequest(bid)?.renderer || index.getAdUnit(bid).renderer;
 
   // a publisher can also define a renderer for a mediaType
   const bidObjectMediaType = bid.mediaType;
@@ -704,8 +704,8 @@ function getPreparedBidForAuction(bid, {index = auctionManager.index} = {}) {
   // the renderer for the mediaType takes precendence
   if (mediaTypeRenderer && mediaTypeRenderer.url && mediaTypeRenderer.render && !(mediaTypeRenderer.backupOnly === true && bid.renderer)) {
     renderer = mediaTypeRenderer;
-  } else if (adUnitRenderer && adUnitRenderer.url && adUnitRenderer.render && !(adUnitRenderer.backupOnly === true && bid.renderer)) {
-    renderer = adUnitRenderer;
+  } else if (bidRenderer && bidRenderer.url && bidRenderer.render && !(bidRenderer.backupOnly === true && bid.renderer)) {
+    renderer = bidRenderer;
   }
 
   if (renderer) {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Allow `renderer` to be specified at the bid-level. This was working, although (to the best of my knowledge) undocumented, until 6.9.

## Other information

Fixes https://github.com/prebid/Prebid.js/issues/9126
