### PR TITLE
AMX Bid Adapter: assumed filterSettings is not null

### DIFF
--- a/modules/amxBidAdapter.js
+++ b/modules/amxBidAdapter.js
@@ -194,6 +194,8 @@ function resolveSize(bid, request, bidId) {
 }
 
 function isSyncEnabled(syncConfigP, syncType) {
+  if (syncConfigP == null) return false;
+
   const syncConfig = syncConfigP[syncType];
   if (syncConfig == null) {
     return false;

--- a/test/spec/modules/amxBidAdapter_spec.js
+++ b/test/spec/modules/amxBidAdapter_spec.js
@@ -362,7 +362,10 @@ describe('AmxBidAdapter', () => {
 
       const base = { d: 2300, l: 2, e: true };
 
-      const tests = [[{
+      const tests = [[
+        undefined,
+        { ...base, t: 0 }
+      ], [{
         image: {
           bidders: '*',
           filter: 'include'


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

The most recent version of the AMX Bid adapter assumed that sync settings filterSettings was not null -- this is a bug

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
