### PR TITLE
Rubicon Bid Adapter: fix saving state of single request option

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -322,8 +322,7 @@ export const spec = {
         )
       );
     });
-    // if (rubiConf.singleRequest !== true) {
-    if (config.getConfig('rubicon.singleRequest') !== true) {
+    if (rubiConf.singleRequest !== true) {
       // bids are not grouped if single request mode is not enabled
       requests = filteredHttpRequest.concat(bannerBidRequests.map(bidRequest => {
         const bidParams = spec.createSlotParams(bidRequest, bidderRequest);

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -27,7 +27,7 @@ const DEFAULT_PBS_INTEGRATION = 'pbjs';
 const DEFAULT_RENDERER_URL = 'https://video-outstream.rubiconproject.com/apex-2.2.1.js';
 // renderer code at https://github.com/rubicon-project/apex2
 
-let rubiConf = {};
+let rubiConf = config.getConfig('rubicon') || {};
 // we are saving these as global to this module so that if a pub accidentally overwrites the entire
 // rubicon object, then we do not lose other data
 config.getConfig('rubicon', config => {
@@ -322,6 +322,7 @@ export const spec = {
         )
       );
     });
+    // if (rubiConf.singleRequest !== true) {
     if (config.getConfig('rubicon.singleRequest') !== true) {
       // bids are not grouped if single request mode is not enabled
       requests = filteredHttpRequest.concat(bannerBidRequests.map(bidRequest => {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1229,6 +1229,30 @@ describe('the rubicon adapter', function () {
             });
           });
 
+          it('should still use single request if other rubicon configs are set after', function () {
+            // set single request to true
+            config.setConfig({ rubicon: { singleRequest: true } });
+
+            // execute some other rubicon setConfig
+            config.setConfig({ rubicon: { netRevenue: true } });
+
+            const bidCopy = utils.deepClone(bidderRequest.bids[0]);
+            bidderRequest.bids.push(bidCopy);
+            bidderRequest.bids.push(bidCopy);
+            bidderRequest.bids.push(bidCopy);
+
+            let serverRequests = spec.buildRequests(bidderRequest.bids, bidderRequest);
+
+            // should have 1 request only
+            expect(serverRequests).that.is.an('array').of.length(1);
+
+            // get the built query
+            let data = parseQuery(serverRequests[0].data);
+
+            // num slots should be 4
+            expect(data.slots).to.equal('4');
+          });
+
           it('should not group bid requests if singleRequest does not equal true', function () {
             config.setConfig({rubicon: {singleRequest: false}});
 


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Reverts the logic in PR #9050

This PR introduces a regression where if user runs multiple `rubicon` `setConfigs` it will not save state of the singleRequest.

See my comment in the PR for more details: https://github.com/prebid/Prebid.js/pull/9050#issuecomment-1670416910

This PR also introduces logic to gather the current state of the `rubicon` config at init time if for some reason prebid core had processed `setConfigs` before modules had been loaded. 

Which I have not encountered as of yet, but perhaps there are use cases where prebid core is loaded, then the que block is executed, and then modules are initialized?

Or if a module is loaded dynamically later on or something.

Now the rubicon adapter will grab the current state at init time as the initial default instead of empty object.