### PR TITLE
Referer Detection: updated logic for refererInfo.page

### DIFF
--- a/src/refererDetection.js
+++ b/src/refererDetection.js
@@ -120,6 +120,7 @@ export function detectReferer(win) {
     const stack = [];
     const ancestors = getAncestorOrigins(win);
     const maxNestedIframes = config.getConfig('maxNestedIframes');
+
     let currentWindow;
     let bestLocation;
     let bestCanonicalUrl;
@@ -226,7 +227,11 @@ export function detectReferer(win) {
 
     const location = reachedTop || hasTopLocation ? bestLocation : null;
     const canonicalUrl = config.getConfig('pageUrl') || bestCanonicalUrl || null;
-    const page = ensureProtocol(canonicalUrl, win) || location;
+    let page = config.getConfig('pageUrl') || location || ensureProtocol(canonicalUrl, win);
+
+    if (location && location.indexOf('?') > -1 && page.indexOf('?') === -1) {
+      page = `${page}${location.substring(location.indexOf('?'))}`;
+    }
 
     return {
       reachedTop,

--- a/test/spec/modules/enrichmentFpdModule_spec.js
+++ b/test/spec/modules/enrichmentFpdModule_spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import {config} from 'src/config.js';
 import { getRefererInfo } from 'src/refererDetection.js';
 import {processFpd, coreStorage, resetEnrichments} from 'modules/enrichmentFpdModule.js';
 import * as enrichmentModule from 'modules/enrichmentFpdModule.js';
@@ -77,10 +78,10 @@ describe('the first party data enrichment module', function() {
     expect(validated.site.keywords).to.be.undefined;
   });
 
-  it('adds page domain values if canonical url exists', function() {
+  it('adds page domain values if pageUrl url exists', function() {
+    config.setConfig({'pageUrl': 'https://www.subdomain.domain.co.uk/path?query=12345'});
     width = 800;
     height = 500;
-    canonical.href = 'https://www.subdomain.domain.co.uk/path?query=12345';
 
     let validated = syncProcessFpd({}, {}).global;
 

--- a/test/spec/modules/fpdModule_spec.js
+++ b/test/spec/modules/fpdModule_spec.js
@@ -130,7 +130,7 @@ describe('the first party data module', function () {
         }
       };
 
-      canonical.href = 'https://www.domain.com/path?query=12345';
+      config.setConfig({'pageUrl': 'https://www.domain.com/path?query=12345'});
       width = 1120;
       height = 750;
 

--- a/test/spec/refererDetection_spec.js
+++ b/test/spec/refererDetection_spec.js
@@ -128,9 +128,47 @@ describe('Referer detection', () => {
           numIframes: 0,
           stack: ['https://example.com/some/page'],
           canonicalUrl: 'https://example.com/canonical/page',
-          page: 'https://example.com/canonical/page',
+          page: 'https://example.com/some/page',
           ref: 'https://othersite.com/',
           domain: 'example.com'
+        });
+      });
+
+      it('Should set page and canonical to pageUrl value set in config if present, even if canonical url is also present in head', () => {
+        config.setConfig({'pageUrl': 'https://www.set-from-config.com/path'});
+        const testWindow = buildWindowTree(['https://example.com/some/page'], 'https://othersite.com/', 'https://example.com/canonical/page'),
+          result = detectReferer(testWindow)();
+
+        sinon.assert.match(result, {
+          topmostLocation: 'https://example.com/some/page',
+          location: 'https://example.com/some/page',
+          reachedTop: true,
+          isAmp: false,
+          numIframes: 0,
+          stack: ['https://example.com/some/page'],
+          canonicalUrl: 'https://www.set-from-config.com/path',
+          page: 'https://www.set-from-config.com/path',
+          ref: 'https://othersite.com/',
+          domain: 'www.set-from-config.com'
+        });
+      });
+
+      it('Should set page with query params if canonical url is present without query params but the current page does have them', () => {
+        config.setConfig({'pageUrl': 'https://www.set-from-config.com/path'});
+        const testWindow = buildWindowTree(['https://example.com/some/page?query1=123&query2=456'], 'https://othersite.com/', 'https://example.com/canonical/page'),
+          result = detectReferer(testWindow)();
+
+        sinon.assert.match(result, {
+          topmostLocation: 'https://example.com/some/page?query1=123&query2=456',
+          location: 'https://example.com/some/page?query1=123&query2=456',
+          reachedTop: true,
+          isAmp: false,
+          numIframes: 0,
+          stack: ['https://example.com/some/page?query1=123&query2=456'],
+          canonicalUrl: 'https://www.set-from-config.com/path',
+          page: 'https://www.set-from-config.com/path?query1=123&query2=456',
+          ref: 'https://othersite.com/',
+          domain: 'www.set-from-config.com'
         });
       });
     });
@@ -174,7 +212,7 @@ describe('Referer detection', () => {
             'https://example.com/third/page'
           ],
           canonicalUrl: 'https://example.com/canonical/page',
-          page: 'https://example.com/canonical/page',
+          page: 'https://example.com/some/page',
           ref: 'https://othersite.com/',
           domain: 'example.com'
         });
@@ -317,7 +355,7 @@ describe('Referer detection', () => {
           'https://ad-iframe.ampproject.org/ad'
         ],
         canonicalUrl: 'https://example.com/some/page/',
-        page: 'https://example.com/some/page/',
+        page: 'https://example.com/some/page/amp/',
         ref: null,
         domain: 'example.com'
       });
@@ -344,7 +382,7 @@ describe('Referer detection', () => {
           'https://ad-iframe.ampproject.org/ad'
         ],
         canonicalUrl: 'https://example.com/some/page/',
-        page: 'https://example.com/some/page/',
+        page: 'https://example.com/some/page/amp/',
         ref: null,
         domain: 'example.com'
       });
@@ -384,7 +422,7 @@ describe('Referer detection', () => {
             'https://ad-iframe.ampproject.org/ad'
           ],
           canonicalUrl: 'https://example.com/some/page/',
-          page: 'https://example.com/some/page/',
+          page: 'https://example.com/some/page/amp/',
           ref: null,
           domain: 'example.com',
         });
@@ -412,7 +450,7 @@ describe('Referer detection', () => {
             'https://ad-iframe.ampproject.org/ad'
           ],
           canonicalUrl: 'https://example.com/some/page/',
-          page: 'https://example.com/some/page/',
+          page: 'https://example.com/some/page/amp/',
           ref: null,
           domain: 'example.com'
         });
@@ -441,7 +479,7 @@ describe('Referer detection', () => {
             'https://ad-iframe.ampproject.org/ad'
           ],
           canonicalUrl: 'https://example.com/some/page/',
-          page: 'https://example.com/some/page/',
+          page: 'https://example.com/some/page/amp/',
           ref: null,
           domain: 'example.com',
         });


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
- updated refererInfo.page logic to be --> getConfig('pageUrl') || refererInfo.location || refererInfo.canonicalUrl
- added support to append query params pageUrl if they are absent but present on location url
- updated/created relative tests

## Other information
Github Issue: xhttps://github.com/prebid/Prebid.js/issues/9185
@dgirardi @patmmccann could you review?  Followed the thread on the issue page, let me know if I missed anything or something should change.
