### PR TITLE
beopBidAdapter: Fix gdpr applies

### DIFF
--- a/modules/beopBidAdapter.js
+++ b/modules/beopBidAdapter.js
@@ -64,6 +64,7 @@ export const spec = {
       dbg: false,
       slts: slots,
       is_amp: deepAccess(bidderRequest, 'referrerInfo.isAmp'),
+      gdpr_applies: gdpr ? gdpr.gdprApplies : false,
       tc_string: (gdpr && gdpr.gdprApplies) ? gdpr.consentString : null,
     };
 

--- a/test/spec/modules/beopBidAdapter_spec.js
+++ b/test/spec/modules/beopBidAdapter_spec.js
@@ -99,6 +99,8 @@ describe('BeOp Bid Adapter tests', () => {
       expect(url).to.equal(ENDPOINT);
       expect(payload.pid).to.exist;
       expect(payload.pid).to.equal('5a8af500c9e77c00017e4cad');
+      expect(payload.gdpr_applies).to.exist;
+      expect(payload.gdpr_applies).to.equals(false);
       expect(payload.slts[0].name).to.exist;
       expect(payload.slts[0].name).to.equal('bellow-article');
       expect(payload.slts[0].flr).to.equal(10);
@@ -121,6 +123,8 @@ describe('BeOp Bid Adapter tests', () => {
 
       const request = spec.buildRequests(bidRequests, bidderRequest);
       const payload = JSON.parse(request.data);
+      expect(payload.gdpr_applies).to.exist;
+      expect(payload.gdpr_applies).to.equals(true);
       expect(payload.tc_string).to.exist;
       expect(payload.tc_string).to.equal('BOJ8RZsOJ8RZsABAB8AAAAAZ+A==');
       expect(payload.url).to.exist;


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description of change
Send to our server if GDPR applies or not, instead of just providing the consentString if present

## Other information
Linked to https://github.com/prebid/Prebid.js/issues/7775
