### PR TITLE
Ortb Converter : add support for top level 'native' prop for PBS native admarkup

### DIFF
--- a/libraries/ortbConverter/processors/native.js
+++ b/libraries/ortbConverter/processors/native.js
@@ -26,6 +26,10 @@ export function fillNativeResponse(bidResponse, bid) {
       ortb = bid.adm;
     }
 
+    if (ortb?.native) {
+      ortb = ortb.native;
+    }
+
     if (isPlainObject(ortb) && Array.isArray(ortb.assets)) {
       bidResponse.native = {
         ortb,

--- a/test/spec/ortbConverter/native_spec.js
+++ b/test/spec/ortbConverter/native_spec.js
@@ -64,7 +64,9 @@ describe('ortb -> ortb native response', () => {
   }
   Object.entries({
     'serialized': JSON.stringify(MOCK_NATIVE_RESPONSE),
-    'an object': MOCK_NATIVE_RESPONSE
+    'serialized_with_top_native': JSON.stringify({native: MOCK_NATIVE_RESPONSE}),
+    'an object': MOCK_NATIVE_RESPONSE,
+    'an object_with_top_native': {native: MOCK_NATIVE_RESPONSE},
   }).forEach(([t, adm]) => {
     describe(`when adm is ${t}`, () => {
       let bid;


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

During pbjs-to-pbs integration test I noticed that ortbConverter library does not support native response with top-level property **native**, which is correct according to native 1.1/1.2 specs. I've checked and found that some PBS adaptors may return native admarkup in this way:

https://github.com/prebid/prebid-server/blob/master/adapters/datablocks/datablockstest/exemplary/native.json#L112

https://github.com/prebid/prebid-server/blob/master/adapters/pulsepoint/pulsepointtest/exemplary/native.json#L88


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
https://github.com/prebid/Prebid.js/pull/8738
