### PR TITLE
fledgeForGpt: consolidate publisher configuration

### DIFF
--- a/modules/fledgeForGpt.js
+++ b/modules/fledgeForGpt.js
@@ -62,8 +62,8 @@ export function markForFledge(next, bidderRequests) {
       const useGlobalConfig = globalFledgeConfig?.enabled && (bidders.length == 0 || bidders.includes(req.bidderCode));
       Object.assign(req, config.runWithBidder(req.bidderCode, () => {
         return {
-          fledgeEnabled: config.getConfig('fledgeEnabled') ?? (useGlobalConfig && globalFledgeConfig.enabled),
-          defaultForSlots: config.getConfig('defaultForSlots') ?? (useGlobalConfig && globalFledgeConfig?.defaultForSlots)
+          fledgeEnabled: config.getConfig('fledgeEnabled') ?? (useGlobalConfig ? globalFledgeConfig.enabled : undefined),
+          defaultForSlots: config.getConfig('defaultForSlots') ?? (useGlobalConfig ? globalFledgeConfig?.defaultForSlots : undefined)
         }
       }));
     });

--- a/modules/fledgeForGpt.js
+++ b/modules/fledgeForGpt.js
@@ -56,18 +56,26 @@ function isFledgeSupported() {
 
 export function markForFledge(next, bidderRequests) {
   if (isFledgeSupported()) {
+    const globalFledgeConfig = config.getConfig('fledgeForGpt');
+    const bidders = globalFledgeConfig?.bidders ?? [];
     bidderRequests.forEach((req) => {
-      req.fledgeEnabled = config.runWithBidder(req.bidderCode, () => config.getConfig('fledgeEnabled'))
-    })
+      const useGlobalConfig = globalFledgeConfig?.enabled && (bidders.length == 0 || bidders.includes(req.bidderCode));
+      Object.assign(req, config.runWithBidder(req.bidderCode, () => {
+        return {
+          fledgeEnabled: config.getConfig('fledgeEnabled') ?? (useGlobalConfig && globalFledgeConfig.enabled),
+          defaultForSlots: config.getConfig('defaultForSlots') ?? (useGlobalConfig && globalFledgeConfig?.defaultForSlots)
+        }
+      }));
+    });
   }
   next(bidderRequests);
 }
 getHook('makeBidRequests').after(markForFledge);
 
 export function setImpExtAe(imp, bidRequest, context) {
-  if (!context.bidderRequest.fledgeEnabled) {
-    delete imp.ext?.ae;
-  }
+  const impExt = imp.ext ?? {};
+  impExt.ae = context.bidderRequest.fledgeEnabled ? (impExt.ae ?? context.bidderRequest.defaultForSlots) : undefined;
+  imp.ext = impExt;
 }
 registerOrtbProcessor({type: IMP, name: 'impExtAe', fn: setImpExtAe});
 

--- a/modules/fledgeForGpt.md
+++ b/modules/fledgeForGpt.md
@@ -15,8 +15,8 @@ This is accomplished by adding the `fledgeForGpt` module to the list of modules 
 gulp build --modules=fledgeForGpt,...
 ```
 
-Second, they must enable FLEDGE in their Prebid.js configuration. To provide a high degree of flexiblity for testing, FLEDGE
-settings exist at the module level, the bidder level, and the slot level.
+Second, they must enable FLEDGE in their Prebid.js configuration. 
+This is done through module level configuration, but to provide a high degree of flexiblity for testing, FLEDGE settings also exist at the bidder level and slot level.
 
 ### Module Configuration
 This module exposes the following settings:
@@ -24,15 +24,20 @@ This module exposes the following settings:
 |Name |Type |Description |Notes |
 | :------------ | :------------ | :------------ |:------------ |
 |enabled | Boolean |Enable/disable the module |Defaults to `false` |
+|bidders | Array[String] |Optional list of bidders |Defaults to all bidders |
+|defaultForSlots | Number |Default value for `imp.ext.ae` in requests for specified bidders |Should be 1 |
 
-As noted above, FLEDGE support is disabled by default. To enable it, set the `enabled` value to `true` for this module
-using the `setConfig` method of Prebid.js:
+As noted above, FLEDGE support is disabled by default. To enable it, set the `enabled` value to `true` for this module and configure `defaultForSlots` to be `1` (meaning _Client-side auction_).
+using the `setConfig` method of Prebid.js. Optionally, a list of 
+bidders to apply these settings to may be provided:
 
 ```js
 pbjs.que.push(function() {
   pbjs.setConfig({
     fledgeForGpt: {
-      enabled: true
+      enabled: true,
+      bidders: ['openx', 'rtbhouse'],
+      defaultForSlots: 1
     }
   });
 });
