### PR TITLE
Video Module: Ad Queueing

### DIFF
--- a/integrationExamples/videoModule/jwplayer/bidMarkedAsUsed.html
+++ b/integrationExamples/videoModule/jwplayer/bidMarkedAsUsed.html
@@ -76,10 +76,6 @@
           console.log('player setup failed: ', e);
         });
 
-        pbjs.onEvent('videoPlaybackRequest', (e) => {
-          pbjs.requestBids(adUnits);
-        });
-
         pbjs.onEvent('videoBidError', e => {
           console.log('An Ad Error came from a Bid: ', e);
         });
@@ -87,6 +83,8 @@
         pbjs.onEvent('videoBidImpression', e => {
           console.log('An Ad Impression came from a Bid: ', e);
         });
+
+        pbjs.requestBids(adUnits);
       });
     </script>
 </head>

--- a/integrationExamples/videoModule/jwplayer/eventListeners.html
+++ b/integrationExamples/videoModule/jwplayer/eventListeners.html
@@ -87,7 +87,6 @@
 
         pbjs.onEvent('videoPlaybackRequest', (e) => {
           console.log('videos pb playbackRequest: ', e);
-          pbjs.requestBids(adUnits);
         });
 
         pbjs.onEvent('videoAutostartBlocked', (e) => {
@@ -233,6 +232,8 @@
         pbjs.onEvent('videoBidError', event => {
           console.log('The ad error resulted from a bid! \n', event);
         });
+
+        pbjs.requestBids(adUnits);
       });
     </script>
 </head>

--- a/integrationExamples/videoModule/jwplayer/eventListeners.html
+++ b/integrationExamples/videoModule/jwplayer/eventListeners.html
@@ -221,6 +221,10 @@
           console.log('videos pb auction ad load attempt: ', e);
         });
 
+        pbjs.onEvent('videoAuctionAdLoadQueued', (e) => {
+          console.log('videos pb auction ad load queued: ', e);
+        });
+
         pbjs.onEvent('videoAuctionAdLoadAttempt', event => {
           console.log('The Video Module is attempting to load an ad into the player! \n', event);
         });

--- a/integrationExamples/videoModule/jwplayer/eventListeners.html
+++ b/integrationExamples/videoModule/jwplayer/eventListeners.html
@@ -8,11 +8,6 @@
     <script async src="../../../build/dev/prebid.js"></script>
     <script src="https://cdn.jwplayer.com/libraries/l5MchIxB.js"></script>
 
-
-</head>
-
-<body>
-    <div id ="player"></div>
     <script>
       var pbjs = pbjs || {};
       pbjs.que = pbjs.que || [];
@@ -34,228 +29,221 @@
           }
         }]
       }];
