### PR TITLE
AJA Bid Adapter: add support for user agent client hints

### DIFF
--- a/modules/ajaBidAdapter.js
+++ b/modules/ajaBidAdapter.js
@@ -1,4 +1,4 @@
-import { getBidIdParameter, tryAppendQueryString, createTrackPixelHtml, logError, logWarn } from '../src/utils.js';
+import { getBidIdParameter, tryAppendQueryString, createTrackPixelHtml, logError, logWarn, deepAccess } from '../src/utils.js';
 import { Renderer } from '../src/Renderer.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { VIDEO, BANNER, NATIVE } from '../src/mediaTypes.js';
@@ -62,6 +62,11 @@ export const spec = {
         queryString = tryAppendQueryString(queryString, 'eids', JSON.stringify({
           'eids': eids,
         }))
+      }
+
+      const sua = deepAccess(bidRequest, 'ortb2.device.sua');
+      if (sua) {
+        queryString = tryAppendQueryString(queryString, 'sua', JSON.stringify(sua));
       }
 
       bidRequests.push({

--- a/test/spec/modules/ajaBidAdapter_spec.js
+++ b/test/spec/modules/ajaBidAdapter_spec.js
@@ -45,6 +45,26 @@ describe('AjaAdapter', function () {
         bidId: '30b31c1838de1e',
         bidderRequestId: '22edbae2733bf6',
         auctionId: '1d1a030790a475',
+        ortb2: {
+          device: {
+            sua: {
+              source: 2,
+              platform: {
+                brand: 'Android',
+                version: ['8', '0', '0']
+              },
+              browsers: [
+                {brand: 'Not_A Brand', version: ['99', '0', '0', '0']},
+                {brand: 'Google Chrome', version: ['109', '0', '5414', '119']},
+                {brand: 'Chromium', version: ['109', '0', '5414', '119']}
+              ],
+              mobile: 1,
+              model: 'SM-G955U',
+              bitness: '64',
+              architecture: ''
+            }
+          }
+        }
       }
     ];
 
@@ -58,7 +78,7 @@ describe('AjaAdapter', function () {
       const requests = spec.buildRequests(bidRequests, bidderRequest);
       expect(requests[0].url).to.equal(ENDPOINT);
       expect(requests[0].method).to.equal('GET');
-      expect(requests[0].data).to.equal('asi=123456&skt=5&prebid_id=30b31c1838de1e&prebid_ver=$prebid.version$&page_url=https%3A%2F%2Fhoge.com&');
+      expect(requests[0].data).to.equal('asi=123456&skt=5&prebid_id=30b31c1838de1e&prebid_ver=$prebid.version$&page_url=https%3A%2F%2Fhoge.com&sua=%7B%22source%22%3A2%2C%22platform%22%3A%7B%22brand%22%3A%22Android%22%2C%22version%22%3A%5B%228%22%2C%220%22%2C%220%22%5D%7D%2C%22browsers%22%3A%5B%7B%22brand%22%3A%22Not_A%20Brand%22%2C%22version%22%3A%5B%2299%22%2C%220%22%2C%220%22%2C%220%22%5D%7D%2C%7B%22brand%22%3A%22Google%20Chrome%22%2C%22version%22%3A%5B%22109%22%2C%220%22%2C%225414%22%2C%22119%22%5D%7D%2C%7B%22brand%22%3A%22Chromium%22%2C%22version%22%3A%5B%22109%22%2C%220%22%2C%225414%22%2C%22119%22%5D%7D%5D%2C%22mobile%22%3A1%2C%22model%22%3A%22SM-G955U%22%2C%22bitness%22%3A%2264%22%2C%22architecture%22%3A%22%22%7D&');
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
- [x] Feature

## Description of change

Added user agent client hints support for ajaBidAdapter.
Passing UserAgent object as sua query parameter for our ad server.


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
