### PR TITLE
Ozone Bid Adapter : updates 2.9.0 and tid

### DIFF
--- a/modules/ozoneBidAdapter.js
+++ b/modules/ozoneBidAdapter.js
@@ -373,7 +373,6 @@ export const spec = {
         ozoneRequest.id = ozUuid; // Unique ID of the bid request, provided by the exchange. (REQUIRED)
         ozoneRequest.imp = tosendtags.slice(i, i + 10);
         ozoneRequest.ext = extObj;
-        deepSetValue(ozoneRequest, 'source.tid', ozUuid);// RTB 2.5 : tid is Transaction ID that must be common across all participants in this bid request (e.g., potentially multiple exchanges).
         deepSetValue(ozoneRequest, 'user.ext.eids', userExtEids);
         if (ozoneRequest.imp.length > 0) {
           arrRet.push({

--- a/modules/ozoneBidAdapter.js
+++ b/modules/ozoneBidAdapter.js
@@ -7,7 +7,8 @@ import {
   isArray,
   contains,
   mergeDeep,
-  parseUrl
+  parseUrl,
+  generateUUID
 } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
@@ -16,15 +17,15 @@ import {getPriceBucketString} from '../src/cpmBucketManager.js';
 import { Renderer } from '../src/Renderer.js';
 import {getRefererInfo} from '../src/refererDetection.js';
 const BIDDER_CODE = 'ozone';
-const ORIGIN = 'https://elb.the-ozone-project.com'; // applies only to auction & cookie
+const ORIGIN = 'https://elb.the-ozone-project.com' // applies only to auction & cookie
 const AUCTIONURI = '/openrtb2/auction';
 const OZONECOOKIESYNC = '/static/load-cookie.html';
 const OZONE_RENDERER_URL = 'https://prebid.the-ozone-project.com/ozone-renderer.js';
 const ORIGIN_DEV = 'https://test.ozpr.net';
-const OZONEVERSION = '2.8.0';
+const OZONEVERSION = '2.9.0';
 export const spec = {
   gvlid: 524,
-  aliases: [{code: 'lmc', gvlid: 524}],
+  aliases: [{code: 'lmc', gvlid: 524}, {code: 'newspassid', gvlid: 524}, {code: 'newspass', gvlid: 524}],
   version: OZONEVERSION,
   code: BIDDER_CODE,
   supportedMediaTypes: [VIDEO, BANNER],
@@ -36,7 +37,8 @@ export const spec = {
     'keyPrefix': 'oz',
     'auctionUrl': ORIGIN + AUCTIONURI,
     'cookieSyncUrl': ORIGIN + OZONECOOKIESYNC,
-    'rendererUrl': OZONE_RENDERER_URL
+    'rendererUrl': OZONE_RENDERER_URL,
+    'batchRequests': false /* you can change this to true OR override it in the config: config.ozone.batchRequests */
   },
   loadWhitelabelData(bid) {
     if (this.propertyBag.whitelabel) { return; }
@@ -73,6 +75,9 @@ export const spec = {
         this.propertyBag.whitelabel.auctionUrl = bidderConfig.endpointOverride.auctionUrl;
       }
     }
+    if (bidderConfig.hasOwnProperty('batchRequests')) {
+      this.propertyBag.whitelabel.batchRequests = bidderConfig.batchRequests;
+    }
     try {
       if (arr.hasOwnProperty('auction') && arr.auction === 'dev') {
         logInfo('GET: auction=dev');
@@ -94,11 +99,14 @@ export const spec = {
   getRendererUrl() {
     return this.propertyBag.whitelabel.rendererUrl;
   },
+  isBatchRequests() {
+    return this.propertyBag.whitelabel.batchRequests;
+  },
   isBidRequestValid(bid) {
     this.loadWhitelabelData(bid);
     logInfo('isBidRequestValid : ', config.getConfig(), bid);
     let adUnitCode = bid.adUnitCode; // adunit[n].code
-    let err1 = 'VALIDATION FAILED : missing {param} : siteId, placementId and publisherId are REQUIRED';
+    let err1 = 'VALIDATION FAILED : missing {param} : siteId, placementId and publisherId are REQUIRED'
     if (!(bid.params.hasOwnProperty('placementId'))) {
       logError(err1.replace('{param}', 'placementId'), adUnitCode);
       return false;
@@ -199,7 +207,7 @@ export const spec = {
       let placementId = placementIdOverrideFromGetParam || this.getPlacementId(ozoneBidRequest); // prefer to use a valid override param, else the bidRequest placement Id
       obj.id = ozoneBidRequest.bidId; // this causes an error if we change it to something else, even if you update the bidRequest object: "WARNING: Bidder ozone made bid for unknown request ID: mb7953.859498327448. Ignoring."
       obj.tagid = placementId;
-      let parsed = parseUrl(getRefererInfo().page);
+      let parsed = parseUrl(this.getRefererInfo().page);
       obj.secure = parsed.protocol === 'https' ? 1 : 0;
       let arrBannerSizes = [];
       if (!ozoneBidRequest.hasOwnProperty('mediaTypes')) {
@@ -262,9 +270,7 @@ export const spec = {
       obj.placementId = placementId;
       deepSetValue(obj, 'ext.prebid', {'storedrequest': {'id': placementId}});
       obj.ext[whitelabelBidder] = {};
-      // TODO: fix auctionId/transactionID leak: https://github.com/prebid/Prebid.js/issues/9781
       obj.ext[whitelabelBidder].adUnitCode = ozoneBidRequest.adUnitCode; // eg. 'mpu'
-      obj.ext[whitelabelBidder].transactionId = ozoneBidRequest.transactionId; // this is the transactionId PER adUnit, common across bidders for this unit
       if (ozoneBidRequest.params.hasOwnProperty('customData')) {
         obj.ext[whitelabelBidder].customData = ozoneBidRequest.params.customData;
       }
@@ -290,6 +296,10 @@ export const spec = {
       }
       if (!schain && deepAccess(ozoneBidRequest, 'schain')) {
         schain = ozoneBidRequest.schain;
+      }
+      let gpid = deepAccess(ozoneBidRequest, 'ortb2Imp.ext.gpid');
+      if (gpid) {
+        deepSetValue(obj, 'ext.gpid', gpid);
       }
       return obj;
     });
@@ -326,7 +336,7 @@ export const spec = {
     let userExtEids = deepAccess(validBidRequests, '0.userIdAsEids', []); // generate the UserIDs in the correct format for UserId module
     ozoneRequest.site = {
       'publisher': {'id': htmlParams.publisherId},
-      'page': getRefererInfo().page,
+      'page': this.getRefererInfo().page,
       'id': htmlParams.siteId
     };
     ozoneRequest.test = config.getConfig('debug') ? 1 : 0;
@@ -355,13 +365,34 @@ export const spec = {
     if (config.getConfig('coppa') === true) {
       deepSetValue(ozoneRequest, 'regs.coppa', 1);
     }
+    let ozUuid = generateUUID();
+    if (this.isBatchRequests()) {
+      logInfo('going to batch the requests');
+      let arrRet = []; // return an array of objects containing data describing max 10 bids
+      for (let i = 0; i < tosendtags.length; i += 10) {
+        ozoneRequest.id = ozUuid; // Unique ID of the bid request, provided by the exchange. (REQUIRED)
+        ozoneRequest.imp = tosendtags.slice(i, i + 10);
+        ozoneRequest.ext = extObj;
+        deepSetValue(ozoneRequest, 'source.tid', ozUuid);// RTB 2.5 : tid is Transaction ID that must be common across all participants in this bid request (e.g., potentially multiple exchanges).
+        deepSetValue(ozoneRequest, 'user.ext.eids', userExtEids);
+        if (ozoneRequest.imp.length > 0) {
+          arrRet.push({
+            method: 'POST',
+            url: this.getAuctionUrl(),
+            data: JSON.stringify(ozoneRequest),
+            bidderRequest: bidderRequest
+          });
+        }
+      }
+      logInfo('batch request going to return : ', arrRet);
+      return arrRet;
+    }
+    logInfo('requests will not be batched.');
     if (singleRequest) {
       logInfo('buildRequests starting to generate response for a single request');
-      ozoneRequest.id = bidderRequest.auctionId; // Unique ID of the bid request, provided by the exchange.
-      ozoneRequest.auctionId = bidderRequest.auctionId; // not sure if this should be here?
+      ozoneRequest.id = ozUuid; // Unique ID of the bid request, provided by the exchange. (REQUIRED)
       ozoneRequest.imp = tosendtags;
       ozoneRequest.ext = extObj;
-      deepSetValue(ozoneRequest, 'source.tid', bidderRequest.auctionId);// RTB 2.5 : tid is Transaction ID that must be common across all participants in this bid request (e.g., potentially multiple exchanges).
       deepSetValue(ozoneRequest, 'user.ext.eids', userExtEids);
       var ret = {
         method: 'POST',
@@ -378,11 +409,10 @@ export const spec = {
       logInfo('buildRequests starting to generate non-single response, working on imp : ', imp);
       let ozoneRequestSingle = Object.assign({}, ozoneRequest);
       imp.ext[whitelabelBidder].pageAuctionId = bidderRequest['auctionId']; // make a note in the ext object of what the original auctionId was, in the bidderRequest object
-      ozoneRequestSingle.id = imp.ext[whitelabelBidder].transactionId; // Unique ID of the bid request, provided by the exchange.
-      ozoneRequestSingle.auctionId = imp.ext[whitelabelBidder].transactionId; // not sure if this should be here?
+      deepSetValue(ozoneRequestSingle, 'source.tid', ozUuid);// RTB 2.5 : tid is Transaction ID that must be common across all participants in this bid request (e.g., potentially multiple exchanges).
+      ozoneRequestSingle.id = generateUUID(); // Unique ID of the bid request, provided by the exchange. (REQUIRED)
       ozoneRequestSingle.imp = [imp];
       ozoneRequestSingle.ext = extObj;
-      deepSetValue(ozoneRequestSingle, 'source.tid', bidderRequest.auctionId);// RTB 2.5 : tid is Transaction ID that must be common across all participants in this bid request (e.g., potentially multiple exchanges).
       deepSetValue(ozoneRequestSingle, 'user.ext.eids', userExtEids);
       logInfo('buildRequests RequestSingle (for non-single) = ', ozoneRequestSingle);
       return {
@@ -686,9 +716,28 @@ export const spec = {
     return null;
   },
   getGetParametersAsObject() {
-    let parsed = parseUrl(getRefererInfo().page);
+    let parsed = parseUrl(this.getRefererInfo().location);
     logInfo('getGetParametersAsObject found:', parsed.search);
     return parsed.search;
+  },
+  getRefererInfo() {
+    if (getRefererInfo().hasOwnProperty('location')) {
+      logInfo('FOUND location on getRefererInfo OK (prebid >= 7); will use getRefererInfo for location & page');
+      return getRefererInfo();
+    } else {
+      logInfo('DID NOT FIND location on getRefererInfo (prebid < 7); will use legacy code that ALWAYS worked reliably to get location & page ;-)');
+      try {
+        return {
+          page: top.location.href,
+          location: top.location.href
+        };
+      } catch (e) {
+        return {
+          page: window.location.href,
+          location: window.location.href
+        };
+      }
+    }
   },
   blockTheRequest() {
     let ozRequest = this.getWhitelabelConfigItem('ozone.oz_request');

--- a/modules/ozoneBidAdapter.js
+++ b/modules/ozoneBidAdapter.js
@@ -25,7 +25,7 @@ const ORIGIN_DEV = 'https://test.ozpr.net';
 const OZONEVERSION = '2.9.0';
 export const spec = {
   gvlid: 524,
-  aliases: [{code: 'lmc', gvlid: 524}, {code: 'newspassid', gvlid: 524}, {code: 'newspass', gvlid: 524}],
+  aliases: [{code: 'lmc', gvlid: 524}],
   version: OZONEVERSION,
   code: BIDDER_CODE,
   supportedMediaTypes: [VIDEO, BANNER],
@@ -407,8 +407,6 @@ export const spec = {
     let arrRet = tosendtags.map(imp => {
       logInfo('buildRequests starting to generate non-single response, working on imp : ', imp);
       let ozoneRequestSingle = Object.assign({}, ozoneRequest);
-      imp.ext[whitelabelBidder].pageAuctionId = bidderRequest['auctionId']; // make a note in the ext object of what the original auctionId was, in the bidderRequest object
-      deepSetValue(ozoneRequestSingle, 'source.tid', ozUuid);// RTB 2.5 : tid is Transaction ID that must be common across all participants in this bid request (e.g., potentially multiple exchanges).
       ozoneRequestSingle.id = generateUUID(); // Unique ID of the bid request, provided by the exchange. (REQUIRED)
       ozoneRequestSingle.imp = [imp];
       ozoneRequestSingle.ext = extObj;
@@ -453,6 +451,7 @@ export const spec = {
     logInfo(`interpretResponse time: ${startTime} . Time between buildRequests done and interpretResponse start was ${startTime - this.propertyBag.buildRequestsEnd}ms`);
     logInfo(`serverResponse, request`, JSON.parse(JSON.stringify(serverResponse)), JSON.parse(JSON.stringify(request)));
     serverResponse = serverResponse.body || {};
+    let aucId = serverResponse.id; // this will be correct for single requests and non-single
     if (!serverResponse.hasOwnProperty('seatbid')) {
       return [];
     }
@@ -547,7 +546,7 @@ export const spec = {
           }
         }
         let {seat: winningSeat, bid: winningBid} = ozoneGetWinnerForRequestBid(thisBid.bidId, serverResponse.seatbid);
-        adserverTargeting[whitelabelPrefix + '_auc_id'] = String(request.bidderRequest.auctionId);
+        adserverTargeting[whitelabelPrefix + '_auc_id'] = String(aucId); // was request.bidderRequest.auctionId
         adserverTargeting[whitelabelPrefix + '_winner'] = String(winningSeat);
         adserverTargeting[whitelabelPrefix + '_bid'] = 'true';
         adserverTargeting[whitelabelPrefix + '_cache_id'] = deepAccess(thisBid, 'ext.prebid.targeting.hb_cache_id', 'no-id');

--- a/modules/ozoneBidAdapter.md
+++ b/modules/ozoneBidAdapter.md
@@ -73,6 +73,8 @@ adUnits = [{
                 }];
 ```
 
+
+```
 //Instream Video adUnit
 
 adUnits = [{


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature

## Description of change

- changes required for PB 8 https://github.com/prebid/Prebid.js/issues/8573 - removed transaction IDs
- added support for batching/limiting to 10 impression objects in a single request with a config switch - onpage and also in the adapter. Off by default. In the config use ozone.batchRequests: true
- added our own auction id as required by ozone server & also openrtb spec

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
engineering@ozoneproject.com
rupesh@ozoneproject.com

testpages:
https://www.ardm.io/ozone/2.9.0/3-adslots-ozone-pb8-20230620-batch.html?pbjs_debug=true
https://www.ardm.io/ozone/2.9.0/3-adslots-ozone-pb8-20230620-nobatch.html?pbjs_debug=true
https://www.ardm.io/ozone/2.9.0/3-adslots-ozone-pb8-20230620-batch-no-gpid.html?pbjs_debug=true - config switches the gpid off

```

```

//Banner adUnit

adUnits = [{
                    code: 'id-of-your-banner-div',
			        mediaTypes: {
			          banner: {
			            sizes: [[300, 250], [300,600]]
			          }
			        },
                    bids: [{
                        bidder: 'ozone',
                        params: {
                            publisherId: 'OZONENUK0001', /* an ID to identify the publisher account  - required */
                            siteId: '4204204201', /* An ID used to identify a site within a publisher account - required */
                            placementId: '0420420421', /* an ID used to identify the piece of inventory - required - for appnexus test use 13144370. */
							customData: [{"settings": {}, "targeting": {"key": "value", "key2": ["value1", "value2"]}}],/* optional array with 'targeting' placeholder for passing publisher specific key-values for targeting. */                            
                        }
                    }]
                }];
```


```

//Outstream Video adUnit

adUnits = [{
                    code: 'id-of-your-video-div',
                    mediaTypes: {
                        video: {
                            playerSize: [640, 360],
                            mimes: ['video/mp4'],
                            context: 'outstream',
                        }
                    },
                    bids: [{
                        bidder: 'ozone',
                        params: {
                            publisherId: 'OZONENUK0001', /* an ID to identify the publisher account  - required */
                            siteId: '4204204201', /* An ID used to identify a site within a publisher account - required */
							customData: [{"settings": {}, "targeting": { "key": "value", "key2": ["value1", "value2"]}}]
                            placementId: '0440440442', /* an ID used to identify the piece of inventory - required - for unruly test use 0440440442. */
							video: {
                                skippable: true, /* optional */
                                playback_method: ['auto_play_sound_off'], /* optional */
                                targetDiv: 'some-different-div-id-to-my-adunitcode' /* optional */
                            }
                        }
                    }]
                }];
```


```
//Instream Video adUnit

adUnits = [{
					code: 'video1',
					mediaTypes: {
						video: {
							playerSize: [640, 480],
							context: 'instream',
							mimes: ['video/mp4'],
							protocols: [1, 2, 3, 4, 5, 6, 7, 8],
							playbackmethod: [2]
						}
					},
					bids: [{
							bidder: 'ozone',
							params: {
								publisherId: 'OZONENUK0001',
								placementId: '8000000328', // or 999
								siteId: '4204204201',
								video: {
									skippable: true,
									playback_method: ['auto_play_sound_off']
								},
							customData: [{
							      "settings": {},
							      "targeting": {
							          "key": "value",
								  "key2": ["value1", "value2"]
								  }
							}
							]

							}
						}]
				};
```


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
https://github.com/prebid/Prebid.js/issues/8573