### PR TITLE
SharedId: use `sharedId` instead of `pubCommonId` for accessing storage

### DIFF
--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -13,7 +13,7 @@ import {VENDORLESS_GVLID} from '../src/consentHandler.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 import {domainOverrideToRootDomain} from '../libraries/domainOverrideToRootDomain/index.js';
 
-export const storage = getStorageManager({moduleType: MODULE_TYPE_UID, moduleName: 'pubCommonId'});
+export const storage = getStorageManager({moduleType: MODULE_TYPE_UID, moduleName: 'sharedId'});
 const COOKIE = 'cookie';
 const LOCAL_STORAGE = 'html5';
 const OPTOUT_NAME = '_pubcid_optout';


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fix a bug introduced with https://github.com/prebid/Prebid.js/pull/9736 - access to storage is now controlled using module names, which are later mapped to their corresponding GVL IDs. Since the sharedId module calls itself `sharedId`, but tries to access storage as `pubCommonId`, it fails to map into a GVL ID (as reported [here](https://github.com/prebid/Prebid.js/issues/9717#issuecomment-1602313230)).

