### PR TITLE
Activity Controls GPP: invalidate covered = 0 in mspa

### DIFF
--- a/libraries/mspa/activityControls.js
+++ b/libraries/mspa/activityControls.js
@@ -24,7 +24,9 @@ export function isBasicConsentDenied(cd) {
     // minors 13+ who have not given consent
     cd.KnownChildSensitiveDataConsents[0] === 1 ||
     // minors under 13 cannot consent
-    isApplicable(cd.KnownChildSensitiveDataConsents[1]);
+    isApplicable(cd.KnownChildSensitiveDataConsents[1]) ||
+    // covered cannot be zero
+    cd.MspaCoveredTransaction === 0;
 }
 
 export function sensitiveNoticeIs(cd, value) {

--- a/test/spec/libraries/mspa/activityControls_spec.js
+++ b/test/spec/libraries/mspa/activityControls_spec.js
@@ -35,6 +35,12 @@ describe('Consent interpretation', () => {
       }));
       expect(result).to.equal(true);
     });
+    it('should be true (basic consent conditions do not pass) with covered set to zero (invalid state)', () => {
+      const result = isBasicConsentDenied(mkConsent({
+        MspaCoveredTransaction: 0
+      }));
+      expect(result).to.equal(true);
+    });
     it('should not deny when consent for under-13 is null', () => {
       expect(isBasicConsentDenied(mkConsent({
         KnownChildSensitiveDataConsents: [0, null]


### PR DESCRIPTION
as per https://github.com/IABTechLab/iabgpp-java/issues/29 many CMP are returning invalid values for covered. We don't range check most values, but this one seems to have a lot of invalid values in the wild. 