### PR TITLE
AdKernel Bid Adapter: support qortex

### DIFF
--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -90,7 +90,6 @@ export const spec = {
     {code: 'denakop'},
     {code: 'rtbanalytica'},
     {code: 'unibots'},
-    {code: 'catapultx'},
     {code: 'ergadx'},
     {code: 'turktelekom'},
     {code: 'felixads'},
@@ -100,7 +99,8 @@ export const spec = {
     {code: 'rtbdemand_com'},
     {code: 'bidbuddy'},
     {code: 'adliveconnect'},
-    {code: 'didnadisplay'}
+    {code: 'didnadisplay'},
+    {code: 'qortex'}
   ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 


### PR DESCRIPTION
Remove 'CatapultX' alias and add 'Qortex'

## Type of change
- [x] Other

## Description of change
Removing alias 'catapultx' from AdKernel bid adapter. Adding new company name 'qortex'
