### PR TITLE
Criteo Bid Adapter: do not call API when dataDeletionRequest has no id

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -315,14 +315,14 @@ export const spec = {
     const id = readFromAllStorages(BUNDLE_COOKIE_NAME);
     if (id) {
       deleteFromAllStorages(BUNDLE_COOKIE_NAME);
+      ajax('https://privacy.criteo.com/api/privacy/datadeletionrequest',
+        null,
+        JSON.stringify({ publisherUserId: id }),
+        {
+          contentType: 'application/json',
+          method: 'POST'
+        });
     }
-    ajax('https://privacy.criteo.com/api/privacy/datadeletionrequest',
-      null,
-      JSON.stringify({ publisherUserId: id }),
-      {
-        contentType: 'application/json',
-        method: 'POST'
-      });
   }
 };
 

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -217,14 +217,35 @@ describe('The Criteo bidding adapter', function () {
       }
       getCookieStub.callsFake(cookieName => cookieData[cookieName]);
       setCookieStub.callsFake((cookieName, value, expires) => cookieData[cookieName] = value);
+      getDataFromLocalStorageStub.callsFake(name => lsData[name]);
       removeDataFromLocalStorageStub.callsFake(name => lsData[name] = '');
       spec.onDataDeletionRequest([]);
       expect(getCookieStub.calledOnce).to.equal(true);
       expect(setCookieStub.calledOnce).to.equal(true);
+      expect(getDataFromLocalStorageStub.calledOnce).to.equal(true);
       expect(removeDataFromLocalStorageStub.calledOnce).to.equal(true);
       expect(cookieData.cto_bundle).to.equal('');
       expect(lsData.cto_bundle).to.equal('');
       expect(ajaxStub.calledOnce).to.equal(true);
+    });
+
+    it('should not call API when calling onDataDeletionRequest with no id', () => {
+      const cookieData = {
+        'cto_bundle': ''
+      };
+      const lsData = {
+        'cto_bundle': ''
+      }
+      getCookieStub.callsFake(cookieName => cookieData[cookieName]);
+      setCookieStub.callsFake((cookieName, value, expires) => cookieData[cookieName] = value);
+      getDataFromLocalStorageStub.callsFake(name => lsData[name]);
+      removeDataFromLocalStorageStub.callsFake(name => lsData[name] = '');
+      spec.onDataDeletionRequest([]);
+      expect(getCookieStub.calledOnce).to.be.true;
+      expect(setCookieStub.called).to.be.false;
+      expect(getDataFromLocalStorageStub.calledOnce).to.be.true
+      expect(removeDataFromLocalStorageStub.called).to.be.false;
+      expect(ajaxStub.called).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Call Criteo API only when there is an user id. Criteo has been receiving some requests with no uid.
