### PR TITLE
Criteo Bid Adapter: Map full user & site objects

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -523,9 +523,8 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
       }
     };
   };
-  request.user = {
-    ext: bidderRequest.userExt
-  };
+  request.user = bidderRequest.ortb2?.user || {};
+  request.site = bidderRequest.ortb2?.site || {};
   if (bidderRequest && bidderRequest.ceh) {
     request.user.ceh = bidderRequest.ceh;
   }

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -1156,6 +1156,18 @@ describe('The Criteo bidding adapter', function () {
     it('should properly build a request with first party data', function () {
       const siteData = {
         keywords: ['power tools'],
+        content: {
+          data: [{
+            name: 'some_provider',
+            ext: {
+              segtax: 3
+            },
+            segment: [
+              { 'id': '1001' },
+              { 'id': '1002' }
+            ]
+          }]
+        },
         ext: {
           data: {
             pageType: 'article'
@@ -1164,6 +1176,16 @@ describe('The Criteo bidding adapter', function () {
       };
       const userData = {
         gender: 'M',
+        data: [{
+          name: 'some_provider',
+          ext: {
+            segtax: 3
+          },
+          segment: [
+            { 'id': '1001' },
+            { 'id': '1002' }
+          ]
+        }],
         ext: {
           data: {
             registered: true
@@ -1203,7 +1225,8 @@ describe('The Criteo bidding adapter', function () {
 
       const request = spec.buildRequests(bidRequests, { ...bidderRequest, ortb2 });
       expect(request.data.publisher.ext).to.deep.equal({ data: { pageType: 'article' } });
-      expect(request.data.user.ext).to.deep.equal({ data: { registered: true } });
+      expect(request.data.user).to.deep.equal(userData);
+      expect(request.data.site).to.deep.equal(siteData);
       expect(request.data.slots[0].ext).to.deep.equal({
         bidfloor: 0.75,
         data: {


### PR DESCRIPTION
## Type of change
- [X] Feature

## Description of change
Ensure all user or site first-party data defined according to prebid guidance are sent to our backend.
