### PR TITLE
PBjs Core : filter bidders from config when not server-side

### DIFF
--- a/modules/prebidServerBidAdapter/ortbConverter.js
+++ b/modules/prebidServerBidAdapter/ortbConverter.js
@@ -169,7 +169,8 @@ const PBS_CONVERTER = ortbConverter({
 
         const fpdConfigs = Object.entries(context.s2sBidRequest.ortb2Fragments?.bidder || {}).filter(([bidder]) => {
           const bidders = context.s2sBidRequest.s2sConfig.bidders;
-          return bidders && bidders.includes(bidder);
+          const allowUnknownBidderCodes = context.s2sBidRequest.s2sConfig.allowUnknownBidderCodes;
+          return allowUnknownBidderCodes || (bidders && bidders.includes(bidder));
         }).map(([bidder, ortb2]) => ({
           bidders: [bidder],
           config: {ortb2}

--- a/modules/prebidServerBidAdapter/ortbConverter.js
+++ b/modules/prebidServerBidAdapter/ortbConverter.js
@@ -167,7 +167,10 @@ const PBS_CONVERTER = ortbConverter({
           deepSetValue(ortbRequest, 'ext.prebid', mergeDeep(ortbRequest.ext?.prebid || {}, context.s2sBidRequest.s2sConfig.extPrebid));
         }
 
-        const fpdConfigs = Object.entries(context.s2sBidRequest.ortb2Fragments?.bidder || {}).map(([bidder, ortb2]) => ({
+        const fpdConfigs = Object.entries(context.s2sBidRequest.ortb2Fragments?.bidder || {}).filter(([bidder]) => {
+          const bidders = context.s2sBidRequest.s2sConfig.bidders;
+          return bidders && bidders.includes(bidder);
+        }).map(([bidder, ortb2]) => ({
           bidders: [bidder],
           config: {ortb2}
         }));

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2459,7 +2459,7 @@ describe('S2S Adapter', function () {
       };
       const bcat = ['IAB25', 'IAB7-39'];
       const badv = ['blockedAdv-1.com', 'blockedAdv-2.com'];
-      const allowedBidders = ['rubicon', 'appnexus'];
+      const allowedBidders = ['appnexus'];
 
       const expected = allowedBidders.map(bidder => ({
         bidders: [bidder],


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Filter bidders from config when not they're not server-side. This was causing the site codes object to be duplicated in the rubicon bidder params as well as the global object.

