### PR TITLE
TheMediaGrid Bid Adapters : do not use jwp segments from bid.rtd field

### DIFF
--- a/modules/gridNMBidAdapter.js
+++ b/modules/gridNMBidAdapter.js
@@ -90,13 +90,12 @@ export const spec = {
         auctionId = bid.auctionId;
       }
       const {
-        params: { floorcpm, pubdata, source, secid, pubid, content, video },
+        params: { floorcpm, source, secid, pubid, content, video },
         mediaTypes, bidId, adUnitCode, rtd, ortb2Imp, sizes
       } = bid;
 
       const bidFloor = _getFloor(mediaTypes || {}, bid, isNumber(floorcpm) && floorcpm);
       const jwTargeting = rtd && rtd.jwplayer && rtd.jwplayer.targeting;
-      const jwpseg = (pubdata && pubdata.jwpseg) || (jwTargeting && jwTargeting.segments);
 
       const siteContent = content || (jwTargeting && jwTargeting.content);
 
@@ -154,15 +153,6 @@ export const spec = {
 
       if (siteContent) {
         request.site.content = siteContent;
-      }
-
-      if (jwpseg && jwpseg.length) {
-        user = {
-          data: [{
-            name: 'iow_labs_pub_data',
-            segment: segmentProcessing(jwpseg, 'jwpseg'),
-          }]
-        };
       }
 
       if (gdprConsent && gdprConsent.consentString) {
@@ -427,22 +417,6 @@ export function resetUserSync() {
 
 export function getSyncUrl() {
   return SYNC_URL;
-}
-
-function segmentProcessing(segment, forceSegName) {
-  return segment
-    .map((seg) => {
-      const value = seg && (seg.id || seg);
-      if (typeof value === 'string' || typeof value === 'number') {
-        return {
-          value: value.toString(),
-          ...(forceSegName && { name: forceSegName }),
-          ...(seg.name && { name: seg.name }),
-        };
-      }
-      return null;
-    })
-    .filter((seg) => !!seg);
 }
 
 registerBidder(spec);

--- a/test/spec/modules/gridBidAdapter_spec.js
+++ b/test/spec/modules/gridBidAdapter_spec.js
@@ -667,14 +667,6 @@ describe('TheMediaGrid Adapter', function () {
       const [request] = spec.buildRequests(bidRequestsWithJwTargeting, bidderRequest);
       expect(request.data).to.be.an('string');
       const payload = parseRequest(request.data);
-      expect(payload).to.have.property('user');
-      expect(payload.user.data).to.deep.equal([{
-        name: 'iow_labs_pub_data',
-        segment: [
-          {name: 'jwpseg', value: jsSegments[0]},
-          {name: 'jwpseg', value: jsSegments[1]}
-        ]
-      }]);
       expect(payload).to.have.property('site');
       expect(payload.site.content).to.deep.equal(jsContent);
     });
@@ -793,7 +785,7 @@ describe('TheMediaGrid Adapter', function () {
       expect(payload.site.content.data).to.deep.equal(contentData);
     });
 
-    it('should have right value in user.data when jwpsegments are present', function () {
+    it('should have right value in user.data', function () {
       const userData = [
         {
           name: 'someName',
@@ -823,13 +815,7 @@ describe('TheMediaGrid Adapter', function () {
       });
       const [request] = spec.buildRequests([bidRequestsWithJwTargeting], {...bidderRequest, ortb2});
       const payload = parseRequest(request.data);
-      expect(payload.user.data).to.deep.equal([{
-        name: 'iow_labs_pub_data',
-        segment: [
-          {name: 'jwpseg', value: jsSegments[0]},
-          {name: 'jwpseg', value: jsSegments[1]}
-        ]
-      }, ...userData]);
+      expect(payload.user.data).to.deep.equal(userData);
     });
 
     it('should have site.content.id filled from config ortb2.site.content.id', function () {

--- a/test/spec/modules/gridNMBidAdapter_spec.js
+++ b/test/spec/modules/gridNMBidAdapter_spec.js
@@ -245,14 +245,6 @@ describe('TheMediaGridNM Adapter', function () {
       requests.forEach((req, i) => {
         const payload = req.data;
         expect(req).to.have.property('data');
-        expect(payload).to.have.property('user');
-        expect(payload.user.data).to.deep.equal([{
-          name: 'iow_labs_pub_data',
-          segment: [
-            {name: 'jwpseg', value: jsSegments[0]},
-            {name: 'jwpseg', value: jsSegments[1]}
-          ]
-        }]);
         expect(payload).to.have.property('site');
         expect(payload.site.content).to.deep.equal(jsContent);
       });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Do not use jwp segments from bid.rtd field, use only segments from ortb2.site.content.data


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
@ptmccan please do not merge this pull request until MG and JWP not confirm that all targeting migrated on site.content.data
