### PR TITLE
33Across Bid Adapter: set site.ref in request

### DIFF
--- a/modules/pulsepointBidAdapter.js
+++ b/modules/pulsepointBidAdapter.js
@@ -16,6 +16,7 @@ const DEFAULT_BID_TTL = 20;
 const DEFAULT_CURRENCY = 'USD';
 const DEFAULT_NET_REVENUE = true;
 const KNOWN_PARAMS = ['cp', 'ct', 'cf', 'video', 'battr', 'bcat', 'badv', 'bidfloor'];
+const DEFAULT_TMAX = 500;
 
 /**
  * PulsePoint Bid Adapter.
@@ -54,6 +55,7 @@ export const spec = {
       user: user(bidRequests[0], bidderRequest),
       regs: regs(bidderRequest),
       source: source(bidRequests[0].schain),
+      tmax: bidderRequest.timeout || DEFAULT_TMAX,
     };
     return {
       method: 'POST',

--- a/test/spec/modules/pulsepointBidAdapter_spec.js
+++ b/test/spec/modules/pulsepointBidAdapter_spec.js
@@ -2,7 +2,6 @@
 import {expect} from 'chai';
 import {spec} from 'modules/pulsepointBidAdapter.js';
 import {deepClone} from 'src/utils.js';
-import { config } from 'src/config.js';
 
 describe('PulsePoint Adapter Tests', function () {
   const slotConfigs = [{
@@ -225,6 +224,8 @@ describe('PulsePoint Adapter Tests', function () {
     expect(ortbRequest.imp[1].banner).to.not.equal(null);
     expect(ortbRequest.imp[1].banner.w).to.equal(728);
     expect(ortbRequest.imp[1].banner.h).to.equal(90);
+    // tmax
+    expect(ortbRequest.tmax).to.equal(500);
   });
 
   it('Verify parse response', function () {
@@ -917,5 +918,14 @@ describe('PulsePoint Adapter Tests', function () {
         adUnitSpecificAttribute: '123'
       }
     });
+  });
+
+  it('Verify bid request timeouts', function () {
+    const mkRequest = (bidderRequest) => spec.buildRequests(slotConfigs, bidderRequest).data;
+    // assert default is used when no bidderRequest.timeout value is available
+    expect(mkRequest(bidderRequest).tmax).to.equal(500)
+
+    // assert bidderRequest value is used when available
+    expect(mkRequest(Object.assign({}, { timeout: 6000 }, bidderRequest)).tmax).to.equal(6000)
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes

## Description of change
-Extract ref field from refererInfo and set under site.ref when creating the bid request
