### PR TITLE
Yieldmo Adapter: Send value of tmax in the Bid Request

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -382,6 +382,7 @@ function openRtbRequest(bidRequests, bidderRequest) {
   const schain = bidRequests[0].schain;
   let openRtbRequest = {
     id: bidRequests[0].bidderRequestId,
+    tmax: bidderRequest.timeout || 400,
     at: 1,
     imp: bidRequests.map(bidRequest => openRtbImpression(bidRequest)),
     site: openRtbSite(bidRequests[0], bidderRequest),


### PR DESCRIPTION

- [x] Feature

## Description of change

Sending tmax in the bid request. If none is specified then default to 400.