### PR TITLE
lm_kiviads bid adapter: init 

### DIFF
--- a/modules/kiviadsBidAdapter.js
+++ b/modules/kiviadsBidAdapter.js
@@ -1,0 +1,211 @@
+import { isFn, deepAccess, logMessage, logError } from '../src/utils.js';
+import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
+
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
+import { config } from '../src/config.js';
+
+const BIDDER_CODE = 'kiviads';
+const AD_URL = 'https://lb.kiviads.com/pbjs';
+const SYNC_URL = 'https://sync.kiviads.com';
+
+function isBidResponseValid(bid) {
+  if (!bid.requestId || !bid.cpm || !bid.creativeId || !bid.ttl || !bid.currency) {
+    return false;
+  }
+
+  switch (bid.mediaType) {
+    case BANNER:
+      return Boolean(bid.width && bid.height && bid.ad);
+    case VIDEO:
+      return Boolean(bid.vastUrl || bid.vastXml);
+    case NATIVE:
+      return Boolean(bid.native && bid.native.impressionTrackers && bid.native.impressionTrackers.length);
+    default:
+      return false;
+  }
+}
+
+function getPlacementReqData(bid) {
+  const { params, bidId, mediaTypes } = bid;
+  const schain = bid.schain || {};
+  const { placementId, endpointId } = params;
+  const bidfloor = getBidFloor(bid);
+
+  const placement = {
+    bidId,
+    schain,
+    bidfloor
+  };
+
+  if (placementId) {
+    placement.placementId = placementId;
+    placement.type = 'publisher';
+  } else if (endpointId) {
+    placement.endpointId = endpointId;
+    placement.type = 'network';
+  }
+
+  if (mediaTypes && mediaTypes[BANNER]) {
+    placement.adFormat = BANNER;
+    placement.sizes = mediaTypes[BANNER].sizes;
+  } else if (mediaTypes && mediaTypes[VIDEO]) {
+    placement.adFormat = VIDEO;
+    placement.playerSize = mediaTypes[VIDEO].playerSize;
+    placement.minduration = mediaTypes[VIDEO].minduration;
+    placement.maxduration = mediaTypes[VIDEO].maxduration;
+    placement.mimes = mediaTypes[VIDEO].mimes;
+    placement.protocols = mediaTypes[VIDEO].protocols;
+    placement.startdelay = mediaTypes[VIDEO].startdelay;
+    placement.placement = mediaTypes[VIDEO].placement;
+    placement.skip = mediaTypes[VIDEO].skip;
+    placement.skipafter = mediaTypes[VIDEO].skipafter;
+    placement.minbitrate = mediaTypes[VIDEO].minbitrate;
+    placement.maxbitrate = mediaTypes[VIDEO].maxbitrate;
+    placement.delivery = mediaTypes[VIDEO].delivery;
+    placement.playbackmethod = mediaTypes[VIDEO].playbackmethod;
+    placement.api = mediaTypes[VIDEO].api;
+    placement.linearity = mediaTypes[VIDEO].linearity;
+  } else if (mediaTypes && mediaTypes[NATIVE]) {
+    placement.native = mediaTypes[NATIVE];
+    placement.adFormat = NATIVE;
+  }
+
+  return placement;
+}
+
+function getBidFloor(bid) {
+  if (!isFn(bid.getFloor)) {
+    return deepAccess(bid, 'params.bidfloor', 0);
+  }
+
+  try {
+    const bidFloor = bid.getFloor({
+      currency: 'USD',
+      mediaType: '*',
+      size: '*',
+    });
+    return bidFloor.floor;
+  } catch (err) {
+    logError(err);
+    return 0;
+  }
+}
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [BANNER, VIDEO, NATIVE],
+
+  isBidRequestValid: (bid = {}) => {
+    const { params, bidId, mediaTypes } = bid;
+    let valid = Boolean(bidId && params && (params.placementId || params.endpointId));
+
+    if (mediaTypes && mediaTypes[BANNER]) {
+      valid = valid && Boolean(mediaTypes[BANNER] && mediaTypes[BANNER].sizes);
+    } else if (mediaTypes && mediaTypes[VIDEO]) {
+      valid = valid && Boolean(mediaTypes[VIDEO] && mediaTypes[VIDEO].playerSize);
+    } else if (mediaTypes && mediaTypes[NATIVE]) {
+      valid = valid && Boolean(mediaTypes[NATIVE]);
+    } else {
+      valid = false;
+    }
+    return valid;
+  },
+
+  buildRequests: (validBidRequests = [], bidderRequest = {}) => {
+    // convert Native ORTB definition to old-style prebid native definition
+    validBidRequests = convertOrtbRequestToProprietaryNative(validBidRequests);
+
+    let deviceWidth = 0;
+    let deviceHeight = 0;
+
+    let winLocation;
+    try {
+      const winTop = window.top;
+      deviceWidth = winTop.screen.width;
+      deviceHeight = winTop.screen.height;
+      winLocation = winTop.location;
+    } catch (e) {
+      logMessage(e);
+      winLocation = window.location;
+    }
+
+    const refferUrl = bidderRequest.refererInfo && bidderRequest.refererInfo.page;
+    let refferLocation;
+    try {
+      refferLocation = refferUrl && new URL(refferUrl);
+    } catch (e) {
+      logMessage(e);
+    }
+    let location = refferLocation || winLocation;
+    const language = (navigator && navigator.language) ? navigator.language.split('-')[0] : '';
+    const host = location.host;
+    const page = location.pathname;
+    const secure = location.protocol === 'https:' ? 1 : 0;
+    const placements = [];
+    const request = {
+      deviceWidth,
+      deviceHeight,
+      language,
+      secure,
+      host,
+      page,
+      placements,
+      coppa: config.getConfig('coppa') === true ? 1 : 0,
+      ccpa: bidderRequest.uspConsent || undefined,
+      gdpr: bidderRequest.gdprConsent || undefined,
+      tmax: config.getConfig('bidderTimeout')
+    };
+
+    const len = validBidRequests.length;
+    for (let i = 0; i < len; i++) {
+      const bid = validBidRequests[i];
+      placements.push(getPlacementReqData(bid));
+    }
+
+    return {
+      method: 'POST',
+      url: AD_URL,
+      data: request
+    };
+  },
+
+  interpretResponse: (serverResponse) => {
+    let response = [];
+    for (let i = 0; i < serverResponse.body.length; i++) {
+      let resItem = serverResponse.body[i];
+      if (isBidResponseValid(resItem)) {
+        const advertiserDomains = resItem.adomain && resItem.adomain.length ? resItem.adomain : [];
+        resItem.meta = { ...resItem.meta, advertiserDomains };
+
+        response.push(resItem);
+      }
+    }
+    return response;
+  },
+
+  getUserSyncs: (syncOptions, serverResponses, gdprConsent, uspConsent) => {
+    let syncType = syncOptions.iframeEnabled ? 'iframe' : 'image';
+    let syncUrl = SYNC_URL + `/${syncType}?pbjs=1`;
+    if (gdprConsent && gdprConsent.consentString) {
+      if (typeof gdprConsent.gdprApplies === 'boolean') {
+        syncUrl += `&gdpr=${Number(gdprConsent.gdprApplies)}&gdpr_consent=${gdprConsent.consentString}`;
+      } else {
+        syncUrl += `&gdpr=0&gdpr_consent=${gdprConsent.consentString}`;
+      }
+    }
+    if (uspConsent && uspConsent.consentString) {
+      syncUrl += `&ccpa_consent=${uspConsent.consentString}`;
+    }
+
+    const coppa = config.getConfig('coppa') ? 1 : 0;
+    syncUrl += `&coppa=${coppa}`;
+
+    return [{
+      type: syncType,
+      url: syncUrl
+    }];
+  }
+};
+
+registerBidder(spec);

