### PR TITLE
Prebid 8: introduce new `transmitTid` activity control

### DIFF
--- a/libraries/objectGuard/objectGuard.js
+++ b/libraries/objectGuard/objectGuard.js
@@ -1,4 +1,4 @@
-import {isData, objectTransformer} from '../../src/activities/redactor.js';
+import {isData, objectTransformer, sessionedApplies} from '../../src/activities/redactor.js';
 import {deepAccess, deepClone, deepEqual, deepSetValue} from '../../src/utils.js';
 
 /**
@@ -41,15 +41,6 @@ export function objectGuard(rules) {
 
   const wpTransformer = objectTransformer(writeRules);
 
-  function mkApplies(session, args) {
-    return function applies(rule) {
-      if (!session.hasOwnProperty(rule.name)) {
-        session[rule.name] = rule.applies(...args);
-      }
-      return session[rule.name];
-    }
-  }
-
   function mkGuard(obj, tree, applies) {
     return new Proxy(obj, {
       get(target, prop, receiver) {
@@ -76,7 +67,7 @@ export function objectGuard(rules) {
   return function guard(obj, ...args) {
     const session = {};
     return {
-      obj: mkGuard(obj, root.children || {}, mkApplies(session, args)),
+      obj: mkGuard(obj, root.children || {}, sessionedApplies(session, ...args)),
       verify: mkVerify(wpTransformer(session, obj, ...args))
     }
   };

--- a/src/activities/activities.js
+++ b/src/activities/activities.js
@@ -45,3 +45,8 @@ export const ACTIVITY_TRANSMIT_UFPD = 'transmitUfpd';
  * transmitPreciseGeo: some component wants access to (and send along) geolocation info
  */
 export const ACTIVITY_TRANSMIT_PRECISE_GEO = 'transmitPreciseGeo';
+
+/**
+ * transmit TID: some component wants access ot (and send along) transaction IDs
+ */
+export const ACTIVITY_TRANSMIT_TID = 'transmitTid';

--- a/src/activities/redactor.js
+++ b/src/activities/redactor.js
@@ -1,6 +1,12 @@
 import {deepAccess} from '../utils.js';
-import {isActivityAllowed} from './rules.js';
-import {ACTIVITY_TRANSMIT_EIDS, ACTIVITY_TRANSMIT_PRECISE_GEO, ACTIVITY_TRANSMIT_UFPD} from './activities.js';
+import {config} from '../config.js';
+import {isActivityAllowed, registerActivityControl} from './rules.js';
+import {
+  ACTIVITY_TRANSMIT_EIDS,
+  ACTIVITY_TRANSMIT_PRECISE_GEO,
+  ACTIVITY_TRANSMIT_TID,
+  ACTIVITY_TRANSMIT_UFPD
+} from './activities.js';
 
 export const ORTB_UFPD_PATHS = ['user.data', 'user.ext.data'];
 export const ORTB_EIDS_PATHS = ['user.eids', 'user.ext.eids'];
@@ -74,20 +80,25 @@ export function objectTransformer(rules) {
   })
   return function applyTransform(session, obj, ...args) {
     const result = [];
+    const applies = sessionedApplies(session, ...args);
     rules.forEach(rule => {
       if (session[rule.name] === false) return;
       for (const [head, tail] of rule.paths) {
         const parent = head == null ? obj : deepAccess(obj, head);
-        result.push(rule.run(obj, head, parent, tail, () => {
-          if (!session.hasOwnProperty(rule.name)) {
-            session[rule.name] = !!rule.applies(...args);
-          }
-          return session[rule.name]
-        }))
+        result.push(rule.run(obj, head, parent, tail, applies.bind(null, rule)));
         if (session[rule.name] === false) return;
       }
     })
     return result.filter(el => el != null);
+  }
+}
+
+export function sessionedApplies(session, ...args) {
+  return function applies(rule) {
+    if (!session.hasOwnProperty(rule.name)) {
+      session[rule.name] = !!rule.applies(...args);
+    }
+    return session[rule.name];
   }
 }
 
