### PR TITLE
Prebid Server: Include adUnitCode in PBS Adapter Requests

### DIFF
--- a/libraries/pbsExtensions/processors/adUnitCode.js
+++ b/libraries/pbsExtensions/processors/adUnitCode.js
@@ -1,0 +1,27 @@
+import {auctionManager} from '../../../src/auctionManager.js';
+import {deepSetValue} from '../../../src/utils.js';
+
+export function setImpAdUnitCode(imp, bidRequest, context, { adUnit, index = auctionManager.index } = {}) {
+  // eslint-disable-next-line no-console
+  console.log('imp: ', imp);
+  // eslint-disable-next-line no-console
+  console.log('bidRequest: ', bidRequest);
+  // eslint-disable-next-line no-console
+  console.log('context: ', context);
+  // eslint-disable-next-line no-console
+  console.log('adUnit: ', adUnit);
+  // eslint-disable-next-line no-console
+  console.log('index.getAdUnit(bidRequest): ', index.getAdUnit(bidRequest));
+  // eslint-disable-next-line no-console
+  console.log('index: ', index);
+
+  adUnit = adUnit || index.getAdUnit(bidRequest);
+
+  if (adUnit) {
+    deepSetValue(
+      imp,
+      `ext.prebid.adunitcode`,
+      adUnit.code
+    );
+  }
+}

--- a/libraries/pbsExtensions/processors/adUnitCode.js
+++ b/libraries/pbsExtensions/processors/adUnitCode.js
@@ -1,14 +1,13 @@
-import {auctionManager} from '../../../src/auctionManager.js';
 import {deepSetValue} from '../../../src/utils.js';
 
