### PR TITLE
TTD Bid Adapter: add support for regs.gpp

### DIFF
--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -38,7 +38,7 @@ function getRegs(bidderRequest) {
   if (utils.deepAccess(bidderRequest, 'ortb2.regs.coppa') === 1 || config.getConfig('coppa') === true) {
     regs.coppa = 1;
   }
-  if (utils.deepAccess(bidderRequest, 'ortb2.regs.gpp') && utils.deepAccess(bidderRequest, 'ortb2.regs.gpp') === 'string') {
+  if (utils.deepAccess(bidderRequest, 'ortb2.regs.gpp') && typeof utils.deepAccess(bidderRequest, 'ortb2.regs.gpp') === 'string') {
     utils.deepSetValue(regs, 'gpp', utils.deepAccess(bidderRequest, 'ortb2.regs.gpp'));
   }
   if (utils.deepAccess(bidderRequest, 'ortb2.regs.gpp_sid') && Array.isArray(utils.deepAccess(bidderRequest, 'ortb2.regs.gpp_sid'))) {

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -40,7 +40,7 @@ function getRegs(bidderRequest) {
   }
   if (bidderRequest.ortb2.regs && bidderRequest.ortb2.regs.length) {
     regs = utils.mergeDeep(regs, bidderRequest.ortb2.regs);
-  };
+  }
 
   return regs;
 }

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -38,7 +38,7 @@ function getRegs(bidderRequest) {
   if (config.getConfig('coppa') === true) {
     regs.coppa = 1;
   }
-  if (bidderRequest.ortb2.regs) {
+  if (bidderRequest.ortb2.regs && bidderRequest.ortb2.regs.length) {
     regs = utils.mergeDeep(regs, bidderRequest.ortb2.regs);
   };
 

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -38,7 +38,7 @@ function getRegs(bidderRequest) {
   if (config.getConfig('coppa') === true) {
     regs.coppa = 1;
   }
-  if (bidderRequest.ortb2.regs && bidderRequest.ortb2.regs.length) {
+  if (bidderRequest.ortb2.regs) {
     regs = utils.mergeDeep(regs, bidderRequest.ortb2.regs);
   }
 

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -38,7 +38,7 @@ function getRegs(bidderRequest) {
   if (config.getConfig('coppa') === true) {
     regs.coppa = 1;
   }
-  if(bidderRequest.ortb2.regs) {
+  if (bidderRequest.ortb2.regs) {
     regs = utils.mergeDeep(regs, bidderRequest.ortb2.regs);
   };
 

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -38,7 +38,7 @@ function getRegs(bidderRequest) {
   if (utils.deepAccess(bidderRequest, 'ortb2.regs.coppa') === 1 || config.getConfig('coppa') === true) {
     regs.coppa = 1;
   }
-  if (utils.deepAccess(bidderRequest, 'ortb2.regs.gpp') && utils.deepAccess(bidderRequest, 'ortb2.regs.gpp') === 'string')) {
+  if (utils.deepAccess(bidderRequest, 'ortb2.regs.gpp') && utils.deepAccess(bidderRequest, 'ortb2.regs.gpp') === 'string') {
     utils.deepSetValue(regs, 'gpp', utils.deepAccess(bidderRequest, 'ortb2.regs.gpp'));
   }
   if (utils.deepAccess(bidderRequest, 'ortb2.regs.gpp_sid') && Array.isArray(utils.deepAccess(bidderRequest, 'ortb2.regs.gpp_sid'))) {

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -39,7 +39,7 @@ function getRegs(bidderRequest) {
     regs.coppa = 1;
   }
   if (bidderRequest.ortb2.regs) {
-    regs = utils.mergeDeep(regs, bidderRequest.ortb2.regs);
+    utils.mergeDeep(regs, bidderRequest.ortb2.regs);
   }
 
   return regs;

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -35,8 +35,14 @@ function getRegs(bidderRequest) {
   if (bidderRequest.uspConsent) {
     utils.deepSetValue(regs, 'ext.us_privacy', bidderRequest.uspConsent);
   }
-  if (config.getConfig('coppa') === true) {
+  if (utils.deepAccess(bidderRequest, 'ortb2.regs.coppa') === 1 || config.getConfig('coppa') === true) {
     regs.coppa = 1;
+  }
+  if (utils.deepAccess(bidderRequest, 'ortb2.regs.gpp') && utils.deepAccess(bidderRequest, 'ortb2.regs.gpp') === 'string')) {
+    utils.deepSetValue(regs, 'gpp', utils.deepAccess(bidderRequest, 'ortb2.regs.gpp'));
+  }
+  if (utils.deepAccess(bidderRequest, 'ortb2.regs.gpp_sid') && Array.isArray(utils.deepAccess(bidderRequest, 'ortb2.regs.gpp_sid'))) {
+    utils.deepSetValue(regs, 'gpp_sid', utils.deepAccess(bidderRequest, 'ortb2.regs.gpp_sid'));
   }
   return regs;
 }

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -38,7 +38,7 @@ function getRegs(bidderRequest) {
   if (config.getConfig('coppa') === true) {
     regs.coppa = 1;
   }
-  if (bidderRequest.ortb2.regs) {
+  if (bidderRequest.ortb2?.regs) {
     utils.mergeDeep(regs, bidderRequest.ortb2.regs);
   }
 

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -35,15 +35,13 @@ function getRegs(bidderRequest) {
   if (bidderRequest.uspConsent) {
     utils.deepSetValue(regs, 'ext.us_privacy', bidderRequest.uspConsent);
   }
-  if (utils.deepAccess(bidderRequest, 'ortb2.regs.coppa') === 1 || config.getConfig('coppa') === true) {
+  if (config.getConfig('coppa') === true) {
     regs.coppa = 1;
   }
-  if (utils.deepAccess(bidderRequest, 'ortb2.regs.gpp') && typeof utils.deepAccess(bidderRequest, 'ortb2.regs.gpp') === 'string') {
-    utils.deepSetValue(regs, 'gpp', utils.deepAccess(bidderRequest, 'ortb2.regs.gpp'));
-  }
-  if (utils.deepAccess(bidderRequest, 'ortb2.regs.gpp_sid') && Array.isArray(utils.deepAccess(bidderRequest, 'ortb2.regs.gpp_sid'))) {
-    utils.deepSetValue(regs, 'gpp_sid', utils.deepAccess(bidderRequest, 'ortb2.regs.gpp_sid'));
-  }
+  if(bidderRequest.ortb2.regs) {
+    regs = utils.mergeDeep(regs, bidderRequest.ortb2.regs);
+  };
+
   return regs;
 }
 

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -403,7 +403,7 @@ describe('ttdBidAdapter', function () {
     it('adds gpp consent info to the request', function () {
       let clonedBidderRequest = deepClone(baseBidderRequest);
 
-      config.setConfig({ortb2: {regs: {gpp: 'somegppstring', gpp_sid: [6, 7] }}});
+      config.setConfig({ortb2: {regs: {gpp:'somegppstring', gpp_sid: [6, 7] }}});
       const requestBody = testBuildRequests(baseBannerBidRequests, clonedBidderRequest).data;
       config.resetConfig();
       expect(requestBody.regs.gpp).to.equal('somegppstring');

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -411,7 +411,7 @@ describe('ttdBidAdapter', function () {
       const requestBody = testBuildRequests(baseBannerBidRequests, clonedBidderRequest).data;
       config.resetConfig();
       expect(requestBody.regs.gpp).to.equal('somegppstring');
-      expect(requestBody.regs.gpp_sid).to.equal([6, 7]);
+      expect(requestBody.regs.gpp_sid).to.eql([6, 7]);
     });
 
     it('adds schain info to the request', function () {

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -403,11 +403,11 @@ describe('ttdBidAdapter', function () {
     it('adds gpp consent info to the request', function () {
       let clonedBidderRequest = deepClone(baseBidderRequest);
 
-      config.setConfig(pbjs.setConfig({ ortb2: { regs: { gpp: 'somegppstring', gpp_sid: [6,7] }}}));
+      config.setConfig(pbjs.setConfig({ortb2: {regs: {gpp: 'somegppstring', gpp_sid: [6, 7] }}}));
       const requestBody = testBuildRequests(baseBannerBidRequests, clonedBidderRequest).data;
       config.resetConfig();
       expect(requestBody.regs.gpp).to.equal('somegppstring');
-      expect(requestBody.regs.gpp_sid).to.equal([6,7]);
+      expect(requestBody.regs.gpp_sid).to.equal([6, 7]);
     });
 
     it('adds schain info to the request', function () {

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -403,7 +403,7 @@ describe('ttdBidAdapter', function () {
     it('adds gpp consent info to the request', function () {
       let clonedBidderRequest = deepClone(baseBidderRequest);
 
-      config.setConfig(pbjs.setConfig({ortb2: {regs: {gpp: 'somegppstring', gpp_sid: [6, 7] }}}));
+      config.setConfig({ortb2: {regs: {gpp: 'somegppstring', gpp_sid: [6, 7] }}});
       const requestBody = testBuildRequests(baseBannerBidRequests, clonedBidderRequest).data;
       config.resetConfig();
       expect(requestBody.regs.gpp).to.equal('somegppstring');

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -401,9 +401,13 @@ describe('ttdBidAdapter', function () {
     });
 
     it('adds gpp consent info to the request', function () {
-      let clonedBidderRequest = deepClone(baseBidderRequest);
-
-      config.setConfig({ortb2:{regs:{gpp:'somegppstring', gpp_sid: [6, 7] }}});
+      const ortb2 = {
+        regs: {
+          gpp: 'somegppstring',
+          gpp_sid: [6, 7]
+        }
+      };
+      let clonedBidderRequest = {...deepClone(baseBidderRequest), ortb2};
       const requestBody = testBuildRequests(baseBannerBidRequests, clonedBidderRequest).data;
       config.resetConfig();
       expect(requestBody.regs.gpp).to.equal('somegppstring');

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -403,7 +403,7 @@ describe('ttdBidAdapter', function () {
     it('adds gpp consent info to the request', function () {
       let clonedBidderRequest = deepClone(baseBidderRequest);
 
-      config.setConfig({ortb2: {regs: {gpp:'somegppstring', gpp_sid: [6, 7] }}});
+      config.setConfig({ortb2:{regs:{gpp:'somegppstring', gpp_sid: [6, 7] }}});
       const requestBody = testBuildRequests(baseBannerBidRequests, clonedBidderRequest).data;
       config.resetConfig();
       expect(requestBody.regs.gpp).to.equal('somegppstring');

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -400,6 +400,16 @@ describe('ttdBidAdapter', function () {
       expect(requestBody.regs.coppa).to.equal(1);
     });
 
+    it('adds gpp consent info to the request', function () {
+      let clonedBidderRequest = deepClone(baseBidderRequest);
+
+      config.setConfig(pbjs.setConfig({ ortb2: { regs: { gpp: 'somegppstring', gpp_sid: [6,7] }}}));
+      const requestBody = testBuildRequests(baseBannerBidRequests, clonedBidderRequest).data;
+      config.resetConfig();
+      expect(requestBody.regs.gpp).to.equal('somegppstring');
+      expect(requestBody.regs.gpp_sid).to.equal([6,7]);
+    });
+
     it('adds schain info to the request', function () {
       const schain = {
         'ver': '1.0',


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->

- [X] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

While we don't yet have a GPP module as described in #8991 ; publishers (or perhaps even CMPs?) may already be setting the gpp string as per https://github.com/InteractiveAdvertisingBureau/openrtb2.x/pull/22 via setConfig eg

` pbjs.setConfig({
   ortb2: {
       regs: {
           gpp: ...,
           gpp_sid: ...
}}})`

This PR supports that scenario, as well as the case where the module puts the string in the same location