### PR TITLE
Brandmetrics RTD Module: support billable event

### DIFF
--- a/modules/brandmetricsRtdProvider.md
+++ b/modules/brandmetricsRtdProvider.md
@@ -16,10 +16,10 @@ Enable the Brandmetrics RTD in your Prebid configuration, using the below format
 pbjs.setConfig({
   ...,
   realTimeData: {
-    auctionDelay: 500, // auction delay
+    auctionDelay: 500,
     dataProviders: [{
       name: 'brandmetrics',
-      waitForIt: true // should be true if there's an `auctionDelay`,
+      waitForIt: true,
       params: {
         scriptId: '00000000-0000-0000-0000-000000000000',
         bidders: ['ozone']
@@ -29,6 +29,7 @@ pbjs.setConfig({
   ...
 })
 ```
+The scriptId- parameter is provided by brandmetrics or a brandmetrics partner.
 
 ## Parameters
 | Name              | Type                 | Description        | Default        |
@@ -38,3 +39,17 @@ pbjs.setConfig({
 | params            | Object               |                 | - |
 | params.bidders    | String[]             | An array of bidders which should receive targeting keys. | `[]` |
 | params.scriptId   | String               | A script- id GUID if the brandmetrics- script should be initialized. | `undefined` |
+
+## Billable events
+The module emits a billable event for creatives that are measured by brandmetrics and are considered in- view.
+
+```javascript
+{
+  vendor: 'brandmetrics',
+  type: 'creative_in_view',
+  measurementId: string, // UUID, brandmetrics measurement id
+  billingId: string, // UUID, unique billing id
+  auctionId: string, // Prebid auction id
+  transactionId: string, //Prebid transaction id
+}
+```

--- a/test/spec/modules/brandmetricsRtdProvider_spec.js
+++ b/test/spec/modules/brandmetricsRtdProvider_spec.js
@@ -1,5 +1,7 @@
 import * as brandmetricsRTD from '../../../modules/brandmetricsRtdProvider.js';
 import {config} from 'src/config.js';
+import * as events from '../../../src/events';
+import * as sinon from 'sinon';
 
 const VALID_CONFIG = {
   name: 'brandmetrics',
@@ -77,14 +79,16 @@ function mockSurveyLoaded(surveyConf) {
   });
 }
 
-function scriptTagExists(url) {
-  const tags = document.getElementsByTagName('script');
-  for (let i = 0; i < tags.length; i++) {
-    if (tags[i].src === url) {
-      return true;
+function mockCreativeInView(creativeInViewConf) {
+  const commands = window._brandmetrics || [];
+  commands.forEach(command => {
+    if (command.cmd === '_addeventlistener') {
+      const conf = command.val;
+      if (conf.event === 'creative_in_view') {
+        conf.handler(creativeInViewConf);
+      }
     }
-  }
-  return false;
+  })
 }
 
 describe('BrandmetricsRTD module', () => {
@@ -187,5 +191,63 @@ describe('getBidRequestData', () => {
     expected.forEach(exp => {
       expect(bidderOrtb2[exp].user.ext.data.brandmetrics_survey).to.equal('mockMeasurementId')
     })
+  });
+
+  describe('billable events', () => {
+    let sandbox;
+    let eventsEmitSpy;
+
+    before(() => {
+      sandbox = sinon.sandbox.create();
+      eventsEmitSpy = sandbox.spy(events, ['emit']);
+    });
+
+    beforeEach(() => {
+      eventsEmitSpy.resetHistory();
+    })
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should emit billable event from prebid events', () => {
+      const expectedEvent = {
+        vendor: 'brandmetrics',
+        type: 'creative_in_view',
+        measurementId: 'mockMeasurementId',
+        auctionId: 'mockAuctionId',
+        transactionId: 'mockTransactionId'
+      };
+
+      mockCreativeInView({
+        mid: expectedEvent.measurementId,
+        source: {
+          type: 'pbj',
+          data: {
+            auctionId: expectedEvent.auctionId,
+            transactionId: expectedEvent.transactionId
+          },
+        }
+      });
+
+      expect(eventsEmitSpy.callCount).to.equal(1);
+
+      const event = eventsEmitSpy.getCalls()[0].args[1];
+      delete event['billingId'];
+
+      expect(event).to.deep.equal(expectedEvent);
+    });
+
+    it('should not emit billable event from non prebid- sources', () => {
+      mockCreativeInView({
+        mid: 'mockMeasurementId',
+        source: {
+          type: 'gpt',
+          data: {},
+        }
+      });
+
+      expect(eventsEmitSpy.callCount).to.equal(0);
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Brandmetrics RTD module will now submit a billable event for each creative measured and considered inview by Brandmetrics.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
