### PR TITLE
Prebid 8: add bidResponse before emitting the event BID_RESPONSE

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -579,8 +579,8 @@ export function addBidToAuction(auctionInstance, bidResponse) {
   setupBidTargeting(bidResponse);
 
   useMetrics(bidResponse.metrics).timeSince('addBidResponse', 'addBidResponse.total');
-  events.emit(CONSTANTS.EVENTS.BID_RESPONSE, bidResponse);
   auctionInstance.addBidReceived(bidResponse);
+  events.emit(CONSTANTS.EVENTS.BID_RESPONSE, bidResponse);
 
   doCallbacksIfTimedout(auctionInstance, bidResponse);
 }

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -874,6 +874,17 @@ describe('auctionmanager.js', function () {
         assert.equal(registeredBid.adserverTargeting[CONSTANTS.TARGETING_KEYS.BIDDER], BIDDER_CODE);
         assert.equal(registeredBid.adserverTargeting.extra, 'stuff');
       });
+      it('should add the bidResponse to the collection before calling BID_RESPONSE', function () {
+        let hasBid = false;
+        const eventHandler = function(bid) {
+          const storedBid = auction.getBidsReceived().pop();
+          hasBid = storedBid === bid;
+        }
+        events.on(CONSTANTS.EVENTS.BID_RESPONSE, eventHandler);
+        auction.callBids();
+        events.off(CONSTANTS.EVENTS.BID_RESPONSE, eventHandler);
+        assert.ok(hasBid, 'Bid not available');
+      });
 
       describe('install publisher-defined renderers', () => {
         Object.entries({


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Right now when an `auction` instance receives a bid, it triggers the event `BID_RESPONSE` and then add's it to the internal collection `_bidsReceived`. This becomes problematic when you depend on the bid already available in the auction. I think the order should be reversed, so that it first stores the bid, and then triggers the `BID_RESPONSE` event. I don't expect this to break existing functionalities.

## Other information
original changes: https://github.com/prebid/Prebid.js/pull/2067
