### PR TITLE
Permutive RTD Module: migrate appnexus to ortb2

### DIFF
--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -208,6 +208,9 @@ function updateOrtbConfig(bidder, currConfig, segmentIDs, sspSegmentIDs, transfo
 function setSegments (reqBidsConfigObj, moduleConfig, segmentData) {
   const adUnits = (reqBidsConfigObj && reqBidsConfigObj.adUnits) || getGlobal().adUnits
   const utils = { deepSetValue, deepAccess, isFn, mergeDeep }
+  const aliasMap = {
+    appnexusAst: 'appnexus'
+  }
 
   if (!adUnits) {
     return
@@ -216,6 +219,9 @@ function setSegments (reqBidsConfigObj, moduleConfig, segmentData) {
   adUnits.forEach(adUnit => {
     adUnit.bids.forEach(bid => {
       let { bidder } = bid
+      if (typeof aliasMap[bidder] !== 'undefined') {
+        bidder = aliasMap[bidder]
+      }
       const acEnabled = isAcEnabled(moduleConfig, bidder)
       const customFn = getCustomBidderFn(moduleConfig, bidder)
       const defaultFn = getDefaultBidderFn(bidder)

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -208,9 +208,6 @@ function updateOrtbConfig(bidder, currConfig, segmentIDs, sspSegmentIDs, transfo
 function setSegments (reqBidsConfigObj, moduleConfig, segmentData) {
   const adUnits = (reqBidsConfigObj && reqBidsConfigObj.adUnits) || getGlobal().adUnits
   const utils = { deepSetValue, deepAccess, isFn, mergeDeep }
-  const aliasMap = {
-    appnexusAst: 'appnexus'
-  }
 
   if (!adUnits) {
     return
@@ -219,9 +216,6 @@ function setSegments (reqBidsConfigObj, moduleConfig, segmentData) {
   adUnits.forEach(adUnit => {
     adUnit.bids.forEach(bid => {
       let { bidder } = bid
-      if (typeof aliasMap[bidder] !== 'undefined') {
-        bidder = aliasMap[bidder]
-      }
       const acEnabled = isAcEnabled(moduleConfig, bidder)
       const customFn = getCustomBidderFn(moduleConfig, bidder)
       const defaultFn = getDefaultBidderFn(bidder)

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -159,25 +159,11 @@ function updateOrtbConfig(bidder, currConfig, segmentIDs, sspSegmentIDs, transfo
   deepSetValue(ortbConfig, 'ortb2.user.data', updatedUserData)
 
   // Set ortb2.user.keywords
-  const getBidderSpecificKeywordGroups = () => {
-    if (bidder === 'appnexus') {
-      const keywords = {
-        [PERMUTIVE_CUSTOM_COHORTS_KEYWORD]: segmentData.appnexus
-      }
-      logger.logInfo(`Bidder specific ortb2.user.keywords`, {
-        bidder,
-        keywords,
-      })
-      return keywords
-    }
-
-    return {}
-  }
   const currentKeywords = deepAccess(ortbConfig, 'ortb2.user.keywords')
   const keywordGroups = {
     [PERMUTIVE_STANDARD_KEYWORD]: segmentIDs,
     [PERMUTIVE_STANDARD_AUD_KEYWORD]: sspSegmentIDs,
-    ...getBidderSpecificKeywordGroups(),
+    [PERMUTIVE_CUSTOM_COHORTS_KEYWORD]: customCohortsData,
   }
 
   // Transform groups of key-values into a single array of strings

--- a/test/spec/modules/permutiveRtdProvider_spec.js
+++ b/test/spec/modules/permutiveRtdProvider_spec.js
@@ -514,25 +514,6 @@ describe('permutiveRtdProvider', function () {
   })
 
   describe('Default segment targeting', function () {
-    it('sets segment targeting for Xandr', function () {
-      const data = transformedTargeting()
-      const adUnits = getAdUnits()
-      const config = getConfig()
-
-      readAndSetCohorts({ adUnits }, config)
-
-      adUnits.forEach(adUnit => {
-        adUnit.bids.forEach(bid => {
-          const { bidder, params } = bid
-
-          if (bidder === 'appnexus') {
-            expect(deepAccess(params, 'keywords.permutive')).to.eql(data.appnexus)
-            expect(deepAccess(params, 'keywords.p_standard')).to.eql(data.ac.concat(data.ssp.cohorts))
-          }
-        })
-      })
-    })
-
     it('sets segment targeting for Ozone', function () {
       const data = transformedTargeting()
       const adUnits = getAdUnits()

--- a/test/spec/modules/permutiveRtdProvider_spec.js
+++ b/test/spec/modules/permutiveRtdProvider_spec.js
@@ -312,20 +312,12 @@ describe('permutiveRtdProvider', function () {
 
       setBidderRtb(bidderConfig, moduleConfig, segmentsData)
 
-      const getBidderKeywords = (bidder) => {
-        if (bidder === 'appnexus') {
-          return {
-            [PERMUTIVE_CUSTOM_COHORTS_KEYWORD]: segmentsData.appnexus
-          }
-        }
-        return {}
-      }
-
       acBidders.forEach(bidder => {
+        const customCohortsData = segmentsData[bidder] || []
         const keywordGroups = {
           [PERMUTIVE_STANDARD_KEYWORD]: segmentsData.ac,
           [PERMUTIVE_STANDARD_AUD_KEYWORD]: segmentsData.ssp.cohorts,
-          ...getBidderKeywords(bidder),
+          [PERMUTIVE_CUSTOM_COHORTS_KEYWORD]: customCohortsData
         }
 
         // Transform groups of key-values into a single array of strings

--- a/test/spec/modules/permutiveRtdProvider_spec.js
+++ b/test/spec/modules/permutiveRtdProvider_spec.js
@@ -8,6 +8,9 @@ import {
   getModuleConfig,
   PERMUTIVE_SUBMODULE_CONFIG_KEY,
   readAndSetCohorts,
+  PERMUTIVE_STANDARD_KEYWORD,
+  PERMUTIVE_STANDARD_AUD_KEYWORD,
+  PERMUTIVE_CUSTOM_COHORTS_KEYWORD,
 } from 'modules/permutiveRtdProvider.js'
 import { deepAccess, deepSetValue, mergeDeep } from '../../../src/utils.js'
 import { config } from 'src/config.js'
@@ -309,10 +312,32 @@ describe('permutiveRtdProvider', function () {
 
       setBidderRtb(bidderConfig, moduleConfig, segmentsData)
 
+      const getBidderKeywords = (bidder) => {
+        if (bidder === 'appnexus') {
+          return {
+            [PERMUTIVE_CUSTOM_COHORTS_KEYWORD]: segmentsData.appnexus
+          }
+        }
+        return {}
+      }
+
       acBidders.forEach(bidder => {
+        const keywordGroups = {
+          [PERMUTIVE_STANDARD_KEYWORD]: segmentsData.ac,
+          [PERMUTIVE_STANDARD_AUD_KEYWORD]: segmentsData.ssp.cohorts,
+          ...getBidderKeywords(bidder),
+        }
+
+        // Transform groups of key-values into a single array of strings
+        // i.e { permutive: ['1', '2'], p_standard: ['3', '4'] } => ['permutive=1', 'permutive=2', 'p_standard=3',' p_standard=4']
+        const transformedKeywordGroups = Object.entries(keywordGroups)
+          .flatMap(([keyword, ids]) => ids.map(id => `${keyword}=${id}`))
+
+        const keywords = `${sampleOrtbConfig.user.keywords},${transformedKeywordGroups.join(',')}`
+
         expect(bidderConfig[bidder].site.name).to.equal(sampleOrtbConfig.site.name)
         expect(bidderConfig[bidder].user.data).to.deep.include.members([sampleOrtbConfig.user.data[0]])
-        expect(bidderConfig[bidder].user.keywords).to.deep.equal('a,b,p_standard_aud=123,p_standard_aud=abc')
+        expect(bidderConfig[bidder].user.keywords).to.deep.equal(keywords)
       })
     })
     it('should merge ortb2 correctly for ac and ssps', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->

Adds additional keywords to ortb2 that enables us to migrate away from appnexus' special handlings.


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

In a recent https://github.com/prebid/Prebid.js/pull/9236#discussion_r1043632338, our special bid.params handlings were put on notice of being removed if we didn't address the issue by the end of Q2. This PR migrates `appnexus` handlers We've coordinated with each partner on the best place to make data available in ortb2 that each bidder expects.