### PR TITLE
Adtelligent Bid Adapter : add Copper6 alias adapter

### DIFF
--- a/modules/adtelligentBidAdapter.js
+++ b/modules/adtelligentBidAdapter.js
@@ -24,7 +24,8 @@ const HOST_GETTERS = {
   pgam: () => 'ghb.pgamssp.com',
   ocm: () => 'ghb.cenarius.orangeclickmedia.com',
   vidcrunchllc: () => 'ghb.platform.vidcrunch.com',
-  '9dotsmedia': () => 'ghb.platform.audiodots.com'
+  '9dotsmedia': () => 'ghb.platform.audiodots.com',
+  copper6: () => 'ghb.app.copper6.com'
 }
 const getUri = function (bidderCode) {
   let bidderWithoutSuffix = bidderCode.split('_')[0];
@@ -51,7 +52,8 @@ export const spec = {
     'pgam',
     { code: 'ocm', gvlid: 1148 },
     { code: 'vidcrunchllc', gvlid: 1145 },
-    '9dotsmedia'
+    '9dotsmedia',
+    'copper6',
   ],
   supportedMediaTypes: [VIDEO, BANNER],
   isBidRequestValid: function (bid) {

--- a/test/spec/modules/adtelligentBidAdapter_spec.js
+++ b/test/spec/modules/adtelligentBidAdapter_spec.js
@@ -22,6 +22,7 @@ const aliasEP = {
   'ocm': 'https://ghb.cenarius.orangeclickmedia.com/v2/auction/',
   'vidcrunchllc': 'https://ghb.platform.vidcrunch.com/v2/auction/',
   '9dotsmedia': 'https://ghb.platform.audiodots.com/v2/auction/',
+  'copper6': 'https://ghb.app.copper6.com/v2/auction/',
 };
 
 const DEFAULT_ADATPER_REQ = { bidderCode: 'adtelligent' };


### PR DESCRIPTION
## Type of change

- [x] New bidder adapter 

## Description of change
Add new bidder alias "copper6"


- contact email of the adapter’s maintainer:  info@copper6.com
- test parameters for validating bids:
```
{
        code: 'test-div',
        mediaTypes:{
            banner:{
                sizes: [[300, 250]]
            }
        }
        bids: [{
          bidder: 'copper6',
          params: {
            aid: 529814
          }
        }]
      }
}
```



## Other information
Doc PR: https://github.com/prebid/prebid.github.io/pull/4587
