### PR TITLE
Yieldmo Bid Adapter : dont require params.video

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -432,12 +432,12 @@ function openRtbImpression(bidRequest) {
     }
   };
 
-  const mediaTypesParams = deepAccess(bidRequest, 'mediaTypes.video');
+  const mediaTypesParams = deepAccess(bidRequest, 'mediaTypes.video', {});
   Object.keys(mediaTypesParams)
     .filter(param => includes(OPENRTB_VIDEO_BIDPARAMS, param))
     .forEach(param => imp.video[param] = mediaTypesParams[param]);
 
-  const videoParams = deepAccess(bidRequest, 'params.video');
+  const videoParams = deepAccess(bidRequest, 'params.video', {});
   Object.keys(videoParams)
     .filter(param => includes(OPENRTB_VIDEO_BIDPARAMS, param))
     .forEach(param => imp.video[param] = videoParams[param]);

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -425,6 +425,18 @@ describe('YieldmoAdapter', function () {
         expect(requests[0].url).to.be.equal(VIDEO_ENDPOINT);
       });
 
+      it('should not require params.video if required props in mediaTypes.video', function () {
+        videoBid.mediaTypes.video = {
+          ...videoBid.mediaTypes.video,
+          ...videoBid.params.video
+        };
+        delete videoBid.params.video;
+        const requests = build([videoBid]);
+        expect(requests.length).to.equal(1);
+        expect(requests[0].method).to.equal('POST');
+        expect(requests[0].url).to.be.equal(VIDEO_ENDPOINT);
+      });
+
       it('should add mediaTypes.video prop to the imp.video prop', function () {
         utils.deepAccess(videoBid, 'mediaTypes.video')['minduration'] = 40;
         expect(buildVideoBidAndGetVideoParam().minduration).to.equal(40);


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
The [Yieldmo Bidder Docs](https://docs.prebid.org/dev-docs/bidders/yieldmo.html?pbjs_debug=true) show example configurations where video ortb data can be in either `mediaTypes.video` OR `params.video`

However it breaks if at least one params.video parameter is NOT there (not safe checking Object.keys)

Not sure if this is intended or not, but it was an easy fix so I updated it.

![image](https://github.com/prebid/Prebid.js/assets/13972794/ca733905-d6cc-45a9-b3b4-019bc15f7f7d)


![image](https://github.com/prebid/Prebid.js/assets/13972794/98ef1875-5c67-42db-9dd0-94d792fad952)


