### PR TITLE
AdFusion Bid Adapter : initial release

### DIFF
--- a/modules/adfusionBidAdapter.js
+++ b/modules/adfusionBidAdapter.js
@@ -1,0 +1,90 @@
+import { ortbConverter } from '../libraries/ortbConverter/converter.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import * as utils from '../src/utils.js';
+
+const adpterVersion = '1.0';
+export const REQUEST_URL = 'https://spicyrtb.com/auction/prebid';
+
+export const spec = {
+  code: 'adfusion',
+  gvlid: 844,
+  supportedMediaTypes: [BANNER, VIDEO],
+  isBidRequestValid,
+  buildRequests,
+  interpretResponse,
+  isBannerBid,
+  isVideoBid,
+};
+
+registerBidder(spec);
+
+const converter = ortbConverter({
+  context: {
+    netRevenue: true,
+    ttl: 300,
+  },
+  request(buildRequest, imps, bidderRequest, context) {
+    const req = buildRequest(imps, bidderRequest, context);
+    const bid = context.bidRequests[0];
+    utils.mergeDeep(req, {
+      at: 1,
+      ext: {
+        prebid: {
+          accountid: bid.params.accountId,
+          adapterVersion: `${adpterVersion}`,
+        },
+      },
+    });
+    return req;
+  },
+  response(buildResponse, bidResponses, ortbResponse, context) {
+    const response = buildResponse(bidResponses, ortbResponse, context);
+    return response.bids;
+  },
+});
+
+function isBidRequestValid(bidRequest) {
+  const isValid = bidRequest.params.accountId;
+  if (!isValid) {
+    utils.logError('AdFusion adapter bidRequest has no accountId');
+    return false;
+  }
+  return true;
+}
+
+function buildRequests(bids, bidderRequest) {
+  let videoBids = bids.filter((bid) => isVideoBid(bid));
+  let bannerBids = bids.filter((bid) => isBannerBid(bid));
+  let requests = bannerBids.length
+    ? [createRequest(bannerBids, bidderRequest, BANNER)]
+    : [];
+  videoBids.forEach((bid) => {
+    requests.push(createRequest([bid], bidderRequest, VIDEO));
+  });
+  return requests;
+}
+
+function createRequest(bidRequests, bidderRequest, mediaType) {
+  return {
+    method: 'POST',
+    url: REQUEST_URL,
+    data: converter.toORTB({
+      bidRequests,
+      bidderRequest,
+      context: { mediaType },
+    }),
+  };
+}
+
+function isVideoBid(bid) {
+  return utils.deepAccess(bid, 'mediaTypes.video');
+}
+
+function isBannerBid(bid) {
+  return utils.deepAccess(bid, 'mediaTypes.banner');
+}
+
+function interpretResponse(resp, req) {
+  return converter.fromORTB({ request: req.data, response: resp.body });
+}

--- a/modules/adfusionBidAdapter.md
+++ b/modules/adfusionBidAdapter.md
@@ -1,0 +1,61 @@
+# Overview
+
+```
+Module Name: AdFusion Bid Adapter
+Module Type: Bidder Adapter
+Maintainer: prebid@adfusion.pl
+```
+
+# Description
+
+Module that connects to AdFusion demand sources
+
+# Banner Test Parameters
+
+```js
+var adUnits = [
+  {
+    code: "test-banner",
+    mediaTypes: {
+      banner: {
+        sizes: [
+          [300, 250],
+          [300, 600],
+          [320, 480],
+        ],
+      },
+    },
+    bids: [
+      {
+        bidder: "adfusion",
+        params: {
+          accountId: 1234, // required
+        },
+      },
+    ],
+  },
+];
+```
+
+# Video Test Parameters
+
+```js
+var videoAdUnit = {
+  code: "video1",
+  mediaTypes: {
+    video: {
+      context: "instream",
+      playerSize: [640, 480],
+      mimes: ["video/mp4"],
+    },
+  },
+  bids: [
+    {
+      bidder: "adfusion",
+      params: {
+        accountId: 1234, // required
+      },
+    },
+  ],
+};
+```

--- a/test/spec/modules/adfusionBidAdapter_spec.js
+++ b/test/spec/modules/adfusionBidAdapter_spec.js
@@ -1,0 +1,97 @@
+import { expect } from 'chai';
+import { spec } from 'modules/adfusionBidAdapter';
+import 'modules/priceFloors.js';
+import { newBidder } from 'src/adapters/bidderFactory';
+
+describe('adfusionBidAdapter', function () {
+  const adapter = newBidder(spec);
+  describe('inherited functions', function () {
+    it('exists and is a function', function () {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+  });
+
+  describe('isBidRequestValid', function () {
+    const bid = {
+      bidder: 'adfusion',
+      params: {
+        accountId: 1234,
+      },
+      adUnitCode: '/adunit-code/test-path',
+      bidId: 'test-bid-id-1',
+      bidderRequestId: 'test-bid-request-1',
+      auctionId: 'test-auction-1',
+      transactionId: 'test-transactionId-1',
+    };
+
+    it('should return true when required params found', function () {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should return false when params.accountID is missing', function () {
+      let localbid = Object.assign({}, bid);
+      delete localbid.params.accountId;
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', function () {
+    let bidRequests, bidderRequest;
+    beforeEach(function () {
+      bidRequests = [
+        {
+          bidder: 'adfusion',
+          params: {
+            accountId: 1234,
+          },
+          mediaTypes: {
+            banner: {
+              sizes: [
+                [300, 250],
+                [300, 600],
+              ],
+            },
+          },
+          adUnitCode: '/adunit-code/test-path',
+          bidId: 'test-bid-id-1',
+          bidderRequestId: 'test-bid-request-1',
+          auctionId: 'test-auction-1',
+          transactionId: 'test-transactionId-1',
+        },
+        {
+          bidder: 'adfusion',
+          params: {
+            accountId: 1234,
+          },
+          adUnitCode: 'adunit-code',
+          mediaTypes: {
+            video: {
+              playerSize: [640, 480],
+            },
+          },
+          bidId: 'test-bid-id-2',
+          bidderRequestId: 'test-bid-request-2',
+          auctionId: 'test-auction-2',
+          transactionId: 'test-transactionId-2',
+        },
+      ];
+      bidderRequest = { refererInfo: {} };
+    });
+
+    it('should return an empty array when no bid requests', function () {
+      const bidRequest = spec.buildRequests([], bidderRequest);
+      expect(bidRequest).to.be.an('array');
+      expect(bidRequest.length).to.equal(0);
+    });
+
+    it('should return a valid bid request object', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      expect(request).to.be.an('array');
+      expect(request[0].data).to.be.an('object');
+      expect(request[0].method).to.equal('POST');
+      expect(request[0].url).to.not.equal('');
+      expect(request[0].url).to.not.equal(undefined);
+      expect(request[0].url).to.not.equal(null);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 

## Description of change
<!-- Describe the change proposed in this pull request -->

- contact email of the adapter’s maintainer: prebid@adfusion.pl
- test parameters for validating bids:
```
{
  bidder: 'adfusion',
  mediaTypes: {
     banner: {
       sizes: [[300, 250]],
     }
  },
  params: {
    accountId: 42, // Required
  }
}
```


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Docs PR:
https://github.com/prebid/prebid.github.io/pull/4855
