### PR TITLE
Conversant Bid Adapter : support the timeout parameter

### DIFF
--- a/modules/conversantBidAdapter.js
+++ b/modules/conversantBidAdapter.js
@@ -142,6 +142,10 @@ export const spec = {
     }
 
     if (bidderRequest) {
+      if (bidderRequest.timeout) {
+        deepSetValue(payload, 'tmax', bidderRequest.timeout);
+      }
+
       // Add GDPR flag and consent string
       if (bidderRequest.gdprConsent) {
         userExt.consent = bidderRequest.gdprConsent.consentString;

--- a/test/spec/modules/conversantBidAdapter_spec.js
+++ b/test/spec/modules/conversantBidAdapter_spec.js
@@ -389,6 +389,14 @@ describe('Conversant adapter tests', function() {
     expect(payload.device).to.have.property('ua', navigator.userAgent);
 
     expect(payload).to.not.have.property('user'); // there should be no user by default
+    expect(payload).to.not.have.property('tmax'); // there should be no user by default
+  });
+
+  it('Verify timeout', () => {
+    const bidderRequest = { timeout: 9999 };
+    const request = spec.buildRequests(bidRequests, bidderRequest);
+    const payload = request.data;
+    expect(payload.tmax).equals(bidderRequest.timeout);
   });
 
   it('Verify first party data', () => {


### PR DESCRIPTION

## Type of change
- [X ] Feature


## Description of change
Pass the timeout value set in the prebid configuration to the Conversant backend



## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
