### PR TITLE
Triplelift Bid Adapter: set networkId in response

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -436,6 +436,10 @@ function _buildResponseObject(bidderRequest, bid) {
     if (bid.tl_source && bid.tl_source == 'tlx') {
       bidResponse.meta.mediaType = 'native';
     }
+
+    if (creativeId) {
+      bidResponse.meta.networkId = creativeId.slice(0, creativeId.indexOf('_'));
+    }
   };
   return bidResponse;
 }

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -1437,6 +1437,13 @@ describe('triplelift adapter', function () {
       expect(result[0].meta.advertiserDomains[1]).to.equal('internetalerts.org');
       expect(result[1].meta).to.not.have.key('advertiserDomains');
     });
+
+    it('should include networkId in the meta field if available', function () {
+      let result = tripleliftAdapterSpec.interpretResponse(response, {bidderRequest});
+      expect(result[1].meta.networkId).to.equal('10092');
+      expect(result[2].meta.networkId).to.equal('5989');
+      expect(result[3].meta.networkId).to.equal('5989');
+    });
   });
 
   describe('getUserSyncs', function() {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change

- Triplelift passes `crid` in every auction bid response. Added support in our adapter to parse the memberId portion of `crid` and set it as meta.networkId if TLX sends `crid` back in the bid response
- The following Prebid doc was used as a guide:
   [Prebid.org](https://docs.prebid.org/dev-docs/bidder-adaptor.html#interpreting-the-response)
