### PR TITLE
NewspassId Bid Adapter: tid logic change and GPID Module Support

### DIFF
--- a/modules/newspassid.md
+++ b/modules/newspassid.md
@@ -1,0 +1,76 @@
+---
+Module Name: NewspassId Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: techsupport@newspassid.com
+layout: bidder
+title: Newspass ID
+description: LMC Newspass ID Prebid JS Bidder Adapter
+biddercode: newspassid
+gdpr_supported: false
+gvl_id: none
+usp_supported: true
+coppa_supported: false
+schain_supported: true
+dchain_supported: false
+userIds: criteo, id5Id, tdid, identityLink, liveIntentId, parrableId, pubCommonId, lotamePanoramaId, sharedId, fabrickId
+media_types: banner
+safeframes_ok: true
+deals_supported: true
+floors_supported: false
+fpd_supported: false
+pbjs: true
+pbs: false
+prebid_member: false
+multiformat_supported: will-bid-on-any
+---
+
+### Description
+
+LMC Newspass ID Prebid JS Bidder Adapter that connects to the NewspassId demand source(s).
+
+The Newspass bid adapter supports Banner mediaTypes ONLY.
+This is intended for USA audiences only, and does not support GDPR
+
+
+### Bid Params
+
+{: .table .table-bordered .table-striped }
+
+| Name      | Scope    | Description               | Example    | Type     |
+|-----------|----------|---------------------------|------------|----------|
+| `siteId`    | required | The site ID.  		   | `"NPID0000001"` | `string` |
+| `publisherId`    | required | The publisher ID.  | `"4204204201"` | `string` |
+| `placementId`    | required | The placement ID.  | `"0420420421"` | `string` |
+| `customData`     | optional | publisher key-values used for targeting | `[{"settings":{},"targeting":{"key1": "value1", "key2": "value2"}}], ` | `array` |
+ 
+### Test Parameters
+
+
+A test ad unit that will consistently return test creatives:
+
+```
+
+//Banner adUnit
+
+adUnits = [{
+                    code: 'id-of-your-banner-div',
+			        mediaTypes: {
+			          banner: {
+			            sizes: [[300, 250], [300,600]]
+			          }
+			        },
+                    bids: [{
+                        bidder: 'newspassid',
+                        params: {
+                            publisherId: 'NEWSPASS0001', /* an ID to identify the publisher account  - required */
+                            siteId: '4204204201', /* An ID used to identify a site within a publisher account - required */
+                            placementId: '8000000015', /* an ID used to identify the piece of inventory - required - for appnexus test use 13144370. */
+							customData: [{"settings": {}, "targeting": {"key": "value", "key2": ["value1", "value2"]}}],/* optional array with 'targeting' placeholder for passing publisher specific key-values for targeting. */                            
+                        }
+                    }]
+                }];
+```
+
+### Note:
+
+Please contact us at techsupport@newspassid.com for any assistance testing your implementation before going live into production.

--- a/modules/newspassidBidAdapter.js
+++ b/modules/newspassidBidAdapter.js
@@ -1,15 +1,24 @@
-import {contains, deepAccess, deepSetValue, isArray, logError, logInfo, logWarn, parseUrl} from '../src/utils.js';
-import {registerBidder} from '../src/adapters/bidderFactory.js';
-import {BANNER, NATIVE} from '../src/mediaTypes.js';
+import {
+  logInfo,
+  logError,
+  deepAccess,
+  logWarn,
+  deepSetValue,
+  isArray,
+  contains,
+  parseUrl,
+  generateUUID
+} from '../src/utils.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER, NATIVE } from '../src/mediaTypes.js';
 import {config} from '../src/config.js';
 import {getPriceBucketString} from '../src/cpmBucketManager.js';
 import {getRefererInfo} from '../src/refererDetection.js';
-
 const BIDDER_CODE = 'newspassid';
 const ORIGIN = 'https://bidder.newspassid.com' // applies only to auction & cookie
 const AUCTIONURI = '/openrtb2/auction';
 const NEWSPASSCOOKIESYNC = '/static/load-cookie.html';
