### PR TITLE
Smartadserver Bid Adapter: add support for SDA user and site

### DIFF
--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -154,7 +154,9 @@ export const spec = {
         timeout: config.getConfig('bidderTimeout'),
         bidId: bid.bidId,
         prebidVersion: '$prebid.version$',
-        schain: spec.serializeSupplyChain(bid.schain)
+        schain: spec.serializeSupplyChain(bid.schain),
+        sda: deepAccess(config, 'ortb2.user.data', deepAccess(bidderRequest, 'ortb2.user.data', undefined)),
+        sdc: deepAccess(config, 'ortb2.site.content.data', deepAccess(bidderRequest, 'ortb2.site.content.data', undefined))
       };
 
       if (bidderRequest && bidderRequest.gdprConsent) {

--- a/modules/smartadserverBidAdapter.js
+++ b/modules/smartadserverBidAdapter.js
@@ -133,6 +133,8 @@ export const spec = {
     // use bidderRequest.bids[] to get bidder-dependent request info
 
     const adServerCurrency = config.getConfig('currency.adServerCurrency');
+    const sellerDefinedAudience = deepAccess(bidderRequest, 'ortb2.user.data', config.getAnyConfig('ortb2.user.data'));
+    const sellerDefinedContext = deepAccess(bidderRequest, 'ortb2.site.content.data', config.getAnyConfig('ortb2.site.content.data'));
 
     // pull requested transaction ID from bidderRequest.bids[].transactionId
     return validBidRequests.reduce((bidRequests, bid) => {
@@ -155,8 +157,8 @@ export const spec = {
         bidId: bid.bidId,
         prebidVersion: '$prebid.version$',
         schain: spec.serializeSupplyChain(bid.schain),
-        sda: deepAccess(config, 'ortb2.user.data', deepAccess(bidderRequest, 'ortb2.user.data', undefined)),
-        sdc: deepAccess(config, 'ortb2.site.content.data', deepAccess(bidderRequest, 'ortb2.site.content.data', undefined))
+        sda: sellerDefinedAudience,
+        sdc: sellerDefinedContext
       };
 
       if (bidderRequest && bidderRequest.gdprConsent) {

--- a/test/spec/modules/smartadserverBidAdapter_spec.js
+++ b/test/spec/modules/smartadserverBidAdapter_spec.js
@@ -158,12 +158,44 @@ describe('Smart bid adapter tests', function () {
     }
   };
 
+  var sellerDefinedAudience = [
+    {
+      'name': 'hearst.com',
+      'ext': { 'segtax': 1 },
+      'segment': [
+        { 'id': '1001' },
+        { 'id': '1002' }
+      ]
+    }
+  ];
+
+  var sellerDefinedContext = [
+    {
+      'name': 'cnn.com',
+      'ext': { 'segtax': 2 },
+      'segment': [
+        { 'id': '2002' }
+      ]
+    }
+  ];
+
   it('Verify build request', function () {
     config.setConfig({
       'currency': {
         'adServerCurrency': 'EUR'
+      },
+      ortb2: {
+        'user': {
+          'data': sellerDefinedAudience
+        },
+        'site': {
+          'content': {
+            'data': sellerDefinedContext
+          }
+        }
       }
     });
+
     const request = spec.buildRequests(DEFAULT_PARAMS);
     expect(request[0]).to.have.property('url').and.to.equal('https://prg.smartadserver.com/prebid/v1');
     expect(request[0]).to.have.property('method').and.to.equal('POST');
@@ -186,6 +218,8 @@ describe('Smart bid adapter tests', function () {
     expect(requestContent).to.have.property('buid').and.to.equal('7569');
     expect(requestContent).to.have.property('appname').and.to.equal('Mozilla');
     expect(requestContent).to.have.property('ckid').and.to.equal(42);
+    expect(requestContent).to.have.property('sda').and.to.deep.equal(sellerDefinedAudience);
+    expect(requestContent).to.have.property('sdc').and.to.deep.equal(sellerDefinedContext);
   });
 
   it('Verify parse response with no ad', function () {
@@ -358,6 +392,7 @@ describe('Smart bid adapter tests', function () {
 
   describe('gdpr tests', function () {
     afterEach(function () {
+      config.setConfig({ ortb2: undefined });
       config.resetConfig();
       $$PREBID_GLOBAL$$.requestBids.removeAll();
     });
@@ -489,6 +524,16 @@ describe('Smart bid adapter tests', function () {
       config.setConfig({
         'currency': {
           'adServerCurrency': 'EUR'
+        },
+        ortb2: {
+          'user': {
+            'data': sellerDefinedAudience
+          },
+          'site': {
+            'content': {
+              'data': sellerDefinedContext
+            }
+          }
         }
       });
       const request = spec.buildRequests(INSTREAM_DEFAULT_PARAMS);
@@ -507,6 +552,8 @@ describe('Smart bid adapter tests', function () {
       expect(requestContent).to.have.property('buid').and.to.equal('7569');
       expect(requestContent).to.have.property('appname').and.to.equal('Mozilla');
       expect(requestContent).to.have.property('ckid').and.to.equal(42);
+      expect(requestContent).to.have.property('sda').and.to.deep.equal(sellerDefinedAudience);
+      expect(requestContent).to.have.property('sdc').and.to.deep.equal(sellerDefinedContext);
       expect(requestContent).to.have.property('isVideo').and.to.equal(true);
       expect(requestContent).to.have.property('videoData');
       expect(requestContent.videoData).to.have.property('videoProtocol').and.to.equal(6);
@@ -748,6 +795,16 @@ describe('Smart bid adapter tests', function () {
       config.setConfig({
         'currency': {
           'adServerCurrency': 'EUR'
+        },
+        ortb2: {
+          'user': {
+            'data': sellerDefinedAudience
+          },
+          'site': {
+            'content': {
+              'data': sellerDefinedContext
+            }
+          }
         }
       });
       const request = spec.buildRequests(OUTSTREAM_DEFAULT_PARAMS);
@@ -766,6 +823,8 @@ describe('Smart bid adapter tests', function () {
       expect(requestContent).to.have.property('buid').and.to.equal('7579');
       expect(requestContent).to.have.property('appname').and.to.equal('Mozilla');
       expect(requestContent).to.have.property('ckid').and.to.equal(43);
+      expect(requestContent).to.have.property('sda').and.to.deep.equal(sellerDefinedAudience);
+      expect(requestContent).to.have.property('sdc').and.to.deep.equal(sellerDefinedContext);
       expect(requestContent).to.have.property('isVideo').and.to.equal(false);
       expect(requestContent).to.have.property('videoData');
       expect(requestContent.videoData).to.have.property('videoProtocol').and.to.equal(7);


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Add support for Seller-defined audience, following IAB standard format in Smartadserver Bid Adapter.
