### PR TITLE
Adagio Bid Adapter : add new params `splitKeyword` and `dl` to bidRequest payload

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -940,9 +940,9 @@ export const spec = {
       if (bidRequest.params.dataLayer) {
         if (isStr(bidRequest.params.dataLayer) || isNumber(bidRequest.params.dataLayer) || isArray(bidRequest.params.dataLayer) || isFn(bidRequest.params.dataLayer)) {
           logWarn(LOG_PREFIX, 'The dataLayer param is invalid, only object is accepted as a type.');
-          delete bidRequest.params.dataLayer
+          delete bidRequest.params.dataLayer;
         } else {
-          let invalidDlParam = false
+          let invalidDlParam = false;
 
           bidRequest.params.dl = bidRequest.params.dataLayer
           // Remove the dataLayer from the BidRequest to send the `dl` instead of the `dataLayer`
@@ -951,10 +951,10 @@ export const spec = {
           Object.keys(bidRequest.params.dl).forEach((key) => {
             if (bidRequest.params.dl[key]) {
               if (isStr(bidRequest.params.dl[key]) || isNumber(bidRequest.params.dl[key])) {
-                bidRequest.params.dl[key.toString()] = bidRequest.params.dl[key].toString();
+                bidRequest.params.dl[key] = bidRequest.params.dl[key].toString();
               } else {
                 invalidDlParam = true;
-                delete bidRequest.params.dl[key]
+                delete bidRequest.params.dl[key];
               }
             }
           });

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -937,22 +937,31 @@ export const spec = {
       }
 
       // Force the Data Layer key and value to be a String
-      if (bidRequest.params.dl) {
-        let invalidDlParam = false
+      if (bidRequest.params.dataLayer) {
+        if (isStr(bidRequest.params.dataLayer) || isNumber(bidRequest.params.dataLayer) || isArray(bidRequest.params.dataLayer) || isFn(bidRequest.params.dataLayer)) {
+          logWarn(LOG_PREFIX, 'The dataLayer param is invalid, only object is accepted as a type.');
+          delete bidRequest.params.dataLayer
+        } else {
+          let invalidDlParam = false
 
-        Object.keys(bidRequest.params.dl).forEach((key) => {
-          if (bidRequest.params.dl[key]) {
-            if (isStr(bidRequest.params.dl[key]) || isNumber(bidRequest.params.dl[key])) {
-              bidRequest.params.dl[key.toString()] = bidRequest.params.dl[key].toString();
-            } else {
-              delete bidRequest.params.dl[key];
-              invalidDlParam = true;
+          bidRequest.params.dl = bidRequest.params.dataLayer
+          // Remove the dataLayer from the BidRequest to send the `dl` instead of the `dataLayer`
+          delete bidRequest.params.dataLayer
+
+          Object.keys(bidRequest.params.dl).forEach((key) => {
+            if (bidRequest.params.dl[key]) {
+              if (isStr(bidRequest.params.dl[key]) || isNumber(bidRequest.params.dl[key])) {
+                bidRequest.params.dl[key.toString()] = bidRequest.params.dl[key].toString();
+              } else {
+                invalidDlParam = true;
+                delete bidRequest.params.dl[key]
+              }
             }
-          }
-        });
+          });
 
-        if (invalidDlParam) {
-          logWarn(LOG_PREFIX, 'Some parameters of the dl param property have been removed because the type is invalid, accepted type: number or string.');
+          if (invalidDlParam) {
+            logWarn(LOG_PREFIX, 'Some parameters of the dataLayer property have been removed because the type is invalid, accepted type: number or string.');
+          }
         }
       }
 

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -20,6 +20,7 @@ import {
   logInfo,
   logWarn,
   mergeDeep,
+  isStr,
 } from '../src/utils.js';
 import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
@@ -923,6 +924,37 @@ export const spec = {
         print_number: getPrintNumber(bidRequest.adUnitCode, bidderRequest).toString(),
         adunit_position: getSlotPosition(bidRequest.params.adUnitElementId) // adUnitElementId à déplacer ???
       };
+
+      // Force the Split Keyword to be a String
+      if (bidRequest.params.splitKeyword) {
+        if (isStr(bidRequest.params.splitKeyword) || isNumber(bidRequest.params.splitKeyword)) {
+          bidRequest.params.splitKeyword = bidRequest.params.splitKeyword.toString();
+        } else {
+          delete bidRequest.params.splitKeyword;
+
+          logWarn(LOG_PREFIX, 'The splitKeyword param have been removed because the type is invalid, accepted type: number or string.');
+        }
+      }
+
+      // Force the Data Layer key and value to be a String
+      if (bidRequest.params.dl) {
+        let invalidDlParam = false
+
+        Object.keys(bidRequest.params.dl).forEach((key) => {
+          if (bidRequest.params.dl[key]) {
+            if (isStr(bidRequest.params.dl[key]) || isNumber(bidRequest.params.dl[key])) {
+              bidRequest.params.dl[key.toString()] = bidRequest.params.dl[key].toString();
+            } else {
+              delete bidRequest.params.dl[key];
+              invalidDlParam = true;
+            }
+          }
+        });
+
+        if (invalidDlParam) {
+          logWarn(LOG_PREFIX, 'Some parameters of the dl param property have been removed because the type is invalid, accepted type: number or string.');
+        }
+      }
 
       Object.keys(features).forEach((prop) => {
         if (features[prop] === '') {

--- a/modules/adagioBidAdapter.md
+++ b/modules/adagioBidAdapter.md
@@ -61,6 +61,8 @@ Below, the list of Adagio params and where they can be set.
 | debug                          |               | x             |
 | video                          |               | x             |
 | native                         |               | x             |
+| splitKeyword                   |               | x             |
+| dl                             |               | x             |
 
 _* These params are deprecated in favor the Global configuration setup, see below._
 
@@ -115,6 +117,10 @@ var adUnits = [
           context: 1,
           plcmttype: 2
         },
+        splitKeyword: 'splitrule-one',
+        dl: {
+          placement: '1234'
+        }
       }
     }]
   }

--- a/modules/adagioBidAdapter.md
+++ b/modules/adagioBidAdapter.md
@@ -62,7 +62,7 @@ Below, the list of Adagio params and where they can be set.
 | video                          |               | x             |
 | native                         |               | x             |
 | splitKeyword                   |               | x             |
-| dl                             |               | x             |
+| dataLayer                      |               | x             |
 
 _* These params are deprecated in favor the Global configuration setup, see below._
 

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -347,6 +347,50 @@ describe('Adagio bid adapter', () => {
       expect(requests[0].data.adUnits[0].features.url).to.not.exist;
     });
 
+    it('should force split keyword param into a string', function() {
+      const bid01 = new BidRequestBuilder().withParams({
+        splitKeyword: 1234
+      }).build();
+      const bid02 = new BidRequestBuilder().withParams({
+        splitKeyword: ['1234']
+      }).build();
+      const bidderRequest = new BidderRequestBuilder().build();
+
+      const requests = spec.buildRequests([bid01, bid02], bidderRequest);
+
+      expect(requests).to.have.lengthOf(1);
+      expect(requests[0].data).to.have.all.keys(expectedDataKeys);
+      expect(requests[0].data.adUnits[0].params).to.exist;
+      expect(requests[0].data.adUnits[0].params.splitKeyword).to.exist;
+      expect(requests[0].data.adUnits[0].params.splitKeyword).to.equal('1234');
+      expect(requests[0].data.adUnits[1].params.splitKeyword).to.not.exist;
+    });
+
+    it('should force key and value from data layer param into a string', function() {
+      const bid = new BidRequestBuilder().withParams({
+        dl: {
+          1234: 'dlparam',
+          goodkey: 1234,
+          objectvalue: {
+            random: 'result'
+          },
+          arrayvalue: ['1234']
+        }
+      }).build();
+      const bidderRequest = new BidderRequestBuilder().build();
+
+      const requests = spec.buildRequests([bid], bidderRequest);
+
+      expect(requests).to.have.lengthOf(1);
+      expect(requests[0].data).to.have.all.keys(expectedDataKeys);
+      expect(requests[0].data.adUnits[0].params).to.exist;
+      expect(requests[0].data.adUnits[0].params.dl).to.exist;
+      expect(requests[0].data.adUnits[0].params.dl['1234']).to.equal('dlparam');
+      expect(requests[0].data.adUnits[0].params.dl.goodkey).to.equal('1234');
+      expect(requests[0].data.adUnits[0].params.dl.objectvalue).to.not.exist;
+      expect(requests[0].data.adUnits[0].params.dl.arrayvalue).to.not.exist;
+    });
+
     describe('With video mediatype', function() {
       context('Outstream video', function() {
         it('should logWarn if user does not set renderer.backupOnly: true', function() {

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -367,8 +367,8 @@ describe('Adagio bid adapter', () => {
     });
 
     it('should force key and value from data layer param into a string', function() {
-      const bid = new BidRequestBuilder().withParams({
-        dl: {
+      const bid01 = new BidRequestBuilder().withParams({
+        dataLayer: {
           1234: 'dlparam',
           goodkey: 1234,
           objectvalue: {
@@ -377,18 +377,44 @@ describe('Adagio bid adapter', () => {
           arrayvalue: ['1234']
         }
       }).build();
+
+      const bid02 = new BidRequestBuilder().withParams({
+        dataLayer: 'a random string'
+      }).build();
+
+      const bid03 = new BidRequestBuilder().withParams({
+        dataLayer: 1234
+      }).build();
+
+      const bid04 = new BidRequestBuilder().withParams({
+        dataLayer: ['an array']
+      }).build();
+
       const bidderRequest = new BidderRequestBuilder().build();
 
-      const requests = spec.buildRequests([bid], bidderRequest);
+      const requests = spec.buildRequests([bid01, bid02, bid03, bid04], bidderRequest);
 
       expect(requests).to.have.lengthOf(1);
       expect(requests[0].data).to.have.all.keys(expectedDataKeys);
       expect(requests[0].data.adUnits[0].params).to.exist;
+      expect(requests[0].data.adUnits[0].params.dataLayer).to.not.exist;
       expect(requests[0].data.adUnits[0].params.dl).to.exist;
       expect(requests[0].data.adUnits[0].params.dl['1234']).to.equal('dlparam');
       expect(requests[0].data.adUnits[0].params.dl.goodkey).to.equal('1234');
       expect(requests[0].data.adUnits[0].params.dl.objectvalue).to.not.exist;
       expect(requests[0].data.adUnits[0].params.dl.arrayvalue).to.not.exist;
+
+      expect(requests[0].data.adUnits[1].params).to.exist;
+      expect(requests[0].data.adUnits[1].params.dl).to.not.exist;
+      expect(requests[0].data.adUnits[1].params.dataLayer).to.not.exist;
+
+      expect(requests[0].data.adUnits[2].params).to.exist;
+      expect(requests[0].data.adUnits[2].params.dl).to.not.exist;
+      expect(requests[0].data.adUnits[2].params.dataLayer).to.not.exist;
+
+      expect(requests[0].data.adUnits[3].params).to.exist;
+      expect(requests[0].data.adUnits[3].params.dl).to.not.exist;
+      expect(requests[0].data.adUnits[3].params.dataLayer).to.not.exist;
     });
 
     describe('With video mediatype', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

This PR is about to add a new params in our bidRequest payload: 
- `splitKeyword` property which only accept a string or a number
- `dataLayer` property which takes an object of keys values which must be a string or a number

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

Related documentation PR: [prebid/prebid.github.io/pull/4430](https://github.com/prebid/prebid.github.io/pull/4430)