### PR TITLE
Appnexus Bid Adapter: added uol as an alias

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -111,6 +111,7 @@ export const spec = {
     { code: 'adasta', gvlid: 32 },
     { code: 'beintoo', gvlid: 618 },
     { code: 'projectagora', gvlid: 1032 },
+    { code: 'uol', gvlid: 32 },
   ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter

## Description of change
Adding uol as bidder adapter alias for appnexus

Tested in appnexus bidder

Test parameters for validating bids

- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  "bidder": "uol", 
  "params": {
    "placementId": "13144370"
  }
}
```
- contact email of the adapter’s maintainer [l-dev-techops@uolinc.com](mailto:l-dev-techops@uolinc.com)
- official adapter submission

DOCS PR: https://github.com/prebid/prebid.github.io/pull/4601