### PR TITLE
Optidigital Bid Adapter : update getUserSync method (legacy)

### DIFF
--- a/modules/optidigitalBidAdapter.js
+++ b/modules/optidigitalBidAdapter.js
@@ -7,6 +7,7 @@ const GVL_ID = 915;
 const ENDPOINT_URL = 'https://pbs.optidigital.com/bidder';
 const USER_SYNC_URL_IFRAME = 'https://scripts.opti-digital.com/js/presync.html?endpoint=optidigital';
 let CUR = 'USD';
+let isSynced = false;
 
 export const spec = {
   code: BIDDER_CODE,
@@ -136,21 +137,23 @@ export const spec = {
      */
   getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent) {
     let syncurl = '';
+    if (!isSynced) {
+      // Attaching GDPR Consent Params in UserSync url
+      if (gdprConsent) {
+        syncurl += '&gdpr=' + (gdprConsent.gdprApplies ? 1 : 0);
+        syncurl += '&gdpr_consent=' + encodeURIComponent(gdprConsent.consentString || '');
+      }
+      if (uspConsent && uspConsent.consentString) {
+        syncurl += `&ccpa_consent=${uspConsent.consentString}`;
+      }
 
-    // Attaching GDPR Consent Params in UserSync url
-    if (gdprConsent) {
-      syncurl += '&gdpr=' + (gdprConsent.gdprApplies ? 1 : 0);
-      syncurl += '&gdpr_consent=' + encodeURIComponent(gdprConsent.consentString || '');
-    }
-    if (uspConsent && uspConsent.consentString) {
-      syncurl += `&ccpa_consent=${uspConsent.consentString}`;
-    }
-
-    if (syncOptions.iframeEnabled) {
-      return [{
-        type: 'iframe',
-        url: USER_SYNC_URL_IFRAME + syncurl
-      }];
+      if (syncOptions.iframeEnabled) {
+        isSynced = true;
+        return [{
+          type: 'iframe',
+          url: USER_SYNC_URL_IFRAME + syncurl
+        }];
+      }
     }
   },
 };
@@ -216,6 +219,10 @@ function _getFloor (bid, sizes, currency) {
     } catch (err) {}
   }
   return floor !== null ? floor : bid.params.floor;
+}
+
+export function resetSync() {
+  isSynced = false;
 }
 
 registerBidder(spec);

--- a/test/spec/modules/optidigitalBidAdapter_spec.js
+++ b/test/spec/modules/optidigitalBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { spec } from 'modules/optidigitalBidAdapter.js';
+import { spec, resetSync } from 'modules/optidigitalBidAdapter.js';
 import * as utils from 'src/utils.js';
 
 const ENDPOINT = 'https://pbs.optidigital.com/bidder';
@@ -497,6 +497,7 @@ describe('optidigitalAdapterTests', function () {
     let test;
     beforeEach(function () {
       test = sinon.sandbox.create();
+      resetSync();
     });
     afterEach(function() {
       test.restore();
@@ -508,16 +509,22 @@ describe('optidigitalAdapterTests', function () {
       }]);
     });
 
-    it('should return appropriate URL', function() {
+    it('should return appropriate URL with GDPR equals to 1 and GDPR consent', function() {
       expect(spec.getUserSyncs({ iframeEnabled: true }, {}, {gdprApplies: true, consentString: 'foo'}, undefined)).to.deep.equal([{
         type: 'iframe', url: `${syncurlIframe}&gdpr=1&gdpr_consent=foo`
       }]);
+    });
+    it('should return appropriate URL with GDPR equals to 0 and GDPR consent', function() {
       expect(spec.getUserSyncs({ iframeEnabled: true }, {}, {gdprApplies: false, consentString: 'foo'}, undefined)).to.deep.equal([{
         type: 'iframe', url: `${syncurlIframe}&gdpr=0&gdpr_consent=foo`
       }]);
+    });
+    it('should return appropriate URL with GDPR equals to 1 and no consent', function() {
       expect(spec.getUserSyncs({ iframeEnabled: true }, {}, {gdprApplies: true, consentString: undefined}, undefined)).to.deep.equal([{
         type: 'iframe', url: `${syncurlIframe}&gdpr=1&gdpr_consent=`
       }]);
+    });
+    it('should return appropriate URL with GDPR equals to 1, GDPR consent and CCPA consent', function() {
       expect(spec.getUserSyncs({ iframeEnabled: true }, {}, {gdprApplies: true, consentString: 'foo'}, {consentString: 'fooUsp'})).to.deep.equal([{
         type: 'iframe', url: `${syncurlIframe}&gdpr=1&gdpr_consent=foo&ccpa_consent=fooUsp`
       }]);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Update of getUserSync method
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