@@ -44,23 +49,25 @@ This module adds the following setting for bidders:
 |Name |Type |Description |Notes |
 | :------------ | :------------ | :------------ |:------------ |
 | fledgeEnabled | Boolean | Enable/disable a bidder to participate in FLEDGE | Defaults to `false` |
+|defaultForSlots | Number |Default value for `imp.ext.ae` in requests for specified bidders |Should be 1|
 
-In addition to enabling FLEDGE at the module level, individual bidders must also be enabled. This allows publishers to
-selectively test with one or more bidders as they desire. To enable one or more bidders, use the `setBidderConfig` method
+Individual bidders may be further included or excluded here using the `setBidderConfig` method
 of Prebid.js:
 
 ```js
 pbjs.setBidderConfig({
     bidders: ["openx"],
     config: {
-        fledgeEnabled: true
+        fledgeEnabled: true,
+        defaultForSlots: 1
     }
 });
 ```
 
 ### AdUnit Configuration
-Enabling an adunit for FLEDGE eligibility is accomplished by setting an attribute of the `ortb2Imp` object for that
-adunit.
+All adunits can be opted-in to FLEDGE in the global config via the `defaultForSlots` parameter.
+If needed, adunits can be configured individually by setting an attribute of the `ortb2Imp` object for that
+adunit. This attribute will take precedence over `defaultForSlots` setting.
 
 |Name |Type |Description |Notes |
 | :------------ | :------------ | :------------ |:------------ |

--- a/test/spec/modules/fledge_spec.js
+++ b/test/spec/modules/fledge_spec.js
@@ -61,73 +61,131 @@ describe('fledgeEnabled', function () {
     config.resetConfig();
   });
 
