### PR TITLE
Schain module: do not share schain objects across different bid requests

### DIFF
--- a/modules/schain.js
+++ b/modules/schain.js
@@ -10,7 +10,7 @@ import {
   isInteger,
   _each,
   logWarn,
-  deepAccess, deepSetValue
+  deepAccess, deepSetValue, deepClone
 } from '../src/utils.js';
 import {registerOrtbProcessor, REQUEST} from '../src/pbjsORTB.js';
 
@@ -180,7 +180,7 @@ export function makeBidRequestsHook(fn, bidderRequests) {
     bidderRequest.bids.forEach(bid => {
       let result = resolveSchainConfig(schainConfig, bidder);
       if (result) {
-        bid.schain = result;
+        bid.schain = deepClone(result);
       }
     });
   });

--- a/test/spec/modules/schain_spec.js
+++ b/test/spec/modules/schain_spec.js
@@ -469,6 +469,15 @@ describe('#makeBidRequestsHook', function() {
     makeBidRequestsHook(testCallback, testBidderRequests);
   });
 
+  it('should not share the same schain object between different bid requests', (done) => {
+    config.setBidderConfig(goodStrictBidderConfig);
+    makeBidRequestsHook((requests) => {
+      requests[0].bids[0].schain.field = 'value';
+      expect(requests[1].bids[0].schain.field).to.not.exist;
+      done();
+    }, deepClone(bidderRequests))
+  });
+
   it('should reject bad strict config but allow a bad relaxed config for bidders trying to override it', function () {
     function testCallback(bidderRequests) {
       expect(bidderRequests[0].bids[0].schain).to.exist;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

This fixes a bug where if any of the schain consumers decide to modify it, the changes are seen by all other consumers.
