### PR TITLE
Taboola Bid Adapter: fix multiple impressions bug 

### DIFF
--- a/modules/taboolaBidAdapter.js
+++ b/modules/taboolaBidAdapter.js
@@ -167,7 +167,7 @@ export const spec = {
       return [];
     }
 
-    return bids.map((bid, id) => getBid(bid.bidId, currency, bidResponses[id])).filter(Boolean);
+    return bidResponses.map((bidResponse) => getBid(bids, currency, bidResponse)).filter(Boolean);
   },
 };
 
@@ -224,7 +224,7 @@ function getBidResponses({body}) {
 
   const {seatbid, cur} = body;
 
-  if (!seatbid.length || !seatbid[0].bid) {
+  if (!seatbid.length || !seatbid[0].bid || !seatbid[0].bid.length) {
     return [];
   }
 
@@ -234,7 +234,7 @@ function getBidResponses({body}) {
   };
 }
 
-function getBid(requestId, currency, bidResponse) {
+function getBid(bids, currency, bidResponse) {
   if (!bidResponse) {
     return;
   }
@@ -243,6 +243,7 @@ function getBid(requestId, currency, bidResponse) {
     price: cpm, crid: creativeId, adm: ad, w: width, h: height, adomain: advertiserDomains, meta = {}
   } = bidResponse;
 
+  let requestId = bids[bidResponse.impid - 1].bidId;
   if (advertiserDomains && advertiserDomains.length > 0) {
     meta.advertiserDomains = advertiserDomains
   }

--- a/test/spec/modules/taboolaBidAdapter_spec.js
+++ b/test/spec/modules/taboolaBidAdapter_spec.js
@@ -4,7 +4,7 @@ import {config} from '../../../src/config'
 import * as utils from '../../../src/utils'
 
 describe('Taboola Adapter', function () {
-  let hasLocalStorage, cookiesAreEnabled, getDataFromLocalStorage, localStorageIsEnabled, getCookie;
+  let hasLocalStorage, cookiesAreEnabled, getDataFromLocalStorage, localStorageIsEnabled, getCookie, commonBidRequest;
 
   beforeEach(() => {
     hasLocalStorage = sinon.stub(userData.storageManager, 'hasLocalStorage');
@@ -13,6 +13,7 @@ describe('Taboola Adapter', function () {
     getDataFromLocalStorage = sinon.stub(userData.storageManager, 'getDataFromLocalStorage');
     localStorageIsEnabled = sinon.stub(userData.storageManager, 'localStorageIsEnabled');
 
+    commonBidRequest = createBidRequest();
     $$PREBID_GLOBAL$$.bidderSettings = {
       taboola: {
         storageAllowed: true
@@ -30,19 +31,19 @@ describe('Taboola Adapter', function () {
     $$PREBID_GLOBAL$$.bidderSettings = {};
   })
 
-  const commonBidRequest = {
+  const displayBidRequestParams = {
+    sizes: [[300, 250], [300, 600]]
+  }
+
+  const createBidRequest = () => ({
     bidder: 'taboola',
     params: {
       publisherId: 'publisherId',
       tagId: 'placement name'
     },
-    bidId: 'aa43860a-4644-442a-b5e0-93f268cs4d19',
-    auctionId: '65746dca-26f3-4186-be13-dfa63469b1b7',
-  }
-
-  const displayBidRequestParams = {
-    sizes: [[300, 250], [300, 600]]
-  }
+    bidId: utils.generateUUID(),
+    auctionId: utils.generateUUID(),
+  });
 
   describe('isBidRequestValid', function () {
     it('should fail when bid is invalid - tagId isn`t defined', function () {
@@ -93,7 +94,7 @@ describe('Taboola Adapter', function () {
 
   describe('buildRequests', function () {
     const defaultBidRequest = {
-      ...commonBidRequest,
+      ...createBidRequest(),
       ...displayBidRequestParams,
     }
 
@@ -360,6 +361,105 @@ describe('Taboola Adapter', function () {
       expect(res).to.be.an('array').that.is.empty
 
       overriddenServerResponse.body.seatbid[0].bid = bid;
+    });
+
+    it('should interpret multi impression request', function () {
+      const multiRequest = {
+        bids: [
+          {
+            ...createBidRequest(),
+            ...displayBidRequestParams
+          },
+          {
+            ...createBidRequest(),
+            ...displayBidRequestParams
+          }
+        ]
+      }
+
+      const multiServerResponse = {
+        body: {
+          'id': '49ffg4d58ef9a163a69fhgfghd4fad03621b9e036f24f7_15',
+          'seatbid': [
+            {
+              'bid': [
+                {
+                  'id': '0b3dd94348-134b-435f-8db5-6bf5afgfc39e86c',
+                  'impid': '2',
+                  'price': 0.342068,
+                  'adid': '2785119545551083381',
+                  'adm': 'ADM2',
+                  'adomain': [
+                    'example.xyz'
+                  ],
+                  'cid': '15744349',
+                  'crid': '278195503434041083381',
+                  'w': 300,
+                  'h': 250,
+                  'exp': 60,
+                  'lurl': 'http://us-trc.taboola.com/sample'
+                },
+                {
+                  'id': '0b3dd94348-134b-435f-8db5-6bf5afgfc39e86c',
+                  'impid': '1',
+                  'price': 0.342068,
+                  'adid': '2785119545551083381',
+                  'adm': 'ADM1',
+                  'adomain': [
+                    'example.xyz'
+                  ],
+                  'cid': '15744349',
+                  'crid': '278195503434041083381',
+                  'w': 300,
+                  'h': 250,
+                  'exp': 60,
+                  'lurl': 'http://us-trc.taboola.com/sample'
+                }
+              ],
+              'seat': '14204545260'
+            }
+          ],
+          'bidid': 'da43860a-4644-442a-b5e0-93f268cf8d19',
+          'cur': 'USD'
+        }
+      };
+
+      const [bid] = multiServerResponse.body.seatbid[0].bid;
+      const expectedRes = [
+        {
+          requestId: multiRequest.bids[1].bidId,
+          cpm: bid.price,
+          creativeId: bid.crid,
+          ttl: 60,
+          netRevenue: true,
+          currency: multiServerResponse.body.cur,
+          mediaType: 'banner',
+          ad: multiServerResponse.body.seatbid[0].bid[0].adm,
+          width: bid.w,
+          height: bid.h,
+          meta: {
+            'advertiserDomains': bid.adomain
+          },
+        },
+        {
+          requestId: multiRequest.bids[0].bidId,
+          cpm: bid.price,
+          creativeId: bid.crid,
+          ttl: 60,
+          netRevenue: true,
+          currency: multiServerResponse.body.cur,
+          mediaType: 'banner',
+          ad: multiServerResponse.body.seatbid[0].bid[1].adm,
+          width: bid.w,
+          height: bid.h,
+          meta: {
+            'advertiserDomains': bid.adomain
+          },
+        }
+      ]
+
+      const res = spec.interpretResponse(multiServerResponse, multiRequest)
+      expect(res).to.deep.equal(expectedRes)
     });
 
     it('should interpret display response', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Fix handling of multi-impression requests. 
This fix was approved from 7.x versions and above and we would like to commit this essential push to 6.X versions so publishers may simply build the new 6 master branch and deploy. 
