### PR TITLE
Native: privacyLink is now converted to ortb.privacy 

### DIFF
--- a/src/constants.json
+++ b/src/constants.json
@@ -163,7 +163,6 @@
     "MAIN": 3
   },
   "NATIVE_KEYS_THAT_ARE_NOT_ASSETS": [
-    "privacyLink",
     "clickUrl",
     "sendTargetingKeys",
     "adTemplate",

--- a/src/native.js
+++ b/src/native.js
@@ -705,7 +705,7 @@ export function legacyPropertiesToOrtbNative(legacyNative) {
         response.jstracker = Array.isArray(value) ? value.join('') : value;
         break;
       case 'privacyLink':
-        response.privacy = 1;
+        response.privacy = value;
         break;
     }
   });

--- a/src/native.js
+++ b/src/native.js
@@ -629,7 +629,7 @@ export function fromOrtbNativeRequest(openRTBRequest) {
       }
     }
     if (openRTBRequest.privacy) {
-      oldNativeObject.privacyLink = { required: true };
+      oldNativeObject.privacyLink = { required: false };
     }
     // video was not supported by old prebid assets
   }
@@ -704,8 +704,11 @@ export function legacyPropertiesToOrtbNative(legacyNative) {
         // in general, native trackers seem to be neglected and/or broken
         response.jstracker = Array.isArray(value) ? value.join('') : value;
         break;
+      case 'privacyLink':
+        response.privacy = 1;
+        break;
     }
-  })
+  });
   return response;
 }
 

--- a/src/native.js
+++ b/src/native.js
@@ -480,6 +480,11 @@ export function toOrtbNativeRequest(legacyNativeAssets) {
       continue;
     }
 
+    if (key === 'privacyLink') {
+      ortb.privacy = 1;
+      continue;
+    }
+
     const asset = legacyNativeAssets[key];
     let required = 0;
     if (asset.required && isBoolean(asset.required)) {
@@ -622,6 +627,9 @@ export function fromOrtbNativeRequest(openRTBRequest) {
       if (asset.data.len) {
         oldNativeObject[prebidAssetName].len = asset.data.len;
       }
+    }
+    if (openRTBRequest.privacy) {
+      oldNativeObject.privacyLink = { required: true };
     }
     // video was not supported by old prebid assets
   }

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -1204,6 +1204,12 @@ describe('legacyPropertiesToOrtbNative', () => {
       expect(native.jstracker).to.eql('some-markupsome-other-markup');
     })
   });
+  describe('privacylink', () => {
+    it('should convert privacyLink to privacy', () => {
+      const native = legacyPropertiesToOrtbNative({privacyLink: 'https:/my-privacy-link.com'});
+      expect(native.privacy).to.eql('https:/my-privacy-link.com');
+    })
+  })
 });
 
 describe('fireImpressionTrackers', () => {

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -1032,7 +1032,7 @@ describe('validate native', function () {
       len: 140
     });
     expect(oldNativeRequest.privacyLink).to.include({
-      required: true
+      required: false
     });
   });
 

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -860,6 +860,9 @@ describe('validate native', function () {
             }]
           },
           address: {},
+          privacyLink: {
+            required: true
+          }
         },
       },
     };
@@ -915,6 +918,7 @@ describe('validate native', function () {
         type: 9,
       }
     });
+    expect(ortb.privacy).to.equal(1);
   });
 
   ['bogusKey', 'clickUrl', 'privacyLink'].forEach(nativeKey => {
@@ -1022,11 +1026,14 @@ describe('validate native', function () {
     expect(oldNativeRequest.sponsoredBy).to.include({
       required: true,
       len: 25
-    })
+    });
     expect(oldNativeRequest.body).to.include({
       required: true,
       len: 140
-    })
+    });
+    expect(oldNativeRequest.privacyLink).to.include({
+      required: true
+    });
   });
 
   if (FEATURES.NATIVE) {


### PR DESCRIPTION
## Type of change

- [X] Bugfix

## Description of change
In legacy native, users could request `privacyLink`. Current prebid ORTB implementation was not considering this value. We decided that, if `privacyLink: { required: true }`, we set `ortb.privacy = 1`. 

## Other information
Discussion: https://github.com/prebid/Prebid.js/issues/10249 