### PR TITLE
Coinzilla Bid Adapter: change TTL to server response

### DIFF
--- a/modules/coinzillaBidAdapter.js
+++ b/modules/coinzillaBidAdapter.js
@@ -77,7 +77,7 @@ export const spec = {
         dealId: dealId,
         currency: currency,
         netRevenue: netRevenue,
-        ttl: bidRequest.timeout,
+        ttl: response.timeout,
         referrer: referrer,
         ad: response.ad,
         mediaType: response.mediaType,


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Changed the TTL value to be fetched from server response.

## Other information
