### PR TITLE
prebid 8 - read ortb segment data in appnexus keywords library functions

### DIFF
--- a/libraries/appnexusKeywords/anKeywords.js
+++ b/libraries/appnexusKeywords/anKeywords.js
@@ -3,7 +3,6 @@ import {getAllOrtbKeywords} from '../keywords/keywords.js';
 import {CLIENT_SECTIONS} from '../../src/fpd/oneClient.js';
 
 const ORTB_SEGTAX_KEY_MAP = {
-  0: null,
   526: '1plusx',
   527: '1plusx',
   541: 'captify_segments',
@@ -124,7 +123,7 @@ export function getANMapFromOrtbSegments(ortb2) {
     let ortbSegsArrObj = deepAccess(ortb2, path) || [];
     ortbSegsArrObj.forEach(segObj => {
       // only read segment data from known sources
-      const segtax = ORTB_SEGTAX_KEY_MAP[deepAccess(segObj, 'ext.segtax') || 0];
+      const segtax = ORTB_SEGTAX_KEY_MAP[deepAccess(segObj, 'ext.segtax')];
       if (segtax) {
         segObj.segment.forEach(seg => {
           // if source was in multiple locations of ortb or had multiple segments in same area, stack them together into an array

--- a/libraries/appnexusKeywords/anKeywords.js
+++ b/libraries/appnexusKeywords/anKeywords.js
@@ -1,5 +1,17 @@
-import {_each, getValueString, isArray, isStr, mergeDeep, isNumber} from '../../src/utils.js';
+import {_each, deepAccess, getValueString, isArray, isStr, mergeDeep, isNumber} from '../../src/utils.js';
 import {getAllOrtbKeywords} from '../keywords/keywords.js';
+import {CLIENT_SECTIONS} from '../../src/fpd/oneClient.js';
+
+const ORTB_SEGTAX_KEY_MAP = {
+  0: null,
+  526: '1plusx',
+  527: '1plusx',
+  541: 'captify_segments',
+  540: 'perid'
+};
+const ORTB_SEG_PATHS = ['user.data'].concat(
+  CLIENT_SECTIONS.map((prefix) => `${prefix}.content.data`)
+);
 
 /**
  * Converts an object of arrays (either strings or numbers) into an array of objects containing key and value properties
@@ -85,7 +97,7 @@ function convertKeywordsToANMap(kwarray) {
  * @param ortb2
  * @return {{}} appnexus-style keyword map using all keywords contained in ortb2
  */
-export function getANMapFromOrtb(ortb2) {
+export function getANMapFromOrtbKeywords(ortb2) {
   return convertKeywordsToANMap(getAllOrtbKeywords(ortb2));
 }
 
@@ -100,7 +112,30 @@ export function getANKewyordParamFromMaps(...anKeywordMaps) {
 
 export function getANKeywordParam(ortb2, ...anKeywordsMaps) {
   return getANKewyordParamFromMaps(
-    getANMapFromOrtb(ortb2),
+    getANMapFromOrtbKeywords(ortb2),
+    getANMapFromOrtbSegments(ortb2),
     ...anKeywordsMaps
   )
+}
+
+export function getANMapFromOrtbSegments(ortb2) {
+  let ortbSegData = {};
+  ORTB_SEG_PATHS.forEach(path => {
+    let ortbSegsArrObj = deepAccess(ortb2, path) || [];
+    ortbSegsArrObj.forEach(segObj => {
+      // only read segment data from known sources
+      const segtax = ORTB_SEGTAX_KEY_MAP[deepAccess(segObj, 'ext.segtax') || 0];
+      if (segtax) {
+        segObj.segment.forEach(seg => {
+          // if source was in multiple locations of ortb or had multiple segments in same area, stack them together into an array
+          if (ortbSegData[segtax]) {
+            ortbSegData[segtax].push(seg.id);
+          } else {
+            ortbSegData[segtax] = [seg.id]
+          }
+        });
+      }
+    });
+  });
+  return ortbSegData;
 }

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -784,6 +784,69 @@ describe('AppNexusAdapter', function () {
       config.getConfig.restore();
     });
 
+    it('adds ortb2 segments to auction request as keywords', function() {
+      let bidRequest = Object.assign({}, bidRequests[0]);
+      const bidderRequest = {
+        ortb2: {
+          site: {
+            keywords: 'drill',
+            content: {
+              data: [{
+                name: 'siteseg1',
+                ext: {
+                  segtax: 540
+                },
+                segment: [{
+                  id: 's123',
+                }, {
+                  id: 's234'
+                }]
+              }, {
+                name: 'sitseg2',
+                ext: {
+                  segtax: 1
+                },
+                segment: [{
+                  id: 'unknown'
+                }]
+              }, {
+                name: 'siteseg3',
+                ext: {
+                  segtax: 526
+                },
+                segment: [{
+                  id: 'dog'
+                }]
+              }]
+            }
+          },
+          user: {
+            data: [{
+              name: 'userseg1',
+              ext: {
+                segtax: 526
+              },
+              segment: [{
+                id: 'cat'
+              }]
+            }]
+          }
+        }
+      };
+      const request = spec.buildRequests([bidRequest], bidderRequest);
+      const payload = JSON.parse(request.data);
+
+      expectKeywords(payload.keywords, [{
+        'key': 'drill'
+      }, {
+        'key': '1plusx',
+        'value': ['cat', 'dog']
+      }, {
+        'key': 'perid',
+        'value': ['s123', 's234']
+      }]);
+    });
+
     if (FEATURES.NATIVE) {
       it('should attach native params to the request', function () {
         let bidRequest = Object.assign({},


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
This change allows for a way to read ortb2 segment data (from the various possible locations in the ortb2 object) from identified recognized sources (based on `segtax` values) and have the segment data be transformed into a keypair format.  

This approach is based on the existing logic that several RtdProviders used to work for the appnexusBidAdapter; so it should not be entirely new functionality, just formalizing it into a central place (outside of the RtdProviders, which was a need for Prebid 8.0).

**NOTE** The values in the `segtax` map were guesses on my part from some conversations.  If there are other values that should be used, please clarify it here.

Making this a draft PR for now, in case there's a better approach to this change.