### PR TITLE
Adkernel: adliveconnect alias removal

### DIFF
--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -98,7 +98,6 @@ export const spec = {
     {code: 'displayioads'},
     {code: 'rtbdemand_com'},
     {code: 'bidbuddy'},
-    {code: 'adliveconnect'},
     {code: 'didnadisplay'},
     {code: 'qortex'},
     {code: 'adpluto'},


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
Removed adliveconnect alias for adkernel adaptor.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
