### PR TITLE
Cadent Aperture MX Bid Adapter: address auctionId/transactionId leak

### DIFF
--- a/modules/cadentApertureMXBidAdapter.js
+++ b/modules/cadentApertureMXBidAdapter.js
@@ -277,7 +277,7 @@ export const spec = {
       let isVideo = !!bid.mediaTypes.video;
       let data = {
         id: bid.bidId,
-        tid: bid.transactionId,
+        tid: bid.ortb2Imp?.ext?.tid,
         tagid,
         secure
       };
@@ -297,7 +297,7 @@ export const spec = {
     });
 
     let cadentData = {
-      id: bidderRequest.auctionId,
+      id: bidderRequest.auctionId ?? bidderRequest.bidderRequestId,
       imp: cadentImps,
       device,
       site,

--- a/test/spec/modules/cadentApertureMXBidAdapter_spec.js
+++ b/test/spec/modules/cadentApertureMXBidAdapter_spec.js
@@ -237,6 +237,11 @@ describe('cadent_aperture_mx Adapter', function () {
         'bidId': '30b31c2501de1e',
         'auctionId': 'e19f1eff-8b27-42a6-888d-9674e5a6130c',
         'transactionId': 'd7b773de-ceaa-484d-89ca-d9f51b8d61ec',
+        'ortb2Imp': {
+          'ext': {
+            'tid': 'd7b773de-ceaa-484d-89ca-d9f51b8d61ed',
+          },
+        },
       }]
     };
     let request = spec.buildRequests(bidderRequest.bids, bidderRequest);
@@ -297,10 +302,20 @@ describe('cadent_aperture_mx Adapter', function () {
         expect(data.id).to.equal(bidderRequest.auctionId);
         expect(data.imp.length).to.equal(1);
         expect(data.imp[0].id).to.equal('30b31c2501de1e');
-        expect(data.imp[0].tid).to.equal('d7b773de-ceaa-484d-89ca-d9f51b8d61ec');
+        expect(data.imp[0].tid).to.equal('d7b773de-ceaa-484d-89ca-d9f51b8d61ed');
         expect(data.imp[0].tagid).to.equal('25251');
         expect(data.imp[0].secure).to.equal(0);
         expect(data.imp[0].vastXml).to.equal(undefined);
+      });
+
+      it('populates id even when auctionId is not available', function () {
+        // addressing https://github.com/prebid/Prebid.js/issues/9781
+        bidderRequest.auctionId = null;
+        request = spec.buildRequests(bidderRequest.bids, bidderRequest);
+
+        const data = JSON.parse(request.data);
+        expect(data.id).not.to.be.null;
+        expect(data.id).not.to.equal(bidderRequest.auctionId);
       });
 
       it('properly sends site information and protocol', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Addressing the transactionId/auctionId leak from https://github.com/prebid/Prebid.js/issues/9781
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
https://github.com/prebid/Prebid.js/issues/9781