### PR TITLE
Conversant Bid Adapter: add in Epsilon alias

### DIFF
--- a/modules/conversantAnalyticsAdapter.js
+++ b/modules/conversantAnalyticsAdapter.js
@@ -18,6 +18,7 @@ const DOMAIN = 'https://web.hb.ad.cpe.dotomi.com/';
 const ANALYTICS_URL = DOMAIN + 'cvx/event/prebidanalytics';
 const ERROR_URL = DOMAIN + 'cvx/event/prebidanalyticerrors';
 const ANALYTICS_CODE = 'conversant';
+const ANALYTICS_ALIASES = [ANALYTICS_CODE, 'epsilon', 'cnvr'];
 
 export const CNVR_CONSTANTS = {
   LOG_PREFIX: 'Conversant analytics adapter: ',
@@ -688,11 +689,12 @@ conversantAnalytics.disableAnalytics = function () {
   conversantAnalyticsEnabled = false;
   conversantAnalytics.originDisableAnalytics();
 };
-
-adapterManager.registerAnalyticsAdapter({
-  adapter: conversantAnalytics,
-  code: ANALYTICS_CODE,
-  gvlid: GVLID
+ANALYTICS_ALIASES.forEach(alias => {
+  adapterManager.registerAnalyticsAdapter({
+    adapter: conversantAnalytics,
+    code: alias,
+    gvlid: GVLID
+  });
 });
 
 export default conversantAnalytics;

--- a/modules/conversantBidAdapter.js
+++ b/modules/conversantBidAdapter.js
@@ -12,7 +12,7 @@ const URL = 'https://web.hb.ad.cpe.dotomi.com/cvx/client/hb/ortb/25';
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
-  aliases: ['cnvr'], // short code
+  aliases: ['cnvr', 'epsilon'], // short code
   supportedMediaTypes: [BANNER, VIDEO],
 
   /**

--- a/test/spec/modules/conversantBidAdapter_spec.js
+++ b/test/spec/modules/conversantBidAdapter_spec.js
@@ -221,8 +221,9 @@ describe('Conversant adapter tests', function() {
 
   it('Verify basic properties', function() {
     expect(spec.code).to.equal('conversant');
-    expect(spec.aliases).to.be.an('array').with.lengthOf(1);
+    expect(spec.aliases).to.be.an('array').with.lengthOf(2);
     expect(spec.aliases[0]).to.equal('cnvr');
+    expect(spec.aliases[1]).to.equal('epsilon');
     expect(spec.supportedMediaTypes).to.be.an('array').with.lengthOf(2);
     expect(spec.supportedMediaTypes[1]).to.equal('video');
   });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Adding in alias for Epsilon in bid adapter and analytics adapter

## Other information
Will submit matching documentation update