### PR TITLE
gdprEnforcement: check for purpose 4 on `enrichUfpd` as well as `transmitUfpd`

### DIFF
--- a/modules/gdprEnforcement.js
+++ b/modules/gdprEnforcement.js
@@ -24,7 +24,7 @@ import {
 import {registerActivityControl} from '../src/activities/rules.js';
 import {
   ACTIVITY_ACCESS_DEVICE,
-  ACTIVITY_ENRICH_EIDS,
+  ACTIVITY_ENRICH_EIDS, ACTIVITY_ENRICH_UFPD,
   ACTIVITY_FETCH_BIDS,
   ACTIVITY_REPORT_ANALYTICS,
   ACTIVITY_SYNC_USER, ACTIVITY_TRANSMIT_UFPD
@@ -235,7 +235,7 @@ export const fetchBidsRule = ((rule) => {
 
 export const reportAnalyticsRule = gdprRule(7, () => purpose7Rule, analyticsBlocked, (params) => getGvlidFromAnalyticsAdapter(params[ACTIVITY_PARAM_COMPONENT_NAME], params[ACTIVITY_PARAM_ANL_CONFIG]));
 
-export const transmitUfpdRule = gdprRule(4, () => purpose4Rule, ufpdBlocked);
+export const ufpdRule = gdprRule(4, () => purpose4Rule, ufpdBlocked);
 
 /**
  * Compiles the TCF2.0 enforcement results into an object, which is emitted as an event payload to "tcf2Enforcement" event.
@@ -301,7 +301,10 @@ export function setEnforcementConfig(config) {
       RULE_HANDLES.push(registerActivityControl(ACTIVITY_FETCH_BIDS, RULE_NAME, fetchBidsRule));
     }
     if (purpose4Rule) {
-      RULE_HANDLES.push(registerActivityControl(ACTIVITY_TRANSMIT_UFPD, RULE_NAME, transmitUfpdRule));
+      RULE_HANDLES.push(
+        registerActivityControl(ACTIVITY_TRANSMIT_UFPD, RULE_NAME, ufpdRule),
+        registerActivityControl(ACTIVITY_ENRICH_UFPD, RULE_NAME, ufpdRule)
+      );
     }
     if (purpose7Rule) {
       RULE_HANDLES.push(registerActivityControl(ACTIVITY_REPORT_ANALYTICS, RULE_NAME, reportAnalyticsRule));

--- a/test/spec/modules/gdprEnforcement_spec.js
+++ b/test/spec/modules/gdprEnforcement_spec.js
@@ -11,7 +11,7 @@ import {
   reportAnalyticsRule,
   setEnforcementConfig,
   STRICT_STORAGE_ENFORCEMENT,
-  syncUserRule, transmitUfpdRule,
+  syncUserRule, ufpdRule,
   validateRules
 } from 'modules/gdprEnforcement.js';
 import {config} from 'src/config.js';
@@ -479,7 +479,7 @@ describe('gdpr enforcement', function () {
       const consent = setupConsentData();
       consent.vendorData.purpose.consents[4] = true;
       consent.vendorData.vendor.consents[123] = true;
-      expectAllow(true, transmitUfpdRule(activityParams(MODULE_TYPE_BIDDER, 'mockBidder')));
+      expectAllow(true, ufpdRule(activityParams(MODULE_TYPE_BIDDER, 'mockBidder')));
     });
 
     it('should return deny when purpose 4 consent is withheld', () => {
@@ -498,7 +498,7 @@ describe('gdpr enforcement', function () {
       const consent = setupConsentData();
       consent.vendorData.purpose.consents[4] = true;
       consent.vendorData.vendor.consents[123] = false;
-      expectAllow(false, transmitUfpdRule(activityParams(MODULE_TYPE_BIDDER, 'mockBidder')))
+      expectAllow(false, ufpdRule(activityParams(MODULE_TYPE_BIDDER, 'mockBidder')))
     });
   });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

When purpose 4 enforcement is enabled, check for consent on  `enrichUfpd` as well as `transmitUfpd`.

## Other information

followup on https://github.com/prebid/Prebid.js/pull/10199

<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