--- a/modules/kiviadsBidAdapter.js
+++ b/modules/kiviadsBidAdapter.js
@@ -151,10 +151,11 @@ export const spec = {
       host,
       page,
       placements,
-      coppa: config.getConfig('coppa') === true ? 1 : 0,
+      coppa: bidderRequest.coppa === true ? 1 : 0,
       ccpa: bidderRequest.uspConsent || undefined,
       gdpr: bidderRequest.gdprConsent || undefined,
-      tmax: config.getConfig('bidderTimeout')
+      gpp: bidderRequest.gppConsent || undefined,
+      tmax: bidderRequest.bidderTimeout
     };
 
     const len = validBidRequests.length;

--- a/modules/kiviadsBidAdapter.md
+++ b/modules/kiviadsBidAdapter.md
@@ -1,0 +1,79 @@
+# Overview
+
+```
+Module Name: KiviAds Bidder Adapter
+Module Type: KiviAds Bidder Adapter
+Maintainer: prebid@kiviads.com
+```
+
+# Description
+
+Connects to Kivi Ads exchange for bids.
+KiviJS bid adapter supports Banner, Video (instream and outstream) and Native.
+
+# Test Parameters
+```
+    var adUnits = [
+                // Will return static test banner
+                {
+                    code: 'adunit1',
+                    mediaTypes: {
+                        banner: {
+                            sizes: [ [300, 250], [320, 50] ],
+                        }
+                    },
+                    bids: [
+                        {
+                            bidder: 'kiviads',
+                            params: {
+                                placementId: 'testBanner',
+                            }
+                        }
+                    ]
+                },
+                {
+                    code: 'addunit2',
+                    mediaTypes: {
+                        video: {
+                            playerSize: [ [640, 480] ],
+                            context: 'instream',
+                            minduration: 5,
+                            maxduration: 60,
+                        }
+                    },
+                    bids: [
+                        {
+                            bidder: 'kiviads',
+                            params: {
+                                placementId: 'testVideo',
+                            }
+                        }
+                    ]
+                },
+                {
+                    code: 'addunit3',
+                    mediaTypes: {
+                        native: {
+                            title: {
+                                required: true
+                            },
+                            body: {
+                                required: true
+                            },
+                            icon: {
+                                required: true,
+                                size: [64, 64]
+                            }
+                        }
+                    },
+                    bids: [
+                        {
+                            bidder: 'kiviads',
+                            params: {
+                                placementId: 'testNative',
+                            }
+                        }
+                    ]
+                }
+            ];
+```

