### PR TITLE
beOp Bid Adapter : addition of bpsegs attribute to request payload from ORTB2 object

### DIFF
--- a/modules/beopBidAdapter.js
+++ b/modules/beopBidAdapter.js
@@ -48,8 +48,10 @@ export const spec = {
     */
   buildRequests: function(validBidRequests, bidderRequest) {
     const slots = validBidRequests.map(beOpRequestSlotsMaker);
-    const firstPartyData = bidderRequest.ortb2;
-    const psegs = (firstPartyData && firstPartyData.user && firstPartyData.user.ext && firstPartyData.user.ext.data) ? firstPartyData.user.ext.data.permutive : undefined;
+    const firstPartyData = bidderRequest.ortb2 || {};
+    const psegs = firstPartyData.user?.ext?.permutive || firstPartyData.user?.ext?.data?.permutive || [];
+    const userBpSegs = firstPartyData.user?.ext?.bpsegs || firstPartyData.user?.ext?.data?.bpsegs || [];
+    const siteBpSegs = firstPartyData.site?.ext?.bpsegs || firstPartyData.site?.ext?.data?.bpsegs || [];
     const pageUrl = getPageUrl(bidderRequest.refererInfo, window);
     const gdpr = bidderRequest.gdprConsent;
     const firstSlot = slots[0];
@@ -61,6 +63,8 @@ export const spec = {
       nid: firstSlot.nid,
       nptnid: firstSlot.nptnid,
       pid: firstSlot.pid,
+      psegs: psegs,
+      bpsegs: (userBpSegs.concat(siteBpSegs)).map(item => item.toString()),
       url: pageUrl,
       lang: (window.navigator.language || window.navigator.languages[0]),
       kwds: keywords,
@@ -70,10 +74,6 @@ export const spec = {
       gdpr_applies: gdpr ? gdpr.gdprApplies : false,
       tc_string: (gdpr && gdpr.gdprApplies) ? gdpr.consentString : null,
     };
-
-    if (psegs) {
-      Object.assign(payloadObject, {psegs: psegs});
-    }
 
     const payloadString = JSON.stringify(payloadObject);
     return {

--- a/modules/beopBidAdapter.md
+++ b/modules/beopBidAdapter.md
@@ -9,13 +9,14 @@
 Module that connects to BeOp's demand sources
 
 # Test Parameters
+
 ```
     var adUnits = [
         {
             code: 'in-article',
             mediaTypes: {
                 banner: {
-                    sizes: [[1,1]], 
+                    sizes: [[1,1]],
                 }
             },
             bids: [
@@ -31,3 +32,36 @@ Module that connects to BeOp's demand sources
     ];
 ```
 
+# Custom Bidder data
+
+If you want to pass your first party data to BeOp, you can set your bidder `config.ortb2` object with
+
+```json
+{
+  "site": {
+    "ext": {
+      "bpsegs": ["Your", 1, "ST", "party", "data"],
+      "data": {
+        "bpsegs": ["Your", 1, "ST", "party", "data"]
+      }
+    }
+  },
+  "user": {
+    "ext": {
+      "bpsegs": ["Your", 1, "ST", "party", "data"],
+      "data": {
+        "bpsegs": ["Your", 1, "ST", "party", "data"]
+      }
+    }
+  }
+}
+```
+
+You can choose the location between:
+
+- `site.ext`
+- `site.ext.data`
+- `user.ext`
+- `user.ext.data`
+
+and our BidAdapter will be able to find them

--- a/test/spec/modules/beopBidAdapter_spec.js
+++ b/test/spec/modules/beopBidAdapter_spec.js
@@ -130,15 +130,15 @@ describe('BeOp Bid Adapter tests', () => {
       expect(payload.url).to.exist;
       // check that the protocol is added correctly
       expect(payload.url).to.equal('http://test.te');
-      expect(payload.psegs).to.not.exist;
     });
 
-    it('should call the endpoint with psegs data if any', function () {
+    it('should call the endpoint with psegs and bpsegs (stringified) data if any or [] if none', function () {
       let bidderRequest =
       {
         'ortb2': {
           'user': {
             'ext': {
+              'bpsegs': ['axed', 'axec', 1234],
               'data': {
                 'permutive': [1234, 5678, 910]
               }
@@ -154,6 +154,22 @@ describe('BeOp Bid Adapter tests', () => {
       expect(payload.psegs).to.include(5678);
       expect(payload.psegs).to.include(910);
       expect(payload.psegs).to.not.include(1);
+      expect(payload.bpsegs).to.exist;
+      expect(payload.bpsegs).to.include('axed');
+      expect(payload.bpsegs).to.include('axec');
+      expect(payload.bpsegs).to.include('1234');
+
+      let bidderRequest2 =
+      {
+        'ortb2': {}
+      };
+
+      const request2 = spec.buildRequests(bidRequests, bidderRequest2);
+      const payload2 = JSON.parse(request2.data);
+      expect(payload2.psegs).to.exist;
+      expect(payload2.psegs).to.be.empty;
+      expect(payload2.bpsegs).to.exist;
+      expect(payload2.bpsegs).to.be.empty;
     });
 
     it('should not prepend the protocol in page url if already present', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Addition of bpsegs attribute to the BeOp Bidder Request payload in order to add a new feature for publisher. They can know provide their first party data to BeOp for a better usage of our platform