@@ -107,6 +118,11 @@ function bidRequestTransmitRules(isAllowed = isActivityAllowed) {
       name: ACTIVITY_TRANSMIT_EIDS,
       paths: ['userId', 'userIdAsEids'],
       applies: appliesWhenActivityDenied(ACTIVITY_TRANSMIT_EIDS, isAllowed),
+    },
+    {
+      name: ACTIVITY_TRANSMIT_TID,
+      paths: ['ortb2Imp.ext.tid'],
+      applies: appliesWhenActivityDenied(ACTIVITY_TRANSMIT_TID, isAllowed)
     }
   ].map(redactRule)
 }
@@ -130,6 +146,11 @@ export function ortb2TransmitRules(isAllowed = isActivityAllowed) {
       get(val) {
         return Math.round((val + Number.EPSILON) * 100) / 100;
       }
+    },
+    {
+      name: ACTIVITY_TRANSMIT_TID,
+      paths: ['source.tid'],
+      applies: appliesWhenActivityDenied(ACTIVITY_TRANSMIT_TID, isAllowed),
     }
   ].map(redactRule);
 }
@@ -155,3 +176,10 @@ export function redactorFactory(isAllowed = isActivityAllowed) {
  *  that can redact disallowed data from ORTB2 and/or bid request objects.
  */
 export const redactor = redactorFactory();
+
+// by default, TIDs are off since version 8
+registerActivityControl(ACTIVITY_TRANSMIT_TID, 'enableTIDs config', () => {
+  if (!config.getConfig('enableTIDs')) {
+    return {allow: false, reason: 'TIDs are disabled'}
+  }
+});

--- a/test/pages/banner.html
+++ b/test/pages/banner.html
@@ -57,6 +57,7 @@
 		});
 
 		pbjs.que.push(function () {
+			pbjs.setConfig({enableTIDs: true});
 			pbjs.addAdUnits(adUnits);
 			pbjs.requestBids({ bidsBackHandler: sendAdServerRequest });
 		});

