### PR TITLE
update appnexus PBS default configs

### DIFF
--- a/integrationExamples/gpt/prebidServer_example.html
+++ b/integrationExamples/gpt/prebidServer_example.html
@@ -33,31 +33,41 @@
 
     pbjs.que.push(function() {
         var adUnits = [{
-            code: 'div-gpt-ad-1460505748561-0',
-            mediaTypes: {
-              banner: {
-                sizes: [[300, 250]]
-              } 
-            },
-            bids: [
-              {
-                bidder: 'appnexus',
-                params: {
-                   placementId: 13144370
-                }
+          code: 'div-gpt-ad-1460505748561-0',
+          mediaTypes: {
+            banner: {
+              sizes: [600, 500]
+            } 
+          },
+          bids: [
+            {
+              bidder: 'appnexus',
+              params: {
+                placementId: 12883451
               }
-            ]
-          }];
+            }
+          ]
+        }];
 
+        pbjs.bidderSettings = {
+          appnexus: {
+            bidCpmAdjustment: function () {
+              return 10;
+            }
+          }
+        }  
         pbjs.setConfig({
           bidderTimeout: 3000,
           s2sConfig : {
             accountId : '1',
             enabled : true, //default value set to false
-            defaultVendor: 'appnexus',
+            defaultVendor: 'appnexuspsp',
             bidders : ['appnexus'],
             timeout : 1000, //default value is 1000
             adapter : 'prebidServer', //if we have any other s2s adapter, default value is s2s
+          },
+          ortb2: {
+            test: 1
           }
         });
 

--- a/integrationExamples/gpt/prebidServer_fledge_example.html
+++ b/integrationExamples/gpt/prebidServer_fledge_example.html
@@ -50,7 +50,7 @@
         s2sConfig: [{
           accountId : '1',
           enabled : true,
-          defaultVendor: 'appnexus',
+          defaultVendor: 'appnexuspsp',
           bidders : ['openx'],
           timeout : 1500,
           adapter : 'prebidServer'

--- a/modules/prebidServerBidAdapter/config.js
+++ b/modules/prebidServerBidAdapter/config.js
@@ -1,24 +1,15 @@
 // accountId and bidders params are not included here, should be configured by end-user
 export const S2S_VENDORS = {
-  'appnexus': {
-    adapter: 'prebidServer',
-    enabled: true,
-    endpoint: {
-      p1Consent: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction',
-      noP1Consent: 'https://prebid.adnxs-simple.com/pbs/v1/openrtb2/auction'
-    },
-    syncEndpoint: {
-      p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync',
-      noP1Consent: 'https://prebid.adnxs-simple.com/pbs/v1/cookie_sync'
-    },
-    timeout: 1000
-  },
   'appnexuspsp': {
     adapter: 'prebidServer',
     enabled: true,
     endpoint: {
       p1Consent: 'https://ib.adnxs.com/openrtb2/prebid',
       noP1Consent: 'https://ib.adnxs-simple.com/openrtb2/prebid'
+    },
+    syncEndpoint: {
+      p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync',
+      noP1Consent: 'https://prebid.adnxs-simple.com/pbs/v1/cookie_sync'
     },
     timeout: 1000
   },

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -527,7 +527,7 @@ describe('auctionmanager.js', function () {
         s2sConfig: {
           accountId: '1',
           enabled: true,
-          defaultVendor: 'appnexus',
+          defaultVendor: 'appnexuspsp',
           bidders: ['appnexus'],
           timeout: 1000,
           adapter: 'prebidServer'

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -1263,7 +1263,7 @@ describe('auctionmanager.js', function () {
           s2sConfig: [{
             accountId: '1',
             enabled: true,
-            defaultVendor: 'appnexus',
+            defaultVendor: 'appnexuspsp',
             bidders: ['mock-s2s-1'],
             adapter: 'pbs'
           }, {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -3635,33 +3635,6 @@ describe('S2S Adapter', function () {
       sinon.assert.calledOnce(logErrorSpy);
     });
 
-    it('should configure the s2sConfig object with appnexus vendor defaults unless specified by user', function () {
-      const options = {
-        accountId: '123',
-        bidders: ['appnexus'],
-        defaultVendor: 'appnexus',
-        timeout: 750
-      };
-
-      config.setConfig({ s2sConfig: options });
-      sinon.assert.notCalled(logErrorSpy);
-
-      let vendorConfig = config.getConfig('s2sConfig');
-      expect(vendorConfig).to.have.property('accountId', '123');
-      expect(vendorConfig).to.have.property('adapter', 'prebidServer');
-      expect(vendorConfig.bidders).to.deep.equal(['appnexus']);
-      expect(vendorConfig.enabled).to.be.true;
-      expect(vendorConfig.endpoint).to.deep.equal({
-        p1Consent: 'https://prebid.adnxs.com/pbs/v1/openrtb2/auction',
-        noP1Consent: 'https://prebid.adnxs-simple.com/pbs/v1/openrtb2/auction'
-      });
-      expect(vendorConfig.syncEndpoint).to.deep.equal({
-        p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync',
-        noP1Consent: 'https://prebid.adnxs-simple.com/pbs/v1/cookie_sync'
-      });
-      expect(vendorConfig).to.have.property('timeout', 750);
-    });
-
     it('should configure the s2sConfig object with appnexuspsp vendor defaults unless specified by user', function () {
       const options = {
         accountId: '123',
@@ -3682,7 +3655,10 @@ describe('S2S Adapter', function () {
         p1Consent: 'https://ib.adnxs.com/openrtb2/prebid',
         noP1Consent: 'https://ib.adnxs-simple.com/openrtb2/prebid'
       });
-      expect(vendorConfig.syncEndpoint).to.be.undefined;
+      expect(vendorConfig.syncEndpoint).to.deep.equal({
+        p1Consent: 'https://prebid.adnxs.com/pbs/v1/cookie_sync',
+        noP1Consent: 'https://prebid.adnxs-simple.com/pbs/v1/cookie_sync'
+      });
       expect(vendorConfig).to.have.property('timeout', 750);
     });
 


### PR DESCRIPTION

## Type of change
- [x] Other

## Description of change
This PR removes a fully deprecated appnexus PBS endpoint config and adds the syncEndpoint for the appnexus PSP default config.

Confirmed these changes with @SyntaxNode 

