### PR TITLE
Optidigital Bid Adapter: adding userIds

### DIFF
--- a/modules/optidigitalBidAdapter.js
+++ b/modules/optidigitalBidAdapter.js
@@ -87,6 +87,12 @@ export const spec = {
       payload.uspConsent = bidderRequest.uspConsent;
     }
 
+    if (_getEids(validBidRequests[0])) {
+      payload.user = {
+        eids: _getEids(validBidRequests[0])
+      }
+    }
+
     const payloadObject = JSON.stringify(payload);
     return {
       method: 'POST',
@@ -219,6 +225,12 @@ function _getFloor (bid, sizes, currency) {
     } catch (err) {}
   }
   return floor !== null ? floor : bid.params.floor;
+}
+
+function _getEids(bidRequest) {
+  if (deepAccess(bidRequest, 'userIdAsEids')) {
+    return bidRequest.userIdAsEids;
+  }
 }
 
 export function resetSync() {

--- a/modules/optidigitalBidAdapter.md
+++ b/modules/optidigitalBidAdapter.md
@@ -37,10 +37,13 @@ Bidder Adapter for Prebid.js.
 
 ```
 pbjs.setConfig({
-  userSync: {
-    iframeEnabled: true,
-    syncEnabled: true,
-    syncDelay: 3000
+   userSync: {
+    filterSettings: {
+      iframe: {
+        bidders: '*', // '*' represents all bidders
+        filter: 'include'
+      }
+    }
   }
 });
 ```

--- a/test/spec/modules/optidigitalBidAdapter_spec.js
+++ b/test/spec/modules/optidigitalBidAdapter_spec.js
@@ -479,6 +479,28 @@ describe('optidigitalAdapterTests', function () {
       expect(payload.imp[0].bidFloor).to.exist;
     });
 
+    it('should add userEids to payload', function() {
+      const userIdAsEids = [{
+        source: 'pubcid.org',
+        uids: [{
+          id: '121213434342343',
+          atype: 1
+        }]
+      }];
+      validBidRequests[0].userIdAsEids = userIdAsEids;
+      bidderRequest.userIdAsEids = userIdAsEids;
+      const request = spec.buildRequests(validBidRequests, bidderRequest);
+      const payload = JSON.parse(request.data);
+      expect(payload.user.eids).to.deep.equal(userIdAsEids);
+    });
+
+    it('should not add userIdAsEids to payload when userIdAsEids is not present', function() {
+      validBidRequests[0].userIdAsEids = undefined;
+      const request = spec.buildRequests(validBidRequests, bidderRequest);
+      const payload = JSON.parse(request.data);
+      expect(payload.user).to.deep.equal(undefined);
+    });
+
     function returnBannerSizes(mediaTypes, expectedSizes) {
       const bidRequest = Object.assign(validBidRequests[0], mediaTypes);
       const request = spec.buildRequests([bidRequest], bidderRequest);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Adding userid Module support for Optidigital Adapter.
This PR was made to keep keep compatibility with 7.54.x version of Prebid.js
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
