### PR TITLE
Adf Bid Adapter getFloor update

### DIFF
--- a/modules/adfBidAdapter.js
+++ b/modules/adfBidAdapter.js
@@ -69,8 +69,11 @@ export const spec = {
       bid.netRevenue = pt;
 
       const floorInfo = bid.getFloor ? bid.getFloor({
-        currency: currency || 'USD'
+        currency: currency || 'USD',
+        size: '*',
+        mediaType: '*'
       }) : {};
+
       const bidfloor = floorInfo.floor;
       const bidfloorcur = floorInfo.currency;
       const { mid, inv, mname } = bid.params;

--- a/test/spec/modules/adfBidAdapter_spec.js
+++ b/test/spec/modules/adfBidAdapter_spec.js
@@ -411,7 +411,6 @@ describe('Adf adapter', function () {
       });
 
       describe('price floors', function () {
-        let result, mediaTypes;
         it('should not add if floors module not configured', function () {
           const validBidRequests = [{ bidId: 'bidId', params: {mid: 1000}, mediaTypes: {video: {}} }];
           let imp = getRequestImps(validBidRequests)[0];
@@ -449,7 +448,8 @@ describe('Adf adapter', function () {
         });
 
         it('should add correct params to getFloor', function () {
-          mediaTypes = { video: {
+          let result;
+          let mediaTypes = { video: {
             playerSize: [ 100, 200 ]
           } };
           const expectedFloors = [ 1, 1.3, 0.5 ];
@@ -477,21 +477,21 @@ describe('Adf adapter', function () {
           getRequestImps(validBidRequests);
 
           assert.deepEqual(result, { currency: 'DKK', size: '*', mediaType: '*' });
-        });
 
-        function getBidWithFloorTest(floor) {
-          return {
-            params: { mid: 1 },
-            mediaTypes: mediaTypes,
-            getFloor: (args) => {
-              result = args;
-              return {
-                currency: 'DKK',
-                floor
-              };
-            }
-          };
-        }
+          function getBidWithFloorTest(floor) {
+            return {
+              params: { mid: 1 },
+              mediaTypes: mediaTypes,
+              getFloor: (args) => {
+                result = args;
+                return {
+                  currency: 'DKK',
+                  floor
+                };
+              }
+            };
+          }
+        });
 
         function getBidWithFloor(floor) {
           return {

--- a/test/spec/modules/adfBidAdapter_spec.js
+++ b/test/spec/modules/adfBidAdapter_spec.js
@@ -411,7 +411,7 @@ describe('Adf adapter', function () {
       });
 
       describe('price floors', function () {
-        var result, mediaTypes;
+        let result, mediaTypes;
         it('should not add if floors module not configured', function () {
           const validBidRequests = [{ bidId: 'bidId', params: {mid: 1000}, mediaTypes: {video: {}} }];
           let imp = getRequestImps(validBidRequests)[0];


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
`bid.getFloor` fixed to pass correct arguments - `currency, size and mediaType`.

- contact email of the adapter’s maintainer [team.frontline@adform.com](mailto:team.frontline@adform.com)