### PR TITLE
HypeLab Bid Adapter: Initial Release

### DIFF
--- a/modules/hypelabBidAdapter.js
+++ b/modules/hypelabBidAdapter.js
@@ -24,8 +24,8 @@ function isBidRequestValid(request) {
   return true;
 }
 
-function buildRequests(validRequests, request) {
-  const result = validRequests.map((request) => {
+function buildRequests(validBidRequests, bidderRequest) {
+  const result = validBidRequests.map((request) => {
     const uids = (request.userIdAsEids || []).reduce((a, c) => {
       const ids = c.uids.map((uid) => uid.id);
       return [...a, ...ids];
@@ -33,14 +33,16 @@ function buildRequests(validRequests, request) {
 
     const uuid = uids[0] ? uids[0] : generateTemporaryUUID();
 
-    const hypelabRequest = {
+    const payload = {
       property_slug: request.params.property_slug,
       placement_slug: request.params.placement_slug,
       provider_version: request.params.provider_version,
       provider_name: request.params.provider_name,
+      referrer: bidderRequest.refererInfo?.ref,
       sdk_version: request.params.sdk_version,
       sizes: request.sizes,
       wids: [],
+      url: bidderRequest.refererInfo?.page || window.location.href,
       uuid,
     };
 
@@ -48,7 +50,7 @@ function buildRequests(validRequests, request) {
       method: 'POST',
       url: url(REQUEST_ROUTE),
       options: { contentType: 'application/json', withCredentials: false },
-      data: hypelabRequest,
+      data: payload,
       bidId: request.bidId,
     };
   });

--- a/modules/hypelabBidAdapter.js
+++ b/modules/hypelabBidAdapter.js
@@ -1,0 +1,138 @@
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER } from '../src/mediaTypes.js';
+import { generateUUID } from '../src/utils.js';
+import { ajax } from '../src/ajax.js';
+
+export const BIDDER_CODE = 'hypelab';
+export const ENDPOINT_URL = 'https://api.hypelab.com';
+
+export const REQUEST_ROUTE = '/v1/prebid_requests';
+export const EVENT_ROUTE = '/v1/events';
+export const REPORTING_ROUTE = null;
+
+const DEFAULT_TTL = 360;
+
+const url = (route) => ENDPOINT_URL + route;
+
+function mediaSize(data) {
+  if (!data || !data.creative_set) return { width: 0, height: 0 };
+  const media = data.creative_set.video || data.creative_set.image || {};
+  return { width: media.width, height: media.height };
+}
+
+function isBidRequestValid(request) {
+  return true;
+}
+
+function buildRequests(validRequests, request) {
+  const result = validRequests.map((request) => {
+    const uids = (request.userIdAsEids || []).reduce((a, c) => {
+      const ids = c.uids.map((uid) => uid.id);
+      return [...a, ...ids];
+    }, []);
+
+    const uuid = uids[0] ? uids[0] : generateTemporaryUUID();
+
+    const hypelabRequest = {
+      property_slug: request.params.property_slug,
+      placement_slug: request.params.placement_slug,
+      provider_version: request.params.provider_version,
+      provider_name: request.params.provider_name,
+      sdk_version: request.params.sdk_version,
+      sizes: request.sizes,
+      wids: [],
+      uuid,
+    };
+
+    return {
+      method: 'POST',
+      url: url(REQUEST_ROUTE),
+      options: { contentType: 'application/json', withCredentials: false },
+      data: hypelabRequest,
+      bidId: request.bidId,
+    };
+  });
+
+  return result;
+}
+
+function generateTemporaryUUID() {
+  return 'tmp_' + generateUUID();
+}
+
+function interpretResponse(response, request) {
+  const { data } = response.body;
+  const { cpm } = data;
+  if (!cpm) return [];
+
+  const size = mediaSize(data);
+
+  const result = {
+    requestId: request.bidId,
+    cpm,
+    width: size.width,
+    height: size.height,
+    creativeId: data.creative_set_slug || '0',
+    currency: 'USD',
+    netRevenue: true,
+    referrer: request.data.referrer,
+    ttl: data.ttl || DEFAULT_TTL,
+    ad: data.html,
+    mediaType: 'banner',
+    meta: {
+      advertiserDomains: data.advertiserDomains || [],
+    },
+  };
+
+  return [result];
+}
+
+function getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent) {
+  const syncs = [];
+  return syncs;
+}
+
+function report(eventType, data) {
+  if (!REPORTING_ROUTE) return;
+
+  const options = {
+    method: 'POST',
+    contentType: 'application/json',
+    withCredentials: true,
+  };
+
+  const request = { type: eventType, data };
+  ajax(url(REPORTING_ROUTE), null, request, options);
+}
+
+function onTimeout(timeoutData) {
+  report('timeout', timeoutData);
+}
+
+function onBidWon(bid) {
+  report('bidWon', bid);
+}
+
+function onSetTargeting(bid) {
+  report('setTargeting', bid);
+}
+
+function onBidderError(errorData) {
+  report('bidderError', errorData);
+}
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [BANNER],
+  aliases: ['hype'],
+  isBidRequestValid,
+  buildRequests,
+  interpretResponse,
+  getUserSyncs,
+  onTimeout,
+  onBidWon,
+  onSetTargeting,
+  onBidderError,
+};
+
+registerBidder(spec);

--- a/modules/hypelabBidAdapter.md
+++ b/modules/hypelabBidAdapter.md
@@ -1,0 +1,38 @@
+# Overview
+
+```
+Module Name: HypeLab Bid Adapter
+Module Type: Bidder Adapter
+Maintainer: sdk@hypelab.com
+```
+
+# Description
+
+Prebid.JS adapter that connects to HypeLab ad network for bids.
+*NOTE*: The HypeLab Adapter requires setup and approval before use. Please reach out to `partnerships@hypelab.com` for more details. To get started, replace the `property_slug` with your property_slug and the `placement_slug` with your placement slug to receive bids. The placement slug will depend on the required size and can be set via the HypeLab interface.
+
+# Test Parameters
+
+## Sample Banner Ad Unit
+
+```js
+var adUnits = [
+  {
+    code: 'banner-div',
+    mediaTypes: {
+      banner: {
+        sizes: [[728, 90]],
+      },
+    },
+    bids: [
+        {
+            bidder: 'hypelab',
+            params: {
+                property_slug: 'prebid',
+                placement_slug: 'test_placement'
+            }
+        }
+    ]
+  }
+]
+```

--- a/test/spec/modules/hypelabBidAdapter_spec.js
+++ b/test/spec/modules/hypelabBidAdapter_spec.js
@@ -1,0 +1,87 @@
+import { expect } from 'chai';
+import { spec, BIDDER_CODE, ENDPOINT_URL, REQUEST_ROUTE } from 'modules/hypelabBidAdapter.js';
+import { BANNER } from '../../../src/mediaTypes.js';
+
+const mockRequest = {
+  bidder: '',
+  params: {
+    property_slug: 'mock',
+    placement_slug: 'mock'
+  },
+  mediaTypes: {
+    banner: {
+      sizes: [[300, 250]]
+    }
+  }
+};
+
+const mockBids = {
+  data: {},
+  bids: [{ bidId: '0' }]
+};
+
+const mockResponse = {
+  body: {
+    data: {
+      cpm: 0.50,
+      width: 300,
+      height: 250,
+      creativeId: '0',
+      currency: 'USD',
+      netRevenue: true,
+      referrer: 'referrer.com',
+      ttl: 360,
+      ad: '',
+      mediaType: 'banner',
+      meta: {
+        advertiserDomains: []
+      }
+    }
+  }
+};
+
+describe('HypeLab bid adapter', function() {
+  describe('Bidder code valid', function() {
+    expect(spec.code).to.equal(BIDDER_CODE);
+  });
+
+  describe('Media types valid', function() {
+    expect(spec.supportedMediaTypes).to.contain(BANNER);
+  });
+
+  describe('Bid request valid', function() {
+    expect(spec.isBidRequestValid(mockRequest)).to.equal(true);
+  });
+
+  describe('Builds valid request', function() {
+    const result = spec.buildRequests([mockRequest], {});
+    expect(result).to.be.an('array');
+
+    const first = result[0] || {};
+    expect(first).to.be.an('object');
+    expect(first.method).to.equal('POST');
+    expect(first.url).to.be.a('string');
+    expect(first.url).to.equal(ENDPOINT_URL + REQUEST_ROUTE);
+
+    const data = first.data || {};
+    expect(data).to.be.an('object');
+    expect(data.property_slug).to.be.a('string');
+    expect(data.placement_slug).to.be.a('string');
+  });
+
+  describe('Interprets valid response', function() {
+    const result = spec.interpretResponse(mockResponse, mockBids);
+    expect(result).to.be.an('array');
+
+    const data = result[0] || {};
+    expect(data).to.be.an('object');
+    expect(data.cpm).to.be.a('number');
+    expect(data.width).to.be.a('number');
+    expect(data.height).to.be.a('number');
+    expect(data.creativeId).to.be.a('string');
+    expect(data.currency).to.be.a('string');
+    expect(data.ttl).to.be.a('number');
+    expect(data.ad).to.be.a('string');
+    expect(data.mediaType).to.be.a('string');
+  });
+});


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Adding the HypeLab Network's bidding adapter.

- contact email of the adapter’s maintainer: sdk@hypelab.com
- test parameters for validating bids:
```
{
    bidder: 'hypelab',
    params: {
        property_slug: 'prebid',
        placement_slug: 'test_placement'
    }
}
```

Confirmed that the adapter does work with the helloWorld example.
