### PR TITLE
IX Bid Adapter: fix: consolidate banner format array

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -168,6 +168,7 @@ const MEDIA_TYPES = {
 function bidToBannerImp(bid) {
   const imp = bidToImp(bid, BANNER);
   imp.banner = {};
+  imp.adunitCode = bid.adUnitCode;
   const impSize = deepAccess(bid, 'params.size');
   if (impSize) {
     imp.banner.w = impSize[0];
@@ -918,10 +919,10 @@ function addImpressions(impressions, transactionIds, r, adUnitIndex) {
 
   if (bannerImpressions.length > 0) {
     const bannerImpsKeyed = bannerImpressions.reduce((acc, bannerImp) => {
-      if (!acc[bannerImp.id]) {
-        acc[bannerImp.id] = []
+      if (!acc[bannerImp.adunitCode]) {
+        acc[bannerImp.adunitCode] = []
       }
-      acc[bannerImp.id].push(bannerImp);
+      acc[bannerImp.adunitCode].push(bannerImp);
       return acc;
     }, {});
     for (const impId in bannerImpsKeyed) {

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -1966,6 +1966,38 @@ describe('IndexexchangeAdapter', function () {
       });
     });
 
+    it('multi-configured size params should have the correct imp[].banner.format[].ext.siteID', function () {
+      const bid1 = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
+      const bid2 = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
+      bid1.params.siteId = 1234;
+      bid1.bidId = '27fc897708d826';
+      bid2.params.siteId = 4321;
+      bid2.bidId = '34df030c33dc68';
+      bid2.params.size = [300, 600];
+      request = spec.buildRequests([bid1, bid2], DEFAULT_OPTION)[0];
+
+      const payload = extractPayload(request);
+      expect(payload.imp.length).to.equal(1);
+      expect(payload.imp[0].banner.format[0].ext.siteID).to.equal('1234');
+      expect(payload.imp[0].banner.format[1].ext.siteID).to.equal('4321');
+    });
+
+    it('multi-configured size params should be added to the imp[].banner.format[] array', function () {
+      const bid1 = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
+      const bid2 = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
+      bid1.params.siteId = 1234;
+      bid1.bidId = '27fc897708d826';
+      bid2.params.siteId = 4321;
+      bid2.bidId = '34df030c33dc68';
+      bid2.params.size = [300, 600];
+      request = spec.buildRequests([bid1, bid2], DEFAULT_OPTION)[0];
+
+      const payload = extractPayload(request);
+      expect(payload.imp[0].banner.format.length).to.equal(2);
+      expect(`${payload.imp[0].banner.format[0].w}x${payload.imp[0].banner.format[0].h}`).to.equal('300x250');
+      expect(`${payload.imp[0].banner.format[1].w}x${payload.imp[0].banner.format[1].h}`).to.equal('300x600');
+    });
+
     describe('build requests with price floors', () => {
       const highFloor = 4.5;
       const lowFloor = 3.5;
@@ -4009,7 +4041,7 @@ describe('IndexexchangeAdapter', function () {
         expect(extractPayload(request[0]).imp[0].bidfloor).to.equal(2.05);
         expect(extractPayload(request[0]).imp[0].bidfloorcur).to.equal('USD');
         expect(extractPayload(request[0]).imp[0].native.ext.bidfloor).to.equal(2.05);
-        bids[1].adUnitCode = tid;
+        bids[1].transactionId = tid;
       });
 
       it('multiformat banner / native - bid floors, banner imp less', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
This PR fixes an issue where in a scenario where the adUnit is configured with multiple bidder configs, with each bid config having a siteID set to a different size. This would result in a multi-imp request. The request should be a single imp, with the different sizes sent out as a multi-format request.


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
