### PR TITLE
OpenxOrtbAdapter: add back missing params support for coppa and video

### DIFF
--- a/modules/openxOrtbBidAdapter.js
+++ b/modules/openxOrtbBidAdapter.js
@@ -55,6 +55,9 @@ const converter = ortbConverter({
       }
     })
     const bid = context.bidRequests[0];
+    if (bid.params.coppa) {
+      utils.deepSetValue(req, 'regs.coppa', 1);
+    }
     if (bid.params.doNotTrack) {
       utils.deepSetValue(req, 'device.dnt', 1);
     }
@@ -127,6 +130,17 @@ const converter = ortbConverter({
         if (floor.bidfloorcur === 'USD') {
           Object.assign(imp, floor);
         }
+      },
+      video(orig, imp, bidRequest, context) {
+        // `orig` is the video imp processor, which looks at bidRequest.mediaTypes[VIDEO]
+        // to populate imp.video
+        // alter its input `bidRequest` to also pick up parameters from `bidRequest.params`
+        let videoParams = bidRequest.mediaTypes[VIDEO];
+        if (videoParams) {
+          videoParams = Object.assign({}, videoParams, bidRequest.params.video);
+          bidRequest = {...bidRequest, mediaTypes: {[VIDEO]: videoParams}}
+        }
+        orig(imp, bidRequest, context);
       }
     }
   }

--- a/modules/openxOrtbBidAdapter.md
+++ b/modules/openxOrtbBidAdapter.md
@@ -21,7 +21,7 @@ Publishers are welcome to test this adapter and give feedback. Please note you s
 | `customParams` | optional | Object | User-defined targeting key-value pairs. customParams applies to a specific unit. | `{key1: "v1", key2: ["v2","v3"]}`
 | `customFloor` | optional | Number | Minimum price in USD. customFloor applies to a specific unit. For example, use the following value to set a $1.50 floor: 1.50 <br/><br/> **WARNING:**<br/> Misuse of this parameter can impact revenue | 1.50
 | `doNotTrack` | optional | Boolean | Prevents advertiser from using data for this user. <br/><br/> **WARNING:**<br/> Request-level setting.  May impact revenue. | true
-| `coppa` | optional | Boolean | Enables Child's Online Privacy Protection Act (COPPA) regulations. | true
+| `coppa` | optional | Boolean | Enables Child's Online Privacy Protection Act (COPPA) regulations. Use of `pbjs.setConfig({coppa: true});` is now preferred. | true
 
 ## Video
 
@@ -29,7 +29,7 @@ Publishers are welcome to test this adapter and give feedback. Please note you s
 | ---- | ----- | ---- | ----------- | -------
 | `unit` | required | String | OpenX ad unit ID provided by your OpenX representative. | "1611023122"
 | `delDomain` | required | String |  OpenX delivery domain provided by your OpenX representative.  | "PUBLISHER-d.openx.net"
-| `video` | optional | OpenRTB video subtypes | Alternatively can be added under adUnit.mediaTypes.video | `{ video: {mimes: ['video/mp4']}`
+| `video` | optional | OpenRTB video subtypes | Use of adUnit.mediaTypes.video is now preferred. | `{ video: {mimes: ['video/mp4']}`
 
 
 # Example
@@ -68,7 +68,8 @@ var adUnits = [
     mediaTypes: {
       video: {
         playerSize: [640, 480],
-        context: 'instream'
+        context: 'instream',
+        mimes: ['video/x-ms-wmv, video/mp4']
       }
     },
     bids: [{
@@ -77,10 +78,10 @@ var adUnits = [
         unit: '1611023124',
         delDomain: 'PUBLISHER-d.openx.net',
         video: {
-          mimes: ['video/x-ms-wmv, video/mp4']
+          mimes: ['video/x-ms-wmv, video/mp4'] // mediaTypes.video preferred
         }
       }
-    }]
+    }]p
   }
 ];
 ```


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Adding back support for a couple params fields we indicate we support which were removed when this adapter switched the ortbConverter. Also removed a FLEDGE unit test that is no longer needed.