### PR TITLE
Update the Conversant adapter to have source.tid to have auctionId

### DIFF
--- a/modules/conversantBidAdapter.js
+++ b/modules/conversantBidAdapter.js
@@ -124,6 +124,9 @@ export const spec = {
     const payload = {
       id: requestId,
       imp: conversantImps,
+      source: {
+        tid: requestId
+      },
       site: {
         id: siteId,
         mobile: document.querySelector('meta[name="viewport"][content*="width=device-width"]') !== null ? 1 : 0,

--- a/test/spec/modules/conversantBidAdapter_spec.js
+++ b/test/spec/modules/conversantBidAdapter_spec.js
@@ -263,6 +263,7 @@ describe('Conversant adapter tests', function() {
     const payload = request.data;
 
     expect(payload).to.have.property('id', 'req000');
+    expect(payload.source).to.have.property('tid', 'req000');
     expect(payload).to.have.property('at', 1);
     expect(payload).to.have.property('imp');
     expect(payload.imp).to.be.an('array').with.lengthOf(8);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X ] Bugfix

## Description of change
In the Conversant bid adapter set source.tid to the auctionId so that it will conform to the Prebid.js 8 changes
