### PR TITLE
Triplelift Adapter: cast playbackmethod as array if set as an int

### DIFF
--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -195,6 +195,9 @@ function _getORTBVideo(bidRequest) {
       video.placement = 3
     }
   }
+  if (video.playbackmethod && Number.isInteger(video.playbackmethod)) {
+    video.playbackmethod = Array.from(String(video.playbackmethod), Number);
+  }
 
   // clean up oRTB object
   delete video.playerSize;

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -167,7 +167,8 @@ describe('triplelift adapter', function () {
           mediaTypes: {
             video: {
               context: 'instream',
-              playerSize: [640, 480]
+              playerSize: [640, 480],
+              playbackmethod: 5
             }
           },
           adUnitCode: 'adunit-code-instream',
@@ -292,7 +293,8 @@ describe('triplelift adapter', function () {
           mediaTypes: {
             video: {
               context: 'instream',
-              playerSize: [640, 480]
+              playerSize: [640, 480],
+              playbackmethod: [1, 2, 3]
             },
             banner: {
               sizes: [
@@ -1180,6 +1182,16 @@ describe('triplelift adapter', function () {
         'gpp': 'BOJ/P2HOJ/P2HABABMAAAAAZ+A==',
         'gpp_sid': [7]
       })
+    });
+    it('should cast playbackmethod as an array if it is an integer and it exists', function() {
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.imp[1].video.playbackmethod).to.be.a('array');
+      expect(request.data.imp[1].video.playbackmethod).to.deep.equal([5]);
+    });
+    it('should set playbackmethod as an array if it exists as an array', function() {
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.imp[5].video.playbackmethod).to.be.a('array');
+      expect(request.data.imp[5].video.playbackmethod).to.deep.equal([1, 2, 3]);
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Triplelift has received a few instream requests recently in which publishers have wrongly set `video.playbackmethod` as an integer rather than an array of integers. Our adapter currently throws a 500 server error in this case. This PR will cast the integer as an array if a publisher sets `video.playbackmethod` as an integer to avoid this scenario.