### PR TITLE
[Video Module] Bugfix: Allow publishers to override video params

### DIFF
--- a/modules/videoModule/index.js
+++ b/modules/videoModule/index.js
@@ -139,13 +139,15 @@ export function PbVideo(videoCore_, getConfig_, pbGlobal_, pbEvents_, videoEvent
       return;
     }
 
-    const video = Object.assign({}, adUnit.mediaTypes.video, ortbVideo);
+    const video = Object.assign({}, ortbVideo, adUnit.mediaTypes.video);
 
-    video.context = ortbVideo.placement === PLACEMENT.INSTREAM ? 'instream' : 'outstream';
+    if (!video.context) {
+      video.context = ortbVideo.placement === PLACEMENT.INSTREAM ? 'instream' : 'outstream';
+    }
 
     const width = ortbVideo.w;
     const height = ortbVideo.h;
-    if (width && height) {
+    if (!video.playerSize && width && height) {
       video.playerSize = [width, height];
     }
 

--- a/modules/videojsVideoProvider.js
+++ b/modules/videojsVideoProvider.js
@@ -35,7 +35,7 @@ https://github.com/Conviva/conviva-js-videojs/blob/master/conviva-videojs-module
 const setupFailMessage = 'Failed to instantiate the player';
 const AD_MANAGER_EVENTS = [AD_LOADED, AD_STARTED, AD_IMPRESSION, AD_PLAY, AD_PAUSE, AD_TIME, AD_COMPLETE, AD_SKIPPED];
 
-export function VideojsProvider(config, vjs_, adState_, timeState_, callbackStorage_, utils) {
+export function VideojsProvider(providerConfig, vjs_, adState_, timeState_, callbackStorage_, utils) {
   let vjs = vjs_;
   // Supplied callbacks are typically wrapped by handlers
   // we use this dict to keep track of these pairings
@@ -46,7 +46,7 @@ export function VideojsProvider(config, vjs_, adState_, timeState_, callbackStor
   let player = null;
   let playerVersion = null;
   let playerIsSetup = false;
-  const {playerConfig, divId} = config;
+  const {playerConfig, divId} = providerConfig;
   let isMuted;
   let previousLastTimePosition = 0;
   let lastTimePosition = 0;
@@ -521,7 +521,7 @@ export function VideojsProvider(config, vjs_, adState_, timeState_, callbackStor
       return;
     }
 
-    const adConfig = utils.getAdConfig(config);
+    const adConfig = utils.getAdConfig(playerConfig);
     player.ima(adConfig);
   }
 

--- a/test/spec/modules/videoModule/pbVideo_spec.js
+++ b/test/spec/modules/videoModule/pbVideo_spec.js
@@ -174,6 +174,37 @@ describe('Prebid Video', function () {
       expect(nextFn.calledOnce).to.be.true;
       expect(nextFn.getCall(0).args[0].ortb2).to.be.deep.equal({ site: { content: { test: 'contentTestValue' } } });
     });
+
+    it('allows publishers to override video param', function () {
+      const getOrtbVideoSpy = videoCoreMock.getOrtbVideo = sinon.spy(() => ({
+        test: 'videoTestValue',
+        test2: 'videoModuleValue'
+      }));
+
+      let beforeBidRequestCallback;
+      const requestBids = {
+        before: callback_ => beforeBidRequestCallback = callback_
+      };
+
+      pbVideoFactory(null, null, Object.assign({}, pbGlobalMock, { requestBids }));
+      expect(beforeBidRequestCallback).to.not.be.undefined;
+      const nextFn = sinon.spy();
+      const adUnits = [{
+        code: 'ad1',
+        mediaTypes: {
+          video: {
+            test2: 'publisherValue'
+          }
+        },
+        video: { divId: 'divId' }
+      }];
+      beforeBidRequestCallback(nextFn, { adUnits });
+      expect(getOrtbVideoSpy.calledOnce).to.be.true;
+      const adUnit = adUnits[0];
+      expect(adUnit.mediaTypes.video).to.have.property('test', 'videoTestValue');
+      expect(adUnit.mediaTypes.video).to.have.property('test2', 'publisherValue');
+      expect(nextFn.calledOnce).to.be.true;
+    });
   });
 
   describe('Ad tag injection', function () {


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
- Allows values set in the mediaTypes.video object to override the values set by the Video Module. 
  - Though the Video Module aims to be the source of truth for all video params, the publisher has the right to override these values. 
- fixes a bug where adPluginConfig was not being passed into IMA. 


## Other information
Fixes #9560 @spormeon
