### PR TITLE
Criteo Bid Adapter: add support of bcat/badv/bapp

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -541,6 +541,15 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
     request.user.ext = request.user.ext || {};
     request.user.ext.eids = [...userIdAsEids];
   }
+  if (bidderRequest && bidderRequest.ortb2?.bcat) {
+    request.bcat = bidderRequest.ortb2.bcat;
+  }
+  if (bidderRequest && bidderRequest.ortb2?.badv) {
+    request.badv = bidderRequest.ortb2.badv;
+  }
+  if (bidderRequest && bidderRequest.ortb2?.bapp) {
+    request.bapp = bidderRequest.ortb2.bapp;
+  }
   return request;
 }
 

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -1062,6 +1062,90 @@ describe('The Criteo bidding adapter', function () {
       expect(request.data.source.ext.schain).to.equal(expectedSchain);
     });
 
+    it('should properly build a request with bcat field', function () {
+      const bcat = [ 'IAB1', 'IAB2' ];
+      const bidRequests = [
+        {
+          bidder: 'criteo',
+          adUnitCode: 'bid-123',
+          transactionId: 'transaction-123',
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
+          params: {
+            zoneId: 123,
+          },
+        },
+      ];
+      const bidderRequest = {
+        ortb2: {
+          bcat
+        }
+      };
+
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.bcat).to.not.be.null;
+      expect(request.data.bcat).to.equal(bcat);
+    });
+
+    it('should properly build a request with badv field', function () {
+      const badv = [ 'ford.com' ];
+      const bidRequests = [
+        {
+          bidder: 'criteo',
+          adUnitCode: 'bid-123',
+          transactionId: 'transaction-123',
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
+          params: {
+            zoneId: 123,
+          },
+        },
+      ];
+      const bidderRequest = {
+        ortb2: {
+          badv
+        }
+      };
+
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.badv).to.not.be.null;
+      expect(request.data.badv).to.equal(badv);
+    });
+
+    it('should properly build a request with bapp field', function () {
+      const bapp = [ 'com.foo.mygame' ];
+      const bidRequests = [
+        {
+          bidder: 'criteo',
+          adUnitCode: 'bid-123',
+          transactionId: 'transaction-123',
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
+          params: {
+            zoneId: 123,
+          },
+        },
+      ];
+      const bidderRequest = {
+        ortb2: {
+          bapp
+        }
+      };
+
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.bapp).to.not.be.null;
+      expect(request.data.bapp).to.equal(bapp);
+    });
+
     it('should properly build a request with if ccpa consent field is not provided', function () {
       const bidRequests = [
         {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Add support of bcat and badv and bapp OpenRTB fields.
