### PR TITLE
Prebid 8 appnexus bid adapter - update logic setting the banner adtype in ad request

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -28,7 +28,6 @@ import {Renderer} from '../src/Renderer.js';
 import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {ADPOD, BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
-import {auctionManager} from '../src/auctionManager.js';
 import {find, includes} from '../src/polyfill.js';
 import {INSTREAM, OUTSTREAM} from '../src/video.js';
 import {getStorageManager} from '../src/storageManager.js';
@@ -917,9 +916,7 @@ function bidToTag(bid) {
     tag['banner_frameworks'] = bid.params.frameworks;
   }
 
-  // TODO: why does this need to iterate through every ad unit?
-  let adUnit = find(auctionManager.getAdUnits(), au => bid.transactionId === au.transactionId);
-  if (adUnit && adUnit.mediaTypes && adUnit.mediaTypes.banner) {
+  if (deepAccess(bid, `mediaTypes.${BANNER}`)) {
     tag.ad_types.push(BANNER);
   }
 


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
This PR is related to a comment that was raised during the review for https://github.com/prebid/Prebid.js/pull/9969

Based on internal discussion, it seems the logic to populate the ad_types field with `banner` does not require looking at the original adUnit at this time anymore.  We can rely on the bid's mediaTypes information instead.