### PR TITLE
Yahoo bid adapter (PB8): User sync pixels, consent signals update 

### DIFF
--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -101,6 +101,37 @@ function extractUserSyncUrls(syncOptions, pixels) {
   return userSyncObjects;
 }
 
+/**
+ * @param {string} url
+ * @param {object} consentData
+ * @param {object} consentData.gpp
+ * @param {string} consentData.gpp.gppConsent
+ * @param {array} consentData.gpp.applicableSections
+ * @param {object} consentData.gdpr
+ * @param {object} consentData.gdpr.gdprConsent
+ * @param {object} consentData.gdpr.gdprApplies
+ * @param {string} consentData.uspConsent
+ */
+function updateConsentQueryParams(url, consentData) {
+  const parameterMap = {
+    'gdpr_consent': consentData.gdpr.gdprConsent,
+    'gdpr': consentData.gdpr.gdprApplies,
+    'us_privacy': consentData.uspConsent,
+    'gpp': consentData.gpp.gppConsent,
+    'gpp_sid': consentData.gpp.applicableSections? consentData.gpp.applicableSections.join(',') : ''
+  }
+
+  const existingUrl = new URL(url);
+  const params = existingUrl.searchParams;
+
+  for (const [key, value] of Object.entries(parameterMap)) {
+    params.set(key, value);
+  }
+
+  existingUrl.search = search_params.toString();
+  return existingUrl.toString();
+};
+
 function getSupportedEids(bid) {
   if (isArray(deepAccess(bid, 'userIdAsEids'))) {
     return bid.userIdAsEids.filter(eid => {
@@ -244,7 +275,9 @@ function generateOpenRtbObject(bidderRequest, bid) {
       regs: {
         ext: {
           'us_privacy': bidderRequest.uspConsent ? bidderRequest.uspConsent : '',
-          gdpr: bidderRequest.gdprConsent && bidderRequest.gdprConsent.gdprApplies ? 1 : 0
+          gdpr: bidderRequest.gdprConsent && bidderRequest.gdprConsent.gdprApplies ? 1 : 0,
+          gpp: bidderRequest.gpp.gppConsent,
+          gpp_sid: bidderRequest.gpp.applicableSections
         }
       },
       source: {
@@ -518,6 +551,7 @@ function createRenderer(bidderRequest, bidResponse) {
   }
   return renderer;
 }
+
 /* Utility functions */
 
 export const spec = {
@@ -634,11 +668,19 @@ export const spec = {
     return response;
   },
 
-  getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent) {
+  getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) {
     const bidResponse = !isEmpty(serverResponses) && serverResponses[0].body;
 
     if (bidResponse && bidResponse.ext && bidResponse.ext.pixels) {
-      return extractUserSyncUrls(syncOptions, bidResponse.ext.pixels);
+      const userSyncObjects = extractUserSyncUrls(syncOptions, bidResponse.ext.pixels);
+      userSyncObjects.forEach(userSyncObject => {
+        userSyncObject.url = updateConsentQueryParams(userSyncObject.url, {
+          gpp: gppConsent,
+          gdpr: gdprConsent,
+          uspConsent: uspConsent
+        });
+      });
+      return userSyncObjects;
     }
 
     return [];

--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -108,17 +108,17 @@ function extractUserSyncUrls(syncOptions, pixels) {
  * @param {string} consentData.gpp.gppConsent
  * @param {array} consentData.gpp.applicableSections
  * @param {object} consentData.gdpr
- * @param {object} consentData.gdpr.gdprConsent
+ * @param {object} consentData.gdpr.consentString
  * @param {object} consentData.gdpr.gdprApplies
  * @param {string} consentData.uspConsent
  */
 function updateConsentQueryParams(url, consentData) {
   const parameterMap = {
-    'gdpr_consent': consentData.gdpr.gdprConsent,
-    'gdpr': consentData.gdpr.gdprApplies,
+    'gdpr_consent': consentData.gdpr.consentString,
+    'gdpr': consentData.gdpr.gdprApplies ? '1' : '0',
     'us_privacy': consentData.uspConsent,
-    'gpp': consentData.gpp.gppConsent,
-    'gpp_sid': consentData.gpp.applicableSections? consentData.gpp.applicableSections.join(',') : ''
+    'gpp': consentData.gpp.gppString,
+    'gpp_sid': consentData.gpp.applicableSections ? consentData.gpp.applicableSections.join(',') : ''
   }
 
   const existingUrl = new URL(url);
@@ -128,7 +128,7 @@ function updateConsentQueryParams(url, consentData) {
     params.set(key, value);
   }
 
-  existingUrl.search = search_params.toString();
+  existingUrl.search = params.toString();
   return existingUrl.toString();
 };
 
@@ -276,8 +276,8 @@ function generateOpenRtbObject(bidderRequest, bid) {
         ext: {
           'us_privacy': bidderRequest.uspConsent ? bidderRequest.uspConsent : '',
           gdpr: bidderRequest.gdprConsent && bidderRequest.gdprConsent.gdprApplies ? 1 : 0,
-          gpp: bidderRequest.gpp.gppConsent,
-          gpp_sid: bidderRequest.gpp.applicableSections
+          gpp: bidderRequest.gppConsent.gppString,
+          gpp_sid: bidderRequest.gppConsent.applicableSections
         }
       },
       source: {

--- a/modules/yahoosspBidAdapter.md
+++ b/modules/yahoosspBidAdapter.md
@@ -827,6 +827,6 @@ const adUnits = [{
 This adapter does not support passing legacy overrides via 'bidder.params.ext' since most of the data should be passed using prebid modules (First Party Data, Schain, Price Floors etc.).
 If you do not know how to pass a custom parameter that you previously used, please contact us using the information provided above.
 
-Thanks you,
+Thank you,
 Yahoo SSP
 

--- a/test/spec/modules/yahoosspBidAdapter_spec.js
+++ b/test/spec/modules/yahoosspBidAdapter_spec.js
@@ -94,6 +94,10 @@ let generateBidderRequest = (bidRequestArray, adUnitCode, ortb2 = {}) => {
       vendorData: {},
       gdprApplies: true
     },
+    gppConsent: {
+      gppString: 'DBACNYA~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA~1YNN',
+      applicableSections: [1, 2, 3]
+    },
     start: new Date().getTime(),
     timeout: 1000,
     ortb2
@@ -749,7 +753,15 @@ describe('YahooSSP Bid Adapter:', () => {
       expect(options.withCredentials).to.be.false;
     });
 
-    it('adds the ortb2 gpp consent info to the request', function () {
+    it('set the GPP consent data from the data within the bid request', function () {
+      const { validBidRequests, bidderRequest } = generateBuildRequestMock({});
+      let clonedBidderRequest = {...bidderRequest};
+      const data = spec.buildRequests(validBidRequests, clonedBidderRequest)[0].data;
+      expect(data.regs.ext.gpp).to.equal(bidderRequest.gppConsent.gppString);
+      expect(data.regs.ext.gpp_sid).to.eql(bidderRequest.gppConsent.applicableSections);
+    });
+
+    it('overrides the GPP consent data using data from the ortb2 config object', function () {
       const { validBidRequests, bidderRequest } = generateBuildRequestMock({});
       const ortb2 = {
         regs: {
@@ -759,8 +771,8 @@ describe('YahooSSP Bid Adapter:', () => {
       };
       let clonedBidderRequest = {...bidderRequest, ortb2};
       const data = spec.buildRequests(validBidRequests, clonedBidderRequest)[0].data;
-      expect(data.regs.ext.gpp).to.equal('somegppstring');
-      expect(data.regs.ext.gpp_sid).to.eql([6, 7]);
+      expect(data.regs.ext.gpp).to.equal(ortb2.regs.gpp);
+      expect(data.regs.ext.gpp_sid).to.eql(ortb2.regs.gpp_sid);
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Feature

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->
NOTE: This is using the same commits from https://github.com/prebid/Prebid.js/pull/10028.

Addressing this issue picked up by Prebid maintainers: https://github.com/prebid/prebid.github.io/pull/4529/files#diff-d7318b0388c5171115d26fc62fb6cdcfd7387d65af9f8e013e7ba8c4828dd5df

User sync URLs will use the latest available consent data the moment they are fetched. Additionally, we will now consume GPP signals.

It's not a bugfix as such, so submitting as a feature.

I'll open a PR shortly against the documentation site and link to it.