### PR TITLE
Prebid 8: do not call bidder methods (`onBidWon`, `onBidBillable`, ...) for S2S bids

### DIFF
--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -585,9 +585,11 @@ function invokeBidderMethod(bidder, method, spec, fn, ...params) {
 }
 
 function tryCallBidderMethod(bidder, method, param) {
-  const target = getBidderMethod(bidder, method);
-  if (target != null) {
-    invokeBidderMethod(bidder, method, ...target, param);
+  if (param?.src !== CONSTANTS.S2S.SRC) {
+    const target = getBidderMethod(bidder, method);
+    if (target != null) {
+      invokeBidderMethod(bidder, method, ...target, param);
+    }
   }
 }
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Closes https://github.com/prebid/Prebid.js/issues/9515

