### PR TITLE
OpenX Bid Adapter : add support for BidRequest.Device.sua using user agent client hints

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -268,6 +268,11 @@ function buildCommonQueryParamsFromBids(bids, bidderRequest) {
     nocache: new Date().getTime()
   };
 
+  const userAgentClientHints = deepAccess(bidderRequest, 'ortb2.device.sua');
+  if (userAgentClientHints) {
+    defaultParams.sua = JSON.stringify(userAgentClientHints);
+  }
+
   const userDataSegments = buildFpdQueryParams('user.data', bidderRequest.ortb2);
   if (userDataSegments.length > 0) {
     defaultParams.sm = userDataSegments;

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1729,6 +1729,47 @@ describe('OpenxAdapter', function () {
           });
         });
       });
+      describe('with user agent client hints', function () {
+        it('should add json query param sua with BidRequest.device.sua if available', function () {
+          const bidderRequestWithUserAgentClientHints = { refererInfo: {},
+            ortb2: {
+              device: {
+                sua: {
+                  source: 2,
+                  platform: {
+                    brand: 'macOS',
+                    version: [ '12', '4', '0' ]
+                  },
+                  browsers: [
+                    {
+                      brand: 'Chromium',
+                      version: [ '106', '0', '5249', '119' ]
+                    },
+                    {
+                      brand: 'Google Chrome',
+                      version: [ '106', '0', '5249', '119' ]
+                    },
+                    {
+                      brand: 'Not;A=Brand',
+                      version: [ '99', '0', '0', '0' ]
+                    }],
+                  mobile: 0,
+                  model: 'Pro',
+                  bitness: '64',
+                  architecture: 'x86'
+                }
+              }
+            }};
+
+          let request = spec.buildRequests([bidRequest], bidderRequestWithUserAgentClientHints);
+          expect(request[0].data.sua).to.exist;
+          const payload = JSON.parse(request[0].data.sua);
+          expect(payload).to.deep.equal(bidderRequestWithUserAgentClientHints.ortb2.device.sua);
+          const bidderRequestWithoutUserAgentClientHints = {refererInfo: {}, ortb2: {}};
+          request = spec.buildRequests([bidRequest], bidderRequestWithoutUserAgentClientHints);
+          expect(request[0].data.sua).to.not.exist;
+        });
+      });
     });
   })
 

--- a/test/spec/modules/openxOrtbBidAdapter_spec.js
+++ b/test/spec/modules/openxOrtbBidAdapter_spec.js
@@ -573,6 +573,47 @@ describe('OpenxRtbAdapter', function () {
             });
           });
         });
+
+        describe('with user agent client hints', function () {
+          it('should add device.sua if available', function () {
+            const bidderRequestWithUserAgentClientHints = { refererInfo: {},
+              ortb2: {
+                device: {
+                  sua: {
+                    source: 2,
+                    platform: {
+                      brand: 'macOS',
+                      version: [ '12', '4', '0' ]
+                    },
+                    browsers: [
+                      {
+                        brand: 'Chromium',
+                        version: [ '106', '0', '5249', '119' ]
+                      },
+                      {
+                        brand: 'Google Chrome',
+                        version: [ '106', '0', '5249', '119' ]
+                      },
+                      {
+                        brand: 'Not;A=Brand',
+                        version: [ '99', '0', '0', '0' ]
+                      }],
+                    mobile: 0,
+                    model: 'Pro',
+                    bitness: '64',
+                    architecture: 'x86'
+                  }
+                }
+              }};
+
+            let request = spec.buildRequests(bidRequests, bidderRequestWithUserAgentClientHints);
+            expect(request[0].data.device.sua).to.exist;
+            expect(request[0].data.device.sua).to.deep.equal(bidderRequestWithUserAgentClientHints.ortb2.device.sua);
+            const bidderRequestWithoutUserAgentClientHints = {refererInfo: {}, ortb2: {}};
+            request = spec.buildRequests(bidRequests, bidderRequestWithoutUserAgentClientHints);
+            expect(request[0].data.device.sua).to.not.exist;
+          });
+        });
       });
 
       context('when there is a consent management framework', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
The purpose of this change is to make a support for the user agent client hints.
For openxBidAdapter we've added a new json query param `sua`.
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
@kenan-gillet @luigi-sayson @laurb9 @bwschmidt 