### PR TITLE
Seedtag Bid Adapter - Add GPP consent

### DIFF
--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -260,6 +260,18 @@ export const spec = {
       payload.coppa = coppa;
     }
 
+    if (bidderRequest.gppConsent) {
+      payload.gppConsent = {
+        gppString: bidderRequest.gppConsent.gppString,
+        applicableSections: bidderRequest.gppConsent.applicableSections
+      }
+    } else if (bidderRequest.ortb2?.regs?.gpp) {
+      payload.gppConsent = {
+        gppString: bidderRequest.ortb2.regs.gpp,
+        applicableSections: bidderRequest.ortb2.regs.gpp_sid
+      }
+    }
+
     const payloadString = JSON.stringify(payload);
     return {
       method: 'POST',

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -395,6 +395,52 @@ describe('Seedtag Adapter', function () {
         expect(payload.schain).to.not.exist;
       });
     });
+
+    describe('GPP param', function () {
+      it('should be added to payload when bidderRequest has gppConsent param', function () {
+        const gppConsent = {
+          gppString: 'someGppString',
+          applicableSections: [7]
+        }
+        bidderRequest['gppConsent'] = gppConsent
+        const request = spec.buildRequests(validBidRequests, bidderRequest);
+        const data = JSON.parse(request.data);
+        expect(data.gppConsent).to.exist;
+        expect(data.gppConsent.gppString).to.equal(gppConsent.gppString);
+        expect(data.gppConsent.applicableSections[0]).to.equal(gppConsent.applicableSections[0]);
+      });
+
+      it('should be undefined on payload when bidderRequest has not gppConsent param', function () {
+        bidderRequest.gppConsent = undefined
+        const request = spec.buildRequests(validBidRequests, bidderRequest);
+        const data = JSON.parse(request.data);
+        expect(data.gppConsent).to.be.undefined;
+      });
+
+      it('should be added to payload when bidderRequest has ortb2 param', function () {
+        const ortb2 = {
+          regs: {
+            gpp: 'someGppString',
+            gpp_sid: [7]
+          }
+        }
+        bidderRequest['gppConsent'] = undefined
+        bidderRequest['ortb2'] = ortb2;
+        const request = spec.buildRequests(validBidRequests, bidderRequest);
+        const data = JSON.parse(request.data);
+        expect(data.gppConsent).to.exist;
+        expect(data.gppConsent.gppString).to.equal(ortb2.regs.gpp);
+        expect(data.gppConsent.applicableSections[0]).to.equal(ortb2.regs.gpp_sid[0]);
+      });
+
+      it('should be added to payload when bidderRequest has neither gppConsent nor ortb2', function () {
+        bidderRequest['ortb2'] = undefined;
+        bidderRequest['gppConsent'] = undefined;
+        const request = spec.buildRequests(validBidRequests, bidderRequest);
+        const data = JSON.parse(request.data);
+        expect(data.gppConsent).to.be.undefined;
+      });
+    });
   });
 
   describe('interpret response method', function () {
@@ -533,11 +579,11 @@ describe('Seedtag Adapter', function () {
       const timeoutUrl = getTimeoutUrl(timeoutData);
       expect(timeoutUrl).to.equal(
         'https://s.seedtag.com/se/hb/timeout?publisherToken=' +
-          params.publisherId +
-          '&adUnitId=' +
-          params.adUnitId +
-          '&timeout=' +
-          timeout
+        params.publisherId +
+        '&adUnitId=' +
+        params.adUnitId +
+        '&timeout=' +
+        timeout
       );
     });
 
@@ -549,11 +595,11 @@ describe('Seedtag Adapter', function () {
       expect(
         utils.triggerPixel.calledWith(
           'https://s.seedtag.com/se/hb/timeout?publisherToken=' +
-            params.publisherId +
-            '&adUnitId=' +
-            params.adUnitId +
-            '&timeout=' +
-            timeout
+          params.publisherId +
+          '&adUnitId=' +
+          params.adUnitId +
+          '&timeout=' +
+          timeout
         )
       ).to.equal(true);
     });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->

- [x] Feature


## Description of change
<!-- Describe the change proposed in this pull request -->
- add GPP consent
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

PR Related: Documentation -> https://github.com/prebid/prebid.github.io/pull/4271