### PR TITLE
Optimera RTD Module : adding apiVersion param and v1 endpoint

### DIFF
--- a/modules/optimeraRtdProvider.js
+++ b/modules/optimeraRtdProvider.js
@@ -16,6 +16,7 @@
  * @property {string} clientID
  * @property {string} optimeraKeyName
  * @property {string} device
+ * @property {string} apiVersion
  */
 
 import { logInfo, logError } from '../src/utils.js';
@@ -38,7 +39,10 @@ export let optimeraKeyName = 'hb_deal_optimera';
  * the targeting values.
  * @type {string}
  */
-export const scoresBaseURL = 'https://dyv1bugovvq1g.cloudfront.net/';
+export const scoresBaseURL = {
+  v0: 'https://dyv1bugovvq1g.cloudfront.net/',
+  v1: 'https://v1.oapi26b.com/',
+};
 
 /**
  * Optimera Score File URL.
@@ -57,6 +61,12 @@ export let clientID;
  * @type {string}
  */
 export let device = 'default';
+
+/**
+ * Optional apiVersion parameter.
+ * @type {string}
+ */
+export let apiVersion = 'v0';
 
 /**
  * Targeting object for all ad positions.
@@ -127,6 +137,7 @@ export function onAuctionInit(auctionDetails, config, userConsent) {
 
 /**
  * Initialize the Module.
+ * moduleConfig.params.apiVersion can be either v0 or v1.
  */
 export function init(moduleConfig) {
   _moduleParams = moduleConfig.params;
@@ -137,6 +148,9 @@ export function init(moduleConfig) {
     }
     if (_moduleParams.device) {
       device = _moduleParams.device;
+    }
+    if (_moduleParams.apiVersion) {
+      apiVersion = (_moduleParams.apiVersion.includes('v1', 'v0')) ? _moduleParams.apiVersion : 'v0';
     }
     setScoresURL();
     scoreFileRequest();
@@ -162,7 +176,15 @@ export function init(moduleConfig) {
 export function setScoresURL() {
   const optimeraHost = window.location.host;
   const optimeraPathName = window.location.pathname;
-  const newScoresURL = `${scoresBaseURL}${clientID}/${optimeraHost}${optimeraPathName}.js`;
+  const baseUrl = scoresBaseURL[apiVersion] ? scoresBaseURL[apiVersion] : scoresBaseURL.v0;
+  let newScoresURL;
+
+  if (apiVersion === 'v1') {
+    newScoresURL = `${baseUrl}api/products/scores?c=${clientID}&h=${optimeraHost}&p=${optimeraPathName}&s=${device}`;
+  } else {
+    newScoresURL = `${baseUrl}${clientID}/${optimeraHost}${optimeraPathName}.js`;
+  }
+
   if (scoresURL !== newScoresURL) {
     scoresURL = newScoresURL;
     fetchScoreFile = true;

--- a/modules/optimeraRtdProvider.md
+++ b/modules/optimeraRtdProvider.md
@@ -1,6 +1,6 @@
 # Overview
 ```
-Module Name: Optimera Real Time Date Module
+Module Name: Optimera Real Time Data Module
 Module Type: RTD Module
 Maintainer: mcallari@optimera.nyc
 ```
@@ -26,7 +26,8 @@ Configuration example for using RTD module with `optimera` provider
           params: {
             clientID: '9999',
             optimeraKeyName: 'optimera',
-            device: 'de'
+            device: 'de',
+            apiVersion: 'v0',
           }
         }
       ]
@@ -42,3 +43,4 @@ Contact Optimera to get assistance with the params.
 | clientID  | string  | required | Optimera Client ID |
 | optimeraKeyName  | string  | optional |  GAM key name for Optimera. If migrating from the Optimera bidder adapter this will default to hb_deal_optimera and can be ommitted from the configuration. |
 | device  | string  | optional | Device type code for mobile, tablet, or desktop. Either mo, tb, de |
+| apiVersion  | string  | optional | Optimera API Versions. Either v0, or v1. ** Note: v1 wll need to be enabled specifically for your account, otherwise use v0.

--- a/test/spec/modules/optimeraRtdProvider_spec.js
+++ b/test/spec/modules/optimeraRtdProvider_spec.js
@@ -21,10 +21,77 @@ describe('Optimera RTD sub module', () => {
   });
 });
 
-describe('Optimera RTD score file url is properly set', () => {
-  it('Proerly set the score file url', () => {
+describe('Optimera RTD score file URL is properly set for v0', () => {
+  it('should properly set the score file URL', () => {
+    const conf = {
+      dataProviders: [{
+        name: 'optimeraRTD',
+        params: {
+          clientID: '9999',
+          optimeraKeyName: 'optimera',
+          device: 'de',
+          apiVersion: 'v0',
+        }
+      }]
+    };
+    optimeraRTD.init(conf.dataProviders[0]);
+    optimeraRTD.setScores();
+    expect(optimeraRTD.apiVersion).to.equal('v0');
+    expect(optimeraRTD.scoresURL).to.equal('https://dyv1bugovvq1g.cloudfront.net/9999/localhost:9876/context.html.js');
+  });
+
+  it('should properly set the score file URL without apiVersion set', () => {
+    const conf = {
+      dataProviders: [{
+        name: 'optimeraRTD',
+        params: {
+          clientID: '9999',
+          optimeraKeyName: 'optimera',
+          device: 'de',
+        }
+      }]
+    };
+    optimeraRTD.init(conf.dataProviders[0]);
+    optimeraRTD.setScores();
+    expect(optimeraRTD.apiVersion).to.equal('v0');
+    expect(optimeraRTD.scoresURL).to.equal('https://dyv1bugovvq1g.cloudfront.net/9999/localhost:9876/context.html.js');
+  });
+
+  it('should properly set the score file URL with an api version other than v0 or v1', () => {
+    const conf = {
+      dataProviders: [{
+        name: 'optimeraRTD',
+        params: {
+          clientID: '9999',
+          optimeraKeyName: 'optimera',
+          device: 'de',
+          apiVersion: 'v15',
+        }
+      }]
+    };
+    optimeraRTD.init(conf.dataProviders[0]);
     optimeraRTD.setScores();
     expect(optimeraRTD.scoresURL).to.equal('https://dyv1bugovvq1g.cloudfront.net/9999/localhost:9876/context.html.js');
+  });
+});
+
+describe('Optimera RTD score file URL is properly set for v1', () => {
+  it('should properly set the score file URL', () => {
+    const conf = {
+      dataProviders: [{
+        name: 'optimeraRTD',
+        params: {
+          clientID: '9999',
+          optimeraKeyName: 'optimera',
+          device: 'de',
+          apiVersion: 'v1',
+        }
+      }]
+    };
+    optimeraRTD.init(conf.dataProviders[0]);
+    optimeraRTD.setScores();
+    expect(optimeraRTD.apiVersion).to.equal('v1');
+    expect(optimeraRTD.scoresURL).to.equal('https://v1.oapi26b.com/api/products/scores?c=9999&h=localhost:9876&p=/context.html&s=de');
   });
 });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
There is a new endpoint version available. This update adds an apiVersion param to the OptimeraRTD config, and the new endpoint option in the network request for targeting. If an apiVersion is not set, the current version will be used to ensure backwards compatibility.

Doc update:
https://github.com/prebid/prebid.github.io/pull/4860