-      const player = jwplayer('player').setup({
-        file: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4',
-        mediaid: 'd9J2zcaA',
-        advertising: { client: 'vast' }
-      });
-
-      player.on('ready', () => {
-        pbjs.que.push(function () {
-          pbjs.setConfig({
-            video: {
-              providers: [{
-                divId: 'player',
-                vendorCode: 1, // vendorCode for jwplayer
-                // playerConfig: {
-                //   licenseKey: 'IAjLREYRLylTWsfLN3FoN/O3iQLbs+AfgZLlkAoyH8gSf7TnNtmOLcR8CUY=',
-                //   params: {
-                //     vendorConfig: {
-                //       file: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4',
-                //       mediaid: 'd9J2zcaA',
-                //       advertising: { client: 'vast' }
-                //     }
-                //   }
-                // },
-              }]
-            },
-            debugging: {
-              enabled: true,
-              intercept: [
-                {
-                  when: {
-                    adUnitCode: 'div-gpt-ad-51545-0',
-                  },
-                  then: {
-                    cpm: 25,
-                    mediaType: "video",
-                    vastUrl: "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dlinear&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=",
-                    // vastXml: "<VAST version=\"3.0\"> <Ad id=\"123\"> <InLine> <AdSystem>PubMatic</AdSystem> <AdTitle>VAST 2.0 Instream Test</AdTitle> <Description>VAST 2.0 Instream Test</Description> <Error> <![CDATA[https://aktrack.pubmatic.com/er=[ERRORCODE]]]> </Error> <Impression> <![CDATA[https://aktrack.pubmatic.com?e=impression]]> </Impression> <Creatives> <Creative AdID=\"123\"> <Linear> <Duration>00:00:30</Duration> <TrackingEvents> <Tracking event=\"creativeView\"> <![CDATA[https://aktrack.pubmatic.com?e=creativeView]]> </Tracking> <Tracking event=\"start\"> <![CDATA[https://aktrack.pubmatic.com?e=start]]> </Tracking> <Tracking event=\"midpoint\"> <![CDATA[https://aktrack.pubmatic.com?e=midpoint]]> </Tracking> <Tracking event=\"firstQuartile\"> <![CDATA[https://aktrack.pubmatic.com?e=firstQuartile]]> </Tracking> <Tracking event=\"thirdQuartile\"> <![CDATA[https://aktrack.pubmatic.com?e=thirdQuartile]]> </Tracking> <Tracking event=\"complete\"> <![CDATA[https://aktrack.pubmatic.com?e=complete]]> </Tracking> </TrackingEvents> <VideoClicks> <ClickThrough> <![CDATA[https://www.pubmatic.com]]> </ClickThrough> </VideoClicks> <MediaFiles> <MediaFile delivery=\"progressive\" type=\"video/mp4\" bitrate=\"500\" width=\"480\" height=\"460\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/spinning-logo-480x360_video.mp4]]> </MediaFile> <MediaFile delivery=\"progressive\" type=\"video/ogg\" bitrate=\"500\" width=\"480\" height=\"460\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/spinning-logo-480x360_video.ogg]]> </MediaFile> <MediaFile delivery=\"progressive\" type=\"video/x-flv\" bitrate=\"500\" width=\"400\" height=\"300\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_test_video.flv]]> </MediaFile> </MediaFiles> </Linear> </Creative> <Creative AdID=\"123\"> <NonLinearAds> <TrackingEvents></TrackingEvents> <NonLinear height=\"50\" width=\"300\" minSuggestedDuration=\"00:00:05\"> <StaticResource creativeType=\"image/jpeg\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_LetsBeClear_300x50.jpeg]]> </StaticResource> <NonLinearClickThrough> <![CDATA[https://www.pubmatic.com]]> </NonLinearClickThrough> </NonLinear> </NonLinearAds> </Creative> <Creative AdID=\"123\"> <CompanionAds> <Companion width=\"300\" height=\"250\"> <StaticResource creativeType=\"image/jpeg\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_LetsBeClear_320x250.jpg]]> </StaticResource> <CompanionClickThrough> <![CDATA[https://www.pubmatic.com]]> </CompanionClickThrough> </Companion> </CompanionAds> </Creative> </Creatives> </InLine> </Ad> </VAST>",
-                    ad: "<VAST version=\"3.0\"> <Ad id=\"123\"> <InLine> <AdSystem>PubMatic</AdSystem> <AdTitle>VAST 2.0 Instream Test</AdTitle> <Description>VAST 2.0 Instream Test</Description> <Error> <![CDATA[https://aktrack.pubmatic.com/er=[ERRORCODE]]]> </Error> <Impression> <![CDATA[https://aktrack.pubmatic.com?e=impression]]> </Impression> <Creatives> <Creative AdID=\"123\"> <Linear> <Duration>00:00:30</Duration> <TrackingEvents> <Tracking event=\"creativeView\"> <![CDATA[https://aktrack.pubmatic.com?e=creativeView]]> </Tracking> <Tracking event=\"start\"> <![CDATA[https://aktrack.pubmatic.com?e=start]]> </Tracking> <Tracking event=\"midpoint\"> <![CDATA[https://aktrack.pubmatic.com?e=midpoint]]> </Tracking> <Tracking event=\"firstQuartile\"> <![CDATA[https://aktrack.pubmatic.com?e=firstQuartile]]> </Tracking> <Tracking event=\"thirdQuartile\"> <![CDATA[https://aktrack.pubmatic.com?e=thirdQuartile]]> </Tracking> <Tracking event=\"complete\"> <![CDATA[https://aktrack.pubmatic.com?e=complete]]> </Tracking> </TrackingEvents> <VideoClicks> <ClickThrough> <![CDATA[https://www.pubmatic.com]]> </ClickThrough> </VideoClicks> <MediaFiles> <MediaFile delivery=\"progressive\" type=\"video/mp4\" bitrate=\"500\" width=\"480\" height=\"460\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/spinning-logo-480x360_video.mp4]]> </MediaFile> <MediaFile delivery=\"progressive\" type=\"video/ogg\" bitrate=\"500\" width=\"480\" height=\"460\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/spinning-logo-480x360_video.ogg]]> </MediaFile> <MediaFile delivery=\"progressive\" type=\"video/x-flv\" bitrate=\"500\" width=\"400\" height=\"300\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_test_video.flv]]> </MediaFile> </MediaFiles> </Linear> </Creative> <Creative AdID=\"123\"> <NonLinearAds> <TrackingEvents></TrackingEvents> <NonLinear height=\"50\" width=\"300\" minSuggestedDuration=\"00:00:05\"> <StaticResource creativeType=\"image/jpeg\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_LetsBeClear_300x50.jpeg]]> </StaticResource> <NonLinearClickThrough> <![CDATA[https://www.pubmatic.com]]> </NonLinearClickThrough> </NonLinear> </NonLinearAds> </Creative> <Creative AdID=\"123\"> <CompanionAds> <Companion width=\"300\" height=\"250\"> <StaticResource creativeType=\"image/jpeg\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_LetsBeClear_320x250.jpg]]> </StaticResource> <CompanionClickThrough> <![CDATA[https://www.pubmatic.com]]> </CompanionClickThrough> </Companion> </CompanionAds> </Creative> </Creatives> </InLine> </Ad> </VAST>"
+      
+      pbjs.que.push(function () {
+        pbjs.setConfig({
+          video: {
+            providers: [{
+              divId: 'player',
+              vendorCode: 1, // vendorCode for jwplayer
+              playerConfig: {
+                licenseKey: 'IAjLREYRLylTWsfLN3FoN/O3iQLbs+AfgZLlkAoyH8gSf7TnNtmOLcR8CUY=',
+                params: {
+                  vendorConfig: {
+                    file: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4',
+                    mediaid: 'd9J2zcaA',
+                    advertising: { client: 'vast' }
                   }
+                }
+              },
+            }]
+          },
+          debugging: {
+            enabled: true,
+            intercept: [
+              {
+                when: {
+                  adUnitCode: 'div-gpt-ad-51545-0',
                 },
-              ]
-            }
-          });
-
-
-
-          pbjs.addAdUnits(adUnits);
-
-          pbjs.onEvent('videoSetupComplete', (e) => {
-            console.log('player setup complete: ', e);
-          });
-
-          pbjs.onEvent('videoSetupFailed', e => {
-            console.log('player setup failed: ', e);
-          });
-
-          pbjs.onEvent('videoDestroyed', e => {
-            console.log('player destroyed: ', e);
-          });
-
-          pbjs.onEvent('videoPlaylist', (e) => {
-            console.log('videos pb playlist: ', e);
-          });
-
-          pbjs.onEvent('videoPlaybackRequest', (e) => {
-            console.log('videos pb playbackRequest: ', e);
-          });
-
-          pbjs.onEvent('videoAutostartBlocked', (e) => {
-            console.log('videos pb autostartBlocked: ', e);
-          });
-
-          pbjs.onEvent('videoPlayAttemptFailed', (e) => {
-            console.log('videos pb playAttemptFailed: ', e);
-          });
-
-          pbjs.onEvent('videoContentLoaded', (e) => {
-            console.log('videos pb contentLoaded: ', e);
-          });
-
-          pbjs.onEvent('videoPlay', (e) => {
-            console.log('videos pb play: ', e);
-          });
-
-          pbjs.onEvent('videoPause', (e) => {
-            console.log('videos pb pause: ', e);
-          });
-
-          pbjs.onEvent('videoBuffer', (e) => {
-            console.log('videos pb buffer: ', e);
-          });
-
-          pbjs.onEvent('videoSeekStart', (e) => {
-            console.log('videos pb seekStart: ', e);
-          });
-
-          pbjs.onEvent('videoSeekEnd', (e) => {
-            console.log('videos pb seekEnd: ', e);
-          });
-
-          pbjs.onEvent('videoRenditionUpdate', (e) => {
-            console.log('videos pb renditionUpdate: ', e);
-          });
-
-          pbjs.onEvent('videoMute', (e) => {
-            console.log('videos pb mute: ', e);
-          });
-
-          pbjs.onEvent('videoVolume', (e) => {
-            console.log('videos pb volume: ', e);
-          });
-
-          // pbjs.onEvent('videoTime', (e) => {
-          //   console.log('videos pb time: ', e);
-          // });
-
-          pbjs.onEvent('videoComplete', (e) => {
-            console.log('videos pb complete: ', e);
-          });
-
-          pbjs.onEvent('videoPlaylistComplete', (e) => {
-            console.log('videos pb playlistComplete: ', e);
-          });
-
-          pbjs.onEvent('videoFullscreen', (e) => {
-            console.log('videos pb fullscreen: ', e);
-          });
-
-          pbjs.onEvent('videoPlayerResize', (e) => {
-            console.log('videos pb playerResize: ', e);
-          });
-
-          pbjs.onEvent('videoError', (e) => {
-            console.log('videos pb error: ', e);
-          });
-
-          pbjs.onEvent('videoViewable', (e) => {
-            console.log('videos pb viewable: ', e);
-          });
-
-          pbjs.onEvent('videoCast', (e) => {
-            console.log('videos pb cast: ', e);
-          });
-
-          pbjs.onEvent('videoAdBreakStart', e => {
-            console.log('videos pb ad break start: ', e);
-          });
-
-          pbjs.onEvent('videoAdRequest', (e) => {
-            console.log('videos pb ad request: ', e);
-          });
-
-          pbjs.onEvent('videoAdLoaded', e => {
-            console.log('videos pb ad load: ', e);
-          });
-
-          pbjs.onEvent('videoAdImpression', (e) => {
-            console.log('videos pb ad impression: ', e);
-          });
-
-          pbjs.onEvent('videoAdStarted', (e) => {
-            console.log('videos pb ad started: ', e);
-          });
-
-          pbjs.onEvent('videoAdPlay', (e) => {
-            console.log('videos pb ad play: ', e);
-          });
-
-          pbjs.onEvent('videoAdPause', (e) => {
-            console.log('videos pb ad pause: ', e);
-          });
-
-          // pbjs.onEvent('videoAdTime', (e) => {
-          //   console.log('videos pb ad time: ', e);
-          // });
-
-          pbjs.onEvent('videoAdComplete', (e) => {
-            console.log('videos pb ad complete: ', e);
-          });
-
-          pbjs.onEvent('videoAdSkipped', (e) => {
-            console.log('videos pb ad skipped: ', e);
-          });
-
-          pbjs.onEvent('videoAdClick', (e) => {
-            console.log('videos pb ad click: ', e);
-          });
-
-          pbjs.onEvent('videoAdError', (e) => {
-            console.log('videos pb ad error: ', e);
-          });
-
-          pbjs.onEvent('videoAdBreakStart', e => {
-            console.log('videos pb ad break start: ', e);
-          });
-
-          pbjs.onEvent('videoAuctionAdLoadAbort', (e) => {
-            console.log('videos pb auction ad load attempt: ', e);
-          });
-
-          pbjs.onEvent('videoAuctionAdLoadQueued', (e) => {
-            console.log('videos pb auction ad load queued: ', e);
-          });
-
-          pbjs.onEvent('videoAuctionAdLoadAttempt', event => {
-            console.log('The Video Module is attempting to load an ad into the player! \n', event);
-          });
-
-          pbjs.onEvent('videoBidImpression', event => {
-            console.log('The ad impression resulted from a bid! \n', event);
-          });
-
-          pbjs.onEvent('videoBidError', event => {
-            console.log('The ad error resulted from a bid! \n', event);
-          });
-
-          pbjs.requestBids(adUnits);
+                then: {
+                  cpm: 25,
+                  mediaType: "video",
+                  vastUrl: "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dlinear&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=",
+                  // vastXml: "<VAST version=\"3.0\"> <Ad id=\"123\"> <InLine> <AdSystem>PubMatic</AdSystem> <AdTitle>VAST 2.0 Instream Test</AdTitle> <Description>VAST 2.0 Instream Test</Description> <Error> <![CDATA[https://aktrack.pubmatic.com/er=[ERRORCODE]]]> </Error> <Impression> <![CDATA[https://aktrack.pubmatic.com?e=impression]]> </Impression> <Creatives> <Creative AdID=\"123\"> <Linear> <Duration>00:00:30</Duration> <TrackingEvents> <Tracking event=\"creativeView\"> <![CDATA[https://aktrack.pubmatic.com?e=creativeView]]> </Tracking> <Tracking event=\"start\"> <![CDATA[https://aktrack.pubmatic.com?e=start]]> </Tracking> <Tracking event=\"midpoint\"> <![CDATA[https://aktrack.pubmatic.com?e=midpoint]]> </Tracking> <Tracking event=\"firstQuartile\"> <![CDATA[https://aktrack.pubmatic.com?e=firstQuartile]]> </Tracking> <Tracking event=\"thirdQuartile\"> <![CDATA[https://aktrack.pubmatic.com?e=thirdQuartile]]> </Tracking> <Tracking event=\"complete\"> <![CDATA[https://aktrack.pubmatic.com?e=complete]]> </Tracking> </TrackingEvents> <VideoClicks> <ClickThrough> <![CDATA[https://www.pubmatic.com]]> </ClickThrough> </VideoClicks> <MediaFiles> <MediaFile delivery=\"progressive\" type=\"video/mp4\" bitrate=\"500\" width=\"480\" height=\"460\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/spinning-logo-480x360_video.mp4]]> </MediaFile> <MediaFile delivery=\"progressive\" type=\"video/ogg\" bitrate=\"500\" width=\"480\" height=\"460\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/spinning-logo-480x360_video.ogg]]> </MediaFile> <MediaFile delivery=\"progressive\" type=\"video/x-flv\" bitrate=\"500\" width=\"400\" height=\"300\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_test_video.flv]]> </MediaFile> </MediaFiles> </Linear> </Creative> <Creative AdID=\"123\"> <NonLinearAds> <TrackingEvents></TrackingEvents> <NonLinear height=\"50\" width=\"300\" minSuggestedDuration=\"00:00:05\"> <StaticResource creativeType=\"image/jpeg\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_LetsBeClear_300x50.jpeg]]> </StaticResource> <NonLinearClickThrough> <![CDATA[https://www.pubmatic.com]]> </NonLinearClickThrough> </NonLinear> </NonLinearAds> </Creative> <Creative AdID=\"123\"> <CompanionAds> <Companion width=\"300\" height=\"250\"> <StaticResource creativeType=\"image/jpeg\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_LetsBeClear_320x250.jpg]]> </StaticResource> <CompanionClickThrough> <![CDATA[https://www.pubmatic.com]]> </CompanionClickThrough> </Companion> </CompanionAds> </Creative> </Creatives> </InLine> </Ad> </VAST>",
+                  ad: "<VAST version=\"3.0\"> <Ad id=\"123\"> <InLine> <AdSystem>PubMatic</AdSystem> <AdTitle>VAST 2.0 Instream Test</AdTitle> <Description>VAST 2.0 Instream Test</Description> <Error> <![CDATA[https://aktrack.pubmatic.com/er=[ERRORCODE]]]> </Error> <Impression> <![CDATA[https://aktrack.pubmatic.com?e=impression]]> </Impression> <Creatives> <Creative AdID=\"123\"> <Linear> <Duration>00:00:30</Duration> <TrackingEvents> <Tracking event=\"creativeView\"> <![CDATA[https://aktrack.pubmatic.com?e=creativeView]]> </Tracking> <Tracking event=\"start\"> <![CDATA[https://aktrack.pubmatic.com?e=start]]> </Tracking> <Tracking event=\"midpoint\"> <![CDATA[https://aktrack.pubmatic.com?e=midpoint]]> </Tracking> <Tracking event=\"firstQuartile\"> <![CDATA[https://aktrack.pubmatic.com?e=firstQuartile]]> </Tracking> <Tracking event=\"thirdQuartile\"> <![CDATA[https://aktrack.pubmatic.com?e=thirdQuartile]]> </Tracking> <Tracking event=\"complete\"> <![CDATA[https://aktrack.pubmatic.com?e=complete]]> </Tracking> </TrackingEvents> <VideoClicks> <ClickThrough> <![CDATA[https://www.pubmatic.com]]> </ClickThrough> </VideoClicks> <MediaFiles> <MediaFile delivery=\"progressive\" type=\"video/mp4\" bitrate=\"500\" width=\"480\" height=\"460\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/spinning-logo-480x360_video.mp4]]> </MediaFile> <MediaFile delivery=\"progressive\" type=\"video/ogg\" bitrate=\"500\" width=\"480\" height=\"460\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/spinning-logo-480x360_video.ogg]]> </MediaFile> <MediaFile delivery=\"progressive\" type=\"video/x-flv\" bitrate=\"500\" width=\"400\" height=\"300\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_test_video.flv]]> </MediaFile> </MediaFiles> </Linear> </Creative> <Creative AdID=\"123\"> <NonLinearAds> <TrackingEvents></TrackingEvents> <NonLinear height=\"50\" width=\"300\" minSuggestedDuration=\"00:00:05\"> <StaticResource creativeType=\"image/jpeg\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_LetsBeClear_300x50.jpeg]]> </StaticResource> <NonLinearClickThrough> <![CDATA[https://www.pubmatic.com]]> </NonLinearClickThrough> </NonLinear> </NonLinearAds> </Creative> <Creative AdID=\"123\"> <CompanionAds> <Companion width=\"300\" height=\"250\"> <StaticResource creativeType=\"image/jpeg\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_LetsBeClear_320x250.jpg]]> </StaticResource> <CompanionClickThrough> <![CDATA[https://www.pubmatic.com]]> </CompanionClickThrough> </Companion> </CompanionAds> </Creative> </Creatives> </InLine> </Ad> </VAST>"
+                }
+              },
+            ]
+          }
         });
+
+        pbjs.addAdUnits(adUnits);
+
+        pbjs.onEvent('videoSetupComplete', (e) => {
+          console.log('player setup complete: ', e);
+        });
+
+        pbjs.onEvent('videoSetupFailed', e => {
+          console.log('player setup failed: ', e);
+        });
+
+        pbjs.onEvent('videoDestroyed', e => {
+          console.log('player destroyed: ', e);
+        });
+
+        pbjs.onEvent('videoPlaylist', (e) => {
+          console.log('videos pb playlist: ', e);
+        });
+
+        pbjs.onEvent('videoPlaybackRequest', (e) => {
+          console.log('videos pb playbackRequest: ', e);
+        });
+
+        pbjs.onEvent('videoAutostartBlocked', (e) => {
+          console.log('videos pb autostartBlocked: ', e);
+        });
+
+        pbjs.onEvent('videoPlayAttemptFailed', (e) => {
+          console.log('videos pb playAttemptFailed: ', e);
+        });
+
+        pbjs.onEvent('videoContentLoaded', (e) => {
+          console.log('videos pb contentLoaded: ', e);
+        });
+
+        pbjs.onEvent('videoPlay', (e) => {
+          console.log('videos pb play: ', e);
+        });
+
+        pbjs.onEvent('videoPause', (e) => {
+          console.log('videos pb pause: ', e);
+        });
+
+        pbjs.onEvent('videoBuffer', (e) => {
+          console.log('videos pb buffer: ', e);
+        });
+
+        pbjs.onEvent('videoSeekStart', (e) => {
+          console.log('videos pb seekStart: ', e);
+        });
+
+        pbjs.onEvent('videoSeekEnd', (e) => {
+          console.log('videos pb seekEnd: ', e);
+        });
+
+        pbjs.onEvent('videoRenditionUpdate', (e) => {
+          console.log('videos pb renditionUpdate: ', e);
+        });
+
+        pbjs.onEvent('videoMute', (e) => {
+          console.log('videos pb mute: ', e);
+        });
+
+        pbjs.onEvent('videoVolume', (e) => {
+          console.log('videos pb volume: ', e);
+        });
+
+        // pbjs.onEvent('videoTime', (e) => {
+        //   console.log('videos pb time: ', e);
+        // });
+
+        pbjs.onEvent('videoComplete', (e) => {
+          console.log('videos pb complete: ', e);
+        });
+
+        pbjs.onEvent('videoPlaylistComplete', (e) => {
+          console.log('videos pb playlistComplete: ', e);
+        });
+
+        pbjs.onEvent('videoFullscreen', (e) => {
+          console.log('videos pb fullscreen: ', e);
+        });
+
+        pbjs.onEvent('videoPlayerResize', (e) => {
+          console.log('videos pb playerResize: ', e);
+        });
+
+        pbjs.onEvent('videoError', (e) => {
+          console.log('videos pb error: ', e);
+        });
+
+        pbjs.onEvent('videoViewable', (e) => {
+          console.log('videos pb viewable: ', e);
+        });
+
+        pbjs.onEvent('videoCast', (e) => {
+          console.log('videos pb cast: ', e);
+        });
+
+        pbjs.onEvent('videoAdBreakStart', e => {
+          console.log('videos pb ad break start: ', e);
+        });
+
+        pbjs.onEvent('videoAdRequest', (e) => {
+          console.log('videos pb ad request: ', e);
+        });
+
+        pbjs.onEvent('videoAdLoaded', e => {
+          console.log('videos pb ad load: ', e);
+        });
+
+        pbjs.onEvent('videoAdImpression', (e) => {
+          console.log('videos pb ad impression: ', e);
+        });
+
+        pbjs.onEvent('videoAdStarted', (e) => {
+          console.log('videos pb ad started: ', e);
+        });
+
+        pbjs.onEvent('videoAdPlay', (e) => {
+          console.log('videos pb ad play: ', e);
+        });
+
+        pbjs.onEvent('videoAdPause', (e) => {
+          console.log('videos pb ad pause: ', e);
+        });
+
+        // pbjs.onEvent('videoAdTime', (e) => {
+        //   console.log('videos pb ad time: ', e);
+        // });
+
+        pbjs.onEvent('videoAdComplete', (e) => {
+          console.log('videos pb ad complete: ', e);
+        });
+
+        pbjs.onEvent('videoAdSkipped', (e) => {
+          console.log('videos pb ad skipped: ', e);
+        });
+
+        pbjs.onEvent('videoAdClick', (e) => {
+          console.log('videos pb ad click: ', e);
+        });
+
+        pbjs.onEvent('videoAdError', (e) => {
+          console.log('videos pb ad error: ', e);
+        });
+
+        pbjs.onEvent('videoAdBreakStart', e => {
+          console.log('videos pb ad break start: ', e);
+        });
+
+        pbjs.onEvent('videoAuctionAdLoadAbort', (e) => {
+          console.log('videos pb auction ad load attempt: ', e);
+        });
+
+        pbjs.onEvent('videoAuctionAdLoadQueued', (e) => {
+          console.log('videos pb auction ad load queued: ', e);
+        });
+
+        pbjs.onEvent('videoAuctionAdLoadAttempt', event => {
+          console.log('The Video Module is attempting to load an ad into the player! \n', event);
+        });
+
+        pbjs.onEvent('videoBidImpression', event => {
+          console.log('The ad impression resulted from a bid! \n', event);
+        });
+
+        pbjs.onEvent('videoBidError', event => {
+          console.log('The ad error resulted from a bid! \n', event);
+        });
+
+        pbjs.requestBids(adUnits);
       });
-
-
     </script>
+</head>
+
+<body>
+    <div id ="player"></div>
 </body>
 
 </html>

--- a/integrationExamples/videoModule/jwplayer/eventListeners.html
+++ b/integrationExamples/videoModule/jwplayer/eventListeners.html
@@ -8,6 +8,11 @@
     <script async src="../../../build/dev/prebid.js"></script>
     <script src="https://cdn.jwplayer.com/libraries/l5MchIxB.js"></script>
 
+
+</head>
+
+<body>
+    <div id ="player"></div>
     <script>
       var pbjs = pbjs || {};
       pbjs.que = pbjs.que || [];
@@ -29,221 +34,228 @@
           }
         }]
       }];
-      
-      pbjs.que.push(function () {
-        pbjs.setConfig({
-          video: {
-            providers: [{
-              divId: 'player',
-              vendorCode: 1, // vendorCode for jwplayer
-              playerConfig: {
-                licenseKey: 'IAjLREYRLylTWsfLN3FoN/O3iQLbs+AfgZLlkAoyH8gSf7TnNtmOLcR8CUY=',
-                params: {
-                  vendorConfig: {
-                    file: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4',
-                    mediaid: 'd9J2zcaA',
-                    advertising: { client: 'vast' }
-                  }
-                }
-              },
-            }]
-          },
-          debugging: {
-            enabled: true,
-            intercept: [
-              {
-                when: {
-                  adUnitCode: 'div-gpt-ad-51545-0',
-                },
-                then: {
-                  cpm: 25,
-                  mediaType: "video",
-                  vastUrl: "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dlinear&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=",
-                  // vastXml: "<VAST version=\"3.0\"> <Ad id=\"123\"> <InLine> <AdSystem>PubMatic</AdSystem> <AdTitle>VAST 2.0 Instream Test</AdTitle> <Description>VAST 2.0 Instream Test</Description> <Error> <![CDATA[https://aktrack.pubmatic.com/er=[ERRORCODE]]]> </Error> <Impression> <![CDATA[https://aktrack.pubmatic.com?e=impression]]> </Impression> <Creatives> <Creative AdID=\"123\"> <Linear> <Duration>00:00:30</Duration> <TrackingEvents> <Tracking event=\"creativeView\"> <![CDATA[https://aktrack.pubmatic.com?e=creativeView]]> </Tracking> <Tracking event=\"start\"> <![CDATA[https://aktrack.pubmatic.com?e=start]]> </Tracking> <Tracking event=\"midpoint\"> <![CDATA[https://aktrack.pubmatic.com?e=midpoint]]> </Tracking> <Tracking event=\"firstQuartile\"> <![CDATA[https://aktrack.pubmatic.com?e=firstQuartile]]> </Tracking> <Tracking event=\"thirdQuartile\"> <![CDATA[https://aktrack.pubmatic.com?e=thirdQuartile]]> </Tracking> <Tracking event=\"complete\"> <![CDATA[https://aktrack.pubmatic.com?e=complete]]> </Tracking> </TrackingEvents> <VideoClicks> <ClickThrough> <![CDATA[https://www.pubmatic.com]]> </ClickThrough> </VideoClicks> <MediaFiles> <MediaFile delivery=\"progressive\" type=\"video/mp4\" bitrate=\"500\" width=\"480\" height=\"460\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/spinning-logo-480x360_video.mp4]]> </MediaFile> <MediaFile delivery=\"progressive\" type=\"video/ogg\" bitrate=\"500\" width=\"480\" height=\"460\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/spinning-logo-480x360_video.ogg]]> </MediaFile> <MediaFile delivery=\"progressive\" type=\"video/x-flv\" bitrate=\"500\" width=\"400\" height=\"300\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_test_video.flv]]> </MediaFile> </MediaFiles> </Linear> </Creative> <Creative AdID=\"123\"> <NonLinearAds> <TrackingEvents></TrackingEvents> <NonLinear height=\"50\" width=\"300\" minSuggestedDuration=\"00:00:05\"> <StaticResource creativeType=\"image/jpeg\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_LetsBeClear_300x50.jpeg]]> </StaticResource> <NonLinearClickThrough> <![CDATA[https://www.pubmatic.com]]> </NonLinearClickThrough> </NonLinear> </NonLinearAds> </Creative> <Creative AdID=\"123\"> <CompanionAds> <Companion width=\"300\" height=\"250\"> <StaticResource creativeType=\"image/jpeg\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_LetsBeClear_320x250.jpg]]> </StaticResource> <CompanionClickThrough> <![CDATA[https://www.pubmatic.com]]> </CompanionClickThrough> </Companion> </CompanionAds> </Creative> </Creatives> </InLine> </Ad> </VAST>",
-                  ad: "<VAST version=\"3.0\"> <Ad id=\"123\"> <InLine> <AdSystem>PubMatic</AdSystem> <AdTitle>VAST 2.0 Instream Test</AdTitle> <Description>VAST 2.0 Instream Test</Description> <Error> <![CDATA[https://aktrack.pubmatic.com/er=[ERRORCODE]]]> </Error> <Impression> <![CDATA[https://aktrack.pubmatic.com?e=impression]]> </Impression> <Creatives> <Creative AdID=\"123\"> <Linear> <Duration>00:00:30</Duration> <TrackingEvents> <Tracking event=\"creativeView\"> <![CDATA[https://aktrack.pubmatic.com?e=creativeView]]> </Tracking> <Tracking event=\"start\"> <![CDATA[https://aktrack.pubmatic.com?e=start]]> </Tracking> <Tracking event=\"midpoint\"> <![CDATA[https://aktrack.pubmatic.com?e=midpoint]]> </Tracking> <Tracking event=\"firstQuartile\"> <![CDATA[https://aktrack.pubmatic.com?e=firstQuartile]]> </Tracking> <Tracking event=\"thirdQuartile\"> <![CDATA[https://aktrack.pubmatic.com?e=thirdQuartile]]> </Tracking> <Tracking event=\"complete\"> <![CDATA[https://aktrack.pubmatic.com?e=complete]]> </Tracking> </TrackingEvents> <VideoClicks> <ClickThrough> <![CDATA[https://www.pubmatic.com]]> </ClickThrough> </VideoClicks> <MediaFiles> <MediaFile delivery=\"progressive\" type=\"video/mp4\" bitrate=\"500\" width=\"480\" height=\"460\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/spinning-logo-480x360_video.mp4]]> </MediaFile> <MediaFile delivery=\"progressive\" type=\"video/ogg\" bitrate=\"500\" width=\"480\" height=\"460\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/spinning-logo-480x360_video.ogg]]> </MediaFile> <MediaFile delivery=\"progressive\" type=\"video/x-flv\" bitrate=\"500\" width=\"400\" height=\"300\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_test_video.flv]]> </MediaFile> </MediaFiles> </Linear> </Creative> <Creative AdID=\"123\"> <NonLinearAds> <TrackingEvents></TrackingEvents> <NonLinear height=\"50\" width=\"300\" minSuggestedDuration=\"00:00:05\"> <StaticResource creativeType=\"image/jpeg\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_LetsBeClear_300x50.jpeg]]> </StaticResource> <NonLinearClickThrough> <![CDATA[https://www.pubmatic.com]]> </NonLinearClickThrough> </NonLinear> </NonLinearAds> </Creative> <Creative AdID=\"123\"> <CompanionAds> <Companion width=\"300\" height=\"250\"> <StaticResource creativeType=\"image/jpeg\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_LetsBeClear_320x250.jpg]]> </StaticResource> <CompanionClickThrough> <![CDATA[https://www.pubmatic.com]]> </CompanionClickThrough> </Companion> </CompanionAds> </Creative> </Creatives> </InLine> </Ad> </VAST>"
-                }
-              },
-            ]
-          }
-        });
-
-        pbjs.addAdUnits(adUnits);
-
-        pbjs.onEvent('videoSetupComplete', (e) => {
-          console.log('player setup complete: ', e);
-        });
-
-        pbjs.onEvent('videoSetupFailed', e => {
-          console.log('player setup failed: ', e);
-        });
-
-        pbjs.onEvent('videoDestroyed', e => {
-          console.log('player destroyed: ', e);
-        });
-
-        pbjs.onEvent('videoPlaylist', (e) => {
-          console.log('videos pb playlist: ', e);
-        });
-
-        pbjs.onEvent('videoPlaybackRequest', (e) => {
-          console.log('videos pb playbackRequest: ', e);
-        });
-
-        pbjs.onEvent('videoAutostartBlocked', (e) => {
-          console.log('videos pb autostartBlocked: ', e);
-        });
-
-        pbjs.onEvent('videoPlayAttemptFailed', (e) => {
-          console.log('videos pb playAttemptFailed: ', e);
-        });
-
-        pbjs.onEvent('videoContentLoaded', (e) => {
-          console.log('videos pb contentLoaded: ', e);
-        });
-
-        pbjs.onEvent('videoPlay', (e) => {
-          console.log('videos pb play: ', e);
-        });
-
-        pbjs.onEvent('videoPause', (e) => {
-          console.log('videos pb pause: ', e);
-        });
-
-        pbjs.onEvent('videoBuffer', (e) => {
-          console.log('videos pb buffer: ', e);
-        });
-
-        pbjs.onEvent('videoSeekStart', (e) => {
-          console.log('videos pb seekStart: ', e);
-        });
-
-        pbjs.onEvent('videoSeekEnd', (e) => {
-          console.log('videos pb seekEnd: ', e);
-        });
-
-        pbjs.onEvent('videoRenditionUpdate', (e) => {
-          console.log('videos pb renditionUpdate: ', e);
-        });
-
-        pbjs.onEvent('videoMute', (e) => {
-          console.log('videos pb mute: ', e);
-        });
-
-        pbjs.onEvent('videoVolume', (e) => {
-          console.log('videos pb volume: ', e);
-        });
-
-        // pbjs.onEvent('videoTime', (e) => {
-        //   console.log('videos pb time: ', e);
-        // });
-
-        pbjs.onEvent('videoComplete', (e) => {
-          console.log('videos pb complete: ', e);
-        });
-
-        pbjs.onEvent('videoPlaylistComplete', (e) => {
-          console.log('videos pb playlistComplete: ', e);
-        });
-
-        pbjs.onEvent('videoFullscreen', (e) => {
-          console.log('videos pb fullscreen: ', e);
-        });
-
-        pbjs.onEvent('videoPlayerResize', (e) => {
-          console.log('videos pb playerResize: ', e);
-        });
-
-        pbjs.onEvent('videoError', (e) => {
-          console.log('videos pb error: ', e);
-        });
-
-        pbjs.onEvent('videoViewable', (e) => {
-          console.log('videos pb viewable: ', e);
-        });
-
-        pbjs.onEvent('videoCast', (e) => {
-          console.log('videos pb cast: ', e);
-        });
-
-        pbjs.onEvent('videoAdBreakStart', e => {
-          console.log('videos pb ad break start: ', e);
-        });
-
-        pbjs.onEvent('videoAdRequest', (e) => {
-          console.log('videos pb ad request: ', e);
-        });
-
-        pbjs.onEvent('videoAdLoaded', e => {
-          console.log('videos pb ad load: ', e);
-        });
-
-        pbjs.onEvent('videoAdImpression', (e) => {
-          console.log('videos pb ad impression: ', e);
-        });
-
-        pbjs.onEvent('videoAdStarted', (e) => {
-          console.log('videos pb ad started: ', e);
-        });
-
-        pbjs.onEvent('videoAdPlay', (e) => {
-          console.log('videos pb ad play: ', e);
-        });
-
-        pbjs.onEvent('videoAdPause', (e) => {
-          console.log('videos pb ad pause: ', e);
-        });
-
-        // pbjs.onEvent('videoAdTime', (e) => {
-        //   console.log('videos pb ad time: ', e);
-        // });
-
-        pbjs.onEvent('videoAdComplete', (e) => {
-          console.log('videos pb ad complete: ', e);
-        });
-
-        pbjs.onEvent('videoAdSkipped', (e) => {
-          console.log('videos pb ad skipped: ', e);
-        });
-
-        pbjs.onEvent('videoAdClick', (e) => {
-          console.log('videos pb ad click: ', e);
-        });
-
-        pbjs.onEvent('videoAdError', (e) => {
-          console.log('videos pb ad error: ', e);
-        });
-
-        pbjs.onEvent('videoAdBreakStart', e => {
-          console.log('videos pb ad break start: ', e);
-        });
-
-        pbjs.onEvent('videoAuctionAdLoadAbort', (e) => {
-          console.log('videos pb auction ad load attempt: ', e);
-        });
-
-        pbjs.onEvent('videoAuctionAdLoadQueued', (e) => {
-          console.log('videos pb auction ad load queued: ', e);
-        });
-
-        pbjs.onEvent('videoAuctionAdLoadAttempt', event => {
-          console.log('The Video Module is attempting to load an ad into the player! \n', event);
-        });
-
-        pbjs.onEvent('videoBidImpression', event => {
-          console.log('The ad impression resulted from a bid! \n', event);
-        });
-
-        pbjs.onEvent('videoBidError', event => {
-          console.log('The ad error resulted from a bid! \n', event);
-        });
-
-        pbjs.requestBids(adUnits);
+      const player = jwplayer('player').setup({
+        file: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4',
+        mediaid: 'd9J2zcaA',
+        advertising: { client: 'vast' }
       });
-    </script>
-</head>
 
-<body>
-    <div id ="player"></div>
+      player.on('ready', () => {
+        pbjs.que.push(function () {
+          pbjs.setConfig({
+            video: {
+              providers: [{
+                divId: 'player',
+                vendorCode: 1, // vendorCode for jwplayer
+                // playerConfig: {
+                //   licenseKey: 'IAjLREYRLylTWsfLN3FoN/O3iQLbs+AfgZLlkAoyH8gSf7TnNtmOLcR8CUY=',
+                //   params: {
+                //     vendorConfig: {
+                //       file: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4',
+                //       mediaid: 'd9J2zcaA',
+                //       advertising: { client: 'vast' }
+                //     }
+                //   }
+                // },
+              }]
+            },
+            debugging: {
+              enabled: true,
+              intercept: [
+                {
+                  when: {
+                    adUnitCode: 'div-gpt-ad-51545-0',
+                  },
+                  then: {
+                    cpm: 25,
+                    mediaType: "video",
+                    vastUrl: "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dlinear&ciu_szs=300x250%2C728x90&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=",
+                    // vastXml: "<VAST version=\"3.0\"> <Ad id=\"123\"> <InLine> <AdSystem>PubMatic</AdSystem> <AdTitle>VAST 2.0 Instream Test</AdTitle> <Description>VAST 2.0 Instream Test</Description> <Error> <![CDATA[https://aktrack.pubmatic.com/er=[ERRORCODE]]]> </Error> <Impression> <![CDATA[https://aktrack.pubmatic.com?e=impression]]> </Impression> <Creatives> <Creative AdID=\"123\"> <Linear> <Duration>00:00:30</Duration> <TrackingEvents> <Tracking event=\"creativeView\"> <![CDATA[https://aktrack.pubmatic.com?e=creativeView]]> </Tracking> <Tracking event=\"start\"> <![CDATA[https://aktrack.pubmatic.com?e=start]]> </Tracking> <Tracking event=\"midpoint\"> <![CDATA[https://aktrack.pubmatic.com?e=midpoint]]> </Tracking> <Tracking event=\"firstQuartile\"> <![CDATA[https://aktrack.pubmatic.com?e=firstQuartile]]> </Tracking> <Tracking event=\"thirdQuartile\"> <![CDATA[https://aktrack.pubmatic.com?e=thirdQuartile]]> </Tracking> <Tracking event=\"complete\"> <![CDATA[https://aktrack.pubmatic.com?e=complete]]> </Tracking> </TrackingEvents> <VideoClicks> <ClickThrough> <![CDATA[https://www.pubmatic.com]]> </ClickThrough> </VideoClicks> <MediaFiles> <MediaFile delivery=\"progressive\" type=\"video/mp4\" bitrate=\"500\" width=\"480\" height=\"460\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/spinning-logo-480x360_video.mp4]]> </MediaFile> <MediaFile delivery=\"progressive\" type=\"video/ogg\" bitrate=\"500\" width=\"480\" height=\"460\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/spinning-logo-480x360_video.ogg]]> </MediaFile> <MediaFile delivery=\"progressive\" type=\"video/x-flv\" bitrate=\"500\" width=\"400\" height=\"300\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_test_video.flv]]> </MediaFile> </MediaFiles> </Linear> </Creative> <Creative AdID=\"123\"> <NonLinearAds> <TrackingEvents></TrackingEvents> <NonLinear height=\"50\" width=\"300\" minSuggestedDuration=\"00:00:05\"> <StaticResource creativeType=\"image/jpeg\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_LetsBeClear_300x50.jpeg]]> </StaticResource> <NonLinearClickThrough> <![CDATA[https://www.pubmatic.com]]> </NonLinearClickThrough> </NonLinear> </NonLinearAds> </Creative> <Creative AdID=\"123\"> <CompanionAds> <Companion width=\"300\" height=\"250\"> <StaticResource creativeType=\"image/jpeg\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_LetsBeClear_320x250.jpg]]> </StaticResource> <CompanionClickThrough> <![CDATA[https://www.pubmatic.com]]> </CompanionClickThrough> </Companion> </CompanionAds> </Creative> </Creatives> </InLine> </Ad> </VAST>",
+                    ad: "<VAST version=\"3.0\"> <Ad id=\"123\"> <InLine> <AdSystem>PubMatic</AdSystem> <AdTitle>VAST 2.0 Instream Test</AdTitle> <Description>VAST 2.0 Instream Test</Description> <Error> <![CDATA[https://aktrack.pubmatic.com/er=[ERRORCODE]]]> </Error> <Impression> <![CDATA[https://aktrack.pubmatic.com?e=impression]]> </Impression> <Creatives> <Creative AdID=\"123\"> <Linear> <Duration>00:00:30</Duration> <TrackingEvents> <Tracking event=\"creativeView\"> <![CDATA[https://aktrack.pubmatic.com?e=creativeView]]> </Tracking> <Tracking event=\"start\"> <![CDATA[https://aktrack.pubmatic.com?e=start]]> </Tracking> <Tracking event=\"midpoint\"> <![CDATA[https://aktrack.pubmatic.com?e=midpoint]]> </Tracking> <Tracking event=\"firstQuartile\"> <![CDATA[https://aktrack.pubmatic.com?e=firstQuartile]]> </Tracking> <Tracking event=\"thirdQuartile\"> <![CDATA[https://aktrack.pubmatic.com?e=thirdQuartile]]> </Tracking> <Tracking event=\"complete\"> <![CDATA[https://aktrack.pubmatic.com?e=complete]]> </Tracking> </TrackingEvents> <VideoClicks> <ClickThrough> <![CDATA[https://www.pubmatic.com]]> </ClickThrough> </VideoClicks> <MediaFiles> <MediaFile delivery=\"progressive\" type=\"video/mp4\" bitrate=\"500\" width=\"480\" height=\"460\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/spinning-logo-480x360_video.mp4]]> </MediaFile> <MediaFile delivery=\"progressive\" type=\"video/ogg\" bitrate=\"500\" width=\"480\" height=\"460\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/spinning-logo-480x360_video.ogg]]> </MediaFile> <MediaFile delivery=\"progressive\" type=\"video/x-flv\" bitrate=\"500\" width=\"400\" height=\"300\" scalable=\"true\" maintainAspectRatio=\"true\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_test_video.flv]]> </MediaFile> </MediaFiles> </Linear> </Creative> <Creative AdID=\"123\"> <NonLinearAds> <TrackingEvents></TrackingEvents> <NonLinear height=\"50\" width=\"300\" minSuggestedDuration=\"00:00:05\"> <StaticResource creativeType=\"image/jpeg\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_LetsBeClear_300x50.jpeg]]> </StaticResource> <NonLinearClickThrough> <![CDATA[https://www.pubmatic.com]]> </NonLinearClickThrough> </NonLinear> </NonLinearAds> </Creative> <Creative AdID=\"123\"> <CompanionAds> <Companion width=\"300\" height=\"250\"> <StaticResource creativeType=\"image/jpeg\"> <![CDATA[https://staging.pubmatic.com:8443/test/PubMatic_LetsBeClear_320x250.jpg]]> </StaticResource> <CompanionClickThrough> <![CDATA[https://www.pubmatic.com]]> </CompanionClickThrough> </Companion> </CompanionAds> </Creative> </Creatives> </InLine> </Ad> </VAST>"
+                  }
+                },
+              ]
+            }
+          });
+
+
+
+          pbjs.addAdUnits(adUnits);
+
+          pbjs.onEvent('videoSetupComplete', (e) => {
+            console.log('player setup complete: ', e);
+          });
+
+          pbjs.onEvent('videoSetupFailed', e => {
+            console.log('player setup failed: ', e);
+          });
+
+          pbjs.onEvent('videoDestroyed', e => {
+            console.log('player destroyed: ', e);
+          });
+
+          pbjs.onEvent('videoPlaylist', (e) => {
+            console.log('videos pb playlist: ', e);
+          });
+
+          pbjs.onEvent('videoPlaybackRequest', (e) => {
+            console.log('videos pb playbackRequest: ', e);
+          });
+
+          pbjs.onEvent('videoAutostartBlocked', (e) => {
+            console.log('videos pb autostartBlocked: ', e);
+          });
+
+          pbjs.onEvent('videoPlayAttemptFailed', (e) => {
+            console.log('videos pb playAttemptFailed: ', e);
+          });
+
+          pbjs.onEvent('videoContentLoaded', (e) => {
+            console.log('videos pb contentLoaded: ', e);
+          });
+
+          pbjs.onEvent('videoPlay', (e) => {
+            console.log('videos pb play: ', e);
+          });
+
+          pbjs.onEvent('videoPause', (e) => {
+            console.log('videos pb pause: ', e);
+          });
+
+          pbjs.onEvent('videoBuffer', (e) => {
+            console.log('videos pb buffer: ', e);
+          });
+
+          pbjs.onEvent('videoSeekStart', (e) => {
+            console.log('videos pb seekStart: ', e);
+          });
+
+          pbjs.onEvent('videoSeekEnd', (e) => {
+            console.log('videos pb seekEnd: ', e);
+          });
+
+          pbjs.onEvent('videoRenditionUpdate', (e) => {
+            console.log('videos pb renditionUpdate: ', e);
+          });
+
+          pbjs.onEvent('videoMute', (e) => {
+            console.log('videos pb mute: ', e);
+          });
+
+          pbjs.onEvent('videoVolume', (e) => {
+            console.log('videos pb volume: ', e);
+          });
+
+          // pbjs.onEvent('videoTime', (e) => {
+          //   console.log('videos pb time: ', e);
+          // });
+
+          pbjs.onEvent('videoComplete', (e) => {
+            console.log('videos pb complete: ', e);
+          });
+
+          pbjs.onEvent('videoPlaylistComplete', (e) => {
+            console.log('videos pb playlistComplete: ', e);
+          });
+
+          pbjs.onEvent('videoFullscreen', (e) => {
+            console.log('videos pb fullscreen: ', e);
+          });
+
+          pbjs.onEvent('videoPlayerResize', (e) => {
+            console.log('videos pb playerResize: ', e);
+          });
+
+          pbjs.onEvent('videoError', (e) => {
+            console.log('videos pb error: ', e);
+          });
+
+          pbjs.onEvent('videoViewable', (e) => {
+            console.log('videos pb viewable: ', e);
+          });
+
+          pbjs.onEvent('videoCast', (e) => {
+            console.log('videos pb cast: ', e);
+          });
+
+          pbjs.onEvent('videoAdBreakStart', e => {
+            console.log('videos pb ad break start: ', e);
+          });
+
+          pbjs.onEvent('videoAdRequest', (e) => {
+            console.log('videos pb ad request: ', e);
+          });
+
+          pbjs.onEvent('videoAdLoaded', e => {
+            console.log('videos pb ad load: ', e);
+          });
+
+          pbjs.onEvent('videoAdImpression', (e) => {
+            console.log('videos pb ad impression: ', e);
+          });
+
+          pbjs.onEvent('videoAdStarted', (e) => {
+            console.log('videos pb ad started: ', e);
+          });
+
+          pbjs.onEvent('videoAdPlay', (e) => {
+            console.log('videos pb ad play: ', e);
+          });
+
+          pbjs.onEvent('videoAdPause', (e) => {
+            console.log('videos pb ad pause: ', e);
+          });
+
+          // pbjs.onEvent('videoAdTime', (e) => {
+          //   console.log('videos pb ad time: ', e);
+          // });
+
+          pbjs.onEvent('videoAdComplete', (e) => {
+            console.log('videos pb ad complete: ', e);
+          });
+
+          pbjs.onEvent('videoAdSkipped', (e) => {
+            console.log('videos pb ad skipped: ', e);
+          });
+
+          pbjs.onEvent('videoAdClick', (e) => {
+            console.log('videos pb ad click: ', e);
+          });
+
+          pbjs.onEvent('videoAdError', (e) => {
+            console.log('videos pb ad error: ', e);
+          });
+
+          pbjs.onEvent('videoAdBreakStart', e => {
+            console.log('videos pb ad break start: ', e);
+          });
+
+          pbjs.onEvent('videoAuctionAdLoadAbort', (e) => {
+            console.log('videos pb auction ad load attempt: ', e);
+          });
+
+          pbjs.onEvent('videoAuctionAdLoadQueued', (e) => {
+            console.log('videos pb auction ad load queued: ', e);
+          });
+
+          pbjs.onEvent('videoAuctionAdLoadAttempt', event => {
+            console.log('The Video Module is attempting to load an ad into the player! \n', event);
+          });
+
+          pbjs.onEvent('videoBidImpression', event => {
+            console.log('The ad impression resulted from a bid! \n', event);
+          });
+
+          pbjs.onEvent('videoBidError', event => {
+            console.log('The ad error resulted from a bid! \n', event);
+          });
+
+          pbjs.requestBids(adUnits);
+        });
+      });
+
+
+    </script>
 </body>
 
 </html>

--- a/integrationExamples/videoModule/jwplayer/gamAdServerMediation.html
+++ b/integrationExamples/videoModule/jwplayer/gamAdServerMediation.html
@@ -94,10 +94,6 @@
           console.log('player setup failed: ', e);
         });
 
-        pbjs.onEvent('videoPlaybackRequest', (e) => {
-          pbjs.requestBids(adUnits);
-        });
-
         pbjs.onEvent('videoAdRequest', (e) => {
           console.log('videos pb ad request: ', e);
         });
@@ -109,6 +105,8 @@
         pbjs.onEvent('videoBidImpression', e => {
           console.log('An Ad Impression came from a Bid: ', e);
         });
+
+        pbjs.requestBids(adUnits);
       });
     </script>
 </head>

