### PR TITLE
Eplanning Bid Adapter : cut url when url size greater than 255

### DIFF
--- a/modules/eplanningBidAdapter.js
+++ b/modules/eplanningBidAdapter.js
@@ -24,6 +24,7 @@ const VAST_INSTREAM = 1;
 const VAST_OUTSTREAM = 2;
 const VAST_VERSION_DEFAULT = 3;
 const DEFAULT_SIZE_VAST = '640x480';
+const MAX_LEN_URL = 255;
 
 export const spec = {
   code: BIDDER_CODE,
@@ -60,7 +61,7 @@ export const spec = {
       params = {
         rnd: rnd,
         e: spaces.str,
-        ur: pageUrl || FILE,
+        ur: cutUrl(pageUrl || FILE),
         pbv: '$prebid.version$',
         ncb: '1',
         vs: spaces.vs
@@ -70,7 +71,7 @@ export const spec = {
       }
 
       if (referrerUrl) {
-        params.fr = referrerUrl;
+        params.fr = cutUrl(referrerUrl);
       }
 
       if (bidderRequest && bidderRequest.gdprConsent) {
@@ -489,6 +490,17 @@ function visibilityHandler(obj) {
     registerAuction(STORAGE_RENDER_PREFIX + obj.name);
     getViewabilityTracker().onView(obj.div, registerAuction.bind(undefined, STORAGE_VIEW_PREFIX + obj.name));
   }
+}
+
+function cutUrl (url) {
+  if (url.length > MAX_LEN_URL) {
+    url = url.split('?')[0];
+    if (url.length > MAX_LEN_URL) {
+      url = url.slice(0, MAX_LEN_URL);
+    }
+  }
+
+  return url;
 }
 
 function registerAuction(storageID) {

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -732,16 +732,15 @@ describe('E-Planning Adapter', function () {
     it('should return ur parameter without params query string when current window url length is greater than 255', function () {
       let bidderRequestParams = bidderRequest;
 
-      bidderRequestParams.refererInfo.page = refererUrl + "?param=" + "x".repeat(255);
+      bidderRequestParams.refererInfo.page = refererUrl + '?param=' + 'x'.repeat(255);
       const ur = spec.buildRequests(bidRequests, bidderRequest).data.ur;
       expect(ur).to.equal(refererUrl);
     });
 
     it('should return ur parameter with a length of 255 when url length is greater than 255', function () {
-      let bidderRequestParams = bidderRequest,
-      url_255_characters = "https://localhost/abc" + "/subse".repeat(39),
-      refererUrl = url_255_characters + "/ext".repeat(5) + "?param=" + "x".repeat(15);
-
+      let bidderRequestParams = bidderRequest;
+      let url_255_characters = 'https://localhost/abc' + '/subse'.repeat(39);
+      let refererUrl = url_255_characters + '/ext'.repeat(5) + '?param=' + 'x'.repeat(15);
 
       bidderRequestParams.refererInfo.page = refererUrl;
       const ur = spec.buildRequests(bidRequests, bidderRequest).data.ur;
@@ -756,16 +755,15 @@ describe('E-Planning Adapter', function () {
     it('should return fr parameter without params query string when ref length is greater than 255', function () {
       let bidderRequestParams = bidderRequest;
 
-      bidderRequestParams.refererInfo.ref = refererUrl + "?param=" + "x".repeat(255);
+      bidderRequestParams.refererInfo.ref = refererUrl + '?param=' + 'x'.repeat(255);
       const fr = spec.buildRequests(bidRequests, bidderRequest).data.fr;
       expect(fr).to.equal(refererUrl);
     });
 
     it('should return fr parameter with a length of 255 when url length is greater than 255', function () {
-      let bidderRequestParams = bidderRequest,
-      url_255_characters = "https://localhost/abc" + "/subse".repeat(39),
-      refererUrl = url_255_characters + "/ext".repeat(5) + "?param=" + "x".repeat(15);
-
+      let bidderRequestParams = bidderRequest;
+      let url_255_characters = 'https://localhost/abc' + '/subse'.repeat(39);
+      let refererUrl = url_255_characters + '/ext'.repeat(5) + '?param=' + 'x'.repeat(15);
 
       bidderRequestParams.refererInfo.ref = refererUrl;
       const fr = spec.buildRequests(bidRequests, bidderRequest).data.fr;

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -729,10 +729,47 @@ describe('E-Planning Adapter', function () {
       expect(ur).to.equal(bidderRequest.refererInfo.page);
     });
 
+    it('should return ur parameter without params query string when current window url length is greater than 255', function () {
+      let bidderRequestParams = bidderRequest;
+
+      bidderRequestParams.refererInfo.page = refererUrl + "?param=" + "x".repeat(255);
+      const ur = spec.buildRequests(bidRequests, bidderRequest).data.ur;
+      expect(ur).to.equal(refererUrl);
+    });
+
+    it('should return ur parameter with a length of 255 when url length is greater than 255', function () {
+      let bidderRequestParams = bidderRequest,
+      url_255_characters = "https://localhost/abc" + "/subse".repeat(39),
+      refererUrl = url_255_characters + "/ext".repeat(5) + "?param=" + "x".repeat(15);
+
+
+      bidderRequestParams.refererInfo.page = refererUrl;
+      const ur = spec.buildRequests(bidRequests, bidderRequest).data.ur;
+      expect(ur).to.equal(url_255_characters);
+    });
+
     it('should return fr parameter when there is a referrer', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest);
       const dataRequest = request.data;
       expect(dataRequest.fr).to.equal(refererUrl);
+    });
+    it('should return fr parameter without params query string when ref length is greater than 255', function () {
+      let bidderRequestParams = bidderRequest;
+
+      bidderRequestParams.refererInfo.ref = refererUrl + "?param=" + "x".repeat(255);
+      const fr = spec.buildRequests(bidRequests, bidderRequest).data.fr;
+      expect(fr).to.equal(refererUrl);
+    });
+
+    it('should return fr parameter with a length of 255 when url length is greater than 255', function () {
+      let bidderRequestParams = bidderRequest,
+      url_255_characters = "https://localhost/abc" + "/subse".repeat(39),
+      refererUrl = url_255_characters + "/ext".repeat(5) + "?param=" + "x".repeat(15);
+
+
+      bidderRequestParams.refererInfo.ref = refererUrl;
+      const fr = spec.buildRequests(bidRequests, bidderRequest).data.fr;
+      expect(fr).to.equal(url_255_characters);
     });
 
     it('should return crs parameter with document charset', function () {


### PR DESCRIPTION
## Type of change
- [ x ] Feature

## Description of change
As we send the current URL in every request, we need it to be shorter than 255 chars. This change will remove all parameters from the URL (or short it up to 255 chars) when it's too long

ndigrazia@e-planning.net
- [ x] official adapter submission