### PR TITLE
Sonobi Bid Adapter : now passing the entire mediaType.video object value as a new query param

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -85,6 +85,7 @@ export const spec = {
 
     const payload = {
       'key_maker': JSON.stringify(data),
+      video_options: _getVideoOptions(validBidRequests),
       // TODO: is 'page' the right value here?
       'ref': bidderRequest.refererInfo.page,
       's': generateUUID(),
@@ -93,7 +94,6 @@ export const spec = {
       'lib_name': 'prebid',
       'lib_v': '$prebid.version$',
       'us': 0,
-
     };
 
     const fpd = bidderRequest.ortb2;
@@ -295,7 +295,7 @@ function _findBidderRequest(bidderRequests, bidId) {
   }
 }
 
-// This function takes all the possible sizes 
+// This function takes all the possible sizes
 // returns string csv
 function _validateSize(bid) {
   let size = [];
@@ -316,7 +316,7 @@ function _validateSize(bid) {
   }
   // Pass the 2d sizes array into parseSizeInput to flatten it into an array of x separated sizes.
   // Then throw it into Set to uniquify it.
-  // Then spread it to an array again. Then join it into a csv of sizes
+  // Spread it to an array again. Then join it into a csv of sizes
   return [...new Set(parseSizesInput(...size))].join(',');
 }
 
@@ -396,6 +396,15 @@ export function _getPlatform(context = window) {
     return 'tablet'
   }
   return 'desktop';
+}
+
+function _getVideoOptions(bids) {
+  const videoOptions = bids.map(bid => {
+    if (deepAccess(bid, 'mediaTypes.video')) {
+      return deepAccess(bid, 'mediaTypes.video');
+    }
+  })
+  return JSON.stringify(videoOptions);
 }
 
 function newRenderer(adUnitCode, bid, rendererOptions = {}) {

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -300,8 +300,8 @@ function _validateSize(bid) {
   if (deepAccess(bid, 'mediaTypes.video')) {
     if (deepAccess(bid, 'mediaTypes.video.playerSize')) {
       size = deepAccess(bid, 'mediaTypes.video.playerSize');
-    } else if (deepAccess(bid, 'mediaTypes.video.sizes')) {
-      size = deepAccess(bid, 'mediaTypes.video.sizes');
+    } else if (deepAccess(bid, 'mediaTypes.video.size')) {
+      size = deepAccess(bid, 'mediaTypes.video.size');
     }
   } else if (bid.params.sizes) {
     size = bid.params.sizes;

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -296,23 +296,23 @@ function _findBidderRequest(bidderRequests, bidId) {
 }
 
 function _validateSize(bid) {
-  let size = null;
-  if (deepAccess(bid, 'mediaTypes.video')) {
-    if (deepAccess(bid, 'mediaTypes.video.playerSize')) {
-      size = deepAccess(bid, 'mediaTypes.video.playerSize');
-    } else if (deepAccess(bid, 'mediaTypes.video.size')) {
-      size = deepAccess(bid, 'mediaTypes.video.size');
-    }
-  } else if (bid.params.sizes) {
-    size = bid.params.sizes;
-  } else if (deepAccess(bid, 'mediaTypes.banner.sizes')) {
-    size = deepAccess(bid, 'mediaTypes.banner.sizes')
+  let size = [];
+  if (deepAccess(bid, 'mediaTypes.video.playerSize')) {
+    size.push(deepAccess(bid, 'mediaTypes.video.playerSize'))
   }
-  // Handle deprecated sizes definition if still unset
-  if (!size && bid.sizes) {
-    size = bid.sizes;
+  if (deepAccess(bid, 'mediaTypes.video.sizes')) {
+    size.push(deepAccess(bid, 'mediaTypes.video.sizes'))
   }
-  return parseSizesInput(size).join(',');
+  if (deepAccess(bid, 'params.sizes')) {
+    size.push(deepAccess(bid, 'params.sizes'));
+  }
+  if (deepAccess(bid, 'mediaTypes.banner.sizes')) {
+    size.push(deepAccess(bid, 'mediaTypes.banner.sizes'))
+  }
+  if (deepAccess(bid, 'sizes')) {
+    size.push(deepAccess(bid, 'sizes'))
+  }
+  return [...new Set(parseSizesInput(...size))].join(',');
 }
 
 function _validateSlot(bid) {

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -296,24 +296,22 @@ function _findBidderRequest(bidderRequests, bidId) {
 }
 
 function _validateSize(bid) {
-  let size;
-  // Handle deprecated sizes definition
-  if (bid.sizes) {
-    size = bid.sizes;
-  }
-  if (bid.params.sizes) {
-    size = bid.params.sizes;
-  }
+  let size = null;
   if (deepAccess(bid, 'mediaTypes.video')) {
     if (deepAccess(bid, 'mediaTypes.video.playerSize')) {
       size = deepAccess(bid, 'mediaTypes.video.playerSize');
-    } else if (deepAccess(bid, 'mediaTypes.video.sizes')) {
-      size = deepAccess(bid, 'mediaTypes.video.sizes');
+    } else if (deepAccess(bid, 'mediaTypes.video.size')) {
+      size = deepAccess(bid, 'mediaTypes.video.size');
     }
+  } else if (bid.params.sizes) {
+    size = bid.params.sizes;
   } else if (deepAccess(bid, 'mediaTypes.banner.sizes')) {
     size = deepAccess(bid, 'mediaTypes.banner.sizes')
   }
-
+  // Handle deprecated sizes definition if still unset
+  if (!size && bid.sizes) {
+    size = bid.sizes;
+  }
   return parseSizesInput(size).join(',');
 }
 

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -296,21 +296,23 @@ function _findBidderRequest(bidderRequests, bidId) {
 }
 
 function _validateSize(bid) {
+  let size;
   if (deepAccess(bid, 'mediaTypes.video')) {
-    return ''; // Video bids arent allowed to override sizes via the trinity request
+    if (deepAccess(bid, 'mediaTypes.video.playerSize')) {
+      size = deepAccess(bid, 'mediaTypes.video.playerSize');
+    } else if (deepAccess(bid, 'mediaTypes.video.sizes')) {
+      size = deepAccess(bid, 'mediaTypes.video.sizes');
+    }
+  } else if (bid.params.sizes) {
+    size = bid.params.sizes;
+  } else if (deepAccess(bid, 'mediaTypes.banner.sizes')) {
+    size = deepAccess(bid, 'mediaTypes.banner.sizes')
   }
-
-  if (bid.params.sizes) {
-    return parseSizesInput(bid.params.sizes).join(',');
-  }
-  if (deepAccess(bid, 'mediaTypes.banner.sizes')) {
-    return parseSizesInput(deepAccess(bid, 'mediaTypes.banner.sizes')).join(',');
-  }
-
   // Handle deprecated sizes definition
   if (bid.sizes) {
-    return parseSizesInput(bid.sizes).join(',');
+    size = bid.sizes;
   }
+  return parseSizesInput(size).join(',');
 }
 
 function _validateSlot(bid) {

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -297,21 +297,23 @@ function _findBidderRequest(bidderRequests, bidId) {
 
 function _validateSize(bid) {
   let size;
-  if (deepAccess(bid, 'mediaTypes.video')) {
-    if (deepAccess(bid, 'mediaTypes.video.playerSize')) {
-      size = deepAccess(bid, 'mediaTypes.video.playerSize');
-    } else if (deepAccess(bid, 'mediaTypes.video.size')) {
-      size = deepAccess(bid, 'mediaTypes.video.size');
-    }
-  } else if (bid.params.sizes) {
-    size = bid.params.sizes;
-  } else if (deepAccess(bid, 'mediaTypes.banner.sizes')) {
-    size = deepAccess(bid, 'mediaTypes.banner.sizes')
-  }
   // Handle deprecated sizes definition
   if (bid.sizes) {
     size = bid.sizes;
   }
+  if (bid.params.sizes) {
+    size = bid.params.sizes;
+  }
+  if (deepAccess(bid, 'mediaTypes.video')) {
+    if (deepAccess(bid, 'mediaTypes.video.playerSize')) {
+      size = deepAccess(bid, 'mediaTypes.video.playerSize');
+    } else if (deepAccess(bid, 'mediaTypes.video.sizes')) {
+      size = deepAccess(bid, 'mediaTypes.video.sizes');
+    }
+  } else if (deepAccess(bid, 'mediaTypes.banner.sizes')) {
+    size = deepAccess(bid, 'mediaTypes.banner.sizes')
+  }
+
   return parseSizesInput(size).join(',');
 }
 

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -295,6 +295,8 @@ function _findBidderRequest(bidderRequests, bidId) {
   }
 }
 
+// This function takes all the possible sizes 
+// returns string csv
 function _validateSize(bid) {
   let size = [];
   if (deepAccess(bid, 'mediaTypes.video.playerSize')) {
@@ -312,6 +314,9 @@ function _validateSize(bid) {
   if (deepAccess(bid, 'sizes')) {
     size.push(deepAccess(bid, 'sizes'))
   }
+  // Pass the 2d sizes array into parseSizeInput to flatten it into an array of x separated sizes.
+  // Then throw it into Set to uniquify it.
+  // Then spread it to an array again. Then join it into a csv of sizes
   return [...new Set(parseSizesInput(...size))].join(',');
 }
 

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -287,6 +287,7 @@ describe('SonobiBidAdapter', function () {
       },
       mediaTypes: {
         video: {
+          sizes: [[300, 250], [300, 600]],
           context: 'outstream'
         }
       }
@@ -331,7 +332,7 @@ describe('SonobiBidAdapter', function () {
     }];
 
     let keyMakerData = {
-      '30b31c1838de1f': '1a2b3c4d5e6f1a2b3c4d||f=1.25,gpid=/123123/gpt_publisher/adunit-code-1,c=v,',
+      '30b31c1838de1f': '1a2b3c4d5e6f1a2b3c4d|300x250,300x600|f=1.25,gpid=/123123/gpt_publisher/adunit-code-1,c=v,',
       '30b31c1838de1d': '1a2b3c4d5e6f1a2b3c4e|300x250,300x600|f=0.42,gpid=/123123/gpt_publisher/adunit-code-3,c=d,',
       '/7780971/sparks_prebid_LB|30b31c1838de1e': '300x250,300x600|gpid=/7780971/sparks_prebid_LB,c=d,',
     };


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->
Now passing the entire `mediaType.video` object value as a new query param to trinity.json called “video_options”. The expected value would be a JSON string 
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  },
  video: {
    // ...
   },
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
<img width="824" alt="Screen Shot 2023-01-12 at 3 13 58 PM" src="https://user-images.githubusercontent.com/30053857/212171946-adf08f98-f4b8-479b-b10d-3e08ea2b1015.png">
