### PR TITLE
YieldlabBidAdapter updated native asset mapping

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -184,13 +184,12 @@ export const spec = {
 
         if (isNative(bidRequest, adType)) {
           // there may be publishers still rely on it
-          const url = `${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/?ts=${timestamp}${extId}${gdprApplies}${gdprConsent}${pvId}`;
-          bidResponse.adUrl = url;
+          bidResponse.adUrl = `${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/?ts=${timestamp}${extId}${gdprApplies}${gdprConsent}${pvId}`;
           bidResponse.mediaType = NATIVE;
-          const nativeImageAssetObj = find(matchedBid.native.assets, e => e.id === 2);
+          const nativeImageAssetObj = find(matchedBid.native.assets, asset => hasValidProperty(asset, 'img'));
           const nativeImageAsset = nativeImageAssetObj ? nativeImageAssetObj.img : { url: '', w: 0, h: 0 };
-          const nativeTitleAsset = find(matchedBid.native.assets, e => e.id === 1);
-          const nativeBodyAsset = find(matchedBid.native.assets, e => e.id === 3);
+          const nativeTitleAsset = find(matchedBid.native.assets, asset => hasValidProperty(asset, 'title'));
+          const nativeBodyAsset = find(matchedBid.native.assets, asset => hasValidProperty(asset, 'data'));
           bidResponse.native = {
             title: nativeTitleAsset ? nativeTitleAsset.title.text : '',
             body: nativeBodyAsset ? nativeBodyAsset.data.value : '',
@@ -201,6 +200,7 @@ export const spec = {
             },
             clickUrl: matchedBid.native.link.url,
             impressionTrackers: matchedBid.native.imptrackers,
+            assets: matchedBid.native.assets,
           };
         }
 
@@ -503,6 +503,17 @@ function getBidFloor(bid, sizes) {
     return (floor.floor * 100).toFixed(0);
   }
   return undefined;
+}
+
+/**
+ * Checks if an object has a property with a given name and the property value is not null or undefined.
+ *
+ * @param {Object} obj - The object to check.
+ * @param {string} propName - The name of the property to check.
+ * @returns {boolean} Returns true if the object has a property with the given name and the property value is not null or undefined, otherwise false.
+ */
+function hasValidProperty(obj, propName) {
+  return obj.hasOwnProperty(propName) && obj[propName] != null;
 }
 
 registerBidder(spec);

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -186,7 +186,7 @@ export const spec = {
           // there may be publishers still rely on it
           bidResponse.adUrl = `${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/?ts=${timestamp}${extId}${gdprApplies}${gdprConsent}${pvId}`;
           bidResponse.mediaType = NATIVE;
-          const nativeImageAssetObj = find(matchedBid.native.assets, asset => hasValidProperty(asset, 'img'));
+          const nativeImageAssetObj = find(matchedBid.native.assets, asset => isMainImage(asset));
           const nativeImageAsset = nativeImageAssetObj ? nativeImageAssetObj.img : { url: '', w: 0, h: 0 };
           const nativeTitleAsset = find(matchedBid.native.assets, asset => hasValidProperty(asset, 'title'));
           const nativeBodyAsset = find(matchedBid.native.assets, asset => hasValidProperty(asset, 'data'));
@@ -514,6 +514,17 @@ function getBidFloor(bid, sizes) {
  */
 function hasValidProperty(obj, propName) {
   return obj.hasOwnProperty(propName) && obj[propName] != null;
+}
+
+/**
+ * Checks if an asset object is a main image.
+ * A main image is defined as an image asset whose type value is 3.
+ *
+ * @param {Object} asset - The asset object to check.
+ * @returns {boolean} Returns true if the object has a property img.type with a value of 3, otherwise false.
+ */
+function isMainImage(asset) {
+  return asset?.img?.type === 3
 }
 
 registerBidder(spec);

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -569,6 +569,12 @@ describe('yieldlabBidAdapter', () => {
       expect(result[0].native.image.height).to.equal(100);
       expect(result[0].native.clickUrl).to.equal('https://www.yieldlab.de');
       expect(result[0].native.impressionTrackers.length).to.equal(3);
+      const titleAsset = result[0].native.assets.find(asset => 'title' in asset);
+      const imageAsset = result[0].native.assets.find(asset => 'img' in asset);
+      const bodyAsset = result[0].native.assets.find(asset => 'data' in asset);
+      expect(titleAsset).to.exist.and.to.have.nested.property('id', 1)
+      expect(imageAsset).to.exist.and.to.have.nested.property('id', 2)
+      expect(bodyAsset).to.exist.and.to.have.nested.property('id', 3)
     });
 
     it('should add adUrl and default native assets when type is Native', () => {

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -191,6 +191,7 @@ const NATIVE_RESPONSE = Object.assign({}, RESPONSE, {
           url: 'https://localhost:8080/yl-logo100x100.jpg',
           w: 100,
           h: 100,
+          type: 3,
         },
       },
       {
@@ -557,7 +558,6 @@ describe('yieldlabBidAdapter', () => {
 
     it('should add adUrl and native assets when type is Native', () => {
       const result = spec.interpretResponse({body: [NATIVE_RESPONSE]}, {validBidRequests: [NATIVE_REQUEST()], queryParams: REQPARAMS});
-
       expect(result[0].requestId).to.equal('2d925f27f5079f');
       expect(result[0].cpm).to.equal(0.01);
       expect(result[0].mediaType).to.equal('native');
@@ -569,6 +569,7 @@ describe('yieldlabBidAdapter', () => {
       expect(result[0].native.image.height).to.equal(100);
       expect(result[0].native.clickUrl).to.equal('https://www.yieldlab.de');
       expect(result[0].native.impressionTrackers.length).to.equal(3);
+      expect(result[0].native.assets.length).to.equal(3);
       const titleAsset = result[0].native.assets.find(asset => 'title' in asset);
       const imageAsset = result[0].native.assets.find(asset => 'img' in asset);
       const bodyAsset = result[0].native.assets.find(asset => 'data' in asset);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
YieldlabBidAdapter added asset mapping for native ad server responses and mapped native assets based on property names instead of IDs to account for dynamic assets.

## Other information
One approving review from a Yieldlab team member required. (@rey1128, @Mufas61 or @kippsterr)
