### PR TITLE
Core & priceFloors: pass bid request to `bidCpmAdjustment`; warn about invalid `adUnit.floors` definitions

### DIFF
--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -310,6 +310,8 @@ export function getFloorDataFromAdUnits(adUnits) {
         // copy over the new rules into our values object
         Object.assign(accum.values, newRules);
       }
+    } else if (adUnit.floors != null) {
+      logWarn(`adUnit '${adUnit.code}' provides an invalid \`floor\` definition, it will be ignored for floor calculations`, adUnit);
     }
     return accum;
   }, {});

--- a/src/auction.js
+++ b/src/auction.js
@@ -93,6 +93,7 @@ import CONSTANTS from './constants.json';
 import {GreedyPromise} from './utils/promise.js';
 import {useMetrics} from './utils/perfMetrics.js';
 import {createBid} from './bidfactory.js';
+import {adjustCpm} from './utils/cpm.js';
 
 const { syncUsers } = userSync;
 
@@ -971,17 +972,7 @@ function setKeys(keyValues, bidderSettings, custBidObj, bidReq) {
 }
 
 export function adjustBids(bid) {
-  let code = bid.bidderCode;
-  let bidPriceAdjusted = bid.cpm;
-  const bidCpmAdjustment = bidderSettings.get(code || null, 'bidCpmAdjustment');
-
-  if (bidCpmAdjustment && typeof bidCpmAdjustment === 'function') {
-    try {
-      bidPriceAdjusted = bidCpmAdjustment(bid.cpm, Object.assign({}, bid));
-    } catch (e) {
-      logError('Error during bid adjustment', 'bidmanager.js', e);
-    }
-  }
+  let bidPriceAdjusted = adjustCpm(bid.cpm, bid);
 
   if (bidPriceAdjusted >= 0) {
     bid.cpm = bidPriceAdjusted;

--- a/src/utils/cpm.js
+++ b/src/utils/cpm.js
@@ -1,0 +1,17 @@
+import {auctionManager} from '../auctionManager.js';
+import {bidderSettings} from '../bidderSettings.js';
+import {logError} from '../utils.js';
+
+export function adjustCpm(cpm, bidResponse, bidRequest, {index = auctionManager.index, bs = bidderSettings} = {}) {
+  bidRequest = bidRequest || index.getBidRequest(bidResponse);
+  const bidCpmAdjustment = bs.get(bidResponse?.bidderCode || bidRequest?.bidder, 'bidCpmAdjustment');
+
+  if (bidCpmAdjustment && typeof bidCpmAdjustment === 'function') {
+    try {
+      return bidCpmAdjustment(cpm, Object.assign({}, bidResponse), bidRequest);
+    } catch (e) {
+      logError('Error during bid adjustment', e);
+    }
+  }
+  return cpm;
+}

--- a/test/spec/unit/utils/cpm_spec.js
+++ b/test/spec/unit/utils/cpm_spec.js
@@ -1,0 +1,64 @@
+import {adjustCpm} from '../../../../src/utils/cpm.js';
+
+describe('adjustCpm', () => {
+  const bidderCode = 'mockBidder';
+  let adjustmentFn, bs, index;
+  beforeEach(() => {
+    bs = {
+      get: sinon.stub()
+    }
+    index = {
+      getBidRequest: sinon.stub()
+    }
+    adjustmentFn = sinon.stub().callsFake((cpm) => cpm * 2);
+  })
+
+  it('throws when neither bidRequest nor bidResponse are provided', () => {
+    expect(() => adjustCpm(1)).to.throw();
+  })
+
+  it('always provides an object as bidResponse for the adjustment fn', () => {
+    bs.get.callsFake(() => adjustmentFn);
+    adjustCpm(1, null, {bidder: bidderCode}, {index, bs});
+    sinon.assert.calledWith(adjustmentFn, 1, {});
+  });
+
+  describe('when no bidRequest is provided', () => {
+    Object.entries({
+      'unavailable': undefined,
+      'found': {foo: 'bar'}
+    }).forEach(([t, req]) => {
+      describe(`and it is ${t} in the index`, () => {
+        beforeEach(() => {
+          bs.get.callsFake(() => adjustmentFn);
+          index.getBidRequest.callsFake(() => req)
+        });
+
+        it('provides it to the adjustment fn', () => {
+          const bidResponse = {bidderCode};
+          adjustCpm(1, bidResponse, undefined, {index, bs});
+          sinon.assert.calledWith(index.getBidRequest, bidResponse);
+          sinon.assert.calledWith(adjustmentFn, 1, bidResponse, req);
+        })
+      })
+    })
+  });
+
+  Object.entries({
+    'bidResponse': [{bidderCode}],
+    'bidRequest': [null, {bidder: bidderCode}],
+  }).forEach(([t, [bidResp, bidReq]]) => {
+    describe(`when passed ${t}`, () => {
+      beforeEach(() => {
+        bs.get.callsFake((bidder) => { if (bidder === bidderCode) return adjustmentFn });
+      });
+      it('retrieves the correct bidder code', () => {
+        expect(adjustCpm(1, bidResp, bidReq, {bs, index})).to.eql(2);
+      });
+      it('passes them to the adjustment fn', () => {
+        adjustCpm(1, bidResp, bidReq, {bs, index});
+        sinon.assert.calledWith(adjustmentFn, 1, bidResp == null ? sinon.match.any : bidResp, bidReq);
+      });
+    });
+  })
+});


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

- Change calls calls to `bidCpmAdjustment` to pass in the bid request (if available) as the third argument
- Update the priceFloors module to warn when an adUnit provides invalid floor configuration.

## Other information

Closes https://github.com/prebid/Prebid.js/issues/9312

