### PR TITLE
IX Bid Adapter: remove usage of transactionID in compliant with Prebid 8 [PB-1743]

### DIFF
--- a/modules/eskimiBidAdapter.js
+++ b/modules/eskimiBidAdapter.js
@@ -1,7 +1,7 @@
-import {registerBidder} from '../src/adapters/bidderFactory.js';
-import {BANNER} from '../src/mediaTypes.js';
+import { ortbConverter } from '../libraries/ortbConverter/converter.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import * as utils from '../src/utils.js';
-import {ortbConverter} from '../libraries/ortbConverter/converter.js'
 
 const BIDDER_CODE = 'eskimi';
 // const ENDPOINT = 'https://hb.eskimi.com/bids'
@@ -12,43 +12,35 @@ const DEFAULT_CURRENCY = 'USD';
 const DEFAULT_NET_REVENUE = true;
 const GVLID = 814;
 
+const VIDEO_ORTB_PARAMS = [
+  'mimes',
+  'minduration',
+  'maxduration',
+  'placement',
+  'protocols',
+  'startdelay',
+  'skip',
+  'skipafter',
+  'minbitrate',
+  'maxbitrate',
+  'delivery',
+  'playbackmethod',
+  'api',
+  'linearity',
+  'battr'
+];
+
+const BANNER_ORTB_PARAMS = [
+  'battr'
+]
+
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
-  supportedMediaTypes: [BANNER],
-
-  isBidRequestValid: function (bid) {
-    return !!bid.params.placementId;
-  },
-
-  buildRequests(bidRequests, bidderRequest) {
-    const data = converter.toORTB({bidRequests, bidderRequest})
-
-    let bid = bidRequests.find((b) => b.params.placementId)
-    if (!data.site) data.site = {}
-    data.site.ext = {placementId: bid.params.placementId}
-
-    if (bidderRequest.gdprConsent) {
-      if (!data.user) data.user = {};
-      if (!data.user.ext) data.user.ext = {};
-      if (!data.regs) data.regs = {};
-      if (!data.regs.ext) data.regs.ext = {};
-      data.user.ext.consent = bidderRequest.gdprConsent.consentString;
-      data.regs.ext.gdpr = bidderRequest.gdprConsent.gdprApplies ? 1 : 0;
-    }
-
-    return [{
-      method: 'POST',
-      url: ENDPOINT,
-      data,
-      options: {contentType: 'application/json;charset=UTF-8', withCredentials: false}
-    }]
-  },
-
-  interpretResponse(response, request) {
-    return converter.fromORTB({response: response.body, request: request.data}).bids;
-  },
-
+  supportedMediaTypes: [BANNER, VIDEO],
+  isBidRequestValid,
+  buildRequests,
+  interpretResponse,
   /**
    * Register bidder specific code, which will execute if a bid from this bidder won the auction
    * @param {Bid} bid The bid that won the auction
@@ -60,13 +52,151 @@ export const spec = {
   }
 }
 
-const converter = ortbConverter({
+registerBidder(spec);
+
+const CONVERTER = ortbConverter({
   context: {
     netRevenue: DEFAULT_NET_REVENUE,
     ttl: DEFAULT_BID_TTL,
-    currency: DEFAULT_CURRENCY,
-    mediaType: BANNER // TODO: support more types, we should set mtype on the winning bid
+    currency: DEFAULT_CURRENCY
+  },
+  imp(buildImp, bidRequest, context) {
+    let imp = buildImp(bidRequest, context);
+    imp.secure = Number(window.location.protocol === 'https:');
+    if (!imp.bidfloor && bidRequest.params.bidFloor) {
+      imp.bidfloor = bidRequest.params.bidFloor;
+      imp.bidfloorcur = utils.getBidIdParameter('bidFloorCur', bidRequest.params).toUpperCase() || 'USD'
+    }
+
+    if (bidRequest.mediaTypes[VIDEO]) {
+      imp = buildVideoImp(bidRequest, imp);
+    } else if (bidRequest.mediaTypes[BANNER]) {
+      imp = buildBannerImp(bidRequest, imp);
+    }
+
+    return imp;
   }
 });
 
-registerBidder(spec);
+function isBidRequestValid(bidRequest) {
+  return (isPlacementIdValid(bidRequest) && (isValidBannerRequest(bidRequest) || isValidVideoRequest(bidRequest)));
+}
+
+function isPlacementIdValid(bidRequest) {
+  return utils.isNumber(bidRequest.params.placementId);
+}
+
+function isValidBannerRequest(bidRequest) {
+  const bannerSizes = utils.deepAccess(bidRequest, `mediaTypes.${BANNER}.sizes`);
+  return utils.isArray(bannerSizes) && bannerSizes.length > 0 && bannerSizes.every(size => utils.isNumber(size[0]) && utils.isNumber(size[1]));
+}
+
+function isValidVideoRequest(bidRequest) {
+  const videoSizes = utils.deepAccess(bidRequest, `mediaTypes.${VIDEO}.playerSize`);
+
+  return utils.isArray(videoSizes) && videoSizes.length > 0 && videoSizes.every(size => utils.isNumber(size[0]) && utils.isNumber(size[1]));
+}
+
+function buildRequests(validBids, bidderRequest) {
+  let videoBids = validBids.filter(bid => isVideoBid(bid));
+  let bannerBids = validBids.filter(bid => isBannerBid(bid));
+  let requests = [];
+
+  bannerBids.forEach(bid => {
+    requests.push(createRequest([bid], bidderRequest, BANNER));
+  });
+
+  videoBids.forEach(bid => {
+    requests.push(createRequest([bid], bidderRequest, VIDEO));
+  });
+
+  return requests;
+}
+
+function interpretResponse(response, request) {
+  return CONVERTER.fromORTB({ request: request.data, response: response.body }).bids;
+}
+
+function buildVideoImp(bidRequest, imp) {
+  const videoAdUnitParams = utils.deepAccess(bidRequest, `mediaTypes.${VIDEO}`, {});
+  const videoBidderParams = utils.deepAccess(bidRequest, `params.${VIDEO}`, {});
+
+  const videoParams = { ...videoAdUnitParams, ...videoBidderParams };
+
+  const videoSizes = (videoAdUnitParams && videoAdUnitParams.playerSize) || [];
+
+  if (videoSizes && videoSizes.length > 0) {
+    utils.deepSetValue(imp, 'video.w', videoSizes[0][0]);
+    utils.deepSetValue(imp, 'video.h', videoSizes[0][1]);
+  }
+
+  VIDEO_ORTB_PARAMS.forEach((param) => {
+    if (videoParams.hasOwnProperty(param)) {
+      utils.deepSetValue(imp, `video.${param}`, videoParams[param]);
+    }
+  });
+
+  if (imp.video && videoParams?.context === 'outstream') {
+    imp.video.placement = imp.video.placement || 4;
+  }
+
+  return { ...imp };
+}
+
+function buildBannerImp(bidRequest, imp) {
+  const bannerAdUnitParams = utils.deepAccess(bidRequest, `mediaTypes.${BANNER}`, {});
+  const bannerBidderParams = utils.deepAccess(bidRequest, `params.${BANNER}`, {});
+
+  const bannerParams = { ...bannerAdUnitParams, ...bannerBidderParams };
+
+  let sizes = bidRequest.mediaTypes.banner.sizes;
+
+  if (sizes) {
+    utils.deepSetValue(imp, 'banner.w', sizes[0][0]);
+    utils.deepSetValue(imp, 'banner.h', sizes[0][1]);
+  }
+
+  BANNER_ORTB_PARAMS.forEach((param) => {
+    if (bannerParams.hasOwnProperty(param)) {
+      utils.deepSetValue(imp, `banner.${param}`, bannerParams[param]);
+    }
+  });
+
+  return { ...imp };
+}
+
+function createRequest(bidRequests, bidderRequest, mediaType) {
+  const data = CONVERTER.toORTB({ bidRequests, bidderRequest, context: { mediaType } })
+
+  const bid = bidRequests.find((b) => b.params.placementId)
+  if (!data.site) data.site = {}
+  data.site.ext = { placementId: bid.params.placementId }
+
+  if (bidderRequest.gdprConsent) {
+    if (!data.user) data.user = {};
+    if (!data.user.ext) data.user.ext = {};
+    if (!data.regs) data.regs = {};
+    if (!data.regs.ext) data.regs.ext = {};
+    data.user.ext.consent = bidderRequest.gdprConsent.consentString;
+    data.regs.ext.gdpr = bidderRequest.gdprConsent.gdprApplies ? 1 : 0;
+  }
+
+  if (bid.params.bcat) data.bcat = bid.params.bcat;
+  if (bid.params.badv) data.badv = bid.params.badv;
+  if (bid.params.bapp) data.bapp = bid.params.bapp;
+
+  return {
+    method: 'POST',
+    url: ENDPOINT,
+    data: data,
+    options: { contentType: 'application/json;charset=UTF-8', withCredentials: false }
+  }
+}
+
+function isVideoBid(bid) {
+  return utils.deepAccess(bid, 'mediaTypes.video');
+}
+
+function isBannerBid(bid) {
+  return utils.deepAccess(bid, 'mediaTypes.banner') || !isVideoBid(bid);
+}

--- a/modules/eskimiBidAdapter.md
+++ b/modules/eskimiBidAdapter.md
@@ -6,29 +6,48 @@ Maintainer: tech@eskimi.com
 
 # Description
 
-An adapter to get a bid from Eskimi DSP.
+Module that connects to Eskimi demand sources to fetch bids using OpenRTB standard.
+Banner and video formats are supported.
 
 # Test Parameters
 ```javascript
     var adUnits = [{
-       code: 'div-gpt-ad-1460505748561-0',
-       mediaTypes: {
-           banner: {
-               sizes: [[300, 250], [300, 600]]
-           }
-       },
-       
-       bids: [{
-           bidder: 'eskimi',
-           params: {
-               placementId: 612
-           }
-       }]
-
-   }];
+        code: '/19968336/prebid_banner_example_1',
+        mediaTypes: {
+            banner: {
+                sizes: [[ 300, 250 ]],
+                ... // battr
+            }
+        },
+        bids: [{
+            bidder: 'eskimi',
+            params: {
+                placementId: 612,
+                ... // bcat, badv, bapp
+            }
+        }]
+    }, {
+        code: '/19968336/prebid_video_example_1',
+        mediaTypes: {
+            video: {
+                context: 'outstream',
+                mimes: ['video/mp4'],
+                api: [1, 2, 4, 6],
+                ... // Aditional ORTB video params (including battr)
+            }
+        },
+        bids: [{
+            bidder: 'eskimi',
+            params: {
+                placementId: 612,
+                ... // bcat, badv, bapp
+            }
+        }]
+    }];
 ```
 
 Where:
 
 * placementId - Placement ID of the ad unit (required)
+* bcat, badv, bapp, battr - ORTB blocking parameters as specified by OpenRTB 2.5
 

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -640,16 +640,15 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
   siteID = validBidRequests[0].params.siteId;
   payload.s = siteID;
 
-  // TODO: this logic should stop relying on `transactionId` always being available; see: https://github.com/prebid/Prebid.js/issues/9781
-  const transactionIds = Object.keys(impressions);
+  const impKeys = Object.keys(impressions);
   let isFpdAdded = false;
 
-  for (let adUnitIndex = 0; adUnitIndex < transactionIds.length; adUnitIndex++) {
+  for (let adUnitIndex = 0; adUnitIndex < impKeys.length; adUnitIndex++) {
     if (requests.length >= MAX_REQUEST_LIMIT) {
       break;
     }
 
-    r = addImpressions(impressions, transactionIds, r, adUnitIndex);
+    r = addImpressions(impressions, impKeys, r, adUnitIndex);
 
     const fpd = deepAccess(bidderRequest, 'ortb2') || {};
     const site = { ...(fpd.site || fpd.context) };
@@ -666,9 +665,9 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
     }
 
     // add identifiers info to ixDiag
-    r = addIdentifiersInfo(impressions, r, transactionIds, adUnitIndex, payload, baseUrl);
+    r = addIdentifiersInfo(impressions, r, impKeys, adUnitIndex, payload, baseUrl);
 
-    const isLastAdUnit = adUnitIndex === transactionIds.length - 1;
+    const isLastAdUnit = adUnitIndex === impKeys.length - 1;
 
     if (isLastAdUnit) {
       requests.push({
@@ -862,13 +861,13 @@ function applyRegulations(r, bidderRequest) {
  * addImpressions adds impressions to request object
  *
  * @param  {array}  impressions        List of impressions to be added to the request.
- * @param  {array}  transactionIds     List of transaction Ids.
+ * @param  {array}  impKeys            List of impression keys.
  * @param  {object} r                  Reuqest object.
  * @param  {int}    adUnitIndex        Index of the current add unit
  * @return {object}                    Reqyest object with added impressions describing the request to the server.
  */
