### PR TITLE
Adnuntius Bid Adaptor: Better support for Deals

### DIFF
--- a/integrationExamples/gpt/adnuntiusGamExample.html
+++ b/integrationExamples/gpt/adnuntiusGamExample.html
@@ -1,0 +1,119 @@
+<html>
+<head>
+    <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="../../../build/dev/prebid.js"></script>
+    <script>
+      var FAILSAFE_TIMEOUT = 3000;
+
+      var adUnits = [
+        {
+          code: 'ad-div-1',
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250]]
+            }
+          },
+          bids: [{
+            bidder: 'adnuntius',
+            params: {
+              auId: "201208",
+              network: "adnuntius",
+              maxDeals: 1
+            }
+          }]
+        },
+        {
+          code: 'ad-div-2',
+          mediaTypes: {
+            banner: {
+              sizes: [300, 250],
+            }
+          },
+          bids: [{
+            bidder: "adnuntius",
+            params: {
+              auId: "201208",
+              network: "adnuntius",
+            }
+          }]
+        }
+      ];
+      var googletag = googletag || {};
+      googletag.cmd = googletag.cmd || [];
+      googletag.cmd.push(function() {
+        googletag.pubads().disableInitialLoad();
+      });
+
+      var pbjs = pbjs || {};
+      pbjs.que = pbjs.que || [];
+
+      pbjs.que.push(function() {
+        pbjs.setConfig({
+          enableSendAllBids: true,
+          targetingControls: {
+            alwaysIncludeDeals: true
+          },
+          userSync: {
+            syncEnabled: false
+          }
+        });
+        pbjs.bidderSettings = {
+          adnuntius: {
+            allowAlternateBidderCodes: true,
+            allowedAlternateBidderCodes: ["adndeal1", "adndeal2", "adndeal3"],
+          }
+        };
+        pbjs.addAdUnits(adUnits);
+        pbjs.requestBids({bidsBackHandler: initAdserver});
+      });
+
+      function initAdserver() {
+        if (pbjs.initAdserverSet) return;
+        pbjs.initAdserverSet = true;
+        googletag.cmd.push(function() {
+          pbjs.que.push(function() {
+            pbjs.setTargetingForGPTAsync('ad-div-1');
+            pbjs.setTargetingForGPTAsync('ad-div-2');
+            googletag.pubads().refresh();
+          });
+        });
+      }
+      // in case PBJS doesn't load
+      setTimeout(function() {
+        initAdserver();
+      }, FAILSAFE_TIMEOUT);
+
+      googletag.cmd.push(function() {
+        googletag.defineSlot('/19968336/header-bid-tag-0', [[300, 250]], 'ad-div-1').addService(googletag.pubads());
+        googletag.pubads().enableSingleRequest();
+        googletag.enableServices();
+      });
+
+      googletag.cmd.push(function() {
+        googletag.defineSlot('/19968336/header-bid-tag-0', [[300, 250]], 'ad-div-2').addService(googletag.pubads());
+        googletag.pubads().enableSingleRequest();
+        googletag.enableServices();
+      });
+
+    </script>
+</head>
+<body>
+<h2>Adnuntius Prebid Adapator Test</h2>
+<h5>Ad Slot 1</h5>
+<div id='ad-div-1'>
+    <script type='text/javascript'>
+      googletag.cmd.push(function() {
+        googletag.display('ad-div-1');
+      });
+    </script>
+</div>
+<h5>Ad Slot 2</h5>
+<div id='ad-div-2'>
+    <script type='text/javascript'>
+      googletag.cmd.push(function() {
+        googletag.display('ad-div-2');
+      });
+    </script>
+</div>
+</body>
+</html>

--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -9,7 +9,6 @@ const ENDPOINT_URL = 'https://ads.adnuntius.delivery/i';
 const ENDPOINT_URL_EUROPE = 'https://europe.delivery.adnuntius.com/i';
 const GVLID = 855;
 const DEFAULT_VAST_VERSION = 'vast4'
-// const DEFAULT_NATIVE = 'native'
 
 const checkSegment = function (segment) {
   if (isStr(segment)) return segment;
@@ -28,32 +27,6 @@ const getSegmentsFromOrtb = function (ortb2) {
   }
   return segments
 }
