### PR TITLE
UserId module: avoid eids passing and empty array to s2s bidder

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -593,7 +593,9 @@ function emitNonBids(seatnonbid, auctionId) {
  * @param {array} newEidPermissions
  */
 function setEidPermissions(newEidPermissions) {
-  eidPermissions = newEidPermissions;
+  if (newEidPermissions.length > 0) {
+    eidPermissions = newEidPermissions;
+  }
 }
 getPrebidInternal().setEidPermissions = setEidPermissions;
 

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -1583,7 +1583,9 @@ describe('User ID', function () {
         setSubmoduleRegistry([sharedIdSystemSubmodule]);
         let eidPermissions;
         getPrebidInternal().setEidPermissions = function (newEidPermissions) {
-          eidPermissions = newEidPermissions;
+          if (newEidPermissions.length > 0) {
+            eidPermissions = newEidPermissions;
+          }
         }
         config.setConfig({
           userSync: {
@@ -1649,7 +1651,9 @@ describe('User ID', function () {
         setSubmoduleRegistry([sharedIdSystemSubmodule]);
         let eidPermissions;
         getPrebidInternal().setEidPermissions = function (newEidPermissions) {
-          eidPermissions = newEidPermissions;
+          if (newEidPermissions.length > 0) {
+            eidPermissions = newEidPermissions;
+          }
         }
         config.setConfig({
           userSync: {
@@ -1668,9 +1672,7 @@ describe('User ID', function () {
         });
 
         requestBidsHook(function () {
-          expect(eidPermissions).to.deep.equal(
-            []
-          );
+          expect(eidPermissions).to.be.undefined;
           adUnits.forEach(unit => {
             unit.bids.forEach(bid => {
               expect(bid).to.have.deep.nested.property('userId.pubcid');


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ X ] Bugfix
- [ X ] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
We started seeing an increase on server to server bidder errors on PBS (Java) server caused by Prebid sending an empty array on user.eids 
```No auction context or bid request (auction). Errors:[Invalid request format: 
request.user.eids must contain at least one element or be undefined]```
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
