### PR TITLE
Nexx360 Bid Adapter : Ad and adUrl banner split 

### DIFF
--- a/modules/nexx360BidAdapter.js
+++ b/modules/nexx360BidAdapter.js
@@ -192,7 +192,13 @@ function interpretResponse(serverResponse) {
       };
       if (allowAlternateBidderCodes) response.bidderCode = `n360-${bid.ext.ssp}`;
 
-      if (bid.ext.mediaType === BANNER) response.adUrl = bid.ext.adUrl;
+      if (bid.ext.mediaType === BANNER) {
+        if (bid.adm) {
+          response.ad = bid.adm;
+        } else {
+          response.adUrl = bid.ext.adUrl;
+        }
+      }
       if ([INSTREAM, OUTSTREAM].includes(bid.ext.mediaType)) response.vastXml = bid.ext.vastXml;
 
       if (bid.ext.mediaType === OUTSTREAM) {

--- a/test/spec/modules/nexx360BidAdapter_spec.js
+++ b/test/spec/modules/nexx360BidAdapter_spec.js
@@ -434,7 +434,7 @@ describe('Nexx360 bid adapter tests', function () {
       const output = spec.interpretResponse(response);
       expect(output.length).to.be.eql(0);
     });
-    it('banner responses', function() {
+    it('banner responses with adUrl only', function() {
       const response = {
         body: {
           'id': 'a8d3a675-a4ba-4d26-807f-c8f2fad821e0',
@@ -475,6 +475,53 @@ describe('Nexx360 bid adapter tests', function () {
       };
       const output = spec.interpretResponse(response);
       expect(output[0].adUrl).to.be.eql(response.body.seatbid[0].bid[0].ext.adUrl);
+      expect(output[0].mediaType).to.be.eql(response.body.seatbid[0].bid[0].ext.mediaType);
+      expect(output[0].currency).to.be.eql(response.body.cur);
+      expect(output[0].cpm).to.be.eql(response.body.seatbid[0].bid[0].price);
+    });
+    it('banner responses with adm', function() {
+      const response = {
+        body: {
+          'id': 'a8d3a675-a4ba-4d26-807f-c8f2fad821e0',
+          'cur': 'USD',
+          'seatbid': [
+            {
+              'bid': [
+                {
+                  'id': '4427551302944024629',
+                  'impid': '226175918ebeda',
+                  'price': 1.5,
+                  'adomain': [
+                    'http://prebid.org'
+                  ],
+                  'crid': '98493581',
+                  'ssp': 'appnexus',
+                  'h': 600,
+                  'w': 300,
+                  'adm': '<div>TestAd</div>',
+                  'cat': [
+                    'IAB3-1'
+                  ],
+                  'ext': {
+                    'adUnitCode': 'div-1',
+                    'mediaType': 'banner',
+                    'adUrl': 'https://fast.nexx360.io/cache?uuid=fdddcebc-1edf-489d-880d-1418d8bdc493',
+                    'ssp': 'appnexus',
+                  }
+                }
+              ],
+              'seat': 'appnexus'
+            }
+          ],
+          'ext': {
+            'id': 'de3de7c7-e1cf-4712-80a9-94eb26bfc718',
+            'cookies': []
+          },
+        }
+      };
+      const output = spec.interpretResponse(response);
+      expect(output[0].ad).to.be.eql(response.body.seatbid[0].bid[0].adm);
+      expect(output[0].adUrl).to.be.eql(undefined);
       expect(output[0].mediaType).to.be.eql(response.body.seatbid[0].bid[0].ext.mediaType);
       expect(output[0].currency).to.be.eql(response.body.cur);
       expect(output[0].cpm).to.be.eql(response.body.seatbid[0].bid[0].price);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This PR allows us to display ads through both ad and adUrl.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
