### PR TITLE
LiveIntent UserId module: update LiveConnect dependency

### DIFF
--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -102,7 +102,7 @@ function initializeLiveConnect(configParams) {
   liveConnectConfig.wrapperName = 'prebid';
   liveConnectConfig.identityResolutionConfig = identityResolutionConfig;
   liveConnectConfig.identifiersToResolve = configParams.identifiersToResolve || [];
-  liveConnectConfig.defaultEventDelay = configParams.defaultEventDelay;
+  liveConnectConfig.fireEventDelay = configParams.fireEventDelay;
   const usPrivacyString = uspDataHandler.getConsentData();
   if (usPrivacyString) {
     liveConnectConfig.usPrivacyString = usPrivacyString;
@@ -128,7 +128,7 @@ const setEventFiredFlag = function(_) {
 
 function tryFireEvent() {
   if (!eventFired && liveConnect) {
-    const eventDelay = liveConnect.config.defaultEventDelay || 500
+    const eventDelay = liveConnect.config.fireEventDelay || 500
     setTimeout(() => {
       const instances = window.liQ_instances
       instances.forEach(i => i.eventBus.once(EVENTS_TOPIC, setEventFiredFlag))

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -132,7 +132,7 @@ function tryFireEvent() {
     setTimeout(() => {
       const instances = window.liQ_instances
       instances.forEach(i => i.eventBus.once(EVENTS_TOPIC, setEventFiredFlag))
-      if (!eventFired) {
+      if (!eventFired && liveConnect) {
         liveConnect.fire();
       }
     }, eventDelay)

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -50,9 +50,9 @@ export function reset() {
 }
 
 /**
- * This function is used in tests
+ * This function is also used in tests
  */
-export function doNotFireEvent() {
+export function setEventFiredFlag() {
   eventFired = true;
 }
 
@@ -127,10 +127,6 @@ function initializeLiveConnect(configParams) {
     liveConnect.push({ hash: configParams.emailHash })
   }
   return liveConnect;
-}
-
-const setEventFiredFlag = function(_) {
-  eventFired = true
 }
 
 function tryFireEvent() {

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -49,6 +49,13 @@ export function reset() {
   liveConnect = null;
 }
 
+/**
+ * This function is used in tests
+ */
+export function doNotFireEvent() {
+  eventFired = true;
+}
+
 function parseLiveIntentCollectorConfig(collectConfig) {
   const config = {};
   collectConfig = collectConfig || {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "prebid.js",
-      "version": "7.36.0-pre",
+      "version": "7.39.0-pre",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.7",
@@ -22,7 +22,7 @@
         "express": "^4.15.4",
         "fun-hooks": "^0.9.9",
         "just-clone": "^1.0.2",
-        "live-connect-js": "^4.0.0"
+        "live-connect-js": "^5.0.0"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.16.5",
@@ -112,6 +112,18 @@
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2"
+      }
+    },
+    ".yalc/live-connect-js": {
+      "version": "4.0.1-alpha.0",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "live-connect-common": "^1.0.0",
+        "tiny-hashes": "1.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -16228,11 +16240,20 @@
       "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
       "dev": true
     },
+    "node_modules/live-connect-common": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-1.0.0.tgz",
+      "integrity": "sha512-LBZsvykcGeVRYI1eqqXrrNZsoBdL2a8cpyrYPIiGAF/CpixbyRbvqGslaFw511lH294QB16J3fYYg21aYuaM2Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/live-connect-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-4.0.0.tgz",
-      "integrity": "sha512-uycBgFBdEwSq95NImrsOSkTlszUMTGf8luK9GZDWw4D+DL5yFNnCPcrjxUk15U9n9aPmaM1SKmWH5qUXFr8aIA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-5.0.0.tgz",
+      "integrity": "sha512-Bv0wQQ+/1VU0/YczEpObbWtHbuXwaHGxwg1+Pe7ZlDgBLb334CrqSQvOL1uyZw3//zs+fSO94yYaQzjjkTd5OQ==",
       "dependencies": {
+        "live-connect-common": "^1.0.0",
         "tiny-hashes": "1.0.1"
       },
       "engines": {
@@ -37864,11 +37885,17 @@
       "integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==",
       "dev": true
     },
+    "live-connect-common": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-1.0.0.tgz",
+      "integrity": "sha512-LBZsvykcGeVRYI1eqqXrrNZsoBdL2a8cpyrYPIiGAF/CpixbyRbvqGslaFw511lH294QB16J3fYYg21aYuaM2Q=="
+    },
     "live-connect-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-4.0.0.tgz",
-      "integrity": "sha512-uycBgFBdEwSq95NImrsOSkTlszUMTGf8luK9GZDWw4D+DL5yFNnCPcrjxUk15U9n9aPmaM1SKmWH5qUXFr8aIA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-5.0.0.tgz",
+      "integrity": "sha512-Bv0wQQ+/1VU0/YczEpObbWtHbuXwaHGxwg1+Pe7ZlDgBLb334CrqSQvOL1uyZw3//zs+fSO94yYaQzjjkTd5OQ==",
       "requires": {
+        "live-connect-common": "^1.0.0",
         "tiny-hashes": "1.0.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,18 +114,6 @@
         "fsevents": "^2.3.2"
       }
     },
-    ".yalc/live-connect-js": {
-      "version": "4.0.1-alpha.0",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "live-connect-common": "^1.0.0",
-        "tiny-hashes": "1.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -24356,9 +24344,9 @@
       "dev": true
     },
     "node_modules/webpack": {
-      "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "version": "5.76.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.0.tgz",
+      "integrity": "sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -44159,9 +44147,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "version": "5.76.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.0.tgz",
+      "integrity": "sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "express": "^4.15.4",
     "fun-hooks": "^0.9.9",
     "just-clone": "^1.0.2",
-    "live-connect-js": "^4.0.0"
+    "live-connect-js": "^5.0.0"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -5,7 +5,7 @@ import { server } from 'test/mocks/xhr.js';
 resetLiveIntentIdSubmodule();
 liveIntentIdSubmodule.setModuleMode('standard')
 const PUBLISHER_ID = '89899';
-const defaultConfigParams = { params: {publisherId: PUBLISHER_ID, defaultEventDelay: 1} };
+const defaultConfigParams = { params: {publisherId: PUBLISHER_ID, fireEventDelay: 1} };
 const responseHeader = {'Content-Type': 'application/json'}
 
 describe('LiveIntentId', function() {

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -5,7 +5,7 @@ import { server } from 'test/mocks/xhr.js';
 resetLiveIntentIdSubmodule();
 liveIntentIdSubmodule.setModuleMode('standard')
 const PUBLISHER_ID = '89899';
-const defaultConfigParams = { params: {publisherId: PUBLISHER_ID, defaultEventDelay: 50} };
+const defaultConfigParams = { params: {publisherId: PUBLISHER_ID, defaultEventDelay: 1} };
 const responseHeader = {'Content-Type': 'application/json'}
 
 describe('LiveIntentId', function() {
@@ -69,7 +69,7 @@ describe('LiveIntentId', function() {
     setTimeout(() => {
       expect(server.requests[0].url).to.match(/https:\/\/rp.liadm.com\/j\?.*&us_privacy=1YNY.*&wpn=prebid.*&gdpr=1&n3pc=1&n3pct=1&nb=1&gdpr_consent=consentDataString.*/);
       done();
-    }, 100);
+    }, 200);
   });
 
   it('should fire an event when getId and a hash is provided', function(done) {
@@ -80,7 +80,7 @@ describe('LiveIntentId', function() {
     setTimeout(() => {
       expect(server.requests[0].url).to.match(/https:\/\/rp.liadm.com\/j\?.*e=58131bc547fb87af94cebdaf3102321f.+/)
       done();
-    }, 100);
+    }, 200);
   });
 
   it('should initialize LiveConnect with the config params when decode and emit an event', function (done) {
@@ -97,7 +97,7 @@ describe('LiveIntentId', function() {
     setTimeout(() => {
       expect(server.requests[0].url).to.match(/https:\/\/collector.liveintent.com\/j\?.*aid=a-0001.*&wpn=prebid.*/);
       done();
-    }, 100);
+    }, 200);
   });
 
   it('should initialize LiveConnect and emit an event with a privacy string when decode', function(done) {
@@ -110,7 +110,7 @@ describe('LiveIntentId', function() {
     setTimeout(() => {
       expect(server.requests[0].url).to.match(/.*us_privacy=1YNY.*&gdpr=0&gdpr_consent=consentDataString.*/);
       done();
-    }, 100);
+    }, 200);
   });
 
   it('should fire an event when decode and a hash is provided', function(done) {
@@ -121,7 +121,7 @@ describe('LiveIntentId', function() {
     setTimeout(() => {
       expect(server.requests[0].url).to.match(/https:\/\/rp.liadm.com\/j\?.*e=58131bc547fb87af94cebdaf3102321f.+/);
       done();
-    }, 100);
+    }, 200);
   });
 
   it('should not return a decoded identifier when the unifiedId is not present in the value', function() {
@@ -134,7 +134,7 @@ describe('LiveIntentId', function() {
     setTimeout(() => {
       expect(server.requests[0].url).to.be.not.null
       done();
-    }, 100);
+    }, 200);
   });
 
   it('should initialize LiveConnect and send data only once', function(done) {

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -5,7 +5,7 @@ import { server } from 'test/mocks/xhr.js';
 resetLiveIntentIdSubmodule();
 liveIntentIdSubmodule.setModuleMode('standard')
 const PUBLISHER_ID = '89899';
-const defaultConfigParams = { params: {publisherId: PUBLISHER_ID} };
+const defaultConfigParams = { params: {publisherId: PUBLISHER_ID, defaultEventDelay: 50} };
 const responseHeader = {'Content-Type': 'application/json'}
 
 describe('LiveIntentId', function() {
@@ -45,7 +45,7 @@ describe('LiveIntentId', function() {
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
-    let request = server.requests[1];
+    let request = server.requests[0];
     expect(request.url).to.match(/.*us_privacy=1YNY.*&gdpr=1&n3pc=1&gdpr_consent=consentDataString.*/);
     const response = {
       unifiedId: 'a_unified_id',
@@ -59,25 +59,31 @@ describe('LiveIntentId', function() {
     expect(callBackSpy.calledOnceWith(response)).to.be.true;
   });
 
-  it('should fire an event when getId', function() {
+  it('should fire an event when getId', function(done) {
     uspConsentDataStub.returns('1YNY');
     gdprConsentDataStub.returns({
       gdprApplies: true,
       consentString: 'consentDataString'
     })
     liveIntentIdSubmodule.getId(defaultConfigParams);
-    expect(server.requests[0].url).to.match(/https:\/\/rp.liadm.com\/j\?.*&us_privacy=1YNY.*&wpn=prebid.*&gdpr=1&n3pc=1&n3pct=1&nb=1&gdpr_consent=consentDataString.*/);
+    setTimeout(() => {
+      expect(server.requests[0].url).to.match(/https:\/\/rp.liadm.com\/j\?.*&us_privacy=1YNY.*&wpn=prebid.*&gdpr=1&n3pc=1&n3pct=1&nb=1&gdpr_consent=consentDataString.*/);
+      done();
+    }, 100);
   });
 
-  it('should fire an event when getId and a hash is provided', function() {
+  it('should fire an event when getId and a hash is provided', function(done) {
     liveIntentIdSubmodule.getId({ params: {
       ...defaultConfigParams,
       emailHash: '58131bc547fb87af94cebdaf3102321f'
     }});
-    expect(server.requests[0].url).to.match(/https:\/\/rp.liadm.com\/j\?.*e=58131bc547fb87af94cebdaf3102321f.+/)
+    setTimeout(() => {
+      expect(server.requests[0].url).to.match(/https:\/\/rp.liadm.com\/j\?.*e=58131bc547fb87af94cebdaf3102321f.+/)
+      done();
+    }, 100);
   });
 
-  it('should initialize LiveConnect with the config params when decode and emit an event', function () {
+  it('should initialize LiveConnect with the config params when decode and emit an event', function (done) {
     liveIntentIdSubmodule.decode({}, { params: {
       ...defaultConfigParams.params,
       ...{
@@ -88,25 +94,34 @@ describe('LiveIntentId', function() {
         }
       }
     }});
-    expect(server.requests[0].url).to.match(/https:\/\/collector.liveintent.com\/j\?.*aid=a-0001.*&wpn=prebid.*/);
+    setTimeout(() => {
+      expect(server.requests[0].url).to.match(/https:\/\/collector.liveintent.com\/j\?.*aid=a-0001.*&wpn=prebid.*/);
+      done();
+    }, 100);
   });
 
-  it('should initialize LiveConnect and emit an event with a privacy string when decode', function() {
+  it('should initialize LiveConnect and emit an event with a privacy string when decode', function(done) {
     uspConsentDataStub.returns('1YNY');
     gdprConsentDataStub.returns({
       gdprApplies: false,
       consentString: 'consentDataString'
     })
     liveIntentIdSubmodule.decode({}, defaultConfigParams);
-    expect(server.requests[0].url).to.match(/.*us_privacy=1YNY.*&gdpr=0&gdpr_consent=consentDataString.*/);
+    setTimeout(() => {
+      expect(server.requests[0].url).to.match(/.*us_privacy=1YNY.*&gdpr=0&gdpr_consent=consentDataString.*/);
+      done();
+    }, 100);
   });
 
-  it('should fire an event when decode and a hash is provided', function() {
+  it('should fire an event when decode and a hash is provided', function(done) {
     liveIntentIdSubmodule.decode({}, { params: {
       ...defaultConfigParams.params,
       emailHash: '58131bc547fb87af94cebdaf3102321f'
     }});
-    expect(server.requests[0].url).to.match(/https:\/\/rp.liadm.com\/j\?.*e=58131bc547fb87af94cebdaf3102321f.+/);
+    setTimeout(() => {
+      expect(server.requests[0].url).to.match(/https:\/\/rp.liadm.com\/j\?.*e=58131bc547fb87af94cebdaf3102321f.+/);
+      done();
+    }, 100);
   });
 
   it('should not return a decoded identifier when the unifiedId is not present in the value', function() {
@@ -114,25 +129,31 @@ describe('LiveIntentId', function() {
     expect(result).to.be.eql({});
   });
 
-  it('should fire an event when decode', function() {
+  it('should fire an event when decode', function(done) {
     liveIntentIdSubmodule.decode({}, defaultConfigParams);
-    expect(server.requests[0].url).to.be.not.null
+    setTimeout(() => {
+      expect(server.requests[0].url).to.be.not.null
+      done();
+    }, 100);
   });
 
-  it('should initialize LiveConnect and send data only once', function() {
+  it('should initialize LiveConnect and send data only once', function(done) {
     liveIntentIdSubmodule.getId(defaultConfigParams);
     liveIntentIdSubmodule.decode({}, defaultConfigParams);
     liveIntentIdSubmodule.getId(defaultConfigParams);
     liveIntentIdSubmodule.decode({}, defaultConfigParams);
-    expect(server.requests.length).to.be.eq(1);
+    setTimeout(() => {
+      expect(server.requests.length).to.be.eq(1);
+      done();
+    }, 200);
   });
 
-  it('should call the Custom URL of the LiveIntent Identity Exchange endpoint', function() {
+  it('should call the custom URL of the LiveIntent Identity Exchange endpoint', function() {
     getCookieStub.returns(null);
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId({ params: {...defaultConfigParams.params, ...{'url': 'https://dummy.liveintent.com/idex'}} }).callback;
     submoduleCallback(callBackSpy);
-    let request = server.requests[1];
+    let request = server.requests[0];
     expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/prebid/89899?resolve=nonId');
     request.respond(
       204,
@@ -152,7 +173,7 @@ describe('LiveIntentId', function() {
       }
     } }).callback;
     submoduleCallback(callBackSpy);
-    let request = server.requests[1];
+    let request = server.requests[0];
     expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/rubicon/89899?resolve=nonId');
     request.respond(
       200,
@@ -167,7 +188,7 @@ describe('LiveIntentId', function() {
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
-    let request = server.requests[1];
+    let request = server.requests[0];
     expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?resolve=nonId');
     request.respond(
       200,
@@ -182,7 +203,7 @@ describe('LiveIntentId', function() {
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
-    let request = server.requests[1];
+    let request = server.requests[0];
     expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?resolve=nonId');
     request.respond(
       503,
@@ -199,7 +220,7 @@ describe('LiveIntentId', function() {
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
-    let request = server.requests[1];
+    let request = server.requests[0];
     expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?duid=${oldCookie}&resolve=nonId`);
     request.respond(
       200,
@@ -222,7 +243,7 @@ describe('LiveIntentId', function() {
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId(configParams).callback;
     submoduleCallback(callBackSpy);
-    let request = server.requests[1];
+    let request = server.requests[0];
     expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?duid=${oldCookie}&_thirdPC=third-pc&resolve=nonId`);
     request.respond(
       200,
@@ -244,7 +265,7 @@ describe('LiveIntentId', function() {
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId(configParams).callback;
     submoduleCallback(callBackSpy);
-    let request = server.requests[1];
+    let request = server.requests[0];
     expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?_thirdPC=%7B%22key%22%3A%22value%22%7D&resolve=nonId');
     request.respond(
       200,
@@ -277,7 +298,7 @@ describe('LiveIntentId', function() {
       ...{ requestedAttributesOverrides: { 'foo': true, 'bar': false } }
     } }).callback;
     submoduleCallback(callBackSpy);
-    let request = server.requests[1];
+    let request = server.requests[0];
     expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?resolve=nonId&resolve=foo`);
     request.respond(
       200,
@@ -304,7 +325,7 @@ describe('LiveIntentId', function() {
       ...{ requestedAttributesOverrides: { 'nonId': false, 'uid2': true } }
     } }).callback;
     submoduleCallback(callBackSpy);
-    let request = server.requests[1];
+    let request = server.requests[0];
     expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?resolve=uid2`);
     request.respond(
       200,

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -27,7 +27,7 @@ import {britepoolIdSubmodule} from 'modules/britepoolIdSystem.js';
 import {id5IdSubmodule} from 'modules/id5IdSystem.js';
 import {identityLinkSubmodule} from 'modules/identityLinkIdSystem.js';
 import {dmdIdSubmodule} from 'modules/dmdIdSystem.js';
-import {liveIntentIdSubmodule, doNotFireEvent as liveIntentIdSubmoduleDoNotFireEvent} from 'modules/liveIntentIdSystem.js';
+import {liveIntentIdSubmodule, setEventFiredFlag as liveIntentIdSubmoduleDoNotFireEvent} from 'modules/liveIntentIdSystem.js';
 import {merkleIdSubmodule} from 'modules/merkleIdSystem.js';
 import {netIdSubmodule} from 'modules/netIdSystem.js';
 import {intentIqIdSubmodule} from 'modules/intentIqIdSystem.js';

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -27,7 +27,7 @@ import {britepoolIdSubmodule} from 'modules/britepoolIdSystem.js';
 import {id5IdSubmodule} from 'modules/id5IdSystem.js';
 import {identityLinkSubmodule} from 'modules/identityLinkIdSystem.js';
 import {dmdIdSubmodule} from 'modules/dmdIdSystem.js';
-import {liveIntentIdSubmodule} from 'modules/liveIntentIdSystem.js';
+import {liveIntentIdSubmodule, doNotFireEvent as liveIntentIdSubmoduleDoNotFireEvent} from 'modules/liveIntentIdSystem.js';
 import {merkleIdSubmodule} from 'modules/merkleIdSystem.js';
 import {netIdSubmodule} from 'modules/netIdSystem.js';
 import {intentIqIdSubmodule} from 'modules/intentIqIdSystem.js';
@@ -147,6 +147,7 @@ describe('User ID', function () {
     hook.ready();
     uninstallGdprEnforcement();
     localStorage.removeItem(PBJS_USER_ID_OPTOUT_NAME);
+    liveIntentIdSubmoduleDoNotFireEvent();
   });
 
   beforeEach(function () {


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change

A new version of the live-connect module has been released. Release notes can be found here: https://github.com/LiveIntent/live-connect/releases/tag/v5.0.0. 

The main change is that `live-connect` does not attach LiveConnect to `window.liQ` and also does not expose the global message bus `window.__li__evt_bus`. For users of the LiveIntent Prebid user id module this change is transparent. 

Additionally to the library update, this PR introduces a guard that prevents firing duplicate events in cases where other LiveConnect installations are present on the same page. 

## Other information
- live-connect 5.0.0 release notes: https://github.com/LiveIntent/live-connect/releases/tag/v5.0.0
- live-connect NPM module: https://www.npmjs.com/package/live-connect-js
