### PR TITLE
33across Id System: Stop generating error for all cookied users

### DIFF
--- a/modules/33acrossIdSystem.js
+++ b/modules/33acrossIdSystem.js
@@ -17,8 +17,11 @@ const CALLER_NAME = 'pbjs';
 
 function getEnvelope(response) {
   if (!response.succeeded) {
-    logError(`${MODULE_NAME}: Unsuccessful response`);
-
+    if(response.error = 'Cookied User') {
+      logMessage(`${MODULE_NAME}: Unsuccessful response`.concat(' ',response.error));
+    } else {
+      logError(`${MODULE_NAME}: Unsuccessful response`.concat(' ',response.error));
+    }
     return;
   }
 

--- a/modules/33acrossIdSystem.js
+++ b/modules/33acrossIdSystem.js
@@ -17,10 +17,10 @@ const CALLER_NAME = 'pbjs';
 
 function getEnvelope(response) {
   if (!response.succeeded) {
-    if(response.error = 'Cookied User') {
-      logMessage(`${MODULE_NAME}: Unsuccessful response`.concat(' ',response.error));
+    if (response.error == 'Cookied User') {
+      logMessage(`${MODULE_NAME}: Unsuccessful response`.concat(' ', response.error));
     } else {
-      logError(`${MODULE_NAME}: Unsuccessful response`.concat(' ',response.error));
+      logError(`${MODULE_NAME}: Unsuccessful response`.concat(' ', response.error));
     }
     return;
   }

--- a/test/spec/modules/33acrossIdSystem_spec.js
+++ b/test/spec/modules/33acrossIdSystem_spec.js
@@ -282,7 +282,7 @@ describe('33acrossIdSystem', () => {
           error: 'foo'
         }));
 
-        expect(logErrorSpy.calledOnceWithExactly(`${thirthyThreeAcrossIdSubmodule.name}: Unsuccessful response`)).to.be.true;
+        expect(logErrorSpy.calledOnceWithExactly(`${thirthyThreeAcrossIdSubmodule.name}: Unsuccessful response foo`)).to.be.true;
 
         logErrorSpy.restore();
       });


### PR DESCRIPTION
33across Id system is spamming errors, generating one for all cookied users.

![image](https://user-images.githubusercontent.com/1683175/229822168-9cd38f39-0dc1-48d5-a015-8d5e9b0da85f.png)
