### PR TITLE
Criteo Bid Adapter: add eids to bid request sent to bidder

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -407,6 +407,7 @@ function checkNativeSendId(bidRequest) {
 function buildCdbRequest(context, bidRequests, bidderRequest) {
   let networkId;
   let schain;
+  let userIdAsEids;
   const request = {
     publisher: {
       url: context.url,
@@ -418,6 +419,9 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
       gpp_sid: bidderRequest.ortb2?.regs?.gpp_sid
     },
     slots: bidRequests.map(bidRequest => {
+      if (!userIdAsEids) {
+        userIdAsEids = bidRequest.userIdAsEids;
+      }
       networkId = bidRequest.params.networkId || networkId;
       schain = bidRequest.schain || schain;
       const slot = {
@@ -435,7 +439,7 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
         slot.ext = Object.assign({}, slot.ext, bidRequest.params.ext);
       }
       if (bidRequest.nativeOrtbRequest?.assets) {
-        slot.ext = Object.assign({}, slot.ext, {assets: bidRequest.nativeOrtbRequest.assets});
+        slot.ext = Object.assign({}, slot.ext, { assets: bidRequest.nativeOrtbRequest.assets });
       }
       if (bidRequest.params.publisherSubId) {
         slot.publishersubid = bidRequest.params.publisherSubId;
@@ -515,6 +519,10 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
   if (bidderRequest && bidderRequest.ortb2?.device?.sua) {
     request.user.ext = request.user.ext || {};
     request.user.ext.sua = bidderRequest.ortb2?.device?.sua || {};
+  }
+  if (userIdAsEids) {
+    request.user.ext = request.user.ext || {};
+    request.user.ext.eids = [...userIdAsEids];
   }
   return request;
 }

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -710,6 +710,42 @@ describe('The Criteo bidding adapter', function () {
       expect(ortbRequest.slots[0].native).to.equal(true);
     });
 
+    it('should properly forward eids', function () {
+      const bidRequests = [
+        {
+          bidder: 'criteo',
+          adUnitCode: 'bid-123',
+          transactionId: 'transaction-123',
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
+          userIdAsEids: [
+            {
+              source: 'criteo.com',
+              uids: [{
+                id: 'abc',
+                atype: 1
+              }]
+            }
+          ],
+          params: {}
+        },
+      ];
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const ortbRequest = request.data;
+      expect(ortbRequest.user.ext.eids).to.deep.equal([
+        {
+          source: 'criteo.com',
+          uids: [{
+            id: 'abc',
+            atype: 1
+          }]
+        }
+      ]);
+    });
+
     it('should properly detect and forward native flag', function () {
       const bidRequests = [
         {


### PR DESCRIPTION
## Type of change
- [X] Feature

## Description of change
Ensure that eids from id modules are sent to bidder.

## Other information
Question to the reviewer: wouldn't it be interesting to automatically feed ortb2.user.ext.eids with id modules ids rather than expecting the bidder to grab them from bid level userIdAsEids? (sorry if my question looks stupid and there's an obvious reason we should really not do this)
