### PR TITLE
userId: group UIDs by source when possible

### DIFF
--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -32,34 +32,23 @@ function createEidObject(userIdData, subModuleKey) {
   return null;
 }
 
-// this function will generate eids array for all available IDs in bidRequest.userId
-// this function will be called by userId module
-// if any adapter does not want any particular userId to be passed then adapter can use Array.filter(e => e.source != 'tdid')
 export function createEidsArray(bidRequestUserId) {
-  let eids = [];
-
-  for (const subModuleKey in bidRequestUserId) {
-    if (bidRequestUserId.hasOwnProperty(subModuleKey)) {
-      if (subModuleKey === 'pubProvidedId') {
-        eids = eids.concat(bidRequestUserId['pubProvidedId']);
-      } else if (Array.isArray(bidRequestUserId[subModuleKey])) {
-        bidRequestUserId[subModuleKey].forEach((config, index, arr) => {
-          const eid = createEidObject(config, subModuleKey);
-
-          if (eid) {
-            eids.push(eid);
-          }
-        })
-      } else {
-        const eid = createEidObject(bidRequestUserId[subModuleKey], subModuleKey);
-        if (eid) {
-          eids.push(eid);
-        }
-      }
+  const allEids = {};
+  function collect(eid) {
+    const key = JSON.stringify([eid.source?.toLowerCase(), eid.ext]);
+    if (allEids.hasOwnProperty(key)) {
+      allEids[key].uids.push(...eid.uids);
+    } else {
+      allEids[key] = eid;
     }
   }
 
-  return eids;
+  Object.entries(bidRequestUserId).forEach(([name, values]) => {
+    values = Array.isArray(values) ? values : [values];
+    const eids = name === 'pubProvidedId' ? values : values.map(value => createEidObject(value, name));
+    eids.filter(eid => eid != null).forEach(collect);
+  })
+  return Object.values(allEids);
 }
 
 /**

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -382,6 +382,75 @@ describe('User ID', function () {
       });
     });
 
+    describe('createEidsArray', () => {
+      beforeEach(() => {
+        init(config);
+        setSubmoduleRegistry([
+          createMockIdSubmodule('mockId1', null, null,
+            {'mockId1': {source: 'mock1source', atype: 1}}),
+          createMockIdSubmodule('mockId2v1', null, null,
+            {'mockId2v1': {source: 'mock2source', atype: 2, getEidExt: () => ({v: 1})}}),
+          createMockIdSubmodule('mockId2v2', null, null,
+            {'mockId2v2': {source: 'mock2source', atype: 2, getEidExt: () => ({v: 2})}}),
+        ]);
+      });
+
+      it('should group UIDs by source and ext', () => {
+        const eids = createEidsArray({
+          mockId1: ['mock-1-1', 'mock-1-2'],
+          mockId2v1: ['mock-2-1', 'mock-2-2'],
+          mockId2v2: ['mock-2-1', 'mock-2-2']
+        });
+        expect(eids).to.eql([
+          {
+            source: 'mock1source',
+            uids: [
+              {
+                id: 'mock-1-1',
+                atype: 1,
+              },
+              {
+                id: 'mock-1-2',
+                atype: 1,
+              }
+            ]
+          },
+          {
+            source: 'mock2source',
+            ext: {
+              v: 1
+            },
+            uids: [
+              {
+                id: 'mock-2-1',
+                atype: 2,
+              },
+              {
+                id: 'mock-2-2',
+                atype: 2,
+              }
+            ]
+          },
+          {
+            source: 'mock2source',
+            ext: {
+              v: 2
+            },
+            uids: [
+              {
+                id: 'mock-2-1',
+                atype: 2,
+              },
+              {
+                id: 'mock-2-2',
+                atype: 2,
+              }
+            ]
+          }
+        ])
+      })
+    })
+
     it('pbjs.getUserIds', function (done) {
       init(config);
       setSubmoduleRegistry([sharedIdSystemSubmodule]);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Prebid Server requires `user.eids` to be [grouped by source](https://github.com/prebid/prebid-server/issues/3097). This updates the userID module to accomodate it when possible (all EIDs for a given source have the same values in `ext`).

## Other information

Fixes https://github.com/prebid/Prebid.js/issues/10479
