### PR TITLE
Grid Bid Adapter: add support for video.plcmt

### DIFF
--- a/modules/gridBidAdapter.js
+++ b/modules/gridBidAdapter.js
@@ -957,6 +957,7 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
           api: bidRequest.mediaTypes.video.api,
           skip: bidRequest.mediaTypes.video.skip,
           placement: bidRequest.mediaTypes.video.placement,
+          plcmt: bidRequest.mediaTypes.video.plcmt,
           minduration: bidRequest.mediaTypes.video.minduration,
           playbackmethod: bidRequest.mediaTypes.video.playbackmethod,
           startdelay: bidRequest.mediaTypes.video.startdelay

--- a/test/spec/modules/gridBidAdapter_spec.js
+++ b/test/spec/modules/gridBidAdapter_spec.js
@@ -423,6 +423,7 @@ describe('TheMediaGrid Adapter', function () {
               api: [1, 2],
               skip: 1,
               placement: 1,
+              plcmt: 2,
               minduration: 0,
               playbackmethod: 1,
               startdelay: 0
@@ -531,6 +532,7 @@ describe('TheMediaGrid Adapter', function () {
             ],
             'minduration': 0,
             'placement': 1,
+            'plcmt': 2,
             'playbackmethod': 1,
             'playersizes': [
               '400x600'


### PR DESCRIPTION
Support for new openrtb 2.6 field (https://github.com/InteractiveAdvertisingBureau/AdCOM/blob/develop/AdCOM%20v1.0%20FINAL.md#list_plcmtsubtypesvideo)

Friendly PR from not the adapter maintainer, what do you think @TheMediaGrid ?