### PR TITLE
Smartyads Bid Adapter: bid won functionality

### DIFF
--- a/modules/smartyadsBidAdapter.js
+++ b/modules/smartyadsBidAdapter.js
@@ -3,6 +3,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
+import { ajax } from '../src/ajax.js';
 
 const BIDDER_CODE = 'smartyads';
 const AD_URL = 'https://n1.smartyads.com/?c=o&m=prebid&secret_key=prebid_js';
@@ -122,7 +123,23 @@ export const spec = {
     }
 
     return syncs
-  }
+  },
+
+  onBidWon: function(bid) {
+    if (bid.winUrl) {
+      ajax(bid.winUrl, () => {}, JSON.stringify(bid));
+    } else {
+      ajax('https://et-nd43.itdsmr.com/?c=o&m=prebid&secret_key=prebid_js&winTest=1', () => {}, JSON.stringify(bid));
+    }
+  },
+
+  onTimeout: function(bid) {
+    ajax('https://et-nd43.itdsmr.com/?c=o&m=prebid&secret_key=prebid_js&bidTimeout=1', () => {}, JSON.stringify(bid));
+  },
+
+  onBidderError: function(bid) {
+    ajax('https://et-nd43.itdsmr.com/?c=o&m=prebid&secret_key=prebid_js&bidderError=1', () => {}, JSON.stringify(bid));
+  },
 
 };
 

--- a/test/spec/modules/smartyadsBidAdapter_spec.js
+++ b/test/spec/modules/smartyadsBidAdapter_spec.js
@@ -1,6 +1,7 @@
 import {expect} from 'chai';
 import {spec} from '../../../modules/smartyadsBidAdapter.js';
 import { config } from '../../../src/config.js';
+import {server} from '../../mocks/xhr';
 
 describe('SmartyadsAdapter', function () {
   let bid = {
@@ -12,6 +13,21 @@ describe('SmartyadsAdapter', function () {
       accountid: '0',
       traffic: 'banner'
     }
+  };
+
+  let bidResponse = {
+    width: 300,
+    height: 250,
+    mediaType: 'banner',
+    ad: `<img src='https://dummyimage.com/300x250&text=Test+Mode' width=300 height=250 alt='test mode'>`,
+    requestId: '23fhj33i987f',
+    cpm: 0.1,
+    ttl: 120,
+    creativeId: '123',
+    netRevenue: true,
+    currency: 'USD',
+    dealId: 'HASH',
+    sid: 1234
   };
 
   describe('isBidRequestValid', function () {
@@ -255,6 +271,39 @@ describe('SmartyadsAdapter', function () {
       expect(userSync).to.deep.equal([
         { type: 'iframe', url: syncUrl }
       ]);
+    });
+  });
+
+  describe('onBidWon', function () {
+    it('should exists', function () {
+      expect(spec.onBidWon).to.exist.and.to.be.a('function');
+    });
+
+    it('should send a valid bid won notice', function () {
+      spec.onBidWon(bidResponse);
+      expect(server.requests.length).to.equal(1);
+    });
+  });
+
+  describe('onTimeout', function () {
+    it('should exists', function () {
+      expect(spec.onTimeout).to.exist.and.to.be.a('function');
+    });
+
+    it('should send a valid bid timeout notice', function () {
+      spec.onTimeout({});
+      expect(server.requests.length).to.equal(1);
+    });
+  });
+
+  describe('onBidderError', function () {
+    it('should exists', function () {
+      expect(spec.onBidderError).to.exist.and.to.be.a('function');
+    });
+
+    it('should send a valid bidder error notice', function () {
+      spec.onBidderError({});
+      expect(server.requests.length).to.equal(1);
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
Bid won, timeout and onBidderError methods in Smartyads adapter

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