--- a/integrationExamples/videoModule/jwplayer/mediaMetadata.html
+++ b/integrationExamples/videoModule/jwplayer/mediaMetadata.html
@@ -56,7 +56,6 @@
 
         pbjs.onEvent('videoSetupComplete', e => {
           console.log('player setup complete: ', e);
-          pbjs.requestBids(adUnits);
         });
 
         pbjs.onEvent('videoSetupFailed', e => {
@@ -66,6 +65,8 @@
         pbjs.onEvent('videoContentLoaded', (e) => {
           console.log('videos pb contentLoaded: ', e);
         });
+
+        pbjs.requestBids(adUnits);
       });
     </script>
 

--- a/integrationExamples/videoModule/jwplayer/playlist.html
+++ b/integrationExamples/videoModule/jwplayer/playlist.html
@@ -97,7 +97,6 @@
       // request a bid when media is loaded
       pbjs.onEvent('videoContentLoaded', (e) => {
         console.log('videos pb contentLoaded: ', e);
-        pbjs.requestBids(adUnits);
       });
 
       pbjs.onEvent('videoComplete', (e) => {
@@ -107,6 +106,8 @@
       pbjs.onEvent('videoPlaylistComplete', (e) => {
         console.log('videos pb playlistComplete: ', e);
       });
+
+      pbjs.requestBids(adUnits);
     });
   </script>
 

