### PR TITLE
Prebid 8: remove shutdown company from appnexus aliases

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -101,9 +101,7 @@ export const spec = {
   gvlid: GVLID,
   aliases: [
     { code: 'appnexusAst', gvlid: 32 },
-    { code: 'emxdigital', gvlid: 183 },
     { code: 'pagescience', gvlid: 32 },
-    { code: 'defymedia', gvlid: 32 },
     { code: 'gourmetads', gvlid: 32 },
     { code: 'matomy', gvlid: 32 },
     { code: 'featureforward', gvlid: 32 },

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -101,6 +101,7 @@ export const spec = {
   gvlid: GVLID,
   aliases: [
     { code: 'appnexusAst', gvlid: 32 },
+    { code: 'emxdigital', gvlid: 183 },
     { code: 'pagescience', gvlid: 32 },
     { code: 'gourmetads', gvlid: 32 },
     { code: 'matomy', gvlid: 32 },


### PR DESCRIPTION
As reported in the press, EMX and Defy Media are no longer companies. 