### PR TITLE
Appnexus Bid Adapter : support alternate format for bid.params properties

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -790,8 +790,8 @@ function bidToTag(bid) {
     tag.code = bid.params.inv_code;
   }
   tag.allow_smaller_sizes = bid.params.allow_smaller_sizes || false;
-  tag.use_pmt_rule = (typeof bid.params.use_payment_rule === 'boolean') ? bid.params.use_payment_rule : 
-    (typeof bid.params.use_pmt_rule === 'boolean') ? bid.params.use_pmt_rule : false;
+  tag.use_pmt_rule = (typeof bid.params.use_payment_rule === 'boolean') ? bid.params.use_payment_rule
+    : (typeof bid.params.use_pmt_rule === 'boolean') ? bid.params.use_pmt_rule : false;
   tag.prebid = true;
   tag.disable_psa = true;
   let bidFloor = getBidFloor(bid);

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -44,7 +44,7 @@ const URL_SIMPLE = 'https://ib.adnxs-simple.com/ut/v3/prebid';
 const VIDEO_TARGETING = ['id', 'minduration', 'maxduration',
   'skippable', 'playback_method', 'frameworks', 'context', 'skipoffset'];
 const VIDEO_RTB_TARGETING = ['minduration', 'maxduration', 'skip', 'skipafter', 'playbackmethod', 'api', 'startdelay'];
