### PR TITLE
Js 1763 add intent iqid

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -440,7 +440,7 @@ function loadOrCreateFirstPartyData() {
         }
       }
     } catch (error) {
-
+      return;
     }
   };
   var firstPartyData = tryParse(readData(FIRST_PARTY_KEY));

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -398,39 +398,18 @@ export function _getPlatform(context = window) {
  */
 function loadOrCreateFirstPartyData() {
   var localStorageEnabled;
-  // var wasDebugCheck = false;
-  // var isDebugMode = false;
+
   var FIRST_PARTY_KEY = '_iiq_fdata';
-  // var isDebug = function () {
-  //   if (!wasDebugCheck) {
-  //     if (hasLocalStorage()) {
-  //       var dbgValue = readData('_iiq_debug_level');
-  //       if (dbgValue !== null) {
-  //         isDebugMode = true;
-  //       }
-  //     }
-  //     wasDebugCheck = true;
-  //   }
-  //   return isDebugMode;
-  // };
-  var logger = function (msg) {
-    // if (isDebug()) { console.log('IIQ  ' + '%c' + msg, 'color: yellow ; background-color: blue; border-radius: 3px'); }
-  };
   var tryParse = function (data) {
     try {
       return JSON.parse(data);
     } catch (err) {
-      logger(err);
+      return null;
     }
-    return null;
   };
   var readData = function (key) {
-    try {
-      if (hasLocalStorage()) {
-        return window.localStorage.getItem(key);
-      }
-    } catch (error) {
-      logger(error);
+    if (hasLocalStorage()) {
+      return window.localStorage.getItem(key);
     }
     return null;
   };
@@ -441,7 +420,6 @@ function loadOrCreateFirstPartyData() {
         return localStorageEnabled;
       } catch (e) {
         localStorageEnabled = false;
-        logger('Local storage api disabled');
       }
     }
     return false;
@@ -457,22 +435,19 @@ function loadOrCreateFirstPartyData() {
   var storeData = function (key, value) {
     try {
       if (typeof key === 'string' && key.startsWith('_iiq_fdata')) {
-        logger('IntentIQ: storing data: key=' + key + ' value=' + value);
         if (value && hasLocalStorage()) {
           window.localStorage.setItem(key, value);
         }
       }
     } catch (error) {
-      logger(error);
+
     }
   };
   var firstPartyData = tryParse(readData(FIRST_PARTY_KEY));
   if (!firstPartyData || !firstPartyData.pcid) {
-    logger('Generetaing new key.');
     var firstPartyId = generateGUID();
     firstPartyData = { pcid: firstPartyId, pcidDate: Date.now() };
   } else if (firstPartyData && !firstPartyData.pcidDate) {
-    logger('Key retreived. Adding timestamp.');
     firstPartyData.pcidDate = Date.now();
   }
   storeData(FIRST_PARTY_KEY, JSON.stringify(firstPartyData));

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -238,6 +238,13 @@ describe('SonobiBidAdapter', function () {
   });
 
   describe('.buildRequests', function () {
+    before(function () {
+      $$PREBID_GLOBAL$$.bidderSettings = {
+        sonobi: {
+          storageAllowed: true
+        }
+      };
+    });
     let sandbox;
     beforeEach(function () {
       sinon.stub(userSync, 'canBidderRegisterSync');
@@ -398,6 +405,7 @@ describe('SonobiBidAdapter', function () {
       expect(bidRequests.data.ref).not.to.be.empty
       expect(bidRequests.data.s).not.to.be.empty
       expect(bidRequests.data.pv).to.equal(bidRequestsPageViewID.data.pv)
+      expect(bidRequests.data.iqid).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
       expect(bidRequests.data.hfa).to.not.exist
       expect(bidRequests.bidderRequests).to.eql(bidRequest);
       expect(bidRequests.data.ref).to.equal('overrides_top_window_location');


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
 Sonobi adapter will mint a new intent iq id **Only when storageAllowed is true.** We will send this in the /trinity.json request as a separate query param called “iqid”. The value of this will be a non-encrypted intent iq user id string.
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
