### PR TITLE
Mediasquare Bid Adapter: Avoid to run bidwon event on video impressions

### DIFF
--- a/modules/mediasquareBidAdapter.js
+++ b/modules/mediasquareBidAdapter.js
@@ -127,6 +127,9 @@ export const spec = {
             'advertiserDomains': value['adomain']
           }
         };
+        if ('context' in value) {
+          bidResponse['mediasquare']['context'] = value['context'];
+        }
         if ('match' in value) {
           bidResponse['mediasquare']['match'] = value['match'];
         }
@@ -173,13 +176,15 @@ export const spec = {
     // fires a pixel to confirm a winning bid
     let params = { pbjs: '$prebid.version$', referer: encodeURIComponent(getRefererInfo().page || getRefererInfo().topmostLocation) };
     let endpoint = document.location.search.match(/msq_test=true/) ? BIDDER_URL_TEST : BIDDER_URL_PROD;
-    let paramsToSearchFor = ['cpm', 'size', 'mediaType', 'currency', 'creativeId', 'adUnitCode', 'timeToRespond', 'requestId', 'auctionId', 'originalCpm', 'originalCurrency'];
+    let paramsToSearchFor = ['bidder', 'code', 'match', 'hasConsent', 'context'];
     if (bid.hasOwnProperty('mediasquare')) {
-      if (bid['mediasquare'].hasOwnProperty('bidder')) { params['bidder'] = bid['mediasquare']['bidder']; }
-      if (bid['mediasquare'].hasOwnProperty('code')) { params['code'] = bid['mediasquare']['code']; }
-      if (bid['mediasquare'].hasOwnProperty('match')) { params['match'] = bid['mediasquare']['match']; }
-      if (bid['mediasquare'].hasOwnProperty('hasConsent')) { params['hasConsent'] = bid['mediasquare']['hasConsent']; }
+      for (let i = 0; i < paramsToSearchFor.length; i++) {
+        if (bid['mediasquare'].hasOwnProperty(paramsToSearchFor[i])) {
+          params[paramsToSearchFor[i]] = bid['mediasquare'][paramsToSearchFor[i]];
+        }
+      }
     };
+    paramsToSearchFor = ['cpm', 'size', 'mediaType', 'currency', 'creativeId', 'adUnitCode', 'timeToRespond', 'requestId', 'auctionId', 'originalCpm', 'originalCurrency'];
     for (let i = 0; i < paramsToSearchFor.length; i++) {
       if (bid.hasOwnProperty(paramsToSearchFor[i])) {
         params[paramsToSearchFor[i]] = bid[paramsToSearchFor[i]];

--- a/modules/mediasquareBidAdapter.js
+++ b/modules/mediasquareBidAdapter.js
@@ -174,8 +174,9 @@ export const spec = {
      */
   onBidWon: function(bid) {
     // fires a pixel to confirm a winning bid
-    if (bid.hasOwnProperty('mediaType') && bid.mediaType == 'video')
+    if (bid.hasOwnProperty('mediaType') && bid.mediaType == 'video') {
       return;
+    }
     let params = { pbjs: '$prebid.version$', referer: encodeURIComponent(getRefererInfo().page || getRefererInfo().topmostLocation) };
     let endpoint = document.location.search.match(/msq_test=true/) ? BIDDER_URL_TEST : BIDDER_URL_PROD;
     let paramsToSearchFor = ['bidder', 'code', 'match', 'hasConsent', 'context'];

--- a/modules/mediasquareBidAdapter.js
+++ b/modules/mediasquareBidAdapter.js
@@ -174,6 +174,8 @@ export const spec = {
      */
   onBidWon: function(bid) {
     // fires a pixel to confirm a winning bid
+    if (bid.hasOwnProperty('mediaType') && bid.mediaType == 'video')
+      return;
     let params = { pbjs: '$prebid.version$', referer: encodeURIComponent(getRefererInfo().page || getRefererInfo().topmostLocation) };
     let endpoint = document.location.search.match(/msq_test=true/) ? BIDDER_URL_TEST : BIDDER_URL_PROD;
     let paramsToSearchFor = ['bidder', 'code', 'match', 'hasConsent', 'context'];

--- a/test/spec/modules/mediasquareBidAdapter_spec.js
+++ b/test/spec/modules/mediasquareBidAdapter_spec.js
@@ -98,6 +98,7 @@ describe('MediaSquare bid adapter tests', function () {
       'code': 'test/publishername_atf_desktop_rg_pave',
       'bid_id': 'aaaa1234',
       'adomain': ['test.com'],
+      'context': 'instream',
     }],
   }};
 
@@ -161,7 +162,10 @@ describe('MediaSquare bid adapter tests', function () {
     expect(bid.ttl).to.equal(300);
     expect(bid.requestId).to.equal('aaaa1234');
     expect(bid.mediasquare).to.exist;
+    expect(bid.mediasquare.bidder).to.exist;
     expect(bid.mediasquare.bidder).to.equal('msqClassic');
+    expect(bid.mediasquare.context).to.exist;
+    expect(bid.mediasquare.context).to.equal('instream');
     expect(bid.mediasquare.code).to.equal([DEFAULT_PARAMS[0].params.owner, DEFAULT_PARAMS[0].params.code].join('/'));
     expect(bid.meta).to.exist;
     expect(bid.meta.advertiserDomains).to.exist;


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
We already track video impression though vast even so running bidwon event makes it a duplicate event.