### PR TITLE
Rubicon Bid Adapter: Format rubicon EID

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -537,7 +537,9 @@ export const spec = {
             data['eid_id5-sync.com'] = `${eid.uids[0].id}^${eid.uids[0].atype}^${(eid.uids[0].ext && eid.uids[0].ext.linkType) || ''}`;
           } else {
             // add anything else with this generic format
-            data[`eid_${eid.source}`] = `${eid.uids[0].id}^${eid.uids[0].atype || ''}`;
+            // if rubicon drop ^
+            const id = eid.source === 'rubiconproject.com' ? eid.uids[0].id : `${eid.uids[0].id}^${eid.uids[0].atype || ''}`
+            data[`eid_${eid.source}`] = id;
           }
           // send AE "ppuid" signal if exists, and hasn't already been sent
           if (!data['ppuid']) {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1578,7 +1578,7 @@ describe('the rubicon adapter', function () {
               expect(data['eid_catchall']).to.equal('11111^2');
             });
 
-            it('should send rubiconproejct special case', function () {
+            it('should send rubiconproject special case', function () {
               const clonedBid = utils.deepClone(bidderRequest.bids[0]);
               // Hardcoding userIdAsEids since createEidsArray returns empty array if source not found in eids.js
               clonedBid.userIdAsEids = [{

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1577,6 +1577,22 @@ describe('the rubicon adapter', function () {
 
               expect(data['eid_catchall']).to.equal('11111^2');
             });
+
+            it('should send rubiconproejct special case', function () {
+              const clonedBid = utils.deepClone(bidderRequest.bids[0]);
+              // Hardcoding userIdAsEids since createEidsArray returns empty array if source not found in eids.js
+              clonedBid.userIdAsEids = [{
+                source: 'rubiconproject.com',
+                uids: [{
+                  id: 'some-cool-id',
+                  atype: 3
+                }]
+              }]
+              let [request] = spec.buildRequests([clonedBid], bidderRequest);
+              let data = parseQuery(request.data);
+
+              expect(data['eid_rubiconproject.com']).to.equal('some-cool-id');
+            });
           });
 
           describe('Config user.id support', function () {


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change
`rubiconproject.com` eids are coming with the default `^${atype}` appended to the id value, new requirements state for this specific one we should drop it! 