### PR TITLE
Weborama RTD Module : start Bidder specific handling removal

### DIFF
--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -690,7 +690,7 @@ class WeboramaRtdProvider {
     const bidder = bidderAliasRegistry[bid.bidder] || bid.bidder;
 
     if (bidder == 'appnexus') {
-      this.#handleAppnexusBid(bid, profile);
+      this.#handleAppnexusBid(reqBidsConfigObj, bid, profile);
     }
   }
 
@@ -708,16 +708,19 @@ class WeboramaRtdProvider {
   /** handle appnexus/xandr bid
    * @method
    * @private
+   * @param {Object} reqBidsConfigObj
+   * @param {Object} reqBidsConfigObj.ortb2Fragments
+   * @param {Object} reqBidsConfigObj.ortb2Fragments.bidder
    * @param {Object} bid
-   * @param {Object} bid.params
-   * @param {Object} bid.params.keyword
+   * @param {Object} bid.parameters
    * @param {Profile} profile
    * @returns {void}
    */
   // eslint-disable-next-line no-dupe-class-members
-  #handleAppnexusBid(bid, profile) {
+  #handleAppnexusBid(reqBidsConfigObj, bid, profile) {
     const base = 'params.keywords';
     this.#assignProfileToObject(bid, base, profile);
+    // this.#setBidderOrtb2(reqBidsConfigObj.ortb2Fragments?.bidder, bid.bidder, base, profile);
   }
 
   /** handle generic bid via ortb2 arbitrary data

--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -693,9 +693,6 @@ class WeboramaRtdProvider {
       case 'appnexus':
         this.#handleAppnexusBid(bid, profile);
         break;
-      case 'pubmatic':
-        this.#handlePubmaticBid(bid, profile);
-        break;
       case 'smartadserver':
         this.#handleSmartadserverBid(bid, profile);
         break;
@@ -729,34 +726,6 @@ class WeboramaRtdProvider {
   #handleAppnexusBid(bid, profile) {
     const base = 'params.keywords';
     this.#assignProfileToObject(bid, base, profile);
-  }
-
-  /** handle pubmatic bid
-   * @method
-   * @private
-   * @param {Object} bid
-   * @param {Object} bid.params
-   * @param {string} bid.params.dctr
-   * @param {Profile} profile
-   * @returns {void}
-   */
-  // eslint-disable-next-line no-dupe-class-members
-  #handlePubmaticBid(bid, profile) {
-    const sep = '|';
-    const subsep = ',';
-
-    bid.params ||= {};
-
-    const data = bid.params.dctr || '';
-    const target = new Set(data.split(sep).filter((x) => x.length > 0));
-
-    Object.entries(profile).forEach(([key, values]) => {
-      const value = values.join(subsep);
-      const keyword = `${key}=${value}`;
-      target.add(keyword);
-    });
-
-    bid.params.dctr = Array.from(target).join(sep);
   }
 
   /** handle smartadserver bid

--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -756,6 +756,7 @@ class WeboramaRtdProvider {
    * @param {Profile} profile
    * @returns {void}
    */
+  // eslint-disable-next-line no-dupe-class-members
   #setBidderOrtb2(bidderOrtb2Fragments, bidder, path, profile) {
     const base = `${bidder}.${path}`;
     this.#assignProfileToObject(bidderOrtb2Fragments, base, profile)

--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -719,9 +719,10 @@ class WeboramaRtdProvider {
    */
   // eslint-disable-next-line no-dupe-class-members
   #handleAppnexusBid(reqBidsConfigObj, bid, profile, metadata) {
-    this.#assignProfileToObject(bid, 'params.keywords', profile);
     if (metadata.user) {
       this.#setBidderOrtb2(reqBidsConfigObj.ortb2Fragments?.bidder, bid.bidder, 'user.keywords', profile);
+    } else {
+      this.#assignProfileToObject(bid, 'params.keywords', profile);
     }
   }
 

--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -719,10 +719,9 @@ class WeboramaRtdProvider {
    */
   // eslint-disable-next-line no-dupe-class-members
   #handleAppnexusBid(reqBidsConfigObj, bid, profile, metadata) {
+    this.#assignProfileToObject(bid, 'params.keywords', profile);
     if (metadata.user) {
       this.#setBidderOrtb2(reqBidsConfigObj.ortb2Fragments?.bidder, bid.bidder, 'user.keywords', profile);
-    } else {
-      this.#assignProfileToObject(bid, 'params.keywords', profile);
     }
   }
 

--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -693,9 +693,6 @@ class WeboramaRtdProvider {
       case 'appnexus':
         this.#handleAppnexusBid(bid, profile);
         break;
-      case 'smartadserver':
-        this.#handleSmartadserverBid(bid, profile);
-        break;
       case 'rubicon':
         this.#handleRubiconBid(bid, profile, metadata);
         break;
@@ -726,34 +723,6 @@ class WeboramaRtdProvider {
   #handleAppnexusBid(bid, profile) {
     const base = 'params.keywords';
     this.#assignProfileToObject(bid, base, profile);
-  }
-
-  /** handle smartadserver bid
-   * @method
-   * @private
-   * @param {Object} bid
-   * @param {Object} bid.params
-   * @param {string} bid.params.target
-   * @param {Profile} profile
-   * @returns {void}
-   */
-  // eslint-disable-next-line no-dupe-class-members
-  #handleSmartadserverBid(bid, profile) {
-    const sep = ';';
-
-    bid.params ||= {};
-
-    const data = bid.params.target || '';
-    const target = new Set(data.split(sep).filter((x) => x.length > 0));
-
-    Object.entries(profile).forEach(([key, values]) => {
-      values.forEach(value => {
-        const keyword = `${key}=${value}`;
-        target.add(keyword);
-      })
-    });
-
-    bid.params.target = Array.from(target).join(sep);
   }
 
   /** handle rubicon bid

--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -690,7 +690,7 @@ class WeboramaRtdProvider {
     const bidder = bidderAliasRegistry[bid.bidder] || bid.bidder;
 
     if (bidder == 'appnexus') {
-      this.#handleAppnexusBid(reqBidsConfigObj, bid, profile, metadata);
+      this.#handleAppnexusBid(reqBidsConfigObj, bid, profile);
     }
   }
 
@@ -714,15 +714,13 @@ class WeboramaRtdProvider {
    * @param {Object} bid
    * @param {Object} bid.parameters
    * @param {Profile} profile
-   * @param {dataCallbackMetadata} metadata
    * @returns {void}
    */
   // eslint-disable-next-line no-dupe-class-members
-  #handleAppnexusBid(reqBidsConfigObj, bid, profile, metadata) {
-    this.#assignProfileToObject(bid, 'params.keywords', profile);
-    if (metadata.user) {
-      this.#setBidderOrtb2(reqBidsConfigObj.ortb2Fragments?.bidder, bid.bidder, 'user.keywords', profile);
-    }
+  #handleAppnexusBid(reqBidsConfigObj, bid, profile) {
+    const base = 'params.keywords';
+    this.#assignProfileToObject(bid, base, profile);
+    // this.#setBidderOrtb2(reqBidsConfigObj.ortb2Fragments?.bidder, bid.bidder, base, profile);
   }
 
   /** handle generic bid via ortb2 arbitrary data

--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -153,7 +153,7 @@ const SFBX_LITE_DATA_SOURCE_LABEL = 'lite';
 /** @type {number} */
 const GVLID = 284;
 /** @type {string} */
