### PR TITLE
Currency Module : cpm should be always a number

### DIFF
--- a/modules/currency.js
+++ b/modules/currency.js
@@ -204,7 +204,7 @@ export const addBidResponseHook = timedBidResponseHook('currency', function addB
 
   // used for analytics
   bid.getCpmInNewCurrency = function(toCurrency) {
-    return (parseFloat(this.cpm) * getCurrencyConversion(this.currency, toCurrency)).toFixed(3);
+    return Number((parseFloat(this.cpm) * getCurrencyConversion(this.currency, toCurrency)).toFixed(3));
   };
 
   // execute immediately if the bid is already in the desired currency
@@ -234,7 +234,7 @@ function wrapFunction(fn, context, params) {
       try {
         let conversion = getCurrencyConversion(fromCurrency);
         if (conversion !== 1) {
-          bid.cpm = (parseFloat(bid.cpm) * conversion).toFixed(4);
+          bid.cpm = Number((parseFloat(bid.cpm) * conversion).toFixed(4));
           bid.currency = adServerCurrency;
         }
       } catch (e) {


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Set cpm to number, as the cpm from bidResponse has to be a number and not a string.
![image](https://user-images.githubusercontent.com/43609048/201778327-8d723376-ad29-4cd9-b226-39e8ed8592bd.png)


## Other information
Tested on prebid 7.22.0 and 7.26.0
