### PR TITLE
Criteo Bid Adapter: add support of static floors

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -644,26 +644,46 @@ for (var i = 0; i < 10; ++i) {
 </script>`;
 }
 
+function pickAvailableGetFloorFunc(bidRequest) {
+  if (bidRequest.getFloor) {
+    return bidRequest.getFloor;
+  }
+  if (bidRequest.params.bidFloor && bidRequest.params.bidFloorCur) {
+    try {
+      const floor = parseFloat(bidRequest.params.bidFloor);
+      return () => {
+        return {
+          currency: bidRequest.params.bidFloorCur,
+          floor: floor
+        };
+      };
+    } catch { }
+  }
+  return undefined;
+}
+
 function enrichSlotWithFloors(slot, bidRequest) {
   try {
     const slotFloors = {};
 
-    if (bidRequest.getFloor) {
+    const getFloor = pickAvailableGetFloorFunc(bidRequest);
+
+    if (getFloor) {
       if (bidRequest.mediaTypes?.banner) {
         slotFloors.banner = {};
         const bannerSizes = parseSizes(deepAccess(bidRequest, 'mediaTypes.banner.sizes'))
-        bannerSizes.forEach(bannerSize => slotFloors.banner[parseSize(bannerSize).toString()] = bidRequest.getFloor({ size: bannerSize, mediaType: BANNER }));
+        bannerSizes.forEach(bannerSize => slotFloors.banner[parseSize(bannerSize).toString()] = getFloor({ size: bannerSize, mediaType: BANNER }));
       }
 
       if (bidRequest.mediaTypes?.video) {
         slotFloors.video = {};
         const videoSizes = parseSizes(deepAccess(bidRequest, 'mediaTypes.video.playerSize'))
-        videoSizes.forEach(videoSize => slotFloors.video[parseSize(videoSize).toString()] = bidRequest.getFloor({ size: videoSize, mediaType: VIDEO }));
+        videoSizes.forEach(videoSize => slotFloors.video[parseSize(videoSize).toString()] = getFloor({ size: videoSize, mediaType: VIDEO }));
       }
 
       if (bidRequest.mediaTypes?.native) {
         slotFloors.native = {};
-        slotFloors.native['*'] = bidRequest.getFloor({ size: '*', mediaType: NATIVE });
+        slotFloors.native['*'] = getFloor({ size: '*', mediaType: NATIVE });
       }
 
       if (Object.keys(slotFloors).length > 0) {

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -1279,6 +1279,34 @@ describe('The Criteo bidding adapter', function () {
       });
     });
 
+    it('should properly build a request with static floors', function () {
+      const bidRequests = [
+        {
+          bidder: 'criteo',
+          adUnitCode: 'bid-123',
+          transactionId: 'transaction-123',
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250], [728, 90]]
+            }
+          },
+          params: {
+            networkId: 456,
+            bidFloor: 1,
+            bidFloorCur: 'EUR'
+          },
+        },
+      ];
+      const bidderRequest = {};
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.slots[0].ext.floors).to.deep.equal({
+        'banner': {
+          '300x250': { 'currency': 'EUR', 'floor': 1 },
+          '728x90': { 'currency': 'EUR', 'floor': 1 }
+        }
+      });
+    });
+
     it('should properly build a video request with several player sizes with floors', function () {
       const bidRequests = [
         {


### PR DESCRIPTION
## Type of change
- [X] Feature

## Description of change
We want publishers that are not interested in using Prebid floor module to be able to send us floor/floorCur through bid params.

```
{
  bidder: 'criteo',
  adUnitCode: 'bid-123',
  mediaTypes: {
    banner: {
      sizes: [[300, 250], [728, 90]]
    }
  },
  params: {
    networkId: 456,
    bidFloor: 1,
    bidFloorCur: 'EUR'
  },
}
```