### PR TITLE
Prebid core: do not enforce valid size in bid responses

### DIFF
--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -1434,9 +1434,5 @@ describe('bid response isValid', () => {
     it('should succeed when response has a size that was in request', () => {
       expect(checkValid(mkResponse(3, 4))).to.be.true;
     });
-
-    it('should fail when response has a size that was not in request', () => {
-      expect(checkValid(mkResponse(10, 11))).to.be.false;
-    });
   })
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Do not enforce that a bid response's size matches one of the sizes that were requested.

## Other information

Fixes https://github.com/prebid/Prebid.js/issues/9137

