### PR TITLE
Vidoomy Bid Adapter: schain serialize fixes

### DIFF
--- a/test/spec/modules/vidoomyBidAdapter_spec.js
+++ b/test/spec/modules/vidoomyBidAdapter_spec.js
@@ -74,6 +74,33 @@ describe('vidoomyBidAdapter', function() {
             'sizes': [[300, 250], [200, 100]]
           }
         },
+        'schain': {
+          ver: '1.0',
+          complete: 1,
+          nodes: [
+            {
+              'asi': 'exchange1.com',
+              'sid': '1234!abcd',
+              'hp': 1,
+              'rid': 'bid-request-1',
+              'name': 'publisher, Inc.',
+              'domain': 'publisher.com'
+            },
+            {
+              'asi': 'exchange2.com',
+              'sid': 'abcd',
+              'hp': 1
+            },
+            {
+              'asi': 'exchange2.com',
+              'sid': 'abcd',
+              'hp': 1,
+              'rid': 'bid-request-2',
+              'name': 'intermediary',
+              'domain': 'intermediary.com'
+            }
+          ]
+        }
       },
       {
         'bidder': 'vidoomy',
@@ -127,6 +154,12 @@ describe('vidoomyBidAdapter', function() {
       expect('' + request[0].data.pid).to.equal('123123');
       expect('' + request[1].data.id).to.equal('456456');
       expect('' + request[1].data.pid).to.equal('456456');
+    });
+
+    it('should send schain parameter in serialized form', function () {
+      const serializedForm = '1.0,1!exchange1.com,1234%21abcd,1,bid-request-1,publisher%2C%20Inc.,publisher.com!exchange2.com,abcd,1,,,!exchange2.com,abcd,1,bid-request-2,intermediary,intermediary.com'
+      expect(request[0].data).to.include.any.keys('schain');
+      expect(request[0].data.schain).to.eq(serializedForm);
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
This is the bug fix of vidoomy adapter schain object serialization as per[ IAB ](https://github.com/InteractiveAdvertisingBureau/openrtb/blob/master/supplychainobject.md)standard. Tests cases are also added.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
