### PR TITLE
topicsFpdModule: replace ad-hoc GDPR logic with `transmitUfpd` acitivity check; check for topics support before loading frames

### DIFF
--- a/modules/topicsFpdModule.js
+++ b/modules/topicsFpdModule.js
@@ -1,18 +1,22 @@
-import {logError, logWarn, mergeDeep, isEmpty, safeJSONParse, logInfo, hasDeviceAccess} from '../src/utils.js';
+import {isEmpty, logError, logWarn, mergeDeep, safeJSONParse} from '../src/utils.js';
 import {getRefererInfo} from '../src/refererDetection.js';
 import {submodule} from '../src/hook.js';
 import {GreedyPromise} from '../src/utils/promise.js';
 import {config} from '../src/config.js';
 import {getCoreStorageManager} from '../src/storageManager.js';
 import {includes} from '../src/polyfill.js';
-import {gdprDataHandler} from '../src/adapterManager.js';
+import {isActivityAllowed} from '../src/activities/rules.js';
+import {ACTIVITY_TRANSMIT_UFPD} from '../src/activities/activities.js';
+import {activityParams} from '../src/activities/activityParams.js';
+import {MODULE_TYPE_BIDDER} from '../src/activities/modules.js';
 
 const MODULE_NAME = 'topicsFpd';
 const DEFAULT_EXPIRATION_DAYS = 21;
-const TCF_REQUIRED_PURPOSES = ['1', '2', '3', '4'];
-let HAS_GDPR_CONSENT = true;
 let LOAD_TOPICS_INITIALISE = false;
-const HAS_DEVICE_ACCESS = hasDeviceAccess();
+
+export function reset() {
+  LOAD_TOPICS_INITIALISE = false;
+}
 
 const bidderIframeList = {
   maxTopicCaller: 1,
@@ -83,10 +87,14 @@ export function getTopicsData(name, topics, taxonomies = TAXONOMIES) {
     );
 }
 
