### PR TITLE
Pubwise Analytics Adapter: Fix empty-string sessionId when loading unexpired sessions

### DIFF
--- a/modules/pubwiseAnalyticsAdapter.js
+++ b/modules/pubwiseAnalyticsAdapter.js
@@ -304,11 +304,14 @@ pubwiseAnalytics.storeSessionID = function (userSessID) {
 
 // ensure a session exists, if not make one, always store it
 pubwiseAnalytics.ensureSession = function () {
-  if (sessionExpired() === true || userSessionID() === null || userSessionID() === '') {
+  let sessionId = userSessionID();
+  if (sessionExpired() === true || sessionId === null || sessionId === '') {
     let generatedId = generateUUID();
     expireUtmData();
     this.storeSessionID(generatedId);
     sessionData.sessionId = generatedId;
+  } else if (sessionId != null) {
+    sessionData.sessionId = sessionId;
   }
   // eslint-disable-next-line
   // console.log('ensured session');


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix


## Description of change
Event metadata currently fails to properly send sessionId if the sessionId has not yet expired. Fixing that logic path + trivial 'don't hit localStorage repeatedly' var name refactor to the currently errant function.