### PR TITLE
FPD Enrichment: use low entropy method by default to fetch user agent data

### DIFF
--- a/src/fpd/enrichment.js
+++ b/src/fpd/enrichment.js
@@ -69,7 +69,7 @@ function winFallback(fn) {
 
 function getSUA() {
   const hints = config.getConfig('firstPartyData.uaHints');
-  return Array.isArray(hints) && hints.length === 0
+  return !Array.isArray(hints) || hints.length === 0
     ? GreedyPromise.resolve(dep.getLowEntropySUA())
     : dep.getHighEntropySUA(hints);
 }


### PR DESCRIPTION
## Type of change
- [X] (kind of) Bugfix

- [X] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
FPD enrichement will use "high entropy" method by default to fetch information about user agent. This causes an increase of bid timeouts (please see #9709)

We have tested to deploy this change in production and it has a positive effect on timeout (same level as it was before FPD enrichment became included by default)
