### PR TITLE
UID2 & EUID Modules: Add support for EUID and prefer localStorage for both modules.

### DIFF
--- a/integrationExamples/gpt/userId_example.html
+++ b/integrationExamples/gpt/userId_example.html
@@ -251,17 +251,31 @@
             {
               "name": "uid2",
               "params": {
+                "uid2ApiBase": "https://operator-integ.uidapi.com", // Omit this setting for production
                 "uid2Token": {
-                  "advertising_token": "example token",
-                  "refresh_token": "aslkdjaslkjdaslkhj",
-                  "identity_expires": Date.now() + 60*1000,
+                  "advertising_token": "advertising token goes here",
+                  "refresh_token": "refresh token goes here",
+                  "identity_expires": Date.now() + 60*1000, // These timestamps should be from the token generate response
                   "refresh_from": Date.now() - 10*1000,
                   "refresh_expires": Date.now() + 12*60*60*1000,
-                  "refresh_response_key": null
+                  "refresh_response_key": "refresh key goes here"
                 }
               }
-            }
-            ,
+            },
+            {
+              "name": "euid",
+              "params": {
+                "euidApiBase": "https://integ.euid.eu", // Omit this setting for production
+                "euidToken": {
+                  "advertising_token": "advertising token goes here",
+                  "refresh_token": "refresh token goes here",
+                  "identity_expires": Date.now() + 60*1000, // These timestamps should be from the token generate response
+                  "refresh_from": Date.now() - 10*1000,
+                  "refresh_expires": Date.now() + 12*60*60*1000,
+                  "refresh_response_key": "refresh key goes here"
+                }
+              }
+            },
             {
               "name": "imuid",
               "params": {

--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -40,6 +40,7 @@
       "tncIdSystem",
       "trustpidSystem",
       "uid2IdSystem",
+      "euidIdSystem",
       "unifiedIdSystem",
       "verizonMediaIdSystem",
       "zeotapIdPlusIdSystem",

--- a/modules/euidIdSystem.js
+++ b/modules/euidIdSystem.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /**
  * This module adds EUID ID support to the User ID module. It shares significant functionality with the UID2 module.
  * The {@link module:modules/userId} module is required.

--- a/modules/euidIdSystem.js
+++ b/modules/euidIdSystem.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 /**
- * This module adds uid2 ID support to the User ID module
+ * This module adds EUID ID support to the User ID module. It shares significant functionality with the UID2 module.
  * The {@link module:modules/userId} module is required.
- * @module modules/uid2IdSystem
+ * @module modules/euidIdSystem
  * @requires module:modules/userId
  */
 
@@ -12,18 +12,18 @@ import {getStorageManager} from '../src/storageManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 import { Uid2ApiClient, Uid2StorageManager, Uid2GetId } from './uid2IdSystem_shared.js';
 
-const MODULE_NAME = 'uid2';
-const MODULE_REVISION = `1.0`;
+const MODULE_NAME = 'euid';
+const MODULE_REVISION = `2.0`;
 const PREBID_VERSION = '$prebid.version$';
-const UID2_CLIENT_ID = `PrebidJS-${PREBID_VERSION}-UID2Module-${MODULE_REVISION}`;
-const GVLID = 887;
-const LOG_PRE_FIX = 'UID2: ';
-const ADVERTISING_COOKIE = '__uid2_advertising_token';
+const EUID_CLIENT_ID = `PrebidJS-${PREBID_VERSION}-EUIDModule-${MODULE_REVISION}`;
+const GVLID = 21; // The Trade Desk - is this correct? Found it from https://iabeurope.eu/vendor-list-tcf-v2-0/
+const LOG_PRE_FIX = 'EUID: ';
+const ADVERTISING_COOKIE = '__euid_advertising_token';
 
 // eslint-disable-next-line no-unused-vars
-const UID2_TEST_URL = 'https://operator-integ.uidapi.com';
-const UID2_PROD_URL = 'https://prod.uidapi.com';
-const UID2_BASE_URL = UID2_PROD_URL;
+const EUID_TEST_URL = 'https://integ.euid.eu/v2';
+const EUID_PROD_URL = 'https://prod.euid.eu/v2';
+const EUID_BASE_URL = EUID_PROD_URL;
 
 function createLogger(logger, prefix) {
   return function (...strings) {
@@ -36,7 +36,7 @@ const _logWarn = createLogger(logWarn, LOG_PRE_FIX);
 export const storage = getStorageManager({moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME});
 
 /** @type {Submodule} */
-export const uid2IdSubmodule = {
+export const euidIdSubmodule = {
   /**
    * used to link submodule with config
    * @type {string}
@@ -52,11 +52,11 @@ export const uid2IdSubmodule = {
    * decode the stored id value for passing to bid requests
    * @function
    * @param {string} value
-   * @returns {{uid2:{ id: string } }} or undefined if value doesn't exists
+   * @returns {{euid:{ id: string } }} or undefined if value doesn't exists
    */
   decode(value) {
     const result = decodeImpl(value);
-    _logInfo('UID2 decode returned', result);
+    _logInfo('EUID decode returned', result);
     return result;
   },
 
@@ -65,37 +65,34 @@ export const uid2IdSubmodule = {
    * @function
    * @param {SubmoduleConfig} [configparams]
    * @param {ConsentData|undefined} consentData
-   * @returns {uid2Id}
+   * @returns {euidId}
    */
   getId(config, consentData) {
-    // TODO: handle old uid2ApiBase
     const mappedConfig = {
-      apiBaseUrl: config?.params?.uid2ApiBase ?? UID2_BASE_URL,
-      paramToken: config?.params?.uid2Token,
-      serverCookieName: config?.params?.uid2ServerCookie,
+      apiBaseUrl: config?.params?.euidApiBase ?? EUID_BASE_URL,
+      paramToken: config?.params?.euidToken,
+      serverCookieName: config?.params?.euidServerCookie,
       storage: config?.params?.storage ?? 'localStorage',
-      clientId: UID2_CLIENT_ID,
+      clientId: EUID_CLIENT_ID,
       internalStorage: ADVERTISING_COOKIE
     }
     const result = Uid2GetId(mappedConfig, storage, _logInfo, _logWarn);
-    _logInfo(`UID2 getId returned`, result);
+    _logInfo(`EUID getId returned`, result);
     return result;
   },
 };
 
-// TODO: Tests
-
 function decodeImpl(value) {
   if (typeof value === 'string') {
     _logInfo('Found server-only token. Refresh is unavailable for this token.');
-    const result = { uid2: { id: value } };
+    const result = { euid: { id: value } };
     return result;
   }
   if (Date.now() < value.latestToken.identity_expires) {
-    return { uid2: { id: value.latestToken.advertising_token } };
+    return { euid: { id: value.latestToken.advertising_token } };
   }
   return null;
 }
 
 // Register submodule for userId
-submodule('userId', uid2IdSubmodule);
+submodule('userId', euidIdSubmodule);

--- a/modules/euidIdSystem.js
+++ b/modules/euidIdSystem.js
@@ -15,7 +15,7 @@ const MODULE_NAME = 'euid';
 const MODULE_REVISION = Uid2CodeVersion;
 const PREBID_VERSION = '$prebid.version$';
 const EUID_CLIENT_ID = `PrebidJS-${PREBID_VERSION}-EUIDModule-${MODULE_REVISION}`;
-const GVLID = 21; // The Trade Desk - is this correct? Found it from https://iabeurope.eu/vendor-list-tcf-v2-0/
+const GVLID = 21; // The Trade Desk
 const LOG_PRE_FIX = 'EUID: ';
 const ADVERTISING_COOKIE = '__euid_advertising_token';
 
@@ -70,7 +70,7 @@ export const euidIdSubmodule = {
     const mappedConfig = {
       apiBaseUrl: config?.params?.euidApiBase ?? EUID_BASE_URL,
       paramToken: config?.params?.euidToken,
-      serverCookieName: config?.params?.euidServerCookie,
+      serverCookieName: config?.params?.euidCookie,
       storage: config?.params?.storage ?? 'localStorage',
       clientId: EUID_CLIENT_ID,
       internalStorage: ADVERTISING_COOKIE

--- a/modules/euidIdSystem.js
+++ b/modules/euidIdSystem.js
@@ -10,10 +10,10 @@ import { logInfo, logWarn } from '../src/utils.js';
 import {submodule} from '../src/hook.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
-import { Uid2ApiClient, Uid2StorageManager, Uid2GetId } from './uid2IdSystem_shared.js';
+import { Uid2GetId, Uid2CodeVersion } from './uid2IdSystem_shared.js';
 
 const MODULE_NAME = 'euid';
-const MODULE_REVISION = `2.0`;
+const MODULE_REVISION = Uid2CodeVersion;
 const PREBID_VERSION = '$prebid.version$';
 const EUID_CLIENT_ID = `PrebidJS-${PREBID_VERSION}-EUIDModule-${MODULE_REVISION}`;
 const GVLID = 21; // The Trade Desk - is this correct? Found it from https://iabeurope.eu/vendor-list-tcf-v2-0/
@@ -21,8 +21,8 @@ const LOG_PRE_FIX = 'EUID: ';
 const ADVERTISING_COOKIE = '__euid_advertising_token';
 
 // eslint-disable-next-line no-unused-vars
-const EUID_TEST_URL = 'https://integ.euid.eu/v2';
-const EUID_PROD_URL = 'https://prod.euid.eu/v2';
+const EUID_TEST_URL = 'https://integ.euid.eu';
+const EUID_PROD_URL = 'https://prod.euid.eu';
 const EUID_BASE_URL = EUID_PROD_URL;
 
 function createLogger(logger, prefix) {
@@ -44,7 +44,7 @@ export const euidIdSubmodule = {
   name: MODULE_NAME,
 
   /**
-   * Vendor id of Prebid
+   * Vendor id of The Trade Desk
    * @type {Number}
    */
   gvlid: GVLID,

--- a/modules/euidIdSystem.js
+++ b/modules/euidIdSystem.js
@@ -9,6 +9,9 @@ import { logInfo, logWarn } from '../src/utils.js';
 import {submodule} from '../src/hook.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
+
+// RE below lint exception: UID2 and EUID are separate modules, but the protocol is the same and shared code makes sense here.
+// eslint-disable-next-line prebid/validate-imports
 import { Uid2GetId, Uid2CodeVersion } from './uid2IdSystem_shared.js';
 
 const MODULE_NAME = 'euid';

--- a/modules/euidIdSystem.md
+++ b/modules/euidIdSystem.md
@@ -1,0 +1,54 @@
+## UID 2.0 User ID Submodule
+
+UID 2.0 ID Module.
+
+### Prebid Params
+
+Individual params may be set for the UID 2.0 Submodule. At least one identifier must be set in the params.
+
+The module will handle refreshing the token periodically and storing the updated token using the Prebid.js storage manager. If you provide an expired identity and the module has a valid identity which was refreshed from the identity you provide, it will use the refreshed identity. The module stores the original token used for refreshing the token, and it will use the refreshed tokens as long as the original token matches the one supplied.
+
+```
+pbjs.setConfig({
+    userSync: {
+        userIds: [{
+            name: 'uid2',
+            params: {
+                // Either:
+                uid2ServerCookie: 'your_UID2_server_set_cookie_name'
+                // Or:
+                uid2Token: {
+                    'advertising_token': '...',
+                    'refresh_token': '...',
+                    // etc. - see the Sample Token below for contents of this object
+                }
+            }
+        }]
+    }
+});
+```
+## Parameter Descriptions for the `usersync` Configuration Section
+The below parameters apply only to the UID 2.0 User ID Module integration.
+
+You should supply either `uid2Token` or `uid2ServerCookie`.
+
+If you provide `uid2Token`, the value should be a JavaScript/JSON object with the decrypted `body` payload response from a call to either `/token/generate` or `/token/refresh`.
+
+If you provide `uid2ServerCookie`, the module will expect that same JSON object to be stored in the cookie - i.e. it will pass the cookie value to `JSON.parse` and expect to receive an object containing similar to what you see in the `Sample token` section below.
+
+The module will make calls to the `/token/refresh` endpoint to update the token it stores internally, so bids may contain an updated token.
+
+If neither of `uid2Token` or `uid2ServerCookie` are supplied, and the module has stored a token using the Prebid.js storage system (typically in a cookie named `__uid2_advertising_token`), it will use that token. This cookie is internal to the module and should not be set directly.
+
+If a new token is supplied which does not match the original token used to generate any refreshed tokens, all stored tokens will be discarded and the new token used instead (refreshed if necessary).
+
+### Sample token
+
+`{`<br />&nbsp;&nbsp;`"advertising_token": "...",`<br />&nbsp;&nbsp;`"refresh_token": "...",`<br />&nbsp;&nbsp;`"identity_expires": 1633643601000,`<br />&nbsp;&nbsp;`"refresh_from": 1633643001000,`<br />&nbsp;&nbsp;`"refresh_expires": 1636322000000,`<br />&nbsp;&nbsp;`"refresh_response_key": "wR5t6HKMfJ2r4J7fEGX9Gw=="`<br />`}`
+
+| Param under userSync.userIds[] | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| name | Required | String | ID value for the UID20 module - `"uid2"` | `"uid2"` |
+| params.uid2Token | Optional | Object | The initial UID2 token. This should be `body` element of the decrypted response from a call to the `/token/generate` or `/token/refresh` endpoint. | See the sample token above. |
+| params.uid2ServerCookie | Optional | String | The name of a cookie which holds the initial UID2 token, set by the server. The cookie should contain JSON in the same format as the alternative uid2Token param. **If uid2Token is supplied, this param is ignored.** | See the sample token above. |
+| params.uid2ApiBase | Optional | String | Overrides the default UID2 API endpoint. | `https://prod.uidapi.com` _(default)_ |

--- a/modules/euidIdSystem.md
+++ b/modules/euidIdSystem.md
@@ -125,7 +125,7 @@ The below parameters apply only to the EUID User ID Module integration.
 | --- | --- | --- | --- | --- |
 | name | Required | String | ID value for the EUID module - `"euid"` | `"euid"` |
 | value | Optional, Server only | Object | An object containing the value for the advertising token. | See the example above. |
-| params.euidToken | Optional, Client refresh | Object | The initial UID2 token. This should be `body` element of the decrypted response from a call to the `/token/generate` or `/token/refresh` endpoint. | See the sample token above. |
+| params.euidToken | Optional, Client refresh | Object | The initial EUID token. This should be `body` element of the decrypted response from a call to the `/token/generate` or `/token/refresh` endpoint. | See the sample token above. |
 | params.euidCookie | Optional, Client refresh | String | The name of a cookie which holds the initial EUID token, set by the server. The cookie should contain JSON in the same format as the euidToken param. **If euidToken is supplied, this param is ignored.** | See the sample token above. |
-| params.euidApiBase | Optional, Client refresh | String | Overrides the default UID2 API endpoint. | `"https://prod.uidapi.com"` _(default)_|
+| params.euidApiBase | Optional, Client refresh | String | Overrides the default EUID API endpoint. | `"https://prod.euid.eu"` _(default)_|
 | params.storage | Optional, Client refresh | String | Specify whether to use `cookie` or `localStorage` for module-internal storage. It is recommended to not provide this and allow the module to use the default. | `localStorage` _(default)_ |

--- a/modules/euidIdSystem.md
+++ b/modules/euidIdSystem.md
@@ -1,25 +1,52 @@
-## UID 2.0 User ID Submodule
+## EUID User ID Submodule
 
-UID 2.0 ID Module.
+EUID requires initial tokens to be generated server-side. The EUID module handles storing, providing, and optionally refreshing them. The module can operate in one of two different modes: *Client Refresh* mode or *Server Only* mode.
 
-### Prebid Params
+*Server Only* mode was originally referred to as *legacy mode*, but it is a popular mode for new integrations where publishers prefer to handle token refresh server-side.
 
-Individual params may be set for the UID 2.0 Submodule. At least one identifier must be set in the params.
+## Client Refresh mode
 
-The module will handle refreshing the token periodically and storing the updated token using the Prebid.js storage manager. If you provide an expired identity and the module has a valid identity which was refreshed from the identity you provide, it will use the refreshed identity. The module stores the original token used for refreshing the token, and it will use the refreshed tokens as long as the original token matches the one supplied.
+This is the recommended mode for most scenarios. In this mode, the full response body from the EUID Token Generate or Token Refresh endpoint must be provided to the module. As long as the refresh token remains valid, the module will refresh the advertising token as needed.
 
+To configure the module to use this mode, you must **either**:
+1. Set `params.euidCookie` to the name of the cookie which contains the response body as a JSON string, **or**
+2. Set `params.euidToken` to the response body as a JavaScript object.
+
+### Client refresh cookie example
+
+In this example, the cookie is called `euid_pub_cookie`.
+
+Cookie:
+```
+euid_pub_cookie={"advertising_token":"...advertising token...","refresh_token":"...refresh token...","identity_expires":1684741472161,"refresh_from":1684741425653,"refresh_expires":1684784643668,"refresh_response_key":"...response key..."}
+```
+
+Configuration:
 ```
 pbjs.setConfig({
     userSync: {
         userIds: [{
-            name: 'uid2',
+            name: 'euid',
             params: {
-                // Either:
-                uid2ServerCookie: 'your_UID2_server_set_cookie_name'
-                // Or:
-                uid2Token: {
-                    'advertising_token': '...',
-                    'refresh_token': '...',
+                euidCookie: 'euid_pub_cookie'
+            }
+        }]
+    }
+});
+```
+
+### Client refresh euidToken example
+
+Configuration:
+```
+pbjs.setConfig({
+    userSync: {
+        userIds: [{
+            name: 'euid',
+            params: {
+                euidToken: {
+                    'advertising_token': '...advertising token...',
+                    'refresh_token': '...refresh token...',
                     // etc. - see the Sample Token below for contents of this object
                 }
             }
@@ -27,28 +54,79 @@ pbjs.setConfig({
     }
 });
 ```
-## Parameter Descriptions for the `usersync` Configuration Section
-The below parameters apply only to the UID 2.0 User ID Module integration.
 
-You should supply either `uid2Token` or `uid2ServerCookie`.
+## Server-Only Mode
 
-If you provide `uid2Token`, the value should be a JavaScript/JSON object with the decrypted `body` payload response from a call to either `/token/generate` or `/token/refresh`.
+In this mode, only the advertising token is provided to the module. The module will not be able to refresh the token. The publisher is responsible for implementing some other way to refresh the token.
 
-If you provide `uid2ServerCookie`, the module will expect that same JSON object to be stored in the cookie - i.e. it will pass the cookie value to `JSON.parse` and expect to receive an object containing similar to what you see in the `Sample token` section below.
+To configure the module to use this mode, you must **either**:
+1. Set a cookie named `__euid_advertising_token` to the advertising token, **or**
+2. Set `value` to an ID block containing the advertising token.
 
-The module will make calls to the `/token/refresh` endpoint to update the token it stores internally, so bids may contain an updated token.
+### Server only cookie example
 
-If neither of `uid2Token` or `uid2ServerCookie` are supplied, and the module has stored a token using the Prebid.js storage system (typically in a cookie named `__uid2_advertising_token`), it will use that token. This cookie is internal to the module and should not be set directly.
+Cookie:
+```
+__euid_advertising_token=...advertising token...
+```
 
-If a new token is supplied which does not match the original token used to generate any refreshed tokens, all stored tokens will be discarded and the new token used instead (refreshed if necessary).
+Configuration:
+```
+pbjs.setConfig({
+    userSync: {
+        userIds: [{
+            name: 'euid'
+        }]
+    }
+});
+```
 
-### Sample token
+### Server only value example
+
+Configuration:
+```
+pbjs.setConfig({
+    userSync: {
+        userIds: [{
+            name: 'euid'
+            value: {
+                'euid': {
+                    'id': '...advertising token...'
+                }
+            }
+        }]
+    }
+});
+```
+
+## Storage
+
+The module stores a number of internal values. By default, all values are stored in HTML5 local storage. You can switch to cookie storage by setting `params.storage` to `cookie`. The cookie size can be significant and this is not recommended, but is provided as an option if local storage is not an option.
+
+## Sample token
 
 `{`<br />&nbsp;&nbsp;`"advertising_token": "...",`<br />&nbsp;&nbsp;`"refresh_token": "...",`<br />&nbsp;&nbsp;`"identity_expires": 1633643601000,`<br />&nbsp;&nbsp;`"refresh_from": 1633643001000,`<br />&nbsp;&nbsp;`"refresh_expires": 1636322000000,`<br />&nbsp;&nbsp;`"refresh_response_key": "wR5t6HKMfJ2r4J7fEGX9Gw=="`<br />`}`
 
+### Notes
+
+If you are trying to limit the size of cookies, provide the token in configuration and use the default option of local storage.
+
+If you provide an expired identity and the module has a valid identity which was refreshed from the identity you provide, it will use the refreshed identity. The module stores the original token used for refreshing the token, and it will use the refreshed tokens as long as the original token matches the one supplied.
+
+If a new token is supplied which does not match the original token used to generate any refreshed tokens, all stored tokens will be discarded and the new token used instead (refreshed if necessary).
+
+You can set `params.euidApiBase` to `"https://integ.euid.eu"` during integration testing. Be aware that you must use the same environment (production or integration) here as you use for generating tokens.
+
+## Parameter Descriptions for the `usersync` Configuration Section
+
+The below parameters apply only to the EUID User ID Module integration.
+
 | Param under userSync.userIds[] | Scope | Type | Description | Example |
 | --- | --- | --- | --- | --- |
-| name | Required | String | ID value for the UID20 module - `"uid2"` | `"uid2"` |
-| params.uid2Token | Optional | Object | The initial UID2 token. This should be `body` element of the decrypted response from a call to the `/token/generate` or `/token/refresh` endpoint. | See the sample token above. |
-| params.uid2ServerCookie | Optional | String | The name of a cookie which holds the initial UID2 token, set by the server. The cookie should contain JSON in the same format as the alternative uid2Token param. **If uid2Token is supplied, this param is ignored.** | See the sample token above. |
-| params.uid2ApiBase | Optional | String | Overrides the default UID2 API endpoint. | `https://prod.uidapi.com` _(default)_ |
+| name | Required | String | ID value for the EUID module - `"euid"` | `"euid"` |
+| apiBaseUrl | Optional | String | Base URL for the EUID operator to use. Defaults to the production public operator. You can use this to use the integration environment during testing. |  |
+| value | Optional, Server only | Object | An object containing the value for the advertising token. | See the example above. |
+| params.euidToken | Optional, Client refresh | Object | The initial UID2 token. This should be `body` element of the decrypted response from a call to the `/token/generate` or `/token/refresh` endpoint. | See the sample token above. |
+| params.euidCookie | Optional, Client refresh | String | The name of a cookie which holds the initial EUID token, set by the server. The cookie should contain JSON in the same format as the euidToken param. **If euidToken is supplied, this param is ignored.** | See the sample token above. |
+| params.euidApiBase | Optional, Client refresh | String | Overrides the default UID2 API endpoint. | `"https://prod.uidapi.com"` _(default)_|
+| params.storage | Optional, Client refresh | String | Specify whether to use `cookie` or `localStorage` for module-internal storage. It is recommended to not provide this and allow the module to use the default of `localStorage`. | `localStorage` |

--- a/modules/euidIdSystem.md
+++ b/modules/euidIdSystem.md
@@ -124,9 +124,8 @@ The below parameters apply only to the EUID User ID Module integration.
 | Param under userSync.userIds[] | Scope | Type | Description | Example |
 | --- | --- | --- | --- | --- |
 | name | Required | String | ID value for the EUID module - `"euid"` | `"euid"` |
-| apiBaseUrl | Optional | String | Base URL for the EUID operator to use. Defaults to the production public operator. You can use this to use the integration environment during testing. |  |
 | value | Optional, Server only | Object | An object containing the value for the advertising token. | See the example above. |
 | params.euidToken | Optional, Client refresh | Object | The initial UID2 token. This should be `body` element of the decrypted response from a call to the `/token/generate` or `/token/refresh` endpoint. | See the sample token above. |
 | params.euidCookie | Optional, Client refresh | String | The name of a cookie which holds the initial EUID token, set by the server. The cookie should contain JSON in the same format as the euidToken param. **If euidToken is supplied, this param is ignored.** | See the sample token above. |
 | params.euidApiBase | Optional, Client refresh | String | Overrides the default UID2 API endpoint. | `"https://prod.uidapi.com"` _(default)_|
-| params.storage | Optional, Client refresh | String | Specify whether to use `cookie` or `localStorage` for module-internal storage. It is recommended to not provide this and allow the module to use the default of `localStorage`. | `localStorage` |
+| params.storage | Optional, Client refresh | String | Specify whether to use `cookie` or `localStorage` for module-internal storage. It is recommended to not provide this and allow the module to use the default. | `localStorage` _(default)_ |

--- a/modules/uid2IdSystem.js
+++ b/modules/uid2IdSystem.js
@@ -72,7 +72,7 @@ export const uid2IdSubmodule = {
     const mappedConfig = {
       apiBaseUrl: config?.params?.uid2ApiBase ?? UID2_BASE_URL,
       paramToken: config?.params?.uid2Token,
-      serverCookieName: config?.params?.uid2ServerCookie,
+      serverCookieName: config?.params?.uid2Cookie ?? config?.params?.uid2ServerCookie,
       storage: config?.params?.storage ?? 'localStorage',
       clientId: UID2_CLIENT_ID,
       internalStorage: ADVERTISING_COOKIE

--- a/modules/uid2IdSystem.js
+++ b/modules/uid2IdSystem.js
@@ -19,7 +19,6 @@ const MODULE_NAME = 'uid2';
 const MODULE_REVISION = Uid2CodeVersion;
 const PREBID_VERSION = '$prebid.version$';
 const UID2_CLIENT_ID = `PrebidJS-${PREBID_VERSION}-UID2Module-${MODULE_REVISION}`;
-const GVLID = 887;
 const LOG_PRE_FIX = 'UID2: ';
 const ADVERTISING_COOKIE = '__uid2_advertising_token';
 
@@ -47,11 +46,6 @@ export const uid2IdSubmodule = {
   name: MODULE_NAME,
 
   /**
-   * Vendor id of Prebid
-   * @type {Number}
-   */
-  gvlid: GVLID,
-  /**
    * decode the stored id value for passing to bid requests
    * @function
    * @param {string} value
@@ -71,6 +65,11 @@ export const uid2IdSubmodule = {
    * @returns {uid2Id}
    */
   getId(config, consentData) {
+    if (consentData?.gdprApplies === true) {
+      _logWarn('UID2 is not intended for use where GDPR applies. The UID2 module will not run.');
+      return;
+    }
+
     const mappedConfig = {
       apiBaseUrl: config?.params?.uid2ApiBase ?? UID2_BASE_URL,
       paramToken: config?.params?.uid2Token,

--- a/modules/uid2IdSystem.js
+++ b/modules/uid2IdSystem.js
@@ -77,6 +77,7 @@ export const uid2IdSubmodule = {
       clientId: UID2_CLIENT_ID,
       internalStorage: ADVERTISING_COOKIE
     }
+    _logInfo(`UID2 configuration loaded and mapped.`, mappedConfig);
     const result = Uid2GetId(mappedConfig, storage, _logInfo, _logWarn);
     _logInfo(`UID2 getId returned`, result);
     return result;

--- a/modules/uid2IdSystem.js
+++ b/modules/uid2IdSystem.js
@@ -10,10 +10,10 @@ import { logInfo, logWarn } from '../src/utils.js';
 import {submodule} from '../src/hook.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
-import { Uid2ApiClient, Uid2StorageManager, Uid2GetId } from './uid2IdSystem_shared.js';
+import { Uid2GetId, Uid2CodeVersion } from './uid2IdSystem_shared.js';
 
 const MODULE_NAME = 'uid2';
-const MODULE_REVISION = `1.0`;
+const MODULE_REVISION = Uid2CodeVersion;
 const PREBID_VERSION = '$prebid.version$';
 const UID2_CLIENT_ID = `PrebidJS-${PREBID_VERSION}-UID2Module-${MODULE_REVISION}`;
 const GVLID = 887;
@@ -82,8 +82,6 @@ export const uid2IdSubmodule = {
     return result;
   },
 };
-
-// TODO: Tests
 
 function decodeImpl(value) {
   if (typeof value === 'string') {

--- a/modules/uid2IdSystem.js
+++ b/modules/uid2IdSystem.js
@@ -71,7 +71,6 @@ export const uid2IdSubmodule = {
    * @returns {uid2Id}
    */
   getId(config, consentData) {
-    // TODO: handle old uid2ApiBase
     const mappedConfig = {
       apiBaseUrl: config?.params?.uid2ApiBase ?? UID2_BASE_URL,
       paramToken: config?.params?.uid2Token,

--- a/modules/uid2IdSystem.js
+++ b/modules/uid2IdSystem.js
@@ -10,6 +10,9 @@ import { logInfo, logWarn } from '../src/utils.js';
 import {submodule} from '../src/hook.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
+
+// RE below lint exception: UID2 and EUID are separate modules, but the protocol is the same and shared code makes sense here.
+// eslint-disable-next-line prebid/validate-imports
 import { Uid2GetId, Uid2CodeVersion } from './uid2IdSystem_shared.js';
 
 const MODULE_NAME = 'uid2';

--- a/modules/uid2IdSystem.js
+++ b/modules/uid2IdSystem.js
@@ -10,7 +10,7 @@ import { logInfo, logWarn } from '../src/utils.js';
 import {submodule} from '../src/hook.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
-import { Uid2ApiClient } from './uid2IdSystem_shared.js';
+import { Uid2ApiClient, UidStorageManager } from './uid2IdSystem_shared.js';
 
 const MODULE_NAME = 'uid2';
 const MODULE_REVISION = `1.0`;
@@ -34,45 +34,6 @@ const _logInfo = createLogger(logInfo, LOG_PRE_FIX);
 const _logWarn = createLogger(logWarn, LOG_PRE_FIX);
 
 export const storage = getStorageManager({moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME});
-function readLocalStorage(key) {
-  return storage.localStorageIsEnabled() ? storage.getDataFromLocalStorage(key) : null;
-}
-
-function readCookie(cookieName) {
-  return storage.cookiesAreEnabled() ? storage.getCookie(cookieName) : null;
-}
-
-function readModuleCookie() {
-  return parseIfContainsBraces(readCookie(ADVERTISING_COOKIE));
-}
-
-function writeModuleCookie(value) {
-  storage.setCookie(ADVERTISING_COOKIE, JSON.stringify(value), Date.now() + 60 * 60 * 24 * 1000);
-}
-
-function readModuleStorage() {
-  return parseIfContainsBraces(readLocalStorage(ADVERTISING_COOKIE));
-}
-
-function writeModuleStorage(value) {
-  storage.setDataInLocalStorage(ADVERTISING_COOKIE, JSON.stringify(value));
-}
-
-function parseIfContainsBraces(value) {
-  return (value?.includes('{')) ? JSON.parse(value) : value;
-}
-
-function readProvidedCookie(cookieName) {
-  return JSON.parse(readCookie(cookieName));
-}
-
-function storeValue(value) {
-  if (storage.cookiesAreEnabled()) {
-    storage.setCookie(ADVERTISING_COOKIE, JSON.stringify(value), Date.now() + 60 * 60 * 24 * 1000);
-  } else if (storage.localStorageIsEnabled()) {
-    storage.setLocalStorage(ADVERTISING_COOKIE, value);
-  }
-}
 
 /** @type {Submodule} */
 export const uid2IdSubmodule = {
@@ -107,56 +68,39 @@ export const uid2IdSubmodule = {
    * @returns {uid2Id}
    */
   getId(config, consentData) {
-    const result = getIdImpl(config, consentData);
+    // TODO: handle old uid2ApiBase
+    const mappedConfig = {
+      apiBaseUrl: config?.params?.uid2ApiBase ?? UID2_BASE_URL,
+      paramToken: config?.params?.uid2Token,
+      serverCookieName: config?.params?.uid2ServerCookie,
+      storage: config?.params?.storage ?? 'localStorage',
+      clientId: UID2_CLIENT_ID,
+    }
+    const result = getIdImpl(mappedConfig);
     _logInfo(`UID2 getId returned`, result);
     return result;
   },
 };
 
-function refreshTokenAndStore(baseUrl, token) {
+function refreshTokenAndStore(baseUrl, token, useLocalStorage, clientId, storageManager) {
   _logInfo('UID2 base url provided: ', baseUrl);
-  const client = new Uid2ApiClient({baseUrl}, UID2_CLIENT_ID, _logInfo, _logWarn);
+  const client = new Uid2ApiClient({baseUrl}, clientId, _logInfo, _logWarn);
   return client.callRefreshApi(token).then((response) => {
     _logInfo('Refresh endpoint responded with:', response);
     const tokens = {
       originalToken: token,
       latestToken: response.identity,
     };
-    storeValue(tokens);
+    storageManager.storeValue(tokens);
     return tokens;
   });
 }
 
 // TODO: Tests
-function getStoredValueWithFallback(preferLocalStorage) {
-  const preferredStorageLabel = preferLocalStorage ? 'local storage' : 'cookie';
-  const preferredStorageGet = preferLocalStorage ? readModuleStorage : readModuleCookie;
-  const preferredStorageSet = preferLocalStorage ? writeModuleStorage : writeModuleCookie;
-  const fallbackStorageGet = preferLocalStorage ? readModuleCookie : readModuleStorage;
-
-  const storedValue = preferredStorageGet();
-
-  if (!storedValue) {
-    const fallbackValue = fallbackStorageGet();
-    if (fallbackValue) {
-      _logInfo(`${preferredStorageLabel} was empty, but found a fallback value. Copying the fallback value to ${preferredStorageLabel}.`);
-      preferredStorageSet(fallbackValue);
-      return fallbackValue;
-    }
-  } else if (typeof storedValue === 'string') {
-    const fallbackValue = fallbackStorageGet();
-    if (fallbackValue && typeof fallbackValue === 'object') {
-      _logInfo(`${preferredStorageLabel} contained a basic token, but found a refreshable token fallback. Copying the fallback value to ${preferredStorageLabel}.`);
-      preferredStorageSet(fallbackValue);
-      return fallbackValue;
-    }
-  }
-  return storedValue;
-}
 
 function decodeImpl(value) {
   if (typeof value === 'string') {
-    _logInfo('Found directly-supplied token. Refresh is unavailable for this token.');
+    _logInfo('Found server-only token. Refresh is unavailable for this token.');
     const result = { uid2: { id: value } };
     return result;
   }
@@ -166,26 +110,20 @@ function decodeImpl(value) {
   return null;
 }
 
-function getIdImpl(config, consentData) {
+function getIdImpl(config) {
   let suppliedToken = null;
-  const availableTokens = {};
+  const preferLocalStorage = (config.storage !== 'cookie');
+  const storageManager = new UidStorageManager(storage, preferLocalStorage, ADVERTISING_COOKIE, _logInfo);
+  _logInfo(`UID2 module is using ${preferLocalStorage ? 'local storage' : 'cookies'} for internal storage.`);
 
-  const uid2BaseUrl = config?.params?.uid2ApiBase ?? UID2_BASE_URL;
-  const preferLocalStorage = (config?.params?.storage !== 'cookie');
-
-  if (config && config.params) {
-    if (config.params.uid2Token) {
-      suppliedToken = config.params.uid2Token;
-      availableTokens.fullFromConfig = config.params.uid2Token;
-      _logInfo('Read token from params', suppliedToken);
-    } else if (config.params.uid2ServerCookie) {
-      suppliedToken = readProvidedCookie(config.params.uid2ServerCookie);
-      availableTokens.fullFromCookie = suppliedToken;
-      _logInfo('Read token from server-supplied cookie', suppliedToken);
-    }
+  if (config.paramToken) {
+    suppliedToken = config.paramToken;
+    _logInfo('Read token from params', suppliedToken);
+  } else if (config.serverCookieName) {
+    suppliedToken = storageManager.readProvidedCookie(config.serverCookieName);
+    _logInfo('Read token from server-supplied cookie', suppliedToken);
   }
-  let storedTokens = getStoredValueWithFallback(preferLocalStorage);
-  console.log('Mod-stored value:', storedTokens);
+  let storedTokens = storageManager.getStoredValueWithFallback();
   _logInfo('Loaded module-stored tokens:', storedTokens);
 
   if (storedTokens && typeof storedTokens === 'string') {
@@ -211,12 +149,13 @@ function getIdImpl(config, consentData) {
   const useSuppliedToken = !(storedTokens?.latestToken) || (suppliedToken && suppliedToken.identity_expires > storedTokens.latestToken.identity_expires);
   const newestAvailableToken = useSuppliedToken ? suppliedToken : storedTokens.latestToken;
   _logInfo('UID2 module selected latest token', useSuppliedToken, newestAvailableToken);
+  console.log('UID2 module selected latest token', useSuppliedToken, newestAvailableToken);
   if (!newestAvailableToken || Date.now() > newestAvailableToken.refresh_expires) {
     _logInfo('Newest available token is expired and not refreshable.');
     return { id: null };
   }
   if (Date.now() > newestAvailableToken.identity_expires) {
-    const promise = refreshTokenAndStore(uid2BaseUrl, newestAvailableToken);
+    const promise = refreshTokenAndStore(config.apiBaseUrl, newestAvailableToken, preferLocalStorage, config.clientId, storageManager);
     _logInfo('Token is expired but can be refreshed, attempting refresh.');
     return { callback: (cb) => {
       promise.then((result) => {
@@ -228,13 +167,13 @@ function getIdImpl(config, consentData) {
   // If should refresh (but don't need to), refresh in the background.
   if (Date.now() > newestAvailableToken.refresh_from) {
     _logInfo(`Refreshing token in background with low priority.`);
-    refreshTokenAndStore(uid2BaseUrl, newestAvailableToken);
+    refreshTokenAndStore(config.apiBaseUrl, newestAvailableToken, preferLocalStorage, config.clientId, storageManager);
   }
   const tokens = {
     originalToken: suppliedToken ?? storedTokens?.originalToken,
     latestToken: newestAvailableToken,
   };
-  storeValue(tokens);
+  storageManager.storeValue(tokens);
   return { id: tokens };
 }
 

--- a/modules/uid2IdSystem.md
+++ b/modules/uid2IdSystem.md
@@ -4,6 +4,8 @@ UID2 requires initial tokens to be generated server-side. The UID2 module handle
 
 *Server Only* mode was originally referred to as *legacy mode*, but it is a popular mode for new integrations where publishers prefer to handle token refresh server-side.
 
+**Important information:** UID2 is not designed to be used where GDPR applies. The module checks the passed-in consent data and will not operate if the `gdprApplies` flag is true.
+
 ## Client Refresh mode
 
 This is the recommended mode for most scenarios. In this mode, the full response body from the UID2 Token Generate or Token Refresh endpoint must be provided to the module. As long as the refresh token remains valid, the module will refresh the advertising token as needed.

--- a/modules/uid2IdSystem.md
+++ b/modules/uid2IdSystem.md
@@ -1,25 +1,54 @@
-## UID 2.0 User ID Submodule
+## UID2 User ID Submodule
 
-UID 2.0 ID Module.
+UID2 requires initial tokens to be generated server-side. The UID2 module handles storing, providing, and optionally refreshing them. The module can operate in one of two different modes: *Client Refresh* mode or *Server Only* mode.
 
-### Prebid Params
+*Server Only* mode was originally referred to as *legacy mode*, but it is a popular mode for new integrations where publishers prefer to handle token refresh server-side.
 
-Individual params may be set for the UID 2.0 Submodule. At least one identifier must be set in the params.
+## Client Refresh mode
 
-The module will handle refreshing the token periodically and storing the updated token using the Prebid.js storage manager. If you provide an expired identity and the module has a valid identity which was refreshed from the identity you provide, it will use the refreshed identity. The module stores the original token used for refreshing the token, and it will use the refreshed tokens as long as the original token matches the one supplied.
+This is the recommended mode for most scenarios. In this mode, the full response body from the UID2 Token Generate or Token Refresh endpoint must be provided to the module. As long as the refresh token remains valid, the module will refresh the advertising token as needed.
 
+To configure the module to use this mode, you must **either**:
+1. Set `params.uid2Cookie` to the name of the cookie which contains the response body as a JSON string, **or**
+2. Set `params.uid2Token` to the response body as a JavaScript object.
+
+The `uid2Cookie` param was originally `uid2ServerCookie`. The old name can still be used, however the inclusion of the word 'server' was causing some confusion. If both values are provided, `uid2ServerCookie` will be ignored.
+
+### Client refresh cookie example
+
+In this example, the cookie is called `uid2_pub_cookie`.
+
+Cookie:
+```
+uid2_pub_cookie={"advertising_token":"...advertising token...","refresh_token":"...refresh token...","identity_expires":1684741472161,"refresh_from":1684741425653,"refresh_expires":1684784643668,"refresh_response_key":"...response key..."}
+```
+
+Configuration:
 ```
 pbjs.setConfig({
     userSync: {
         userIds: [{
             name: 'uid2',
             params: {
-                // Either:
-                uid2ServerCookie: 'your_UID2_server_set_cookie_name'
-                // Or:
+                uid2Cookie: 'uid2_pub_cookie'
+            }
+        }]
+    }
+});
+```
+
+### Client refresh uid2Token example
+
+Configuration:
+```
+pbjs.setConfig({
+    userSync: {
+        userIds: [{
+            name: 'uid2',
+            params: {
                 uid2Token: {
-                    'advertising_token': '...',
-                    'refresh_token': '...',
+                    'advertising_token': '...advertising token...',
+                    'refresh_token': '...refresh token...',
                     // etc. - see the Sample Token below for contents of this object
                 }
             }
@@ -27,28 +56,78 @@ pbjs.setConfig({
     }
 });
 ```
-## Parameter Descriptions for the `usersync` Configuration Section
-The below parameters apply only to the UID 2.0 User ID Module integration.
 
-You should supply either `uid2Token` or `uid2ServerCookie`.
+## Server-Only Mode
 
-If you provide `uid2Token`, the value should be a JavaScript/JSON object with the decrypted `body` payload response from a call to either `/token/generate` or `/token/refresh`.
+In this mode, only the advertising token is provided to the module. The module will not be able to refresh the token. The publisher is responsible for implementing some other way to refresh the token.
 
-If you provide `uid2ServerCookie`, the module will expect that same JSON object to be stored in the cookie - i.e. it will pass the cookie value to `JSON.parse` and expect to receive an object containing similar to what you see in the `Sample token` section below.
+To configure the module to use this mode, you must **either**:
+1. Set a cookie named `__uid2_advertising_token` to the advertising token, **or**
+2. Set `value` to an ID block containing the advertising token (see "Server only value" example below).
 
-The module will make calls to the `/token/refresh` endpoint to update the token it stores internally, so bids may contain an updated token.
+### Server only cookie example
 
-If neither of `uid2Token` or `uid2ServerCookie` are supplied, and the module has stored a token using the Prebid.js storage system (typically in a cookie named `__uid2_advertising_token`), it will use that token. This cookie is internal to the module and should not be set directly.
+Cookie:
+```
+__uid2_advertising_token=...advertising token...
+```
 
-If a new token is supplied which does not match the original token used to generate any refreshed tokens, all stored tokens will be discarded and the new token used instead (refreshed if necessary).
+Configuration:
+```
+pbjs.setConfig({
+    userSync: {
+        userIds: [{
+            name: 'uid2'
+        }]
+    }
+});
+```
 
-### Sample token
+### Server only value example
+
+Configuration:
+```
+pbjs.setConfig({
+    userSync: {
+        userIds: [{
+            name: 'uid2'
+            value: {
+                'uid2': {
+                    'id': '...advertising token...'
+                }
+            }
+        }]
+    }
+});
+```
+
+## Storage
+
+The module stores a number of internal values. By default, all values are stored in HTML5 local storage. You can switch to cookie storage by setting `params.storage` to `cookie`. The cookie size can be significant and this is not recommended, but is provided as an option if local storage is not an option.
+
+## Sample token
 
 `{`<br />&nbsp;&nbsp;`"advertising_token": "...",`<br />&nbsp;&nbsp;`"refresh_token": "...",`<br />&nbsp;&nbsp;`"identity_expires": 1633643601000,`<br />&nbsp;&nbsp;`"refresh_from": 1633643001000,`<br />&nbsp;&nbsp;`"refresh_expires": 1636322000000,`<br />&nbsp;&nbsp;`"refresh_response_key": "wR5t6HKMfJ2r4J7fEGX9Gw=="`<br />`}`
 
+### Notes
+
+If you are trying to limit the size of cookies, provide the token in configuration and use the default option of local storage.
+
+If you provide an expired identity and the module has a valid identity which was refreshed from the identity you provide, it will use the refreshed identity. The module stores the original token used for refreshing the token, and it will use the refreshed tokens as long as the original token matches the one supplied.
+
+If a new token is supplied which does not match the original token used to generate any refreshed tokens, all stored tokens will be discarded and the new token used instead (refreshed if necessary).
+
+You can set `params.uid2ApiBase` to `"https://operator-integ.uidapi.com"` during integration testing. Be aware that you must use the same environment (production or integration) here as you use for generating tokens.
+
+## Parameter Descriptions for the `usersync` Configuration Section
+
+The below parameters apply only to the UID2 User ID Module integration.
+
 | Param under userSync.userIds[] | Scope | Type | Description | Example |
 | --- | --- | --- | --- | --- |
-| name | Required | String | ID value for the UID20 module - `"uid2"` | `"uid2"` |
-| params.uid2Token | Optional | Object | The initial UID2 token. This should be `body` element of the decrypted response from a call to the `/token/generate` or `/token/refresh` endpoint. | See the sample token above. |
-| params.uid2ServerCookie | Optional | String | The name of a cookie which holds the initial UID2 token, set by the server. The cookie should contain JSON in the same format as the alternative uid2Token param. **If uid2Token is supplied, this param is ignored.** | See the sample token above. |
-| params.uid2ApiBase | Optional | String | Overrides the default UID2 API endpoint. | `https://prod.uidapi.com` _(default)_ |
+| name | Required | String | ID value for the UID2 module - `"uid2"` | `"uid2"` |
+| value | Optional, Server only | Object | An object containing the value for the advertising token. | See the example above. |
+| params.uid2Token | Optional, Client refresh | Object | The initial UID2 token. This should be `body` element of the decrypted response from a call to the `/token/generate` or `/token/refresh` endpoint. | See the sample token above. |
+| params.uid2Cookie | Optional, Client refresh | String | The name of a cookie which holds the initial UID2 token, set by the server. The cookie should contain JSON in the same format as the uid2Token param. **If uid2Token is supplied, this param is ignored.** | See the sample token above. |
+| params.uid2ApiBase | Optional, Client refresh | String | Overrides the default UID2 API endpoint. | `"https://prod.uidapi.com"` _(default)_|
+| params.storage | Optional, Client refresh | String | Specify whether to use `cookie` or `localStorage` for module-internal storage. It is recommended to not provide this and allow the module to use the default. | `localStorage` _(default)_ |

--- a/modules/uid2IdSystem_shared.js
+++ b/modules/uid2IdSystem_shared.js
@@ -133,8 +133,11 @@ export class Uid2StorageManager {
     if (!storedValue) {
       const fallbackValue = fallbackStorageGet();
       if (fallbackValue) {
-        this._logInfo(`${preferredStorageLabel} was empty, but found a fallback value. Copying the fallback value to ${preferredStorageLabel}.`);
-        preferredStorageSet(fallbackValue);
+        this._logInfo(`${preferredStorageLabel} was empty, but found a fallback value.`)
+        if (typeof fallbackValue === 'object') {
+          this._logInfo(`Copying the fallback value to ${preferredStorageLabel}.`);
+          preferredStorageSet(fallbackValue);
+        }
         return fallbackValue;
       }
     } else if (typeof storedValue === 'string') {

--- a/modules/uid2IdSystem_shared.js
+++ b/modules/uid2IdSystem_shared.js
@@ -1,3 +1,6 @@
+/* eslint-disable no-console */
+export const Uid2CodeVersion = '1.1';
+
 function isValidIdentity(identity) {
   return !!(typeof identity === 'object' && identity !== null && identity.advertising_token && identity.identity_expires && identity.refresh_from && identity.refresh_token && identity.refresh_expires);
 }
@@ -199,7 +202,6 @@ export function Uid2GetId(config, prebidStorageManager, _logInfo, _logWarn) {
   const useSuppliedToken = !(storedTokens?.latestToken) || (suppliedToken && suppliedToken.identity_expires > storedTokens.latestToken.identity_expires);
   const newestAvailableToken = useSuppliedToken ? suppliedToken : storedTokens.latestToken;
   _logInfo('UID2 module selected latest token', useSuppliedToken, newestAvailableToken);
-  console.log('UID2 module selected latest token', useSuppliedToken, newestAvailableToken);
   if (!newestAvailableToken || Date.now() > newestAvailableToken.refresh_expires) {
     _logInfo('Newest available token is expired and not refreshable.');
     return { id: null };

--- a/modules/uid2IdSystem_shared.js
+++ b/modules/uid2IdSystem_shared.js
@@ -121,7 +121,6 @@ export class Uid2StorageManager {
     }
   }
 
-  // TODO: Tests
   getStoredValueWithFallback() {
     const preferredStorageLabel = this._preferLocalStorage ? 'local storage' : 'cookie';
     const preferredStorageGet = (this._preferLocalStorage ? this.readModuleStorage : this.readModuleCookie).bind(this);

--- a/modules/uid2IdSystem_shared.js
+++ b/modules/uid2IdSystem_shared.js
@@ -32,7 +32,7 @@ export class Uid2ApiClient {
     if (this.isValidRefreshResponse(response)) {
       if (response.status === 'success') { return { status: response.status, identity: response.body }; }
       return response;
-    } else { return "Response didn't contain a valid status"; }
+    } else { return `Response didn't contain a valid status`; }
   }
   callRefreshApi(refreshDetails) {
     const url = this._baseUrl + '/v2/token/refresh';
@@ -77,7 +77,7 @@ export class Uid2ApiClient {
         rejectPromise(err);
       }
     };
-    this._logInfo('Sending refresh request', req);
+    this._logInfo('Sending refresh request', refreshDetails);
     req.send(refreshDetails.refresh_token);
     return promise;
   }
@@ -167,7 +167,7 @@ export function Uid2GetId(config, prebidStorageManager, _logInfo, _logWarn) {
   let suppliedToken = null;
   const preferLocalStorage = (config.storage !== 'cookie');
   const storageManager = new Uid2StorageManager(prebidStorageManager, preferLocalStorage, config.internalStorage, _logInfo);
-  _logInfo(`UID2 module is using ${preferLocalStorage ? 'local storage' : 'cookies'} for internal storage.`);
+  _logInfo(`Module is using ${preferLocalStorage ? 'local storage' : 'cookies'} for internal storage.`);
 
   if (config.paramToken) {
     suppliedToken = config.paramToken;

--- a/modules/uid2IdSystem_shared.js
+++ b/modules/uid2IdSystem_shared.js
@@ -1,0 +1,81 @@
+function isValidIdentity(identity) {
+  return !!(typeof identity === 'object' && identity !== null && identity.advertising_token && identity.identity_expires && identity.refresh_from && identity.refresh_token && identity.refresh_expires);
+}
+
+// This is extracted from an in-progress API client. Once it's available via NPM, this class should be replaced with the NPM package.
+export class Uid2ApiClient {
+  constructor(opts, clientId, logInfo, logWarn) {
+    this._baseUrl = opts.baseUrl;
+    this._clientVersion = clientId;
+    this._logInfo = logInfo;
+    this._logWarn = logWarn;
+  }
+  createArrayBuffer(text) {
+    const arrayBuffer = new Uint8Array(text.length);
+    for (let i = 0; i < text.length; i++) {
+      arrayBuffer[i] = text.charCodeAt(i);
+    }
+    return arrayBuffer;
+  }
+  hasStatusResponse(response) {
+    return typeof (response) === 'object' && response && response.status;
+  }
+  isValidRefreshResponse(response) {
+    return this.hasStatusResponse(response) && (
+      response.status === 'optout' || response.status === 'expired_token' || (response.status === 'success' && response.body && isValidIdentity(response.body))
+    );
+  }
+  ResponseToRefreshResult(response) {
+    if (this.isValidRefreshResponse(response)) {
+      if (response.status === 'success') { return { status: response.status, identity: response.body }; }
+      return response;
+    } else { return "Response didn't contain a valid status"; }
+  }
+  callRefreshApi(refreshDetails) {
+    const url = this._baseUrl + '/v2/token/refresh';
+    const req = new XMLHttpRequest();
+    req.overrideMimeType('text/plain');
+    req.open('POST', url, true);
+    req.setRequestHeader('X-UID2-Client-Version', this._clientVersion);
+    let resolvePromise;
+    let rejectPromise;
+    const promise = new Promise((resolve, reject) => {
+      resolvePromise = resolve;
+      rejectPromise = reject;
+    });
+    req.onreadystatechange = () => {
+      if (req.readyState !== req.DONE) { return; }
+      try {
+        if (!refreshDetails.refresh_response_key || req.status !== 200) {
+          this._logInfo('Error status OR no response decryption key available, assuming unencrypted JSON');
+          const response = JSON.parse(req.responseText);
+          const result = this.ResponseToRefreshResult(response);
+          if (typeof result === 'string') { rejectPromise(result); } else { resolvePromise(result); }
+        } else {
+          this._logInfo('Decrypting refresh API response');
+          const encodeResp = this.createArrayBuffer(atob(req.responseText));
+          window.crypto.subtle.importKey('raw', this.createArrayBuffer(atob(refreshDetails.refresh_response_key)), { name: 'AES-GCM' }, false, ['decrypt']).then((key) => {
+            this._logInfo('Imported decryption key')
+            // returns the symmetric key
+            window.crypto.subtle.decrypt({
+              name: 'AES-GCM',
+              iv: encodeResp.slice(0, 12),
+              tagLength: 128, // The tagLength you used to encrypt (if any)
+            }, key, encodeResp.slice(12)).then((decrypted) => {
+              const decryptedResponse = String.fromCharCode(...new Uint8Array(decrypted));
+              this._logInfo('Decrypted to:', decryptedResponse);
+              const response = JSON.parse(decryptedResponse);
+              const result = this.ResponseToRefreshResult(response);
+              if (typeof result === 'string') { rejectPromise(result); } else { resolvePromise(result); }
+            }, (reason) => this._logWarn(`Call to UID2 API failed`, reason));
+          }, (reason) => this._logWarn(`Call to UID2 API failed`, reason));
+        }
+      } catch (err) {
+        rejectPromise(err);
+      }
+    };
+    this._logInfo('Sending refresh request', req);
+    req.send(refreshDetails.refresh_token);
+    return promise;
+  }
+}

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -291,6 +291,14 @@ export const USER_IDS_CONFIG = {
     }
   },
 
+  'euid': {
+    source: 'euid.eu', // TODO: Is this correct?
+    atype: 3, // TODO: What is this?
+    getValue: function(data) {
+      return data.id;
+    }
+  },
+
   'deepintentId': {
     source: 'deepintent.com',
     atype: 3

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -292,8 +292,8 @@ export const USER_IDS_CONFIG = {
   },
 
   'euid': {
-    source: 'euid.eu', // TODO: Is this correct?
-    atype: 3, // TODO: What is this?
+    source: 'euid.eu',
+    atype: 3,
     getValue: function(data) {
       return data.id;
     }

--- a/modules/userId/userId.md
+++ b/modules/userId/userId.md
@@ -126,7 +126,8 @@ pbjs.setConfig({
             }
         },{
             name: 'uid2'
-        }
+        }, {
+            name: 'euid'
         }, {
               name: 'admixerId',
               params: {

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -348,6 +348,21 @@ describe('eids array generation for known sub-modules', function() {
     });
   });
 
+  it('euid', function() {
+    const userId = {
+      euid: {'id': 'Sample_AD_Token'}
+    };
+    const newEids = createEidsArray(userId);
+    expect(newEids.length).to.equal(1);
+    expect(newEids[0]).to.deep.equal({
+      source: 'euid.eu', // TODO: Fix
+      uids: [{
+        id: 'Sample_AD_Token',
+        atype: 3
+      }]
+    });
+  });
+
   it('kpuid', function() {
     const userId = {
       kpuid: 'Sample_Token'

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -355,7 +355,7 @@ describe('eids array generation for known sub-modules', function() {
     const newEids = createEidsArray(userId);
     expect(newEids.length).to.equal(1);
     expect(newEids[0]).to.deep.equal({
-      source: 'euid.eu', // TODO: Fix
+      source: 'euid.eu',
       uids: [{
         id: 'Sample_AD_Token',
         atype: 3

--- a/test/spec/modules/euidIdSystem_spec.js
+++ b/test/spec/modules/euidIdSystem_spec.js
@@ -1,0 +1,108 @@
+import {coreStorage, init, setSubmoduleRegistry, requestBidsHook} from 'modules/userId/index.js';
+import {config} from 'src/config.js';
+import * as utils from 'src/utils.js';
+import { euidIdSubmodule } from 'modules/euidIdSystem.js';
+import 'src/prebid.js';
+import { getGlobal } from 'src/prebidGlobal.js';
+import { server } from 'test/mocks/xhr.js';
+import { configureTimerInterceptors } from 'test/mocks/timers.js';
+import { cookieHelpers, runAuction, apiHelpers } from './uid2IdSystem_helpers.js';
+import {hook} from 'src/hook.js';
+import {uninstall as uninstallGdprEnforcement} from 'modules/gdprEnforcement.js';
+
+let expect = require('chai').expect;
+
+// N.B. Most of the EUID code is shared with UID2 - the tests here only cover the happy path.
+// Most of the functionality is covered by the UID2 tests.
+
+const moduleCookieName = '__euid_advertising_token';
+const publisherCookieName = '__EUID_SERVER_COOKIE';
+const initialToken = `initial-advertising-token`;
+const legacyToken = 'legacy-advertising-token';
+const refreshedToken = 'refreshed-advertising-token';
+const auctionDelayMs = 10;
+
+const makeEuidIdentityContainer = (token) => ({euid: {id: token}});
+const useLocalStorage = true;
+const makePrebidConfig = (params = null, extraSettings = {}, debug = false) => ({
+  userSync: { auctionDelay: auctionDelayMs, userIds: [{name: 'euid', params: {storage: useLocalStorage ? 'localStorage' : 'cookie', ...params}, ...extraSettings}] }, debug
+});
+
+const apiUrl = 'https://prod.euid.eu/v2/token/refresh';
+const headers = { 'Content-Type': 'application/json' };
+const makeSuccessResponseBody = () => btoa(JSON.stringify({ status: 'success', body: { ...apiHelpers.makeTokenResponse(initialToken), advertising_token: refreshedToken } }));
+const configureEuidResponse = (httpStatus, response) => server.respondWith('POST', apiUrl, (xhr) => xhr.respond(httpStatus, headers, response));
+const expectToken = (bid, token) => expect(bid?.userId ?? {}).to.deep.include(makeEuidIdentityContainer(token));
+
+describe('EUID module', function() {
+  let suiteSandbox, testSandbox, timerSpy, fullTestTitle, restoreSubtleToUndefined = false;
+  before(function() {
+    uninstallGdprEnforcement();
+    hook.ready();
+    suiteSandbox = sinon.sandbox.create();
+    if (typeof window.crypto.subtle === 'undefined') {
+      restoreSubtleToUndefined = true;
+      window.crypto.subtle = { importKey: () => {}, decrypt: () => {} };
+    }
+    suiteSandbox.stub(window.crypto.subtle, 'importKey').callsFake(() => Promise.resolve());
+    suiteSandbox.stub(window.crypto.subtle, 'decrypt').callsFake((settings, key, data) => Promise.resolve(new Uint8Array([...settings.iv, ...data])));
+  });
+  after(function() {
+    suiteSandbox.restore();
+    // timerSpy.restore();
+    if (restoreSubtleToUndefined) window.crypto.subtle = undefined;
+  });
+  beforeEach(function() {
+    init(config);
+    setSubmoduleRegistry([euidIdSubmodule]);
+  });
+  afterEach(function() {
+    $$PREBID_GLOBAL$$.requestBids.removeAll();
+    config.resetConfig();
+    cookieHelpers.clearCookies(moduleCookieName, publisherCookieName);
+    coreStorage.removeDataFromLocalStorage(moduleCookieName);
+  });
+
+  it('When a server-only token value is provided in config, it is available to the auction.', async function() {
+    config.setConfig(makePrebidConfig(null, {value: makeEuidIdentityContainer(initialToken)}));
+    const bid = await runAuction();
+    expectToken(bid, initialToken);
+  });
+
+  it('When a server-only token is provided in the module storage cookie, it is available to the auction.', async function() {
+    coreStorage.setCookie(moduleCookieName, legacyToken, cookieHelpers.getFutureCookieExpiry());
+    config.setConfig({userSync: {auctionDelay: auctionDelayMs, userIds: [{name: 'euid'}]}});
+    const bid = await runAuction();
+    expectToken(bid, legacyToken);
+  })
+
+  it('When a valid response body is provided in config, it is available to the auction', async function() {
+    const euidToken = apiHelpers.makeTokenResponse(initialToken, false, false);
+    config.setConfig(makePrebidConfig({euidToken}));
+    const bid = await runAuction();
+    expectToken(bid, initialToken);
+  })
+
+  it('When a valid response body is provided via cookie, it is available to the auction', async function() {
+    const euidToken = apiHelpers.makeTokenResponse(initialToken, false, false);
+    cookieHelpers.setPublisherCookie(publisherCookieName, euidToken);
+    config.setConfig(makePrebidConfig({euidServerCookie: publisherCookieName}));
+    const bid = await runAuction();
+    expectToken(bid, initialToken);
+  })
+
+  it('When an expired token is provided in config, it calls the API.', function() {
+    const euidToken = apiHelpers.makeTokenResponse(initialToken, true, true);
+    config.setConfig(makePrebidConfig({euidToken}));
+    expect(server.requests[0]?.url).to.have.string('https://prod.euid.eu/');
+  });
+
+  it('When an expired token is provided and the API responds in time, the refreshed token is provided to the auction.', async function() {
+    const euidToken = apiHelpers.makeTokenResponse(initialToken, true, true);
+    configureEuidResponse(200, makeSuccessResponseBody());
+    config.setConfig(makePrebidConfig({euidToken}));
+    apiHelpers.respondAfterDelay(1);
+    const bid = await runAuction();
+    expectToken(bid, refreshedToken);
+  });
+});

--- a/test/spec/modules/euidIdSystem_spec.js
+++ b/test/spec/modules/euidIdSystem_spec.js
@@ -49,7 +49,6 @@ describe('EUID module', function() {
   });
   after(function() {
     suiteSandbox.restore();
-    // timerSpy.restore();
     if (restoreSubtleToUndefined) window.crypto.subtle = undefined;
   });
   beforeEach(function() {

--- a/test/spec/modules/euidIdSystem_spec.js
+++ b/test/spec/modules/euidIdSystem_spec.js
@@ -85,7 +85,7 @@ describe('EUID module', function() {
   it('When a valid response body is provided via cookie, it is available to the auction', async function() {
     const euidToken = apiHelpers.makeTokenResponse(initialToken, false, false);
     cookieHelpers.setPublisherCookie(publisherCookieName, euidToken);
-    config.setConfig(makePrebidConfig({euidServerCookie: publisherCookieName}));
+    config.setConfig(makePrebidConfig({euidCookie: publisherCookieName}));
     const bid = await runAuction();
     expectToken(bid, initialToken);
   })

--- a/test/spec/modules/uid2IdSystem_helpers.js
+++ b/test/spec/modules/uid2IdSystem_helpers.js
@@ -1,0 +1,40 @@
+import { server } from 'test/mocks/xhr.js';
+import {coreStorage, init, setSubmoduleRegistry, requestBidsHook} from 'modules/userId/index.js';
+
+const msIn12Hours = 60 * 60 * 12 * 1000;
+const expireCookieDate = 'Thu, 01 Jan 1970 00:00:01 GMT';
+
+export const cookieHelpers = {
+  getFutureCookieExpiry: () => new Date(Date.now() + msIn12Hours).toUTCString(),
+  setPublisherCookie: (cookieName, token) => coreStorage.setCookie(cookieName, JSON.stringify(token), cookieHelpers.getFutureCookieExpiry()),
+  clearCookies: (...cookieNames) => cookieNames.forEach(cookieName => coreStorage.setCookie(cookieName, '', expireCookieDate)),
+}
+
+export const runAuction = async () => {
+  const adUnits = [{
+    code: 'adUnit-code',
+    mediaTypes: {banner: {}, native: {}},
+    sizes: [[300, 200], [300, 600]],
+    bids: [{bidder: 'sampleBidder', params: {placementId: 'banner-only-bidder'}}]
+  }];
+  return new Promise(function(resolve) {
+    requestBidsHook(function() {
+      resolve(adUnits[0].bids[0]);
+    }, {adUnits});
+  });
+}
+
+export const apiHelpers = {
+  makeTokenResponse: (token, shouldRefresh = false, expired = false) => ({
+    advertising_token: token,
+    refresh_token: 'fake-refresh-token',
+    identity_expires: expired ? Date.now() - 1000 : Date.now() + 60 * 60 * 1000,
+    refresh_from: shouldRefresh ? Date.now() - 1000 : Date.now() + 60 * 1000,
+    refresh_expires: Date.now() + 24 * 60 * 60 * 1000, // 24 hours
+    refresh_response_key: 'wR5t6HKMfJ2r4J7fEGX9Gw==', // Fake data
+  }),
+  respondAfterDelay: (delay) => new Promise((resolve) => setTimeout(() => {
+    server.respond();
+    setTimeout(() => resolve());
+  }, delay)),
+}

--- a/test/spec/modules/uid2IdSystem_helpers.js
+++ b/test/spec/modules/uid2IdSystem_helpers.js
@@ -1,3 +1,4 @@
+import { setConsentConfig } from 'modules/consentManagement.js';
 import { server } from 'test/mocks/xhr.js';
 import {coreStorage, init, setSubmoduleRegistry, requestBidsHook} from 'modules/userId/index.js';
 
@@ -37,4 +38,33 @@ export const apiHelpers = {
     server.respond();
     setTimeout(() => resolve());
   }, delay)),
+}
+
+export const setGdprApplies = (consent = false) => {
+  const consentDetails = consent ? {
+    tcString: 'CPhJRpMPhJRpMABAMBFRACBoALAAAEJAAIYgAKwAQAKgArABAAqAAA',
+    purpose: {
+      consents: {
+        '1': true,
+      },
+    },
+    vendor: {
+      consents: {
+        '21': true,
+      },
+    }
+
+  } : {
+    tcString: 'CPhJRpMPhJRpMABAMBFRACBoALAAAEJAAIYgAKwAQAKgArABAAqAAA'
+  };
+  const staticConfig = {
+    cmpApi: 'static',
+    timeout: 7500,
+    consentData: {
+      gdprApplies: true,
+      ...consentDetails
+    }
+  }
+  setConsentConfig(staticConfig);
+  return staticConfig;
 }

--- a/test/spec/modules/uid2IdSystem_spec.js
+++ b/test/spec/modules/uid2IdSystem_spec.js
@@ -25,7 +25,8 @@ const legacyToken = 'legacy-advertising-token';
 const refreshedToken = 'refreshed-advertising-token';
 
 const legacyConfigParams = null;
-const serverCookieConfigParams = { uid2ServerCookie: publisherCookieName }
+const serverCookieConfigParams = { uid2ServerCookie: publisherCookieName };
+const newServerCookieConfigParams = { uid2Cookie: publisherCookieName };
 
 const makeUid2IdentityContainer = (token) => ({uid2: {id: token}});
 let useLocalStorage = false;
@@ -187,8 +188,10 @@ describe(`UID2 module`, function () {
       createLegacyTest(legacyConfigParams, [expectLegacyToken]));
     it('and a server cookie config is used without a valid server cookie, it should provide the legacy cookie',
       createLegacyTest(serverCookieConfigParams, [expectLegacyToken]));
-    it('and a server cookie is used with a valid server cookie, it should provide the server cookie',
+    it('and a server cookie is used with a valid server cookie configured using the new param name, it should provide the server cookie',
       async function() { cookieHelpers.setPublisherCookie(publisherCookieName, apiHelpers.makeTokenResponse(initialToken)); await createLegacyTest(serverCookieConfigParams, [(bid) => expectToken(bid, initialToken), expectNoLegacyToken])(); });
+    it('and a server cookie is used with a valid server cookie, it should provide the server cookie',
+      async function() { cookieHelpers.setPublisherCookie(publisherCookieName, apiHelpers.makeTokenResponse(initialToken)); await createLegacyTest(newServerCookieConfigParams, [(bid) => expectToken(bid, initialToken), expectNoLegacyToken])(); });
     it('and a token is provided in config, it should provide the config token',
       createLegacyTest({uid2Token: apiHelpers.makeTokenResponse(initialToken)}, [(bid) => expectToken(bid, initialToken), expectNoLegacyToken]));
   });

--- a/test/spec/modules/uid2IdSystem_spec.js
+++ b/test/spec/modules/uid2IdSystem_spec.js
@@ -143,6 +143,7 @@ describe(`UID2 module`, function () {
     }
     coreStorage.setCookie(moduleCookieName, '', expireCookieDate);
     coreStorage.setCookie(publisherCookieName, '', expireCookieDate);
+    coreStorage.removeDataFromLocalStorage(moduleCookieName);
 
     debugOutput('----------------- END TEST ------------------');
   });

--- a/test/spec/modules/uid2IdSystem_spec.js
+++ b/test/spec/modules/uid2IdSystem_spec.js
@@ -195,7 +195,7 @@ describe(`UID2 module`, function () {
     it('and a token is provided in config, it should provide the config token',
       createLegacyTest({uid2Token: apiHelpers.makeTokenResponse(initialToken)}, [(bid) => expectToken(bid, initialToken), expectNoLegacyToken]));
 
-    it.only('multiple runs do not change the value', async function() {
+    it('multiple runs do not change the value', async function() {
       coreStorage.setCookie(moduleCookieName, legacyToken, cookieHelpers.getFutureCookieExpiry());
       config.setConfig(makePrebidConfig(legacyConfigParams));
 

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -2365,7 +2365,6 @@ describe('User ID', function () {
         coreStorage.setCookie('deepintentId', 'testdeepintentId', new Date(Date.now() + 5000).toUTCString());
         coreStorage.setCookie('MOCKID', JSON.stringify({'MOCKID': '123456778'}), new Date(Date.now() + 5000).toUTCString());
         coreStorage.setCookie('__uid2_advertising_token', 'Sample_AD_Token', (new Date(Date.now() + 5000).toUTCString()));
-        coreStorage.setCookie('__euid_advertising_token', 'Sample_EUID_Token', (new Date(Date.now() + 5000).toUTCString()));
         localStorage.setItem('amxId', 'test_amxid_id');
         localStorage.setItem('amxId_exp', new Date(Date.now() + 5000).toUTCString())
         coreStorage.setCookie('kpuid', 'KINESSO_ID', (new Date(Date.now() + 5000).toUTCString()));
@@ -2404,8 +2403,6 @@ describe('User ID', function () {
               name: 'mockId', storage: {name: 'MOCKID', type: 'cookie'}
             }, {
               name: 'uid2'
-            }, {
-              name: 'euid'
             }, {
               name: 'deepintentId', storage: {name: 'deepintentId', type: 'cookie'}
             }, {
@@ -2471,9 +2468,6 @@ describe('User ID', function () {
               expect(bid.userId.uid2).to.deep.equal({
                 id: 'Sample_AD_Token'
               });
-              expect(bid.userId.euid).to.deep.equal({
-                id: 'Sample_EUID_Token'
-              });
 
               expect(bid).to.have.deep.nested.property('userId.amxId');
               expect(bid.userId.amxId).to.equal('test_amxid_id');
@@ -2491,7 +2485,7 @@ describe('User ID', function () {
 
               expect(bid).to.have.deep.nested.property('userId.qid');
               expect(bid.userId.qid).to.equal('testqid');
-              expect(bid.userIdAsEids.length).to.equal(17);
+              expect(bid.userIdAsEids.length).to.equal(16);
             });
           });
           coreStorage.setCookie('pubcid', '', EXPIRED_COOKIE_DATE);
@@ -2513,7 +2507,6 @@ describe('User ID', function () {
           localStorage.removeItem('amxId_exp');
           coreStorage.setCookie('kpuid', EXPIRED_COOKIE_DATE);
           coreStorage.setCookie('__uid2_advertising_token', '', EXPIRED_COOKIE_DATE);
-          coreStorage.setCookie('__euid_advertising_token', '', EXPIRED_COOKIE_DATE);
           done();
         }, {adUnits});
       });

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -41,6 +41,7 @@ import {tapadIdSubmodule} from 'modules/tapadIdSystem.js';
 import {tncidSubModule} from 'modules/tncIdSystem.js';
 import {getPrebidInternal} from 'src/utils.js';
 import {uid2IdSubmodule} from 'modules/uid2IdSystem.js';
+import {euidIdSubmodule} from 'modules/euidIdSystem.js';
 import {admixerIdSubmodule} from 'modules/admixerIdSystem.js';
 import {deepintentDpesSubmodule} from 'modules/deepintentDpesIdSystem.js';
 import {amxIdSubmodule} from '../../../modules/amxIdSystem.js';
@@ -870,7 +871,7 @@ describe('User ID', function () {
 
     it('handles config with no usersync object', function () {
       init(config);
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, merkleIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, merkleIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, euidIdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       config.setConfig({});
       // usersync is undefined, and no logInfo message for 'User ID - usersync config updated'
       expect(typeof utils.logInfo.args[0]).to.equal('undefined');
@@ -878,14 +879,14 @@ describe('User ID', function () {
 
     it('handles config with empty usersync object', function () {
       init(config);
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, merkleIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, merkleIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, euidIdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       config.setConfig({userSync: {}});
       expect(typeof utils.logInfo.args[0]).to.equal('undefined');
     });
 
     it('handles config with usersync and userIds that are empty objs', function () {
       init(config);
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, merkleIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, merkleIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, euidIdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       config.setConfig({
         userSync: {
           userIds: [{}]
@@ -896,7 +897,7 @@ describe('User ID', function () {
 
     it('handles config with usersync and userIds with empty names or that dont match a submodule.name', function () {
       init(config);
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, merkleIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, merkleIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, euidIdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       config.setConfig({
         userSync: {
           userIds: [{
@@ -913,7 +914,7 @@ describe('User ID', function () {
 
     it('config with 1 configurations should create 1 submodules', function () {
       init(config);
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, euidIdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       config.setConfig(getConfigMock(['unifiedId', 'unifiedid', 'cookie']));
 
       expect(utils.logInfo.args[0][0]).to.exist.and.to.contain('User ID - usersync config updated for 1 submodules');
@@ -933,9 +934,9 @@ describe('User ID', function () {
       expect(utils.logInfo.args[0][0]).to.exist.and.to.contain('User ID - usersync config updated for 1 submodules');
     });
 
-    it('config with 22 configurations should result in 22 submodules add', function () {
+    it('config with 23 configurations should result in 23 submodules add', function () {
       init(config);
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, liveIntentIdSubmodule, britepoolIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule, tncidSubModule]);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, liveIntentIdSubmodule, britepoolIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, euidIdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule, tncidSubModule]);
       config.setConfig({
         userSync: {
           syncDelay: 0,
@@ -979,6 +980,8 @@ describe('User ID', function () {
           }, {
             name: 'uid2'
           }, {
+            name: 'euid'
+          }, {
             name: 'admixerId',
             storage: {name: 'admixerId', type: 'cookie'}
           }, {
@@ -1001,12 +1004,12 @@ describe('User ID', function () {
           }]
         }
       });
-      expect(utils.logInfo.args[0][0]).to.exist.and.to.contain('User ID - usersync config updated for 22 submodules');
+      expect(utils.logInfo.args[0][0]).to.exist.and.to.contain('User ID - usersync config updated for 23 submodules');
     });
 
     it('config syncDelay updates module correctly', function () {
       init(config);
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, euidIdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       config.setConfig({
         userSync: {
           syncDelay: 99,
@@ -1021,7 +1024,7 @@ describe('User ID', function () {
 
     it('config auctionDelay updates module correctly', function () {
       init(config);
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, euidIdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       config.setConfig({
         userSync: {
           auctionDelay: 100,
@@ -1036,7 +1039,7 @@ describe('User ID', function () {
 
     it('config auctionDelay defaults to 0 if not a number', function () {
       init(config);
-      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
+      setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, pubProvidedIdSubmodule, criteoIdSubmodule, mwOpenLinkIdSubModule, tapadIdSubmodule, uid2IdSubmodule, euidIdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
       config.setConfig({
         userSync: {
           auctionDelay: '',
@@ -2362,6 +2365,7 @@ describe('User ID', function () {
         coreStorage.setCookie('deepintentId', 'testdeepintentId', new Date(Date.now() + 5000).toUTCString());
         coreStorage.setCookie('MOCKID', JSON.stringify({'MOCKID': '123456778'}), new Date(Date.now() + 5000).toUTCString());
         coreStorage.setCookie('__uid2_advertising_token', 'Sample_AD_Token', (new Date(Date.now() + 5000).toUTCString()));
+        coreStorage.setCookie('__euid_advertising_token', 'Sample_EUID_Token', (new Date(Date.now() + 5000).toUTCString()));
         localStorage.setItem('amxId', 'test_amxid_id');
         localStorage.setItem('amxId_exp', new Date(Date.now() + 5000).toUTCString())
         coreStorage.setCookie('kpuid', 'KINESSO_ID', (new Date(Date.now() + 5000).toUTCString()));
@@ -2400,6 +2404,8 @@ describe('User ID', function () {
               name: 'mockId', storage: {name: 'MOCKID', type: 'cookie'}
             }, {
               name: 'uid2'
+            }, {
+              name: 'euid'
             }, {
               name: 'deepintentId', storage: {name: 'deepintentId', type: 'cookie'}
             }, {
@@ -2464,6 +2470,9 @@ describe('User ID', function () {
               expect(bid.userId.hadronId).to.equal('testHadronId1');
               expect(bid.userId.uid2).to.deep.equal({
                 id: 'Sample_AD_Token'
+              });
+              expect(bid.userId.euid).to.deep.equal({
+                id: 'Sample_EUID_Token'
               });
 
               expect(bid).to.have.deep.nested.property('userId.amxId');

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -2373,7 +2373,7 @@ describe('User ID', function () {
         localStorage.setItem('qid_exp', new Date(Date.now() + 5000).toUTCString())
 
         init(config);
-        setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, britepoolIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, uid2IdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
+        setSubmoduleRegistry([sharedIdSystemSubmodule, unifiedIdSubmodule, id5IdSubmodule, identityLinkSubmodule, britepoolIdSubmodule, netIdSubmodule, intentIqIdSubmodule, zeotapIdPlusSubmodule, hadronIdSubmodule, uid2IdSubmodule, euidIdSubmodule, admixerIdSubmodule, deepintentDpesSubmodule, dmdIdSubmodule, amxIdSubmodule, kinessoIdSubmodule, adqueryIdSubmodule]);
 
         config.setConfig({
           userSync: {

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -2491,7 +2491,7 @@ describe('User ID', function () {
 
               expect(bid).to.have.deep.nested.property('userId.qid');
               expect(bid.userId.qid).to.equal('testqid');
-              expect(bid.userIdAsEids.length).to.equal(16);
+              expect(bid.userIdAsEids.length).to.equal(17);
             });
           });
           coreStorage.setCookie('pubcid', '', EXPIRED_COOKIE_DATE);

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -2512,6 +2512,8 @@ describe('User ID', function () {
           localStorage.removeItem('amxId');
           localStorage.removeItem('amxId_exp');
           coreStorage.setCookie('kpuid', EXPIRED_COOKIE_DATE);
+          coreStorage.setCookie('__uid2_advertising_token', '', EXPIRED_COOKIE_DATE);
+          coreStorage.setCookie('__euid_advertising_token', '', EXPIRED_COOKIE_DATE);
           done();
         }, {adUnits});
       });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
I've extracted most of the functionality from the UID2 module to a shared file, to allow re-use with the new EUID module.
I've added a new EUID module.
Both modules now prefer local storage - the UID2 module originally preferred cookie storage. No configs need to change - it's all backward-compatible.

## Other information
Docs change PR: https://github.com/prebid/prebid.github.io/pull/4603
