### PR TITLE
[Weborama RTD Submodule] Fix appnexus implementation

### DIFF
--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -47,6 +47,8 @@
  * @property {?setPrebidTargetingCallback|?boolean|?Object} setPrebidTargeting if true, will set the GAM targeting (default undefined)
  * @property {?sendToBiddersCallback|?boolean|?Object} sendToBidders if true, will send the contextual profile to all bidders, else expects a list of allowed bidders (default undefined)
  * @property {?dataCallback} onData callback
+ * @property {?string|?string[]|?Object.<string,boolean>} setProfileAsBidderKeywords specifies one or more bidders to send data as keywords ('site.content.keywords' or 'user.keywords'). Default is 'appnexus'.
+ * @property {?boolean} checkBidderAliasForKeywords if true, will check for exact bidder name or using the alias registry. Default is 'true'.
  * @property {?WeboCtxConf} weboCtxConf site-centric contextual configuration
  * @property {?WeboUserDataConf} weboUserDataConf user-centric wam configuration
  * @property {?SfbxLiteDataConf} sfbxLiteDataConf site-centric lite configuration
@@ -67,6 +69,8 @@
  * @property {?Profile} defaultProfile to be used if the profile is not found
  * @property {?boolean} enabled if false, will ignore this configuration
  * @property {?string} baseURLProfileAPI to be used to point to a different domain than ctx.weborama.com
+ * @property {?string|?string[]|?Object.<string,boolean>} setProfileAsBidderKeywords specifies one or more bidders to send data as keywords ('site.content.keywords' or 'user.keywords'). Default is 'appnexus'.
+ * @property {?boolean} checkBidderAliasForKeywords if true, will check for exact bidder name or using the alias registry. Default is 'true'.
  */
 
 /**
@@ -78,6 +82,8 @@
  * @property {?dataCallback} onData callback
  * @property {?string} localStorageProfileKey can be used to customize the local storage key (default is 'webo_wam2gam_entry')
  * @property {?boolean} enabled if false, will ignore this configuration
+ * @property {?string|?string[]|?Object.<string,boolean>} setProfileAsBidderKeywords specifies one or more bidders to send data as keywords ('site.content.keywords' or 'user.keywords'). Default is 'appnexus'.
+ * @property {?boolean} checkBidderAliasForKeywords if true, will check for exact bidder name or using the alias registry. Default is 'true'.
  */
 
 /**
@@ -88,6 +94,8 @@
  * @property {?dataCallback} onData callback
  * @property {?string} localStorageProfileKey can be used to customize the local storage key (default is '_lite')
  * @property {?boolean} enabled if false, will ignore this configuration
+ * @property {?string|?string[]|?Object.<string,boolean>} setProfileAsBidderKeywords specifies one or more bidders to send data as keywords ('site.content.keywords' or 'user.keywords'). Default is 'appnexus'.
+ * @property {?boolean} checkBidderAliasForKeywords if true, will check for exact bidder name or using the alias registry. Default is 'true'.
  */
 
 /** common configuration between contextual, wam and sfbx
@@ -152,6 +160,8 @@ const WEBO_USER_DATA_SOURCE_LABEL = 'wam';
 const SFBX_LITE_DATA_SOURCE_LABEL = 'lite';
 /** @type {number} */
 const GVLID = 284;