-const LEGACY_SITE_KEYWORDS_BIDDERS = ['appnexus'];
+const APPNEXUS_BIDDER = 'appnexus';
 
 export const storage = getStorageManager({
   moduleType: MODULE_TYPE_RTD,
@@ -683,6 +683,12 @@ class WeboramaRtdProvider {
    */
   // eslint-disable-next-line no-dupe-class-members
   #handleBid(reqBidsConfigObj, bid, profile, metadata) {
+    if (!isBoolean(metadata.user)) {
+      logMessage(`SKIP unsupported bidder '${bid.bidder}', data from '${metadata.source}' is not defined as user or site-centric`);
+
+      return
+    }
+
     this.#handleBidViaORTB2(reqBidsConfigObj, bid.bidder, profile, metadata);
 
     /** @type {Object.<string,string>} */
@@ -691,8 +697,8 @@ class WeboramaRtdProvider {
     /** @type {string} */
     const bidder = bidderAliasRegistry[bid.bidder] || bid.bidder;
 
-    if (LEGACY_SITE_KEYWORDS_BIDDERS.includes(bidder)) {
-      this.#handleSiteLegacyKeywordsBidders(reqBidsConfigObj, bid, profile, metadata);
+    if (bidder === APPNEXUS_BIDDER) {
+      this.#handleAppnexusBidder(reqBidsConfigObj, bid, profile, metadata);
     }
   }
 
@@ -707,25 +713,26 @@ class WeboramaRtdProvider {
     return [deepClone(ph.data), deepClone(ph.metadata)];
   }
 
-  /** handle site legacy keywords bidders like appnexus/xandr
+  /** handle data to appnexus/xandr bidder.
    * @method
    * @private
    * @param {Object} reqBidsConfigObj
    * @param {Object} reqBidsConfigObj.ortb2Fragments
    * @param {Object} reqBidsConfigObj.ortb2Fragments.bidder
    * @param {Object} bid
+   * @param {string} bid.bidder
    * @param {Object} bid.parameters
    * @param {Profile} profile
    * @param {dataCallbackMetadata} metadata
    * @returns {void}
    */
   // eslint-disable-next-line no-dupe-class-members
-  #handleSiteLegacyKeywordsBidders(reqBidsConfigObj, bid, profile, metadata) {
-    if (metadata.user) {
-      this.#setBidderOrtb2(reqBidsConfigObj.ortb2Fragments?.bidder, bid.bidder, 'user.keywords', profile);
-    } else {
-      this.#assignProfileToObject(bid, 'params.keywords', profile);
-    }
+  #handleAppnexusBidder(reqBidsConfigObj, bid, profile, metadata) {
+    const bidder = bid.bidder;
+    const section = metadata.user ? 'user' : 'site';
+    const path = `${section}.keywords`;
+
+    this.#setBidderOrtb2(reqBidsConfigObj.ortb2Fragments?.bidder, bidder, path, profile);
   }
 
   /** handle generic bid via ortb2 arbitrary data
@@ -741,15 +748,11 @@ class WeboramaRtdProvider {
    */
   // eslint-disable-next-line no-dupe-class-members
   #handleBidViaORTB2(reqBidsConfigObj, bidder, profile, metadata) {
-    if (isBoolean(metadata.user)) {
-      logMessage(`bidder '${bidder}' is not directly supported, trying set data via bidder ortb2 fpd`);
-      const section = metadata.user ? 'user' : 'site';
-      const path = `${section}.ext.data`;
+    logMessage(`bidder '${bidder}' is not directly supported, trying set data via bidder ortb2 fpd`);
+    const section = metadata.user ? 'user' : 'site';
+    const path = `${section}.ext.data`;
 
-      this.#setBidderOrtb2(reqBidsConfigObj.ortb2Fragments?.bidder, bidder, path, profile)
-    } else {
-      logMessage(`SKIP unsupported bidder '${bidder}', data from '${metadata.source}' is not defined as user or site-centric`);
-    }
+    this.#setBidderOrtb2(reqBidsConfigObj.ortb2Fragments?.bidder, bidder, path, profile);
   }
   /**
    * set bidder ortb2 data

--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -690,7 +690,7 @@ class WeboramaRtdProvider {
     const bidder = bidderAliasRegistry[bid.bidder] || bid.bidder;
 
     if (bidder == 'appnexus') {
-      this.#handleAppnexusBid(reqBidsConfigObj, bid, profile);
+      this.#handleAppnexusBid(reqBidsConfigObj, bid, profile, metadata);
     }
   }
 
@@ -714,13 +714,15 @@ class WeboramaRtdProvider {
    * @param {Object} bid
    * @param {Object} bid.parameters
    * @param {Profile} profile
+   * @param {dataCallbackMetadata} metadata
    * @returns {void}
    */
   // eslint-disable-next-line no-dupe-class-members
-  #handleAppnexusBid(reqBidsConfigObj, bid, profile) {
-    const base = 'params.keywords';
-    this.#assignProfileToObject(bid, base, profile);
-    // this.#setBidderOrtb2(reqBidsConfigObj.ortb2Fragments?.bidder, bid.bidder, base, profile);
+  #handleAppnexusBid(reqBidsConfigObj, bid, profile, metadata) {
+    this.#assignProfileToObject(bid, 'params.keywords', profile);
+    if (metadata.user) {
+      this.#setBidderOrtb2(reqBidsConfigObj.ortb2Fragments?.bidder, bid.bidder, 'user.keywords', profile);
+    }
   }
 
   /** handle generic bid via ortb2 arbitrary data

--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -736,14 +736,27 @@ class WeboramaRtdProvider {
     if (isBoolean(metadata.user)) {
       logMessage(`bidder '${bidder}' is not directly supported, trying set data via bidder ortb2 fpd`);
       const section = metadata.user ? 'user' : 'site';
-      const base = `${bidder}.${section}.ext.data`;
+      const path = `${section}.ext.data`;
 
-      this.#assignProfileToObject(reqBidsConfigObj.ortb2Fragments?.bidder, base, profile);
+      this.#setBidderOrtb2(reqBidsConfigObj.ortb2Fragments?.bidder, bidder, path, profile)
     } else {
       logMessage(`SKIP unsupported bidder '${bidder}', data from '${metadata.source}' is not defined as user or site-centric`);
     }
   }
-
+  /**
+   * set bidder ortb2 data
+   * @method
+   * @private
+   * @param {Object} bidderOrtb2Fragments
+   * @param {string} bidder
+   * @param {string} path
+   * @param {Profile} profile
+   * @returns {void}
+   */
+  #setBidderOrtb2(bidderOrtb2Fragments, bidder, path, profile) {
+    const base = `${bidder}.${path}`;
+    this.#assignProfileToObject(bidderOrtb2Fragments, base, profile)
+  }
   /**
    * assign profile to object
    * @method

--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -689,13 +689,8 @@ class WeboramaRtdProvider {
     /** @type {string} */
     const bidder = bidderAliasRegistry[bid.bidder] || bid.bidder;
 
-    switch (bidder) {
-      case 'appnexus':
-        this.#handleAppnexusBid(bid, profile);
-        break;
-      case 'rubicon':
-        this.#handleRubiconBid(bid, profile, metadata);
-        break;
+    if (bidder == 'appnexus') {
+      this.#handleAppnexusBid(bid, profile);
     }
   }
 
@@ -723,26 +718,6 @@ class WeboramaRtdProvider {
   #handleAppnexusBid(bid, profile) {
     const base = 'params.keywords';
     this.#assignProfileToObject(bid, base, profile);
-  }
-
-  /** handle rubicon bid
-   * @method
-   * @private
-   * @param {Object} bid
-   * @param {string} bid.bidder
-   * @param {Profile} profile
-   * @param {dataCallbackMetadata} metadata
-   * @returns {void}
-   */
-  // eslint-disable-next-line no-dupe-class-members
-  #handleRubiconBid(bid, profile, metadata) {
-    if (isBoolean(metadata.user)) {
-      const section = metadata.user ? 'visitor' : 'inventory';
-      const base = `params.${section}`;
-      this.#assignProfileToObject(bid, base, profile);
-    } else {
-      logMessage(`SKIP bidder '${bid.bidder}', data from '${metadata.source}' is not defined as user or site-centric`);
-    }
   }
 
   /** handle generic bid via ortb2 arbitrary data

--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -152,6 +152,8 @@ const WEBO_USER_DATA_SOURCE_LABEL = 'wam';
 const SFBX_LITE_DATA_SOURCE_LABEL = 'lite';
 /** @type {number} */
 const GVLID = 284;
