### PR TITLE
LiveIntent UserId module: Add support for magnite id 

### DIFF
--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -196,6 +196,10 @@ export const liveIntentIdSubmodule = {
         result.medianet = { 'id': value.medianet }
       }
 
+      if (value.magnite) {
+        result.magnite = { 'id': value.magnite }
+      }
+
       return result
     }
 

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -164,6 +164,15 @@ export const USER_IDS_CONFIG = {
     }
   },
 
+  // magnite
+  'magnite': {
+    source: 'rubiconproject.com',
+    atype: 3,
+    getValue: function(data) {
+      return data.id;
+    }
+  },
+
   // britepoolId
   'britepoolid': {
     source: 'britepool.com',

--- a/modules/userId/eids.md
+++ b/modules/userId/eids.md
@@ -115,6 +115,14 @@ userIdAsEids = [
     },
     
     {
+        source: 'rubiconproject.com',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 3
+        }]
+    },
+    
+    {
         source: 'media.net',
         uids: [{
             id: 'some-random-id-value',

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -202,6 +202,21 @@ describe('eids array generation for known sub-modules', function() {
     });
   });
 
+  it('magnite', function() {
+    const userId = {
+      magnite: {'id': 'sample_id'}
+    };
+    const newEids = createEidsArray(userId);
+    expect(newEids.length).to.equal(1);
+    expect(newEids[0]).to.deep.equal({
+      source: 'rubiconproject.com',
+      uids: [{
+        id: 'sample_id',
+        atype: 3
+      }]
+    });
+  });
+
   it('liveIntentId; getValue call and NO ext', function() {
     const userId = {
       lipb: {

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -323,6 +323,11 @@ describe('LiveIntentId', function() {
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'medianet': 'bar'}, 'medianet': {'id': 'bar'}});
   });
 
+  it('should decode a magnite id to a seperate object when present', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', magnite: 'bar' });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'magnite': 'bar'}, 'magnite': {'id': 'bar'}});
+  });
+
   it('should decode values with uid2 but no nonId', function() {
     const result = liveIntentIdSubmodule.decode({ uid2: 'bar' });
     expect(result).to.eql({'uid2': {'id': 'bar'}});


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
This pull request adds eid mapping for the magnite ids that now can be resolved via the LiveIntent UserId module.

## Other information

- repository of the backing live-connect module: https://github.com/LiveIntent/live-connect
- documentation PR: https://github.com/prebid/prebid.github.io/pull/4498
