### PR TITLE
USP consent management: handle errors from CMPs that cannot deal with `registerDeletion`

### DIFF
--- a/modules/consentManagementUsp.js
+++ b/modules/consentManagementUsp.js
@@ -100,6 +100,14 @@ function lookupUspConsent({onSuccess, onError}) {
     return onError('USP CMP not found.');
   }
 
+  function registerDataDelHandler(invoker, arg2) {
+    try {
+      invoker('registerDeletion', arg2, adapterManager.callDataDeletionRequest);
+    } catch (e) {
+      logError('Error invoking CMP `registerDeletion`:', e);
+    }
+  }
+
   // to collect the consent information from the user, we perform a call to USPAPI
   // to collect the user's consent choices represented as a string (via getUSPData)
 
@@ -115,11 +123,7 @@ function lookupUspConsent({onSuccess, onError}) {
       USPAPI_VERSION,
       callbackHandler.consentDataCallback
     );
-    uspapiFunction(
-      'registerDeletion',
-      USPAPI_VERSION,
-      adapterManager.callDataDeletionRequest
-    )
+    registerDataDelHandler(uspapiFunction, USPAPI_VERSION);
   } else {
     logInfo(
       'Detected USP CMP is outside the current iframe where Prebid.js is located, calling it now...'
@@ -129,11 +133,7 @@ function lookupUspConsent({onSuccess, onError}) {
       uspapiFrame,
       callbackHandler.consentDataCallback
     );
-    callUspApiWhileInIframe(
-      'registerDeletion',
-      uspapiFrame,
-      adapterManager.callDataDeletionRequest
-    );
+    registerDataDelHandler(callUspApiWhileInIframe, uspapiFrame);
   }
 
   let listening = false;

--- a/test/spec/modules/consentManagementUsp_spec.js
+++ b/test/spec/modules/consentManagementUsp_spec.js
@@ -8,7 +8,7 @@ import {
 } from 'modules/consentManagementUsp.js';
 import * as utils from 'src/utils.js';
 import { config } from 'src/config.js';
-import adapterManager, {uspDataHandler} from 'src/adapterManager.js';
+import adapterManager, {gdprDataHandler, uspDataHandler} from 'src/adapterManager.js';
 import 'src/prebid.js';
 import {defer} from '../../../src/utils/promise.js';
 
@@ -508,7 +508,20 @@ describe('consentManagement', function () {
         sinon.assert.notCalled(adapterManager.callDataDeletionRequest);
         listener();
         sinon.assert.calledOnce(adapterManager.callDataDeletionRequest);
-      })
+      });
+
+      it('does not fail if CMP does not support registerDeletion', () => {
+        sandbox.stub(window, '__uspapi').callsFake((cmd, _, cb) => {
+          if (cmd === 'registerDeletion') {
+            throw new Error('CMP not compliant');
+          } else if (cmd === 'getUSPData') {
+            // eslint-disable-next-line standard/no-callback-literal
+            cb({uspString: 'string'}, true);
+          }
+        });
+        setConsentConfig(goodConfig);
+        expect(uspDataHandler.getConsentData()).to.eql('string');
+      });
     });
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Some CMPs throw errors when asked to deal with USP data deletion (https://github.com/prebid/Prebid.js/issues/9425). This updates the USP module to handle those gracefully.

## Other information

Closes https://github.com/prebid/Prebid.js/issues/9425
