### PR TITLE
SmileWanted Bid Adapter : add gvlid

### DIFF
--- a/modules/smilewantedBidAdapter.js
+++ b/modules/smilewantedBidAdapter.js
@@ -4,9 +4,12 @@ import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 
+const GVL_ID = 639;
+
 export const spec = {
   code: 'smilewanted',
   aliases: ['smile', 'sw'],
+  gvlid: GVL_ID,
   supportedMediaTypes: [BANNER, VIDEO],
   /**
    * Determines whether or not the given bid request is valid.


### PR DESCRIPTION
## Overview
In the context of ensuring compliance with the IAB's Transparency and Consent Framework (TCF) v2.2, it was identified that the `smilewanted` adapter lacked a defined `gvlid`. This omission led to issues with the handling of user consent, resulting in warnings and the adapter not being called as expected.

This PR addresses the oversight by adding the `gvlid` for SmileWanted, which is `639`, to the adapter's definition. It's related to the issue reported [here](https://github.com/prebid/Prebid.js/issues/10422).

## Changes
- Added `gvlid: 639` to the `smilewanted` bid adapter.

## Expected Impact
- Resolves the warning: `WARNING: Activity control: TCF2 denied 'fetchBids' for 'bidder.smilewanted'`.
- Ensures the `smilewanted` adapter can participate in auctions when appropriate consent or legitimate interest is established.
