### PR TITLE
Prebid 8: do not use hardcoded `bidderCode` in responses from bid adapters

### DIFF
--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -681,7 +681,6 @@ function _createBidResponse(bid, cur) {
     bid.adomain && bid.adomain.length;
   const bidResponse = {
     requestId: bid.impid,
-    bidderCode: BIDDER_CODE,
     cpm: bid.price,
     width: bid.w,
     height: bid.h,

--- a/modules/adkernelAdnBidAdapter.js
+++ b/modules/adkernelAdnBidAdapter.js
@@ -99,7 +99,6 @@ function buildSite(refInfo) {
 function buildBid(tag) {
   let bid = {
     requestId: tag.impid,
-    bidderCode: spec.code,
     cpm: tag.bid,
     creativeId: tag.crid,
     currency: 'USD',

--- a/modules/advangelistsBidAdapter.js
+++ b/modules/advangelistsBidAdapter.js
@@ -58,7 +58,6 @@ export const spec = {
       if (isVideoBid(bidRequest)) {
         let bidResponse = {
           requestId: response.id,
-          bidderCode: BIDDER_CODE,
           cpm: response.seatbid[0].bid[0].price,
           width: response.seatbid[0].bid[0].w,
           height: response.seatbid[0].bid[0].h,

--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -103,7 +103,6 @@ export const spec = {
       let responseMeta = Object.assign({ mediaType: VIDEO, advertiserDomains: [] }, response.meta);
       let bidResponse = {
         requestId: bidRequest.bidId,
-        bidderCode: spec.code,
         cpm: response.bidPrice,
         width: firstSize.w,
         height: firstSize.h,

--- a/modules/browsiBidAdapter.js
+++ b/modules/browsiBidAdapter.js
@@ -98,7 +98,6 @@ export const spec = {
       width: w,
       height: h,
       currency: cur,
-      bidderCode: BIDDER_CODE,
       ...extraParams
     };
     bidResponses.push(bidResponse);

--- a/modules/finativeBidAdapter.js
+++ b/modules/finativeBidAdapter.js
@@ -174,7 +174,6 @@ export const spec = {
             netRevenue: (!bid.netRevenue || bid.netRevenue === 'net'),
             currency: cur,
             mediaType: NATIVE,
-            bidderCode: BIDDER_CODE,
             native: parseNative(bidResponse),
             meta: {
               advertiserDomains: bidResponse.adomain && bidResponse.adomain.length > 0 ? bidResponse.adomain : []

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -125,7 +125,6 @@ export const spec = {
         `(function() { var img = new Image(); img.src = "${beaconUrl}"})()` +
         `</script>`;
       let data = {
-        bidderCode: BIDDER_CODE,
         requestId: res.id,
         currency: res.cur,
         cpm: parseFloat(bid.price) || 0,

--- a/modules/kulturemediaBidAdapter.js
+++ b/modules/kulturemediaBidAdapter.js
@@ -440,7 +440,6 @@ function _createBidResponse(bid) {
     bid.adomain && bid.adomain.length;
   const bidResponse = {
     requestId: bid.impid,
-    bidderCode: spec.code,
     cpm: bid.price,
     width: bid.w,
     height: bid.h,

--- a/modules/livewrappedBidAdapter.js
+++ b/modules/livewrappedBidAdapter.js
@@ -130,7 +130,6 @@ export const spec = {
     serverResponse.body.ads.forEach(function(ad) {
       var bidResponse = {
         requestId: ad.bidId,
-        bidderCode: BIDDER_CODE,
         cpm: ad.cpmBid,
         width: ad.width,
         height: ad.height,

--- a/modules/mediasniperBidAdapter.js
+++ b/modules/mediasniperBidAdapter.js
@@ -116,7 +116,6 @@ export const spec = {
           bidderSeat.bid.forEach((bid) => {
             const newBid = {
               requestId: bid.impid,
-              bidderCode: spec.code,
               cpm: bid.price || 0,
               width: bid.w,
               height: bid.h,

--- a/modules/revcontentBidAdapter.js
+++ b/modules/revcontentBidAdapter.js
@@ -120,8 +120,6 @@ export const spec = {
         currency: response.cur || 'USD',
         ttl: 360,
         netRevenue: true,
-        bidder: 'revcontent',
-        bidderCode: 'revcontent'
       };
       if ('banner' in imp) {
         prBid.mediaType = BANNER;

--- a/modules/rhythmoneBidAdapter.js
+++ b/modules/rhythmoneBidAdapter.js
@@ -16,7 +16,6 @@ function RhythmOneBidAdapter() {
   let SUPPORTED_VIDEO_DELIVERY = [1];
   let SUPPORTED_VIDEO_API = [1, 2, 5];
   let slotsToBids = {};
-  let that = this;
   let version = '2.1';
 
   this.isBidRequestValid = function (bid) {
@@ -237,7 +236,6 @@ function RhythmOneBidAdapter() {
       let bidRequest = slotsToBids[bid.impid];
       let bidResponse = {
         requestId: bidRequest.bidId,
-        bidderCode: that.code,
         cpm: parseFloat(bid.price),
         width: bid.w,
         height: bid.h,

--- a/modules/saambaaBidAdapter.js
+++ b/modules/saambaaBidAdapter.js
@@ -62,7 +62,6 @@ export const spec = {
       if (isVideoBid(bidRequest)) {
         let bidResponse = {
           requestId: response.id,
-          bidderCode: BIDDER_CODE,
           cpm: response.seatbid[0].bid[0].price,
           width: response.seatbid[0].bid[0].w,
           height: response.seatbid[0].bid[0].h,

--- a/modules/seedingAllianceBidAdapter.js
+++ b/modules/seedingAllianceBidAdapter.js
@@ -167,7 +167,6 @@ export const spec = {
             netRevenue: true,
             currency: cur,
             mediaType: type,
-            bidderCode: BIDDER_CODE,
             meta: {
               advertiserDomains: bidResponse.adomain && bidResponse.adomain.length > 0 ? bidResponse.adomain : []
             }

--- a/modules/showheroes-bsBidAdapter.js
+++ b/modules/showheroes-bsBidAdapter.js
@@ -86,7 +86,6 @@ export const spec = {
           bidId: bid.bidId,
           context: context,
           auctionId: bidderRequest.auctionId,
-          bidderCode: BIDDER_CODE,
           start: +new Date(),
           timeout: 3000,
           params: bid.params,

--- a/modules/smartytechBidAdapter.js
+++ b/modules/smartytechBidAdapter.js
@@ -119,7 +119,6 @@ export const spec = {
     const bidObject = {
       requestId: request.bidId,
       adUnitCode: request.adUnitCode,
-      bidderCode: BIDDER_CODE,
       ad: response.ad,
       cpm: response.cpm,
       width: response.width,

--- a/modules/sspBCBidAdapter.js
+++ b/modules/sspBCBidAdapter.js
@@ -736,7 +736,6 @@ const spec = {
               ttl: exp,
               width: w,
               height: h,
-              bidderCode: BIDDER_CODE,
               meta: {
                 advertiserDomains: adomain,
                 networkName: seat,

--- a/modules/theAdxBidAdapter.js
+++ b/modules/theAdxBidAdapter.js
@@ -253,7 +253,6 @@ export const spec = {
         }
 
         let response = {
-          bidderCode: BIDDER_CODE,
           requestId: request.bidId,
           cpm: bid.price,
           width: bidWidth | 0,

--- a/modules/underdogmediaBidAdapter.js
+++ b/modules/underdogmediaBidAdapter.js
@@ -185,7 +185,6 @@ export const spec = {
 
       const bidResponse = {
         requestId: bidParam.bidId,
-        bidderCode: spec.code,
         cpm: parseFloat(mid.cpm),
         width: mid.width,
         height: mid.height,

--- a/modules/videobyteBidAdapter.js
+++ b/modules/videobyteBidAdapter.js
@@ -90,7 +90,6 @@ export const spec = {
       if (bid.adm && bid.price) {
         let bidResponse = {
           requestId: response.id,
-          bidderCode: spec.code,
           cpm: bid.price,
           width: bid.w,
           height: bid.h,

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -1945,7 +1945,6 @@ describe('33acrossBidAdapter:', function () {
         };
         const bidResponse = {
           requestId: 'b1',
-          bidderCode: BIDDER_CODE,
           cpm: 0.0938,
           width: 300,
           height: 250,
@@ -1991,7 +1990,6 @@ describe('33acrossBidAdapter:', function () {
         };
         const bidResponse = {
           requestId: 'b1',
-          bidderCode: BIDDER_CODE,
           cpm: 0.0938,
           width: 300,
           height: 250,
@@ -2035,7 +2033,6 @@ describe('33acrossBidAdapter:', function () {
           // Bid response below doesn't contain meta.advertiserDomains
           const bidResponse = {
             requestId: 'b1',
-            bidderCode: BIDDER_CODE,
             cpm: 0.0938,
             width: 300,
             height: 250,
@@ -2115,7 +2112,6 @@ describe('33acrossBidAdapter:', function () {
         const bidResponse = [
           {
             requestId: 'b1',
-            bidderCode: BIDDER_CODE,
             cpm: 0.0940,
             width: 300,
             height: 250,
@@ -2128,7 +2124,6 @@ describe('33acrossBidAdapter:', function () {
           },
           {
             requestId: 'b2',
-            bidderCode: BIDDER_CODE,
             cpm: 0.0938,
             width: 300,
             height: 250,
@@ -2141,7 +2136,6 @@ describe('33acrossBidAdapter:', function () {
           },
           {
             requestId: 'b3',
-            bidderCode: BIDDER_CODE,
             cpm: 0.0938,
             width: 300,
             height: 250,

--- a/test/spec/modules/adkernelAdnBidAdapter_spec.js
+++ b/test/spec/modules/adkernelAdnBidAdapter_spec.js
@@ -374,7 +374,6 @@ describe('AdkernelAdn adapter', function () {
 
     it('should return fully-initialized bid-response', function () {
       let resp = responses[0];
-      expect(resp).to.have.property('bidderCode', 'adkernelAdn');
       expect(resp).to.have.property('requestId', '2c5e951baeeadd');
       expect(resp).to.have.property('cpm', 5.0);
       expect(resp).to.have.property('width', 300);
@@ -394,7 +393,6 @@ describe('AdkernelAdn adapter', function () {
 
     it('should return fully-initialized video bid-response', function () {
       let resp = responses[2];
-      expect(resp).to.have.property('bidderCode', 'adkernelAdn');
       expect(resp).to.have.property('requestId', '57d602ad1c9545');
       expect(resp).to.have.property('cpm', 10.0);
       expect(resp).to.have.property('creativeId', '108_158802');

--- a/test/spec/modules/advangelistsBidAdapter_spec.js
+++ b/test/spec/modules/advangelistsBidAdapter_spec.js
@@ -93,7 +93,6 @@ describe('advangelistsBidAdapter', function () {
         delete bidResponseVid['ad'];
         expect(bidResponseVid).to.deep.equal({
           requestId: bidRequestsVid[0].bidId,
-          bidderCode: 'advangelists',
           creativeId: serverResponseVid.seatbid[0].bid[0].crid,
           cpm: serverResponseVid.seatbid[0].bid[0].price,
           width: serverResponseVid.seatbid[0].bid[0].w,

--- a/test/spec/modules/beachfrontBidAdapter_spec.js
+++ b/test/spec/modules/beachfrontBidAdapter_spec.js
@@ -695,7 +695,6 @@ describe('BeachfrontAdapter', function () {
         const bidResponse = spec.interpretResponse({ body: serverResponse }, { bidRequest });
         expect(bidResponse).to.deep.equal({
           requestId: bidRequest.bidId,
-          bidderCode: spec.code,
           cpm: serverResponse.bidPrice,
           creativeId: serverResponse.crid,
           vastUrl: serverResponse.url,

--- a/test/spec/modules/browsiBidAdapter_spec.js
+++ b/test/spec/modules/browsiBidAdapter_spec.js
@@ -157,7 +157,6 @@ describe('browsi Bid Adapter Test', function () {
       const actualBidResponse = bidResponses[0];
       const expectedBidResponse = {
         requestId: bidRequest.data.bidId,
-        bidderCode: 'browsi',
         bidId: 'bidId1',
         width: 300,
         height: 250,

--- a/test/spec/modules/finativeBidAdapter_spec.js
+++ b/test/spec/modules/finativeBidAdapter_spec.js
@@ -166,7 +166,6 @@ describe('Finative adapter', function () {
       assert.deepEqual(result[0].cpm, bid.price);
       assert.deepEqual(result[0].creativeId, bid.crid);
       assert.deepEqual(result[0].mediaType, 'native');
-      assert.deepEqual(result[0].bidderCode, 'finative');
     });
 
     it('should return the correct tracking links', function () {

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -319,7 +319,6 @@ describe('fluctAdapter', function () {
 
       const expectedResponse = [
         {
-          bidderCode: 'fluct',
           requestId: '237f4d1a293f99',
           currency: 'JPY',
           cpm: 100,
@@ -376,7 +375,6 @@ describe('fluctAdapter', function () {
 
       const expectedResponse = [
         {
-          bidderCode: 'fluct',
           requestId: '237f4d1a293f99',
           currency: 'JPY',
           cpm: 100,

--- a/test/spec/modules/kulturemediaBidAdapter_spec.js
+++ b/test/spec/modules/kulturemediaBidAdapter_spec.js
@@ -530,7 +530,6 @@ describe('kulturemediaBidAdapter:', function () {
         let o = {
           requestId: serverResponse.seatbid[0].bid[0].impid,
           ad: '<VAST></VAST>',
-          bidderCode: spec.code,
           cpm: serverResponse.seatbid[0].bid[0].price,
           creativeId: serverResponse.seatbid[0].bid[0].crid,
           vastXml: serverResponse.seatbid[0].bid[0].adm,

--- a/test/spec/modules/livewrappedBidAdapter_spec.js
+++ b/test/spec/modules/livewrappedBidAdapter_spec.js
@@ -1211,7 +1211,6 @@ describe('Livewrapped adapter tests', function () {
 
       let expectedResponse = [{
         requestId: '32e50fad901ae89',
-        bidderCode: 'livewrapped',
         cpm: 2.565917,
         width: 300,
         height: 250,
@@ -1251,7 +1250,6 @@ describe('Livewrapped adapter tests', function () {
 
       let expectedResponse = [{
         requestId: '32e50fad901ae89',
-        bidderCode: 'livewrapped',
         cpm: 2.565917,
         width: 300,
         height: 250,
@@ -1293,7 +1291,6 @@ describe('Livewrapped adapter tests', function () {
 
       let expectedResponse = [{
         requestId: '32e50fad901ae89',
-        bidderCode: 'livewrapped',
         cpm: 2.565917,
         width: 300,
         height: 250,
@@ -1347,7 +1344,6 @@ describe('Livewrapped adapter tests', function () {
 
       let expectedResponse = [{
         requestId: '32e50fad901ae89',
-        bidderCode: 'livewrapped',
         cpm: 2.565917,
         width: 300,
         height: 250,
@@ -1359,7 +1355,6 @@ describe('Livewrapped adapter tests', function () {
         meta: undefined
       }, {
         requestId: '42e50fad901ae89',
-        bidderCode: 'livewrapped',
         cpm: 3.565917,
         width: 980,
         height: 240,
@@ -1398,7 +1393,6 @@ describe('Livewrapped adapter tests', function () {
 
       let expectedResponse = [{
         requestId: '32e50fad901ae89',
-        bidderCode: 'livewrapped',
         cpm: 2.565917,
         width: 300,
         height: 250,

--- a/test/spec/modules/revcontentBidAdapter_spec.js
+++ b/test/spec/modules/revcontentBidAdapter_spec.js
@@ -266,8 +266,6 @@ describe('revcontent adapter', function () {
     it('should set correct native params', function () {
       const result = spec.interpretResponse(serverResponse, bidRequest)[0];
 
-      assert.equal(result.bidder, 'revcontent');
-      assert.equal(result.bidderCode, 'revcontent');
       assert.equal(result.mediaType, 'native');
       assert.equal(result.requestId, '294a7f446202848');
       assert.equal(result.cpm, '0.1');
@@ -279,8 +277,6 @@ describe('revcontent adapter', function () {
       bidRequest.bid[0].params.size.height = 90;
 
       const result = spec.interpretResponse(serverResponse, bidRequest)[0];
-      assert.equal(result.bidder, 'revcontent');
-      assert.equal(result.bidderCode, 'revcontent');
       assert.equal(result.mediaType, 'native');
       assert.equal(result.requestId, '294a7f446202848');
       assert.equal(result.cpm, '0.1');
@@ -292,8 +288,6 @@ describe('revcontent adapter', function () {
       bidRequest.bid[0].params.size.height = 600;
 
       const result = spec.interpretResponse(serverResponse, bidRequest)[0];
-      assert.equal(result.bidder, 'revcontent');
-      assert.equal(result.bidderCode, 'revcontent');
       assert.equal(result.mediaType, 'native');
       assert.equal(result.requestId, '294a7f446202848');
       assert.equal(result.cpm, '0.1');
@@ -304,8 +298,6 @@ describe('revcontent adapter', function () {
       bidRequest.bid[0].params.template = '<a href="{clickUrl}" rel="nofollow sponsored"  target="_blank" style="    border: 1px solid #eee;    width: 298px;    height: 248px;    display: block;"><div style="background-image:url({image});width: 300px;height: 165px;background-repeat: none;background-size: cover;"><div style="position: absolute;top: 160px;left:12px"><h1 style="color: #000;font-family: Arial, sans-serif;font-size: 19px; position: relative; width: 290px;">{title}</h1> <div style="border:1px solid #000;text-align:center;width:94%;font-family:Verdana;font-size:12px;color:#000">SEE MORE</div></div></div></a>';
 
       const result = spec.interpretResponse(serverResponse, bidRequest)[0];
-      assert.equal(result.bidder, 'revcontent');
-      assert.equal(result.bidderCode, 'revcontent');
       assert.equal(result.mediaType, 'native');
       assert.equal(result.requestId, '294a7f446202848');
       assert.equal(result.cpm, '0.1');
@@ -317,8 +309,6 @@ describe('revcontent adapter', function () {
       bidRequest.bid[0].params.size.height = 200;
 
       const result = spec.interpretResponse(serverResponse, bidRequest)[0];
-      assert.equal(result.bidder, 'revcontent');
-      assert.equal(result.bidderCode, 'revcontent');
       assert.equal(result.mediaType, 'native');
       assert.equal(result.requestId, '294a7f446202848');
       assert.equal(result.cpm, '0.1');

--- a/test/spec/modules/seedingAllianceAdapter_spec.js
+++ b/test/spec/modules/seedingAllianceAdapter_spec.js
@@ -189,7 +189,6 @@ describe('SeedingAlliance adapter', function () {
       const resultNative = spec.interpretResponse(goodNativeResponse, bidNativeRequest);
       const bidNative = goodNativeResponse.body.seatbid[0].bid[0];
 
-      assert.deepEqual(resultNative[0].bidderCode, 'seedingAlliance');
       assert.deepEqual(resultNative[0].currency, goodNativeResponse.body.cur);
       assert.deepEqual(resultNative[0].requestId, bidNativeRequest.bidRequests[0].bidId);
       assert.deepEqual(resultNative[0].cpm, bidNative.price);
@@ -198,7 +197,6 @@ describe('SeedingAlliance adapter', function () {
 
       const resultBanner = spec.interpretResponse(goodBannerResponse, bidBannerRequest);
 
-      assert.deepEqual(resultBanner[0].bidderCode, 'seedingAlliance');
       assert.deepEqual(resultBanner[0].mediaType, 'banner');
       assert.deepEqual(resultBanner[0].width, bidBannerRequest.bidRequests[0].sizes[0]);
       assert.deepEqual(resultBanner[0].height, bidBannerRequest.bidRequests[0].sizes[1]);

--- a/test/spec/modules/sspBCBidAdapter_spec.js
+++ b/test/spec/modules/sspBCBidAdapter_spec.js
@@ -611,14 +611,14 @@ describe('SSPBC adapter', function () {
 
       expect(result.length).to.equal(bids.length);
       expect(resultSingle.length).to.equal(1);
-      expect(resultSingle[0]).to.have.keys('ad', 'cpm', 'width', 'height', 'bidderCode', 'mediaType', 'meta', 'requestId', 'creativeId', 'currency', 'netRevenue', 'ttl', 'vurls');
+      expect(resultSingle[0]).to.have.keys('ad', 'cpm', 'width', 'height', 'mediaType', 'meta', 'requestId', 'creativeId', 'currency', 'netRevenue', 'ttl', 'vurls');
     });
 
     it('should create bid from OneCode (parameter-less) request, if response contains siteId', function () {
       let resultOneCode = spec.interpretResponse(serverResponseOneCode, requestOneCode);
 
       expect(resultOneCode.length).to.equal(1);
-      expect(resultOneCode[0]).to.have.keys('ad', 'cpm', 'width', 'height', 'bidderCode', 'mediaType', 'meta', 'requestId', 'creativeId', 'currency', 'netRevenue', 'ttl', 'vurls');
+      expect(resultOneCode[0]).to.have.keys('ad', 'cpm', 'width', 'height', 'mediaType', 'meta', 'requestId', 'creativeId', 'currency', 'netRevenue', 'ttl', 'vurls');
     });
 
     it('should not create bid from OneCode (parameter-less) request, if response does not contain siteId', function () {
@@ -649,7 +649,7 @@ describe('SSPBC adapter', function () {
       expect(resultVideo.length).to.equal(1);
 
       let videoBid = resultVideo[0];
-      expect(videoBid).to.have.keys('adType', 'bidderCode', 'cpm', 'creativeId', 'currency', 'width', 'height', 'meta', 'mediaType', 'netRevenue', 'requestId', 'ttl', 'vastContent', 'vastXml', 'vastUrl', 'vurls');
+      expect(videoBid).to.have.keys('adType', 'cpm', 'creativeId', 'currency', 'width', 'height', 'meta', 'mediaType', 'netRevenue', 'requestId', 'ttl', 'vastContent', 'vastXml', 'vastUrl', 'vurls');
       expect(videoBid.adType).to.equal('instream');
       expect(videoBid.mediaType).to.equal('video');
       expect(videoBid.vastXml).to.match(/^<\?xml.*<\/VAST>$/);
@@ -663,7 +663,7 @@ describe('SSPBC adapter', function () {
       expect(resultNative.length).to.equal(1);
 
       let nativeBid = resultNative[0];
-      expect(nativeBid).to.have.keys('bidderCode', 'cpm', 'creativeId', 'currency', 'width', 'height', 'meta', 'mediaType', 'netRevenue', 'requestId', 'ttl', 'native', 'vurls');
+      expect(nativeBid).to.have.keys('cpm', 'creativeId', 'currency', 'width', 'height', 'meta', 'mediaType', 'netRevenue', 'requestId', 'ttl', 'native', 'vurls');
       expect(nativeBid.native).to.have.keys('image', 'icon', 'title', 'sponsoredBy', 'body', 'clickUrl', 'impressionTrackers', 'javascriptTrackers', 'clickTrackers');
     });
   });

--- a/test/spec/modules/underdogmediaBidAdapter_spec.js
+++ b/test/spec/modules/underdogmediaBidAdapter_spec.js
@@ -967,7 +967,6 @@ describe('UnderdogMedia adapter', function () {
         expect(bids).to.be.lengthOf(2);
 
         expect(bids[0].meta.advertiserDomains).to.deep.equal(['domain1'])
-        expect(bids[0].bidderCode).to.equal('underdogmedia');
         expect(bids[0].cpm).to.equal(2.5);
         expect(bids[0].width).to.equal('160');
         expect(bids[0].height).to.equal('600');

--- a/test/spec/modules/videobyteBidAdapter_spec.js
+++ b/test/spec/modules/videobyteBidAdapter_spec.js
@@ -463,7 +463,6 @@ describe('VideoByteBidAdapter', function () {
       });
       let o = {
         requestId: serverResponse.id,
-        bidderCode: spec.code,
         cpm: serverResponse.seatbid[0].bid[0].price,
         creativeId: serverResponse.seatbid[0].bid[0].crid,
         vastXml: serverResponse.seatbid[0].bid[0].adm,


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fix a number of adapters that break aliasing by forcing their `bidderCode`.


## Other information

Closes https://github.com/prebid/Prebid.js/issues/9047

