### PR TITLE
ConnectId: support for GPP parameters

### DIFF
--- a/modules/connectIdSystem.js
+++ b/modules/connectIdSystem.js
@@ -66,6 +66,11 @@ export const connectIdSubmodule = {
       us_privacy: consentData && consentData.uspConsent ? consentData.uspConsent : ''
     };
 
+    if (connectIdSubmodule.isUnderGPPJurisdiction(consentData)) {
+      data.gpp = consentData.gppConsent.gppString;
+      data.gpp_sid = encodeURIComponent(consentData.gppConsent.applicableSections.join(','));
+    }
+
     INPUT_PARAM_KEYS.forEach(key => {
       if (typeof params[key] != 'undefined') {
         data[key] = params[key];
@@ -98,12 +103,21 @@ export const connectIdSubmodule = {
   },
 
   /**
-   * Utility function that returns a boolean flag indicating if the opporunity
+   * Utility function that returns a boolean flag indicating if the opportunity
    * is subject to GDPR
    * @returns {Boolean}
    */
   isEUConsentRequired(consentData) {
     return !!(consentData && consentData.gdpr && consentData.gdpr.gdprApplies);
+  },
+
+  /**
+   * Utility function that returns a boolean flag indicating if the opportunity
+   * is subject to GPP jurisdiction.
+   * @returns {Boolean}
+   */
+  isUnderGPPJurisdiction(consentData) {
+    return !!(consentData && consentData.gppConsent && consentData.gppConsent.gppString);
   },
 
   /**

--- a/test/spec/modules/connectIdSystem_spec.js
+++ b/test/spec/modules/connectIdSystem_spec.js
@@ -31,7 +31,11 @@ describe('Yahoo ConnectID Submodule', () => {
           gdprApplies: 1,
           consentString: 'GDPR_CONSENT_STRING'
         },
-        uspConsent: 'USP_CONSENT_STRING'
+        uspConsent: 'USP_CONSENT_STRING',
+        gppConsent: {
+          gppString: 'header~section6~section7',
+          applicableSections: [6, 7]
+        }
       };
     });
 
@@ -157,7 +161,9 @@ describe('Yahoo ConnectID Submodule', () => {
         '1p': '0',
         gdpr: '1',
         gdpr_consent: consentData.gdpr.consentString,
-        us_privacy: consentData.uspConsent
+        us_privacy: consentData.uspConsent,
+        gpp: consentData.gppConsent.gppString,
+        gpp_sid: '6%2C7'
       };
       const requestQueryParams = parseQS(ajaxStub.firstCall.args[0].split('?')[1]);
 
@@ -178,7 +184,9 @@ describe('Yahoo ConnectID Submodule', () => {
         '1p': '0',
         gdpr: '1',
         gdpr_consent: consentData.gdpr.consentString,
-        us_privacy: consentData.uspConsent
+        us_privacy: consentData.uspConsent,
+        gpp: consentData.gppConsent.gppString,
+        gpp_sid: '6%2C7'
       };
       const requestQueryParams = parseQS(ajaxStub.firstCall.args[0].split('?')[1]);
 
@@ -201,7 +209,9 @@ describe('Yahoo ConnectID Submodule', () => {
         '1p': '0',
         gdpr: '1',
         gdpr_consent: consentData.gdpr.consentString,
-        us_privacy: consentData.uspConsent
+        us_privacy: consentData.uspConsent,
+        gpp: consentData.gppConsent.gppString,
+        gpp_sid: '6%2C7'
       };
       const requestQueryParams = parseQS(ajaxStub.firstCall.args[0].split('?')[1]);
 
@@ -221,7 +231,9 @@ describe('Yahoo ConnectID Submodule', () => {
         '1p': '0',
         gdpr: '1',
         gdpr_consent: consentData.gdpr.consentString,
-        us_privacy: consentData.uspConsent
+        us_privacy: consentData.uspConsent,
+        gpp: consentData.gppConsent.gppString,
+        gpp_sid: '6%2C7'
       };
       const requestQueryParams = parseQS(ajaxStub.firstCall.args[0].split('?')[1]);
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Support for the GPP params in the call made for the user id.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
