### PR TITLE
OpenX bid adapter: support optional video compilation

### DIFF
--- a/test/spec/modules/adlooxAdServerVideo_spec.js
+++ b/test/spec/modules/adlooxAdServerVideo_spec.js
@@ -235,7 +235,7 @@ describe('Adloox Ad Server Video', function () {
       it('should fetch, retry on withoutCredentials, follow and return a wrapped blob that expires', function (done) {
         BID.responseTimestamp = utils.timestamp();
         BID.ttl = 30;
-        this.timeout(5000)
+        this.timeout(7500)
 
         const clock = sandbox.useFakeTimers(BID.responseTimestamp);
 

--- a/test/spec/modules/realvuAnalyticsAdapter_spec.js
+++ b/test/spec/modules/realvuAnalyticsAdapter_spec.js
@@ -50,6 +50,7 @@ describe('RealVu', function() {
 
   describe('Analytics Adapter.', function () {
     it('enableAnalytics', function () {
+      this.timeout(5500)
       const config = {
         options: {
           partnerId: '1Y',


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->

This PR builds off of #9543 adding support for optional video compilation to the OpenX bid adapter.

#### PLEASE NOTE

After rebasing from `master` it looks like there's a couple of unrelated tests timing out (the same tests from #9728). I bumped the timeouts on those tests in this commit 582a043fd58dcde54d1b9f021e7977496e48b6f0 in an effort to get a green build.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

**TESTING:** We have been testing these changes in our fork of Prebid on our website for over a month. We have seen no significant changes in any of our metrics (CPM, CTR, viewability, etc).