### PR TITLE
Smaato Bid Adapter : add gpp support

### DIFF
--- a/modules/smaatoBidAdapter.js
+++ b/modules/smaatoBidAdapter.js
@@ -8,7 +8,7 @@ import CONSTANTS from '../src/constants.json';
 const { NATIVE_IMAGE_TYPES } = CONSTANTS;
 const BIDDER_CODE = 'smaato';
 const SMAATO_ENDPOINT = 'https://prebid.ad.smaato.net/oapi/prebid';
-const SMAATO_CLIENT = 'prebid_js_$prebid.version$_1.7'
+const SMAATO_CLIENT = 'prebid_js_$prebid.version$_1.8'
 const CURRENCY = 'USD';
 
 const buildOpenRtbBidRequest = (bidRequest, bidderRequest) => {
@@ -61,6 +61,11 @@ const buildOpenRtbBidRequest = (bidRequest, bidderRequest) => {
 
   if (bidderRequest.uspConsent !== undefined) {
     deepSetValue(requestTemplate, 'regs.ext.us_privacy', bidderRequest.uspConsent);
+  }
+
+  if (ortb2.regs?.gpp !== undefined) {
+    deepSetValue(requestTemplate, 'regs.ext.gpp', ortb2.regs.gpp);
+    deepSetValue(requestTemplate, 'regs.ext.gpp_sid', ortb2.regs.gpp_sid);
   }
 
   if (deepAccess(bidRequest, 'params.app')) {

--- a/test/spec/modules/smaatoBidAdapter_spec.js
+++ b/test/spec/modules/smaatoBidAdapter_spec.js
@@ -297,6 +297,21 @@ describe('smaatoBidAdapterTest', () => {
         expect(req.regs.ext.us_privacy).to.equal('uspConsentString');
       });
 
+      it('sends gpp', () => {
+        const ortb2 = {
+          regs: {
+            gpp: 'gppString',
+            gpp_sid: [7]
+          }
+        };
+
+        const reqs = spec.buildRequests([singleBannerBidRequest], {...defaultBidderRequest, ortb2});
+
+        const req = extractPayloadOfFirstAndOnlyRequest(reqs);
+        expect(req.regs.ext.gpp).to.eql('gppString');
+        expect(req.regs.ext.gpp_sid).to.eql([7]);
+      });
+
       it('sends no schain if no schain exists', () => {
         const reqs = spec.buildRequests([singleBannerBidRequest], defaultBidderRequest);
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
Yes, here is [PR](https://github.com/prebid/prebid.github.io/pull/4371) for it

## Description of change
Added gpp support for Smaato adapter

<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->