### PR TITLE
VIS.X Bid Adapter : add first-party id

### DIFF
--- a/modules/visxBidAdapter.js
+++ b/modules/visxBidAdapter.js
@@ -3,6 +3,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { INSTREAM as VIDEO_INSTREAM } from '../src/video.js';
+import {getStorageManager} from '../src/storageManager.js';
 const BIDDER_CODE = 'visx';
 const GVLID = 154;
 const BASE_URL = 'https://t.visx.net';
@@ -29,6 +30,7 @@ const LOG_ERROR_MESS = {
   videoMissing: 'Bid request videoType property is missing - '
 };
 const currencyWhiteList = ['EUR', 'USD', 'GBP', 'PLN'];
+export const storage = getStorageManager({bidderCode: BIDDER_CODE});
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
@@ -117,10 +119,13 @@ export const spec = {
         ...(payloadSchain && { schain: payloadSchain })
       }
     };
+
+    const vads = _getUserId();
     const user = {
       ext: {
         ...(payloadUserEids && { eids: payloadUserEids }),
-        ...(payload.gdpr_consent && { consent: payload.gdpr_consent })
+        ...(payload.gdpr_consent && { consent: payload.gdpr_consent }),
+        ...(vads && { vads })
       }
     };
     const regs = ('gdpr_applies' in payload) && {
@@ -380,6 +385,51 @@ function _isAdSlotExists(adUnitCode) {
   }
 
   return false;
+}
+
+// Generate user id (25 chars) with NanoID
+// https://github.com/ai/nanoid/
+function _generateUserId() {
+  for (
+    var t = 'useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict',
+      e = new Date().getTime() % 1073741824,
+      i = '',
+      o = 0;
+    o < 5;
+    o++
+  ) {
+    i += t[e % 64];
+    e = Math.floor(e / 64);
+  }
+  for (o = 20; o--;) i += t[(64 * Math.random()) | 0];
+  return i;
+}
+
+function _getUserId() {
+  const USER_ID_KEY = '__vads';
+  let vads;
+
+  if (storage.cookiesAreEnabled()) {
+    vads = storage.getCookie(USER_ID_KEY);
+  } else if (storage.localStorageIsEnabled()) {
+    vads = storage.getDataFromLocalStorage(USER_ID_KEY);
+  }
+
+  if (vads && vads.length) {
+    return vads;
+  }
+
+  vads = _generateUserId();
+  if (storage.cookiesAreEnabled()) {
+    const expires = new Date(Date.now() + 2592e6).toUTCString();
+    storage.setCookie(USER_ID_KEY, vads, expires);
+    return vads;
+  } else if (storage.localStorageIsEnabled()) {
+    storage.setDataInLocalStorage(USER_ID_KEY, vads);
+    return vads;
+  }
+
+  return null;
 }
 
 registerBidder(spec);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
We have added the first-party user id for VIS.X bidder.

## Other information

