### PR TITLE
Permutive RTD Module: migrate magnite to ortb2

### DIFF
--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -133,6 +133,8 @@ export function setBidderRtb (bidderOrtb2, moduleConfig, segmentData) {
  * @return {Object} Merged ortb2 object
  */
 function updateOrtbConfig(bidder, currConfig, segmentIDs, sspSegmentIDs, transformationConfigs, segmentData) {
+  const customCohortsData = deepAccess(segmentData, bidder) || []
+
   const name = 'permutive.com'
 
   const permutiveUserData = {
@@ -159,17 +161,15 @@ function updateOrtbConfig(bidder, currConfig, segmentIDs, sspSegmentIDs, transfo
   const updatedUserKeywords = (currentUserKeywords === '') ? keywords : `${currentUserKeywords},${keywords}`
   deepSetValue(ortbConfig, 'ortb2.user.keywords', updatedUserKeywords)
 
-  // Set bidder specific extensions
-  if (bidder === 'rubicon') {
-    if (segmentIDs.length > 0) {
-      deepSetValue(ortbConfig, 'ortb2.user.ext.data.' + PERMUTIVE_STANDARD_KEYWORD, segmentIDs)
-    }
+  // Set user extensions
+  if (segmentIDs.length > 0) {
+    deepSetValue(ortbConfig, `ortb2.user.ext.data.${PERMUTIVE_STANDARD_KEYWORD}`, segmentIDs)
+    logger.logInfo(`Extending ortb2.user.ext.data with "${PERMUTIVE_STANDARD_KEYWORD}"`, segmentIDs)
+  }
 
-    if (segmentData?.rubicon?.length > 0) {
-      deepSetValue(ortbConfig, 'ortb2.user.ext.data.' + PERMUTIVE_CUSTOM_COHORTS_KEYWORD, segmentData.rubicon.map(String))
-    }
-
-    logger.logInfo(`Extending ortb2.user.ext.data for ${bidder}`, deepAccess(ortbConfig, 'ortb2.user.ext.data'))
+  if (customCohortsData.length > 0) {
+    deepSetValue(ortbConfig, `ortb2.user.ext.data.${PERMUTIVE_CUSTOM_COHORTS_KEYWORD}`, customCohortsData.map(String))
+    logger.logInfo(`Extending ortb2.user.ext.data with "${PERMUTIVE_CUSTOM_COHORTS_KEYWORD}"`, customCohortsData)
   }
 
   logger.logInfo(`Updating ortb2 config for ${bidder}`, ortbConfig)

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -272,7 +272,12 @@ function getDefaultBidderFn (bidder) {
     }
   }
 
-  return bidderMap[bidder]
+  // On no default bidder just return the same bid as passed in
+  function bidIdentity(bid) {
+    return bid
+  }
+
+  return bidderMap[bidder] || bidIdentity
 }
 
 /**

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -414,7 +414,7 @@ export const permutiveSubmodule = {
     readAndSetCohorts(reqBidsConfigObj, moduleConfig)
 
     makeSafe(function () {
-      if (permutiveSDKInRealTime || !moduleConfig.waitForIt || !isPermutiveOnPage()) {
+      if (permutiveSDKInRealTime || !(moduleConfig.waitForIt && isPermutiveOnPage())) {
         return completeBidRequestData()
       }
 

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -12,9 +12,8 @@ import {deepAccess, deepSetValue, isFn, logError, mergeDeep, isPlainObject, safe
 import {includes} from '../src/polyfill.js';
 
 const MODULE_NAME = 'permutive'
-const PREFIX = MODULE_NAME + 'RTD'
 
-const logger = prefixLog(PREFIX)
+const logger = prefixLog('[PermutiveRTD]')
 
 export const PERMUTIVE_SUBMODULE_CONFIG_KEY = 'permutive-prebid-rtd'
 export const PERMUTIVE_STANDARD_KEYWORD = 'p_standard'
@@ -170,8 +169,10 @@ function updateOrtbConfig(bidder, currConfig, segmentIDs, sspSegmentIDs, transfo
       deepSetValue(ortbConfig, 'ortb2.user.ext.data.' + PERMUTIVE_CUSTOM_COHORTS_KEYWORD, segmentData.rubicon.map(String))
     }
 
-    logger.message(`Extend rubicon 'ortb2.user.ext.data'`, deepAccess(ortbConfig, 'ortb2.user.ext.data'))
+    logger.logInfo(`Extending ortb2.user.ext.data for ${bidder}`, deepAccess(ortbConfig, 'ortb2.user.ext.data'))
   }
+
+  logger.logInfo(`Updating ortb2 config for ${bidder}`, ortbConfig)
 
   return ortbConfig
 }

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -383,7 +383,7 @@ function iabSegmentId(permutiveSegmentId, iabIds) {
  * @param reqBidsConfigObj - Bidder provided config for request
  * @param customModuleConfig - Publisher provide config
  */
-function readAndSetCohorts(reqBidsConfigObj, moduleConfig) {
+export function readAndSetCohorts(reqBidsConfigObj, moduleConfig) {
   const segmentData = getSegments(deepAccess(moduleConfig, 'params.maxSegs'))
 
   makeSafe(function () {

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -398,7 +398,7 @@ export function readAndSetCohorts(reqBidsConfigObj, moduleConfig) {
   })
 }
 
-let permutiveReadyCallbackRegistered = false
+let permutiveSDKInRealTime = false
 
 /** @type {RtdSubmodule} */
 export const permutiveSubmodule = {
@@ -414,20 +414,18 @@ export const permutiveSubmodule = {
     readAndSetCohorts(reqBidsConfigObj, moduleConfig)
 
     makeSafe(function () {
-      if (!permutiveReadyCallbackRegistered && moduleConfig.waitForIt && isPermutiveOnPage()) {
-        // Prevent multiple calls to set cohorts
-        permutiveReadyCallbackRegistered = true
-
-        window.permutive.ready(function () {
-          logger.logInfo(`SDK is realtime, updating cohorts`)
-          readAndSetCohorts(reqBidsConfigObj, getModuleConfig(customModuleConfig))
-          completeBidRequestData()
-        }, 'realtime')
-
-        logger.logInfo(`Registered cohort update when SDK is realtime`)
-      } else {
-        completeBidRequestData()
+      if (permutiveSDKInRealTime || !moduleConfig.waitForIt || !isPermutiveOnPage()) {
+        return completeBidRequestData()
       }
+
+      window.permutive.ready(function () {
+        logger.logInfo(`SDK is realtime, updating cohorts`)
+        permutiveSDKInRealTime = true
+        readAndSetCohorts(reqBidsConfigObj, getModuleConfig(customModuleConfig))
+        completeBidRequestData()
+      }, 'realtime')
+
+      logger.logInfo(`Registered cohort update when SDK is realtime`)
     })
   },
   init: init


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

This is the first step to migrating away from the pre-v4.30 of setting targeting values. The RTD module is now making `rubicon` targeting values available on the ortb2 object. After inspecting the `rubiconBidAdapter`, they automatically convert targeting key-values from `params.visitor` to `ortb2.user.ext.data`. So the migration for the RTD module is to just remove our mutation of `params.visitor` and write these targeting values directly to `ortb2.user.ext.data`. This data is only applicable to rubicon and follows the OpenRTB 2.5 specification of placing bidder-specific extensions in `.ext` properties.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
In a recent [PR](https://github.com/prebid/Prebid.js/pull/9236#discussion_r1043632338), our special `bid.params` handlings were put on notice of being removed if we didn't address the issue by the end of Q2. This PR is the first step in migrating these handlers. `rubicon` is the first bidder we're migrating with `appnexus` and `ozone` committed to being addressed by the end of Q2. We're working with each partner on the best place to make data available in ortb2 that each bidder expects.


