### PR TITLE
Core: Fix sua low entropy check for empty objects

### DIFF
--- a/src/fpd/sua.js
+++ b/src/fpd/sua.js
@@ -15,6 +15,12 @@ export const HIGH_ENTROPY_HINTS = [
   'fullVersionList'
 ]
 
+export const LOW_ENTROPY_HINTS = [
+  'brands',
+  'mobile',
+  'platform'
+]
+
 /**
  * Returns low entropy UA client hints encoded as an ortb2.6 device.sua object; or null if no UA client hints are available.
  */
@@ -32,7 +38,7 @@ export const getLowEntropySUA = lowEntropySUAAccessor();
 export const getHighEntropySUA = highEntropySUAAccessor();
 
 export function lowEntropySUAAccessor(uaData = window.navigator?.userAgentData) {
-  const sua = isEmpty(uaData) ? null : Object.freeze(uaDataToSUA(SUA_SOURCE_LOW_ENTROPY, uaData));
+  const sua = (uaData && LOW_ENTROPY_HINTS.some(h => typeof uaData[h] !== 'undefined')) ? Object.freeze(uaDataToSUA(SUA_SOURCE_LOW_ENTROPY, uaData)) : null;
   return function () {
     return sua;
   }
@@ -85,7 +91,7 @@ export function uaDataToSUA(source, uaData) {
   if (uaData.fullVersionList || uaData.brands) {
     sua.browsers = (uaData.fullVersionList || uaData.brands).map(({brand, version}) => toBrandVersion(brand, version));
   }
-  if (uaData.hasOwnProperty('mobile')) {
+  if (typeof uaData['mobile'] !== 'undefined') {
     sua.mobile = uaData.mobile ? 1 : 0;
   }
   ['model', 'bitness', 'architecture'].forEach(prop => {

--- a/test/spec/fpd/enrichment_spec.js
+++ b/test/spec/fpd/enrichment_spec.js
@@ -275,7 +275,13 @@ describe('FPD enrichment', () => {
 
   describe('sua', () => {
     it('does not set device.sua if resolved sua is null', () => {
-      sandbox.stub(dep, 'getHighEntropySUA').returns(Promise.resolve())
+      sandbox.stub(dep, 'getHighEntropySUA').returns(Promise.resolve());
+      // Add hints so it will attempt to retrieve high entropy values
+      config.setConfig({
+        firstPartyData: {
+          uaHints: ['bitness'],
+        }
+      });
       return fpd().then(ortb2 => {
         expect(ortb2.device.sua).to.not.exist;
       })

--- a/test/spec/fpd/sua_spec.js
+++ b/test/spec/fpd/sua_spec.js
@@ -165,6 +165,14 @@ describe('uaDataToSUA', () => {
 });
 
 describe('lowEntropySUAAccessor', () => {
+  // Set up a mock data with readonly property
+  class MockUserAgentData {}
+  Object.defineProperty(MockUserAgentData.prototype, 'mobile', {
+    value: false,
+    writable: false,
+    enumerable: true
+  });
+
   function getSUA(uaData) {
     return lowEntropySUAAccessor(uaData)();
   }
@@ -180,6 +188,10 @@ describe('lowEntropySUAAccessor', () => {
 
   it('should return null if uaData is empty', () => {
     expect(getSUA({})).to.eql(null);
+  })
+
+  it('should return mobile and source', () => {
+    expect(getSUA(new MockUserAgentData())).to.eql({mobile: 0, source: 1})
   })
 });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Device.sua is not generated by default because window.navigator.userAgentData is mistakenly identified as empty.  On Chrome, this object has read-only properties that doesn't work with hasOwnProperty checks.  

https://jsfiddle.net/bwspyja9/

```javascript
let uaData = window.navigator.userAgentData;

function isEmpty(obj) {
   if (!obj) return true;
   for (let x in obj) {
      if (Object.prototype.hasOwnProperty.call(obj, x)) return false;
   }
   return true;
}

function isReallyEmpty(obj) {
   if (!obj) return true;
   for (let x in obj) return false;
   return true;
}

console.log(uaData);
console.log('is empty? ', isEmpty(uaData));
console.log('is really empty? ', isReallyEmpty(uaData));
```

```
 "Running fiddle"
[object NavigatorUAData] {
  brands: [{
  brand: "Not.A/Brand",
  version: "8"
}, {
  brand: "Chromium",
  version: "114"
}, {
  brand: "Google Chrome",
  version: "114"
}],
  getHighEntropyValues: function getHighEntropyValues() { [native code] },
  mobile: false,
  platform: "macOS",
  toJSON: function toJSON() { [native code] }
}
"is empty? ", true
"is really empty? ", false
```

<!-- For new bidder adapters, please provide the following
- contact email: paul.yang@epsilon.com


Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
