### PR TITLE
Permutive RTD Module: adds a safety check to prevent errors in the case a nested property doesn't exist

### DIFF
--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -243,7 +243,7 @@ function getCustomBidderFn (moduleConfig, bidder) {
  */
 function getDefaultBidderFn (bidder) {
   const isPStandardTargetingEnabled = (data, acEnabled) => {
-    return (acEnabled && data.ac && data.ac.length) || (data.ssp && data.ssp.cohorts.length)
+    return (acEnabled && data.ac && data.ac.length) || (data.ssp && data.ssp.cohorts && data.ssp.cohorts.length)
   }
   const pStandardTargeting = (data, acEnabled) => {
     const ac = (acEnabled) ? (data.ac ?? []) : []


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Adds a safety check to ensure a nested property exists inside an object before we access any properties on the nested property.

This was sometimes throwing as pointed out in the discussion here: https://github.com/prebid/Prebid.js/pull/9236#discussion_r1066043015

## Other information
Relates to the work done in #9236
