### PR TITLE
beOp BidAdapter: FirstPartyData management and ingest Permutive segments

### DIFF
--- a/modules/beopBidAdapter.js
+++ b/modules/beopBidAdapter.js
@@ -38,7 +38,7 @@ export const spec = {
   buildRequests: function(validBidRequests, bidderRequest) {
     const slots = validBidRequests.map(beOpRequestSlotsMaker);
     const firstPartyData = bidderRequest.ortb2;
-    const psegs = (firstPartyData && firstPartyData.user && firstPartyData.user.ext && firstPartyData.user.ext.data) ? firstPartyData.user.ext.data.p_standard : undefined;
+    const psegs = (firstPartyData && firstPartyData.user && firstPartyData.user.ext && firstPartyData.user.ext.data) ? firstPartyData.user.ext.data.permutive : undefined;
     const pageUrl = getPageUrl(bidderRequest.refererInfo, window);
     const gdpr = bidderRequest.gdprConsent;
     const firstSlot = slots[0];

--- a/modules/beopBidAdapter.js
+++ b/modules/beopBidAdapter.js
@@ -37,6 +37,8 @@ export const spec = {
     */
   buildRequests: function(validBidRequests, bidderRequest) {
     const slots = validBidRequests.map(beOpRequestSlotsMaker);
+    const firstPartyData = bidderRequest.ortb2;
+    const psegs = (firstPartyData && firstPartyData.user) ? firstPartyData.user.psegs : undefined;
     const pageUrl = getPageUrl(bidderRequest.refererInfo, window);
     const gdpr = bidderRequest.gdprConsent;
     const firstSlot = slots[0];
@@ -66,6 +68,10 @@ export const spec = {
       is_amp: deepAccess(bidderRequest, 'referrerInfo.isAmp'),
       tc_string: (gdpr && gdpr.gdprApplies) ? gdpr.consentString : null,
     };
+
+    if (psegs) {
+      Object.assign(payloadObject, {psegs: psegs});
+    }
 
     const payloadString = JSON.stringify(payloadObject);
     return {

--- a/modules/beopBidAdapter.js
+++ b/modules/beopBidAdapter.js
@@ -38,7 +38,7 @@ export const spec = {
   buildRequests: function(validBidRequests, bidderRequest) {
     const slots = validBidRequests.map(beOpRequestSlotsMaker);
     const firstPartyData = bidderRequest.ortb2;
-    const psegs = (firstPartyData && firstPartyData.user) ? firstPartyData.user.psegs : undefined;
+    const psegs = (firstPartyData && firstPartyData.user && firstPartyData.user.ext && firstPartyData.user.ext.data) ? firstPartyData.user.ext.data.p_standard : undefined;
     const pageUrl = getPageUrl(bidderRequest.refererInfo, window);
     const gdpr = bidderRequest.gdprConsent;
     const firstSlot = slots[0];

--- a/test/spec/modules/beopBidAdapter_spec.js
+++ b/test/spec/modules/beopBidAdapter_spec.js
@@ -136,7 +136,7 @@ describe('BeOp Bid Adapter tests', () => {
           'user': {
             'ext': {
               'data': {
-                'p_standard': [1234, 5678, 910]
+                'permutive': [1234, 5678, 910]
               }
             }
           }

--- a/test/spec/modules/beopBidAdapter_spec.js
+++ b/test/spec/modules/beopBidAdapter_spec.js
@@ -134,7 +134,11 @@ describe('BeOp Bid Adapter tests', () => {
       {
         'ortb2': {
           'user': {
-            'psegs': [1234, 5678, 910]
+            'ext': {
+              'data': {
+                'p_standard': [1234, 5678, 910]
+              }
+            }
           }
         }
       };

--- a/test/spec/modules/beopBidAdapter_spec.js
+++ b/test/spec/modules/beopBidAdapter_spec.js
@@ -126,6 +126,26 @@ describe('BeOp Bid Adapter tests', () => {
       expect(payload.url).to.exist;
       // check that the protocol is added correctly
       expect(payload.url).to.equal('http://test.te');
+      expect(payload.psegs).to.not.exist;
+    });
+
+    it('should call the endpoint with psegs data if any', function () {
+      let bidderRequest =
+      {
+        'ortb2': {
+          'user': {
+            'psegs': [1234, 5678, 910]
+          }
+        }
+      };
+
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const payload = JSON.parse(request.data);
+      expect(payload.psegs).to.exist;
+      expect(payload.psegs).to.include(1234);
+      expect(payload.psegs).to.include(5678);
+      expect(payload.psegs).to.include(910);
+      expect(payload.psegs).to.not.include(1);
     });
 
     it('should not prepend the protocol in page url if already present', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
First implementation for BeOp Bid Adapter of the `ortb2` object getting the user data. We will then improve our documentation for our publishers to let them know that BeOp can now ingest segments from Permutive. We will add compatibility with others DMPs in the future. 
