### PR TITLE
Add GVLID to adup tech

### DIFF
--- a/modules/aduptechBidAdapter.js
+++ b/modules/aduptechBidAdapter.js
@@ -4,6 +4,7 @@ import {BANNER, NATIVE} from '../src/mediaTypes.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 
 export const BIDDER_CODE = 'aduptech';
+export const GVLID = 647;
 export const ENDPOINT_URL_PUBLISHER_PLACEHOLDER = '{PUBLISHER}';
 export const ENDPOINT_URL = 'https://rtb.d.adup-tech.com/prebid/' + ENDPOINT_URL_PUBLISHER_PLACEHOLDER + '_bid';
 export const ENDPOINT_METHOD = 'POST';
@@ -190,7 +191,8 @@ export const internal = {
 export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: [BANNER, NATIVE],
-
+  gvlid: GVLID,
+  
   /**
    * Validate given bid request
    *


### PR DESCRIPTION
Axel Springer Teaser Ad GmbH (647) is the vendor running this bid adatper

## Type of change

- [x] Bugfix

## Description of change

Adds the `gvlid` for aduptech bidder, which allows user syncing out-of-the-box with the gdpr enforcement module.

## Other information

cc @SteffenAnders 
