### PR TITLE
Glomex Bid Adapter: add GVL id

### DIFF
--- a/modules/glomexBidAdapter.js
+++ b/modules/glomexBidAdapter.js
@@ -4,9 +4,11 @@ import {BANNER} from '../src/mediaTypes.js';
 
 const ENDPOINT = 'https://prebid.mes.glomex.cloud/request-bid'
 const BIDDER_CODE = 'glomex'
+const GVLID = 967
 
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVLID,
   supportedMediaTypes: [BANNER],
 
   isBidRequestValid: function (bid) {

--- a/test/spec/modules/glomexBidAdapter_spec.js
+++ b/test/spec/modules/glomexBidAdapter_spec.js
@@ -49,6 +49,10 @@ const RESPONSE = {
 describe('glomexBidAdapter', function () {
   const adapter = newBidder(spec)
 
+  it('should expose gvlid', function() {
+    expect(spec.gvlid).to.equal(967)
+  });
+
   describe('inherited functions', function () {
     it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function')


### PR DESCRIPTION
## Type of change
- [x] Feature: expose glomex GVL id 967 on adapter

## Description of change
We are registered as IAB vendor with ID 967 and our prebid adapter should use this ID so that the prebid GDPR modules can take this information into account.