### PR TITLE
Build system: disallow `describe.only` and `it.only`

### DIFF
--- a/test/test_index.js
+++ b/test/test_index.js
@@ -1,3 +1,15 @@
+
+[it, describe].forEach((ob) => {
+  ob.only = function () {
+    [
+      'describe.only and it.only are disabled unless you provide a single spec --file,',
+      'because they can silently break the pipeline tests',
+      // eslint-disable-next-line no-console
+    ].forEach(l => console.error(l))
+    throw new Error('do not use .only()')
+  }
+})
+
 require('./test_deps.js');
 
 var testsContext = require.context('.', true, /_spec$/);


### PR DESCRIPTION
## Type of change

- [x] Build related changes
	
## Description of change

In mocha one can apparently silently break the entire test suite with `describe.only` / `it.only` (https://mochajs.org/#exclusive-tests) - most tests will be ignored, but it will still count as a successful run ([example](https://app.circleci.com/pipelines/github/prebid/Prebid.js/15033/workflows/f5167775-93b7-4b88-879c-bfa669ffc7ca/jobs/27493))

This attempts to disable that feature for tests running in the pipeline.

## Other information

See https://github.com/prebid/Prebid.js/pull/9691 for the trigger
