### PR TITLE
Permutive Rtd Provider: convert rubicon video targeting to string

### DIFF
--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -191,7 +191,8 @@ function getDefaultBidderFn (bidder) {
         deepSetValue(bid, 'params.visitor.p_standard', data.ac)
       }
       if (data.rubicon && data.rubicon.length) {
-        deepSetValue(bid, 'params.visitor.permutive', data.rubicon)
+        const rubiconCohorts = deepAccess(bid, 'params.video') ? data.rubicon.map(String) : data.rubicon
+        deepSetValue(bid, 'params.visitor.permutive', rubiconCohorts)
       }
 
       return bid

--- a/modules/permutiveRtdProvider.md
+++ b/modules/permutiveRtdProvider.md
@@ -45,16 +45,51 @@ as well as enabling settings for specific use cases mentioned above (e.g. acbidd
 | params.acBidders       | String[] | An array of bidders which should receive AC cohorts.                                          | `[]`    |
 | params.maxSegs         | Integer  | Maximum number of cohorts to be included in either the `permutive` or `p_standard` key-value. | `500`   |
 | params.transformations | Object[] | An array of configurations for ORTB2 user data transformations                                |         |
+| params.overwrites      | Object   | An object specifying functions for custom targeting logic for bidders.                        | -       |
 
 ##### The `transformations` parameter
 
 This array contains configurations for transformations we'll apply to the Permutive object in the ORTB2 `user.data` array. The results of these transformations will be appended to the `user.data` array that's attached to ORTB2 bid requests.
 
-##### Supported transformations
+###### Supported transformations
 
 | Name           | ID  | Config structure                                  | Description                                                                          |
 |----------------|-----|---------------------------------------------------|--------------------------------------------------------------------------------------|
 | IAB taxonomies | iab | { segtax: number, iabIds: Object<number, number>} | Transform segment IDs from Permutive to IAB (note: alpha version, subject to change) |
+
+##### The `overwrites` parameter
+
+The keys for this object should match a bidder (e.g. `rubicon`), which then can define a function to overwrite the customer targeting logic.
+
+```javascript
+{
+  params: {
+    overwrites: {
+      rubicon: function customTargeting(bid, data, acEnabled, utils, defaultFn) {
+        if (defaultFn) {
+          bid = defaultFn(bid, data, acEnabled)
+        }
+        if (data.gam && data.gam.length) {
+          utils.deepSetValue(bid, 'params.visitor.permutive', data.gam)
+        }
+      } 
+    }
+  }
+}
+```
+
+###### `customTargeting` function parameters
+
+| Name         | Description                                                                    |
+|--------------|--------------------------------------------------------------------------------|
+| `bid`        | The bid request object.                                                        |
+| `data`       | Permutive's targeting data read from localStorage.                             |
+| `acEnabled`  | Boolean stating whether Audience Connect is enabled via `acBidders`.           |
+| `utils`      | An object of helpful utilities. `(deepSetValue, deepAccess, isFn, mergeDeep)`. |
+| `defaultFn`  | The default targeting function.                                                |
+
+
+
 
 #### Context
 

--- a/test/spec/modules/permutiveRtdProvider_spec.js
+++ b/test/spec/modules/permutiveRtdProvider_spec.js
@@ -11,13 +11,13 @@ import { deepAccess } from '../../../src/utils.js'
 import { config } from 'src/config.js'
 
 describe('permutiveRtdProvider', function () {
-  before(function () {
+  beforeEach(function () {
     const data = getTargetingData()
     setLocalStorage(data)
     config.resetConfig()
   })
 
-  after(function () {
+  afterEach(function () {
     const data = getTargetingData()
     removeLocalStorage(data)
     config.resetConfig()
@@ -167,6 +167,7 @@ describe('permutiveRtdProvider', function () {
         })
       }
     })
+
     it('sets segment targeting for Magnite', function () {
       const data = transformedTargeting()
       const adUnits = getAdUnits()
@@ -187,6 +188,38 @@ describe('permutiveRtdProvider', function () {
         })
       }
     })
+
+    it('sets segment targeting for Magnite video', function () {
+      const targetingData = getTargetingData()
+      targetingData._prubicons.push(321)
+
+      setLocalStorage(targetingData)
+
+      const data = transformedTargeting(targetingData)
+      const config = getConfig()
+
+      const adUnits = getAdUnits().filter(adUnit => adUnit.mediaTypes.video)
+      expect(adUnits).to.have.lengthOf(1)
+
+      initSegments({ adUnits }, callback, config)
+
+      function callback() {
+        adUnits.forEach(adUnit => {
+          adUnit.bids.forEach(bid => {
+            const { bidder, params } = bid
+
+            if (bidder === 'rubicon') {
+              expect(
+                deepAccess(params, 'visitor.permutive'),
+                'Should map all targeting values to a string',
+              ).to.eql(data.rubicon.map(String))
+              expect(deepAccess(params, 'visitor.p_standard')).to.eql(data.ac)
+            }
+          })
+        })
+      }
+    })
+
     it('sets segment targeting for Ozone', function () {
       const data = transformedTargeting()
       const adUnits = getAdUnits()
@@ -366,9 +399,7 @@ function getConfig () {
   }
 }
 
-function transformedTargeting () {
-  const data = getTargetingData()
-
+function transformedTargeting (data = getTargetingData()) {
   return {
     ac: [...data._pcrprs, ...data._ppam, ...data._psegs.filter(seg => seg >= 1000000)],
     appnexus: data._papns,
@@ -490,6 +521,34 @@ function getAdUnits () {
           }
         }
       ]
+    },
+    {
+      code: 'myVideoAdUnit',
+      mediaTypes: {
+        video: {
+          context: 'instream',
+          playerSize: [640, 480],
+          mimes: ['video/mp4', 'video/x-ms-wmv'],
+          protocols: [2, 3, 5, 6],
+          api: [2],
+          maxduration: 30,
+          linearity: 1
+        }
+      },
+      bids: [{
+        bidder: 'rubicon',
+        params: {
+          accountId: '9840',
+          siteId: '123564',
+          zoneId: '583584',
+          video: {
+            language: 'en'
+          },
+          visitor: {
+            test_kv: ['true']
+          }
+        }
+      }]
     }
   ]
 }


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Rubicon requires string targeting information for its video ads. This PR performs this mapping when the `params.video` property is found for the bid. [This property is required for video requests](https://docs.prebid.org/dev-docs/bidders/rubicon.html#bid-params).

The `overwrites` param for the Permutive RTD is also surfaced in an effort to let users configure targeting uniquely to them.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
N/A