--- a/integrationExamples/videoModule/videojs/bidMarkedAsUsed.html
+++ b/integrationExamples/videoModule/videojs/bidMarkedAsUsed.html
@@ -101,10 +101,6 @@
           console.log('player setup failed: ', e);
         });
 
-        pbjs.onEvent('videoContentLoaded', (e) => {
-          pbjs.requestBids(adUnits);
-        });
-
         pbjs.onEvent('videoBidError', e => {
           console.log('An Ad Error came from a Bid: ', e);
         });
@@ -113,6 +109,7 @@
           console.log('An Ad Impression came from a Bid: ', e);
         });
 
+        pbjs.requestBids(adUnits);
       });
     </script>
 </head>

--- a/integrationExamples/videoModule/videojs/eventListeners.html
+++ b/integrationExamples/videoModule/videojs/eventListeners.html
@@ -209,6 +209,10 @@
         console.log('videos pb auction ad load attempt: ', e);
       });
 
+      pbjs.onEvent('videoAuctionAdLoadQueued', (e) => {
+        console.log('videos pb auction ad load queued: ', e);
+      });
+
       pbjs.onEvent('videoAuctionAdLoadAbort', (e) => {
         console.log('videos pb auction ad load attempt: ', e);
       });

--- a/integrationExamples/videoModule/videojs/gamAdServerMediation.html
+++ b/integrationExamples/videoModule/videojs/gamAdServerMediation.html
@@ -96,8 +96,6 @@
 
         pbjs.addAdUnits(adUnits);
 
