### PR TITLE
Yahoo Bid Adapter: prevent error being thrown if GPP consent module is not enabled

### DIFF
--- a/modules/yahoosspBidAdapter.js
+++ b/modules/yahoosspBidAdapter.js
@@ -114,11 +114,12 @@ function extractUserSyncUrls(syncOptions, pixels) {
  */
 function updateConsentQueryParams(url, consentData) {
   const parameterMap = {
-    'gdpr_consent': consentData.gdpr.consentString,
-    'gdpr': consentData.gdpr.gdprApplies ? '1' : '0',
-    'us_privacy': consentData.uspConsent,
-    'gpp': consentData.gpp.gppString,
-    'gpp_sid': consentData.gpp.applicableSections ? consentData.gpp.applicableSections.join(',') : ''
+    'gdpr_consent': consentData.gdpr ? consentData.gdpr.consentString : '',
+    'gdpr': consentData.gdpr && consentData.gdpr.gdprApplies ? '1' : '0',
+    'us_privacy': consentData.uspConsent ? consentData.uspConsent : '',
+    'gpp': consentData.gpp ? consentData.gpp.gppString : '',
+    'gpp_sid': consentData.gpp && Array.isArray(consentData.gpp.applicableSections)
+      ? consentData.gpp.applicableSections.join(',') : ''
   }
 
   const existingUrl = new URL(url);
@@ -276,8 +277,8 @@ function generateOpenRtbObject(bidderRequest, bid) {
         ext: {
           'us_privacy': bidderRequest.uspConsent ? bidderRequest.uspConsent : '',
           gdpr: bidderRequest.gdprConsent && bidderRequest.gdprConsent.gdprApplies ? 1 : 0,
-          gpp: bidderRequest.gppConsent.gppString,
-          gpp_sid: bidderRequest.gppConsent.applicableSections
+          gpp: bidderRequest.gppConsent ? bidderRequest.gppConsent.gppString : '',
+          gpp_sid: bidderRequest.gppConsent ? bidderRequest.gppConsent.applicableSections : []
         }
       },
       source: {

--- a/test/spec/modules/yahoosspBidAdapter_spec.js
+++ b/test/spec/modules/yahoosspBidAdapter_spec.js
@@ -271,33 +271,63 @@ describe('YahooSSP Bid Adapter:', () => {
     });
 
     describe('user consent parameters are updated', () => {
-      let syncOptions = {
+      const syncOptions = {
         iframeEnabled: true,
         pixelEnabled: true
       };
-      let pixelObjects = spec.getUserSyncs(
-        syncOptions,
-        SERVER_RESPONSES,
-        bidderRequest.gdprConsent,
-        bidderRequest.uspConsent,
-        bidderRequest.gppConsent
-      );
-      pixelObjects.forEach(pixelObject => {
-        let url = pixelObject.url;
-        let urlParams = new URL(url).searchParams;
-        const expectedParams = {
-          'baz': 'true',
-          'gdpr_consent': bidderRequest.gdprConsent.consentString,
-          'gdpr': bidderRequest.gdprConsent.gdprApplies ? '1' : '0',
-          'us_privacy': bidderRequest.uspConsent,
-          'gpp': bidderRequest.gppConsent.gppString,
-          'gpp_sid': Array.isArray(bidderRequest.gppConsent.applicableSections) ? bidderRequest.gppConsent.applicableSections.join(',') : ''
-        }
-        for (const [key, value] of Object.entries(expectedParams)) {
-          it(`Updates the ${key} consent param in user sync URL ${url}`, () => {
-            expect(urlParams.get(key)).to.equal(value);
-          });
-        };
+
+      describe('when all consent data is set', () => {
+        const pixelObjects = spec.getUserSyncs(
+          syncOptions,
+          SERVER_RESPONSES,
+          bidderRequest.gdprConsent,
+          bidderRequest.uspConsent,
+          bidderRequest.gppConsent
+        );
+        pixelObjects.forEach(pixelObject => {
+          let url = pixelObject.url;
+          let urlParams = new URL(url).searchParams;
+          const expectedParams = {
+            'baz': 'true',
+            'gdpr_consent': bidderRequest.gdprConsent.consentString,
+            'gdpr': bidderRequest.gdprConsent.gdprApplies ? '1' : '0',
+            'us_privacy': bidderRequest.uspConsent,
+            'gpp': bidderRequest.gppConsent.gppString,
+            'gpp_sid': Array.isArray(bidderRequest.gppConsent.applicableSections) ? bidderRequest.gppConsent.applicableSections.join(',') : ''
+          }
+          for (const [key, value] of Object.entries(expectedParams)) {
+            it(`Updates the ${key} consent param in user sync URL ${url}`, () => {
+              expect(urlParams.get(key)).to.equal(value);
+            });
+          };
+        });
+      });
+
+      describe('when no consent data is set', () => {
+        const pixelObjects = spec.getUserSyncs(
+          syncOptions,
+          SERVER_RESPONSES,
+          undefined,
+          undefined,
+          undefined
+        );
+        pixelObjects.forEach(pixelObject => {
+          let url = pixelObject.url;
+          let urlParams = new URL(url).searchParams;
+          const expectedParams = {
+            'baz': 'true',
+            'gdpr_consent': '',
+            'gdpr': '0',
+            'us_privacy': '',
+            'gpp': '',
+            'gpp_sid': ''
+          }
+          for (const [key, value] of Object.entries(expectedParams)) {
+            it(`Updates the ${key} consent param in user sync URL ${url}`, () => {
+              expect(urlParams.get(key)).to.equal(value);
+            });
+          };
+        });
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This bug was introduced when we started to consume GPP signals. We've been lucky in that not many publishers switched to this bid adapter from the legacy AOL bid adapter. Issue has already been addressed for v8.x, so this fix ensures that any publishers who switch to the yahoossp bid adapter without upgrading to v8 (we are actively encouraging publishers to do this now) will not have this issue.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
