### PR TITLE
[Video Module] Include a type property in all events

### DIFF
--- a/libraries/video/shared/helpers.js
+++ b/libraries/video/shared/helpers.js
@@ -1,5 +1,19 @@
 import { videoKey } from '../constants/constants.js'
 
 export function getExternalVideoEventName(eventName) {
+  if (!eventName) {
+    return '';
+  }
   return videoKey + eventName.replace(/^./, eventName[0].toUpperCase());
+}
+
+export function getExternalVideoEventPayload(eventName, payload) {
+  if (!payload) {
+    payload = {};
+  }
+
+  if (!payload.type) {
+    payload.type = eventName;
+  }
+  return payload;
 }

--- a/modules/videoModule/adQueue.js
+++ b/modules/videoModule/adQueue.js
@@ -1,5 +1,5 @@
 import { AD_BREAK_END, AUCTION_AD_LOAD_ATTEMPT, AUCTION_AD_LOAD_QUEUED, SETUP_COMPLETE } from '../../libraries/video/constants/events.js'
-import { getExternalVideoEventName } from '../../libraries/video/shared/helpers.js'
+import { getExternalVideoEventName, getExternalVideoEventPayload } from '../../libraries/video/shared/helpers.js'
 
 export function AdQueueCoordinator(videoCore, pbEvents) {
   const storage = {};
@@ -58,6 +58,6 @@ export function AdQueueCoordinator(videoCore, pbEvents) {
 
   function triggerEvent(eventName, adTagUrl, options) {
     const payload = Object.assign({ adTagUrl }, options);
-    pbEvents.emit(getExternalVideoEventName(eventName), payload);
+    pbEvents.emit(getExternalVideoEventName(eventName), getExternalVideoEventPayload(eventName, payload));
   }
 }

--- a/modules/videoModule/index.js
+++ b/modules/videoModule/index.js
@@ -20,7 +20,7 @@ import { videoCoreFactory } from './coreVideo.js';
 import { gamSubmoduleFactory } from './gamAdServerSubmodule.js';
 import { videoImpressionVerifierFactory } from './videoImpressionVerifier.js';
 import { AdQueueCoordinator } from './adQueue.js';
-import { getExternalVideoEventName } from '../../libraries/video/shared/helpers.js'
+import { getExternalVideoEventName, getExternalVideoEventPayload } from '../../libraries/video/shared/helpers.js'
 
 const allVideoEvents = Object.keys(videoEvents).map(eventKey => videoEvents[eventKey]);
 events.addEvents(allVideoEvents.concat([AUCTION_AD_LOAD_ATTEMPT, AUCTION_AD_LOAD_QUEUED, AUCTION_AD_LOAD_ABORT, BID_IMPRESSION, BID_ERROR]).map(getExternalVideoEventName));
@@ -54,7 +54,7 @@ export function PbVideo(videoCore_, getConfig_, pbGlobal_, pbEvents_, videoEvent
         adQueueCoordinator.registerProvider(divId);
         videoCore.initProvider(divId);
         videoCore.onEvents(videoEvents, (type, payload) => {
-          pbEvents.emit(getExternalVideoEventName(type), payload);
+          pbEvents.emit(getExternalVideoEventName(type), getExternalVideoEventPayload(type, payload));
         }, divId);
 
         const adServerConfig = provider.adServer;
@@ -199,7 +199,7 @@ export function PbVideo(videoCore_, getConfig_, pbGlobal_, pbEvents_, videoEvent
 
     const highestCpmBids = pbGlobal.getHighestCpmBids(adUnitCode);
     if (!highestCpmBids.length) {
-      pbEvents.emit(getExternalVideoEventName(AUCTION_AD_LOAD_ABORT), options);
+      pbEvents.emit(getExternalVideoEventName(AUCTION_AD_LOAD_ABORT), getExternalVideoEventPayload(AUCTION_AD_LOAD_ABORT, options));
       return;
     }
 
@@ -223,7 +223,7 @@ export function PbVideo(videoCore_, getConfig_, pbGlobal_, pbEvents_, videoEvent
     }
 
     pbGlobal.markWinningBidAsUsed(bid);
-    pbEvents.emit(getExternalVideoEventName(eventName), { bid, adEvent: adEventPayload });
+    pbEvents.emit(getExternalVideoEventName(eventName), getExternalVideoEventPayload(eventName, { bid, adEvent: adEventPayload }));
   }
 
   function getBid(adPayload) {

--- a/test/spec/modules/videoModule/shared/helpers_spec.js
+++ b/test/spec/modules/videoModule/shared/helpers_spec.js
@@ -1,0 +1,22 @@
+import { getExternalVideoEventName, getExternalVideoEventPayload } from 'libraries/video/shared/helpers.js';
+import { expect } from 'chai';
+
+describe('Helpers', function () {
+  describe('getExternalVideoEventName', function () {
+    it('should append video prefix and stay camelcase', function () {
+      expect(getExternalVideoEventName('eventName')).to.equal('videoEventName');
+      expect(getExternalVideoEventName(null)).to.equal('');
+    });
+  });
+
+  describe('getExternalVideoEventPayload', function () {
+    it('should include type in payload when absent', function () {
+      const testType = 'testType';
+      const payloadWithType = { datum: 'datum', type: 'existingType' };
+      expect(getExternalVideoEventPayload(testType, payloadWithType).type).to.equal('existingType');
+
+      const payloadWithoutType = { datum: 'datum' };
+      expect(getExternalVideoEventPayload(testType, payloadWithoutType).type).to.equal(testType);
+    });
+  });
+});


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
The `type` property is missing from certain events fired by the video module. For consistency, we have added a util.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


