### PR TITLE
fluct Bid Adapter: add user.data to bid requests

### DIFF
--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -43,7 +43,7 @@ export const spec = {
       data.user = {
         data: bidderRequest.ortb2?.user?.data ?? [],
         eids: [
-          ...(request.userIdAsEids || []),
+          ...(request.userIdAsEids ?? []),
           ...(bidderRequest.ortb2?.user?.ext?.eids ?? []),
         ],
       };

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -36,6 +36,7 @@ export const spec = {
    * Make a server request from the list of BidRequests.
    *
    * @param {validBidRequests[]} - an array of bids.
+   * @param {bidderRequest} bidderRequest bidder request object
    * @return ServerRequest Info describing the request to the server.
    */
   buildRequests: (validBidRequests, bidderRequest) => {
@@ -50,7 +51,8 @@ export const spec = {
       data.bidId = request.bidId;
       data.transactionId = request.ortb2Imp?.ext?.tid;
       data.user = {
-        eids: (request.userIdAsEids || []).filter((eid) => SUPPORTED_USER_ID_SOURCES.indexOf(eid.source) !== -1)
+        data: bidderRequest.ortb2?.user?.data ?? [],
+        eids: (request.userIdAsEids ?? []).filter((eid) => SUPPORTED_USER_ID_SOURCES.indexOf(eid.source) !== -1)
       };
 
       if (bidderRequest.gdprConsent) {

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -42,7 +42,10 @@ export const spec = {
       data.transactionId = request.ortb2Imp?.ext?.tid;
       data.user = {
         data: bidderRequest.ortb2?.user?.data ?? [],
-        eids: request.userIdAsEids || [],
+        eids: [
+          ...(request.userIdAsEids || []),
+          ...(bidderRequest.ortb2?.user?.ext?.eids ?? []),
+        ],
       };
 
       if (bidderRequest.gdprConsent) {

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -26,7 +26,7 @@ export const spec = {
    * Make a server request from the list of BidRequests.
    *
    * @param {validBidRequests[]} - an array of bids.
-   * @param {bidderRequest} bidderRequest bidder request object
+   * @param {bidderRequest} bidderRequest bidder request object.
    * @return ServerRequest Info describing the request to the server.
    */
   buildRequests: (validBidRequests, bidderRequest) => {

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -189,7 +189,7 @@ describe('fluctAdapter', function () {
     });
 
     it('includes user.data if any exists', function () {
-      const bidderRequest2 = Object.assign(bidderRequest, {
+      const bidderRequest2 = Object.assign({}, bidderRequest, {
         ortb2: {
           user: {
             data: [
@@ -227,7 +227,7 @@ describe('fluctAdapter', function () {
 
     it('includes data.params.kv if any exists', function () {
       const bidRequests2 = bidRequests.map(
-        (bidReq) => Object.assign(bidReq, {
+        (bidReq) => Object.assign({}, bidReq, {
           params: {
             kv: {
               imsids: ['imsid1', 'imsid2']
@@ -244,7 +244,7 @@ describe('fluctAdapter', function () {
     it('includes data.schain if any exists', function () {
       // this should be done by schain.js
       const bidRequests2 = bidRequests.map(
-        (bidReq) => Object.assign(bidReq, {
+        (bidReq) => Object.assign({}, bidReq, {
           schain: {
             ver: '1.0',
             complete: 1,

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -205,11 +205,21 @@ describe('fluctAdapter', function () {
                   segtax: 900,
                 },
                 segment: [
-                  {id: 'id-1'},
-                  {id: 'id-2'},
+                  { id: 'seg-1' },
+                  { id: 'seg-2' },
                 ],
               },
             ],
+            ext: {
+              eids: [
+                {
+                  source: 'a1mediagroup.com',
+                  uids: [
+                    { id: 'aud-1' }
+                  ],
+                },
+              ],
+            },
           },
         },
       });
@@ -222,12 +232,19 @@ describe('fluctAdapter', function () {
               segtax: 900,
             },
             segment: [
-              {id: 'id-1'},
-              {id: 'id-2'},
+              { id: 'seg-1' },
+              { id: 'seg-2' },
             ],
           },
         ],
-        eids: [],
+        eids: [
+          {
+            source: 'a1mediagroup.com',
+            uids: [
+              { id: 'aud-1' }
+            ],
+          },
+        ],
       });
     });
 

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -121,7 +121,7 @@ describe('fluctAdapter', function () {
 
     it('includes filtered user.eids if any exist', function () {
       const bidRequests2 = bidRequests.map(
-        (bidReq) => Object.assign(bidReq, {
+        (bidReq) => Object.assign({}, bidReq, {
           userIdAsEids: [
             {
               source: 'foobar.com',
@@ -157,32 +157,72 @@ describe('fluctAdapter', function () {
         })
       );
       const request = spec.buildRequests(bidRequests2, bidderRequest)[0];
-      expect(request.data.user.eids).to.eql([
-        {
-          source: 'adserver.org',
-          uids: [
-            { id: 'tdid' }
-          ],
+      expect(request.data.user).to.eql({
+        data: [],
+        eids: [
+          {
+            source: 'adserver.org',
+            uids: [
+              { id: 'tdid' }
+            ],
+          },
+          {
+            source: 'criteo.com',
+            uids: [
+              { id: 'criteo-id' }
+            ],
+          },
+          {
+            source: 'intimatemerger.com',
+            uids: [
+              { id: 'imuid' }
+            ],
+          },
+          {
+            source: 'liveramp.com',
+            uids: [
+              { id: 'idl-env' }
+            ],
+          },
+        ],
+      });
+    });
+
+    it('includes user.data if any exists', function () {
+      const bidderRequest2 = Object.assign(bidderRequest, {
+        ortb2: {
+          user: {
+            data: [
+              {
+                name: 'a1mediagroup.com',
+                ext: {
+                  segtax: 900,
+                },
+                segment: [
+                  {id: 'id-1'},
+                  {id: 'id-2'},
+                ],
+              },
+            ],
+          },
         },
-        {
-          source: 'criteo.com',
-          uids: [
-            { id: 'criteo-id' }
-          ],
-        },
-        {
-          source: 'intimatemerger.com',
-          uids: [
-            { id: 'imuid' }
-          ],
-        },
-        {
-          source: 'liveramp.com',
-          uids: [
-            { id: 'idl-env' }
-          ],
-        },
-      ]);
+      });
+      const request = spec.buildRequests(bidRequests, bidderRequest2)[0];
+      expect(request.data.user).to.eql({
+        data: [
+          {
+            name: 'a1mediagroup.com',
+            ext: {
+              segtax: 900,
+            },
+            segment: [
+              {id: 'id-1'},
+              {id: 'id-2'},
+            ],
+          },
+        ],
+        eids: [],
+      });
     });
 
     it('includes data.params.kv if any exists', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

To add `user.data` data provided by RTD providers to bid requests.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

This update follows #10268