### PR TITLE
Grid Bid Adapter: parse timeout and bidfloor to integer and float values

### DIFF
--- a/modules/gridBidAdapter.js
+++ b/modules/gridBidAdapter.js
@@ -91,7 +91,7 @@ export const spec = {
     let {bidderRequestId, gdprConsent, uspConsent, timeout, refererInfo, gppConsent} = bidderRequest || {};
 
     const referer = refererInfo ? encodeURIComponent(refererInfo.page) : '';
-    const tmax = timeout;
+    const tmax = parseInt(timeout) || null;
     const imp = [];
     const bidsMap = {};
     const requests = [];
@@ -133,7 +133,7 @@ export const spec = {
       };
       if (ortb2Imp) {
         if (ortb2Imp.instl) {
-          impObj.instl = ortb2Imp.instl;
+          impObj.instl = parseInt(ortb2Imp.instl) || null;
         }
 
         if (ortb2Imp.ext) {
@@ -485,7 +485,7 @@ export const spec = {
  */
 function _getFloor (mediaTypes, bid) {
   const curMediaType = mediaTypes.video ? 'video' : 'banner';
-  let floor = bid.params.bidFloor || bid.params.floorcpm || 0;
+  let floor = parseFloat(bid.params.bidFloor || bid.params.floorcpm || 0) || null;
 
   if (typeof bid.getFloor === 'function') {
     const floorInfo = bid.getFloor({
@@ -595,8 +595,8 @@ function createVideoRequest(videoParams, mediaType, bidSizes) {
 
   if (!videoData.w || !videoData.h) return;
 
-  const minDur = mind || durationRangeSec[0] || videoData.minduration;
-  const maxDur = maxd || durationRangeSec[1] || videoData.maxduration;
+  const minDur = mind || durationRangeSec[0] || parseInt(videoData.minduration) || null;
+  const maxDur = maxd || durationRangeSec[1] || parseInt(videoData.maxduration) || null;
 
   if (minDur) {
     videoData.minduration = minDur;

--- a/test/spec/modules/gridBidAdapter_spec.js
+++ b/test/spec/modules/gridBidAdapter_spec.js
@@ -941,6 +941,15 @@ describe('TheMediaGrid Adapter', function () {
       getDataFromLocalStorageStub.restore();
     })
 
+    it('tmax should be set as integer', function() {
+      let [request] = spec.buildRequests([bidRequests[0]], {...bidderRequest, timeout: '10'});
+      let payload = parseRequest(request.data);
+      expect(payload.tmax).to.equal(10);
+      [request] = spec.buildRequests([bidRequests[0]], {...bidderRequest, timeout: 'ddqwdwdq'});
+      payload = parseRequest(request.data);
+      expect(payload.tmax).to.equal(null);
+    })
+
     describe('floorModule', function () {
       const floorTestData = {
         'currency': 'USD',
@@ -974,6 +983,15 @@ describe('TheMediaGrid Adapter', function () {
         expect(request.data).to.be.an('string');
         const payload = parseRequest(request.data);
         expect(payload.imp[0].bidfloor).to.equal(bidfloor);
+      });
+      it('should return the bidfloor string value if it is greater than getFloor.floor', function () {
+        const bidfloor = '1.80';
+        const bidRequestsWithFloor = { ...bidRequest };
+        bidRequestsWithFloor.params = Object.assign({bidFloor: bidfloor}, bidRequestsWithFloor.params);
+        const [request] = spec.buildRequests([bidRequestsWithFloor], bidderRequest);
+        expect(request.data).to.be.an('string');
+        const payload = parseRequest(request.data);
+        expect(payload.imp[0].bidfloor).to.equal(1.80);
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
