### PR TITLE
Missena Bid Adapter: fix alias

### DIFF
--- a/modules/missenaBidAdapter.js
+++ b/modules/missenaBidAdapter.js
@@ -8,7 +8,7 @@ const EVENTS_DOMAIN = 'events.missena.io';
 const EVENTS_DOMAIN_DEV = 'events.staging.missena.xyz';
 
 export const spec = {
-  aliases: [BIDDER_CODE],
+  aliases: ['msna'],
   code: BIDDER_CODE,
   gvlid: 687,
   supportedMediaTypes: [BANNER],


### PR DESCRIPTION
## Type of change 
- [x] Bugfix 

## Description of change
The adapter accidentally declared its own code as an alias and this resulted in the sync not firing when `aliasSyncEnabled` is `false` (the default value for that setting). 
 
 