### PR TITLE
Criteo Bid Adapter: add onDataDeletionRequest method

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -10,6 +10,7 @@ import { getRefererInfo } from '../src/refererDetection.js';
 import { hasPurpose1Consent } from '../src/utils/gpdr.js';
 import { Renderer } from '../src/Renderer.js';
 import { OUTSTREAM } from '../src/video.js';
+import { ajax } from '../src/ajax.js';
 
 const GVLID = 91;
 export const ADAPTER_VERSION = 36;
@@ -306,6 +307,23 @@ export const spec = {
       adapter.handleSetTargeting(bid);
     }
   },
+
+  /**
+   * @param {BidRequest[]} bidRequests
+   */
+  onDataDeletionRequest: (bidRequests) => {
+    const id = readFromAllStorages(BUNDLE_COOKIE_NAME);
+    if (id) {
+      deleteFromAllStorages(BUNDLE_COOKIE_NAME);
+    }
+    ajax('https://privacy.criteo.com/api/privacy/datadeletionrequest',
+      null,
+      JSON.stringify({ publisherUserId: id }),
+      {
+        contentType: 'application/json',
+        method: 'POST'
+      });
+  }
 };
 
 function readFromAllStorages(name) {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Comply with US Privacy data deletion requests by providing spec.onDataDeletionRequest method.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
