### PR TITLE
Revert "Bump live-connect version"

### DIFF
--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -10,6 +10,7 @@ import { submodule } from '../src/hook.js';
 import { LiveConnect } from 'live-connect-js/esm/initializer.js';
 import { gdprDataHandler, uspDataHandler } from '../src/adapterManager.js';
 import { getStorageManager } from '../src/storageManager.js';
+import { MinimalLiveConnect } from 'live-connect-js/esm/minimal-live-connect.js';
 
 const MODULE_NAME = 'liveIntentId';
 export const storage = getStorageManager({gvlid: null, moduleName: MODULE_NAME});
@@ -139,7 +140,7 @@ export const liveIntentIdSubmodule = {
     this.moduleMode = mode
   },
   getInitializer() {
-    return (liveConnectConfig, storage, calls) => LiveConnect(liveConnectConfig, storage, calls, this.moduleMode)
+    return this.moduleMode === 'minimal' ? MinimalLiveConnect : LiveConnect
   },
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "express": "^4.15.4",
         "fun-hooks": "^0.9.9",
         "just-clone": "^1.0.2",
-        "live-connect-js": "3.0.1"
+        "live-connect-js": "2.4.0"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.16.5",
@@ -16229,9 +16229,9 @@
       "dev": true
     },
     "node_modules/live-connect-js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-3.0.1.tgz",
-      "integrity": "sha512-rwB0IQfuKPJM+I96nLyq8Utr3LkQ7Z/iuq/xKlWDckQRJLYyWkk7F7yaavf/VsjazzLK2dpJeXGijoDkK4Vz8g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-2.4.0.tgz",
+      "integrity": "sha512-MSBLKfnXoxH+pqwji/Mf8yZu3VZMq4tnNfwMw7NTWN5a+TBM6f0RWgwui1YMA3nHmMhX/nzxxsso0SkyKcF0fA==",
       "dependencies": {
         "tiny-hashes": "1.0.1"
       },
@@ -37868,9 +37868,9 @@
       "dev": true
     },
     "live-connect-js": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-3.0.1.tgz",
-      "integrity": "sha512-rwB0IQfuKPJM+I96nLyq8Utr3LkQ7Z/iuq/xKlWDckQRJLYyWkk7F7yaavf/VsjazzLK2dpJeXGijoDkK4Vz8g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-2.4.0.tgz",
+      "integrity": "sha512-MSBLKfnXoxH+pqwji/Mf8yZu3VZMq4tnNfwMw7NTWN5a+TBM6f0RWgwui1YMA3nHmMhX/nzxxsso0SkyKcF0fA==",
       "requires": {
         "tiny-hashes": "1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "express": "^4.15.4",
     "fun-hooks": "^0.9.9",
     "just-clone": "^1.0.2",
-    "live-connect-js": "3.0.1"
+    "live-connect-js": "2.4.0"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"


### PR DESCRIPTION
Reverts prebid/Prebid.js#9317

This deletes an important feature, live connect minimal mode. Please document why you'd like to like to do this as well as summarize changes in the build dependency 

Appears to be a breaking change? 