### PR TITLE
Core & PBS adapter: introduce bidder-level `ortb2Imp`; s2s-only `module` bids; PBS bidder-level `imp` params

### DIFF
--- a/modules/prebidServerBidAdapter/ortbConverter.js
+++ b/modules/prebidServerBidAdapter/ortbConverter.js
@@ -32,6 +32,12 @@ const PBS_CONVERTER = ortbConverter({
   imp(buildImp, proxyBidRequest, context) {
     Object.assign(context, proxyBidRequest.pbsData);
     const imp = buildImp(proxyBidRequest, context);
+    (proxyBidRequest.bids || []).forEach(bid => {
+      if (bid.ortb2Imp && Object.keys(bid.ortb2Imp).length > 0) {
+        // set bidder-level imp attributes; see https://github.com/prebid/prebid-server/issues/2335
+        deepSetValue(imp, `ext.prebid.imp.${bid.bidder}`, bid.ortb2Imp);
+      }
+    });
     if (Object.values(SUPPORTED_MEDIA_TYPES).some(mtype => imp[mtype])) {
       imp.secure = context.s2sBidRequest.s2sConfig.secure;
       return imp;

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -65,8 +65,12 @@ var _analyticsRegistry = {};
 
 function getBids({bidderCode, auctionId, bidderRequestId, adUnits, src, metrics}) {
   return adUnits.reduce((result, adUnit) => {
-    result.push(adUnit.bids.filter(bid => bid.bidder === bidderCode)
-      .reduce((bids, bid) => {
+    const bids = adUnit.bids.filter(bid => bid.bidder === bidderCode);
+    if (bidderCode == null && bids.length === 0 && adUnit.s2sBid != null) {
+      bids.push({bidder: null});
+    }
+    result.push(
+      bids.reduce((bids, bid) => {
         bid = Object.assign({}, bid,
           {ortb2Imp: mergeDeep({}, adUnit.ortb2Imp, bid.ortb2Imp)},
           getDefinedParams(adUnit, [
@@ -130,9 +134,18 @@ export const filterBidsForAdUnit = hook('sync', _filterBidsForAdUnit, 'filterBid
 
 function getAdUnitCopyForPrebidServer(adUnits, s2sConfig) {
   let adUnitsCopy = deepClone(adUnits);
+  let hasModuleBids = false;
 
   adUnitsCopy.forEach((adUnit) => {
     // filter out client side bids
+    const s2sBids = adUnit.bids.filter((b) => b.module === 'pbsBidAdapter' && b.params?.configName === s2sConfig.configName);
+    if (s2sBids.length === 1) {
+      adUnit.s2sBid = s2sBids[0];
+      hasModuleBids = true;
+      adUnit.ortb2Imp = mergeDeep({}, adUnit.s2sBid.ortb2Imp, adUnit.ortb2Imp);
+    } else if (s2sBids.length > 1) {
+      logWarn('Multiple "module" bids for the same s2s configuration; all will be ignored', s2sBids);
+    }
     adUnit.bids = filterBidsForAdUnit(adUnit.bids, s2sConfig)
       .map((bid) => {
         bid.bid_id = getUniqueIdentifierStr();
@@ -142,9 +155,9 @@ function getAdUnitCopyForPrebidServer(adUnits, s2sConfig) {
 
   // don't send empty requests
   adUnitsCopy = adUnitsCopy.filter(adUnit => {
-    return adUnit.bids.length !== 0;
+    return adUnit.bids.length !== 0 || adUnit.s2sBid != null;
   });
-  return adUnitsCopy;
+  return {adUnits: adUnitsCopy, hasModuleBids};
 }
 
 function getAdUnitCopyForClientAdapters(adUnits) {
@@ -246,11 +259,12 @@ adapterManager.makeBidRequests = hook('sync', function (adUnits, auctionStart, a
 
   _s2sConfigs.forEach(s2sConfig => {
     if (s2sConfig && s2sConfig.enabled) {
-      let adUnitsS2SCopy = getAdUnitCopyForPrebidServer(adUnits, s2sConfig);
+      let {adUnits: adUnitsS2SCopy, hasModuleBids} = getAdUnitCopyForPrebidServer(adUnits, s2sConfig);
 
       // uniquePbsTid is so we know which server to send which bids to during the callBids function
       let uniquePbsTid = generateUUID();
-      serverBidders.forEach(bidderCode => {
+
+      (serverBidders.length === 0 && hasModuleBids ? [null] : serverBidders).forEach(bidderCode => {
         const bidderRequestId = getUniqueIdentifierStr();
         const metrics = auctionMetrics.fork();
         const bidderRequest = addOrtb2({
@@ -281,7 +295,7 @@ adapterManager.makeBidRequests = hook('sync', function (adUnits, auctionStart, a
 
       bidRequests.forEach(request => {
         if (request.adUnitsS2SCopy === undefined) {
-          request.adUnitsS2SCopy = adUnitsS2SCopy.filter(adUnitCopy => adUnitCopy.bids.length > 0);
+          request.adUnitsS2SCopy = adUnitsS2SCopy.filter(au => au.bids.length > 0 || au.s2sBid != null);
         }
       });
     }

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -67,13 +67,15 @@ function getBids({bidderCode, auctionId, bidderRequestId, adUnits, src, metrics}
   return adUnits.reduce((result, adUnit) => {
     result.push(adUnit.bids.filter(bid => bid.bidder === bidderCode)
       .reduce((bids, bid) => {
-        bid = Object.assign({}, bid, getDefinedParams(adUnit, [
-          'nativeParams',
-          'nativeOrtbRequest',
-          'ortb2Imp',
-          'mediaType',
-          'renderer'
-        ]));
+        bid = Object.assign({}, bid,
+          {ortb2Imp: mergeDeep({}, adUnit.ortb2Imp, bid.ortb2Imp)},
+          getDefinedParams(adUnit, [
+            'nativeParams',
+            'nativeOrtbRequest',
+            'mediaType',
+            'renderer'
+          ])
+        );
 
         const mediaTypes = bid.mediaTypes == null ? adUnit.mediaTypes : bid.mediaTypes
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -710,7 +710,7 @@ export function getKeyByValue(obj, value) {
 export function getBidderCodes(adUnits = $$PREBID_GLOBAL$$.adUnits) {
   // this could memoize adUnits
   return adUnits.map(unit => unit.bids.map(bid => bid.bidder)
-    .reduce(flatten, [])).reduce(flatten, []).filter(uniques);
+    .reduce(flatten, [])).reduce(flatten, []).filter((bidder) => typeof bidder !== 'undefined').filter(uniques);
 }
 
 export function isGptPubadsDefined() {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2522,6 +2522,62 @@ describe('S2S Adapter', function () {
     });
   });
 
+  describe('Bidder-level ortb2Imp', () => {
+    beforeEach(() => {
+      config.setConfig({
+        s2sConfig: {
+          ...CONFIG,
+          bidders: ['A', 'B']
+        }
+      })
+    })
+    it('should be set on imp.ext.prebid.imp', () => {
+      const s2sReq = utils.deepClone(REQUEST);
+      s2sReq.ad_units[0].ortb2Imp = {l0: 'adUnit'};
+      s2sReq.ad_units[0].bids = [
+        {
+          bidder: 'A',
+          bid_id: 1,
+          ortb2Imp: {
+            l2: 'A'
+          }
+        },
+        {
+          bidder: 'B',
+          bid_id: 2,
+          ortb2Imp: {
+            l2: 'B'
+          }
+        }
+      ];
+      const bidderReqs = [
+        {
+          ...BID_REQUESTS[0],
+          bidderCode: 'A',
+          bids: [{
+            bidId: 1,
+            bidder: 'A'
+          }]
+        },
+        {
+          ...BID_REQUESTS[0],
+          bidderCode: 'B',
+          bids: [{
+            bidId: 2,
+            bidder: 'B'
+          }]
+        }
+      ]
+      adapter.callBids(s2sReq, bidderReqs, addBidResponse, done, ajax);
+      const req = JSON.parse(server.requests[0].requestBody);
+      expect(req.imp[0].l0).to.eql('adUnit');
+      expect(req.imp[0].ext.prebid.imp).to.eql({
+        A: {l2: 'A'},
+        B: {l2: 'B'}
+      });
+    });
+  });
+
   describe('ext.prebid config', function () {
     it('should send \"imp.ext.prebid.storedrequest.id\" if \"ortb2Imp.ext.prebid.storedrequest.id\" is set', function () {
       const consentConfig = { s2sConfig: CONFIG };

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1767,15 +1767,15 @@ describe('adapterManager tests', function () {
         adapterManager.makeBidRequests([adUnit], 123, 'auction-id', 123, [], {})
           .map((req) => [req.bidderCode, req])
       );
-      expect(reqs[adUnit.bids[0].bidder].bids[0].ortb2Imp).to.eql({
+      sinon.assert.match(reqs[adUnit.bids[0].bidder].bids[0].ortb2Imp, {
         oneone: {
           twoone: 'val',
           twotwo: 'val',
         },
         onetwo: 'val2',
         onethree: 'val'
-      });
-      expect(reqs[adUnit.bids[1].bidder].bids[0].ortb2Imp).to.eql(adUnit.ortb2Imp);
+      })
+      sinon.assert.match(reqs[adUnit.bids[1].bidder].bids[0].ortb2Imp, adUnit.ortb2Imp)
     })
 
     it('picks ortb2Imp from "module" when only one s2sConfig is set', () => {
@@ -1803,7 +1803,7 @@ describe('adapterManager tests', function () {
       };
       const req = adapterManager.makeBidRequests([adUnit], 123, 'auction-id', 123, [], {})[0];
       [req.adUnitsS2SCopy[0].ortb2Imp, req.bids[0].ortb2Imp].forEach(imp => {
-        expect(imp).to.eql({
+        sinon.assert.match(imp, {
           p1: 'adUnit',
           p2: 'module'
         });
@@ -1855,16 +1855,16 @@ describe('adapterManager tests', function () {
         };
         const reqs = adapterManager.makeBidRequests([adUnit], 123, 'auction-id', 123, [], {});
         [reqs[0].adUnitsS2SCopy[0].ortb2Imp, reqs[0].bids[0].ortb2Imp].forEach(imp => {
-          expect(imp).to.eql({
+          sinon.assert.match(imp, {
             p1: 'adUnit',
             p2: 'one'
-          });
+          })
         });
         [reqs[1].adUnitsS2SCopy[0].ortb2Imp, reqs[1].bids[0].ortb2Imp].forEach(imp => {
-          expect(imp).to.eql({
+          sinon.assert.match(imp, {
             p1: 'adUnit',
             p2: 'two'
-          });
+          })
         });
       });
 
@@ -1892,15 +1892,15 @@ describe('adapterManager tests', function () {
         };
         const reqs = adapterManager.makeBidRequests([adUnit], 123, 'auction-id', 123, [], {});
         expect(reqs.length).to.equal(1);
-        expect(reqs[0].adUnitsS2SCopy[0].ortb2Imp).to.eql({
+        sinon.assert.match(reqs[0].adUnitsS2SCopy[0].ortb2Imp, {
           p1: 'adUnit',
           p2: 'one'
-        });
-        expect(reqs[0].bids[0].ortb2Imp).to.eql({
+        })
+        sinon.assert.match(reqs[0].bids[0].ortb2Imp, {
           p1: 'adUnit',
           p2: 'one',
           p3: 'bidderA'
-        });
+        })
       });
     });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

- Introduce bidder-level `ortb2Imp` property. For example:
    ```
      pbjs.addAdUnits([{
        code: 'example-pmp',
        mediaTypes: { banner: { sizes: [[300, 250]]}},
        ortb2Imp: {
          ext: { gpid: "homepage" }
        },
        bids: [{
           bidder: "bidderA",
           ortb2Imp: {
                pmp: { deals: [{id: "A"}]}
           }
         },{
           bidder: "bidderB",
           ortb2Imp: {
                pmp: { deals: [{id: "B"}]}
           }
         }
      }]
    ```

    will generate bid requests that have `pmp.deals[0].id === 'A'` for bidder `A` and `'B'` for bidder `B`.

- Introduce bidder-level `imp` overrides for PBS as detailed in https://github.com/prebid/prebid-server/issues/2335
- Introduce "module" bids as detailed in https://github.com/prebid/Prebid.js/issues/8668


## Other information

Closes https://github.com/prebid/Prebid.js/issues/8668


