### PR TITLE
Fluct Bid Adapter: add schain support

### DIFF
--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -62,6 +62,11 @@ export const spec = {
       });
 
       data.params = request.params;
+
+      if (request.schain) {
+        data.schain = request.schain;
+      }
+
       const searchParams = new URLSearchParams({
         dfpUnitCode: request.params.dfpUnitCode,
         tagId: request.params.tagId,

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -94,6 +94,11 @@ describe('fluctAdapter', function () {
       expect(request.data.params.kv).to.eql(undefined);
     });
 
+    it('includes no data.schain by default', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.schain).to.eql(undefined);
+    });
+
     it('includes filtered user.eids if any exists', function () {
       const bidRequests2 = bidRequests.map(
         (bidReq) => Object.assign(bidReq, {
@@ -173,6 +178,37 @@ describe('fluctAdapter', function () {
       const request = spec.buildRequests(bidRequests2, bidderRequest)[0];
       expect(request.data.params.kv).to.eql({
         imsids: ['imsid1', 'imsid2']
+      });
+    });
+
+    it('includes data.schain if any exists', function () {
+      // this should be done by schain.js
+      const bidRequests2 = bidRequests.map(
+        (bidReq) => Object.assign(bidReq, {
+          schain: {
+            ver: '1.0',
+            complete: 1,
+            nodes: [
+              {
+                asi: 'example.com',
+                sid: 'publisher-id',
+                hp: 1
+              }
+            ]
+          }
+        })
+      );
+      const request = spec.buildRequests(bidRequests2, bidderRequest)[0];
+      expect(request.data.schain).to.eql({
+        ver: '1.0',
+        complete: 1,
+        nodes: [
+          {
+            asi: 'example.com',
+            sid: 'publisher-id',
+            hp: 1
+          }
+        ]
       });
     });
   });

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -99,7 +99,7 @@ describe('fluctAdapter', function () {
       expect(request.data.schain).to.eql(undefined);
     });
 
-    it('includes filtered user.eids if any exists', function () {
+    it('includes filtered user.eids if any exist', function () {
       const bidRequests2 = bidRequests.map(
         (bidReq) => Object.assign(bidReq, {
           userIdAsEids: [


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->

- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->

Attach a `schain` object to a bid request if configured.

<img width="709" alt="スクリーンショット 2022-11-21 17 38 27" src="https://user-images.githubusercontent.com/213709/203007158-f5a40575-f576-429a-9c31-c7ff1c2179a6.png">
 

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
