### PR TITLE
Generic bid adapter for PBS using stored requests, including adapter for Relevant Digital

### DIFF
--- a/modules/prebidServerBidAdapter/storedRequestBidAdapterBase.js
+++ b/modules/prebidServerBidAdapter/storedRequestBidAdapterBase.js
@@ -197,14 +197,14 @@ class StoredRequestBidAdapterBase {
     req.imp = req.imp.reduce((acc, imp) => {
       const { prebid = {} } = imp.ext || {};
       const params = prebid.bidder?.[info.bidder] || {};
-      const adUnitFiedName = this.nameMap.adUnitCode || 'adUnitCode';
-      const adUnitCode = params[adUnitFiedName];
+      const adUnitFieldName = this.nameMap.adUnitCode || 'adUnitCode';
+      const adUnitCode = params[adUnitFieldName];
       if (adUnitCode) {
         // Use params.adUnitCode as stored request id
         deepSetValue(imp, 'ext.prebid.storedrequest.id', adUnitCode);
         acc.push(imp);
       } else {
-        logWarn(`${info.bidder} is skipping '${imp.id}' as '${adUnitFiedName}' is missing`);
+        logWarn(`${info.bidder} is skipping '${imp.id}' as '${adUnitFieldName}' is missing`);
       }
       delete prebid.bidder; // Delete prebid.bidder as we're using a stored request instead
       return acc;

--- a/modules/prebidServerBidAdapter/storedRequestBidAdapterBase.js
+++ b/modules/prebidServerBidAdapter/storedRequestBidAdapterBase.js
@@ -1,0 +1,292 @@
+import {getHook} from '../../src/hook.js';
+import adapterManager from '../../src/adapterManager.js';
+import {s2sDefaultConfig} from './index.js'; // eslint-disable-line prebid/validate-imports
+import {isEmpty, deepSetValue, logWarn} from '../../src/utils.js';
+import {config} from '../../src/config.js';
+import {BANNER, VIDEO, NATIVE} from '../../src/mediaTypes.js';
+import {GreedyPromise} from '../../src/utils/promise.js';
+
+/**
+ * Parameters can be set using the following methods (in that order)
+ *  - pbjs.setConfig({ [bidder]: { [param]: '[value]' }})
+ *  - params.[param] in adUnit.bids
+ *  - params[param] where params is the argument supplied to the constructor
+ */
+const CONFIG_PARAMS = ['accountId', 'pbsHost'];
+
+/**
+ * This class can be used to create bid adapters for anyone using Prebid Server along with stored requests.
+ * If customisations using constructor parameters isn't enough, it is possible to extend the class.
+ * Example usage:
+ *
+ * const ExampleBidAdapter = new StoredRequestBidAdapterBase({
+ *   pbsHost: 'prebid-server.example.com',
+ *   spec: {
+ *    code: 'examplebidder',
+ *   },
+ * });
+ * registerBidder(ExampleBidAdapter.spec);
+ */
+class StoredRequestBidAdapterBase {
+  /**
+   * @param {Object} params
+   * @param {Object} params.spec additional properties for the BidderSpec object
+   *                 required properties: @property spec.code
+   * @param {number} params.pbsBufferMs milliseconds to deduct from the prebid timeout to make the PBS timeout
+   * @param {boolean} params.accountIdRequired if true, bids will be rejected if accountId is missing in config/params
+   * @param {Array} params.nameMap optional mapping of all field names used in config/params.
+   *                Example: { adUnitId: 'zoneId', accountId: 'customerId' }
+   * @param {String} params.pbsHost Hostname for prebid server, will be used when not specified in config/params.
+   *                 Example: 'prebid-server.example.com'
+   */
+  constructor(params) {
+    if (!params?.spec?.code) {
+      throw Error('params.spec.code must be supplied');
+    }
+    const throwErr = () => { throw Error('Not supported by StoredRequestBidAdapterBase') };
+    Object.assign(this, {
+      pbsBufferMs: 250,
+      accountIdRequired: false,
+      ...params,
+      spec: {
+        supportedMediaTypes: [BANNER, VIDEO, NATIVE],
+        isBidRequestValid: () => false, // Will happen when a required config parameter (like pbsHost) is missing
+        buildRequests: throwErr,
+        interpretResponse: throwErr,
+        ...params.spec,
+      },
+      byBidderCode: {},
+      nameMap: {
+        ...params?.nameMap,
+      },
+    });
+    this.hookOn('startAuction', 'onStartAuction');
+  }
+
+  /**
+   * Helper function that calls this[memberFn](parameters) in getHook(name).before(...)
+   * If the return value of memberFn is truthy, it will be used as the first parameter to fn() */
+  hookOn(name, memberFn) {
+    const that = this;
+    getHook(name).before(function (fn, param, ...rest) {
+      fn.call(this, that[memberFn](param, ...rest) || param, ...rest);
+    });
+  }
+
+  /** Returns true if the bidderCode is for this adapter, either directly of via an alias */
+  isOurBidder(bidderCode) {
+    const code = adapterManager.aliasRegistry[bidderCode] || bidderCode;
+    return code === this.spec.code;
+  }
+
+  /** Returns true if the supplied s2sConfig object is the one created by this adapter  */
+  isOurS2SConfig({ bidders }) {
+    return (bidders || []).length === 1 && this.isOurBidder(bidders[0]);
+  }
+
+  /** Returns the state-object for the bidder s2sConfig was created for, if it was created by this adapter */
+  getInfoFrom(s2sConfig) {
+    return this.isOurS2SConfig(s2sConfig || {}) && this.byBidderCode[s2sConfig.bidders[0]];
+  }
+
+  /** Add a new s2sConfig-object for a bidder using this adapter. Override method to customize s2sConfig settings */
+  addNewS2sConfig(s2sConfigArr, newConfig) {
+    config.setConfig({
+      s2sConfig: [
+        // Filter out default s2sconfig object as it will otherwise disable s2s
+        ...s2sConfigArr.filter((cfg) => cfg.bidders?.length || cfg.enabled),
+        newConfig,
+      ],
+    });
+  }
+
+  getNewBiddersFromAdUnits(adUnits) {
+    const newBidders = [];
+    const seenNewBidders = {};
+    // Search for bidders created using this adapter
+    adUnits.forEach(({ bids = [] }) => {
+      bids.forEach(({ bidder, params = {} }) => {
+        if (!this.isOurBidder(bidder) || this.byBidderCode[bidder]) {
+          return; // Other bidder or already initialized
+        }
+        let info = seenNewBidders[bidder];
+        if (!info) {
+          // Create new state-object for this (previously unseen) bidder.
+          info = { bidder, waitingSync: {}, synced: {} };
+          newBidders.push(info);
+          seenNewBidders[bidder] = info;
+        }
+        // Set, when previously not set - config parameters from .params
+        CONFIG_PARAMS.forEach((field) => {
+          const fieldCustom = this.nameMap[field] || field;
+          info[field] = info[field] || params[fieldCustom];
+        });
+      });
+    });
+    return newBidders;
+  }
+
+  /** Called the first time we've found any bidder(s) using this adapter */
+  onFirstBiddersFound() {
+    // time to init additional hooks
+    this.hookOn('modifyPBSRequest', 'onModifyPBSRequest');
+    this.hookOn('modifyPBSResult', 'onModifyPBSResult');
+    this.hookOn('processPBSCookieSync', 'onProcessPBSCookieSync');
+  }
+
+  /** Called by the 'startAuction' hook. Will create one s2sConfig for each new bidder-code belonging to this adapter */
+  onStartAuction({ adUnits, timeout }) {
+    const newBidders = this.getNewBiddersFromAdUnits(adUnits);
+    const hasBidders = () => !isEmpty(this.byBidderCode);
+    const hadBidders = hasBidders();
+    newBidders.forEach((info) => { // Create one s2sConfig for each new bidder found
+      const { bidder } = info;
+      let s2sConfigArr = config.getConfig('s2sConfig') || [];
+      s2sConfigArr = Array.isArray(s2sConfigArr) ? s2sConfigArr : [s2sConfigArr];
+      const bidderConfiguration = config.getConfig(bidder) || {};
+      // Setup config paramters, see CONFIG_PARAMETERS
+      for (const field of CONFIG_PARAMS) {
+        const fieldCustom = this.nameMap[field] || field;
+        info[field] = bidderConfiguration[fieldCustom] || info[field] || this[field];
+      };
+      if (!info.pbsHost || (!info.accountId && this.accountIdRequired)) {
+        return; // missing config parameter(s), will result in invalid bid requests by: isBidRequestValid: () => false
+      }
+      info.pbsHost = info.pbsHost.trim().replace('http://', 'https://');
+      if (info.pbsHost.indexOf('https://') < 0) {
+        info.pbsHost = `https://${info.pbsHost}`;
+      }
+      const endpoint = `${info.pbsHost}/openrtb2/auction`;
+      const syncEndpoint = `${info.pbsHost}/cookie_sync`;
+      const { pbsBufferMs } = this;
+      const pbjsTimeout = timeout || 1000;
+      this.addNewS2sConfig(s2sConfigArr, {
+        ...s2sDefaultConfig,
+        bidders: [bidder],
+        accountId: info.accountId || '1',
+        enabled: true,
+        endpoint: { p1Consent: endpoint, noP1Consent: endpoint },
+        syncEndpoint: { p1Consent: syncEndpoint, noP1Consent: syncEndpoint },
+        timeout: Math.min(Math.max(pbjsTimeout - pbsBufferMs, pbsBufferMs), pbjsTimeout),
+        ...bidderConfiguration.s2sConfig,
+      });
+      this.byBidderCode[bidder] = info; // New bidder added
+    });
+    if (hasBidders() && !hadBidders) {
+      this.onFirstBiddersFound();
+    }
+  }
+
+  /** Called by the 'modifyPBSRequest' hook. */
+  onModifyPBSRequest(req, { s2sConfig }) {
+    // Remove aliases in PBS-request for all bidders belonging to adapter. This is necessary also for the normal
+    // PBS requests (not using this adapter), as our aliases will then be included - which causes error-responses.
+    const { aliases = {} } = req.ext?.prebid || {};
+    for (const key in aliases) {
+      if (this.byBidderCode[key]) {
+        delete aliases[key];
+      }
+    }
+    const info = this.getInfoFrom(s2sConfig);
+    if (!info) {
+      return; // Request didn't belong to this adapter
+    }
+    if (info.accountId) { // Use account-id as a stored BidRequest id
+      deepSetValue(req, 'ext.prebid.storedrequest.id', info.accountId);
+    }
+    req.imp = req.imp.reduce((acc, imp) => {
+      const { prebid = {} } = imp.ext || {};
+      const params = prebid.bidder?.[info.bidder] || {};
+      const adUnitFiedName = this.nameMap.adUnitCode || 'adUnitCode';
+      const adUnitCode = params[adUnitFiedName];
+      if (adUnitCode) {
+        // Use params.adUnitCode as stored request id
+        deepSetValue(imp, 'ext.prebid.storedrequest.id', adUnitCode);
+        acc.push(imp);
+      } else {
+        logWarn(`${info.bidder} is skipping '${imp.id}' as '${adUnitFiedName}' is missing`);
+      }
+      delete prebid.bidder; // Delete prebid.bidder as we're using a stored request instead
+      return acc;
+    }, []);
+  }
+
+  /** Called by the 'modifyPBSResult' hook. */
+  onModifyPBSResult(resp, { s2sConfig }) {
+    const info = this.getInfoFrom(s2sConfig);
+    if (!info) {
+      return; // Response didn't belong to this adapter
+    }
+    const editBid = (bid) => { // Modify bidder-codes in bid to the bidder code for this bidder
+      const { prebid = {} } = bid.ext || {};
+      const { meta, targeting } = prebid;
+      if (meta?.adaptercode) {
+        meta.adaptercode = info.bidder;
+      }
+      if (targeting?.hb_bidder) {
+        targeting.hb_bidder = info.bidder;
+      }
+      return bid;
+    };
+    // Create a single seat for this bidder - that holds the bids for all seats returned
+    if (Array.isArray(resp.seatbid)) {
+      resp.seatbid = [{
+        seat: info.bidder,
+        bid: [].concat(...resp.seatbid.map(({ bid }) => (bid || []).map(editBid))),
+      }];
+    }
+    // Modify response times for actual PBS bidders into a single value that should be the response-time for this bidder
+    const { responsetimemillis } = resp.ext || {};
+    if (!isEmpty(responsetimemillis)) {
+      resp.ext.responsetimemillis = {
+        [info.bidder]: Math.max(...Object.values(responsetimemillis)),
+      };
+    }
+    // Find PBS-bidders that we've not cookie-synced yet
+    const unsynced = Object.keys(responsetimemillis).filter((bidder) => !info.synced[bidder]);
+    unsynced.forEach((bidder) => {
+      info.waitingSync[bidder] = true;
+    });
+    const { pendingSync } = info;
+    if (pendingSync && !isEmpty(info.waitingSync)) {
+      // If there's a cookie-sync call pending and we're having un-synced PBS bidders, then resume that call.
+      // See onProcessPBSCookieSync()
+      delete info.pendingSync;
+      pendingSync();
+    }
+  }
+
+  /**
+   * Called by the 'processPBSCookieSync' hook.
+   * As the server will perform the auction for us, the bidders are not known until after the auction response.
+   * Delay the cookie sync to after the response and perform the syncing for the actual bidders.
+   * @note it is possible for the promise to never resolve - for unnecessary cookie-sync calls or if
+   * the PBS auction request fails.
+   */
+  onProcessPBSCookieSync(promise) {
+    return promise.then((params) => new GreedyPromise((resolve) => {
+      const {payload, s2sConfig} = params;
+      const next = () => resolve(params);
+      const info = this.getInfoFrom(s2sConfig);
+      if (!info) {
+        next();
+        return; // Cookie-sync didn't belong to this adapter
+      }
+      const doSync = () => { // Trigger the cookie-syncing after changing which bidders to include
+        payload.bidders = Object.keys(info.waitingSync);
+        payload.bidders.forEach((bidder) => {
+          info.synced[bidder] = true;
+        });
+        info.waitingSync = {};
+        next();
+      };
+      if (!isEmpty(info.waitingSync)) {
+        doSync(); // We're already waiting to sync some bidders, continue and do the call
+      } else {
+        info.pendingSync = doSync; // Wait for PBS auction response.
+      }
+    }));
+  }
+}
+
+export default StoredRequestBidAdapterBase;

--- a/modules/relevantDigitalBidAdapter.js
+++ b/modules/relevantDigitalBidAdapter.js
@@ -1,0 +1,12 @@
+import StoredRequestBidAdapterBase from './prebidServerBidAdapter/storedRequestBidAdapterBase.js'
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+
+const RelevantAdapter = new StoredRequestBidAdapterBase({
+  accountIdRequired: true,
+  spec: {
+    gvlid: 1100,
+    code: 'relevantdigital',
+  },
+});
+
+registerBidder(RelevantAdapter.spec);

--- a/modules/relevantDigitalBidAdapter.md
+++ b/modules/relevantDigitalBidAdapter.md
@@ -1,0 +1,111 @@
+# Overview
+
+```
+Module Name:  Relevant Digital Bid Adapter
+Module Type:  Bidder Adapter
+Maintainer: support@relevant-digital.com
+```
+
+# Description
+
+This adapter is used for integration with providers using the **[Relevant Yield](https://www.relevant-digital.com/relevantyield)** platform. The provider will supply the necessary **pbsHost** and **accountId** settings along with the **adUnitCode** bid parameters per ad unit.
+
+# Example setup using pbjs.setConfig()
+This is the recommended method to set the global configuration parameters.
+```javascript
+pbjs.setConfig({
+  relevantdigital: {
+    pbsHost: 'pbs-example.relevant-digital.com',
+    accountId: '620533ae7f5bbe1691bbb815',
+  },
+});
+
+var adUnits = [
+  {
+    code: 'test-div',
+    mediaTypes: { banner: { sizes: [[728, 90]] }},
+    bids: [
+      {
+        bidder: 'relevantdigital',
+        params: {
+          adUnitCode: '610525862d7517bfd4bbb81e_620523b7d1dbed6b0fbbb817',
+        }
+      }
+   ],
+  }
+];
+```
+# Example setup using only bid params
+This method to set the global configuration parameters (like **pbsHost**) in **params** could simplify integration of a provider for some publishers. Setting different global config-parameters on different bids is not supported, as the first settings found will be used and any subsequent global settings will be ignored.
+```javascript
+var adUnits = [
+  {
+    code: 'test-div',
+    mediaTypes: { banner: { sizes: [[728, 90]] }},
+    bids: [
+      {
+        bidder: 'relevantdigital',
+        params: {
+          adUnitCode: '610525862d7517bfd4bbb81e_620523b7d1dbed6b0fbbb817',
+          pbsHost: 'pbs-example.relevant-digital.com',
+          accountId: '620533ae7f5bbe1691bbb815',
+        }
+      }
+   ],
+  }
+];
+```
+
+# Example setup with multiple providers
+```javascript
+
+pbjs.aliasBidder('relevantdigital', 'providerA');
+pbjs.aliasBidder('relevantdigital', 'providerB');
+
+pbjs.setConfig({
+  providerA: {
+    pbsHost: 'pbs-example-a.relevant-digital.com',
+    accountId: '620533ae7f5bbe1691bbb815',
+  },
+  providerB: {
+    pbsHost: 'pbs-example-b.relevant-digital.com',
+    accountId: '990533ae7f5bbe1691bbb815',
+  },  
+});
+
+var adUnits = [
+  {
+    code: 'test-div',
+    mediaTypes: { banner: { sizes: [[728, 90]] }},
+    bids: [
+      {
+        bidder: 'providerA',
+        params: {
+          adUnitCode: '610525862d7517bfd4bbb81e_620523b7d1dbed6b0fbbb817',
+        }
+      },
+      {
+        bidder: 'providerB',
+        params: {
+          adUnitCode: '990525862d7517bfd4bbb81e_770523b7d1dbed6b0fbbb817',
+        }
+      },      
+   ],
+  }
+];
+```
+
+# Bid Parameters
+
+| Name          | Scope    | Description                                             | Example                    | Type         |
+|---------------|----------|---------------------------------------------------------|----------------------------|--------------|
+| `adUnitCode`       | required | The placement id.  | `'610525862d7517bfd4bbb81e_620523b7d1dbed6b0fbbb817'`      | `String`     |
+| `pbsHost` | required if not set in config | Host name of the server. | `'pbs-example.relevant-digital.com'`                | `String`     |
+| `accountId`        | required if not set in config | The account id.  | `620533ae7f5bbe1691bbb815`               | `String`      |
+
+# Config Parameters
+
+| Name          | Scope    | Description                                             | Example                    | Type         |
+|---------------|----------|---------------------------------------------------------|----------------------------|--------------|
+| `pbsHost` | required if not set in bid parameters | Host name of the server. | `'pbs-example.relevant-digital.com'`                | `String`     |
+| `accountId`        | required if not set in bid parameters | The account id.  | `620533ae7f5bbe1691bbb815`               | `String`      |

--- a/modules/storedRequestBidAdapter.js
+++ b/modules/storedRequestBidAdapter.js
@@ -1,0 +1,10 @@
+import StoredRequestBidAdapterBase from './prebidServerBidAdapter/storedRequestBidAdapterBase.js'
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+
+const StoredRequestBidAdapter = new StoredRequestBidAdapterBase({
+  spec: {
+    code: 'pbsGenericBidder',
+  },
+});
+
+registerBidder(StoredRequestBidAdapter.spec);

--- a/modules/storedRequestBidAdapter.md
+++ b/modules/storedRequestBidAdapter.md
@@ -1,0 +1,112 @@
+# Overview
+
+```
+Module Name:  Stored Request Bid Adapter
+Module Type:  Bidder Adapter
+Maintainer: support@relevant-digital.com
+```
+
+# Description
+
+This adapter simplifies integration with providers hosting Prebid Server that are managing bidders/SSPs by using Prebid Server's [stored request mechanism](https://docs.prebid.org/prebid-server/features/pbs-storedreqs.html).
+
+# Example setup using pbjs.setConfig()
+This is the recommended method to set the global configuration parameters.
+```javascript
+pbjs.setConfig({
+  pbsGenericBidder: {
+    pbsHost: 'prebid-server.example.com',
+    accountId: 'myAccount-123',
+  },
+});
+
+var adUnits = [
+  {
+    code: 'test-div',
+    mediaTypes: { banner: { sizes: [[728, 90]] }},
+    bids: [
+      {
+        bidder: 'pbsGenericBidder',
+        params: {
+          adUnitCode: '123456',
+        }
+      }
+   ],
+  }
+];
+```
+# Example setup using only bid params
+This method to set the global configuration parameters (like **pbsHost**) in **params** could simplify integration of a provider for some publishers. Setting different global config-parameters on different bids is not supported, as the first settings found will be used and any subsequent global settings will be ignored.
+```javascript
+var adUnits = [
+  {
+    code: 'test-div',
+    mediaTypes: { banner: { sizes: [[728, 90]] }},
+    bids: [
+      {
+        bidder: 'pbsGenericBidder',
+        params: {
+          adUnitCode: '123456',
+          pbsHost: 'prebid-server.example.com',
+          accountId: 'myAccount-123',
+        }
+      }
+   ],
+  }
+];
+```
+
+# Example setup with multiple providers
+```javascript
+
+pbjs.aliasBidder('pbsGenericBidder', 'providerA');
+pbjs.aliasBidder('pbsGenericBidder', 'providerB');
+
+pbjs.setConfig({
+  providerA: {
+    pbsHost: 'aaaa.example.com',
+    accountId: 'myAccount-123',
+  },
+  providerB: {
+    pbsHost: 'bbbb.example.com',
+    accountId: 'anotherAccount-987',
+  },  
+});
+
+var adUnits = [
+  {
+    code: 'test-div',
+    mediaTypes: { banner: { sizes: [[728, 90]] }},
+    bids: [
+      {
+        bidder: 'providerA',
+        params: {
+          adUnitCode: '123456',
+        }
+      },
+      {
+        bidder: 'providerB',
+        params: {
+          adUnitCode: 'ABCDEFGH',
+        }
+      },      
+   ],
+  }
+];
+```
+
+# Bid Parameters
+
+| Name          | Scope    | Description                                             | Example                    | Type         |
+|---------------|----------|---------------------------------------------------------|----------------------------|--------------|
+| `adUnitCode`       | required | The placement id. This will be the id of a stored request in Prebid Server | `'123456'`      | `String`     |
+| `pbsHost` | required if not set in config | The Prebid Server host name | `'prebid-server.example.com'`                | `String`     |
+| `accountId`        | might be required if not set in config | The account id. This will be the id of a stored BidRequest in Prebid Server. This might be required by some providers.  | `myAccount-123`               | `String`      |
+
+# Config Parameters
+
+| Name          | Scope    | Description                                             | Example                    | Type         |
+|---------------|----------|---------------------------------------------------------|----------------------------|--------------|
+| `pbsHost` | required if not set in bid parameters | The Prebid Server host name | `'prebid-server.example.com'`                | `String`     |
+| `accountId`        | might be required if not set in bid parameters | The account id. This will be the id of a stored BidRequest in Prebid Server. This might be required by some providers.  | `myAccount-123`               | `String`      |
+

--- a/src/auctionManager.js
+++ b/src/auctionManager.js
@@ -120,8 +120,8 @@ export function newAuctionManager() {
     return _auctions.length && _auctions[_auctions.length - 1].getAuctionId()
   };
 
-  auctionManager.clearAllAuctions = function() {
-    _auctions.length = 0;
+  auctionManager.clearAllAuctions = function(shouldRemoveCondition = () => true) {
+    _auctions.splice(0, Infinity, ..._auctions.filter((auction) => !shouldRemoveCondition(auction)));
   }
 
   function _addAuction(auction) {

--- a/test/spec/modules/storedRequestBidAdapter_spec.js
+++ b/test/spec/modules/storedRequestBidAdapter_spec.js
@@ -107,7 +107,7 @@ function onModifyPBSRequest(fn, ...args) {
   fn.call(this, ...args);
 }
 
-const findReq = (str) => server.requests.findLast((r) => r.url.includes(str));
+const findReq = (str) => server.requests.find((r) => r.url.includes(str));
 
 describe('Stored Request Bid Adaper', function () {
   before(function() {

--- a/test/spec/modules/storedRequestBidAdapter_spec.js
+++ b/test/spec/modules/storedRequestBidAdapter_spec.js
@@ -1,0 +1,144 @@
+import 'src/prebid.js';
+import { registerBidder } from 'src/adapters/bidderFactory.js';
+import StoredRequestBidAdapterBase from 'modules/prebidServerBidAdapter/storedRequestBidAdapterBase';
+import {server} from 'test/mocks/xhr.js';
+import {getHook} from 'src/hook';
+import {auctionManager} from 'src/auctionManager.js';
+
+const expect = require('chai').expect;
+
+const HOST = 'dev-api.relevant-digital.com';
+const IMP_ID = '/12345/stored/request/test';
+const ADAPTER_CODE = 'storedRequestTestAdapter';
+
+const BID = {
+  bidder: 'storedRequestTestAdapter',
+  params: {
+    adUnitCode: '620525862d7518bfd4bbb81e_620523b5d1dbed6b0fbbb817',
+    accountId: '620523ae7f4bbe1691bbb815',
+    pbsHost: HOST,
+  },
+};
+
+const AD_UNIT = {
+  code: IMP_ID,
+  mediaTypes: {
+    banner: {
+      sizes: [[300, 250], [300, 600], [320, 320]],
+    }
+  },
+  bids: [BID],
+};
+
+const response = ({ id, host }) => ({
+  'id': id,
+  'seatbid': [
+    {
+      'bid': [
+        {
+          'id': '613673EF-A07C-4486-8EE9-3FC71A7DC73D',
+          'impid': IMP_ID,
+          'price': 10.76091063668997,
+          'adm': '<html><a href="http://www.pubmatic.com" target="_blank"><img src ="https://stagingva.pubmatic.com:8443/image/300x250.jpg" /></a></html>',
+          'adomain': [
+            'www.addomain.com'
+          ],
+          'iurl': 'http://localhost11',
+          'crid': 'creative111',
+          'w': 300,
+          'h': 250,
+          'ext': {
+            'bidtype': 0,
+            'dspid': 6,
+            'origbidcpm': 1,
+            'origbidcur': 'USD',
+            'prebid': {
+              'meta': {
+                'adaptercode': 'pubmatic'
+              },
+              'targeting': {
+                'hb_bidder': 'pubmatic',
+                'hb_cache_host': host,
+                'hb_cache_path': '/analytics_cache/read',
+                'hb_format': 'banner',
+                'hb_pb': '10.70',
+                'hb_size': '300x250'
+              },
+              'type': 'banner',
+              'video': {
+                'duration': 0,
+                'primary_category': ''
+              },
+              'events': {
+                'win': `https://${host}/event?t=win&b=fed970f7-4295-456d-a251-38013faab795&a=620523ae7f4bbe1691bbb815&bidder=pubmatic&ts=1678646619765`,
+                'imp': `https://${host}/event?t=imp&b=fed970f7-4295-456d-a251-38013faab795&a=620523ae7f4bbe1691bbb815&bidder=pubmatic&ts=1678646619765`
+              },
+              'bidid': 'fed970f7-4295-456d-a251-38013faab795'
+            }
+          }
+        }
+      ],
+      'seat': 'pubmatic'
+    }
+  ],
+  'cur': 'SEK',
+  'ext': {
+    'responsetimemillis': {
+      'appnexus': 305,
+      'pubmatic': 156
+    },
+    'tmaxrequest': 2750,
+    'prebid': {
+      'auctiontimestamp': 1678646619765
+    }
+  }
+});
+
+let waitingPbs;
+
+function onModifyPBSRequest(fn, ...args) {
+  setTimeout(() => {
+    const waiter = waitingPbs;
+    if (waiter) {
+      waitingPbs = null;
+      waiter();
+    }
+  });
+  fn.call(this, ...args);
+}
+
+const findReq = (str) => server.requests.findLast((r) => r.url.includes(str));
+
+describe('Stored Request Bid Adaper', function () {
+  before(function() {
+    registerBidder(new StoredRequestBidAdapterBase({ spec: { code: ADAPTER_CODE } }).spec);
+    getHook('modifyPBSRequest').before(onModifyPBSRequest, 10);
+  });
+  after(function () {
+    getHook('modifyPBSRequest').getHooks({hook: onModifyPBSRequest}).remove();
+    auctionManager.clearAllAuctions((auction) => auction.getAuctionId().includes('storedRequest'));
+  });
+  describe('Make requests', function () {
+    it('should work', async function() {
+      $$PREBID_GLOBAL$$.requestBids({ adUnits: [AD_UNIT], auctionId: 'storedRequest' + Math.random() });
+      await new Promise((resolve) => { waitingPbs = resolve; });
+      const req = findReq('/openrtb2/auction');
+      const reqBody = JSON.parse(req.requestBody);
+      const { id, ext } = reqBody;
+      const { prebid } = reqBody.imp[0].ext;
+      req.respond(200, {}, JSON.stringify(response({ id, host: HOST })));
+      const cookieReq = findReq('/cookie_sync');
+      const syncedBidders = JSON.parse(cookieReq.requestBody).bidders.sort();
+      const bid = $$PREBID_GLOBAL$$.getBidResponses()[IMP_ID]?.bids?.[0];
+
+      expect(!!bid).to.be.true;
+      expect(bid.bidderCode).to.be.equal(ADAPTER_CODE);
+      expect(syncedBidders).to.deep.equal(['appnexus', 'pubmatic']);
+      expect(req.url.startsWith(`https://${HOST}`)).to.be.true;
+      expect(cookieReq.url.startsWith(`https://${HOST}`)).to.be.true;
+      expect(prebid.bidders).to.not.exist;
+      expect(prebid.storedrequest.id).to.be.equal(BID.params.adUnitCode);
+      expect(ext.prebid.storedrequest.id).to.be.equal(BID.params.accountId);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 

## Description of change
<!-- Describe the change proposed in this pull request -->
The purpose of this change is to support "SSPs" that are in fact Prebid Server instances configured using [stored requests](https://docs.prebid.org/prebid-server/features/pbs-storedreqs.html). The use-case is that we have network customers (and ourselves) that would like to let publishers add their demand via a prebid-adapter. The actual bidders are then configured server-side using stored requests in Prebid Server.

Instead of creating a normal bid adapter - this solution adds one `s2sConfig` object per bidder, as there might be multiple bidders for the same adapter using aliasing. By adding hook-functions in `prebidServerBidAdapter` the adapter-code will modify the `BidRequest` + `BidReponse` to/from Prebid Server to add a stored-request-id from `param.adUnitCode` and adjust the response so that it will appear as the result from a single bidder, instead of the actual different bidders used by PBS. It will also use a hook to delay and modify the `/cookie_sync` call to PBS in order to include the bidders actually used once getting the `BidResponse` from PBS. The implementation of the cookie-sync hook is using a promise along with a `sync`-hook, which might seem a bit convoluted. But we found very strange/buggy behavior when using `async` hooks. (I can provide a simple test-case of that if needed).

The actual code is added in `modules/prebidServerBidAdapter/storedRequestBidAdapterBase.js` (feel free to suggest an alternative location for this file).

There are then 2 minimal adapters added using that implementation:

- `storedRequestBidAdapter.js` - Default adapter that can be used by anyone by using `bidder: 'pbsGenericBidder'`.
- `relevantDigitalBidAdapter.js` - Adapter with minor customisations for users of our Relevant Yield platform.

```javascript
{
 bidder: 'pbsGenericBidder',
 params: {
    adUnitCode: '123456',
    pbsHost: 'prebid-server.example.com',
    accountId: 'myAccount-123',
  }
}
```
The `pbsHost` and (optional) `accountId` parameters can also, preferably, be set via `pbjs.setConfig()`.

## Motivation

This use-case can "sort of" already be achieved by setting `params.ortb2Imp.ext.prebid.storedrequest.id` in the bids, make sure that `bidder` is one that in fact will participate in the auction on the ad unit - and then manually add a suitable `s2sConfig` with `allowUnknownBidderCodes: true`. However, this might appear cumbersome for site-owners and cookie-syncing with the actual bidders will not be done.

The other option would be to create an adapter using the _ORTB Conversion library_. But in this case we'll miss out on a lot of things (user-ids, bid-floors, cookie-syncing, etc) handled by the `prebidServerBidAdapter`. We would then need to copy-paste functionality and struggle to stay up to date with the S2S-adapter, resulting in further unnecessary pull requests.

Therefore we instead suggest this solution. It might for sure be possible to implement this differently, but we've tried to make a solution that changes as little as possible in the existing code.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
There is also a fix in `prebidServerBidAdapter.js` where the wrong variable-name (`option` vs `options`) was used which prevented normalization of of `endpoint` and `cookie_sync` URLs when s2sConfig is turned into an array. This was necessary to include in this pull requests, as otherwise the normal Prebid Server integration, if any, would risk breaking.

PR for the documentation repository will arrive shortly.