### PR TITLE
Brightcom, Brightcom SSP bid adapter: add iiq first party data support

### DIFF
--- a/modules/brightcomBidAdapter.js
+++ b/modules/brightcomBidAdapter.js
@@ -2,7 +2,7 @@ import { getBidIdParameter, _each, isArray, getWindowTop, getUniqueIdentifierStr
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
-import { bidderSettings } from "../src/bidderSettings.js";
+import { bidderSettings } from '../src/bidderSettings.js';
 
 const BIDDER_CODE = 'brightcom';
 const URL = 'https://brightcombid.marphezis.com/hb';

--- a/modules/brightcomSSPBidAdapter.js
+++ b/modules/brightcomSSPBidAdapter.js
@@ -15,6 +15,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER} from '../src/mediaTypes.js';
 import {config} from '../src/config.js';
 import {ajax} from '../src/ajax.js';
+import {bidderSettings} from '../src/bidderSettings.js';
 
 const BIDDER_CODE = 'bcmssp';
 const URL = 'https://rt.marphezis.com/hb';
@@ -110,6 +111,10 @@ function buildRequests(bidReqs, bidderRequest) {
 
     if (bidReqs?.[0].userId) {
       deepSetValue(payload, 'user.ext.ids', bidReqs[0].userId || [])
+    }
+
+    if (bidderSettings.get(BIDDER_CODE, 'storageAllowed')) {
+      deepSetValue(payload, 'user.ext.iiq', JSON.stringify(_getFirstPartyData()));
     }
 
     return {
@@ -317,6 +322,74 @@ function _getBidFloor(bid) {
     return floor.floor;
   }
   return null;
+}
+
+function _getFirstPartyData() {
+  const generateGUID = function () {
+    let d = new Date().getTime()
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+      const r = (d + Math.random() * 16) % 16 | 0
+      d = Math.floor(d / 16)
+      return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16)
+    })
+  };
+
+  const tryParse = function (data) {
+    try {
+      return JSON.parse(data)
+    } catch (err) {
+      return null;
+    }
+  };
+  const readData = function (key) {
+    try {
+      if (hasLocalStorage()) {
+        return window.localStorage.getItem(key)
+      }
+    } catch (error) {
+      return null;
+    }
+    return null
+  };
+
+  const storeData = function (key, value) {
+    try {
+      if (isDefined(value)) {
+        if (hasLocalStorage()) {
+          window.localStorage.setItem(key, value)
+        }
+      }
+    } catch (error) {
+      return null;
+    }
+  };
+  const hasLocalStorage = function () {
+    try {
+      return !!window.localStorage
+    } catch (e) {
+      return null;
+    }
+  }
+  const isDefined = function (val) {
+    return typeof val !== 'undefined' && val != null
+  };
+
+  const loadOrCreateFirstPartyData = function () {
+    var FIRST_PARTY_KEY = '_iiq_fdata';
+    var firstPartyData = tryParse(readData(FIRST_PARTY_KEY))
+    if (!firstPartyData || !firstPartyData.pcid) {
+      var firstPartyId = generateGUID()
+      firstPartyData = {pcid: firstPartyId, pcidDate: Date.now()}
+      storeData(FIRST_PARTY_KEY, JSON.stringify(firstPartyData))
+    } else if (firstPartyData && !firstPartyData.pcidDate) {
+      firstPartyData.pcidDate = Date.now()
+      storeData(FIRST_PARTY_KEY, JSON.stringify(firstPartyData))
+    }
+
+    return firstPartyData
+  };
+
+  return loadOrCreateFirstPartyData();
 }
 
 registerBidder(spec);

--- a/test/spec/modules/brightcomBidAdapter_spec.js
+++ b/test/spec/modules/brightcomBidAdapter_spec.js
@@ -12,6 +12,14 @@ describe('brightcomBidAdapter', function() {
   let bidRequests;
   let sandbox;
 
+  before(function() {
+    $$PREBID_GLOBAL$$.bidderSettings = {
+      bcmssp: {
+        storageAllowed: true
+      }
+    };
+  });
+
   beforeEach(function() {
     element = {
       x: 0,
@@ -324,6 +332,10 @@ describe('brightcomBidAdapter', function() {
         const payload = JSON.parse(request.data);
         expect(payload.imp[0].banner.ext.viewability).to.equal(0);
       });
+    });
+
+    it('should have storageAllowed set to true', function () {
+      expect($$PREBID_GLOBAL$$.bidderSettings.bcmssp.storageAllowed).to.be.true;
     });
   });
 

--- a/test/spec/modules/brightcomSSPBidAdapter_spec.js
+++ b/test/spec/modules/brightcomSSPBidAdapter_spec.js
@@ -12,6 +12,14 @@ describe('brightcomSSPBidAdapter', function() {
   let bidRequests;
   let sandbox;
 
+  before(function() {
+    $$PREBID_GLOBAL$$.bidderSettings = {
+      bcmssp: {
+        storageAllowed: true
+      }
+    };
+  });
+
   beforeEach(function() {
     element = {
       x: 0,
@@ -324,6 +332,10 @@ describe('brightcomSSPBidAdapter', function() {
         const payload = JSON.parse(request.data);
         expect(payload.imp[0].banner.ext.viewability).to.equal(0);
       });
+    });
+
+    it('should have storageAllowed set to true', function () {
+      expect($$PREBID_GLOBAL$$.bidderSettings.bcmssp.storageAllowed).to.be.true;
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
We have included support for first-party data (as an ID) in the iiq system. We will retrieve and save this data using local storage, but only if the "storageAllowed" setting is enabled

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->
