### PR TITLE
Cadent Aperture MX Bid Adapter: Include gpp consent in usersync endpoint

### DIFF
--- a/modules/cadentApertureMXBidAdapter.js
+++ b/modules/cadentApertureMXBidAdapter.js
@@ -374,7 +374,7 @@ export const spec = {
     }
     return cadentBidResponses;
   },
-  getUserSyncs: function (syncOptions, responses, gdprConsent, uspConsent) {
+  getUserSyncs: function (syncOptions, responses, gdprConsent, uspConsent, gppConsent) {
     const syncs = [];
     const consentParams = [];
     if (syncOptions.iframeEnabled) {
@@ -389,6 +389,14 @@ export const spec = {
       }
       if (uspConsent && typeof uspConsent.consentString === 'string') {
         consentParams.push(`usp=${uspConsent.consentString}`);
+      }
+      if(gppConsent && typeof gppConsent === 'object'){
+        if(gppConsent.gppString && typeof gppConsent.gppString === 'string'){
+          consentParams.push(`gpp=${gppConsent.gppString}`);
+        }
+        if(gppConsent.applicableSections && typeof gppConsent.applicableSections === 'object'){
+          consentParams.push(`gpp_sid=${gppConsent.applicableSections}`);
+        }
       }
       if (consentParams.length > 0) {
         url = url + '?' + consentParams.join('&');

--- a/modules/cadentApertureMXBidAdapter.js
+++ b/modules/cadentApertureMXBidAdapter.js
@@ -390,11 +390,11 @@ export const spec = {
       if (uspConsent && typeof uspConsent.consentString === 'string') {
         consentParams.push(`usp=${uspConsent.consentString}`);
       }
-      if(gppConsent && typeof gppConsent === 'object'){
-        if(gppConsent.gppString && typeof gppConsent.gppString === 'string'){
+      if (gppConsent && typeof gppConsent === 'object') {
+        if (gppConsent.gppString && typeof gppConsent.gppString === 'string') {
           consentParams.push(`gpp=${gppConsent.gppString}`);
         }
-        if(gppConsent.applicableSections && typeof gppConsent.applicableSections === 'object'){
+        if (gppConsent.applicableSections && typeof gppConsent.applicableSections === 'object') {
           consentParams.push(`gpp_sid=${gppConsent.applicableSections}`);
         }
       }

--- a/test/spec/modules/cadentApertureMXBidAdapter_spec.js
+++ b/test/spec/modules/cadentApertureMXBidAdapter_spec.js
@@ -834,5 +834,38 @@ describe('cadent_aperture_mx Adapter', function () {
       expect(syncs[0].url).to.contains('usp=test');
       expect(syncs[0].url).to.equal('https://biddr.brealtime.com/check.html?gdpr=1&gdpr_consent=test&usp=test')
     });
+    
+    it('should pass gpp string and section id' , function(){
+      let syncs = spec.getUserSyncs({iframeEnabled: true}, {}, {},{}, {
+        gppString: 'abcdefgs',
+        applicableSections: [1,2,4]
+      });
+      expect(syncs).to.not.be.an('undefined');
+      expect(syncs[0].url).to.contains('gpp=abcdefgs')
+      expect(syncs[0].url).to.contains('gpp_sid=1,2,4')
+    });
+
+    it('should pass us_privacy and gdpr string and gpp string', function () {
+      let syncs = spec.getUserSyncs({ iframeEnabled: true }, {},
+        {
+          gdprApplies: true,
+          consentString: 'test'
+        },
+        {
+          consentString: 'test'
+        },
+        {
+          gppString: 'abcdefgs',
+          applicableSections: [1,2,4]
+        }
+        );
+      expect(syncs).to.not.be.an('undefined');
+      expect(syncs).to.have.lengthOf(1);
+      expect(syncs[0].type).to.equal('iframe');
+      expect(syncs[0].url).to.contains('gdpr=1');
+      expect(syncs[0].url).to.contains('usp=test');
+      expect(syncs[0].url).to.contains('gpp=abcdefgs');
+      expect(syncs[0].url).to.equal('https://biddr.brealtime.com/check.html?gdpr=1&gdpr_consent=test&usp=test&gpp=abcdefgs&gpp_sid=1,2,4');
+    });
   });
 });

--- a/test/spec/modules/cadentApertureMXBidAdapter_spec.js
+++ b/test/spec/modules/cadentApertureMXBidAdapter_spec.js
@@ -834,11 +834,11 @@ describe('cadent_aperture_mx Adapter', function () {
       expect(syncs[0].url).to.contains('usp=test');
       expect(syncs[0].url).to.equal('https://biddr.brealtime.com/check.html?gdpr=1&gdpr_consent=test&usp=test')
     });
-    
-    it('should pass gpp string and section id' , function(){
-      let syncs = spec.getUserSyncs({iframeEnabled: true}, {}, {},{}, {
+
+    it('should pass gpp string and section id', function() {
+      let syncs = spec.getUserSyncs({iframeEnabled: true}, {}, {}, {}, {
         gppString: 'abcdefgs',
-        applicableSections: [1,2,4]
+        applicableSections: [1, 2, 4]
       });
       expect(syncs).to.not.be.an('undefined');
       expect(syncs[0].url).to.contains('gpp=abcdefgs')
@@ -856,9 +856,9 @@ describe('cadent_aperture_mx Adapter', function () {
         },
         {
           gppString: 'abcdefgs',
-          applicableSections: [1,2,4]
+          applicableSections: [1, 2, 4]
         }
-        );
+      );
       expect(syncs).to.not.be.an('undefined');
       expect(syncs).to.have.lengthOf(1);
       expect(syncs[0].type).to.equal('iframe');


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Include gpp string and section id in usersync endpoint
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
