### PR TITLE
clean.io RTD Module: Use loadExternalScript function instead of insertElement() method

### DIFF
--- a/modules/cleanioRtdProvider.js
+++ b/modules/cleanioRtdProvider.js
@@ -7,6 +7,7 @@
  */
 
 import { submodule } from '../src/hook.js';
+import { loadExternalScript } from '../src/adloader.js';
 import { logError, generateUUID, insertElement } from '../src/utils.js';
 import * as events from '../src/events.js';
 import CONSTANTS from '../src/constants.json';
@@ -52,10 +53,7 @@ function pageInitStepPreloadScript(scriptURL) {
  * @param {string} scriptURL The script URL to add to the page for protection
  */
 function pageInitStepProtectPage(scriptURL) {
-  const scriptElement = document.createElement('script');
-  scriptElement.type = 'text/javascript';
-  scriptElement.src = scriptURL;
-  insertElement(scriptElement);
+  loadExternalScript(scriptURL, 'clean.io');
 }
 
 /**

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -22,7 +22,8 @@ const _approvedLoadExternalJSList = [
   'improvedigital',
   'aaxBlockmeter',
   'confiant',
-  'arcspan'
+  'arcspan',
+  'clean.io'
 ]
 
 /**

--- a/test/spec/modules/cleanioRtdProvider_spec.js
+++ b/test/spec/modules/cleanioRtdProvider_spec.js
@@ -1,3 +1,4 @@
+import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
 import * as utils from '../../../src/utils.js';
 import * as hook from '../../../src/hook.js'
 import * as events from '../../../src/events.js';
@@ -68,10 +69,8 @@ describe('clean.io RTD module', function () {
     it('pageInitStepProtectPage() should insert script element', function() {
       pageInitStepProtectPage(fakeScriptURL);
 
-      sinon.assert.calledOnce(insertElementStub);
-      sinon.assert.calledWith(insertElementStub, sinon.match(elem => elem.tagName === 'SCRIPT'));
-      sinon.assert.calledWith(insertElementStub, sinon.match(elem => elem.type === 'text/javascript'));
-      sinon.assert.calledWith(insertElementStub, sinon.match(elem => elem.src === fakeScriptURL));
+      sinon.assert.calledOnce(loadExternalScriptStub);
+      sinon.assert.calledWith(loadExternalScriptStub, fakeScriptURL, 'clean.io');
     });
   });
 
@@ -133,14 +132,14 @@ describe('clean.io RTD module', function () {
     it('should refuse initialization with incorrect parameters', function () {
       const { init } = getModule();
       expect(init({ params: { cdnUrl: 'abc', protectionMode: 'full' } }, {})).to.equal(false); // too short distribution name
-      sinon.assert.notCalled(insertElementStub);
+      sinon.assert.notCalled(loadExternalScriptStub);
     });
 
-    it('should iniitalize in full (page) protection mode', function () {
+    it('should initialize in full (page) protection mode', function () {
       const { init, onBidResponseEvent } = getModule();
       expect(init({ params: { cdnUrl: 'https://abc1234567890.cloudfront.net/script.js', protectionMode: 'full' } }, {})).to.equal(true);
-      sinon.assert.calledOnce(insertElementStub);
-      sinon.assert.calledWith(insertElementStub, sinon.match(elem => elem.tagName === 'SCRIPT'));
+      sinon.assert.calledOnce(loadExternalScriptStub);
+      sinon.assert.calledWith(loadExternalScriptStub, 'https://abc1234567890.cloudfront.net/script.js', 'clean.io');
 
       const fakeBidResponse = makeFakeBidResponse();
       onBidResponseEvent(fakeBidResponse, {}, {});


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Use loadExternalScript function instead of insertElement() method to insert the Clean.io script. Fixes issue https://github.com/prebid/Prebid.js/issues/8421

## Other information
Documentation: [clean.io module](https://docs.prebid.org/dev-docs/modules/cleanioRtdProvider.html)