### PR TITLE
Proxistore Bid Adapter: migrate to new subdomain

### DIFF
--- a/modules/proxistoreBidAdapter.js
+++ b/modules/proxistoreBidAdapter.js
@@ -3,9 +3,9 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 
 const BIDDER_CODE = 'proxistore';
 const PROXISTORE_VENDOR_ID = 418;
-const COOKIE_BASE_URL = 'https://abs.proxistore.com/v3/rtb/prebid/multi';
+const COOKIE_BASE_URL = 'https://api.proxistore.com/v3/rtb/prebid/multi';
 const COOKIE_LESS_URL =
-  'https://abs.cookieless-proxistore.com/v3/rtb/prebid/multi';
+  'https://api.cookieless-proxistore.com/v3/rtb/prebid/multi';
 
 function _createServerRequest(bidRequests, bidderRequest) {
   var sizeIds = [];

--- a/test/spec/modules/proxistoreBidAdapter_spec.js
+++ b/test/spec/modules/proxistoreBidAdapter_spec.js
@@ -55,9 +55,9 @@ describe('ProxistoreBidAdapter', function () {
   });
   describe('buildRequests', function () {
     const url = {
-      cookieBase: 'https://abs.proxistore.com/v3/rtb/prebid/multi',
+      cookieBase: 'https://api.proxistore.com/v3/rtb/prebid/multi',
       cookieLess:
-        'https://abs.cookieless-proxistore.com/v3/rtb/prebid/multi',
+        'https://api.cookieless-proxistore.com/v3/rtb/prebid/multi',
     };
 
     let request = spec.buildRequests([bid], bidderRequest);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
We are migrating to a new subdomain for our bidder.