### PR TITLE
Yieldlab Bid Adapter: read and pass UserIdsAsEids atype information

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -306,17 +306,17 @@ function createUserIdString(eids) {
 
 /**
  * Creates a string from an array of eids with ID provider and atype if atype exists
- * @param {Array} eids
+ * @param {Array.<{source: String, uids: Array.<{id: String, atype: Number, ext: Object}>}>} eids
  * @returns {String} idprovider:atype,idprovider2:atype2,...
  */
 function createUserIdAtypesString(eids) {
-  const str = []
+  const str = [];
   for (let i = 0; i < eids.length; i++) {
     if (eids[i].uids[0].atype) {
-      str.push(eids[i].source + ':' + eids[i].uids[0].atype)
+      str.push(eids[i].source + ':' + eids[i].uids[0].atype);
     }
   }
-  return str.join(',')
+  return str.join(',');
 }
 
 /**

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -62,6 +62,7 @@ export const spec = {
       }
       if (bid.userIdAsEids && Array.isArray(bid.userIdAsEids)) {
         query.ids = createUserIdString(bid.userIdAsEids)
+        query.atypes = createUserIdAtypesString(bid.userIdAsEids)
       }
       if (bid.params.customParams && isPlainObject(bid.params.customParams)) {
         for (const prop in bid.params.customParams) {
@@ -299,6 +300,21 @@ function createUserIdString(eids) {
   const str = []
   for (let i = 0; i < eids.length; i++) {
     str.push(eids[i].source + ':' + eids[i].uids[0].id)
+  }
+  return str.join(',')
+}
+
+/**
+ * Creates a string from an array of eids with ID provider and atype if atype exists
+ * @param {Array} eids
+ * @returns {String} idprovider:atype,idprovider2:atype2,...
+ */
+function createUserIdAtypesString(eids) {
+  const str = []
+  for (let i = 0; i < eids.length; i++) {
+    if (eids[i].uids[0].atype) {
+      str.push(eids[i].source + ':' + eids[i].uids[0].atype)
+    }
   }
   return str.join(',')
 }

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -45,6 +45,12 @@ const DEFAULT_REQUEST = () => ({
       id: 'fH5A3n2O8_CZZyPoJVD-eabc6ECb7jhxCicsds7qSg',
       atype: 1
     }]
+  }, {
+    source: 'digitrust.de',
+    uids: [{
+      id: 'd8aa10fa-d86c-451d-aad8-5f16162a9e64',
+      atype: 2
+    }]
   }],
   schain: {
     ver: '1.0',
@@ -271,7 +277,11 @@ describe('yieldlabBidAdapter', () => {
       })
 
       it('passes userids to bid request', () => {
-        expect(request.url).to.include('ids=netid.de%3AfH5A3n2O8_CZZyPoJVD-eabc6ECb7jhxCicsds7qSg')
+        expect(request.url).to.include('ids=netid.de%3AfH5A3n2O8_CZZyPoJVD-eabc6ECb7jhxCicsds7qSg%2Cdigitrust.de%3Ad8aa10fa-d86c-451d-aad8-5f16162a9e64')
+      })
+
+      it('passes atype to bid request', () => {
+        expect(request.url).to.include('atypes=netid.de%3A1%2Cdigitrust.de%3A2')
       })
 
       it('passes extra params to bid request', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Read atype information from UserIdsAsEids and pass it as query parameter (atypes={idprovider}:{atype},{idprovider2}:{atype2},...)

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
One approving review from a Yieldlab team member required. (@brushmate, @rey1128, @Mufas61 or @kippsterr)