### PR TITLE
Yieldmo Bid Adapter : empty array instead of string

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -83,7 +83,7 @@ export const spec = {
           gdprApplies: deepAccess(bidderRequest, 'gdprConsent.gdprApplies') || '',
           cmp: deepAccess(bidderRequest, 'gdprConsent.consentString') || '',
           gpp: deepAccess(bidderRequest, 'gppConsent.gppString') || '',
-          gpp_sid: deepAccess(bidderRequest, 'gppConsent.applicableSections') || ''
+          gpp_sid: deepAccess(bidderRequest, 'gppConsent.applicableSections') || []
         }),
         us_privacy: deepAccess(bidderRequest, 'uspConsent') || ''
       };
@@ -525,7 +525,7 @@ function populateOpenRtbGdpr(openRtbRequest, bidderRequest) {
     deepSetValue(openRtbRequest, 'regs.ext.gdpr', gdpr && gdpr.gdprApplies ? 1 : 0);
     deepSetValue(openRtbRequest, 'user.ext.consent', gdpr && gdpr.consentString ? gdpr.consentString : '');
   }
-  if (gppsid) {
+  if (gppsid && gppsid.length > 0) {
     deepSetValue(openRtbRequest, 'regs.ext.gpp_sid', gppsid);
   }
   const uspConsent = deepAccess(bidderRequest, 'uspConsent');

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -212,7 +212,7 @@ describe('YieldmoAdapter', function () {
         expect(data.hasOwnProperty('h')).to.be.true;
         expect(data.hasOwnProperty('w')).to.be.true;
         expect(data.hasOwnProperty('pubcid')).to.be.true;
-        expect(data.userConsent).to.equal('{"gdprApplies":"","cmp":"","gpp":"","gpp_sid":""}');
+        expect(data.userConsent).to.equal('{"gdprApplies":"","cmp":"","gpp":"","gpp_sid":[]}');
         expect(data.us_privacy).to.equal('');
       });
 
@@ -263,7 +263,7 @@ describe('YieldmoAdapter', function () {
             gdprApplies: true,
             cmp: 'BOJ/P2HOJ/P2HABABMAAAAAZ+A==',
             gpp: '',
-            gpp_sid: '',
+            gpp_sid: [],
           })
         );
       });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Changing the default value of gpp_sid to empty array instead of string. 

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