-        pbjs.requestBids(adUnits);
-
         pbjs.onEvent('videoSetupComplete', e => {
           // Load media with its Metadata when the video player is done instantiating.
           videojs('player').loadMedia({
@@ -125,6 +123,7 @@
           console.log('An Ad Impression came from a Bid: ', e);
         });
 
+        pbjs.requestBids(adUnits);
       });
     </script>
 </head>

--- a/integrationExamples/videoModule/videojs/playlist.html
+++ b/integrationExamples/videoModule/videojs/playlist.html
@@ -126,15 +126,15 @@
         console.log('videos pb playlist: ', e);
       });
 
-      // request a bid when media is loaded
       pbjs.onEvent('videoContentLoaded', (e) => {
         console.log('videos pb contentLoaded: ', e);
-        pbjs.requestBids(adUnits);
       });
 
       pbjs.onEvent('videoComplete', (e) => {
         console.log('videos pb complete: ', e);
       });
+
+      pbjs.requestBids(adUnits);
     });
   </script>
 

--- a/libraries/video/constants/constants.js
+++ b/libraries/video/constants/constants.js
@@ -1,3 +1,5 @@
+export const videoKey = 'video';
+
 export const PLAYBACK_MODE = {
   VOD: 0,
   LIVE: 1,

--- a/libraries/video/constants/events.js
+++ b/libraries/video/constants/events.js
@@ -52,6 +52,7 @@ export const allVideoEvents = [
 ];
 
 export const AUCTION_AD_LOAD_ATTEMPT = 'auctionAdLoadAttempt';
+export const AUCTION_AD_LOAD_QUEUED = 'auctionAdLoadQueued';
 export const AUCTION_AD_LOAD_ABORT = 'auctionAdLoadAbort';
 export const BID_IMPRESSION = 'bidImpression';
 export const BID_ERROR = 'bidError';

--- a/libraries/video/shared/helpers.js
+++ b/libraries/video/shared/helpers.js
@@ -1,0 +1,5 @@
+import { videoKey } from '../constants/constants.js'
+
+export function getExternalVideoEventName(eventName) {
+  return videoKey + eventName.replace(/^./, eventName[0].toUpperCase());
+}

--- a/libraries/video/shared/parentModule.js
+++ b/libraries/video/shared/parentModule.js
@@ -72,7 +72,6 @@ export function SubmoduleBuilder(submoduleDirectory_, sharedUtils_) {
     }
 
     const submodule = submoduleFactory(config, sharedUtils);
-    submodule && submodule.init && submodule.init();
     return submodule;
   }
 

