### PR TITLE
consumable Bid Adapter: support gdpr and usp user sync params

### DIFF
--- a/modules/consumableBidAdapter.js
+++ b/modules/consumableBidAdapter.js
@@ -180,12 +180,26 @@ export const spec = {
     return bidResponses;
   },
 
-  getUserSyncs: function(syncOptions, serverResponses) {
+  getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent) {
+    let syncUrl = 'https://sync.serverbid.com/ss/' + siteId + '.html';
+
     if (syncOptions.iframeEnabled) {
+      if (gdprConsent && gdprConsent.consentString) {
+        if (typeof gdprConsent.gdprApplies === 'boolean') {
+          syncUrl = appendUrlParam(syncUrl, `gdpr=${Number(gdprConsent.gdprApplies)}&gdpr_consent=${gdprConsent.consentString}`);
+        } else {
+          syncUrl = appendUrlParam(syncUrl, `gdpr=0&gdpr_consent=${gdprConsent.consentString}`);
+        }
+      }
+
+      if (uspConsent && uspConsent.consentString) {
+        syncUrl = appendUrlParam(syncUrl, `us_privacy=${uspConsent.consentString}`);
+      }
+
       if (!serverResponses || serverResponses.length === 0 || !serverResponses[0].body.bdr || serverResponses[0].body.bdr !== 'cx') {
         return [{
           type: 'iframe',
-          url: 'https://sync.serverbid.com/ss/' + siteId + '.html'
+          url: syncUrl
         }];
       }
     }
@@ -292,6 +306,10 @@ function getBidFloor(bid, sizes) {
   }
 
   return floor;
+}
+
+function appendUrlParam(url, queryString) {
+  return `${url}${url.indexOf('?') > -1 ? '&' : '?'}${queryString}`;
 }
 
 registerBidder(spec);

--- a/test/spec/modules/consumableBidAdapter_spec.js
+++ b/test/spec/modules/consumableBidAdapter_spec.js
@@ -625,6 +625,52 @@ describe('Consumable BidAdapter', function () {
       expect(opts.length).to.equal(1);
     });
 
+    it('should return a sync url if iframe syncs are enabled and GDPR applies', function () {
+      let gdprConsent = {
+        consentString: 'GDPR_CONSENT_STRING',
+        gdprApplies: true,
+      }
+      let opts = spec.getUserSyncs(syncOptions, [AD_SERVER_RESPONSE], gdprConsent);
+
+      expect(opts.length).to.equal(1);
+      expect(opts[0].url).to.equal('https://sync.serverbid.com/ss/730181.html?gdpr=1&gdpr_consent=GDPR_CONSENT_STRING');
+    })
+
+    it('should return a sync url if iframe syncs are enabled and GDPR is undefined', function () {
+      let gdprConsent = {
+        consentString: 'GDPR_CONSENT_STRING',
+        gdprApplies: undefined,
+      }
+      let opts = spec.getUserSyncs(syncOptions, [AD_SERVER_RESPONSE], gdprConsent);
+
+      expect(opts.length).to.equal(1);
+      expect(opts[0].url).to.equal('https://sync.serverbid.com/ss/730181.html?gdpr=0&gdpr_consent=GDPR_CONSENT_STRING');
+    })
+
+    it('should return a sync url if iframe syncs are enabled and USP applies', function () {
+      let uspConsent = {
+        consentString: 'USP_CONSENT_STRING',
+      }
+      let opts = spec.getUserSyncs(syncOptions, [AD_SERVER_RESPONSE], {}, uspConsent);
+
+      expect(opts.length).to.equal(1);
+      expect(opts[0].url).to.equal('https://sync.serverbid.com/ss/730181.html?us_privacy=USP_CONSENT_STRING');
+    })
+
+    it('should return a sync url if iframe syncs are enabled, GDPR and USP applies', function () {
+      let gdprConsent = {
+        consentString: 'GDPR_CONSENT_STRING',
+        gdprApplies: true,
+      }
+      let uspConsent = {
+        consentString: 'USP_CONSENT_STRING',
+      }
+      let opts = spec.getUserSyncs(syncOptions, [AD_SERVER_RESPONSE], gdprConsent, uspConsent);
+
+      expect(opts.length).to.equal(1);
+      expect(opts[0].url).to.equal('https://sync.serverbid.com/ss/730181.html?gdpr=1&gdpr_consent=GDPR_CONSENT_STRING&us_privacy=USP_CONSENT_STRING');
+    })
+
     it('should return a sync url if pixel syncs are enabled and some are returned from the server', function () {
       let syncOptions = {'pixelEnabled': true};
       let opts = spec.getUserSyncs(syncOptions, [AD_SERVER_RESPONSE]);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Adds support for `gdpr`, `gdpr_consent`, and `us_privacy` query parameters in the user sync url.

