### PR TITLE
Sonobi Bid Adapter:  Updated outstream size to use the video player 

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -5,7 +5,7 @@ import { config } from '../src/config.js';
 import { Renderer } from '../src/Renderer.js';
 import { userSync } from '../src/userSync.js';
 import { bidderSettings } from '../src/bidderSettings.js';
-import {getAllOrtbKeywords} from '../libraries/keywords/keywords.js';
+import { getAllOrtbKeywords } from '../libraries/keywords/keywords.js';
 const BIDDER_CODE = 'sonobi';
 const STR_ENDPOINT = 'https://apex.go.sonobi.com/trinity.json';
 const PAGEVIEW_ID = generateUUID();
@@ -39,8 +39,8 @@ export const spec = {
         return false;
       }
     } else if (deepAccess(bid, 'mediaTypes.video')) {
-      if (deepAccess(bid, 'mediaTypes.video.context') === 'outstream' && !bid.params.sizes) {
-        // bids.params.sizes is required for outstream video adUnits
+      if (deepAccess(bid, 'mediaTypes.video.context') === 'outstream' && !deepAccess(bid, 'mediaTypes.video.playerSize')) {
+        // playerSize is required for outstream video adUnits
         return false;
       }
       if (deepAccess(bid, 'mediaTypes.video.context') === 'instream' && !deepAccess(bid, 'mediaTypes.video.playerSize')) {
@@ -248,10 +248,7 @@ export const spec = {
             bidRequest,
             'renderer.options'
           ));
-          let videoSize = deepAccess(bidRequest, 'params.sizes');
-          if (Array.isArray(videoSize) && Array.isArray(videoSize[0])) { // handle case of multiple sizes
-            videoSize = videoSize[0]; // Only take the first size for outstream
-          }
+          let videoSize = deepAccess(bidRequest, 'mediaTypes.video.playerSize');
           if (videoSize) {
             bids.width = videoSize[0];
             bids.height = videoSize[1];

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -193,7 +193,7 @@ describe('SonobiBidAdapter', function () {
       });
 
       describe('outstream', () => {
-        it('should return false if there is no param sizes', () => {
+        it('should return false if there is no playerSize', () => {
           const bid = {
             'bidder': 'sonobi',
             'adUnitCode': 'adunit-code',
@@ -203,7 +203,6 @@ describe('SonobiBidAdapter', function () {
             'mediaTypes': {
               video: {
                 context: 'outstream',
-                playerSize: [300, 250]
               }
             },
             'bidId': '30b31c1838de1e',
@@ -213,7 +212,7 @@ describe('SonobiBidAdapter', function () {
           expect(spec.isBidRequestValid(bid)).to.equal(false);
         });
 
-        it('should return true if there is param sizes', () => {
+        it('should return true if there is playerSize', () => {
           const bid = {
             'bidder': 'sonobi',
             'adUnitCode': 'adunit-code',
@@ -224,7 +223,8 @@ describe('SonobiBidAdapter', function () {
             },
             'mediaTypes': {
               video: {
-                context: 'outstream'
+                context: 'outstream',
+                playerSize: [640, 480]
               }
             },
             'bidId': '30b31c1838de1e',
@@ -294,7 +294,7 @@ describe('SonobiBidAdapter', function () {
       },
       mediaTypes: {
         video: {
-          sizes: [[300, 250], [300, 600]],
+          playerSize: [640, 480],
           context: 'outstream'
         }
       }
@@ -339,7 +339,7 @@ describe('SonobiBidAdapter', function () {
     }];
 
     let keyMakerData = {
-      '30b31c1838de1f': '1a2b3c4d5e6f1a2b3c4d|300x250,300x600|f=1.25,gpid=/123123/gpt_publisher/adunit-code-1,c=v,',
+      '30b31c1838de1f': '1a2b3c4d5e6f1a2b3c4d|640x480|f=1.25,gpid=/123123/gpt_publisher/adunit-code-1,c=v,',
       '30b31c1838de1d': '1a2b3c4d5e6f1a2b3c4e|300x250,300x600|f=0.42,gpid=/123123/gpt_publisher/adunit-code-3,c=d,',
       '/7780971/sparks_prebid_LB|30b31c1838de1e': '300x250,300x600|gpid=/7780971/sparks_prebid_LB,c=d,',
     };
@@ -635,12 +635,12 @@ describe('SonobiBidAdapter', function () {
           bidder: 'sonobi',
           mediaTypes: {
             video: {
-              context: 'outstream'
+              context: 'outstream',
+              playerSize: [640, 480]
             }
           },
           params: {
-            placement_id: '92e95368e86639dbd86d',
-            sizes: [[640, 480]]
+            placement_id: '92e95368e86639dbd86d'
           }
         }
       ]
@@ -658,7 +658,7 @@ describe('SonobiBidAdapter', function () {
             'sbi_adomain': 'sonobi.com'
           },
           '30b31c1838de1e': {
-            'sbi_size': '300x250',
+            'sbi_size': '640x480',
             'sbi_apoc': 'remnant',
             'sbi_aid': '30292e432662bd5f86d90774b944b038',
             'sbi_mouse': 1.25,
@@ -668,7 +668,7 @@ describe('SonobiBidAdapter', function () {
 
           },
           '/7780971/sparks_prebid_LB_OUTSTREAM|30b31c1838de1g': {
-            'sbi_size': '300x600',
+            'sbi_size': '640x480',
             'sbi_apoc': 'remnant',
             'sbi_crid': '1234abcd',
             'sbi_aid': '30292e432662bd5f86d90774b944b038',
@@ -720,8 +720,8 @@ describe('SonobiBidAdapter', function () {
       {
         'requestId': '30b31c1838de1e',
         'cpm': 1.25,
-        'width': 300,
-        'height': 250,
+        'width': 640,
+        'height': 480,
         'vastUrl': 'https://mco-1-apex.go.sonobi.com/vast.xml?vid=30292e432662bd5f86d90774b944b038&ref=https%3A%2F%2Flocalhost%2F',
         'ttl': 500,
         'creativeId': '30292e432662bd5f86d90774b944b038',
@@ -737,8 +737,8 @@ describe('SonobiBidAdapter', function () {
       {
         'requestId': '30b31c1838de1g',
         'cpm': 1.07,
-        'width': 300,
-        'height': 600,
+        'width': 640,
+        'height': 480,
         'ad': `<script type="text/javascript" src="https://mco-1-apex.go.sonobi.com/sbi.js?aid=30292e432662bd5f86d90774b944b038&as=null&ref=https%3A%2F%2Flocalhost%2F"></script>`,
         'ttl': 500,
         'creativeId': '1234abcd',


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix


## Description of change
Changed the size of the outstream ad unit check to use the playerSize in the video object instead of the "sizes" bidder param.

