### PR TITLE
Rubicon Bid Adapter: params.position NATIVE Fix

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -196,8 +196,8 @@ export const converter = ortbConverter({
     if (config.getConfig('s2sConfig.defaultTtl')) {
       imp.exp = config.getConfig('s2sConfig.defaultTtl');
     };
-    bidRequest.params.position === 'atf' && (imp.video.pos = 1);
-    bidRequest.params.position === 'btf' && (imp.video.pos = 3);
+    bidRequest.params.position === 'atf' && imp.video && (imp.video.pos = 1);
+    bidRequest.params.position === 'btf' && imp.video && (imp.video.pos = 3);
     delete imp.ext?.prebid?.storedrequest;
 
     if (bidRequest.params.bidonmultiformat === true && bidRequestType.length > 1) {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -2636,6 +2636,18 @@ describe('the rubicon adapter', function () {
               expect(request.data.imp).to.have.nested.property('[0].native');
             });
 
+            it('should not break if position is set and no video MT', function () {
+              const bidReq = addNativeToBidRequest(bidderRequest);
+              delete bidReq.bids[0].mediaTypes.banner;
+              bidReq.bids[0].params = {
+                position: 'atf'
+              }
+              let [request] = spec.buildRequests(bidReq.bids, bidReq);
+              expect(request.method).to.equal('POST');
+              expect(request.url).to.equal('https://prebid-server.rubiconproject.com/openrtb2/auction');
+              expect(request.data.imp).to.have.nested.property('[0].native');
+            });
+
             describe('that contains also a banner mediaType', function () {
               it('should send the banner to fastlane BUT NOT the native bid because missing params.video', function() {
                 const bidReq = addNativeToBidRequest(bidderRequest);


### PR DESCRIPTION
## Type of change
- [X] Bugfix


## Description of change
Fixes #10400 

Only set `imp.video.pos` if video object is there.