-const NEWSPASSVERSION = '1.0.1';
+const NEWSPASSVERSION = '1.1.4';
 export const spec = {
   version: NEWSPASSVERSION,
   code: BIDDER_CODE,
@@ -155,7 +164,7 @@ export const spec = {
       let placementId = placementIdOverrideFromGetParam || this.getPlacementId(npBidRequest); // prefer to use a valid override param, else the bidRequest placement Id
       obj.id = npBidRequest.bidId; // this causes an error if we change it to something else, even if you update the bidRequest object: "WARNING: Bidder newspass made bid for unknown request ID: mb7953.859498327448. Ignoring."
       obj.tagid = placementId;
-      let parsed = parseUrl(getRefererInfo().page);
+      let parsed = parseUrl(this.getRefererInfo().page);
       obj.secure = parsed.protocol === 'https' ? 1 : 0;
       let arrBannerSizes = [];
       if (!npBidRequest.hasOwnProperty('mediaTypes')) {
@@ -189,7 +198,6 @@ export const spec = {
       deepSetValue(obj, 'ext.prebid', {'storedrequest': {'id': placementId}});
       obj.ext['newspassid'] = {};
       obj.ext['newspassid'].adUnitCode = npBidRequest.adUnitCode; // eg. 'mpu'
-      obj.ext['newspassid'].transactionId = npBidRequest.transactionId; // this is the transactionId PER adUnit, common across bidders for this unit
       if (npBidRequest.params.hasOwnProperty('customData')) {
         obj.ext['newspassid'].customData = npBidRequest.params.customData;
       }
@@ -216,6 +224,10 @@ export const spec = {
       if (!schain && deepAccess(npBidRequest, 'schain')) {
         schain = npBidRequest.schain;
       }
+      let gpid = deepAccess(npBidRequest, 'ortb2Imp.ext.gpid');
+      if (gpid) {
+        deepSetValue(obj, 'ext.gpid', gpid);
+      }
       return obj;
     });
     let extObj = {};
@@ -240,7 +252,7 @@ export const spec = {
     let userExtEids = deepAccess(validBidRequests, '0.userIdAsEids', []); // generate the UserIDs in the correct format for UserId module
     npRequest.site = {
       'publisher': {'id': htmlParams.publisherId},
-      'page': getRefererInfo().page,
+      'page': this.getRefererInfo().page,
       'id': htmlParams.siteId
     };
     npRequest.test = config.getConfig('debug') ? 1 : 0;
@@ -259,12 +271,9 @@ export const spec = {
     }
     if (singleRequest) {
       logInfo('buildRequests starting to generate response for a single request');
-      // TODO: fix auctionId & transactionId leak: https://github.com/prebid/Prebid.js/issues/9781
-      npRequest.id = bidderRequest.auctionId; // Unique ID of the bid request, provided by the exchange.
-      npRequest.auctionId = bidderRequest.auctionId; // not sure if this should be here?
+      npRequest.id = generateUUID(); // Unique ID of the bid request, provided by the exchange. (REQUIRED)
       npRequest.imp = tosendtags;
       npRequest.ext = extObj;
-      deepSetValue(npRequest, 'source.tid', bidderRequest.auctionId);// RTB 2.5 : tid is Transaction ID that must be common across all participants in this bid request (e.g., potentially multiple exchanges).
       deepSetValue(npRequest, 'user.ext.eids', userExtEids);
       var ret = {
         method: 'POST',
@@ -280,12 +289,9 @@ export const spec = {
     let arrRet = tosendtags.map(imp => {
       logInfo('buildRequests starting to generate non-single response, working on imp : ', imp);
       let npRequestSingle = Object.assign({}, npRequest);
-      imp.ext['newspassid'].pageAuctionId = bidderRequest['auctionId']; // make a note in the ext object of what the original auctionId was, in the bidderRequest object
-      npRequestSingle.id = imp.ext['newspassid'].transactionId; // Unique ID of the bid request, provided by the exchange.
-      npRequestSingle.auctionId = imp.ext['newspassid'].transactionId; // not sure if this should be here?
+      npRequestSingle.id = generateUUID();
       npRequestSingle.imp = [imp];
       npRequestSingle.ext = extObj;
-      deepSetValue(npRequestSingle, 'source.tid', bidderRequest.auctionId);// RTB 2.5 : tid is Transaction ID that must be common across all participants in this bid request (e.g., potentially multiple exchanges).
       deepSetValue(npRequestSingle, 'user.ext.eids', userExtEids);
       logInfo('buildRequests RequestSingle (for non-single) = ', npRequestSingle);
       return {
@@ -305,6 +311,7 @@ export const spec = {
     logInfo(`interpretResponse time: ${startTime}. buildRequests done -> interpretResponse start was ${startTime - this.propertyBag.buildRequestsEnd}ms`);
     logInfo(`serverResponse, request`, JSON.parse(JSON.stringify(serverResponse)), JSON.parse(JSON.stringify(request)));
     serverResponse = serverResponse.body || {};
+    let aucId = serverResponse.id; // this will be correct for single requests and non-single
     if (!serverResponse.hasOwnProperty('seatbid')) {
       return [];
     }
@@ -351,7 +358,7 @@ export const spec = {
           logInfo(`newspassid.enhancedAdserverTargeting is set to false, no per-bid keys will be sent to adserver.`);
         }
         let {seat: winningSeat, bid: winningBid} = this.getWinnerForRequestBid(thisBid.bidId, serverResponse.seatbid);
-        adserverTargeting['np_auc_id'] = String(request.bidderRequest.auctionId);
+        adserverTargeting['np_auc_id'] = String(aucId);
         adserverTargeting['np_winner'] = String(winningSeat);
         adserverTargeting['np_bid'] = 'true';
         if (enhancedAdserverTargeting) {
@@ -490,9 +497,28 @@ export const spec = {
     return null;
   },
   getGetParametersAsObject() {
-    let parsed = parseUrl(getRefererInfo().page);
+    let parsed = parseUrl(this.getRefererInfo().location); // was getRefererInfo().page but this is not backwards compatible
     logInfo('getGetParametersAsObject found:', parsed.search);
     return parsed.search;
+  },
+  getRefererInfo() {
+    if (getRefererInfo().hasOwnProperty('location')) {
+      logInfo('FOUND location on getRefererInfo OK (prebid >= 7); will use getRefererInfo for location & page');
+      return getRefererInfo();
+    } else {
+      logInfo('DID NOT FIND location on getRefererInfo (prebid < 7); will use legacy code that ALWAYS worked reliably to get location & page ;-)');
+      try {
+        return {
+          page: top.location.href,
+          location: top.location.href
+        };
+      } catch (e) {
+        return {
+          page: window.location.href,
+          location: window.location.href
+        };
+      }
+    }
   },
   blockTheRequest() {
     let npRequest = config.getConfig('newspassid.np_request');

--- a/test/spec/modules/newspassidBidAdapter_spec.js
+++ b/test/spec/modules/newspassidBidAdapter_spec.js
@@ -1667,6 +1667,12 @@ describe('newspassid Adapter', function () {
       expect(result[0]['price']).to.equal(0.9);
       expect(result[0]['adserverTargeting']['np_npappnexus_adId']).to.equal('2899ec066a91ff8-0-np-1');
     });
+    it('should add np_auc_id (response id value)', function () {
+      const request = spec.buildRequests(validBidRequests, validBidderRequest);
+      let validres = JSON.parse(JSON.stringify(validBidResponse1adWith2Bidders));
+      const result = spec.interpretResponse(validres, request);
+      expect(utils.deepAccess(result[0].adserverTargeting, 'np_auc_id')).to.equal(validBidResponse1adWith2Bidders.body.id);
+    });
     it('should correctly process an auction with 2 adunits & multiple bidders one of which bids for both adslots', function() {
       let validres = JSON.parse(JSON.stringify(multiResponse1));
       let request = spec.buildRequests(multiRequest1, multiBidderRequest1.bidderRequest);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature

## Description of change
addresses #8573 
added support for GPID module

- test parameters for validating bids:

```

//Banner adUnit

adUnits = [{
                    code: 'id-of-your-banner-div',
			        mediaTypes: {
			          banner: {
			            sizes: [[300, 250], [300,600]]
			          }
			        },
                    bids: [{
                        bidder: 'newspassid',
                        params: {
                            publisherId: 'NEWSPASS0001', /* an ID to identify the publisher account  - required */
                            siteId: '4204204201', /* An ID used to identify a site within a publisher account - required */
                            placementId: '8000000015', /* an ID used to identify the piece of inventory - required - for appnexus test use 13144370. */
							customData: [{"settings": {}, "targeting": {"key": "value", "key2": ["value1", "value2"]}}],/* optional array with 'targeting' placeholder for passing publisher specific key-values for targeting. */                            
                        }
                    }]
                }];
```


-->
