### PR TITLE
CORE: disable the requirement for having a url, when enabling renderNow in Renderer

### DIFF
--- a/src/Renderer.js
+++ b/src/Renderer.js
@@ -22,6 +22,7 @@ export function Renderer(options) {
   this.config = config;
   this.handlers = {};
   this.id = id;
+  this.renderNow = renderNow;
 
   // a renderer may push to the command queue to delay rendering until the
   // render function is loaded by loadExternalScript, at which point the the command
@@ -110,7 +111,7 @@ Renderer.prototype.process = function() {
  * @returns {Boolean}
  */
 export function isRendererRequired(renderer) {
-  return !!(renderer && renderer.url);
+  return !!(renderer && (renderer.url || renderer.renderNow));
 }
 
 /**

--- a/test/spec/renderer_spec.js
+++ b/test/spec/renderer_spec.js
@@ -52,7 +52,7 @@ describe('Renderer', function () {
       expect(testRenderer2.getConfig()).to.deep.equal({ test: 'config2' });
     });
 
-    it('sets a render function with setRender method', function () {
+    it('sets a render function with the setRender method', function () {
       testRenderer1.setRender(spyRenderFn);
       expect(typeof testRenderer1.render).to.equal('function');
       testRenderer1.render();

--- a/test/spec/renderer_spec.js
+++ b/test/spec/renderer_spec.js
@@ -110,7 +110,6 @@ describe('Renderer', function () {
 
     it('renders immediately when requested', function () {
       const testRenderer3 = Renderer.install({
-        url: 'https://httpbin.org/post',
         config: { test: 'config2' },
         id: 2,
         renderNow: true


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Right now when you specify a `Renderer` for a `Bid` instance, which shouldn't load any url, the `renderNow` can be set, however this flow currently requires you to set a dummy url, otherwise the check on `isRendererRequired` would fail. I've altered this check so either the `url` could be set or the `renderNow` flag.