+/** @type {string} */
+const BIDDER_APPNEXUS = 'appnexus'
 
 export const storage = getStorageManager({
   moduleType: MODULE_TYPE_RTD,
@@ -199,6 +209,8 @@ class WeboramaRtdProvider {
     const globalDefaults = {
       setPrebidTargeting: true,
       sendToBidders: true,
+      setProfileAsBidderKeywords: [BIDDER_APPNEXUS],
+      checkBidderAliasForKeywords: true,
       onData: () => {
         /* do nothing */
       }
@@ -304,24 +316,25 @@ class WeboramaRtdProvider {
    */
   #initSubSection(moduleParams, subSection, ...requiredFields) {
     /** @type {CommonConf} */
-    const weboSectionConf = moduleParams[subSection] || { enabled: false };
+    const subSectionConf = moduleParams[subSection] || { enabled: false };
 
-    if (weboSectionConf.enabled === false) {
+    if (subSectionConf.enabled === false) {
       delete moduleParams[subSection];
 
       return false;
     }
 
     try {
-      this.#normalizeConf(moduleParams, weboSectionConf);
+      this.#normalizeConf(moduleParams, subSectionConf);
 
       requiredFields.forEach(field => {
-        if (!(field in weboSectionConf)) {
+        if (!(field in subSectionConf)) {
           throw `missing required field '${field}''`;
         }
       });
     } catch (e) {
       logError(`unable to initialize: error on ${subSection} configuration:`, e);
+
       return false;
     }
 
@@ -342,10 +355,16 @@ class WeboramaRtdProvider {
   #normalizeConf(moduleParams, submoduleParams) {
     submoduleParams.defaultProfile = submoduleParams.defaultProfile || {};
 
-    const { setPrebidTargeting, sendToBidders, onData } = moduleParams;
+    const { setPrebidTargeting,
+      sendToBidders,
+      setProfileAsBidderKeywords,
+      checkBidderAliasForKeywords,
+      onData } = moduleParams;
 
     submoduleParams.setPrebidTargeting ??= setPrebidTargeting;
     submoduleParams.sendToBidders ??= sendToBidders;
+    submoduleParams.setProfileAsBidderKeywords ??= setProfileAsBidderKeywords;
+    submoduleParams.checkBidderAliasForKeywords ??= !!checkBidderAliasForKeywords;
     submoduleParams.onData ??= onData;
 
     // handle setPrebidTargeting
@@ -354,12 +373,19 @@ class WeboramaRtdProvider {
     // handle sendToBidders
     this.#coerceSendToBidders(submoduleParams);
 
+    // handle setProfileAsBidderKeywords
+    this.#coerceSetProfileAsBidderKeywords(submoduleParams)
+
     if (!isFn(submoduleParams.onData)) {
       throw 'onData parameter should be a callback';
     }
 
     if (!isValidProfile(submoduleParams.defaultProfile)) {
       throw 'defaultProfile is not valid';
+    }
+
+    if (!isBoolean(submoduleParams.checkBidderAliasForKeywords)) {
+      throw 'checkBidderAliasForKeywords parameter should be a boolean';
     }
   }
 
@@ -422,6 +448,31 @@ class WeboramaRtdProvider {
     }
   }
 
+  /** coerce setProfileAsBidderKeywords to a map
+   * @method
+   * @private
+   * @param {CommonConf} submoduleParams
+   * @return {void}
+   * @throws will throw an error in case of invalid configuration
+   */
+  // eslint-disable-next-line no-dupe-class-members
+  #coerceSetProfileAsBidderKeywords(submoduleParams) {
+    let setProfileAsBidderKeywords = submoduleParams.setProfileAsBidderKeywords;
+
+    if (isStr(setProfileAsBidderKeywords)) {
+      setProfileAsBidderKeywords = {[setProfileAsBidderKeywords]: true};
+    } else if (isArray(setProfileAsBidderKeywords)) {
+      setProfileAsBidderKeywords = setProfileAsBidderKeywords.reduce((m, bidder) => {
+        m[bidder] = true
+        return m;
+      }, {});
+    } else if (!isPlainObject(setProfileAsBidderKeywords)) {
+      throw `invalid setProfileAsBidderKeywords: expect an object, array of strings or a single string`;
+    }
+
+    submoduleParams.setProfileAsBidderKeywords = setProfileAsBidderKeywords;
+  }
+
   /**
    * @typedef {Object} AdUnit
    * @property {Object[]} bids
@@ -457,7 +508,10 @@ class WeboramaRtdProvider {
             if (ph.sendToBidders(bid, adUnit.code, data, metadata)) {
               // logMessage(`handling bidder '${bid.bidder}' with ${ph.metadata.source} data`);
 
-              this.#handleBid(reqBidsConfigObj, bid, data, ph.metadata);
+              this.#handleBid(reqBidsConfigObj, bid, data, ph.metadata, {
+                setBidderKeywords: ph.setProfileAsBidderKeywords,
+                checkBidderAlias: !!ph.checkBidderAliasForKeywords,
+              });
             }
           })
         )
@@ -620,6 +674,8 @@ class WeboramaRtdProvider {
    * @property {setPrebidTargetingCallback} setTargeting
    * @property {sendToBiddersCallback} sendToBidders
    * @property {dataCallback} onData
+   * @property {?Object.<string,boolean>} setProfileAsBidderKeywords
+   * @property {boolean} checkBidderAliasForKeywords
    */
 
   /**
@@ -664,9 +720,12 @@ class WeboramaRtdProvider {
       },
       setTargeting: dataConf.setPrebidTargeting,
       sendToBidders: dataConf.sendToBidders,
+      setProfileAsBidderKeywords: dataConf.setProfileAsBidderKeywords,
+      checkBidderAliasForKeywords: !!dataConf.checkBidderAliasForKeywords,
       onData: dataConf.onData,
     };
   }
+
   /** handle individual bid
    * @method
    * @private
@@ -677,19 +736,28 @@ class WeboramaRtdProvider {
    * @param {string} bid.bidder
    * @param {Profile} profile
    * @param {dataCallbackMetadata} metadata
+   * @param {Object} extraConf
+   * @param {Object.<string,boolean>} extraConf.setBidderKeywords
+   * @param {boolean} extraConf.checkBidderAlias
    * @returns {void}
    */
   // eslint-disable-next-line no-dupe-class-members
-  #handleBid(reqBidsConfigObj, bid, profile, metadata) {
+  #handleBid(reqBidsConfigObj, bid, profile, metadata, extraConf) {
     this.#handleBidViaORTB2(reqBidsConfigObj, bid.bidder, profile, metadata);
 
     /** @type {Object.<string,string>} */
     const bidderAliasRegistry = adapterManager.aliasRegistry || {};
 
-    /** @type {string} */
-    const BIDDER_APPNEXUS = 'appnexus'
+    /** @type {boolean} */
+    let shouldSetProfileAsKeywords = !!extraConf.setBidderKeywords[bid.bidder];
 
-    if (bid.bidder === BIDDER_APPNEXUS || bidderAliasRegistry[bid.bidder] === BIDDER_APPNEXUS) {
+    if (!shouldSetProfileAsKeywords && extraConf.checkBidderAlias) {
+      const originalBidder = bidderAliasRegistry[bid.bidder];
+
+      shouldSetProfileAsKeywords = !!extraConf.setBidderKeywords[originalBidder];
+    }
+
+    if (shouldSetProfileAsKeywords) {
       this.#handleORTB2KeywordsData(reqBidsConfigObj, bid, profile, metadata);
     }
   }

--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -720,8 +720,6 @@ class WeboramaRtdProvider {
    */
   // eslint-disable-next-line no-dupe-class-members
   #handleORTB2KeywordsData(reqBidsConfigObj, bid, profile, metadata) {
-    this.#assignProfileToObject(bid, 'params.keywords', profile);
-
     const target = new Set();
 
     Object.entries(profile).forEach(([key, values]) => {

--- a/modules/weboramaRtdProvider.md
+++ b/modules/weboramaRtdProvider.md
@@ -98,6 +98,8 @@ This is the main configuration section
 | params.weboUserDataConf | Object | Weborama WAM User-Centric Configuration | Optional |
 | params.sfbxLiteDataConf | Object | Sfbx LiTE Site-Centric Configuration | Optional |
 | params.onData | Callback | If set, will receive the profile and metadata | Optional. Affects the `weboCtxConf`, `weboUserDataConf` and `sfbxLiteDataConf` sections |
+| params.setProfileAsBidderKeywords | Object | If present, specify one or more bidders to send data also as keywords (`site.content.keywords` or `user.keywords`) | Optional. Affects the `weboCtxConf`, `weboUserDataConf` and `sfbxLiteDataConf` sections  |
+| params.checkBidderAliasForKeywords | Boolean | Modify `params.setProfileAsBidderKeywords` to search in the bidder alias registry| Optional. Affects the `weboCtxConf`, `weboUserDataConf` and `sfbxLiteDataConf` sections  |
 
 #### Contextual Site-Centric Configuration
 
@@ -116,6 +118,8 @@ On this section we will explain the `params.weboCtxConf` subconfiguration:
 | onData | Callback | If set, will receive the profile and metadata | Optional. Default is `params.onData` (if any) or log via prebid debug |
 | enabled | Boolean| if false, will ignore this configuration| Default is `true` if this section is present|
 | baseURLProfileAPI | String| if present, update the domain of the contextual api| Optional. Default is `ctx.weborama.com` |
+| setProfileAsBidderKeywords | String or Array | If present, specify one or more bidders to send data also as keywords (`site.content.keywords` or `user.keywords`) | Optional. Default is `appnexus`. |
+| checkBidderAliasForKeywords | Boolean | Modify `setProfileAsBidderKeywords` to search in the bidder alias registry. | Optional. Default is `true` |
 
 #### WAM User-Centric Configuration
 
@@ -133,6 +137,8 @@ On this section we will explain the `params.weboUserDataConf` subconfiguration:
 | defaultProfile | Object | default value of the profile to be used when there are no response from contextual api (such as timeout)| Optional. Default is `{}` |
 | localStorageProfileKey| String | can be used to customize the local storage key | Optional |
 | enabled | Boolean| if false, will ignore this configuration| Default is `true` if this section is present|
+| setProfileAsBidderKeywords | String or Array | If present, specify one or more bidders to send data also as keywords (`site.content.keywords` or `user.keywords`) | Optional. Default is `appnexus`. |
+| checkBidderAliasForKeywords | Boolean | Modify `setProfileAsBidderKeywords` to search in the bidder alias registry. | Optional. Default is `true` |
 
 #### Sfbx LiTE Site-Centric Configuration
 
@@ -148,6 +154,8 @@ On this section we will explain the `params.sfbxLiteDataConf` subconfiguration:
 | defaultProfile | Object | default value of the profile to be used when there are no response from contextual api (such as timeout)| Optional. Default is `{}` |
 | localStorageProfileKey| String | can be used to customize the local storage key | Optional |
 | enabled | Boolean| if false, will ignore this configuration| Default is `true` if this section is present|
+| setProfileAsBidderKeywords | String or Array | If present, specify one or more bidders to send data also as keywords (`site.content.keywords` or `user.keywords`) | Optional. Default is `appnexus`. |
+| checkBidderAliasForKeywords | Boolean | Modify `setProfileAsBidderKeywords` to search in the bidder alias registry. | Optional. Default is `true` |
 
 ##### Property setPrebidTargeting supported types
 
@@ -156,9 +164,9 @@ This property support the following types
 | Type  | Description | Example   | Notes  |
 | :------------ | :------------ | :------------ |:------------ |
 | Boolean|If true, set prebid targeting for all adunits, or not in case of false| `true` | default value |
-| String|Will set prebid targeting only for one adunit | `'adUnitCode1'` |  |
-| Array of Strings|Will set prebid targeting only for some adunits| `['adUnitCode1','adUnitCode2']` |  |
-| Callback |Will be executed for each adunit, expects return a true value to set prebid targeting or not| `function(adUnitCode){return adUnitCode == 'adUnitCode';}` |  |
+| String|Will set prebid targeting only for one adunit | `'adUnitCode1'` | **DEPRECATED** |
+| Array of Strings|Will set prebid targeting only for some adunits| `['adUnitCode1','adUnitCode2']` | **DEPRECATED** |
+| Callback |Will be executed for each adunit, expects return a true value to set prebid targeting or not| `function(adUnitCode){return adUnitCode == 'adUnitCode';}` | **DEPRECATED** |
 
 The complete callback function signature is:
 
@@ -168,26 +176,7 @@ setPrebidTargeting: function(adUnitCode, data, metadata){
 }
 ```
 
-This callback will be executed with the adUnitCode, profile and a metadata with the following fields
-
-| Name  |Type | Description   | Notes  |
-| :------------ | :------------ | :------------ |:------------ |
-| user | Boolean | If true, it contains user-centric data |  |
-| source | String | Represent the source of data | can be `contextual`, `wam` or `lite`  |
-| isDefault | Boolean | If true, it contains the default profile defined in the configuration |  |
-
-It is possible customize the targeting based on the parameters:
-
-```javascript
-setPrebidTargeting: function(adUnitCode, data, metadata){
-    // check metadata.source can be omitted if defined in params.weboUserDataConf
-    if (adUnitCode == 'adUnitCode1' && metadata.source == 'wam'){
-        data['foo']=['bar'];  // add this section only for adUnitCode1
-        delete data['other']; // remove this section
-    }
-    return true;
-}
-```
+Since `Prebid.js` version 8, we use First Party Data Support to propagate data to differente SSPs. We will deprecate the support to other formats than Boolean.
 
 ##### Property sendToBidders supported types
 
@@ -198,8 +187,8 @@ This property support the following types
 | Boolean|If true, send data to all bidders, or not in case of false| `true` | default value |
 | String|Will send data to only one bidder | `'appnexus'` |  |
 | Array of Strings|Will send data to only some bidders | `['appnexus','pubmatic']` |  |
-| Object |Will send data to only some bidders and some ad units | `{appnexus: true, pubmatic:['adUnitCode1']}` |  |
-| Callback |Will be executed for each adunit, expects return a true value to set prebid targeting or not| `function(bid, adUnitCode){return bid.bidder == 'appnexus' && adUnitCode == 'adUnitCode';}` |  |
+| Object |Will send data to only some bidders and some ad units | `{appnexus: true, pubmatic:['adUnitCode1']}` | **DEPRECATED** |
+| Callback |Will be executed for each adunit, expects return a true value to set prebid targeting or not| `function(bid, adUnitCode){return bid.bidder == 'appnexus' && adUnitCode == 'adUnitCode';}` | the parameter `adUnitCode` can be consider **DEPRECATED** |
 
 A better look on the `Object` type
 
@@ -218,7 +207,7 @@ sendToBidders: function(bid, adUnitCode, data, metadata){
 }
 ```
 
-This callback will be executed with the bid object (contains a field `bidder` with name), adUnitCode, profile and a metadata with the following fields
+This callback will be executed with the bid object (contains a field `bidder` with name), adUnitCode (**deprecated**), profile and a metadata with the following fields
 
 | Name  |Type | Description   | Notes  |
 | :------------ | :------------ | :------------ |:------------ |
@@ -230,13 +219,15 @@ It is possible customize the targeting based on the parameters:
 
 ```javascript
 sendToBidders: function(bid, adUnitCode, data, metadata){
-    if (bid.bidder == 'appnexus' && adUnitCode == 'adUnitCode1'){
+    if (bid.bidder == 'appnexus'){
         data['foo']=['bar']; // add this section only for appnexus + adUnitCode1
         delete data['other']; // remove this section
     }
     return true;
 }
 ```
+
+Since `Prebid.js` version 8, we use First Party Data Support to propagate data to differente SSPs. We will deprecate the support to formats that thandle with `adUnitCode` at some point.
 
 To be possible customize the way we send data to bidders via this callback:
 
@@ -537,10 +528,10 @@ pbjs.que.push(function () {
                     },
                     weboUserDataConf: {
                         accountId: 12345,           // recommended
-                        setPrebidTargeting: ['adUnitCode1',...], // set target only on certain adunits 
+                        setPrebidTargeting: true 
                         sendToBidders: { // send to only some bidders and adunits
-                            'appnexus': true,               // all adunits for appnexus 
-                            'pubmatic': ['adUnitCode1',...] // some adunits for pubmatic
+                            'appnexus': true,               // enable appnexus 
+                            'pubmatic': false               // explicit disable pubmatic
                             // other bidders will be ignored
                         },
                         defaultProfile: {           // optional
@@ -552,11 +543,9 @@ pbjs.que.push(function () {
                         //, onData: function (data, ...) { ...}
                     },
                     sfbxLiteDataConf: {
-                        setPrebidTargeting: function(adUnitCode){ // specify set target via callback
-                            return adUnitCode == 'adUnitCode1';
-                        },
+                        setPrebidTargeting: true,
                         sendToBidders: function(bid, adUnitCode){ // specify sendToBidders via callback
-                            return bid.bidder == 'appnexus' && adUnitCode == 'adUnitCode1';
+                            return bid.bidder == 'appnexus';
                         }
                         defaultProfile: {           // optional
                             lite_occupation: ['gérant', 'bénévole'],
@@ -575,7 +564,7 @@ pbjs.que.push(function () {
 
 ### Supported Bidders
 
-We currently support the following bidder adapters with dedicated code:
+We currently support the following bidder adapters using `First Party Data Support` but using ortb2 keywords `site.content.keywords` and`user.keywords`:
 
 * AppNexus SSP
 

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -733,6 +733,36 @@ describe('weboramaRtdProvider', function() {
             };
             const adUnitCode1 = 'adunit1';
             const adUnitCode2 = 'adunit2';
+            const adUnitsBids = [{
+              bidder: 'smartadserver',
+              params: {
+                target: 'foo=bar'
+              }
+            }, {
+              bidder: 'pubmatic',
+              params: {
+                dctr: 'foo=bar'
+              }
+            }, {
+              bidder: 'appnexus',
+              params: {
+                keywords: {
+                  foo: ['bar']
+                }
+              }
+            }, {
+              bidder: 'rubicon',
+              params: {
+                inventory: {
+                  foo: 'bar',
+                },
+                visitor: {
+                  baz: 'bam',
+                }
+              }
+            }, {
+              bidder: 'other',
+            }];
             const reqBidsConfigObj = {
               ortb2Fragments: {
                 global: {},
@@ -740,68 +770,10 @@ describe('weboramaRtdProvider', function() {
               },
               adUnits: [{
                 code: adUnitCode1,
-                bids: [{
-                  bidder: 'smartadserver',
-                  params: {
-                    target: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'pubmatic',
-                  params: {
-                    dctr: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'appnexus',
-                  params: {
-                    keywords: {
-                      foo: ['bar']
-                    }
-                  }
-                }, {
-                  bidder: 'rubicon',
-                  params: {
-                    inventory: {
-                      foo: 'bar',
-                    },
-                    visitor: {
-                      baz: 'bam',
-                    }
-                  }
-                }, {
-                  bidder: 'other',
-                }]
+                bids: deepClone(adUnitsBids),
               }, {
                 code: adUnitCode2,
-                bids: [{
-                  bidder: 'smartadserver',
-                  params: {
-                    target: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'pubmatic',
-                  params: {
-                    dctr: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'appnexus',
-                  params: {
-                    keywords: {
-                      foo: ['bar']
-                    }
-                  }
-                }, {
-                  bidder: 'rubicon',
-                  params: {
-                    inventory: {
-                      foo: 'bar',
-                    },
-                    visitor: {
-                      baz: 'bam',
-                    }
-                  }
-                }, {
-                  bidder: 'other',
-                }]
+                bids: deepClone(adUnitsBids),
               }]
             };
             const onDoneSpy = sinon.spy();
@@ -827,24 +799,13 @@ describe('weboramaRtdProvider', function() {
             });
 
             reqBidsConfigObj.adUnits.forEach(adUnit => {
-              expect(adUnit.bids.length).to.equal(5);
-              expect(adUnit.bids[0].params.target).to.equal('foo=bar');
-              expect(adUnit.bids[1].params.dctr).to.equal('foo=bar');
-              expect(adUnit.bids[2].params.keywords).to.deep.equal({
-                foo: ['bar']
-              });
-              expect(adUnit.bids[3].params).to.deep.equal({
-                inventory: {
-                  foo: 'bar',
-                },
-                visitor: {
-                  baz: 'bam',
-                }
-              });
+              expect(adUnit.bids).to.deep.equal(adUnitsBids);
             });
-            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
-            })
+
+            expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+              global: {},
+              bidder: {},
+            });
           });
         });
       });
@@ -876,6 +837,36 @@ describe('weboramaRtdProvider', function() {
             };
             const adUnitCode1 = 'adunit1';
             const adUnitCode2 = 'adunit2';
+            const adUnitsBids = [{
+              bidder: 'smartadserver',
+              params: {
+                target: 'foo=bar'
+              }
+            }, {
+              bidder: 'pubmatic',
+              params: {
+                dctr: 'foo=bar'
+              }
+            }, {
+              bidder: 'appnexus',
+              params: {
+                keywords: {
+                  foo: ['bar']
+                }
+              }
+            }, {
+              bidder: 'rubicon',
+              params: {
+                inventory: {
+                  foo: 'bar',
+                },
+                visitor: {
+                  baz: 'bam',
+                }
+              }
+            }, {
+              bidder: 'other',
+            }];
             const reqBidsConfigObj = {
               ortb2Fragments: {
                 global: {},
@@ -883,68 +874,10 @@ describe('weboramaRtdProvider', function() {
               },
               adUnits: [{
                 code: adUnitCode1,
-                bids: [{
-                  bidder: 'smartadserver',
-                  params: {
-                    target: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'pubmatic',
-                  params: {
-                    dctr: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'appnexus',
-                  params: {
-                    keywords: {
-                      foo: ['bar']
-                    }
-                  }
-                }, {
-                  bidder: 'rubicon',
-                  params: {
-                    inventory: {
-                      foo: 'bar',
-                    },
-                    visitor: {
-                      baz: 'bam',
-                    }
-                  }
-                }, {
-                  bidder: 'other',
-                }]
+                bids: deepClone(adUnitsBids),
               }, {
                 code: adUnitCode2,
-                bids: [{
-                  bidder: 'smartadserver',
-                  params: {
-                    target: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'pubmatic',
-                  params: {
-                    dctr: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'appnexus',
-                  params: {
-                    keywords: {
-                      foo: ['bar']
-                    }
-                  }
-                }, {
-                  bidder: 'rubicon',
-                  params: {
-                    inventory: {
-                      foo: 'bar',
-                    },
-                    visitor: {
-                      baz: 'bam',
-                    }
-                  }
-                }, {
-                  bidder: 'other',
-                }]
+                bids: deepClone(adUnitsBids),
               }]
             };
             const onDoneSpy = sinon.spy();
@@ -970,24 +903,13 @@ describe('weboramaRtdProvider', function() {
             });
 
             reqBidsConfigObj.adUnits.forEach(adUnit => {
-              expect(adUnit.bids.length).to.equal(5);
-              expect(adUnit.bids[0].params.target).to.equal('foo=bar');
-              expect(adUnit.bids[1].params.dctr).to.equal('foo=bar');
-              expect(adUnit.bids[2].params.keywords).to.deep.equal({
-                foo: ['bar']
-              });
-              expect(adUnit.bids[3].params).to.deep.equal({
-                inventory: {
-                  foo: 'bar',
-                },
-                visitor: {
-                  baz: 'bam',
-                }
-              });
+              expect(adUnit.bids).to.deep.equal(adUnitsBids);
             });
-            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
-            })
+
+            expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+              global: {},
+              bidder: {},
+            });
           });
         });
       });
@@ -1776,6 +1698,36 @@ describe('weboramaRtdProvider', function() {
 
             const adUnitCode1 = 'adunit1';
             const adUnitCode2 = 'adunit2';
+            const adUnitsBids = [{
+              bidder: 'smartadserver',
+              params: {
+                target: 'foo=bar'
+              }
+            }, {
+              bidder: 'pubmatic',
+              params: {
+                dctr: 'foo=bar'
+              }
+            }, {
+              bidder: 'appnexus',
+              params: {
+                keywords: {
+                  foo: ['bar']
+                }
+              }
+            }, {
+              bidder: 'rubicon',
+              params: {
+                inventory: {
+                  foo: 'bar'
+                },
+                visitor: {
+                  baz: 'bam'
+                }
+              }
+            }, {
+              bidder: 'other'
+            }];
             const reqBidsConfigObj = {
               ortb2Fragments: {
                 global: {},
@@ -1783,68 +1735,10 @@ describe('weboramaRtdProvider', function() {
               },
               adUnits: [{
                 code: adUnitCode1,
-                bids: [{
-                  bidder: 'smartadserver',
-                  params: {
-                    target: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'pubmatic',
-                  params: {
-                    dctr: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'appnexus',
-                  params: {
-                    keywords: {
-                      foo: ['bar']
-                    }
-                  }
-                }, {
-                  bidder: 'rubicon',
-                  params: {
-                    inventory: {
-                      foo: 'bar'
-                    },
-                    visitor: {
-                      baz: 'bam'
-                    }
-                  }
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }, {
                 code: adUnitCode2,
-                bids: [{
-                  bidder: 'smartadserver',
-                  params: {
-                    target: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'pubmatic',
-                  params: {
-                    dctr: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'appnexus',
-                  params: {
-                    keywords: {
-                      foo: ['bar']
-                    }
-                  }
-                }, {
-                  bidder: 'rubicon',
-                  params: {
-                    inventory: {
-                      foo: 'bar'
-                    },
-                    visitor: {
-                      baz: 'bam'
-                    }
-                  }
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }]
             };
             const onDoneSpy = sinon.spy();
@@ -1862,24 +1756,13 @@ describe('weboramaRtdProvider', function() {
             });
 
             reqBidsConfigObj.adUnits.forEach(adUnit => {
-              expect(adUnit.bids.length).to.equal(5);
-              expect(adUnit.bids[0].params.target).to.equal('foo=bar');
-              expect(adUnit.bids[1].params.dctr).to.equal('foo=bar');
-              expect(adUnit.bids[2].params.keywords).to.deep.equal({
-                foo: ['bar']
-              });
-              expect(adUnit.bids[3].params).to.deep.equal({
-                inventory: {
-                  foo: 'bar'
-                },
-                visitor: {
-                  baz: 'bam'
-                }
-              });
+              expect(adUnit.bids).to.deep.equal(adUnitsBids);
             });
-            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
-            })
+
+            expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+              global: {},
+              bidder: {},
+            });
           });
         });
       });
@@ -1921,6 +1804,36 @@ describe('weboramaRtdProvider', function() {
 
             const adUnitCode1 = 'adunit1';
             const adUnitCode2 = 'adunit2';
+            const adUnitsBids = [{
+              bidder: 'smartadserver',
+              params: {
+                target: 'foo=bar'
+              }
+            }, {
+              bidder: 'pubmatic',
+              params: {
+                dctr: 'foo=bar'
+              }
+            }, {
+              bidder: 'appnexus',
+              params: {
+                keywords: {
+                  foo: ['bar']
+                }
+              }
+            }, {
+              bidder: 'rubicon',
+              params: {
+                inventory: {
+                  foo: 'bar'
+                },
+                visitor: {
+                  baz: 'bam'
+                }
+              }
+            }, {
+              bidder: 'other'
+            }];
             const reqBidsConfigObj = {
               ortb2Fragments: {
                 global: {},
@@ -1928,68 +1841,10 @@ describe('weboramaRtdProvider', function() {
               },
               adUnits: [{
                 code: adUnitCode1,
-                bids: [{
-                  bidder: 'smartadserver',
-                  params: {
-                    target: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'pubmatic',
-                  params: {
-                    dctr: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'appnexus',
-                  params: {
-                    keywords: {
-                      foo: ['bar']
-                    }
-                  }
-                }, {
-                  bidder: 'rubicon',
-                  params: {
-                    inventory: {
-                      foo: 'bar'
-                    },
-                    visitor: {
-                      baz: 'bam'
-                    }
-                  }
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }, {
                 code: adUnitCode2,
-                bids: [{
-                  bidder: 'smartadserver',
-                  params: {
-                    target: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'pubmatic',
-                  params: {
-                    dctr: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'appnexus',
-                  params: {
-                    keywords: {
-                      foo: ['bar']
-                    }
-                  }
-                }, {
-                  bidder: 'rubicon',
-                  params: {
-                    inventory: {
-                      foo: 'bar'
-                    },
-                    visitor: {
-                      baz: 'bam'
-                    }
-                  }
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }]
             };
             const onDoneSpy = sinon.spy();
@@ -2007,24 +1862,13 @@ describe('weboramaRtdProvider', function() {
             });
 
             reqBidsConfigObj.adUnits.forEach(adUnit => {
-              expect(adUnit.bids.length).to.equal(5);
-              expect(adUnit.bids[0].params.target).to.equal('foo=bar');
-              expect(adUnit.bids[1].params.dctr).to.equal('foo=bar');
-              expect(adUnit.bids[2].params.keywords).to.deep.equal({
-                foo: ['bar']
-              });
-              expect(adUnit.bids[3].params).to.deep.equal({
-                inventory: {
-                  foo: 'bar'
-                },
-                visitor: {
-                  baz: 'bam'
-                }
-              });
+              expect(adUnit.bids).to.deep.equal(adUnitsBids);
             });
-            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
-            })
+
+            expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+              global: {},
+              bidder: {},
+            });
           });
         });
       });
@@ -2884,6 +2728,36 @@ describe('weboramaRtdProvider', function() {
 
             const adUnitCode1 = 'adunit1';
             const adUnitCode2 = 'adunit2';
+            const adUnitsBids = [{
+              bidder: 'smartadserver',
+              params: {
+                target: 'foo=bar'
+              }
+            }, {
+              bidder: 'pubmatic',
+              params: {
+                dctr: 'foo=bar'
+              }
+            }, {
+              bidder: 'appnexus',
+              params: {
+                keywords: {
+                  foo: ['bar']
+                }
+              }
+            }, {
+              bidder: 'rubicon',
+              params: {
+                inventory: {
+                  foo: 'bar'
+                },
+                visitor: {
+                  baz: 'bam'
+                }
+              }
+            }, {
+              bidder: 'other'
+            }];
             const reqBidsConfigObj = {
               ortb2Fragments: {
                 global: {},
@@ -2891,68 +2765,10 @@ describe('weboramaRtdProvider', function() {
               },
               adUnits: [{
                 code: adUnitCode1,
-                bids: [{
-                  bidder: 'smartadserver',
-                  params: {
-                    target: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'pubmatic',
-                  params: {
-                    dctr: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'appnexus',
-                  params: {
-                    keywords: {
-                      foo: ['bar']
-                    }
-                  }
-                }, {
-                  bidder: 'rubicon',
-                  params: {
-                    inventory: {
-                      foo: 'bar'
-                    },
-                    visitor: {
-                      baz: 'bam'
-                    }
-                  }
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }, {
                 code: adUnitCode2,
-                bids: [{
-                  bidder: 'smartadserver',
-                  params: {
-                    target: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'pubmatic',
-                  params: {
-                    dctr: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'appnexus',
-                  params: {
-                    keywords: {
-                      foo: ['bar']
-                    }
-                  }
-                }, {
-                  bidder: 'rubicon',
-                  params: {
-                    inventory: {
-                      foo: 'bar'
-                    },
-                    visitor: {
-                      baz: 'bam'
-                    }
-                  }
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }]
             };
             const onDoneSpy = sinon.spy();
@@ -2970,24 +2786,13 @@ describe('weboramaRtdProvider', function() {
             });
 
             reqBidsConfigObj.adUnits.forEach(adUnit => {
-              expect(adUnit.bids.length).to.equal(5);
-              expect(adUnit.bids[0].params.target).to.equal('foo=bar');
-              expect(adUnit.bids[1].params.dctr).to.equal('foo=bar');
-              expect(adUnit.bids[2].params.keywords).to.deep.equal({
-                foo: ['bar']
-              });
-              expect(adUnit.bids[3].params).to.deep.equal({
-                inventory: {
-                  foo: 'bar'
-                },
-                visitor: {
-                  baz: 'bam'
-                }
-              });
+              expect(adUnit.bids).to.deep.equal(adUnitsBids);
             });
-            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
-            })
+
+            expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+              global: {},
+              bidder: {},
+            });
           });
         });
       });
@@ -3028,6 +2833,36 @@ describe('weboramaRtdProvider', function() {
 
             const adUnitCode1 = 'adunit1';
             const adUnitCode2 = 'adunit2';
+            const adUnitsBids = [{
+              bidder: 'smartadserver',
+              params: {
+                target: 'foo=bar'
+              }
+            }, {
+              bidder: 'pubmatic',
+              params: {
+                dctr: 'foo=bar'
+              }
+            }, {
+              bidder: 'appnexus',
+              params: {
+                keywords: {
+                  foo: ['bar']
+                }
+              }
+            }, {
+              bidder: 'rubicon',
+              params: {
+                inventory: {
+                  foo: 'bar'
+                },
+                visitor: {
+                  baz: 'bam'
+                }
+              }
+            }, {
+              bidder: 'other'
+            }];
             const reqBidsConfigObj = {
               ortb2Fragments: {
                 global: {},
@@ -3035,68 +2870,10 @@ describe('weboramaRtdProvider', function() {
               },
               adUnits: [{
                 code: adUnitCode1,
-                bids: [{
-                  bidder: 'smartadserver',
-                  params: {
-                    target: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'pubmatic',
-                  params: {
-                    dctr: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'appnexus',
-                  params: {
-                    keywords: {
-                      foo: ['bar']
-                    }
-                  }
-                }, {
-                  bidder: 'rubicon',
-                  params: {
-                    inventory: {
-                      foo: 'bar'
-                    },
-                    visitor: {
-                      baz: 'bam'
-                    }
-                  }
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }, {
                 code: adUnitCode2,
-                bids: [{
-                  bidder: 'smartadserver',
-                  params: {
-                    target: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'pubmatic',
-                  params: {
-                    dctr: 'foo=bar'
-                  }
-                }, {
-                  bidder: 'appnexus',
-                  params: {
-                    keywords: {
-                      foo: ['bar']
-                    }
-                  }
-                }, {
-                  bidder: 'rubicon',
-                  params: {
-                    inventory: {
-                      foo: 'bar'
-                    },
-                    visitor: {
-                      baz: 'bam'
-                    }
-                  }
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }]
             };
             const onDoneSpy = sinon.spy();
@@ -3114,24 +2891,13 @@ describe('weboramaRtdProvider', function() {
             });
 
             reqBidsConfigObj.adUnits.forEach(adUnit => {
-              expect(adUnit.bids.length).to.equal(5);
-              expect(adUnit.bids[0].params.target).to.equal('foo=bar');
-              expect(adUnit.bids[1].params.dctr).to.equal('foo=bar');
-              expect(adUnit.bids[2].params.keywords).to.deep.equal({
-                foo: ['bar']
-              });
-              expect(adUnit.bids[3].params).to.deep.equal({
-                inventory: {
-                  foo: 'bar'
-                },
-                visitor: {
-                  baz: 'bam'
-                }
-              });
+              expect(adUnit.bids).to.deep.equal(adUnitsBids);
             });
-            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
-            })
+
+            expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+              global: {},
+              bidder: {},
+            });
           });
         });
       });

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -137,7 +137,9 @@ describe('weboramaRtdProvider', function() {
         const expectedAdunitsBid = deepClone(adUnitsBids);
         expectedAdunitsBid[2].params = {keywords: data}; // appnexus case
 
-        expect(reqBidsConfigObj.adUnits[0].bids).to.deep.equal(expectedAdunitsBid);
+        reqBidsConfigObj.adUnits.forEach(adUnit => {
+          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+        });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
         const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
@@ -238,7 +240,9 @@ describe('weboramaRtdProvider', function() {
         const expectedAdunitsBid = deepClone(adUnitsBids);
         expectedAdunitsBid[2].params = {keywords: data}; // appnexus case
 
-        expect(reqBidsConfigObj.adUnits[0].bids).to.deep.equal(expectedAdunitsBid);
+        reqBidsConfigObj.adUnits.forEach(adUnit => {
+          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+        });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
         const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
@@ -339,7 +343,9 @@ describe('weboramaRtdProvider', function() {
         const expectedAdunitsBid = deepClone(adUnitsBids);
         expectedAdunitsBid[2].params = {keywords: data}; // appnexus case
 
-        expect(reqBidsConfigObj.adUnits[0].bids).to.deep.equal(expectedAdunitsBid);
+        reqBidsConfigObj.adUnits.forEach(adUnit => {
+          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+        });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
         const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
@@ -578,7 +584,9 @@ describe('weboramaRtdProvider', function() {
             const expectedAdunitsBid = deepClone(adUnitsBids);
             expectedAdunitsBid[2].params = {keywords: data}; // appnexus case
 
-            expect(reqBidsConfigObj.adUnits[0].bids).to.deep.equal(expectedAdunitsBid);
+            reqBidsConfigObj.adUnits.forEach(adUnit => {
+              expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+            });
 
             const expectedORTB2BidderFragments = {
               [APPNEXUS]: {
@@ -1177,7 +1185,9 @@ describe('weboramaRtdProvider', function() {
           },
         };
 
-        expect(reqBidsConfigObj.adUnits[0].bids).to.deep.equal(expectedAdunitsBid);
+        reqBidsConfigObj.adUnits.forEach(adUnit => {
+          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+        });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
         const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
@@ -1269,8 +1279,9 @@ describe('weboramaRtdProvider', function() {
 
         const expectedAdunitsBid = deepClone(adUnitsBids);
         expectedAdunitsBid[2].params = { keywords: defaultProfile }; // appnexus case
-
-        expect(reqBidsConfigObj.adUnits[0].bids).to.deep.equal(expectedAdunitsBid);
+        reqBidsConfigObj.adUnits.forEach(adUnit => {
+          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+        });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
         const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
@@ -1447,7 +1458,6 @@ describe('weboramaRtdProvider', function() {
     });
 
     describe('Add user-centric data (wam)', function() {
-      /*
       it('should set gam targeting from local storage and send to bidders by default', function() {
         let onDataResponse = {};
         const moduleConfig = {
@@ -1479,6 +1489,17 @@ describe('weboramaRtdProvider', function() {
           .returns(JSON.stringify(entry));
 
         const adUnitCode = 'adunit1';
+        const adUnitsBids = [{
+          bidder: 'smartadserver'
+        }, {
+          bidder: 'pubmatic'
+        }, {
+          bidder: 'appnexus'
+        }, {
+          bidder: 'rubicon'
+        }, {
+          bidder: 'other'
+        }];
         const reqBidsConfigObj = {
           ortb2Fragments: {
             global: {},
@@ -1486,17 +1507,7 @@ describe('weboramaRtdProvider', function() {
           },
           adUnits: [{
             code: adUnitCode,
-            bids: [{
-              bidder: 'smartadserver'
-            }, {
-              bidder: 'pubmatic'
-            }, {
-              bidder: 'appnexus'
-            }, {
-              bidder: 'rubicon'
-            }, {
-              bidder: 'other'
-            }]
+            bids: deepClone(adUnitsBids),
           }]
         };
         const onDoneSpy = sinon.spy();
@@ -1512,20 +1523,33 @@ describe('weboramaRtdProvider', function() {
           'adunit1': data,
         });
 
-        expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
-        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+        const expectedAdunitsBid = deepClone(adUnitsBids);
+        expectedAdunitsBid[2].params = {keywords: data}; // appnexus case
+
+        reqBidsConfigObj.adUnits.forEach(adUnit => {
+          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+        });
+
+        const bidders = Object.values(adUnitsBids).map(v => v.bidder);
+        const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
+          frag[bidder] = {
             user: {
               ext: {
                 data: data
               },
             }
-          });
-        })
+          };
+
+          return frag
+        }, {});
+
+        expectedORTB2BidderFragments[APPNEXUS].user.keywords = 'webo_cs=foo,webo_cs=bar,webo_audiences=baz';
+
+        expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+          global: {},
+          bidder: expectedORTB2BidderFragments,
+        });
+
         expect(onDataResponse).to.deep.equal({
           data: data,
           meta: {
@@ -1590,6 +1614,17 @@ describe('weboramaRtdProvider', function() {
 
             const adUnitCode1 = 'adunit1';
             const adUnitCode2 = 'adunit2';
+            const adUnitsBids = [{
+              bidder: 'smartadserver'
+            }, {
+              bidder: 'pubmatic'
+            }, {
+              bidder: 'appnexus'
+            }, {
+              bidder: 'rubicon'
+            }, {
+              bidder: 'other'
+            }];
             const reqBidsConfigObj = {
               ortb2Fragments: {
                 global: {},
@@ -1597,30 +1632,10 @@ describe('weboramaRtdProvider', function() {
               },
               adUnits: [{
                 code: adUnitCode1,
-                bids: [{
-                  bidder: 'smartadserver'
-                }, {
-                  bidder: 'pubmatic'
-                }, {
-                  bidder: 'appnexus'
-                }, {
-                  bidder: 'rubicon'
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }, {
                 code: adUnitCode2,
-                bids: [{
-                  bidder: 'smartadserver'
-                }, {
-                  bidder: 'pubmatic'
-                }, {
-                  bidder: 'appnexus'
-                }, {
-                  bidder: 'rubicon'
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }]
             };
             const onDoneSpy = sinon.spy();
@@ -1637,28 +1652,29 @@ describe('weboramaRtdProvider', function() {
               'adunit2': data,
             });
 
+            const expectedAdunitsBid = deepClone(adUnitsBids);
+            expectedAdunitsBid[2].params = {keywords: data}; // appnexus case
+
             reqBidsConfigObj.adUnits.forEach(adUnit => {
-              expect(adUnit.bids.length).to.equal(5);
-              expect(adUnit.bids[0].params).to.be.undefined;
-              expect(adUnit.bids[1].params).to.be.undefined;
-              expect(adUnit.bids[2].params.keywords).to.deep.equal(data);
-              expect(adUnit.bids[3].params).to.be.undefined;
+              expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
             });
-            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-              if (v == 'appnexus') {
-                expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-                  user: {
-                    ext: {
-                      data: data
-                    },
-                  }
-                });
 
-                return
-              }
+            const expectedORTB2BidderFragments = {
+              [APPNEXUS]: {
+                user: {
+                  ext: {
+                    data: data,
+                  },
+                  keywords: 'webo_cs=foo,webo_cs=bar,webo_audiences=baz',
+                },
+              },
+            };
 
-              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
-            })
+            expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+              global: {},
+              bidder: expectedORTB2BidderFragments,
+            });
+
             expect(onDataResponse).to.deep.equal({
               data: data,
               meta: {
@@ -1769,21 +1785,22 @@ describe('weboramaRtdProvider', function() {
               expect(adUnit.bids[1].params).to.be.undefined;
               expect(adUnit.bids[3].params).to.be.undefined;
             });
-            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-              if (v == 'appnexus') {
-                expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-                  user: {
-                    ext: {
-                      data: data
-                    },
-                  }
-                });
 
-                return
-              }
+            const expectedORTB2BidderFragments = {
+              [APPNEXUS]: {
+                user: {
+                  ext: {
+                    data: data,
+                  },
+                  keywords: 'webo_cs=foo,webo_cs=bar,webo_audiences=baz',
+                },
+              },
+            };
 
-              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
-            })
+            expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+              global: {},
+              bidder: expectedORTB2BidderFragments,
+            });
 
             expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
             expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
@@ -2186,6 +2203,36 @@ describe('weboramaRtdProvider', function() {
           .returns(JSON.stringify(entry));
 
         const adUnitCode = 'adunit1';
+        const adUnitsBids = [{
+          bidder: 'smartadserver',
+          params: {
+            target: 'foo=bar'
+          }
+        }, {
+          bidder: 'pubmatic',
+          params: {
+            dctr: 'foo=bar'
+          }
+        }, {
+          bidder: 'appnexus',
+          params: {
+            keywords: {
+              foo: ['bar']
+            }
+          }
+        }, {
+          bidder: 'rubicon',
+          params: {
+            inventory: {
+              foo: 'bar',
+            },
+            visitor: {
+              baz: 'bam',
+            }
+          }
+        }, {
+          bidder: 'other'
+        }];
         const reqBidsConfigObj = {
           ortb2Fragments: {
             global: {},
@@ -2193,36 +2240,7 @@ describe('weboramaRtdProvider', function() {
           },
           adUnits: [{
             code: adUnitCode,
-            bids: [{
-              bidder: 'smartadserver',
-              params: {
-                target: 'foo=bar'
-              }
-            }, {
-              bidder: 'pubmatic',
-              params: {
-                dctr: 'foo=bar'
-              }
-            }, {
-              bidder: 'appnexus',
-              params: {
-                keywords: {
-                  foo: ['bar']
-                }
-              }
-            }, {
-              bidder: 'rubicon',
-              params: {
-                inventory: {
-                  foo: 'bar',
-                },
-                visitor: {
-                  baz: 'bam',
-                }
-              }
-            }, {
-              bidder: 'other'
-            }]
+            bids: deepClone(adUnitsBids),
           }]
         };
         const onDoneSpy = sinon.spy();
@@ -2254,15 +2272,26 @@ describe('weboramaRtdProvider', function() {
             baz: 'bam',
           }
         });
-        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+
+        const bidders = Object.values(adUnitsBids).map(v => v.bidder);
+        const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
+          frag[bidder] = {
             user: {
               ext: {
                 data: data
               },
             }
-          });
-        })
+          };
+
+          return frag
+        }, {});
+
+        expectedORTB2BidderFragments[APPNEXUS].user.keywords = 'webo_cs=foo,webo_cs=bar,webo_audiences=baz';
+
+        expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+          global: {},
+          bidder: expectedORTB2BidderFragments,
+        });
       });
 
       it('should use default profile in case of nothing on local storage', function() {
@@ -2283,6 +2312,17 @@ describe('weboramaRtdProvider', function() {
         sandbox.stub(storage, 'localStorageIsEnabled').returns(true);
 
         const adUnitCode = 'adunit1';
+        const adUnitsBids = [{
+          bidder: 'smartadserver'
+        }, {
+          bidder: 'pubmatic'
+        }, {
+          bidder: 'appnexus'
+        }, {
+          bidder: 'rubicon'
+        }, {
+          bidder: 'other'
+        }];
         const reqBidsConfigObj = {
           ortb2Fragments: {
             global: {},
@@ -2290,17 +2330,7 @@ describe('weboramaRtdProvider', function() {
           },
           adUnits: [{
             code: adUnitCode,
-            bids: [{
-              bidder: 'smartadserver'
-            }, {
-              bidder: 'pubmatic'
-            }, {
-              bidder: 'appnexus'
-            }, {
-              bidder: 'rubicon'
-            }, {
-              bidder: 'other'
-            }]
+            bids: deepClone(adUnitsBids),
           }]
         };
         const onDoneSpy = sinon.spy();
@@ -2316,20 +2346,32 @@ describe('weboramaRtdProvider', function() {
           'adunit1': defaultProfile,
         });
 
-        expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
-        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+        const expectedAdunitsBid = deepClone(adUnitsBids);
+        expectedAdunitsBid[2].params = {keywords: defaultProfile}; // appnexus case
+
+        reqBidsConfigObj.adUnits.forEach(adUnit => {
+          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+        });
+
+        const bidders = Object.values(adUnitsBids).map(v => v.bidder);
+        const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
+          frag[bidder] = {
             user: {
               ext: {
-                data: defaultProfile
+                data: defaultProfile,
               },
             }
-          });
-        })
+          };
+
+          return frag
+        }, {});
+
+        expectedORTB2BidderFragments[APPNEXUS].user.keywords = 'webo_audiences=baz';
+
+        expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+          global: {},
+          bidder: expectedORTB2BidderFragments,
+        });
       });
 
       it('should use default profile if cant read from local storage', function() {
@@ -2357,6 +2399,17 @@ describe('weboramaRtdProvider', function() {
         sandbox.stub(storage, 'localStorageIsEnabled').returns(false);
 
         const adUnitCode = 'adunit1';
+        const adUnitsBids = [{
+          bidder: 'smartadserver'
+        }, {
+          bidder: 'pubmatic'
+        }, {
+          bidder: 'appnexus'
+        }, {
+          bidder: 'rubicon'
+        }, {
+          bidder: 'other'
+        }];
         const reqBidsConfigObj = {
           ortb2Fragments: {
             global: {},
@@ -2364,17 +2417,7 @@ describe('weboramaRtdProvider', function() {
           },
           adUnits: [{
             code: adUnitCode,
-            bids: [{
-              bidder: 'smartadserver'
-            }, {
-              bidder: 'pubmatic'
-            }, {
-              bidder: 'appnexus'
-            }, {
-              bidder: 'rubicon'
-            }, {
-              bidder: 'other'
-            }]
+            bids: deepClone(adUnitsBids),
           }]
         };
         const onDoneSpy = sinon.spy();
@@ -2395,15 +2438,27 @@ describe('weboramaRtdProvider', function() {
         expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
         expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
-        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+
+        const bidders = Object.values(adUnitsBids).map(v => v.bidder);
+        const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
+          frag[bidder] = {
             user: {
               ext: {
-                data: defaultProfile
+                data: defaultProfile,
               },
             }
-          });
-        })
+          };
+
+          return frag
+        }, {});
+
+        expectedORTB2BidderFragments[APPNEXUS].user.keywords = 'webo_audiences=baz';
+
+        expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+          global: {},
+          bidder: expectedORTB2BidderFragments,
+        });
+
         expect(onDataResponse).to.deep.equal({
           data: defaultProfile,
           meta: {
@@ -2459,6 +2514,17 @@ describe('weboramaRtdProvider', function() {
 
         const adUnitCode1 = 'adunit1';
         const adUnitCode2 = 'adunit2';
+        const adUnitsBids = [{
+          bidder: 'smartadserver'
+        }, {
+          bidder: 'pubmatic'
+        }, {
+          bidder: 'appnexus'
+        }, {
+          bidder: 'rubicon'
+        }, {
+          bidder: 'other'
+        }];
         const reqBidsConfigObj = {
           ortb2Fragments: {
             global: {},
@@ -2466,30 +2532,10 @@ describe('weboramaRtdProvider', function() {
           },
           adUnits: [{
             code: adUnitCode1,
-            bids: [{
-              bidder: 'smartadserver'
-            }, {
-              bidder: 'pubmatic'
-            }, {
-              bidder: 'appnexus'
-            }, {
-              bidder: 'rubicon'
-            }, {
-              bidder: 'other'
-            }]
+            bids: deepClone(adUnitsBids),
           }, {
             code: adUnitCode2,
-            bids: [{
-              bidder: 'smartadserver'
-            }, {
-              bidder: 'pubmatic'
-            }, {
-              bidder: 'appnexus'
-            }, {
-              bidder: 'rubicon'
-            }, {
-              bidder: 'other'
-            }]
+            bids: deepClone(adUnitsBids),
           }]
         };
 
@@ -2517,31 +2563,35 @@ describe('weboramaRtdProvider', function() {
           expect(adUnit.bids[1].params).to.be.undefined;
           expect(adUnit.bids[3].params).to.be.undefined;
         });
-        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
-            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-              user: {
-                ext: {
-                  data: {
-                    webo_cs: ['foo', 'bar'],
-                    webo_audiences: ['baz'],
-                    webo_bar: ['baz'],
-                  }
-                },
-              }
-            });
 
-            return
-          }
-
-          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+        const bidders = Object.values(adUnitsBids).map(v => v.bidder);
+        const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
+          frag[bidder] = {
             user: {
               ext: {
-                data: data
+                data: data,
               },
             }
-          });
-        })
+          };
+
+          return frag
+        }, {});
+
+        expectedORTB2BidderFragments[APPNEXUS].user = {
+          ext: {
+            data: {
+              webo_cs: ['foo', 'bar'],
+              webo_audiences: ['baz'],
+              webo_bar: ['baz'],
+            }
+          },
+          keywords: 'webo_cs=foo,webo_cs=bar,webo_audiences=baz',
+        };
+
+        expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+          global: {},
+          bidder: expectedORTB2BidderFragments,
+        });
 
         expect(onDataResponse).to.deep.equal({
           data: data,
@@ -2552,7 +2602,6 @@ describe('weboramaRtdProvider', function() {
           },
         });
       });
-      */
     });
   /*
     describe('Add support to sfbx lite', function() {

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -134,9 +134,8 @@ describe('weboramaRtdProvider', function() {
           'adunit1': data,
         });
 
-        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+          expect(adUnit.bids).to.deep.equal(adUnitsBids);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -235,9 +234,8 @@ describe('weboramaRtdProvider', function() {
           'adunit1': data,
         });
 
-        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+          expect(adUnit.bids).to.deep.equal(adUnitsBids);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -336,9 +334,8 @@ describe('weboramaRtdProvider', function() {
           'adunit1': data,
         });
 
-        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+          expect(adUnit.bids).to.deep.equal(adUnitsBids);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -575,9 +572,8 @@ describe('weboramaRtdProvider', function() {
               'adunit2': data,
             });
 
-            const expectedAdunitsBid = deepClone(adUnitsBids);
             reqBidsConfigObj.adUnits.forEach(adUnit => {
-              expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+              expect(adUnit.bids).to.deep.equal(adUnitsBids);
             });
 
             const expectedORTB2BidderFragments = {
@@ -693,9 +689,8 @@ describe('weboramaRtdProvider', function() {
               'adunit2': data,
             });
 
-            const expectedAdunitsBid = deepClone(adUnitsBids);
             reqBidsConfigObj.adUnits.forEach(adUnit => {
-              expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+              expect(adUnit.bids).to.deep.equal(adUnitsBids);
             });
 
             expect(onDataResponse).to.deep.equal({
@@ -1144,9 +1139,8 @@ describe('weboramaRtdProvider', function() {
           'adunit1': {},
         });
 
-        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+          expect(adUnit.bids).to.deep.equal(adUnitsBids);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -1237,9 +1231,8 @@ describe('weboramaRtdProvider', function() {
           'adunit1': defaultProfile,
         });
 
-        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+          expect(adUnit.bids).to.deep.equal(adUnitsBids);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -1360,9 +1353,8 @@ describe('weboramaRtdProvider', function() {
           'adunit2': data,
         });
 
-        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+          expect(adUnit.bids).to.deep.equal(adUnitsBids);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -1473,9 +1465,8 @@ describe('weboramaRtdProvider', function() {
           'adunit1': data,
         });
 
-        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+          expect(adUnit.bids).to.deep.equal(adUnitsBids);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -1600,9 +1591,8 @@ describe('weboramaRtdProvider', function() {
               'adunit2': data,
             });
 
-            const expectedAdunitsBid = deepClone(adUnitsBids);
             reqBidsConfigObj.adUnits.forEach(adUnit => {
-              expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+              expect(adUnit.bids).to.deep.equal(adUnitsBids);
             });
 
             const expectedORTB2BidderFragments = {
@@ -1716,9 +1706,8 @@ describe('weboramaRtdProvider', function() {
               'adunit2': data,
             });
 
-            const expectedAdunitsBid = deepClone(adUnitsBids);
             reqBidsConfigObj.adUnits.forEach(adUnit => {
-              expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+              expect(adUnit.bids).to.deep.equal(adUnitsBids);
             });
 
             const expectedORTB2BidderFragments = {
@@ -2188,9 +2177,8 @@ describe('weboramaRtdProvider', function() {
           'adunit1': {},
         });
 
-        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+          expect(adUnit.bids).to.deep.equal(adUnitsBids);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -2266,9 +2254,8 @@ describe('weboramaRtdProvider', function() {
           'adunit1': defaultProfile,
         });
 
-        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+          expect(adUnit.bids).to.deep.equal(adUnitsBids);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -2351,9 +2338,8 @@ describe('weboramaRtdProvider', function() {
           'adunit1': defaultProfile,
         });
 
-        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+          expect(adUnit.bids).to.deep.equal(adUnitsBids);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -2586,9 +2572,8 @@ describe('weboramaRtdProvider', function() {
           'adunit1': data,
         });
 
-        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+          expect(adUnit.bids).to.deep.equal(adUnitsBids);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -2714,9 +2699,8 @@ describe('weboramaRtdProvider', function() {
               'adunit2': data,
             });
 
-            const expectedAdunitsBid = deepClone(adUnitsBids);
             reqBidsConfigObj.adUnits.forEach(adUnit => {
-              expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+              expect(adUnit.bids).to.deep.equal(adUnitsBids);
             });
 
             const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -2830,9 +2814,8 @@ describe('weboramaRtdProvider', function() {
               'adunit2': data,
             });
 
-            const expectedAdunitsBid = deepClone(adUnitsBids);
             reqBidsConfigObj.adUnits.forEach(adUnit => {
-              expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+              expect(adUnit.bids).to.deep.equal(adUnitsBids);
             });
 
             const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -3303,9 +3286,8 @@ describe('weboramaRtdProvider', function() {
           'adunit1': {},
         });
 
-        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+          expect(adUnit.bids).to.deep.equal(adUnitsBids);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -3382,9 +3364,8 @@ describe('weboramaRtdProvider', function() {
           'adunit1': defaultProfile,
         });
 
-        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+          expect(adUnit.bids).to.deep.equal(adUnitsBids);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -3468,9 +3449,8 @@ describe('weboramaRtdProvider', function() {
           'adunit1': defaultProfile,
         });
 
-        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+          expect(adUnit.bids).to.deep.equal(adUnitsBids);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -3562,9 +3542,8 @@ describe('weboramaRtdProvider', function() {
           'adunit1': defaultProfile,
         });
 
-        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+          expect(adUnit.bids).to.deep.equal(adUnitsBids);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -3686,9 +3665,8 @@ describe('weboramaRtdProvider', function() {
           'adunit2': data,
         });
 
-        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+          expect(adUnit.bids).to.deep.equal(adUnitsBids);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -135,8 +135,6 @@ describe('weboramaRtdProvider', function() {
         });
 
         const expectedAdunitsBid = deepClone(adUnitsBids);
-        expectedAdunitsBid[2].params = {keywords: data}; // appnexus case
-
         reqBidsConfigObj.adUnits.forEach(adUnit => {
           expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
         });
@@ -238,8 +236,6 @@ describe('weboramaRtdProvider', function() {
         });
 
         const expectedAdunitsBid = deepClone(adUnitsBids);
-        expectedAdunitsBid[2].params = {keywords: data}; // appnexus case
-
         reqBidsConfigObj.adUnits.forEach(adUnit => {
           expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
         });
@@ -341,8 +337,6 @@ describe('weboramaRtdProvider', function() {
         });
 
         const expectedAdunitsBid = deepClone(adUnitsBids);
-        expectedAdunitsBid[2].params = {keywords: data}; // appnexus case
-
         reqBidsConfigObj.adUnits.forEach(adUnit => {
           expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
         });
@@ -582,8 +576,6 @@ describe('weboramaRtdProvider', function() {
             });
 
             const expectedAdunitsBid = deepClone(adUnitsBids);
-            expectedAdunitsBid[2].params = {keywords: data}; // appnexus case
-
             reqBidsConfigObj.adUnits.forEach(adUnit => {
               expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
             });
@@ -653,6 +645,17 @@ describe('weboramaRtdProvider', function() {
             };
             const adUnitCode1 = 'adunit1';
             const adUnitCode2 = 'adunit2';
+            const adUnitsBids = [{
+              bidder: 'smartadserver'
+            }, {
+              bidder: 'pubmatic'
+            }, {
+              bidder: 'appnexus'
+            }, {
+              bidder: 'rubicon'
+            }, {
+              bidder: 'other'
+            }];
 
             const reqBidsConfigObj = {
               ortb2Fragments: {
@@ -661,30 +664,10 @@ describe('weboramaRtdProvider', function() {
               },
               adUnits: [{
                 code: adUnitCode1,
-                bids: [{
-                  bidder: 'smartadserver'
-                }, {
-                  bidder: 'pubmatic'
-                }, {
-                  bidder: 'appnexus'
-                }, {
-                  bidder: 'rubicon'
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }, {
                 code: adUnitCode2,
-                bids: [{
-                  bidder: 'smartadserver'
-                }, {
-                  bidder: 'pubmatic'
-                }, {
-                  bidder: 'appnexus'
-                }, {
-                  bidder: 'rubicon'
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }]
             };
 
@@ -710,16 +693,10 @@ describe('weboramaRtdProvider', function() {
               'adunit2': data,
             });
 
+            const expectedAdunitsBid = deepClone(adUnitsBids);
             reqBidsConfigObj.adUnits.forEach(adUnit => {
-              expect(adUnit.bids.length).to.equal(5);
-              expect(adUnit.bids[0].params).to.be.undefined;
-              expect(adUnit.bids[1].params).to.be.undefined;
-              expect(adUnit.bids[3].params).to.be.undefined;
-              expect(adUnit.bids[4].ortb2).to.be.undefined;
+              expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
             });
-
-            expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
-            expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
 
             expect(onDataResponse).to.deep.equal({
               data: data,
@@ -1167,24 +1144,7 @@ describe('weboramaRtdProvider', function() {
           'adunit1': {},
         });
 
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
-          inventory: {
-            foo: 'bar',
-          },
-          visitor: {
-            baz: 'bam',
-          }
-        });
-
         const expectedAdunitsBid = deepClone(adUnitsBids);
-        expectedAdunitsBid[2].params = { // appnexus case
-          keywords: {
-            foo: ['bar'],
-            webo_ctx: ['foo', 'bar'],
-            webo_ds: ['baz'],
-          },
-        };
-
         reqBidsConfigObj.adUnits.forEach(adUnit => {
           expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
         });
@@ -1278,7 +1238,6 @@ describe('weboramaRtdProvider', function() {
         });
 
         const expectedAdunitsBid = deepClone(adUnitsBids);
-        expectedAdunitsBid[2].params = { keywords: defaultProfile }; // appnexus case
         reqBidsConfigObj.adUnits.forEach(adUnit => {
           expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
         });
@@ -1401,11 +1360,9 @@ describe('weboramaRtdProvider', function() {
           'adunit2': data,
         });
 
+        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids.length).to.equal(5);
-          expect(adUnit.bids[0].params).to.be.undefined;
-          expect(adUnit.bids[1].params).to.be.undefined;
-          expect(adUnit.bids[3].params).to.be.undefined;
+          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -1438,13 +1395,6 @@ describe('weboramaRtdProvider', function() {
           global: {},
           bidder: expectedORTB2BidderFragments,
         });
-
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
-          webo_ctx: ['foo', 'bar'],
-          webo_ds: ['baz'],
-          webo_bar: ['baz'],
-        });
-        expect(reqBidsConfigObj.adUnits[1].bids[2].params.keywords).to.deep.equal(data);
 
         expect(onDataResponse).to.deep.equal({
           data: data,
@@ -1524,8 +1474,6 @@ describe('weboramaRtdProvider', function() {
         });
 
         const expectedAdunitsBid = deepClone(adUnitsBids);
-        expectedAdunitsBid[2].params = {keywords: data}; // appnexus case
-
         reqBidsConfigObj.adUnits.forEach(adUnit => {
           expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
         });
@@ -1653,8 +1601,6 @@ describe('weboramaRtdProvider', function() {
             });
 
             const expectedAdunitsBid = deepClone(adUnitsBids);
-            expectedAdunitsBid[2].params = {keywords: data}; // appnexus case
-
             reqBidsConfigObj.adUnits.forEach(adUnit => {
               expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
             });
@@ -1732,6 +1678,17 @@ describe('weboramaRtdProvider', function() {
 
             const adUnitCode1 = 'adunit1';
             const adUnitCode2 = 'adunit2';
+            const adUnitsBids = [{
+              bidder: 'smartadserver'
+            }, {
+              bidder: 'pubmatic'
+            }, {
+              bidder: 'appnexus'
+            }, {
+              bidder: 'rubicon'
+            }, {
+              bidder: 'other'
+            }];
             const reqBidsConfigObj = {
               ortb2Fragments: {
                 global: {},
@@ -1739,30 +1696,10 @@ describe('weboramaRtdProvider', function() {
               },
               adUnits: [{
                 code: adUnitCode1,
-                bids: [{
-                  bidder: 'smartadserver'
-                }, {
-                  bidder: 'pubmatic'
-                }, {
-                  bidder: 'appnexus'
-                }, {
-                  bidder: 'rubicon'
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }, {
                 code: adUnitCode2,
-                bids: [{
-                  bidder: 'smartadserver'
-                }, {
-                  bidder: 'pubmatic'
-                }, {
-                  bidder: 'appnexus'
-                }, {
-                  bidder: 'rubicon'
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }]
             };
             const onDoneSpy = sinon.spy();
@@ -1779,11 +1716,9 @@ describe('weboramaRtdProvider', function() {
               'adunit2': data,
             });
 
+            const expectedAdunitsBid = deepClone(adUnitsBids);
             reqBidsConfigObj.adUnits.forEach(adUnit => {
-              expect(adUnit.bids.length).to.equal(5);
-              expect(adUnit.bids[0].params).to.be.undefined;
-              expect(adUnit.bids[1].params).to.be.undefined;
-              expect(adUnit.bids[3].params).to.be.undefined;
+              expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
             });
 
             const expectedORTB2BidderFragments = {
@@ -1801,9 +1736,6 @@ describe('weboramaRtdProvider', function() {
               global: {},
               bidder: expectedORTB2BidderFragments,
             });
-
-            expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
-            expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
 
             expect(onDataResponse).to.deep.equal({
               data: data,
@@ -2256,21 +2188,9 @@ describe('weboramaRtdProvider', function() {
           'adunit1': {},
         });
 
-        expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('foo=bar');
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('foo=bar');
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
-          foo: ['bar'],
-          webo_cs: ['foo', 'bar'],
-          webo_audiences: ['baz'],
-        });
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
-          inventory: {
-            foo: 'bar',
-          },
-          visitor: {
-            baz: 'bam',
-          }
+        const expectedAdunitsBid = deepClone(adUnitsBids);
+        reqBidsConfigObj.adUnits.forEach(adUnit => {
+          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -2347,8 +2267,6 @@ describe('weboramaRtdProvider', function() {
         });
 
         const expectedAdunitsBid = deepClone(adUnitsBids);
-        expectedAdunitsBid[2].params = {keywords: defaultProfile}; // appnexus case
-
         reqBidsConfigObj.adUnits.forEach(adUnit => {
           expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
         });
@@ -2433,11 +2351,10 @@ describe('weboramaRtdProvider', function() {
           'adunit1': defaultProfile,
         });
 
-        expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
+        const expectedAdunitsBid = deepClone(adUnitsBids);
+        reqBidsConfigObj.adUnits.forEach(adUnit => {
+          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+        });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
         const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
@@ -2670,8 +2587,6 @@ describe('weboramaRtdProvider', function() {
         });
 
         const expectedAdunitsBid = deepClone(adUnitsBids);
-        expectedAdunitsBid[2].params = {keywords: data}; // appnexus case
-
         reqBidsConfigObj.adUnits.forEach(adUnit => {
           expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
         });
@@ -2800,8 +2715,6 @@ describe('weboramaRtdProvider', function() {
             });
 
             const expectedAdunitsBid = deepClone(adUnitsBids);
-            expectedAdunitsBid[2].params = {keywords: data}; // appnexus case
-
             reqBidsConfigObj.adUnits.forEach(adUnit => {
               expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
             });
@@ -2917,15 +2830,10 @@ describe('weboramaRtdProvider', function() {
               'adunit2': data,
             });
 
+            const expectedAdunitsBid = deepClone(adUnitsBids);
             reqBidsConfigObj.adUnits.forEach(adUnit => {
-              expect(adUnit.bids.length).to.equal(5);
-              expect(adUnit.bids[0].params).to.be.undefined;
-              expect(adUnit.bids[1].params).to.be.undefined;
-              expect(adUnit.bids[3].params).to.be.undefined;
+              expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
             });
-
-            expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
-            expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
 
             const bidders = Object.values(adUnitsBids).map(v => v.bidder);
             const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
@@ -3395,22 +3303,11 @@ describe('weboramaRtdProvider', function() {
           'adunit1': {},
         });
 
-        expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params.target).to.equal('foo=bar');
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params.dctr).to.equal('foo=bar');
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
-          foo: ['bar'],
-          lite_occupation: ['gérant', 'bénévole'],
-          lite_hobbies: ['sport', 'cinéma'],
+        const expectedAdunitsBid = deepClone(adUnitsBids);
+        reqBidsConfigObj.adUnits.forEach(adUnit => {
+          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
         });
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.deep.equal({
-          inventory: {
-            foo: 'bar',
-          },
-          visitor: {
-            baz: 'bam',
-          }
-        });
+
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
         const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
           frag[bidder] = {
@@ -3486,8 +3383,6 @@ describe('weboramaRtdProvider', function() {
         });
 
         const expectedAdunitsBid = deepClone(adUnitsBids);
-        expectedAdunitsBid[2].params = {keywords: defaultProfile}; // appnexus case
-
         reqBidsConfigObj.adUnits.forEach(adUnit => {
           expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
         });
@@ -3574,8 +3469,6 @@ describe('weboramaRtdProvider', function() {
         });
 
         const expectedAdunitsBid = deepClone(adUnitsBids);
-        expectedAdunitsBid[2].params = {keywords: defaultProfile}; // appnexus case
-
         reqBidsConfigObj.adUnits.forEach(adUnit => {
           expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
         });
@@ -3670,8 +3563,6 @@ describe('weboramaRtdProvider', function() {
         });
 
         const expectedAdunitsBid = deepClone(adUnitsBids);
-        expectedAdunitsBid[2].params = {keywords: defaultProfile}; // appnexus case
-
         reqBidsConfigObj.adUnits.forEach(adUnit => {
           expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
         });
@@ -3795,11 +3686,9 @@ describe('weboramaRtdProvider', function() {
           'adunit2': data,
         });
 
+        const expectedAdunitsBid = deepClone(adUnitsBids);
         reqBidsConfigObj.adUnits.forEach(adUnit => {
-          expect(adUnit.bids.length).to.equal(5);
-          expect(adUnit.bids[0].params).to.be.undefined;
-          expect(adUnit.bids[1].params).to.be.undefined;
-          expect(adUnit.bids[3].params).to.be.undefined;
+          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
         });
 
         const bidders = Object.values(adUnitsBids).map(v => v.bidder);
@@ -3832,13 +3721,6 @@ describe('weboramaRtdProvider', function() {
           global: {},
           bidder: expectedORTB2BidderFragments,
         });
-
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
-          lite_occupation: ['gérant', 'bénévole'],
-          lite_hobbies: ['sport', 'cinéma'],
-          lito_bar: ['baz'],
-        });
-        expect(reqBidsConfigObj.adUnits[1].bids[2].params.keywords).to.deep.equal(data);
 
         expect(onDataResponse).to.deep.equal({
           data: data,

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -2603,7 +2603,7 @@ describe('weboramaRtdProvider', function() {
         });
       });
     });
-  /*
+
     describe('Add support to sfbx lite', function() {
       it('should set gam targeting from local storage and send to bidders by default', function() {
         let onDataResponse = {};
@@ -2635,6 +2635,17 @@ describe('weboramaRtdProvider', function() {
           .returns(JSON.stringify(entry));
 
         const adUnitCode = 'adunit1';
+        const adUnitsBids = [{
+          bidder: 'smartadserver'
+        }, {
+          bidder: 'pubmatic'
+        }, {
+          bidder: 'appnexus'
+        }, {
+          bidder: 'rubicon'
+        }, {
+          bidder: 'other'
+        }];
         const reqBidsConfigObj = {
           ortb2Fragments: {
             global: {},
@@ -2642,17 +2653,7 @@ describe('weboramaRtdProvider', function() {
           },
           adUnits: [{
             code: adUnitCode,
-            bids: [{
-              bidder: 'smartadserver'
-            }, {
-              bidder: 'pubmatic'
-            }, {
-              bidder: 'appnexus'
-            }, {
-              bidder: 'rubicon'
-            }, {
-              bidder: 'other'
-            }]
+            bids: deepClone(adUnitsBids),
           }]
         };
         const onDoneSpy = sinon.spy();
@@ -2668,20 +2669,35 @@ describe('weboramaRtdProvider', function() {
           'adunit1': data,
         });
 
-        expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
-        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+        const expectedAdunitsBid = deepClone(adUnitsBids);
+        expectedAdunitsBid[2].params = {keywords: data}; // appnexus case
+
+        reqBidsConfigObj.adUnits.forEach(adUnit => {
+          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+        });
+
+        const bidders = Object.values(adUnitsBids).map(v => v.bidder);
+        const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
+          frag[bidder] = {
             site: {
               ext: {
                 data: data
               },
             }
-          });
-        })
+          };
+
+          return frag
+        }, {});
+
+        expectedORTB2BidderFragments[APPNEXUS].site.content = {
+          keywords: 'lite_occupation=gérant,lite_occupation=bénévole,lite_hobbies=sport,lite_hobbies=cinéma',
+        };
+
+        expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+          global: {},
+          bidder: expectedORTB2BidderFragments,
+        });
+
         expect(onDataResponse).to.deep.equal({
           data: data,
           meta: {
@@ -2745,6 +2761,17 @@ describe('weboramaRtdProvider', function() {
 
             const adUnitCode1 = 'adunit1';
             const adUnitCode2 = 'adunit2';
+            const adUnitsBids = [{
+              bidder: 'smartadserver'
+            }, {
+              bidder: 'pubmatic'
+            }, {
+              bidder: 'appnexus'
+            }, {
+              bidder: 'rubicon'
+            }, {
+              bidder: 'other'
+            }];
             const reqBidsConfigObj = {
               ortb2Fragments: {
                 global: {},
@@ -2752,30 +2779,10 @@ describe('weboramaRtdProvider', function() {
               },
               adUnits: [{
                 code: adUnitCode1,
-                bids: [{
-                  bidder: 'smartadserver'
-                }, {
-                  bidder: 'pubmatic'
-                }, {
-                  bidder: 'appnexus'
-                }, {
-                  bidder: 'rubicon'
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }, {
                 code: adUnitCode2,
-                bids: [{
-                  bidder: 'smartadserver'
-                }, {
-                  bidder: 'pubmatic'
-                }, {
-                  bidder: 'appnexus'
-                }, {
-                  bidder: 'rubicon'
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }]
             };
             const onDoneSpy = sinon.spy();
@@ -2792,28 +2799,29 @@ describe('weboramaRtdProvider', function() {
               'adunit2': data,
             });
 
+            const expectedAdunitsBid = deepClone(adUnitsBids);
+            expectedAdunitsBid[2].params = {keywords: data}; // appnexus case
+
             reqBidsConfigObj.adUnits.forEach(adUnit => {
-              expect(adUnit.bids.length).to.equal(5);
-              expect(adUnit.bids[0].params).to.be.undefined;
-              expect(adUnit.bids[1].params).to.be.undefined;
-              expect(adUnit.bids[2].params.keywords).to.deep.equal(data);
-              expect(adUnit.bids[3].params).to.be.undefined;
+              expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
             });
-            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-              if (v == 'appnexus') {
-                expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-                  site: {
-                    ext: {
-                      data: data
-                    },
-                  }
-                });
 
-                return
-              }
+            const bidders = Object.values(adUnitsBids).map(v => v.bidder);
+            const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
+              frag[bidder] = {
+                site: {
+                  ext: {
+                    data: data
+                  },
+                }
+              };
 
-              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
-            })
+              return frag
+            }, {});
+
+            expectedORTB2BidderFragments[APPNEXUS].site.content = {
+              keywords: 'lite_occupation=gérant,lite_occupation=bénévole,lite_hobbies=sport,lite_hobbies=cinéma',
+            };
 
             expect(onDataResponse).to.deep.equal({
               data: data,
@@ -2871,6 +2879,17 @@ describe('weboramaRtdProvider', function() {
 
             const adUnitCode1 = 'adunit1';
             const adUnitCode2 = 'adunit2';
+            const adUnitsBids = [{
+              bidder: 'smartadserver'
+            }, {
+              bidder: 'pubmatic'
+            }, {
+              bidder: 'appnexus'
+            }, {
+              bidder: 'rubicon'
+            }, {
+              bidder: 'other'
+            }];
             const reqBidsConfigObj = {
               ortb2Fragments: {
                 global: {},
@@ -2878,30 +2897,10 @@ describe('weboramaRtdProvider', function() {
               },
               adUnits: [{
                 code: adUnitCode1,
-                bids: [{
-                  bidder: 'smartadserver'
-                }, {
-                  bidder: 'pubmatic'
-                }, {
-                  bidder: 'appnexus'
-                }, {
-                  bidder: 'rubicon'
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }, {
                 code: adUnitCode2,
-                bids: [{
-                  bidder: 'smartadserver'
-                }, {
-                  bidder: 'pubmatic'
-                }, {
-                  bidder: 'appnexus'
-                }, {
-                  bidder: 'rubicon'
-                }, {
-                  bidder: 'other'
-                }]
+                bids: deepClone(adUnitsBids),
               }]
             };
             const onDoneSpy = sinon.spy();
@@ -2928,21 +2927,22 @@ describe('weboramaRtdProvider', function() {
             expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(data);
             expect(reqBidsConfigObj.adUnits[1].bids[2].params).to.be.undefined;
 
-            ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-              if (v == 'appnexus') {
-                expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-                  site: {
-                    ext: {
-                      data: data
-                    },
-                  }
-                });
+            const bidders = Object.values(adUnitsBids).map(v => v.bidder);
+            const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
+              frag[bidder] = {
+                site: {
+                  ext: {
+                    data: data
+                  },
+                }
+              };
 
-                return
-              }
+              return frag
+            }, {});
 
-              expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.be.undefined;
-            })
+            expectedORTB2BidderFragments[APPNEXUS].site.content = {
+              keywords: 'lite_occupation=gérant,lite_occupation=bénévole,lite_hobbies=sport,lite_hobbies=cinéma',
+            };
 
             expect(onDataResponse).to.deep.equal({
               data: data,
@@ -3342,6 +3342,36 @@ describe('weboramaRtdProvider', function() {
           .returns(JSON.stringify(entry));
 
         const adUnitCode = 'adunit1';
+        const adUnitsBids = [{
+          bidder: 'smartadserver',
+          params: {
+            target: 'foo=bar'
+          }
+        }, {
+          bidder: 'pubmatic',
+          params: {
+            dctr: 'foo=bar'
+          }
+        }, {
+          bidder: 'appnexus',
+          params: {
+            keywords: {
+              foo: ['bar']
+            }
+          }
+        }, {
+          bidder: 'rubicon',
+          params: {
+            inventory: {
+              foo: 'bar',
+            },
+            visitor: {
+              baz: 'bam',
+            }
+          }
+        }, {
+          bidder: 'other'
+        }];
         const reqBidsConfigObj = {
           ortb2Fragments: {
             global: {},
@@ -3349,36 +3379,7 @@ describe('weboramaRtdProvider', function() {
           },
           adUnits: [{
             code: adUnitCode,
-            bids: [{
-              bidder: 'smartadserver',
-              params: {
-                target: 'foo=bar'
-              }
-            }, {
-              bidder: 'pubmatic',
-              params: {
-                dctr: 'foo=bar'
-              }
-            }, {
-              bidder: 'appnexus',
-              params: {
-                keywords: {
-                  foo: ['bar']
-                }
-              }
-            }, {
-              bidder: 'rubicon',
-              params: {
-                inventory: {
-                  foo: 'bar',
-                },
-                visitor: {
-                  baz: 'bam',
-                }
-              }
-            }, {
-              bidder: 'other'
-            }]
+            bids: deepClone(adUnitsBids),
           }]
         };
         const onDoneSpy = sinon.spy();
@@ -3410,15 +3411,27 @@ describe('weboramaRtdProvider', function() {
             baz: 'bam',
           }
         });
-        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+        const bidders = Object.values(adUnitsBids).map(v => v.bidder);
+        const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
+          frag[bidder] = {
             site: {
               ext: {
                 data: data
               },
             }
-          });
-        })
+          };
+
+          return frag
+        }, {});
+
+        expectedORTB2BidderFragments[APPNEXUS].site.content = {
+          keywords: 'lite_occupation=gérant,lite_occupation=bénévole,lite_hobbies=sport,lite_hobbies=cinéma',
+        };
+
+        expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+          global: {},
+          bidder: expectedORTB2BidderFragments,
+        });
       });
 
       it('should use default profile in case of nothing on local storage', function() {
@@ -3438,6 +3451,17 @@ describe('weboramaRtdProvider', function() {
         sandbox.stub(storage, 'localStorageIsEnabled').returns(true);
 
         const adUnitCode = 'adunit1';
+        const adUnitsBids = [{
+          bidder: 'smartadserver'
+        }, {
+          bidder: 'pubmatic'
+        }, {
+          bidder: 'appnexus'
+        }, {
+          bidder: 'rubicon'
+        }, {
+          bidder: 'other'
+        }];
         const reqBidsConfigObj = {
           ortb2Fragments: {
             global: {},
@@ -3445,17 +3469,7 @@ describe('weboramaRtdProvider', function() {
           },
           adUnits: [{
             code: adUnitCode,
-            bids: [{
-              bidder: 'smartadserver'
-            }, {
-              bidder: 'pubmatic'
-            }, {
-              bidder: 'appnexus'
-            }, {
-              bidder: 'rubicon'
-            }, {
-              bidder: 'other'
-            }]
+            bids: deepClone(adUnitsBids),
           }]
         };
         const onDoneSpy = sinon.spy();
@@ -3471,20 +3485,34 @@ describe('weboramaRtdProvider', function() {
           'adunit1': defaultProfile,
         });
 
-        expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
-        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+        const expectedAdunitsBid = deepClone(adUnitsBids);
+        expectedAdunitsBid[2].params = {keywords: defaultProfile}; // appnexus case
+
+        reqBidsConfigObj.adUnits.forEach(adUnit => {
+          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+        });
+
+        const bidders = Object.values(adUnitsBids).map(v => v.bidder);
+        const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
+          frag[bidder] = {
             site: {
               ext: {
                 data: defaultProfile
               },
             }
-          });
-        })
+          };
+
+          return frag
+        }, {});
+
+        expectedORTB2BidderFragments[APPNEXUS].site.content = {
+          keywords: 'lite_hobbies=sport,lite_hobbies=cinéma',
+        };
+
+        expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+          global: {},
+          bidder: expectedORTB2BidderFragments,
+        });
       });
 
       it('should use default profile if cant read from local storage', function() {
@@ -3511,6 +3539,17 @@ describe('weboramaRtdProvider', function() {
         sandbox.stub(storage, 'localStorageIsEnabled').returns(false);
 
         const adUnitCode = 'adunit1';
+        const adUnitsBids = [{
+          bidder: 'smartadserver'
+        }, {
+          bidder: 'pubmatic'
+        }, {
+          bidder: 'appnexus'
+        }, {
+          bidder: 'rubicon'
+        }, {
+          bidder: 'other'
+        }];
         const reqBidsConfigObj = {
           ortb2Fragments: {
             global: {},
@@ -3518,17 +3557,7 @@ describe('weboramaRtdProvider', function() {
           },
           adUnits: [{
             code: adUnitCode,
-            bids: [{
-              bidder: 'smartadserver'
-            }, {
-              bidder: 'pubmatic'
-            }, {
-              bidder: 'appnexus'
-            }, {
-              bidder: 'rubicon'
-            }, {
-              bidder: 'other'
-            }]
+            bids: deepClone(adUnitsBids),
           }]
         };
         const onDoneSpy = sinon.spy();
@@ -3544,27 +3573,35 @@ describe('weboramaRtdProvider', function() {
           'adunit1': defaultProfile,
         });
 
-        expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
-        expect(reqBidsConfigObj.ortb2Fragments.bidder.other).to.deep.equal({
-          site: {
-            ext: {
-              data: defaultProfile,
-            },
-          },
+        const expectedAdunitsBid = deepClone(adUnitsBids);
+        expectedAdunitsBid[2].params = {keywords: defaultProfile}; // appnexus case
+
+        reqBidsConfigObj.adUnits.forEach(adUnit => {
+          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
         });
-        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+
+        const bidders = Object.values(adUnitsBids).map(v => v.bidder);
+        const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
+          frag[bidder] = {
             site: {
               ext: {
-                data: defaultProfile,
+                data: defaultProfile
               },
             }
-          });
-        })
+          };
+
+          return frag
+        }, {});
+
+        expectedORTB2BidderFragments[APPNEXUS].site.content = {
+          keywords: 'lite_hobbies=sport,lite_hobbies=cinéma',
+        };
+
+        expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+          global: {},
+          bidder: expectedORTB2BidderFragments,
+        });
+
         expect(onDataResponse).to.deep.equal({
           data: defaultProfile,
           meta: {
@@ -3598,6 +3635,17 @@ describe('weboramaRtdProvider', function() {
         sandbox.stub(storage, 'hasLocalStorage').returns(false);
 
         const adUnitCode = 'adunit1';
+        const adUnitsBids = [{
+          bidder: 'smartadserver'
+        }, {
+          bidder: 'pubmatic'
+        }, {
+          bidder: 'appnexus'
+        }, {
+          bidder: 'rubicon'
+        }, {
+          bidder: 'other'
+        }];
         const reqBidsConfigObj = {
           ortb2Fragments: {
             global: {},
@@ -3605,17 +3653,7 @@ describe('weboramaRtdProvider', function() {
           },
           adUnits: [{
             code: adUnitCode,
-            bids: [{
-              bidder: 'smartadserver'
-            }, {
-              bidder: 'pubmatic'
-            }, {
-              bidder: 'appnexus'
-            }, {
-              bidder: 'rubicon'
-            }, {
-              bidder: 'other'
-            }]
+            bids: deepClone(adUnitsBids),
           }]
         };
         const onDoneSpy = sinon.spy();
@@ -3631,20 +3669,35 @@ describe('weboramaRtdProvider', function() {
           'adunit1': defaultProfile,
         });
 
-        expect(reqBidsConfigObj.adUnits[0].bids.length).to.equal(5);
-        expect(reqBidsConfigObj.adUnits[0].bids[0].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[1].params).to.be.undefined;
-        expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal(defaultProfile);
-        expect(reqBidsConfigObj.adUnits[0].bids[3].params).to.be.undefined;
-        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+        const expectedAdunitsBid = deepClone(adUnitsBids);
+        expectedAdunitsBid[2].params = {keywords: defaultProfile}; // appnexus case
+
+        reqBidsConfigObj.adUnits.forEach(adUnit => {
+          expect(adUnit.bids).to.deep.equal(expectedAdunitsBid);
+        });
+
+        const bidders = Object.values(adUnitsBids).map(v => v.bidder);
+        const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
+          frag[bidder] = {
             site: {
               ext: {
                 data: defaultProfile
               },
             }
-          });
-        })
+          };
+
+          return frag
+        }, {});
+
+        expectedORTB2BidderFragments[APPNEXUS].site.content = {
+          keywords: 'lite_hobbies=sport,lite_hobbies=cinéma',
+        };
+
+        expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+          global: {},
+          bidder: expectedORTB2BidderFragments,
+        });
+
         expect(onDataResponse).to.deep.equal({
           data: defaultProfile,
           meta: {
@@ -3654,6 +3707,7 @@ describe('weboramaRtdProvider', function() {
           },
         });
       });
+
       it('should be possible update profile from callbacks for a given bidder/adUnitCode', function() {
         let onDataResponse = {};
         const moduleConfig = {
@@ -3698,6 +3752,17 @@ describe('weboramaRtdProvider', function() {
 
         const adUnitCode1 = 'adunit1';
         const adUnitCode2 = 'adunit2';
+        const adUnitsBids = [{
+          bidder: 'smartadserver'
+        }, {
+          bidder: 'pubmatic'
+        }, {
+          bidder: 'appnexus'
+        }, {
+          bidder: 'rubicon'
+        }, {
+          bidder: 'other'
+        }];
         const reqBidsConfigObj = {
           ortb2Fragments: {
             global: {},
@@ -3705,30 +3770,10 @@ describe('weboramaRtdProvider', function() {
           },
           adUnits: [{
             code: adUnitCode1,
-            bids: [{
-              bidder: 'smartadserver'
-            }, {
-              bidder: 'pubmatic'
-            }, {
-              bidder: 'appnexus'
-            }, {
-              bidder: 'rubicon'
-            }, {
-              bidder: 'other'
-            }]
+            bids: deepClone(adUnitsBids),
           }, {
             code: adUnitCode2,
-            bids: [{
-              bidder: 'smartadserver'
-            }, {
-              bidder: 'pubmatic'
-            }, {
-              bidder: 'appnexus'
-            }, {
-              bidder: 'rubicon'
-            }, {
-              bidder: 'other'
-            }]
+            bids: deepClone(adUnitsBids),
           }]
         };
 
@@ -3756,31 +3801,37 @@ describe('weboramaRtdProvider', function() {
           expect(adUnit.bids[1].params).to.be.undefined;
           expect(adUnit.bids[3].params).to.be.undefined;
         });
-        ['smartadserver', 'pubmatic', 'appnexus', 'rubicon', 'other'].forEach((v) => {
-          if (v == 'appnexus') {
-            expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
-              site: {
-                ext: {
-                  data: {
-                    lite_occupation: ['gérant', 'bénévole'],
-                    lite_hobbies: ['sport', 'cinéma'],
-                    lito_bar: ['baz'],
-                  },
-                },
-              }
-            });
 
-            return
-          }
-
-          expect(reqBidsConfigObj.ortb2Fragments.bidder[v]).to.deep.equal({
+        const bidders = Object.values(adUnitsBids).map(v => v.bidder);
+        const expectedORTB2BidderFragments = bidders.reduce((frag, bidder) => {
+          frag[bidder] = {
             site: {
               ext: {
-                data: data,
+                data: data
               },
             }
-          });
-        })
+          };
+
+          return frag
+        }, {});
+
+        expectedORTB2BidderFragments[APPNEXUS].site = {
+          ext: {
+            data: {
+              lite_occupation: ['gérant', 'bénévole'],
+              lite_hobbies: ['sport', 'cinéma'],
+              lito_bar: ['baz'],
+            },
+          },
+          content: {
+            keywords: 'lite_occupation=gérant,lite_occupation=bénévole,lite_hobbies=sport,lite_hobbies=cinéma',
+          },
+        };
+
+        expect(reqBidsConfigObj.ortb2Fragments).to.deep.equal({
+          global: {},
+          bidder: expectedORTB2BidderFragments,
+        });
 
         expect(reqBidsConfigObj.adUnits[0].bids[2].params.keywords).to.deep.equal({
           lite_occupation: ['gérant', 'bénévole'],
@@ -3799,6 +3850,5 @@ describe('weboramaRtdProvider', function() {
         });
       });
     });
-    */
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Refactoring (no functional changes, no api changes)

## Description of change

This Pull Requests finish the work started on https://github.com/prebid/Prebid.js/pull/10005

Here we:

1. send data to AppNexus using `site.content.keywords` or `user.keywords` using the format `key=foo,key=bar,...`
2. remove the hard coded bidder name `appnexus` to use it as a default value. Other aliases can be added via configuration
3. check the bidder alias registry based on configuration

Today we check for appnexus and registered aliases and we don't want to remove this behavior without warn all of our customers. We plan some modifications to do in the next releases to avoid break backward compatibility.
