### PR TITLE
Admatic Bid Adapter: pixad alias and bid floor features activated

### DIFF
--- a/modules/admaticBidAdapter.js
+++ b/modules/admaticBidAdapter.js
@@ -1,0 +1,147 @@
+import { getValue, logError, deepAccess, getBidIdParameter, isArray } from '../src/utils.js';
+import { loadExternalScript } from '../src/adloader.js';
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+
+const ENDPOINT_URL = 'https://layer.serve.admatic.com.tr/pb';
+const SYNC_URL = 'https://cdn.serve.admatic.com.tr/showad/sync.js';
+const BIDDER_CODE = 'admatic';
+
+export const spec = {
+  code: 'admatic',
+  supportedMediaTypes: ['video', 'banner'],
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: function(bid) {
+    let isValid = false;
+    if (typeof bid.params !== 'undefined') {
+      let isValidNetworkId = _validateId(getValue(bid.params, 'networkId'));
+      isValid = isValidNetworkId;// && isValidTypeId;
+    }
+
+    if (!isValid) {
+      logError('AdMatic networkId parameters are required. Bid aborted.');
+    }
+    return isValid;
+  },
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} an array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
+  buildRequests: function(validBidRequests, bidderRequest) {
+    const bids = validBidRequests.map(buildRequestObject);
+    const networkId = getValue(validBidRequests[0].params, 'networkId');
+    const currency = getValue(validBidRequests[0].params, 'currency') || 'TRY';
+
+    setTimeout(() => {
+      loadExternalScript(SYNC_URL, BIDDER_CODE);
+    }, bidderRequest.timeout);
+
+    const payload = {
+      'user': {
+        'ua': navigator.userAgent
+      },
+      'blacklist': [],
+      'site': {
+        'page': location.href,
+        'ref': location.origin,
+        'publisher': {
+          'name': location.hostname,
+          'publisherId': networkId
+        }
+      },
+      imp: bids,
+      ext: {
+        'cur': currency,
+        'type': 'admatic'
+      }
+    };
+
+    const payloadString = JSON.stringify(payload);
+    return {
+      method: 'POST',
+      url: ENDPOINT_URL,
+      data: payloadString,
+      options: {
+        contentType: 'application/json'
+      }
+    };
+  },
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {*} serverResponse A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: (response, request) => {
+    const body = response.body || response;
+    const bidResponses = [];
+    if (body.data.length > 0) {
+      body.data.forEach(function (bid) {
+        const resbid = {
+          requestId: bid.id,
+          cpm: bid.price,
+          width: bid.width,
+          height: bid.height,
+          currency: body.cur,
+          netRevenue: true,
+          ad: bid.party_tag,
+          creativeId: bid.creative_id,
+          meta: {
+            advertiserDomains: bid && bid.adomain ? bid.adomain : []
+          },
+          ttl: 360,
+          bidder: 'admatic',
+          timeToRespond: 1,
+          requestTimestamp: 1
+        };
+        bidResponses.push(resbid);
+      });
+    };
+    return bidResponses;
+  }
+};
+
+function buildRequestObject(bid) {
+  const reqObj = {};
+  reqObj.size = getSizes(bid);
+  reqObj.id = getBidIdParameter('bidId', bid);
+  reqObj.floor = getValue(bid.params, 'floor') || 0.01;
+  return reqObj;
+}
+
+function getSizes(bid) {
+  return concatSizes(bid);
+}
+
+function concatSizes(bid) {
+  let playerSize = deepAccess(bid, 'mediaTypes.video.playerSize');
+  let videoSizes = deepAccess(bid, 'mediaTypes.video.sizes');
+  let bannerSizes = deepAccess(bid, 'mediaTypes.banner.sizes');
+
+  if (isArray(bannerSizes) || isArray(playerSize) || isArray(videoSizes)) {
+    let mediaTypesSizes = [bannerSizes, videoSizes, playerSize];
+    return mediaTypesSizes
+      .reduce(function(acc, currSize) {
+        if (isArray(currSize)) {
+          if (isArray(currSize[0])) {
+            currSize.forEach(function (childSize) {
+              acc.push({ w: childSize[0], h: childSize[1] });
+            })
+          }
+        }
+        return acc;
+      }, []);
+  }
+}
+
+function _validateId(id) {
+  return (parseInt(id) > 0);
+}
+
+registerBidder(spec);

