### PR TITLE
Grid Bid Adapter: fix GPID priorities

### DIFF
--- a/modules/gridBidAdapter.js
+++ b/modules/gridBidAdapter.js
@@ -137,16 +137,9 @@ export const spec = {
         }
 
         if (ortb2Imp.ext) {
+          impObj.ext.gpid = ortb2Imp.ext.gpid?.toString() || ortb2Imp.ext.data?.pbadslot?.toString() || ortb2Imp.ext.data?.adserver?.adslot?.toString();
           if (ortb2Imp.ext.data) {
             impObj.ext.data = ortb2Imp.ext.data;
-            if (impObj.ext.data.adserver && impObj.ext.data.adserver.adslot) {
-              impObj.ext.gpid = impObj.ext.data.adserver.adslot.toString();
-            } else if (ortb2Imp.ext.data.pbadslot) {
-              impObj.ext.gpid = ortb2Imp.ext.data.pbadslot.toString();
-            }
-          }
-          if (ortb2Imp.ext.gpid) {
-            impObj.ext.gpid = ortb2Imp.ext.gpid.toString();
           }
         }
       }

--- a/test/spec/modules/gridBidAdapter_spec.js
+++ b/test/spec/modules/gridBidAdapter_spec.js
@@ -786,6 +786,74 @@ describe('TheMediaGrid Adapter', function () {
       });
     });
 
+    it('should prioritize pbadslot over adslot', function() {
+      const ortb2Imp = [{
+        ext: {
+          data: {
+            adserver: {
+              adslot: 'adslot'
+            }
+          }
+        }
+      }, {
+        ext: {
+          data: {
+            adserver: {
+              adslot: 'adslot'
+            },
+            pbadslot: 'pbadslot'
+          }
+        }
+      }];
+      const bidRequestsWithOrtb2Imp = bidRequests.slice(0, 2).map((bid, ind) => {
+        return Object.assign({}, bid, ortb2Imp[ind] ? { ortb2Imp: {...bid.ortb2Imp, ...ortb2Imp[ind]} } : {});
+      });
+      const [request] = spec.buildRequests(bidRequestsWithOrtb2Imp, bidderRequest);
+      expect(request.data).to.be.an('string');
+      const payload = parseRequest(request.data);
+      expect(payload.imp[0].ext.gpid).to.equal(ortb2Imp[0].ext.data.adserver.adslot);
+      expect(payload.imp[1].ext.gpid).to.equal(ortb2Imp[1].ext.data.pbadslot);
+    });
+
+    it('should prioritize gpid over pbadslot and adslot', function() {
+      const ortb2Imp = [{
+        ext: {
+          gpid: 'gpid',
+          data: {
+            adserver: {
+              adslot: 'adslot'
+            },
+            pbadslot: 'pbadslot'
+          }
+        }
+      }, {
+        ext: {
+          gpid: 'gpid',
+          data: {
+            adserver: {
+              adslot: 'adslot'
+            }
+          }
+        }
+      }, {
+        ext: {
+          gpid: 'gpid',
+          data: {
+            pbadslot: 'pbadslot'
+          }
+        }
+      }];
+      const bidRequestsWithOrtb2Imp = bidRequests.slice(0, 3).map((bid, ind) => {
+        return Object.assign({}, bid, ortb2Imp[ind] ? { ortb2Imp: {...bid.ortb2Imp, ...ortb2Imp[ind]} } : {});
+      });
+      const [request] = spec.buildRequests(bidRequestsWithOrtb2Imp, bidderRequest);
+      expect(request.data).to.be.an('string');
+      const payload = parseRequest(request.data);
+      expect(payload.imp[0].ext.gpid).to.equal(ortb2Imp[0].ext.gpid);
+      expect(payload.imp[1].ext.gpid).to.equal(ortb2Imp[1].ext.gpid);
+      expect(payload.imp[2].ext.gpid).to.equal(ortb2Imp[2].ext.gpid);
+    });
+
     it('should contain imp[].instl if available', function() {
       const ortb2Imp = [{
         instl: 1


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Prioritize `imp.ext.gpid` value over `imp.ext.data.pbaslot` and `imp.ext.data.adserver.adslot`.

## Other information
Related issue: #10187
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
