### PR TITLE
Kargo Bid Adapter: Adding Vast URL Support

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -116,7 +116,11 @@ export const spec = {
       };
 
       if (meta.mediaType == VIDEO) {
-        bidResponse.vastXml = adUnit.adm;
+        if (adUnit.admUrl) {
+          bidResponse.vastUrl = adUnit.admUrl;
+        } else {
+          bidResponse.vastXml = adUnit.adm;
+        }
       }
 
       bidResponses.push(bidResponse);

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -556,6 +556,17 @@ describe('kargo adapter tests', function () {
           mediaType: 'video',
           metadata: {},
           currency: 'EUR'
+        },
+        6: {
+          id: 'bar',
+          cpm: 2.5,
+          adm: '',
+          admUrl: 'https://foobar.com/vast_adm',
+          width: 300,
+          height: 250,
+          mediaType: 'video',
+          metadata: {},
+          currency: 'EUR'
         }
       }}, {
         currency: 'USD',
@@ -581,6 +592,11 @@ describe('kargo adapter tests', function () {
           }
         }, {
           bidId: 5,
+          params: {
+            placementId: 'bar'
+          }
+        }, {
+          bidId: 6,
           params: {
             placementId: 'bar'
           }
@@ -655,6 +671,22 @@ describe('kargo adapter tests', function () {
         height: 250,
         ad: '<VAST></VAST>',
         vastXml: '<VAST></VAST>',
+        ttl: 300,
+        creativeId: 'bar',
+        dealId: undefined,
+        netRevenue: true,
+        currency: 'EUR',
+        mediaType: 'video',
+        meta: {
+          mediaType: 'video'
+        }
+      }, {
+        requestId: '6',
+        cpm: 2.5,
+        width: 300,
+        height: 250,
+        ad: '',
+        vastUrl: 'https://foobar.com/vast_adm',
         ttl: 300,
         creativeId: 'bar',
         dealId: undefined,


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change

Adding support for Vast URLs from Kargo in the bid response instead of Vast XML. Kargo's Bid Adapter will support both going forward.

The returned Vast URL is set under the `vastUrl` in the bid response object.
