### PR TITLE
Price Floors: fix a typo bug with noDecodeURL

### DIFF
--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -82,7 +82,7 @@ const getHostname = (() => {
   let domain;
   return function() {
     if (domain == null) {
-      domain = parseUrl(getRefererInfo().topmostLocation, {noDecodeWholeUrl: true}).hostname;
+      domain = parseUrl(getRefererInfo().topmostLocation, {noDecodeWholeURL: true}).hostname;
     }
     return domain;
   }


### PR DESCRIPTION
## Type of change
Bugfix

## Description of change
Fix typo. According to the `utils.js` below, the option object passing to `parseUrl` should be `noDecodeWholeURL` rather than `noDecodeWholeUrl`.

- https://github.com/prebid/Prebid.js/blob/master/src/utils.js#L1224-L1243
```
export function parseUrl(url, options) {
  let parsed = document.createElement('a');
  if (options && 'noDecodeWholeURL' in options && options.noDecodeWholeURL) {
    parsed.href = url;
  } else {
    parsed.href = decodeURIComponent(url);
  }
  // in window.location 'search' is string, not object
  let qsAsString = (options && 'decodeSearchAsString' in options && options.decodeSearchAsString);
  return {
    href: parsed.href,
    protocol: (parsed.protocol || '').replace(/:$/, ''),
    hostname: parsed.hostname,
    port: +parsed.port,
    pathname: parsed.pathname.replace(/^(?!\/)/, '/'),
    search: (qsAsString) ? parsed.search : internal.parseQS(parsed.search || ''),
    hash: (parsed.hash || '').replace(/^#/, ''),
    host: parsed.host || window.location.host
  };
}
```

## Other information
- Fixes #9149
- As simple testing, I tweak a minified PBJS library with Local Override. I confirmed this change fix the URI malformed I mentioned above. 
```
            domain: function() {
                return null == k && (k = (0,
                a.parseUrl)((0,
                v.nH)().topmostLocation, {
                    noDecodeWholeUrl: !0
                }).hostname),
                k
            },
```            
->
```
            domain: function() {
                return null == k && (k = (0,
                a.parseUrl)((0,
                v.nH)().topmostLocation, {
                    noDecodeWholeURL: !0
                }).hostname),
                k
            },
```            

And sending floor data to bidders. This is an example of rubiconBidAdapter's XHR before/after the change.

```
...(snip)...
rp_secure: 1
rp_maxbids: 1
...(snip)...
```
->
```
...(snip)...
rp_secure: 1
rp_hard_floor: 0.07
rp_maxbids: 1
...(snip)...
```