### PR TITLE
Impactify Bid Adapter : Remove syncstore from adapter

### DIFF
--- a/modules/impactifyBidAdapter.js
+++ b/modules/impactifyBidAdapter.js
@@ -91,7 +91,6 @@ const createOpenRtbRequest = (validBidRequests, bidderRequest) => {
 
   if (bidderRequest.uspConsent) {
     deepSetValue(request, 'regs.ext.us_privacy', bidderRequest.uspConsent);
-    this.syncStore.uspConsent = bidderRequest.uspConsent;
   }
 
   if (GETCONFIG('coppa') == true) deepSetValue(request, 'regs.coppa', 1);


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
We removed the usage of syncstore, which was causing an error when the us_privacy parameter was sent.