### PR TITLE
use-convention-for-bidfloor-extraction

### DIFF
--- a/modules/taboolaBidAdapter.js
+++ b/modules/taboolaBidAdapter.js
@@ -170,15 +170,24 @@ function getSiteProperties({publisherId, bcat = []}, refererInfo) {
 
 function getImps(validBidRequests) {
   return validBidRequests.map((bid, id) => {
-    const {tagId, bidfloor = null, bidfloorcur = CURRENCY} = bid.params;
-
-    return {
+    const {tagId} = bid.params;
+    const imp = {
       id: id + 1,
       banner: getBanners(bid),
-      tagid: tagId,
-      bidfloor,
-      bidfloorcur,
-    };
+      tagid: tagId
+    }
+    if (typeof bid.getFloor === 'function') {
+      const floorInfo = bid.getFloor({
+        currency: CURRENCY,
+        mediaType: BANNER,
+        size: '*'
+      });
+      if (typeof floorInfo === 'object' && floorInfo.currency === CURRENCY && !isNaN(parseFloat(floorInfo.floor))) {
+        imp.bidfloor = parseFloat(floorInfo.floor);
+        imp.bidfloorcur = CURRENCY;
+      }
+    }
+    return imp;
   });
 }
 

--- a/test/spec/modules/taboolaBidAdapter_spec.js
+++ b/test/spec/modules/taboolaBidAdapter_spec.js
@@ -121,8 +121,6 @@ describe('Taboola Adapter', function () {
             ]
           },
           'tagid': commonBidRequest.params.tagId,
-          'bidfloor': null,
-          'bidfloorcur': 'USD'
         }],
         'site': {
           'id': commonBidRequest.params.publisherId,
@@ -148,23 +146,6 @@ describe('Taboola Adapter', function () {
 
       expect(res.url).to.equal(`${END_POINT_URL}/${commonBidRequest.params.publisherId}`);
       expect(res.data).to.deep.equal(JSON.stringify(expectedData));
-    });
-
-    it('should pass optional parameters in request', function () {
-      const optionalParams = {
-        bidfloor: 0.25,
-        bidfloorcur: 'EUR'
-      };
-
-      const bidRequest = {
-        ...defaultBidRequest,
-        params: {...commonBidRequest.params, ...optionalParams}
-      };
-
-      const res = spec.buildRequests([bidRequest], commonBidderRequest);
-      const resData = JSON.parse(res.data);
-      expect(resData.imp[0].bidfloor).to.deep.equal(0.25);
-      expect(resData.imp[0].bidfloorcur).to.deep.equal('EUR');
     });
 
     it('should pass bidder timeout', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
accepting the bid floor by calling the getFloors() function instead of bidder-specific parameter.
https://github.com/prebid/Prebid.js/issues/9275