### PR TITLE
Prebid core: filter adUnits (by `adUnitCodes`) before sending them to RTD and FPD modules

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -628,6 +628,13 @@ $$PREBID_GLOBAL$$.requestBids = (function() {
     events.emit(REQUEST_BIDS);
     const cbTimeout = timeout || config.getConfig('bidderTimeout');
     logInfo('Invoking $$PREBID_GLOBAL$$.requestBids', arguments);
+    if (adUnitCodes && adUnitCodes.length) {
+      // if specific adUnitCodes supplied filter adUnits for those codes
+      adUnits = adUnits.filter(unit => includes(adUnitCodes, unit.code));
+    } else {
+      // otherwise derive adUnitCodes from adUnits
+      adUnitCodes = adUnits && adUnits.map(unit => unit.code);
+    }
     const ortb2Fragments = {
       global: mergeDeep({}, config.getAnyConfig('ortb2') || {}, ortb2 || {}),
       bidder: Object.fromEntries(Object.entries(config.getBidderConfig()).map(([bidder, cfg]) => [bidder, cfg.ortb2]).filter(([_, ortb2]) => ortb2 != null))
@@ -659,14 +666,6 @@ $$PREBID_GLOBAL$$.requestBids = (function() {
 export const startAuction = hook('async', function ({ bidsBackHandler, timeout: cbTimeout, adUnits, ttlBuffer, adUnitCodes, labels, auctionId, ortb2Fragments, metrics, defer } = {}) {
   const s2sBidders = getS2SBidderSet(config.getConfig('s2sConfig') || []);
   adUnits = useMetrics(metrics).measureTime('requestBids.validate', () => checkAdUnitSetup(adUnits));
-
-  if (adUnitCodes && adUnitCodes.length) {
-    // if specific adUnitCodes supplied filter adUnits for those codes
-    adUnits = adUnits.filter(unit => includes(adUnitCodes, unit.code));
-  } else {
-    // otherwise derive adUnitCodes from adUnits
-    adUnitCodes = adUnits && adUnits.map(unit => unit.code);
-  }
 
   function auctionDone(bids, timedOut, auctionId) {
     if (typeof bidsBackHandler === 'function') {

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1810,6 +1810,16 @@ describe('Unit: Prebid Module', function () {
         })
       });
 
+      it('filtering adUnits by adUnitCodes', () => {
+        $$PREBID_GLOBAL$$.requestBids({
+          adUnits: [{code: 'one'}, {code: 'two'}],
+          adUnitCodes: 'two'
+        });
+        sinon.assert.calledWith(startAuctionStub, sinon.match({
+          adUnits: [{code: 'two'}]
+        }));
+      });
+
       it('passing bidder-specific FPD as ortb2Fragments.bidder', () => {
         configObj.setBidderConfig({
           bidders: ['bidderA', 'bidderC'],
@@ -1869,6 +1879,7 @@ describe('Unit: Prebid Module', function () {
           mediaTypes: {banner: {sizes: [[300, 250]]}},
           bids: [{bidder: 'bd'}]
         }],
+        adUnitCodes: ['au'],
         ortb2Fragments
       });
       sinon.assert.calledWith(newAuctionStub, sinon.match({


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

This changes the input of RTD and FPD modules so that they only see adUnits that are included in the auction. This is to help prevent them from accidentally working on adUnits that are not relevant - as dissussed [here](https://github.com/prebid/Prebid.js/issues/9141).

## Other information
Closes https://github.com/prebid/Prebid.js/issues/9141