--- a/modules/admaticBidAdapter.js
+++ b/modules/admaticBidAdapter.js
@@ -20,7 +20,7 @@ export const spec = {
     let isValid = false;
     if (typeof bid.params !== 'undefined') {
       let isValidNetworkId = _validateId(getValue(bid.params, 'networkId'));
-      let isValidHost = _validateString(getValue(bid.params, 'host'));
+      let isValidHost = getValue(bid.params, 'host');
       isValid = isValidNetworkId && isValidHost;
     }
 
@@ -196,10 +196,6 @@ function concatSizes(bid) {
 
 function _validateId(id) {
   return (parseInt(id) > 0);
-}
-
-function _validateString(str) {
-  return (typeof str == 'string');
 }
 
 registerBidder(spec);

--- a/modules/admaticBidAdapter.js
+++ b/modules/admaticBidAdapter.js
@@ -20,7 +20,7 @@ export const spec = {
     let isValid = false;
     if (typeof bid.params !== 'undefined') {
       let isValidNetworkId = _validateId(getValue(bid.params, 'networkId'));
-      let isValidHost = getValue(bid.params, 'host');
+      let isValidHost = _validateString(getValue(bid.params, 'host'));
       isValid = isValidNetworkId && isValidHost;
     }
 
@@ -196,6 +196,10 @@ function concatSizes(bid) {
 
 function _validateId(id) {
   return (parseInt(id) > 0);
+}
+
+function _validateString(str) {
+  return (typeof str == 'string');
 }
 
 registerBidder(spec);

--- a/modules/admaticBidAdapter.js
+++ b/modules/admaticBidAdapter.js
@@ -7,7 +7,7 @@ const SYNC_URL = 'https://cdn.serve.admatic.com.tr/showad/sync.js';
 export const spec = {
   code: 'admatic',
   aliases: [
-    {code: 'adpixel'}
+    {code: 'pixad'}
   ],
   supportedMediaTypes: ['video', 'banner'],
   /**

--- a/modules/admaticBidAdapter.js
+++ b/modules/admaticBidAdapter.js
@@ -111,7 +111,6 @@ function buildRequestObject(bid) {
   const reqObj = {};
   reqObj.size = getSizes(bid);
   reqObj.id = getBidIdParameter('bidId', bid);
-  reqObj.floor = getValue(bid.params, 'floor') || 0.01;
   return reqObj;
 }
 

--- a/modules/admaticBidAdapter.js
+++ b/modules/admaticBidAdapter.js
@@ -1,6 +1,7 @@
 import { getValue, logError, deepAccess, getBidIdParameter, isArray } from '../src/utils.js';
 import { loadExternalScript } from '../src/adloader.js';
-import {registerBidder} from '../src/adapters/bidderFactory.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER, VIDEO } from '../src/mediaTypes.js';
 
 const ENDPOINT_URL = 'https://layer.serve.admatic.com.tr/pb';
 const SYNC_URL = 'https://cdn.serve.admatic.com.tr/showad/sync.js';
@@ -100,6 +101,7 @@ export const spec = {
           timeToRespond: 1,
           requestTimestamp: 1
         };
+
         bidResponses.push(resbid);
       });
     };
@@ -107,10 +109,58 @@ export const spec = {
   }
 };
 
+function enrichSlotWithFloors(slot, bidRequest) {
+  try {
+    const slotFloors = {};
+
+    if (bidRequest.getFloor) {
+      if (bidRequest.mediaTypes?.banner) {
+        slotFloors.banner = {};
+        const bannerSizes = parseSizes(deepAccess(bidRequest, 'mediaTypes.banner.sizes'))
+        bannerSizes.forEach(bannerSize => slotFloors.banner[parseSize(bannerSize).toString()] = bidRequest.getFloor({ size: bannerSize, mediaType: BANNER }));
+      }
+
+      if (bidRequest.mediaTypes?.video) {
+        slotFloors.video = {};
+        const videoSizes = parseSizes(deepAccess(bidRequest, 'mediaTypes.video.playerSize'))
+        videoSizes.forEach(videoSize => slotFloors.video[parseSize(videoSize).toString()] = bidRequest.getFloor({ size: videoSize, mediaType: VIDEO }));
+      }
+
+      if (Object.keys(slotFloors).length > 0) {
+        if (!slot) {
+          slot = {}
+        }
+        Object.assign(slot, {
+          floors: slotFloors
+        });
+      }
+    }
+  } catch (e) {
+    logError('Could not parse floors from Prebid: ' + e);
+  }
+}
+
+function parseSizes(sizes, parser = s => s) {
+  if (sizes == undefined) {
+    return [];
+  }
+  if (Array.isArray(sizes[0])) { // is there several sizes ? (ie. [[728,90],[200,300]])
+    return sizes.map(size => parser(size));
+  }
+  return [parser(sizes)]; // or a single one ? (ie. [728,90])
+}
+
+function parseSize(size) {
+  return size[0] + 'x' + size[1];
+}
+
 function buildRequestObject(bid) {
   const reqObj = {};
   reqObj.size = getSizes(bid);
   reqObj.id = getBidIdParameter('bidId', bid);
+
+  enrichSlotWithFloors(reqObj, bid);
+
   return reqObj;
 }
 

--- a/modules/admaticBidAdapter.md
+++ b/modules/admaticBidAdapter.md
@@ -2,13 +2,13 @@
 
 **Module Name**: Admatic Bidder Adapter  
 **Module Type**: Bidder Adapter  
-**Maintainer**: prebid.js@admatic.com.tr
+**Maintainer**: prebid@admatic.com.tr
 
 # Description
 
 Use `admatic` as bidder.
 
-`networkId` & `typeId` are required and must be integers.
+`networkId` is required and must be integer.
 
 ## AdUnits configuration example
 ```
@@ -19,7 +19,7 @@ Use `admatic` as bidder.
           bidder: 'admatic',
           params: { 
               placementId: 12345,
-              pageId: 14
+              floor: 0.5
           }
       }]
     },{
@@ -29,7 +29,7 @@ Use `admatic` as bidder.
           bidder: 'admatic',
           params: { 
               placementId: 12345,
-              pageId: 9
+              floor: 0.5
           }
       }]
     }];

--- a/modules/admaticBidAdapter.md
+++ b/modules/admaticBidAdapter.md
@@ -18,8 +18,7 @@ Use `admatic` as bidder.
       bids: [{
           bidder: 'admatic',
           params: { 
-              networkId: 12345,
-              floor: 0.5
+              networkId: 12345
           }
       }]
     },{
@@ -28,8 +27,7 @@ Use `admatic` as bidder.
       bids: [{
           bidder: 'admatic',
           params: { 
-              networkId: 12345,
-              floor: 0.5
+              networkId: 12345
           }
       }]
     }];

--- a/modules/admaticBidAdapter.md
+++ b/modules/admaticBidAdapter.md
@@ -1,0 +1,48 @@
+# Overview
+
+**Module Name**: Admatic Bidder Adapter  
+**Module Type**: Bidder Adapter  
+**Maintainer**: prebid.js@admatic.com.tr
+
+# Description
+
+Use `admatic` as bidder.
+
+`networkId` & `typeId` are required and must be integers.
+
+## AdUnits configuration example
+```
+    var adUnits = [{
+      code: 'your-slot_1-div', //use exactly the same code as your slot div id.
+      sizes: [[300, 250]],
+      bids: [{
+          bidder: 'admatic',
+          params: { 
+              placementId: 12345,
+              pageId: 14
+          }
+      }]
+    },{
+      code: 'your-slot_2-div', //use exactly the same code as your slot div id.
+      sizes: [[600, 800]],
+      bids: [{
+          bidder: 'admatic',
+          params: { 
+              placementId: 12345,
+              pageId: 9
+          }
+      }]
+    }];
+```
+
+## UserSync example
+
+```
+pbjs.setConfig({
+  userSync: {
+    iframeEnabled: true,
+    syncEnabled: true,
+    syncDelay: 1
+  }
+});
+```

--- a/modules/admaticBidAdapter.md
+++ b/modules/admaticBidAdapter.md
@@ -18,7 +18,8 @@ Use `admatic` as bidder.
       bids: [{
           bidder: 'admatic',
           params: { 
-              networkId: 12345
+              networkId: 12345,
+              host: 'layer.serve.admatic.com.tr'
           }
       }]
     },{
@@ -27,14 +28,14 @@ Use `admatic` as bidder.
       bids: [{
           bidder: 'admatic',
           params: { 
-              networkId: 12345
+              networkId: 12345,
+              host: 'layer.serve.admatic.com.tr'
           }
       }]
     }];
 ```
 
 ## UserSync example
-
 ```
 pbjs.setConfig({
   userSync: {

--- a/modules/admaticBidAdapter.md
+++ b/modules/admaticBidAdapter.md
@@ -18,7 +18,7 @@ Use `admatic` as bidder.
       bids: [{
           bidder: 'admatic',
           params: { 
-              placementId: 12345,
+              networkId: 12345,
               floor: 0.5
           }
       }]
@@ -28,7 +28,7 @@ Use `admatic` as bidder.
       bids: [{
           bidder: 'admatic',
           params: { 
-              placementId: 12345,
+              networkId: 12345,
               floor: 0.5
           }
       }]

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -7,7 +7,7 @@ const _approvedLoadExternalJSList = [
   'debugging',
   'adloox',
   'admatic',
-  'adpixel',
+  'pixad',
   'criteo',
   'outstream',
   'adagio',

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -6,6 +6,7 @@ const _requestCache = new WeakMap();
 const _approvedLoadExternalJSList = [
   'debugging',
   'adloox',
+  'admatic',
   'criteo',
   'outstream',
   'adagio',

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -7,6 +7,7 @@ const _approvedLoadExternalJSList = [
   'debugging',
   'adloox',
   'admatic',
+  'adpixel',
   'criteo',
   'outstream',
   'adagio',

--- a/test/spec/modules/admaticBidAdapter_spec.js
+++ b/test/spec/modules/admaticBidAdapter_spec.js
@@ -1,0 +1,46 @@
+import {expect} from 'chai';
+import {spec, storage} from 'modules/admaticBidAdapter.js';
+import {newBidder} from 'src/adapters/bidderFactory.js';
+import {getStorageManager} from 'src/storageManager';
+
+const ENDPOINT = 'https://layer.serve.admatic.com.tr/v1';
+
+describe('admaticBidAdapter', () => {
+  const adapter = newBidder(spec);
+
+  describe('inherited functions', () => {
+    it('exists and is a function', () => {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+  });
+
+  describe('isBidRequestValid', function() {
+    let bid = {
+      'bidder': 'admatic',
+      'params': {
+        'networkId': 10433394
+      },
+      'adUnitCode': 'adunit-code',
+      'sizes': [[300, 250], [300, 600]],
+      'bidId': '30b31c1838de1e',
+      'bidderRequestId': '22edbae2733bf6',
+      'auctionId': '1d1a030790a475',
+      'creativeId': 'er2ee'
+    };
+
+    it('should return true when required params found', function() {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should return false when required params are not passed', function() {
+      let bid = Object.assign({}, bid);
+      delete bid.params;
+
+      bid.params = {
+        'networkId': 0
+      };
+
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+  });
+});

--- a/test/spec/modules/admaticBidAdapter_spec.js
+++ b/test/spec/modules/admaticBidAdapter_spec.js
@@ -3,7 +3,7 @@ import {spec, storage} from 'modules/admaticBidAdapter.js';
 import {newBidder} from 'src/adapters/bidderFactory.js';
 import {getStorageManager} from 'src/storageManager';
 
-const ENDPOINT = 'https://layer.serve.admatic.com.tr/v1';
+const ENDPOINT = 'https://layer.serve.admatic.com.tr/pb';
 
 describe('admaticBidAdapter', () => {
   const adapter = newBidder(spec);
@@ -18,7 +18,8 @@ describe('admaticBidAdapter', () => {
     let bid = {
       'bidder': 'admatic',
       'params': {
-        'networkId': 10433394
+        'networkId': 10433394,
+        'host': 'layer.serve.admatic.com.tr'
       },
       'adUnitCode': 'adunit-code',
       'sizes': [[300, 250], [300, 600]],
@@ -37,7 +38,8 @@ describe('admaticBidAdapter', () => {
       delete bid.params;
 
       bid.params = {
-        'networkId': 0
+        'networkId': 0,
+        'host': 'layer.serve.admatic.com.tr'
       };
 
       expect(spec.isBidRequestValid(bid)).to.equal(false);

--- a/test/spec/modules/admaticBidAdapter_spec.js
+++ b/test/spec/modules/admaticBidAdapter_spec.js
@@ -3,7 +3,7 @@ import {spec, storage} from 'modules/admaticBidAdapter.js';
 import {newBidder} from 'src/adapters/bidderFactory.js';
 import {getStorageManager} from 'src/storageManager';
 
-const ENDPOINT = 'https://layer.serve.admatic.com.tr/pb';
+const ENDPOINT = 'https://layer.serve.admatic.com.tr/v1';
 
 describe('admaticBidAdapter', () => {
   const adapter = newBidder(spec);
@@ -18,8 +18,7 @@ describe('admaticBidAdapter', () => {
     let bid = {
       'bidder': 'admatic',
       'params': {
-        'networkId': 10433394,
-        'host': 'layer.serve.admatic.com.tr'
+        'networkId': 10433394
       },
       'adUnitCode': 'adunit-code',
       'sizes': [[300, 250], [300, 600]],
@@ -38,8 +37,7 @@ describe('admaticBidAdapter', () => {
       delete bid.params;
 
       bid.params = {
-        'networkId': 0,
-        'host': 'layer.serve.admatic.com.tr'
+        'networkId': 0
       };
 
       expect(spec.isBidRequestValid(bid)).to.equal(false);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->
Hello,
- We now support the bid floor module.
- Alias feature has been activated. Pixad bid adapter enabled.

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] New bidder adapter
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following -->
- Pixad test parameters for validating bids:
```
{
    bidder: 'pixad',
    params: { 
        networkId: 12345,
        host: 'layer.serve.admatic.com.tr'
    }
}
```

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
For any changes that affect user-facing APIs or example code documented on http://prebid.org/, please provide:
- A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/pull/4130
