### PR TITLE
Multiple modules: do not use bidderTimeout as TTL

### DIFF
--- a/modules/ablidaBidAdapter.js
+++ b/modules/ablidaBidAdapter.js
@@ -77,7 +77,7 @@ export const spec = {
     const response = serverResponse.body;
 
     response.forEach(function(bid) {
-      bid.ttl = config.getConfig('_bidderTimeout');
+      bid.ttl = 60
       bidResponses.push(bid);
     });
     return bidResponses;

--- a/modules/ablidaBidAdapter.js
+++ b/modules/ablidaBidAdapter.js
@@ -1,8 +1,7 @@
-import { triggerPixel } from '../src/utils.js';
-import {config} from '../src/config.js';
+import {triggerPixel} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
-import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
-import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
+import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
+import {convertOrtbRequestToProprietaryNative} from '../src/native.js';
 
 const BIDDER_CODE = 'ablida';
 const ENDPOINT_URL = 'https://bidder.ablida.net/prebid';

--- a/modules/axonixBidAdapter.js
+++ b/modules/axonixBidAdapter.js
@@ -150,7 +150,7 @@ export const spec = {
     for (const resp of response) {
       if (resp.requestId) {
         responses.push(Object.assign(resp, {
-          ttl: config.getConfig('_bidderTimeout')
+          ttl: 60
         }));
       }
     }

--- a/modules/axonixBidAdapter.js
+++ b/modules/axonixBidAdapter.js
@@ -1,8 +1,8 @@
-import { isArray, logError, deepAccess, isEmpty, triggerPixel, replaceAuctionPrice } from '../src/utils.js';
-import { registerBidder } from '../src/adapters/bidderFactory.js';
-import { BANNER, VIDEO } from '../src/mediaTypes.js';
-import { config } from '../src/config.js';
-import { ajax } from '../src/ajax.js';
+import {deepAccess, isArray, isEmpty, logError, replaceAuctionPrice, triggerPixel} from '../src/utils.js';
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+import {BANNER, VIDEO} from '../src/mediaTypes.js';
+import {config} from '../src/config.js';
+import {ajax} from '../src/ajax.js';
 
 const BIDDER_CODE = 'axonix';
 const BIDDER_VERSION = '1.0.2';

--- a/modules/dspxBidAdapter.js
+++ b/modules/dspxBidAdapter.js
@@ -183,7 +183,7 @@ export const spec = {
         currency: currency,
         netRevenue: netRevenue,
         type: response.type,
-        ttl: config.getConfig('_bidderTimeout'),
+        ttl: 60,
         meta: {
           advertiserDomains: response.adomain || []
         }

--- a/modules/dspxBidAdapter.js
+++ b/modules/dspxBidAdapter.js
@@ -1,5 +1,4 @@
-import {deepAccess, getBidIdParameter, logError, logMessage, logWarn, isFn} from '../src/utils.js';
-import {config} from '../src/config.js';
+import {deepAccess, getBidIdParameter, isFn, logError, logMessage, logWarn} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {Renderer} from '../src/Renderer.js';

--- a/modules/iqmBidAdapter.js
+++ b/modules/iqmBidAdapter.js
@@ -1,6 +1,5 @@
 import {_each, deepAccess, getBidIdParameter, isArray} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
-import {config} from '../src/config.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {INSTREAM} from '../src/video.js';
 

--- a/modules/iqmBidAdapter.js
+++ b/modules/iqmBidAdapter.js
@@ -155,7 +155,7 @@ export const spec = {
               auctionId: bidRequest.data.auctionId,
               mediaType: bidRequest.data.imp.mediatype,
 
-              ttl: bid.ttl || config.getConfig('_bidderTimeout')
+              ttl: bid.ttl || 60
             };
 
             if (bidRequest.data.imp.mediatype === VIDEO) {

--- a/modules/orbitsoftBidAdapter.js
+++ b/modules/orbitsoftBidAdapter.js
@@ -1,6 +1,5 @@
 import * as utils from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
-import {config} from '../src/config.js';
 
 const BIDDER_CODE = 'orbitsoft';
 let styleParamsMap = {

--- a/modules/orbitsoftBidAdapter.js
+++ b/modules/orbitsoftBidAdapter.js
@@ -122,7 +122,7 @@ export const spec = {
     const HEIGHT = serverBody.height;
     const CREATIVE = serverBody.content_url;
     const CALLBACK_UID = serverBody.callback_uid;
-    const TIME_TO_LIVE = config.getConfig('_bidderTimeout');
+    const TIME_TO_LIVE = 60;
     const REFERER = utils.getWindowTop();
     let bidRequest = request.bidRequest;
     if (CPM > 0 && WIDTH > 0 && HEIGHT > 0) {

--- a/modules/radsBidAdapter.js
+++ b/modules/radsBidAdapter.js
@@ -1,7 +1,6 @@
-import { deepAccess } from '../src/utils.js';
-import {config} from '../src/config.js';
+import {deepAccess} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
-import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import {BANNER, VIDEO} from '../src/mediaTypes.js';
 
 const BIDDER_CODE = 'rads';
 const ENDPOINT_URL = 'https://rads.recognified.net/md.request.php';

--- a/modules/radsBidAdapter.js
+++ b/modules/radsBidAdapter.js
@@ -86,7 +86,7 @@ export const spec = {
         dealId: dealId,
         currency: currency,
         netRevenue: netRevenue,
-        ttl: config.getConfig('_bidderTimeout'),
+        ttl: 60,
         meta: {
           advertiserDomains: response.adomain || []
         }

--- a/modules/stvBidAdapter.js
+++ b/modules/stvBidAdapter.js
@@ -128,7 +128,7 @@ export const spec = {
         dealId: dealId,
         currency: currency,
         netRevenue: netRevenue,
-        ttl: config.getConfig('_bidderTimeout'),
+        ttl: 60,
         meta: {
           advertiserDomains: response.adomain || []
         }

--- a/modules/stvBidAdapter.js
+++ b/modules/stvBidAdapter.js
@@ -1,7 +1,6 @@
-import { deepAccess } from '../src/utils.js';
-import { config } from '../src/config.js';
-import { registerBidder } from '../src/adapters/bidderFactory.js';
-import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import {deepAccess} from '../src/utils.js';
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {includes} from '../src/polyfill.js';
 
 const BIDDER_CODE = 'stv';

--- a/modules/underdogmediaBidAdapter.js
+++ b/modules/underdogmediaBidAdapter.js
@@ -1,21 +1,18 @@
 import {
-  logMessage,
+  deepAccess,
   flatten,
-  parseSizesInput,
+  getWindowSelf,
+  getWindowTop,
   isGptPubadsDefined,
   isSlotMatchingAdUnitCode,
   logInfo,
+  logMessage,
   logWarn,
-  getWindowSelf,
-  getWindowTop,
-  deepAccess
+  parseSizesInput
 } from '../src/utils.js';
-import {
-  config
-} from '../src/config.js';
-import {
-  registerBidder
-} from '../src/adapters/bidderFactory.js';
+import {config} from '../src/config.js';
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+
 const BIDDER_CODE = 'underdogmedia';
 const UDM_ADAPTER_VERSION = '7.30V';
 const UDM_VENDOR_ID = '159';

--- a/modules/underdogmediaBidAdapter.js
+++ b/modules/underdogmediaBidAdapter.js
@@ -377,7 +377,7 @@ function makeNotification(bid, mid, bidParam) {
   url += `;version=${UDM_ADAPTER_VERSION}`;
   url += ';cb=' + Math.random();
   url += ';qqq=' + (1 / bid.cpm);
-  url += ';hbt=' + config.getConfig('_bidderTimeout');
+  url += ';hbt=' + config.getConfig('bidderTimeout');
   url += ';style=adapter';
   url += ';vis=' + encodeURIComponent(document.visibilityState);
 

--- a/modules/vdoaiBidAdapter.js
+++ b/modules/vdoaiBidAdapter.js
@@ -87,7 +87,7 @@ export const spec = {
         // dealId: dealId,
         currency: currency,
         netRevenue: netRevenue,
-        ttl: config.getConfig('_bidderTimeout'),
+        ttl: 60,
         // referrer: referrer,
         // ad: response.adm
         // ad: adCreative,

--- a/modules/vdoaiBidAdapter.js
+++ b/modules/vdoaiBidAdapter.js
@@ -1,5 +1,4 @@
-import { getAdUnitSizes } from '../src/utils.js';
-import {config} from '../src/config.js';
+import {getAdUnitSizes} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 

--- a/modules/wipesBidAdapter.js
+++ b/modules/wipesBidAdapter.js
@@ -1,5 +1,4 @@
-import { logWarn } from '../src/utils.js';
-import {config} from '../src/config.js';
+import {logWarn} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER} from '../src/mediaTypes.js';
 

--- a/modules/wipesBidAdapter.js
+++ b/modules/wipesBidAdapter.js
@@ -50,7 +50,7 @@ function interpretResponse(serverResponse, bidRequest) {
       dealId: response.deal_id,
       currency: 'JPY',
       netRevenue: netRevenue,
-      ttl: config.getConfig('_bidderTimeout'),
+      ttl: 60,
       referrer: bidRequest.data.r || '',
       mediaType: BANNER,
       ad: response.ad_tag,

--- a/modules/yieldoneBidAdapter.js
+++ b/modules/yieldoneBidAdapter.js
@@ -147,7 +147,7 @@ export const spec = {
         dealId: dealId,
         currency: currency,
         netRevenue: netRevenue,
-        ttl: config.getConfig('_bidderTimeout'),
+        ttl: 60,
         referrer: referrer,
         meta: {
           advertiserDomains: response.adomain ? response.adomain : []

--- a/modules/yieldoneBidAdapter.js
+++ b/modules/yieldoneBidAdapter.js
@@ -1,8 +1,7 @@
 import {deepAccess, isEmpty, isStr, logWarn, parseSizesInput} from '../src/utils.js';
-import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
-import { Renderer } from '../src/Renderer.js';
-import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import {Renderer} from '../src/Renderer.js';
+import {BANNER, VIDEO} from '../src/mediaTypes.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory').Bid} Bid


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Multiple bid adapters are setting TTL from `getConfig('_bidderTimeout')`, which stopped working since https://github.com/prebid/Prebid.js/pull/9704 .
Since bid TTL is not related in any way to network timeouts, this PR changes them to use 60 seconds instead.

Bidders are welcome to select a different value or set it to a value returned in the payload. 


In one case - underdog media (@Jacobkmiller) - it's not as clear that this was unintentional, so I have kept the previous behavior.


## Other information

Closes https://github.com/prebid/Prebid.js/issues/9876