--- a/test/pages/bidderSettings.html
+++ b/test/pages/bidderSettings.html
@@ -67,6 +67,7 @@
     });
 
     pbjs.que.push(function () {
+      pbjs.setConfig({enableTIDs: true});
       pbjs.addAdUnits(adUnits);
       pbjs.bidderSettings = {
         appnexus: {

--- a/test/pages/consent_mgt_gdpr.html
+++ b/test/pages/consent_mgt_gdpr.html
@@ -146,6 +146,7 @@
     pbjs.que.push(function () {
       pbjs.addAdUnits(adUnits);
       pbjs.setConfig({
+        enableTIDs: true,
         consentManagement: {
           gdpr: {
             cmpApi: 'static',

--- a/test/pages/currency.html
+++ b/test/pages/currency.html
@@ -77,6 +77,7 @@
 
         pbjs.que.push(function() {
             pbjs.setConfig({
+                enableTIDs: true,
                 "currency": {
                     "adServerCurrency": "GBP",
                     "granularityMultiplier": 1,

--- a/test/pages/instream.html
+++ b/test/pages/instream.html
@@ -60,6 +60,7 @@
 
         pbjs.addAdUnits(videoAdUnit);
         pbjs.setConfig({
+                    enableTIDs: true,
                     debug: true,
                     cache: {
                         url: 'https://prebid.adnxs.com/pbc/v1/cache'

--- a/test/pages/multiple_bidders.html
+++ b/test/pages/multiple_bidders.html
@@ -72,7 +72,7 @@
           }
         }]
       }];
-
+      pbjs.setConfig({enableTIDs: true});
       pbjs.addAdUnits(adUnits);
       pbjs.requestBids({
         timeout: PREBID_TIMEOUT,

--- a/test/pages/native.html
+++ b/test/pages/native.html
@@ -83,6 +83,7 @@
 		});
 
 		pbjs.que.push(function () {
+			pbjs.setConfig({enableTIDs: true});
 			pbjs.addAdUnits(adUnits);
 			pbjs.requestBids({ bidsBackHandler: sendAdServerRequest });
 		});

--- a/test/pages/outstream.html
+++ b/test/pages/outstream.html
@@ -61,7 +61,10 @@
 		googletag.cmd = googletag.cmd || [];
 
 		pbjs.que.push(function () {
-			pbjs.setConfig({ debug: true });
+			pbjs.setConfig({
+				enableTIDs: true,
+				debug: true
+			});
       pbjs.addAdUnits(outstreamVideoAdUnit);
       pbjs.bidderSettings = {
         appnexus: {

--- a/test/spec/activities/redactor_spec.js
+++ b/test/spec/activities/redactor_spec.js
@@ -7,7 +7,7 @@ import {
 import {ACTIVITY_PARAM_COMPONENT_NAME, ACTIVITY_PARAM_COMPONENT_TYPE} from '../../../src/activities/params.js';
 import {
   ACTIVITY_TRANSMIT_EIDS,
-  ACTIVITY_TRANSMIT_PRECISE_GEO,
+  ACTIVITY_TRANSMIT_PRECISE_GEO, ACTIVITY_TRANSMIT_TID,
   ACTIVITY_TRANSMIT_UFPD
 } from '../../../src/activities/activities.js';
 import {deepAccess, deepSetValue} from '../../../src/utils.js';
@@ -271,6 +271,10 @@ describe('redactor', () => {
     testAllowDeny(ACTIVITY_TRANSMIT_EIDS, (allowed) => {
       testPropertiesAreRemoved(() => redactor.bidRequest, ['userId', 'userIdAsEids'], allowed);
     });
+
+    testAllowDeny(ACTIVITY_TRANSMIT_TID, (allowed) => {
+      testPropertiesAreRemoved(() => redactor.bidRequest, ['ortb2Imp.ext.tid'], allowed);
+    })
   });
 
   describe('.ortb2', () => {
@@ -282,6 +286,10 @@ describe('redactor', () => {
       testPropertiesAreRemoved(() => redactor.ortb2, ORTB_UFPD_PATHS, allowed)
     });
 
+    testAllowDeny(ACTIVITY_TRANSMIT_TID, (allowed) => {
+      testPropertiesAreRemoved(() => redactor.ortb2, ['source.tid'], allowed);
+    });
+
     testAllowDeny(ACTIVITY_TRANSMIT_PRECISE_GEO, (allowed) => {
       ORTB_GEO_PATHS.forEach(path => {
         it(`should ${allowed ? 'NOT ' : ''} round down ${path}`, () => {
@@ -291,6 +299,6 @@ describe('redactor', () => {
           expect(deepAccess(ortb2, path)).to.eql(allowed ? 1.2345 : 1.23);
         })
       })
-    })
+    });
   });
 })

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1862,10 +1862,22 @@ describe('adapterManager tests', function () {
       requests.appnexus.bids.forEach((bid) => expect(bid.ortb2).to.eql(requests.appnexus.ortb2));
     });
 
-    it('should populate ortb2.source.tid with auctionId', () => {
-      const reqs = adapterManager.makeBidRequests(adUnits, 0, 'mockAuctionId', 1000, [], {global: {}});
-      expect(reqs[0].ortb2.source.tid).to.equal('mockAuctionId');
-    })
+    describe('source.tid', () => {
+      beforeEach(() => {
+        sinon.stub(dep, 'redact').returns({
+          ortb2: (o) => o,
+          bidRequest: (b) => b,
+        });
+      });
+      afterEach(() => {
+        dep.redact.restore();
+      });
+
+      it('should be populated with auctionId', () => {
+        const reqs = adapterManager.makeBidRequests(adUnits, 0, 'mockAuctionId', 1000, [], {global: {}});
+        expect(reqs[0].ortb2.source.tid).to.equal('mockAuctionId');
+      })
+    });
 
     it('should merge in bid-level ortb2Imp with adUnit-level ortb2Imp', () => {
       const adUnit = {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

This introduces the `trasmitTid` activity that, when denied, disables TIDs for bidders; as well as a new `enableTIDs` config as a shorthand for allowing the activity.

## Other information

Closes https://github.com/prebid/Prebid.js/issues/9781
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
