### PR TITLE
LiveIntent UserId module: add support for distributorId configuration parameter

### DIFF
--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -107,6 +107,12 @@ function initializeLiveConnect(configParams) {
   }
 
   const liveConnectConfig = parseLiveIntentCollectorConfig(configParams.liCollectConfig);
+
+  if (!liveConnectConfig.appId && configParams.distributorId) {
+    liveConnectConfig.distributorId = configParams.distributorId;
+    identityResolutionConfig.source = configParams.distributorId;
+  }
+
   liveConnectConfig.wrapperName = 'prebid';
   liveConnectConfig.identityResolutionConfig = identityResolutionConfig;
   liveConnectConfig.identifiersToResolve = configParams.identifiersToResolve || [];

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -92,15 +92,11 @@ function initializeLiveConnect(configParams) {
 
   const publisherId = configParams.publisherId || 'any';
   const identityResolutionConfig = {
-    source: 'prebid',
     publisherId: publisherId,
     requestedAttributes: parseRequestedAttributes(configParams.requestedAttributesOverrides)
   };
   if (configParams.url) {
     identityResolutionConfig.url = configParams.url
-  }
-  if (configParams.partner) {
-    identityResolutionConfig.source = configParams.partner
   }
   if (configParams.ajaxTimeout) {
     identityResolutionConfig.ajaxTimeout = configParams.ajaxTimeout;
@@ -111,6 +107,8 @@ function initializeLiveConnect(configParams) {
   if (!liveConnectConfig.appId && configParams.distributorId) {
     liveConnectConfig.distributorId = configParams.distributorId;
     identityResolutionConfig.source = configParams.distributorId;
+  } else {
+    identityResolutionConfig.source = configParams.partner || 'prebid'
   }
 
   liveConnectConfig.wrapperName = 'prebid';

--- a/test/spec/modules/liveIntentIdMinimalSystem_spec.js
+++ b/test/spec/modules/liveIntentIdMinimalSystem_spec.js
@@ -73,6 +73,34 @@ describe('LiveIntentMinimalId', function() {
     expect(callBackSpy.calledOnce).to.be.true;
   });
 
+  it('should call the Identity Exchange endpoint with the privided distributorId', function() {
+    getCookieStub.returns(null);
+    let callBackSpy = sinon.spy();
+    let submoduleCallback = liveIntentIdSubmodule.getId({ params: { fireEventDelay: 1, distributorId: 'did-1111' } }).callback;
+    submoduleCallback(callBackSpy);
+    let request = server.requests[0];
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/did-1111/any?did=did-1111&resolve=nonId');
+    request.respond(
+      204,
+      responseHeader
+    );
+    expect(callBackSpy.calledOnceWith({})).to.be.true;
+  });
+
+  it('should call the Identity Exchange endpoint without the privided distributorId when appId is provided', function() {
+    getCookieStub.returns(null);
+    let callBackSpy = sinon.spy();
+    let submoduleCallback = liveIntentIdSubmodule.getId({ params: { fireEventDelay: 1, distributorId: 'did-1111', liCollectConfig: { appId: 'a-0001' } } }).callback;
+    submoduleCallback(callBackSpy);
+    let request = server.requests[0];
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/any?resolve=nonId');
+    request.respond(
+      204,
+      responseHeader
+    );
+    expect(callBackSpy.calledOnceWith({})).to.be.true;
+  });
+
   it('should call the default url of the LiveIntent Identity Exchange endpoint, with a partner', function() {
     getCookieStub.returns(null);
     let callBackSpy = sinon.spy();

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -100,6 +100,14 @@ describe('LiveIntentId', function() {
     }, 200);
   });
 
+  it('should fire an event with the provided distributorId', function (done) {
+    liveIntentIdSubmodule.decode({}, { params: { fireEventDelay: 1, distributorId: 'did-1111' } });
+    setTimeout(() => {
+      expect(server.requests[0].url).to.match(/https:\/\/rp.liadm.com\/j\?.*did=did-1111.*&wpn=prebid.*/);
+      done();
+    }, 200);
+  });
+
   it('should fire an event without the provided distributorId when appId is provided', function (done) {
     liveIntentIdSubmodule.decode({}, { params: { fireEventDelay: 1, distributorId: 'did-1111', liCollectConfig: { appId: 'a-0001' } } });
     setTimeout(() => {

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -100,6 +100,15 @@ describe('LiveIntentId', function() {
     }, 200);
   });
 
+  it('should fire an event without the provided distributorId when appId is provided', function (done) {
+    liveIntentIdSubmodule.decode({}, { params: { fireEventDelay: 1, distributorId: 'did-1111', liCollectConfig: { appId: 'a-0001' } } });
+    setTimeout(() => {
+      expect(server.requests[0].url).to.match(/https:\/\/rp.liadm.com\/j\?.*aid=a-0001.*&wpn=prebid.*/);
+      expect(server.requests[0].url).to.not.match(/.*did=*/);
+      done();
+    }, 200);
+  });
+
   it('should initialize LiveConnect and emit an event with a privacy string when decode', function(done) {
     uspConsentDataStub.returns('1YNY');
     gdprConsentDataStub.returns({
@@ -155,6 +164,34 @@ describe('LiveIntentId', function() {
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
     expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/prebid/89899?resolve=nonId');
+    request.respond(
+      204,
+      responseHeader
+    );
+    expect(callBackSpy.calledOnceWith({})).to.be.true;
+  });
+
+  it('should call the Identity Exchange endpoint with the privided distributorId', function() {
+    getCookieStub.returns(null);
+    let callBackSpy = sinon.spy();
+    let submoduleCallback = liveIntentIdSubmodule.getId({ params: { fireEventDelay: 1, distributorId: 'did-1111' } }).callback;
+    submoduleCallback(callBackSpy);
+    let request = server.requests[0];
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/did-1111/any?did=did-1111&resolve=nonId');
+    request.respond(
+      204,
+      responseHeader
+    );
+    expect(callBackSpy.calledOnceWith({})).to.be.true;
+  });
+
+  it('should call the Identity Exchange endpoint without the privided distributorId when appId is provided', function() {
+    getCookieStub.returns(null);
+    let callBackSpy = sinon.spy();
+    let submoduleCallback = liveIntentIdSubmodule.getId({ params: { fireEventDelay: 1, distributorId: 'did-1111', liCollectConfig: { appId: 'a-0001' } } }).callback;
+    submoduleCallback(callBackSpy);
+    let request = server.requests[0];
+    expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/any?resolve=nonId');
     request.respond(
       204,
       responseHeader


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
This PR introduces the `distributorId` configuration parameter to LiveIntent userId module.


## Other information
- doc PR: https://github.com/prebid/prebid.github.io/pull/4580