-
-// function createNative(ad) {
-//   const native = {};
-//   const assets = ad.assets
-//   native.title = ad.text.title.content;
-//   native.image = {
-//     url: assets.image.cdnId,
-//     height: assets.image.height,
-//     width: assets.image.width,
-//   };
-//   if (assets.icon) {
-//     native.icon = {
-//       url: assets.icon.cdnId,
-//       height: assets.icon.height,
-//       width: assets.icon.width,
-//     };
-//   }
-
-//   native.sponsoredBy = ad.text.sponsoredBy?.content || '';
-//   native.body = ad.text.body?.content || '';
-//   native.cta = ad.text.cta?.content || '';
-//   native.clickUrl = ad.destinationUrls.destination || '';
-//   native.impressionTrackers = ad.impressionTrackingUrls || [ad.renderedPixel];
-
-//   return native;
-// }
 
 const handleMeta = function () {
   const storage = getStorageManager({ bidderCode: BIDDER_CODE })
@@ -110,10 +83,6 @@ export const spec = {
         network += '_video'
       }
 
-      // if (bid.mediaTypes && bid.mediaTypes.native) {
-      //   network += '_native'
-      // }
-
       bidRequests[network] = bidRequests[network] || [];
       bidRequests[network].push(bid);
 
@@ -132,7 +101,6 @@ export const spec = {
       const networkRequest = [...request]
       if (network.indexOf('_video') > -1) { networkRequest.push('tt=' + DEFAULT_VAST_VERSION) }
       const requestURL = gdprApplies ? ENDPOINT_URL_EUROPE : ENDPOINT_URL
-      // if (network.indexOf('_native') > -1) { networkRequest.push('tt=' + DEFAULT_NATIVE) }
       requests.push({
         method: 'POST',
         url: requestURL + '?' + networkRequest.join('&'),
@@ -172,9 +140,6 @@ export const spec = {
         if (adUnit.vastXml) {
           adResponse[adUnit.targetId].vastXml = adUnit.vastXml
           adResponse[adUnit.targetId].mediaType = VIDEO
-          // } else if (ad.assets && ad.assets.image && ad.text && ad.text.title && ad.text.body && ad.destinationUrls && ad.destinationUrls.destination) {
-          //   adResponse[adUnit.targetId].native = createNative(ad);
-          //   adResponse[adUnit.targetId].mediaType = NATIVE;
         } else {
           adResponse[adUnit.targetId].ad = adUnit.html
         }

--- a/modules/adnuntiusBidAdapter.md
+++ b/modules/adnuntiusBidAdapter.md
@@ -8,8 +8,38 @@ Maintainer: info@adnuntius.com
 
 # Description
 
-Adnuntius Bidder Adapter for Prebid.js. 
-Only Banner format is supported.
+Adnuntius Bidder Adapter for Prebid.js. Video and Banner formats are supported.
+
+The adaptor supports returning both the highest bidder **and**
+bids with Deal IDs when a `maxDeals` parameter greater than `0`
+is provided.
+
+If deal bids are returned, they are assigned a `bidderCode` using
+one of the aliases supplied for this bidder:
+
+- `adndeal1`
+- `adndeal2`
+- `adndeal3`
+- `adndeal4`
+- `adndeal5`
+
+If you want to accept these responses, you must add the following 
+configuration:
+
+```javascript
+pbjs.bidderSettings = {
+            adnuntius: {
+                allowAlternateBidderCodes: true,
+                allowedAlternateBidderCodes: [
+                  "adndeal1", 
+                  "adndeal2", 
+                  "adndeal3",
+                  "adndeal4",
+                  "adndeal5"
+                ],
+            }
+        };
+```
 
 # Test Parameters
 ```
@@ -27,6 +57,7 @@ Only Banner format is supported.
                         params: {
                             auId: "8b6bc",
                             network: "adnuntius",
+                            maxDeals: 1
                         }
                     },
                 ]

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -72,30 +72,6 @@ describe('adnuntiusBidAdapter', function () {
     }
   ]
 
-  // const nativeBidderRequest = [
-  //   {
-  //     bidId: '123',
-  //     bidder: 'adnuntius',
-  //     params: {
-  //       auId: '8b6bc',
-  //       network: 'adnuntius',
-  //     },
-  //     mediaTypes: {
-  //       native: {
-  //         title: {
-  //           required: true
-  //         },
-  //         image: {
-  //           required: true
-  //         },
-  //         body: {
-  //           required: true
-  //         }
-  //       }
-  //     },
-  //   }
-  // ]
-
   const singleBidRequest = {
     bid: [
       {
@@ -238,83 +214,6 @@ describe('adnuntiusBidAdapter', function () {
       ]
     }
   }
-  // const serverNativeResponse = {
-  //   body: {
-  //     'adUnits': [
-  //       {
-  //         'auId': '000000000008b6bc',
-  //         'targetId': '123',
-  //         'html': '<h1>hi!</h1>',
-  //         'matchedAdCount': 1,
-  //         'responseId': 'adn-rsp-1460129238',
-  //         'ads': [
-  //           {
-  //             'destinationUrlEsc': 'https%3A%2F%2Fdelivery.adnuntius.com%2Fc%2F52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN%3Fct%3D2501%26r%3Dhttp%253A%252F%252Fgoogle.com',
-  //             'assets': {
-  //               'image': {
-  //                 'cdnId': 'https://assets.adnuntius.com/K9rfXC6wJvgVuy4Fbt5P8oEEGXme9ZaP8BNDzz3OMGQ.jpg',
-  //                 'width': '300',
-  //                 'height': '250'
-  //               }
-  //             },
-  //             'text': {
-  //               'body': {
-  //                 'content': 'Testing Native ad from Adnuntius',
-  //                 'length': '32',
-  //                 'minLength': '0',
-  //                 'maxLength': '100'
-  //               },
-  //               'title': {
-  //                 'content': 'Native Ad',
-  //                 'length': '9',
-  //                 'minLength': '5',
-  //                 'maxLength': '100'
-  //               }
-  //             },
-  //             'clickUrl': 'https://delivery.adnuntius.com/c/52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
-  //             'urls': {
-  //               'destination': 'https://delivery.adnuntius.com/c/52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN?ct=2501&r=http%3A%2F%2Fgoogle.com'
-  //             },
-  //             'urlsEsc': {
-  //               'destination': 'https%3A%2F%2Fdelivery.adnuntius.com%2Fc%2F52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN%3Fct%3D2501%26r%3Dhttp%253A%252F%252Fgoogle.com'
-  //             },
-  //             'destinationUrls': {
-  //               'destination': 'http://google.com'
-  //             },
-  //             'cpm': { 'amount': 5.0, 'currency': 'NOK' },
-  //             'bid': { 'amount': 0.005, 'currency': 'NOK' },
-  //             'cost': { 'amount': 0.005, 'currency': 'NOK' },
-  //             'impressionTrackingUrls': [],
-  //             'impressionTrackingUrlsEsc': [],
-  //             'adId': 'adn-id-1347343135',
-  //             'selectedColumn': '0',
-  //             'selectedColumnPosition': '0',
-  //             'renderedPixel': 'https://delivery.adnuntius.com/b/52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN.html',
-  //             'renderedPixelEsc': 'https%3A%2F%2Fdelivery.adnuntius.com%2Fb%2F52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN.html',
-  //             'visibleUrl': 'https://delivery.adnuntius.com/s?rt=52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
-  //             'visibleUrlEsc': 'https%3A%2F%2Fdelivery.adnuntius.com%2Fs%3Frt%3D52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
-  //             'viewUrl': 'https://delivery.adnuntius.com/v?rt=52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
-  //             'viewUrlEsc': 'https%3A%2F%2Fdelivery.adnuntius.com%2Fv%3Frt%3D52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
-  //             'rt': '52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
-  //             'creativeWidth': '980',
-  //             'creativeHeight': '120',
-  //             'creativeId': 'wgkq587vgtpchsx1',
-  //             'lineItemId': 'scyjdyv3mzgdsnpf',
-  //             'layoutId': 'sw6gtws2rdj1kwby',
-  //             'layoutName': 'Responsive image'
-  //           },
-
-  //         ]
-  //       },
-  //       {
-  //         'auId': '000000000008b6bc',
-  //         'targetId': '456',
-  //         'matchedAdCount': 0,
-  //         'responseId': 'adn-rsp-1460129238',
-  //       }
-  //     ]
-  //   }
-  // }
 
   describe('inherited functions', function () {
     it('exists and is a function', function () {
@@ -515,6 +414,7 @@ describe('adnuntiusBidAdapter', function () {
       expect(interpretedResponse[0].ttl).to.equal(360);
     });
   });
+
   describe('interpretVideoResponse', function () {
     it('should return valid response when passed valid server response', function () {
       const interpretedResponse = spec.interpretResponse(serverVideoResponse, videoBidRequest);
@@ -532,21 +432,4 @@ describe('adnuntiusBidAdapter', function () {
       expect(interpretedResponse[0].vastXml).to.equal(serverVideoResponse.body.adUnits[0].vastXml);
     });
   });
-  // describe('interpretNativeResponse', function () {
-  //   it('should return valid response when passed valid server response', function () {
-  //     const interpretedResponse = spec.interpretResponse(serverNativeResponse, nativeBidRequest);
-  //     const ad = serverNativeResponse.body.adUnits[0].ads[0]
-  //     expect(interpretedResponse).to.have.lengthOf(1);
-  //     expect(interpretedResponse[0].cpm).to.equal(ad.cpm.amount);
-  //     expect(interpretedResponse[0].width).to.equal(Number(ad.creativeWidth));
-  //     expect(interpretedResponse[0].height).to.equal(Number(ad.creativeHeight));
-  //     expect(interpretedResponse[0].creativeId).to.equal(ad.creativeId);
-  //     expect(interpretedResponse[0].currency).to.equal(ad.bid.currency);
-  //     expect(interpretedResponse[0].netRevenue).to.equal(false);
-  //     expect(interpretedResponse[0].meta).to.have.property('advertiserDomains');
-  //     expect(interpretedResponse[0].meta.advertiserDomains).to.have.lengthOf(1);
-  //     expect(interpretedResponse[0].meta.advertiserDomains[0]).to.equal('google.com');
-  //     expect(interpretedResponse[0].native.body).to.equal(serverNativeResponse.body.adUnits[0].ads[0].text.body.content);
-  //   });
-  // });
 });

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -1,12 +1,13 @@
 // import or require modules necessary for the test, e.g.:
-import { expect } from 'chai'; // may prefer 'assert' in place of 'expect'
-import { spec } from 'modules/adnuntiusBidAdapter.js';
-import { newBidder } from 'src/adapters/bidderFactory.js';
-import { config } from 'src/config.js';
+import {expect} from 'chai'; // may prefer 'assert' in place of 'expect'
+import {misc, spec} from 'modules/adnuntiusBidAdapter.js';
+import {newBidder} from 'src/adapters/bidderFactory.js';
+import {config} from 'src/config.js';
 import * as utils from 'src/utils.js';
-import { getStorageManager } from 'src/storageManager.js';
+import {getStorageManager} from 'src/storageManager.js';
+import {getGlobal} from '../../../src/prebidGlobal';
 
-describe('adnuntiusBidAdapter', function () {
+describe('adnuntiusBidAdapter', function() {
   const URL = 'https://ads.adnuntius.delivery/i?tzo=';
   const EURO_URL = 'https://europe.delivery.adnuntius.com/i?tzo=';
   const GVLID = 855;
@@ -27,29 +28,44 @@ describe('adnuntiusBidAdapter', function () {
     $$PREBID_GLOBAL$$.bidderSettings = {};
   });
 
-  afterEach(function () {
+  afterEach(function() {
     config.resetConfig();
   });
 
   const tzo = new Date().getTimezoneOffset();
-  const ENDPOINT_URL = `${URL}${tzo}&format=json&userId=${usi}`;
-  const ENDPOINT_URL_VIDEO = `${URL}${tzo}&format=json&userId=${usi}&tt=vast4`;
-  const ENDPOINT_URL_NOCOOKIE = `${URL}${tzo}&format=json&userId=${usi}&noCookies=true`;
-  const ENDPOINT_URL_SEGMENTS = `${URL}${tzo}&format=json&segments=segment1,segment2,segment3&userId=${usi}`;
+  const ENDPOINT_URL_BASE = `${URL}${tzo}&format=json`;
+  const ENDPOINT_URL = `${ENDPOINT_URL_BASE}&userId=${usi}`;
+  const ENDPOINT_URL_VIDEO = `${ENDPOINT_URL_BASE}&userId=${usi}&tt=vast4`;
+  const ENDPOINT_URL_NOCOOKIE = `${ENDPOINT_URL_BASE}&userId=${usi}&noCookies=true`;
+  const ENDPOINT_URL_SEGMENTS = `${ENDPOINT_URL_BASE}&segments=segment1,segment2,segment3&userId=${usi}`;
   const ENDPOINT_URL_CONSENT = `${EURO_URL}${tzo}&format=json&consentString=consentString&userId=${usi}`;
   const adapter = newBidder(spec);
 
   const bidderRequests = [
     {
-      bidId: '123',
+      bidId: 'adn-000000000008b6bc',
       bidder: 'adnuntius',
       params: {
-        auId: '8b6bc',
+        auId: '000000000008b6bc',
         network: 'adnuntius',
+        maxDeals: 1
       },
       mediaTypes: {
         banner: {
           sizes: [[640, 480], [600, 400]],
+        }
+      },
+    },
+    {
+      bidId: 'adn-0000000000000551',
+      bidder: 'adnuntius',
+      params: {
+        auId: '0000000000000551',
+        network: 'adnuntius',
+      },
+      mediaTypes: {
+        banner: {
+          sizes: [[1640, 1480], [1600, 1400]],
         }
       },
     }
@@ -57,10 +73,10 @@ describe('adnuntiusBidAdapter', function () {
 
   const videoBidderRequest = [
     {
-      bidId: '123',
+      bidId: 'adn-0000000000000551',
       bidder: 'adnuntius',
       params: {
-        auId: '8b6bc',
+        auId: '0000000000000551',
         network: 'adnuntius',
       },
       mediaTypes: {
@@ -75,7 +91,7 @@ describe('adnuntiusBidAdapter', function () {
   const singleBidRequest = {
     bid: [
       {
-        bidId: '123',
+        bidId: 'adn-0000000000000551',
       }
     ]
   }
@@ -84,130 +100,329 @@ describe('adnuntiusBidAdapter', function () {
     bid: videoBidderRequest
   }
 
-  // const nativeBidRequest = {
-  //   bid: nativeBidderRequest
-  // }
-
   const serverResponse = {
     body: {
       'adUnits': [
         {
-          'auId': '000000000008b6bc',
-          'targetId': '123',
-          'html': '<h1>hi!</h1>',
+          'auId': '0000000000000551',
+          'targetId': 'adn-0000000000000551',
+          'html': "<!DOCTYPE html>\n<html>\n<head>\n    <meta charset=\"utf-8\">\n    <style media=\"all\">\n        html, body, .responseCtr {\n            margin: 0;\n            padding: 0;\n            outline: 0;\n            border: 0;\n            overflow: hidden;\n        }\n\n        .responseCtr {\n            display: inline-block;\n            line-height: 0;\n            vertical-align: top;\n        }\n\n        .responseCtr a {\n            line-height: 0;\n        }\n\n        .responseCtr *, .responseCtr a * {\n            line-height: normal;\n        }\n\n        .responseCtr .contentWrapperPerItem {\n            margin: 0;\n            padding: 0;\n            outline: 0;\n            border: 0;\n            display: inline-block;\n            line-height: 0;\n            vertical-align: top;\n        }\n\n        a img {\n            border: none;\n            outline: none;\n        }\n\n        img {\n            margin: 0;\n            padding: 0;\n        }\n\n        /* need this displayNone class to ensure images are preloaded for smooth transition */\n        img.displayNone {\n            position: absolute;\n            top: -99999px;\n            left: -99999px;\n        }\n\n        .contentWrapperTrailer {\n            clear: both;\n        }\n    </style>\n    <script src=\"https://cdn.adnuntius.com/adn.js\"></script>\n</head>\n<body>\n<div id=\"adn-rsp--229633088\" class=\"responseCtr\">\n<div class=\"contentWrapperPerItem\" id=\"adn-id-1488629603\" data-line-item-id=\"cr3hnkkxhnkw9ldy\" data-creative-id=\"s90t0q03pm\" data-creative-width=\"100\" data-creative-height=\"30\" data-response-token=\"5Mu-vFVsaf4dWWx8uyZoV7Mz0sPkF1_j9bSupMwX8dMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxqqTYxj2sS0FkMriztxcORshj3zRbT0KsV7XnDXE0F-OsHX7Ok6_FNLuIDTOMJyx6ZZCB10wGqA3OaSe1Eq9D85h8gP1gGsobC0KsAISm_PYNkJ6ve6qZLnB79fX6XHLYSRqTBM8sBCRXQAetnVzeo7AHoQhkFeouS444YA_q4JCTlRI2peWFIuxFlOYyeX9Kzg\"><a rel=\"nofollow\" target=\"_top\" href=\"https://ads.adnuntius.delivery/c/5Mu-vFVsaf4dWWx8uyZoV7Mz0sPkF1_j9bSupMwX8dMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxqqTYxj2sS0FkMriztxcORshj3zRbT0KsV7XnDXE0F-OsHX7Ok6_FNLuIDTOMJyx6ZZCB10wGqA3OaSe1Eq9D85h8gP1gGsobC0KsAISm_PYNkJ6ve6qZLnB79fX6XHLYSRqTBM8sBCRXQAetnVzeo7AHoQhkFeouS444YA_q4JCTlRI2peWFIuxFlOYyeX9Kzg?ct=673&r=http%3A%2F%2Fadnuntius.com\"><img src=\"https://cdn.adnuntius.com/cdn/iBgqruUNbaUb2hmD3vws7WTi84jg_WB_-VOF_FeOZ7A.png\" width=\"728\" height=\"90\" alt=\"\"/></a><div class=\"contentWrapperTrailer\"></div></div>\n</div><script>\n            //<![CDATA[\n            (function() {\n                var impTrackers = [];impTrackers.push(\"https://ads.adnuntius.delivery/b/5Mu-vFVsaf4dWWx8uyZoV7Mz0sPkF1_j9bSupMwX8dMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxqqTYxj2sS0FkMriztxcORshj3zRbT0KsV7XnDXE0F-OsHX7Ok6_FNLuIDTOMJyx6ZZCB10wGqA3OaSe1Eq9D85h8gP1gGsobC0KsAISm_PYNkJ6ve6qZLnB79fX6XHLYSRqTBM8sBCRXQAetnVzeo7AHoQhkFeouS444YA_q4JCTlRI2peWFIuxFlOYyeX9Kzg.html\");var body = document.getElementsByTagName(\"body\")[0];\n                for (var i = 0; i < impTrackers.length; i++) {\n                    var impTracker = impTrackers[i];\n                    var ifr = document.createElement(\"iframe\");\n                    ifr.src = impTracker + (impTracker.match(/\\?/) ? '&' : '?') + 'cb=' + Math.random();\n                    ifr.setAttribute(\"scrolling\", \"no\");\n                    ifr.setAttribute(\"frameborder\", \"0\");\n                    ifr.setAttribute(\"width\", \"1\");\n                    ifr.setAttribute(\"height\", \"1\");\n                    ifr.setAttribute(\"style\", \"position:absolute;top:-10000px;left:-100000px;\");\n                    body.appendChild(ifr);\n                }\n            })();\n            //]]>\n            </script>\n    \n<script>\n//<![CDATA[\n(function() {\n    var matchedAdCount = 1;\n    if (window.adn && adn.inIframe && adn.inIframe.processAdResponse) {\n        return adn.inIframe.processAdResponse({ matchedAdCount: matchedAdCount });\n    }\n    window.adn = window.adn || {};\n    adn.calls = adn.calls || [];\n    adn.calls.push(function() {\n        adn.inIframe.processAdResponse({ matchedAdCount: matchedAdCount });\n    });\n})();\n//]]>\n</script></body>\n</html>",
           'matchedAdCount': 1,
-          'responseId': 'adn-rsp-1460129238',
-          'ads': [
+          'responseId': 'adn-rsp--229633088',
+          'deals': [
             {
-              'destinationUrlEsc': 'https%3A%2F%2Fdelivery.adnuntius.com%2Fc%2F52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN%3Fct%3D2501%26r%3Dhttp%253A%252F%252Fgoogle.com',
+              'destinationUrlEsc': 'http%3A%2F%2Fads.adnuntius.delivery%2Fc%2FyQtMUwYBn5P4v72WJMqLW4z7uJOBFXJTfjoRyz0z_wsAAAAQCtjQz9kbGWD4nuZy3q6HaCYxq6Lckz2kThplNb227EJdQ5032jcIGkf-UrPmXCU2EbXVaQ3Ok6_FNLuIDTONJyx6ZZCB10wGqA3OaSe1EqwQp84u1_5iQZAWDk73UYf7_vcIypn7ev-SICZ3qaevb2jYSRqTVZx6AiBZQQGlzlOOrbZU9AU1F-JwTds-YV3qtJHGlxI2peWFIuxFlOYyeX9Kzg%3Fct%3D673%26r%3Dhttp%253A%252F%252Fadnuntius.com',
               'assets': {
-                'image': {
-                  'cdnId': 'https://assets.adnuntius.com/oEmZa5uYjxENfA1R692FVn6qIveFpO8wUbpyF2xSOCc.jpg',
-                  'width': '980',
-                  'height': '120'
+                'Image': {
+                  'cdnId': 'https://cdn.adnuntius.com/cdn/iBgqruUNbaUb2hmD3vws7WTi84jg_WB_-VOF_FeOZ7A.png',
+                  'width': '640',
+                  'height': '480'
                 }
               },
-              'clickUrl': 'https://delivery.adnuntius.com/c/52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
+              'text': {},
+              'choices': {},
+              'clickUrl': 'https://ads.adnuntius.delivery/c/yQtMUwYBn5P4v72WJMqLW4z7uJOBFXJTfjoRyz0z_wsAAAAQCtjQz9kbGWD4nuZy3q6HaCYxq6Lckz2kThplNb227EJdQ5032jcIGkf-UrPmXCU2EbXVaQ3Ok6_FNLuIDTONJyx6ZZCB10wGqA3OaSe1EqwQp84u1_5iQZAWDk73UYf7_vcIypn7ev-SICZ3qaevb2jYSRqTVZx6AiBZQQGlzlOOrbZU9AU1F-JwTds-YV3qtJHGlxI2peWFIuxFlOYyeX9Kzg',
               'urls': {
-                'destination': 'https://delivery.adnuntius.com/c/52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN?ct=2501&r=http%3A%2F%2Fgoogle.com'
+                'destination': 'https://ads.adnuntius.delivery/c/yQtMUwYBn5P4v72WJMqLW4z7uJOBFXJTfjoRyz0z_wsAAAAQCtjQz9kbGWD4nuZy3q6HaCYxq6Lckz2kThplNb227EJdQ5032jcIGkf-UrPmXCU2EbXVaQ3Ok6_FNLuIDTONJyx6ZZCB10wGqA3OaSe1EqwQp84u1_5iQZAWDk73UYf7_vcIypn7ev-SICZ3qaevb2jYSRqTVZx6AiBZQQGlzlOOrbZU9AU1F-JwTds-YV3qtJHGlxI2peWFIuxFlOYyeX9Kzg?ct=673&r=http%3A%2F%2Fadnuntius.com'
               },
               'urlsEsc': {
-                'destination': 'https%3A%2F%2Fdelivery.adnuntius.com%2Fc%2F52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN%3Fct%3D2501%26r%3Dhttp%253A%252F%252Fgoogle.com'
+                'destination': 'https%3A%2F%2Fads.adnuntius.delivery%2Fc%2FyQtMUwYBn5P4v72WJMqLW4z7uJOBFXJTfjoRyz0z_wsAAAAQCtjQz9kbGWD4nuZy3q6HaCYxq6Lckz2kThplNb227EJdQ5032jcIGkf-UrPmXCU2EbXVaQ3Ok6_FNLuIDTONJyx6ZZCB10wGqA3OaSe1EqwQp84u1_5iQZAWDk73UYf7_vcIypn7ev-SICZ3qaevb2jYSRqTVZx6AiBZQQGlzlOOrbZU9AU1F-JwTds-YV3qtJHGlxI2peWFIuxFlOYyeX9Kzg%3Fct%3D673%26r%3Dhttp%253A%252F%252Fadnuntius.com'
               },
               'destinationUrls': {
-                'destination': 'http://google.com'
+                'destination': 'https://adnuntius.com'
               },
-              'cpm': { 'amount': 5.0, 'currency': 'NOK' },
-              'bid': { 'amount': 0.005, 'currency': 'NOK' },
-              'cost': { 'amount': 0.005, 'currency': 'NOK' },
+              'cpm': {
+                'amount': 9,
+                'currency': 'USD'
+              },
+              'bid': {
+                'amount': 0.009,
+                'currency': 'USD'
+              },
+              'grossBid': {
+                'amount': 0.009,
+                'currency': 'USD'
+              },
+              'netBid': {
+                'amount': 0.0081,
+                'currency': 'USD'
+              },
+              'dealId': 'abc123xyz',
               'impressionTrackingUrls': [],
               'impressionTrackingUrlsEsc': [],
-              'adId': 'adn-id-1347343135',
+              'adId': 'adn-id-1064238860',
               'selectedColumn': '0',
               'selectedColumnPosition': '0',
-              'renderedPixel': 'https://delivery.adnuntius.com/b/52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN.html',
-              'renderedPixelEsc': 'https%3A%2F%2Fdelivery.adnuntius.com%2Fb%2F52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN.html',
-              'visibleUrl': 'https://delivery.adnuntius.com/s?rt=52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
-              'visibleUrlEsc': 'https%3A%2F%2Fdelivery.adnuntius.com%2Fs%3Frt%3D52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
-              'viewUrl': 'https://delivery.adnuntius.com/v?rt=52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
-              'viewUrlEsc': 'https%3A%2F%2Fdelivery.adnuntius.com%2Fv%3Frt%3D52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
-              'rt': '52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
-              'creativeWidth': '980',
-              'creativeHeight': '120',
-              'creativeId': 'wgkq587vgtpchsx1',
-              'lineItemId': 'scyjdyv3mzgdsnpf',
-              'layoutId': 'sw6gtws2rdj1kwby',
-              'layoutName': 'Responsive image'
-            },
-
+              'renderedPixel': 'https://ads.adnuntius.delivery/b/yQtMUwYBn5P4v72WJMqLW4z7uJOBFXJTfjoRyz0z_wsAAAAQCtjQz9kbGWD4nuZy3q6HaCYxq6Lckz2kThplNb227EJdQ5032jcIGkf-UrPmXCU2EbXVaQ3Ok6_FNLuIDTONJyx6ZZCB10wGqA3OaSe1EqwQp84u1_5iQZAWDk73UYf7_vcIypn7ev-SICZ3qaevb2jYSRqTVZx6AiBZQQGlzlOOrbZU9AU1F-JwTds-YV3qtJHGlxI2peWFIuxFlOYyeX9Kzg.html',
+              'renderedPixelEsc': 'http%3A%2F%2Fads.adnuntius.delivery%2Fb%2FyQtMUwYBn5P4v72WJMqLW4z7uJOBFXJTfjoRyz0z_wsAAAAQCtjQz9kbGWD4nuZy3q6HaCYxq6Lckz2kThplNb227EJdQ5032jcIGkf-UrPmXCU2EbXVaQ3Ok6_FNLuIDTONJyx6ZZCB10wGqA3OaSe1EqwQp84u1_5iQZAWDk73UYf7_vcIypn7ev-SICZ3qaevb2jYSRqTVZx6AiBZQQGlzlOOrbZU9AU1F-JwTds-YV3qtJHGlxI2peWFIuxFlOYyeX9Kzg.html',
+              'visibleUrl': 'https://ads.adnuntius.delivery/s?rt=yQtMUwYBn5P4v72WJMqLW4z7uJOBFXJTfjoRyz0z_wsAAAAQCtjQz9kbGWD4nuZy3q6HaCYxq6Lckz2kThplNb227EJdQ5032jcIGkf-UrPmXCU2EbXVaQ3Ok6_FNLuIDTONJyx6ZZCB10wGqA3OaSe1EqwQp84u1_5iQZAWDk73UYf7_vcIypn7ev-SICZ3qaevb2jYSRqTVZx6AiBZQQGlzlOOrbZU9AU1F-JwTds-YV3qtJHGlxI2peWFIuxFlOYyeX9Kzg',
+              'visibleUrlEsc': 'http%3A%2F%2Fads.adnuntius.delivery%2Fs%3Frt%3DyQtMUwYBn5P4v72WJMqLW4z7uJOBFXJTfjoRyz0z_wsAAAAQCtjQz9kbGWD4nuZy3q6HaCYxq6Lckz2kThplNb227EJdQ5032jcIGkf-UrPmXCU2EbXVaQ3Ok6_FNLuIDTONJyx6ZZCB10wGqA3OaSe1EqwQp84u1_5iQZAWDk73UYf7_vcIypn7ev-SICZ3qaevb2jYSRqTVZx6AiBZQQGlzlOOrbZU9AU1F-JwTds-YV3qtJHGlxI2peWFIuxFlOYyeX9Kzg',
+              'viewUrl': 'https://ads.adnuntius.delivery/v?rt=yQtMUwYBn5P4v72WJMqLW4z7uJOBFXJTfjoRyz0z_wsAAAAQCtjQz9kbGWD4nuZy3q6HaCYxq6Lckz2kThplNb227EJdQ5032jcIGkf-UrPmXCU2EbXVaQ3Ok6_FNLuIDTONJyx6ZZCB10wGqA3OaSe1EqwQp84u1_5iQZAWDk73UYf7_vcIypn7ev-SICZ3qaevb2jYSRqTVZx6AiBZQQGlzlOOrbZU9AU1F-JwTds-YV3qtJHGlxI2peWFIuxFlOYyeX9Kzg',
+              'viewUrlEsc': 'http%3A%2F%2Fads.adnuntius.delivery%2Fv%3Frt%3DyQtMUwYBn5P4v72WJMqLW4z7uJOBFXJTfjoRyz0z_wsAAAAQCtjQz9kbGWD4nuZy3q6HaCYxq6Lckz2kThplNb227EJdQ5032jcIGkf-UrPmXCU2EbXVaQ3Ok6_FNLuIDTONJyx6ZZCB10wGqA3OaSe1EqwQp84u1_5iQZAWDk73UYf7_vcIypn7ev-SICZ3qaevb2jYSRqTVZx6AiBZQQGlzlOOrbZU9AU1F-JwTds-YV3qtJHGlxI2peWFIuxFlOYyeX9Kzg',
+              'rt': 'yQtMUwYBn5P4v72WJMqLW4z7uJOBFXJTfjoRyz0z_wsAAAAQCtjQz9kbGWD4nuZy3q6HaCYxq6Lckz2kThplNb227EJdQ5032jcIGkf-UrPmXCU2EbXVaQ3Ok6_FNLuIDTONJyx6ZZCB10wGqA3OaSe1EqwQp84u1_5iQZAWDk73UYf7_vcIypn7ev-SICZ3qaevb2jYSRqTVZx6AiBZQQGlzlOOrbZU9AU1F-JwTds-YV3qtJHGlxI2peWFIuxFlOYyeX9Kzg',
+              'creativeWidth': '640',
+              'creativeHeight': '480',
+              'creativeId': 's90t0q03pm',
+              'lineItemId': 'cr3hnkkxhnkw9ldy',
+              'layoutId': 'buyers_network_image_layout_1',
+              'layoutName': 'Image',
+              'layoutExternalReference': '',
+              'html': "<!DOCTYPE html>\n<html>\n<head>\n    <meta charset=\"utf-8\">\n    <style media=\"all\">\n        html, body, .responseCtr {\n            margin: 0;\n            padding: 0;\n            outline: 0;\n            border: 0;\n            overflow: hidden;\n        }\n\n        .responseCtr {\n            display: inline-block;\n            line-height: 0;\n            vertical-align: top;\n        }\n\n        .responseCtr a {\n            line-height: 0;\n        }\n\n        .responseCtr *, .responseCtr a * {\n            line-height: normal;\n        }\n\n        .responseCtr .contentWrapperPerItem {\n            margin: 0;\n            padding: 0;\n            outline: 0;\n            border: 0;\n            display: inline-block;\n            line-height: 0;\n            vertical-align: top;\n        }\n\n        a img {\n            border: none;\n            outline: none;\n        }\n\n        img {\n            margin: 0;\n            padding: 0;\n        }\n\n        /* need this displayNone class to ensure images are preloaded for smooth transition */\n        img.displayNone {\n            position: absolute;\n            top: -99999px;\n            left: -99999px;\n        }\n\n        .contentWrapperTrailer {\n            clear: both;\n        }\n    </style>\n    <script src=\"https://cdn.adnuntius.com/adn.js\"></script>\n</head>\n<body>\n<div id=\"adn-rsp--91674201\" class=\"responseCtr\">\n<div class=\"contentWrapperPerItem\" id=\"adn-id-1064238860\" data-line-item-id=\"cr3hnkkxhnkw9ldy\" data-creative-id=\"s90t0q03pm\" data-creative-width=\"100\" data-creative-height=\"30\" data-response-token=\"yQtMUwYBn5P4v72WJMqLW4z7uJOBFXJTfjoRyz0z_wsAAAAQCtjQz9kbGWD4nuZy3q6HaCYxq6Lckz2kThplNb227EJdQ5032jcIGkf-UrPmXCU2EbXVaQ3Ok6_FNLuIDTONJyx6ZZCB10wGqA3OaSe1EqwQp84u1_5iQZAWDk73UYf7_vcIypn7ev-SICZ3qaevb2jYSRqTVZx6AiBZQQGlzlOOrbZU9AU1F-JwTds-YV3qtJHGlxI2peWFIuxFlOYyeX9Kzg\"><a rel=\"nofollow\" target=\"_top\" href=\"https://ads.adnuntius.delivery/c/yQtMUwYBn5P4v72WJMqLW4z7uJOBFXJTfjoRyz0z_wsAAAAQCtjQz9kbGWD4nuZy3q6HaCYxq6Lckz2kThplNb227EJdQ5032jcIGkf-UrPmXCU2EbXVaQ3Ok6_FNLuIDTONJyx6ZZCB10wGqA3OaSe1EqwQp84u1_5iQZAWDk73UYf7_vcIypn7ev-SICZ3qaevb2jYSRqTVZx6AiBZQQGlzlOOrbZU9AU1F-JwTds-YV3qtJHGlxI2peWFIuxFlOYyeX9Kzg?ct=673&r=http%3A%2F%2Fadnuntius.com\"><img src=\"https://cdn.adnuntius.com/cdn/iBgqruUNbaUb2hmD3vws7WTi84jg_WB_-VOF_FeOZ7A.png\" width=\"728\" height=\"90\" alt=\"\"/></a><div class=\"contentWrapperTrailer\"></div></div>\n</div><script>\n            //<![CDATA[\n            (function() {\n                var impTrackers = [];impTrackers.push(\"https://ads.adnuntius.delivery/b/yQtMUwYBn5P4v72WJMqLW4z7uJOBFXJTfjoRyz0z_wsAAAAQCtjQz9kbGWD4nuZy3q6HaCYxq6Lckz2kThplNb227EJdQ5032jcIGkf-UrPmXCU2EbXVaQ3Ok6_FNLuIDTONJyx6ZZCB10wGqA3OaSe1EqwQp84u1_5iQZAWDk73UYf7_vcIypn7ev-SICZ3qaevb2jYSRqTVZx6AiBZQQGlzlOOrbZU9AU1F-JwTds-YV3qtJHGlxI2peWFIuxFlOYyeX9Kzg.html\");var body = document.getElementsByTagName(\"body\")[0];\n                for (var i = 0; i < impTrackers.length; i++) {\n                    var impTracker = impTrackers[i];\n                    var ifr = document.createElement(\"iframe\");\n                    ifr.src = impTracker + (impTracker.match(/\\?/) ? '&' : '?') + 'cb=' + Math.random();\n                    ifr.setAttribute(\"scrolling\", \"no\");\n                    ifr.setAttribute(\"frameborder\", \"0\");\n                    ifr.setAttribute(\"width\", \"1\");\n                    ifr.setAttribute(\"height\", \"1\");\n                    ifr.setAttribute(\"style\", \"position:absolute;top:-10000px;left:-100000px;\");\n                    body.appendChild(ifr);\n                }\n            })();\n            //]]>\n            </script>\n    \n<script>\n//<![CDATA[\n(function() {\n    var matchedAdCount = 1;\n    if (window.adn && adn.inIframe && adn.inIframe.processAdResponse) {\n        return adn.inIframe.processAdResponse({ matchedAdCount: matchedAdCount });\n    }\n    window.adn = window.adn || {};\n    adn.calls = adn.calls || [];\n    adn.calls.push(function() {\n        adn.inIframe.processAdResponse({ matchedAdCount: matchedAdCount });\n    });\n})();\n//]]>\n</script></body>\n</html>",
+              'renderTemplate': '<a rel="nofollow" target="_top" href="{{{urls.destination.url}}}"><img src="{{{assets.Image.cdnId}}}" width="{{assets.Image.width}}" height="{{assets.Image.height}}" alt=""/></a>'
+            }
+          ],
+          'ads': [
+            {
+              'destinationUrlEsc': 'http%3A%2F%2Fads.adnuntius.delivery%2Fc%2F5Mu-vFVsaf4dWWx8uyZoV7Mz0sPkF1_j9bSupMwX8dMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxqqTYxj2sS0FkMriztxcORshj3zRbT0KsV7XnDXE0F-OsHX7Ok6_FNLuIDTOMJyx6ZZCB10wGqA3OaSe1Eq9D85h8gP1gGsobC0KsAISm_PYNkJ6ve6qZLnB79fX6XHLYSRqTBM8sBCRXQAetnVzeo7AHoQhkFeouS444YA_q4JCTlRI2peWFIuxFlOYyeX9Kzg%3Fct%3D673%26r%3Dhttp%253A%252F%252Fadnuntius.com',
+              'assets': {
+                'Image': {
+                  'cdnId': 'https://cdn.adnuntius.com/cdn/iBgqruUNbaUb2hmD3vws7WTi84jg_WB_-VOF_FeOZ7A.png',
+                  'width': '640',
+                  'height': '480'
+                }
+              },
+              'text': {},
+              'choices': {},
+              'clickUrl': 'https://ads.adnuntius.delivery/c/5Mu-vFVsaf4dWWx8uyZoV7Mz0sPkF1_j9bSupMwX8dMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxqqTYxj2sS0FkMriztxcORshj3zRbT0KsV7XnDXE0F-OsHX7Ok6_FNLuIDTOMJyx6ZZCB10wGqA3OaSe1Eq9D85h8gP1gGsobC0KsAISm_PYNkJ6ve6qZLnB79fX6XHLYSRqTBM8sBCRXQAetnVzeo7AHoQhkFeouS444YA_q4JCTlRI2peWFIuxFlOYyeX9Kzg',
+              'urls': {
+                'destination': 'https://ads.adnuntius.delivery/c/5Mu-vFVsaf4dWWx8uyZoV7Mz0sPkF1_j9bSupMwX8dMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxqqTYxj2sS0FkMriztxcORshj3zRbT0KsV7XnDXE0F-OsHX7Ok6_FNLuIDTOMJyx6ZZCB10wGqA3OaSe1Eq9D85h8gP1gGsobC0KsAISm_PYNkJ6ve6qZLnB79fX6XHLYSRqTBM8sBCRXQAetnVzeo7AHoQhkFeouS444YA_q4JCTlRI2peWFIuxFlOYyeX9Kzg?ct=673&r=http%3A%2F%2Fadnuntius.com'
+              },
+              'urlsEsc': {
+                'destination': 'http%3A%2F%2Fads.adnuntius.delivery%2Fc%2F5Mu-vFVsaf4dWWx8uyZoV7Mz0sPkF1_j9bSupMwX8dMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxqqTYxj2sS0FkMriztxcORshj3zRbT0KsV7XnDXE0F-OsHX7Ok6_FNLuIDTOMJyx6ZZCB10wGqA3OaSe1Eq9D85h8gP1gGsobC0KsAISm_PYNkJ6ve6qZLnB79fX6XHLYSRqTBM8sBCRXQAetnVzeo7AHoQhkFeouS444YA_q4JCTlRI2peWFIuxFlOYyeX9Kzg%3Fct%3D673%26r%3Dhttp%253A%252F%252Fadnuntius.com'
+              },
+              'destinationUrls': {
+                'destination': 'https://adnuntius.com'
+              },
+              'cpm': {
+                'amount': 9,
+                'currency': 'USD'
+              },
+              'bid': {
+                'amount': 0.009,
+                'currency': 'USD'
+              },
+              'grossBid': {
+                'amount': 0.009,
+                'currency': 'USD'
+              },
+              'netBid': {
+                'amount': 0.0081,
+                'currency': 'USD'
+              },
+              'dealId': 'abc123xyz',
+              'impressionTrackingUrls': [],
+              'impressionTrackingUrlsEsc': [],
+              'adId': 'adn-id-1488629603',
+              'selectedColumn': '0',
+              'selectedColumnPosition': '0',
+              'renderedPixel': 'https://ads.adnuntius.delivery/b/5Mu-vFVsaf4dWWx8uyZoV7Mz0sPkF1_j9bSupMwX8dMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxqqTYxj2sS0FkMriztxcORshj3zRbT0KsV7XnDXE0F-OsHX7Ok6_FNLuIDTOMJyx6ZZCB10wGqA3OaSe1Eq9D85h8gP1gGsobC0KsAISm_PYNkJ6ve6qZLnB79fX6XHLYSRqTBM8sBCRXQAetnVzeo7AHoQhkFeouS444YA_q4JCTlRI2peWFIuxFlOYyeX9Kzg.html',
+              'renderedPixelEsc': 'http%3A%2F%2Fads.adnuntius.delivery%2Fb%2F5Mu-vFVsaf4dWWx8uyZoV7Mz0sPkF1_j9bSupMwX8dMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxqqTYxj2sS0FkMriztxcORshj3zRbT0KsV7XnDXE0F-OsHX7Ok6_FNLuIDTOMJyx6ZZCB10wGqA3OaSe1Eq9D85h8gP1gGsobC0KsAISm_PYNkJ6ve6qZLnB79fX6XHLYSRqTBM8sBCRXQAetnVzeo7AHoQhkFeouS444YA_q4JCTlRI2peWFIuxFlOYyeX9Kzg.html',
+              'visibleUrl': 'https://ads.adnuntius.delivery/s?rt=5Mu-vFVsaf4dWWx8uyZoV7Mz0sPkF1_j9bSupMwX8dMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxqqTYxj2sS0FkMriztxcORshj3zRbT0KsV7XnDXE0F-OsHX7Ok6_FNLuIDTOMJyx6ZZCB10wGqA3OaSe1Eq9D85h8gP1gGsobC0KsAISm_PYNkJ6ve6qZLnB79fX6XHLYSRqTBM8sBCRXQAetnVzeo7AHoQhkFeouS444YA_q4JCTlRI2peWFIuxFlOYyeX9Kzg',
+              'visibleUrlEsc': 'http%3A%2F%2Fads.adnuntius.delivery%2Fs%3Frt%3D5Mu-vFVsaf4dWWx8uyZoV7Mz0sPkF1_j9bSupMwX8dMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxqqTYxj2sS0FkMriztxcORshj3zRbT0KsV7XnDXE0F-OsHX7Ok6_FNLuIDTOMJyx6ZZCB10wGqA3OaSe1Eq9D85h8gP1gGsobC0KsAISm_PYNkJ6ve6qZLnB79fX6XHLYSRqTBM8sBCRXQAetnVzeo7AHoQhkFeouS444YA_q4JCTlRI2peWFIuxFlOYyeX9Kzg',
+              'viewUrl': 'https://ads.adnuntius.delivery/v?rt=5Mu-vFVsaf4dWWx8uyZoV7Mz0sPkF1_j9bSupMwX8dMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxqqTYxj2sS0FkMriztxcORshj3zRbT0KsV7XnDXE0F-OsHX7Ok6_FNLuIDTOMJyx6ZZCB10wGqA3OaSe1Eq9D85h8gP1gGsobC0KsAISm_PYNkJ6ve6qZLnB79fX6XHLYSRqTBM8sBCRXQAetnVzeo7AHoQhkFeouS444YA_q4JCTlRI2peWFIuxFlOYyeX9Kzg',
+              'viewUrlEsc': 'http%3A%2F%2Fads.adnuntius.delivery%2Fv%3Frt%3D5Mu-vFVsaf4dWWx8uyZoV7Mz0sPkF1_j9bSupMwX8dMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxqqTYxj2sS0FkMriztxcORshj3zRbT0KsV7XnDXE0F-OsHX7Ok6_FNLuIDTOMJyx6ZZCB10wGqA3OaSe1Eq9D85h8gP1gGsobC0KsAISm_PYNkJ6ve6qZLnB79fX6XHLYSRqTBM8sBCRXQAetnVzeo7AHoQhkFeouS444YA_q4JCTlRI2peWFIuxFlOYyeX9Kzg',
+              'rt': '5Mu-vFVsaf4dWWx8uyZoV7Mz0sPkF1_j9bSupMwX8dMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxqqTYxj2sS0FkMriztxcORshj3zRbT0KsV7XnDXE0F-OsHX7Ok6_FNLuIDTOMJyx6ZZCB10wGqA3OaSe1Eq9D85h8gP1gGsobC0KsAISm_PYNkJ6ve6qZLnB79fX6XHLYSRqTBM8sBCRXQAetnVzeo7AHoQhkFeouS444YA_q4JCTlRI2peWFIuxFlOYyeX9Kzg',
+              'creativeWidth': '640',
+              'creativeHeight': '480',
+              'creativeId': 's90t0q03pm',
+              'lineItemId': 'cr3hnkkxhnkw9ldy',
+              'layoutId': 'buyers_network_image_layout_1',
+              'layoutName': 'Image',
+              'layoutExternalReference': '',
+              'html': '<a rel="nofollow" target="_top" href="https://ads.adnuntius.delivery/c/5Mu-vFVsaf4dWWx8uyZoV7Mz0sPkF1_j9bSupMwX8dMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxqqTYxj2sS0FkMriztxcORshj3zRbT0KsV7XnDXE0F-OsHX7Ok6_FNLuIDTOMJyx6ZZCB10wGqA3OaSe1Eq9D85h8gP1gGsobC0KsAISm_PYNkJ6ve6qZLnB79fX6XHLYSRqTBM8sBCRXQAetnVzeo7AHoQhkFeouS444YA_q4JCTlRI2peWFIuxFlOYyeX9Kzg?ct=673&r=http%3A%2F%2Fadnuntius.com"><img src="https://cdn.adnuntius.com/cdn/iBgqruUNbaUb2hmD3vws7WTi84jg_WB_-VOF_FeOZ7A.png" width="728" height="90" alt=""/></a>',
+              'renderTemplate': '<a rel="nofollow" target="_top" href="{{{urls.destination.url}}}"><img src="{{{assets.Image.cdnId}}}" width="{{assets.Image.width}}" height="{{assets.Image.height}}" alt=""/></a>'
+            }
           ]
         },
         {
           'auId': '000000000008b6bc',
-          'targetId': '456',
+          'targetId': 'adn-000000000008b6bc',
           'matchedAdCount': 0,
           'responseId': 'adn-rsp-1460129238',
         }
-      ]
+      ],
+      'metaData': {
+        'usi': 'from-api-server dude',
+        'voidAuIds': '00000000000abcde;00000000000fffff',
+        'randomApiKey': 'randomApiValue'
+      }
     }
   }
   const serverVideoResponse = {
     body: {
       'adUnits': [
         {
-          'auId': '000000000008b6bc',
-          'targetId': '123',
-          'html': '<h1>hi!</h1>',
+          'auId': '0000000000000551',
+          'targetId': 'adn-0000000000000551',
+          'vastXml': '<VAST version=\\"3.0\\">\\n<Ad id=\\"adn-id-500662301\\">\\n    <InLine>\\n        <AdSystem>Adnuntius</AdSystem>\\n        <AdTitle>adn-id-500662301</AdTitle>\\n        <Impression></Impression>\\n        <Creatives>\\n            <Creative>\\n                <Linear>\\n                    <Duration>00:00:15</Duration>\\n                    <TrackingEvents>\\n                        <Tracking event=\\"creativeView\\"><![CDATA[http://localhost:8078/b/ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX.html]]></Tracking>\\n                        <Tracking event=\\"start\\"><![CDATA[http://localhost:8078/s?rt=ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX]]></Tracking>\\n                        <Tracking event=\\"firstQuartile\\"><![CDATA[https://localhost:8078/u?rt=ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX&customType=whatevs]]></Tracking>\\n                        <Tracking event=\\"midpoint\\"><![CDATA[http://localhost:8078/v?rt=ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX]]></Tracking>\\n                        <Tracking event=\\"thirdQuartile\\"><![CDATA[https://localhost:8078/u?rt=ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX&customType=whatevs]]></Tracking>\\n                        <Tracking event=\\"complete\\"><![CDATA[https://localhost:8078/u?rt=ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX&customType=whatevs]]></Tracking>\\n                    </TrackingEvents>\\n                    <VideoClicks>\\n                        <ClickThrough><![CDATA[http://adnuntius.com]]></ClickThrough>\\n                        <ClickTracking><![CDATA[http://localhost:8078/c/ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX]]></ClickTracking>\\n                    </VideoClicks>\\n                    <MediaFiles>\\n                        <MediaFile delivery=\\"progressive\\" type=\\"video/mp4\\" bitrate=\\"92421\\" width=\\"1920\\" height=\\"1080\\" scalable=\\"true\\" maintainAspectRatio=\\"true\\">\\n                            <![CDATA[http://localhost:8079/cdn/9urJusYWpjFDLcpOwfejrkWlLP1heM3vWIJjuHk48BQ.mp4]]>\\n                        </MediaFile>\\n                    </MediaFiles>\\n                </Linear>\\n            </Creative>\\n        </Creatives>\\n    </InLine>\\n</Ad>\\n</VAST>',
           'matchedAdCount': 1,
-          'responseId': 'adn-rsp-1460129238',
-          'ads': [
+          'responseId': '',
+          'deals': [
             {
-              'destinationUrlEsc': 'https%3A%2F%2Fdelivery.adnuntius.com%2Fc%2F52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN%3Fct%3D2501%26r%3Dhttp%253A%252F%252Fgoogle.com',
+              'destinationUrlEsc': '',
               'assets': {
-                'image': {
-                  'cdnId': 'https://assets.adnuntius.com/oEmZa5uYjxENfA1R692FVn6qIveFpO8wUbpyF2xSOCc.jpg',
-                  'width': '980',
-                  'height': '120'
+                'Video': {
+                  'cdnId': 'http://localhost:8079/cdn/9urJusYWpjFDLcpOwfejrkWlLP1heM3vWIJjuHk48BQ.mp4',
+                  'width': '1920',
+                  'height': '1080'
                 }
               },
-              'clickUrl': 'https://delivery.adnuntius.com/c/52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
+              'text': {
+                'thirdQuartile': {
+                  'content': 'whatevs',
+                  'length': '7',
+                  'minLength': '1',
+                  'maxLength': '64'
+                },
+                'complete': {
+                  'content': 'whatevs',
+                  'length': '7',
+                  'minLength': '1',
+                  'maxLength': '64'
+                },
+                'firstQuartile': {
+                  'content': 'whatevs',
+                  'length': '7',
+                  'minLength': '1',
+                  'maxLength': '64'
+                }
+              },
+              'choices': {},
+              'clickUrl': 'http://localhost:8078/c/7MRhdEcIndSrWxWhFtMVVnDULl8BOwEaV6vi9558AbYAAAAQCtjQz9kbGWD4nuZy3q6HaCYx_6vZlT33ShgzYb616hZZSpoy2jkAHkGrB-XmXyJmEOCSQ0PLk6_FNLuCBzONJyx6ZZCB10wGqA3OaSe1EqMWoJp41f83FcJLX0SpBoT1-qBbx5_8La-ULiAnqaGtMRDYSRqTBZh5DCANFQWnm1fa8rEE9VRgRORwTNxvZFjq5JCSkEQ2peWFIuxFlOYyeX9Kzg',
               'urls': {
-                'destination': 'https://delivery.adnuntius.com/c/52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN?ct=2501&r=http%3A%2F%2Fgoogle.com'
+                'destinationUrl': 'http://localhost:8078/c/7MRhdEcIndSrWxWhFtMVVnDULl8BOwEaV6vi9558AbYAAAAQCtjQz9kbGWD4nuZy3q6HaCYx_6vZlT33ShgzYb616hZZSpoy2jkAHkGrB-XmXyJmEOCSQ0PLk6_FNLuCBzONJyx6ZZCB10wGqA3OaSe1EqMWoJp41f83FcJLX0SpBoT1-qBbx5_8La-ULiAnqaGtMRDYSRqTBZh5DCANFQWnm1fa8rEE9VRgRORwTNxvZFjq5JCSkEQ2peWFIuxFlOYyeX9Kzg?ct=682&r=http%3A%2F%2Fadnuntius.com'
               },
               'urlsEsc': {
-                'destination': 'https%3A%2F%2Fdelivery.adnuntius.com%2Fc%2F52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN%3Fct%3D2501%26r%3Dhttp%253A%252F%252Fgoogle.com'
+                'destinationUrl': 'http%3A%2F%2Flocalhost%3A8078%2Fc%2F7MRhdEcIndSrWxWhFtMVVnDULl8BOwEaV6vi9558AbYAAAAQCtjQz9kbGWD4nuZy3q6HaCYx_6vZlT33ShgzYb616hZZSpoy2jkAHkGrB-XmXyJmEOCSQ0PLk6_FNLuCBzONJyx6ZZCB10wGqA3OaSe1EqMWoJp41f83FcJLX0SpBoT1-qBbx5_8La-ULiAnqaGtMRDYSRqTBZh5DCANFQWnm1fa8rEE9VRgRORwTNxvZFjq5JCSkEQ2peWFIuxFlOYyeX9Kzg%3Fct%3D682%26r%3Dhttp%253A%252F%252Fadnuntius.com'
               },
               'destinationUrls': {
-                'destination': 'http://google.com'
+                'destinationUrl': 'http://adnuntius.com'
               },
-              'cpm': { 'amount': 5.0, 'currency': 'NOK' },
-              'bid': { 'amount': 0.005, 'currency': 'NOK' },
-              'cost': { 'amount': 0.005, 'currency': 'NOK' },
+              'cpm': {
+                'amount': 9,
+                'currency': 'USD'
+              },
+              'bid': {
+                'amount': 0.009,
+                'currency': 'USD'
+              },
+              'grossBid': {
+                'amount': 0.009,
+                'currency': 'USD'
+              },
+              'netBid': {
+                'amount': 0.0081,
+                'currency': 'USD'
+              },
+              'dealId': 'abc123xyz',
               'impressionTrackingUrls': [],
               'impressionTrackingUrlsEsc': [],
-              'adId': 'adn-id-1347343135',
+              'adId': 'adn-id-1465065992',
               'selectedColumn': '0',
               'selectedColumnPosition': '0',
-              'renderedPixel': 'https://delivery.adnuntius.com/b/52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN.html',
-              'renderedPixelEsc': 'https%3A%2F%2Fdelivery.adnuntius.com%2Fb%2F52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN.html',
-              'visibleUrl': 'https://delivery.adnuntius.com/s?rt=52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
-              'visibleUrlEsc': 'https%3A%2F%2Fdelivery.adnuntius.com%2Fs%3Frt%3D52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
-              'viewUrl': 'https://delivery.adnuntius.com/v?rt=52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
-              'viewUrlEsc': 'https%3A%2F%2Fdelivery.adnuntius.com%2Fv%3Frt%3D52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
-              'rt': '52AHNuxCqxB_Y9ZP9ERWkMBPCOha4zuV3aKn5cog5jsAAAAQCtjQz9kbGWD4nuZy3q6HaHGLB4-k_fySWECIOOmHKY6iokgHNFH-U57ew_-1QHlKnFr2NT8y4QK1oU5HxnDLbYPz-GmQ3C2JyxLGpKmIb-P-3bm7HYPEreNjPdhjRG51A8NGuc4huUhns7nEUejHuOjOHE5sV1zfYxCRWRx9wPDN9EUCC7KN',
-              'creativeWidth': '980',
-              'creativeHeight': '120',
-              'creativeId': 'wgkq587vgtpchsx1',
-              'lineItemId': 'scyjdyv3mzgdsnpf',
-              'layoutId': 'sw6gtws2rdj1kwby',
-              'layoutName': 'Responsive image'
-            },
-
+              'renderedPixel': 'http://localhost:8078/b/7MRhdEcIndSrWxWhFtMVVnDULl8BOwEaV6vi9558AbYAAAAQCtjQz9kbGWD4nuZy3q6HaCYx_6vZlT33ShgzYb616hZZSpoy2jkAHkGrB-XmXyJmEOCSQ0PLk6_FNLuCBzONJyx6ZZCB10wGqA3OaSe1EqMWoJp41f83FcJLX0SpBoT1-qBbx5_8La-ULiAnqaGtMRDYSRqTBZh5DCANFQWnm1fa8rEE9VRgRORwTNxvZFjq5JCSkEQ2peWFIuxFlOYyeX9Kzg.html',
+              'renderedPixelEsc': 'http%3A%2F%2Flocalhost%3A8078%2Fb%2F7MRhdEcIndSrWxWhFtMVVnDULl8BOwEaV6vi9558AbYAAAAQCtjQz9kbGWD4nuZy3q6HaCYx_6vZlT33ShgzYb616hZZSpoy2jkAHkGrB-XmXyJmEOCSQ0PLk6_FNLuCBzONJyx6ZZCB10wGqA3OaSe1EqMWoJp41f83FcJLX0SpBoT1-qBbx5_8La-ULiAnqaGtMRDYSRqTBZh5DCANFQWnm1fa8rEE9VRgRORwTNxvZFjq5JCSkEQ2peWFIuxFlOYyeX9Kzg.html',
+              'visibleUrl': 'http://localhost:8078/s?rt=7MRhdEcIndSrWxWhFtMVVnDULl8BOwEaV6vi9558AbYAAAAQCtjQz9kbGWD4nuZy3q6HaCYx_6vZlT33ShgzYb616hZZSpoy2jkAHkGrB-XmXyJmEOCSQ0PLk6_FNLuCBzONJyx6ZZCB10wGqA3OaSe1EqMWoJp41f83FcJLX0SpBoT1-qBbx5_8La-ULiAnqaGtMRDYSRqTBZh5DCANFQWnm1fa8rEE9VRgRORwTNxvZFjq5JCSkEQ2peWFIuxFlOYyeX9Kzg',
+              'visibleUrlEsc': 'http%3A%2F%2Flocalhost%3A8078%2Fs%3Frt%3D7MRhdEcIndSrWxWhFtMVVnDULl8BOwEaV6vi9558AbYAAAAQCtjQz9kbGWD4nuZy3q6HaCYx_6vZlT33ShgzYb616hZZSpoy2jkAHkGrB-XmXyJmEOCSQ0PLk6_FNLuCBzONJyx6ZZCB10wGqA3OaSe1EqMWoJp41f83FcJLX0SpBoT1-qBbx5_8La-ULiAnqaGtMRDYSRqTBZh5DCANFQWnm1fa8rEE9VRgRORwTNxvZFjq5JCSkEQ2peWFIuxFlOYyeX9Kzg',
+              'viewUrl': 'http://localhost:8078/v?rt=7MRhdEcIndSrWxWhFtMVVnDULl8BOwEaV6vi9558AbYAAAAQCtjQz9kbGWD4nuZy3q6HaCYx_6vZlT33ShgzYb616hZZSpoy2jkAHkGrB-XmXyJmEOCSQ0PLk6_FNLuCBzONJyx6ZZCB10wGqA3OaSe1EqMWoJp41f83FcJLX0SpBoT1-qBbx5_8La-ULiAnqaGtMRDYSRqTBZh5DCANFQWnm1fa8rEE9VRgRORwTNxvZFjq5JCSkEQ2peWFIuxFlOYyeX9Kzg',
+              'viewUrlEsc': 'http%3A%2F%2Flocalhost%3A8078%2Fv%3Frt%3D7MRhdEcIndSrWxWhFtMVVnDULl8BOwEaV6vi9558AbYAAAAQCtjQz9kbGWD4nuZy3q6HaCYx_6vZlT33ShgzYb616hZZSpoy2jkAHkGrB-XmXyJmEOCSQ0PLk6_FNLuCBzONJyx6ZZCB10wGqA3OaSe1EqMWoJp41f83FcJLX0SpBoT1-qBbx5_8La-ULiAnqaGtMRDYSRqTBZh5DCANFQWnm1fa8rEE9VRgRORwTNxvZFjq5JCSkEQ2peWFIuxFlOYyeX9Kzg',
+              'rt': '7MRhdEcIndSrWxWhFtMVVnDULl8BOwEaV6vi9558AbYAAAAQCtjQz9kbGWD4nuZy3q6HaCYx_6vZlT33ShgzYb616hZZSpoy2jkAHkGrB-XmXyJmEOCSQ0PLk6_FNLuCBzONJyx6ZZCB10wGqA3OaSe1EqMWoJp41f83FcJLX0SpBoT1-qBbx5_8La-ULiAnqaGtMRDYSRqTBZh5DCANFQWnm1fa8rEE9VRgRORwTNxvZFjq5JCSkEQ2peWFIuxFlOYyeX9Kzg',
+              'creativeWidth': '640',
+              'creativeHeight': '480',
+              'creativeId': 'p6sqtvcgxczy258j',
+              'lineItemId': 'cr3hnkkxhnkw9ldy',
+              'layoutId': 'buyers_networkvast_single_format_layout',
+              'layoutName': 'Vast (video upload)',
+              'layoutExternalReference': '',
+              'vastXml': '<VAST version="3.0">\n<Ad id="adn-id-1465065992">\n    <InLine>\n        <AdSystem>Adnuntius</AdSystem>\n        <AdTitle>adn-id-1465065992</AdTitle>\n        <Impression></Impression>\n        <Creatives>\n            <Creative>\n                <Linear>\n                    <Duration>00:00:15</Duration>\n                    <TrackingEvents>\n                        <Tracking event="creativeView"><![CDATA[http://localhost:8078/b/7MRhdEcIndSrWxWhFtMVVnDULl8BOwEaV6vi9558AbYAAAAQCtjQz9kbGWD4nuZy3q6HaCYx_6vZlT33ShgzYb616hZZSpoy2jkAHkGrB-XmXyJmEOCSQ0PLk6_FNLuCBzONJyx6ZZCB10wGqA3OaSe1EqMWoJp41f83FcJLX0SpBoT1-qBbx5_8La-ULiAnqaGtMRDYSRqTBZh5DCANFQWnm1fa8rEE9VRgRORwTNxvZFjq5JCSkEQ2peWFIuxFlOYyeX9Kzg.html]]></Tracking>\n                        <Tracking event="start"><![CDATA[http://localhost:8078/s?rt=7MRhdEcIndSrWxWhFtMVVnDULl8BOwEaV6vi9558AbYAAAAQCtjQz9kbGWD4nuZy3q6HaCYx_6vZlT33ShgzYb616hZZSpoy2jkAHkGrB-XmXyJmEOCSQ0PLk6_FNLuCBzONJyx6ZZCB10wGqA3OaSe1EqMWoJp41f83FcJLX0SpBoT1-qBbx5_8La-ULiAnqaGtMRDYSRqTBZh5DCANFQWnm1fa8rEE9VRgRORwTNxvZFjq5JCSkEQ2peWFIuxFlOYyeX9Kzg]]></Tracking>\n                        <Tracking event="firstQuartile"><![CDATA[https://localhost:8078/u?rt=7MRhdEcIndSrWxWhFtMVVnDULl8BOwEaV6vi9558AbYAAAAQCtjQz9kbGWD4nuZy3q6HaCYx_6vZlT33ShgzYb616hZZSpoy2jkAHkGrB-XmXyJmEOCSQ0PLk6_FNLuCBzONJyx6ZZCB10wGqA3OaSe1EqMWoJp41f83FcJLX0SpBoT1-qBbx5_8La-ULiAnqaGtMRDYSRqTBZh5DCANFQWnm1fa8rEE9VRgRORwTNxvZFjq5JCSkEQ2peWFIuxFlOYyeX9Kzg&customType=whatevs]]></Tracking>\n                        <Tracking event="midpoint"><![CDATA[http://localhost:8078/v?rt=7MRhdEcIndSrWxWhFtMVVnDULl8BOwEaV6vi9558AbYAAAAQCtjQz9kbGWD4nuZy3q6HaCYx_6vZlT33ShgzYb616hZZSpoy2jkAHkGrB-XmXyJmEOCSQ0PLk6_FNLuCBzONJyx6ZZCB10wGqA3OaSe1EqMWoJp41f83FcJLX0SpBoT1-qBbx5_8La-ULiAnqaGtMRDYSRqTBZh5DCANFQWnm1fa8rEE9VRgRORwTNxvZFjq5JCSkEQ2peWFIuxFlOYyeX9Kzg]]></Tracking>\n                        <Tracking event="thirdQuartile"><![CDATA[https://localhost:8078/u?rt=7MRhdEcIndSrWxWhFtMVVnDULl8BOwEaV6vi9558AbYAAAAQCtjQz9kbGWD4nuZy3q6HaCYx_6vZlT33ShgzYb616hZZSpoy2jkAHkGrB-XmXyJmEOCSQ0PLk6_FNLuCBzONJyx6ZZCB10wGqA3OaSe1EqMWoJp41f83FcJLX0SpBoT1-qBbx5_8La-ULiAnqaGtMRDYSRqTBZh5DCANFQWnm1fa8rEE9VRgRORwTNxvZFjq5JCSkEQ2peWFIuxFlOYyeX9Kzg&customType=whatevs]]></Tracking>\n                        <Tracking event="complete"><![CDATA[https://localhost:8078/u?rt=7MRhdEcIndSrWxWhFtMVVnDULl8BOwEaV6vi9558AbYAAAAQCtjQz9kbGWD4nuZy3q6HaCYx_6vZlT33ShgzYb616hZZSpoy2jkAHkGrB-XmXyJmEOCSQ0PLk6_FNLuCBzONJyx6ZZCB10wGqA3OaSe1EqMWoJp41f83FcJLX0SpBoT1-qBbx5_8La-ULiAnqaGtMRDYSRqTBZh5DCANFQWnm1fa8rEE9VRgRORwTNxvZFjq5JCSkEQ2peWFIuxFlOYyeX9Kzg&customType=whatevs]]></Tracking>\n                    </TrackingEvents>\n                    <VideoClicks>\n                        <ClickThrough><![CDATA[http://adnuntius.com]]></ClickThrough>\n                        <ClickTracking><![CDATA[http://localhost:8078/c/7MRhdEcIndSrWxWhFtMVVnDULl8BOwEaV6vi9558AbYAAAAQCtjQz9kbGWD4nuZy3q6HaCYx_6vZlT33ShgzYb616hZZSpoy2jkAHkGrB-XmXyJmEOCSQ0PLk6_FNLuCBzONJyx6ZZCB10wGqA3OaSe1EqMWoJp41f83FcJLX0SpBoT1-qBbx5_8La-ULiAnqaGtMRDYSRqTBZh5DCANFQWnm1fa8rEE9VRgRORwTNxvZFjq5JCSkEQ2peWFIuxFlOYyeX9Kzg]]></ClickTracking>\n                    </VideoClicks>\n                    <MediaFiles>\n                        <MediaFile delivery="progressive" type="video/mp4" bitrate="92421" width="1920" height="1080" scalable="true" maintainAspectRatio="true">\n                            <![CDATA[http://localhost:8079/cdn/9urJusYWpjFDLcpOwfejrkWlLP1heM3vWIJjuHk48BQ.mp4]]>\n                        </MediaFile>\n                    </MediaFiles>\n                </Linear>\n            </Creative>\n        </Creatives>\n    </InLine>\n</Ad>\n</VAST>',
+              'renderTemplate': '<Ad id="{{adId}}">\n    <InLine>\n        <AdSystem>Adnuntius</AdSystem>\n        <AdTitle>{{{adId}}}</AdTitle>\n        <Impression></Impression>\n        <Creatives>\n            <Creative>{{#ifEquals vastVersion "4.0"}}\n                <UniversalAdId idRegistry="unknown" idValue="unknown"></UniversalAdId>{{/ifEquals}}\n                <Linear>\n                    <Duration>{{assets.Video.duration}}</Duration>\n                    <TrackingEvents>\n                        <Tracking event="creativeView"><![CDATA[{{{renderedPixel}}}]]></Tracking>\n                        <Tracking event="start"><![CDATA[{{{visibleUrl}}}]]></Tracking>{{#unless preview}}{{#each impressionTrackingUrls}}\n                        <Tracking event="start"><![CDATA[{{{this}}}]]></Tracking>{{/each}}{{/unless}}{{#if text.firstQuartile.content}}\n                        <Tracking event="firstQuartile"><![CDATA[https://{{{adServerHost}}}/u?rt={{{rt}}}&customType={{text.firstQuartile.content}}]]></Tracking>{{/if}}\n                        <Tracking event="midpoint"><![CDATA[{{{viewUrl}}}]]></Tracking>{{#if text.thirdQuartile.content}}\n                        <Tracking event="thirdQuartile"><![CDATA[https://{{{adServerHost}}}/u?rt={{{rt}}}&customType={{text.thirdQuartile.content}}]]></Tracking>{{/if}}{{#if text.complete.content}}\n                        <Tracking event="complete"><![CDATA[https://{{{adServerHost}}}/u?rt={{{rt}}}&customType={{text.complete.content}}]]></Tracking>{{/if}}\n                    </TrackingEvents>\n                    <VideoClicks>\n                        <ClickThrough><![CDATA[{{{urls.destinationUrl.destinationUrl}}}]]></ClickThrough>\n                        <ClickTracking><![CDATA[{{{clickUrl}}}]]></ClickTracking>\n                    </VideoClicks>\n                    <MediaFiles>\n                        <MediaFile delivery="progressive" type="{{assets.Video.mimeType}}" bitrate="{{assets.Video.bps}}" width="{{assets.Video.width}}" height="{{assets.Video.height}}" scalable="true" maintainAspectRatio="true">\n                            <![CDATA[{{{assets.Video.cdnId}}}]]>\n                        </MediaFile>\n                    </MediaFiles>\n                </Linear>\n            </Creative>\n        </Creatives>\n    </InLine>\n</Ad>'
+            }
+          ],
+          'ads': [
+            {
+              'destinationUrlEsc': '',
+              'assets': {
+                'Video': {
+                  'cdnId': 'http://localhost:8079/cdn/9urJusYWpjFDLcpOwfejrkWlLP1heM3vWIJjuHk48BQ.mp4',
+                  'width': '1920',
+                  'height': '1080'
+                }
+              },
+              'text': {
+                'thirdQuartile': {
+                  'content': 'whatevs',
+                  'length': '7',
+                  'minLength': '1',
+                  'maxLength': '64'
+                },
+                'complete': {
+                  'content': 'whatevs',
+                  'length': '7',
+                  'minLength': '1',
+                  'maxLength': '64'
+                },
+                'firstQuartile': {
+                  'content': 'whatevs',
+                  'length': '7',
+                  'minLength': '1',
+                  'maxLength': '64'
+                }
+              },
+              'choices': {},
+              'clickUrl': 'http://localhost:8078/c/ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX',
+              'urls': {
+                'destinationUrl': 'http://localhost:8078/c/ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX?ct=682&r=http%3A%2F%2Fadnuntius.com'
+              },
+              'urlsEsc': {
+                'destinationUrl': 'http%3A%2F%2Flocalhost%3A8078%2Fc%2FZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX%3Fct%3D682%26r%3Dhttp%253A%252F%252Fadnuntius.com'
+              },
+              'destinationUrls': {
+                'destinationUrl': 'http://adnuntius.com'
+              },
+              'cpm': {
+                'amount': 9,
+                'currency': 'USD'
+              },
+              'bid': {
+                'amount': 0.009,
+                'currency': 'USD'
+              },
+              'grossBid': {
+                'amount': 0.009,
+                'currency': 'USD'
+              },
+              'netBid': {
+                'amount': 0.0081,
+                'currency': 'USD'
+              },
+              'dealId': 'abc123xyz',
+              'impressionTrackingUrls': [],
+              'impressionTrackingUrlsEsc': [],
+              'adId': 'adn-id-500662301',
+              'selectedColumn': '0',
+              'selectedColumnPosition': '0',
+              'renderedPixel': 'http://localhost:8078/b/ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX.html',
+              'renderedPixelEsc': 'http%3A%2F%2Flocalhost%3A8078%2Fb%2FZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX.html',
+              'visibleUrl': 'http://localhost:8078/s?rt=ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX',
+              'visibleUrlEsc': 'http%3A%2F%2Flocalhost%3A8078%2Fs%3Frt%3DZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX',
+              'viewUrl': 'http://localhost:8078/v?rt=ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX',
+              'viewUrlEsc': 'http%3A%2F%2Flocalhost%3A8078%2Fv%3Frt%3DZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX',
+              'rt': 'ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX',
+              'creativeWidth': '640',
+              'creativeHeight': '480',
+              'creativeId': 'p6sqtvcgxczy258j',
+              'lineItemId': 'cr3hnkkxhnkw9ldy',
+              'layoutId': 'buyers_networkvast_single_format_layout',
+              'layoutName': 'Vast (video upload)',
+              'layoutExternalReference': '',
+              'vastXml': '<Ad id="adn-id-500662301">\n    <InLine>\n        <AdSystem>Adnuntius</AdSystem>\n        <AdTitle>adn-id-500662301</AdTitle>\n        <Impression></Impression>\n        <Creatives>\n            <Creative>\n                <Linear>\n                    <Duration>00:00:15</Duration>\n                    <TrackingEvents>\n                        <Tracking event="creativeView"><![CDATA[http://localhost:8078/b/ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX.html]]></Tracking>\n                        <Tracking event="start"><![CDATA[http://localhost:8078/s?rt=ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX]]></Tracking>\n                        <Tracking event="firstQuartile"><![CDATA[https://localhost:8078/u?rt=ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX&customType=whatevs]]></Tracking>\n                        <Tracking event="midpoint"><![CDATA[http://localhost:8078/v?rt=ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX]]></Tracking>\n                        <Tracking event="thirdQuartile"><![CDATA[https://localhost:8078/u?rt=ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX&customType=whatevs]]></Tracking>\n                        <Tracking event="complete"><![CDATA[https://localhost:8078/u?rt=ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX&customType=whatevs]]></Tracking>\n                    </TrackingEvents>\n                    <VideoClicks>\n                        <ClickThrough><![CDATA[http://adnuntius.com]]></ClickThrough>\n                        <ClickTracking><![CDATA[http://localhost:8078/c/ZxGSsEJ8IzI8iCTQ17fHxnE29-y7VILLg2CLjhEbphMAAAAQCtjQz9kbGWD4nuZy3q6HaCYxpfXelzygS0s1MLax6koIS8pnjDAOShX4CbPkDyIzELe5BlfLk6_FNLuCBzOMJyx6ZZCB10wGqA3OaSe1EqpGosot0vsyFMtIWRWtUoKk-aANx531KaOWLyonoP2uC6UpxkXRUJ8iVCcMF1KmmAfe9rNYplI0E-ErHtVvZgm7uZeal_VymQxr0zkhjS_bW0PX]]></ClickTracking>\n                    </VideoClicks>\n                    <MediaFiles>\n                        <MediaFile delivery="progressive" type="video/mp4" bitrate="92421" width="1920" height="1080" scalable="true" maintainAspectRatio="true">\n                            <![CDATA[http://localhost:8079/cdn/9urJusYWpjFDLcpOwfejrkWlLP1heM3vWIJjuHk48BQ.mp4]]>\n                        </MediaFile>\n                    </MediaFiles>\n                </Linear>\n            </Creative>\n        </Creatives>\n    </InLine>\n</Ad>',
+              'renderTemplate': '<Ad id="{{adId}}">\n    <InLine>\n        <AdSystem>Adnuntius</AdSystem>\n        <AdTitle>{{{adId}}}</AdTitle>\n        <Impression></Impression>\n        <Creatives>\n            <Creative>{{#ifEquals vastVersion "4.0"}}\n                <UniversalAdId idRegistry="unknown" idValue="unknown"></UniversalAdId>{{/ifEquals}}\n                <Linear>\n                    <Duration>{{assets.Video.duration}}</Duration>\n                    <TrackingEvents>\n                        <Tracking event="creativeView"><![CDATA[{{{renderedPixel}}}]]></Tracking>\n                        <Tracking event="start"><![CDATA[{{{visibleUrl}}}]]></Tracking>{{#unless preview}}{{#each impressionTrackingUrls}}\n                        <Tracking event="start"><![CDATA[{{{this}}}]]></Tracking>{{/each}}{{/unless}}{{#if text.firstQuartile.content}}\n                        <Tracking event="firstQuartile"><![CDATA[https://{{{adServerHost}}}/u?rt={{{rt}}}&customType={{text.firstQuartile.content}}]]></Tracking>{{/if}}\n                        <Tracking event="midpoint"><![CDATA[{{{viewUrl}}}]]></Tracking>{{#if text.thirdQuartile.content}}\n                        <Tracking event="thirdQuartile"><![CDATA[https://{{{adServerHost}}}/u?rt={{{rt}}}&customType={{text.thirdQuartile.content}}]]></Tracking>{{/if}}{{#if text.complete.content}}\n                        <Tracking event="complete"><![CDATA[https://{{{adServerHost}}}/u?rt={{{rt}}}&customType={{text.complete.content}}]]></Tracking>{{/if}}\n                    </TrackingEvents>\n                    <VideoClicks>\n                        <ClickThrough><![CDATA[{{{urls.destinationUrl.destinationUrl}}}]]></ClickThrough>\n                        <ClickTracking><![CDATA[{{{clickUrl}}}]]></ClickTracking>\n                    </VideoClicks>\n                    <MediaFiles>\n                        <MediaFile delivery="progressive" type="{{assets.Video.mimeType}}" bitrate="{{assets.Video.bps}}" width="{{assets.Video.width}}" height="{{assets.Video.height}}" scalable="true" maintainAspectRatio="true">\n                            <![CDATA[{{{assets.Video.cdnId}}}]]>\n                        </MediaFile>\n                    </MediaFiles>\n                </Linear>\n            </Creative>\n        </Creatives>\n    </InLine>\n</Ad>'
+            }
           ]
         },
         {
           'auId': '000000000008b6bc',
-          'targetId': '456',
+          'targetId': 'adn-000000000008b6bc',
           'matchedAdCount': 0,
           'responseId': 'adn-rsp-1460129238',
         }
@@ -215,20 +430,20 @@ describe('adnuntiusBidAdapter', function () {
     }
   }
 
-  describe('inherited functions', function () {
-    it('exists and is a function', function () {
+  describe('inherited functions', function() {
+    it('exists and is a function', function() {
       expect(adapter.callBids).to.exist.and.to.be.a('function');
     });
   });
 
-  describe('isBidRequestValid', function () {
-    it('should return true when required params found', function () {
+  describe('isBidRequestValid', function() {
+    it('should return true when required params found', function() {
       expect(spec.isBidRequestValid(bidderRequests[0])).to.equal(true);
     });
   });
 
-  describe('buildRequests', function () {
-    it('Test requests', function () {
+  describe('buildRequests', function() {
+    it('Test requests', function() {
       const request = spec.buildRequests(bidderRequests, {});
       expect(request.length).to.equal(1);
       expect(request[0]).to.have.property('bid');
@@ -237,10 +452,10 @@ describe('adnuntiusBidAdapter', function () {
       expect(request[0]).to.have.property('url');
       expect(request[0].url).to.equal(ENDPOINT_URL);
       expect(request[0]).to.have.property('data');
-      expect(request[0].data).to.equal('{\"adUnits\":[{\"auId\":\"8b6bc\",\"targetId\":\"123\",\"dimensions\":[[640,480],[600,400]]}],\"metaData\":{\"usi\":\"' + usi + '\"}}');
+      expect(request[0].data).to.equal('{"adUnits":[{"auId":"000000000008b6bc","targetId":"adn-000000000008b6bc","maxDeals":1,"dimensions":[[640,480],[600,400]]},{"auId":"0000000000000551","targetId":"adn-0000000000000551","maxDeals":0,"dimensions":[[1640,1480],[1600,1400]]}],"metaData":{"usi":"' + usi + '"}}');
     });
 
-    it('Test Video requests', function () {
+    it('Test Video requests', function() {
       const request = spec.buildRequests(videoBidderRequest, {});
       expect(request.length).to.equal(1);
       expect(request[0]).to.have.property('bid');
@@ -250,12 +465,12 @@ describe('adnuntiusBidAdapter', function () {
       expect(request[0].url).to.equal(ENDPOINT_URL_VIDEO);
     });
 
-    it('should pass segments if available in config', function () {
+    it('should pass segments if available in config', function() {
       const ortb2 = {
         user: {
           data: [{
             name: 'adnuntius',
-            segment: [{ id: 'segment1' }, { id: 'segment2' }]
+            segment: [{id: 'segment1'}, {id: 'segment2'}]
           },
           {
             name: 'other',
@@ -264,18 +479,18 @@ describe('adnuntiusBidAdapter', function () {
         }
       };
 
-      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidderRequests, { ortb2 }));
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidderRequests, {ortb2}));
       expect(request.length).to.equal(1);
       expect(request[0]).to.have.property('url')
       expect(request[0].url).to.equal(ENDPOINT_URL_SEGMENTS);
     });
 
-    it('should skip segments in config if not either id or array of strings', function () {
+    it('should skip segments in config if not either id or array of strings', function() {
       const ortb2 = {
         user: {
           data: [{
             name: 'adnuntius',
-            segment: [{ id: 'segment1' }, { id: 'segment2' }, { id: 'segment3' }]
+            segment: [{id: 'segment1'}, {id: 'segment2'}, {id: 'segment3'}]
           },
           {
             name: 'other',
@@ -286,34 +501,34 @@ describe('adnuntiusBidAdapter', function () {
         }
       };
 
-      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidderRequests, { ortb2 }));
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidderRequests, {ortb2}));
       expect(request.length).to.equal(1);
       expect(request[0]).to.have.property('url')
       expect(request[0].url).to.equal(ENDPOINT_URL_SEGMENTS);
     });
   });
 
-  describe('user privacy', function () {
-    it('should send GDPR Consent data if gdprApplies', function () {
-      let request = spec.buildRequests(bidderRequests, { gdprConsent: { gdprApplies: true, consentString: 'consentString' } });
+  describe('user privacy', function() {
+    it('should send GDPR Consent data if gdprApplies', function() {
+      let request = spec.buildRequests(bidderRequests, {gdprConsent: {gdprApplies: true, consentString: 'consentString'}});
       expect(request.length).to.equal(1);
       expect(request[0]).to.have.property('url')
       expect(request[0].url).to.equal(ENDPOINT_URL_CONSENT);
     });
 
-    it('should not send GDPR Consent data if gdprApplies equals undefined', function () {
-      let request = spec.buildRequests(bidderRequests, { gdprConsent: { gdprApplies: undefined, consentString: 'consentString' } });
+    it('should not send GDPR Consent data if gdprApplies equals undefined', function() {
+      let request = spec.buildRequests(bidderRequests, {gdprConsent: {gdprApplies: undefined, consentString: 'consentString'}});
       expect(request.length).to.equal(1);
       expect(request[0]).to.have.property('url')
       expect(request[0].url).to.equal(ENDPOINT_URL);
     });
 
-    it('should pass segments if available in config', function () {
+    it('should pass segments if available in config', function() {
       const ortb2 = {
         user: {
           data: [{
             name: 'adnuntius',
-            segment: [{ id: 'segment1' }, { id: 'segment2' }]
+            segment: [{id: 'segment1'}, {id: 'segment2'}]
           },
           {
             name: 'other',
@@ -322,18 +537,18 @@ describe('adnuntiusBidAdapter', function () {
         }
       }
 
-      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidderRequests, { ortb2 }));
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidderRequests, {ortb2}));
       expect(request.length).to.equal(1);
       expect(request[0]).to.have.property('url')
       expect(request[0].url).to.equal(ENDPOINT_URL_SEGMENTS);
     });
 
-    it('should skip segments in config if not either id or array of strings', function () {
+    it('should skip segments in config if not either id or array of strings', function() {
       const ortb2 = {
         user: {
           data: [{
             name: 'adnuntius',
-            segment: [{ id: 'segment1' }, { id: 'segment2' }, { id: 'segment3' }]
+            segment: [{id: 'segment1'}, {id: 'segment2'}, {id: 'segment3'}]
           },
           {
             name: 'other',
@@ -344,44 +559,44 @@ describe('adnuntiusBidAdapter', function () {
         }
       };
 
-      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidderRequests, { ortb2 }));
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidderRequests, {ortb2}));
       expect(request.length).to.equal(1);
       expect(request[0]).to.have.property('url')
       expect(request[0].url).to.equal(ENDPOINT_URL_SEGMENTS);
     });
 
-    it('should user user ID if present in ortb2.user.id field', function () {
+    it('should user user ID if present in ortb2.user.id field', function() {
       const ortb2 = {
         user: {
           id: usi
         }
       };
 
-      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidderRequests, { ortb2 }));
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidderRequests, {ortb2}));
       expect(request.length).to.equal(1);
       expect(request[0]).to.have.property('url')
       expect(request[0].url).to.equal(ENDPOINT_URL);
     });
   });
 
-  describe('user privacy', function () {
-    it('should send GDPR Consent data if gdprApplies', function () {
-      let request = spec.buildRequests(bidderRequests, { gdprConsent: { gdprApplies: true, consentString: 'consentString' } });
+  describe('user privacy', function() {
+    it('should send GDPR Consent data if gdprApplies', function() {
+      let request = spec.buildRequests(bidderRequests, {gdprConsent: {gdprApplies: true, consentString: 'consentString'}});
       expect(request.length).to.equal(1);
       expect(request[0]).to.have.property('url')
       expect(request[0].url).to.equal(ENDPOINT_URL_CONSENT);
     });
 
-    it('should not send GDPR Consent data if gdprApplies equals undefined', function () {
-      let request = spec.buildRequests(bidderRequests, { gdprConsent: { gdprApplies: undefined, consentString: 'consentString' } });
+    it('should not send GDPR Consent data if gdprApplies equals undefined', function() {
+      let request = spec.buildRequests(bidderRequests, {gdprConsent: {gdprApplies: undefined, consentString: 'consentString'}});
       expect(request.length).to.equal(1);
       expect(request[0]).to.have.property('url')
       expect(request[0].url).to.equal(ENDPOINT_URL);
     });
   });
 
-  describe('use cookie', function () {
-    it('should send noCookie in url if set to false.', function () {
+  describe('use cookie', function() {
+    it('should send noCookie in url if set to false.', function() {
       config.setBidderConfig({
         bidders: ['adnuntius'],
         config: {
@@ -396,31 +611,119 @@ describe('adnuntiusBidAdapter', function () {
     });
   });
 
-  describe('interpretResponse', function () {
-    it('should return valid response when passed valid server response', function () {
-      const interpretedResponse = spec.interpretResponse(serverResponse, singleBidRequest);
-      const ad = serverResponse.body.adUnits[0].ads[0]
-      expect(interpretedResponse).to.have.lengthOf(1);
-      expect(interpretedResponse[0].cpm).to.equal(ad.cpm.amount);
-      expect(interpretedResponse[0].width).to.equal(Number(ad.creativeWidth));
-      expect(interpretedResponse[0].height).to.equal(Number(ad.creativeHeight));
-      expect(interpretedResponse[0].creativeId).to.equal(ad.creativeId);
-      expect(interpretedResponse[0].currency).to.equal(ad.bid.currency);
-      expect(interpretedResponse[0].netRevenue).to.equal(false);
-      expect(interpretedResponse[0].meta).to.have.property('advertiserDomains');
-      expect(interpretedResponse[0].meta.advertiserDomains).to.have.lengthOf(1);
-      expect(interpretedResponse[0].meta.advertiserDomains[0]).to.equal('google.com');
-      expect(interpretedResponse[0].ad).to.equal(serverResponse.body.adUnits[0].html);
-      expect(interpretedResponse[0].ttl).to.equal(360);
+  describe('request deals', function() {
+    it('Should set max deals.', function() {
+      config.setBidderConfig({
+        bidders: ['adnuntius'],
+      });
+
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidderRequests, {}));
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(ENDPOINT_URL);
+      expect(request[0]).to.have.property('data');
+      const data = JSON.parse(request[0].data);
+      expect(data.adUnits.length).to.equal(2);
+      expect(bidderRequests[0].params.maxDeals).to.equal(1);
+      expect(data.adUnits[0].maxDeals).to.equal(bidderRequests[0].params.maxDeals);
+      expect(bidderRequests[1].params).to.not.have.property('maxBids');
+      expect(data.adUnits[1].maxDeals).to.equal(0);
+    });
+    it('Should allow a maximum of 5 deals.', function() {
+      config.setBidderConfig({
+        bidders: ['adnuntius'],
+      });
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests([
+        {
+          bidId: 'adn-000000000008b6bc',
+          bidder: 'adnuntius',
+          params: {
+            auId: '000000000008b6bc',
+            network: 'adnuntius',
+            maxDeals: 10
+          }
+        }
+      ], {}));
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(ENDPOINT_URL);
+      expect(request[0]).to.have.property('data');
+      const data = JSON.parse(request[0].data);
+      expect(data.adUnits.length).to.equal(1);
+      expect(data.adUnits[0].maxDeals).to.equal(5);
+    });
+    it('Should allow a minumum of 0 deals.', function() {
+      config.setBidderConfig({
+        bidders: ['adnuntius'],
+      });
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests([
+        {
+          bidId: 'adn-000000000008b6bc',
+          bidder: 'adnuntius',
+          params: {
+            auId: '000000000008b6bc',
+            network: 'adnuntius',
+            maxDeals: -1
+          }
+        }
+      ], {}));
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(ENDPOINT_URL);
+      expect(request[0]).to.have.property('data');
+      const data = JSON.parse(request[0].data);
+      expect(data.adUnits.length).to.equal(1);
+      expect(data.adUnits[0].maxDeals).to.equal(0);
+    });
+    it('Should set max deals using bidder config.', function() {
+      config.setBidderConfig({
+        bidders: ['adnuntius'],
+        config: {
+          maxDeals: 2
+        }
+      });
+
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidderRequests, {}));
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(ENDPOINT_URL + '&ds=2');
+    });
+    it('Should allow a maximum of 5 deals when using bidder config.', function() {
+      config.setBidderConfig({
+        bidders: ['adnuntius'],
+        config: {
+          maxDeals: 6
+        }
+      });
+
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidderRequests, {}));
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(ENDPOINT_URL + '&ds=5');
+    });
+    it('Should allow a minimum of 0 deals when using bidder config.', function() {
+      config.setBidderConfig({
+        bidders: ['adnuntius'],
+        config: {
+          maxDeals: -1
+        }
+      });
+
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidderRequests, {}));
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      // The maxDeals value is ignored because it is less than zero
+      expect(request[0].url).to.equal(ENDPOINT_URL);
     });
   });
 
-  describe('interpretVideoResponse', function () {
-    it('should return valid response when passed valid server response', function () {
-      const interpretedResponse = spec.interpretResponse(serverVideoResponse, videoBidRequest);
-      const ad = serverVideoResponse.body.adUnits[0].ads[0]
-      expect(interpretedResponse).to.have.lengthOf(1);
-      expect(interpretedResponse[0].cpm).to.equal(ad.cpm.amount);
+  describe('interpretResponse', function() {
+    it('should return valid response when passed valid server response', function() {
+      const interpretedResponse = spec.interpretResponse(serverResponse, singleBidRequest);
+      expect(interpretedResponse).to.have.lengthOf(2);
+      const ad = serverResponse.body.adUnits[0].ads[0];
+      expect(interpretedResponse[0].bidderCode).to.equal('adnuntius');
+      expect(interpretedResponse[0].cpm).to.equal(ad.bid.amount * 1000);
       expect(interpretedResponse[0].width).to.equal(Number(ad.creativeWidth));
       expect(interpretedResponse[0].height).to.equal(Number(ad.creativeHeight));
       expect(interpretedResponse[0].creativeId).to.equal(ad.creativeId);
@@ -428,8 +731,56 @@ describe('adnuntiusBidAdapter', function () {
       expect(interpretedResponse[0].netRevenue).to.equal(false);
       expect(interpretedResponse[0].meta).to.have.property('advertiserDomains');
       expect(interpretedResponse[0].meta.advertiserDomains).to.have.lengthOf(1);
-      expect(interpretedResponse[0].meta.advertiserDomains[0]).to.equal('google.com');
+      expect(interpretedResponse[0].meta.advertiserDomains[0]).to.equal('adnuntius.com');
+      expect(interpretedResponse[0].ad).to.equal(serverResponse.body.adUnits[0].html);
+      expect(interpretedResponse[0].ttl).to.equal(360);
+
+      const deal = serverResponse.body.adUnits[0].deals[0];
+      expect(interpretedResponse[1].bidderCode).to.equal('adndeal1');
+      expect(interpretedResponse[1].cpm).to.equal(deal.bid.amount * 1000);
+      expect(interpretedResponse[1].width).to.equal(Number(deal.creativeWidth));
+      expect(interpretedResponse[1].height).to.equal(Number(deal.creativeHeight));
+      expect(interpretedResponse[1].creativeId).to.equal(deal.creativeId);
+      expect(interpretedResponse[1].currency).to.equal(deal.bid.currency);
+      expect(interpretedResponse[1].netRevenue).to.equal(false);
+      expect(interpretedResponse[1].meta).to.have.property('advertiserDomains');
+      expect(interpretedResponse[1].meta.advertiserDomains).to.have.lengthOf(1);
+      expect(interpretedResponse[1].meta.advertiserDomains[0]).to.equal('adnuntius.com');
+      expect(interpretedResponse[1].ad).to.equal(serverResponse.body.adUnits[0].deals[0].html);
+      expect(interpretedResponse[1].ttl).to.equal(360);
+    });
+  });
+
+  describe('interpretVideoResponse', function() {
+    it('should return valid response when passed valid server response', function() {
+      const interpretedResponse = spec.interpretResponse(serverVideoResponse, videoBidRequest);
+      const ad = serverVideoResponse.body.adUnits[0].ads[0]
+      const deal = serverVideoResponse.body.adUnits[0].deals[0]
+      expect(interpretedResponse).to.have.lengthOf(2);
+
+      expect(interpretedResponse[0].bidderCode).to.equal('adnuntius');
+      expect(interpretedResponse[0].cpm).to.equal(ad.bid.amount * 1000);
+      expect(interpretedResponse[0].width).to.equal(Number(ad.creativeWidth));
+      expect(interpretedResponse[0].height).to.equal(Number(ad.creativeHeight));
+      expect(interpretedResponse[0].creativeId).to.equal(ad.creativeId);
+      expect(interpretedResponse[0].currency).to.equal(ad.bid.currency);
+      expect(interpretedResponse[0].netRevenue).to.equal(false);
+      expect(interpretedResponse[0].meta).to.have.property('advertiserDomains');
+      expect(interpretedResponse[0].meta.advertiserDomains).to.have.lengthOf(1);
+      expect(interpretedResponse[0].meta.advertiserDomains[0]).to.equal('adnuntius.com');
       expect(interpretedResponse[0].vastXml).to.equal(serverVideoResponse.body.adUnits[0].vastXml);
+
+      expect(interpretedResponse[1].bidderCode).to.equal('adndeal1');
+      expect(interpretedResponse[1].cpm).to.equal(deal.bid.amount * 1000);
+      expect(interpretedResponse[1].width).to.equal(Number(deal.creativeWidth));
+      expect(interpretedResponse[1].height).to.equal(Number(deal.creativeHeight));
+      expect(interpretedResponse[1].creativeId).to.equal(deal.creativeId);
+      expect(interpretedResponse[1].currency).to.equal(deal.bid.currency);
+      expect(interpretedResponse[1].netRevenue).to.equal(false);
+      expect(interpretedResponse[1].meta).to.have.property('advertiserDomains');
+      expect(interpretedResponse[1].meta.advertiserDomains).to.have.lengthOf(1);
+      expect(interpretedResponse[1].meta.advertiserDomains[0]).to.equal('adnuntius.com');
+      expect(interpretedResponse[1].vastXml).to.equal(deal.vastXml);
     });
   });
 });


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change

Note: This change includes TWO commits and can be separated into two separate pull requests if required. The first commit only removes inactive commented-out code and has no functional consquences at all.

This change adds better support for deals to the Adnuntius Bid Adaptor.

It adds a new `maxDeals` parameter, which defaults to `0`, that allows the adaptor to return responses for both the highest bidding advertisement AND (when `maxDeals` > `0`) deal advertisements.

If deal advertisements are returned, they are reported using one of the new bidder code aliases:

- `adndeal1`
- `adndeal2`
- `adndeal3`
- `adndeal4`
- `adndeal5`

The usage of these aliases allows for the deals and the highest bidder to all be returned to the publisher's ad server.

## Other information

This change introduces a new **optional** parameter, which will require an update to the adaptor documentation (will be submitted shortly) but it does not affect functionality for existing users.  