-export function setImpAdUnitCode(imp, bidRequest, context, { adUnit, index = auctionManager.index } = {}) {
-  adUnit = adUnit || index.getAdUnit(bidRequest);
+export function setImpAdUnitCode(imp, bidRequest) {
+  const adUnitCode = bidRequest.adUnitCode;
 
-  if (adUnit) {
+  if (adUnitCode) {
     deepSetValue(
       imp,
       `ext.prebid.adunitcode`,
-      adUnit.code
+      adUnitCode
     );
   }
 }

--- a/libraries/pbsExtensions/processors/adUnitCode.js
+++ b/libraries/pbsExtensions/processors/adUnitCode.js
@@ -2,19 +2,6 @@ import {auctionManager} from '../../../src/auctionManager.js';
 import {deepSetValue} from '../../../src/utils.js';
 
 export function setImpAdUnitCode(imp, bidRequest, context, { adUnit, index = auctionManager.index } = {}) {
-  // eslint-disable-next-line no-console
-  console.log('imp: ', imp);
-  // eslint-disable-next-line no-console
-  console.log('bidRequest: ', bidRequest);
-  // eslint-disable-next-line no-console
-  console.log('context: ', context);
-  // eslint-disable-next-line no-console
-  console.log('adUnit: ', adUnit);
-  // eslint-disable-next-line no-console
-  console.log('index.getAdUnit(bidRequest): ', index.getAdUnit(bidRequest));
-  // eslint-disable-next-line no-console
-  console.log('index: ', index);
-
   adUnit = adUnit || index.getAdUnit(bidRequest);
 
   if (adUnit) {

--- a/libraries/pbsExtensions/processors/pbs.js
+++ b/libraries/pbsExtensions/processors/pbs.js
@@ -3,6 +3,7 @@ import {deepAccess, isPlainObject, isStr, mergeDeep} from '../../../src/utils.js
 import {extPrebidMediaType} from './mediaType.js';
 import {setRequestExtPrebidAliases} from './aliases.js';
 import {setImpBidParams} from './params.js';
+import {setImpAdUnitCode} from './adUnitCode.js';
 import {setRequestExtPrebid, setRequestExtPrebidChannel} from './requestExtPrebid.js';
 import {setBidResponseVideoCache} from './video.js';
 
@@ -26,6 +27,10 @@ export const PBS_PROCESSORS = {
       // sets bid ext.prebid.bidder.[bidderCode] with bidRequest.params, passed through transformBidParams if necessary
       fn: setImpBidParams
     },
+    adUnitCode: {
+      // sets bid ext.prebid.adunitcode
+      fn: setImpAdUnitCode
+    }
   },
   [BID_RESPONSE]: {
     mediaType: {

--- a/libraries/pbsExtensions/processors/pbs.js
+++ b/libraries/pbsExtensions/processors/pbs.js
@@ -28,7 +28,7 @@ export const PBS_PROCESSORS = {
       fn: setImpBidParams
     },
     adUnitCode: {
-      // sets bid ext.prebid.adunitcode
+      // sets bid ext.prebid.adunitc ode
       fn: setImpAdUnitCode
     }
   },

--- a/libraries/pbsExtensions/processors/pbs.js
+++ b/libraries/pbsExtensions/processors/pbs.js
@@ -28,7 +28,7 @@ export const PBS_PROCESSORS = {
       fn: setImpBidParams
     },
     adUnitCode: {
-      // sets bid ext.prebid.adunitc ode
+      // sets bid ext.prebid.adunitcode
       fn: setImpAdUnitCode
     }
   },

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -423,14 +423,10 @@ function getConsentData(bidRequests) {
  * Bidder adapter for Prebid Server
  */
 export function PrebidServer() {
-  // eslint-disable-next-line no-console
-  console.log('PrebidServer func invoked');
   const baseAdapter = new Adapter('prebidServer');
 
   /* Prebid executes this function when the page asks to send out bid requests */
   baseAdapter.callBids = function(s2sBidRequest, bidRequests, addBidResponse, done, ajax) {
-    // eslint-disable-next-line no-console
-    console.log('baseAdapter.callBids func invoked');
     const adapterMetrics = s2sBidRequest.metrics = useMetrics(deepAccess(bidRequests, '0.metrics'))
       .newMetrics()
       .renameWith((n) => [`adapter.s2s.${n}`, `adapters.s2s.${s2sBidRequest.s2sConfig.defaultVendor}.${n}`])
@@ -440,11 +436,7 @@ export function PrebidServer() {
     let { gdprConsent, uspConsent } = getConsentData(bidRequests);
 
     if (Array.isArray(_s2sConfigs)) {
-      // eslint-disable-next-line no-console
-      console.log('_s2sConfigs is an array');
       if (s2sBidRequest.s2sConfig && s2sBidRequest.s2sConfig.syncEndpoint && getMatchingConsentUrl(s2sBidRequest.s2sConfig.syncEndpoint, gdprConsent)) {
-        // eslint-disable-next-line no-console
-        console.log('all is true: s2sBidRequest.s2sConfig && s2sBidRequest.s2sConfig.syncEndpoint && getMatchingConsentUrl(s2sBidRequest.s2sConfig.syncEndpoint, gdprConsent)');
         let syncBidders = s2sBidRequest.s2sConfig.bidders
           .map(bidder => adapterManager.aliasRegistry[bidder] || bidder)
           .filter((bidder, index, array) => (array.indexOf(bidder) === index));
@@ -454,11 +446,7 @@ export function PrebidServer() {
 
       processPBSRequest(s2sBidRequest, bidRequests, ajax, {
         onResponse: function (isValid, requestedBidders) {
-          // eslint-disable-next-line no-console
-          console.log('onResponse func invoked');
           if (isValid) {
-            // eslint-disable-next-line no-console
-            console.log('isValid is true');
             bidRequests.forEach(bidderRequest => events.emit(CONSTANTS.EVENTS.BIDDER_DONE, bidderRequest));
           }
           done();
@@ -466,30 +454,18 @@ export function PrebidServer() {
         },
         onError: done,
         onBid: function ({adUnit, bid}) {
-          // eslint-disable-next-line no-console
-          console.log('onBid func invoked');
           const metrics = bid.metrics = s2sBidRequest.metrics.fork().renameWith();
           metrics.checkpoint('addBidResponse');
           if ((bid.requestId == null || bid.requestBidder == null) && !s2sBidRequest.s2sConfig.allowUnknownBidderCodes) {
-            // eslint-disable-next-line no-console
-            console.log('this criteria was met: (bid.requestId == null || bid.requestBidder == null) && !s2sBidRequest.s2sConfig.allowUnknownBidderCodes');
             logWarn(`PBS adapter received bid from unknown bidder (${bid.bidder}), but 's2sConfig.allowUnknownBidderCodes' is not set. Ignoring bid.`);
             addBidResponse.reject(adUnit, bid, CONSTANTS.REJECTION_REASON.BIDDER_DISALLOWED);
           } else {
-            // eslint-disable-next-line no-console
-            console.log('this criteria was NOT met: (bid.requestId == null || bid.requestBidder == null) && !s2sBidRequest.s2sConfig.allowUnknownBidderCodes');
             if (metrics.measureTime('addBidResponse.validate', () => isValid(adUnit, bid))) {
-              // eslint-disable-next-line no-console
-              console.log("this criteria was met: metrics.measureTime('addBidResponse.validate', () => isValid(adUnit, bid))");
               addBidResponse(adUnit, bid);
               if (bid.pbsWurl) {
-                // eslint-disable-next-line no-console
-                console.log('this criteria was met: bid.pbsWurl');
                 addWurl(bid.auctionId, bid.adId, bid.pbsWurl);
               }
             } else {
-              // eslint-disable-next-line no-console
-              console.log("this criteria was NOT met: metrics.measureTime('addBidResponse.validate', () => isValid(adUnit, bid))");
               addBidResponse.reject(adUnit, bid, CONSTANTS.REJECTION_REASON.INVALID);
             }
           }
@@ -519,8 +495,6 @@ export function PrebidServer() {
  * @param onBid {function({})} invoked once for each bid in the response - with the bid as returned by interpretResponse
  */
 export const processPBSRequest = hook('sync', function (s2sBidRequest, bidRequests, ajax, {onResponse, onError, onBid}) {
-  // eslint-disable-next-line no-console
-  console.log('processPBSRequest func invoked');
   let { gdprConsent } = getConsentData(bidRequests);
   const adUnits = deepClone(s2sBidRequest.ad_units);
 

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -423,10 +423,14 @@ function getConsentData(bidRequests) {
  * Bidder adapter for Prebid Server
  */
 export function PrebidServer() {
+  // eslint-disable-next-line no-console
+  console.log('PrebidServer func invoked');
   const baseAdapter = new Adapter('prebidServer');
 
   /* Prebid executes this function when the page asks to send out bid requests */
   baseAdapter.callBids = function(s2sBidRequest, bidRequests, addBidResponse, done, ajax) {
+    // eslint-disable-next-line no-console
+    console.log('baseAdapter.callBids func invoked');
     const adapterMetrics = s2sBidRequest.metrics = useMetrics(deepAccess(bidRequests, '0.metrics'))
       .newMetrics()
       .renameWith((n) => [`adapter.s2s.${n}`, `adapters.s2s.${s2sBidRequest.s2sConfig.defaultVendor}.${n}`])
@@ -436,7 +440,11 @@ export function PrebidServer() {
     let { gdprConsent, uspConsent } = getConsentData(bidRequests);
 
     if (Array.isArray(_s2sConfigs)) {
+      // eslint-disable-next-line no-console
+      console.log('_s2sConfigs is an array');
       if (s2sBidRequest.s2sConfig && s2sBidRequest.s2sConfig.syncEndpoint && getMatchingConsentUrl(s2sBidRequest.s2sConfig.syncEndpoint, gdprConsent)) {
+        // eslint-disable-next-line no-console
+        console.log('all is true: s2sBidRequest.s2sConfig && s2sBidRequest.s2sConfig.syncEndpoint && getMatchingConsentUrl(s2sBidRequest.s2sConfig.syncEndpoint, gdprConsent)');
         let syncBidders = s2sBidRequest.s2sConfig.bidders
           .map(bidder => adapterManager.aliasRegistry[bidder] || bidder)
           .filter((bidder, index, array) => (array.indexOf(bidder) === index));
@@ -446,7 +454,11 @@ export function PrebidServer() {
 
       processPBSRequest(s2sBidRequest, bidRequests, ajax, {
         onResponse: function (isValid, requestedBidders) {
+          // eslint-disable-next-line no-console
+          console.log('onResponse func invoked');
           if (isValid) {
+            // eslint-disable-next-line no-console
+            console.log('isValid is true');
             bidRequests.forEach(bidderRequest => events.emit(CONSTANTS.EVENTS.BIDDER_DONE, bidderRequest));
           }
           done();
@@ -454,18 +466,30 @@ export function PrebidServer() {
         },
         onError: done,
         onBid: function ({adUnit, bid}) {
+          // eslint-disable-next-line no-console
+          console.log('onBid func invoked');
           const metrics = bid.metrics = s2sBidRequest.metrics.fork().renameWith();
           metrics.checkpoint('addBidResponse');
           if ((bid.requestId == null || bid.requestBidder == null) && !s2sBidRequest.s2sConfig.allowUnknownBidderCodes) {
+            // eslint-disable-next-line no-console
+            console.log('this criteria was met: (bid.requestId == null || bid.requestBidder == null) && !s2sBidRequest.s2sConfig.allowUnknownBidderCodes');
             logWarn(`PBS adapter received bid from unknown bidder (${bid.bidder}), but 's2sConfig.allowUnknownBidderCodes' is not set. Ignoring bid.`);
             addBidResponse.reject(adUnit, bid, CONSTANTS.REJECTION_REASON.BIDDER_DISALLOWED);
           } else {
+            // eslint-disable-next-line no-console
+            console.log('this criteria was NOT met: (bid.requestId == null || bid.requestBidder == null) && !s2sBidRequest.s2sConfig.allowUnknownBidderCodes');
             if (metrics.measureTime('addBidResponse.validate', () => isValid(adUnit, bid))) {
+              // eslint-disable-next-line no-console
+              console.log("this criteria was met: metrics.measureTime('addBidResponse.validate', () => isValid(adUnit, bid))");
               addBidResponse(adUnit, bid);
               if (bid.pbsWurl) {
+                // eslint-disable-next-line no-console
+                console.log('this criteria was met: bid.pbsWurl');
                 addWurl(bid.auctionId, bid.adId, bid.pbsWurl);
               }
             } else {
+              // eslint-disable-next-line no-console
+              console.log("this criteria was NOT met: metrics.measureTime('addBidResponse.validate', () => isValid(adUnit, bid))");
               addBidResponse.reject(adUnit, bid, CONSTANTS.REJECTION_REASON.INVALID);
             }
           }
@@ -495,6 +519,8 @@ export function PrebidServer() {
  * @param onBid {function({})} invoked once for each bid in the response - with the bid as returned by interpretResponse
  */
 export const processPBSRequest = hook('sync', function (s2sBidRequest, bidRequests, ajax, {onResponse, onError, onBid}) {
+  // eslint-disable-next-line no-console
+  console.log('processPBSRequest func invoked');
   let { gdprConsent } = getConsentData(bidRequests);
   const adUnits = deepClone(s2sBidRequest.ad_units);
 

--- a/modules/prebidServerBidAdapter/ortbConverter.js
+++ b/modules/prebidServerBidAdapter/ortbConverter.js
@@ -246,6 +246,7 @@ export function buildPBSRequest(s2sBidRequest, bidderRequests, adUnits, requeste
     impIds.add(impId)
     proxyBidRequests.push({
       ...adUnit,
+      adUnitCode: adUnit.code,
       ...getDefinedParams(actualBidRequests.values().next().value || {}, ['userId', 'userIdAsEids', 'schain']),
       pbsData: {impId, actualBidRequests, adUnit}
     });

--- a/test/spec/ortbConverter/pbsExtensions/adUnitCode_spec.js
+++ b/test/spec/ortbConverter/pbsExtensions/adUnitCode_spec.js
@@ -1,0 +1,46 @@
+import {setImpAdUnitCode} from '../../../../libraries/pbsExtensions/processors/adUnitCode.js';
+
+describe('pbjs -> ortb adunit code to imp[].ext.prebid.adunitcode', () => {
+  let index, adUnit, adUnitObj;
+  beforeEach(() => {
+    adUnit = '';
+    adUnitObj = {code: 'mockAdUnit'};
+    index = {
+      getAdUnit() {
+        return adUnitObj;
+      }
+    }
+  });
+
+  function setImp(bidRequest, context, deps = {}) {
+    const imp = {};
+    setImpAdUnitCode(imp, bidRequest, context, Object.assign({adUnit, index}, deps))
+    return imp;
+  }
+
+  it('falls back to index.getAdUnit if adUnit is not present to set adunitcode in ext.prebid.adunitcode', () => {
+    expect(setImp({bidder: 'mockBidder'})).to.eql({
+      'ext': {
+        'prebid': {
+          'adunitcode': 'mockAdUnit'
+        }
+      }
+    })
+  });
+
+  it('overrides index.getAdUnit if adUnit is present to set adunitcode in ext.prebid.adunitcode', () => {
+    adUnit = {code: 'mockAdUnit2'};
+    expect(setImp({bidder: 'mockBidder'})).to.eql({
+      'ext': {
+        'prebid': {
+          'adunitcode': 'mockAdUnit2'
+        }
+      }
+    })
+  });
+
+  it('does not set adunitcode in ext.prebid.adunitcode if adUnit is undefined', () => {
+    adUnitObj = undefined;
+    expect(setImp({bidder: 'mockBidder'})).to.eql({});
+  });
+});

--- a/test/spec/ortbConverter/pbsExtensions/adUnitCode_spec.js
+++ b/test/spec/ortbConverter/pbsExtensions/adUnitCode_spec.js
@@ -1,25 +1,14 @@
 import {setImpAdUnitCode} from '../../../../libraries/pbsExtensions/processors/adUnitCode.js';
 
 describe('pbjs -> ortb adunit code to imp[].ext.prebid.adunitcode', () => {
-  let index, adUnit, adUnitObj;
-  beforeEach(() => {
-    adUnit = '';
-    adUnitObj = {code: 'mockAdUnit'};
-    index = {
-      getAdUnit() {
-        return adUnitObj;
-      }
-    }
-  });
-
-  function setImp(bidRequest, context, deps = {}) {
+  function setImp(bidRequest) {
     const imp = {};
-    setImpAdUnitCode(imp, bidRequest, context, Object.assign({adUnit, index}, deps))
+    setImpAdUnitCode(imp, bidRequest);
     return imp;
   }
 
-  it('falls back to index.getAdUnit if adUnit is not present to set adunitcode in ext.prebid.adunitcode', () => {
-    expect(setImp({bidder: 'mockBidder'})).to.eql({
+  it('it sets adunitcode in ext.prebid.adunitcode when adUnitCode is present', () => {
+    expect(setImp({bidder: 'mockBidder', adUnitCode: 'mockAdUnit'})).to.eql({
       'ext': {
         'prebid': {
           'adunitcode': 'mockAdUnit'
@@ -28,19 +17,7 @@ describe('pbjs -> ortb adunit code to imp[].ext.prebid.adunitcode', () => {
     })
   });
 
-  it('overrides index.getAdUnit if adUnit is present to set adunitcode in ext.prebid.adunitcode', () => {
-    adUnit = {code: 'mockAdUnit2'};
-    expect(setImp({bidder: 'mockBidder'})).to.eql({
-      'ext': {
-        'prebid': {
-          'adunitcode': 'mockAdUnit2'
-        }
-      }
-    })
-  });
-
   it('does not set adunitcode in ext.prebid.adunitcode if adUnit is undefined', () => {
-    adUnitObj = undefined;
     expect(setImp({bidder: 'mockBidder'})).to.eql({});
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
- Now including ad unit codes under `imp[].ext.prebid.adunitcode` when sending PBS requests

## Other information
Related Issue: https://github.com/prebid/Prebid.js/issues/9024
