### PR TITLE
Appnnexus Bid Adapter : support for adomain

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -625,9 +625,8 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     }
   };
 
-  // WE DON'T FULLY SUPPORT THIS ATM - future spot for adomain code; creating a stub for 5.0 compliance
   if (rtbBid.adomain) {
-    bid.meta = Object.assign({}, bid.meta, { advertiserDomains: [] });
+    bid.meta = Object.assign({}, bid.meta, { advertiserDomains: [rtbBid.adomain] });
   }
 
   if (rtbBid.advertiser_id) {

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -1735,7 +1735,7 @@ describe('AppNexusAdapter', function () {
 
     it('should add advertiserDomains', function () {
       let responseAdvertiserId = deepClone(response);
-      responseAdvertiserId.tags[0].ads[0].adomain = ['123'];
+      responseAdvertiserId.tags[0].ads[0].adomain = '123';
 
       let bidderRequest = {
         bids: [{
@@ -1745,7 +1745,7 @@ describe('AppNexusAdapter', function () {
       }
       let result = spec.interpretResponse({ body: responseAdvertiserId }, { bidderRequest });
       expect(Object.keys(result[0].meta)).to.include.members(['advertiserDomains']);
-      expect(Object.keys(result[0].meta.advertiserDomains)).to.deep.equal([]);
+      expect(result[0].meta.advertiserDomains).to.deep.equal(['123']);
     });
   });
 


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
This PR updates the placeholder logic we had in the appnexus bid adapter for the adomain field, so that the new field in the ad server's bid response populates the appropriate `bid.meta` for prebid.js.