### PR TITLE
consentManagementGPP: do not cancel auctions when CMP is not version 1.0 (7.54.x-legacy backport)

### DIFF
--- a/modules/consentManagementGpp.js
+++ b/modules/consentManagementGpp.js
@@ -160,11 +160,20 @@ function lookupIabConsent({onSuccess, onError}) {
     : 'Detected GPP CMP is outside the current iframe where Prebid.js is located, calling it now...';
   logInfo(startupMsg);
 
+  let versionMismatch = false;
+
   invokeCMP({
     command: 'addEventListener',
     callback: function (evt) {
-      if (evt) {
+      if (evt && !versionMismatch) {
         logInfo(`Received a ${(cmpDirectAccess ? 'direct' : 'postmsg')} response from GPP CMP for event`, evt);
+        const cmpVer = evt?.pingData?.gppVersion;
+        if (cmpVer != null && cmpVer !== '1.0') {
+          logWarn(`Unsupported GPP CMP version: ${cmpVer}. Continuing auction without consent`);
+          versionMismatch = true;
+          onSuccess(storeConsentData());
+          return;
+        }
         if (evt.eventName === 'sectionChange' || evt.pingData.cmpStatus === 'loaded') {
           invokeCMP({command: 'getGPPData'}, function (gppData) {
             logInfo(`Received a ${cmpDirectAccess ? 'direct' : 'postmsg'} response from GPP CMP for getGPPData`, gppData);

--- a/test/spec/modules/consentManagementGpp_spec.js
+++ b/test/spec/modules/consentManagementGpp_spec.js
@@ -525,18 +525,14 @@ describe('consentManagementGpp', function () {
             })
           }
 
-          function mockGppCmp(gppdata) {
+          function mockGppCmp(gppData, pingData = {cmpStatus: 'loaded'}) {
             gppStub.callsFake((api, cb) => {
               if (api === 'addEventListener') {
                 // eslint-disable-next-line standard/no-callback-literal
-                cb({
-                  pingData: {
-                    cmpStatus: 'loaded'
-                  }
-                }, true);
+                cb({pingData}, true);
               }
-              if (api === 'getGPPData') {
-                return gppdata;
+              if (gppData != null && api === 'getGPPData') {
+                return gppData;
               }
             });
           }
@@ -547,6 +543,16 @@ describe('consentManagementGpp', function () {
 
           afterEach(() => {
             gppStub.restore();
+          })
+
+          it('should continue auction with null consent when CMP is not version 1.0', () => {
+            mockGppCmp(null, {cmpStatus: 'loaded', gppVersion: '1.1'});
+            return runAuction().then(() => {
+              sinon.assert.match(gppDataHandler.getConsentData(), {
+                gppString: undefined,
+                applicableSections: [],
+              })
+            })
           })
 
           it('should continue auction with null consent when CMP is unresponsive', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Do not cancel auctions when CMP is using version 1.1 - https://github.com/prebid/Prebid.js/issues/10245

