### PR TITLE
Adagio Bid Adapter: external script loading improvement

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -38,7 +38,8 @@ const LOG_PREFIX = 'Adagio:';
 const FEATURES_VERSION = '1';
 export const ENDPOINT = 'https://mp.4dex.io/prebid';
 const SUPPORTED_MEDIA_TYPES = [BANNER, NATIVE, VIDEO];
-const ADAGIO_TAG_URL = 'https://script.4dex.io/localstore.js';
+const ADAGIO_TAG_URL = 'https://script.4dex.io/adagio.js';
+const ADAGIO_CACHE_TAG_URL = 'https://script.4dex.io/localstore.js';
 const ADAGIO_LOCALSTORAGE_KEY = 'adagioScript';
 const GVLID = 617;
 export const storage = getStorageManager({gvlid: GVLID, bidderCode: BIDDER_CODE});
@@ -177,7 +178,7 @@ export function getAdagioScript() {
 
   storage.localStorageIsEnabled(isValid => {
     if (isValid) {
-      loadExternalScript(ADAGIO_TAG_URL, BIDDER_CODE);
+      loadExternalScript(ADAGIO_CACHE_TAG_URL, BIDDER_CODE);
     } else {
       // Try-catch to avoid error when 3rd party cookies is disabled (e.g. in privacy mode)
       try {
@@ -191,6 +192,8 @@ export function getAdagioScript() {
       } catch (e) {
         logInfo(`${LOG_PREFIX} unable to clear Adagio scripts from localstorage.`);
       }
+
+      loadExternalScript(ADAGIO_TAG_URL, BIDDER_CODE);
     }
   });
 }

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -1521,6 +1521,8 @@ describe('Adagio bid adapter', () => {
     const VALID_SCRIPT_CONTENT = 'var _ADAGIO=function(){};(_ADAGIO)();\n';
     const INVALID_SCRIPT_CONTENT = 'var _ADAGIO=function(){//corrupted};(_ADAGIO)();\n';
     const ADAGIO_LOCALSTORAGE_KEY = 'adagioScript';
+    const ADAGIO_TAG_URL = 'https://script.4dex.io/adagio.js';
+    const ADAGIO_CACHE_TAG_URL = 'https://script.4dex.io/localstore.js';
 
     beforeEach(function() {
       localStorage.removeItem(ADAGIO_LOCALSTORAGE_KEY);
@@ -1538,18 +1540,20 @@ describe('Adagio bid adapter', () => {
         sinon.assert.callCount(adagio.adagioScriptFromLocalStorageCb, 1);
       });
 
-      it('should load external script if the user consent', function() {
+      it('should load localstore.js external script if the user consent', function() {
         sandbox.stub(storage, 'localStorageIsEnabled').callsArgWith(0, true);
         getAdagioScript();
 
         expect(loadExternalScript.called).to.be.true;
+        sinon.assert.calledWith(loadExternalScript, ADAGIO_CACHE_TAG_URL);
       });
 
-      it('should not load external script if the user does not consent', function() {
+      it('should load adagio.js external script if the user does not consent', function() {
         sandbox.stub(storage, 'localStorageIsEnabled').callsArgWith(0, false);
         getAdagioScript();
 
-        expect(loadExternalScript.called).to.be.false;
+        expect(loadExternalScript.called).to.be.true;
+        sinon.assert.calledWith(loadExternalScript, ADAGIO_TAG_URL);
       });
 
       it('should remove the localStorage key if exists and the user does not consent', function() {
@@ -1558,7 +1562,6 @@ describe('Adagio bid adapter', () => {
 
         getAdagioScript();
 
-        expect(loadExternalScript.called).to.be.false;
         expect(localStorage.getItem(ADAGIO_LOCALSTORAGE_KEY)).to.be.null;
       });
     });


### PR DESCRIPTION
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
This PR is about to ensure our external script is loaded when we cannot use localStorage.
Note that we DON'T use LocalStorage, the script is loaded and executed, but it is never cached.
