### PR TITLE
Missena Bid Adapter: add format params and onBidWon pixel

### DIFF
--- a/modules/missenaBidAdapter.js
+++ b/modules/missenaBidAdapter.js
@@ -1,9 +1,11 @@
-import { formatQS, logInfo } from '../src/utils.js';
+import { buildUrl, formatQS, logInfo, triggerPixel } from '../src/utils.js';
 import { BANNER } from '../src/mediaTypes.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 
 const BIDDER_CODE = 'missena';
 const ENDPOINT_URL = 'https://bid.missena.io/';
+const EVENTS_DOMAIN = 'events.missena.io';
+const EVENTS_DOMAIN_DEV = 'events.staging.missena.xyz';
 
 export const spec = {
   aliases: [BIDDER_CODE],
@@ -30,6 +32,7 @@ export const spec = {
   buildRequests: function (validBidRequests, bidderRequest) {
     return validBidRequests.map((bidRequest) => {
       const payload = {
+        adunit: bidRequest.adUnitCode,
         request_id: bidRequest.bidId,
         timeout: bidderRequest.timeout,
       };
@@ -47,6 +50,15 @@ export const spec = {
       const baseUrl = bidRequest.params.baseUrl || ENDPOINT_URL;
       if (bidRequest.params.test) {
         payload.test = bidRequest.params.test;
+      }
+      if (bidRequest.params.placement) {
+        payload.placement = bidRequest.params.placement;
+      }
+      if (bidRequest.params.formats) {
+        payload.formats = bidRequest.params.formats;
+      }
+      if (bidRequest.params.isInternal) {
+        payload.is_internal = bidRequest.params.isInternal;
       }
       return {
         method: 'POST',
@@ -109,6 +121,15 @@ export const spec = {
    * @param {Bid} The bid that won the auction
    */
   onBidWon: function (bid) {
+    const hostname = bid.params[0].baseUrl ? EVENTS_DOMAIN_DEV : EVENTS_DOMAIN;
+    triggerPixel(
+      buildUrl({
+        protocol: 'https',
+        hostname,
+        pathname: '/v1/bidsuccess',
+        search: { t: bid.params[0].apiKey },
+      })
+    );
     logInfo('Missena - Bid won', bid);
   },
 };

--- a/test/spec/modules/missenaBidAdapter_spec.js
+++ b/test/spec/modules/missenaBidAdapter_spec.js
@@ -13,6 +13,8 @@ describe('Missena Adapter', function () {
     sizes: [[1, 1]],
     params: {
       apiKey: 'PA-34745704',
+      placement: 'sticky',
+      formats: ['sticky-banner'],
     },
   };
 
@@ -68,6 +70,14 @@ describe('Missena Adapter', function () {
 
     it('should send the bidder id', function () {
       expect(payload.request_id).to.equal(bidId);
+    });
+
+    it('should send placement', function () {
+      expect(payload.placement).to.equal('sticky');
+    });
+
+    it('should send formats', function () {
+      expect(payload.formats).to.eql(['sticky-banner']);
     });
 
     it('should send referer information to the request', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
We added a few parameters that are designed to help our internal use of prebid. 

The changes should have no impact on external users of our bid adapter as the extra params are not yet ready for external use.

The PR also contains a `trackingPixel`  for `onBidWon` event. 

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
