### PR TITLE
Core: fix native render when adUnits defines `mediaTypes.native.ortb` but adapter replies with "legacy" native bid

### DIFF
--- a/src/native.js
+++ b/src/native.js
@@ -9,8 +9,8 @@ import {
   isNumber,
   isPlainObject,
   logError,
-  triggerPixel,
-  pick
+  pick,
+  triggerPixel
 } from './utils.js';
 import {includes} from './polyfill.js';
 import {auctionManager} from './auctionManager.js';
@@ -385,16 +385,19 @@ export function getNativeTargeting(bid, {index = auctionManager.index} = {}) {
   return keyValues;
 }
 
-function assetsMessage(data, adObject, keys) {
+function assetsMessage(data, adObject, keys, {index = auctionManager.index} = {}) {
   const message = {
     message: 'assetResponse',
     adId: data.adId,
   };
 
+  const adUnit = index.getAdUnit(adObject);
   let nativeResp = adObject.native;
 
   if (adObject.native.ortb) {
     message.ortb = adObject.native.ortb;
+  } else if (adUnit.mediaTypes?.native?.ortb) {
+    message.ortb = toOrtbNativeResponse(adObject.native, adUnit.nativeOrtbRequest);
   }
   message.assets = [];
 

--- a/src/native.js
+++ b/src/native.js
@@ -698,7 +698,7 @@ export function toOrtbNativeResponse(legacyResponse, ortbRequest) {
   }
 
   Object.keys(legacyResponse).filter(key => !!legacyResponse[key]).forEach(key => {
-    const value = legacyResponse[key];
+    const value = getAssetValue(legacyResponse[key]);
     switch (key) {
       // process titles
       case 'title':

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -1303,5 +1303,24 @@ describe('toOrtbNativeResponse', () => {
         text: 'vtitle'
       }
     })
+  });
+
+  it('should accept objects as legacy assets', () => {
+    const legacyResponse = {
+      icon: {
+        url: 'image-url'
+      }
+    }
+    const request = toOrtbNativeRequest({
+      icon: {
+        required: true
+      }
+    });
+    const response = toOrtbNativeResponse(legacyResponse, request);
+    sinon.assert.match(response.assets[0], {
+      img: {
+        url: 'image-url'
+      }
+    })
   })
 })

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -14,6 +14,7 @@ import {
 import CONSTANTS from 'src/constants.json';
 import { stubAuctionIndex } from '../helpers/indexStub.js';
 import { convertOrtbRequestToProprietaryNative, fromOrtbNativeRequest } from '../../src/native.js';
+import {auctionManager} from '../../src/auctionManager.js';
 const utils = require('src/utils');
 
 const bid = {
@@ -430,158 +431,180 @@ describe('native.js', function () {
     sinon.assert.calledWith(triggerPixelStub, bid.native.clickTrackers[0]);
   });
 
-  it('creates native asset message', function () {
-    const messageRequest = {
-      message: 'Prebid Native',
-      action: 'assetRequest',
-      adId: '123',
-      assets: ['hb_native_body', 'hb_native_image', 'hb_native_linkurl'],
-    };
+  describe('native postMessages', () => {
+    let adUnit;
+    beforeEach(() => {
+      adUnit = {};
+      sinon.stub(auctionManager, 'index').get(() => ({
+        getAdUnit: () => adUnit
+      }))
+    });
 
-    const message = getAssetMessage(messageRequest, bid);
+    it('creates native asset message', function () {
+      const messageRequest = {
+        message: 'Prebid Native',
+        action: 'assetRequest',
+        adId: '123',
+        assets: ['hb_native_body', 'hb_native_image', 'hb_native_linkurl'],
+      };
 
-    expect(message.assets.length).to.equal(3);
-    expect(message.assets).to.deep.include({
-      key: 'body',
-      value: bid.native.body,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'image',
-      value: bid.native.image.url,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'clickUrl',
-      value: bid.native.clickUrl,
-    });
-  });
+      const message = getAssetMessage(messageRequest, bid);
 
-  it('creates native all asset message', function () {
-    const messageRequest = {
-      message: 'Prebid Native',
-      action: 'allAssetRequest',
-      adId: '123',
-    };
+      expect(message.assets.length).to.equal(3);
+      expect(message.assets).to.deep.include({
+        key: 'body',
+        value: bid.native.body,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'image',
+        value: bid.native.image.url,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'clickUrl',
+        value: bid.native.clickUrl,
+      });
+    });
 
-    const message = getAllAssetsMessage(messageRequest, bid);
+    it('creates native all asset message', function () {
+      const messageRequest = {
+        message: 'Prebid Native',
+        action: 'allAssetRequest',
+        adId: '123',
+      };
 
-    expect(message.assets.length).to.equal(10);
-    expect(message.assets).to.deep.include({
-      key: 'body',
-      value: bid.native.body,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'image',
-      value: bid.native.image.url,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'clickUrl',
-      value: bid.native.clickUrl,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'title',
-      value: bid.native.title,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'icon',
-      value: bid.native.icon.url,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'cta',
-      value: bid.native.cta,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'sponsoredBy',
-      value: bid.native.sponsoredBy,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'foo',
-      value: bid.native.ext.foo,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'baz',
-      value: bid.native.ext.baz,
-    });
-  });
+      const message = getAllAssetsMessage(messageRequest, bid);
 
-  it('creates native all asset message with only defined fields', function () {
-    const messageRequest = {
-      message: 'Prebid Native',
-      action: 'allAssetRequest',
-      adId: '123',
-    };
+      expect(message.assets.length).to.equal(10);
+      expect(message.assets).to.deep.include({
+        key: 'body',
+        value: bid.native.body,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'image',
+        value: bid.native.image.url,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'clickUrl',
+        value: bid.native.clickUrl,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'title',
+        value: bid.native.title,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'icon',
+        value: bid.native.icon.url,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'cta',
+        value: bid.native.cta,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'sponsoredBy',
+        value: bid.native.sponsoredBy,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'foo',
+        value: bid.native.ext.foo,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'baz',
+        value: bid.native.ext.baz,
+      });
+    });
 
-    const message = getAllAssetsMessage(messageRequest, bidWithUndefinedFields);
+    it('creates native all asset message with only defined fields', function () {
+      const messageRequest = {
+        message: 'Prebid Native',
+        action: 'allAssetRequest',
+        adId: '123',
+      };
 
-    expect(message.assets.length).to.equal(4);
-    expect(message.assets).to.deep.include({
-      key: 'clickUrl',
-      value: bid.native.clickUrl,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'title',
-      value: bid.native.title,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'sponsoredBy',
-      value: bid.native.sponsoredBy,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'foo',
-      value: bid.native.ext.foo,
-    });
-  });
+      const message = getAllAssetsMessage(messageRequest, bidWithUndefinedFields);
 
-  it('creates native all asset message with complete format', function () {
-    const messageRequest = {
-      message: 'Prebid Native',
-      action: 'allAssetRequest',
-      adId: '123',
-    };
+      expect(message.assets.length).to.equal(4);
+      expect(message.assets).to.deep.include({
+        key: 'clickUrl',
+        value: bid.native.clickUrl,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'title',
+        value: bid.native.title,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'sponsoredBy',
+        value: bid.native.sponsoredBy,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'foo',
+        value: bid.native.ext.foo,
+      });
+    });
 
-    const message = getAllAssetsMessage(messageRequest, completeNativeBid);
+    it('creates native all asset message with complete format', function () {
+      const messageRequest = {
+        message: 'Prebid Native',
+        action: 'allAssetRequest',
+        adId: '123',
+      };
 
-    expect(message.assets.length).to.equal(10);
-    expect(message.assets).to.deep.include({
-      key: 'body',
-      value: bid.native.body,
+      const message = getAllAssetsMessage(messageRequest, completeNativeBid);
+
+      expect(message.assets.length).to.equal(10);
+      expect(message.assets).to.deep.include({
+        key: 'body',
+        value: bid.native.body,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'image',
+        value: bid.native.image.url,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'clickUrl',
+        value: bid.native.clickUrl,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'title',
+        value: bid.native.title,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'icon',
+        value: bid.native.icon.url,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'cta',
+        value: bid.native.cta,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'sponsoredBy',
+        value: bid.native.sponsoredBy,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'privacyLink',
+        value: ortbBid.native.ortb.privacy,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'foo',
+        value: bid.native.ext.foo,
+      });
+      expect(message.assets).to.deep.include({
+        key: 'baz',
+        value: bid.native.ext.baz,
+      });
     });
-    expect(message.assets).to.deep.include({
-      key: 'image',
-      value: bid.native.image.url,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'clickUrl',
-      value: bid.native.clickUrl,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'title',
-      value: bid.native.title,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'icon',
-      value: bid.native.icon.url,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'cta',
-      value: bid.native.cta,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'sponsoredBy',
-      value: bid.native.sponsoredBy,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'privacyLink',
-      value: ortbBid.native.ortb.privacy,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'foo',
-      value: bid.native.ext.foo,
-    });
-    expect(message.assets).to.deep.include({
-      key: 'baz',
-      value: bid.native.ext.baz,
-    });
-  });
+
+    it('if necessary, adds ortb response when the request was in ortb', () => {
+      const messageRequest = {
+        message: 'Prebid Native',
+        action: 'allAssetRequest',
+        adId: '123',
+      };
+      adUnit = {mediaTypes: {native: {ortb: ortbRequest}}, nativeOrtbRequest: ortbRequest}
+      const message = getAllAssetsMessage(messageRequest, bid);
+      const expected = toOrtbNativeResponse(bid.native, ortbRequest)
+      expect(message.ortb).to.eql(expected);
+    })
+  })
 
   const SAMPLE_ORTB_REQUEST = toOrtbNativeRequest({
     title: 'vtitle',


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fix an issue where adUnits that rely on "new" ORTB native templates (`##hb_native_asset_id_N##`) do not work properly with "legacy" native bidders.

## Other information

https://github.com/prebid/Prebid.js/issues/9622
