### PR TITLE
Build system: set up `hook` for tests

### DIFF
--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -110,7 +110,7 @@ module.exports = function(codeCoverage, browserstack, watchMode, file, disableFe
   var webpackConfig = newWebpackConfig(codeCoverage, disableFeatures);
   var plugins = newPluginsArray(browserstack);
 
-  var files = file ? ['test/test_deps.js', file].flatMap(f => f) : ['test/test_index.js'];
+  var files = file ? ['test/test_deps.js', file, 'test/helpers/hookSetup.js'].flatMap(f => f) : ['test/test_index.js'];
   // This file opens the /debug.html tab automatically.
   // It has no real value unless you're running --watch, and intend to do some debugging in the browser.
   if (watchMode) {

--- a/test/helpers/hookSetup.js
+++ b/test/helpers/hookSetup.js
@@ -1,0 +1,5 @@
+import {hook} from '../../src/hook.js';
+
+before(() => {
+  hook.ready();
+});


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes

## Description of change

This adds some global test setup to make functionality that depends on hooks (such as `storageManager`) work during tests. 

Normally a test run would do this already, indirectly through `pbjs.processQueue()`; but if one runs only a single spec file that does not import the Prebid machinery itself, tests fail as in #9348.



## Other information

Closes #9348
