### PR TITLE
Utiq: Update domain resolving logic and tests

### DIFF
--- a/modules/utiqSystem.js
+++ b/modules/utiqSystem.js
@@ -11,7 +11,6 @@ import { MODULE_TYPE_UID } from '../src/activities/modules.js';
 
 const MODULE_NAME = 'utiq';
 const LOG_PREFIX = 'Utiq module';
-let mnoDomain = '';
 
 export const storage = getStorageManager({
   moduleType: MODULE_TYPE_UID,
@@ -19,81 +18,39 @@ export const storage = getStorageManager({
 });
 
 /**
- * Handle an event for an iframe.
- * Takes the body.url parameter from event and returns the string domain.
- * i.e.: "fc.vodafone.de"
- * @param event
- */
-function messageHandler(event) {
-  try {
-    if (event && event.data && typeof event.data === 'string') {
-      const msg = JSON.parse(event.data);
-      if (msg.msgType === 'MNOSELECTOR' && msg.body && msg.body.url) {
-        let URL = msg.body.url.split('//');
-        let domainURL = URL[1].split('/');
-        mnoDomain = domainURL[0];
-        logInfo(`${LOG_PREFIX}: Message handler set domain to ${mnoDomain}`);
-      }
-    }
-  } catch (e) {
-    logInfo(
-      `${LOG_PREFIX}: Unsupported message caught. Origin: ${event.origin}, data: ${event.data}.`
-    );
-  }
-}
-
-// Set a listener to handle the iframe response message.
-window.addEventListener('message', messageHandler, false);
-
-/**
  * Get the "atid" from html5 local storage to make it available to the UserId module.
  * @param config
  * @returns {{utiq: (*|string)}}
  */
 function getUtiqFromStorage() {
-  // Get the domain either from localStorage or global
-  let domain =
-    JSON.parse(storage.getDataFromLocalStorage('fcIdConnectDomain')) ||
-    mnoDomain;
-  logInfo(`${LOG_PREFIX}: Local storage domain: ${domain}`);
-
-  if (!domain) {
-    logInfo(`${LOG_PREFIX}: Local storage domain not found, returning null`);
-    return {
-      utiq: null,
-    };
-  }
-
-  let fcIdConnectObject;
-  let fcIdConnectData = JSON.parse(
-    storage.getDataFromLocalStorage('fcIdConnectData')
+  let utiqPass;
+  let utiqPassStorage = JSON.parse(
+    storage.getDataFromLocalStorage('utiqPass')
   );
   logInfo(
-    `${LOG_PREFIX}: Local storage fcIdConnectData: ${JSON.stringify(
-      fcIdConnectData
+    `${LOG_PREFIX}: Local storage utiqPass: ${JSON.stringify(
+      utiqPassStorage
     )}`
   );
 
   if (
-    fcIdConnectData &&
-    fcIdConnectData.connectId &&
-    Array.isArray(fcIdConnectData.connectId.idGraph) &&
-    fcIdConnectData.connectId.idGraph.length > 0
+    utiqPassStorage &&
+    utiqPassStorage.connectId &&
+    Array.isArray(utiqPassStorage.connectId.idGraph) &&
+    utiqPassStorage.connectId.idGraph.length > 0
   ) {
-    fcIdConnectObject = fcIdConnectData.connectId.idGraph.find((item) => {
-      return item.domain === domain;
-    });
+    utiqPass = utiqPassStorage.connectId.idGraph[0];
   }
   logInfo(
-    `${LOG_PREFIX}: Local storage fcIdConnectObject for domain: ${JSON.stringify(
-      fcIdConnectObject
+    `${LOG_PREFIX}: Graph of utiqPass: ${JSON.stringify(
+      utiqPass
     )}`
   );
 
   return {
     utiq:
-      fcIdConnectObject && fcIdConnectObject.atid
-        ? fcIdConnectObject.atid
+      utiqPass && utiqPass.atid
+        ? utiqPass.atid
         : null,
   };
 }

--- a/test/spec/modules/utiqSystem_spec.js
+++ b/test/spec/modules/utiqSystem_spec.js
@@ -3,8 +3,7 @@ import { utiqSubmodule } from 'modules/utiqSystem.js';
 import { storage } from 'modules/utiqSystem.js';
 
 describe('utiqSystem', () => {
-  const connectDataKey = 'fcIdConnectData';
-  const connectDomainKey = 'fcIdConnectDomain';
+  const utiqPassKey = 'utiqPass';
 
   const getStorageData = (idGraph) => {
     if (!idGraph) {
@@ -23,20 +22,15 @@ describe('utiqSystem', () => {
 
   describe('utiq getId()', () => {
     afterEach(() => {
-      storage.removeDataFromLocalStorage(connectDataKey);
-      storage.removeDataFromLocalStorage(connectDomainKey);
+      storage.removeDataFromLocalStorage(utiqPassKey);
     });
-
-    after(() => {
-      window.FC_CONF = {};
-    })
 
     it('it should return object with key callback', () => {
       expect(utiqSubmodule.getId()).to.have.property('callback');
     });
 
     it('should return object with key callback with value type - function', () => {
-      storage.setDataInLocalStorage(connectDataKey, JSON.stringify(getStorageData()));
+      storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData()));
       expect(utiqSubmodule.getId()).to.have.property('callback');
       expect(typeof utiqSubmodule.getId().callback).to.be.equal('function');
     });
@@ -46,18 +40,8 @@ describe('utiqSystem', () => {
         'domain': 'domainValue',
         'atid': 'atidValue',
       };
-      storage.setDataInLocalStorage(connectDataKey, JSON.stringify(getStorageData(idGraph)));
-      expect(JSON.parse(storage.getDataFromLocalStorage(connectDataKey))).to.have.property('connectId');
-    });
-
-    it('returns {callback: func} if domains don\'t match', () => {
-      const idGraph = {
-        'domain': 'domainValue',
-        'atid': 'atidValue',
-      };
-      storage.setDataInLocalStorage(connectDomainKey, JSON.stringify('differentDomainValue'));
-      storage.setDataInLocalStorage(connectDataKey, JSON.stringify(getStorageData(idGraph)));
-      expect(utiqSubmodule.getId()).to.have.property('callback');
+      storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData(idGraph)));
+      expect(JSON.parse(storage.getDataFromLocalStorage(utiqPassKey))).to.have.property('connectId');
     });
 
     it('returns {id: {utiq: data.utiq}} if we have the right data stored in the localstorage ', () => {
@@ -65,8 +49,7 @@ describe('utiqSystem', () => {
         'domain': 'test.domain',
         'atid': 'atidValue',
       };
-      storage.setDataInLocalStorage(connectDomainKey, JSON.stringify('test.domain'));
-      storage.setDataInLocalStorage(connectDataKey, JSON.stringify(getStorageData(idGraph)));
+      storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData(idGraph)));
       const response = utiqSubmodule.getId();
       expect(response).to.have.property('id');
       expect(response.id).to.have.property('utiq');
@@ -83,35 +66,11 @@ describe('utiqSystem', () => {
       expect(response.callback.toString()).contain('result(callback)');
 
       if (typeof response.callback === 'function') {
-        storage.setDataInLocalStorage(connectDomainKey, JSON.stringify('test.domain'));
-        storage.setDataInLocalStorage(connectDataKey, JSON.stringify(getStorageData(idGraph)));
+        storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData(idGraph)));
         response.callback(function (result) {
           expect(result).to.not.be.null;
           expect(result).to.have.property('utiq');
           expect(result.utiq).to.be.equal('atidValue');
-          done()
-        })
-      }
-    });
-
-    it('returns null if domains don\'t match', (done) => {
-      const idGraph = {
-        'domain': 'test.domain',
-        'atid': 'atidValue',
-      };
-      storage.setDataInLocalStorage(connectDomainKey, JSON.stringify('differentDomainValue'));
-      storage.setDataInLocalStorage(connectDataKey, JSON.stringify(getStorageData(idGraph)));
-
-      const response = utiqSubmodule.getId();
-      expect(response).to.have.property('callback');
-      expect(response.callback.toString()).contain('result(callback)');
-
-      if (typeof response.callback === 'function') {
-        setTimeout(() => {
-          expect(JSON.parse(storage.getDataFromLocalStorage(connectDomainKey))).to.be.equal('differentDomainValue');
-        }, 100)
-        response.callback(function (result) {
-          expect(result).to.be.null;
           done()
         })
       }
@@ -129,8 +88,7 @@ describe('utiqSystem', () => {
 
       if (typeof response.callback === 'function') {
         setTimeout(() => {
-          storage.setDataInLocalStorage(connectDomainKey, JSON.stringify('test.domain'));
-          storage.setDataInLocalStorage(connectDataKey, JSON.stringify(getStorageData(idGraph)));
+          storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData(idGraph)));
         }, 500);
         response.callback(function (result) {
           expect(result).to.not.be.null;
@@ -153,8 +111,7 @@ describe('utiqSystem', () => {
 
       if (typeof response.callback === 'function') {
         setTimeout(() => {
-          storage.setDataInLocalStorage(connectDomainKey, JSON.stringify('test.domain'));
-          storage.setDataInLocalStorage(connectDataKey, JSON.stringify(getStorageData(idGraph)));
+          storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData(idGraph)));
         }, 500);
         response.callback(function (result) {
           expect(result).to.be.null;
@@ -196,13 +153,8 @@ describe('utiqSystem', () => {
 
   describe('utiq messageHandler', () => {
     afterEach(() => {
-      storage.removeDataFromLocalStorage(connectDataKey);
-      storage.removeDataFromLocalStorage(connectDomainKey);
+      storage.removeDataFromLocalStorage(utiqPassKey);
     });
-
-    after(() => {
-      window.FC_CONF = {};
-    })
 
     const domains = [
       'domain1',
@@ -217,8 +169,7 @@ describe('utiqSystem', () => {
           'atid': 'atidValue',
         };
 
-        storage.setDataInLocalStorage(connectDomainKey, JSON.stringify(domain));
-        storage.setDataInLocalStorage(connectDataKey, JSON.stringify(getStorageData(idGraph)));
+        storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData(idGraph)));
 
         const eventData = {
           data: `{\"msgType\":\"MNOSELECTOR\",\"body\":{\"url\":\"https://${domain}/some/path\"}}`


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Refactoring (no functional changes, no api changes)
## Description of change
<!-- Describe the change proposed in this pull request -->

Removal of domain checks which became irrelevant due to the data layer changes. Naming changes for data layer.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Changes moved from PR to master (https://github.com/prebid/Prebid.js/pull/9995) since the renaming of this module (TrustPid -> Utiq) in the PR https://github.com/prebid/Prebid.js/pull/9872 was merged to `prebid-8` branch. This PR is also targeting `prebid-8`.