### PR TITLE
Core: fix bug where the PBS adapter always times out

### DIFF
--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -422,7 +422,7 @@ adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, request
             bidRequest.start = timestamp();
             return function () {
               onTimelyResponse(bidRequest.bidderRequestId);
-              doneCbs.apply(bidRequest, arguments);
+              doneCb.apply(bidRequest, arguments);
             }
           });
 

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -965,13 +965,23 @@ describe('adapterManager tests', function () {
     }];
 
     it('invokes callBids on the S2S adapter', function () {
+      const done = sinon.stub();
+      const onTimelyResponse = sinon.stub();
+      prebidServerAdapterMock.callBids.callsFake((_1, _2, _3, done) => {
+        done();
+      });
       adapterManager.callBids(
         getAdUnits(),
         bidRequests,
         () => {},
-        () => () => {}
+        done,
+        undefined,
+        undefined,
+        onTimelyResponse
       );
       sinon.assert.calledTwice(prebidServerAdapterMock.callBids);
+      sinon.assert.calledTwice(done);
+      bidRequests.forEach(br => sinon.assert.calledWith(onTimelyResponse, br.bidderRequestId));
     });
 
     // Enable this test when prebidServer adapter is made 1.0 compliant


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fix bug introduced by #10379 - a typo makes the s2s adapter always time out

## Other information
Closes https://github.com/prebid/Prebid.js/issues/10500

