### PR TITLE
RTBHouse Adapter: `bcat` & `badv` support

### DIFF
--- a/modules/rtbhouseBidAdapter.js
+++ b/modules/rtbhouseBidAdapter.js
@@ -85,15 +85,12 @@ export const spec = {
     }
 
     const ortb2Params = bidderRequest?.ortb2 || {};
-    if (ortb2Params.site) {
-      mergeDeep(request, { site: ortb2Params.site });
-    }
-    if (ortb2Params.user) {
-      mergeDeep(request, { user: ortb2Params.user });
-    }
-    if (ortb2Params.device) {
-      mergeDeep(request, { device: ortb2Params.device });
-    }
+    ['site', 'user', 'device', 'bcat', 'badv'].forEach(entry => {
+      const ortb2Param = ortb2Params[entry];
+      if (ortb2Param) {
+        mergeDeep(request, { [entry]: ortb2Param });
+      }
+    });
 
     let computedEndpointUrl = ENDPOINT_URL;
 

--- a/test/spec/modules/rtbhouseBidAdapter_spec.js
+++ b/test/spec/modules/rtbhouseBidAdapter_spec.js
@@ -282,6 +282,28 @@ describe('RTBHouseAdapter', () => {
       expect(data.source).to.not.have.property('ext');
     });
 
+    it('should include first party data', function () {
+      const bidRequest = Object.assign([], bidRequests);
+      const localBidderRequest = {
+        ...bidderRequest,
+        ortb2: {
+          bcat: ['IAB1', 'IAB2-1'],
+          badv: ['domain1.com', 'domain2.com'],
+          site: { ext: { data: 'some site data' } },
+          device: { ext: { data: 'some device data' } },
+          user: { ext: { data: 'some user data' } }
+        }
+      };
+
+      const request = spec.buildRequests(bidRequest, localBidderRequest);
+      const data = JSON.parse(request.data);
+      expect(data.bcat).to.deep.equal(localBidderRequest.ortb2.bcat);
+      expect(data.badv).to.deep.equal(localBidderRequest.ortb2.badv);
+      expect(data.site).to.nested.include({'ext.data': 'some site data'});
+      expect(data.device).to.nested.include({'ext.data': 'some device data'});
+      expect(data.user).to.nested.include({'ext.data': 'some user data'});
+    });
+
     context('FLEDGE', function() {
       afterEach(function () {
         config.resetConfig();


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)

## Description of change
The PR aims at adding `bcat` and `badv` ORTB2 fields to the request. Additionally all the accepted ORTB2 fields are now defined as an array and included in the request in a uniform way.

## Other information
PR to documentation change: https://github.com/prebid/prebid.github.io/pull/4522

## Contact
Please reach us at [inventory_support@rtbhouse.com](mailto:inventory_support@rtbhouse.com) with [piotr.jaworski@rtbhouse.com](mailto:piotr.jaworski@rtbhouse.com) and cc [leandro.otani@rtbhouse.com](mailto:leandro.otani@rtbhouse.com).

