### PR TITLE
JW Player RTD Module: prefer segment.id to segment.value

### DIFF
--- a/modules/gridBidAdapter.js
+++ b/modules/gridBidAdapter.js
@@ -606,7 +606,7 @@ function getUserIdFromFPDStorage() {
 function segmentProcessing(segment, forceSegName) {
   return segment
     .map((seg) => {
-      const value = seg && (seg.value || seg.id || seg);
+      const value = seg && (seg.id || seg);
       if (typeof value === 'string' || typeof value === 'number') {
         return {
           value: value.toString(),

--- a/modules/gridBidAdapter.js
+++ b/modules/gridBidAdapter.js
@@ -606,7 +606,7 @@ function getUserIdFromFPDStorage() {
 function segmentProcessing(segment, forceSegName) {
   return segment
     .map((seg) => {
-      const value = seg && (seg.value || seg.id || seg);
+      const value = seg && (seg.value || seg);
       if (typeof value === 'string' || typeof value === 'number') {
         return {
           value: value.toString(),

--- a/modules/gridBidAdapter.js
+++ b/modules/gridBidAdapter.js
@@ -606,7 +606,7 @@ function getUserIdFromFPDStorage() {
 function segmentProcessing(segment, forceSegName) {
   return segment
     .map((seg) => {
-      const value = seg && (seg.value || seg);
+      const value = seg && (seg.value || seg.id || seg);
       if (typeof value === 'string' || typeof value === 'number') {
         return {
           value: value.toString(),

--- a/modules/gridNMBidAdapter.js
+++ b/modules/gridNMBidAdapter.js
@@ -432,7 +432,7 @@ export function getSyncUrl() {
 function segmentProcessing(segment, forceSegName) {
   return segment
     .map((seg) => {
-      const value = seg && (seg.value || seg.id || seg);
+      const value = seg && (seg.id || seg);
       if (typeof value === 'string' || typeof value === 'number') {
         return {
           value: value.toString(),

--- a/modules/gridNMBidAdapter.js
+++ b/modules/gridNMBidAdapter.js
@@ -432,7 +432,7 @@ export function getSyncUrl() {
 function segmentProcessing(segment, forceSegName) {
   return segment
     .map((seg) => {
-      const value = seg && (seg.value || seg.id || seg);
+      const value = seg && (seg.value || seg);
       if (typeof value === 'string' || typeof value === 'number') {
         return {
           value: value.toString(),

--- a/modules/gridNMBidAdapter.js
+++ b/modules/gridNMBidAdapter.js
@@ -432,7 +432,7 @@ export function getSyncUrl() {
 function segmentProcessing(segment, forceSegName) {
   return segment
     .map((seg) => {
-      const value = seg && (seg.value || seg);
+      const value = seg && (seg.value || seg.id || seg);
       if (typeof value === 'string' || typeof value === 'number') {
         return {
           value: value.toString(),

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -274,8 +274,7 @@ export function getContentSegments(segments) {
 
   const formattedSegments = segments.reduce((convertedSegments, rawSegment) => {
     convertedSegments.push({
-      id: rawSegment,
-      value: rawSegment
+      id: rawSegment
     });
     return convertedSegments;
   }, []);

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -274,7 +274,6 @@ export function getContentSegments(segments) {
 
   const formattedSegments = segments.reduce((convertedSegments, rawSegment) => {
     convertedSegments.push({
-      id: rawSegment,
       value: rawSegment
     });
     return convertedSegments;

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -274,6 +274,7 @@ export function getContentSegments(segments) {
 
   const formattedSegments = segments.reduce((convertedSegments, rawSegment) => {
     convertedSegments.push({
+      id: rawSegment,
       value: rawSegment
     });
     return convertedSegments;

--- a/modules/jwplayerRtdProvider.md
+++ b/modules/jwplayerRtdProvider.md
@@ -101,9 +101,9 @@ Example:
                         cids: ['abc123']
                     },
                     segment: [{ 
-                        id: '123'
+                        value: '123'
                     }, { 
-                        id: '456'
+                        value: '456'
                     }]
                 }]
             }
@@ -122,7 +122,7 @@ where:
         - `ext.segtax` whose `502` value is the unique identifier for JW Player's proprietary taxonomy
         - `ext.cids` is an array containing the list of extended content ids as defined in [oRTB's community extensions](https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/extensions/community_extensions/extended-content-ids.md#example---content-id-and-seller-defined-context). 
         - `segment` is an array containing the segment taxonomy values as an object where:
-          - `id` is the string representation of the data segment value. 
+          - `value` is the string representation of the data segment. 
   
 **Example:**
 

--- a/modules/jwplayerRtdProvider.md
+++ b/modules/jwplayerRtdProvider.md
@@ -101,9 +101,9 @@ Example:
                         cids: ['abc123']
                     },
                     segment: [{ 
-                        value: '123'
+                        id: '123'
                     }, { 
-                        value: '456'
+                        id: '456'
                     }]
                 }]
             }
@@ -122,7 +122,7 @@ where:
         - `ext.segtax` whose `502` value is the unique identifier for JW Player's proprietary taxonomy
         - `ext.cids` is an array containing the list of extended content ids as defined in [oRTB's community extensions](https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/extensions/community_extensions/extended-content-ids.md#example---content-id-and-seller-defined-context). 
         - `segment` is an array containing the segment taxonomy values as an object where:
-          - `value` is the string representation of the data segment. 
+          - `id` is the string representation of the data segment value. 
   
 **Example:**
 

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -659,9 +659,9 @@ describe('jwplayerRtdProvider', function() {
       const segment2 = 'segment2';
       const segment3 = 'segment3';
       const contentSegments = getContentSegments([segment1, segment2, segment3]);
-      expect(contentSegments[0]).to.deep.equal({ id: segment1, value: segment1 });
-      expect(contentSegments[1]).to.deep.equal({ id: segment2, value: segment2 });
-      expect(contentSegments[2]).to.deep.equal({ id: segment3, value: segment3 });
+      expect(contentSegments[0]).to.deep.equal({ id: segment1 });
+      expect(contentSegments[1]).to.deep.equal({ id: segment2 });
+      expect(contentSegments[2]).to.deep.equal({ id: segment3 });
     });
   });
 

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -470,8 +470,8 @@ describe('jwplayerRtdProvider', function() {
       expect(datum.segment).to.have.length(2);
       const segment1 = datum.segment[0];
       const segment2 = datum.segment[1];
-      expect(segment1).to.have.property('id', 'test_seg_1');
-      expect(segment2).to.have.property('id', 'test_seg_2');
+      expect(segment1).to.have.property('value', 'test_seg_1');
+      expect(segment2).to.have.property('value', 'test_seg_2');
     });
 
     it('should remove obsolete jwplayer data', function () {
@@ -501,13 +501,13 @@ describe('jwplayerRtdProvider', function() {
               id: 'randomContentId',
               data: [{
                 name: 'random',
-                segment: [{id: 'random'}]
+                segment: [{value: 'random'}]
               }, {
                 name: 'jwplayer.com',
-                segment: [{id: 'randomJwPlayer'}]
+                segment: [{value: 'randomJwPlayer'}]
               }, {
                 name: 'random2',
-                segment: [{id: 'random2'}]
+                segment: [{value: 'random2'}]
               }]
             }
           }
@@ -541,11 +541,11 @@ describe('jwplayerRtdProvider', function() {
 
       const randomDatum = data[0];
       expect(randomDatum).to.have.property('name', 'random');
-      expect(randomDatum.segment).to.deep.equal([{id: 'random'}]);
+      expect(randomDatum.segment).to.deep.equal([{value: 'random'}]);
 
       const randomDatum2 = data[1];
       expect(randomDatum2).to.have.property('name', 'random2');
-      expect(randomDatum2.segment).to.deep.equal([{id: 'random2'}]);
+      expect(randomDatum2.segment).to.deep.equal([{value: 'random2'}]);
 
       const jwplayerDatum = data[2];
       expect(jwplayerDatum).to.have.property('name', 'jwplayer.com');
@@ -554,8 +554,8 @@ describe('jwplayerRtdProvider', function() {
       expect(jwplayerDatum.segment).to.have.length(2);
       const segment1 = jwplayerDatum.segment[0];
       const segment2 = jwplayerDatum.segment[1];
-      expect(segment1).to.have.property('id', 'test_seg_1');
-      expect(segment2).to.have.property('id', 'test_seg_2');
+      expect(segment1).to.have.property('value', 'test_seg_1');
+      expect(segment2).to.have.property('value', 'test_seg_2');
     });
   });
 
@@ -659,16 +659,16 @@ describe('jwplayerRtdProvider', function() {
       const segment2 = 'segment2';
       const segment3 = 'segment3';
       const contentSegments = getContentSegments([segment1, segment2, segment3]);
-      expect(contentSegments[0]).to.deep.equal({ id: segment1, value: segment1 });
-      expect(contentSegments[1]).to.deep.equal({ id: segment2, value: segment2 });
-      expect(contentSegments[2]).to.deep.equal({ id: segment3, value: segment3 });
+      expect(contentSegments[0]).to.deep.equal({ value: segment1 });
+      expect(contentSegments[1]).to.deep.equal({ value: segment2 });
+      expect(contentSegments[2]).to.deep.equal({ value: segment3 });
     });
   });
 
   describe('Get Content Data', function () {
     it('should return proper format', function () {
       const testMediaId = 'test_media_id';
-      const testSegments = [{ id: 1 }, { id: 2 }];
+      const testSegments = [{ value: 1 }, { value: 2 }];
       const contentData = getContentData(testMediaId, testSegments);
       expect(contentData).to.have.property('name', 'jwplayer.com');
       expect(contentData.ext).to.have.property('segtax', 502);
@@ -690,7 +690,7 @@ describe('jwplayerRtdProvider', function() {
     });
 
     it('should only set cids when a media id is provided', function () {
-      const testSegments = [{ id: 1 }, { id: 2 }];
+      const testSegments = [{ value: 1 }, { value: 2 }];
       const contentData = getContentData(null, testSegments);
       expect(contentData).to.have.property('name', 'jwplayer.com');
       expect(contentData.ext).to.have.property('segtax', 502);

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -470,8 +470,8 @@ describe('jwplayerRtdProvider', function() {
       expect(datum.segment).to.have.length(2);
       const segment1 = datum.segment[0];
       const segment2 = datum.segment[1];
-      expect(segment1).to.have.property('value', 'test_seg_1');
-      expect(segment2).to.have.property('value', 'test_seg_2');
+      expect(segment1).to.have.property('id', 'test_seg_1');
+      expect(segment2).to.have.property('id', 'test_seg_2');
     });
 
     it('should remove obsolete jwplayer data', function () {
@@ -501,13 +501,13 @@ describe('jwplayerRtdProvider', function() {
               id: 'randomContentId',
               data: [{
                 name: 'random',
-                segment: [{value: 'random'}]
+                segment: [{id: 'random'}]
               }, {
                 name: 'jwplayer.com',
-                segment: [{value: 'randomJwPlayer'}]
+                segment: [{id: 'randomJwPlayer'}]
               }, {
                 name: 'random2',
-                segment: [{value: 'random2'}]
+                segment: [{id: 'random2'}]
               }]
             }
           }
@@ -541,11 +541,11 @@ describe('jwplayerRtdProvider', function() {
 
       const randomDatum = data[0];
       expect(randomDatum).to.have.property('name', 'random');
-      expect(randomDatum.segment).to.deep.equal([{value: 'random'}]);
+      expect(randomDatum.segment).to.deep.equal([{id: 'random'}]);
 
       const randomDatum2 = data[1];
       expect(randomDatum2).to.have.property('name', 'random2');
-      expect(randomDatum2.segment).to.deep.equal([{value: 'random2'}]);
+      expect(randomDatum2.segment).to.deep.equal([{id: 'random2'}]);
 
       const jwplayerDatum = data[2];
       expect(jwplayerDatum).to.have.property('name', 'jwplayer.com');
@@ -554,8 +554,8 @@ describe('jwplayerRtdProvider', function() {
       expect(jwplayerDatum.segment).to.have.length(2);
       const segment1 = jwplayerDatum.segment[0];
       const segment2 = jwplayerDatum.segment[1];
-      expect(segment1).to.have.property('value', 'test_seg_1');
-      expect(segment2).to.have.property('value', 'test_seg_2');
+      expect(segment1).to.have.property('id', 'test_seg_1');
+      expect(segment2).to.have.property('id', 'test_seg_2');
     });
   });
 
@@ -659,16 +659,16 @@ describe('jwplayerRtdProvider', function() {
       const segment2 = 'segment2';
       const segment3 = 'segment3';
       const contentSegments = getContentSegments([segment1, segment2, segment3]);
-      expect(contentSegments[0]).to.deep.equal({ value: segment1 });
-      expect(contentSegments[1]).to.deep.equal({ value: segment2 });
-      expect(contentSegments[2]).to.deep.equal({ value: segment3 });
+      expect(contentSegments[0]).to.deep.equal({ id: segment1, value: segment1 });
+      expect(contentSegments[1]).to.deep.equal({ id: segment2, value: segment2 });
+      expect(contentSegments[2]).to.deep.equal({ id: segment3, value: segment3 });
     });
   });
 
   describe('Get Content Data', function () {
     it('should return proper format', function () {
       const testMediaId = 'test_media_id';
-      const testSegments = [{ value: 1 }, { value: 2 }];
+      const testSegments = [{ id: 1 }, { id: 2 }];
       const contentData = getContentData(testMediaId, testSegments);
       expect(contentData).to.have.property('name', 'jwplayer.com');
       expect(contentData.ext).to.have.property('segtax', 502);
@@ -690,7 +690,7 @@ describe('jwplayerRtdProvider', function() {
     });
 
     it('should only set cids when a media id is provided', function () {
-      const testSegments = [{ value: 1 }, { value: 2 }];
+      const testSegments = [{ id: 1 }, { id: 2 }];
       const contentData = getContentData(null, testSegments);
       expect(contentData).to.have.property('name', 'jwplayer.com');
       expect(contentData.ext).to.have.property('segtax', 502);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix


## Description of change
To reduce payload size we have decided to drop `segment.id`. `segment.id` was always identical to `segment.value` therefore there is no benefit to including it. 

Merging is blocked until all partners have communicated that this will not require changes on their end.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
