### PR TITLE
UserId Module : Updated correct variable name while setting cookie

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -240,7 +240,7 @@ export function setStoredValue(submodule, value) {
     const valueStr = isPlainObject(value) ? JSON.stringify(value) : value;
     if (storage.type === COOKIE) {
       const setCookie = cookieSetter(submodule);
-      setCookie(null, value, expiresStr);
+      setCookie(null, valueStr, expiresStr);
       if (typeof storage.refreshInSeconds === 'number') {
         setCookie('_last', new Date().toUTCString(), expiresStr);
       }


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Hi @dgirardi @patmmccann ,
During our testing, we have observed that the cookies are not getting set for TTD, on further investigation we found that in index.js file, the original `value` is set as cookie instead of the `valueStr` (which is already calculated on [line 240](https://github.com/prebid/Prebid.js/blob/master/modules/userId/index.js#L240) but not used in `IF` statement)
We have made the related changes, please have a look at it once.
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
