### PR TITLE
Sharethrough Bid Adapter: add GDPR and GPP support

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -216,9 +216,7 @@ export const sharethroughAdapterSpec = {
     });
   },
 
-  // TODO: IG-178207212: we could consider adding gdpr & gpp as params to this method
-  // e.g. function(syncOptions, serverResponses, gdprConsent, usPrivacy, gppConsent)
-  getUserSyncs: (syncOptions, serverResponses, gdprConsent, gppConsent, uspConsent ) => {
+  getUserSyncs: (syncOptions, serverResponses, gdprConsent, gppConsent ) => {
     const shouldCookieSync =
       syncOptions.pixelEnabled && deepAccess(serverResponses, '0.body.cookieSyncUrls') !== undefined;
 

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -218,18 +218,25 @@ export const sharethroughAdapterSpec = {
 
   // TODO: IG-178207212: we could consider adding gdpr & gpp as params to this method
   // e.g. function(syncOptions, serverResponses, gdprConsent, usPrivacy, gppConsent)
-  getUserSyncs: (syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) => {
+  getUserSyncs: (syncOptions, serverResponses, gdprConsent, gppConsent, uspConsent ) => {
     const shouldCookieSync =
       syncOptions.pixelEnabled && deepAccess(serverResponses, '0.body.cookieSyncUrls') !== undefined;
 
+    let syncurl = '';
+
+    // Attaching GDPR Consent Params in UserSync url
+    if (gdprConsent) {
+      syncurl += '&gdpr=' + (gdprConsent.gdprApplies ? 1 : 0);
+      syncurl += '&gdpr_consent=' + encodeURIComponent(gdprConsent.consentString || '');
+    }
+    if (gppConsent) {
+      syncurl += '&gpp=' + encodeURIComponent(gppConsent?.gppString);
+      syncurl += '&gpp_sid=' + encodeURIComponent(gppConsent?.applicableSections?.join(','));
+    }
+
     return shouldCookieSync ? serverResponses[0].body.cookieSyncUrls.map((url) => (
       { type: 'image',
-        url: url +
-          '&gdpr=' + (gdprConsent && gdprConsent.gdprApplies ? 1 : 0) +
-          '&gdpr_consent=' + encodeURIComponent((gdprConsent ? gdprConsent.consentString : '')) +
-          '&us_privacy=' + encodeURIComponent((uspConsent || '')) +
-          '&gpp=' + encodeURIComponent(gppConsent?.gppString) +
-          '&gpp_sid=' + encodeURIComponent(gppConsent?.applicableSections?.join(','))
+        url: url + syncurl
       })) : [];
   },
 

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -218,7 +218,7 @@ export const sharethroughAdapterSpec = {
 
   // TODO: IG-178207212: we could consider adding gdpr & gpp as params to this method
   // e.g. function(syncOptions, serverResponses, gdprConsent, usPrivacy, gppConsent)
-  getUserSyncs: (syncOptions, serverResponses, gdprConsent, gppConsent) => {
+  getUserSyncs: (syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) => {
     const shouldCookieSync =
       syncOptions.pixelEnabled && deepAccess(serverResponses, '0.body.cookieSyncUrls') !== undefined;
 

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -1,7 +1,7 @@
-import { deepAccess, generateUUID, inIframe } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import { deepAccess, generateUUID, inIframe } from '../src/utils.js';
 
 const VERSION = '4.3.0';
 const BIDDER_CODE = 'sharethrough';
@@ -18,14 +18,14 @@ export const sharethroughAdapterSpec = {
   code: BIDDER_CODE,
   supportedMediaTypes: [VIDEO, BANNER],
   gvlid: 80,
-  isBidRequestValid: bid => !!bid.params.pkey && bid.bidder === BIDDER_CODE,
+  isBidRequestValid: (bid) => !!bid.params.pkey && bid.bidder === BIDDER_CODE,
 
   buildRequests: (bidRequests, bidderRequest) => {
     const timeout = bidderRequest.timeout;
     const firstPartyData = bidderRequest.ortb2 || {};
 
     const nonHttp = sharethroughInternal.getProtocol().indexOf('http') < 0;
-    const secure = nonHttp || (sharethroughInternal.getProtocol().indexOf('https') > -1);
+    const secure = nonHttp || sharethroughInternal.getProtocol().indexOf('https') > -1;
 
     const req = {
       id: generateUUID(),
@@ -79,64 +79,82 @@ export const sharethroughAdapterSpec = {
       req.regs.ext.us_privacy = bidderRequest.uspConsent;
     }
 
-    const imps = bidRequests.map(bidReq => {
-      const impression = { ext: {} };
+    // TODO: IG-178207212: this is probably where we could add our GPP
+    // logic
+    // // example from another adapter:
+    // if (bidderRequest?.gppConsent?.gppString) {
+    //   deepSetValue(payload, 'regs.gpp', bidderRequest.gppConsent.gppString);
+    //   deepSetValue(payload, 'regs.gpp_sid', bidderRequest.gppConsent.applicableSections);
+    // } else if (bidderRequest?.ortb2?.regs?.gpp) {
+    //   deepSetValue(payload, 'regs.gpp', bidderRequest.ortb2.regs.gpp);
+    //   deepSetValue(payload, 'regs.gpp_sid', bidderRequest.ortb2.regs.gpp_sid);
+    // }
 
-      // mergeDeep(impression, bidReq.ortb2Imp); // leaving this out for now as we may want to leave stuff out on purpose
-      const tid = deepAccess(bidReq, 'ortb2Imp.ext.tid');
-      if (tid) impression.ext.tid = tid;
-      const gpid = deepAccess(bidReq, 'ortb2Imp.ext.gpid', deepAccess(bidReq, 'ortb2Imp.ext.data.pbadslot'));
-      if (gpid) impression.ext.gpid = gpid;
+    const imps = bidRequests
+      .map((bidReq) => {
+        const impression = { ext: {} };
 
-      const videoRequest = deepAccess(bidReq, 'mediaTypes.video');
+        // mergeDeep(impression, bidReq.ortb2Imp); // leaving this out for now as we may want to leave stuff out on purpose
+        const tid = deepAccess(bidReq, 'ortb2Imp.ext.tid');
+        if (tid) impression.ext.tid = tid;
+        const gpid = deepAccess(bidReq, 'ortb2Imp.ext.gpid', deepAccess(bidReq, 'ortb2Imp.ext.data.pbadslot'));
+        if (gpid) impression.ext.gpid = gpid;
 
-      if (videoRequest) {
-        // default playerSize, only change this if we know width and height are properly defined in the request
-        let [w, h] = [640, 360];
-        if (videoRequest.playerSize && videoRequest.playerSize[0] && videoRequest.playerSize[0][0] && videoRequest.playerSize[0][1]) {
-          [w, h] = videoRequest.playerSize[0];
+        const videoRequest = deepAccess(bidReq, 'mediaTypes.video');
+
+        if (videoRequest) {
+          // default playerSize, only change this if we know width and height are properly defined in the request
+          let [w, h] = [640, 360];
+          if (
+            videoRequest.playerSize &&
+            videoRequest.playerSize[0] &&
+            videoRequest.playerSize[0][0] &&
+            videoRequest.playerSize[0][1]
+          ) {
+            [w, h] = videoRequest.playerSize[0];
+          }
+
+          impression.video = {
+            pos: nullish(videoRequest.pos, 0),
+            topframe: inIframe() ? 0 : 1,
+            skip: nullish(videoRequest.skip, 0),
+            linearity: nullish(videoRequest.linearity, 1),
+            minduration: nullish(videoRequest.minduration, 5),
+            maxduration: nullish(videoRequest.maxduration, 60),
+            playbackmethod: videoRequest.playbackmethod || [2],
+            api: getVideoApi(videoRequest),
+            mimes: videoRequest.mimes || ['video/mp4'],
+            protocols: getVideoProtocols(videoRequest),
+            w,
+            h,
+            startdelay: nullish(videoRequest.startdelay, 0),
+            skipmin: nullish(videoRequest.skipmin, 0),
+            skipafter: nullish(videoRequest.skipafter, 0),
+            placement: videoRequest.context === 'instream' ? 1 : +deepAccess(videoRequest, 'placement', 4),
+          };
+
+          if (videoRequest.delivery) impression.video.delivery = videoRequest.delivery;
+          if (videoRequest.companiontype) impression.video.companiontype = videoRequest.companiontype;
+          if (videoRequest.companionad) impression.video.companionad = videoRequest.companionad;
+        } else {
+          impression.banner = {
+            pos: deepAccess(bidReq, 'mediaTypes.banner.pos', 0),
+            topframe: inIframe() ? 0 : 1,
+            format: bidReq.sizes.map((size) => ({ w: +size[0], h: +size[1] })),
+          };
         }
 
-        impression.video = {
-          pos: nullish(videoRequest.pos, 0),
-          topframe: inIframe() ? 0 : 1,
-          skip: nullish(videoRequest.skip, 0),
-          linearity: nullish(videoRequest.linearity, 1),
-          minduration: nullish(videoRequest.minduration, 5),
-          maxduration: nullish(videoRequest.maxduration, 60),
-          playbackmethod: videoRequest.playbackmethod || [2],
-          api: getVideoApi(videoRequest),
-          mimes: videoRequest.mimes || ['video/mp4'],
-          protocols: getVideoProtocols(videoRequest),
-          w,
-          h,
-          startdelay: nullish(videoRequest.startdelay, 0),
-          skipmin: nullish(videoRequest.skipmin, 0),
-          skipafter: nullish(videoRequest.skipafter, 0),
-          placement: videoRequest.context === 'instream' ? 1 : +deepAccess(videoRequest, 'placement', 4),
+        return {
+          id: bidReq.bidId,
+          tagid: String(bidReq.params.pkey),
+          secure: secure ? 1 : 0,
+          bidfloor: getBidRequestFloor(bidReq),
+          ...impression,
         };
+      })
+      .filter((imp) => !!imp);
 
-        if (videoRequest.delivery) impression.video.delivery = videoRequest.delivery;
-        if (videoRequest.companiontype) impression.video.companiontype = videoRequest.companiontype;
-        if (videoRequest.companionad) impression.video.companionad = videoRequest.companionad;
-      } else {
-        impression.banner = {
-          pos: deepAccess(bidReq, 'mediaTypes.banner.pos', 0),
-          topframe: inIframe() ? 0 : 1,
-          format: bidReq.sizes.map(size => ({ w: +size[0], h: +size[1] })),
-        };
-      }
-
-      return {
-        id: bidReq.bidId,
-        tagid: String(bidReq.params.pkey),
-        secure: secure ? 1 : 0,
-        bidfloor: getBidRequestFloor(bidReq),
-        ...impression,
-      };
-    }).filter(imp => !!imp);
-
-    return imps.map(impression => {
+    return imps.map((impression) => {
       return {
         method: 'POST',
         url: STR_ENDPOINT,
@@ -149,11 +167,17 @@ export const sharethroughAdapterSpec = {
   },
 
   interpretResponse: ({ body }, req) => {
-    if (!body || !body.seatbid || body.seatbid.length === 0 || !body.seatbid[0].bid || body.seatbid[0].bid.length === 0) {
+    if (
+      !body ||
+      !body.seatbid ||
+      body.seatbid.length === 0 ||
+      !body.seatbid[0].bid ||
+      body.seatbid[0].bid.length === 0
+    ) {
       return [];
     }
 
-    return body.seatbid[0].bid.map(bid => {
+    return body.seatbid[0].bid.map((bid) => {
       // Spec: https://docs.prebid.org/dev-docs/bidder-adaptor.html#interpreting-the-response
       const response = {
         requestId: bid.impid,
@@ -195,25 +219,23 @@ export const sharethroughAdapterSpec = {
     });
   },
 
+  // TODO: IG-178207212: we could consider adding gdpr & gpp as params to this method
+  // e.g. function(syncOptions, serverResponses, gdprConsent, usPrivacy, gppConsent)
   getUserSyncs: (syncOptions, serverResponses) => {
-    const shouldCookieSync = syncOptions.pixelEnabled && deepAccess(serverResponses, '0.body.cookieSyncUrls') !== undefined;
+    const shouldCookieSync =
+      syncOptions.pixelEnabled && deepAccess(serverResponses, '0.body.cookieSyncUrls') !== undefined;
 
-    return shouldCookieSync
-      ? serverResponses[0].body.cookieSyncUrls.map(url => ({ type: 'image', url: url }))
-      : [];
+    return shouldCookieSync ? serverResponses[0].body.cookieSyncUrls.map((url) => ({ type: 'image', url: url })) : [];
   },
 
   // Empty implementation for prebid core to be able to find it
-  onTimeout: (data) => {
-  },
+  onTimeout: (data) => {},
 
   // Empty implementation for prebid core to be able to find it
-  onBidWon: (bid) => {
-  },
+  onBidWon: (bid) => {},
 
   // Empty implementation for prebid core to be able to find it
-  onSetTargeting: (bid) => {
-  },
+  onSetTargeting: (bid) => {},
 };
 
 function getVideoApi({ api }) {
@@ -240,7 +262,7 @@ function getBidRequestFloor(bid) {
     const floorInfo = bid.getFloor({
       currency: 'USD',
       mediaType: bid.mediaTypes && bid.mediaTypes.video ? 'video' : 'banner',
-      size: bid.sizes.map(size => ({ w: size[0], h: size[1] })),
+      size: bid.sizes.map((size) => ({ w: size[0], h: size[1] })),
     });
     if (typeof floorInfo === 'object' && floorInfo.currency === 'USD' && !isNaN(parseFloat(floorInfo.floor))) {
       floor = parseFloat(floorInfo.floor);

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -216,7 +216,7 @@ export const sharethroughAdapterSpec = {
     });
   },
 
-  getUserSyncs: (syncOptions, serverResponses, gdprConsent, gppConsent ) => {
+  getUserSyncs: (syncOptions, serverResponses, gdprConsent, gppConsent) => {
     const shouldCookieSync =
       syncOptions.pixelEnabled && deepAccess(serverResponses, '0.body.cookieSyncUrls') !== undefined;
 

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -618,7 +618,7 @@ describe('sharethrough adapter spec', function () {
           badv: ['domain1.com', 'domain2.com'],
           regs: {
             gpp: 'gpp_string',
-              gpp_sid: [7]
+            gpp_sid: [7]
           },
         };
 
@@ -882,7 +882,7 @@ describe('sharethrough adapter spec', function () {
       });
 
       it('returns GPP Consent Params in UserSync url', function () {
-        const syncArray = spec.getUserSyncs({ pixelEnabled: true }, serverResponses, {}, {gppString: 'gpp-string', applicableSections: [1,2]});
+        const syncArray = spec.getUserSyncs({ pixelEnabled: true }, serverResponses, {}, {gppString: 'gpp-string', applicableSections: [1, 2]});
         expect(syncArray).to.deep.equal([
           { type: 'image', url: 'cookieUrl1&gdpr=0&gdpr_consent=&gpp=gpp-string&gpp_sid=1%2C2' },
           { type: 'image', url: 'cookieUrl2&gdpr=0&gdpr_consent=&gpp=gpp-string&gpp_sid=1%2C2' },

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -251,7 +251,15 @@ describe('sharethrough adapter spec', function () {
         refererInfo: {
           ref: 'https://referer.com',
         },
+        gppConsent: {
+          gppString: 'abc12345234',
+          applicableSections: [7, 8]
+        },
         ortb2: {
+          regs: {
+            gpp: 'abc12345234',
+            gpp_sid: [7, 8]
+          },
           source: {
             tid: 'auction-id',
           },
@@ -314,6 +322,12 @@ describe('sharethrough adapter spec', function () {
               expect(eid.uids[0].id).to.equal(expectedEids[eid.source].id);
               expect(eid.uids[0].atype).to.be.ok;
             }
+
+            expect(openRtbReq.regs.gpp).to.equal(bidderRequest.gppConsent.gppString);
+            expect(openRtbReq.regs.gpp_sid).to.equal(bidderRequest.gppConsent.applicableSections);
+
+            expect(openRtbReq.regs.ext.gpp).to.equal(bidderRequest.ortb2.regs.gpp);
+            expect(openRtbReq.regs.ext.gpp_sid).to.equal(bidderRequest.ortb2.regs.gpp_sid);
 
             expect(openRtbReq.device.ua).to.equal(navigator.userAgent);
             expect(openRtbReq.regs.coppa).to.equal(1);

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
-import * as sinon from 'sinon';
 import { sharethroughAdapterSpec, sharethroughInternal } from 'modules/sharethroughBidAdapter.js';
+import * as sinon from 'sinon';
 import { newBidder } from 'src/adapters/bidderFactory.js';
 import { config } from 'src/config';
 import * as utils from 'src/utils';
@@ -73,7 +73,10 @@ describe('sharethrough adapter spec', function () {
           bidder: 'sharethrough',
           bidId: 'bidId1',
           transactionId: 'transactionId1',
-          sizes: [[300, 250], [300, 600]],
+          sizes: [
+            [300, 250],
+            [300, 600],
+          ],
           params: {
             pkey: 'aaaa1111',
             bcat: ['cat1', 'cat2'],
@@ -95,104 +98,104 @@ describe('sharethrough adapter spec', function () {
           },
           userIdAsEids: [
             {
-              'source': 'pubcid.org',
-              'uids': [
+              source: 'pubcid.org',
+              uids: [
                 {
-                  'atype': 1,
-                  'id': 'fake-pubcid'
+                  atype: 1,
+                  id: 'fake-pubcid',
                 },
-              ]
+              ],
             },
             {
-              'source': 'liveramp.com',
-              'uids': [
+              source: 'liveramp.com',
+              uids: [
                 {
-                  'atype': 1,
-                  'id': 'fake-identity-link'
-                }
-              ]
+                  atype: 1,
+                  id: 'fake-identity-link',
+                },
+              ],
             },
             {
-              'source': 'id5-sync.com',
-              'uids': [
+              source: 'id5-sync.com',
+              uids: [
                 {
-                  'atype': 1,
-                  'id': 'fake-id5id'
-                }
-              ]
+                  atype: 1,
+                  id: 'fake-id5id',
+                },
+              ],
             },
             {
-              'source': 'adserver.org',
-              'uids': [
+              source: 'adserver.org',
+              uids: [
                 {
-                  'atype': 1,
-                  'id': 'fake-tdid'
-                }
-              ]
+                  atype: 1,
+                  id: 'fake-tdid',
+                },
+              ],
             },
             {
-              'source': 'criteo.com',
-              'uids': [
+              source: 'criteo.com',
+              uids: [
                 {
-                  'atype': 1,
-                  'id': 'fake-criteo'
-                }
-              ]
+                  atype: 1,
+                  id: 'fake-criteo',
+                },
+              ],
             },
             {
-              'source': 'britepool.com',
-              'uids': [
+              source: 'britepool.com',
+              uids: [
                 {
-                  'atype': 1,
-                  'id': 'fake-britepool'
-                }
-              ]
+                  atype: 1,
+                  id: 'fake-britepool',
+                },
+              ],
             },
             {
-              'source': 'liveintent.com',
-              'uids': [
+              source: 'liveintent.com',
+              uids: [
                 {
-                  'atype': 1,
-                  'id': 'fake-lipbid'
-                }
-              ]
+                  atype: 1,
+                  id: 'fake-lipbid',
+                },
+              ],
             },
             {
-              'source': 'intentiq.com',
-              'uids': [
+              source: 'intentiq.com',
+              uids: [
                 {
-                  'atype': 1,
-                  'id': 'fake-intentiq'
-                }
-              ]
+                  atype: 1,
+                  id: 'fake-intentiq',
+                },
+              ],
             },
             {
-              'source': 'crwdcntrl.net',
-              'uids': [
+              source: 'crwdcntrl.net',
+              uids: [
                 {
-                  'atype': 1,
-                  'id': 'fake-lotame'
-                }
-              ]
+                  atype: 1,
+                  id: 'fake-lotame',
+                },
+              ],
             },
             {
-              'source': 'parrable.com',
-              'uids': [
+              source: 'parrable.com',
+              uids: [
                 {
-                  'atype': 1,
-                  'id': 'fake-parrable'
-                }
-              ]
+                  atype: 1,
+                  id: 'fake-parrable',
+                },
+              ],
             },
             {
-              'source': 'netid.de',
-              'uids': [
+              source: 'netid.de',
+              uids: [
                 {
-                  'atype': 1,
-                  'id': 'fake-netid'
-                }
-              ]
-            }
+                  atype: 1,
+                  id: 'fake-netid',
+                },
+              ],
+            },
           ],
           crumbs: {
             pubcid: 'fake-pubcid-in-crumbs-obj',
@@ -250,10 +253,10 @@ describe('sharethrough adapter spec', function () {
         },
         ortb2: {
           source: {
-            tid: 'auction-id'
-          }
+            tid: 'auction-id',
+          },
         },
-        timeout: 242
+        timeout: 242,
       };
     });
 
@@ -395,6 +398,16 @@ describe('sharethrough adapter spec', function () {
             expect(openRtbReq.regs.coppa).to.equal(0);
           });
         });
+
+        // TODO: IG-178207212 -- add support for gpp
+        // this is just starter code
+        describe('gpp', () => {
+          it('should properly attach GPP information to the request when applicable', () => {
+            config.setConfig({ gpp: 'some value to figure out' });
+            const openRtbReq = spec.buildRequests(bidRequests, bidderRequest)[0].data;
+            expect(openRtbReq['gpp']).to.equal('some value to figure out');
+          });
+        });
       });
 
       describe('transaction id at the impression level', () => {
@@ -455,7 +468,10 @@ describe('sharethrough adapter spec', function () {
           const bannerImp = builtRequest.data.imp[0].banner;
           expect(bannerImp.pos).to.equal(1);
           expect(bannerImp.topframe).to.equal(1);
-          expect(bannerImp.format).to.deep.equal([{ w: 300, h: 250 }, { w: 300, h: 600 }]);
+          expect(bannerImp.format).to.deep.equal([
+            { w: 300, h: 250 },
+            { w: 300, h: 600 },
+          ]);
         });
 
         it('should default to pos 0 if not provided', () => {
@@ -588,7 +604,7 @@ describe('sharethrough adapter spec', function () {
         };
 
         it('should include first party data in open rtb request, site section', () => {
-          const openRtbReq = spec.buildRequests(bidRequests, {...bidderRequest, ortb2: firstPartyData})[0].data;
+          const openRtbReq = spec.buildRequests(bidRequests, { ...bidderRequest, ortb2: firstPartyData })[0].data;
 
           expect(openRtbReq.site.name).to.equal(firstPartyData.site.name);
           expect(openRtbReq.site.keywords).to.equal(firstPartyData.site.keywords);
@@ -624,26 +640,31 @@ describe('sharethrough adapter spec', function () {
           request = spec.buildRequests(bidRequests, bidderRequest)[0];
           response = {
             body: {
-              seatbid: [{
-                bid: [{
-                  id: '123',
-                  impid: 'bidId1',
-                  w: 300,
-                  h: 250,
-                  price: 42,
-                  crid: 'creative',
-                  dealid: 'deal',
-                  adomain: ['domain.com'],
-                  adm: 'markup',
-                }, {
-                  id: '456',
-                  impid: 'bidId2',
-                  w: 640,
-                  h: 480,
-                  price: 42,
-                  adm: 'vastTag',
-                }],
-              }],
+              seatbid: [
+                {
+                  bid: [
+                    {
+                      id: '123',
+                      impid: 'bidId1',
+                      w: 300,
+                      h: 250,
+                      price: 42,
+                      crid: 'creative',
+                      dealid: 'deal',
+                      adomain: ['domain.com'],
+                      adm: 'markup',
+                    },
+                    {
+                      id: '456',
+                      impid: 'bidId2',
+                      w: 640,
+                      h: 480,
+                      price: 42,
+                      adm: 'vastTag',
+                    },
+                  ],
+                },
+              ],
             },
           };
         });
@@ -673,16 +694,20 @@ describe('sharethrough adapter spec', function () {
           request = spec.buildRequests(bidRequests, bidderRequest)[1];
           response = {
             body: {
-              seatbid: [{
-                bid: [{
-                  id: '456',
-                  impid: 'bidId2',
-                  w: 640,
-                  h: 480,
-                  price: 42,
-                  adm: 'vastTag',
-                }],
-              }],
+              seatbid: [
+                {
+                  bid: [
+                    {
+                      id: '456',
+                      impid: 'bidId2',
+                      w: 640,
+                      h: 480,
+                      price: 42,
+                      adm: 'vastTag',
+                    },
+                  ],
+                },
+              ],
             },
           };
         });
@@ -712,24 +737,28 @@ describe('sharethrough adapter spec', function () {
           request = spec.buildRequests(bidRequests, bidderRequest)[0];
           response = {
             body: {
-              seatbid: [{
-                bid: [{
-                  id: '123',
-                  impid: 'bidId1',
-                  w: 300,
-                  h: 250,
-                  price: 42,
-                  crid: 'creative',
-                  dealid: 'deal',
-                  adomain: ['domain.com'],
-                  adm: 'markup',
-                }],
-              }],
+              seatbid: [
+                {
+                  bid: [
+                    {
+                      id: '123',
+                      impid: 'bidId1',
+                      w: 300,
+                      h: 250,
+                      price: 42,
+                      crid: 'creative',
+                      dealid: 'deal',
+                      adomain: ['domain.com'],
+                      adm: 'markup',
+                    },
+                  ],
+                },
+              ],
             },
           };
         });
 
-        it('should have null optional fields when the response\'s optional seatbid[].bid[].ext field is empty', () => {
+        it("should have null optional fields when the response's optional seatbid[].bid[].ext field is empty", () => {
           const bid = spec.interpretResponse(response, request)[0];
 
           expect(bid.meta.networkId).to.be.null;
@@ -747,7 +776,7 @@ describe('sharethrough adapter spec', function () {
           expect(bid.meta.mediaType).to.be.null;
         });
 
-        it('should have populated fields when the response\'s optional seatbid[].bid[].ext fields are filled', () => {
+        it("should have populated fields when the response's optional seatbid[].bid[].ext fields are filled", () => {
           response.body.seatbid[0].bid[0].ext = {
             networkId: 'my network id',
             networkName: 'my network name',
@@ -792,8 +821,8 @@ describe('sharethrough adapter spec', function () {
         expect(syncArray).to.deep.equal([
           { type: 'image', url: 'cookieUrl1' },
           { type: 'image', url: 'cookieUrl2' },
-          { type: 'image', url: 'cookieUrl3' }],
-        );
+          { type: 'image', url: 'cookieUrl3' },
+        ]);
       });
 
       it('returns an empty array if serverResponses is empty', function () {


### PR DESCRIPTION
## Type of change

- [x] Feature

## Description of change
Adding support for GDPR and GPP to the request-building code of our (Sharethrough's) bid adapter.