### PR TITLE
Core: improve FPD enrichment

### DIFF
--- a/libraries/ortbConverter/processors/default.js
+++ b/libraries/ortbConverter/processors/default.js
@@ -1,10 +1,10 @@
-import {deepSetValue, logWarn, mergeDeep} from '../../../src/utils.js';
+import {deepSetValue, mergeDeep} from '../../../src/utils.js';
 import {bannerResponseProcessor, fillBannerImp} from './banner.js';
 import {fillVideoImp, fillVideoResponse} from './video.js';
 import {setResponseMediaType} from './mediaType.js';
 import {fillNativeImp, fillNativeResponse} from './native.js';
 import {BID_RESPONSE, IMP, REQUEST} from '../../../src/pbjsORTB.js';
-import {config} from '../../../src/config.js';
+import {clientSectionChecker} from '../../../src/fpd/oneClient.js';
 
 export const DEFAULT_PROCESSORS = {
   [REQUEST]: {
@@ -15,14 +15,10 @@ export const DEFAULT_PROCESSORS = {
         mergeDeep(ortbRequest, bidderRequest.ortb2)
       }
     },
-    // override FPD app, site, and device with getConfig('app'), etc if defined
-    // TODO: these should be deprecated for v8
-    appFpd: fpdFromTopLevelConfig('app'),
-    siteFpd: fpdFromTopLevelConfig('site'),
-    deviceFpd: fpdFromTopLevelConfig('device'),
     onlyOneClient: {
+      // make sure only one of 'dooh', 'app', 'site' is set in request
       priority: -99,
-      fn: onlyOneClientSection
+      fn: clientSectionChecker('ORTB request')
     },
     props: {
       // sets request properties id, tmax, test, source.tid
@@ -124,30 +120,4 @@ if (FEATURES.NATIVE) {
     // populates bidResponse.native if bidResponse.mediaType === NATIVE
     fn: fillNativeResponse
   }
-}
-
-function fpdFromTopLevelConfig(prop) {
-  return {
-    priority: 90, // after FPD from 'ortb2', before the rest
-    fn(ortbRequest) {
-      const data = config.getConfig(prop);
-      if (typeof data === 'object') {
-        ortbRequest[prop] = mergeDeep({}, ortbRequest[prop], data);
-      }
-    }
-  }
-}
-
-export function onlyOneClientSection(ortbRequest) {
-  ['dooh', 'app', 'site'].reduce((found, section) => {
-    if (ortbRequest[section] != null && Object.keys(ortbRequest[section]).length > 0) {
-      if (found != null) {
-        logWarn(`ORTB request specifies both '${found}' and '${section}'; dropping the latter.`)
-        delete ortbRequest[section];
-      } else {
-        found = section;
-      }
-    }
-    return found;
-  }, null);
 }

--- a/src/fpd/enrichment.js
+++ b/src/fpd/enrichment.js
@@ -3,7 +3,7 @@ import {getRefererInfo, parseDomain} from '../refererDetection.js';
 import {findRootDomain} from './rootDomain.js';
 import {deepSetValue, getDefinedParams, getDNT, getWindowSelf, getWindowTop, mergeDeep} from '../utils.js';
 import {config} from '../config.js';
-import {getHighEntropySUA, getLowEntropySUA} from '../../libraries/fpd/sua.js';
+import {getHighEntropySUA, getLowEntropySUA} from './sua.js';
 import {GreedyPromise} from '../utils/promise.js';
 
 export const dep = {

--- a/src/fpd/enrichment.js
+++ b/src/fpd/enrichment.js
@@ -5,6 +5,7 @@ import {deepSetValue, getDefinedParams, getDNT, getWindowSelf, getWindowTop, mer
 import {config} from '../config.js';
 import {getHighEntropySUA, getLowEntropySUA} from './sua.js';
 import {GreedyPromise} from '../utils/promise.js';
+import {CLIENT_SECTIONS, clientSectionChecker, hasSection} from './oneClient.js';
 
 export const dep = {
   getRefererInfo,
@@ -15,6 +16,8 @@ export const dep = {
   getLowEntropySUA,
 };
 
+const oneClient = clientSectionChecker('FPD')
+
 /**
  * Enrich an ortb2 object with first party data.
  * @param {Promise[{}]} fpd: a promise to an ortb2 object.
@@ -23,8 +26,10 @@ export const dep = {
 export const enrichFPD = hook('sync', (fpd) => {
   return GreedyPromise.all([fpd, getSUA().catch(() => null)])
     .then(([ortb2, sua]) => {
+      const ri = dep.getRefererInfo();
+      mergeLegacySetConfigs(ortb2);
       Object.entries(ENRICHMENTS).forEach(([section, getEnrichments]) => {
-        const data = getEnrichments();
+        const data = getEnrichments(ortb2, ri);
         if (data && Object.keys(data).length > 0) {
           ortb2[section] = mergeDeep({}, data, ortb2[section]);
         }
@@ -32,9 +37,27 @@ export const enrichFPD = hook('sync', (fpd) => {
       if (sua) {
         deepSetValue(ortb2, 'device.sua', Object.assign({}, sua, ortb2.device.sua));
       }
+      ortb2 = oneClient(ortb2);
+      for (let section of CLIENT_SECTIONS) {
+        if (hasSection(ortb2, section)) {
+          ortb2[section] = mergeDeep({}, clientEnrichment(ortb2, ri), ortb2[section]);
+          break;
+        }
+      }
       return ortb2;
     });
 });
+
+function mergeLegacySetConfigs(ortb2) {
+  // merge in values from "legacy" setConfig({app, site, device})
+  // TODO: deprecate these eventually
+  ['app', 'site', 'device'].forEach(prop => {
+    const cfg = config.getConfig(prop);
+    if (cfg != null) {
+      ortb2[prop] = mergeDeep({}, cfg, ortb2[prop]);
+    }
+  })
+}
 
 function winFallback(fn) {
   try {
@@ -51,20 +74,19 @@ function getSUA() {
     : dep.getHighEntropySUA(hints);
 }
 
+function removeUndef(obj) {
+  return getDefinedParams(obj, Object.keys(obj))
+}
+
 const ENRICHMENTS = {
-  site() {
-    const ri = dep.getRefererInfo();
-    const domain = parseDomain(ri.page, {noLeadingWww: true});
-    const keywords = winFallback((win) => win.document.querySelector('meta[name=\'keywords\']'))
-      ?.content?.replace?.(/\s/g, '');
-    return (site => getDefinedParams(site, Object.keys(site)))({
+  site(ortb2, ri) {
+    if (CLIENT_SECTIONS.filter(p => p !== 'site').some(hasSection.bind(null, ortb2))) {
+      // do not enrich site if dooh or app are set
+      return;
+    }
+    return removeUndef({
       page: ri.page,
       ref: ri.ref,
-      domain,
-      keywords,
-      publisher: {
-        domain: dep.findRootDomain(domain)
-      }
     });
   },
   device() {
@@ -92,3 +114,18 @@ const ENRICHMENTS = {
     return regs;
   }
 };
+
+// Enrichment of properties common across dooh, app and site - will be dropped into whatever
+// section is appropriate
+function clientEnrichment(ortb2, ri) {
+  const domain = parseDomain(ri.page, {noLeadingWww: true});
+  const keywords = winFallback((win) => win.document.querySelector('meta[name=\'keywords\']'))
+    ?.content?.replace?.(/\s/g, '');
+  return removeUndef({
+    domain,
+    keywords,
+    publisher: removeUndef({
+      domain: dep.findRootDomain(domain)
+    })
+  })
+}

--- a/src/fpd/oneClient.js
+++ b/src/fpd/oneClient.js
@@ -1,0 +1,26 @@
+import {logWarn} from '../utils.js';
+
+// mutually exclusive ORTB sections in order of priority - 'dooh' beats 'app' & 'site' and 'app' beats 'site';
+// if one is set, the others will be removed
+export const CLIENT_SECTIONS = ['dooh', 'app', 'site']
+
+export function clientSectionChecker(logPrefix) {
+  return function onlyOneClientSection(ortb2) {
+    CLIENT_SECTIONS.reduce((found, section) => {
+      if (hasSection(ortb2, section)) {
+        if (found != null) {
+          logWarn(`${logPrefix} specifies both '${found}' and '${section}'; dropping the latter.`)
+          delete ortb2[section];
+        } else {
+          found = section;
+        }
+      }
+      return found;
+    }, null);
+    return ortb2;
+  }
+}
+
+export function hasSection(ortb2, section) {
+  return ortb2[section] != null && Object.keys(ortb2[section]).length > 0
+}

--- a/src/fpd/sua.js
+++ b/src/fpd/sua.js
@@ -1,5 +1,5 @@
-import {isEmptyStr, isStr, isEmpty} from '../../src/utils.js';
-import {GreedyPromise} from '../../src/utils/promise.js';
+import {isEmptyStr, isStr, isEmpty} from '../utils.js';
+import {GreedyPromise} from '../utils/promise.js';
 
 export const SUA_SOURCE_UNKNOWN = 0;
 export const SUA_SOURCE_LOW_ENTROPY = 1;

--- a/test/spec/fpd/oneClient.js
+++ b/test/spec/fpd/oneClient.js
@@ -1,6 +1,7 @@
-import {onlyOneClientSection} from '../../../libraries/ortbConverter/processors/default.js';
+import {clientSectionChecker} from '../../../src/fpd/oneClient.js';
 
 describe('onlyOneClientSection', () => {
+  const oneClient = clientSectionChecker();
   [
     [['app'], 'app'],
     [['site'], 'site'],
@@ -11,13 +12,13 @@ describe('onlyOneClientSection', () => {
   ].forEach(([sections, winner]) => {
     it(`should leave only ${winner} in request when it contains ${sections.join(', ')}`, () => {
       const req = Object.fromEntries(sections.map(s => [s, {foo: 'bar'}]));
-      onlyOneClientSection(req);
+      oneClient(req);
       expect(Object.keys(req)).to.eql([winner]);
     })
   });
   it('should not choke if none of the sections are in the request', () => {
     const req = {};
-    onlyOneClientSection(req);
+    oneClient(req);
     expect(req).to.eql({});
   });
 });

--- a/test/spec/fpd/sua_spec.js
+++ b/test/spec/fpd/sua_spec.js
@@ -6,7 +6,7 @@ import {
   SUA_SOURCE_UNKNOWN,
   suaFromUAData,
   uaDataToSUA
-} from '../../../libraries/fpd/sua.js';
+} from '../../../src/fpd/sua.js';
 
 describe('uaDataToSUA', () => {
   Object.entries({

--- a/test/spec/modules/improvedigitalBidAdapter_spec.js
+++ b/test/spec/modules/improvedigitalBidAdapter_spec.js
@@ -1,9 +1,9 @@
-import { expect } from 'chai';
+import {expect} from 'chai';
 import {CONVERTER, spec} from 'modules/improvedigitalBidAdapter.js';
-import { config } from 'src/config.js';
-import { deepClone } from 'src/utils.js';
+import {config} from 'src/config.js';
+import {deepClone} from 'src/utils.js';
 import {BANNER, NATIVE, VIDEO} from '../../../src/mediaTypes';
-import { deepSetValue } from '../../../src/utils';
+import {deepSetValue} from '../../../src/utils';
 // load modules that register ORTB processors
 import 'src/prebid.js';
 import 'modules/currency.js';
@@ -13,7 +13,7 @@ import 'modules/priceFloors.js';
 import 'modules/consentManagement.js';
 import 'modules/consentManagementUsp.js';
 import 'modules/schain.js';
-import {decorateAdUnitsWithNativeParams, toLegacyResponse} from '../../../src/native.js';
+import {decorateAdUnitsWithNativeParams} from '../../../src/native.js';
 import {createEidsArray} from '../../../modules/userId/eids.js';
 import {syncAddFPDToBidderRequest} from '../../helpers/fpd.js';
 import {hook} from '../../../src/hook.js';
@@ -670,7 +670,7 @@ describe('Improve Digital Adapter Tests', function () {
     it('should not set site when app is defined in CONFIG', function () {
       getConfigStub = sinon.stub(config, 'getConfig');
       getConfigStub.withArgs('app').returns({ content: 'XYZ' });
-      let request = spec.buildRequests([simpleBidRequest], bidderRequest)[0];
+      let request = spec.buildRequests([simpleBidRequest], syncAddFPDToBidderRequest(bidderRequest))[0];
       let payload = JSON.parse(request.data);
       expect(payload.site).does.not.exist;
       expect(payload.app).does.exist;
@@ -709,7 +709,7 @@ describe('Improve Digital Adapter Tests', function () {
       getConfigStub = sinon.stub(config, 'getConfig');
       getConfigStub.withArgs('app').returns(undefined);
       getConfigStub.withArgs('site').returns({});
-      let request = spec.buildRequests([simpleBidRequest], bidderRequest)[0];
+      let request = spec.buildRequests([simpleBidRequest], syncAddFPDToBidderRequest(bidderRequest))[0];
       let payload = JSON.parse(request.data);
       expect(payload.site).does.exist;
       expect(payload.app).does.not.exist;

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -994,7 +994,7 @@ describe('S2S Adapter', function () {
         w: window.innerWidth,
         h: window.innerHeight
       })
-      expect(requestBid.app).to.deep.equal({
+      sinon.assert.match(requestBid.app, {
         bundle: 'com.test.app',
         publisher: { 'id': '1' }
       });
@@ -1021,7 +1021,7 @@ describe('S2S Adapter', function () {
         w: window.innerWidth,
         h: window.innerHeight
       })
-      expect(requestBid.app).to.deep.equal({
+      sinon.assert.match(requestBid.app, {
         bundle: 'com.test.app',
         publisher: { 'id': '1' }
       });
@@ -1383,7 +1383,7 @@ describe('S2S Adapter', function () {
             w: window.innerWidth,
             h: window.innerHeight
           })
-          expect(requestBid.app).to.deep.equal({
+          sinon.assert.match(requestBid.app, {
             bundle: 'com.test.app',
             publisher: { 'id': '1' }
           });
@@ -1522,7 +1522,7 @@ describe('S2S Adapter', function () {
       };
 
       config.setConfig(_config);
-      adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
+      adapter.callBids(addFpdEnrichmentsToS2SRequest(REQUEST, BID_REQUESTS), BID_REQUESTS, addBidResponse, done, ajax);
       const requestBid = JSON.parse(server.requests[0].requestBody);
       expect(requestBid.site).to.not.exist;
       expect(requestBid.app).to.exist.and.to.be.a('object');
@@ -1732,9 +1732,9 @@ describe('S2S Adapter', function () {
         const s2sBidRequest = utils.deepClone(REQUEST);
         cookieSyncConfig.syncEndpoint = { p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync' };
         s2sBidRequest.s2sConfig = cookieSyncConfig;
-  
+
         config.setConfig({ userSync, s2sConfig: cookieSyncConfig });
-  
+
         let bidRequest = utils.deepClone(BID_REQUESTS);
         adapter.callBids(s2sBidRequest, bidRequest, addBidResponse, done, ajax);
         return JSON.parse(server.requests[0].requestBody);
@@ -1762,7 +1762,7 @@ describe('S2S Adapter', function () {
           }
         });
       });
-  
+
       it('correctly adds filterSettings to the cookie_sync request if userSync.filterSettings is present in the config and only the iframe key is present in userSync.filterSettings', function () {
         const userSync = {
           filterSettings: {
@@ -1944,7 +1944,7 @@ describe('S2S Adapter', function () {
           device: device
         });
 
-        adapter.callBids(s2sBidRequest, BID_REQUESTS, addBidResponse, done, ajax);
+        adapter.callBids(addFpdEnrichmentsToS2SRequest(s2sBidRequest, BID_REQUESTS), BID_REQUESTS, addBidResponse, done, ajax);
         const requestBid = JSON.parse(server.requests[0].requestBody);
 
         expect(requestBid.site).to.exist.and.to.be.a('object');


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

This improves FPD enrichment logic:

 - if `dooh` or `app` are provided by the pub, do not attempt to enrich `site`
 - put `keywords`, `domain` and `publisher.domain` in one of `dooh`, `app` or `site`
 - "legacy" setConfig({app, device, site}) are now merged in with "standard" FPD


**Note**: I did not attempt to fill in `device.devicetype`; there are several adapters that attempt to guess it based on the user agent, but that seems too fragile to me, and also not very useful (the other end could also just look at the user agent since that's in the request)

## Other information

Closes https://github.com/prebid/Prebid.js/issues/9335