--- a/modules/jwplayerVideoProvider.js
+++ b/modules/jwplayerVideoProvider.js
@@ -7,7 +7,7 @@ import {
   AUTOSTART_BLOCKED, PLAY_ATTEMPT_FAILED, CONTENT_LOADED, PLAY, PAUSE, BUFFER, TIME, SEEK_START, SEEK_END, MUTE, VOLUME,
   RENDITION_UPDATE, ERROR, COMPLETE, PLAYLIST_COMPLETE, FULLSCREEN, PLAYER_RESIZE, VIEWABLE, CAST
 } from '../libraries/video/constants/events.js';
-import { PLAYBACK_MODE } from '../libraries/video/constants/enums.js';
+import { PLAYBACK_MODE } from '../libraries/video/constants/constants.js';
 import stateFactory from '../libraries/video/shared/state.js';
 import { JWPLAYER_VENDOR } from '../libraries/video/constants/vendorCodes.js';
 import { getEventHandler } from '../libraries/video/shared/eventHandler.js';

--- a/modules/videoModule/adQueue.js
+++ b/modules/videoModule/adQueue.js
@@ -1,0 +1,54 @@
+import { AD_BREAK_END, SETUP_COMPLETE } from '../../libraries/video/constants/events.js'
+
+export function AdQueueCoordinator(videoCore) {
+  const storage = {};
+
+  function registerProvider(divId) {
+    storage[divId] = [];
+    videoCore.onEvents([SETUP_COMPLETE], onSetupComplete, divId);
+  }
+
+  function requiresQueueing(divId) {
+    return !!storage[divId];
+  }
+
+  function queueAd(adUrl, divId, options) {
+    const queue = storage[divId];
+    if (queue) {
+      queue.push({adUrl, options});
+    }
+  }
+
+  return {
+    registerProvider,
+    requiresQueueing,
+    queueAd
+  };
+
+  function onSetupComplete(eventPayload) {
+    const divId = eventPayload.divId;
+    videoCore.offEvents([SETUP_COMPLETE], onSetupComplete, divId);
+    loadNextAd(divId);
+  }
+
+  function onAdBreakEnd(eventPayload) {
+    loadNextAd(eventPayload.divId);
+  }
+
+  function loadNextAd(divId) {
+    videoCore.offEvents([AD_BREAK_END], onAdBreakEnd, divId);
+    const adQueue = storage[divId];
+    if (!adQueue) {
+      return;
+    }
+
+    if (!adQueue.length) {
+      delete storage[divId];
+      return;
+    }
+
+    const queuedAd = adQueue.shift();
+    videoCore.onEvents([AD_BREAK_END], onAdBreakEnd, divId);
+    videoCore.setAdTagUrl(queuedAd.adUrl, divId, queuedAd.options);
+  }
+}

--- a/modules/videoModule/adQueue.js
+++ b/modules/videoModule/adQueue.js
@@ -25,13 +25,13 @@ export function AdQueueCoordinator(videoCore) {
     queueAd
   };
 