-  it('should set fledgeEnabled correctly per bidder', function () {
-    config.setConfig({bidderSequence: 'fixed'})
-    config.setBidderConfig({
-      bidders: ['appnexus'],
-      config: {
-        fledgeEnabled: true,
-      }
+  const adUnits = [{
+    'code': '/19968336/header-bid-tag1',
+    'mediaTypes': {
+      'banner': {
+        'sizes': [[728, 90]]
+      },
+    },
+    'bids': [
+      {
+        'bidder': 'appnexus',
+      },
+      {
+        'bidder': 'rubicon',
+      },
+    ]
+  }];
+
+  describe('with setBidderConfig()', () => {
+    it('should set fledgeEnabled correctly per bidder', function () {
+      config.setConfig({bidderSequence: 'fixed'})
+      config.setBidderConfig({
+        bidders: ['appnexus'],
+        config: {
+          fledgeEnabled: true,
+          defaultForSlots: 1,
+        }
+      });
+
+      const bidRequests = adapterManager.makeBidRequests(
+        adUnits,
+        Date.now(),
+        utils.getUniqueIdentifierStr(),
+        function callback() {},
+        []
+      );
+
+      expect(bidRequests[0].bids[0].bidder).equals('appnexus');
+      expect(bidRequests[0].fledgeEnabled).to.be.true;
+      expect(bidRequests[0].defaultForSlots).to.equal(1);
+
+      expect(bidRequests[1].bids[0].bidder).equals('rubicon');
+      expect(bidRequests[1].fledgeEnabled).to.be.undefined;
+      expect(bidRequests[1].defaultForSlots).to.be.undefined;
+    });
+  });
+
+  describe('with setConfig()', () => {
+    it('should set fledgeEnabled correctly per bidder', function () {
+      config.setConfig({
+        bidderSequence: 'fixed',
+        fledgeForGpt: {
+          enabled: true,
+          bidders: ['appnexus'],
+          defaultForSlots: 1,
+        }
+      });
+
+      const bidRequests = adapterManager.makeBidRequests(
+        adUnits,
+        Date.now(),
+        utils.getUniqueIdentifierStr(),
+        function callback() {},
+        []
+      );
+
+      expect(bidRequests[0].bids[0].bidder).equals('appnexus');
+      expect(bidRequests[0].fledgeEnabled).to.be.true;
+      expect(bidRequests[0].defaultForSlots).to.equal(1);
+
+      expect(bidRequests[1].bids[0].bidder).equals('rubicon');
+      expect(bidRequests[1].fledgeEnabled).to.be.undefined;
+      expect(bidRequests[1].defaultForSlots).to.be.undefined;
     });
 
-    const adUnits = [{
-      'code': '/19968336/header-bid-tag1',
-      'mediaTypes': {
-        'banner': {
-          'sizes': [[728, 90]]
-        },
-      },
-      'bids': [
-        {
-          'bidder': 'appnexus',
-        },
-        {
-          'bidder': 'rubicon',
-        },
-      ]
-    }];
+    it('should set fledgeEnabled correctly for all bidders', function () {
+      config.setConfig({
+        bidderSequence: 'fixed',
+        fledgeForGpt: {
+          enabled: true,
+          defaultForSlots: 1,
+        }
+      });
 
-    const bidRequests = adapterManager.makeBidRequests(
-      adUnits,
-      Date.now(),
-      utils.getUniqueIdentifierStr(),
-      function callback() {},
-      []
-    );
+      const bidRequests = adapterManager.makeBidRequests(
+        adUnits,
+        Date.now(),
+        utils.getUniqueIdentifierStr(),
+        function callback() {},
+        []
+      );
 
-    expect(bidRequests[0].bids[0].bidder).equals('appnexus');
-    expect(bidRequests[0].fledgeEnabled).to.be.true;
+      expect(bidRequests[0].bids[0].bidder).equals('appnexus');
+      expect(bidRequests[0].fledgeEnabled).to.be.true;
+      expect(bidRequests[0].defaultForSlots).to.equal(1);
 
-    expect(bidRequests[1].bids[0].bidder).equals('rubicon');
-    expect(bidRequests[1].fledgeEnabled).to.be.undefined;
+      expect(bidRequests[1].bids[0].bidder).equals('rubicon');
+      expect(bidRequests[0].fledgeEnabled).to.be.true;
+      expect(bidRequests[0].defaultForSlots).to.equal(1);
+    });
   });
 });
 
 describe('ortb processors for fledge', () => {
-  describe('imp.ext.ae', () => {
-    describe('when defaultForSlots is set', () => {
-      it('should be set if fledge is enabled', () => {
-        const imp = {};
-        setImpExtAe(imp, {}, {bidderRequest: {fledgeEnabled: true, defaultForSlots: 1}});
-        expect(imp.ext.ae).to.equal(1);
-      });
-      it('should be left intact if set on adunit and fledge is enabled', () => {
-        const imp = {ext: {ae: false}};
-        setImpExtAe(imp, {}, {bidderRequest: {fledgeEnabled: true, defaultForSlots: 1}});
-        expect(imp.ext.ae).to.equal(false);
-      });
+  describe('when defaultForSlots is set', () => {
+    it('imp.ext.ae should be set if fledge is enabled', () => {
+      const imp = {};
+      setImpExtAe(imp, {}, {bidderRequest: {fledgeEnabled: true, defaultForSlots: 1}});
+      expect(imp.ext.ae).to.equal(1);
     });
-    describe('when defaultForSlots is not set', () => {
-      it('should be removed if fledge is not enabled', () => {
-        const imp = {ext: {ae: 1}};
-        setImpExtAe(imp, {}, {bidderRequest: {}});
-        expect(imp.ext.ae).to.not.exist;
-      })
-      it('should be left intact if fledge is enabled', () => {
-        const imp = {ext: {ae: false}};
-        setImpExtAe(imp, {}, {bidderRequest: {fledgeEnabled: true}});
-        expect(imp.ext.ae).to.equal(false);
-      });
+    it('imp.ext.ae should be left intact if set on adunit and fledge is enabled', () => {
+      const imp = {ext: {ae: 2}};
+      setImpExtAe(imp, {}, {bidderRequest: {fledgeEnabled: true, defaultForSlots: 1}});
+      expect(imp.ext.ae).to.equal(2);
+    });
+  });
+  describe('when defaultForSlots is not defined', () => {
+    it('imp.ext.ae should be removed if fledge is not enabled', () => {
+      const imp = {ext: {ae: 1}};
+      setImpExtAe(imp, {}, {bidderRequest: {}});
+      expect(imp.ext.ae).to.not.exist;
+    })
+    it('imp.ext.ae should be left intact if fledge is enabled', () => {
+      const imp = {ext: {ae: 2}};
+      setImpExtAe(imp, {}, {bidderRequest: {fledgeEnabled: true}});
+      expect(imp.ext.ae).to.equal(2);
     });
   });
   describe('parseExtPrebidFledge', () => {

--- a/test/spec/modules/fledge_spec.js
+++ b/test/spec/modules/fledge_spec.js
@@ -105,15 +105,29 @@ describe('fledgeEnabled', function () {
 
 describe('ortb processors for fledge', () => {
   describe('imp.ext.ae', () => {
-    it('should be removed if fledge is not enabled', () => {
-      const imp = {ext: {ae: 1}};
-      setImpExtAe(imp, {}, {bidderRequest: {}});
-      expect(imp.ext.ae).to.not.exist;
-    })
-    it('should be left intact if fledge is enabled', () => {
-      const imp = {ext: {ae: false}};
-      setImpExtAe(imp, {}, {bidderRequest: {fledgeEnabled: true}});
-      expect(imp.ext.ae).to.equal(false);
+    describe('when defaultForSlots is set', () => {
+      it('should be set if fledge is enabled', () => {
+        const imp = {};
+        setImpExtAe(imp, {}, {bidderRequest: {fledgeEnabled: true, defaultForSlots: 1}});
+        expect(imp.ext.ae).to.equal(1);
+      });
+      it('should be left intact if set on adunit and fledge is enabled', () => {
+        const imp = {ext: {ae: false}};
+        setImpExtAe(imp, {}, {bidderRequest: {fledgeEnabled: true, defaultForSlots: 1}});
+        expect(imp.ext.ae).to.equal(false);
+      });
+    });
+    describe('when defaultForSlots is not set', () => {
+      it('should be removed if fledge is not enabled', () => {
+        const imp = {ext: {ae: 1}};
+        setImpExtAe(imp, {}, {bidderRequest: {}});
+        expect(imp.ext.ae).to.not.exist;
+      })
+      it('should be left intact if fledge is enabled', () => {
+        const imp = {ext: {ae: false}};
+        setImpExtAe(imp, {}, {bidderRequest: {fledgeEnabled: true}});
+        expect(imp.ext.ae).to.equal(false);
+      });
     });
   });
   describe('parseExtPrebidFledge', () => {


### PR DESCRIPTION
## Type of change
- [x] Feature

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Allows enabling fledge for all adunits and specified bidders with a single global config:
```js
pbjs.setConfig({
  fledgeForGpt: {
    enabled: true,
    bidders: ['openx', 'rtbhouse'],
    defaultForSlots: 1
  }
});
```

The previous documented use of `setBidderConfig()` and `addAdUnits() setting imp.ext.ae` continue to be supported, as they offer additional control over the configuration.

- Behavior with `bidders=[]` is the same as missing `bidders`, meaning _all bidders_. If this can cause confusion, we could change it.
- imp.ext.ae is still removed as before, if it was set on adunit but fledge is disabled for bidder.

## Other information
Resolves #10105 
