### PR TITLE
NeuwoRtdModule: The global.site.cattax field is not set anymore as it is not defined in openrtb 2.5

### DIFF
--- a/modules/neuwoRtdProvider.js
+++ b/modules/neuwoRtdProvider.js
@@ -7,7 +7,6 @@ import CONSTANTS from '../src/constants.json';
 
 export const DATA_PROVIDER = 'neuwo.ai';
 const SEGTAX_IAB = 6 // IAB - Content Taxonomy version 2
-const CATTAX_IAB = 6 // IAB Tech Lab Content Taxonomy 2.2
 const RESPONSE_IAB_TIER_1 = 'marketing_categories.iab_tier_1'
 const RESPONSE_IAB_TIER_2 = 'marketing_categories.iab_tier_2'
 
@@ -106,7 +105,6 @@ export function injectTopics(topics, bidsConfig) {
 
   // upgrade category taxonomy to IAB 2.2, inject result to page categories
   if (segment.length > 0) {
-    addFragment(bidsConfig.ortb2Fragments.global, 'site.cattax', CATTAX_IAB)
     addFragment(bidsConfig.ortb2Fragments.global, 'site.pagecat', segment.map(s => s.id))
   }
 

--- a/test/spec/modules/neuwoRtdProvider_spec.js
+++ b/test/spec/modules/neuwoRtdProvider_spec.js
@@ -60,7 +60,6 @@ describe('neuwoRtdProvider', function () {
         neuwo.injectTopics(topics, bidsConfig, () => { })
         expect(bidsConfig.ortb2Fragments.global.site.content.data[0].name, 'name of first content data object').to.equal(neuwo.DATA_PROVIDER)
         expect(bidsConfig.ortb2Fragments.global.site.content.data[0].segment[0].id, 'id of first segment in content.data').to.equal(TAX_ID)
-        expect(bidsConfig.ortb2Fragments.global.site.cattax, 'category taxonomy code for pagecat').to.equal(6) // CATTAX_IAB
         expect(bidsConfig.ortb2Fragments.global.site.pagecat[0], 'category taxonomy code for pagecat').to.equal(TAX_ID)
       })
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
