### PR TITLE
Vidoomy Adapter: Added userId module

### DIFF
--- a/modules/vidoomyBidAdapter.js
+++ b/modules/vidoomyBidAdapter.js
@@ -128,6 +128,12 @@ const buildRequests = (validBidRequests, bidderRequest) => {
     const bidfloor = deepAccess(bid, `params.bidfloor`, 0);
     const floor = getBidFloor(bid, adType, sizes, bidfloor);
 
+    let eids;
+    const userEids = deepAccess(bid, 'userIdAsEids');
+    if (Array.isArray(userEids) && userEids.length > 0) {
+      eids = JSON.stringify(userEids) || '';
+    }
+
     const queryParams = {
       id: bid.params.id,
       adtype: adType,
@@ -141,6 +147,7 @@ const buildRequests = (validBidRequests, bidderRequest) => {
       pid: bid.params.pid,
       requestId: bid.bidId,
       schain: serializeSupplyChainObj(bid.schain) || '',
+      eids: eids || '',
       bidfloor: floor,
       d: getDomainWithoutSubdomain(hostname), // 'vidoomy.com',
       // TODO: does the fallback make sense here?

--- a/test/spec/modules/vidoomyBidAdapter_spec.js
+++ b/test/spec/modules/vidoomyBidAdapter_spec.js
@@ -162,6 +162,29 @@ describe('vidoomyBidAdapter', function() {
       expect(request[0].data.schain).to.eq(serializedForm);
     });
 
+    it('should return standard json formated eids', function () {
+      const eids = [{
+        source: 'pubcid.org',
+        uids: [
+          {
+            id: 'some-random-id-value-1',
+            atype: 1
+          }
+        ]
+      },
+      {
+        source: 'adserver.org',
+        uids: [{
+          id: 'some-random-id-value-2',
+          atype: 1
+        }]
+      }]
+      bidRequests[0].userIdAsEids = eids
+      const bidRequest = spec.buildRequests(bidRequests, bidderRequest);
+      expect(bidRequest[0].data).to.include.any.keys('eids');
+      expect(JSON.parse(bidRequest[0].data.eids)).to.eql(eids);
+    });
+
     it('should set the bidfloor if getFloor module is undefined but static bidfloor is present', function () {
       const request = { ...bidRequests[0], params: { bidfloor: 2.5 } }
       const req = spec.buildRequests([request], bidderRequest)[0];


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
## Description of change
<!-- Describe the change proposed in this pull request -->
Added userid Module support for Vidoomy Adapter.
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Its doc PR: https://github.com/prebid/prebid.github.io/pull/4474