### PR TITLE
TTD Bid Adapter: add support for video.plcmt and imp.rwdd

### DIFF
--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -164,15 +164,18 @@ function getImpression(bidRequest) {
 
   const gpid = utils.deepAccess(bidRequest, 'ortb2Imp.ext.gpid');
   const tid = utils.deepAccess(bidRequest, 'ortb2Imp.ext.tid');
+  const rwdd = utils.deepAccess(bidRequest, 'ortb2Imp.rwdd');
   if (gpid || tid) {
     impression.ext = {}
     if (gpid) { impression.ext.gpid = gpid }
     if (tid) { impression.ext.tid = tid }
   }
-
+  if (rwdd) {
+    impression.rwdd = rwdd;
+  }
   const tagid = gpid || bidRequest.params.placementId;
   if (tagid) {
-    impression.tagid = tagid
+    impression.tagid = tagid;
   }
 
   const mediaTypesVideo = utils.deepAccess(bidRequest, 'mediaTypes.video');

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -251,6 +251,7 @@ function video(bid) {
   const api = utils.deepAccess(bid, 'mediaTypes.video.api');
   const mimes = utils.deepAccess(bid, 'mediaTypes.video.mimes');
   const placement = utils.deepAccess(bid, 'mediaTypes.video.placement');
+  const plcmt = utils.deepAccess(bid, 'mediaTypes.video.plcmt');
   const protocols = utils.deepAccess(bid, 'mediaTypes.video.protocols');
   const playbackmethod = utils.deepAccess(bid, 'mediaTypes.video.playbackmethod');
   const pos = utils.deepAccess(bid, 'mediaTypes.video.pos');
@@ -285,6 +286,9 @@ function video(bid) {
 
   if (playbackmethod) {
     video.playbackmethod = playbackmethod;
+  }
+  if (plcmt) {
+    video.plcmt = plcmt;
   }
   if (pos) {
     video.pos = pos;

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -878,7 +878,7 @@ describe('ttdBidAdapter', function () {
       expect(requestBody.imp[0].video.placement).to.equal(3);
     });
 
-  it('sets plcmt correctly if sent', function () {
+    it('sets plcmt correctly if sent', function () {
       let clonedVideoRequests = deepClone(baseVideoBidRequests);
       clonedVideoRequests[0].mediaTypes.video.plcmt = 3;
 

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -879,6 +879,15 @@ describe('ttdBidAdapter', function () {
     });
   });
 
+  it('sets plcmt correctly if sent', function () {
+      let clonedVideoRequests = deepClone(baseVideoBidRequests);
+      clonedVideoRequests[0].mediaTypes.video.plcmt = 3;
+
+      const requestBody = testBuildRequests(clonedVideoRequests, baseBidderRequest).data;
+      expect(requestBody.imp[0].video.plcmt).to.equal(3);
+    });
+  });
+
   describe('interpretResponse-empty', function () {
     it('should handle empty response', function () {
       let result = spec.interpretResponse({});

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -282,6 +282,21 @@ describe('ttdBidAdapter', function () {
       expect(requestBody.imp[0].ext.gpid).to.equal(gpid);
     });
 
+    it('sends rwdd in imp.rwdd if present', function () {
+      let clonedBannerRequests = deepClone(baseBannerBidRequests);
+      const gpid = '/1111/home#header';
+      const rwdd = 1;
+      clonedBannerRequests[0].ortb2Imp = {
+        rwdd: rwdd,
+        ext: {
+          gpid: gpid
+        }
+      };
+      const requestBody = testBuildRequests(clonedBannerRequests, baseBidderRequest).data;
+      expect(requestBody.imp[0].rwdd).to.be.not.null;
+      expect(requestBody.imp[0].rwdd).to.equal(1);
+    });
+
     it('sends auction id in source.tid', function () {
       const requestBody = testBuildRequests(baseBannerBidRequests, baseBidderRequest).data;
       expect(requestBody.source).to.be.not.null;

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -887,8 +887,6 @@ describe('ttdBidAdapter', function () {
     });
   });
 
-
-
   describe('interpretResponse-empty', function () {
     it('should handle empty response', function () {
       let result = spec.interpretResponse({});

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -877,7 +877,6 @@ describe('ttdBidAdapter', function () {
       const requestBody = testBuildRequests(clonedVideoRequests, baseBidderRequest).data;
       expect(requestBody.imp[0].video.placement).to.equal(3);
     });
-  });
 
   it('sets plcmt correctly if sent', function () {
       let clonedVideoRequests = deepClone(baseVideoBidRequests);
@@ -887,6 +886,8 @@ describe('ttdBidAdapter', function () {
       expect(requestBody.imp[0].video.plcmt).to.equal(3);
     });
   });
+
+
 
   describe('interpretResponse-empty', function () {
     it('should handle empty response', function () {


### PR DESCRIPTION
Implements new https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/develop/AdCOM%20v1.0%20FINAL.md#list_plcmtsubtypesvideo video field in openrtb2.6

Rewarded declaration documented here: https://github.com/prebid/prebid.github.io/pull/4468/files