### PR TITLE
Prebid core: allow configurable TTL buffer

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -666,6 +666,7 @@ export const callPrebidCache = hook('async', function(auctionInstance, bidRespon
  */
 function addCommonResponseProperties(bidResponse, adUnitCode, {index = auctionManager.index} = {}) {
   const bidderRequest = index.getBidderRequest(bidResponse);
+  const adUnit = index.getAdUnit(bidResponse);
   const start = (bidderRequest && bidderRequest.start) || bidResponse.requestTimestamp;
 
   Object.assign(bidResponse, {
@@ -675,6 +676,10 @@ function addCommonResponseProperties(bidResponse, adUnitCode, {index = auctionMa
     bidder: bidResponse.bidder || bidResponse.bidderCode,
     adUnitCode
   });
+
+  if (adUnit?.ttlBuffer != null) {
+    bidResponse.ttlBuffer = adUnit.ttlBuffer;
+  }
 
   bidResponse.timeToRespond = bidResponse.responseTimestamp - bidResponse.requestTimestamp;
 }

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -28,7 +28,15 @@ import CONSTANTS from './constants.json';
 var pbTargetingKeys = [];
 
 const MAX_DFP_KEYLENGTH = 20;
-const TTL_BUFFER = 1000;
+let DEFAULT_TTL_BUFFER = 1;
+
+config.getConfig('ttlBuffer', (cfg) => {
+  if (typeof cfg.ttlBuffer === 'number') {
+    DEFAULT_TTL_BUFFER = cfg.ttlBuffer;
+  } else {
+    logError('Invalid value for ttlBuffer', cfg.ttlBuffer);
+  }
+})
 
 const CFG_ALLOW_TARGETING_KEYS = `targetingControls.allowTargetingKeys`;
 const CFG_ADD_TARGETING_KEYS = `targetingControls.addTargetingKeys`;
@@ -39,7 +47,7 @@ export const TARGETING_KEYS = Object.keys(CONSTANTS.TARGETING_KEYS).map(
 );
 
 // return unexpired bids
-const isBidNotExpired = (bid) => (bid.responseTimestamp + bid.ttl * 1000 - TTL_BUFFER) > timestamp();
+const isBidNotExpired = (bid) => (bid.responseTimestamp + (bid.ttl - (bid.hasOwnProperty('ttlBuffer') ? bid.ttlBuffer : DEFAULT_TTL_BUFFER)) * 1000) > timestamp();
 
 // return bids whose status is not set. Winning bids can only have a status of `rendered`.
 const isUnusedBid = (bid) => bid && ((bid.status && !includes([CONSTANTS.BID_STATUS.RENDERED], bid.status)) || !bid.status);

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -955,6 +955,12 @@ describe('auctionmanager.js', function () {
         const addedBid = find(auction.getBidsReceived(), bid => bid.adUnitCode == ADUNIT_CODE);
         assert.equal(addedBid.renderer.url, 'renderer.js');
       });
+
+      it('sets bidResponse.ttlBuffer from adUnit.ttlBuffer', () => {
+        adUnits[0].ttlBuffer = 0;
+        auction.callBids();
+        expect(auction.getBidsReceived()[0].ttlBuffer).to.eql(0);
+      });
     });
 
     describe('when auction timeout is 20', function () {

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -269,6 +269,40 @@ describe('targeting tests', function () {
     bidCacheFilterFunction = undef;
   });
 
+  describe('isBidNotExpired', () => {
+    let clock;
+    beforeEach(() => {
+      clock = sandbox.useFakeTimers(0);
+    });
+
+    Object.entries({
+      'bid.ttlBuffer': (bid, ttlBuffer) => {
+        bid.ttlBuffer = ttlBuffer
+      },
+      'setConfig({ttlBuffer})': (_, ttlBuffer) => {
+        config.setConfig({ttlBuffer})
+      },
+    }).forEach(([t, setup]) => {
+      describe(`respects ${t}`, () => {
+        [0, 2].forEach(ttlBuffer => {
+          it(`when ttlBuffer is ${ttlBuffer}`, () => {
+            const bid = {
+              responseTimestamp: 0,
+              ttl: 10,
+            }
+            setup(bid, ttlBuffer);
+
+            expect(filters.isBidNotExpired(bid)).to.be.true;
+            clock.tick((bid.ttl - ttlBuffer) * 1000 - 100);
+            expect(filters.isBidNotExpired(bid)).to.be.true;
+            clock.tick(101);
+            expect(filters.isBidNotExpired(bid)).to.be.false;
+          });
+        });
+      });
+    });
+  });
+
   describe('getAllTargeting', function () {
     let amBidsReceivedStub;
     let amGetAdUnitsStub;

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1458,7 +1458,7 @@ describe('Unit: Prebid Module', function () {
 
   describe('requestBids', function () {
     let logMessageSpy;
-    let makeRequestsStub;
+    let makeRequestsStub, createAuctionStub;
     let adUnits;
     let clock;
     before(function () {
@@ -1527,7 +1527,7 @@ describe('Unit: Prebid Module', function () {
         callback: bidsBackHandlerStub,
         cbTimeout: 2000
       });
-      let createAuctionStub = sinon.stub(auctionModule, 'newAuction');
+      createAuctionStub = sinon.stub(auctionModule, 'newAuction');
       createAuctionStub.returns(auction);
     });
 
@@ -1536,6 +1536,7 @@ describe('Unit: Prebid Module', function () {
       adapterManager.makeBidRequests.restore();
       auctionModule.newAuction.restore();
       utils.logMessage.restore();
+      createAuctionStub.restore();
     });
 
     it('should execute callback after timeout', function () {
@@ -1616,6 +1617,16 @@ describe('Unit: Prebid Module', function () {
       $$PREBID_GLOBAL$$.setTargetingForGPTAsync();
 
       sinon.assert.called(spec.onSetTargeting);
+    });
+
+    it('should transfer ttlBuffer to adUnit.ttlBuffer', () => {
+      $$PREBID_GLOBAL$$.requestBids({
+        ttlBuffer: 123,
+        adUnits: [adUnits[0], {...adUnits[0], ttlBuffer: 0}]
+      });
+      sinon.assert.calledWithMatch(createAuctionStub, {
+        adUnits: sinon.match((units) => units[0].ttlBuffer === 123 && units[1].ttlBuffer === 0)
+      })
     });
   })
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

Currently there is a hardcoded 1 second "TTL buffer" used by targeting logic to decide if a bid has expired: a bid with a TTL of 30 seconds is considered expired after 29 seconds.

This adds a `ttlBuffer` option accepted as:

- `setConfig({ttlBuffer})` that acts as the global default (default is 1 second)
- `requestBids({ttlBuffer})` acts as the default within an auction
- `adUnit.ttlBuffer` acts on a single ad unit.

## Other information

Closes https://github.com/prebid/Prebid.js/issues/8953
Documentation: https://github.com/prebid/prebid.github.io/pull/4097
