### PR TITLE
Rubicon Bid Adapter : access x_source.tid from ortb2 object

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -464,7 +464,7 @@ export const spec = {
       'rp_floor': (params.floor = parseFloat(params.floor)) >= 0.01 ? params.floor : undefined,
       'rp_secure': '1',
       'tk_flint': `${rubiConf.int_type || DEFAULT_INTEGRATION}_v$prebid.version$`,
-      'x_source.tid': bidRequest.transactionId,
+      'x_source.tid': deepAccess(bidderRequest, 'ortb2.source.tid'),
       'x_imp.ext.tid': bidRequest.transactionId,
       'l_pb_bid_id': bidRequest.bidId,
       'p_screen_res': _getScreenResolution(),

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -89,6 +89,7 @@ describe('the rubicon adapter', function () {
       bidderCode: 'rubicon',
       auctionId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
       bidderRequestId: '178e34bad3658f',
+      ortb2: { source: {tid: 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b'}},
       bids: [
         {
           bidder: 'rubicon',
@@ -346,6 +347,7 @@ describe('the rubicon adapter', function () {
           transactionId: 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b'
         }
       ],
+      ortb2: { source: {tid: 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b'}},
       start: 1472239426002,
       auctionStart: 1472239426000,
       timeout: 5000
@@ -619,7 +621,6 @@ describe('the rubicon adapter', function () {
             'rand': '0.1',
             'tk_flint': INTEGRATION,
             'x_source.tid': 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b',
-            'x_imp.ext.tid': 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b',
             'p_screen_res': /\d+x\d+/,
             'tk_user_key': '12346',
             'kw': 'a,b,c',
@@ -2276,6 +2277,8 @@ describe('the rubicon adapter', function () {
       });
 
       describe('createSlotParams', function () {
+        const localBidderRequest = Object.assign({}, bidderRequest);
+        localBidderRequest.ortb2 = {source: {tid: 'faked707-a418-42ec-b8a7-b70a6c6fab0b'}};
         it('should return a valid slot params object', function () {
           let expectedQuery = {
             'account_id': '14062',
@@ -2286,7 +2289,8 @@ describe('the rubicon adapter', function () {
             'p_pos': 'atf',
             'rp_secure': /[01]/,
             'tk_flint': INTEGRATION,
-            'x_source.tid': 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b',
+            'x_source.tid': 'faked707-a418-42ec-b8a7-b70a6c6fab0b',
+            'x_imp.ext.tid': 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b',
             'p_screen_res': /\d+x\d+/,
             'tk_user_key': '12346',
             'kw': 'a,b,c',
@@ -2299,7 +2303,7 @@ describe('the rubicon adapter', function () {
             'rf': 'localhost'
           };
 
-          const slotParams = spec.createSlotParams(bidderRequest.bids[0], bidderRequest);
+          const slotParams = spec.createSlotParams(bidderRequest.bids[0], localBidderRequest);
 
           // test that all values above are both present and correct
           Object.keys(expectedQuery).forEach(key => {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -89,7 +89,7 @@ describe('the rubicon adapter', function () {
       bidderCode: 'rubicon',
       auctionId: 'c45dd708-a418-42ec-b8a7-b70a6c6fab0a',
       bidderRequestId: '178e34bad3658f',
-      ortb2: { source: {tid: 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b'}},
+      ortb2: { source: { tid: 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b' } },
       bids: [
         {
           bidder: 'rubicon',
@@ -347,7 +347,7 @@ describe('the rubicon adapter', function () {
           transactionId: 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b'
         }
       ],
-      ortb2: { source: {tid: 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b'}},
+      ortb2: { source: { tid: 'd45dd707-a418-42ec-b8a7-b70a6c6fab0b' } },
       start: 1472239426002,
       auctionStart: 1472239426000,
       timeout: 5000


### PR DESCRIPTION
<!--
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ x ] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Access ortb2 object to obtain x_source.tid value

<!-- For new bidder adapters, please provide the following

```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
@robertrmartinez 
