### PR TITLE
Brandmetrics RTD Module : set default value of consent to undefined

### DIFF
--- a/test/spec/modules/brandmetricsRtdProvider_spec.js
+++ b/test/spec/modules/brandmetricsRtdProvider_spec.js
@@ -67,6 +67,8 @@ const NO_USP_CONSENT = {
   usp: '1NYY'
 };
 
+const UNDEFINED_USER_CONSENT = {};
+
 function mockSurveyLoaded(surveyConf) {
   const commands = window._brandmetrics || [];
   commands.forEach(command => {
@@ -119,6 +121,10 @@ describe('BrandmetricsRTD module', () => {
 
   it('should not init when there is no usp- consent', () => {
     expect(brandmetricsRTD.brandmetricsSubmodule.init(VALID_CONFIG, NO_USP_CONSENT)).to.equal(false);
+  });
+
+  it('should init if there are no consent- objects defined', () => {
+    expect(brandmetricsRTD.brandmetricsSubmodule.init(VALID_CONFIG, UNDEFINED_USER_CONSENT)).to.equal(true);
   });
 });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->

Default the consent- check to undefined if there is no consent data available and cancel module initialization only if gdpr or usp is available (and consent is not given).

This change allows the module to be used in regions where gdpr/usp does not apply and in environments where consent is handled in a non- standard way.


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
