### PR TITLE
Smaato: Accept geolocation data also from ortb2

### DIFF
--- a/modules/smaatoBidAdapter.js
+++ b/modules/smaatoBidAdapter.js
@@ -68,11 +68,23 @@ const buildOpenRtbBidRequest = (bidRequest, bidderRequest) => {
     deepSetValue(requestTemplate, 'regs.ext.gpp_sid', ortb2.regs.gpp_sid);
   }
 
+  if (ortb2.device?.ifa !== undefined) {
+    deepSetValue(requestTemplate, 'device.ifa', ortb2.device.ifa);
+  }
+
+  if (ortb2.device?.geo !== undefined) {
+    deepSetValue(requestTemplate, 'device.geo', ortb2.device.geo);
+  }
+
   if (deepAccess(bidRequest, 'params.app')) {
-    const geo = deepAccess(bidRequest, 'params.app.geo');
-    deepSetValue(requestTemplate, 'device.geo', geo);
-    const ifa = deepAccess(bidRequest, 'params.app.ifa');
-    deepSetValue(requestTemplate, 'device.ifa', ifa);
+    if (!deepAccess(requestTemplate, 'device.geo')) {
+      const geo = deepAccess(bidRequest, 'params.app.geo');
+      deepSetValue(requestTemplate, 'device.geo', geo);
+    }
+    if (!deepAccess(requestTemplate, 'device.ifa')) {
+      const ifa = deepAccess(bidRequest, 'params.app.ifa');
+      deepSetValue(requestTemplate, 'device.ifa', ifa);
+    }
   }
 
   const eids = deepAccess(bidRequest, 'userIdAsEids');

--- a/test/spec/modules/smaatoBidAdapter_spec.js
+++ b/test/spec/modules/smaatoBidAdapter_spec.js
@@ -356,6 +356,13 @@ describe('smaatoBidAdapterTest', () => {
             keywords: 'a,b',
             gender: 'M',
             yob: 1984
+          },
+          device: {
+            ifa: 'ifa',
+            geo: {
+              lat: 53.5488,
+              lon: 9.9872
+            }
           }
         };
 
@@ -368,6 +375,9 @@ describe('smaatoBidAdapterTest', () => {
         expect(req.user.ext.consent).to.equal(CONSENT_STRING);
         expect(req.site.keywords).to.eql('power tools,drills');
         expect(req.site.publisher.id).to.equal('publisherId');
+        expect(req.device.ifa).to.equal('ifa');
+        expect(req.device.geo.lat).to.equal(53.5488);
+        expect(req.device.geo.lon).to.equal(9.9872);
       });
 
       it('has no user ids', () => {
@@ -1005,6 +1015,28 @@ describe('smaatoBidAdapterTest', () => {
         const req = extractPayloadOfFirstAndOnlyRequest(reqs);
         expect(req.device.geo).to.deep.equal(LOCATION);
         expect(req.device.ifa).to.equal(DEVICE_ID);
+      });
+
+      it('when geo and ifa info present and fpd present, then prefer fpd', () => {
+        const ortb2 = {
+          device: {
+            ifa: 'ifa',
+            geo: {
+              lat: 53.5488,
+              lon: 9.9872
+            }
+          }
+        };
+
+        const inAppBidRequest = utils.deepClone(inAppBidRequestWithoutAppParams);
+        inAppBidRequest.params.app = {ifa: DEVICE_ID, geo: LOCATION};
+
+        const reqs = spec.buildRequests([inAppBidRequest], {...defaultBidderRequest, ortb2});
+
+        const req = extractPayloadOfFirstAndOnlyRequest(reqs);
+        expect(req.device.geo.lat).to.equal(53.5488);
+        expect(req.device.geo.lon).to.equal(9.9872);
+        expect(req.device.ifa).to.equal('ifa');
       });
 
       it('when ifa is present but geo is missing, then add only ifa to device object', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
As described in #9676 adapters should also accept geolocation from ortb2


## Other information
#9676