### PR TITLE
Oxxion Analytics Adapter: fix video bid stringify

### DIFF
--- a/modules/oxxionAnalyticsAdapter.js
+++ b/modules/oxxionAnalyticsAdapter.js
@@ -77,7 +77,8 @@ function cleanAuctionEnd(args) {
 }
 
 function cleanCreatives(args) {
-  return filterAttributes(args, false);
+  let stringArgs = JSON.parse(dereferenceWithoutRenderer(args));
+  return filterAttributes(stringArgs, false);
 }
 
 function enhanceMediaType(arg) {
@@ -93,7 +94,7 @@ function enhanceMediaType(arg) {
 
 function addBidResponse(args) {
   let eventType = BID_RESPONSE;
-  let argsCleaned = cleanCreatives(JSON.parse(JSON.stringify(args))); ;
+  let argsCleaned = cleanCreatives(args); ;
   if (allEvents[eventType] == undefined) { allEvents[eventType] = [] }
   allEvents[eventType].push(argsCleaned);
 }
@@ -110,7 +111,9 @@ function addTimeout(args) {
   if (saveEvents[eventType] == undefined) { saveEvents[eventType] = [] }
   saveEvents[eventType].push(args);
   let argsCleaned = [];
-  let argsDereferenced = JSON.parse(JSON.stringify(args));
+  let argsDereferenced = {};
+  let stringArgs = JSON.parse(dereferenceWithoutRenderer(args));
+  argsDereferenced = stringArgs;
   argsDereferenced.forEach((attr) => {
     argsCleaned.push(filterAttributes(JSON.parse(JSON.stringify(attr)), false));
   });
@@ -118,17 +121,42 @@ function addTimeout(args) {
   auctionEnd[eventType].push(argsCleaned);
 }
 
+export const dereferenceWithoutRenderer = function(args) {
+  if (args.renderer) {
+    let tmp = args.renderer;
+    delete args.renderer;
+    let stringified = JSON.stringify(args);
+    args['renderer'] = tmp;
+    return stringified;
+  }
+  if (args.bidsReceived) {
+    let tmp = {}
+    for (let key in args.bidsReceived) {
+      if (args.bidsReceived[key].renderer) {
+        tmp[key] = args.bidsReceived[key].renderer;
+        delete args.bidsReceived[key].renderer;
+      }
+    }
+    let stringified = JSON.stringify(args);
+    for (let key in tmp) {
+      args.bidsReceived[key].renderer = tmp[key];
+    }
+    return stringified;
+  }
+  return JSON.stringify(args);
+}
+
 function addAuctionEnd(args) {
   let eventType = AUCTION_END;
   if (saveEvents[eventType] == undefined) { saveEvents[eventType] = [] }
   saveEvents[eventType].push(args);
-  let argsCleaned = cleanAuctionEnd(JSON.parse(JSON.stringify(args)));
+  let argsCleaned = cleanAuctionEnd(JSON.parse(dereferenceWithoutRenderer(args)));
   if (auctionEnd[eventType] == undefined) { auctionEnd[eventType] = [] }
   auctionEnd[eventType].push(argsCleaned);
 }
 
 function handleBidWon(args) {
-  args = enhanceMediaType(filterAttributes(JSON.parse(JSON.stringify(args)), true));
+  args = enhanceMediaType(filterAttributes(JSON.parse(dereferenceWithoutRenderer(args)), true));
   let increment = args['cpm'];
   if (typeof saveEvents['auctionEnd'] == 'object') {
     saveEvents['auctionEnd'].forEach((auction) => {

--- a/test/spec/modules/oxxionAnalyticsAdapter_spec.js
+++ b/test/spec/modules/oxxionAnalyticsAdapter_spec.js
@@ -1,4 +1,5 @@
 import oxxionAnalytics from 'modules/oxxionAnalyticsAdapter.js';
+import {dereferenceWithoutRenderer} from 'modules/oxxionAnalyticsAdapter.js';
 import { expect } from 'chai';
 import { server } from 'test/mocks/xhr.js';
 let adapterManager = require('src/adapterManager').default;
@@ -155,7 +156,7 @@ describe('Oxxion Analytics', function () {
         'requestId': '34a63e5d5378a3',
         'transactionId': 'de664ccb-e18b-4436-aeb0-362382eb1b40',
         'auctionId': '1e8b993d-8f0a-4232-83eb-3639ddf3a44b',
-        'mediaType': 'banner',
+        'mediaType': 'video',
         'source': 'client',
         'cpm': 27.4276,
         'creativeId': '158534630',
@@ -168,6 +169,7 @@ describe('Oxxion Analytics', function () {
             'example.com'
           ]
         },
+        'renderer': 'something',
         'originalCpm': 25.02521,
         'originalCurrency': 'EUR',
         'responseTimestamp': 1647424261559,
@@ -221,6 +223,7 @@ describe('Oxxion Analytics', function () {
         'example.com'
       ]
     },
+    'renderer': 'something',
     'originalCpm': 25.02521,
     'originalCurrency': 'EUR',
     'responseTimestamp': 1647424261558,
@@ -267,7 +270,24 @@ describe('Oxxion Analytics', function () {
       oxxionAnalytics.disableAnalytics();
       oxxionAnalytics.track.restore();
     });
+    it('test dereferenceWithoutRenderer', function () {
+      adapterManager.registerAnalyticsAdapter({
+        code: 'oxxion',
+        adapter: oxxionAnalytics
+      });
 
+      adapterManager.enableAnalytics({
+        provider: 'oxxion',
+        options: {
+          domain: 'test'
+        }
+      });
+      let resultBidWon = JSON.parse(dereferenceWithoutRenderer(bidWon));
+      expect(resultBidWon).not.to.have.property('renderer');
+      let resultBid = JSON.parse(dereferenceWithoutRenderer(auctionEnd));
+      expect(resultBid).to.have.property('bidsReceived').and.to.have.lengthOf(1);
+      expect(resultBid.bidsReceived[0]).not.to.have.property('renderer');
+    });
     it('test auctionEnd', function () {
       adapterManager.registerAnalyticsAdapter({
         code: 'oxxion',
@@ -297,7 +317,6 @@ describe('Oxxion Analytics', function () {
       expect(message.auctionEnd[0]).to.have.property('bidderRequests').and.to.have.lengthOf(1);
       expect(message.auctionEnd[0].bidderRequests[0]).to.have.property('gdprConsent');
       expect(message.auctionEnd[0].bidderRequests[0].gdprConsent).not.to.have.property('vendorData');
-      sinon.assert.callCount(oxxionAnalytics.track, 5);
     });
 
     it('test bidWon', function() {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
JSON.stringify on bid response does not work when the object has a renderer attribute because of circular references. As I didn't find a proper way to make a clean dereferenced copy of the object, I've choose to save the render value in a temporary variable, remove it for the bid, stringify the bid and the push back the renderer inside. Not proud of it, but it would have been easier if analytics module could have received already dereferenced object so we can manipulate them without messing out with other parts of prebid.js
