### PR TITLE
Criteo Bid Adapter: Fix deal property name mapping from bidder response

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -223,7 +223,7 @@ export const spec = {
           creativeId: slot.creativecode,
           width: slot.width,
           height: slot.height,
-          dealId: slot.dealCode,
+          dealId: slot.deal,
         };
         if (body.ext?.paf?.transmission && slot.ext?.paf?.content_id) {
           const pafResponseMeta = {

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -1475,7 +1475,7 @@ describe('The Criteo bidding adapter', function () {
             creativecode: 'test-crId',
             width: 728,
             height: 90,
-            dealCode: 'myDealCode',
+            deal: 'myDealCode',
             adomain: ['criteo.com'],
           }],
         },


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Currently, our PBJS adapter code expects to receive a property called 'dealCode' where our bidder emits 'deal' instead. We've updated our backend to temporarily emit both dealCode & deal but long term we'd like to align to use 'deal 'across all integrations.