### PR TITLE
DFP video adserver module: set `description_url` to pub's URL by default; do not skip setting it if `cache.url` is set

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -12,6 +12,7 @@ import { gdprDataHandler, uspDataHandler, gppDataHandler } from '../src/adapterM
 import * as events from '../src/events.js';
 import CONSTANTS from '../src/constants.json';
 import {getPPID} from '../src/adserver.js';
+import {getRefererInfo} from '../src/refererDetection.js';
 
 /**
  * @typedef {Object} DfpVideoParams
@@ -51,6 +52,10 @@ const defaultParamConstants = {
 };
 
 export const adpodUtils = {};
+
+export const dep = {
+  ri: getRefererInfo
+}
 
 /**
  * Merge all the bid data and publisher-supplied options into a single URL, and then return it.
@@ -259,14 +264,7 @@ function buildUrlFromAdserverUrlComponents(components, bid, options) {
  * @return {string | undefined} The encoded vast url if it exists, or undefined
  */
 function getDescriptionUrl(bid, components, prop) {
-  if (config.getConfig('cache.url')) { return; }
-
-  if (!deepAccess(components, `${prop}.description_url`)) {
-    const vastUrl = bid && bid.vastUrl;
-    if (vastUrl) { return encodeURIComponent(vastUrl); }
-  } else {
-    logError(`input cannnot contain description_url`);
-  }
+  return deepAccess(components, `${prop}.description_url`) || dep.ri().page;
 }
 
 /**
@@ -293,6 +291,8 @@ function getCustParams(bid, options, urlCustParams) {
     allTargetingData,
     adserverTargeting,
   );
+
+  // TODO: WTF is this? just firing random events, guessing at the argument, hoping noone notices?
   events.emit(CONSTANTS.EVENTS.SET_TARGETING, {[adUnit.code]: prebidTargetingSet});
 
   // merge the prebid + publisher targeting sets


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fixes https://github.com/prebid/Prebid.js/issues/9228
Fixes https://github.com/prebid/Prebid.js/issues/9227

