### PR TITLE
GumGum Bid Adapter: fix bug  not passing GPP consent object as a string

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -383,15 +383,11 @@ function buildRequests(validBidRequests, bidderRequest) {
       data.uspConsent = uspConsent;
     }
     if (gppConsent) {
-      data.gppConsent = {
-        gppString: bidderRequest.gppConsent.gppString,
-        gpp_sid: bidderRequest.gppConsent.applicableSections
-      }
+      data.gppString = bidderRequest.gppConsent.gppString ? bidderRequest.gppConsent.gppString : ''
+      data.gppSid = Array.isArray(bidderRequest.gppConsent.applicableSections) ? bidderRequest.gppConsent.applicableSections.join(',') : ''
     } else if (!gppConsent && bidderRequest?.ortb2?.regs?.gpp) {
-      data.gppConsent = {
-        gppString: bidderRequest.ortb2.regs.gpp,
-        gpp_sid: bidderRequest.ortb2.regs.gpp_sid
-      };
+      data.gppString = bidderRequest.ortb2.regs.gpp
+      data.gppSid = Array.isArray(bidderRequest.ortb2.regs.gpp_sid) ? bidderRequest.ortb2.regs.gpp_sid.join(',') : ''
     }
     if (coppa) {
       data.coppa = coppa;

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -102,6 +102,8 @@ describe('gumgumAdapter', function () {
     let sizesArray = [[300, 250], [300, 600]];
     let bidRequests = [
       {
+        gppString: 'DBACNYA~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA~1YNN',
+        gppSid: [7],
         bidder: 'gumgum',
         params: {
           inSlot: 9
@@ -503,10 +505,9 @@ describe('gumgumAdapter', function () {
       const gppConsent = { gppString: 'DBACNYA~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA~1YNN', applicableSections: [7] }
       const fakeBidRequest = { gppConsent: gppConsent };
       const bidRequest = spec.buildRequests(bidRequests, fakeBidRequest)[0];
-      expect(bidRequest.data.gppConsent).to.exist;
-      expect(bidRequest.data.gppConsent.gppString).to.equal(gppConsent.gppString);
-      expect(bidRequest.data.gppConsent.gpp_sid).to.equal(gppConsent.applicableSections);
-      expect(bidRequest.data.gppConsent.gppString).to.eq('DBACNYA~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA~1YNN');
+      expect(bidRequest.data.gppString).to.equal(gppConsent.gppString);
+      expect(bidRequest.data.gppSid).to.equal(gppConsent.applicableSections.join(','));
+      expect(bidRequest.data.gppString).to.eq('DBACNYA~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA~1YNN');
     });
     it('should handle ortb2 parameters', function () {
       const ortb2 = {
@@ -517,15 +518,14 @@ describe('gumgumAdapter', function () {
       }
       const fakeBidRequest = { gppConsent: ortb2 };
       const bidRequest = spec.buildRequests(bidRequests, fakeBidRequest)[0];
-      expect(bidRequest.data.gppConsent.gppString).to.eq(fakeBidRequest[0])
+      expect(bidRequest.data.gpp).to.eq(fakeBidRequest[0])
     });
     it('should handle gppConsent is present but values are undefined case', function () {
       const gppConsent = { gppString: undefined, applicableSections: undefined }
       const fakeBidRequest = { gppConsent: gppConsent };
       const bidRequest = spec.buildRequests(bidRequests, fakeBidRequest)[0];
-      expect(bidRequest.data.gppConsent).to.exist;
-      expect(bidRequest.data.gppConsent.gppString).to.equal(undefined);
-      expect(bidRequest.data.gppConsent.gpp_sid).to.equal(undefined);
+      expect(bidRequest.data.gppString).to.equal('');
+      expect(bidRequest.data.gppSid).to.equal('');
     });
     it('should handle ortb2  undefined parameters', function () {
       const ortb2 = {
@@ -536,8 +536,8 @@ describe('gumgumAdapter', function () {
       }
       const fakeBidRequest = { gppConsent: ortb2 };
       const bidRequest = spec.buildRequests(bidRequests, fakeBidRequest)[0];
-      expect(bidRequest.data.gppConsent.gppString).to.eq(undefined)
-      expect(bidRequest.data.gppConsent.gpp_sid).to.eq(undefined)
+      expect(bidRequest.data.gppString).to.eq('')
+      expect(bidRequest.data.gppSid).to.eq('')
     });
     it('should not set coppa parameter if coppa config is set to false', function () {
       config.setConfig({


### PR DESCRIPTION
## Type of change

- [x ] Bugfix

## Description of change
This PR fixes https://github.com/prebid/Prebid.js/issues/10469 
Removed the gppConsent object and sent separate fields in the query string.