### PR TITLE
Improve digital bid adapter: do not set `device.sua` in request

### DIFF
--- a/modules/improvedigitalBidAdapter.js
+++ b/modules/improvedigitalBidAdapter.js
@@ -162,6 +162,8 @@ export const CONVERTER = ortbConverter({
         }
       },
     });
+    // Remove 2.6 device.sua; see #9250
+    delete request.device?.sua;
     return request;
   },
   bidResponse(buildBidResponse, bid, context) {

--- a/test/spec/modules/improvedigitalBidAdapter_spec.js
+++ b/test/spec/modules/improvedigitalBidAdapter_spec.js
@@ -824,6 +824,11 @@ describe('Improve Digital Adapter Tests', function () {
       request = spec.buildRequests([bidRequest], bidderRequestWithConsent)[0];
       expect(request.url).to.equal(AD_SERVER_URL);
     });
+
+    it('should not set device.sua in request', () => {
+      const req = JSON.parse(spec.buildRequests([simpleBidRequest], {...bidderRequest, ortb2: {device: {sua: {source: 1}}}})[0].data);
+      expect(req?.device?.sua).to.not.exist;
+    })
   });
 
   const serverResponse = {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Temporary fix for #9250 - ID endpoint does not accept 2.6 fields such as `device.sua`

@jbartek25 
