### PR TITLE
Medianet RTD module: fix `getTargetingData` to retrieve correct adUnits

### DIFF
--- a/modules/medianetRtdProvider.js
+++ b/modules/medianetRtdProvider.js
@@ -59,14 +59,14 @@ function onAuctionInitEvent(auctionInit) {
   }, SOURCE));
 }
 
-function getTargetingData(adUnitCode) {
-  const adUnits = getAdUnits(undefined, adUnitCode);
+function getTargetingData(adUnitCodes, config, consent, auction) {
+  const adUnits = getAdUnits(auction.adUnits, adUnitCodes);
   let targetingData = {};
   if (window.mnjs.loaded && isFn(window.mnjs.getTargetingData)) {
-    targetingData = window.mnjs.getTargetingData(adUnitCode, adUnits, SOURCE) || {};
+    targetingData = window.mnjs.getTargetingData(adUnitCodes, adUnits, SOURCE) || {};
   }
   const targeting = {};
-  adUnitCode.forEach(adUnitCode => {
+  adUnitCodes.forEach(adUnitCode => {
     targeting[adUnitCode] = targeting[adUnitCode] || {};
     targetingData[adUnitCode] = targetingData[adUnitCode] || {};
     targeting[adUnitCode] = {

--- a/test/spec/modules/medianetRtdProvider_spec.js
+++ b/test/spec/modules/medianetRtdProvider_spec.js
@@ -66,12 +66,12 @@ describe('medianet realtime module', function () {
   describe('getTargeting should work correctly', function () {
     it('should return empty if not loaded', function () {
       window.mnjs.loaded = false;
-      assert.deepEqual(medianetRTD.medianetRtdModule.getTargetingData([]), {});
+      assert.deepEqual(medianetRTD.medianetRtdModule.getTargetingData([], {}, {}, {}), {});
     });
 
     it('should return ad unit codes when ad units are present', function () {
       const adUnitCodes = ['code1', 'code2'];
-      assert.deepEqual(medianetRTD.medianetRtdModule.getTargetingData(adUnitCodes), {
+      assert.deepEqual(medianetRTD.medianetRtdModule.getTargetingData(adUnitCodes, {}, {}, {}), {
         code1: {'mnadc': 'code1'},
         code2: {'mnadc': 'code2'},
       });
@@ -79,7 +79,7 @@ describe('medianet realtime module', function () {
 
     it('should call mnjs.getTargetingData if loaded', function () {
       window.mnjs.loaded = true;
-      medianetRTD.medianetRtdModule.getTargetingData([]);
+      medianetRTD.medianetRtdModule.getTargetingData([], {}, {}, {});
       assert.equal(getTargetingDataSpy.called, true);
     });
   });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

The original RTD module API does not make it possible to access the correct ad units from `getTargetingData`. Instead, some adapters are using `getGlobal().adUnits` - which is not in general correct, see [this discussion](https://github.com/prebid/Prebid.js/pull/9383#discussion_r1060821447).

From my code scan, Medianet and Adloox are the only adapters affected.

