### PR TITLE
Kargo Bid Adapter: page URL from topmostLocation

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -225,7 +225,7 @@ export const spec = {
   _getAllMetadata(bidderRequest, tdid) {
     return {
       userIDs: spec._getUserIds(tdid, bidderRequest.uspConsent, bidderRequest.gdprConsent),
-      pageURL: bidderRequest.refererInfo && bidderRequest.refererInfo.page,
+      pageURL: bidderRequest?.refererInfo?.topmostLocation || bidderRequest?.refererInfo?.page,
       rawCRB: storage.getCookie('krg_crb'),
       rawCRBLocalStorage: spec._getLocalStorageSafely('krg_crb')
     };


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Updates to pull page URL from `topmostLocation` with a fallback to `page`

- contact email of the adapter’s maintainer: jeremy@kargo.com