### PR TITLE
Smartadserver Bid Adapter: Add support for SDA user and site

### DIFF
--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -154,7 +154,9 @@ export const spec = {
         timeout: config.getConfig('bidderTimeout'),
         bidId: bid.bidId,
         prebidVersion: '$prebid.version$',
-        schain: spec.serializeSupplyChain(bid.schain)
+        schain: spec.serializeSupplyChain(bid.schain),
+        sda: deepAccess(bidderRequest, 'ortb2.user.data', undefined),
+        sdc: deepAccess(bidderRequest, 'ortb2.site.content.data', undefined)
       };
 
       if (bidderRequest && bidderRequest.gdprConsent) {


### PR DESCRIPTION
## Type of change
- [x] Feature
## Description of change
Add support for Seller-defined audience, following IAB standard format in Smartadserver Bid Adapter.