-function addImpressions(impressions, transactionIds, r, adUnitIndex) {
-  const adUnitImpressions = impressions[transactionIds[adUnitIndex]];
+function addImpressions(impressions, impKeys, r, adUnitIndex) {
+  const adUnitImpressions = impressions[impKeys[adUnitIndex]];
   const { missingImps: missingBannerImpressions = [], ixImps = [] } = adUnitImpressions;
   const sourceImpressions = { ixImps, missingBannerImpressions };
   const impressionObjects = Object.keys(sourceImpressions)
@@ -876,10 +875,10 @@ function addImpressions(impressions, transactionIds, r, adUnitIndex) {
     .filter(item => Array.isArray(item))
     .reduce((acc, curr) => acc.concat(...curr), []);
 
-  const gpid = impressions[transactionIds[adUnitIndex]].gpid;
-  const dfpAdUnitCode = impressions[transactionIds[adUnitIndex]].dfp_ad_unit_code;
-  const tid = impressions[transactionIds[adUnitIndex]].tid;
-  const sid = impressions[transactionIds[adUnitIndex]].sid
+  const gpid = impressions[impKeys[adUnitIndex]].gpid;
+  const dfpAdUnitCode = impressions[impKeys[adUnitIndex]].dfp_ad_unit_code;
+  const tid = impressions[impKeys[adUnitIndex]].tid;
+  const sid = impressions[impKeys[adUnitIndex]].sid
 
   if (impressionObjects.length && BANNER in impressionObjects[0]) {
     const { id, banner: { topframe } } = impressionObjects[0];
@@ -903,7 +902,7 @@ function addImpressions(impressions, transactionIds, r, adUnitIndex) {
       }
     }
 
-    const position = impressions[transactionIds[adUnitIndex]].pos;
+    const position = impressions[impKeys[adUnitIndex]].pos;
     if (isInteger(position)) {
       _bannerImpression.banner.pos = position;
     }
@@ -924,7 +923,7 @@ function addImpressions(impressions, transactionIds, r, adUnitIndex) {
       _bannerImpression.bidfloorcur = impressionObjects[0].bidfloorcur;
     }
 
-    const adUnitFPD = impressions[transactionIds[adUnitIndex]].adUnitFPD
+    const adUnitFPD = impressions[impKeys[adUnitIndex]].adUnitFPD
     if (adUnitFPD) {
       _bannerImpression.ext.data = adUnitFPD;
     }
@@ -1061,17 +1060,17 @@ function addAdUnitFPD(imp, bid) {
  *
  * @param  {array}  impressions        List of impressions to be added to the request.
  * @param  {object} r                  Reuqest object.
- * @param  {array}  transactionIds     List of transaction Ids.
+ * @param  {array}  impKeys            List of impression keys.
  * @param  {int}    adUnitIndex        Index of the current add unit
  * @param  {object} payload            Request payload object.
  * @param  {string} baseUrl            Base exchagne URL.
  * @return {object}                    Reqyest object with added indentigfier info to ixDiag.
  */
-function addIdentifiersInfo(impressions, r, transactionIds, adUnitIndex, payload, baseUrl) {
-  const pbaAdSlot = impressions[transactionIds[adUnitIndex]].pbadslot;
-  const tagId = impressions[transactionIds[adUnitIndex]].tagId;
-  const adUnitCode = impressions[transactionIds[adUnitIndex]].adUnitCode;
-  const divId = impressions[transactionIds[adUnitIndex]].divId;
+function addIdentifiersInfo(impressions, r, impKeys, adUnitIndex, payload, baseUrl) {
+  const pbaAdSlot = impressions[impKeys[adUnitIndex]].pbadslot;
+  const tagId = impressions[impKeys[adUnitIndex]].tagId;
+  const adUnitCode = impressions[impKeys[adUnitIndex]].adUnitCode;
+  const divId = impressions[impKeys[adUnitIndex]].divId;
   if (pbaAdSlot || tagId || adUnitCode || divId) {
     r.ext.ixdiag.pbadslot = pbaAdSlot;
     r.ext.ixdiag.tagid = tagId;
@@ -1101,7 +1100,7 @@ function _getUserIds(bidRequest) {
  */
 function buildIXDiag(validBidRequests) {
   var adUnitMap = validBidRequests
-    .map(bidRequest => bidRequest.transactionId)
+    .map(bidRequest => bidRequest.adUnitCode)
     .filter((value, index, arr) => arr.indexOf(value) === index);
 
   var ixdiag = {
@@ -1120,7 +1119,7 @@ function buildIXDiag(validBidRequests) {
 
   // create ad unit map and collect the required diag properties
   for (let i = 0; i < adUnitMap.length; i++) {
-    var bid = validBidRequests.filter(bidRequest => bidRequest.transactionId === adUnitMap[i])[0];
+    var bid = validBidRequests.filter(bidRequest => bidRequest.adUnitCode === adUnitMap[i])[0];
 
     if (deepAccess(bid, 'mediaTypes')) {
       if (Object.keys(bid.mediaTypes).length > 1) {
@@ -1182,18 +1181,18 @@ function createNativeImps(validBidRequest, nativeImps) {
   const imp = bidToNativeImp(validBidRequest);
 
   if (Object.keys(imp).length != 0) {
-    nativeImps[validBidRequest.transactionId] = {};
-    nativeImps[validBidRequest.transactionId].ixImps = [];
-    nativeImps[validBidRequest.transactionId].ixImps.push(imp);
-    nativeImps[validBidRequest.transactionId].gpid = deepAccess(validBidRequest, 'ortb2Imp.ext.gpid');
-    nativeImps[validBidRequest.transactionId].dfp_ad_unit_code = deepAccess(validBidRequest, 'ortb2Imp.ext.data.adserver.adslot');
-    nativeImps[validBidRequest.transactionId].pbadslot = deepAccess(validBidRequest, 'ortb2Imp.ext.data.pbadslot');
-    nativeImps[validBidRequest.transactionId].tagId = deepAccess(validBidRequest, 'params.tagId');
+    nativeImps[validBidRequest.adUnitCode] = {};
+    nativeImps[validBidRequest.adUnitCode].ixImps = [];
+    nativeImps[validBidRequest.adUnitCode].ixImps.push(imp);
+    nativeImps[validBidRequest.adUnitCode].gpid = deepAccess(validBidRequest, 'ortb2Imp.ext.gpid');
+    nativeImps[validBidRequest.adUnitCode].dfp_ad_unit_code = deepAccess(validBidRequest, 'ortb2Imp.ext.data.adserver.adslot');
+    nativeImps[validBidRequest.adUnitCode].pbadslot = deepAccess(validBidRequest, 'ortb2Imp.ext.data.pbadslot');
+    nativeImps[validBidRequest.adUnitCode].tagId = deepAccess(validBidRequest, 'params.tagId');
 
     const adUnitCode = validBidRequest.adUnitCode;
     const divId = document.getElementById(adUnitCode) ? adUnitCode : getGptSlotInfoForAdUnitCode(adUnitCode).divId;
-    nativeImps[validBidRequest.transactionId].adUnitCode = adUnitCode;
-    nativeImps[validBidRequest.transactionId].divId = divId;
+    nativeImps[validBidRequest.adUnitCode].adUnitCode = adUnitCode;
+    nativeImps[validBidRequest.adUnitCode].divId = divId;
   }
 }
 
@@ -1205,18 +1204,18 @@ function createNativeImps(validBidRequest, nativeImps) {
 function createVideoImps(validBidRequest, videoImps) {
   const imp = bidToVideoImp(validBidRequest);
   if (Object.keys(imp).length != 0) {
-    videoImps[validBidRequest.transactionId] = {};
-    videoImps[validBidRequest.transactionId].ixImps = [];
-    videoImps[validBidRequest.transactionId].ixImps.push(imp);
-    videoImps[validBidRequest.transactionId].gpid = deepAccess(validBidRequest, 'ortb2Imp.ext.gpid');
-    videoImps[validBidRequest.transactionId].dfp_ad_unit_code = deepAccess(validBidRequest, 'ortb2Imp.ext.data.adserver.adslot');
-    videoImps[validBidRequest.transactionId].pbadslot = deepAccess(validBidRequest, 'ortb2Imp.ext.data.pbadslot');
-    videoImps[validBidRequest.transactionId].tagId = deepAccess(validBidRequest, 'params.tagId');
+    videoImps[validBidRequest.adUnitCode] = {};
+    videoImps[validBidRequest.adUnitCode].ixImps = [];
+    videoImps[validBidRequest.adUnitCode].ixImps.push(imp);
+    videoImps[validBidRequest.adUnitCode].gpid = deepAccess(validBidRequest, 'ortb2Imp.ext.gpid');
+    videoImps[validBidRequest.adUnitCode].dfp_ad_unit_code = deepAccess(validBidRequest, 'ortb2Imp.ext.data.adserver.adslot');
+    videoImps[validBidRequest.adUnitCode].pbadslot = deepAccess(validBidRequest, 'ortb2Imp.ext.data.pbadslot');
+    videoImps[validBidRequest.adUnitCode].tagId = deepAccess(validBidRequest, 'params.tagId');
 
     const adUnitCode = validBidRequest.adUnitCode;
     const divId = document.getElementById(adUnitCode) ? adUnitCode : getGptSlotInfoForAdUnitCode(adUnitCode).divId;
-    videoImps[validBidRequest.transactionId].adUnitCode = adUnitCode;
-    videoImps[validBidRequest.transactionId].divId = divId;
+    videoImps[validBidRequest.adUnitCode].adUnitCode = adUnitCode;
+    videoImps[validBidRequest.adUnitCode].divId = divId;
   }
 }
 
@@ -1231,39 +1230,39 @@ function createBannerImps(validBidRequest, missingBannerSizes, bannerImps) {
 
   const bannerSizeDefined = includesSize(deepAccess(validBidRequest, 'mediaTypes.banner.sizes'), deepAccess(validBidRequest, 'params.size'));
 
-  if (!bannerImps.hasOwnProperty(validBidRequest.transactionId)) {
-    bannerImps[validBidRequest.transactionId] = {};
+  if (!bannerImps.hasOwnProperty(validBidRequest.adUnitCode)) {
+    bannerImps[validBidRequest.adUnitCode] = {};
   }
 
-  bannerImps[validBidRequest.transactionId].gpid = deepAccess(validBidRequest, 'ortb2Imp.ext.gpid');
-  bannerImps[validBidRequest.transactionId].dfp_ad_unit_code = deepAccess(validBidRequest, 'ortb2Imp.ext.data.adserver.adslot');
-  bannerImps[validBidRequest.transactionId].tid = deepAccess(validBidRequest, 'ortb2Imp.ext.tid');
-  bannerImps[validBidRequest.transactionId].pbadslot = deepAccess(validBidRequest, 'ortb2Imp.ext.data.pbadslot');
-  bannerImps[validBidRequest.transactionId].tagId = deepAccess(validBidRequest, 'params.tagId');
-  bannerImps[validBidRequest.transactionId].pos = deepAccess(validBidRequest, 'mediaTypes.banner.pos');
+  bannerImps[validBidRequest.adUnitCode].gpid = deepAccess(validBidRequest, 'ortb2Imp.ext.gpid');
+  bannerImps[validBidRequest.adUnitCode].dfp_ad_unit_code = deepAccess(validBidRequest, 'ortb2Imp.ext.data.adserver.adslot');
+  bannerImps[validBidRequest.adUnitCode].tid = deepAccess(validBidRequest, 'ortb2Imp.ext.tid');
+  bannerImps[validBidRequest.adUnitCode].pbadslot = deepAccess(validBidRequest, 'ortb2Imp.ext.data.pbadslot');
+  bannerImps[validBidRequest.adUnitCode].tagId = deepAccess(validBidRequest, 'params.tagId');
+  bannerImps[validBidRequest.adUnitCode].pos = deepAccess(validBidRequest, 'mediaTypes.banner.pos');
 
   // AdUnit-Specific First Party Data
   const adUnitFPD = deepAccess(validBidRequest, 'ortb2Imp.ext.data');
   if (adUnitFPD) {
-    bannerImps[validBidRequest.transactionId].adUnitFPD = adUnitFPD;
+    bannerImps[validBidRequest.adUnitCode].adUnitFPD = adUnitFPD;
   }
 
   const sid = deepAccess(validBidRequest, 'params.id');
   if (sid && (typeof sid === 'string' || typeof sid === 'number')) {
-    bannerImps[validBidRequest.transactionId].sid = String(sid);
+    bannerImps[validBidRequest.adUnitCode].sid = String(sid);
   }
 
   const adUnitCode = validBidRequest.adUnitCode;
   const divId = document.getElementById(adUnitCode) ? adUnitCode : getGptSlotInfoForAdUnitCode(adUnitCode).divId;
-  bannerImps[validBidRequest.transactionId].adUnitCode = adUnitCode;
-  bannerImps[validBidRequest.transactionId].divId = divId;
+  bannerImps[validBidRequest.adUnitCode].adUnitCode = adUnitCode;
+  bannerImps[validBidRequest.adUnitCode].divId = divId;
 
   // Create IX imps from params.size
   if (bannerSizeDefined) {
-    if (!bannerImps[validBidRequest.transactionId].hasOwnProperty('ixImps')) {
-      bannerImps[validBidRequest.transactionId].ixImps = [];
+    if (!bannerImps[validBidRequest.adUnitCode].hasOwnProperty('ixImps')) {
+      bannerImps[validBidRequest.adUnitCode].ixImps = [];
     }
-    bannerImps[validBidRequest.transactionId].ixImps.push(imp);
+    bannerImps[validBidRequest.adUnitCode].ixImps.push(imp);
   }
 
   updateMissingSizes(validBidRequest, missingBannerSizes, imp);
@@ -1277,14 +1276,13 @@ function createBannerImps(validBidRequest, missingBannerSizes, bannerImps) {
  * @param {object} imp                The impression for the bidrequest
  */
 function updateMissingSizes(validBidRequest, missingBannerSizes, imp) {
-  const transactionID = validBidRequest.transactionId;
-  if (missingBannerSizes.hasOwnProperty(transactionID)) {
+  if (missingBannerSizes.hasOwnProperty(validBidRequest.adUnitCode)) {
     let currentSizeList = [];
-    if (missingBannerSizes[transactionID].hasOwnProperty('missingSizes')) {
-      currentSizeList = missingBannerSizes[transactionID].missingSizes;
+    if (missingBannerSizes[validBidRequest.adUnitCode].hasOwnProperty('missingSizes')) {
+      currentSizeList = missingBannerSizes[validBidRequest.adUnitCode].missingSizes;
     }
     removeFromSizes(currentSizeList, validBidRequest.params.size);
-    missingBannerSizes[transactionID].missingSizes = currentSizeList;
+    missingBannerSizes[validBidRequest.adUnitCode].missingSizes = currentSizeList;
   } else {
     // New Ad Unit
     if (deepAccess(validBidRequest, 'mediaTypes.banner.sizes')) {
@@ -1294,7 +1292,7 @@ function updateMissingSizes(validBidRequest, missingBannerSizes, imp) {
         'missingSizes': sizeList,
         'impression': imp
       };
-      missingBannerSizes[transactionID] = newAdUnitEntry;
+      missingBannerSizes[validBidRequest.adUnitCode] = newAdUnitEntry;
     }
   }
 }
@@ -1612,23 +1610,23 @@ export const spec = {
     });
 
     // Step 2: Update banner impressions with missing sizes
-    for (let transactionId in missingBannerSizes) {
-      if (missingBannerSizes.hasOwnProperty(transactionId)) {
-        let missingSizes = missingBannerSizes[transactionId].missingSizes;
+    for (let adunitCode in missingBannerSizes) {
+      if (missingBannerSizes.hasOwnProperty(adunitCode)) {
+        let missingSizes = missingBannerSizes[adunitCode].missingSizes;
 
-        if (!bannerImps.hasOwnProperty(transactionId)) {
-          bannerImps[transactionId] = {};
+        if (!bannerImps.hasOwnProperty(adunitCode)) {
+          bannerImps[adunitCode] = {};
         }
-        if (!bannerImps[transactionId].hasOwnProperty('missingImps')) {
-          bannerImps[transactionId].missingImps = [];
-          bannerImps[transactionId].missingCount = 0;
+        if (!bannerImps[adunitCode].hasOwnProperty('missingImps')) {
+          bannerImps[adunitCode].missingImps = [];
+          bannerImps[adunitCode].missingCount = 0;
         }
 
-        let origImp = missingBannerSizes[transactionId].impression;
+        let origImp = missingBannerSizes[adunitCode].impression;
         for (let i = 0; i < missingSizes.length; i++) {
           let newImp = createMissingBannerImp(validBidRequests[0], origImp, missingSizes[i]);
-          bannerImps[transactionId].missingImps.push(newImp);
-          bannerImps[transactionId].missingCount++;
+          bannerImps[adunitCode].missingImps.push(newImp);
+          bannerImps[adunitCode].missingCount++;
         }
       }
     }

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -597,7 +597,7 @@ function getEidInfo(allEids) {
  *
  * @param  {array}  validBidRequests A list of valid bid request config objects.
  * @param  {object} bidderRequest    An object containing other info like gdprConsent.
- * @param  {object} impressions      An object containing a list of impression objects describing the bids for each transactionId
+ * @param  {object} impressions      An object containing a list of impression objects describing the bids for each transaction
  * @param  {array}  version          Endpoint version denoting banner, video or native.
  * @return {array}                   List of objects describing the request to the server.
  *
@@ -776,10 +776,8 @@ function enrichRequest(r, bidderRequest, impressions, validBidRequests, userEids
   // Add number of available imps to ixDiag.
   r.ext.ixdiag.imps = Object.keys(impressions).length;
 
-  // set source.tid to auctionId for outgoing request to Exchange.
-  r.source = {
-    tid: bidderRequest?.ortb2?.source?.tid
-  }
+  // set source.tid for outgoing request to Exchange.
+  deepSetValue(r, 'source.tid', validBidRequests[0].ortb2?.source?.tid || validBidRequests[0].auctionId);
 
   // if an schain is provided, send it along
   if (validBidRequests[0].schain) {

--- a/modules/logicadBidAdapter.js
+++ b/modules/logicadBidAdapter.js
@@ -1,6 +1,7 @@
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, NATIVE} from '../src/mediaTypes.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
+import { deepAccess } from '../src/utils.js';
 
 const BIDDER_CODE = 'logicad';
 const ENDPOINT_URL = 'https://pb.ladsp.com/adrequest/prebid';
@@ -52,8 +53,7 @@ export const spec = {
 };
 
 function newBidRequest(bid, bidderRequest) {
-  return {
-    // TODO: fix auctionId leak: https://github.com/prebid/Prebid.js/issues/9781
+  const data = {
     auctionId: bid.auctionId,
     bidderRequestId: bid.bidderRequestId,
     bids: [{
@@ -70,6 +70,18 @@ function newBidRequest(bid, bidderRequest) {
     auctionStartTime: bidderRequest.auctionStart,
     eids: bid.userIdAsEids,
   };
+
+  const sua = deepAccess(bid, 'ortb2.device.sua');
+  if (sua) {
+    data.sua = sua;
+  }
+
+  const userData = deepAccess(bid, 'ortb2.user.data');
+  if (userData) {
+    data.userData = userData;
+  }
+
+  return data;
 }
 
 registerBidder(spec);

--- a/modules/nexx360BidAdapter.js
+++ b/modules/nexx360BidAdapter.js
@@ -23,6 +23,7 @@ const ALIASES = [
   { code: 'adwebone' },
   { code: 'league-m', gvlid: 965 },
   { code: 'prjads' },
+  { code: 'pubtech' },
 ];
 
 export const storage = getStorageManager({

--- a/modules/pairIdSystem.js
+++ b/modules/pairIdSystem.js
@@ -32,11 +32,16 @@ export const pairIdSubmodule = {
   */
   name: MODULE_NAME,
   /**
-   * decode the stored id value for passing to bid requests
-   * @function
-   * @param { string | undefined } value
-   * @returns {{pairId:string} | undefined }
-   */
+  * used to specify vendor id
+  * @type {number}
+  */
+  gvlid: 755,
+  /**
+  * decode the stored id value for passing to bid requests
+  * @function
+  * @param { string | undefined } value
+  * @returns {{pairId:string} | undefined }
+  */
   decode(value) {
     return value && Array.isArray(value) ? {'pairId': value} : undefined
   },

--- a/modules/richaudienceBidAdapter.js
+++ b/modules/richaudienceBidAdapter.js
@@ -55,8 +55,9 @@ export const spec = {
         videoData: raiGetVideoInfo(bid),
         scr_rsl: raiGetResolution(),
         cpuc: (typeof window.navigator != 'undefined' ? window.navigator.hardwareConcurrency : null),
-        kws: getAllOrtbKeywords(bidderRequest.ortb2, bid.params.keywords).join(','),
-        schain: bid.schain
+        kws: (!isEmpty(bid.params.keywords) ? bid.params.keywords : null),
+        schain: bid.schain,
+        gpid: raiSetPbAdSlot(bid)
       };
 
       // TODO: is 'page' the right value here?
@@ -283,6 +284,14 @@ function raiGetResolution() {
     resolution = window.screen.width + 'x' + window.screen.height;
   }
   return resolution;
+}
+
+function raiSetPbAdSlot(bid) {
+  let pbAdSlot = '';
+  if (deepAccess(bid, 'ortb2Imp.ext.data.pbadslot') != null) {
+    pbAdSlot = deepAccess(bid, 'ortb2Imp.ext.data.pbadslot')
+  }
+  return pbAdSlot
 }
 
 function raiGetSyncInclude(config) {

--- a/modules/riseBidAdapter.js
+++ b/modules/riseBidAdapter.js
@@ -417,8 +417,7 @@ function generateGeneralParams(generalObject, bidderRequest) {
     device_type: getDeviceType(navigator.userAgent),
     ua: navigator.userAgent,
     is_wrapper: !!generalBidParams.isWrapper,
-    // TODO: fix auctionId leak: https://github.com/prebid/Prebid.js/issues/9781
-    session_id: generalBidParams.sessionId || getBidIdParameter('auctionId', generalObject),
+    session_id: generalBidParams.sessionId || getBidIdParameter('bidderRequestId', generalObject),
     tmax: timeout
   };
 

--- a/test/spec/modules/eskimiBidAdapter_spec.js
+++ b/test/spec/modules/eskimiBidAdapter_spec.js
@@ -1,155 +1,307 @@
-import {expect} from 'chai';
-import {spec} from 'modules/eskimiBidAdapter.js';
+import { expect } from 'chai';
+import { spec } from 'modules/eskimiBidAdapter.js';
+import * as utils from 'src/utils';
 
-const REQUEST = {
-  'bidderCode': 'eskimi',
-  'auctionId': 'auctionId-56a2-4f71-9098-720a68f2f708',
-  'bidderRequestId': 'requestId',
-  'bidRequest': [{
-    'bidder': 'eskimi',
-    'params': {
-      'placementId': 1003000,
-      'accId': 123
-    },
-    'sizes': [
-      [300, 250]
-    ],
-    'bidId': 'bidId1',
-    'adUnitCode': 'adUnitCode1',
-    'bidderRequestId': 'bidderRequestId',
-    'auctionId': 'auctionId-56a2-4f71-9098-720a68f2f708'
+const BANNER_BID = {
+  bidder: 'eskimi',
+  params: {
+    placementId: 1003000
   },
-  {
-    'bidder': 'eskimi',
-    'params': {
-      'placementId': 1003001,
-      'accId': 123
+  mediaTypes: {
+    banner: {
+      sizes: [
+        [300, 250]
+      ],
     },
-    'sizes': [
-      [300, 250]
-    ],
-    'bidId': 'bidId2',
-    'adUnitCode': 'adUnitCode2',
-    'bidderRequestId': 'bidderRequestId',
-    'auctionId': 'auctionId-56a2-4f71-9098-720a68f2f708'
-  }],
-  'start': 1487883186070,
-  'auctionStart': 1487883186069,
-  'timeout': 3000
+  },
+  adUnitCode: 'adUnitCode1',
+  bidId: 'bidId',
+  bidderRequestId: 'bidderRequestId',
+  auctionId: 'auctionId-56a2-4f71-9098-720a68f2f708',
 };
 
-const RESPONSE = {
-  'headers': null,
-  'body': {
-    'id': 'requestId',
-    'seatbid': [
-      {
-        'bid': [
-          {
-            'id': 'bidId1',
-            'impid': 'bidId1',
-            'price': 0.18,
-            'adm': '<script>adm</script>',
-            'adid': '144762342',
-            'adomain': [
-              'https://dummydomain.com'
-            ],
-            'iurl': 'iurl',
-            'cid': '109',
-            'crid': 'creativeId',
-            'cat': [],
-            'w': 300,
-            'h': 250,
-            'ext': {
-              'prebid': {
-                'type': 'banner'
-              },
-              'bidder': {
-                'eskimi': {
-                  'brand_id': 334553,
-                  'auction_id': 514667951122925701,
-                  'bidder_id': 2,
-                  'bid_ad_type': 0
-                }
-              }
-            }
-          }
-        ],
-        'seat': 'seat'
-      }
-    ]
+const VIDEO_BID = {
+  bidder: 'eskimi',
+  params: {
+    placementId: 1003000
+  },
+  mediaTypes: {
+    video: {
+      context: 'outstream',
+      api: [1, 2, 4, 6],
+      mimes: ['video/mp4'],
+      playbackmethod: [2, 4, 6],
+      playerSize: [[1024, 768]],
+      protocols: [3, 4, 7, 8, 10],
+      placement: 1,
+      minduration: 0,
+      maxduration: 60,
+      startdelay: 0
+    },
+  },
+  adUnitCode: 'adUnitCode1',
+  bidId: 'bidId',
+  bidderRequestId: 'bidderRequestId',
+  auctionId: 'auctionId-56a2-4f71-9098-720a68f2f708',
+};
+
+const BIDDER_REQUEST = {
+  auctionId: 'auctionId-56a2-4f71-9098-720a68f2f708',
+  bidderRequestId: 'bidderRequestId',
+  timeout: 3000,
+  refererInfo: {
+    page: 'https://hello-world-page.com/',
+    domain: 'hello-world-page.com',
+    ref: 'http://example-domain.com/foo',
   }
 };
 
+const BANNER_BID_RESPONSE = {
+  'id': 'bidderRequestId',
+  'bidId': 'bidid',
+  'seatbid': [
+    {
+      'bid': [
+        {
+          'id': 'id',
+          'impid': 'bidId',
+          'price': 0.18,
+          'adm': '<script>adm</script>',
+          'adid': '144762342',
+          'burl': 'http://0.0.0.0:8181/burl',
+          'adomain': [
+            'https://dummydomain.com'
+          ],
+          'cid': 'cid',
+          'crid': 'crid',
+          'iurl': 'iurl',
+          'cat': [],
+          'w': 300,
+          'h': 250
+        }
+      ]
+    }
+  ],
+  'cur': 'USD'
+};
+
+const VIDEO_BID_RESPONSE = {
+  'id': 'bidderRequestId',
+  'bidid': 'bidid',
+  'seatbid': [
+    {
+      'bid': [
+        {
+          'id': 'id',
+          'impid': 'bidId',
+          'price': 1.09,
+          'adid': '144762342',
+          'burl': 'http://0.0.0.0:8181/burl',
+          'adm': '<VAST version="4.2"></VAST>',
+          'adomain': [
+            'https://dummydomain.com'
+          ],
+          'cid': 'cid',
+          'crid': 'crid',
+          'iurl': 'iurl',
+          'cat': [],
+          'h': 768,
+          'w': 1024
+        }
+      ]
+    }
+  ],
+  'cur': 'USD'
+};
+
 describe('Eskimi bid adapter', function () {
-  describe('isBidRequestValid', function () {
+  describe('isBidRequestValid()', function () {
     it('should accept request if placementId is passed', function () {
       let bid = {
         bidder: 'eskimi',
         params: {
           placementId: 123
+        },
+        mediaTypes: {
+          banner: {
+            sizes: [[300, 250]]
+          }
         }
       };
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
-    it('reject requests without params', function () {
+
+    it('should reject requests without params', function () {
       let bid = {
         bidder: 'eskimi',
         params: {}
       };
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
+
+    it('should return true when required params found', () => {
+      expect(spec.isBidRequestValid(BANNER_BID)).to.equal(true);
+      expect(spec.isBidRequestValid(VIDEO_BID)).to.equal(true);
+    });
   });
 
-  describe('buildRequests', function () {
-    it('creates request data', function () {
-      let request = spec.buildRequests(REQUEST.bidRequest, REQUEST)[0];
-      expect(request).to.exist.and.to.be.a('object');
-      const payload = request.data;
-      expect(payload.imp[0]).to.have.property('id', REQUEST.bidRequest[0].bidId);
-      expect(payload.imp[1]).to.have.property('id', REQUEST.bidRequest[1].bidId);
-    });
+  describe('buildRequests()', function () {
+    it('should have gdpr data if applicable', function () {
+      const bid = utils.deepClone(BANNER_BID);
 
-    it('has gdpr data if applicable', function () {
-      const req = Object.assign({}, REQUEST, {
+      const req = Object.assign({}, BIDDER_REQUEST, {
         gdprConsent: {
           consentString: 'consentString',
           gdprApplies: true,
         }
       });
-      let request = spec.buildRequests(REQUEST.bidRequest, req)[0];
+      let request = spec.buildRequests([bid], req)[0];
 
       const payload = request.data;
       expect(payload.user.ext).to.have.property('consent', req.gdprConsent.consentString);
       expect(payload.regs.ext).to.have.property('gdpr', 1);
     });
+
+    it('should properly forward ORTB blocking params', function () {
+      let bid = utils.deepClone(BANNER_BID);
+      bid = utils.mergeDeep(bid, {
+        params: { bcat: ['IAB1-1'], badv: ['example.com'], bapp: ['com.example'] },
+        mediaTypes: { banner: { battr: [1] } }
+      });
+
+      let [request] = spec.buildRequests([bid], BIDDER_REQUEST);
+
+      expect(request).to.exist.and.to.be.an('object');
+      const payload = request.data;
+      expect(payload).to.have.deep.property('bcat', ['IAB1-1']);
+      expect(payload).to.have.deep.property('badv', ['example.com']);
+      expect(payload).to.have.deep.property('bapp', ['com.example']);
+      expect(payload.imp[0].banner).to.have.deep.property('battr', [1]);
+    });
+
+    context('when mediaType is banner', function () {
+      it('should build correct request for banner bid with both w, h', () => {
+        const bid = utils.deepClone(BANNER_BID);
+
+        const [request] = spec.buildRequests([bid], BIDDER_REQUEST);
+        const requestData = request.data;
+
+        expect(requestData.imp[0].banner.w).to.equal(300);
+        expect(requestData.imp[0].banner.h).to.equal(250);
+      });
+
+      it('should create request data', function () {
+        const bid = utils.deepClone(BANNER_BID);
+
+        let [request] = spec.buildRequests([bid], BIDDER_REQUEST);
+        expect(request).to.exist.and.to.be.a('object');
+        const payload = request.data;
+        expect(payload.imp[0]).to.have.property('id', bid.bidId);
+      });
+    });
+
+    context('when mediaType is video', function () {
+      it('should return false when there is no video in mediaTypes', () => {
+        const bid = utils.deepClone(VIDEO_BID);
+        delete bid.mediaTypes.video;
+
+        expect(spec.isBidRequestValid(bid)).to.equal(false);
+      });
+
+      it('should reutrn false if player size is not set', () => {
+        const bid = utils.deepClone(VIDEO_BID);
+        delete bid.mediaTypes.video.playerSize;
+
+        expect(spec.isBidRequestValid(bid)).to.equal(false);
+      });
+
+      it('should use bidder video params if they are set', () => {
+        const videoBidWithParams = utils.deepClone(VIDEO_BID);
+        const bidderVideoParams = {
+          api: [1, 2],
+          mimes: ['video/mp4', 'video/x-flv'],
+          playbackmethod: [3, 4],
+          protocols: [5, 6],
+          placement: 1,
+          minduration: 0,
+          maxduration: 60,
+          w: 1024,
+          h: 768,
+          startdelay: 0
+        };
+
+        videoBidWithParams.params.video = bidderVideoParams;
+
+        const requests = spec.buildRequests([videoBidWithParams], BIDDER_REQUEST);
+        const request = requests[0].data;
+
+        expect(request.imp[0]).to.deep.include({
+          video: {
+            ...bidderVideoParams,
+            w: videoBidWithParams.mediaTypes.video.playerSize[0][0],
+            h: videoBidWithParams.mediaTypes.video.playerSize[0][1],
+          },
+        });
+      });
+    });
   });
 
-  describe('interpretResponse', function () {
-    it('has bids', function () {
-      let request = spec.buildRequests(REQUEST.bidRequest, REQUEST)[0];
-      let bids = spec.interpretResponse(RESPONSE, request);
-      expect(bids).to.be.an('array').that.is.not.empty;
-      validateBidOnIndex(0);
+  describe('interpretResponse()', function () {
+    context('when mediaType is banner', function () {
+      it('should correctly interpret valid banner response', function () {
+        const bid = utils.deepClone(BANNER_BID);
+        const [request] = spec.buildRequests([bid], BIDDER_REQUEST);
+        const response = utils.deepClone(BANNER_BID_RESPONSE);
 
-      function validateBidOnIndex(index) {
-        expect(bids[index]).to.have.property('currency', 'USD');
-        expect(bids[index]).to.have.property('requestId', RESPONSE.body.seatbid[0].bid[index].id);
-        expect(bids[index]).to.have.property('cpm', RESPONSE.body.seatbid[0].bid[index].price);
-        expect(bids[index]).to.have.property('width', RESPONSE.body.seatbid[0].bid[index].w);
-        expect(bids[index]).to.have.property('height', RESPONSE.body.seatbid[0].bid[index].h);
-        expect(bids[index]).to.have.property('ad', RESPONSE.body.seatbid[0].bid[index].adm);
-        expect(bids[index]).to.have.property('creativeId', RESPONSE.body.seatbid[0].bid[index].crid);
-        expect(bids[index]).to.have.property('ttl', 30);
-        expect(bids[index]).to.have.property('netRevenue', true);
-      }
-    });
+        const bids = spec.interpretResponse({ body: response }, request);
+        expect(bids).to.be.an('array').that.is.not.empty;
 
-    it('handles empty response', function () {
-      let request = spec.buildRequests(REQUEST.bidRequest, REQUEST)[0];
-      const EMPTY_RESP = Object.assign({}, RESPONSE, {'body': {}});
-      const bids = spec.interpretResponse(EMPTY_RESP, request);
-      expect(bids).to.be.empty;
+        expect(bids[0].mediaType).to.equal('banner');
+        expect(bids[0].burl).to.equal(BANNER_BID_RESPONSE.seatbid[0].bid[0].burl);
+        expect(bids[0].currency).to.equal('USD');
+        expect(bids[0].requestId).to.equal(BANNER_BID_RESPONSE.seatbid[0].bid[0].impid);
+        expect(bids[0].cpm).to.equal(BANNER_BID_RESPONSE.seatbid[0].bid[0].price);
+        expect(bids[0].width).to.equal(BANNER_BID_RESPONSE.seatbid[0].bid[0].w);
+        expect(bids[0].height).to.equal(BANNER_BID_RESPONSE.seatbid[0].bid[0].h);
+        expect(bids[0].ad).to.equal(BANNER_BID_RESPONSE.seatbid[0].bid[0].adm);
+        expect(bids[0].creativeId).to.equal(BANNER_BID_RESPONSE.seatbid[0].bid[0].crid);
+        expect(bids[0].meta.advertiserDomains[0]).to.equal('https://dummydomain.com');
+        expect(bids[0].ttl).to.equal(30);
+        expect(bids[0].netRevenue).to.equal(true);
+      });
+
+      it('should handle empty bid response', function () {
+        const bid = utils.deepClone(BANNER_BID);
+
+        let request = spec.buildRequests([bid], BIDDER_REQUEST)[0];
+        const EMPTY_RESP = Object.assign({}, BANNER_BID_RESPONSE, { 'body': {} });
+        const bids = spec.interpretResponse(EMPTY_RESP, request);
+        expect(bids).to.be.empty;
+      });
     });
+    if (FEATURES.VIDEO) {
+      context('when mediaType is video', function () {
+        it('should correctly interpret valid instream video response', () => {
+          const bid = utils.deepClone(VIDEO_BID);
+
+          const [request] = spec.buildRequests([bid], BIDDER_REQUEST);
+          const bids = spec.interpretResponse({ body: VIDEO_BID_RESPONSE }, request);
+          expect(bids).to.be.an('array').that.is.not.empty;
+
+          expect(bids[0].mediaType).to.equal('video');
+          expect(bids[0].burl).to.equal(VIDEO_BID_RESPONSE.seatbid[0].bid[0].burl);
+          expect(bids[0].currency).to.equal('USD');
+          expect(bids[0].requestId).to.equal(VIDEO_BID_RESPONSE.seatbid[0].bid[0].impid);
+          expect(bids[0].cpm).to.equal(VIDEO_BID_RESPONSE.seatbid[0].bid[0].price);
+          expect(bids[0].width).to.equal(VIDEO_BID_RESPONSE.seatbid[0].bid[0].w);
+          expect(bids[0].height).to.equal(VIDEO_BID_RESPONSE.seatbid[0].bid[0].h);
+          expect(bids[0].vastXml).to.equal(VIDEO_BID_RESPONSE.seatbid[0].bid[0].adm);
+          expect(bids[0].creativeId).to.equal(VIDEO_BID_RESPONSE.seatbid[0].bid[0].crid);
+          expect(bids[0].meta.advertiserDomains[0]).to.equal('https://dummydomain.com');
+          expect(bids[0].ttl).to.equal(30);
+          expect(bids[0].netRevenue).to.equal(true);
+        });
+      });
+    }
   });
 });

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -389,11 +389,11 @@ describe('IndexexchangeAdapter', function () {
         ext: {
           tid: '173f49a8-7549-4218-a23c-e7ba59b47230',
           data: {
-            pbadslot: 'div-gpt-ad-1460505748562-0'
+            pbadslot: 'div-gpt-ad-1460505748562-1'
           }
         }
       },
-      adUnitCode: 'div-gpt-ad-1460505748562-0',
+      adUnitCode: 'div-gpt-ad-1460505748562-1',
       transactionId: '273f49a8-7549-4218-a23c-e7ba59b47230',
       bidId: '1a2b3c4e',
       bidderRequestId: '11a22b33c44e',
@@ -2435,9 +2435,11 @@ describe('IndexexchangeAdapter', function () {
       bid1.bidId = '2f6g5s5e';
 
       const bid2 = utils.deepClone(bid1);
+      bid2.adUnitCode = 'div-gpt-2'
       bid2.transactionId = 'tr2';
       bid2.mediaTypes.banner.sizes = [[220, 221], [222, 223], [300, 250]];
       const bid3 = utils.deepClone(bid1);
+      bid3.adUnitCode = 'div-gpt-3'
       bid3.transactionId = 'tr3';
       bid3.mediaTypes.banner.sizes = [[330, 331], [332, 333], [300, 250]];
 

--- a/test/spec/modules/logicadBidAdapter_spec.js
+++ b/test/spec/modules/logicadBidAdapter_spec.js
@@ -35,7 +35,52 @@ describe('LogicadAdapter', function () {
           third: 'fakesharedid'
         }
       }]
-    }]
+    }],
+    ortb2: {
+      device: {
+        sua: {
+          source: 2,
+          platform: {
+            brand: 'Windows',
+            version: ['10', '0', '0']
+          },
+          browsers: [
+            {
+              brand: 'Chromium',
+              version: ['112', '0', '5615', '20']
+            },
+            {
+              brand: 'Google Chrome',
+              version: ['112', '0', '5615', '20']
+            },
+            {
+              brand: 'Not:A-Brand',
+              version: ['99', '0', '0', '0']
+            }
+          ],
+          mobile: 0,
+          model: '',
+          bitness: '64',
+          architecture: 'x86'
+        }
+      },
+      user: {
+        data: [
+          {
+            ext: {
+              segtax: 600,
+              segclass: '2206021246'
+            },
+            segment: [
+              {
+                id: '1'
+              }
+            ],
+            name: 'cd.ladsp.com'
+          }
+        ]
+      }
+    }
   }];
   const nativeBidRequests = [{
     bidder: 'logicad',
@@ -77,7 +122,52 @@ describe('LogicadAdapter', function () {
           third: 'fakesharedid'
         }
       }]
-    }]
+    }],
+    ortb2: {
+      device: {
+        sua: {
+          source: 2,
+          platform: {
+            brand: 'Windows',
+            version: ['10', '0', '0']
+          },
+          browsers: [
+            {
+              brand: 'Chromium',
+              version: ['112', '0', '5615', '20']
+            },
+            {
+              brand: 'Google Chrome',
+              version: ['112', '0', '5615', '20']
+            },
+            {
+              brand: 'Not:A-Brand',
+              version: ['99', '0', '0', '0']
+            }
+          ],
+          mobile: 0,
+          model: '',
+          bitness: '64',
+          architecture: 'x86'
+        }
+      },
+      user: {
+        data: [
+          {
+            ext: {
+              segtax: 600,
+              segclass: '2206021246'
+            },
+            segment: [
+              {
+                id: '1'
+              }
+            ],
+            name: 'cd.ladsp.com'
+          }
+        ]
+      }
+    }
   }];
   const bidderRequest = {
     refererInfo: {
@@ -184,6 +274,36 @@ describe('LogicadAdapter', function () {
       expect(data.auctionId).to.equal('18fd8b8b0bd757');
       expect(data.eids[0].source).to.equal('sharedid.org');
       expect(data.eids[0].uids[0].id).to.equal('fakesharedid');
+
+      expect(data.sua.source).to.equal(2);
+      expect(data.sua.platform.brand).to.equal('Windows');
+      expect(data.sua.platform.version[0]).to.equal('10');
+      expect(data.sua.platform.version[1]).to.equal('0');
+      expect(data.sua.platform.version[2]).to.equal('0');
+      expect(data.sua.browsers[0].brand).to.equal('Chromium');
+      expect(data.sua.browsers[0].version[0]).to.equal('112');
+      expect(data.sua.browsers[0].version[1]).to.equal('0');
+      expect(data.sua.browsers[0].version[2]).to.equal('5615');
+      expect(data.sua.browsers[0].version[3]).to.equal('20');
+      expect(data.sua.browsers[1].brand).to.equal('Google Chrome');
+      expect(data.sua.browsers[1].version[0]).to.equal('112');
+      expect(data.sua.browsers[1].version[1]).to.equal('0');
+      expect(data.sua.browsers[1].version[2]).to.equal('5615');
+      expect(data.sua.browsers[1].version[3]).to.equal('20');
+      expect(data.sua.browsers[2].brand).to.equal('Not:A-Brand');
+      expect(data.sua.browsers[2].version[0]).to.equal('99');
+      expect(data.sua.browsers[2].version[1]).to.equal('0');
+      expect(data.sua.browsers[2].version[2]).to.equal('0');
+      expect(data.sua.browsers[2].version[3]).to.equal('0');
+      expect(data.sua.mobile).to.equal(0);
+      expect(data.sua.model).to.equal('');
+      expect(data.sua.bitness).to.equal('64');
+      expect(data.sua.architecture).to.equal('x86');
+
+      expect(data.userData[0].name).to.equal('cd.ladsp.com');
+      expect(data.userData[0].segment[0].id).to.equal('1');
+      expect(data.userData[0].ext.segtax).to.equal(600);
+      expect(data.userData[0].ext.segclass).to.equal('2206021246');
     });
   });
 

--- a/test/spec/modules/richaudienceBidAdapter_spec.js
+++ b/test/spec/modules/richaudienceBidAdapter_spec.js
@@ -33,6 +33,37 @@ describe('Richaudience adapter tests', function () {
     user: {}
   }];
 
+  var DEFAULT_PARAMS_NEW_SIZES_GPID = [{
+    adUnitCode: 'test-div',
+    bidId: '2c7c8e9c900244',
+    ortb2Imp: {
+      ext: {
+        gpid: '/19968336/header-bid-tag-1#example-2',
+        data: {
+          pbadslot: '/19968336/header-bid-tag-1#example-2'
+        }
+      }
+    },
+    mediaTypes: {
+      banner: {
+        sizes: [
+          [300, 250], [300, 600], [728, 90], [970, 250]]
+      }
+    },
+    bidder: 'richaudience',
+    params: {
+      bidfloor: 0.5,
+      pid: 'ADb1f40rmi',
+      supplyType: 'site',
+      keywords: 'key1=value1;key2=value2'
+    },
+    auctionId: '0cb3144c-d084-4686-b0d6-f5dbe917c563',
+    bidRequestsCount: 1,
+    bidderRequestId: '1858b7382993ca',
+    transactionId: '29df2112-348b-4961-8863-1b33684d95e6',
+    user: {}
+  }];
+
   var DEFAULT_PARAMS_VIDEO_IN = [{
     adUnitCode: 'test-div',
     bidId: '2c7c8e9c900244',
@@ -240,6 +271,7 @@ describe('Richaudience adapter tests', function () {
     expect(requestContent).to.have.property('numIframes').and.to.equal(0);
     expect(typeof requestContent.scr_rsl === 'string')
     expect(typeof requestContent.cpuc === 'number')
+    expect(typeof requestContent.gpid === 'string')
     expect(requestContent).to.have.property('kws').and.to.equal('key1=value1;key2=value2');
   })
 
@@ -833,6 +865,18 @@ describe('Richaudience adapter tests', function () {
     })
     const requestContent = JSON.parse(request[0].data);
     expect(requestContent).to.have.property('schain').to.deep.equal(schain);
+  })
+
+  it('should pass gpid', function() {
+    const request = spec.buildRequests(DEFAULT_PARAMS_NEW_SIZES_GPID, {
+      gdprConsent: {
+        consentString: 'BOZcQl_ObPFjWAeABAESCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NohBgA',
+        gdprApplies: true
+      },
+      refererInfo: {}
+    })
+    const requestContent = JSON.parse(request[0].data);
+    expect(requestContent).to.have.property('gpid').and.to.equal('/19968336/header-bid-tag-1#example-2');
   })
 
   describe('userSync', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
To be compliant with Prebid 8 Privacy requirements, this PR updates IX adapter to not rely on transactionId anymore.

More details can be found here: https://github.com/prebid/Prebid.js/pull/9969

For more info, contact shahin.rahbariasl@indexexchange.com.