+/** @type {string} */
+const LEGACY_SITE_KEYWORDS_BIDDERS = ['appnexus'];
 
 export const storage = getStorageManager({
   moduleType: MODULE_TYPE_RTD,
@@ -689,8 +691,8 @@ class WeboramaRtdProvider {
     /** @type {string} */
     const bidder = bidderAliasRegistry[bid.bidder] || bid.bidder;
 
-    if (bidder == 'appnexus') {
-      this.#handleAppnexusBid(reqBidsConfigObj, bid, profile, metadata);
+    if (LEGACY_SITE_KEYWORDS_BIDDERS.includes(bidder)) {
+      this.#handleSiteLegacyKeywordsBidders(reqBidsConfigObj, bid, profile, metadata);
     }
   }
 
@@ -705,7 +707,7 @@ class WeboramaRtdProvider {
     return [deepClone(ph.data), deepClone(ph.metadata)];
   }
 
-  /** handle appnexus/xandr bid
+  /** handle site legacy keywords bidders like appnexus/xandr
    * @method
    * @private
    * @param {Object} reqBidsConfigObj
@@ -718,7 +720,7 @@ class WeboramaRtdProvider {
    * @returns {void}
    */
   // eslint-disable-next-line no-dupe-class-members
-  #handleAppnexusBid(reqBidsConfigObj, bid, profile, metadata) {
+  #handleSiteLegacyKeywordsBidders(reqBidsConfigObj, bid, profile, metadata) {
     if (metadata.user) {
       this.#setBidderOrtb2(reqBidsConfigObj.ortb2Fragments?.bidder, bid.bidder, 'user.keywords', profile);
     } else {

--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -152,8 +152,6 @@ const WEBO_USER_DATA_SOURCE_LABEL = 'wam';
 const SFBX_LITE_DATA_SOURCE_LABEL = 'lite';
 /** @type {number} */
 const GVLID = 284;
-/** @type {string} */
-const LEGACY_SITE_KEYWORDS_BIDDERS = ['appnexus'];
 
 export const storage = getStorageManager({
   moduleType: MODULE_TYPE_RTD,
@@ -691,8 +689,8 @@ class WeboramaRtdProvider {
     /** @type {string} */
     const bidder = bidderAliasRegistry[bid.bidder] || bid.bidder;
 
-    if (LEGACY_SITE_KEYWORDS_BIDDERS.includes(bidder)) {
-      this.#handleSiteLegacyKeywordsBidders(reqBidsConfigObj, bid, profile, metadata);
+    if (bidder == 'appnexus') {
+      this.#handleAppnexusBid(reqBidsConfigObj, bid, profile, metadata);
     }
   }
 
@@ -707,7 +705,7 @@ class WeboramaRtdProvider {
     return [deepClone(ph.data), deepClone(ph.metadata)];
   }
 
-  /** handle site legacy keywords bidders like appnexus/xandr
+  /** handle appnexus/xandr bid
    * @method
    * @private
    * @param {Object} reqBidsConfigObj
@@ -720,7 +718,7 @@ class WeboramaRtdProvider {
    * @returns {void}
    */
   // eslint-disable-next-line no-dupe-class-members
-  #handleSiteLegacyKeywordsBidders(reqBidsConfigObj, bid, profile, metadata) {
+  #handleAppnexusBid(reqBidsConfigObj, bid, profile, metadata) {
     if (metadata.user) {
       this.#setBidderOrtb2(reqBidsConfigObj.ortb2Fragments?.bidder, bid.bidder, 'user.keywords', profile);
     } else {

--- a/modules/weboramaRtdProvider.md
+++ b/modules/weboramaRtdProvider.md
@@ -575,11 +575,11 @@ pbjs.que.push(function () {
 
 ### Supported Bidders
 
-We set the bidder (and global, if no specific bidders are set on `sendToBidders`) ortb2 `site.ext.data` and `user.ext.data` sections (as arbitrary data).
+We currently support the following bidder adapters with dedicated code:
 
-For `Appnexus SSP` we also set the user data into `users.keywords` fragment.
+* AppNexus SSP
 
-The following bidders may support it, to be sure, check the `First Party Data Support` on the feature list for the particular bidder from [here](https://docs.prebid.org/dev-docs/bidders).
+We also set the bidder (and global, if no specific bidders are set on `sendToBidders`) ortb2 `site.ext.data` and `user.ext.data` sections (as arbitrary data). The following bidders may support it, to be sure, check the `First Party Data Support` on the feature list for the particular bidder from [here](https://docs.prebid.org/dev-docs/bidders).
 
 * Adagio
 * AdformOpenRTB

--- a/modules/weboramaRtdProvider.md
+++ b/modules/weboramaRtdProvider.md
@@ -575,10 +575,9 @@ pbjs.que.push(function () {
 
 ### Supported Bidders
 
-We currently support the following bidder adapters:
+We currently support the following bidder adapters with dedicated code:
 
 * AppNexus SSP
-* Rubicon SSP
 
 We also set the bidder (and global, if no specific bidders are set on `sendToBidders`) ortb2 `site.ext.data` and `user.ext.data` sections (as arbitrary data). The following bidders may support it, to be sure, check the `First Party Data Support` on the feature list for the particular bidder from [here](https://docs.prebid.org/dev-docs/bidders).
 
@@ -605,6 +604,7 @@ We also set the bidder (and global, if no specific bidders are set on `sendToBid
 * Proxistore
 * PubMatic SSP
 * Rise
+* Rubicon SSP
 * Smaato
 * Smart ADServer SSP
 * Sonobi

--- a/modules/weboramaRtdProvider.md
+++ b/modules/weboramaRtdProvider.md
@@ -578,7 +578,6 @@ pbjs.que.push(function () {
 We currently support the following bidder adapters:
 
 * SmartADServer SSP
-* PubMatic SSP
 * AppNexus SSP
 * Rubicon SSP
 
@@ -605,6 +604,7 @@ We also set the bidder (and global, if no specific bidders are set on `sendToBid
 * Opt Out Advertising
 * Ozone Project
 * Proxistore
+* PubMatic SSP
 * Rise
 * Smaato
 * Sonobi

--- a/modules/weboramaRtdProvider.md
+++ b/modules/weboramaRtdProvider.md
@@ -577,7 +577,6 @@ pbjs.que.push(function () {
 
 We currently support the following bidder adapters:
 
-* SmartADServer SSP
 * AppNexus SSP
 * Rubicon SSP
 
@@ -607,6 +606,7 @@ We also set the bidder (and global, if no specific bidders are set on `sendToBid
 * PubMatic SSP
 * Rise
 * Smaato
+* Smart ADServer SSP
 * Sonobi
 * TheMediaGrid
 * TripleLift

--- a/modules/weboramaRtdProvider.md
+++ b/modules/weboramaRtdProvider.md
@@ -575,11 +575,11 @@ pbjs.que.push(function () {
 
 ### Supported Bidders
 
-We currently support the following bidder adapters with dedicated code:
+We set the bidder (and global, if no specific bidders are set on `sendToBidders`) ortb2 `site.ext.data` and `user.ext.data` sections (as arbitrary data).
 
-* AppNexus SSP
+For `Appnexus SSP` we also set the user data into `users.keywords` fragment.
 
-We also set the bidder (and global, if no specific bidders are set on `sendToBidders`) ortb2 `site.ext.data` and `user.ext.data` sections (as arbitrary data). The following bidders may support it, to be sure, check the `First Party Data Support` on the feature list for the particular bidder from [here](https://docs.prebid.org/dev-docs/bidders).
+The following bidders may support it, to be sure, check the `First Party Data Support` on the feature list for the particular bidder from [here](https://docs.prebid.org/dev-docs/bidders).
 
 * Adagio
 * AdformOpenRTB

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -1446,7 +1446,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           if (v == 'appnexus') {
@@ -1585,7 +1585,7 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids.length).to.equal(5);
               expect(adUnit.bids[0].params).to.be.undefined;
               expect(adUnit.bids[1].params).to.be.undefined;
-              expect(adUnit.bids[2].params).to.be.undefined;
+              expect(adUnit.bids[2].params.keywords).to.deep.equal(data);
               expect(adUnit.bids[3].params).to.be.undefined;
             });
             ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
@@ -1712,7 +1712,6 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids.length).to.equal(5);
               expect(adUnit.bids[0].params).to.be.undefined;
               expect(adUnit.bids[1].params).to.be.undefined;
-              expect(adUnit.bids[2].params).to.be.undefined;
               expect(adUnit.bids[3].params).to.be.undefined;
             });
             ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
@@ -1731,6 +1730,9 @@ describe('weboramaRtdProvider', function() {
 
               expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
             })
+
+            expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
+            expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
 
             expect(onDataResponse).to.deep.equal({
               data: data,
@@ -2187,6 +2189,8 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('foo=bar');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
           foo: ['bar'],
+          webo_cs: ['foo', 'bar'],
+          webo_audiences: ['baz'],
         });
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: {
@@ -2274,7 +2278,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           if (v == 'appnexus') {
@@ -2361,7 +2365,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           if (v == 'appnexus') {
@@ -2649,7 +2653,7 @@ describe('weboramaRtdProvider', function() {
 
         Object.keys(testcases).forEach(label => {
           const sendToBidders = testcases[label];
-          it(`check sendToBidders as '${label}'`, function() {
+          it(`check sendToBidders as ${label}`, function() {
             let onDataResponse = {};
             const moduleConfig = {
               params: {

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -132,21 +132,9 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
-            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-              site: {
-                ext: {
-                  data: data,
-                },
-                keywords: data,
-              }
-            });
-
-            return
-          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -231,21 +219,9 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
-            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-              site: {
-                ext: {
-                  data: data,
-                },
-                keywords: data,
-              }
-            });
-
-            return
-          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -330,21 +306,9 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
-            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-              site: {
-                ext: {
-                  data: data,
-                },
-                keywords: data,
-              }
-            });
-
-            return
-          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -577,7 +541,7 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids.length).to.equal(5);
               expect(adUnit.bids[0].params).to.be.undefined;
               expect(adUnit.bids[1].params).to.be.undefined;
-              expect(adUnit.bids[2].params).to.be.undefined;
+              expect(adUnit.bids[2].params.keywords).to.deep.equal(data);
               expect(adUnit.bids[3].params).to.be.undefined;
             });
             ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
@@ -585,9 +549,8 @@ describe('weboramaRtdProvider', function() {
                 expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
                   site: {
                     ext: {
-                      data: data,
+                      data: data
                     },
-                    keywords: data,
                   }
                 });
 
@@ -708,7 +671,7 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids[4].ortb2).to.be.undefined;
             });
 
-            expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
+            expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
             expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
 
             expect(onDataResponse).to.deep.equal({
@@ -1161,6 +1124,8 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('foo=bar');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
           foo: ['bar'],
+          webo_ctx: ['foo', 'bar'],
+          webo_ds: ['baz'],
         });
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: {
@@ -1171,18 +1136,6 @@ describe('weboramaRtdProvider', function() {
           }
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
-            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-              site: {
-                ext: {
-                  data: data,
-                },
-                keywords: data,
-              }
-            });
-
-            return
-          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -1260,21 +1213,9 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
-            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-              site: {
-                ext: {
-                  data: defaultProfile,
-                },
-                keywords: defaultProfile,
-              }
-            });
-
-            return
-          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -1392,7 +1333,6 @@ describe('weboramaRtdProvider', function() {
           expect(adUnit.bids.length).to.equal(5);
           expect(adUnit.bids[0].params).to.be.undefined;
           expect(adUnit.bids[1].params).to.be.undefined;
-          expect(adUnit.bids[2].params).to.be.undefined;
           expect(adUnit.bids[3].params).to.be.undefined;
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
@@ -1405,11 +1345,6 @@ describe('weboramaRtdProvider', function() {
                     webo_ds: ['baz'],
                     webo_bar: ['baz'],
                   }
-                },
-                keywords: {
-                  webo_ctx: ['foo', 'bar'],
-                  webo_ds: ['baz'],
-                  webo_bar: ['baz'],
                 },
               }
             });
@@ -1425,8 +1360,12 @@ describe('weboramaRtdProvider', function() {
             }
           });
         })
-
-        expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
+          webo_ctx: ['foo', 'bar'],
+          webo_ds: ['baz'],
+          webo_bar: ['baz'],
+        });
+        expect(reqBidsConfigObj.adUnits[1].bids[2].params.keywords).to.deep.equal(data);
 
         expect(onDataResponse).to.deep.equal({
           data: data,
@@ -2668,21 +2607,9 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
-            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-              site: {
-                ext: {
-                  data: data,
-                },
-                keywords: data,
-              }
-            });
-
-            return
-          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -2805,7 +2732,7 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids.length).to.equal(5);
               expect(adUnit.bids[0].params).to.be.undefined;
               expect(adUnit.bids[1].params).to.be.undefined;
-              expect(adUnit.bids[2].params).to.be.undefined;
+              expect(adUnit.bids[2].params.keywords).to.deep.equal(data);
               expect(adUnit.bids[3].params).to.be.undefined;
             });
             ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
@@ -2813,9 +2740,8 @@ describe('weboramaRtdProvider', function() {
                 expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
                   site: {
                     ext: {
-                      data: data,
+                      data: data
                     },
-                    keywords: data,
                   }
                 });
 
@@ -2935,7 +2861,7 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids[3].params).to.be.undefined;
             });
 
-            expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
+            expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
             expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
 
             ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
@@ -2945,7 +2871,6 @@ describe('weboramaRtdProvider', function() {
                     ext: {
                       data: data
                     },
-                    keywords: data,
                   }
                 });
 
@@ -3410,6 +3335,8 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('foo=bar');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
           foo: ['bar'],
+          lite_occupation: ['gérant', 'bénévole'],
+          lite_hobbies: ['sport', 'cinéma'],
         });
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: {
@@ -3420,18 +3347,6 @@ describe('weboramaRtdProvider', function() {
           }
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
-            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-              site: {
-                ext: {
-                  data: data,
-                },
-                keywords: data,
-              }
-            });
-
-            return
-          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -3495,25 +3410,13 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
-            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-              site: {
-                ext: {
-                  data: defaultProfile,
-                },
-                keywords: defaultProfile,
-              }
-            });
-
-            return
-          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
-                data: defaultProfile,
+                data: defaultProfile
               },
             }
           });
@@ -3580,7 +3483,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
           site: {
@@ -3590,18 +3493,6 @@ describe('weboramaRtdProvider', function() {
           },
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
-            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-              site: {
-                ext: {
-                  data: defaultProfile,
-                },
-                keywords: defaultProfile,
-              }
-            });
-
-            return
-          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -3679,21 +3570,9 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
-            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-              site: {
-                ext: {
-                  data: defaultProfile,
-                },
-                keywords: defaultProfile,
-              }
-            });
-
-            return
-          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -3811,7 +3690,6 @@ describe('weboramaRtdProvider', function() {
           expect(adUnit.bids.length).to.equal(5);
           expect(adUnit.bids[0].params).to.be.undefined;
           expect(adUnit.bids[1].params).to.be.undefined;
-          expect(adUnit.bids[2].params).to.be.undefined;
           expect(adUnit.bids[3].params).to.be.undefined;
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
@@ -3824,11 +3702,6 @@ describe('weboramaRtdProvider', function() {
                     lite_hobbies: ['sport', 'cinéma'],
                     lito_bar: ['baz'],
                   },
-                },
-                keywords: {
-                  lite_occupation: ['gérant', 'bénévole'],
-                  lite_hobbies: ['sport', 'cinéma'],
-                  lito_bar: ['baz'],
                 },
               }
             });
@@ -3845,7 +3718,12 @@ describe('weboramaRtdProvider', function() {
           });
         })
 
-        expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
+          lite_occupation: ['gérant', 'bénévole'],
+          lite_hobbies: ['sport', 'cinéma'],
+          lito_bar: ['baz'],
+        });
+        expect(reqBidsConfigObj.adUnits[1].bids[2].params.keywords).to.deep.equal(data);
 
         expect(onDataResponse).to.deep.equal({
           data: data,

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -133,9 +133,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
-          inventory: data
-        });
+        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
@@ -222,9 +220,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
-          inventory: data
-        });
+        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
@@ -311,9 +307,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
-          inventory: data
-        });
+        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
@@ -1136,8 +1130,6 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: {
             foo: 'bar',
-            webo_ctx: ['foo', 'bar'],
-            webo_ds: ['baz'],
           },
           visitor: {
             baz: 'bam',
@@ -1222,9 +1214,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
-          inventory: defaultProfile
-        });
+        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
@@ -1343,9 +1333,7 @@ describe('weboramaRtdProvider', function() {
           expect(adUnit.bids.length).to.equal(5);
           expect(adUnit.bids[0].params).to.be.undefined;
           expect(adUnit.bids[1].params).to.be.undefined;
-          expect(adUnit.bids[3].params).to.deep.equal({
-            inventory: data
-          });
+          expect(adUnit.bids[3].params).to.be.undefined;
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           if (v == 'appnexus') {
@@ -1459,9 +1447,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
-          visitor: data
-        });
+        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             user: {
@@ -2197,8 +2183,6 @@ describe('weboramaRtdProvider', function() {
           },
           visitor: {
             baz: 'bam',
-            webo_cs: ['foo', 'bar'],
-            webo_audiences: ['baz'],
           }
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
@@ -2267,9 +2251,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
-          visitor: defaultProfile
-        });
+        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             user: {
@@ -2343,9 +2325,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
-          visitor: defaultProfile
-        });
+        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             user: {
@@ -2466,9 +2446,7 @@ describe('weboramaRtdProvider', function() {
           expect(adUnit.bids.length).to.equal(5);
           expect(adUnit.bids[0].params).to.be.undefined;
           expect(adUnit.bids[1].params).to.be.undefined;
-          expect(adUnit.bids[3].params).to.deep.equal({
-            visitor: data
-          });
+          expect(adUnit.bids[3].params).to.be.undefined;
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           if (v == 'appnexus') {
@@ -2575,9 +2553,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
-          inventory: data,
-        });
+        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
@@ -3310,8 +3286,6 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: {
             foo: 'bar',
-            lite_occupation: ['gérant', 'bénévole'],
-            lite_hobbies: ['sport', 'cinéma'],
           },
           visitor: {
             baz: 'bam',
@@ -3382,9 +3356,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
-          inventory: defaultProfile,
-        });
+        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
@@ -3457,9 +3429,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
-          inventory: defaultProfile,
-        });
+        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
           site: {
             ext: {
@@ -3546,9 +3516,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
-          inventory: defaultProfile,
-        });
+        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
@@ -3667,9 +3635,7 @@ describe('weboramaRtdProvider', function() {
           expect(adUnit.bids.length).to.equal(5);
           expect(adUnit.bids[0].params).to.be.undefined;
           expect(adUnit.bids[1].params).to.be.undefined;
-          expect(adUnit.bids[3].params).to.deep.equal({
-            inventory: data,
-          });
+          expect(adUnit.bids[3].params).to.be.undefined;
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           if (v == 'appnexus') {

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -132,9 +132,21 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          if (v == 'appnexus') {
+            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+              site: {
+                ext: {
+                  data: data,
+                },
+                keywords: data,
+              }
+            });
+
+            return
+          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -219,9 +231,21 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          if (v == 'appnexus') {
+            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+              site: {
+                ext: {
+                  data: data,
+                },
+                keywords: data,
+              }
+            });
+
+            return
+          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -306,9 +330,21 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          if (v == 'appnexus') {
+            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+              site: {
+                ext: {
+                  data: data,
+                },
+                keywords: data,
+              }
+            });
+
+            return
+          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -541,7 +577,7 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids.length).to.equal(5);
               expect(adUnit.bids[0].params).to.be.undefined;
               expect(adUnit.bids[1].params).to.be.undefined;
-              expect(adUnit.bids[2].params.keywords).to.deep.equal(data);
+              expect(adUnit.bids[2].params).to.be.undefined;
               expect(adUnit.bids[3].params).to.be.undefined;
             });
             ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
@@ -549,8 +585,9 @@ describe('weboramaRtdProvider', function() {
                 expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
                   site: {
                     ext: {
-                      data: data
+                      data: data,
                     },
+                    keywords: data,
                   }
                 });
 
@@ -671,7 +708,7 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids[4].ortb2).to.be.undefined;
             });
 
-            expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
+            expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
             expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
 
             expect(onDataResponse).to.deep.equal({
@@ -1124,8 +1161,6 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('foo=bar');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
           foo: ['bar'],
-          webo_ctx: ['foo', 'bar'],
-          webo_ds: ['baz'],
         });
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: {
@@ -1136,6 +1171,18 @@ describe('weboramaRtdProvider', function() {
           }
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          if (v == 'appnexus') {
+            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+              site: {
+                ext: {
+                  data: data,
+                },
+                keywords: data,
+              }
+            });
+
+            return
+          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -1213,9 +1260,21 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          if (v == 'appnexus') {
+            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+              site: {
+                ext: {
+                  data: defaultProfile,
+                },
+                keywords: defaultProfile,
+              }
+            });
+
+            return
+          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -1333,6 +1392,7 @@ describe('weboramaRtdProvider', function() {
           expect(adUnit.bids.length).to.equal(5);
           expect(adUnit.bids[0].params).to.be.undefined;
           expect(adUnit.bids[1].params).to.be.undefined;
+          expect(adUnit.bids[2].params).to.be.undefined;
           expect(adUnit.bids[3].params).to.be.undefined;
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
@@ -1345,6 +1405,11 @@ describe('weboramaRtdProvider', function() {
                     webo_ds: ['baz'],
                     webo_bar: ['baz'],
                   }
+                },
+                keywords: {
+                  webo_ctx: ['foo', 'bar'],
+                  webo_ds: ['baz'],
+                  webo_bar: ['baz'],
                 },
               }
             });
@@ -1360,12 +1425,8 @@ describe('weboramaRtdProvider', function() {
             }
           });
         })
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
-          webo_ctx: ['foo', 'bar'],
-          webo_ds: ['baz'],
-          webo_bar: ['baz'],
-        });
-        expect(reqBidsConfigObj.adUnits[1].bids[2].params.keywords).to.deep.equal(data);
+
+        expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
 
         expect(onDataResponse).to.deep.equal({
           data: data,
@@ -2607,9 +2668,21 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          if (v == 'appnexus') {
+            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+              site: {
+                ext: {
+                  data: data,
+                },
+                keywords: data,
+              }
+            });
+
+            return
+          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -2732,7 +2805,7 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids.length).to.equal(5);
               expect(adUnit.bids[0].params).to.be.undefined;
               expect(adUnit.bids[1].params).to.be.undefined;
-              expect(adUnit.bids[2].params.keywords).to.deep.equal(data);
+              expect(adUnit.bids[2].params).to.be.undefined;
               expect(adUnit.bids[3].params).to.be.undefined;
             });
             ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
@@ -2740,8 +2813,9 @@ describe('weboramaRtdProvider', function() {
                 expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
                   site: {
                     ext: {
-                      data: data
+                      data: data,
                     },
+                    keywords: data,
                   }
                 });
 
@@ -2861,7 +2935,7 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids[3].params).to.be.undefined;
             });
 
-            expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
+            expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
             expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
 
             ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
@@ -2871,6 +2945,7 @@ describe('weboramaRtdProvider', function() {
                     ext: {
                       data: data
                     },
+                    keywords: data,
                   }
                 });
 
@@ -3335,8 +3410,6 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('foo=bar');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
           foo: ['bar'],
-          lite_occupation: ['gérant', 'bénévole'],
-          lite_hobbies: ['sport', 'cinéma'],
         });
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: {
@@ -3347,6 +3420,18 @@ describe('weboramaRtdProvider', function() {
           }
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          if (v == 'appnexus') {
+            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+              site: {
+                ext: {
+                  data: data,
+                },
+                keywords: data,
+              }
+            });
+
+            return
+          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -3410,13 +3495,25 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          if (v == 'appnexus') {
+            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+              site: {
+                ext: {
+                  data: defaultProfile,
+                },
+                keywords: defaultProfile,
+              }
+            });
+
+            return
+          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
-                data: defaultProfile
+                data: defaultProfile,
               },
             }
           });
@@ -3483,7 +3580,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
           site: {
@@ -3493,6 +3590,18 @@ describe('weboramaRtdProvider', function() {
           },
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          if (v == 'appnexus') {
+            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+              site: {
+                ext: {
+                  data: defaultProfile,
+                },
+                keywords: defaultProfile,
+              }
+            });
+
+            return
+          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -3570,9 +3679,21 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          if (v == 'appnexus') {
+            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+              site: {
+                ext: {
+                  data: defaultProfile,
+                },
+                keywords: defaultProfile,
+              }
+            });
+
+            return
+          }
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
@@ -3690,6 +3811,7 @@ describe('weboramaRtdProvider', function() {
           expect(adUnit.bids.length).to.equal(5);
           expect(adUnit.bids[0].params).to.be.undefined;
           expect(adUnit.bids[1].params).to.be.undefined;
+          expect(adUnit.bids[2].params).to.be.undefined;
           expect(adUnit.bids[3].params).to.be.undefined;
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
@@ -3702,6 +3824,11 @@ describe('weboramaRtdProvider', function() {
                     lite_hobbies: ['sport', 'cinéma'],
                     lito_bar: ['baz'],
                   },
+                },
+                keywords: {
+                  lite_occupation: ['gérant', 'bénévole'],
+                  lite_hobbies: ['sport', 'cinéma'],
+                  lito_bar: ['baz'],
                 },
               }
             });
@@ -3718,12 +3845,7 @@ describe('weboramaRtdProvider', function() {
           });
         })
 
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
-          lite_occupation: ['gérant', 'bénévole'],
-          lite_hobbies: ['sport', 'cinéma'],
-          lito_bar: ['baz'],
-        });
-        expect(reqBidsConfigObj.adUnits[1].bids[2].params.keywords).to.deep.equal(data);
+        expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
 
         expect(onDataResponse).to.deep.equal({
           data: data,

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -1449,19 +1449,6 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
-            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-              user: {
-                ext: {
-                  data: data
-                },
-                keywords: data,
-              }
-            });
-
-            return
-          }
-
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             user: {
               ext: {
@@ -1595,7 +1582,6 @@ describe('weboramaRtdProvider', function() {
                     ext: {
                       data: data
                     },
-                    keywords: data,
                   }
                 });
 
@@ -1721,7 +1707,6 @@ describe('weboramaRtdProvider', function() {
                     ext: {
                       data: data
                     },
-                    keywords: data
                   }
                 });
 
@@ -2201,19 +2186,6 @@ describe('weboramaRtdProvider', function() {
           }
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
-            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-              user: {
-                ext: {
-                  data: data
-                },
-                keywords: data,
-              }
-            });
-
-            return
-          }
-
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             user: {
               ext: {
@@ -2281,19 +2253,6 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
-            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-              user: {
-                ext: {
-                  data: defaultProfile
-                },
-                keywords: defaultProfile,
-              }
-            });
-
-            return
-          }
-
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             user: {
               ext: {
@@ -2368,19 +2327,6 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
-            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-              user: {
-                ext: {
-                  data: defaultProfile
-                },
-                keywords: defaultProfile,
-              }
-            });
-
-            return
-          }
-
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             user: {
               ext: {
@@ -2511,12 +2457,7 @@ describe('weboramaRtdProvider', function() {
                     webo_cs: ['foo', 'bar'],
                     webo_audiences: ['baz'],
                     webo_bar: ['baz'],
-                  },
-                },
-                keywords: {
-                  webo_cs: ['foo', 'bar'],
-                  webo_audiences: ['baz'],
-                  webo_bar: ['baz'],
+                  }
                 },
               }
             });

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -1446,7 +1446,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           if (v == 'appnexus') {
@@ -1585,7 +1585,7 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids.length).to.equal(5);
               expect(adUnit.bids[0].params).to.be.undefined;
               expect(adUnit.bids[1].params).to.be.undefined;
-              expect(adUnit.bids[2].params.keywords).to.deep.equal(data);
+              expect(adUnit.bids[2].params).to.be.undefined;
               expect(adUnit.bids[3].params).to.be.undefined;
             });
             ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
@@ -1712,6 +1712,7 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids.length).to.equal(5);
               expect(adUnit.bids[0].params).to.be.undefined;
               expect(adUnit.bids[1].params).to.be.undefined;
+              expect(adUnit.bids[2].params).to.be.undefined;
               expect(adUnit.bids[3].params).to.be.undefined;
             });
             ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
@@ -1730,9 +1731,6 @@ describe('weboramaRtdProvider', function() {
 
               expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
             })
-
-            expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
-            expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
 
             expect(onDataResponse).to.deep.equal({
               data: data,
@@ -2189,8 +2187,6 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('foo=bar');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
           foo: ['bar'],
-          webo_cs: ['foo', 'bar'],
-          webo_audiences: ['baz'],
         });
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: {
@@ -2278,7 +2274,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           if (v == 'appnexus') {
@@ -2365,7 +2361,7 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
+        expect(reqBidsConfigObj.adUnits[0].bids[2].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
           if (v == 'appnexus') {
@@ -2653,7 +2649,7 @@ describe('weboramaRtdProvider', function() {
 
         Object.keys(testcases).forEach(label => {
           const sendToBidders = testcases[label];
-          it(`check sendToBidders as ${label}`, function() {
+          it(`check sendToBidders as '${label}'`, function() {
             let onDataResponse = {};
             const moduleConfig = {
               params: {

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -131,7 +131,7 @@ describe('weboramaRtdProvider', function() {
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('webo_ctx=foo;webo_ctx=bar;webo_ds=baz');
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('webo_ctx=foo,bar|webo_ds=baz');
+        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: data
@@ -218,7 +218,7 @@ describe('weboramaRtdProvider', function() {
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('webo_vctx=foo;webo_vctx=bar');
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('webo_vctx=foo,bar');
+        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: data
@@ -305,7 +305,7 @@ describe('weboramaRtdProvider', function() {
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('webo_vctx=foo;webo_vctx=bar');
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('webo_vctx=foo,bar');
+        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: data
@@ -1106,7 +1106,7 @@ describe('weboramaRtdProvider', function() {
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('foo=bar;webo_ctx=foo;webo_ctx=bar;webo_ds=baz');
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('foo=bar|webo_ctx=foo,bar|webo_ds=baz');
+        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('foo=bar');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
           foo: ['bar'],
           webo_ctx: ['foo', 'bar'],
@@ -1197,7 +1197,7 @@ describe('weboramaRtdProvider', function() {
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('webo_ctx=baz');
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('webo_ctx=baz');
+        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: defaultProfile
@@ -1317,7 +1317,7 @@ describe('weboramaRtdProvider', function() {
         reqBidsConfigObj.adUnits.forEach(adUnit => {
           expect(adUnit.bids.length).to.equal(5);
           expect(adUnit.bids[0].params.target).to.equal('webo_ctx=foo;webo_ctx=bar;webo_ds=baz');
-          expect(adUnit.bids[1].params.dctr).to.equal('webo_ctx=foo,bar|webo_ds=baz');
+          expect(adUnit.bids[1]).to.not.have.property('params');
           expect(adUnit.bids[3].params).to.deep.equal({
             inventory: data
           });
@@ -1415,7 +1415,7 @@ describe('weboramaRtdProvider', function() {
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('webo_cs=foo;webo_cs=bar;webo_audiences=baz');
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('webo_cs=foo,bar|webo_audiences=baz');
+        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           visitor: data
@@ -2110,7 +2110,7 @@ describe('weboramaRtdProvider', function() {
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('foo=bar;webo_cs=foo;webo_cs=bar;webo_audiences=baz');
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('foo=bar|webo_cs=foo,bar|webo_audiences=baz');
+        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('foo=bar');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
           foo: ['bar'],
           webo_cs: ['foo', 'bar'],
@@ -2188,7 +2188,7 @@ describe('weboramaRtdProvider', function() {
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('webo_audiences=baz');
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('webo_audiences=baz');
+        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           visitor: defaultProfile
@@ -2262,7 +2262,7 @@ describe('weboramaRtdProvider', function() {
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('webo_audiences=baz');
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('webo_audiences=baz');
+        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           visitor: defaultProfile
@@ -2384,7 +2384,7 @@ describe('weboramaRtdProvider', function() {
         reqBidsConfigObj.adUnits.forEach(adUnit => {
           expect(adUnit.bids.length).to.equal(5);
           expect(adUnit.bids[0].params.target).to.equal('webo_cs=foo;webo_cs=bar;webo_audiences=baz');
-          expect(adUnit.bids[1].params.dctr).to.equal('webo_cs=foo,bar|webo_audiences=baz');
+          expect(adUnit.bids[1]).to.not.have.property('params');
           expect(adUnit.bids[3].params).to.deep.equal({
             visitor: data
           });
@@ -2481,7 +2481,7 @@ describe('weboramaRtdProvider', function() {
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('lite_occupation=gérant;lite_occupation=bénévole;lite_hobbies=sport;lite_hobbies=cinéma');
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('lite_occupation=gérant,bénévole|lite_hobbies=sport,cinéma');
+        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: data,
@@ -3174,7 +3174,7 @@ describe('weboramaRtdProvider', function() {
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('foo=bar;lite_occupation=gérant;lite_occupation=bénévole;lite_hobbies=sport;lite_hobbies=cinéma');
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('foo=bar|lite_occupation=gérant,bénévole|lite_hobbies=sport,cinéma');
+        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('foo=bar');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
           foo: ['bar'],
           lite_occupation: ['gérant', 'bénévole'],
@@ -3251,7 +3251,7 @@ describe('weboramaRtdProvider', function() {
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('lite_hobbies=sport;lite_hobbies=cinéma');
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('lite_hobbies=sport,cinéma');
+        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: defaultProfile,
@@ -3324,7 +3324,7 @@ describe('weboramaRtdProvider', function() {
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('lite_hobbies=sport;lite_hobbies=cinéma');
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('lite_hobbies=sport,cinéma');
+        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: defaultProfile,
@@ -3404,7 +3404,7 @@ describe('weboramaRtdProvider', function() {
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
         expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('lite_hobbies=sport;lite_hobbies=cinéma');
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('lite_hobbies=sport,cinéma');
+        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: defaultProfile,
@@ -3524,7 +3524,7 @@ describe('weboramaRtdProvider', function() {
         reqBidsConfigObj.adUnits.forEach(adUnit => {
           expect(adUnit.bids.length).to.equal(5);
           expect(adUnit.bids[0].params.target).to.equal('lite_occupation=gérant;lite_occupation=bénévole;lite_hobbies=sport;lite_hobbies=cinéma');
-          expect(adUnit.bids[1].params.dctr).to.equal('lite_occupation=gérant,bénévole|lite_hobbies=sport,cinéma');
+          expect(adUnit.bids[1]).to.not.have.property('params');
           expect(adUnit.bids[3].params).to.deep.equal({
             inventory: data,
           });

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -130,8 +130,8 @@ describe('weboramaRtdProvider', function() {
         });
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('webo_ctx=foo;webo_ctx=bar;webo_ds=baz');
-        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
+        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: data
@@ -217,8 +217,8 @@ describe('weboramaRtdProvider', function() {
         });
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('webo_vctx=foo;webo_vctx=bar');
-        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
+        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: data
@@ -304,8 +304,8 @@ describe('weboramaRtdProvider', function() {
         });
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('webo_vctx=foo;webo_vctx=bar');
-        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
+        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: data
@@ -1105,7 +1105,7 @@ describe('weboramaRtdProvider', function() {
         });
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('foo=bar;webo_ctx=foo;webo_ctx=bar;webo_ds=baz');
+        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('foo=bar');
         expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('foo=bar');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
           foo: ['bar'],
@@ -1196,8 +1196,8 @@ describe('weboramaRtdProvider', function() {
         });
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('webo_ctx=baz');
-        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
+        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: defaultProfile
@@ -1316,8 +1316,8 @@ describe('weboramaRtdProvider', function() {
 
         reqBidsConfigObj.adUnits.forEach(adUnit => {
           expect(adUnit.bids.length).to.equal(5);
-          expect(adUnit.bids[0].params.target).to.equal('webo_ctx=foo;webo_ctx=bar;webo_ds=baz');
-          expect(adUnit.bids[1]).to.not.have.property('params');
+          expect(adUnit.bids[0].params).to.be.undefined;
+          expect(adUnit.bids[1].params).to.be.undefined;
           expect(adUnit.bids[3].params).to.deep.equal({
             inventory: data
           });
@@ -1414,8 +1414,8 @@ describe('weboramaRtdProvider', function() {
         });
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('webo_cs=foo;webo_cs=bar;webo_audiences=baz');
-        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
+        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           visitor: data
@@ -2109,7 +2109,7 @@ describe('weboramaRtdProvider', function() {
         });
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('foo=bar;webo_cs=foo;webo_cs=bar;webo_audiences=baz');
+        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('foo=bar');
         expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('foo=bar');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
           foo: ['bar'],
@@ -2187,8 +2187,8 @@ describe('weboramaRtdProvider', function() {
         });
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('webo_audiences=baz');
-        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
+        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           visitor: defaultProfile
@@ -2261,8 +2261,8 @@ describe('weboramaRtdProvider', function() {
         });
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('webo_audiences=baz');
-        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
+        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           visitor: defaultProfile
@@ -2383,8 +2383,8 @@ describe('weboramaRtdProvider', function() {
 
         reqBidsConfigObj.adUnits.forEach(adUnit => {
           expect(adUnit.bids.length).to.equal(5);
-          expect(adUnit.bids[0].params.target).to.equal('webo_cs=foo;webo_cs=bar;webo_audiences=baz');
-          expect(adUnit.bids[1]).to.not.have.property('params');
+          expect(adUnit.bids[0].params).to.be.undefined;
+          expect(adUnit.bids[1].params).to.be.undefined;
           expect(adUnit.bids[3].params).to.deep.equal({
             visitor: data
           });
@@ -2480,8 +2480,8 @@ describe('weboramaRtdProvider', function() {
         });
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('lite_occupation=gérant;lite_occupation=bénévole;lite_hobbies=sport;lite_hobbies=cinéma');
-        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
+        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: data,
@@ -3173,7 +3173,7 @@ describe('weboramaRtdProvider', function() {
         });
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('foo=bar;lite_occupation=gérant;lite_occupation=bénévole;lite_hobbies=sport;lite_hobbies=cinéma');
+        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('foo=bar');
         expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('foo=bar');
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
           foo: ['bar'],
@@ -3250,8 +3250,8 @@ describe('weboramaRtdProvider', function() {
         });
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('lite_hobbies=sport;lite_hobbies=cinéma');
-        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
+        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: defaultProfile,
@@ -3323,8 +3323,8 @@ describe('weboramaRtdProvider', function() {
         });
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('lite_hobbies=sport;lite_hobbies=cinéma');
-        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
+        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: defaultProfile,
@@ -3403,8 +3403,8 @@ describe('weboramaRtdProvider', function() {
         });
 
         expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('lite_hobbies=sport;lite_hobbies=cinéma');
-        expect(reqBidsConfigObj.adUnits[0].bids[1]).to.not.have.property('params');
+        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
+        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: defaultProfile,
@@ -3523,8 +3523,8 @@ describe('weboramaRtdProvider', function() {
 
         reqBidsConfigObj.adUnits.forEach(adUnit => {
           expect(adUnit.bids.length).to.equal(5);
-          expect(adUnit.bids[0].params.target).to.equal('lite_occupation=gérant;lite_occupation=bénévole;lite_hobbies=sport;lite_hobbies=cinéma');
-          expect(adUnit.bids[1]).to.not.have.property('params');
+          expect(adUnit.bids[0].params).to.be.undefined;
+          expect(adUnit.bids[1].params).to.be.undefined;
           expect(adUnit.bids[3].params).to.deep.equal({
             inventory: data,
           });

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -136,13 +136,15 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: data
         });
-        expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
-          site: {
-            ext: {
-              data: data
-            },
-          }
-        });
+        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+            site: {
+              ext: {
+                data: data
+              },
+            }
+          });
+        })
         expect(onDataResponse).to.deep.equal({
           data: data,
           meta: {
@@ -223,13 +225,15 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: data
         });
-        expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
-          site: {
-            ext: {
-              data: data
-            },
-          }
-        });
+        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+            site: {
+              ext: {
+                data: data
+              },
+            }
+          });
+        })
         expect(onDataResponse).to.deep.equal({
           data: data,
           meta: {
@@ -310,13 +314,15 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: data
         });
-        expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
-          site: {
-            ext: {
-              data: data
-            },
-          }
-        });
+        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+            site: {
+              ext: {
+                data: data
+              },
+            }
+          });
+        })
         expect(onDataResponse).to.deep.equal({
           data: data,
           meta: {
@@ -543,9 +549,22 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids[1].params).to.be.undefined;
               expect(adUnit.bids[2].params.keywords).to.deep.equal(data);
               expect(adUnit.bids[3].params).to.be.undefined;
-              expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.be.undefined;
             });
+            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+              if (v == 'appnexus') {
+                expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+                  site: {
+                    ext: {
+                      data: data
+                    },
+                  }
+                });
 
+                return;
+              }
+
+              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
+            })
             expect(onDataResponse).to.deep.equal({
               data: data,
               meta: {
@@ -809,9 +828,10 @@ describe('weboramaRtdProvider', function() {
                   baz: 'bam',
                 }
               });
-
-              expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.be.undefined;
             });
+            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
+            })
           });
         });
       });
@@ -951,9 +971,10 @@ describe('weboramaRtdProvider', function() {
                   baz: 'bam',
                 }
               });
-
-              expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.be.undefined;
             });
+            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
+            })
           });
         });
       });
@@ -1122,13 +1143,15 @@ describe('weboramaRtdProvider', function() {
             baz: 'bam',
           }
         });
-        expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
-          site: {
-            ext: {
-              data: data
-            },
-          }
-        });
+        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+            site: {
+              ext: {
+                data: data
+              },
+            }
+          });
+        })
       });
 
       it('should use default profile in case of api error', function() {
@@ -1202,13 +1225,15 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: defaultProfile
         });
-        expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
-          site: {
-            ext: {
-              data: defaultProfile
-            },
-          }
-        });
+        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+            site: {
+              ext: {
+                data: defaultProfile
+              },
+            }
+          });
+        })
         expect(onDataResponse).to.deep.equal({
           data: defaultProfile,
           meta: {
@@ -1321,15 +1346,32 @@ describe('weboramaRtdProvider', function() {
           expect(adUnit.bids[3].params).to.deep.equal({
             inventory: data
           });
-          expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
+        });
+        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          if (v == 'appnexus') {
+            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+              site: {
+                ext: {
+                  data: {
+                    webo_ctx: ['foo', 'bar'],
+                    webo_ds: ['baz'],
+                    webo_bar: ['baz'],
+                  }
+                },
+              }
+            });
+
+            return
+          }
+
+          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             site: {
               ext: {
                 data: data
               },
             }
           });
-        });
-
+        })
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
           webo_ctx: ['foo', 'bar'],
           webo_ds: ['baz'],
@@ -1420,13 +1462,15 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           visitor: data
         });
-        expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
-          user: {
-            ext: {
-              data: data
-            },
-          }
-        });
+        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+            user: {
+              ext: {
+                data: data
+              },
+            }
+          });
+        })
         expect(onDataResponse).to.deep.equal({
           data: data,
           meta: {
@@ -1545,8 +1589,21 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids[2].params.keywords).to.deep.equal(data);
               expect(adUnit.bids[3].params).to.be.undefined;
             });
-            expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.be.undefined;
+            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+              if (v == 'appnexus') {
+                expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+                  user: {
+                    ext: {
+                      data: data
+                    },
+                  }
+                });
 
+                return
+              }
+
+              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
+            })
             expect(onDataResponse).to.deep.equal({
               data: data,
               meta: {
@@ -1657,7 +1714,21 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids[1].params).to.be.undefined;
               expect(adUnit.bids[3].params).to.be.undefined;
             });
-            expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.be.undefined;
+            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+              if (v == 'appnexus') {
+                expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+                  user: {
+                    ext: {
+                      data: data
+                    },
+                  }
+                });
+
+                return
+              }
+
+              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
+            })
 
             expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
             expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
@@ -1813,7 +1884,9 @@ describe('weboramaRtdProvider', function() {
                 }
               });
             });
-            expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.be.undefined;
+            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
+            })
           });
         });
       });
@@ -1956,7 +2029,9 @@ describe('weboramaRtdProvider', function() {
                 }
               });
             });
-            expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.be.undefined;
+            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
+            })
           });
         });
       });
@@ -2126,13 +2201,15 @@ describe('weboramaRtdProvider', function() {
             webo_audiences: ['baz'],
           }
         });
-        expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
-          user: {
-            ext: {
-              data: data
-            },
-          }
-        });
+        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+            user: {
+              ext: {
+                data: data
+              },
+            }
+          });
+        })
       });
 
       it('should use default profile in case of nothing on local storage', function() {
@@ -2193,13 +2270,15 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           visitor: defaultProfile
         });
-        expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
-          user: {
-            ext: {
-              data: defaultProfile
-            },
-          }
-        });
+        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+            user: {
+              ext: {
+                data: defaultProfile
+              },
+            }
+          });
+        })
       });
 
       it('should use default profile if cant read from local storage', function() {
@@ -2267,13 +2346,15 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           visitor: defaultProfile
         });
-        expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
-          user: {
-            ext: {
-              data: defaultProfile
-            },
-          }
-        });
+        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+            user: {
+              ext: {
+                data: defaultProfile
+              },
+            }
+          });
+        })
         expect(onDataResponse).to.deep.equal({
           data: defaultProfile,
           meta: {
@@ -2388,21 +2469,32 @@ describe('weboramaRtdProvider', function() {
           expect(adUnit.bids[3].params).to.deep.equal({
             visitor: data
           });
-          expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
+        });
+        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          if (v == 'appnexus') {
+            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+              user: {
+                ext: {
+                  data: {
+                    webo_cs: ['foo', 'bar'],
+                    webo_audiences: ['baz'],
+                    webo_bar: ['baz'],
+                  }
+                },
+              }
+            });
+
+            return
+          }
+
+          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             user: {
               ext: {
                 data: data
               },
             }
           });
-        });
-
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
-          webo_cs: ['foo', 'bar'],
-          webo_audiences: ['baz'],
-          webo_bar: ['baz'],
-        });
-        expect(reqBidsConfigObj.adUnits[1].bids[2].params.keywords).to.deep.equal(data);
+        })
 
         expect(onDataResponse).to.deep.equal({
           data: data,
@@ -2486,13 +2578,15 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: data,
         });
-        expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
-          site: {
-            ext: {
-              data: data,
-            },
-          },
-        });
+        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+            site: {
+              ext: {
+                data: data
+              },
+            }
+          });
+        })
         expect(onDataResponse).to.deep.equal({
           data: data,
           meta: {
@@ -2610,7 +2704,21 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids[2].params.keywords).to.deep.equal(data);
               expect(adUnit.bids[3].params).to.be.undefined;
             });
-            expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.be.undefined;
+            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+              if (v == 'appnexus') {
+                expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+                  site: {
+                    ext: {
+                      data: data
+                    },
+                  }
+                });
+
+                return
+              }
+
+              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
+            })
 
             expect(onDataResponse).to.deep.equal({
               data: data,
@@ -2721,10 +2829,25 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids[1].params).to.be.undefined;
               expect(adUnit.bids[3].params).to.be.undefined;
             });
-            expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.be.undefined;
 
             expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
             expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
+
+            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+              if (v == 'appnexus') {
+                expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+                  site: {
+                    ext: {
+                      data: data
+                    },
+                  }
+                });
+
+                return
+              }
+
+              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
+            })
 
             expect(onDataResponse).to.deep.equal({
               data: data,
@@ -2876,7 +2999,9 @@ describe('weboramaRtdProvider', function() {
                 }
               });
             });
-            expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.be.undefined;
+            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
+            })
           });
         });
       });
@@ -3018,7 +3143,9 @@ describe('weboramaRtdProvider', function() {
                 }
               });
             });
-            expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.be.undefined;
+            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
+            })
           });
         });
       });
@@ -3190,13 +3317,15 @@ describe('weboramaRtdProvider', function() {
             baz: 'bam',
           }
         });
-        expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
-          site: {
-            ext: {
-              data: data,
-            },
-          },
-        });
+        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+            site: {
+              ext: {
+                data: data
+              },
+            }
+          });
+        })
       });
 
       it('should use default profile in case of nothing on local storage', function() {
@@ -3256,13 +3385,15 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: defaultProfile,
         });
-        expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
-          site: {
-            ext: {
-              data: defaultProfile,
-            },
-          },
-        });
+        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+            site: {
+              ext: {
+                data: defaultProfile
+              },
+            }
+          });
+        })
       });
 
       it('should use default profile if cant read from local storage', function() {
@@ -3336,6 +3467,15 @@ describe('weboramaRtdProvider', function() {
             },
           },
         });
+        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+            site: {
+              ext: {
+                data: defaultProfile,
+              },
+            }
+          });
+        })
         expect(onDataResponse).to.deep.equal({
           data: defaultProfile,
           meta: {
@@ -3409,13 +3549,15 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
           inventory: defaultProfile,
         });
-        expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
-          site: {
-            ext: {
-              data: defaultProfile,
-            },
-          },
-        });
+        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+            site: {
+              ext: {
+                data: defaultProfile
+              },
+            }
+          });
+        })
         expect(onDataResponse).to.deep.equal({
           data: defaultProfile,
           meta: {
@@ -3529,13 +3671,31 @@ describe('weboramaRtdProvider', function() {
             inventory: data,
           });
         });
-        expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
-          site: {
-            ext: {
-              data: data,
-            },
-          },
-        });
+        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          if (v == 'appnexus') {
+            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+              site: {
+                ext: {
+                  data: {
+                    lite_occupation: ['gérant', 'bénévole'],
+                    lite_hobbies: ['sport', 'cinéma'],
+                    lito_bar: ['baz'],
+                  },
+                },
+              }
+            });
+
+            return
+          }
+
+          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+            site: {
+              ext: {
+                data: data,
+              },
+            }
+          });
+        })
 
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
           lite_occupation: ['gérant', 'bénévole'],

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -1449,6 +1449,19 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          if (v == 'appnexus') {
+            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+              user: {
+                ext: {
+                  data: data
+                },
+                keywords: data,
+              }
+            });
+
+            return
+          }
+
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             user: {
               ext: {
@@ -1582,6 +1595,7 @@ describe('weboramaRtdProvider', function() {
                     ext: {
                       data: data
                     },
+                    keywords: data,
                   }
                 });
 
@@ -1707,6 +1721,7 @@ describe('weboramaRtdProvider', function() {
                     ext: {
                       data: data
                     },
+                    keywords: data
                   }
                 });
 
@@ -2186,6 +2201,19 @@ describe('weboramaRtdProvider', function() {
           }
         });
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          if (v == 'appnexus') {
+            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+              user: {
+                ext: {
+                  data: data
+                },
+                keywords: data,
+              }
+            });
+
+            return
+          }
+
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             user: {
               ext: {
@@ -2253,6 +2281,19 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          if (v == 'appnexus') {
+            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+              user: {
+                ext: {
+                  data: defaultProfile
+                },
+                keywords: defaultProfile,
+              }
+            });
+
+            return
+          }
+
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             user: {
               ext: {
@@ -2327,6 +2368,19 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
         ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
+          if (v == 'appnexus') {
+            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+              user: {
+                ext: {
+                  data: defaultProfile
+                },
+                keywords: defaultProfile,
+              }
+            });
+
+            return
+          }
+
           expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
             user: {
               ext: {
@@ -2457,7 +2511,12 @@ describe('weboramaRtdProvider', function() {
                     webo_cs: ['foo', 'bar'],
                     webo_audiences: ['baz'],
                     webo_bar: ['baz'],
-                  }
+                  },
+                },
+                keywords: {
+                  webo_cs: ['foo', 'bar'],
+                  webo_audiences: ['baz'],
+                  webo_bar: ['baz'],
                 },
               }
             });


### PR DESCRIPTION
move bidder specific handling to ortb2 except appnexus

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Refactoring (no functional changes, no api changes)

## Description of change

bidder specific handling removal : use ortb2 instead

related to

- sirdata pull request https://github.com/prebid/Prebid.js/pull/9970
- prebid issue https://github.com/prebid/Prebid.js/issues/8596