-  function onSetupComplete(eventPayload) {
+  function onSetupComplete(eventName, eventPayload) {
     const divId = eventPayload.divId;
     videoCore.offEvents([SETUP_COMPLETE], onSetupComplete, divId);
     loadNextAd(divId);
   }
 
-  function onAdBreakEnd(eventPayload) {
+  function onAdBreakEnd(eventName, eventPayload) {
     loadNextAd(eventPayload.divId);
   }
 

--- a/modules/videoModule/addingSubmodule.md
+++ b/modules/videoModule/addingSubmodule.md
@@ -481,6 +481,13 @@ No additional params.
 | adTagUrl | string | The URL for the ad tag associated with the given ad event |
 | adUnitCode | string | Unique identifier that was used when creating the ad unit. |
 
+###### AUCTION_AD_LOAD_QUEUED
+
+| argument name | type | description |
+| ------------- | ---- | ----------- |
+| adTagUrl | string | The URL for the ad tag associated with the given ad event |
+| adUnitCode | string | Unique identifier that was used when creating the ad unit. |
+
 ###### AUCTION_AD_LOAD_ABORT
 
 | argument name | type | description |

--- a/modules/videoModule/coreVideo.js
+++ b/modules/videoModule/coreVideo.js
@@ -127,6 +127,11 @@ export function VideoCore(parentModule_) {
     } catch (e) {}
   }
 
+  function initProvider(divId) {
+    const submodule = parentModule.getSubmodule(divId);
+    submodule && submodule.init && submodule.init();
+  }
+
   /**
    * @name VideoCore#getOrtbVideo
    * @summary Obtains the oRTB Video params for a player's current video session.
@@ -208,6 +213,7 @@ export function VideoCore(parentModule_) {
 
   return {
     registerProvider,
+    initProvider,
     getOrtbVideo,
     getOrtbContent,
     setAdTagUrl,

--- a/modules/videoModule/index.js
+++ b/modules/videoModule/index.js
@@ -52,6 +52,7 @@ export function PbVideo(videoCore_, getConfig_, pbGlobal_, pbEvents_, videoEvent
         const divId = provider.divId;
         videoCore.registerProvider(provider);
         adQueueCoordinator.registerProvider(divId);
+        videoCore.initProvider(divId);
         videoCore.onEvents(videoEvents, (type, payload) => {
           pbEvents.emit(getExternalVideoEventName(type), payload);
         }, divId);

--- a/modules/videoModule/index.js
+++ b/modules/videoModule/index.js
@@ -18,7 +18,7 @@ import { PLACEMENT } from '../../libraries/video/constants/ortb.js';
 import { videoCoreFactory } from './coreVideo.js';
 import { gamSubmoduleFactory } from './gamAdServerSubmodule.js';
 import { videoImpressionVerifierFactory } from './videoImpressionVerifier.js';
-import { AdQueueCoordinator } from './adQueue'
+import { AdQueueCoordinator } from './adQueue.js';
 
 const videoKey = 'video';
 

--- a/modules/videoModule/index.js
+++ b/modules/videoModule/index.js
@@ -51,7 +51,7 @@ export function PbVideo(videoCore_, getConfig_, pbGlobal_, pbEvents_, videoEvent
       video.providers.forEach(provider => {
         const divId = provider.divId;
         videoCore.registerProvider(provider);
-        adQueueCoordinator.registerProvider(divId)
+        adQueueCoordinator.registerProvider(divId);
         videoCore.onEvents(videoEvents, (type, payload) => {
           pbEvents.emit(getExternalVideoEventName(type), payload);
         }, divId);

--- a/modules/videojsVideoProvider.js
+++ b/modules/videojsVideoProvider.js
@@ -11,7 +11,7 @@ import {
 import { VIDEO_JS_VENDOR } from '../libraries/video/constants/vendorCodes.js';
 import { submodule } from '../src/hook.js';
 import stateFactory from '../libraries/video/shared/state.js';
-import { PLAYBACK_MODE } from '../libraries/video/constants/enums.js';
+import { PLAYBACK_MODE } from '../libraries/video/constants/constants.js';
 import { getEventHandler } from '../libraries/video/shared/eventHandler.js';
 
 /*

--- a/test/spec/modules/videoModule/adQueue_spec.js
+++ b/test/spec/modules/videoModule/adQueue_spec.js
@@ -94,5 +94,42 @@ describe('Ad Queue Coordinator', function () {
     expect(mockVideoCore.setAdTagUrl.calledThrice).to.be.true;
     setAdTagArgs = mockVideoCore.setAdTagUrl.thirdCall.args;
     expect(setAdTagArgs[0]).to.be.equal('testAdTag3');
-  })
+
+    adBreakEnd({ divId: testId });
+    expect(mockVideoCore.setAdTagUrl.calledThrice).to.be.true;
+  });
+
+  it('should empty queue as adBreaks end', function () {
+    const mockVideoCore = mockVideoCoreFactory();
+    let setupComplete;
+    let adBreakEnd;
+
+    mockVideoCore.onEvents = function(events, callback, id) {
+      if (events[0] === SETUP_COMPLETE && id === testId) {
+        setupComplete = callback;
+      }
+
+      if (events[0] === AD_BREAK_END && id === testId) {
+        adBreakEnd = callback;
+      }
+    };
+
+    const coordinator = AdQueueCoordinator(mockVideoCore);
+    coordinator.registerProvider(testId);
+    coordinator.queueAd('testAdTag', testId);
+    coordinator.queueAd('testAdTag2', testId);
+    coordinator.queueAd('testAdTag3', testId);
+
+    setupComplete({ divId: testId });
+    adBreakEnd({ divId: testId });
+    adBreakEnd({ divId: testId });
+    expect(mockVideoCore.setAdTagUrl.calledThrice).to.be.true;
+    expect(coordinator.requiresQueueing(testId)).to.be.true;
+    adBreakEnd({ divId: testId });
+    expect(mockVideoCore.setAdTagUrl.calledThrice).to.be.true;
+    expect(coordinator.requiresQueueing(testId)).to.be.false;
+    adBreakEnd({ divId: testId });
+    expect(mockVideoCore.setAdTagUrl.calledThrice).to.be.true;
+    expect(coordinator.requiresQueueing(testId)).to.be.false;
+  });
 });

--- a/test/spec/modules/videoModule/adQueue_spec.js
+++ b/test/spec/modules/videoModule/adQueue_spec.js
@@ -29,7 +29,7 @@ describe('Ad Queue Coordinator', function () {
       };
       const coordinator = AdQueueCoordinator(mockVideoCore);
       coordinator.registerProvider(testId);
-      setupComplete({ divId: testId });
+      setupComplete('', { divId: testId });
 
       expect(coordinator.requiresQueueing(testId)).to.be.false;
       expect(mockVideoCore.offEvents.calledTwice).to.be.true;
@@ -51,7 +51,7 @@ describe('Ad Queue Coordinator', function () {
       const coordinator = AdQueueCoordinator(mockVideoCore);
       coordinator.registerProvider(testId);
       coordinator.queueAd('testAdTag', testId, { param: {} });
-      setupComplete({ divId: testId });
+      setupComplete('', { divId: testId });
       expect(mockVideoCore.setAdTagUrl.calledOnce).to.be.true;
     });
   });
@@ -77,25 +77,25 @@ describe('Ad Queue Coordinator', function () {
     coordinator.queueAd('testAdTag2', testId);
     coordinator.queueAd('testAdTag3', testId);
 
-    setupComplete({ divId: testId });
+    setupComplete('', { divId: testId });
 
     expect(mockVideoCore.setAdTagUrl.calledOnce).to.be.true;
     let setAdTagArgs = mockVideoCore.setAdTagUrl.firstCall.args;
     expect(setAdTagArgs[0]).to.be.equal('testAdTag');
 
-    adBreakEnd({ divId: testId });
+    adBreakEnd('', { divId: testId });
 
     expect(mockVideoCore.setAdTagUrl.calledTwice).to.be.true;
     setAdTagArgs = mockVideoCore.setAdTagUrl.secondCall.args;
     expect(setAdTagArgs[0]).to.be.equal('testAdTag2');
 
-    adBreakEnd({ divId: testId });
+    adBreakEnd('', { divId: testId });
 
     expect(mockVideoCore.setAdTagUrl.calledThrice).to.be.true;
     setAdTagArgs = mockVideoCore.setAdTagUrl.thirdCall.args;
     expect(setAdTagArgs[0]).to.be.equal('testAdTag3');
 
-    adBreakEnd({ divId: testId });
+    adBreakEnd('', { divId: testId });
     expect(mockVideoCore.setAdTagUrl.calledThrice).to.be.true;
   });
 
@@ -120,15 +120,15 @@ describe('Ad Queue Coordinator', function () {
     coordinator.queueAd('testAdTag2', testId);
     coordinator.queueAd('testAdTag3', testId);
 
-    setupComplete({ divId: testId });
-    adBreakEnd({ divId: testId });
-    adBreakEnd({ divId: testId });
+    setupComplete('', { divId: testId });
+    adBreakEnd('', { divId: testId });
+    adBreakEnd('', { divId: testId });
     expect(mockVideoCore.setAdTagUrl.calledThrice).to.be.true;
     expect(coordinator.requiresQueueing(testId)).to.be.true;
-    adBreakEnd({ divId: testId });
+    adBreakEnd('', { divId: testId });
     expect(mockVideoCore.setAdTagUrl.calledThrice).to.be.true;
     expect(coordinator.requiresQueueing(testId)).to.be.false;
-    adBreakEnd({ divId: testId });
+    adBreakEnd('', { divId: testId });
     expect(mockVideoCore.setAdTagUrl.calledThrice).to.be.true;
     expect(coordinator.requiresQueueing(testId)).to.be.false;
   });

--- a/test/spec/modules/videoModule/adQueue_spec.js
+++ b/test/spec/modules/videoModule/adQueue_spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { AdQueueCoordinator } from '../../../../modules/videoModule/adQueue.js';
-import { SETUP_COMPLETE } from '../../../../libraries/video/constants/events.js';
+import { AD_BREAK_END, SETUP_COMPLETE } from '../../../../libraries/video/constants/events.js'
 
 const testId = 'testId';
 describe('Ad Queue Coordinator', function () {
@@ -11,10 +11,6 @@ describe('Ad Queue Coordinator', function () {
       setAdTagUrl: sinon.spy(),
     }
   };
-
-  describe('Register Provider', function () {
-
-  });
 
   describe('Requires Queuing', function () {
     it('should be true when provider is not setup', function() {
@@ -36,10 +32,67 @@ describe('Ad Queue Coordinator', function () {
       setupComplete({ divId: testId });
 
       expect(coordinator.requiresQueueing(testId)).to.be.false;
+      expect(mockVideoCore.offEvents.calledTwice).to.be.true;
+      const offSetupCompleteArgs = mockVideoCore.offEvents.firstCall.args;
+      expect(offSetupCompleteArgs[0]).to.deep.equal([SETUP_COMPLETE]);
+      expect(offSetupCompleteArgs[2]).to.equal(testId);
     });
   });
 
   describe('Queue Ad', function () {
-
+    it('should push ad to queue', function () {
+      const mockVideoCore = mockVideoCoreFactory();
+      let setupComplete;
+      mockVideoCore.onEvents = function(events, callback, id) {
+        if (events[0] === SETUP_COMPLETE && id === testId) {
+          setupComplete = callback;
+        }
+      };
+      const coordinator = AdQueueCoordinator(mockVideoCore);
+      coordinator.registerProvider(testId);
+      coordinator.queueAd('testAdTag', testId, { param: {} });
+      setupComplete({ divId: testId });
+      expect(mockVideoCore.setAdTagUrl.calledOnce).to.be.true;
+    });
   });
+
+  it('should load from queue on Ad Break End', function () {
+    const mockVideoCore = mockVideoCoreFactory();
+    let setupComplete;
+    let adBreakEnd;
+
+    mockVideoCore.onEvents = function(events, callback, id) {
+      if (events[0] === SETUP_COMPLETE && id === testId) {
+        setupComplete = callback;
+      }
+
+      if (events[0] === AD_BREAK_END && id === testId) {
+        adBreakEnd = callback;
+      }
+    };
+
+    const coordinator = AdQueueCoordinator(mockVideoCore);
+    coordinator.registerProvider(testId);
+    coordinator.queueAd('testAdTag', testId);
+    coordinator.queueAd('testAdTag2', testId);
+    coordinator.queueAd('testAdTag3', testId);
+
+    setupComplete({ divId: testId });
+
+    expect(mockVideoCore.setAdTagUrl.calledOnce).to.be.true;
+    let setAdTagArgs = mockVideoCore.setAdTagUrl.firstCall.args;
+    expect(setAdTagArgs[0]).to.be.equal('testAdTag');
+
+    adBreakEnd({ divId: testId });
+
+    expect(mockVideoCore.setAdTagUrl.calledTwice).to.be.true;
+    setAdTagArgs = mockVideoCore.setAdTagUrl.secondCall.args;
+    expect(setAdTagArgs[0]).to.be.equal('testAdTag2');
+
+    adBreakEnd({ divId: testId });
+
+    expect(mockVideoCore.setAdTagUrl.calledThrice).to.be.true;
+    setAdTagArgs = mockVideoCore.setAdTagUrl.thirdCall.args;
+    expect(setAdTagArgs[0]).to.be.equal('testAdTag3');
+  })
 });

--- a/test/spec/modules/videoModule/adQueue_spec.js
+++ b/test/spec/modules/videoModule/adQueue_spec.js
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import { AdQueueCoordinator } from '../../../../modules/videoModule/adQueue.js';
+import { SETUP_COMPLETE } from '../../../../libraries/video/constants/events.js';
+
+const testId = 'testId';
+describe('Ad Queue Coordinator', function () {
+  const mockVideoCoreFactory = function () {
+    return {
+      onEvents: sinon.spy(),
+      offEvents: sinon.spy(),
+      setAdTagUrl: sinon.spy(),
+    }
+  };
+
+  describe('Register Provider', function () {
+
+  });
+
+  describe('Requires Queuing', function () {
+    it('should be true when provider is not setup', function() {
+      const coordinator = AdQueueCoordinator(mockVideoCoreFactory());
+      coordinator.registerProvider(testId);
+      expect(coordinator.requiresQueueing(testId)).to.be.true;
+    });
+
+    it('should be false when provider is setup', function() {
+      const mockVideoCore = mockVideoCoreFactory();
+      let setupComplete;
+      mockVideoCore.onEvents = function(events, callback, id) {
+        if (events[0] === SETUP_COMPLETE && id === testId) {
+          setupComplete = callback;
+        }
+      };
+      const coordinator = AdQueueCoordinator(mockVideoCore);
+      coordinator.registerProvider(testId);
+      setupComplete({ divId: testId });
+
+      expect(coordinator.requiresQueueing(testId)).to.be.false;
+    });
+  });
+
+  describe('Queue Ad', function () {
+
+  });
+});

--- a/test/spec/modules/videoModule/pbVideo_spec.js
+++ b/test/spec/modules/videoModule/pbVideo_spec.js
@@ -22,7 +22,6 @@ function resetTestVars() {
   ortbContentMock = {};
   videoCoreMock = {
     registerProvider: sinon.spy(),
-    initProvider: sinon.spy(),
     onEvents: sinon.spy(),
     getOrtbVideo: () => ortbVideoMock,
     getOrtbContent: () => ortbContentMock,

--- a/test/spec/modules/videoModule/pbVideo_spec.js
+++ b/test/spec/modules/videoModule/pbVideo_spec.js
@@ -22,6 +22,7 @@ function resetTestVars() {
   ortbContentMock = {};
   videoCoreMock = {
     registerProvider: sinon.spy(),
+    initProvider: sinon.spy(),
     onEvents: sinon.spy(),
     getOrtbVideo: () => ortbVideoMock,
     getOrtbContent: () => ortbContentMock,

--- a/test/spec/modules/videoModule/pbVideo_spec.js
+++ b/test/spec/modules/videoModule/pbVideo_spec.js
@@ -59,7 +59,6 @@ function resetTestVars() {
 
   adQueueCoordinatorMock = {
     registerProvider: sinon.spy(),
-    requiresQueueing: sinon.spy(),
     queueAd: sinon.spy()
   };
 
@@ -262,10 +261,10 @@ describe('Prebid Video', function () {
       pbVideoFactory(null, getConfig, pbGlobal, pbEvents, null, gamSubmoduleFactory);
       beforeBidRequestCallback(() => {}, {});
       auctionEndCallback(auctionResults);
-      expect(videoCoreMock.setAdTagUrl.calledOnce).to.be.true;
-      expect(videoCoreMock.setAdTagUrl.args[0][0]).to.be.equal(expectedAdTag);
-      expect(videoCoreMock.setAdTagUrl.args[0][1]).to.be.equal(expectedDivId);
-      expect(videoCoreMock.setAdTagUrl.args[0][2]).to.have.property('adUnitCode', expectedAdUnitCode);
+      expect(adQueueCoordinatorMock.queueAd.calledOnce).to.be.true;
+      expect(adQueueCoordinatorMock.queueAd.args[0][0]).to.be.equal(expectedAdTag);
+      expect(adQueueCoordinatorMock.queueAd.args[0][1]).to.be.equal(expectedDivId);
+      expect(adQueueCoordinatorMock.queueAd.args[0][2]).to.have.property('adUnitCode', expectedAdUnitCode);
     });
 
     it('should load ad tag from highest bid when ad server is not configured', function () {
@@ -287,72 +286,11 @@ describe('Prebid Video', function () {
       pbVideoFactory(null, () => ({ providers: [] }), pbGlobal, pbEvents);
       beforeBidRequestCallback(() => {}, {});
       auctionEndCallback(auctionResults);
-      expect(videoCoreMock.setAdTagUrl.calledOnce).to.be.true;
-      expect(videoCoreMock.setAdTagUrl.args[0][0]).to.be.equal(expectedVastUrl);
-      expect(videoCoreMock.setAdTagUrl.args[0][1]).to.be.equal(expectedDivId);
-      expect(videoCoreMock.setAdTagUrl.args[0][2]).to.have.property('adUnitCode', expectedAdUnitCode);
-      expect(videoCoreMock.setAdTagUrl.args[0][2]).to.have.property('adXml', expectedVastXml);
-    });
-
-    it('should queue ad when required', function () {
-      const expectedVastUrl = 'expectedVastUrl';
-      const expectedVastXml = 'expectedVastXml';
-      const pbGlobal = Object.assign({}, pbGlobalMock, {
-        requestBids,
-        getHighestCpmBids: () => [{
-          vastUrl: expectedVastUrl,
-          vastXml: expectedVastXml
-        }, {}, {}, {}]
-      });
-      const expectedAdUnit = {
-        code: expectedAdUnitCode,
-        video: { divId: expectedDivId }
-      };
-      const auctionResults = { adUnits: [ expectedAdUnit, {} ] };
-
-      const adQueueCoordinator = Object.assign({}, adQueueCoordinatorMock, { requiresQueueing: () => true });
-      const pbEventsSpy = Object.assign({}, pbEvents, { emit: sinon.spy() });
-
-      pbVideoFactory(null, () => ({ providers: [] }), pbGlobal, pbEventsSpy, null, null, null, adQueueCoordinator);
-      beforeBidRequestCallback(() => {}, {});
-      auctionEndCallback(auctionResults);
-
-      expect(videoCoreMock.setAdTagUrl.called).to.be.false;
-
-      expect(adQueueCoordinator.queueAd.called).to.be.true;
-      const queueAdArgs = adQueueCoordinator.queueAd.firstCall.args;
-      expect(queueAdArgs[0]).to.be.equal(expectedVastUrl);
-      expect(queueAdArgs[1]).to.be.equal(expectedDivId);
-
-      expect(pbEventsSpy.emit.calledOnce).to.be.true;
-      expect(pbEventsSpy.emit.firstCall.args[0]).to.be.equal('videoAuctionAdLoadQueued');
-    });
-
-    it('should load tag when queueing not required', function () {
-      const expectedVastUrl = 'expectedVastUrl';
-      const expectedVastXml = 'expectedVastXml';
-      const pbGlobal = Object.assign({}, pbGlobalMock, {
-        requestBids,
-        getHighestCpmBids: () => [{
-          vastUrl: expectedVastUrl,
-          vastXml: expectedVastXml
-        }, {}, {}, {}]
-      });
-      const expectedAdUnit = {
-        code: expectedAdUnitCode,
-        video: { divId: expectedDivId }
-      };
-      const auctionResults = { adUnits: [ expectedAdUnit, {} ] };
-      const pbEventsSpy = Object.assign({}, pbEvents, { emit: sinon.spy() });
-
-      pbVideoFactory(null, () => ({ providers: [] }), pbGlobal, pbEventsSpy);
-      beforeBidRequestCallback(() => {}, {});
-      auctionEndCallback(auctionResults);
-
-      expect(adQueueCoordinatorMock.queueAd.called).to.be.false;
-      expect(videoCoreMock.setAdTagUrl.called).to.be.true;
-      expect(pbEventsSpy.emit.calledOnce).to.be.true;
-      expect(pbEventsSpy.emit.firstCall.args[0]).to.be.equal('videoAuctionAdLoadAttempt');
+      expect(adQueueCoordinatorMock.queueAd.calledOnce).to.be.true;
+      expect(adQueueCoordinatorMock.queueAd.args[0][0]).to.be.equal(expectedVastUrl);
+      expect(adQueueCoordinatorMock.queueAd.args[0][1]).to.be.equal(expectedDivId);
+      expect(adQueueCoordinatorMock.queueAd.args[0][2]).to.have.property('adUnitCode', expectedAdUnitCode);
+      expect(adQueueCoordinatorMock.queueAd.args[0][2]).to.have.property('adXml', expectedVastXml);
     });
   });
 

--- a/test/spec/modules/videoModule/shared/parentModule_spec.js
+++ b/test/spec/modules/videoModule/shared/parentModule_spec.js
@@ -62,7 +62,6 @@ describe('Submodule Builder', function () {
 
   it('should instantiate the submodule, when supported', function () {
     const submodule = submoduleBuilder.build(vendorCode2);
-    expect(initSpy.calledOnce).to.be.true;
     expect(submodule).to.be.equal(submodule2);
   });
 

--- a/test/spec/modules/videoModule/shared/parentModule_spec.js
+++ b/test/spec/modules/videoModule/shared/parentModule_spec.js
@@ -62,6 +62,7 @@ describe('Submodule Builder', function () {
 
   it('should instantiate the submodule, when supported', function () {
     const submodule = submoduleBuilder.build(vendorCode2);
+    expect(initSpy.calledOnce).to.be.true;
     expect(submodule).to.be.equal(submodule2);
   });
 

--- a/test/spec/modules/videoModule/submodules/jwplayerVideoProvider_spec.js
+++ b/test/spec/modules/videoModule/submodules/jwplayerVideoProvider_spec.js
@@ -14,7 +14,7 @@ import {
   SETUP_COMPLETE, SETUP_FAILED, PLAY, AD_IMPRESSION, videoEvents
 } from 'libraries/video/constants/events.js';
 
-import { PLAYBACK_MODE } from 'libraries/video/constants/enums.js';
+import { PLAYBACK_MODE } from 'libraries/video/constants/constants.js';
 
 function getPlayerMock() {
   return makePlayerFactoryMock({


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
For Auctions executing at page load, a race condition occurs where the auction may resolve  before the player has been instantiated. In order to ensure that the ad is not lost, we are introducing an Ad Queue. 
The Ad Queue will attempt to load the ad when the video provider is done setting up. When a ad break ends, the next ad in the queue will be loaded, until the queue is exhausted. 


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Docs: https://github.com/prebid/prebid.github.io/pull/4138