### PR TITLE
consumableBidAdapter: add gpp user sync params

### DIFF
--- a/modules/consumableBidAdapter.js
+++ b/modules/consumableBidAdapter.js
@@ -65,6 +65,11 @@ export const spec = {
       };
     }
 
+    if (bidderRequest && bidderRequest.gppConsent && bidderRequest.gppConsent.gppString) {
+      data.gpp = bidderRequest.gppConsent.gppString;
+      data.gpp_sid = bidderRequest.gppConsent.applicableSections;
+    }
+
     if (bidderRequest && bidderRequest.uspConsent) {
       data.ccpa = bidderRequest.uspConsent;
     }
@@ -180,7 +185,7 @@ export const spec = {
     return bidResponses;
   },
 
-  getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent) {
+  getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) {
     let syncUrl = 'https://sync.serverbid.com/ss/' + siteId + '.html';
 
     if (syncOptions.iframeEnabled) {
@@ -190,6 +195,9 @@ export const spec = {
         } else {
           syncUrl = appendUrlParam(syncUrl, `gdpr=0&gdpr_consent=${gdprConsent.consentString}`);
         }
+      }
+      if (gppConsent && gppConsent.gppString) {
+        syncUrl = appendUrlParam(syncUrl, `gpp=${gppConsent.gppString}&gpp_sid=${gppConsent.applicableSections}`);
       }
 
       if (uspConsent && uspConsent.consentString) {

--- a/test/spec/modules/consumableBidAdapter_spec.js
+++ b/test/spec/modules/consumableBidAdapter_spec.js
@@ -53,6 +53,10 @@ const BIDDER_REQUEST_1 = {
     consentString: 'consent-test',
     gdprApplies: false
   },
+  gppConsent: {
+    applicableSections: [1,2],
+    gppString: 'consent-string'
+  },
   refererInfo: {
     referer: 'http://example.com/page.html',
     reachedTop: true,
@@ -645,6 +649,17 @@ describe('Consumable BidAdapter', function () {
 
       expect(opts.length).to.equal(1);
       expect(opts[0].url).to.equal('https://sync.serverbid.com/ss/730181.html?gdpr=0&gdpr_consent=GDPR_CONSENT_STRING');
+    })
+
+    it('should return a sync url if iframe syncs are enabled and GPP applies', function () {
+      let gppConsent = {
+        applicableSections: [1, 2],
+        gppString: 'GPP_CONSENT_STRING'
+      }
+      let opts = spec.getUserSyncs(syncOptions, [AD_SERVER_RESPONSE], {}, {}, gppConsent);
+
+      expect(opts.length).to.equal(1);
+      expect(opts[0].url).to.equal('https://sync.serverbid.com/ss/730181.html?gpp=GPP_CONSENT_STRING&gpp_sid=1,2');
     })
 
     it('should return a sync url if iframe syncs are enabled and USP applies', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add GPP support to Consumable Bid Adapter

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
Docs already updated here https://github.com/prebid/prebid.github.io/pull/4696
