### PR TITLE
Permutive RTD Module: fixes potential error when reading _pssps localStorage key

### DIFF
--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -311,16 +311,19 @@ export function isPermutiveOnPage () {
  * @return {Object}
  */
 export function getSegments (maxSegs) {
-  const legacySegs = readSegments('_psegs').map(Number).filter(seg => seg >= 1000000).map(String)
-  const _ppam = readSegments('_ppam')
-  const _pcrprs = readSegments('_pcrprs')
+  const legacySegs = readSegments('_psegs', []).map(Number).filter(seg => seg >= 1000000).map(String)
+  const _ppam = readSegments('_ppam', [])
+  const _pcrprs = readSegments('_pcrprs', [])
 
   const segments = {
     ac: [..._pcrprs, ..._ppam, ...legacySegs],
-    rubicon: readSegments('_prubicons'),
-    appnexus: readSegments('_papns'),
-    gam: readSegments('_pdfps'),
-    ssp: readSegments('_pssps'),
+    rubicon: readSegments('_prubicons', []),
+    appnexus: readSegments('_papns', []),
+    gam: readSegments('_pdfps', []),
+    ssp: readSegments('_pssps', {
+      cohorts: [],
+      ssps: []
+    }),
   }
 
   for (const bidder in segments) {
@@ -338,15 +341,17 @@ export function getSegments (maxSegs) {
 
 /**
  * Gets an array of segment IDs from LocalStorage
- * or returns an empty array
+ * or return the default value provided.
+ * @template A
  * @param {string} key
- * @return {string[]|number[]}
+ * @param {A} defaultValue
+ * @return {A}
  */
-function readSegments (key) {
+function readSegments (key, defaultValue) {
   try {
-    return JSON.parse(storage.getDataFromLocalStorage(key) || '[]')
+    return JSON.parse(storage.getDataFromLocalStorage(key)) || defaultValue
   } catch (e) {
-    return []
+    return defaultValue
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
It's possible an exception could be thrown when reading the _pssps and the segments inside due to incorrect assumption about the type of it (previously all segments localStorage locations were assumed to be arrays of strings or numbers - this is incorrect for _pssps).


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

Follow up to https://github.com/prebid/Prebid.js/pull/9236.
