### PR TITLE
Prebid 8: remove special augmentation of `auctionInit` event

### DIFF
--- a/libraries/analyticsAdapter/AnalyticsAdapter.js
+++ b/libraries/analyticsAdapter/AnalyticsAdapter.js
@@ -134,13 +134,7 @@ export default function AnalyticsAdapter({ url, analyticsType, global, handler }
       handlers = Object.fromEntries(
         Array.from(trackedEvents)
           .map((ev) => {
-            const handler = ev === CONSTANTS.EVENTS.AUCTION_INIT
-              ? (args) => {
-                // TODO: remove this special case in v8
-                args.config = typeof config === 'object' ? config.options || {} : {};
-                this.enqueue({eventType: ev, args});
-              }
-              : (args) => this.enqueue({eventType: ev, args});
+            const handler = (args) => this.enqueue({eventType: ev, args});
             events.on(ev, handler);
             return [ev, handler];
           })

--- a/modules/genericAnalyticsAdapter.js
+++ b/modules/genericAnalyticsAdapter.js
@@ -115,11 +115,6 @@ export function GenericAnalytics() {
         }
       },
       track(event) {
-        if (event.eventType === CONSTANTS.EVENTS.AUCTION_INIT && event.args.hasOwnProperty('config')) {
-          // clean up auctionInit event
-          // TODO: remove this special case in v8
-          delete event.args.config;
-        }
         const datum = translate(event);
         if (datum != null) {
           batch.push(datum);

--- a/test/spec/modules/terceptAnalyticsAdapter_spec.js
+++ b/test/spec/modules/terceptAnalyticsAdapter_spec.js
@@ -709,7 +709,6 @@ describe('tercept analytics adapter', function () {
         'bidsReceived': [],
         'winningBids': [],
         'timeout': 1000,
-        'config': initOptions
       },
       'initOptions': initOptions
     };


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change

For reasons lost in time, the `auctionInit` event payload is modified to include analytics init configuration before being sent to analyics adaptesrs. 
Since that configuration is already available to them, and none of the existing adapters seem to use it (except for getting rid of it), this removes the special case.

## Other information
Closes https://github.com/prebid/Prebid.js/issues/9889
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
