### PR TITLE
ttd Bid Adapter: use bidderRequestId instead of auctionid

### DIFF
--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -4,7 +4,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import {isNumber} from '../src/utils.js';
 
-const BIDADAPTERVERSION = 'TTD-PREBID-2022.06.28';
+const BIDADAPTERVERSION = 'TTD-PREBID-2023.09.05';
 const BIDDER_CODE = 'ttd';
 const BIDDER_CODE_LONG = 'thetradedesk';
 const BIDDER_ENDPOINT = 'https://direct.adsrvr.org/bid/bidder/';
@@ -406,7 +406,7 @@ export const spec = {
   buildRequests: function (validBidRequests, bidderRequest) {
     const firstPartyData = bidderRequest.ortb2 || {};
     let topLevel = {
-      id: bidderRequest.auctionId,
+      id: bidderRequest.bidderRequestId,
       imp: validBidRequests.map(bidRequest => getImpression(bidRequest)),
       site: getSite(bidderRequest, firstPartyData),
       device: getDevice(firstPartyData),

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -262,6 +262,11 @@ describe('ttdBidAdapter', function () {
       expect(request.data).to.be.not.null;
     });
 
+    it('sets bidrequest.id to bidderRequestId', function () {
+      const requestBody = testBuildRequests(baseBannerBidRequests, baseBidderRequest).data;
+      expect(requestBody.id).to.equal('18084284054531');
+    });
+
     it('sets impression id to ad unit\'s bid id', function () {
       const requestBody = testBuildRequests(baseBannerBidRequests, baseBidderRequest).data;
       expect(requestBody.imp[0].id).to.equal('243310435309b5');


### PR DESCRIPTION
## Type of change
- [x] Bugfix

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org? 
No

## Description of change
<!-- Describe the change proposed in this pull request -->
Notice that ttd adapter is using `bidderRequest.auctionId` instead of  `bidderRequest.bidderRequestId`.

Looking at https://github.com/prebid/Prebid.js/commit/df66cdb1b90ddde1aaa7960b9f3c09eb89242ee8 it seems like it should be  `bidderRequest.bidderRequestId`

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
