### PR TITLE
ShareThrough Bid Adapter : fix playerSize

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -93,8 +93,8 @@ export const sharethroughAdapterSpec = {
       if (videoRequest) {
         // default playerSize, only change this if we know width and height are properly defined in the request
         let [w, h] = [640, 360];
-        if (videoRequest.playerSize && videoRequest.playerSize[0] && videoRequest.playerSize[1]) {
-          [w, h] = videoRequest.playerSize;
+        if (videoRequest.playerSize && videoRequest.playerSize[0] && videoRequest.playerSize[0][0] && videoRequest.playerSize[0][1]) {
+          [w, h] = videoRequest.playerSize[0];
         }
 
         impression.video = {

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -230,7 +230,7 @@ describe('sharethrough adapter spec', function () {
               api: [3],
               mimes: ['video/3gpp'],
               protocols: [2, 3],
-              playerSize: [640, 480],
+              playerSize: [[640, 480]],
               startdelay: 42,
               skipmin: 10,
               skipafter: 20,


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Addresses https://github.com/prebid/Prebid.js/issues/9988 for ShareThrough
`playerSize` is an array of arrays, and even when providing `[640, 480]` as a size Prebid converts it to `[[ 640, 480 ]]` beforehand.
Note that this transformation does not happen when running the unit tests, which is why this bug was not found.

