### PR TITLE
PBjs Core: make video cache timeout configurable

### DIFF
--- a/src/videoCache.js
+++ b/src/videoCache.js
@@ -9,8 +9,8 @@
  * This trickery helps integrate with ad servers, which set character limits on request params.
  */
 
-import { ajax } from './ajax.js';
-import { config } from './config.js';
+import {ajaxBuilder} from './ajax.js';
+import {config} from './config.js';
 import {auctionManager} from './auctionManager.js';
 
 /**
@@ -142,11 +142,11 @@ function shimStorageCallback(done) {
  * @param {videoCacheStoreCallback} [done] An optional callback which should be executed after
  * the data has been stored in the cache.
  */
-export function store(bids, done) {
+export function store(bids, done, getAjax = ajaxBuilder) {
   const requestData = {
     puts: bids.map(toStorageRequest)
   };
-
+  const ajax = getAjax(config.getConfig('cache.timeout'));
   ajax(config.getConfig('cache.url'), shimStorageCallback(done), JSON.stringify(requestData), {
     contentType: 'text/plain',
     withCredentials: true

--- a/test/spec/videoCache_spec.js
+++ b/test/spec/videoCache_spec.js
@@ -72,6 +72,29 @@ describe('The video cache', function () {
       config.resetConfig();
     });
 
+    describe('cache.timeout', () => {
+      let getAjax, cb;
+      beforeEach(() => {
+        getAjax = sinon.stub().callsFake(() => sinon.stub());
+        cb = sinon.stub();
+      });
+
+      it('should be respected', () => {
+        config.setConfig({
+          cache: {
+            timeout: 1
+          }
+        });
+        store([{ vastUrl: 'my-mock-url.com' }], cb, getAjax);
+        sinon.assert.calledWith(getAjax, 1);
+      });
+
+      it('should use default when not specified', () => {
+        store([], cb, getAjax);
+        sinon.assert.calledWith(getAjax, undefined);
+      })
+    });
+
     it('should execute the callback with a successful result when store() is called', function () {
       const uuid = 'c488b101-af3e-4a99-b538-00423e5a3371';
       const callback = fakeServerCall(


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

This introduces a new setting, `cache.timeout`, for controlling network timeout on video cache requests.

## Other information

Closes https://github.com/prebid/Prebid.js/issues/7382
Documentation https://github.com/prebid/prebid.github.io/pull/4384

