### PR TITLE
Adyoulike Bid Adapter : support getUserSyncs

### DIFF
--- a/modules/adyoulikeBidAdapter.js
+++ b/modules/adyoulikeBidAdapter.js
@@ -1,5 +1,6 @@
 import {buildUrl, deepAccess, parseSizesInput} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
+import { config } from '../src/config.js';
 import {find} from '../src/polyfill.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
@@ -166,6 +167,50 @@ export const spec = {
       }
     });
     return bidResponses;
+  },
+
+  /**
+   * List user sync endpoints.
+   * Legal information have to be added to the request.
+   * Only iframe syncs are supported.
+   *
+   * @param {*} syncOptions Publisher prebid configuration.
+   * @param {*} serverResponses A successful response from the server.
+   * @return {syncs[]} An array of syncs that should be executed.
+   */
+  getUserSyncs: function (syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) {
+    if (!syncOptions.iframeEnabled) {
+      return [];
+    }
+
+    let params = '';
+
+    // GDPR
+    if (gdprConsent) {
+      params += '&gdpr=' + (gdprConsent.gdprApplies ? 1 : 0);
+      params += '&gdpr_consent=' + encodeURIComponent(gdprConsent.consentString || '');
+    }
+
+    // coppa compliance
+    if (config.getConfig('coppa') === true) {
+      params += '&coppa=1';
+    }
+
+    // CCPA
+    if (uspConsent) {
+      params += '&us_privacy=' + encodeURIComponent(uspConsent);
+    }
+
+    // GPP
+    if (gppConsent?.gppString && gppConsent?.applicableSections?.length) {
+      params += '&gpp=' + encodeURIComponent(gppConsent.gppString);
+      params += '&gpp_sid=' + encodeURIComponent(gppConsent?.applicableSections?.join(','));
+    }
+
+    return [{
+      type: 'iframe',
+      url: `https://visitor.omnitagjs.com/visitor/isync?uid=19340f4f097d16f41f34fc0274981ca4${params}`
+    }];
   }
 }
 

--- a/test/spec/modules/adyoulikeBidAdapter_spec.js
+++ b/test/spec/modules/adyoulikeBidAdapter_spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import { spec } from 'modules/adyoulikeBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
+import { config } from 'src/config.js';
 
 describe('Adyoulike Adapter', function () {
   const canonicalUrl = 'https://canonical.url/?t=%26';
@@ -886,5 +887,116 @@ describe('Adyoulike Adapter', function () {
     it('should expose gvlid', function() {
       expect(spec.gvlid).to.equal(259)
     })
+  });
+
+  describe('getUserSyncs', function () {
+    const syncurl_iframe = 'https://visitor.omnitagjs.com/visitor/isync?uid=19340f4f097d16f41f34fc0274981ca4';
+
+    const emptySync = [];
+
+    describe('with iframe enabled', function() {
+      const userSyncConfig = { iframeEnabled: true };
+
+      it('should not add parameters if not provided', function() {
+        expect(spec.getUserSyncs(userSyncConfig, {}, undefined, undefined)).to.deep.equal([{
+          type: 'iframe', url: `${syncurl_iframe}`
+        }]);
+      });
+
+      it('should add GDPR parameters if provided', function() {
+        expect(spec.getUserSyncs(userSyncConfig, {}, {gdprApplies: true, consentString: undefined}, undefined)).to.deep.equal([{
+          type: 'iframe', url: `${syncurl_iframe}&gdpr=1&gdpr_consent=`
+        }]);
+
+        expect(spec.getUserSyncs(userSyncConfig, {}, {gdprApplies: true, consentString: 'foo?'}, undefined)).to.deep.equal([{
+          type: 'iframe', url: `${syncurl_iframe}&gdpr=1&gdpr_consent=foo%3F`
+        }]);
+        expect(spec.getUserSyncs(userSyncConfig, {}, {gdprApplies: false, consentString: 'bar'}, undefined)).to.deep.equal([{
+          type: 'iframe', url: `${syncurl_iframe}&gdpr=0&gdpr_consent=bar`
+        }]);
+      });
+
+      it('should add CCPA parameters if provided', function() {
+        expect(spec.getUserSyncs(userSyncConfig, {}, undefined, 'foo?')).to.deep.equal([{
+          type: 'iframe', url: `${syncurl_iframe}&us_privacy=foo%3F`
+        }]);
+      });
+
+      describe('COPPA', function() {
+        let sandbox;
+
+        this.beforeEach(function() {
+          sandbox = sinon.sandbox.create();
+        });
+
+        this.afterEach(function() {
+          sandbox.restore();
+        });
+
+        it('should add coppa parameters if provided', function() {
+          sandbox.stub(config, 'getConfig').callsFake(key => {
+            const config = {
+              'coppa': true
+            };
+            return config[key];
+          });
+
+          expect(spec.getUserSyncs(userSyncConfig, {}, undefined, undefined)).to.deep.equal([{
+            type: 'iframe', url: `${syncurl_iframe}&coppa=1`
+          }]);
+        });
+      });
+
+      describe('GPP', function() {
+        it('should not apply if not gppConsent.gppString', function() {
+          const gppConsent = { gppString: '', applicableSections: [123] };
+          const result = spec.getUserSyncs(userSyncConfig, {}, undefined, undefined, gppConsent);
+          expect(result).to.deep.equal([{
+            type: 'iframe', url: `${syncurl_iframe}`
+          }]);
+        });
+
+        it('should not apply if not gppConsent.applicableSections', function() {
+          const gppConsent = { gppString: '', applicableSections: undefined };
+          const result = spec.getUserSyncs(userSyncConfig, {}, undefined, undefined, gppConsent);
+          expect(result).to.deep.equal([{
+            type: 'iframe', url: `${syncurl_iframe}`
+          }]);
+        });
+
+        it('should not apply if empty gppConsent.applicableSections', function() {
+          const gppConsent = { gppString: '', applicableSections: [] };
+          const result = spec.getUserSyncs(userSyncConfig, {}, undefined, undefined, gppConsent);
+          expect(result).to.deep.equal([{
+            type: 'iframe', url: `${syncurl_iframe}`
+          }]);
+        });
+
+        it('should apply if all above are available', function() {
+          const gppConsent = { gppString: 'foo?', applicableSections: [123] };
+          const result = spec.getUserSyncs(userSyncConfig, {}, undefined, undefined, gppConsent);
+          expect(result).to.deep.equal([{
+            type: 'iframe', url: `${syncurl_iframe}&gpp=foo%3F&gpp_sid=123`
+          }]);
+        });
+
+        it('should support multiple sections', function() {
+          const gppConsent = { gppString: 'foo', applicableSections: [123, 456] };
+          const result = spec.getUserSyncs(userSyncConfig, {}, undefined, undefined, gppConsent);
+          expect(result).to.deep.equal([{
+            type: 'iframe', url: `${syncurl_iframe}&gpp=foo&gpp_sid=123%2C456`
+          }]);
+        });
+      });
+    });
+
+    describe('with iframe disabled', function() {
+      const userSyncConfig = { iframeEnabled: false };
+
+      it('should return empty list of syncs', function() {
+        expect(spec.getUserSyncs(userSyncConfig, {}, undefined, undefined)).to.deep.equal(emptySync);
+        expect(spec.getUserSyncs(userSyncConfig, {}, {gdprApplies: true, consentString: 'foo'}, 'bar')).to.deep.equal(emptySync);
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Add support of getUserSyncs for Adyoulike bidder

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
