### PR TITLE
Core & multiple modules: populate ortb2.source.tid

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "prebid-8" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "master" ]
+    branches: [ "master", "prebid-8" ]
   schedule:
     - cron: '22 11 * * 0'
 

--- a/libraries/ortbConverter/processors/default.js
+++ b/libraries/ortbConverter/processors/default.js
@@ -1,4 +1,4 @@
-import {deepSetValue, mergeDeep} from '../../../src/utils.js';
+import {generateUUID, mergeDeep} from '../../../src/utils.js';
 import {bannerResponseProcessor, fillBannerImp} from './banner.js';
 import {fillVideoImp, fillVideoResponse} from './video.js';
 import {setResponseMediaType} from './mediaType.js';
@@ -21,17 +21,16 @@ export const DEFAULT_PROCESSORS = {
       fn: clientSectionChecker('ORTB request')
     },
     props: {
-      // sets request properties id, tmax, test, source.tid
+      // sets request properties id, tmax, test
       fn(ortbRequest, bidderRequest) {
         Object.assign(ortbRequest, {
-          id: ortbRequest.id || bidderRequest.auctionId,
+          id: ortbRequest.id || generateUUID(),
           test: ortbRequest.test || 0
         });
         const timeout = parseInt(bidderRequest.timeout, 10);
         if (!isNaN(timeout)) {
           ortbRequest.tmax = timeout;
         }
-        deepSetValue(ortbRequest, 'source.tid', ortbRequest.source?.tid || bidderRequest.auctionId);
       }
     }
   },

--- a/modules/prebidServerBidAdapter/ortbConverter.js
+++ b/modules/prebidServerBidAdapter/ortbConverter.js
@@ -51,7 +51,6 @@ const PBS_CONVERTER = ortbConverter({
       const request = buildRequest(imps, proxyBidderRequest, context);
 
       request.tmax = s2sBidRequest.s2sConfig.timeout;
-      deepSetValue(request, 'source.tid', proxyBidderRequest.auctionId);
 
       [request.app, request.dooh, request.site].forEach(section => {
         if (section && !section.publisher?.id) {

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -252,7 +252,7 @@ adapterManager.makeBidRequests = hook('sync', function (adUnits, auctionStart, a
   const bidderOrtb2 = ortb2Fragments.bidder || {};
 
   function addOrtb2(bidderRequest) {
-    const fpd = Object.freeze(mergeDeep({}, ortb2, bidderOrtb2[bidderRequest.bidderCode]));
+    const fpd = Object.freeze(mergeDeep({source: {tid: auctionId}}, ortb2, bidderOrtb2[bidderRequest.bidderCode]));
     bidderRequest.ortb2 = fpd;
     bidderRequest.bids.forEach((bid) => bid.ortb2 = fpd);
     return bidderRequest;

--- a/test/spec/modules/ivsBidAdapter_spec.js
+++ b/test/spec/modules/ivsBidAdapter_spec.js
@@ -112,9 +112,7 @@ describe('ivsBidAdapter', function () {
     it('should contain the required parameters', function () {
       const bidRequest = spec.buildRequests(validBidRequests, validBidderRequest);
       const bidderRequest = bidRequest.data;
-      assert.equal(bidderRequest.id, validBidderRequest.auctionId);
       assert.ok(bidderRequest.site);
-      assert.ok(bidderRequest.source);
       assert.lengthOf(bidderRequest.imp, 1);
     });
   });

--- a/test/spec/modules/nexx360BidAdapter_spec.js
+++ b/test/spec/modules/nexx360BidAdapter_spec.js
@@ -354,7 +354,6 @@ describe('Nexx360 bid adapter tests', function () {
         const request = spec.buildRequests(displayBids, bidderRequest);
         const requestContent = request.data;
         expect(request).to.have.property('method').and.to.equal('POST');
-        expect(requestContent.id).to.be.eql('2e684815-b44e-4e04-b812-56da54adbe74');
         expect(requestContent.cur[0]).to.be.eql('USD');
         expect(requestContent.imp.length).to.be.eql(2);
         expect(requestContent.imp[0].id).to.be.eql('44a2706ac3574');

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -636,15 +636,12 @@ describe('S2S Adapter', function () {
       resetSyncedStatus();
     });
 
-    it('should set id and source.tid to auction ID', function () {
+    it('should pick source.tid from FPD', () => {
       config.setConfig({ s2sConfig: CONFIG });
-
-      adapter.callBids(OUTSTREAM_VIDEO_REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
-
-      const requestBid = JSON.parse(server.requests[0].requestBody);
-      expect(requestBid.id).to.equal(BID_REQUESTS[0].auctionId);
-      expect(requestBid.source.tid).to.equal(BID_REQUESTS[0].auctionId);
-    });
+      adapter.callBids({...REQUEST, ortb2Fragments: {global: {source: {tid: 'mock-tid'}}}}, BID_REQUESTS, addBidResponse, done, ajax);
+      const req = JSON.parse(server.requests[0].requestBody)
+      expect(req.source.tid).to.eql('mock-tid');
+    })
 
     it('should set tmax to s2sConfig.timeout', () => {
       const cfg = {...CONFIG, timeout: 123};

--- a/test/spec/modules/scatteredBidAdapter_spec.js
+++ b/test/spec/modules/scatteredBidAdapter_spec.js
@@ -97,9 +97,7 @@ describe('Scattered adapter', function () {
     it('has the right fields filled', function () {
       let request = spec.buildRequests(arrayOfValidBidRequests, validBidderRequest);
       const bidderRequest = request.data;
-      assert.equal(bidderRequest.id, validBidderRequest.auctionId);
       assert.ok(bidderRequest.site);
-      assert.ok(bidderRequest.source);
       assert.lengthOf(bidderRequest.imp, 1);
     });
 

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1762,6 +1762,11 @@ describe('adapterManager tests', function () {
       requests.appnexus.bids.forEach((bid) => expect(bid.ortb2).to.eql(requests.appnexus.ortb2));
     });
 
+    it('should populate ortb2.source.tid with auctionId', () => {
+      const reqs = adapterManager.makeBidRequests(adUnits, 0, 'mockAuctionId', 1000, [], {global: {}});
+      expect(reqs[0].ortb2.source.tid).to.equal('mockAuctionId');
+    })
+
     it('should merge in bid-level ortb2Imp with adUnit-level ortb2Imp', () => {
       const adUnit = {
         ...adUnits[1],


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

This is a first step towards [turning off transaction IDs](https://github.com/prebid/Prebid.js/issues/9781):

 - `ortb2.source.tid` is now populated with the auction ID by default
 - ortbConverter (and adapters that use it) carries it over, but no longer uses the auction ID to populate the top-level `id`

The plan is to refactor every other adapter to also pick `source.tid` instead of `auctionId`, and once [activity controls](https://github.com/prebid/Prebid.js/pull/9802) are merged, use that to "turn off" `source.tid` (and `imp[].ext.tid`).




