### PR TITLE
Set a globalVarName to support LC configurations in different instances

### DIFF
--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -4,7 +4,7 @@
  * @module modules/liveIntentIdSystem
  * @requires module:modules/userId
  */
-import { triggerPixel, logError } from '../src/utils.js';
+import { generateUUID, triggerPixel, logError } from '../src/utils.js';
 import { ajaxBuilder } from '../src/ajax.js';
 import { submodule } from '../src/hook.js';
 import { LiveConnect } from 'live-connect-js/esm/initializer.js';
@@ -14,6 +14,7 @@ import { getStorageManager } from '../src/storageManager.js';
 const MODULE_NAME = 'liveIntentId';
 export const storage = getStorageManager({gvlid: null, moduleName: MODULE_NAME});
 const defaultRequestedAttributes = {'nonId': true}
+const globalVarName = `prebid_liQ_${generateUUID().slice(0, 8)}`
 const calls = {
   ajaxGet: (url, onSuccess, onError, timeout) => {
     ajaxBuilder(timeout)(
@@ -109,6 +110,7 @@ function initializeLiveConnect(configParams) {
     liveConnectConfig.gdprApplies = gdprConsent.gdprApplies;
     liveConnectConfig.gdprConsent = gdprConsent.consentString;
   }
+  liveConnectConfig.globalVarName = globalVarName
 
   // The second param is the storage object, LS & Cookie manipulation uses PBJS
   // The third param is the ajax and pixel object, the ajax and pixel use PBJS

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -10,7 +10,6 @@ import { submodule } from '../src/hook.js';
 import { LiveConnect } from 'live-connect-js/esm/initializer.js';
 import { gdprDataHandler, uspDataHandler } from '../src/adapterManager.js';
 import { getStorageManager } from '../src/storageManager.js';
-import { MinimalLiveConnect } from 'live-connect-js/esm/minimal-live-connect.js';
 
 const MODULE_NAME = 'liveIntentId';
 export const storage = getStorageManager({gvlid: null, moduleName: MODULE_NAME});
@@ -113,7 +112,7 @@ function initializeLiveConnect(configParams) {
 
   // The second param is the storage object, LS & Cookie manipulation uses PBJS
   // The third param is the ajax and pixel object, the ajax and pixel use PBJS
-  liveConnect = liveIntentIdSubmodule.getInitializer()(liveConnectConfig, storage, calls);
+  liveConnect = LiveConnect(liveConnectConfig, storage, calls);
   if (configParams.emailHash) {
     liveConnect.push({ hash: configParams.emailHash })
   }
@@ -138,9 +137,6 @@ export const liveIntentIdSubmodule = {
 
   setModuleMode(mode) {
     this.moduleMode = mode
-  },
-  getInitializer() {
-    return this.moduleMode === 'minimal' ? MinimalLiveConnect : LiveConnect
   },
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "prebid.js",
-      "version": "7.21.0-pre",
+      "version": "7.23.0-pre",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.7",
@@ -22,7 +22,7 @@
         "express": "^4.15.4",
         "fun-hooks": "^0.9.9",
         "just-clone": "^1.0.2",
-        "live-connect-js": "2.4.0"
+        "live-connect-js": "3.0.0-alpha.1"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.16.5",
@@ -13957,9 +13957,9 @@
       "dev": true
     },
     "node_modules/live-connect-js": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-2.4.0.tgz",
-      "integrity": "sha512-MSBLKfnXoxH+pqwji/Mf8yZu3VZMq4tnNfwMw7NTWN5a+TBM6f0RWgwui1YMA3nHmMhX/nzxxsso0SkyKcF0fA==",
+      "version": "3.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-3.0.0-alpha.1.tgz",
+      "integrity": "sha512-Z3V4t/Chk3XUBPogXOLNEall/9rWrQsZL5OA2yl6gxaLQpEKxM+xNJht/G4NXs/NU2bYODfJ5XlVApLmIaC7tQ==",
       "dependencies": {
         "tiny-hashes": "1.0.1"
       },
@@ -32987,9 +32987,9 @@
       "dev": true
     },
     "live-connect-js": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-2.4.0.tgz",
-      "integrity": "sha512-MSBLKfnXoxH+pqwji/Mf8yZu3VZMq4tnNfwMw7NTWN5a+TBM6f0RWgwui1YMA3nHmMhX/nzxxsso0SkyKcF0fA==",
+      "version": "3.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-3.0.0-alpha.1.tgz",
+      "integrity": "sha512-Z3V4t/Chk3XUBPogXOLNEall/9rWrQsZL5OA2yl6gxaLQpEKxM+xNJht/G4NXs/NU2bYODfJ5XlVApLmIaC7tQ==",
       "requires": {
         "tiny-hashes": "1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "express": "^4.15.4",
     "fun-hooks": "^0.9.9",
     "just-clone": "^1.0.2",
-    "live-connect-js": "2.4.0"
+    "live-connect-js": "3.0.0-alpha.1"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
