### PR TITLE
fluct Bid Adapter: add gpid to bid requests

### DIFF
--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -49,6 +49,7 @@ export const spec = {
       data.adUnitCode = request.adUnitCode;
       data.bidId = request.bidId;
       data.transactionId = request.ortb2Imp?.ext?.tid;
+      data.gpid = request.ortb2Imp?.ext?.gpid;
       data.user = {
         eids: (request.userIdAsEids || []).filter((eid) => SUPPORTED_USER_ID_SOURCES.indexOf(eid.source) !== -1)
       };

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -43,17 +43,20 @@ export const spec = {
     const page = bidderRequest.refererInfo.page;
 
     _each(validBidRequests, (request) => {
+      const impExt = request.ortb2Imp?.ext;
       const data = Object();
 
       data.page = page;
       data.adUnitCode = request.adUnitCode;
       data.bidId = request.bidId;
-      data.transactionId = request.ortb2Imp?.ext?.tid;
-      data.gpid = request.ortb2Imp?.ext?.gpid;
       data.user = {
         eids: (request.userIdAsEids || []).filter((eid) => SUPPORTED_USER_ID_SOURCES.indexOf(eid.source) !== -1)
       };
 
+      if (impExt) {
+        data.transactionId = impExt.tid;
+        data.gpid = impExt.gpid ?? impExt.data?.pbadslot ?? impExt.data?.adserver?.adslot;
+      }
       if (bidderRequest.gdprConsent) {
         deepSetValue(data, 'regs.gdpr', {
           consent: bidderRequest.gdprConsent.consentString,

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -110,10 +110,49 @@ describe('fluctAdapter', function () {
         ortb2Imp: {
           ext: {
             gpid: 'gpid',
+            data: {
+              pbadslot: 'data-pbadslot',
+              adserver: {
+                adslot: 'data-adserver-adslot',
+              },
+            },
           },
         },
       })), bidderRequest)[0];
       expect(request.data.gpid).to.eql('gpid');
+    });
+
+    it('sends ortb2Imp.ext.data.pbadslot as gpid', function () {
+      const request = spec.buildRequests(bidRequests.map((req) => ({
+        ...req,
+        ortb2Imp: {
+          ext: {
+            data: {
+              pbadslot: 'data-pbadslot',
+              adserver: {
+                adslot: 'data-adserver-adslot',
+              },
+            },
+          },
+        },
+      })), bidderRequest)[0];
+      expect(request.data.gpid).to.eql('data-pbadslot');
+    });
+
+    it('sends ortb2Imp.ext.data.adserver.adslot as gpid', function () {
+      const request = spec.buildRequests(bidRequests.map((req) => ({
+        ...req,
+        ortb2Imp: {
+          ext: {
+            data: {
+              adserver: {
+                adslot: 'data-adserver-adslot',
+              },
+            },
+          },
+        },
+      })), bidderRequest)[0];
+      expect(request.data.gpid).to.eql('data-adserver-adslot');
     });
 
     it('includes data.user.eids = [] by default', function () {

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -99,6 +99,23 @@ describe('fluctAdapter', function () {
       expect(request.data.page).to.eql('http://example.com');
     });
 
+    it('sends no transactionId by default', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.transactionId).to.eql(undefined);
+    });
+
+    it('sends ortb2Imp.ext.tid as transactionId', function () {
+      const request = spec.buildRequests(bidRequests.map((req) => ({
+        ...req,
+        ortb2Imp: {
+          ext: {
+            tid: 'tid',
+          }
+        },
+      })), bidderRequest)[0];
+      expect(request.data.transactionId).to.eql('tid');
+    });
+
     it('sends no gpid by default', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.data.gpid).to.eql(undefined);

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -99,6 +99,23 @@ describe('fluctAdapter', function () {
       expect(request.data.page).to.eql('http://example.com');
     });
 
+    it('sends no gpid by default', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.gpid).to.eql(undefined);
+    });
+
+    it('sends ortb2Imp.ext.gpid as gpid', function () {
+      const request = spec.buildRequests(bidRequests.map((req) => ({
+        ...req,
+        ortb2Imp: {
+          ext: {
+            gpid: 'gpid',
+          },
+        },
+      })), bidderRequest)[0];
+      expect(request.data.gpid).to.eql('gpid');
+    });
+
     it('includes data.user.eids = [] by default', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.data.user.eids).to.eql([]);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Add GPID to bid requests.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
