### PR TITLE
Core & userId module: reload userIDs when GDPR consent changes

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -588,20 +588,28 @@ function idSystemInitializer({delay = GreedyPromise.timeout} = {}) {
     return gdprDataHandler.promise.finally(initMetrics.startTiming('userId.init.gdpr'));
   }
 
-  let done = cancelAndTry(
-    GreedyPromise.all([hooksReady, startInit.promise])
-      .then(timeGdpr)
-      .then(checkRefs((consentData) => {
-        initSubmodules(initModules, allModules, consentData);
-      }))
-      .then(() => startCallbacks.promise.finally(initMetrics.startTiming('userId.callbacks.pending')))
-      .then(checkRefs(() => {
-        const modWithCb = initModules.filter(item => isFn(item.callback));
-        if (modWithCb.length) {
-          return new GreedyPromise((resolve) => processSubmoduleCallbacks(modWithCb, resolve));
-        }
-      }))
-  );
+  let done = GreedyPromise.resolve();
+
+  function loadIds() {
+    done = cancelAndTry(
+      done.catch(() => null)
+        .then(() => GreedyPromise.all([hooksReady, startInit.promise]))
+        .then(timeGdpr)
+        .then(checkRefs((consentData) => {
+          initSubmodules(initModules, allModules, consentData);
+        }))
+        .then(() => startCallbacks.promise.finally(initMetrics.startTiming('userId.callbacks.pending')))
+        .then(checkRefs(() => {
+          const modWithCb = initModules.filter(item => isFn(item.callback));
+          if (modWithCb.length) {
+            return new GreedyPromise((resolve) => processSubmoduleCallbacks(modWithCb, resolve));
+          }
+        }))
+    );
+  }
+
+  loadIds();
+  gdprDataHandler.onConsentChange(loadIds);
 
   /**
    * with `ready` = true, starts initialization; with `refresh` = true, reinitialize submodules (optionally

--- a/src/consentHandler.js
+++ b/src/consentHandler.js
@@ -1,11 +1,13 @@
-import {isStr, timestamp} from './utils.js';
+import {isStr, timestamp, deepEqual, logError} from './utils.js';
 import {defer, GreedyPromise} from './utils/promise.js';
 
 export class ConsentHandler {
   #enabled;
   #data;
+  #hasData = false;
   #defer;
   #ready;
+  #listeners;
   generatedTime;
 
   constructor() {
@@ -14,8 +16,19 @@ export class ConsentHandler {
 
   #resolve(data) {
     this.#ready = true;
+    const hasChanged = !this.#hasData || !deepEqual(this.#data, data);
     this.#data = data;
+    this.#hasData = true;
     this.#defer.resolve(data);
+    if (hasChanged) {
+      this.#listeners.forEach(cb => {
+        try {
+          cb(data)
+        } catch (e) {
+          logError(e);
+        }
+      })
+    }
   }
 
   /**
@@ -27,6 +40,15 @@ export class ConsentHandler {
     this.#data = null;
     this.#ready = false;
     this.generatedTime = null;
+    this.#listeners = [];
+  }
+
+  /**
+   * Register a callback to run each time consent data changes.
+   * @param {(consentData) => any} fn
+   */
+  onConsentChange(fn) {
+    this.#listeners.push(fn);
   }
 
   /**

--- a/test/helpers/consentData.js
+++ b/test/helpers/consentData.js
@@ -2,9 +2,14 @@ import {gdprDataHandler} from 'src/adapterManager.js';
 import {GreedyPromise} from '../../src/utils/promise.js';
 
 export function mockGdprConsent(sandbox, getConsentData = () => null) {
-  sandbox.stub(gdprDataHandler, 'enabled').get(() => true)
-  sandbox.stub(gdprDataHandler, 'promise').get(() => GreedyPromise.resolve(getConsentData()));
-  sandbox.stub(gdprDataHandler, 'getConsentData').callsFake(getConsentData)
+  const s1 = sandbox.stub(gdprDataHandler, 'enabled').get(() => true)
+  const s2 = sandbox.stub(gdprDataHandler, 'promise').get(() => GreedyPromise.resolve(getConsentData()));
+  const s3 = sandbox.stub(gdprDataHandler, 'getConsentData').callsFake(getConsentData)
+  return function unMock() {
+    s1.restore();
+    s2.restore();
+    s3.restore();
+  }
 }
 
 beforeEach(() => {

--- a/test/spec/unit/core/consentHandler_spec.js
+++ b/test/spec/unit/core/consentHandler_spec.js
@@ -56,4 +56,38 @@ describe('Consent data handler', () => {
       })
     })
   });
+
+  it('should run onConsentChange listeners when consent data changes', () => {
+    handler.setConsentData({consent: 'data'});
+    const listener = sinon.stub();
+    handler.onConsentChange(listener);
+    handler.setConsentData({consent: 'data'});
+    sinon.assert.notCalled(listener);
+    const newConsent = {other: 'data'};
+    handler.setConsentData(newConsent);
+    sinon.assert.calledWith(listener, newConsent);
+  });
+
+  it('should not choke if listener throws', () => {
+    handler.onConsentChange(sinon.stub().throws(new Error()));
+    const listener = sinon.stub();
+    handler.onConsentChange(listener);
+    const consent = {consent: 'data'};
+    handler.setConsentData(consent);
+    sinon.assert.calledWith(listener, consent);
+  });
+
+  Object.entries({
+    'undefined': undefined,
+    'null': null
+  }).forEach(([t, val]) => {
+    it(`should run onConsentChange when consent is first set to ${t}`, () => {
+      const listener = sinon.stub();
+      handler.onConsentChange(listener);
+      handler.setConsentData(val);
+      handler.setConsentData(val);
+      sinon.assert.calledOnce(listener);
+      sinon.assert.calledWith(listener, val);
+    })
+  })
 })


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

This re-initializes userID modules whenever GDPR consent changes. Fixes an issue where if `setConfig({userSync})` is run before `setConfig({consentManagement})`, the userId module would start initializing without consent and not notice when the latter is set.



