### PR TITLE
Prebid core: fix image assets in converted legacy response

### DIFF
--- a/src/native.js
+++ b/src/native.js
@@ -750,7 +750,11 @@ export function toLegacyResponse(ortbResponse, ortbRequest) {
     if (asset.title) {
       legacyResponse.title = asset.title.text;
     } else if (asset.img) {
-      legacyResponse[requestAsset.img.type === NATIVE_IMAGE_TYPES.MAIN ? 'image' : 'icon'] = asset.img.url;
+      legacyResponse[requestAsset.img.type === NATIVE_IMAGE_TYPES.MAIN ? 'image' : 'icon'] = {
+        url: asset.img.url,
+        width: asset.img.w,
+        height: asset.img.h
+      };
     } else if (asset.data) {
       legacyResponse[PREBID_NATIVE_DATA_KEYS_TO_ORTB_INVERSE[NATIVE_ASSET_TYPES_INVERSE[requestAsset.data.type]]] = asset.data.value;
     }

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -1403,8 +1403,8 @@ describe('auctionmanager.js', function () {
         assert.equal(addedBid.native.title, 'Sample title')
         assert.equal(addedBid.native.sponsoredBy, 'Sample sponsoredBy')
         assert.equal(addedBid.native.clickUrl, 'http://www.click.com')
-        assert.equal(addedBid.native.image, 'https://www.example.com/image.png')
-        assert.equal(addedBid.native.icon, 'https://www.example.com/icon.png')
+        assert.equal(addedBid.native.image.url, 'https://www.example.com/image.png')
+        assert.equal(addedBid.native.icon.url, 'https://www.example.com/icon.png')
         assert.equal(addedBid.native.impressionTrackers[0], 'http://www.imptracker.com')
         assert.equal(addedBid.native.javascriptTrackers, '<script async src="http://www.jstracker.com/file.js"></script>')
       });


### PR DESCRIPTION
## Type of change
Bugfix

## Description of change
Bug was already there in #9252
We had some errors with native images, for Index Exchange only (which is using ortb format). 
It seems that the image and icon format of the legacy native response returned by the `toLegacyResponse` function is invalid : it is a string instead of being an object with url, w and h properties. 

Before : 
![image](https://user-images.githubusercontent.com/635021/229520459-0ad93c39-dcdd-4ae4-8b97-7c4181354ebd.png)
After : 
![image](https://user-images.githubusercontent.com/635021/229520545-de7c7ca8-3923-4680-9e8a-ca243ac7f051.png)

(Not sure how I haven't seen that before, I might be missing something, is it possible it is like this by design ?)