### PR TITLE
Core: do not allow bidders to run syncs more than once

### DIFF
--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -463,6 +463,7 @@ export const registerSyncInner = hook('async', function(spec, responses, gdprCon
       syncs.forEach((sync) => {
         userSync.registerSync(sync.type, spec.code, sync.url)
       });
+      userSync.bidderDone(spec.code);
     }
   }
 }, 'registerSyncs')

--- a/src/userSync.js
+++ b/src/userSync.js
@@ -109,10 +109,7 @@ export function newUserSync(userSyncDependencies) {
     // Randomize the order of the pixels before firing
     // This is to avoid giving any bidder who has registered multiple syncs
     // any preferential treatment and balancing them out
-    shuffle(queue).forEach((sync) => {
-      fn(sync);
-      hasFiredBidder.add(sync[0]);
-    });
+    shuffle(queue).forEach(fn);
   }
 
   /**
@@ -211,6 +208,12 @@ export function newUserSync(userSyncDependencies) {
     queue[type].push([bidder, url]);
     numAdapterBids = incrementAdapterBids(numAdapterBids, bidder);
   };
+
+  /**
+   * Mark a bidder as done with its user syncs - no more will be accepted from them in this session.
+   * @param {string} bidderCode
+   */
+  publicApi.bidderDone = hasFiredBidder.add.bind(hasFiredBidder);
 
   /**
    * @function shouldBidderBeBlocked

--- a/test/spec/userSync_spec.js
+++ b/test/spec/userSync_spec.js
@@ -110,9 +110,10 @@ describe('user sync', function () {
     expect(insertUserSyncIframeStub.getCall(0).args[0]).to.equal('http://example.com/iframe');
   });
 
-  it('should only trigger syncs once per page per bidder', function () {
+  it('should stop triggering user syncs after bidderDone', function () {
     const userSync = newTestUserSync({ pixelEnabled: true });
     userSync.registerSync('image', 'testBidder', 'http://example.com/1');
+    userSync.bidderDone('testBidder');
     userSync.syncUsers();
     userSync.registerSync('image', 'testBidder', 'http://example.com/2');
     userSync.registerSync('image', 'testBidder2', 'http://example.com/3');


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fix a bug where user syncs from the same bidder would be run more than once if you time the auctions just right.

## Other information

Fixes https://github.com/prebid/Prebid.js/issues/9689

