### PR TITLE
ID5 User Id module - accept partner in a string format

### DIFF
--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -108,7 +108,7 @@ export const id5IdSubmodule = {
    * @returns {IdResponse|undefined}
    */
   getId(submoduleConfig, consentData, cacheIdObj) {
-    if (!hasRequiredConfig(submoduleConfig)) {
+    if (!validateConfig(submoduleConfig)) {
       return undefined;
     }
 
@@ -142,14 +142,12 @@ export const id5IdSubmodule = {
    * @return {(IdResponse|function(callback:function))} A response object that contains id and/or callback.
    */
   extendId(config, consentData, cacheIdObj) {
-    hasRequiredConfig(config);
-
     if (!hasWriteConsentToLocalStorage(consentData)) {
       logInfo(LOG_PREFIX + 'No consent given for ID5 local storage writing, skipping nb increment.')
       return cacheIdObj;
     }
 
-    const partnerId = (config && config.params && config.params.partner) || 0;
+    const partnerId = validateConfig(config) ? config.params.partner : 0;
     incrementNb(partnerId);
 
     logInfo(LOG_PREFIX + 'using cached ID', cacheIdObj);
@@ -293,9 +291,23 @@ class IdFetchFlow {
   }
 }
 
-function hasRequiredConfig(config) {
-  if (!config || !config.params || !config.params.partner || typeof config.params.partner !== 'number') {
-    logError(LOG_PREFIX + 'partner required to be defined as a number');
+function validateConfig(config) {
+  if (!config || !config.params || !config.params.partner) {
+    logError(LOG_PREFIX + 'partner required to be defined');
+    return false;
+  }
+
+  const partner = config.params.partner
+  if (typeof partner === 'string' || partner instanceof String) {
+    let parsedPartnerId = parseInt(partner);
+    if (isNaN(parsedPartnerId) || parsedPartnerId < 0) {
+      logError(LOG_PREFIX + 'partner required to be a number or a String parsable to a positive integer');
+      return false;
+    } else {
+      config.params.partner = parsedPartnerId;
+    }
+  } else if (typeof partner !== 'number') {
+    logError(LOG_PREFIX + 'partner required to be a number or a String parsable to a positive integer');
     return false;
   }
 

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -407,6 +407,24 @@ describe('ID5 ID System', function () {
         })
     });
 
+    it('should call the ID5 server for config with partner id being a string', function () {
+      let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
+      let id5FetchConfig = getId5FetchConfig();
+      id5FetchConfig.params.partner = '173';
+      let submoduleResponse = callSubmoduleGetId(id5FetchConfig, undefined, undefined);
+
+      return xhrServerMock.expectConfigRequest()
+        .then(configRequest => {
+          let requestBody = JSON.parse(configRequest.requestBody)
+          expect(requestBody.params.partner).is.eq(173)
+          return xhrServerMock.respondWithConfigAndExpectNext(configRequest)
+        })
+        .then(fetchRequest => {
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse
+        })
+    });
+
     it('should call the ID5 server for config with overridden url', function () {
       let xhrServerMock = new XhrServerMock(sinon.createFakeServer())
       let id5FetchConfig = getId5FetchConfig();


### PR DESCRIPTION
- [x] Feature

We allowed for partners to configure their partner id as a number in string format.
While the documentation says we require `partner` config as number - some partners use it incorrectly passing numbers as string, so we want to also accept those.  
