### PR TITLE
Appnexus Bid Adapter: added projectagora as an alias

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -110,6 +110,7 @@ export const spec = {
     { code: 'oftmedia', gvlid: 32 },
     { code: 'adasta', gvlid: 32 },
     { code: 'beintoo', gvlid: 618 },
+    { code: 'projectagora', gvlid: 1032 },
   ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 

## Description of change


Adding projectagora as bidder adapter alias for appnexus 
- Tested in appnexus bidder 

- Test parameters for validating bids 
```json
{
  "bidder": "projectagora", 
  "params": {
    "placementId": "27096881"
  }
}
```

- contact email of the adapter’s maintainer [psp_product@projectagora.com](mailto:psp_product@projectagora.com)  
- official adapter submission 

DOCS PR: https://github.com/prebid/prebid.github.io/pull/4567