### PR TITLE
Generic Analytics Adapter: initial release

### DIFF
--- a/modules/gdprEnforcement.js
+++ b/modules/gdprEnforcement.js
@@ -124,7 +124,7 @@ function getGvlidForAnalyticsAdapter(code, config) {
     try {
       return gvlid.call(adapter.adapter, config);
     } catch (e) {
-      logError(`Error invoking ${code} adapter gvlid()`, e)
+      logError(`Error invoking ${code} adapter.gvlid()`, e)
     }
   })(adapter?.adapter?.gvlid)
 }
@@ -315,7 +315,7 @@ export function enableAnalyticsHook(fn, config) {
     }
     config = config.filter(conf => {
       const analyticsAdapterCode = conf.provider;
-      const gvlid = getGvlid(analyticsAdapterCode, config);
+      const gvlid = getGvlid(analyticsAdapterCode, conf);
       const isAllowed = !!validateRules(purpose7Rule, consentData, analyticsAdapterCode, gvlid);
       if (!isAllowed) {
         analyticsBlocked.push(analyticsAdapterCode);

--- a/modules/gdprEnforcement.js
+++ b/modules/gdprEnforcement.js
@@ -154,13 +154,14 @@ export function validateRules(rule, consentData, currentModule, gvlId) {
   const purposeId = TCF2[Object.keys(TCF2).filter(purposeName => TCF2[purposeName].name === rule.purpose)[0]].id;
 
   // return 'true' if vendor present in 'vendorExceptions'
-  if (includes(rule.vendorExceptions || [], currentModule)) {
+  if ((rule.vendorExceptions || []).includes(currentModule)) {
     return true;
   }
+  const vendorConsentRequred = !((gvlId === VENDORLESS_GVLID || (rule.softVendorExceptions || []).includes(currentModule)))
 
   // get data from the consent string
   const purposeConsent = deepAccess(consentData, `vendorData.purpose.consents.${purposeId}`);
-  const vendorConsent = gvlId === VENDORLESS_GVLID ? true : deepAccess(consentData, `vendorData.vendor.consents.${gvlId}`);
+  const vendorConsent = vendorConsentRequred ? deepAccess(consentData, `vendorData.vendor.consents.${gvlId}`) : true;
   const liTransparency = deepAccess(consentData, `vendorData.purpose.legitimateInterests.${purposeId}`);
 
   /*

--- a/modules/genericAnalyticsAdapter.js
+++ b/modules/genericAnalyticsAdapter.js
@@ -15,6 +15,7 @@ const TYPES = {
   handler: 'function',
   batchSize: 'number',
   batchDelay: 'number',
+  gvlid: 'number',
 }
 
 const MAX_CALL_DEPTH = 20;
@@ -103,6 +104,9 @@ export function GenericAnalytics() {
   return Object.assign(
     Object.create(parent),
     {
+      gvlid(config) {
+        return config?.options?.gvlid
+      },
       enableAnalytics(config) {
         if (optionsAreValid(config?.options || {})) {
           options = Object.assign({}, DEFAULTS, config.options);
@@ -151,5 +155,4 @@ export function defaultHandler({url, method, batchSize, ajax = ajaxBuilder()}) {
 adapterManager.registerAnalyticsAdapter({
   adapter: GenericAnalytics(),
   code: 'generic',
-  gvlid: VENDORLESS_GVLID,
 });

--- a/modules/genericAnalyticsAdapter.js
+++ b/modules/genericAnalyticsAdapter.js
@@ -1,0 +1,153 @@
+import AnalyticsAdapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
+import {prefixLog, isPlainObject} from '../src/utils.js';
+import * as CONSTANTS from '../src/constants.json';
+import adapterManager from '../src/adapterManager.js';
+import {ajaxBuilder} from '../src/ajax.js';
+
+const DEFAULTS = {
+  batchSize: 1,
+  batchDelay: 100,
+  method: 'POST'
+}
+
+const TYPES = {
+  handler: 'function',
+  batchSize: 'number',
+  batchDelay: 'number',
+}
+
+const MAX_CALL_DEPTH = 20;
+
+export function GenericAnalytics() {
+  const parent = AnalyticsAdapter({analyticsType: 'endpoint'});
+  const {logError, logWarn} = prefixLog('Generic analytics:');
+  let batch = [];
+  let callDepth = 0;
+  let options, handler, timer, translate;
+
+  function optionsAreValid(options) {
+    if (!options.url && !options.handler) {
+      logError('options must specify either `url` or `handler`')
+      return false;
+    }
+    if (options.hasOwnProperty('method') && !['GET', 'POST'].includes(options.method)) {
+      logError('options.method must be GET or POST');
+      return false;
+    }
+    for (const [field, type] of Object.entries(TYPES)) {
+      // eslint-disable-next-line valid-typeof
+      if (options.hasOwnProperty(field) && typeof options[field] !== type) {
+        logError(`options.${field} must be a ${type}`);
+        return false;
+      }
+    }
+    if (options.hasOwnProperty('events')) {
+      if (!isPlainObject(options.events)) {
+        logError('options.events must be an object');
+        return false;
+      }
+      for (const [event, handler] of Object.entries(options.events)) {
+        if (!CONSTANTS.EVENTS.hasOwnProperty(event)) {
+          logWarn(`options.events.${event} does not match any known Prebid event`);
+          if (typeof handler !== 'function') {
+            logError(`options.events.${event} must be a function`);
+            return false;
+          }
+        }
+      }
+    }
+    return true;
+  }
+
+  function processBatch() {
+    const currentBatch = batch;
+    batch = [];
+    callDepth++;
+    try {
+      // the pub-provided handler may inadvertently cause an infinite chain of events;
+      // even just logging an exception from it may cause an AUCTION_DEBUG event, that
+      // gets back to the handler, that throws another exception etc.
+      // to avoid the issue, put a cap on recursion
+      if (callDepth === MAX_CALL_DEPTH) {
+        logError('detected probable infinite recursion, discarding events', currentBatch);
+      }
+      if (callDepth >= MAX_CALL_DEPTH) {
+        return;
+      }
+      try {
+        handler(currentBatch);
+      } catch (e) {
+        logError('error executing options.handler', e);
+      }
+    } finally {
+      callDepth--;
+    }
+  }
+
+  function translator(eventHandlers) {
+    if (!eventHandlers) {
+      return (data) => data;
+    }
+    return function ({eventType, args}) {
+      if (eventHandlers.hasOwnProperty(eventType)) {
+        try {
+          return eventHandlers[eventType](args);
+        } catch (e) {
+          logError(`error executing options.events.${eventType}`, e);
+        }
+      }
+    }
+  }
+
+  return Object.assign(
+    Object.create(parent),
+    {
+      enableAnalytics(config) {
+        if (optionsAreValid(config?.options || {})) {
+          options = Object.assign({}, DEFAULTS, config.options);
+          handler = options.handler || defaultHandler(options);
+          translate = translator(options.events);
+          parent.enableAnalytics.call(this, config);
+        }
+      },
+      track(event) {
+        if (event.eventType === CONSTANTS.EVENTS.AUCTION_INIT && event.args.hasOwnProperty('config')) {
+          // clean up auctionInit event
+          // TODO: remove this special case in v8
+          delete event.args.config;
+        }
+        const datum = translate(event);
+        if (datum != null) {
+          batch.push(datum);
+          if (timer != null) {
+            clearTimeout(timer);
+            timer = null;
+          }
+          if (batch.length >= options.batchSize) {
+            processBatch();
+          } else {
+            timer = setTimeout(processBatch, options.batchDelay);
+          }
+        }
+      }
+    }
+  )
+}
+
+export function defaultHandler({url, method, batchSize, ajax = ajaxBuilder()}) {
+  const callbacks = {
+    success() {},
+    error() {}
+  }
+  const extract = batchSize > 1 ? (events) => events : (events) => events[0];
+  const serialize = method === 'GET' ? (data) => ({data: JSON.stringify(data)}) : (data) => JSON.stringify(data);
+
+  return function (events) {
+    ajax(url, callbacks, serialize(extract(events)), {method})
+  }
+}
+
+adapterManager.registerAnalyticsAdapter({
+  adapter: GenericAnalytics(),
+  code: 'generic'
+});

--- a/modules/genericAnalyticsAdapter.js
+++ b/modules/genericAnalyticsAdapter.js
@@ -3,6 +3,7 @@ import {prefixLog, isPlainObject} from '../src/utils.js';
 import * as CONSTANTS from '../src/constants.json';
 import adapterManager from '../src/adapterManager.js';
 import {ajaxBuilder} from '../src/ajax.js';
+import {VENDORLESS_GVLID} from '../src/consentHandler.js';
 
 const DEFAULTS = {
   batchSize: 1,
@@ -149,5 +150,6 @@ export function defaultHandler({url, method, batchSize, ajax = ajaxBuilder()}) {
 
 adapterManager.registerAnalyticsAdapter({
   adapter: GenericAnalytics(),
-  code: 'generic'
+  code: 'generic',
+  gvlid: VENDORLESS_GVLID,
 });

--- a/modules/genericAnalyticsAdapter.js
+++ b/modules/genericAnalyticsAdapter.js
@@ -3,7 +3,6 @@ import {prefixLog, isPlainObject} from '../src/utils.js';
 import * as CONSTANTS from '../src/constants.json';
 import adapterManager from '../src/adapterManager.js';
 import {ajaxBuilder} from '../src/ajax.js';
-import {VENDORLESS_GVLID} from '../src/consentHandler.js';
 
 const DEFAULTS = {
   batchSize: 1,

--- a/modules/pubCommonId.js
+++ b/modules/pubCommonId.js
@@ -9,8 +9,9 @@ import * as events from '../src/events.js';
 import CONSTANTS from '../src/constants.json';
 import { getStorageManager } from '../src/storageManager.js';
 import {timedAuctionHook} from '../src/utils/perfMetrics.js';
+import {VENDORLESS_GVLID} from '../src/consentHandler.js';
 
-const storage = getStorageManager({moduleName: 'pubCommonId'});
+const storage = getStorageManager({moduleName: 'pubCommonId', gvlid: VENDORLESS_GVLID});
 
 const ID_NAME = '_pubcid';
 const OPTOUT_NAME = '_pubcid_optout';

--- a/modules/pubProvidedIdSystem.js
+++ b/modules/pubProvidedIdSystem.js
@@ -7,6 +7,7 @@
 
 import {submodule} from '../src/hook.js';
 import { logInfo, isArray } from '../src/utils.js';
+import {VENDORLESS_GVLID} from '../src/consentHandler.js';
 
 const MODULE_NAME = 'pubProvidedId';
 
@@ -18,6 +19,7 @@ export const pubProvidedIdSubmodule = {
    * @type {string}
    */
   name: MODULE_NAME,
+  gvlid: VENDORLESS_GVLID,
 
   /**
    * decode the stored id value for passing to bid request

--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -9,8 +9,9 @@ import { parseUrl, buildUrl, triggerPixel, logInfo, hasDeviceAccess, generateUUI
 import {submodule} from '../src/hook.js';
 import { coppaDataHandler } from '../src/adapterManager.js';
 import {getStorageManager} from '../src/storageManager.js';
+import {VENDORLESS_GVLID} from '../src/consentHandler.js';
 
-export const storage = getStorageManager({moduleName: 'pubCommonId'});
+export const storage = getStorageManager({moduleName: 'pubCommonId', gvlid: VENDORLESS_GVLID});
 const COOKIE = 'cookie';
 const LOCAL_STORAGE = 'html5';
 const OPTOUT_NAME = '_pubcid_optout';
@@ -73,6 +74,7 @@ export const sharedIdSystemSubmodule = {
    */
   name: 'sharedId',
   aliasName: 'pubCommonId',
+  gvlid: VENDORLESS_GVLID,
 
   /**
    * decode the stored id value for passing to bid requests

--- a/src/consentHandler.js
+++ b/src/consentHandler.js
@@ -1,6 +1,14 @@
 import {isStr, timestamp} from './utils.js';
 import {defer, GreedyPromise} from './utils/promise.js';
 
+/**
+ * Placeholder gvlid for when vendor consent is not required. When this value is used as gvlid, the gdpr
+ * enforcement module will take it to mean "vendor consent was given".
+ *
+ * see https://github.com/prebid/Prebid.js/issues/8161
+ */
+export const VENDORLESS_GVLID = Object.freeze({});
+
 export class ConsentHandler {
   #enabled;
   #data;

--- a/src/storageManager.js
+++ b/src/storageManager.js
@@ -1,6 +1,7 @@
 import {hook} from './hook.js';
 import {hasDeviceAccess, checkCookieSupport, logError, logInfo, isPlainObject} from './utils.js';
 import {bidderSettings as defaultBidderSettings} from './bidderSettings.js';
+import {VENDORLESS_GVLID} from './consentHandler.js';
 
 const moduleTypeWhiteList = ['core', 'prebid-module'];
 
@@ -33,7 +34,9 @@ export function newStorageManager({gvlid, moduleName, bidderCode, moduleType} = 
     return storageAllowed == null ? false : storageAllowed;
   }
 
-  const isVendorless = moduleTypeWhiteList.includes(moduleType);
+  if (moduleTypeWhiteList.includes(moduleType)) {
+    gvlid = gvlid || VENDORLESS_GVLID;
+  }
 
   function isValid(cb) {
     if (!isBidderAllowed()) {
@@ -45,7 +48,7 @@ export function newStorageManager({gvlid, moduleName, bidderCode, moduleType} = 
       let hookDetails = {
         hasEnforcementHook: false
       }
-      validateStorageEnforcement(isVendorless, gvlid, bidderCode || moduleName, hookDetails, function(result) {
+      validateStorageEnforcement(gvlid, bidderCode || moduleName, hookDetails, function(result) {
         if (result && result.hasEnforcementHook) {
           value = cb(result);
         } else {
@@ -296,7 +299,7 @@ export function newStorageManager({gvlid, moduleName, bidderCode, moduleType} = 
 /**
  * This hook validates the storage enforcement if gdprEnforcement module is included
  */
-export const validateStorageEnforcement = hook('async', function(isVendorless, gvlid, moduleName, hookDetails, callback) {
+export const validateStorageEnforcement = hook('async', function(gvlid, moduleName, hookDetails, callback) {
   callback(hookDetails);
 }, 'validateStorageEnforcement');
 

--- a/test/spec/modules/gdprEnforcement_spec.js
+++ b/test/spec/modules/gdprEnforcement_spec.js
@@ -791,11 +791,12 @@ describe('gdpr enforcement', function () {
   });
 
   describe('validateRules', function () {
-    const createGdprRule = (purposeName = 'storage', enforcePurpose = true, enforceVendor = true, vendorExceptions = []) => ({
+    const createGdprRule = (purposeName = 'storage', enforcePurpose = true, enforceVendor = true, vendorExceptions = [], softVendorExceptions = []) => ({
       purpose: purposeName,
-      enforcePurpose: enforcePurpose,
-      enforceVendor: enforceVendor,
-      vendorExceptions: vendorExceptions
+      enforcePurpose,
+      enforceVendor,
+      vendorExceptions,
+      softVendorExceptions,
     });
 
     const consentData = {
@@ -908,6 +909,19 @@ describe('gdpr enforcement', function () {
       const isAllowed = validateRules(gdprRule, consentData, vendorBlockedModule, vendorBlockedGvlId);
       expect(isAllowed).to.equal(true);
     });
+
+    describe('when the vendor has a softVendorException', () => {
+      const gdprRule = createGdprRule('storage', true, true, [], [vendorBlockedModule]);
+
+      it('should return false if general consent was not given', () => {
+        const isAllowed = validateRules(gdprRule, consentDataWithPurposeConsentFalse, vendorBlockedModule, vendorBlockedGvlId);
+        expect(isAllowed).to.be.false;
+      })
+      it('should return true if general consent was given', () => {
+        const isAllowed = validateRules(gdprRule, consentData, vendorBlockedModule, vendorBlockedGvlId);
+        expect(isAllowed).to.be.true;
+      })
+    })
 
     describe('when module does not need vendor consent', () => {
       Object.entries({
@@ -1214,7 +1228,6 @@ describe('gdpr enforcement', function () {
         adapter.gvlid = () => { throw new Error(); };
         expect(internal.getGvlidForAnalyticsAdapter('analytics')).to.not.be.ok;
       });
-
     });
   })
 });

--- a/test/spec/modules/genericAnalyticsAdapter_spec.js
+++ b/test/spec/modules/genericAnalyticsAdapter_spec.js
@@ -1,0 +1,284 @@
+import {defaultHandler, GenericAnalytics} from '../../../modules/genericAnalyticsAdapter.js';
+import * as events from 'src/events.js';
+import * as CONSTANTS from 'src/constants.json';
+
+const {AUCTION_INIT, BID_RESPONSE} = CONSTANTS.EVENTS;
+
+describe('Generic analytics', () => {
+  describe('adapter', () => {
+    let adapter, sandbox, clock;
+    beforeEach(() => {
+      sandbox = sinon.sandbox.create();
+      sandbox.stub(events, 'getEvents').returns([]);
+      clock = sandbox.useFakeTimers();
+      adapter = new GenericAnalytics();
+    });
+
+    afterEach(() => {
+      adapter.disableAnalytics();
+      sandbox.restore();
+    });
+
+    describe('configuration', () => {
+      it('should be accepted if valid', () => {
+        adapter.enableAnalytics({
+          options: {
+            url: 'mock',
+            method: 'GET',
+            batchSize: 123,
+            batchDelay: 321
+          }
+        });
+        expect(adapter.enabled).to.be.true;
+      });
+
+      describe('should not work if', () => {
+        afterEach(function() {
+          expect(adapter.enabled).to.equal(false, this.currentTest.title);
+        });
+
+        it('neither handler nor url are specified', () => {
+          adapter.enableAnalytics({});
+        });
+
+        ['batchSize', 'batchDelay', 'handler'].forEach(option => {
+          it(`${option} is not valid`, () => {
+            adapter.enableAnalytics({
+              options: {
+                url: 'mock',
+                [option]: false
+              }
+            });
+          });
+        });
+
+        it('method is not GET or POST', () => {
+          adapter.enableAnalytics({
+            options: {
+              url: 'mock',
+              method: 'PATCH'
+            }
+          });
+        });
+
+        it('events is not an object', () => {
+          adapter.enableAnalytics({
+            options: {
+              url: 'mock',
+              events: null
+            }
+          });
+        });
+
+        it('events\' properties are not functions', () => {
+          adapter.enableAnalytics({
+            options: {
+              url: 'mock',
+              events: {
+                bidResponse: null
+              }
+            }
+          });
+        });
+      });
+    });
+
+    describe('when handler is specified', () => {
+      let handler;
+      beforeEach(() => {
+        handler = sinon.stub();
+      });
+
+      it('should collect events in batches, and call handler', () => {
+        adapter.enableAnalytics({
+          options: {
+            handler,
+            batchSize: 2
+          }
+        });
+        events.emit(AUCTION_INIT, {i: 0});
+        sinon.assert.notCalled(handler);
+        events.emit(BID_RESPONSE, {i: 0});
+        sinon.assert.calledWith(handler, sinon.match((arg) => {
+          return sinon.match({eventType: AUCTION_INIT, args: {i: 0}}).test(arg[0]) &&
+            sinon.match({eventType: BID_RESPONSE, args: {i: 0}}).test(arg[1]);
+        }));
+      });
+
+      it('should not choke if handler throws', () => {
+        adapter.enableAnalytics({
+          options: {
+            handler,
+            batchSize: 1
+          }
+        });
+        handler.throws(new Error());
+        events.emit(AUCTION_INIT, {i: 0});
+        let recv;
+        handler.reset();
+        handler.callsFake((arg) => {
+          recv = arg;
+        });
+        events.emit(BID_RESPONSE, {i: 1});
+        expect(recv).to.eql([{eventType: BID_RESPONSE, args: {i: 1}}]);
+      });
+
+      it('should not cause infinite recursion, if handler triggers more events', () => {
+        let i = 0;
+        handler.callsFake(() => {
+          if (i <= 100) {
+            i++;
+            events.emit(BID_RESPONSE, {});
+          }
+        });
+        adapter.enableAnalytics({
+          options: {
+            handler,
+          }
+        });
+        events.emit(AUCTION_INIT, {});
+        expect(i >= 100).to.be.false;
+      });
+
+      it('should send incomplete batch after batchDelay', () => {
+        adapter.enableAnalytics({
+          options: {
+            batchDelay: 100,
+            batchSize: 2,
+            handler
+          }
+        });
+        [0, 1, 2].forEach(i => events.emit(BID_RESPONSE, {i}));
+        sinon.assert.calledOnce(handler);
+        clock.tick(100);
+        sinon.assert.calledTwice(handler);
+      });
+
+      it('does not send empty batches', () => {
+        adapter.enableAnalytics({
+          options: {
+            batchDelay: 100,
+            batchSize: 2,
+            handler
+          }
+        });
+        [0, 1, 2].forEach(i => events.emit(BID_RESPONSE, {i}));
+        sinon.assert.calledOnce(handler);
+        clock.tick(50);
+        events.emit(BID_RESPONSE, {i: 3});
+        sinon.assert.calledTwice(handler);
+        clock.tick(100);
+        sinon.assert.calledTwice(handler);
+      });
+
+      describe('and options.events is specified', () => {
+        it('filters out other events', () => {
+          adapter.enableAnalytics({
+            options: {
+              handler,
+              events: {
+                bidResponse(bid) {
+                  return bid;
+                }
+              }
+            }
+          });
+          events.emit(AUCTION_INIT, {});
+          sinon.assert.notCalled(handler);
+        });
+
+        it('transforms event data', () => {
+          adapter.enableAnalytics({
+            options: {
+              handler,
+              events: {
+                bidResponse(bid) {
+                  return {
+                    extra: 'data',
+                    prop: bid.prop
+                  }
+                }
+              }
+            }
+          });
+          events.emit(BID_RESPONSE, {prop: 'value', i: 0});
+          sinon.assert.calledWith(handler, sinon.match(data => sinon.match({extra: 'data', prop: 'value'}).test(data[0])));
+        });
+
+        it('does not choke if an event handler throws', () => {
+          adapter.enableAnalytics({
+            options: {
+              handler,
+              events: {
+                bidResponse(bid) {
+                  return bid;
+                },
+                auctionInit(auction) {
+                  throw new Error();
+                }
+              }
+            }
+          });
+          events.emit(AUCTION_INIT, {});
+          events.emit(BID_RESPONSE, {i: 0});
+          sinon.assert.calledOnce(handler);
+          sinon.assert.calledWith(handler, sinon.match(data => sinon.match({i: 0}).test(data[0])));
+        });
+
+        it('filters out events when their handler returns undefined', () => {
+          adapter.enableAnalytics({
+            options: {
+              handler,
+              events: {
+                auctionInit(auction) {
+                  return auction;
+                },
+                bidResponse(bid) {}
+              }
+            }
+          });
+          events.emit(AUCTION_INIT, {i: 0});
+          events.emit(BID_RESPONSE, {i: 1});
+          sinon.assert.calledOnce(handler);
+          sinon.assert.calledWith(handler, sinon.match(data => sinon.match({i: 0}).test(data[0])));
+        });
+      });
+    });
+  });
+
+  describe('default handler', () => {
+    const url = 'mock-url';
+
+    let ajax;
+    beforeEach(() => {
+      ajax = sinon.stub();
+    });
+
+    Object.entries({
+      'GET': (data) => JSON.parse(data.data),
+      'POST': (data) => JSON.parse(data)
+    }).forEach(([method, parse]) => {
+      describe(`when HTTP method is ${method}`, () => {
+        it('should send single event when batchSize is 1', () => {
+          const handler = defaultHandler({url, method, batchSize: 1, ajax});
+          const payload = {i: 0};
+          handler([payload, {}]);
+          sinon.assert.calledWith(ajax, url, sinon.match.any,
+            sinon.match(data => sinon.match(payload).test(parse(data))),
+            {method}
+          );
+        });
+
+        it('should send multiple events when batchSize is greater than 1', () => {
+          const handler = defaultHandler({url, method, batchSize: 10, ajax});
+          const payload = [{i: 0}, {i: 1}];
+          handler(payload);
+          sinon.assert.calledWith(ajax, url, sinon.match.any,
+            sinon.match(data => sinon.match(payload).test(parse(data))),
+            {method}
+          );
+        });
+      });
+    });
+  });
+});

--- a/test/spec/unit/core/storageManager_spec.js
+++ b/test/spec/unit/core/storageManager_spec.js
@@ -8,6 +8,7 @@ import {
 import { config } from 'src/config.js';
 import * as utils from 'src/utils.js';
 import {hook} from '../../../../src/hook.js';
+import {VENDORLESS_GVLID} from '../../../../src/consentHandler.js';
 
 describe('storage manager', function() {
   before(() => {
@@ -73,7 +74,7 @@ describe('storage manager', function() {
 
     it('should respect (vendorless) consent enforcement', () => {
       storage.localStorageIsEnabled();
-      expect(validateHook.args[0][1]).to.eql(true); // isVendorless should be set to true
+      expect(validateHook.args[0][1]).to.equal(VENDORLESS_GVLID); // gvlid should be set to VENDORLESS_GVLID
     });
 
     it('should respect the deviceAccess flag', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

This is a new generic analytics adapter, meant for publishers that have their own infrastrucutre for collecting analytics data. The adapter is "vendorless" for the purposes of GDPR enforcement (in the same way that sharedId is).

## Other information

Closes https://github.com/prebid/Prebid.js/issues/8835
Closes https://github.com/prebid/Prebid.js/issues/6564
Documentation: https://github.com/prebid/prebid.github.io/pull/4092

