### PR TITLE
Adkernel Bid Adapter: bidbuddy.co.in alias

### DIFF
--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -97,7 +97,8 @@ export const spec = {
     {code: 'motionspots'},
     {code: 'sonic_twist'},
     {code: 'displayioads'},
-    {code: 'rtbdemand_com'}
+    {code: 'rtbdemand_com'},
+    {code: 'bidbuddy'}
   ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Adaptor alias for bidbuddy.co.in network

<!-- For new bidder adapters, please provide the following -->
- prebid-dev@adkernel.com

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