-const USER_PARAMS = ['age', 'externalUid', 'segments', 'gender', 'dnt', 'language'];
+const USER_PARAMS = ['age', 'externalUid', 'external_uid', 'segments', 'gender', 'dnt', 'language'];
 const APP_DEVICE_PARAMS = ['geo', 'device_id']; // appid is collected separately
 const DEBUG_PARAMS = ['enabled', 'dongle', 'member_id', 'debug_timeout'];
 const DEBUG_QUERY_PARAM_MAP = {
@@ -120,7 +120,9 @@ export const spec = {
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: function (bid) {
-    return !!(bid.params.placementId || (bid.params.member && bid.params.invCode));
+    return !!(
+      (bid.params.placementId || bid.params.placement_id) ||
+      (bid.params.member && (bid.params.invCode || bid.params.inv_code)));
   },
 
   /**
@@ -484,9 +486,6 @@ export const spec = {
     }, params);
 
     if (isOpenRtb) {
-      params.use_pmt_rule = (typeof params.usePaymentRule === 'boolean') ? params.usePaymentRule : false;
-      if (params.usePaymentRule) { delete params.usePaymentRule; }
-
       if (isPopulatedArray(params.keywords)) {
         params.keywords.forEach(deleteValues);
       }
@@ -498,6 +497,9 @@ export const spec = {
           delete params[paramKey];
         }
       });
+
+      params.use_pmt_rule = (typeof params.use_payment_rule === 'boolean') ? params.use_payment_rule : false;
+      if (params.use_payment_rule) { delete params.use_payment_rule; }
     }
 
     return params;
@@ -771,17 +773,25 @@ function newBid(serverBid, rtbBid, bidderRequest) {
 
 function bidToTag(bid) {
   const tag = {};
+  Object.keys(bid.params).forEach(paramKey => {
+    let convertedKey = convertCamelToUnderscore(paramKey);
+    if (convertedKey !== paramKey) {
+      bid.params[convertedKey] = bid.params[paramKey];
+      delete bid.params[paramKey];
+    }
+  });
   tag.sizes = transformSizes(bid.sizes);
   tag.primary_size = tag.sizes[0];
   tag.ad_types = [];
   tag.uuid = bid.bidId;
-  if (bid.params.placementId) {
-    tag.id = parseInt(bid.params.placementId, 10);
+  if (bid.params.placement_id) {
+    tag.id = parseInt(bid.params.placement_id, 10);
   } else {
-    tag.code = bid.params.invCode;
+    tag.code = bid.params.inv_code;
   }
-  tag.allow_smaller_sizes = bid.params.allowSmallerSizes || false;
-  tag.use_pmt_rule = bid.params.usePaymentRule || false;
+  tag.allow_smaller_sizes = bid.params.allow_smaller_sizes || false;
+  tag.use_pmt_rule = (typeof bid.params.use_payment_rule === 'boolean') ? bid.params.use_payment_rule : 
+    (typeof bid.params.use_pmt_rule === 'boolean') ? bid.params.use_pmt_rule : false;
   tag.prebid = true;
   tag.disable_psa = true;
   let bidFloor = getBidFloor(bid);
@@ -798,26 +808,26 @@ function bidToTag(bid) {
       tag.position = (mediaTypePos === 3) ? 2 : mediaTypePos;
     }
   }
-  if (bid.params.trafficSourceCode) {
-    tag.traffic_source_code = bid.params.trafficSourceCode;
+  if (bid.params.traffic_source_code) {
+    tag.traffic_source_code = bid.params.traffic_source_code;
   }
-  if (bid.params.privateSizes) {
-    tag.private_sizes = transformSizes(bid.params.privateSizes);
+  if (bid.params.private_sizes) {
+    tag.private_sizes = transformSizes(bid.params.private_sizes);
   }
-  if (bid.params.supplyType) {
-    tag.supply_type = bid.params.supplyType;
+  if (bid.params.supply_type) {
+    tag.supply_type = bid.params.supply_type;
   }
-  if (bid.params.pubClick) {
-    tag.pubclick = bid.params.pubClick;
+  if (bid.params.pub_click) {
+    tag.pubclick = bid.params.pub_click;
   }
-  if (bid.params.extInvCode) {
-    tag.ext_inv_code = bid.params.extInvCode;
+  if (bid.params.ext_inv_code) {
+    tag.ext_inv_code = bid.params.ext_inv_code;
   }
-  if (bid.params.publisherId) {
-    tag.publisher_id = parseInt(bid.params.publisherId, 10);
+  if (bid.params.publisher_id) {
+    tag.publisher_id = parseInt(bid.params.publisher_id, 10);
   }
-  if (bid.params.externalImpId) {
-    tag.external_imp_id = bid.params.externalImpId;
+  if (bid.params.external_imp_id) {
+    tag.external_imp_id = bid.params.external_imp_id;
   }
 
   let ortb2ImpKwStr = deepAccess(bid, 'ortb2Imp.ext.data.keywords');

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -36,14 +36,31 @@ describe('AppNexusAdapter', function () {
     });
 
     it('should return true when required params found', function () {
-      let bid = Object.assign({}, bid);
-      delete bid.params;
-      bid.params = {
+      let bid1 = deepClone(bid);
+      bid1.params = {
+        'placement_id': 123423
+      }
+      expect(spec.isBidRequestValid(bid1)).to.equal(true);
+    });
+
+    it('should return true when required params found', function () {
+      let bid1 = deepClone(bid);
+      bid1.params = {
         'member': '1234',
         'invCode': 'ABCD'
       };
 
-      expect(spec.isBidRequestValid(bid)).to.equal(true);
+      expect(spec.isBidRequestValid(bid1)).to.equal(true);
+    });
+
+    it('should return true when required params found', function () {
+      let bid1 = deepClone(bid);
+      bid1.params = {
+        'member': '1234',
+        'inv_code': 'ABCD'
+      };
+
+      expect(spec.isBidRequestValid(bid1)).to.equal(true);
     });
 
     it('should return false when required params are not passed', function () {
@@ -51,6 +68,15 @@ describe('AppNexusAdapter', function () {
       delete bid.params;
       bid.params = {
         'placementId': 0
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when required params are not passed', function () {
+      let bid = Object.assign({}, bid);
+      delete bid.params;
+      bid.params = {
+        'placement_id': 0
       };
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
@@ -90,6 +116,24 @@ describe('AppNexusAdapter', function () {
           params: {
             placementId: '10433394',
             privateSizes: [300, 250]
+          }
+        }
+      );
+
+      const request = spec.buildRequests([bidRequest]);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.tags[0].private_sizes).to.exist;
+      expect(payload.tags[0].private_sizes).to.deep.equal([{ width: 300, height: 250 }]);
+    });
+
+    it('should parse out private sizes', function () {
+      let bidRequest = Object.assign({},
+        bidRequests[0],
+        {
+          params: {
+            placementId: '10433394',
+            private_sizes: [300, 250]
           }
         }
       );
@@ -168,6 +212,24 @@ describe('AppNexusAdapter', function () {
       expect(payload.publisher_id).to.deep.equal(1231234);
     });
 
+    it('should add publisher_id in request', function () {
+      let bidRequest = Object.assign({},
+        bidRequests[0],
+        {
+          params: {
+            placement_id: '10433394',
+            publisher_id: '1231234'
+          }
+        });
+      const request = spec.buildRequests([bidRequest]);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.tags[0].publisher_id).to.exist;
+      expect(payload.tags[0].publisher_id).to.deep.equal(1231234);
+      expect(payload.publisher_id).to.exist;
+      expect(payload.publisher_id).to.deep.equal(1231234);
+    });
+
     it('should add source and verison to the tag', function () {
       const request = spec.buildRequests(bidRequests);
       const payload = JSON.parse(request.data);
@@ -189,7 +251,7 @@ describe('AppNexusAdapter', function () {
         bids: [{
           bidder: 'appnexus',
           params: {
-            placementId: '10433394'
+            placement_id: '10433394'
           }
         }],
         transactionId: '04f2659e-c005-4eb1-a57c-fa93145e3843'
@@ -351,7 +413,7 @@ describe('AppNexusAdapter', function () {
         bidRequests[0],
         {
           params: {
-            placementId: '10433394',
+            placement_id: '10433394',
             user: {
               externalUid: '123',
               segments: [123, { id: 987, value: 876 }],
@@ -407,7 +469,7 @@ describe('AppNexusAdapter', function () {
 
       // 2 -> reserve is defined, getFloor not defined > reserve is used
       bidRequest.params = {
-        'placementId': '10433394',
+        'placement_id': '10433394',
         'reserve': 0.5
       };
       request = spec.buildRequests([bidRequest]);
@@ -428,7 +490,7 @@ describe('AppNexusAdapter', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
-          params: { placementId: '14542875' }
+          params: { placement_id: '14542875' }
         },
         {
           mediaTypes: {
@@ -461,7 +523,7 @@ describe('AppNexusAdapter', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
-          params: { placementId: '14542875' }
+          params: { placement_id: '14542875' }
         },
         {
           mediaTypes: {
@@ -484,7 +546,7 @@ describe('AppNexusAdapter', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
-          params: { placementId: '14542875' }
+          params: { placement_id: '14542875' }
         },
         {
           mediaTypes: {
@@ -526,7 +588,7 @@ describe('AppNexusAdapter', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
-          params: { placementId: '14542875' }
+          params: { placement_id: '14542875' }
         },
         {
           mediaTypes: {
@@ -557,7 +619,7 @@ describe('AppNexusAdapter', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
-          params: { placementId: '14542875' }
+          params: { placement_id: '14542875' }
         },
         {
           mediaTypes: {
@@ -585,7 +647,7 @@ describe('AppNexusAdapter', function () {
       let bidRequest = Object.assign({},
         bidRequests[0],
         {
-          params: { placementId: '14542875' }
+          params: { placement_id: '14542875' }
         },
         {
           mediaTypes: {
@@ -610,7 +672,7 @@ describe('AppNexusAdapter', function () {
           mediaType: 'banner',
           params: {
             sizes: [[300, 250], [300, 600]],
-            placementId: 13144370
+            placement_id: 13144370
           }
         }
       );
@@ -786,7 +848,7 @@ describe('AppNexusAdapter', function () {
         bidRequests[0],
         {
           params: {
-            placementId: '10433394',
+            placement_id: '10433394',
             keywords: {
               single: 'val',
               singleArr: ['val'],
@@ -921,6 +983,23 @@ describe('AppNexusAdapter', function () {
           params: {
             placementId: '10433394',
             usePaymentRule: true
+          }
+        }
+      );
+
+      const request = spec.buildRequests([bidRequest]);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.tags[0].use_pmt_rule).to.equal(true);
+    });
+
+    it('should add payment rules to the request', function () {
+      let bidRequest = Object.assign({},
+        bidRequests[0],
+        {
+          params: {
+            placement_id: '10433394',
+            use_payment_rule: true
           }
         }
       );


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
Per some internal requests, we have updated the logic in our bid adapter to support bid params using a lowercase underscore formatting, similar to the params used by the Prebid Server appnexus adapter.

The old camel-case formatting is still supported (the param keys are converted to the new format), so it should not negatively impact existing setups.

Docs PR: https://github.com/prebid/prebid.github.io/pull/4336