### PR TITLE
Appnexus Bid Adapter : support all userId

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -343,20 +343,18 @@ export const spec = {
 
     if (bidRequests[0].userId) {
       let eids = [];
-
-      addUserId(eids, deepAccess(bidRequests[0], `userId.criteoId`), 'criteo.com', null);
-      addUserId(eids, deepAccess(bidRequests[0], `userId.netId`), 'netid.de', null);
-      addUserId(eids, deepAccess(bidRequests[0], `userId.idl_env`), 'liveramp.com', null);
-      addUserId(eids, deepAccess(bidRequests[0], `userId.tdid`), 'adserver.org', 'TDID');
-      addUserId(eids, deepAccess(bidRequests[0], `userId.uid2.id`), 'uidapi.com', 'UID2');
-      if (bidRequests[0].userId.pubProvidedId) {
-        bidRequests[0].userId.pubProvidedId.forEach(ppId => {
-          ppId.uids.forEach(uid => {
-            eids.push({ source: ppId.source, id: uid.id });
-          });
+      bidRequests[0].userIdAsEids.forEach(eid => {
+        if (!eid || !eid.uids || eid.uids.length < 1) { return; }
+        eid.uids.forEach(uid => {
+          let tmp = {'source': eid.source, 'id': uid.id};
+          if (eid.source == 'adserver.org') {
+            tmp.rti_partner = 'TDID';
+          } else if (eid.source == 'uidapi.com') {
+            tmp.rti_partner = 'UID2';
+          }
+          eids.push(tmp);
         });
-      }
-
+      });
       if (eids.length) {
         payload.eids = eids;
       }
@@ -1216,17 +1214,6 @@ function parseMediaType(rtbBid) {
   } else {
     return BANNER;
   }
-}
-
-function addUserId(eids, id, source, rti) {
-  if (id) {
-    if (rti) {
-      eids.push({ source, id, rti_partner: rti });
-    } else {
-      eids.push({ source, id });
-    }
-  }
-  return eids;
 }
 
 function getBidFloor(bid) {

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -1239,9 +1239,33 @@ describe('AppNexusAdapter', function () {
             source: 'puburl2.com',
             uids: [{
               id: 'pubid2'
+            }, {
+              id: 'pubid2-123'
             }]
           }]
-        }
+        },
+        userIdAsEids: [{
+          source: 'adserver.org',
+          uids: [{ id: 'sample-userid' }]
+        }, {
+          source: 'criteo.com',
+          uids: [{ id: 'sample-criteo-userid' }]
+        }, {
+          source: 'netid.de',
+          uids: [{ id: 'sample-netId-userid' }]
+        }, {
+          source: 'liveramp.com',
+          uids: [{ id: 'sample-idl-userid' }]
+        }, {
+          source: 'uidapi.com',
+          uids: [{ id: 'sample-uid2-value' }]
+        }, {
+          source: 'puburl.com',
+          uids: [{ id: 'pubid1' }]
+        }, {
+          source: 'puburl2.com',
+          uids: [{ id: 'pubid2' }, { id: 'pubid2-123' }]
+        }]
       });
 
       const request = spec.buildRequests([bidRequest]);
@@ -1281,6 +1305,10 @@ describe('AppNexusAdapter', function () {
       expect(payload.eids).to.deep.include({
         source: 'puburl2.com',
         id: 'pubid2'
+      });
+      expect(payload.eids).to.deep.include({
+        source: 'puburl2.com',
+        id: 'pubid2-123'
       });
     });
 


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x Feature


## Description of change
This change allows the appnexus bid adapter to support all userIds available in prebid.js rather than select ones.

Docs PR: https://github.com/prebid/prebid.github.io/pull/4339