### PR TITLE
SharedID: wait for ID from pixel on first page load

### DIFF
--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -38,12 +38,15 @@ function readValue(name, type) {
   }
 }
 
-function getIdCallback(pubcid, pixelCallback) {
-  return function (callback) {
-    if (typeof pixelCallback === 'function') {
-      pixelCallback();
+function getIdCallback(pubcid, pixelUrl) {
+  return function (callback, getStoredId) {
+    if (pixelUrl) {
+      queuePixelCallback(pixelUrl, pubcid, () => {
+        callback(getStoredId() || pubcid);
+      })();
+    } else {
+      callback(pubcid);
     }
-    callback(pubcid);
   }
 }
 
@@ -58,7 +61,7 @@ function queuePixelCallback(pixelUrl, id = '', callback) {
   const targetUrl = buildUrl(urlInfo);
 
   return function () {
-    triggerPixel(targetUrl);
+    triggerPixel(targetUrl, callback);
   };
 }
 
@@ -125,8 +128,7 @@ export const sharedIdSystemSubmodule = {
       if (!newId) newId = (create && hasDeviceAccess()) ? generateUUID() : undefined;
     }
 
-    const pixelCallback = queuePixelCallback(pixelUrl, newId);
-    return {id: newId, callback: getIdCallback(newId, pixelCallback)};
+    return {id: newId, callback: getIdCallback(newId, pixelUrl)};
   },
   /**
    * performs action to extend an id.  There are generally two ways to extend the expiration time

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -413,7 +413,7 @@ function processSubmoduleCallbacks(submodules, cb) {
       moduleDone();
     }
     try {
-      submodule.callback(callbackCompleted);
+      submodule.callback(callbackCompleted, getStoredValue.bind(null, submodule.config?.storage));
     } catch (e) {
       logError(`Error in userID module '${submodule.submodule.name}':`, e);
       moduleDone();
@@ -982,7 +982,7 @@ function updateSubmodules() {
       submodule: i,
       config: submoduleConfig,
       callback: undefined,
-      idObj: undefined
+      idObj: undefined,
     } : null;
   }).filter(submodule => submodule !== null)
     .forEach((sm) => submodules.push(sm));

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -53,6 +53,7 @@ import {hook} from '../../../src/hook.js';
 import {mockGdprConsent} from '../../helpers/consentData.js';
 import {getPPID} from '../../../src/adserver.js';
 import {uninstall as uninstallGdprEnforcement} from 'modules/gdprEnforcement.js';
+import {getCoreStorageManager} from '../../../src/storageManager.js';
 
 let assert = require('chai').assert;
 let expect = require('chai').expect;
@@ -423,6 +424,58 @@ describe('User ID', function () {
       return expectImmediateBidHook(() => {}, {adUnits}).then(() => {
         // ppid should have been set without dashes and stuff
         expect(window.googletag._ppid).to.equal('pubCommonidvaluepubCommonidvalue');
+      });
+    });
+
+    describe('submodule callback', () => {
+      const TEST_KEY = 'testKey';
+
+      function setVal(val) {
+        if (val) {
+          coreStorage.setDataInLocalStorage(TEST_KEY, val);
+          coreStorage.setDataInLocalStorage(TEST_KEY + '_exp', '');
+        } else {
+          coreStorage.removeDataFromLocalStorage(TEST_KEY);
+          coreStorage.removeDataFromLocalStorage(TEST_KEY + '_exp');
+        }
+      }
+      afterEach(() => {
+        setVal(null);
+      })
+
+      it('should be able to re-read ID changes', (done) => {
+        setVal(null);
+        init(config);
+        setSubmoduleRegistry([{
+          name: 'mockId',
+          getId: function (_1, _2, storedId) {
+            expect(storedId).to.not.exist;
+            setVal('laterValue');
+            return {
+              callback(_, readId) {
+                expect(readId()).to.eql('laterValue');
+                done();
+              }
+            }
+          },
+          decode(d) {
+            return d
+          }
+        }]);
+        config.setConfig({
+          userSync: {
+            auctionDelay: 10,
+            userIds: [
+              {
+                name: 'mockId',
+                storage: {
+                  type: 'html5',
+                  name: TEST_KEY
+                }
+              }
+            ]
+          }
+        });
       });
     });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

This:

 - passes a new `readStoredId` parameter to ID submodule callbacks that allows them to get a fresh version of their stored ID (for situations where a pixel may update it out-of-band), and
 - fixes https://github.com/prebid/Prebid.js/issues/9733