--- a/modules/lm_kiviadsBidAdapter.js
+++ b/modules/lm_kiviadsBidAdapter.js
@@ -1,0 +1,206 @@
+import {config} from '../src/config.js';
+import {BANNER, VIDEO} from '../src/mediaTypes.js';
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+import {getAdUnitSizes, parseSizesInput, isFn, deepAccess, getBidIdParameter, logError, isArray} from '../src/utils.js';
+
+const CUR = 'USD';
+const BIDDER_CODE = 'lm_kiviads';
+const ENDPOINT = 'https://pbjs.kiviads.live';
+
+/**
+ * Determines whether or not the given bid request is valid.
+ *
+ * @param {BidRequest} bid The bid params to validate.
+ * @return boolean True  if this is a valid bid, and false otherwise.
+ */
+function isBidRequestValid(req) {
+  if (req && typeof req.params !== 'object') {
+    logError('Params is not defined or is incorrect in the bidder settings');
+    return false;
+  }
+
+  if (!getBidIdParameter('env', req.params) || !getBidIdParameter('placement', req.params)) {
+    logError('Env or placement is not present in bidder params');
+    return false;
+  }
+
+  if (deepAccess(req, 'mediaTypes.video') && !isArray(deepAccess(req, 'mediaTypes.video.playerSize'))) {
+    logError('mediaTypes.video.playerSize is required for video');
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Make a server request from the list of BidRequests.
+ *
+ * @param {validBidRequest?pbjs_debug=trues[]} - an array of bids
+ * @return ServerRequest Info describing the request to the server.
+ */
+function buildRequests(validBidRequests, bidderRequest) {
+  const {refererInfo = {}, gdprConsent = {}, uspConsent} = bidderRequest;
+  const requests = validBidRequests.map(req => {
+    const request = {};
+    request.bidId = req.bidId;
+    request.banner = deepAccess(req, 'mediaTypes.banner');
+    request.auctionId = req.ortb2?.source?.tid;
+    request.transactionId = req.ortb2Imp?.ext?.tid;
+    request.sizes = parseSizesInput(getAdUnitSizes(req));
+    request.schain = req.schain;
+    request.location = {
+      page: refererInfo.page,
+      location: refererInfo.location,
+      domain: refererInfo.domain,
+      whost: window.location.host,
+      ref: refererInfo.ref,
+      isAmp: refererInfo.isAmp
+    };
+    request.device = {
+      ua: navigator.userAgent,
+      lang: navigator.language
+    };
+    request.env = {
+      env: req.params.env,
+      placement: req.params.placement
+    };
+    request.ortb2 = req.ortb2;
+    request.ortb2Imp = req.ortb2Imp;
+    request.tz = new Date().getTimezoneOffset();
+    request.ext = req.params.ext;
+    request.bc = req.bidRequestsCount;
+    request.floor = getBidFloor(req);
+
+    if (req.userIdAsEids && req.userIdAsEids.length !== 0) {
+      request.userEids = req.userIdAsEids;
+    } else {
+      request.userEids = [];
+    }
+    if (gdprConsent.gdprApplies) {
+      request.gdprApplies = Number(gdprConsent.gdprApplies);
+      request.consentString = gdprConsent.consentString;
+    } else {
+      request.gdprApplies = 0;
+      request.consentString = '';
+    }
+    if (uspConsent) {
+      request.usPrivacy = uspConsent;
+    } else {
+      request.usPrivacy = '';
+    }
+    if (config.getConfig('coppa')) {
+      request.coppa = 1;
+    } else {
+      request.coppa = 0;
+    }
+
+    const video = deepAccess(req, 'mediaTypes.video');
+    if (video) {
+      request.sizes = parseSizesInput(deepAccess(req, 'mediaTypes.video.playerSize'));
+      request.video = video;
+    }
+
+    return request;
+  });
+
+  return {
+    method: 'POST',
+    url: ENDPOINT + '/bid',
+    data: JSON.stringify(requests),
+    withCredentials: true,
+    bidderRequest,
+    options: {
+      contentType: 'application/json',
+    }
+  };
+}
+
+/**
+ * Unpack the response from the server into a list of bids.
+ *
+ * @param {ServerResponse} serverResponse A successful response from the server.
+ * @return {Bid[]} An array of bids which were nested inside the server.
+ */
+function interpretResponse(serverResponse, {bidderRequest}) {
+  const response = [];
+  if (!isArray(deepAccess(serverResponse, 'body.data'))) {
+    return response;
+  }
+
+  serverResponse.body.data.forEach(serverBid => {
+    const bid = {
+      requestId: bidderRequest.bidId,
+      dealId: bidderRequest.dealId || null,
+      ...serverBid
+    };
+    response.push(bid);
+  });
+
+  return response;
+}
+
+/**
+ * Register the user sync pixels which should be dropped after the auction.
+ *
+ * @param {SyncOptions} syncOptions Which user syncs are allowed?
+ * @param {ServerResponse[]} serverResponses List of server's responses.
+ * @return {UserSync[]} The user syncs which should be dropped.
+ */
+function getUserSyncs(syncOptions, serverResponses, gdprConsent = {}, uspConsent = '') {
+  const syncs = [];
+  const pixels = deepAccess(serverResponses, '0.body.data.0.ext.pixels');
+
+  if ((syncOptions.iframeEnabled || syncOptions.pixelEnabled) && isArray(pixels) && pixels.length !== 0) {
+    const gdprFlag = `&gdpr=${gdprConsent.gdprApplies ? 1 : 0}`;
+    const gdprString = `&gdpr_consent=${encodeURIComponent((gdprConsent.consentString || ''))}`;
+    const usPrivacy = `us_privacy=${encodeURIComponent(uspConsent)}`;
+
+    pixels.forEach(pixel => {
+      const [type, url] = pixel;
+      const sync = {type, url: `${url}&${usPrivacy}${gdprFlag}${gdprString}`};
+      if (type === 'iframe' && syncOptions.iframeEnabled) {
+        syncs.push(sync)
+      } else if (type === 'image' && syncOptions.pixelEnabled) {
+        syncs.push(sync)
+      }
+    });
+  }
+
+  return syncs;
+}
+
+/**
+ * Get valid floor value from getFloor fuction.
+ *
+ * @param {Object} bid Current bid request.
+ * @return {null|Number} Returns floor value when bid.getFloor is function and returns valid floor object with USD currency, otherwise returns null.
+ */
+export function getBidFloor(bid) {
+  if (!isFn(bid.getFloor)) {
+    return null;
+  }
+
+  let floor = bid.getFloor({
+    currency: CUR,
+    mediaType: '*',
+    size: '*'
+  });
+
+  if (typeof floor === 'object' && !isNaN(floor.floor) && floor.currency === CUR) {
+    return floor.floor;
+  }
+
+  return null;
+}
+
+export const spec = {
+  code: BIDDER_CODE,
+  aliases: ['kivi', 'kiviads'],
+  supportedMediaTypes: [BANNER, VIDEO],
+  isBidRequestValid,
+  buildRequests,
+  interpretResponse,
+  getUserSyncs
+}
+
+registerBidder(spec);

--- a/modules/lm_kiviadsBidAdapter.md
+++ b/modules/lm_kiviadsBidAdapter.md
@@ -1,0 +1,54 @@
+# Overview
+
+```
+Module Name: lm_kiviads Bidder Adapter
+Module Type: lm_kiviads Bidder Adapter
+Maintainer: pavlo@xe.works
+```
+
+# Description
+
+Module that connects to kiviads.com demand sources
+
+# Test Parameters
+```
+var adUnits = [
+    {
+        code: 'test-banner',
+        mediaTypes: {
+            banner: {
+                sizes: [[300, 250]],
+            }
+        },
+        bids: [
+            {
+                bidder: 'lm_kiviads',
+                params: {
+                    env: 'lm_kiviads',
+                    placement: '40',
+                    ext: {}
+                }
+            }
+        ]
+    },
+    {
+        code: 'test-video',
+        sizes: [ [ 640, 480 ] ],
+        mediaTypes: {
+            video: {
+                playerSize: [640, 480],
+                context: 'instream',
+                skipppable: true
+            }
+        },
+        bids: [{
+            bidder: 'lm_kiviads',
+            params: {
+                env: 'lm_kiviads',
+                placement: '40',
+                ext: {}
+            }
+        }]
+    }
+];
+```

--- a/test/spec/modules/kiviadsBidAdapter_spec.js
+++ b/test/spec/modules/kiviadsBidAdapter_spec.js
@@ -78,7 +78,8 @@ describe('KiviAdsBidAdapter', function () {
     gdprConsent: 'COvFyGBOvFyGBAbAAAENAPCAAOAAAAAAAAAAAEEUACCKAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw',
     refererInfo: {
       referer: 'https://test.com'
-    }
+    },
+    bidderTimeout: 300
   };
 
   describe('isBidRequestValid', function () {
@@ -121,6 +122,7 @@ describe('KiviAdsBidAdapter', function () {
         'coppa',
         'ccpa',
         'gdpr',
+        'gpp',
         'tmax'
       );
       expect(data.deviceWidth).to.be.a('number');
@@ -128,7 +130,9 @@ describe('KiviAdsBidAdapter', function () {
       expect(data.language).to.be.a('string');
       expect(data.secure).to.be.within(0, 1);
       expect(data.host).to.be.a('string');
+      expect(data.host).to.equal('localhost:9877');
       expect(data.page).to.be.a('string');
+      expect(data.page).to.equal('/');
       expect(data.coppa).to.be.a('number');
       expect(data.gdpr).to.be.a('string');
       expect(data.ccpa).to.be.a('string');

--- a/test/spec/modules/kiviadsBidAdapter_spec.js
+++ b/test/spec/modules/kiviadsBidAdapter_spec.js
@@ -1,0 +1,400 @@
+import { expect } from 'chai';
+import { spec } from '../../../modules/kiviadsBidAdapter.js';
+import { BANNER, VIDEO, NATIVE } from '../../../src/mediaTypes.js';
+import { getUniqueIdentifierStr } from '../../../src/utils.js';
+
+const bidder = 'kiviads'
+const adUrl = 'https://lb.kiviads.com/pbjs';
+const syncUrl = 'https://sync.kiviads.com';
+
+describe('KiviAdsBidAdapter', function () {
+  const bids = [
+    {
+      bidId: getUniqueIdentifierStr(),
+      bidder: bidder,
+      mediaTypes: {
+        [BANNER]: {
+          sizes: [[300, 250]]
+        }
+      },
+      params: {
+        placementId: 'testBanner',
+      }
+    },
+    {
+      bidId: getUniqueIdentifierStr(),
+      bidder: bidder,
+      mediaTypes: {
+        [VIDEO]: {
+          playerSize: [[300, 300]],
+          minduration: 5,
+          maxduration: 60
+        }
+      },
+      params: {
+        placementId: 'testVideo',
+      }
+    },
+    {
+      bidId: getUniqueIdentifierStr(),
+      bidder: bidder,
+      mediaTypes: {
+        [NATIVE]: {
+          native: {
+            title: {
+              required: true
+            },
+            body: {
+              required: true
+            },
+            icon: {
+              required: true,
+              size: [64, 64]
+            }
+          }
+        }
+      },
+      params: {
+        placementId: 'testNative',
+      }
+    }
+  ];
+
+  const invalidBid = {
+    bidId: getUniqueIdentifierStr(),
+    bidder: bidder,
+    mediaTypes: {
+      [BANNER]: {
+        sizes: [[300, 250]]
+      }
+    },
+    params: {
+
+    }
+  }
+
+  const bidderRequest = {
+    uspConsent: '1---',
+    gdprConsent: 'COvFyGBOvFyGBAbAAAENAPCAAOAAAAAAAAAAAEEUACCKAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw',
+    refererInfo: {
+      referer: 'https://test.com'
+    }
+  };
+
+  describe('isBidRequestValid', function () {
+    it('Should return true if there are bidId, params and key parameters present', function () {
+      expect(spec.isBidRequestValid(bids[0])).to.be.true;
+    });
+    it('Should return false if at least one of parameters is not present', function () {
+      expect(spec.isBidRequestValid(invalidBid)).to.be.false;
+    });
+  });
+
+  describe('buildRequests', function () {
+    let serverRequest = spec.buildRequests(bids, bidderRequest);
+
+    it('Creates a ServerRequest object with method, URL and data', function () {
+      expect(serverRequest).to.exist;
+      expect(serverRequest.method).to.exist;
+      expect(serverRequest.url).to.exist;
+      expect(serverRequest.data).to.exist;
+    });
+
+    it('Returns POST method', function () {
+      expect(serverRequest.method).to.equal('POST');
+    });
+
+    it('Returns valid URL', function () {
+      expect(serverRequest.url).to.equal(adUrl);
+    });
+
+    it('Returns general data valid', function () {
+      let data = serverRequest.data;
+      expect(data).to.be.an('object');
+      expect(data).to.have.all.keys('deviceWidth',
+        'deviceHeight',
+        'language',
+        'secure',
+        'host',
+        'page',
+        'placements',
+        'coppa',
+        'ccpa',
+        'gdpr',
+        'tmax'
+      );
+      expect(data.deviceWidth).to.be.a('number');
+      expect(data.deviceHeight).to.be.a('number');
+      expect(data.language).to.be.a('string');
+      expect(data.secure).to.be.within(0, 1);
+      expect(data.host).to.be.a('string');
+      expect(data.page).to.be.a('string');
+      expect(data.coppa).to.be.a('number');
+      expect(data.gdpr).to.be.a('string');
+      expect(data.ccpa).to.be.a('string');
+      expect(data.tmax).to.be.a('number');
+      expect(data.placements).to.have.lengthOf(3);
+    });
+
+    it('Returns valid placements', function () {
+      const { placements } = serverRequest.data;
+      for (let i = 0, len = placements.length; i < len; i++) {
+        const placement = placements[i];
+        expect(placement.placementId).to.be.oneOf(['testBanner', 'testVideo', 'testNative']);
+        expect(placement.adFormat).to.be.oneOf([BANNER, VIDEO, NATIVE]);
+        expect(placement.bidId).to.be.a('string');
+        expect(placement.schain).to.be.an('object');
+        expect(placement.bidfloor).to.exist.and.to.equal(0);
+        expect(placement.type).to.exist.and.to.equal('publisher');
+
+        if (placement.adFormat === BANNER) {
+          expect(placement.sizes).to.be.an('array');
+        }
+        switch (placement.adFormat) {
+          case BANNER:
+            expect(placement.sizes).to.be.an('array');
+            break;
+          case VIDEO:
+            expect(placement.playerSize).to.be.an('array');
+            expect(placement.minduration).to.be.an('number');
+            expect(placement.maxduration).to.be.an('number');
+            break;
+          case NATIVE:
+            expect(placement.native).to.be.an('object');
+            break;
+        }
+      }
+    });
+
+    it('Returns data with gdprConsent and without uspConsent', function () {
+      delete bidderRequest.uspConsent;
+      serverRequest = spec.buildRequests(bids, bidderRequest);
+      let data = serverRequest.data;
+      expect(data.gdpr).to.exist;
+      expect(data.gdpr).to.be.a('string');
+      expect(data.gdpr).to.equal(bidderRequest.gdprConsent);
+      expect(data.ccpa).to.not.exist;
+      delete bidderRequest.gdprConsent;
+    });
+
+    it('Returns data with uspConsent and without gdprConsent', function () {
+      bidderRequest.uspConsent = '1---';
+      delete bidderRequest.gdprConsent;
+      serverRequest = spec.buildRequests(bids, bidderRequest);
+      let data = serverRequest.data;
+      expect(data.ccpa).to.exist;
+      expect(data.ccpa).to.be.a('string');
+      expect(data.ccpa).to.equal(bidderRequest.uspConsent);
+      expect(data.gdpr).to.not.exist;
+    });
+
+    it('Returns empty data if no valid requests are passed', function () {
+      serverRequest = spec.buildRequests([], bidderRequest);
+      let data = serverRequest.data;
+      expect(data.placements).to.be.an('array').that.is.empty;
+    });
+  });
+
+  describe('interpretResponse', function () {
+    it('Should interpret banner response', function () {
+      const banner = {
+        body: [{
+          mediaType: 'banner',
+          width: 300,
+          height: 250,
+          cpm: 0.4,
+          ad: 'Test',
+          requestId: '23fhj33i987f',
+          ttl: 120,
+          creativeId: '2',
+          netRevenue: true,
+          currency: 'USD',
+          dealId: '1',
+          meta: {
+            advertiserDomains: ['google.com'],
+            advertiserId: 1234
+          }
+        }]
+      };
+      let bannerResponses = spec.interpretResponse(banner);
+      expect(bannerResponses).to.be.an('array').that.is.not.empty;
+      let dataItem = bannerResponses[0];
+      expect(dataItem).to.have.all.keys('requestId', 'cpm', 'width', 'height', 'ad', 'ttl', 'creativeId',
+        'netRevenue', 'currency', 'dealId', 'mediaType', 'meta');
+      expect(dataItem.requestId).to.equal(banner.body[0].requestId);
+      expect(dataItem.cpm).to.equal(banner.body[0].cpm);
+      expect(dataItem.width).to.equal(banner.body[0].width);
+      expect(dataItem.height).to.equal(banner.body[0].height);
+      expect(dataItem.ad).to.equal(banner.body[0].ad);
+      expect(dataItem.ttl).to.equal(banner.body[0].ttl);
+      expect(dataItem.creativeId).to.equal(banner.body[0].creativeId);
+      expect(dataItem.netRevenue).to.be.true;
+      expect(dataItem.currency).to.equal(banner.body[0].currency);
+      expect(dataItem.meta).to.be.an('object').that.has.any.key('advertiserDomains');
+    });
+    it('Should interpret video response', function () {
+      const video = {
+        body: [{
+          vastUrl: 'test.com',
+          mediaType: 'video',
+          cpm: 0.5,
+          requestId: '23fhj33i987f',
+          ttl: 120,
+          creativeId: '2',
+          netRevenue: true,
+          currency: 'USD',
+          dealId: '1',
+          meta: {
+            advertiserDomains: ['google.com'],
+            advertiserId: 1234
+          }
+        }]
+      };
+      let videoResponses = spec.interpretResponse(video);
+      expect(videoResponses).to.be.an('array').that.is.not.empty;
+
+      let dataItem = videoResponses[0];
+      expect(dataItem).to.have.all.keys('requestId', 'cpm', 'vastUrl', 'ttl', 'creativeId',
+        'netRevenue', 'currency', 'dealId', 'mediaType', 'meta');
+      expect(dataItem.requestId).to.equal('23fhj33i987f');
+      expect(dataItem.cpm).to.equal(0.5);
+      expect(dataItem.vastUrl).to.equal('test.com');
+      expect(dataItem.ttl).to.equal(120);
+      expect(dataItem.creativeId).to.equal('2');
+      expect(dataItem.netRevenue).to.be.true;
+      expect(dataItem.currency).to.equal('USD');
+      expect(dataItem.meta).to.be.an('object').that.has.any.key('advertiserDomains');
+    });
+    it('Should interpret native response', function () {
+      const native = {
+        body: [{
+          mediaType: 'native',
+          native: {
+            clickUrl: 'test.com',
+            title: 'Test',
+            image: 'test.com',
+            impressionTrackers: ['test.com'],
+          },
+          ttl: 120,
+          cpm: 0.4,
+          requestId: '23fhj33i987f',
+          creativeId: '2',
+          netRevenue: true,
+          currency: 'USD',
+          meta: {
+            advertiserDomains: ['google.com'],
+            advertiserId: 1234
+          }
+        }]
+      };
+      let nativeResponses = spec.interpretResponse(native);
+      expect(nativeResponses).to.be.an('array').that.is.not.empty;
+
+      let dataItem = nativeResponses[0];
+      expect(dataItem).to.have.keys('requestId', 'cpm', 'ttl', 'creativeId', 'netRevenue', 'currency', 'mediaType', 'native', 'meta');
+      expect(dataItem.native).to.have.keys('clickUrl', 'impressionTrackers', 'title', 'image')
+      expect(dataItem.requestId).to.equal('23fhj33i987f');
+      expect(dataItem.cpm).to.equal(0.4);
+      expect(dataItem.native.clickUrl).to.equal('test.com');
+      expect(dataItem.native.title).to.equal('Test');
+      expect(dataItem.native.image).to.equal('test.com');
+      expect(dataItem.native.impressionTrackers).to.be.an('array').that.is.not.empty;
+      expect(dataItem.native.impressionTrackers[0]).to.equal('test.com');
+      expect(dataItem.ttl).to.equal(120);
+      expect(dataItem.creativeId).to.equal('2');
+      expect(dataItem.netRevenue).to.be.true;
+      expect(dataItem.currency).to.equal('USD');
+      expect(dataItem.meta).to.be.an('object').that.has.any.key('advertiserDomains');
+    });
+    it('Should return an empty array if invalid banner response is passed', function () {
+      const invBanner = {
+        body: [{
+          width: 300,
+          cpm: 0.4,
+          ad: 'Test',
+          requestId: '23fhj33i987f',
+          ttl: 120,
+          creativeId: '2',
+          netRevenue: true,
+          currency: 'USD',
+          dealId: '1'
+        }]
+      };
+
+      let serverResponses = spec.interpretResponse(invBanner);
+      expect(serverResponses).to.be.an('array').that.is.empty;
+    });
+    it('Should return an empty array if invalid video response is passed', function () {
+      const invVideo = {
+        body: [{
+          mediaType: 'video',
+          cpm: 0.5,
+          requestId: '23fhj33i987f',
+          ttl: 120,
+          creativeId: '2',
+          netRevenue: true,
+          currency: 'USD',
+          dealId: '1'
+        }]
+      };
+      let serverResponses = spec.interpretResponse(invVideo);
+      expect(serverResponses).to.be.an('array').that.is.empty;
+    });
+    it('Should return an empty array if invalid native response is passed', function () {
+      const invNative = {
+        body: [{
+          mediaType: 'native',
+          clickUrl: 'test.com',
+          title: 'Test',
+          impressionTrackers: ['test.com'],
+          ttl: 120,
+          requestId: '23fhj33i987f',
+          creativeId: '2',
+          netRevenue: true,
+          currency: 'USD',
+        }]
+      };
+      let serverResponses = spec.interpretResponse(invNative);
+      expect(serverResponses).to.be.an('array').that.is.empty;
+    });
+    it('Should return an empty array if invalid response is passed', function () {
+      const invalid = {
+        body: [{
+          ttl: 120,
+          creativeId: '2',
+          netRevenue: true,
+          currency: 'USD',
+          dealId: '1'
+        }]
+      };
+      let serverResponses = spec.interpretResponse(invalid);
+      expect(serverResponses).to.be.an('array').that.is.empty;
+    });
+  });
+
+  describe('getUserSyncs', function() {
+    it('Should return array of objects with proper sync config , include GDPR', function() {
+      const syncData = spec.getUserSyncs({}, {}, {
+        consentString: 'ALL',
+        gdprApplies: true,
+      }, {});
+      expect(syncData).to.be.an('array').which.is.not.empty;
+      expect(syncData[0]).to.be.an('object')
+      expect(syncData[0].type).to.be.a('string')
+      expect(syncData[0].type).to.equal('image')
+      expect(syncData[0].url).to.be.a('string')
+      expect(syncData[0].url).to.equal(`${syncUrl}/image?pbjs=1&gdpr=1&gdpr_consent=ALL&coppa=0`)
+    });
+    it('Should return array of objects with proper sync config , include CCPA', function() {
+      const syncData = spec.getUserSyncs({}, {}, {}, {
+        consentString: '1---'
+      });
+      expect(syncData).to.be.an('array').which.is.not.empty;
+      expect(syncData[0]).to.be.an('object')
+      expect(syncData[0].type).to.be.a('string')
+      expect(syncData[0].type).to.equal('image')
+      expect(syncData[0].url).to.be.a('string')
+      expect(syncData[0].url).to.equal(`${syncUrl}/image?pbjs=1&ccpa_consent=1---&coppa=0`)
+    });
+  });
+});

--- a/test/spec/modules/kiviadsBidAdapter_spec.js
+++ b/test/spec/modules/kiviadsBidAdapter_spec.js
@@ -130,7 +130,7 @@ describe('KiviAdsBidAdapter', function () {
       expect(data.language).to.be.a('string');
       expect(data.secure).to.be.within(0, 1);
       expect(data.host).to.be.a('string');
-      expect(data.host).to.equal('localhost:9877');
+      expect(data.host).to.contain('localhost');
       expect(data.page).to.be.a('string');
       expect(data.page).to.equal('/');
       expect(data.coppa).to.be.a('number');

--- a/test/spec/modules/lm_kiviadsBidAdapter_spec.js
+++ b/test/spec/modules/lm_kiviadsBidAdapter_spec.js
@@ -1,0 +1,455 @@
+import {expect} from 'chai';
+import {config} from 'src/config.js';
+import {spec, getBidFloor} from 'modules/lm_kiviadsBidAdapter.js';
+import {deepClone} from 'src/utils';
+
+const ENDPOINT = 'https://pbjs.kiviads.live';
+
+const defaultRequest = {
+  adUnitCode: 'test',
+  bidId: '1',
+  requestId: 'qwerty',
+  ortb2: {
+    source: {
+      tid: 'auctionId'
+    }
+  },
+  ortb2Imp: {
+    ext: {
+      tid: 'tr1',
+    }
+  },
+  mediaTypes: {
+    banner: {
+      sizes: [
+        [300, 250],
+        [300, 200]
+      ]
+    }
+  },
+  bidder: 'lm_kiviads',
+  params: {
+    env: 'lm_kiviads',
+    placement: '40',
+    ext: {}
+  },
+  bidRequestsCount: 1
+};
+
+const defaultRequestVideo = deepClone(defaultRequest);
+defaultRequestVideo.mediaTypes = {
+  video: {
+    playerSize: [640, 480],
+    context: 'instream',
+    skipppable: true
+  }
+};
+describe('lm_kiviadsBidAdapter', () => {
+  describe('isBidRequestValid', function () {
+    it('should return false when request params is missing', function () {
+      const invalidRequest = deepClone(defaultRequest);
+      delete invalidRequest.params;
+      expect(spec.isBidRequestValid(invalidRequest)).to.equal(false);
+    });
+
+    it('should return false when required env param is missing', function () {
+      const invalidRequest = deepClone(defaultRequest);
+      delete invalidRequest.params.env;
+      expect(spec.isBidRequestValid(invalidRequest)).to.equal(false);
+    });
+
+    it('should return false when required placement param is missing', function () {
+      const invalidRequest = deepClone(defaultRequest);
+      delete invalidRequest.params.placement;
+      expect(spec.isBidRequestValid(invalidRequest)).to.equal(false);
+    });
+
+    it('should return false when video.playerSize is missing', function () {
+      const invalidRequest = deepClone(defaultRequestVideo);
+      delete invalidRequest.mediaTypes.video.playerSize;
+      expect(spec.isBidRequestValid(invalidRequest)).to.equal(false);
+    });
+
+    it('should return true when required params found', function () {
+      expect(spec.isBidRequestValid(defaultRequest)).to.equal(true);
+    });
+  });
+
+  describe('buildRequests', function () {
+    beforeEach(function () {
+      config.resetConfig();
+    });
+
+    it('should send request with correct structure', function () {
+      const request = spec.buildRequests([defaultRequest], {});
+      expect(request.method).to.equal('POST');
+      expect(request.url).to.equal(ENDPOINT + '/bid');
+      expect(request.options).to.have.property('contentType').and.to.equal('application/json');
+      expect(request).to.have.property('data');
+    });
+
+    it('should build basic request structure', function () {
+      const request = JSON.parse(spec.buildRequests([defaultRequest], {}).data)[0];
+      expect(request).to.have.property('bidId').and.to.equal(defaultRequest.bidId);
+      expect(request).to.have.property('auctionId').and.to.equal(defaultRequest.ortb2.source.tid);
+      expect(request).to.have.property('transactionId').and.to.equal(defaultRequest.ortb2Imp.ext.tid);
+      expect(request).to.have.property('tz').and.to.equal(new Date().getTimezoneOffset());
+      expect(request).to.have.property('bc').and.to.equal(1);
+      expect(request).to.have.property('floor').and.to.equal(null);
+      expect(request).to.have.property('banner').and.to.deep.equal({sizes: [[300, 250], [300, 200]]});
+      expect(request).to.have.property('gdprApplies').and.to.equal(0);
+      expect(request).to.have.property('consentString').and.to.equal('');
+      expect(request).to.have.property('userEids').and.to.deep.equal([]);
+      expect(request).to.have.property('usPrivacy').and.to.equal('');
+      expect(request).to.have.property('coppa').and.to.equal(0);
+      expect(request).to.have.property('sizes').and.to.deep.equal(['300x250', '300x200']);
+      expect(request).to.have.property('ext').and.to.deep.equal({});
+      expect(request).to.have.property('env').and.to.deep.equal({
+        env: 'lm_kiviads',
+        placement: '40'
+      });
+      expect(request).to.have.property('device').and.to.deep.equal({
+        ua: navigator.userAgent,
+        lang: navigator.language
+      });
+    });
+
+    it('should build request with schain', function () {
+      const schainRequest = deepClone(defaultRequest);
+      schainRequest.schain = {
+        validation: 'strict',
+        config: {
+          ver: '1.0'
+        }
+      };
+      const request = JSON.parse(spec.buildRequests([schainRequest], {}).data)[0];
+      expect(request).to.have.property('schain').and.to.deep.equal({
+        validation: 'strict',
+        config: {
+          ver: '1.0'
+        }
+      });
+    });
+
+    it('should build request with location', function () {
+      const bidderRequest = {
+        refererInfo: {
+          page: 'page',
+          location: 'location',
+          domain: 'domain',
+          ref: 'ref',
+          isAmp: false
+        }
+      };
+      const request = JSON.parse(spec.buildRequests([defaultRequest], bidderRequest).data)[0];
+      expect(request).to.have.property('location');
+      const location = request.location;
+      expect(location).to.have.property('page').and.to.equal('page');
+      expect(location).to.have.property('location').and.to.equal('location');
+      expect(location).to.have.property('domain').and.to.equal('domain');
+      expect(location).to.have.property('ref').and.to.equal('ref');
+      expect(location).to.have.property('isAmp').and.to.equal(false);
+    });
+
+    it('should build request with ortb2 info', function () {
+      const ortb2Request = deepClone(defaultRequest);
+      ortb2Request.ortb2 = {
+        site: {
+          name: 'name'
+        }
+      };
+      const request = JSON.parse(spec.buildRequests([ortb2Request], {}).data)[0];
+      expect(request).to.have.property('ortb2').and.to.deep.equal({
+        site: {
+          name: 'name'
+        }
+      });
+    });
+
+    it('should build request with ortb2Imp info', function () {
+      const ortb2ImpRequest = deepClone(defaultRequest);
+      ortb2ImpRequest.ortb2Imp = {
+        ext: {
+          data: {
+            pbadslot: 'home1',
+            adUnitSpecificAttribute: '1'
+          }
+        }
+      };
+      const request = JSON.parse(spec.buildRequests([ortb2ImpRequest], {}).data)[0];
+      expect(request).to.have.property('ortb2Imp').and.to.deep.equal({
+        ext: {
+          data: {
+            pbadslot: 'home1',
+            adUnitSpecificAttribute: '1'
+          }
+        }
+      });
+    });
+
+    it('should build request with valid bidfloor', function () {
+      const bfRequest = deepClone(defaultRequest);
+      bfRequest.getFloor = () => ({floor: 5, currency: 'USD'});
+      const request = JSON.parse(spec.buildRequests([bfRequest], {}).data)[0];
+      expect(request).to.have.property('floor').and.to.equal(5);
+    });
+
+    it('should build request with gdpr consent data if applies', function () {
+      const bidderRequest = {
+        gdprConsent: {
+          gdprApplies: true,
+          consentString: 'qwerty'
+        }
+      };
+      const request = JSON.parse(spec.buildRequests([defaultRequest], bidderRequest).data)[0];
+      expect(request).to.have.property('gdprApplies').and.equals(1);
+      expect(request).to.have.property('consentString').and.equals('qwerty');
+    });
+
+    it('should build request with usp consent data if applies', function () {
+      const bidderRequest = {
+        uspConsent: '1YA-'
+      };
+      const request = JSON.parse(spec.buildRequests([defaultRequest], bidderRequest).data)[0];
+      expect(request).to.have.property('usPrivacy').and.equals('1YA-');
+    });
+
+    it('should build request with coppa 1', function () {
+      config.setConfig({
+        coppa: true
+      });
+      const request = JSON.parse(spec.buildRequests([defaultRequest], {}).data)[0];
+      expect(request).to.have.property('coppa').and.equals(1);
+    });
+
+    it('should build request with extended ids', function () {
+      const idRequest = deepClone(defaultRequest);
+      idRequest.userIdAsEids = [
+        {source: 'adserver.org', uids: [{id: 'TTD_ID_FROM_USER_ID_MODULE', atype: 1, ext: {rtiPartner: 'TDID'}}]},
+        {source: 'pubcid.org', uids: [{id: 'pubCommonId_FROM_USER_ID_MODULE', atype: 1}]}
+      ];
+      const request = JSON.parse(spec.buildRequests([idRequest], {}).data)[0];
+      expect(request).to.have.property('userEids').and.deep.equal(idRequest.userIdAsEids);
+    });
+
+    it('should build request with video', function () {
+      const request = JSON.parse(spec.buildRequests([defaultRequestVideo], {}).data)[0];
+      expect(request).to.have.property('video').and.to.deep.equal({
+        playerSize: [640, 480],
+        context: 'instream',
+        skipppable: true
+      });
+      expect(request).to.have.property('sizes').and.to.deep.equal(['640x480']);
+    });
+  });
+
+  describe('interpretResponse', function () {
+    it('should return empty bids', function () {
+      const serverResponse = {
+        body: {
+          data: null
+        }
+      };
+
+      const invalidResponse = spec.interpretResponse(serverResponse, {});
+      expect(invalidResponse).to.be.an('array').that.is.empty;
+    });
+
+    it('should interpret valid response', function () {
+      const serverResponse = {
+        body: {
+          data: [{
+            requestId: 'qwerty',
+            cpm: 1,
+            currency: 'USD',
+            width: 300,
+            height: 250,
+            ttl: 600,
+            meta: {
+              advertiserDomains: ['lm_kiviads']
+            },
+            ext: {
+              pixels: [
+                ['iframe', 'surl1'],
+                ['image', 'surl2'],
+              ]
+            }
+          }]
+        }
+      };
+
+      const validResponse = spec.interpretResponse(serverResponse, {bidderRequest: defaultRequest});
+      const bid = validResponse[0];
+      expect(validResponse).to.be.an('array').that.is.not.empty;
+      expect(bid.requestId).to.equal('qwerty');
+      expect(bid.cpm).to.equal(1);
+      expect(bid.currency).to.equal('USD');
+      expect(bid.width).to.equal(300);
+      expect(bid.height).to.equal(250);
+      expect(bid.ttl).to.equal(600);
+      expect(bid.meta).to.deep.equal({advertiserDomains: ['lm_kiviads']});
+    });
+
+    it('should interpret valid banner response', function () {
+      const serverResponse = {
+        body: {
+          data: [{
+            requestId: 'qwerty',
+            cpm: 1,
+            currency: 'USD',
+            width: 300,
+            height: 250,
+            ttl: 600,
+            mediaType: 'banner',
+            creativeId: 'xe-demo-banner',
+            ad: 'ad',
+            meta: {}
+          }]
+        }
+      };
+
+      const validResponseBanner = spec.interpretResponse(serverResponse, {bidderRequest: defaultRequest});
+      const bid = validResponseBanner[0];
+      expect(validResponseBanner).to.be.an('array').that.is.not.empty;
+      expect(bid.mediaType).to.equal('banner');
+      expect(bid.creativeId).to.equal('xe-demo-banner');
+      expect(bid.ad).to.equal('ad');
+    });
+
+    it('should interpret valid video response', function () {
+      const serverResponse = {
+        body: {
+          data: [{
+            requestId: 'qwerty',
+            cpm: 1,
+            currency: 'USD',
+            width: 600,
+            height: 480,
+            ttl: 600,
+            mediaType: 'video',
+            creativeId: 'xe-demo-video',
+            ad: 'vast-xml',
+            meta: {}
+          }]
+        }
+      };
+
+      const validResponseBanner = spec.interpretResponse(serverResponse, {bidderRequest: defaultRequestVideo});
+      const bid = validResponseBanner[0];
+      expect(validResponseBanner).to.be.an('array').that.is.not.empty;
+      expect(bid.mediaType).to.equal('video');
+      expect(bid.creativeId).to.equal('xe-demo-video');
+      expect(bid.ad).to.equal('vast-xml');
+    });
+  });
+
+  describe('getUserSyncs', function () {
+    it('shoukd handle no params', function () {
+      const opts = spec.getUserSyncs({}, []);
+      expect(opts).to.be.an('array').that.is.empty;
+    });
+
+    it('should return empty if sync is not allowed', function () {
+      const opts = spec.getUserSyncs({iframeEnabled: false, pixelEnabled: false});
+      expect(opts).to.be.an('array').that.is.empty;
+    });
+
+    it('should allow iframe sync', function () {
+      const opts = spec.getUserSyncs({iframeEnabled: true, pixelEnabled: false}, [{
+        body: {
+          data: [{
+            requestId: 'qwerty',
+            ext: {
+              pixels: [
+                ['iframe', 'surl1?a=b'],
+                ['image', 'surl2?a=b'],
+              ]
+            }
+          }]
+        }
+      }]);
+      expect(opts.length).to.equal(1);
+      expect(opts[0].type).to.equal('iframe');
+      expect(opts[0].url).to.equal('surl1?a=b&us_privacy=&gdpr=0&gdpr_consent=');
+    });
+
+    it('should allow pixel sync', function () {
+      const opts = spec.getUserSyncs({iframeEnabled: false, pixelEnabled: true}, [{
+        body: {
+          data: [{
+            requestId: 'qwerty',
+            ext: {
+              pixels: [
+                ['iframe', 'surl1?a=b'],
+                ['image', 'surl2?a=b'],
+              ]
+            }
+          }]
+        }
+      }]);
+      expect(opts.length).to.equal(1);
+      expect(opts[0].type).to.equal('image');
+      expect(opts[0].url).to.equal('surl2?a=b&us_privacy=&gdpr=0&gdpr_consent=');
+    });
+
+    it('should allow pixel sync and parse consent params', function () {
+      const opts = spec.getUserSyncs({iframeEnabled: false, pixelEnabled: true}, [{
+        body: {
+          data: [{
+            requestId: 'qwerty',
+            ext: {
+              pixels: [
+                ['iframe', 'surl1?a=b'],
+                ['image', 'surl2?a=b'],
+              ]
+            }
+          }]
+        }
+      }], {
+        gdprApplies: 1,
+        consentString: '1YA-'
+      });
+      expect(opts.length).to.equal(1);
+      expect(opts[0].type).to.equal('image');
+      expect(opts[0].url).to.equal('surl2?a=b&us_privacy=&gdpr=1&gdpr_consent=1YA-');
+    });
+  });
+
+  describe('getBidFloor', function () {
+    it('should return null when getFloor is not a function', () => {
+      const bid = {getFloor: 2};
+      const result = getBidFloor(bid);
+      expect(result).to.be.null;
+    });
+
+    it('should return null when getFloor doesnt return an object', () => {
+      const bid = {getFloor: () => 2};
+      const result = getBidFloor(bid);
+      expect(result).to.be.null;
+    });
+
+    it('should return null when floor is not a number', () => {
+      const bid = {
+        getFloor: () => ({floor: 'string', currency: 'USD'})
+      };
+      const result = getBidFloor(bid);
+      expect(result).to.be.null;
+    });
+
+    it('should return null when currency is not USD', () => {
+      const bid = {
+        getFloor: () => ({floor: 5, currency: 'EUR'})
+      };
+      const result = getBidFloor(bid);
+      expect(result).to.be.null;
+    });
+
+    it('should return floor value when everything is correct', () => {
+      const bid = {
+        getFloor: () => ({floor: 5, currency: 'USD'})
+      };
+      const result = getBidFloor(bid);
+      expect(result).to.equal(5);
+    });
+  });
+})


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter 

## Description of change
New prebid adapter to connect to kiviads.com demand source

- test parameters for validating bids:
```
[
    {
        code: 'test-banner',
        mediaTypes: {
            banner: {
                sizes: [[300, 250]],
            }
        },
        bids: [
            {
                bidder: 'lm_kiviads',
                params: {
                    env: 'lm_kiviads',
                    placement: '40',
                    ext: {}
                }
            }
        ]
    },
    {
        code: 'test-video',
        sizes: [ [ 640, 480 ] ],
        mediaTypes: {
            video: {
                playerSize: [640, 480],
                context: 'instream',
                skipppable: true
            }
        },
        bids: [{
            bidder: 'lm_kiviads',
            params: {
                env: 'lm_kiviads',
                placement: '40',
                ext: {}
            }
        }]
    }
]
```

-contact email of the adapter’s maintainer: [pavlo@xe.works](mailto: pavlo@xe.works)

## Other information
Docs PR: https://github.com/prebid/prebid.github.io/pull/4819