### PR TITLE
Prebid Core: getHighestCpmCallback should use parseFloat

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -738,10 +738,10 @@ export const getLatestHighestCpmBid = getHighestCpmCallback('responseTimestamp',
 
 function getHighestCpmCallback(useTieBreakerProperty, tieBreakerCallback) {
   return (previous, current) => {
-    if (previous.cpm === current.cpm) {
+    if (parseFloat(previous.cpm) === parseFloat(current.cpm)) {
       return tieBreakerCallback(previous[useTieBreakerProperty], current[useTieBreakerProperty]) ? current : previous;
     }
-    return previous.cpm < current.cpm ? current : previous;
+    return parseFloat(previous.cpm) < parseFloat(current.cpm) ? current : previous;
   }
 }
 

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -916,6 +916,30 @@ describe('targeting tests', function () {
   }); // end getAllTargeting without bids return empty object
 
   describe('Targeting in concurrent auctions', function () {
+    describe('check topBid', function () {
+      it('should select highest bid as top bid properly even when cpm object is mixed type (string/number)', function () {
+        let bidsReceived = [
+          createBidReceived({bidder: 'appnexus', cpm: '100', auctionId: '1', responseTimestamp: 100, adUnitCode: 'cpm-all-strings', adId: 'adid-1'}),
+          createBidReceived({bidder: 'rubicon', cpm: '200', auctionId: '1', responseTimestamp: 101, adUnitCode: 'cpm-all-strings', adId: 'adid-2'}),
+          createBidReceived({bidder: 'criteo', cpm: '5', auctionId: '1', responseTimestamp: 102, adUnitCode: 'cpm-all-strings', adId: 'adid-3'}),
+          createBidReceived({bidder: 'appnexus', cpm: 100, auctionId: '2', responseTimestamp: 103, adUnitCode: 'cpm-all-number', adId: 'adid-4'}),
+          createBidReceived({bidder: 'rubicon', cpm: 200, auctionId: '2', responseTimestamp: 104, adUnitCode: 'cpm-all-number', adId: 'adid-5'}),
+          createBidReceived({bidder: 'criteo', cpm: 5, auctionId: '2', responseTimestamp: 105, adUnitCode: 'cpm-all-number', adId: 'adid-6'}),
+          createBidReceived({bidder: 'appnexus', cpm: '100', auctionId: '3', responseTimestamp: 103, adUnitCode: 'cpm-mixed-string-number', adId: 'adid-7'}),
+          createBidReceived({bidder: 'rubicon', cpm: 200, auctionId: '3', responseTimestamp: 104, adUnitCode: 'cpm-mixed-string-number', adId: 'adid-8'}),
+          createBidReceived({bidder: 'criteo', cpm: 5, auctionId: '3', responseTimestamp: 105, adUnitCode: 'cpm-mixed-string-number', adId: 'adid-9'}),
+        ];
+        let adUnitCodes = ['cpm-all-strings', 'cpm-all-number', 'cpm-mixed-string-number'];
+
+        let bids = targetingInstance.getWinningBids(adUnitCodes, bidsReceived);
+
+        expect(bids.length).to.equal(3);
+        expect(bids[0].adId).to.equal('adid-2');
+        expect(bids[1].adId).to.equal('adid-5');
+        expect(bids[2].adId).to.equal('adid-8');
+      });
+    });
+
     describe('check getOldestBid', function () {
       let bidExpiryStub;
       let auctionManagerStub;


### PR DESCRIPTION
## Type of change
Bugfix

## Description of change
getHighestCpmCallback should use parseFloat in case of variable type is mixed up (string/number). It looks the currency module converts new cpm as type:strings, and I think some bidders use type:strings as their cpm object. So, it would be safe way to use parseFloat to cast the cpm to type:number before comparing. Otherwise, something unexpected comparison like below happened.

```
if ( '13736.3679' < '5.7143' ) {
    console.log('true');
} else {
    console.log('false')
}

true
```

## Other information
- Fixes #9343
- Unit test case works as below. Please ignore, failed test case at `setTargetingForAst`. 

- Before Update Test Case:
```
$ gulp serve-and-test --file test/spec/unit/core/targeting_spec.js

...(snip)...

SUMMARY:
✔ 49 tests completed
✖ 1 test failed

FAILED TESTS:
  targeting tests
    setTargetingForAst
      ✖ "before each" hook for "should set single addUnit code"
        Chrome Headless 108.0.5359.98 (Mac OS 10.15.6)
      Error: Trying to stub property 'setKeywords' of undefined
          at throwOnFalsyObject (node_modules/sinon/pkg/sinon.js:3017:15)
          at stub (node_modules/sinon/pkg/sinon.js:2849:24)
          at Object.stub (node_modules/sinon/pkg/sinon.js:879:33)
          at Context.<anonymous> (/var/folders/t0/jkh30nk50tldvrd0l4mknylm0000gn/T/_karma_webpack_905263/commons.js:12874:28)
```

- After Update Test Case: My test case failed as expected
```
SUMMARY:
✔ 49 tests completed
✖ 2 tests failed

FAILED TESTS:
  targeting tests
    Targeting in concurrent auctions
      check topBid
        ✖ should select highest bid as top bid properly even when cpm object is mixed type (string/number)
          Chrome Headless 108.0.5359.98 (Mac OS 10.15.6)
        AssertionError: expected 'adid-3' to equal 'adid-2'

      + expected - actual

      -adid-3
      +adid-2

    at Context.<anonymous> (/var/folders/t0/jkh30nk50tldvrd0l4mknylm0000gn/T/_karma_webpack_743625/commons.js:12439:44)


    setTargetingForAst
      ✖ "before each" hook for "should set single addUnit code"
        Chrome Headless 108.0.5359.98 (Mac OS 10.15.6)
      Error: Trying to stub property 'setKeywords' of undefined
          at throwOnFalsyObject (node_modules/sinon/pkg/sinon.js:3017:15)
          at stub (node_modules/sinon/pkg/sinon.js:2849:24)
          at Object.stub (node_modules/sinon/pkg/sinon.js:879:33)
          at Context.<anonymous> (/var/folders/t0/jkh30nk50tldvrd0l4mknylm0000gn/T/_karma_webpack_743625/commons.js:12948:28)
```

- After Update `utils.js#getHighestCpmCallback`: My test case passed as expected
```
SUMMARY:
✔ 50 tests completed
✖ 1 test failed

FAILED TESTS:
  targeting tests
    setTargetingForAst
      ✖ "before each" hook for "should set single addUnit code"
        Chrome Headless 108.0.5359.98 (Mac OS 10.15.6)
      Error: Trying to stub property 'setKeywords' of undefined
          at throwOnFalsyObject (node_modules/sinon/pkg/sinon.js:3017:15)
          at stub (node_modules/sinon/pkg/sinon.js:2849:24)
          at Object.stub (node_modules/sinon/pkg/sinon.js:879:33)
          at Context.<anonymous> (/var/folders/t0/jkh30nk50tldvrd0l4mknylm0000gn/T/_karma_webpack_892377/commons.js:12948:28)
```