### PR TITLE
Seedtag Bid Adapter : enable video/banner mediatypes for inImage/inBanner/inArticle/inScreen

### DIFF
--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -60,6 +60,10 @@ function hasVideoMediaType(bid) {
   return !!bid.mediaTypes && !!bid.mediaTypes.video;
 }
 
+function hasBannerMediaType(bid) {
+  return !!bid.mediaTypes && !!bid.mediaTypes.banner;
+}
+
 function hasMandatoryDisplayParams(bid) {
   const p = bid.params;
   return (
@@ -72,17 +76,27 @@ function hasMandatoryDisplayParams(bid) {
 function hasMandatoryVideoParams(bid) {
   const videoParams = getVideoParams(bid);
 
-  return (
+  let isValid =
     !!bid.params.publisherId &&
     !!bid.params.adUnitId &&
     hasVideoMediaType(bid) &&
     !!videoParams.playerSize &&
     isArray(videoParams.playerSize) &&
-    videoParams.playerSize.length > 0 &&
-    // only instream is supported for video
-    videoParams.context === 'instream' &&
-    bid.params.placement === 'inStream'
-  );
+    videoParams.playerSize.length > 0;
+
+  switch (bid.params.placement) {
+    // instream accept only video format
+    case 'inStream':
+      return isValid && videoParams.context === 'instream';
+    // outstream accept banner/native/video format
+    default:
+      return (
+        isValid &&
+        videoParams.context === 'outstream' &&
+        hasBannerMediaType(bid) &&
+        hasMandatoryDisplayParams(bid)
+      );
+  }
 }
 
 function buildBidRequest(validBidRequest) {

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -33,30 +33,60 @@ function createInStreamSlotConfig(mediaType) {
   });
 }
 
+const createBannerSlotConfig = (placement, mediatypes) => {
+  return getSlotConfigs(mediatypes || { banner: {} }, {
+    publisherId: PUBLISHER_ID,
+    adUnitId: ADUNIT_ID,
+    placement,
+  });
+};
+
 describe('Seedtag Adapter', function () {
   describe('isBidRequestValid method', function () {
     describe('returns true', function () {
       describe('when banner slot config has all mandatory params', () => {
-        describe('and placement has the correct value', function () {
-          const createBannerSlotConfig = (placement) => {
-            return getSlotConfigs(
-              { banner: {} },
-              {
-                publisherId: PUBLISHER_ID,
-                adUnitId: ADUNIT_ID,
-                placement,
-              }
+        const placements = ['inBanner', 'inImage', 'inScreen', 'inArticle'];
+        placements.forEach((placement) => {
+          it(placement + 'should be valid', function () {
+            const isBidRequestValid = spec.isBidRequestValid(
+              createBannerSlotConfig(placement)
             );
-          };
-          const placements = ['inBanner', 'inImage', 'inScreen', 'inArticle'];
-          placements.forEach((placement) => {
-            it('should be ' + placement, function () {
+            expect(isBidRequestValid).to.equal(true);
+          });
+
+          it(
+            placement +
+              ' should be valid when has display and video mediatypes, and video context is outstream',
+            function () {
               const isBidRequestValid = spec.isBidRequestValid(
-                createBannerSlotConfig(placement)
+                createBannerSlotConfig(placement, {
+                  banner: {},
+                  video: {
+                    context: 'outstream',
+                    playerSize: [[600, 200]],
+                  },
+                })
               );
               expect(isBidRequestValid).to.equal(true);
-            });
-          });
+            }
+          );
+
+          it(
+            placement +
+              " shouldn't be valid when has display and video mediatypes, and video context is instream",
+            function () {
+              const isBidRequestValid = spec.isBidRequestValid(
+                createBannerSlotConfig(placement, {
+                  banner: {},
+                  video: {
+                    context: 'instream',
+                    playerSize: [[600, 200]],
+                  },
+                })
+              );
+              expect(isBidRequestValid).to.equal(false);
+            }
+          );
         });
       });
       describe('when video slot has all mandatory params', function () {
@@ -70,7 +100,18 @@ describe('Seedtag Adapter', function () {
           const isBidRequestValid = spec.isBidRequestValid(slotConfig);
           expect(isBidRequestValid).to.equal(true);
         });
-        it('should return true, when video context is instream, but placement is not inStream', function () {
+        it('should return true, when video context is instream and mediatype is video and banner', function () {
+          const slotConfig = createInStreamSlotConfig({
+            video: {
+              context: 'instream',
+              playerSize: [[600, 200]],
+            },
+            banner: {},
+          });
+          const isBidRequestValid = spec.isBidRequestValid(slotConfig);
+          expect(isBidRequestValid).to.equal(true);
+        });
+        it('should return false, when video context is instream, but placement is not inStream', function () {
           const slotConfig = getSlotConfigs(
             {
               video: {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This PR enable mediatypes banner + video when placement is `inArticle` or `inScreen` or `inImage` or `inBanner`, and videoContext is `outstream`

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
