### PR TITLE
Yahoo SSP adapter support for extra site publisher info.

### DIFF
--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -380,6 +380,7 @@ function appendFirstPartyData(outBoundBidRequest, bid) {
   const ortb2Object = bid.ortb2;
   const siteObject = deepAccess(ortb2Object, 'site') || undefined;
   const siteContentObject = deepAccess(siteObject, 'content') || undefined;
+  const sitePublisherObject = deepAccess(siteObject, 'publisher') || undefined;
   const siteContentDataArray = deepAccess(siteObject, 'content.data') || undefined;
   const appContentObject = deepAccess(ortb2Object, 'app.content') || undefined;
   const appContentDataArray = deepAccess(ortb2Object, 'app.content.data') || undefined;
@@ -393,6 +394,11 @@ function appendFirstPartyData(outBoundBidRequest, bid) {
     outBoundBidRequest.site = validateAppendObject('array', allowedSiteArrayKeys, siteObject, outBoundBidRequest.site);
     outBoundBidRequest.site = validateAppendObject('object', allowedSiteObjectKeys, siteObject, outBoundBidRequest.site);
   };
+
+  if (sitePublisherObject && isPlainObject(sitePublisherObject)) {
+    const allowedPublisherObjectKeys = ['ext'];
+    outBoundBidRequest.site.publisher = validateAppendObject('object', allowedPublisherObjectKeys, sitePublisherObject, outBoundBidRequest.site.publisher);
+  }
 
   if (siteContentObject && isPlainObject(siteContentObject)) {
     const allowedContentStringKeys = ['id', 'title', 'series', 'season', 'genre', 'contentrating', 'language'];

--- a/modules/yahoosspBidAdapter.md
+++ b/modules/yahoosspBidAdapter.md
@@ -435,6 +435,43 @@ pbjs.setConfig({
             }
         });
 ```
+
+Notes: The first party site info is filtered and only the following specific keys are allowed in the bidRequests:
+
+| Field                       | Type   |
+|-----------------------------|--------|
+| site.name                   | String |
+| site.domain                 | String |
+| site.page                   | String |
+| site.ref                    | String |
+| site.keywords               | String |
+| site.search                 | String |
+| site.cat                    | Array  |
+| site.sectioncat             | Array  |
+| site.pagecat                | Array  |
+| site.ext                    | Object |
+| site.publisher.ext          | Object |
+| site.content.id             | String |
+| site.content.title          | String |
+| site.content.series         | String |
+| site.content.season         | String |
+| site.content.genre          | String |
+| site.content.contentrating  | String |
+| site.content.language       | String |
+| site.content.episode        | Number |
+| site.content.prodq          | Number |
+| site.content.context        | Number |
+| site.content.livestream     | Number |
+| site.content.len            | Number |
+| site.content.cat            | Array  |
+| site.content.ext            | Object |
+| site.content.data           | Array  |
+| site.content.data[].id      | String |
+| site.content.data[].name    | String |
+| site.content.data[].segment | Array  |
+| site.content.data[].ext     | Object |
+
+
 ### Passing First Party "user" data:
 ```javascript
 pbjs.setConfig({

--- a/test/spec/modules/yahoosspBidAdapter_spec.js
+++ b/test/spec/modules/yahoosspBidAdapter_spec.js
@@ -481,6 +481,23 @@ describe('YahooSSP Bid Adapter:', () => {
       });
     });
 
+    const VALID_PUBLISHER_OBJECTS = ['ext'];
+    VALID_PUBLISHER_OBJECTS.forEach(param => {
+      it(`should determine that the ortb2.site.publisher Object key is valid and append to the bid-request:  ${JSON.stringify(param)}`, () => {
+        const ortb2 = {
+          site: {
+            publisher: {
+              [param]: {a: '123', b: '456'}
+            }
+          }
+        };
+        const { validBidRequests, bidderRequest } = generateBuildRequestMock({ortb2});
+        const data = spec.buildRequests(validBidRequests, bidderRequest)[0].data;
+        expect(data.site.publisher[param]).to.be.a('object');
+        expect(data.site.publisher[param]).to.be.equal(ortb2.site.publisher[param]);
+      });
+    });
+
     const VALID_CONTENT_ARRAYS = ['cat'];
     VALID_CONTENT_ARRAYS.forEach(param => {
       it(`should determine that the ortb2.site Array key is valid and append to the bid-request: ${JSON.stringify(param)}`, () => {
@@ -512,7 +529,6 @@ describe('YahooSSP Bid Adapter:', () => {
         const data = spec.buildRequests(validBidRequests, bidderRequest)[0].data;
         expect(data.site.content[param]).to.be.a('object');
         expect(data.site.content[param]).to.be.equal(ortb2.site.content[param]);
-        config.setConfig({ortb2: {}});
       });
     });
   });
@@ -957,6 +973,49 @@ describe('YahooSSP Bid Adapter:', () => {
       validBidRequests[0].params.siteId = '1234567';
       const data = spec.buildRequests(validBidRequests, bidderRequest).data;
       expect(data.site.id).to.equal('1234567');
+    });
+
+    it('should use site publisher ortb2 config in default integration mode', () => {
+      const ortb2 = {
+        site: {
+          publisher: {
+            ext: {
+              publisherblob: 'pblob',
+              bucket: 'bucket'
+            }
+          }
+        }
+      }
+      let { validBidRequests, bidderRequest } = generateBuildRequestMock({ortb2});
+      const data = spec.buildRequests(validBidRequests, bidderRequest).data;
+      expect(data.site.publisher).to.deep.equal({
+        ext: {
+          publisherblob: 'pblob',
+          bucket: 'bucket'
+        }
+      });
+    });
+
+    it('should use site publisher ortb2 config when using "pubId" integration mode', () => {
+      const ortb2 = {
+        site: {
+          publisher: {
+            ext: {
+              publisherblob: 'pblob',
+              bucket: 'bucket'
+            }
+          }
+        }
+      }
+      let { validBidRequests, bidderRequest } = generateBuildRequestMock({pubIdMode: true, ortb2});
+      const data = spec.buildRequests(validBidRequests, bidderRequest).data;
+      expect(data.site.publisher).to.deep.equal({
+        id: DEFAULT_PUBID,
+        ext: {
+          publisherblob: 'pblob',
+          bucket: 'bucket'
+        }
+      });
     });
 
     it('should use placementId value as imp.tagid in the outbound bid-request when using "pubId" integration mode', () => {


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
The purpose of this change is to allow extra first party OpenRTB data to be sent to our back-ends, in particular the openRTB.site.publisher.ext information.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
