### PR TITLE
Core: disregard `transactionId`/`auctionId` set by bid adapters

### DIFF
--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -15,7 +15,7 @@ import {
   logError,
   logWarn, memoize,
   parseQueryStringParameters,
-  parseSizesInput,
+  parseSizesInput, pick,
   uniques
 } from '../utils.js';
 import {hook} from '../hook.js';
@@ -150,6 +150,7 @@ import {ACTIVITY_TRANSMIT_TID} from '../activities/activities.js';
 
 // common params for all mediaTypes
 const COMMON_BID_RESPONSE_KEYS = ['cpm', 'ttl', 'creativeId', 'netRevenue', 'currency'];
+const TIDS = ['auctionId', 'transactionId'];
 
 /**
  * Register a bidder with prebid, using the given spec.
@@ -192,7 +193,7 @@ function guardTids(bidderCode) {
     };
   }
   function get(target, prop, receiver) {
-    if (['transactionId', 'auctionId'].includes(prop)) {
+    if (TIDS.includes(prop)) {
       return null;
     }
     return Reflect.get(target, prop, receiver);
@@ -312,7 +313,7 @@ export function newBidder(spec) {
             bid.originalCpm = bid.cpm;
             bid.originalCurrency = bid.currency;
             bid.meta = bid.meta || Object.assign({}, bid[bidRequest.bidder]);
-            const prebidBid = Object.assign(createBid(CONSTANTS.STATUS.GOOD, bidRequest), bid);
+            const prebidBid = Object.assign(createBid(CONSTANTS.STATUS.GOOD, bidRequest), bid, pick(bidRequest, TIDS));
             addBidWithCode(bidRequest.adUnitCode, prebidBid);
           } else {
             logWarn(`Bidder ${spec.code} made bid for unknown request ID: ${bid.requestId}. Ignoring.`);

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -1107,6 +1107,25 @@ describe('validate bid response: ', function () {
     expect(logErrorSpy.callCount).to.equal(0);
   });
 
+  it('should disregard auctionId/transactionId set by the adapter', () => {
+    let bidderRequest = {
+      bids: [{
+        bidder: CODE,
+        bidId: '1',
+        auctionId: 'aid',
+        transactionId: 'tid',
+        adUnitCode: 'au',
+      }]
+    };
+    const bidder = newBidder(spec);
+    spec.interpretResponse.returns(Object.assign({}, bids[0], {transactionId: 'ignored', auctionId: 'ignored'}));
+    bidder.callBids(bidderRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
+    sinon.assert.calledWith(addBidResponseStub, sinon.match.any, sinon.match({
+      transactionId: 'tid',
+      auctionId: 'aid'
+    }));
+  })
+
   describe(' Check for alternateBiddersList ', function() {
     let bidRequest;
     let bids1;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fix a bug where bid adapters are allowed to override `transactionId` / `auctionId` on bid responses. With prebid 8, if an adapter is copying them over from the request, it will cause errors when TIDs are disabled.


## Other information

Fixes https://github.com/prebid/Prebid.js/issues/10260

