### PR TITLE
JW Player Video Sub Module: Trigger error when missing div id

### DIFF
--- a/modules/jwplayerVideoProvider.js
+++ b/modules/jwplayerVideoProvider.js
@@ -47,19 +47,26 @@ export function JWPlayerProvider(config, jwplayer_, adState_, timeState_, callba
 
   function init() {
     if (!jwplayer) {
-      triggerSetupFailure(-1); // TODO: come up with code for player absent
+      triggerSetupFailure(-1); // TODO: come up with error code schema- player is absent
       return;
     }
 
     playerVersion = jwplayer.version;
 
     if (playerVersion < minimumSupportedPlayerVersion) {
-      triggerSetupFailure(-2); // TODO: come up with code for version not supported
+      triggerSetupFailure(-2); // TODO: come up with error code schema - version not supported
+      return;
+    }
+
+    if (!document.getElementById(divId)) {
+      triggerSetupFailure(-3); // TODO: come up with error code schema - missing div id
       return;
     }
 
     player = jwplayer(divId);
-    if (player.getState() === undefined) {
+    if (!player || !player.getState) {
+      triggerSetupFailure(-4); // TODO: come up with error code schema - factory function failure
+    } else if (player.getState() === undefined) {
       setupPlayer(playerConfig);
     } else {
       const payload = getSetupCompletePayload();


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Checks if div id exists; jwplayer requires a valid div in order to instantiate.

## Other information
Tech debt: **https://github.com/prebid/Prebid.js/issues/9406**
