### PR TITLE
Devcontainer: fix "Cannot start ChromeHeadless" error when running tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,9 @@
 	},
 
 	"postCreateCommand": "bash .devcontainer/postCreate.sh",
-
+	// Make is-docker work again
+	"postStartCommand": "test -f /.dockerenv || sudo touch /.dockerenv",
+	
 	// Set *default* container specific settings.json values on container create.
 	"settings": {},
 


### PR DESCRIPTION
## Type of change
- [x] Other (devcontainer fix)

## Description of change
Hacky fix to allow running the test suite in devcontainer.

[karma.conf.maker.js](https://github.com/prebid/Prebid.js/blob/master/karma.conf.maker.js#L93) uses [is-docker npm plugin](https://github.com/sindresorhus/is-docker) to add the `--no-sandbox` chrome flag when in docker, but the plugin does not work in devcontainers.

The proposed simple fix is to create `/.dockerenv` for now, one of the things is-docker looks for.

Adding `"securityOpt": ["seccomp=unconfined"]` to devcontainer would also work by raising its privileges so the flag isn't needed, but is less secure.

Eventually the test in karma.conf.maker.js should be updated to use something else, requires further discussion to cover all the previous use cases.

## Other information

Resolves #10066 