### PR TITLE
consentManagementGpp: do not require `supportedAPIs` from CMP

### DIFF
--- a/modules/consentManagementGpp.js
+++ b/modules/consentManagementGpp.js
@@ -247,7 +247,7 @@ class GPP10Client extends GPPClient {
 
   getGPPData(pingData) {
     const parsedSections = GreedyPromise.all(
-      pingData.supportedAPIs.map((api) => this.cmp({
+      (pingData.supportedAPIs || pingData.apiSupport || []).map((api) => this.cmp({
         command: 'getSection',
         parameter: api
       }).catch(err => {

--- a/test/spec/modules/consentManagementGpp_spec.js
+++ b/test/spec/modules/consentManagementGpp_spec.js
@@ -572,6 +572,17 @@ describe('consentManagementGpp', function () {
           expect(err.message).to.eql('err');
           done();
         });
+      });
+
+      it('should not choke if supportedAPIs is missing', () => {
+        [gppData, pingData].forEach(ob => { delete ob.supportedAPIs; })
+        mockCmpCommands({
+          getGPPData: () => gppData
+        });
+        return gppClient.getGPPData(pingData).then(res => {
+          expect(res.gppString).to.eql(gppData.gppString);
+          expect(res.parsedSections).to.eql({});
+        })
       })
 
       describe('section data', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Some GPP 1.0 CMPs populate "apiSupport" instead of "supportedAPIs", which breaks our logic and causes auctions to be canceled. This PR looks for either and treats a missing api list as if it were an empty api list.


