### PR TITLE
YieldlabBidAdapter updated native asset mapping

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -186,13 +186,21 @@ export const spec = {
           // there may be publishers still rely on it
           bidResponse.adUrl = `${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/?ts=${timestamp}${extId}${gdprApplies}${gdprConsent}${pvId}`;
           bidResponse.mediaType = NATIVE;
-          const nativeImageAssetObj = find(matchedBid.native.assets, asset => isMainImage(asset));
+          const nativeIconAssetObj = find(matchedBid.native.assets, asset => isImageAssetOfType(asset, 1));
+          const nativeImageAssetObj = find(matchedBid.native.assets, asset => isImageAssetOfType(asset, 3));
           const nativeImageAsset = nativeImageAssetObj ? nativeImageAssetObj.img : { url: '', w: 0, h: 0 };
           const nativeTitleAsset = find(matchedBid.native.assets, asset => hasValidProperty(asset, 'title'));
           const nativeBodyAsset = find(matchedBid.native.assets, asset => hasValidProperty(asset, 'data'));
           bidResponse.native = {
             title: nativeTitleAsset ? nativeTitleAsset.title.text : '',
             body: nativeBodyAsset ? nativeBodyAsset.data.value : '',
+            ...nativeIconAssetObj?.img && {
+              icon: {
+                url: nativeIconAssetObj.img.url,
+                width: nativeIconAssetObj.img.w,
+                height: nativeIconAssetObj.img.h,
+              },
+            },
             image: {
               url: nativeImageAsset.url,
               width: nativeImageAsset.w,
@@ -517,14 +525,14 @@ function hasValidProperty(obj, propName) {
 }
 
 /**
- * Checks if an asset object is a main image.
- * A main image is defined as an image asset whose type value is 3.
+ * Checks if an asset object is of the given type.
  *
  * @param {Object} asset - The asset object to check.
- * @returns {boolean} Returns true if the object has a property img.type with a value of 3, otherwise false.
+ * @param {number} type - The type number to compare.
+ * @returns {boolean} Returns true if the object has a property img.type with a value of the given type, otherwise false.
  */
-function isMainImage(asset) {
-  return asset?.img?.type === 3
+function isImageAssetOfType(asset, type) {
+  return asset?.img?.type === type
 }
 
 registerBidder(spec);

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -200,6 +200,15 @@ const NATIVE_RESPONSE = Object.assign({}, RESPONSE, {
           value: 'Native body value',
         },
       },
+      {
+        id: 4,
+        img: {
+          url: 'https://localhost:8080/assets/favicon/favicon-16x16.png',
+          w: 16,
+          h: 16,
+          type: 1,
+        },
+      },
     ],
     imptrackers: [
       'http://localhost:8080/ve?d=ODE9ZSY2MTI1MjAzNjMzMzYxPXN0JjA0NWUwZDk0NTY5Yi05M2FiLWUwZTQtOWFjNy1hYWY0MzFiZj1kaXQmMj12',
@@ -567,15 +576,24 @@ describe('yieldlabBidAdapter', () => {
       expect(result[0].native.image.url).to.equal('https://localhost:8080/yl-logo100x100.jpg');
       expect(result[0].native.image.width).to.equal(100);
       expect(result[0].native.image.height).to.equal(100);
+      expect(result[0].native.icon.url).to.equal('https://localhost:8080/assets/favicon/favicon-16x16.png');
+      expect(result[0].native.icon.width).to.equal(16);
+      expect(result[0].native.icon.height).to.equal(16);
       expect(result[0].native.clickUrl).to.equal('https://www.yieldlab.de');
       expect(result[0].native.impressionTrackers.length).to.equal(3);
-      expect(result[0].native.assets.length).to.equal(3);
+      expect(result[0].native.assets.length).to.equal(4);
       const titleAsset = result[0].native.assets.find(asset => 'title' in asset);
-      const imageAsset = result[0].native.assets.find(asset => 'img' in asset);
+      const imageAsset = result[0].native.assets.find((asset) => {
+        return asset?.img?.type === 3;
+      });
+      const iconAsset = result[0].native.assets.find((asset) => {
+        return asset?.img?.type === 1;
+      });
       const bodyAsset = result[0].native.assets.find(asset => 'data' in asset);
       expect(titleAsset).to.exist.and.to.have.nested.property('id', 1)
       expect(imageAsset).to.exist.and.to.have.nested.property('id', 2)
       expect(bodyAsset).to.exist.and.to.have.nested.property('id', 3)
+      expect(iconAsset).to.exist.and.to.have.nested.property('id', 4)
     });
 
     it('should add adUrl and default native assets when type is Native', () => {
@@ -599,6 +617,28 @@ describe('yieldlabBidAdapter', () => {
       expect(result[0].native.image.url).to.equal('');
       expect(result[0].native.image.width).to.equal(0);
       expect(result[0].native.image.height).to.equal(0);
+    });
+
+    it('should not add icon if not present in the native response', () => {
+      const NATIVE_RESPONSE_WITHOUT_ICON = Object.assign({}, NATIVE_RESPONSE, {
+        native: {
+          link: {
+            url: 'https://www.yieldlab.de',
+          },
+          assets: [
+            {
+              id: 1,
+              title: {
+                text: 'This is a great headline',
+              }
+            }
+          ],
+          imptrackers: [],
+        },
+      });
+      const result = spec.interpretResponse({body: [NATIVE_RESPONSE_WITHOUT_ICON]}, {validBidRequests: [NATIVE_REQUEST()], queryParams: REQPARAMS});
+      expect(result[0].native.hasOwnProperty('icon')).to.be.false;
+      expect(result[0].native.title).to.equal('This is a great headline');
     });
 
     it('should append gdpr parameters to vastUrl', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
YieldlabBidAdapter updated native asset mapping of type icon for adserver responses. Only adds the `native.icon` if a value is provided in the response.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
One approving review from a Yieldlab team member required. (@rey1128, @Mufas61, @brushmate or @kippsterr)