### PR TITLE
Smartyads Bid Adapter : send notices only on prebid host

### DIFF
--- a/modules/smartyadsBidAdapter.js
+++ b/modules/smartyadsBidAdapter.js
@@ -129,16 +129,22 @@ export const spec = {
     if (bid.winUrl) {
       ajax(bid.winUrl, () => {}, JSON.stringify(bid));
     } else {
-      ajax('https://et-nd43.itdsmr.com/?c=o&m=prebid&secret_key=prebid_js&winTest=1', () => {}, JSON.stringify(bid));
+      if (bid?.postData && bid?.postData[0] && bid?.postData[0].params && bid?.postData[0].params[0].host == 'prebid') {
+        ajax('https://et-nd43.itdsmr.com/?c=o&m=prebid&secret_key=prebid_js&winTest=1', () => {}, JSON.stringify(bid));
+      }
     }
   },
 
   onTimeout: function(bid) {
-    ajax('https://et-nd43.itdsmr.com/?c=o&m=prebid&secret_key=prebid_js&bidTimeout=1', () => {}, JSON.stringify(bid));
+    if (bid?.postData && bid?.postData[0] && bid?.postData[0].params && bid?.postData[0].params[0].host == 'prebid') {
+      ajax('https://et-nd43.itdsmr.com/?c=o&m=prebid&secret_key=prebid_js&bidTimeout=1', () => {}, JSON.stringify(bid));
+    }
   },
 
   onBidderError: function(bid) {
-    ajax('https://et-nd43.itdsmr.com/?c=o&m=prebid&secret_key=prebid_js&bidderError=1', () => {}, JSON.stringify(bid));
+    if (bid?.postData && bid?.postData[0] && bid?.postData[0].params && bid?.postData[0].params[0].host == 'prebid') {
+      ajax('https://et-nd43.itdsmr.com/?c=o&m=prebid&secret_key=prebid_js&bidderError=1', () => {}, JSON.stringify(bid));
+    }
   },
 
 };

--- a/test/spec/modules/smartyadsBidAdapter_spec.js
+++ b/test/spec/modules/smartyadsBidAdapter_spec.js
@@ -280,7 +280,21 @@ describe('SmartyadsAdapter', function () {
     });
 
     it('should send a valid bid won notice', function () {
-      spec.onBidWon(bidResponse);
+      const bid = {
+        'c': 'o',
+        'm': 'prebid',
+        'secret_key': 'prebid_js',
+        'winTest': '1',
+        'postData': [{
+          'bidder': 'smartyads',
+          'params': [
+            {'host': 'prebid',
+              'accountid': '123',
+              'sourceid': '12345'
+            }]
+        }]
+      };
+      spec.onBidWon(bid);
       expect(server.requests.length).to.equal(1);
     });
   });
@@ -291,7 +305,21 @@ describe('SmartyadsAdapter', function () {
     });
 
     it('should send a valid bid timeout notice', function () {
-      spec.onTimeout({});
+      const bid = {
+        'c': 'o',
+        'm': 'prebid',
+        'secret_key': 'prebid_js',
+        'bidTimeout': '1',
+        'postData': [{
+          'bidder': 'smartyads',
+          'params': [
+            {'host': 'prebid',
+              'accountid': '123',
+              'sourceid': '12345'
+            }]
+        }]
+      };
+      spec.onTimeout(bid);
       expect(server.requests.length).to.equal(1);
     });
   });
@@ -302,7 +330,21 @@ describe('SmartyadsAdapter', function () {
     });
 
     it('should send a valid bidder error notice', function () {
-      spec.onBidderError({});
+      const bid = {
+        'c': 'o',
+        'm': 'prebid',
+        'secret_key': 'prebid_js',
+        'bidderError': '1',
+        'postData': [{
+          'bidder': 'smartyads',
+          'params': [
+            {'host': 'prebid',
+              'accountid': '123',
+              'sourceid': '12345'
+            }]
+        }]
+      };
+      spec.onBidderError(bid);
       expect(server.requests.length).to.equal(1);
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
