### PR TITLE
Holid bid adapter: Skip user sync when there are no bidders in bid response

### DIFF
--- a/modules/holidBidAdapter.js
+++ b/modules/holidBidAdapter.js
@@ -85,11 +85,12 @@ export const spec = {
     }
 
     const syncs = []
+    const bidders = getBidders(serverResponse)
 
-    if (optionsType.iframeEnabled) {
+    if (optionsType.iframeEnabled && bidders) {
       const queryParams = []
 
-      queryParams.push('bidders=' + getBidders(serverResponse))
+      queryParams.push('bidders=' + bidders)
       queryParams.push('gdpr=' + +gdprConsent.gdprApplies)
       queryParams.push('gdpr_consent=' + gdprConsent.consentString)
       queryParams.push('usp_consent=' + (uspConsent || ''))
@@ -107,6 +108,8 @@ export const spec = {
 
       return syncs
     }
+
+    return []
   },
 }
 
@@ -136,10 +139,12 @@ function getImp(bid) {
 
 function getBidders(serverResponse) {
   const bidders = serverResponse
-    .map((res) => Object.keys(res.body.ext.responsetimemillis))
+    .map((res) => Object.keys(res.body.ext.responsetimemillis || []))
     .flat(1)
 
-  return encodeURIComponent(JSON.stringify([...new Set(bidders)]))
+  if (bidders.length) {
+    return encodeURIComponent(JSON.stringify([...new Set(bidders)]))
+  }
 }
 
 function addWurl(auctionId, adId, wurl) {

--- a/test/spec/modules/holidBidAdapter_spec.js
+++ b/test/spec/modules/holidBidAdapter_spec.js
@@ -161,5 +161,34 @@ describe('holidBidAdapterTests', () => {
 
       expect(userSyncs).to.deep.equal(expectedUserSyncs)
     })
+
+    it('should return empty user syncs when responsetimemillis is not defined', () => {
+      const optionsType = {
+        iframeEnabled: true,
+        pixelEnabled: true,
+      }
+      const serverResponse = [
+        {
+          body: {
+            ext: {},
+          },
+        },
+      ]
+      const gdprConsent = {
+        gdprApplies: 1,
+        consentString: 'dkj49Sjmfjuj34as:12jaf90123hufabidfy9u23brfpoig',
+      }
+      const uspConsent = 'mkjvbiniwot4827obfoy8sdg8203gb'
+      const expectedUserSyncs = []
+
+      const userSyncs = spec.getUserSyncs(
+        optionsType,
+        serverResponse,
+        gdprConsent,
+        uspConsent
+      )
+
+      expect(userSyncs).to.deep.equal(expectedUserSyncs)
+    })
   })
 })


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
This PR fixes user sync that was failing when there were no bidders returned in bid response