### PR TITLE
Greenbids Analytics Adapter : fix double sampling

### DIFF
--- a/modules/greenbidsAnalyticsAdapter.js
+++ b/modules/greenbidsAnalyticsAdapter.js
@@ -44,10 +44,6 @@ export const greenbidsAnalyticsAdapter = Object.assign(adapter({ANALYTICS_SERVER
       logError('"options.pbuid" is required.');
       return false;
     }
-    analyticsOptions.sampled = true;
-    if (typeof config.options.sampling === 'number') {
-      analyticsOptions.sampled = Math.random() < parseFloat(config.options.sampling);
-    }
 
     analyticsOptions.pbuid = config.options.pbuid
     analyticsOptions.server = ANALYTICS_SERVER;
@@ -149,15 +145,13 @@ export const greenbidsAnalyticsAdapter = Object.assign(adapter({ANALYTICS_SERVER
     });
   },
   track({eventType, args}) {
-    if (analyticsOptions.sampled) {
-      switch (eventType) {
-        case BID_TIMEOUT:
-          this.handleBidTimeout(args);
-          break;
-        case AUCTION_END:
-          this.handleAuctionEnd(args);
-          break;
-      }
+    switch (eventType) {
+      case BID_TIMEOUT:
+        this.handleBidTimeout(args);
+        break;
+      case AUCTION_END:
+        this.handleAuctionEnd(args);
+        break;
     }
   },
   getAnalyticsOptions() {

--- a/test/spec/modules/greenbidsAnalyticsAdapter_spec.js
+++ b/test/spec/modules/greenbidsAnalyticsAdapter_spec.js
@@ -389,7 +389,7 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
     it('should parse config correctly with optional values', function () {
       expect(greenbidsAnalyticsAdapter.getAnalyticsOptions().options).to.deep.equal(configOptions);
       expect(greenbidsAnalyticsAdapter.getAnalyticsOptions().pbuid).to.equal(configOptions.pbuid);
-      expect(greenbidsAnalyticsAdapter.getAnalyticsOptions().sampled).to.equal(false);
+      expect(greenbidsAnalyticsAdapter.getAnalyticsOptions().sampling).to.equal(0);
     });
 
     it('should not enable Analytics when pbuid is missing', function () {
@@ -399,20 +399,6 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
       };
       const validConfig = greenbidsAnalyticsAdapter.initConfig(configOptions);
       expect(validConfig).to.equal(false);
-    });
-    it('should fall back to default value when sampling factor is not number', function () {
-      const configOptions = {
-        options: {
-          pbuid: pbuid,
-          sampling: 'string',
-        }
-      };
-      greenbidsAnalyticsAdapter.enableAnalytics({
-        provider: 'greenbidsAnalytics',
-        options: configOptions
-      });
-
-      expect(greenbidsAnalyticsAdapter.getAnalyticsOptions().sampled).to.equal(false);
     });
   });
 });

--- a/test/spec/modules/greenbidsAnalyticsAdapter_spec.js
+++ b/test/spec/modules/greenbidsAnalyticsAdapter_spec.js
@@ -389,7 +389,6 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
     it('should parse config correctly with optional values', function () {
       expect(greenbidsAnalyticsAdapter.getAnalyticsOptions().options).to.deep.equal(configOptions);
       expect(greenbidsAnalyticsAdapter.getAnalyticsOptions().pbuid).to.equal(configOptions.pbuid);
-      expect(greenbidsAnalyticsAdapter.getAnalyticsOptions().sampling).to.equal(0);
     });
 
     it('should not enable Analytics when pbuid is missing', function () {


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
The sampling of the analytics module was done twice, once in the adapter and once in the generic AnalyticsAdapter.js file which is called by the module, leading the global sampling factor to be squared.

This PR removes the double sampling and only keeps the one from the generic AnalyticsAdapter.js file.