+function isTopicsSupported(doc = document) {
+  return 'browsingTopics' in doc && doc.featurePolicy.allowsFeature('browsing-topics')
+}
+
 export function getTopics(doc = document) {
   let topics = null;
   try {
-    if ('browsingTopics' in doc && doc.featurePolicy.allowsFeature('browsing-topics')) {
+    if (isTopicsSupported(doc)) {
       topics = GreedyPromise.resolve(doc.browsingTopics());
     }
   } catch (e) {
@@ -123,19 +131,16 @@ export function processFpd(config, {global}, {data = topicsData} = {}) {
  */
 export function getCachedTopics() {
   let cachedTopicData = [];
-  if (!HAS_GDPR_CONSENT || !HAS_DEVICE_ACCESS) {
-    return cachedTopicData;
-  }
   const topics = config.getConfig('userSync.topics') || bidderIframeList;
   const bidderList = topics.bidders || [];
   let storedSegments = new Map(safeJSONParse(coreStorage.getDataFromLocalStorage(topicStorageName)));
   storedSegments && storedSegments.forEach((value, cachedBidder) => {
     // Check bidder exist in config for cached bidder data and then only retrieve the cached data
-    let bidderConfigObj = bidderList.find(({bidder}) => cachedBidder == bidder)
-    if (bidderConfigObj) {
+    let bidderConfigObj = bidderList.find(({bidder}) => cachedBidder === bidder)
+    if (bidderConfigObj && isActivityAllowed(ACTIVITY_TRANSMIT_UFPD, activityParams(MODULE_TYPE_BIDDER, cachedBidder))) {
       if (!isCachedDataExpired(value[lastUpdated], bidderConfigObj?.expiry || DEFAULT_EXPIRATION_DAYS)) {
         Object.keys(value).forEach((segData) => {
-          segData != lastUpdated && cachedTopicData.push(value[segData]);
+          segData !== lastUpdated && cachedTopicData.push(value[segData]);
         })
       } else {
         // delete the specific bidder map from the store and store the updated maps
@@ -201,55 +206,23 @@ function listenMessagesFromTopicIframe() {
   window.addEventListener('message', receiveMessage, false);
 }
 
-function checkTCFv2(vendorData, requiredPurposes = TCF_REQUIRED_PURPOSES) {
-  const {gdprApplies, purpose} = vendorData;
-  if (!gdprApplies || !purpose) {
-    return true;
-  }
-  return requiredPurposes.map((purposeNo) => {
-    const purposeConsent = purpose.consents ? purpose.consents[purposeNo] : false;
-    if (purposeConsent) {
-      return true;
-    }
-    return false;
-  }).reduce((a, b) => a && b, true);
-}
-
-export function hasGDPRConsent() {
-  // Check for GDPR consent for purpose 1,2,3,4 and return false if consent has not been given
-  const gdprConsent = gdprDataHandler.getConsentData();
-  const hasGdpr = (gdprConsent && typeof gdprConsent.gdprApplies === 'boolean' && gdprConsent.gdprApplies) ? 1 : 0;
-  const gdprConsentString = hasGdpr ? gdprConsent.consentString : '';
-  if (hasGdpr) {
-    if ((!gdprConsentString || gdprConsentString === '') || !gdprConsent.vendorData) {
-      return false;
-    }
-    return checkTCFv2(gdprConsent.vendorData);
-  }
-  return true;
-}
-
 /**
  * function to load the iframes of the bidder to load the topics data
  */
-function loadTopicsForBidders() {
-  HAS_GDPR_CONSENT = hasGDPRConsent();
-  if (!HAS_GDPR_CONSENT || !HAS_DEVICE_ACCESS) {
-    logInfo('Topics Module : Consent string is required to fetch the topics from third party domains.');
-    return;
-  }
+export function loadTopicsForBidders(doc = document) {
+  if (!isTopicsSupported(doc)) return;
   const topics = config.getConfig('userSync.topics') || bidderIframeList;
   if (topics) {
     listenMessagesFromTopicIframe();
     const randomBidders = getRandomBidders(topics.bidders || [], topics.maxTopicCaller || 1)
     randomBidders && randomBidders.forEach(({ bidder, iframeURL }) => {
       if (bidder && iframeURL) {
-        let ifrm = document.createElement('iframe');
+        let ifrm = doc.createElement('iframe');
         ifrm.name = 'ifrm_'.concat(bidder);
         ifrm.src = ''.concat(iframeURL, '?bidder=').concat(bidder);
         ifrm.style.display = 'none';
         setLoadedIframeURL(new URL(iframeURL).origin);
-        iframeURL && window.document.documentElement.appendChild(ifrm);
+        iframeURL && doc.documentElement.appendChild(ifrm);
       }
     })
   } else {

--- a/modules/topicsFpdModule.js
+++ b/modules/topicsFpdModule.js
@@ -6,7 +6,7 @@ import {config} from '../src/config.js';
 import {getCoreStorageManager} from '../src/storageManager.js';
 import {includes} from '../src/polyfill.js';
 import {isActivityAllowed} from '../src/activities/rules.js';
-import {ACTIVITY_TRANSMIT_UFPD} from '../src/activities/activities.js';
+import {ACTIVITY_ENRICH_UFPD} from '../src/activities/activities.js';
 import {activityParams} from '../src/activities/activityParams.js';
 import {MODULE_TYPE_BIDDER} from '../src/activities/modules.js';
 
@@ -140,7 +140,7 @@ export function getCachedTopics() {
   storedSegments && storedSegments.forEach((value, cachedBidder) => {
     // Check bidder exist in config for cached bidder data and then only retrieve the cached data
     let bidderConfigObj = bidderList.find(({bidder}) => cachedBidder === bidder)
-    if (bidderConfigObj && isActivityAllowed(ACTIVITY_TRANSMIT_UFPD, activityParams(MODULE_TYPE_BIDDER, cachedBidder))) {
+    if (bidderConfigObj && isActivityAllowed(ACTIVITY_ENRICH_UFPD, activityParams(MODULE_TYPE_BIDDER, cachedBidder))) {
       if (!isCachedDataExpired(value[lastUpdated], bidderConfigObj?.expiry || DEFAULT_EXPIRATION_DAYS)) {
         Object.keys(value).forEach((segData) => {
           segData !== lastUpdated && cachedTopicData.push(value[segData]);

--- a/test/spec/modules/topicsFpdModule_spec.js
+++ b/test/spec/modules/topicsFpdModule_spec.js
@@ -1,289 +1,313 @@
 import {
+  getCachedTopics,
   getTopics,
   getTopicsData,
+  loadTopicsForBidders,
   processFpd,
-  hasGDPRConsent,
-  getCachedTopics,
   receiveMessage,
-  topicStorageName
+  topicStorageName,
+  reset
 } from '../../../modules/topicsFpdModule.js';
 import {deepClone, safeJSONParse} from '../../../src/utils.js';
-import {gdprDataHandler} from 'src/adapterManager.js';
 import {getCoreStorageManager} from 'src/storageManager.js';
+import {config} from 'src/config.js'
+import * as activities from '../../../src/activities/rules.js';
+import {ACTIVITY_TRANSMIT_UFPD} from '../../../src/activities/activities.js';
 
-describe('getTopicsData', () => {
-  function makeTopic(topic, modelv, taxv = '1') {
-    return {
-      topic,
-      taxonomyVersion: taxv,
-      modelVersion: modelv
-    };
-  }
+describe('topics', () => {
+  beforeEach(() => {
+    reset();
+  });
 
-  function byTaxClass(segments) {
-    return segments.reduce((memo, segment) => {
-      memo[`${segment.ext.segtax}:${segment.ext.segclass}`] = segment;
-      return memo;
-    }, {});
-  }
+  describe('getTopicsData', () => {
+    function makeTopic(topic, modelv, taxv = '1') {
+      return {
+        topic,
+        taxonomyVersion: taxv,
+        modelVersion: modelv
+      };
+    }
 
-  [
-    {
-      t: 'no topics',
-      topics: [],
-      expected: []
-    },
-    {
-      t: 'single topic',
-      topics: [makeTopic(123, 'm1')],
-      expected: [
-        {
-          ext: {
-            segtax: 600,
-            segclass: 'm1'
-          },
-          segment: [
-            {id: '123'}
-          ]
-        }
-      ]
-    },
-    {
-      t: 'multiple topics with the same model version',
-      topics: [makeTopic(123, 'm1'), makeTopic(321, 'm1')],
-      expected: [
-        {
-          ext: {
-            segtax: 600,
-            segclass: 'm1'
-          },
-          segment: [
-            {id: '123'},
-            {id: '321'}
-          ]
-        }
-      ]
-    },
-    {
-      t: 'multiple topics with different model versions',
-      topics: [makeTopic(1, 'm1'), makeTopic(2, 'm1'), makeTopic(3, 'm2')],
-      expected: [
-        {
-          ext: {
-            segtax: 600,
-            segclass: 'm1'
-          },
-          segment: [
-            {id: '1'},
-            {id: '2'}
-          ]
-        },
-        {
-          ext: {
-            segtax: 600,
-            segclass: 'm2'
-          },
-          segment: [
-            {id: '3'}
-          ]
-        }
-      ]
-    },
-    {
-      t: 'multiple topics, some with a taxonomy version other than "1"',
-      topics: [makeTopic(123, 'm1'), makeTopic(321, 'm1', 'other')],
-      expected: [
-        {
-          ext: {
-            segtax: 600,
-            segclass: 'm1'
-          },
-          segment: [
-            {id: '123'}
-          ]
-        }
-      ]
-    },
-    {
-      t: 'multiple topics in multiple taxonomies',
-      taxonomies: {
-        '1': 600,
-        '2': 601
+    function byTaxClass(segments) {
+      return segments.reduce((memo, segment) => {
+        memo[`${segment.ext.segtax}:${segment.ext.segclass}`] = segment;
+        return memo;
+      }, {});
+    }
+
+    [
+      {
+        t: 'no topics',
+        topics: [],
+        expected: []
       },
-      topics: [
-        makeTopic(123, 'm1', '1'),
-        makeTopic(321, 'm1', '2'),
-        makeTopic(213, 'm2', '1'),
-      ],
-      expected: [
-        {
-          ext: {
-            segtax: 600,
-            segclass: 'm1'
+      {
+        t: 'single topic',
+        topics: [makeTopic(123, 'm1')],
+        expected: [
+          {
+            ext: {
+              segtax: 600,
+              segclass: 'm1'
+            },
+            segment: [
+              {id: '123'}
+            ]
+          }
+        ]
+      },
+      {
+        t: 'multiple topics with the same model version',
+        topics: [makeTopic(123, 'm1'), makeTopic(321, 'm1')],
+        expected: [
+          {
+            ext: {
+              segtax: 600,
+              segclass: 'm1'
+            },
+            segment: [
+              {id: '123'},
+              {id: '321'}
+            ]
+          }
+        ]
+      },
+      {
+        t: 'multiple topics with different model versions',
+        topics: [makeTopic(1, 'm1'), makeTopic(2, 'm1'), makeTopic(3, 'm2')],
+        expected: [
+          {
+            ext: {
+              segtax: 600,
+              segclass: 'm1'
+            },
+            segment: [
+              {id: '1'},
+              {id: '2'}
+            ]
           },
-          segment: [
-            {id: '123'}
-          ]
+          {
+            ext: {
+              segtax: 600,
+              segclass: 'm2'
+            },
+            segment: [
+              {id: '3'}
+            ]
+          }
+        ]
+      },
+      {
+        t: 'multiple topics, some with a taxonomy version other than "1"',
+        topics: [makeTopic(123, 'm1'), makeTopic(321, 'm1', 'other')],
+        expected: [
+          {
+            ext: {
+              segtax: 600,
+              segclass: 'm1'
+            },
+            segment: [
+              {id: '123'}
+            ]
+          }
+        ]
+      },
+      {
+        t: 'multiple topics in multiple taxonomies',
+        taxonomies: {
+          '1': 600,
+          '2': 601
         },
-        {
-          ext: {
-            segtax: 601,
-            segclass: 'm1',
+        topics: [
+          makeTopic(123, 'm1', '1'),
+          makeTopic(321, 'm1', '2'),
+          makeTopic(213, 'm2', '1'),
+        ],
+        expected: [
+          {
+            ext: {
+              segtax: 600,
+              segclass: 'm1'
+            },
+            segment: [
+              {id: '123'}
+            ]
           },
-          segment: [
-            {id: '321'}
-          ]
-        },
-        {
-          ext: {
-            segtax: 600,
-            segclass: 'm2'
+          {
+            ext: {
+              segtax: 601,
+              segclass: 'm1',
+            },
+            segment: [
+              {id: '321'}
+            ]
           },
-          segment: [
-            {id: '213'}
-          ]
-        }
-      ]
-    }
-  ].forEach(({t, topics, expected, taxonomies}) => {
-    describe(`on ${t}`, () => {
-      it('should convert topics to user.data segments correctly', () => {
-        const actual = getTopicsData('mockName', topics, taxonomies);
-        expect(actual.length).to.eql(expected.length);
-        expected = byTaxClass(expected);
-        Object.entries(byTaxClass(actual)).forEach(([key, datum]) => {
-          sinon.assert.match(datum, expected[key]);
-          expect(datum.name).to.equal('mockName');
-        });
-      });
-
-      it('should not set name if null', () => {
-        getTopicsData(null, topics).forEach((data) => {
-          expect(data.hasOwnProperty('name')).to.be.false;
-        });
-      });
-    });
-  });
-});
-
-describe('getTopics', () => {
-  Object.entries({
-    'document with no browsingTopics': {},
-    'document that disallows topics': {
-      featurePolicy: {
-        allowsFeature: sinon.stub().returns(false)
-      }
-    },
-    'document that throws on featurePolicy': {
-      browsingTopics: sinon.stub(),
-      get featurePolicy() {
-        throw new Error();
-      }
-    },
-    'document that throws on browsingTopics': {
-      browsingTopics: sinon.stub().callsFake(() => {
-        throw new Error();
-      }),
-      featurePolicy: {
-        allowsFeature: sinon.stub().returns(true)
-      }
-    },
-  }).forEach(([t, doc]) => {
-    it(`should resolve to an empty list on ${t}`, () => {
-      return getTopics(doc).then((topics) => {
-        expect(topics).to.eql([]);
-      });
-    });
-  });
-
-  it('should call `document.browsingTopics` when allowed', () => {
-    const topics = ['t1', 't2'];
-    return getTopics({
-      browsingTopics: sinon.stub().returns(Promise.resolve(topics)),
-      featurePolicy: {
-        allowsFeature: sinon.stub().returns(true)
-      }
-    }).then((actual) => {
-      expect(actual).to.eql(topics);
-    });
-  });
-});
-
-describe('processFpd', () => {
-  const mockData = [
-    {
-      name: 'domain',
-      segment: [{id: 123}]
-    },
-    {
-      name: 'domain',
-      segment: [{id: 321}]
-    }
-  ];
-
-  it('should add topics data', () => {
-    return processFpd({}, {global: {}}, {data: Promise.resolve(mockData)})
-      .then(({global}) => {
-        expect(global.user.data).to.eql(mockData);
-      });
-  });
-
-  it('should apppend to existing user.data', () => {
-    const global = {
-      user: {
-        data: [
-          {name: 'preexisting'},
+          {
+            ext: {
+              segtax: 600,
+              segclass: 'm2'
+            },
+            segment: [
+              {id: '213'}
+            ]
+          }
         ]
       }
-    };
-    return processFpd({}, {global: deepClone(global)}, {data: Promise.resolve(mockData)})
-      .then((data) => {
-        expect(data.global.user.data).to.eql(global.user.data.concat(mockData));
+    ].forEach(({t, topics, expected, taxonomies}) => {
+      describe(`on ${t}`, () => {
+        it('should convert topics to user.data segments correctly', () => {
+          const actual = getTopicsData('mockName', topics, taxonomies);
+          expect(actual.length).to.eql(expected.length);
+          expected = byTaxClass(expected);
+          Object.entries(byTaxClass(actual)).forEach(([key, datum]) => {
+            sinon.assert.match(datum, expected[key]);
+            expect(datum.name).to.equal('mockName');
+          });
+        });
+
+        it('should not set name if null', () => {
+          getTopicsData(null, topics).forEach((data) => {
+            expect(data.hasOwnProperty('name')).to.be.false;
+          });
+        });
       });
+    });
   });
 
-  it('should not modify fpd when there is no data', () => {
-    return processFpd({}, {global: {}}, {data: Promise.resolve([])})
-      .then((data) => {
-        expect(data.global).to.eql({});
+  describe('getTopics', () => {
+    Object.entries({
+      'document with no browsingTopics': {},
+      'document that disallows topics': {
+        featurePolicy: {
+          allowsFeature: sinon.stub().returns(false)
+        }
+      },
+      'document that throws on featurePolicy': {
+        browsingTopics: sinon.stub(),
+        get featurePolicy() {
+          throw new Error();
+        }
+      },
+      'document that throws on browsingTopics': {
+        browsingTopics: sinon.stub().callsFake(() => {
+          throw new Error();
+        }),
+        featurePolicy: {
+          allowsFeature: sinon.stub().returns(true)
+        }
+      },
+    }).forEach(([t, doc]) => {
+      it(`should resolve to an empty list on ${t}`, () => {
+        return getTopics(doc).then((topics) => {
+          expect(topics).to.eql([]);
+        });
       });
-  });
-});
+    });
 
-describe('Topics Module GDPR consent check', () => {
-  let gdprDataHdlrStub;
-  beforeEach(() => {
-    gdprDataHdlrStub = sinon.stub(gdprDataHandler, 'getConsentData');
-  });
-
-  afterEach(() => {
-    gdprDataHdlrStub.restore();
-  });
-
-  it('should return false when GDPR is applied but consent string is not present', () => {
-    const consentString = '';
-    const consentConfig = {
-      consentString: consentString,
-      gdprApplies: true,
-      vendorData: {}
-    };
-    gdprDataHdlrStub.returns(consentConfig);
-    expect(hasGDPRConsent()).to.equal(false);
+    it('should call `document.browsingTopics` when allowed', () => {
+      const topics = ['t1', 't2'];
+      return getTopics({
+        browsingTopics: sinon.stub().returns(Promise.resolve(topics)),
+        featurePolicy: {
+          allowsFeature: sinon.stub().returns(true)
+        }
+      }).then((actual) => {
+        expect(actual).to.eql(topics);
+      });
+    });
   });
 
-  it('should return true when GDPR doesn\'t apply', () => {
-    const consentString = 'CPi8wgAPi8wgAADABBENCrCsAP_AAH_AAAAAISNB7D==';
-    const consentConfig = {
-      consentString: consentString,
-      gdprApplies: false,
-      vendorData: {}
-    };
+  describe('processFpd', () => {
+    const mockData = [
+      {
+        name: 'domain',
+        segment: [{id: 123}]
+      },
+      {
+        name: 'domain',
+        segment: [{id: 321}]
+      }
+    ];
 
-    gdprDataHdlrStub.returns(consentConfig);
-    expect(hasGDPRConsent()).to.equal(true);
+    it('should add topics data', () => {
+      return processFpd({}, {global: {}}, {data: Promise.resolve(mockData)})
+        .then(({global}) => {
+          expect(global.user.data).to.eql(mockData);
+        });
+    });
+
+    it('should apppend to existing user.data', () => {
+      const global = {
+        user: {
+          data: [
+            {name: 'preexisting'},
+          ]
+        }
+      };
+      return processFpd({}, {global: deepClone(global)}, {data: Promise.resolve(mockData)})
+        .then((data) => {
+          expect(data.global.user.data).to.eql(global.user.data.concat(mockData));
+        });
+    });
+
+    it('should not modify fpd when there is no data', () => {
+      return processFpd({}, {global: {}}, {data: Promise.resolve([])})
+        .then((data) => {
+          expect(data.global).to.eql({});
+        });
+    });
   });
 
-  it('should return true when GDPR is applied and purpose consent is true for all purpose[1,2,3,4]', () => {
+  describe('loadTopicsForBidders', () => {
+    beforeEach(() => {
+      config.setConfig({
+        userSync: {
+          topics: {
+            bidders: [{
+              bidder: 'mockBidder',
+              iframeURL: 'https://mock.iframe'
+            }]
+          }
+        }
+      })
+    });
+    afterEach(() => {
+      config.resetConfig();
+    })
+
+    Object.entries({
+      'support': {},
+      'allow': {
+        browsingTopics: true,
+        featurePolicy: {
+          allowsFeature(feature) {
+            return feature !== 'browsing-topics';
+          }
+        }
+      },
+    }).forEach(([t, doc]) => {
+      it(`does not attempt to load frames if browser does not ${t} topics`, () => {
+        doc.createElement = sinon.stub();
+        loadTopicsForBidders(doc);
+        sinon.assert.notCalled(doc.createElement);
+      });
+    });
+  });
+
+  describe('getCachedTopics()', () => {
+    const storage = getCoreStorageManager('topicsFpd');
+    const expected = [{
+      ext: {
+        segtax: 600,
+        segclass: '2206021246'
+      },
+      segment: [{
+        'id': '243'
+      }, {
+        'id': '265'
+      }],
+      name: 'ads.pubmatic.com'
+    }];
     const consentString = 'CPi8wgAPi8wgAADABBENCrCsAP_AAH_AAAAAISNB7D==';
     const consentConfig = {
       consentString: consentString,
@@ -301,132 +325,94 @@ describe('Topics Module GDPR consent check', () => {
         }
       }
     };
-
-    gdprDataHdlrStub.returns(consentConfig);
-    expect(hasGDPRConsent()).to.equal(true);
-  });
-
-  it('should return false when GDPR is applied and purpose consent is false for one of the purpose[1,2,3,4]', () => {
-    const consentString = 'CPi8wgAPi8wgAADABBENCrCsAP_AAH_AAAAAISNB7D==';
-    const consentConfig = {
-      consentString: consentString,
-      gdprApplies: true,
-      vendorData: {
-        metadata: consentString,
-        gdprApplies: true,
-        purpose: {
-          consents: {
-            1: true,
-            2: true,
-            3: true,
-            4: false
-          }
-        }
+    const mockData = [
+      {
+        name: 'domain',
+        segment: [{id: 123}]
+      },
+      {
+        name: 'domain',
+        segment: [{id: 321}],
       }
+    ];
+
+    const evt = {
+      data: '{"segment":{"domain":"ads.pubmatic.com","topics":[{"configVersion":"chrome.1","modelVersion":"2206021246","taxonomyVersion":"1","topic":165,"version":"chrome.1:1:2206021246"}],"bidder":"pubmatic"},"date":1669743901858}',
+      origin: 'https://ads.pubmatic.com'
     };
 
-    gdprDataHdlrStub.returns(consentConfig);
-    expect(hasGDPRConsent()).to.equal(false);
-  });
-});
+    afterEach(() => {
+      storage.removeDataFromLocalStorage(topicStorageName);
+    });
 
-describe('getCachedTopics()', () => {
-  const storage = getCoreStorageManager('topicsFpd');
-  const expected = [{
-    ext: {
-      segtax: 600,
-      segclass: '2206021246'
-    },
-    segment: [{
-      'id': '243'
-    }, {
-      'id': '265'
-    }],
-    name: 'ads.pubmatic.com'
-  }];
-  const consentString = 'CPi8wgAPi8wgAADABBENCrCsAP_AAH_AAAAAISNB7D==';
-  const consentConfig = {
-    consentString: consentString,
-    gdprApplies: true,
-    vendorData: {
-      metadata: consentString,
-      gdprApplies: true,
-      purpose: {
-        consents: {
-          1: true,
-          2: true,
-          3: true,
-          4: true
-        }
-      }
-    }
-  };
-  const mockData = [
-    {
-      name: 'domain',
-      segment: [{id: 123}]
-    },
-    {
-      name: 'domain',
-      segment: [{id: 321}],
-    }
-  ];
+    describe('when cached data is available and not expired', () => {
+      let sandbox;
+      beforeEach(() => {
+        sandbox = sinon.sandbox.create();
+        const storedSegments = JSON.stringify(
+          [['pubmatic', {
+            '2206021246': {
+              'ext': {'segtax': 600, 'segclass': '2206021246'},
+              'segment': [{'id': '243'}, {'id': '265'}],
+              'name': 'ads.pubmatic.com'
+            },
+            'lastUpdated': new Date().getTime()
+          }]]
+        );
+        storage.setDataInLocalStorage(topicStorageName, storedSegments);
+      });
+      afterEach(() => {
+        sandbox.restore();
+      });
 
-  const evt = {
-    data: '{"segment":{"domain":"ads.pubmatic.com","topics":[{"configVersion":"chrome.1","modelVersion":"2206021246","taxonomyVersion":"1","topic":165,"version":"chrome.1:1:2206021246"}],"bidder":"pubmatic"},"date":1669743901858}',
-    origin: 'https://ads.pubmatic.com'
-  };
+      it('should return segments for bidder if transmitUfpd is allowed', () => {
+        assert.deepEqual(getCachedTopics(), expected);
+      });
 
-  let gdprDataHdlrStub;
-  beforeEach(() => {
-    gdprDataHdlrStub = sinon.stub(gdprDataHandler, 'getConsentData');
-  });
+      it('should NOT return segments for bidder if transmitUfpd is NOT allowed', () => {
+        sandbox.stub(activities, 'isActivityAllowed').callsFake((activity, params) => {
+          if (activity === ACTIVITY_TRANSMIT_UFPD && params.component === 'bidder.pubmatic') {
+            return false;
+          }
+        });
+        expect(getCachedTopics()).to.eql([]);
+      });
+    })
 
-  afterEach(() => {
-    storage.removeDataFromLocalStorage(topicStorageName);
-    gdprDataHdlrStub.restore();
-  });
+    it('should return empty segments for bidder if there is cached segments stored which is expired', () => {
+      let storedSegments = '[["pubmatic",{"2206021246":{"ext":{"segtax":600,"segclass":"2206021246"},"segment":[{"id":"243"},{"id":"265"}],"name":"ads.pubmatic.com"},"lastUpdated":10}]]';
+      storage.setDataInLocalStorage(topicStorageName, storedSegments);
+      assert.deepEqual(getCachedTopics(), []);
+    });
 
-  it('should return segments for bidder if GDPR consent is true and there is cached segments stored which is not expired', () => {
-    const storedSegments = JSON.stringify(
-      [['pubmatic', {
-        '2206021246': {
-          'ext': {'segtax': 600, 'segclass': '2206021246'},
-          'segment': [{'id': '243'}, {'id': '265'}],
-          'name': 'ads.pubmatic.com'
-        },
-        'lastUpdated': new Date().getTime()
-      }]]
-    );
-    storage.setDataInLocalStorage(topicStorageName, storedSegments);
-    gdprDataHdlrStub.returns(consentConfig);
-    assert.deepEqual(getCachedTopics(), expected);
-  });
+    describe('cross-frame messages', () => {
+      beforeEach(() => {
+        // init iframe logic so  that the receiveMessage origin check passes
+        loadTopicsForBidders({
+          browsingTopics: true,
+          featurePolicy: {
+            allowsFeature() { return true }
+          },
+          createElement: sinon.stub().callsFake(() => ({style: {}})),
+          documentElement: {
+            appendChild() {}
+          }
+        });
+      });
 
-  it('should return empty segments for bidder if GDPR consent is true and there is cached segments stored which is expired', () => {
-    let storedSegments = '[["pubmatic",{"2206021246":{"ext":{"segtax":600,"segclass":"2206021246"},"segment":[{"id":"243"},{"id":"265"}],"name":"ads.pubmatic.com"},"lastUpdated":10}]]';
-    storage.setDataInLocalStorage(topicStorageName, storedSegments);
-    gdprDataHdlrStub.returns(consentConfig);
-    assert.deepEqual(getCachedTopics(), []);
-  });
-
-  it('should stored segments if receiveMessage event is triggerred with segment data', () => {
-    return processFpd({}, {global: {}}, {data: Promise.resolve(mockData)})
-      .then(({global}) => {
+      it('should store segments if receiveMessage event is triggered with segment data', () => {
         receiveMessage(evt);
         let segments = new Map(safeJSONParse(storage.getDataFromLocalStorage(topicStorageName)));
         expect(segments.has('pubmatic')).to.equal(true);
       });
-  });
 
-  it('should update stored segments if receiveMessage event is triggerred with segment data', () => {
-    let storedSegments = '[["pubmatic",{"2206021246":{"ext":{"segtax":600,"segclass":"2206021246"},"segment":[{"id":"243"},{"id":"265"}],"name":"ads.pubmatic.com"},"lastUpdated":1669719242027}]]';
-    storage.setDataInLocalStorage(topicStorageName, storedSegments);
-    return processFpd({}, {global: {}}, {data: Promise.resolve(mockData)})
-      .then(({global}) => {
+      it('should update stored segments if receiveMessage event is triggerred with segment data', () => {
+        let storedSegments = '[["pubmatic",{"2206021246":{"ext":{"segtax":600,"segclass":"2206021246"},"segment":[{"id":"243"},{"id":"265"}],"name":"ads.pubmatic.com"},"lastUpdated":1669719242027}]]';
+        storage.setDataInLocalStorage(topicStorageName, storedSegments);
         receiveMessage(evt);
         let segments = new Map(safeJSONParse(storage.getDataFromLocalStorage(topicStorageName)));
         expect(segments.get('pubmatic')[2206021246].segment.length).to.equal(1);
       });
+    });
   });
 });

--- a/test/spec/modules/topicsFpdModule_spec.js
+++ b/test/spec/modules/topicsFpdModule_spec.js
@@ -5,14 +5,14 @@ import {
   loadTopicsForBidders,
   processFpd,
   receiveMessage,
-  topicStorageName,
-  reset
+  reset,
+  topicStorageName
 } from '../../../modules/topicsFpdModule.js';
 import {deepClone, safeJSONParse} from '../../../src/utils.js';
 import {getCoreStorageManager} from 'src/storageManager.js';
-import {config} from 'src/config.js'
+import {config} from 'src/config.js';
 import * as activities from '../../../src/activities/rules.js';
-import {ACTIVITY_TRANSMIT_UFPD} from '../../../src/activities/activities.js';
+import {ACTIVITY_ENRICH_UFPD} from '../../../src/activities/activities.js';
 
 describe('topics', () => {
   beforeEach(() => {
@@ -369,11 +369,9 @@ describe('topics', () => {
         assert.deepEqual(getCachedTopics(), expected);
       });
 
-      it('should NOT return segments for bidder if transmitUfpd is NOT allowed', () => {
+      it('should NOT return segments for bidder if enrichUfpd is NOT allowed', () => {
         sandbox.stub(activities, 'isActivityAllowed').callsFake((activity, params) => {
-          if (activity === ACTIVITY_TRANSMIT_UFPD && params.component === 'bidder.pubmatic') {
-            return false;
-          }
+          return !(activity === ACTIVITY_ENRICH_UFPD && params.component === 'bidder.pubmatic');
         });
         expect(getCachedTopics()).to.eql([]);
       });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

- do not load `userSync.topics` URLs if the browser does not support topics (closes https://github.com/prebid/Prebid.js/issues/10147)
- replaced GDPR logic with a simple `enrichUfpd` activity check. Note that for GDPR, this means replacing the requirement for consent on all of purposes 1, 2, 3, and 4 with just purpose 4 (after https://github.com/prebid/Prebid.js/pull/10219 is merged)  and "implicit" purpose 1 (without it topics would still be retrieved but not persisted for long enough to be of use).

