### PR TITLE
PBjs Core (Price Floors) : Support inverseBidAdjustment function

### DIFF
--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -249,19 +249,12 @@ export function getFloor(requestParams = {currency: 'USD', mediaType: '*', size:
 
   // if cpmAdjustment flag is true and we have a valid floor then run the adjustment on it
   if (floorData.enforcement.bidAdjustment && floorInfo.matchingFloor) {
-    // For cpm adjustments, they may use the "bid response" object now. So we should put as much info in it as we can
-    const fakeBid = {
-      bidder: bidRequest.bidder,
-      mediaType: requestParams.mediaType, // default would be `*` but it is whatever the bidder adds to getFloor
-      size: requestParams.size // similaraliy, this may be * or an actual size, better than nothing!
-    }
-
     // pub provided inverse function takes precedence, otherwise do old adjustment stuff
     const inverseFunction = bidderSettings.get(bidRequest.bidder, 'inverseBidAdjustment');
     if (inverseFunction) {
-      floorInfo.matchingFloor = inverseFunction(floorInfo.matchingFloor, fakeBid, bidRequest);
+      floorInfo.matchingFloor = inverseFunction(floorInfo.matchingFloor, bidRequest);
     } else {
-      let cpmAdjustment = getBiddersCpmAdjustment(bidRequest.bidder, floorInfo.matchingFloor, fakeBid, bidRequest);
+      let cpmAdjustment = getBiddersCpmAdjustment(bidRequest.bidder, floorInfo.matchingFloor, {}, bidRequest);
       floorInfo.matchingFloor = cpmAdjustment ? calculateAdjustedFloor(floorInfo.matchingFloor, cpmAdjustment) : floorInfo.matchingFloor;
     }
   }

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -1568,6 +1568,81 @@ describe('the price floors module', function () {
         expect(functionUsed).to.equal('Appnexus Inverse');
       });
 
+      it('should pass inverseFloorAdjustment the bidRequest object so it can be used', function () {
+        // Adjustment factors based on Bid Media Type
+        const mediaTypeFactors = {
+          banner: 0.5,
+          native: 0.7,
+          video: 0.9
+        }
+        getGlobal().bidderSettings = {
+          rubicon: {
+            bidCpmAdjustment: function (bidCpm, bidResponse) {
+              return bidCpm * mediaTypeFactors[bidResponse.mediaType];
+            },
+            inverseBidAdjustment: function (bidCpm, bidResponse, bidRequest) {
+              // For the inverse we add up each mediaType in the request and divide by number of Mt's to get the inverse number
+              let factor = Object.keys(bidRequest.mediaTypes).reduce((sum, mediaType) => sum += mediaTypeFactors[mediaType], 0);
+              factor = factor / Object.keys(bidRequest.mediaTypes).length;
+              return bidCpm / factor;
+            },
+          }
+        };
+
+        _floorDataForAuction[bidRequest.auctionId] = utils.deepClone(basicFloorConfig);
+
+        _floorDataForAuction[bidRequest.auctionId].data.values = { '*': 1.0 };
+
+        // banner only should be 2
+        bidRequest.mediaTypes = { banner: {} };
+        expect(bidRequest.getFloor()).to.deep.equal({
+          currency: 'USD',
+          floor: 2.0
+        });
+
+        // native only should be 1.4286
+        bidRequest.mediaTypes = { native: {} };
+        expect(bidRequest.getFloor()).to.deep.equal({
+          currency: 'USD',
+          floor: 1.4286
+        });
+
+        // video only should be 1.1112
+        bidRequest.mediaTypes = { video: {} };
+        expect(bidRequest.getFloor()).to.deep.equal({
+          currency: 'USD',
+          floor: 1.1112
+        });
+
+        // video and banner should even out to 0.7 factor so 1.4286
+        bidRequest.mediaTypes = { video: {}, banner: {} };
+        expect(bidRequest.getFloor()).to.deep.equal({
+          currency: 'USD',
+          floor: 1.4286
+        });
+
+        // video and native should even out to 0.8 factor so -- 1.25
+        bidRequest.mediaTypes = { video: {}, native: {} };
+        expect(bidRequest.getFloor()).to.deep.equal({
+          currency: 'USD',
+          floor: 1.25
+        });
+
+        // banner and native should even out to 0.6 factor so -- 1.6667
+        bidRequest.mediaTypes = { banner: {}, native: {} };
+        expect(bidRequest.getFloor()).to.deep.equal({
+          currency: 'USD',
+          floor: 1.6667
+        });
+
+        // all 3 banner video and native should even out to 0.7 factor so -- 1.4286
+        bidRequest.mediaTypes = { banner: {}, native: {}, video: {} };
+        expect(bidRequest.getFloor()).to.deep.equal({
+          currency: 'USD',
+          floor: 1.4286
+        });
+      });
+
       it('should use standard cpmAdjustment if no bidder cpmAdjustment', function () {
         getGlobal().bidderSettings = {
           rubicon: {


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Addresses #9391 

### Inverse Bid Adjustment
New input on bidderSettings called `inverseBidAdjustment`

```js
        pbjs.bidderSettings = {
          rubicon: {
            bidCpmAdjustment: function (bidCpm, bidResponse) {
              bidCpm *= 0.5;
              if (bidResponse.mediaType === 'video') bidCpm -= 0.18;
              return bidCpm;
            },
            inverseBidAdjustment: function (bidCpm, bidResponse) {
              if (bidResponse.mediaType === 'video') bidCpm += 0.18;
              return bidCpm / 0.5;
            },
          }
        };
```

The floors module will now look for this `inverseBidAdjustment` and use it before falling back to the old `calculateAdjustedFloor` logic.


### Fake Bid Response
There have been grumblings of when the getFloor function adjusts floors using `bidCpmAdjustment`, it calls the adjustment function without the bidResponse object.

Well, of course it does because it does not exist yet!

But, we can do some stuff to try and eliviate this by passing in the bidRequest object as well as a "fake" bid response.

Since the `getFloor` function takes in mediaType and sizes, and we know the `bidder` code, we should pass those into the bidResponse "object" part of the adjustment call so it helps at least mitigate some issues.