### PR TITLE
Revert "Grid Bid Adapter: add support for video.plcmt"

### DIFF
--- a/modules/gridBidAdapter.js
+++ b/modules/gridBidAdapter.js
@@ -980,7 +980,6 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
           api: bidRequest.mediaTypes.video.api,
           skip: bidRequest.mediaTypes.video.skip,
           placement: bidRequest.mediaTypes.video.placement,
-          plcmt: bidRequest.mediaTypes.video.plcmt,
           minduration: bidRequest.mediaTypes.video.minduration,
           playbackmethod: bidRequest.mediaTypes.video.playbackmethod,
           startdelay: bidRequest.mediaTypes.video.startdelay

--- a/test/spec/modules/gridBidAdapter_spec.js
+++ b/test/spec/modules/gridBidAdapter_spec.js
@@ -423,7 +423,6 @@ describe('TheMediaGrid Adapter', function () {
               api: [1, 2],
               skip: 1,
               placement: 1,
-              plcmt: 2,
               minduration: 0,
               playbackmethod: 1,
               startdelay: 0
@@ -540,7 +539,6 @@ describe('TheMediaGrid Adapter', function () {
             ],
             'minduration': 0,
             'placement': 1,
-            'plcmt': 2,
             'playbackmethod': 1,
             'playersizes': [
               '400x600'


### PR DESCRIPTION
Reverts prebid/Prebid.js#9763 due to a failed circleci test on master