### PR TITLE
Adloox AdServer Video : lengthen test timeout

### DIFF
--- a/test/spec/modules/adlooxAdServerVideo_spec.js
+++ b/test/spec/modules/adlooxAdServerVideo_spec.js
@@ -235,6 +235,7 @@ describe('Adloox Ad Server Video', function () {
       it('should fetch, retry on withoutCredentials, follow and return a wrapped blob that expires', function (done) {
         BID.responseTimestamp = utils.timestamp();
         BID.ttl = 30;
+        this.timeout(4500)
 
         const clock = sandbox.useFakeTimers(BID.responseTimestamp);
 


### PR DESCRIPTION
Seem to be getting a testing timeout error for this retry test (https://app.circleci.com/pipelines/github/prebid/Prebid.js/15085/workflows/20710f95-749b-4565-84e4-fcf9f12c3281/jobs/27677)