### PR TITLE
LiveIntent UserId module: fix Ajax timeout when calling the collector endpoint

### DIFF
--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -12,6 +12,7 @@ import { gdprDataHandler, uspDataHandler } from '../src/adapterManager.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 
+const DEFAULT_AJAX_TIMEOUT = 5000
 const EVENTS_TOPIC = 'pre_lips'
 const MODULE_NAME = 'liveIntentId';
 const LI_PROVIDER_DOMAIN = 'liveintent.com';
@@ -99,11 +100,10 @@ function initializeLiveConnect(configParams) {
   if (configParams.url) {
     identityResolutionConfig.url = configParams.url
   }
-  if (configParams.ajaxTimeout) {
-    identityResolutionConfig.ajaxTimeout = configParams.ajaxTimeout;
-  }
 
   const liveConnectConfig = parseLiveIntentCollectorConfig(configParams.liCollectConfig);
+
+  liveConnectConfig.ajaxTimeout = configParams.ajaxTimeout || DEFAULT_AJAX_TIMEOUT;
 
   if (!liveConnectConfig.appId && configParams.distributorId) {
     liveConnectConfig.distributorId = configParams.distributorId;

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -66,6 +66,7 @@ function parseLiveIntentCollectorConfig(collectConfig) {
   collectConfig.fpiStorageStrategy && (config.storageStrategy = collectConfig.fpiStorageStrategy);
   collectConfig.fpiExpirationDays && (config.expirationDays = collectConfig.fpiExpirationDays);
   collectConfig.collectorUrl && (config.collectorUrl = collectConfig.collectorUrl);
+  config.ajaxTimeout = collectConfig.ajaxTimeout || DEFAULT_AJAX_TIMEOUT;
   return config;
 }
 
@@ -101,9 +102,9 @@ function initializeLiveConnect(configParams) {
     identityResolutionConfig.url = configParams.url
   }
 
-  const liveConnectConfig = parseLiveIntentCollectorConfig(configParams.liCollectConfig);
+  identityResolutionConfig.ajaxTimeout = configParams.ajaxTimeout || DEFAULT_AJAX_TIMEOUT;
 
-  liveConnectConfig.ajaxTimeout = configParams.ajaxTimeout || DEFAULT_AJAX_TIMEOUT;
+  const liveConnectConfig = parseLiveIntentCollectorConfig(configParams.liCollectConfig);
 
   if (!liveConnectConfig.appId && configParams.distributorId) {
     liveConnectConfig.distributorId = configParams.distributorId;

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "express": "^4.15.4",
         "fun-hooks": "^0.9.9",
         "just-clone": "^1.0.2",
-        "live-connect-js": "^6.0.0"
         "live-connect-js": "^6.0.1"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "fun-hooks": "^0.9.9",
         "just-clone": "^1.0.2",
         "live-connect-js": "^6.0.0"
+        "live-connect-js": "^6.0.1"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.16.5",
@@ -16260,12 +16261,12 @@
       }
     },
     "node_modules/live-connect-js": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.0.0.tgz",
-      "integrity": "sha512-4iMSeDPpueYoGEK4U152yKg+hj7jTxkzyfJUAGxtVHxdgjsjh8QmP3kLlTLBBrR/g/L/WCX47PBQxtGW9z8Rlw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.0.1.tgz",
+      "integrity": "sha512-+TwM7cjgyutqaMNlTQKNY9nJFDPpSWfoazSHmlWxOPlimp10PSZGABIbtulNGGpYbR/Zxgc+C/uW5OxqcNEPXg==",
       "dependencies": {
         "live-connect-common": "^3.0.0",
-        "live-connect-handlers": "^2.0.0",
+        "live-connect-handlers": "^2.1.0",
         "tiny-hashes": "1.0.1"
       },
       "engines": {
@@ -37923,12 +37924,12 @@
       }
     },
     "live-connect-js": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.0.0.tgz",
-      "integrity": "sha512-4iMSeDPpueYoGEK4U152yKg+hj7jTxkzyfJUAGxtVHxdgjsjh8QmP3kLlTLBBrR/g/L/WCX47PBQxtGW9z8Rlw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.0.1.tgz",
+      "integrity": "sha512-+TwM7cjgyutqaMNlTQKNY9nJFDPpSWfoazSHmlWxOPlimp10PSZGABIbtulNGGpYbR/Zxgc+C/uW5OxqcNEPXg==",
       "requires": {
         "live-connect-common": "^3.0.0",
-        "live-connect-handlers": "^2.0.0",
+        "live-connect-handlers": "^2.1.0",
         "tiny-hashes": "1.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "express": "^4.15.4",
     "fun-hooks": "^0.9.9",
     "just-clone": "^1.0.2",
-    "live-connect-js": "^6.0.0"
+    "live-connect-js": "^6.0.1"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Prebid has changed the semantics of the Ajax timeout 0. It used to mean "no timeout". In Prebid version 8 it mean "immediate" timeout. This affected the calls to the collector endpoint which had a default timeout of 0. This PR introduces a default non-zero Ajax timeout for the collector endpoint, makes that timeout configurable and also makes the default Ajax timeout for the resolution endpoint more explicit (not hidden in the live-connect dependency). 

## Other information
- documentation: https://github.com/prebid/prebid.github.io/pull/4835
