### PR TITLE
Medianet Bid Adapter: added trustedstack bidder alias

### DIFF
--- a/modules/medianetBidAdapter.js
+++ b/modules/medianetBidAdapter.js
@@ -20,7 +20,9 @@ import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import {getGlobal} from '../src/prebidGlobal.js';
 
 const BIDDER_CODE = 'medianet';
+const TRUSTEDSTACK_CODE = 'trustedstack';
 const BID_URL = 'https://prebid.media.net/rtb/prebid';
+const TRUSTEDSTACK_URL = 'https://prebid.trustedstack.com/rtb/trustedstack';
 const PLAYER_URL = 'https://prebid.media.net/video/bundle.js';
 const SLOT_VISIBILITY = {
   NOT_DETERMINED: 0,
@@ -49,7 +51,7 @@ mnData.urlData = {
 };
 
 const aliases = [
-  { code: 'aax', gvlid: 720 },
+  { code: TRUSTEDSTACK_CODE },
 ];
 
 getGlobal().medianetGlobals = getGlobal().medianetGlobals || {};
@@ -323,8 +325,9 @@ function normalizeCoordinates(coordinates) {
   }
 }
 
-function getBidderURL(cid) {
-  return BID_URL + '?cid=' + encodeURIComponent(cid);
+function getBidderURL(bidderCode, cid) {
+  const url = (bidderCode === TRUSTEDSTACK_CODE) ? TRUSTEDSTACK_URL : BID_URL;
+  return url + '?cid=' + encodeURIComponent(cid);
 }
 
 function generatePayload(bidRequests, bidderRequests) {
@@ -463,7 +466,7 @@ export const spec = {
     let payload = generatePayload(bidRequests, bidderRequests);
     return {
       method: 'POST',
-      url: getBidderURL(payload.ext.customer_id),
+      url: getBidderURL(bidderRequests.bidderCode, payload.ext.customer_id),
       data: JSON.stringify(payload)
     };
   },

--- a/test/spec/modules/medianetBidAdapter_spec.js
+++ b/test/spec/modules/medianetBidAdapter_spec.js
@@ -915,24 +915,24 @@ let VALID_BID_REQUEST = [{
       cid: '8CUV090'
     }
   },
-  VALID_PARAMS_AAX = {
-    bidder: 'aax',
+  VALID_PARAMS_TS = {
+    bidder: 'trustedstack',
     params: {
-      cid: 'AAXG123'
+      cid: 'TS012345'
     }
   },
   PARAMS_MISSING = {
     bidder: 'medianet',
   },
-  PARAMS_MISSING_AAX = {
-    bidder: 'aax',
+  PARAMS_MISSING_TS = {
+    bidder: 'trustedstack',
   },
   PARAMS_WITHOUT_CID = {
     bidder: 'medianet',
     params: {}
   },
-  PARAMS_WITHOUT_CID_AAX = {
-    bidder: 'aax',
+  PARAMS_WITHOUT_CID_TS = {
+    bidder: 'trustedstack',
     params: {}
   },
   PARAMS_WITH_INTEGER_CID = {
@@ -941,8 +941,8 @@ let VALID_BID_REQUEST = [{
       cid: 8867587
     }
   },
-  PARAMS_WITH_INTEGER_CID_AAX = {
-    bidder: 'aax',
+  PARAMS_WITH_INTEGER_CID_TS = {
+    bidder: 'trustedstack',
     params: {
       cid: 8867587
     }
@@ -953,8 +953,8 @@ let VALID_BID_REQUEST = [{
       cid: ''
     }
   },
-  PARAMS_WITH_EMPTY_CID_AAX = {
-    bidder: 'aax',
+  PARAMS_WITH_EMPTY_CID_TS = {
+    bidder: 'trustedstack',
     params: {
       cid: ''
     }
@@ -1783,34 +1783,34 @@ describe('Media.net bid adapter', function () {
     });
   });
 
-  describe('isBidRequestValid aax', function () {
+  describe('isBidRequestValid trustedstack', function () {
     it('should accept valid bid params', function () {
-      let isValid = spec.isBidRequestValid(VALID_PARAMS_AAX);
+      let isValid = spec.isBidRequestValid(VALID_PARAMS_TS);
       expect(isValid).to.equal(true);
     });
 
     it('should reject bid if cid is not present', function () {
-      let isValid = spec.isBidRequestValid(PARAMS_WITHOUT_CID_AAX);
+      let isValid = spec.isBidRequestValid(PARAMS_WITHOUT_CID_TS);
       expect(isValid).to.equal(false);
     });
 
     it('should reject bid if cid is not a string', function () {
-      let isValid = spec.isBidRequestValid(PARAMS_WITH_INTEGER_CID_AAX);
+      let isValid = spec.isBidRequestValid(PARAMS_WITH_INTEGER_CID_TS);
       expect(isValid).to.equal(false);
     });
 
     it('should reject bid if cid is a empty string', function () {
-      let isValid = spec.isBidRequestValid(PARAMS_WITH_EMPTY_CID_AAX);
+      let isValid = spec.isBidRequestValid(PARAMS_WITH_EMPTY_CID_TS);
       expect(isValid).to.equal(false);
     });
 
     it('should have missing params', function () {
-      let isValid = spec.isBidRequestValid(PARAMS_MISSING_AAX);
+      let isValid = spec.isBidRequestValid(PARAMS_MISSING_TS);
       expect(isValid).to.equal(false);
     });
   });
 
-  describe('interpretResponse aax', function () {
+  describe('interpretResponse trustedstack', function () {
     it('should not push response if no-bid', function () {
       let validBids = [];
       let bids = spec.interpretResponse(SERVER_RESPONSE_NOBID, []);


### PR DESCRIPTION


## Type of change
- [x] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 

## Description of change
Adapter alias for trustedstack network.

- contact email of the adapter’s maintainer: [prebid-support@media.net](mailto:prebid-support@media.net)
- test parameters for validating bids:
```
{
    bidder: 'trustedstack',
    params: {
      cid: 'TSP7P1YS'
      crid: '708667024'
    }
  }

```
