### PR TITLE
Yahoo connect id: storage fixes.

### DIFF
--- a/modules/connectIdSystem.js
+++ b/modules/connectIdSystem.js
@@ -33,7 +33,7 @@ function storeObject(obj) {
     setEtldPlusOneCookie(MODULE_NAME, JSON.stringify(obj), new Date(expires), getSiteHostname());
   } else if (storage.localStorageIsEnabled()) {
     obj.__expires = expires;
-    storage.setDataInLocalStorage(MODULE_NAME, obj);
+    storage.setDataInLocalStorage(MODULE_NAME, JSON.stringify(obj));
   }
 }
 
@@ -71,8 +71,11 @@ function getIdFromCookie() {
 
 function getIdFromLocalStorage() {
   if (storage.localStorageIsEnabled()) {
-    const storedIdData = storage.getDataFromLocalStorage(MODULE_NAME);
+    let storedIdData = storage.getDataFromLocalStorage(MODULE_NAME);
     if (storedIdData) {
+      try {
+        storedIdData = JSON.parse(storedIdData);
+      } catch {}
       if (isPlainObject(storedIdData) && storedIdData.__expires &&
           storedIdData.__expires <= Date.now()) {
         storage.removeDataFromLocalStorage(MODULE_NAME);

--- a/test/spec/modules/connectIdSystem_spec.js
+++ b/test/spec/modules/connectIdSystem_spec.js
@@ -86,7 +86,7 @@ describe('Yahoo ConnectID Submodule', () => {
         {
           detail: 'cookie data over local storage data',
           cookie: '{"connectId":"foo"}',
-          localStorage: {connectId: 'bar'},
+          localStorage: JSON.stringify({connectId: 'bar'}),
           expected: {connectId: 'foo'}
         },
         {
@@ -98,7 +98,7 @@ describe('Yahoo ConnectID Submodule', () => {
         {
           detail: 'local storage data if only it local storage data exists',
           cookie: undefined,
-          localStorage: {connectId: 'bar'},
+          localStorage: JSON.stringify({connectId: 'bar'}),
           expected: {connectId: 'bar'}
         },
         {
@@ -441,10 +441,10 @@ describe('Yahoo ConnectID Submodule', () => {
           const dateNowStub = sinon.stub(Date, 'now');
           dateNowStub.returns(0);
           const upsResponse = {connectid: 'barfoo'};
-          const expectedStoredData = {
+          const expectedStoredData = JSON.stringify({
             connectid: 'barfoo',
             __expires: 60 * 60 * 24 * 14 * 1000
-          };
+          });
           invokeGetIdAPI({
             puid: PUBLISHER_USER_ID,
             pixelId: PIXEL_ID


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

The local storage values has to be strings. 

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
