### PR TITLE
Magnite Analytics Adapter: default 1x1 size if no sizes on adUnit

### DIFF
--- a/modules/magniteAnalyticsAdapter.js
+++ b/modules/magniteAnalyticsAdapter.js
@@ -706,7 +706,7 @@ magniteAdapter.track = ({ eventType, args }) => {
           'code as adUnitCode',
           'transactionId',
           'mediaTypes', mediaTypes => Object.keys(mediaTypes),
-          'sizes as dimensions', sizes => sizes.map(sizeToDimensions),
+          'sizes as dimensions', sizes => (sizes || [[1, 1]]).map(sizeToDimensions),
         ]);
         ad.pbAdSlot = deepAccess(adUnit, 'ortb2Imp.ext.data.pbadslot');
         ad.pattern = deepAccess(adUnit, 'ortb2Imp.ext.data.aupname');

--- a/test/spec/modules/magniteAnalyticsAdapter_spec.js
+++ b/test/spec/modules/magniteAnalyticsAdapter_spec.js
@@ -548,6 +548,26 @@ describe('magnite analytics adapter', function () {
       ]);
     });
 
+    it('should pass along 1x1 size if no sizes in adUnit', function () {
+      const auctionInit = utils.deepClone(MOCK.AUCTION_INIT);
+
+      delete auctionInit.adUnits[0].sizes;
+
+      events.emit(AUCTION_INIT, auctionInit);
+      events.emit(BID_REQUESTED, MOCK.BID_REQUESTED);
+      events.emit(BIDDER_DONE, MOCK.BIDDER_DONE);
+      events.emit(AUCTION_END, MOCK.AUCTION_END);
+      clock.tick(rubiConf.analyticsBatchTimeout + 1000);
+
+      let message = JSON.parse(server.requests[0].requestBody);
+      expect(message.auctions[0].adUnits[0].dimensions).to.deep.equal([
+        {
+          width: 1,
+          height: 1
+        }
+      ]);
+    });
+
     it('should pass along user ids', function () {
       let auctionInit = utils.deepClone(MOCK.AUCTION_INIT);
       auctionInit.bidderRequests[0].bids[0].userId = {


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
If an adUnit does NOT have a sizes attribute passed in (native) our adapter fails miserably!
This fix will default to a 1x1 size in our analytics payload if no sizes is there.