### PR TITLE
Criteo Bid Adapter: remove references to deprecated cookies

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -34,9 +34,6 @@ const PUBLISHER_TAG_URL_TEMPLATE = 'https://static.criteo.net/js/ld/publishertag
 const FAST_BID_PUBKEY_E = 65537;
 const FAST_BID_PUBKEY_N = 'ztQYwCE5BU7T9CDM5he6rKoabstXRmkzx54zFPZkWbK530dwtLBDeaWBMxHBUT55CYyboR/EZ4efghPi3CoNGfGWezpjko9P6p2EwGArtHEeS4slhu/SpSIFMjG6fdrpRoNuIAMhq1Z+Pr/+HOd1pThFKeGFr2/NhtAg+TXAzaU=';
 
-const SID_COOKIE_NAME = 'cto_sid';
-const IDCPY_COOKIE_NAME = 'cto_idcpy';
-const LWID_COOKIE_NAME = 'cto_lwid';
 const OPTOUT_COOKIE_NAME = 'cto_optout';
 const BUNDLE_COOKIE_NAME = 'cto_bundle';
 const GUID_RETENTION_TIME_HOUR = 24 * 30 * 13; // 13 months
@@ -78,15 +75,12 @@ export const spec = {
       const jsonHash = {
         bundle: readFromAllStorages(BUNDLE_COOKIE_NAME),
         cw: storage.cookiesAreEnabled(),
-        localWebId: readFromAllStorages(LWID_COOKIE_NAME),
         lsw: storage.localStorageIsEnabled(),
         optoutCookie: readFromAllStorages(OPTOUT_COOKIE_NAME),
         origin: origin,
         requestId: requestId,
-        secureIdCookie: readFromAllStorages(SID_COOKIE_NAME),
         tld: refererInfo.domain,
         topUrl: refererInfo.domain,
-        uid: readFromAllStorages(IDCPY_COOKIE_NAME),
         version: '$prebid.version$'.replace(/\./g, '_'),
       };
 
@@ -106,25 +100,12 @@ export const spec = {
         const response = event.data;
 
         if (response.optout) {
-          deleteFromAllStorages(IDCPY_COOKIE_NAME);
-          deleteFromAllStorages(SID_COOKIE_NAME);
           deleteFromAllStorages(BUNDLE_COOKIE_NAME);
-          deleteFromAllStorages(LWID_COOKIE_NAME);
 
           saveOnAllStorages(OPTOUT_COOKIE_NAME, true, OPTOUT_RETENTION_TIME_HOUR);
         } else {
-          if (response.uid) {
-            saveOnAllStorages(IDCPY_COOKIE_NAME, response.uid, GUID_RETENTION_TIME_HOUR);
-          }
-
           if (response.bundle) {
             saveOnAllStorages(BUNDLE_COOKIE_NAME, response.bundle, GUID_RETENTION_TIME_HOUR);
-          }
-
-          if (response.removeSid) {
-            deleteFromAllStorages(SID_COOKIE_NAME);
-          } else if (response.sid) {
-            saveOnAllStorages(SID_COOKIE_NAME, response.sid, GUID_RETENTION_TIME_HOUR);
           }
         }
       }, true);
@@ -405,16 +386,6 @@ function buildCdbUrl(context) {
   const optout = readFromAllStorages(OPTOUT_COOKIE_NAME);
   if (optout) {
     url += `&optout=1`;
-  }
-
-  const sid = readFromAllStorages(SID_COOKIE_NAME);
-  if (sid) {
-    url += `&sid=${sid}`;
-  }
-
-  const idcpy = readFromAllStorages(IDCPY_COOKIE_NAME);
-  if (idcpy) {
-    url += `&idcpy=${idcpy}`;
   }
 
   return url;

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -7,12 +7,9 @@ import {
   ADAPTER_VERSION,
   canFastBid, getFastBidUrl, FAST_BID_VERSION_CURRENT
 } from 'modules/criteoBidAdapter.js';
-import { createBid } from 'src/bidfactory.js';
-import CONSTANTS from 'src/constants.json';
 import * as utils from 'src/utils.js';
 import * as refererDetection from 'src/refererDetection.js';
 import { config } from '../../../src/config.js';
-import * as storageManager from 'src/storageManager.js';
 import { BANNER, NATIVE, VIDEO } from '../../../src/mediaTypes.js';
 
 describe('The Criteo bidding adapter', function () {
@@ -128,19 +125,13 @@ describe('The Criteo bidding adapter', function () {
     it('forwards ids from cookies', function () {
       const cookieData = {
         'cto_bundle': 'a',
-        'cto_sid': 'b',
-        'cto_lwid': 'c',
-        'cto_idcpy': 'd',
-        'cto_optout': 'e'
+        'cto_optout': 'b'
       };
 
       const expectedHashWithCookieData = {
         ...expectedHash,
         ...{
           bundle: cookieData['cto_bundle'],
-          localWebId: cookieData['cto_lwid'],
-          secureIdCookie: cookieData['cto_sid'],
-          uid: cookieData['cto_idcpy'],
           optoutCookie: cookieData['cto_optout']
         }
       };
@@ -158,19 +149,13 @@ describe('The Criteo bidding adapter', function () {
     it('forwards ids from local storage', function () {
       const localStorageData = {
         'cto_bundle': 'a',
-        'cto_sid': 'b',
-        'cto_lwid': 'c',
-        'cto_idcpy': 'd',
-        'cto_optout': 'e'
+        'cto_optout': 'b'
       };
 
       const expectedHashWithLocalStorageData = {
         ...expectedHash,
         ...{
           bundle: localStorageData['cto_bundle'],
-          localWebId: localStorageData['cto_lwid'],
-          secureIdCookie: localStorageData['cto_sid'],
-          uid: localStorageData['cto_idcpy'],
           optoutCookie: localStorageData['cto_optout']
         }
       };


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Removing references to cto_sid, cto_lwid and cto_idcpy which are legacy cookies that have been deprecated.