### PR TITLE
IX Bid Adapter: completely change request to POST method

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -16,15 +16,15 @@ import {
   parseQueryStringParameters,
   safeJSONParse
 } from '../src/utils.js';
-import {BANNER, VIDEO, NATIVE} from '../src/mediaTypes.js';
-import {config} from '../src/config.js';
+import { BANNER, VIDEO, NATIVE } from '../src/mediaTypes.js';
+import { config } from '../src/config.js';
 import CONSTANTS from '../src/constants.json';
-import {getStorageManager} from '../src/storageManager.js';
+import { getStorageManager } from '../src/storageManager.js';
 import * as events from '../src/events.js';
-import {find} from '../src/polyfill.js';
-import {registerBidder} from '../src/adapters/bidderFactory.js';
-import {INSTREAM, OUTSTREAM} from '../src/video.js';
-import {Renderer} from '../src/Renderer.js';
+import { find } from '../src/polyfill.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { INSTREAM, OUTSTREAM } from '../src/video.js';
+import { Renderer } from '../src/Renderer.js';
 
 const BIDDER_CODE = 'ix';
 const ALIAS_BIDDER_CODE = 'roundel';
@@ -102,13 +102,13 @@ const VIDEO_PARAMS_ALLOW_LIST = [
 const LOCAL_STORAGE_KEY = 'ixdiag';
 export const LOCAL_STORAGE_FEATURE_TOGGLES_KEY = `${BIDDER_CODE}_features`;
 let hasRegisteredHandler = false;
-export const storage = getStorageManager({gvlid: GLOBAL_VENDOR_ID, bidderCode: BIDDER_CODE});
+export const storage = getStorageManager({ gvlid: GLOBAL_VENDOR_ID, bidderCode: BIDDER_CODE });
 export const FEATURE_TOGGLES = {
   featureToggles: {},
-  isFeatureEnabled: function(ft) {
+  isFeatureEnabled: function (ft) {
     return deepAccess(this.featureToggles, `features.${ft}.activated`)
   },
-  getFeatureToggles: function() {
+  getFeatureToggles: function () {
     if (storage.localStorageIsEnabled()) {
       const parsedToggles = safeJSONParse(storage.getDataFromLocalStorage(LOCAL_STORAGE_FEATURE_TOGGLES_KEY));
       if (deepAccess(parsedToggles, 'expiry') && parsedToggles.expiry >= new Date().getTime()) {
@@ -118,7 +118,7 @@ export const FEATURE_TOGGLES = {
       }
     }
   },
-  setFeatureToggles: function(serverResponse) {
+  setFeatureToggles: function (serverResponse) {
     const responseBody = serverResponse.body;
     const expiryTime = new Date();
     const toggles = deepAccess(responseBody, 'ext.features');
@@ -133,7 +133,7 @@ export const FEATURE_TOGGLES = {
       }
     }
   },
-  clearFeatureToggles: function() {
+  clearFeatureToggles: function () {
     this.featureToggles = {};
     if (storage.localStorageIsEnabled()) {
       storage.removeDataFromLocalStorage(LOCAL_STORAGE_FEATURE_TOGGLES_KEY);
@@ -391,7 +391,7 @@ function parseBid(rawBid, currency, bidRequest) {
     bid.mediaTypes = bidRequest.mediaTypes;
     bid.ttl = isValidExpiry ? rawBid.exp : VIDEO_TIME_TO_LIVE;
   } else if (parsedAdm && parsedAdm.native) {
-    bid.native = {ortb: parsedAdm.native};
+    bid.native = { ortb: parsedAdm.native };
     bid.width = rawBid.w ? rawBid.w : 1;
     bid.height = rawBid.h ? rawBid.h : 1;
     bid.mediaType = NATIVE;
@@ -708,18 +708,6 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
   siteID = validBidRequests[0].params.siteId;
   payload.s = siteID;
 
-  if (!FEATURE_TOGGLES.isFeatureEnabled('pbjs_enable_post')) {
-    if (version) {
-      payload.v = version;
-    }
-    payload.ac = 'j';
-    payload.sd = 1;
-
-    if (version === VIDEO_ENDPOINT_VERSION) {
-      payload.nf = 1;
-    }
-  }
-
   // Parse additional runtime configs.
   const bidderCode = (bidderRequest && bidderRequest.bidderCode) || 'ix';
   const otherIxConfig = config.getConfig(bidderCode);
@@ -760,13 +748,6 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
         currentRequestSize += fpdRequestSize;
       } else {
         logError('IX Bid Adapter: IX config FPD request size has exceeded maximum request size.', { bidder: BIDDER_CODE, code: ERROR_CODES.IX_FPD_EXCEEDS_MAX_SIZE });
-      }
-    }
-
-    if (!FEATURE_TOGGLES.isFeatureEnabled('pbjs_enable_post')) {
-      // Create t in payload if timeout is configured.
-      if (typeof otherIxConfig.timeout === 'number') {
-        payload.t = otherIxConfig.timeout;
       }
     }
   }
@@ -909,36 +890,21 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
     const isLastAdUnit = adUnitIndex === transactionIds.length - 1;
 
     if (wasAdUnitImpressionsTrimmed || isLastAdUnit) {
-      const clonedPayload = deepClone(payload);
       if (!isLastAdUnit || requestSequenceNumber) {
         r.ext.ixdiag.sn = requestSequenceNumber;
-        clonedPayload.sn = requestSequenceNumber;
       }
 
       requestSequenceNumber++;
-      clonedPayload.r = JSON.stringify(r);
 
-      let requestData;
-
-      if (FEATURE_TOGGLES.isFeatureEnabled('pbjs_enable_post')) {
-        requestData = {
-          method: 'POST',
-          url: baseUrl + '?s=' + payload.s,
-          data: deepClone(r),
-          option: {
-            contentType: 'text/plain',
-          },
-          validBidRequests
-        }
-      } else {
-        requestData = {
-          method: 'GET',
-          url: baseUrl,
-          data: clonedPayload,
-          validBidRequests
-        }
-      }
-      requests.push(requestData);
+      requests.push({
+        method: 'POST',
+        url: baseUrl + '?s=' + siteID,
+        data: deepClone(r),
+        option: {
+          contentType: 'text/plain',
+        },
+        validBidRequests
+      });
 
       currentRequestSize = baseRequestSize;
       r.imp = [];
@@ -1532,13 +1498,7 @@ export const spec = {
 
       // Transform rawBid in bid response to the format that will be accepted by prebid.
       const innerBids = seatbid[i].bid;
-      let requestBid;
-
-      if (FEATURE_TOGGLES.isFeatureEnabled('pbjs_enable_post')) {
-        requestBid = bidderRequest.data;
-      } else {
-        requestBid = safeJSONParse(bidderRequest.data.r);
-      }
+      const requestBid = bidderRequest.data;
 
       for (let j = 0; j < innerBids.length; j++) {
         const bidRequest = getBidRequest(innerBids[j].impid, requestBid.imp, bidderRequest.validBidRequests);

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -286,6 +286,44 @@ describe('IndexexchangeAdapter', function () {
     }
   ];
 
+  const DEFAULT_VIDEO_VALID_BID_MEDIUM_SIZE = [
+    {
+      bidder: 'ix',
+      params: {
+        siteId: '456',
+        video: {
+          skippable: false,
+          mimes: [
+            'video/mp4',
+            'video/webm'
+          ],
+          minduration: 0,
+          maxduration: 60,
+          protocols: [2]
+        },
+        size: [640, 480]
+      },
+      sizes: [[640, 480], [200, 400]],
+      mediaTypes: {
+        video: {
+          context: 'instream',
+          playerSize: [[640, 480], [200, 400]]
+        }
+      },
+      ortb2Imp: {
+        ext: {
+          tid: '173f49a8-7549-4218-a23c-e7ba59b47230'
+        }
+      },
+      adUnitCode: 'div-gpt-ad-1460505748562-0',
+      transactionId: '173f49a8-7549-4218-a23c-e7ba59b47230',
+      bidId: '1a2b3c4e',
+      bidderRequestId: '11a22b33c44e',
+      auctionId: '1aa2bb3cc4de',
+      schain: SAMPLE_SCHAIN
+    }
+  ];
+
   const DEFAULT_MULTIFORMAT_BANNER_VALID_BID = [
     {
       bidder: 'ix',
@@ -400,7 +438,7 @@ describe('IndexexchangeAdapter', function () {
         }
       },
       nativeOrtbRequest: {
-        assets: [{id: 0, required: 0, img: {type: 1}}, {id: 1, required: 1, title: {len: 140}}, {id: 2, required: 1, data: {type: 2}}, {id: 3, required: 1, img: {type: 3}}, {id: 4, required: false, video: {mimes: ['video/mp4', 'video/webm'], minduration: 0, maxduration: 120, protocols: [2, 3, 5, 6]}}]
+        assets: [{ id: 0, required: 0, img: { type: 1 } }, { id: 1, required: 1, title: { len: 140 } }, { id: 2, required: 1, data: { type: 2 } }, { id: 3, required: 1, img: { type: 3 } }, { id: 4, required: false, video: { mimes: ['video/mp4', 'video/webm'], minduration: 0, maxduration: 120, protocols: [2, 3, 5, 6] } }]
       },
       adUnitCode: 'div-gpt-ad-1460505748563-0',
       transactionId: '173f49a8-7549-4218-a23c-e7ba59b47231',
@@ -441,7 +479,7 @@ describe('IndexexchangeAdapter', function () {
         }
       },
       nativeOrtbRequest: {
-        assets: [{id: 0, required: 0, img: {type: 1}}, {id: 1, required: 1, title: {len: 140}}, {id: 2, required: 1, data: {type: 2}}, {id: 3, required: 1, img: {type: 3}}, {id: 4, required: false, video: {mimes: ['video/mp4', 'video/webm'], minduration: 0, maxduration: 120, protocols: [2, 3, 5, 6]}}]
+        assets: [{ id: 0, required: 0, img: { type: 1 } }, { id: 1, required: 1, title: { len: 140 } }, { id: 2, required: 1, data: { type: 2 } }, { id: 3, required: 1, img: { type: 3 } }, { id: 4, required: false, video: { mimes: ['video/mp4', 'video/webm'], minduration: 0, maxduration: 120, protocols: [2, 3, 5, 6] } }]
       },
       adUnitCode: 'div-gpt-ad-1460505748562-0',
       transactionId: '173f49a8-7549-4218-a23c-e7ba59b47230',
@@ -633,31 +671,6 @@ describe('IndexexchangeAdapter', function () {
     }
   };
 
-  const DEFAULT_BIDDER_REQUEST_DATA = {
-    ac: 'j',
-    r: JSON.stringify({
-      id: '345',
-      imp: [
-        {
-          id: '1a2b3c4e',
-          video: {
-            w: 640,
-            h: 480,
-            placement: 1
-          }
-        }
-      ],
-      site: {
-        ref: 'https://ref.com/ref.html',
-        page: 'https://page.com'
-      },
-    }),
-    s: '21',
-    sd: 1,
-    t: 1000,
-    v: 8.1
-  };
-
   const DEFAULT_USERID_DATA = {
     idl_env: '1234-5678-9012-3456', // Liveramp
     netId: 'testnetid123', // NetId
@@ -724,6 +737,8 @@ describe('IndexexchangeAdapter', function () {
     lotamePanoramaId: 'bd738d136bdaa841117fe9b331bb4'
   };
 
+  const extractPayload = function (bidRequest) { return bidRequest.data }
+
   describe('inherited functions', function () {
     it('should exists and is a function', function () {
       const adapter = newBidder(spec);
@@ -778,7 +793,7 @@ describe('IndexexchangeAdapter', function () {
           syncsPerBidder: 3
         }
       });
-      let userSync = spec.getUserSyncs(syncOptions, [{'body': {'ext': {'publishersyncsperbidderoverride': 0}}}]);
+      let userSync = spec.getUserSyncs(syncOptions, [{ 'body': { 'ext': { 'publishersyncsperbidderoverride': 0 } } }]);
       expect(userSync.length).to.equal(0);
     });
 
@@ -792,7 +807,7 @@ describe('IndexexchangeAdapter', function () {
           syncsPerBidder: 3
         }
       });
-      let userSync = spec.getUserSyncs(syncOptions, [{'body': {'ext': {'publishersyncsperbidderoverride': 2}}}]);
+      let userSync = spec.getUserSyncs(syncOptions, [{ 'body': { 'ext': { 'publishersyncsperbidderoverride': 2 } } }]);
       expect(userSync[0].type).to.equal('image');
       const USER_SYNC_URL_0 = 'https://dsum.casalemedia.com/pbusermatch?origin=prebid&site_id=123&p=2&i=0&gdpr=1&gdpr_consent=3huaa11=qu3198ae&us_privacy=';
       const USER_SYNC_URL_1 = 'https://dsum.casalemedia.com/pbusermatch?origin=prebid&site_id=123&p=2&i=1&gdpr=1&gdpr_consent=3huaa11=qu3198ae&us_privacy=';
@@ -811,7 +826,7 @@ describe('IndexexchangeAdapter', function () {
           syncsPerBidder: 3
         }
       });
-      let userSync = spec.getUserSyncs(syncOptions, [{'body': {'ext': {'publishersyncsperbidderoverride': 4}}}]);
+      let userSync = spec.getUserSyncs(syncOptions, [{ 'body': { 'ext': { 'publishersyncsperbidderoverride': 4 } } }]);
       expect(userSync[0].type).to.equal('image');
       const USER_SYNC_URL_0 = 'https://dsum.casalemedia.com/pbusermatch?origin=prebid&site_id=123&p=3&i=0&gdpr=1&gdpr_consent=3huaa11=qu3198ae&us_privacy=';
       const USER_SYNC_URL_1 = 'https://dsum.casalemedia.com/pbusermatch?origin=prebid&site_id=123&p=3&i=1&gdpr=1&gdpr_consent=3huaa11=qu3198ae&us_privacy=';
@@ -832,7 +847,7 @@ describe('IndexexchangeAdapter', function () {
           syncsPerBidder: 0
         }
       });
-      let userSync = spec.getUserSyncs(syncOptions, [{'body': {'ext': {'publishersyncsperbidderoverride': 2}}}]);
+      let userSync = spec.getUserSyncs(syncOptions, [{ 'body': { 'ext': { 'publishersyncsperbidderoverride': 2 } } }]);
       expect(userSync[0].type).to.equal('image');
       const USER_SYNC_URL_0 = 'https://dsum.casalemedia.com/pbusermatch?origin=prebid&site_id=123&p=2&i=0&gdpr=1&gdpr_consent=3huaa11=qu3198ae&us_privacy=';
       const USER_SYNC_URL_1 = 'https://dsum.casalemedia.com/pbusermatch?origin=prebid&site_id=123&p=2&i=1&gdpr=1&gdpr_consent=3huaa11=qu3198ae&us_privacy=';
@@ -868,7 +883,7 @@ describe('IndexexchangeAdapter', function () {
       const bid = utils.deepClone(DEFAULT_VIDEO_VALID_BID[0]);
       bid.mediaTypes.video.renderer = {
         url: 'test',
-        render: () => {}
+        render: () => { }
       };
       bid.mediaTypes.video.context = 'outstream';
       bid.mediaTypes.video.playerSize = [[300, 249]];
@@ -1080,7 +1095,7 @@ describe('IndexexchangeAdapter', function () {
       bid.nativeOrtbRequest = {}
       expect(spec.isBidRequestValid(bid)).to.be.false;
 
-      bid.nativeOrtbRequest = {assets: []}
+      bid.nativeOrtbRequest = { assets: [] }
       expect(spec.isBidRequestValid(bid)).to.be.false;
     });
   });
@@ -1104,7 +1119,7 @@ describe('IndexexchangeAdapter', function () {
         const cloneValidBid = utils.deepClone(validBid);
         cloneValidBid[0].userIdAsEids = utils.deepClone(DEFAULT_USERIDASEIDS_DATA);
         const request = spec.buildRequests(cloneValidBid, ALIAS_OPTIONS);
-        const payload = JSON.parse(request[0].data.r);
+        const payload = extractPayload(request[0]);
         expect(request).to.be.an('array');
         expect(request).to.have.lengthOf.above(0); // should be 1 or more
         expect(payload.user.eids).to.have.lengthOf(6);
@@ -1115,7 +1130,7 @@ describe('IndexexchangeAdapter', function () {
 
   describe('buildRequestsIdentity', function () {
     let request;
-    let query;
+    let payload;
     let testCopy;
 
     beforeEach(function () {
@@ -1124,7 +1139,7 @@ describe('IndexexchangeAdapter', function () {
         return testCopy;
       };
       request = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
-      query = request.data;
+      payload = extractPayload(request);
     });
 
     afterEach(function () {
@@ -1137,8 +1152,6 @@ describe('IndexexchangeAdapter', function () {
       });
 
       it('payload should have correct format and value (single identity partner)', function () {
-        const payload = JSON.parse(query.r);
-
         expect(payload.user).to.exist;
         expect(payload.user.eids).to.exist;
         expect(payload.user.eids).to.be.an('array');
@@ -1146,7 +1159,7 @@ describe('IndexexchangeAdapter', function () {
       });
 
       it('identity data in impression should have correct format and value (single identity partner)', function () {
-        const impression = JSON.parse(query.r).user.eids;
+        const impression = payload.user.eids;
         expect(impression[0].source).to.equal(testCopy.IdentityIp.data.source);
         expect(impression[0].uids[0].id).to.equal(testCopy.IdentityIp.data.uids[0].id);
       });
@@ -1166,8 +1179,6 @@ describe('IndexexchangeAdapter', function () {
       });
 
       it('payload should have correct format and value (single identity w/ multi ids)', function () {
-        const payload = JSON.parse(query.r);
-
         expect(payload.user).to.exist;
         expect(payload.user.eids).to.exist;
         expect(payload.user.eids).to.be.an('array');
@@ -1175,7 +1186,7 @@ describe('IndexexchangeAdapter', function () {
       });
 
       it('identity data in impression should have correct format and value (single identity w/ multi ids)', function () {
-        const impression = JSON.parse(query.r).user.eids;
+        const impression = payload.user.eids;
 
         expect(impression[0].source).to.equal(testCopy.IdentityIp.data.source);
         expect(impression[0].uids).to.have.lengthOf(3);
@@ -1210,8 +1221,6 @@ describe('IndexexchangeAdapter', function () {
       });
 
       it('payload should have correct format and value (multiple identity partners)', function () {
-        const payload = JSON.parse(query.r);
-
         expect(payload.user).to.exist;
         expect(payload.user.eids).to.exist;
         expect(payload.user.eids).to.be.an('array');
@@ -1219,7 +1228,7 @@ describe('IndexexchangeAdapter', function () {
       });
 
       it('identity data in impression should have correct format and value (multiple identity partners)', function () {
-        const impression = JSON.parse(query.r).user.eids;
+        const impression = payload.user.eids;
 
         expect(impression[0].source).to.equal(testCopy.IdentityIp.data.source);
         expect(impression[0].uids).to.have.lengthOf(1);
@@ -1242,8 +1251,7 @@ describe('IndexexchangeAdapter', function () {
           return undefined;
         };
         request = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
-        query = request.data;
-        const payload = JSON.parse(query.r);
+        payload = extractPayload(request);
 
         expect(payload.user).to.exist;
         expect(payload.user.eids).to.not.exist;
@@ -1255,8 +1263,7 @@ describe('IndexexchangeAdapter', function () {
           data: {}
         }
         request = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
-        query = request.data;
-        const payload = JSON.parse(query.r);
+        payload = extractPayload(request);
 
         expect(payload.user).to.exist;
         expect(payload.user.eids).to.exist;
@@ -1265,8 +1272,7 @@ describe('IndexexchangeAdapter', function () {
       it('payload should not have any user eids if identity data is pending for all partners', function () {
         testCopy.IdentityIp.responsePending = true;
         request = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
-        query = request.data;
-        const payload = JSON.parse(query.r);
+        payload = extractPayload(request);
 
         expect(payload.user).to.exist;
         expect(payload.user.eids).to.not.exist;
@@ -1276,8 +1282,7 @@ describe('IndexexchangeAdapter', function () {
         testCopy.IdentityIp.responsePending = false;
         testCopy.IdentityIp.data = {};
         request = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
-        query = request.data;
-        const payload = JSON.parse(query.r);
+        payload = extractPayload(request);
 
         expect(payload.user).to.exist;
         expect(payload.user.eids).to.not.exist;
@@ -1304,7 +1309,7 @@ describe('IndexexchangeAdapter', function () {
       const cloneValidBid = utils.deepClone(DEFAULT_VIDEO_VALID_BID);
       cloneValidBid[0].userIdAsEids = utils.deepClone(DEFAULT_USERIDASEIDS_DATA);
       const request = spec.buildRequests(cloneValidBid, DEFAULT_OPTION)[0];
-      const payload = JSON.parse(request.data.r);
+      const payload = extractPayload(request);
 
       expect(payload.user.eids).to.have.lengthOf(6);
       expect(payload.user.eids).to.have.deep.members(DEFAULT_USERID_PAYLOAD);
@@ -1401,7 +1406,7 @@ describe('IndexexchangeAdapter', function () {
       cloneValidBid[0].userIdAsEids = utils.deepClone(DEFAULT_USERIDASEIDS_DATA);
 
       const request = spec.buildRequests(cloneValidBid, DEFAULT_OPTION)[0];
-      const payload = JSON.parse(request.data.r);
+      const payload = extractPayload(request);
 
       validUserIdPayload = utils.deepClone(DEFAULT_USERID_PAYLOAD);
       validUserIdPayload.push({
@@ -1480,7 +1485,7 @@ describe('IndexexchangeAdapter', function () {
         }]
       });
 
-      const payload = JSON.parse(request.data.r);
+      const payload = extractPayload(request);
       expect(payload.user.eids).to.have.lengthOf(7);
       expect(payload.user.eids).to.have.deep.members(validUserIdPayload);
     });
@@ -1503,7 +1508,7 @@ describe('IndexexchangeAdapter', function () {
       bid.userId = DEFAULT_USERID_BID_DATA;
 
       const request = spec.buildRequests([bid], DEFAULT_OPTION)[0];
-      const r = JSON.parse(request.data.r);
+      const r = extractPayload(request);
 
       expect(r.ext.ixdiag.userIds).to.be.an('array');
       expect(r.ext.ixdiag.userIds.should.not.include('lotamePanoramaId'));
@@ -1514,8 +1519,8 @@ describe('IndexexchangeAdapter', function () {
 
   describe('First party data', function () {
     it('should not set ixdiag.fpd value if not defined', function () {
-      const request = spec.buildRequests(DEFAULT_BANNER_VALID_BID, {ortb2: {}})[0];
-      const r = JSON.parse(request.data.r);
+      const request = spec.buildRequests(DEFAULT_BANNER_VALID_BID, { ortb2: {} })[0];
+      const r = extractPayload(request);
 
       expect(r.ext.ixdiag.fpd).to.be.undefined;
     });
@@ -1531,8 +1536,8 @@ describe('IndexexchangeAdapter', function () {
         }
       };
 
-      const request = spec.buildRequests(DEFAULT_BANNER_VALID_BID, {ortb2})[0];
-      const r = JSON.parse(request.data.r);
+      const request = spec.buildRequests(DEFAULT_BANNER_VALID_BID, { ortb2 })[0];
+      const r = extractPayload(request);
 
       expect(r.ext.ixdiag.fpd).to.exist;
     });
@@ -1543,7 +1548,7 @@ describe('IndexexchangeAdapter', function () {
       });
 
       const request = spec.buildRequests(DEFAULT_BANNER_VALID_BID)[0];
-      const r = JSON.parse(request.data.r);
+      const r = extractPayload(request);
 
       expect(r.ext.ixdiag.tmax).to.equal(250);
     });
@@ -1553,7 +1558,7 @@ describe('IndexexchangeAdapter', function () {
         bidderTimeout: null
       })
       const request = spec.buildRequests(DEFAULT_BANNER_VALID_BID)[0];
-      const r = JSON.parse(request.data.r);
+      const r = extractPayload(request);
 
       expect(r.ext.ixdiag.tmax).to.be.undefined
     });
@@ -1571,8 +1576,8 @@ describe('IndexexchangeAdapter', function () {
         }
       };
 
-      const request = spec.buildRequests(DEFAULT_BANNER_VALID_BID, {ortb2})[0];
-      const r = JSON.parse(request.data.r);
+      const request = spec.buildRequests(DEFAULT_BANNER_VALID_BID, { ortb2 })[0];
+      const r = extractPayload(request);
 
       expect(r.site.keywords).to.exist;
       expect(r.site.search).to.exist;
@@ -1595,8 +1600,8 @@ describe('IndexexchangeAdapter', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       bid.mediaTypes.banner.sizes = LARGE_SET_OF_SIZES;
 
-      const request = spec.buildRequests([bid], {ortb2})[0];
-      const r = JSON.parse(request.data.r);
+      const request = spec.buildRequests([bid], { ortb2 })[0];
+      const r = extractPayload(request);
 
       expect(r.site.ref).to.exist;
       expect(r.site.keywords).to.be.undefined;
@@ -1608,32 +1613,24 @@ describe('IndexexchangeAdapter', function () {
     let request = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
     const requestUrl = request.url;
     const requestMethod = request.method;
-    const query = request.data;
+    const payloadData = request.data;
 
     const bidWithoutSchain = utils.deepClone(DEFAULT_BANNER_VALID_BID);
     delete bidWithoutSchain[0].schain;
     const requestWithoutSchain = spec.buildRequests(bidWithoutSchain, DEFAULT_OPTION)[0];
-    const queryWithoutSchain = requestWithoutSchain.data;
+    const payloadWithoutSchain = extractPayload(requestWithoutSchain);
     const GPID = '/19968336/some-adunit-path';
 
-    it('request should be made to IX endpoint with GET method', function () {
-      expect(requestMethod).to.equal('GET');
-      expect(requestUrl).to.equal(IX_SECURE_ENDPOINT);
+    it('request should be made to IX endpoint with POST method and siteId in query param', function () {
+      expect(requestMethod).to.equal('POST');
+      expect(requestUrl).to.equal(IX_SECURE_ENDPOINT + '?s=' + DEFAULT_BANNER_VALID_BID[0].params.siteId);
+      expect(request.option.contentType).to.equal('text/plain')
     });
 
     it('auction type should be set correctly', function () {
-      const at = JSON.parse(query.r).at;
+      const at = payloadData.at;
       expect(at).to.equal(1);
     })
-
-    it('query object (version, siteID and request) should be correct', function () {
-      expect(query.v).to.equal(BANNER_ENDPOINT_VERSION);
-      expect(query.s).to.equal(DEFAULT_BANNER_VALID_BID[0].params.siteId);
-      expect(query.r).to.exist;
-      expect(query.ac).to.equal('j');
-      expect(query.sd).to.equal(1);
-      expect(query.nf).not.to.exist;
-    });
 
     it('should send dfp_adunit_code in request if ortb2Imp.ext.data.adserver.adslot exists', function () {
       const AD_UNIT_CODE = '/19968336/some-adunit-path';
@@ -1649,7 +1646,7 @@ describe('IndexexchangeAdapter', function () {
         }
       };
       const requests = spec.buildRequests(validBids, DEFAULT_OPTION);
-      const { ext: { dfp_ad_unit_code } } = JSON.parse(requests[0].data.r).imp[0];
+      const { ext: { dfp_ad_unit_code } } = extractPayload(requests[0]).imp[0];
       expect(dfp_ad_unit_code).to.equal(AD_UNIT_CODE);
     });
 
@@ -1661,7 +1658,7 @@ describe('IndexexchangeAdapter', function () {
         }
       };
       const requests = spec.buildRequests(validBids, DEFAULT_OPTION);
-      const { ext: { gpid } } = JSON.parse(requests[0].data.r).imp[0];
+      const { ext: { gpid } } = extractPayload(requests[0]).imp[0];
       expect(gpid).to.equal(GPID);
     });
 
@@ -1673,7 +1670,7 @@ describe('IndexexchangeAdapter', function () {
         }
       };
       const requests = spec.buildRequests(validBids, DEFAULT_OPTION);
-      const { ext: { gpid } } = JSON.parse(requests[0].data.r).imp[0];
+      const { ext: { gpid } } = extractPayload(requests[0]).imp[0];
       expect(gpid).to.equal(GPID);
     });
 
@@ -1686,7 +1683,7 @@ describe('IndexexchangeAdapter', function () {
         }
       };
       const requests = spec.buildRequests(validBids, DEFAULT_OPTION);
-      const imp = JSON.parse(requests[0].data.r).imp[0];
+      const imp = extractPayload(requests[0]).imp[0];
       expect(deepAccess(imp, 'ext.dfp_ad_unit_code')).to.not.exist;
     });
 
@@ -1704,7 +1701,7 @@ describe('IndexexchangeAdapter', function () {
         }
       };
       const requests = spec.buildRequests(validBids, DEFAULT_OPTION);
-      const imp = JSON.parse(requests[0].data.r).imp[0];
+      const imp = extractPayload(requests[0]).imp[0];
       expect(deepAccess(imp, 'ext.gpid')).to.not.exist;
     });
 
@@ -1724,13 +1721,13 @@ describe('IndexexchangeAdapter', function () {
         }
       };
       const requests = spec.buildRequests(validBids, DEFAULT_OPTION);
-      const imp = JSON.parse(requests[0].data.r).imp[0];
+      const imp = extractPayload(requests[0]).imp[0];
       expect(deepAccess(imp, 'ext.gpid')).to.equal(GPID);
       expect(deepAccess(imp, 'ext.dfp_ad_unit_code')).to.equal(AD_UNIT_CODE);
     });
 
     it('payload should have correct format and value', function () {
-      const payload = JSON.parse(query.r);
+      const payload = payloadData;
       expect(payload.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidderRequestId);
       expect(payload.id).to.be.a('string');
       expect(payload.site.page).to.equal(DEFAULT_OPTION.refererInfo.page);
@@ -1748,7 +1745,7 @@ describe('IndexexchangeAdapter', function () {
 
       request = spec.buildRequests(bidWithIntId, DEFAULT_OPTION)[0];
 
-      const payload = JSON.parse(request.data.r);
+      const payload = extractPayload(request);
       expect(bidWithIntId[0].bidderRequestId).to.be.a('number');
       expect(payload.id).to.equal(bidWithIntId[0].bidderRequestId.toString());
       expect(payload.id).to.be.a('string');
@@ -1760,19 +1757,21 @@ describe('IndexexchangeAdapter', function () {
 
       request = spec.buildRequests(bidWithIntId, DEFAULT_OPTION)[0];
 
-      const payload = JSON.parse(request.data.r);
+      const payload = extractPayload(request);
       expect(bidWithIntId[0].bidderRequestId).to.be.a('number');
       expect(payload.id).to.equal(bidWithIntId[0].bidderRequestId.toString());
       expect(payload.id).to.be.a('string');
     });
 
     it('payload should not include schain when not provided', function () {
-      const payload = JSON.parse(queryWithoutSchain.r);
-      expect(payload.source.schain).to.not.exist; // source object currently only written for schain
+      const payload = payloadWithoutSchain;
+
+      const actualSchain = (((payload || {}).source || {}).ext || {}).schain;
+      expect(actualSchain).to.not.exist;
     });
 
     it('impression should have correct format and value', function () {
-      const impression = JSON.parse(query.r).imp[0];
+      const impression = payloadData.imp[0];
       const sidValue = DEFAULT_BANNER_VALID_BID[0].params.id;
 
       expect(impression.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidId);
@@ -1797,7 +1796,7 @@ describe('IndexexchangeAdapter', function () {
 
       request = spec.buildRequests([bid], DEFAULT_OPTION)[0];
 
-      const payload = JSON.parse(request.data.r);
+      const payload = extractPayload(request);
       payload.imp[0].banner.format.forEach((imp) => {
         expect(imp.ext.siteID).to.be.a('string');
       });
@@ -1813,7 +1812,7 @@ describe('IndexexchangeAdapter', function () {
         const expectedFloor = 3.25;
         bid.getFloor = () => ({ floor: expectedFloor, currency });
         const request = spec.buildRequests([bid], {})[0];
-        const impression = JSON.parse(request.data.r).imp[0];
+        const impression = extractPayload(request).imp[0];
 
         expect(impression.bidfloor).to.equal(expectedFloor);
         expect(impression.bidfloorcur).to.equal(currency);
@@ -1825,7 +1824,7 @@ describe('IndexexchangeAdapter', function () {
         const expectedFloor = 3.25;
         bid.getFloor = () => ({ floor: expectedFloor, currency });
         const request = spec.buildRequests([bid], {})[0];
-        const impression = JSON.parse(request.data.r).imp[0];
+        const impression = extractPayload(request).imp[0];
 
         expect(impression.bidfloor).to.equal(expectedFloor);
         expect(impression.bidfloorcur).to.equal(currency);
@@ -1837,7 +1836,7 @@ describe('IndexexchangeAdapter', function () {
         bid.params.bidFloor = highFloor;
         bid.params.bidFloorCur = 'USD'
         const request = spec.buildRequests([bid], {})[0];
-        const impression = JSON.parse(request.data.r).imp[0];
+        const impression = extractPayload(request).imp[0];
 
         expect(impression.bidfloor).to.equal(highFloor);
         expect(impression.bidfloorcur).to.equal(bid.params.bidFloorCur);
@@ -1851,7 +1850,7 @@ describe('IndexexchangeAdapter', function () {
         const expectedFloor = highFloor;
         bid.getFloor = () => ({ floor: expectedFloor, currency });
         const requestBidFloor = spec.buildRequests([bid], {})[0];
-        const impression = JSON.parse(requestBidFloor.data.r).imp[0];
+        const impression = extractPayload(requestBidFloor).imp[0];
 
         expect(impression.bidfloor).to.equal(highFloor);
         expect(impression.bidfloorcur).to.equal(bid.params.bidFloorCur);
@@ -1863,7 +1862,7 @@ describe('IndexexchangeAdapter', function () {
         bid.params.bidFloor = 50;
         bid.params.bidFloorCur = 'USD';
         const requestBidFloor = spec.buildRequests([bid], {})[0];
-        const impression = JSON.parse(requestBidFloor.data.r).imp[0];
+        const impression = extractPayload(requestBidFloor).imp[0];
 
         expect(impression.bidfloor).to.equal(bid.params.bidFloor);
         expect(impression.bidfloorcur).to.equal(bid.params.bidFloorCur);
@@ -1875,7 +1874,7 @@ describe('IndexexchangeAdapter', function () {
         bid.params.bidFloor = 50;
         bid.params.bidFloorCur = 'USD';
         const requestBidFloor = spec.buildRequests([bid], {})[0];
-        const impression = JSON.parse(requestBidFloor.data.r).imp[0];
+        const impression = extractPayload(requestBidFloor).imp[0];
 
         expect(impression.bidfloor).to.equal(bid.params.bidFloor);
         expect(impression.bidfloorcur).to.equal(bid.params.bidFloorCur);
@@ -1900,7 +1899,7 @@ describe('IndexexchangeAdapter', function () {
         expect(bid.getFloor.getCall(1).args[0].size[0]).to.equal(500);
         expect(bid.getFloor.getCall(1).args[0].size[1]).to.equal(400);
 
-        const impression = JSON.parse(requestBidFloor.data.r).imp[0];
+        const impression = extractPayload(requestBidFloor).imp[0];
         expect(impression.bidfloor).to.equal(expectedFloor);
         expect(impression.bidfloorcur).to.equal(currency);
       });
@@ -1930,7 +1929,7 @@ describe('IndexexchangeAdapter', function () {
         expect(bid.getFloor.getCall(0).args[0].size[0]).to.equal(300);
         expect(bid.getFloor.getCall(0).args[0].size[1]).to.equal(250);
 
-        const impression = JSON.parse(requestBidFloor.data.r).imp[0];
+        const impression = extractPayload(requestBidFloor).imp[0];
         expect(impression.bidfloor).to.equal(expectedFloor);
         expect(impression.bidfloorcur).to.equal(currency);
       });
@@ -1940,7 +1939,7 @@ describe('IndexexchangeAdapter', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       bid.params.id = 50;
       const requestBidFloor = spec.buildRequests([bid], {})[0];
-      const impression = JSON.parse(requestBidFloor.data.r).imp[0];
+      const impression = extractPayload(requestBidFloor).imp[0];
 
       expect(impression.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidId);
       expect(impression.banner.format[0].w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
@@ -1954,7 +1953,7 @@ describe('IndexexchangeAdapter', function () {
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       bid.params.id = 'abc';
       const requestBidFloor = spec.buildRequests([bid], {})[0];
-      const impression = JSON.parse(requestBidFloor.data.r).imp[0];
+      const impression = extractPayload(requestBidFloor).imp[0];
 
       expect(impression.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidId);
       expect(impression.banner.format[0].w).to.equal(DEFAULT_BANNER_VALID_BID[0].params.size[0]);
@@ -1982,7 +1981,7 @@ describe('IndexexchangeAdapter', function () {
         });
 
         const requestWithFirstPartyData = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
-        const pageUrl = JSON.parse(requestWithFirstPartyData.data.r).site.page;
+        const pageUrl = extractPayload(requestWithFirstPartyData).site.page;
         const expectedPageUrl = DEFAULT_OPTION.refererInfo.page + '?ab=123&cd=123%23ab&e%2Ff=456&h%3Fg=456%23cd';
         expect(pageUrl).to.equal(expectedPageUrl);
       });
@@ -1995,7 +1994,7 @@ describe('IndexexchangeAdapter', function () {
         });
 
         const requestFirstPartyDataNumber = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
-        const pageUrl = JSON.parse(requestFirstPartyDataNumber.data.r).site.page;
+        const pageUrl = extractPayload(requestFirstPartyDataNumber).site.page;
 
         expect(pageUrl).to.equal(DEFAULT_OPTION.refererInfo.page);
       });
@@ -2006,7 +2005,7 @@ describe('IndexexchangeAdapter', function () {
         });
 
         const requestWithoutConfig = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
-        const pageUrl = JSON.parse(requestWithoutConfig.data.r).site.page;
+        const pageUrl = extractPayload(requestWithoutConfig).site.page;
 
         expect(pageUrl).to.equal(DEFAULT_OPTION.refererInfo.page);
         expect(requestWithoutConfig.data.t).to.be.undefined;
@@ -2014,13 +2013,13 @@ describe('IndexexchangeAdapter', function () {
 
       it('should not set first party or timeout if it is setConfig is not called', function () {
         const requestWithoutConfig = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0];
-        const pageUrl = JSON.parse(requestWithoutConfig.data.r).site.page;
+        const pageUrl = extractPayload(requestWithoutConfig).site.page;
 
         expect(pageUrl).to.equal(DEFAULT_OPTION.refererInfo.page);
         expect(requestWithoutConfig.data.t).to.be.undefined;
       });
 
-      it('should set timeout if publisher set it through setConfig', function () {
+      it('should no longer set timeout even if publisher set it through setConfig', function () {
         config.setConfig({
           ix: {
             timeout: 500
@@ -2028,10 +2027,10 @@ describe('IndexexchangeAdapter', function () {
         });
         const requestWithTimeout = spec.buildRequests(DEFAULT_BANNER_VALID_BID, {})[0];
 
-        expect(requestWithTimeout.data.t).to.equal(500);
+        expect(requestWithTimeout.data.t).to.be.undefined;
       });
 
-      it('should set timeout if timeout is a string', function () {
+      it('should no longer set timeout even if timeout is a string', function () {
         config.setConfig({
           ix: {
             timeout: '500'
@@ -2046,11 +2045,10 @@ describe('IndexexchangeAdapter', function () {
     describe('request should contain both banner and video requests', function () {
       const request = spec.buildRequests([DEFAULT_BANNER_VALID_BID[0], DEFAULT_VIDEO_VALID_BID[0]], {});
       it('should have banner request', () => {
-        const bannerImpression = JSON.parse(request[0].data.r).imp[0];
+        const bannerImpression = extractPayload(request[0]).imp[0];
         const sidValue = DEFAULT_BANNER_VALID_BID[0].params.id;
 
-        expect(JSON.parse(request[0].data.r).imp).to.have.lengthOf(1);
-        expect(JSON.parse(request[0].data.v)).to.equal(BANNER_ENDPOINT_VERSION);
+        expect(extractPayload(request[0]).imp).to.have.lengthOf(1);
         expect(bannerImpression.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidId);
 
         expect(bannerImpression.banner.format).to.be.length(2);
@@ -2067,9 +2065,8 @@ describe('IndexexchangeAdapter', function () {
       });
 
       it('should have video request', () => {
-        const videoImpression = JSON.parse(request[1].data.r).imp[0];
+        const videoImpression = extractPayload(request[1]).imp[0];
 
-        expect(JSON.parse(request[1].data.v)).to.equal(VIDEO_ENDPOINT_VERSION);
         expect(videoImpression.id).to.equal(DEFAULT_VIDEO_VALID_BID[0].bidId);
         expect(videoImpression.video.w).to.equal(DEFAULT_VIDEO_VALID_BID[0].params.size[0]);
         expect(videoImpression.video.h).to.equal(DEFAULT_VIDEO_VALID_BID[0].params.size[1]);
@@ -2080,11 +2077,10 @@ describe('IndexexchangeAdapter', function () {
       const request = spec.buildRequests([DEFAULT_BANNER_VALID_BID[0], DEFAULT_NATIVE_VALID_BID[0]]);
 
       it('should have banner request', () => {
-        const bannerImpression = JSON.parse(request[0].data.r).imp[0];
+        const bannerImpression = extractPayload(request[0]).imp[0];
         const sidValue = DEFAULT_BANNER_VALID_BID[0].params.id;
 
-        expect(JSON.parse(request[0].data.r).imp).to.have.lengthOf(1);
-        expect(JSON.parse(request[0].data.v)).to.equal(BANNER_ENDPOINT_VERSION);
+        expect(extractPayload(request[0]).imp).to.have.lengthOf(1);
         expect(bannerImpression.id).to.equal(DEFAULT_BANNER_VALID_BID[0].bidId);
 
         expect(bannerImpression.banner.format).to.be.length(2);
@@ -2101,7 +2097,7 @@ describe('IndexexchangeAdapter', function () {
       });
 
       it('should have native request', () => {
-        const nativeImpression = JSON.parse(request[1].data.r).imp[0];
+        const nativeImpression = extractPayload(request[1]).imp[0];
 
         expect(request[1].data.hasOwnProperty('v')).to.equal(false);
         expect(nativeImpression.id).to.equal(DEFAULT_NATIVE_VALID_BID[0].bidId);
@@ -2133,8 +2129,6 @@ describe('IndexexchangeAdapter', function () {
       const requests = spec.buildRequests([bid, DEFAULT_BANNER_VALID_BID[0]], DEFAULT_OPTION);
       expect(requests).to.be.an('array');
       expect(requests).to.have.lengthOf(2);
-      expect(requests[0].data.sn).to.be.equal(0);
-      expect(requests[1].data.sn).to.be.equal(1);
     });
 
     it('6 ad units should generate only 4 requests', function () {
@@ -2168,10 +2162,7 @@ describe('IndexexchangeAdapter', function () {
       for (var i = 0; i < requests.length; i++) {
         const reqSize = `${requests[i].url}?${utils.parseQueryStringParameters(requests[i].data)}`.length;
         expect(reqSize).to.be.lessThan(8000);
-        let payload = JSON.parse(requests[i].data.r);
-        if (requests.length > 1) {
-          expect(requests[i].data.sn).to.equal(i);
-        }
+        let payload = extractPayload(requests[i]);
         expect(payload.source.ext.schain).to.deep.equal(SAMPLE_SCHAIN);
       }
     });
@@ -2196,7 +2187,7 @@ describe('IndexexchangeAdapter', function () {
       expect(requests).to.be.an('array');
       expect(requests).to.have.lengthOf(1);
 
-      const impressions = JSON.parse(requests[0].data.r).imp;
+      const impressions = extractPayload(requests[0]).imp;
       expect(impressions).to.be.an('array');
       expect(impressions).to.have.lengthOf(3);
       expect(requests[0].data.sn).to.be.undefined;
@@ -2212,7 +2203,7 @@ describe('IndexexchangeAdapter', function () {
       bid2.params.bidId = '2b3c4d5e';
 
       const request = spec.buildRequests([bid, bid2], DEFAULT_OPTION)[0];
-      const impression = JSON.parse(request.data.r).imp[0];
+      const impression = extractPayload(request).imp[0];
       const sidValue = bid.params.id;
 
       expect(impression.id).to.equal(bid.bidId);
@@ -2242,7 +2233,7 @@ describe('IndexexchangeAdapter', function () {
       const bids = [DEFAULT_BANNER_VALID_BID[0], bid];
       const request = spec.buildRequests(bids, DEFAULT_OPTION)[0];
 
-      const impressions = JSON.parse(request.data.r).imp;
+      const impressions = extractPayload(request).imp;
       expect(impressions).to.be.an('array');
       expect(impressions).to.have.lengthOf(2);
       expect(request.data.sn).to.be.undefined;
@@ -2267,7 +2258,7 @@ describe('IndexexchangeAdapter', function () {
 
     it('request should not contain the extra video ad sizes that IX is not configured for', function () {
       const request = spec.buildRequests(DEFAULT_VIDEO_VALID_BID, DEFAULT_OPTION);
-      const impressions = JSON.parse(request[0].data.r).imp;
+      const impressions = extractPayload(request[0]).imp;
 
       expect(impressions).to.be.an('array');
       expect(impressions).to.have.lengthOf(1);
@@ -2280,7 +2271,7 @@ describe('IndexexchangeAdapter', function () {
 
         const requests = spec.buildRequests([bid1, DEFAULT_BANNER_VALID_BID[0]], DEFAULT_OPTION);
 
-        const impressions = JSON.parse(requests[0].data.r).imp;
+        const impressions = extractPayload(requests[0]).imp;
 
         expect(impressions).to.be.an('array');
         expect(impressions).to.have.lengthOf(1);
@@ -2290,24 +2281,15 @@ describe('IndexexchangeAdapter', function () {
 
   describe('buildRequestVideo', function () {
     const request = spec.buildRequests(DEFAULT_VIDEO_VALID_BID, DEFAULT_OPTION);
-    const query = request[0].data;
-
-    it('query object (version, siteID and request) should be correct', function () {
-      expect(query.v).to.equal(VIDEO_ENDPOINT_VERSION);
-      expect(query.s).to.equal(DEFAULT_VIDEO_VALID_BID[0].params.siteId);
-      expect(query.r).to.exist;
-      expect(query.ac).to.equal('j');
-      expect(query.sd).to.equal(1);
-      expect(query.nf).to.equal(1);
-    });
+    const payloadData = request[0].data;
 
     it('auction type should be set correctly', function () {
-      const at = JSON.parse(query.r).at;
+      const at = payloadData.at;
       expect(at).to.equal(1);
     })
 
     it('impression should have correct format and value', function () {
-      const impression = JSON.parse(query.r).imp[0];
+      const impression = payloadData.imp[0];
 
       expect(impression.id).to.equal(DEFAULT_VIDEO_VALID_BID[0].bidId);
       expect(impression.video.w).to.equal(DEFAULT_VIDEO_VALID_BID[0].params.size[0]);
@@ -2326,7 +2308,7 @@ describe('IndexexchangeAdapter', function () {
       bid.mediaTypes.video.context = 'outstream';
       bid.mediaTypes.video.placement = 2;
       const request = spec.buildRequests([bid], {})[0];
-      const impression = JSON.parse(request.data.r).imp[0];
+      const impression = extractPayload(request).imp[0];
 
       expect(impression.id).to.equal(DEFAULT_VIDEO_VALID_BID[0].bidId);
       expect(impression.video.placement).to.equal(2);
@@ -2336,7 +2318,7 @@ describe('IndexexchangeAdapter', function () {
       const bid = utils.deepClone(DEFAULT_VIDEO_VALID_BID[0]);
       bid.params.id = 50;
       const request = spec.buildRequests([bid], {})[0];
-      const impression = JSON.parse(request.data.r).imp[0];
+      const impression = extractPayload(request).imp[0];
 
       expect(impression.ext.sid).to.equal('50');
     });
@@ -2345,7 +2327,7 @@ describe('IndexexchangeAdapter', function () {
       const bid = utils.deepClone(DEFAULT_VIDEO_VALID_BID[0]);
       bid.mediaTypes.video.context = 'instream';
       const request = spec.buildRequests([bid], {})[0];
-      const impression = JSON.parse(request.data.r).imp[0];
+      const impression = extractPayload(request).imp[0];
 
       expect(impression.id).to.equal(DEFAULT_VIDEO_VALID_BID[0].bidId);
       expect(impression.video.placement).to.equal(1);
@@ -2355,7 +2337,7 @@ describe('IndexexchangeAdapter', function () {
       const bid = utils.deepClone(DEFAULT_VIDEO_VALID_BID[0]);
       bid.mediaTypes.video.context = 'outstream';
       const request = spec.buildRequests([bid], {})[0];
-      const impression = JSON.parse(request.data.r).imp[0];
+      const impression = extractPayload(request).imp[0];
 
       expect(impression.id).to.equal(DEFAULT_VIDEO_VALID_BID[0].bidId);
       expect(impression.video.placement).to.equal(4);
@@ -2365,7 +2347,7 @@ describe('IndexexchangeAdapter', function () {
       const bid = utils.deepClone(DEFAULT_VIDEO_VALID_BID[0]);
       bid.mediaTypes.video.context = 'not-valid';
       const request = spec.buildRequests([bid], {})[0];
-      const impression = JSON.parse(request.data.r).imp[0];
+      const impression = extractPayload(request).imp[0];
       expect(impression.video.placement).to.be.undefined;
     });
 
@@ -2375,7 +2357,7 @@ describe('IndexexchangeAdapter', function () {
       bid.mediaTypes.video.protocols = [1];
       bid.mediaTypes.video.mimes = ['video/override'];
       const request = spec.buildRequests([bid], {})[0];
-      const impression = JSON.parse(request.data.r).imp[0];
+      const impression = extractPayload(request).imp[0];
 
       expect(impression.video.protocols[0]).to.equal(2);
       expect(impression.video.mimes[0]).to.not.equal('video/override');
@@ -2386,7 +2368,7 @@ describe('IndexexchangeAdapter', function () {
       bid.mediaTypes.video.context = 'outstream';
       bid.mediaTypes.video.random = true;
       const request = spec.buildRequests([bid], {})[0];
-      const impression = JSON.parse(request.data.r).imp[0];
+      const impression = extractPayload(request).imp[0];
 
       expect(impression.video.random).to.not.exist;
     });
@@ -2401,7 +2383,7 @@ describe('IndexexchangeAdapter', function () {
       bid.mediaTypes.video.api = 2;
       bid.mediaTypes.video.pos = 0;
       const request = spec.buildRequests([bid], {})[0];
-      const impression = JSON.parse(request.data.r).imp[0];
+      const impression = extractPayload(request).imp[0];
 
       expect(impression.video.protocols[0]).to.equal(6);
       expect(impression.video.api).to.equal(2);
@@ -2418,15 +2400,14 @@ describe('IndexexchangeAdapter', function () {
         }
       };
       const requests = spec.buildRequests(validBids, DEFAULT_OPTION);
-      const { ext: { gpid } } = JSON.parse(requests[0].data.r).imp[0];
+      const { ext: { gpid } } = extractPayload(requests[0]).imp[0];
       expect(gpid).to.equal(GPID);
     });
 
     it('should build video request when if video obj is not provided at params level', () => {
       const request = spec.buildRequests([DEFAULT_VIDEO_VALID_BID_NO_VIDEO_PARAMS[0]], {});
-      const videoImpression = JSON.parse(request[0].data.r).imp[0];
+      const videoImpression = extractPayload(request[0]).imp[0];
 
-      expect(JSON.parse(request[0].data.v)).to.equal(VIDEO_ENDPOINT_VERSION);
       expect(videoImpression.id).to.equal(DEFAULT_VIDEO_VALID_BID_NO_VIDEO_PARAMS[0].bidId);
       expect(videoImpression.video.w).to.equal(DEFAULT_VIDEO_VALID_BID_NO_VIDEO_PARAMS[0].mediaTypes.video.playerSize[0][0]);
       expect(videoImpression.video.h).to.equal(DEFAULT_VIDEO_VALID_BID_NO_VIDEO_PARAMS[0].mediaTypes.video.playerSize[0][1]);
@@ -2440,23 +2421,18 @@ describe('IndexexchangeAdapter', function () {
       };
 
       const request = spec.buildRequests([bid]);
-      const videoImpression = JSON.parse(request[0].data.r).imp[0];
+      const videoImpression = extractPayload(request[0]).imp[0];
 
       expect(videoImpression.video.placement).to.eq(5);
     })
   });
 
   describe('buildRequestNative', function () {
-    it('should build request with expected params', function() {
-      const request = spec.buildRequests(DEFAULT_NATIVE_VALID_BID, DEFAULT_OPTION);
-      const query = request[0].data;
+    it('should build request with expected params', function () {
+      const request = spec.buildRequests(DEFAULT_NATIVE_VALID_BID, DEFAULT_OPTION)[0];
 
-      expect(query.hasOwnProperty('v')).to.equal(false);
-      expect(query.s).to.equal(DEFAULT_NATIVE_VALID_BID[0].params.siteId);
-      expect(query.r).to.exist;
-      expect(query.ac).to.equal('j');
-      expect(query.sd).to.equal(1);
-      expect(JSON.parse(query.r).at).to.equal(1);
+      expect(request.data).to.exist;
+      expect(request.method).to.equal('POST')
     });
 
     it('should send gpid in request if ortb2Imp.ext.gpid exists', function () {
@@ -2468,40 +2444,40 @@ describe('IndexexchangeAdapter', function () {
         }
       };
       const requests = spec.buildRequests(bids, DEFAULT_OPTION);
-      const { ext: { gpid } } = JSON.parse(requests[0].data.r).imp[0];
+      const { ext: { gpid } } = extractPayload(requests[0]).imp[0];
       expect(gpid).to.equal(GPID);
     });
 
-    it('should build request with required asset properties with default values', function() {
+    it('should build request with required asset properties with default values', function () {
       const request = spec.buildRequests(DEFAULT_NATIVE_VALID_BID, DEFAULT_OPTION);
-      const nativeImpression = JSON.parse(request[0].data.r).imp[0];
+      const nativeImpression = extractPayload(request[0]).imp[0];
 
       expect(request[0].data.hasOwnProperty('v')).to.equal(false);
       expect(nativeImpression.id).to.equal(DEFAULT_NATIVE_VALID_BID[0].bidId);
       expect(nativeImpression.native).to.deep.equal(DEFAULT_NATIVE_IMP);
     });
 
-    it('should set imp.ext.sid for native imps if params.id exist', function() {
+    it('should set imp.ext.sid for native imps if params.id exist', function () {
       const bid = utils.deepClone(DEFAULT_NATIVE_VALID_BID);
       bid[0].params.id = 'abc'
       const request = spec.buildRequests(bid, DEFAULT_OPTION);
-      const nativeImpression = JSON.parse(request[0].data.r).imp[0];
+      const nativeImpression = extractPayload(request[0]).imp[0];
 
       expect(nativeImpression.id).to.equal(DEFAULT_NATIVE_VALID_BID[0].bidId);
       expect(nativeImpression.ext.sid).to.equal('abc');
     });
 
-    it('should build request with given asset properties', function() {
+    it('should build request with given asset properties', function () {
       let bid = utils.deepClone(DEFAULT_NATIVE_VALID_BID)
       bid[0].nativeOrtbRequest = {
-        assets: [{id: 0, required: 0, title: {len: 140}}, {id: 1, required: 0, video: {mimes: ['javascript'], minduration: 10, maxduration: 60, protocols: [1]}}]
+        assets: [{ id: 0, required: 0, title: { len: 140 } }, { id: 1, required: 0, video: { mimes: ['javascript'], minduration: 10, maxduration: 60, protocols: [1] } }]
       }
       const request = spec.buildRequests(bid, DEFAULT_OPTION);
-      const nativeImpression = JSON.parse(request[0].data.r).imp[0];
-      expect(nativeImpression.native).to.deep.equal({request: '{"assets":[{"id":0,"required":0,"title":{"len":140}},{"id":1,"required":0,"video":{"mimes":["javascript"],"minduration":10,"maxduration":60,"protocols":[1]}}],"eventtrackers":[{"event":1,"methods":[1,2]}],"privacy":1}', ver: '1.2'});
+      const nativeImpression = extractPayload(request[0]).imp[0];
+      expect(nativeImpression.native).to.deep.equal({ request: '{"assets":[{"id":0,"required":0,"title":{"len":140}},{"id":1,"required":0,"video":{"mimes":["javascript"],"minduration":10,"maxduration":60,"protocols":[1]}}],"eventtrackers":[{"event":1,"methods":[1,2]}],"privacy":1}', ver: '1.2' });
     });
 
-    it('should build request with all possible Prebid asset properties', function() {
+    it('should build request with all possible Prebid asset properties', function () {
       let bid = utils.deepClone(DEFAULT_NATIVE_VALID_BID)
       bid[0].nativeOrtbRequest = {
         'ver': '1.2',
@@ -2626,17 +2602,16 @@ describe('IndexexchangeAdapter', function () {
         ]
       }
       const request = spec.buildRequests(bid, DEFAULT_OPTION);
-      const nativeImpression = JSON.parse(request[0].data.r).imp[0];
-      expect(nativeImpression.native).to.deep.equal({request: '{"ver":"1.2","assets":[{"id":0,"required":0,"title":{"len":140}},{"id":1,"required":0,"data":{"type":2}},{"id":2,"required":0,"data":{"type":10}},{"id":3,"required":0,"data":{"type":1}},{"id":4,"required":0,"img":{"type":1}},{"id":5,"required":0,"img":{"type":3}},{"id":6,"required":0},{"id":7,"required":0,"data":{"type":11}},{"id":8,"required":0},{"id":9,"required":0},{"id":10,"required":0,"data":{"type":12}},{"id":11,"required":0,"data":{"type":3}},{"id":12,"required":0,"data":{"type":5}},{"id":13,"required":0,"data":{"type":4}},{"id":14,"required":0,"data":{"type":6}},{"id":15,"required":0,"data":{"type":7}},{"id":16,"required":0,"data":{"type":9}},{"id":17,"required":0,"data":{"type":8}}],"eventtrackers":[{"event":1,"methods":[1,2]}],"privacy":1}', ver: '1.2'});
+      const nativeImpression = extractPayload(request[0]).imp[0];
+      expect(nativeImpression.native).to.deep.equal({ request: '{"ver":"1.2","assets":[{"id":0,"required":0,"title":{"len":140}},{"id":1,"required":0,"data":{"type":2}},{"id":2,"required":0,"data":{"type":10}},{"id":3,"required":0,"data":{"type":1}},{"id":4,"required":0,"img":{"type":1}},{"id":5,"required":0,"img":{"type":3}},{"id":6,"required":0},{"id":7,"required":0,"data":{"type":11}},{"id":8,"required":0},{"id":9,"required":0},{"id":10,"required":0,"data":{"type":12}},{"id":11,"required":0,"data":{"type":3}},{"id":12,"required":0,"data":{"type":5}},{"id":13,"required":0,"data":{"type":4}},{"id":14,"required":0,"data":{"type":6}},{"id":15,"required":0,"data":{"type":7}},{"id":16,"required":0,"data":{"type":9}},{"id":17,"required":0,"data":{"type":8}}],"eventtrackers":[{"event":1,"methods":[1,2]}],"privacy":1}', ver: '1.2' });
     })
   });
 
   describe('buildRequestMultiFormat', function () {
     it('only banner bidder params set', function () {
       const request = spec.buildRequests(DEFAULT_MULTIFORMAT_BANNER_VALID_BID, {})
-      const bannerImpression = JSON.parse(request[0].data.r).imp[0];
-      expect(JSON.parse(request[0].data.r).imp).to.have.lengthOf(1);
-      expect(JSON.parse(request[0].data.v)).to.equal(BANNER_ENDPOINT_VERSION);
+      const bannerImpression = extractPayload(request[0]).imp[0];
+      expect(extractPayload(request[0]).imp).to.have.lengthOf(1);
       expect(bannerImpression.id).to.equal(DEFAULT_MULTIFORMAT_BANNER_VALID_BID[0].bidId);
       expect(bannerImpression.banner.format[0].w).to.equal(DEFAULT_MULTIFORMAT_BANNER_VALID_BID[0].params.size[0]);
       expect(bannerImpression.banner.format[0].h).to.equal(DEFAULT_MULTIFORMAT_BANNER_VALID_BID[0].params.size[1]);
@@ -2645,9 +2620,8 @@ describe('IndexexchangeAdapter', function () {
     describe('only video bidder params set', function () {
       it('should generate video impression', function () {
         const request = spec.buildRequests(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID, {});
-        const videoImp = JSON.parse(request[1].data.r).imp[0];
-        expect(JSON.parse(request[1].data.r).imp).to.have.lengthOf(1);
-        expect(JSON.parse(request[1].data.v)).to.equal(VIDEO_ENDPOINT_VERSION);
+        const videoImp = extractPayload(request[1]).imp[0];
+        expect(extractPayload(request[1]).imp).to.have.lengthOf(1);
         expect(videoImp.id).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].bidId);
         expect(videoImp.video.w).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].params.size[0]);
         expect(videoImp.video.h).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].params.size[1]);
@@ -2659,10 +2633,9 @@ describe('IndexexchangeAdapter', function () {
       const request = spec.buildRequests(bids, {});
 
       it('should return valid banner requests', function () {
-        const impressions = JSON.parse(request[0].data.r).imp;
+        const impressions = extractPayload(request[0]).imp;
 
         expect(impressions).to.have.lengthOf(2);
-        expect(JSON.parse(request[0].data.v)).to.equal(BANNER_ENDPOINT_VERSION);
 
         impressions.map((impression, index) => {
           const bid = bids[index];
@@ -2682,17 +2655,16 @@ describe('IndexexchangeAdapter', function () {
       });
 
       it('should return valid banner and video requests', function () {
-        const videoImpression = JSON.parse(request[1].data.r).imp[0];
+        const videoImpression = extractPayload(request[1]).imp[0];
 
-        expect(JSON.parse(request[1].data.r).imp).to.have.lengthOf(1);
-        expect(JSON.parse(request[1].data.v)).to.equal(VIDEO_ENDPOINT_VERSION);
+        expect(extractPayload(request[1]).imp).to.have.lengthOf(1);
         expect(videoImpression.id).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].bidId);
         expect(videoImpression.video.w).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].mediaTypes.video.playerSize[0][0]);
         expect(videoImpression.video.h).to.equal(DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0].mediaTypes.video.playerSize[0][1]);
       });
 
       it('should contain all correct IXdiag properties', function () {
-        const diagObj = JSON.parse(request[0].data.r).ext.ixdiag;
+        const diagObj = extractPayload(request[0]).ext.ixdiag;
         expect(diagObj.iu).to.equal(0);
         expect(diagObj.nu).to.equal(0);
         expect(diagObj.ou).to.equal(2);
@@ -2709,6 +2681,17 @@ describe('IndexexchangeAdapter', function () {
   });
 
   describe('interpretResponse', function () {
+    // generate bidderRequest with real buildRequest logic for intepretResponse testing
+    let bannerBidderRequest
+    let videoBidderRequest
+    let nativeBidderRequest
+
+    beforeEach(() => {
+      bannerBidderRequest = spec.buildRequests(DEFAULT_BANNER_VALID_BID, {})[0]
+      videoBidderRequest = spec.buildRequests(DEFAULT_VIDEO_VALID_BID_MEDIUM_SIZE, {})[0]
+      nativeBidderRequest = spec.buildRequests(DEFAULT_NATIVE_VALID_BID, {})[0]
+    });
+
     it('should get correct bid response for banner ad', function () {
       const expectedParse = [
         {
@@ -2730,7 +2713,7 @@ describe('IndexexchangeAdapter', function () {
           }
         }
       ];
-      const result = spec.interpretResponse({ body: DEFAULT_BANNER_BID_RESPONSE }, { data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: [] });
+      const result = spec.interpretResponse({ body: DEFAULT_BANNER_BID_RESPONSE }, bannerBidderRequest);
       expect(result[0]).to.deep.equal(expectedParse[0]);
     });
 
@@ -2754,7 +2737,7 @@ describe('IndexexchangeAdapter', function () {
           }
         }
       ];
-      const result = spec.interpretResponse({ body: DEFAULT_BANNER_BID_RESPONSE_WITHOUT_ADOMAIN }, { data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: [] });
+      const result = spec.interpretResponse({ body: DEFAULT_BANNER_BID_RESPONSE_WITHOUT_ADOMAIN }, bannerBidderRequest);
       expect(result[0]).to.deep.equal(expectedParse[0]);
     });
 
@@ -2781,7 +2764,7 @@ describe('IndexexchangeAdapter', function () {
           }
         }
       ];
-      const result = spec.interpretResponse({ body: bidResponse }, { data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: [] });
+      const result = spec.interpretResponse({ body: bidResponse }, bannerBidderRequest);
     });
 
     it('should set Japanese price correctly', function () {
@@ -2807,7 +2790,7 @@ describe('IndexexchangeAdapter', function () {
           }
         }
       ];
-      const result = spec.interpretResponse({ body: bidResponse }, { data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: [] });
+      const result = spec.interpretResponse({ body: bidResponse }, bannerBidderRequest);
       expect(result[0]).to.deep.equal(expectedParse[0]);
     });
 
@@ -2836,7 +2819,7 @@ describe('IndexexchangeAdapter', function () {
           }
         }
       ];
-      const result = spec.interpretResponse({ body: bidResponse }, { data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: [] });
+      const result = spec.interpretResponse({ body: bidResponse }, bannerBidderRequest);
 
       expect(result[0].dealId).to.equal(expectedParse[0].dealId);
     });
@@ -2863,7 +2846,7 @@ describe('IndexexchangeAdapter', function () {
           }
         }
       ];
-      const result = spec.interpretResponse({ body: bidResponse }, { data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: [] });
+      const result = spec.interpretResponse({ body: bidResponse }, bannerBidderRequest);
       expect(result[0]).to.deep.equal(expectedParse[0]);
     });
 
@@ -2891,7 +2874,7 @@ describe('IndexexchangeAdapter', function () {
           }
         }
       ];
-      const result = spec.interpretResponse({ body: bidResponse }, { data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: [] });
+      const result = spec.interpretResponse({ body: bidResponse }, bannerBidderRequest);
       expect(result[0].dealId).to.deep.equal(expectedParse[0].dealId);
     });
 
@@ -2928,7 +2911,7 @@ describe('IndexexchangeAdapter', function () {
         }
       ];
       const result = spec.interpretResponse({ body: DEFAULT_VIDEO_BID_RESPONSE }, {
-        data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: ONE_VIDEO
+        data: videoBidderRequest.data, validBidRequests: ONE_VIDEO
       });
 
       expect(result[0]).to.deep.equal(expectedParse[0]);
@@ -2936,14 +2919,14 @@ describe('IndexexchangeAdapter', function () {
 
     it('should set bid[].renderer if renderer not defined at mediaType.video level', function () {
       const bid = spec.interpretResponse({ body: DEFAULT_VIDEO_BID_RESPONSE }, {
-        data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: DEFAULT_MULTIFORMAT_BANNER_VALID_BID
+        data: videoBidderRequest.data, validBidRequests: DEFAULT_MULTIFORMAT_BANNER_VALID_BID
       });
       expect(bid[0].renderer).to.exist;
     });
 
     it('should set renderer URL by parsing video response', function () {
       const bid = spec.interpretResponse({ body: DEFAULT_VIDEO_BID_RESPONSE }, {
-        data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: DEFAULT_MULTIFORMAT_BANNER_VALID_BID
+        data: videoBidderRequest.data, validBidRequests: DEFAULT_MULTIFORMAT_BANNER_VALID_BID
       });
       expect(bid[0].renderer.url).to.equal(DEFAULT_VIDEO_BID_RESPONSE.ext.videoplayerurl);
     });
@@ -2952,10 +2935,10 @@ describe('IndexexchangeAdapter', function () {
       let outstreamAdUnit = utils.deepClone(DEFAULT_MULTIFORMAT_BANNER_VALID_BID);
       outstreamAdUnit[0].mediaTypes.video.renderer = {
         url: 'test',
-        render: function() {}
+        render: function () { }
       };
       const bid = spec.interpretResponse({ body: DEFAULT_VIDEO_BID_RESPONSE }, {
-        data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: outstreamAdUnit
+        data: videoBidderRequest.data, validBidRequests: outstreamAdUnit
       });
       expect(bid[0].renderer).to.be.undefined;
     });
@@ -2964,10 +2947,10 @@ describe('IndexexchangeAdapter', function () {
       let outstreamAdUnit = utils.deepClone(DEFAULT_MULTIFORMAT_BANNER_VALID_BID);
       outstreamAdUnit[0].renderer = {
         url: 'test',
-        render: function() {}
+        render: function () { }
       };
       const bid = spec.interpretResponse({ body: DEFAULT_VIDEO_BID_RESPONSE }, {
-        data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: outstreamAdUnit
+        data: videoBidderRequest.data, validBidRequests: outstreamAdUnit
       });
       expect(bid[0].renderer).to.be.undefined;
     });
@@ -2978,7 +2961,7 @@ describe('IndexexchangeAdapter', function () {
         url: 'test'
       };
       const bid = spec.interpretResponse({ body: DEFAULT_VIDEO_BID_RESPONSE }, {
-        data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: outstreamAdUnit
+        data: videoBidderRequest.data, validBidRequests: outstreamAdUnit
       });
       expect(bid[0].renderer).to.exist;
     });
@@ -2987,11 +2970,11 @@ describe('IndexexchangeAdapter', function () {
       let outstreamAdUnit = utils.deepClone(DEFAULT_MULTIFORMAT_BANNER_VALID_BID);
       outstreamAdUnit[0].mediaTypes.video.renderer = {
         url: 'test',
-        render: function() {},
+        render: function () { },
         backupOnly: true
       };
       const bid = spec.interpretResponse({ body: DEFAULT_VIDEO_BID_RESPONSE }, {
-        data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: outstreamAdUnit
+        data: videoBidderRequest.data, validBidRequests: outstreamAdUnit
       });
       expect(bid[0].renderer).to.exist;
     });
@@ -3029,7 +3012,7 @@ describe('IndexexchangeAdapter', function () {
         }
       ];
       const result = spec.interpretResponse({ body: DEFAULT_VIDEO_BID_RESPONSE_WITH_MTYPE_SET }, {
-        data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: ONE_VIDEO
+        data: videoBidderRequest.data, validBidRequests: ONE_VIDEO
       });
 
       expect(result[0]).to.deep.equal(expectedParse[0]);
@@ -3038,10 +3021,11 @@ describe('IndexexchangeAdapter', function () {
     it('bidrequest should not have page if options is undefined', function () {
       const options = {};
       const validBidWithoutreferInfo = spec.buildRequests(DEFAULT_BANNER_VALID_BID, options);
-      const requestWithoutreferInfo = JSON.parse(validBidWithoutreferInfo[0].data.r);
+      const requestWithoutreferInfo = extractPayload(validBidWithoutreferInfo[0]);
 
+      const expectedURL = IX_SECURE_ENDPOINT + '?s=' + DEFAULT_BANNER_VALID_BID[0].params.siteId
       expect(requestWithoutreferInfo.site.page).to.be.undefined;
-      expect(validBidWithoutreferInfo[0].url).to.equal(IX_SECURE_ENDPOINT);
+      expect(validBidWithoutreferInfo[0].url).to.equal(expectedURL);
     });
 
     it('bidrequest should not have page if options.refererInfo is an empty object', function () {
@@ -3049,10 +3033,11 @@ describe('IndexexchangeAdapter', function () {
         refererInfo: {}
       };
       const validBidWithoutreferInfo = spec.buildRequests(DEFAULT_BANNER_VALID_BID, options);
-      const requestWithoutreferInfo = JSON.parse(validBidWithoutreferInfo[0].data.r);
+      const requestWithoutreferInfo = extractPayload(validBidWithoutreferInfo[0]);
 
+      const expectedURL = IX_SECURE_ENDPOINT + '?s=' + DEFAULT_BANNER_VALID_BID[0].params.siteId
       expect(requestWithoutreferInfo.site.page).to.be.undefined;
-      expect(validBidWithoutreferInfo[0].url).to.equal(IX_SECURE_ENDPOINT);
+      expect(validBidWithoutreferInfo[0].url).to.equal(expectedURL);
     });
 
     it('bidrequest should sent to secure endpoint if page url is secure', function () {
@@ -3062,10 +3047,11 @@ describe('IndexexchangeAdapter', function () {
         }
       };
       const validBidWithoutreferInfo = spec.buildRequests(DEFAULT_BANNER_VALID_BID, options);
-      const requestWithoutreferInfo = JSON.parse(validBidWithoutreferInfo[0].data.r);
+      const requestWithoutreferInfo = extractPayload(validBidWithoutreferInfo[0]);
 
+      const expectedURL = IX_SECURE_ENDPOINT + '?s=' + DEFAULT_BANNER_VALID_BID[0].params.siteId
       expect(requestWithoutreferInfo.site.page).to.equal(options.refererInfo.page);
-      expect(validBidWithoutreferInfo[0].url).to.equal(IX_SECURE_ENDPOINT);
+      expect(validBidWithoutreferInfo[0].url).to.equal(expectedURL);
     });
 
     it('should set bid[].ttl to seatbid[].bid[].exp value from response', function () {
@@ -3073,16 +3059,16 @@ describe('IndexexchangeAdapter', function () {
       const VIDEO_RESPONSE_WITH_EXP = utils.deepClone(DEFAULT_VIDEO_BID_RESPONSE);
       VIDEO_RESPONSE_WITH_EXP.seatbid[0].bid[0].exp = 200;
       BANNER_RESPONSE_WITH_EXP.seatbid[0].bid[0].exp = 100;
-      const bannerResult = spec.interpretResponse({ body: BANNER_RESPONSE_WITH_EXP }, { data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: [] });
-      const videoResult = spec.interpretResponse({ body: VIDEO_RESPONSE_WITH_EXP }, { data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: [] });
+      const bannerResult = spec.interpretResponse({ body: BANNER_RESPONSE_WITH_EXP }, bannerBidderRequest);
+      const videoResult = spec.interpretResponse({ body: VIDEO_RESPONSE_WITH_EXP }, videoBidderRequest);
 
       expect(bannerResult[0].ttl).to.equal(100);
       expect(videoResult[0].ttl).to.equal(200);
     });
 
     it('should default bid[].ttl if seat[].bid[].exp is not in the resposne', function () {
-      const bannerResult = spec.interpretResponse({ body: DEFAULT_BANNER_BID_RESPONSE }, { data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: [] });
-      const videoResult = spec.interpretResponse({ body: DEFAULT_VIDEO_BID_RESPONSE }, { data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: [] });
+      const bannerResult = spec.interpretResponse({ body: DEFAULT_BANNER_BID_RESPONSE }, bannerBidderRequest);
+      const videoResult = spec.interpretResponse({ body: DEFAULT_VIDEO_BID_RESPONSE }, videoBidderRequest);
 
       expect(bannerResult[0].ttl).to.equal(300);
       expect(videoResult[0].ttl).to.equal(3600);
@@ -3174,7 +3160,7 @@ describe('IndexexchangeAdapter', function () {
           ttl: 3600
         }
       ];
-      const result = spec.interpretResponse({ body: DEFAULT_NATIVE_BID_RESPONSE }, { data: DEFAULT_BIDDER_REQUEST_DATA, validBidRequests: [] });
+      const result = spec.interpretResponse({ body: DEFAULT_NATIVE_BID_RESPONSE }, nativeBidderRequest);
       expect(result[0]).to.deep.equal(expectedParse[0]);
     });
   });
@@ -3182,7 +3168,7 @@ describe('IndexexchangeAdapter', function () {
   describe('bidrequest consent', function () {
     it('should have consent info if gdprApplies and consentString exist', function () {
       const validBidWithConsent = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION);
-      const requestWithConsent = JSON.parse(validBidWithConsent[0].data.r);
+      const requestWithConsent = extractPayload(validBidWithConsent[0]);
 
       expect(requestWithConsent.regs.ext.gdpr).to.equal(1);
       expect(requestWithConsent.user.ext.consent).to.equal('3huaa11=qu3198ae');
@@ -3196,7 +3182,7 @@ describe('IndexexchangeAdapter', function () {
         }
       };
       const validBidWithConsent = spec.buildRequests(DEFAULT_BANNER_VALID_BID, options);
-      const requestWithConsent = JSON.parse(validBidWithConsent[0].data.r);
+      const requestWithConsent = extractPayload(validBidWithConsent[0]);
 
       expect(requestWithConsent.regs.ext.gdpr).to.equal(1);
       expect(requestWithConsent.user).to.be.undefined;
@@ -3210,7 +3196,7 @@ describe('IndexexchangeAdapter', function () {
         }
       };
       const validBidWithConsent = spec.buildRequests(DEFAULT_BANNER_VALID_BID, options);
-      const requestWithConsent = JSON.parse(validBidWithConsent[0].data.r);
+      const requestWithConsent = extractPayload(validBidWithConsent[0]);
 
       expect(requestWithConsent.regs).to.be.undefined;
       expect(requestWithConsent.user.ext.consent).to.equal('3huaa11=qu3198ae');
@@ -3219,7 +3205,7 @@ describe('IndexexchangeAdapter', function () {
     it('should not have consent info if options.gdprConsent is undefined', function () {
       const options = {};
       const validBidWithConsent = spec.buildRequests(DEFAULT_BANNER_VALID_BID, options);
-      const requestWithConsent = JSON.parse(validBidWithConsent[0].data.r);
+      const requestWithConsent = extractPayload(validBidWithConsent[0]);
 
       expect(requestWithConsent.regs).to.be.undefined;
       expect(requestWithConsent.user).to.be.undefined;
@@ -3230,7 +3216,7 @@ describe('IndexexchangeAdapter', function () {
         uspConsent: '1YYN'
       };
       const validBidWithUspConsent = spec.buildRequests(DEFAULT_BANNER_VALID_BID, options);
-      const requestWithUspConsent = JSON.parse(validBidWithUspConsent[0].data.r);
+      const requestWithUspConsent = extractPayload(validBidWithUspConsent[0]);
 
       expect(requestWithUspConsent.regs.ext.us_privacy).to.equal('1YYN');
     });
@@ -3238,7 +3224,7 @@ describe('IndexexchangeAdapter', function () {
     it('should not have us_privacy if uspConsent undefined', function () {
       const options = {};
       const validBidWithUspConsent = spec.buildRequests(DEFAULT_BANNER_VALID_BID, options);
-      const requestWithUspConsent = JSON.parse(validBidWithUspConsent[0].data.r);
+      const requestWithUspConsent = extractPayload(validBidWithUspConsent[0]);
 
       expect(requestWithUspConsent.regs).to.be.undefined;
     });
@@ -3252,7 +3238,7 @@ describe('IndexexchangeAdapter', function () {
         uspConsent: '1YYN'
       };
       const validBidWithConsent = spec.buildRequests(DEFAULT_BANNER_VALID_BID, options);
-      const requestWithConsent = JSON.parse(validBidWithConsent[0].data.r);
+      const requestWithConsent = extractPayload(validBidWithConsent[0]);
       expect(requestWithConsent.regs.ext.gdpr).to.equal(1);
       expect(requestWithConsent.regs.ext.us_privacy).to.equal('1YYN');
     });
@@ -3266,7 +3252,7 @@ describe('IndexexchangeAdapter', function () {
       };
 
       const validBidWithConsent = spec.buildRequests(DEFAULT_BANNER_VALID_BID, options);
-      const requestWithConsent = JSON.parse(validBidWithConsent[0].data.r);
+      const requestWithConsent = extractPayload(validBidWithConsent[0]);
       expect(requestWithConsent.user.ext.consented_providers_settings.consented_providers).to.equal('1~1.35.41.101');
       expect(requestWithConsent.user.ext.consent).to.equal('3huaa11=qu3198ae');
     });
@@ -3279,7 +3265,7 @@ describe('IndexexchangeAdapter', function () {
       };
 
       const validBidWithConsent = spec.buildRequests(DEFAULT_BANNER_VALID_BID, options);
-      const requestWithConsent = JSON.parse(validBidWithConsent[0].data.r);
+      const requestWithConsent = extractPayload(validBidWithConsent[0]);
       expect(utils.deepAccess(requestWithConsent, 'user.ext.consented_providers_settings')).to.not.exist;
       expect(utils.deepAccess(requestWithConsent, 'user.ext.consent')).to.not.exist;
     });
@@ -3287,21 +3273,21 @@ describe('IndexexchangeAdapter', function () {
     it('should set coppa to 1 in config when enabled', () => {
       config.setConfig({ coppa: true })
       const bid = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION);
-      const r = JSON.parse(bid[0].data.r);
+      const r = extractPayload(bid[0]);
 
       expect(r.regs.coppa).to.equal(1);
     });
     it('should not set coppa in config when disabled', () => {
       config.setConfig({ coppa: false })
       const bid = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION);
-      const r = JSON.parse(bid[0].data.r);
+      const r = extractPayload(bid[0]);
 
       expect(r.regs.coppa).to.be.undefined;
     });
     it('should not set coppa when not specified in config', () => {
       config.resetConfig();
       const bid = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION);
-      const r = JSON.parse(bid[0].data.r);
+      const r = extractPayload(bid[0]);
 
       expect(r.regs.coppa).to.be.undefined;
     });
@@ -3401,127 +3387,6 @@ describe('IndexexchangeAdapter', function () {
       FEATURE_TOGGLES.getFeatureToggles(LOCAL_STORAGE_FEATURE_TOGGLES_KEY);
       expect(FEATURE_TOGGLES.isFeatureEnabled('test')).to.be.undefined;
       expect(FEATURE_TOGGLES.featureToggles).to.deep.equal({});
-    });
-
-    it('should create POST request when pbjs_enable_post feature is active', () => {
-      sandbox.stub(storage, 'localStorageIsEnabled').returns(true);
-      serverResponse.body.ext.features.pbjs_enable_post = {
-        activated: true
-      };
-      FEATURE_TOGGLES.setFeatureToggles(serverResponse);
-      const builtRequests = {
-        banner: {
-          request: spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0],
-          siteId: DEFAULT_BANNER_VALID_BID[0].params.siteId
-        },
-        video: {
-          request: spec.buildRequests(DEFAULT_VIDEO_VALID_BID, DEFAULT_OPTION)[0],
-          siteId: DEFAULT_VIDEO_VALID_BID[0].params.siteId
-        },
-        native: {
-          request: spec.buildRequests(DEFAULT_NATIVE_VALID_BID, DEFAULT_OPTION)[0],
-          siteId: DEFAULT_NATIVE_VALID_BID[0].params.siteId
-        }
-      };
-
-      Object.keys(builtRequests).forEach((reqType) => {
-        const request = builtRequests[reqType].request;
-        const siteId = builtRequests[reqType].siteId;
-        expect(request.method).to.equal('POST');
-        expect(request.option.contentType).to.equal('text/plain');
-        expect(request.url).to.be.equal(`${IX_SECURE_ENDPOINT}?s=${siteId}`);
-        expect(request.data.r).to.be.undefined;
-        expect(request.data.ac).to.be.undefined;
-        expect(request.data.sd).to.be.undefined;
-        expect(request.data.v).to.be.undefined;
-        expect(request.data.nf).to.be.undefined;
-      });
-    });
-
-    it('should create GET request when pbjs_enable_post feature is disabled', () => {
-      sandbox.stub(storage, 'localStorageIsEnabled').returns(true);
-      serverResponse.body.ext.features.pbjs_enable_post = {
-        activated: false
-      };
-      FEATURE_TOGGLES.setFeatureToggles(serverResponse);
-      const builtRequests = {
-        banner: {
-          request: spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION)[0],
-          siteId: DEFAULT_BANNER_VALID_BID[0].params.siteId
-        },
-        video: {
-          request: spec.buildRequests(DEFAULT_VIDEO_VALID_BID, DEFAULT_OPTION)[0],
-          siteId: DEFAULT_VIDEO_VALID_BID[0].params.siteId
-        },
-        native: {
-          request: spec.buildRequests(DEFAULT_NATIVE_VALID_BID, DEFAULT_OPTION)[0],
-          siteId: DEFAULT_NATIVE_VALID_BID[0].params.siteId
-        }
-      };
-
-      Object.keys(builtRequests).forEach((reqType) => {
-        const request = builtRequests[reqType].request;
-        const siteId = builtRequests[reqType].siteId;
-        expect(request.method).to.equal('GET');
-        expect(request.url).to.equal(IX_SECURE_ENDPOINT);
-        expect(request.data.r).to.exist;
-        expect(request.data.ac).to.equal('j');
-        expect(request.data.sd).to.equal(1);
-        expect(request.data.s).to.equal(siteId);
-        if (reqType == 'video') {
-          expect(request.data.nf).to.equal(1);
-        }
-
-        if (reqType === 'native') {
-          expect(request.data.v).to.be.undefined;
-        }
-      });
-    });
-
-    it('should interpertResponse correctly when pbjs_enable_post feature is active', function () {
-      serverResponse.body.ext.features.pbjs_enable_post = {
-        activated: true
-      };
-      FEATURE_TOGGLES.setFeatureToggles(serverResponse);
-      const postBiddderRequestData = {
-        id: '345',
-        imp: [
-          {
-            id: '1a2b3c4e',
-            banner: {
-              w: 300,
-              h: 250,
-              placement: 1
-            }
-          }
-        ],
-        site: {
-          ref: 'https://ref.com/ref.html',
-          page: 'https://page.com'
-        },
-      };
-      const expectedParse = [
-        {
-          requestId: '1a2b3c4d',
-          cpm: 1,
-          creativeId: '12345',
-          width: 300,
-          height: 250,
-          mediaType: 'banner',
-          ad: '<a target="_blank" href="https://www.indexexchange.com"></a>',
-          currency: 'USD',
-          ttl: 300,
-          netRevenue: true,
-          meta: {
-            networkId: 50,
-            brandId: 303325,
-            brandName: 'OECTA',
-            advertiserDomains: ['www.abc.com']
-          }
-        }
-      ];
-      const result = spec.interpretResponse({ body: DEFAULT_BANNER_BID_RESPONSE }, { data: postBiddderRequestData, validBidRequests: [] });
-      expect(result[0]).to.deep.equal(expectedParse[0]);
     });
   });
 
@@ -3640,7 +3505,7 @@ describe('IndexexchangeAdapter', function () {
       };
 
       expect(spec.isBidRequestValid(bid)).to.be.true;
-      spec.buildRequests([bid], {ortb2});
+      spec.buildRequests([bid], { ortb2 });
       expect(JSON.parse(localStorageValues[key])).to.deep.equal({ [TODAY]: { [ERROR_CODES.PB_FPD_EXCEEDS_MAX_SIZE]: 2 } });
     });
 
@@ -3694,30 +3559,24 @@ describe('IndexexchangeAdapter', function () {
       expect(spec.isBidRequestValid(request)).to.be.true;
 
       const data = {
-        ...utils.deepClone(DEFAULT_BIDDER_REQUEST_DATA[0]),
-        r: JSON.stringify({
-          id: '345',
-          imp: [
-            {
-              id: '1a2b3c4e',
-            }
-          ],
-          ext: {
-            ixdiag: {
-              err: {
-                '4': 8
-              }
+        id: '345',
+        imp: [
+          {
+            id: '1a2b3c4e',
+          }
+        ],
+        ext: {
+          ixdiag: {
+            err: {
+              '4': 8
             }
           }
-        }),
+        }
       };
 
-      const validBidRequests = [
-        DEFAULT_MULTIFORMAT_BANNER_VALID_BID[0],
-        DEFAULT_MULTIFORMAT_VIDEO_VALID_BID[0]
-      ];
+      const validBidRequest = DEFAULT_MULTIFORMAT_BANNER_VALID_BID[0];
 
-      spec.interpretResponse({ body: DEFAULT_BANNER_BID_RESPONSE }, { data, validBidRequests });
+      spec.interpretResponse({ body: DEFAULT_BANNER_BID_RESPONSE }, { data, validBidRequest });
 
       expect(localStorageValues[key]).to.be.undefined;
     });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Completely migrate IX Adapter requests to POST by removing the runtime toggling logic.

For tests, there is a lot of changes but generally fall into the following categories:
- change the access pattern for the bid request payload data from request.data.r to request.data (introduced a helper function extractPayload to centralize the access pattern)
- remove testings related to parameters used in GET requests, as these fields are no longer included in POST request
- make interpretResponse related test cases depending on the request object generated by real buildRequest logic instead of mocked object.
- remove tests related to specific feature toggle `pbjs_enable_post`

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
N/A