### PR TITLE
Integr8 Bid Adapter : updated endpoint URL

### DIFF
--- a/modules/integr8BidAdapter.js
+++ b/modules/integr8BidAdapter.js
@@ -4,12 +4,12 @@ import { getStorageManager } from '../src/storageManager.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 
 const BIDDER_CODE = 'integr8';
-const ENDPOINT_URL = 'https://integr8.central.gjirafa.tech/bid';
+const DEFAULT_ENDPOINT_URL = 'https://central.sea.integr8.digital/bid';
 const DIMENSION_SEPARATOR = 'x';
 const SIZE_SEPARATOR = ';';
-const BISKO_ID = 'biskoId';
+const BISKO_ID = 'integr8Id';
 const STORAGE_ID = 'bisko-sid';
-const SEGMENTS = 'biskoSegments';
+const SEGMENTS = 'integr8Segments';
 const storage = getStorageManager({bidderCode: BIDDER_CODE});
 
 export const spec = {
@@ -31,6 +31,7 @@ export const spec = {
    * @return ServerRequest Info describing the request to the server.
    */
   buildRequests: function (validBidRequests, bidderRequest) {
+    let deliveryUrl = '';
     const storageId = storage.localStorageIsEnabled() ? storage.getDataFromLocalStorage(STORAGE_ID) || '' : '';
     const biskoId = storage.localStorageIsEnabled() ? storage.getDataFromLocalStorage(BISKO_ID) || '' : '';
     const segments = storage.localStorageIsEnabled() ? JSON.parse(storage.getDataFromLocalStorage(SEGMENTS)) || [] : [];
@@ -55,6 +56,9 @@ export const spec = {
       if (!pageViewGuid) { pageViewGuid = bidRequest.params.pageViewGuid || ''; }
       if (!contents.length && bidRequest.params.contents && bidRequest.params.contents.length) { contents = bidRequest.params.contents; }
       if (!Object.keys(data).length && bidRequest.params.data && Object.keys(bidRequest.params.data).length) { data = bidRequest.params.data; }
+      if (!deliveryUrl && bidRequest.params && typeof bidRequest.params.deliveryUrl === 'string') {
+        deliveryUrl = bidRequest.params.deliveryUrl;
+      }
 
       return {
         sizes: generateSizeParam(bidRequest.sizes),
@@ -66,6 +70,10 @@ export const spec = {
         floor: getBidFloor(bidRequest)
       };
     });
+
+    if (!deliveryUrl) {
+      deliveryUrl = DEFAULT_ENDPOINT_URL;
+    }
 
     let body = {
       propertyId: propertyId,
@@ -82,7 +90,7 @@ export const spec = {
 
     return [{
       method: 'POST',
-      url: ENDPOINT_URL,
+      url: deliveryUrl,
       data: body
     }];
   },

--- a/modules/integr8BidAdapter.md
+++ b/modules/integr8BidAdapter.md
@@ -23,8 +23,8 @@ var adUnits = [
         bids: [{
             bidder: 'integr8',
             params: {
-                propertyId: '105109',   //Required
-                placementId: '846835',  //Required,
+                propertyId: '105135',   //Required
+                placementId: '846837',  //Required,
                 deliveryUrl: 'https://central.sea.integr8.digital/bid', //Optional
                 data: {                 //Optional
                     catalogs: [{
@@ -49,8 +49,8 @@ var adUnits = [
         bids: [{
             bidder: 'integr8',
             params: {
-                propertyId: '105109',  //Required
-                placementId: '846830', //Required,
+                propertyId: '105135',  //Required
+                placementId: '846835', //Required,
                 deliveryUrl: 'https://central.sea.integr8.digital/bid', //Optional
                 data: {                //Optional
                     catalogs: [{

--- a/modules/integr8BidAdapter.md
+++ b/modules/integr8BidAdapter.md
@@ -3,7 +3,7 @@ Module Name: Integr8 Bidder Adapter Module
 
 Type: Bidder Adapter
 
-Maintainer: arditb@gjirafa.com
+Maintainer: myhedin@gjirafa.com
 
 # Description
 Integr8 Bidder Adapter for Prebid.js.
@@ -24,7 +24,8 @@ var adUnits = [
             bidder: 'integr8',
             params: {
                 propertyId: '105109',   //Required
-                placementId: '846835',  //Required
+                placementId: '846835',  //Required,
+                deliveryUrl: 'https://central.sea.integr8.digital/bid', //Optional
                 data: {                 //Optional
                     catalogs: [{
                         catalogId: "699229",
@@ -49,7 +50,8 @@ var adUnits = [
             bidder: 'integr8',
             params: {
                 propertyId: '105109',  //Required
-                placementId: '846830', //Required
+                placementId: '846830', //Required,
+                deliveryUrl: 'https://central.sea.integr8.digital/bid', //Optional
                 data: {                //Optional
                     catalogs: [{
                         catalogId: "699229",

--- a/test/spec/modules/integr8BidAdapter_spec.js
+++ b/test/spec/modules/integr8BidAdapter_spec.js
@@ -72,7 +72,7 @@ describe('integr8AdapterTest', () => {
     });
 
     it('bidRequest url', () => {
-      const endpointUrl = 'https://integr8.central.gjirafa.tech/bid';
+      const endpointUrl = 'https://central.sea.integr8.digital/bid';
       const requests = spec.buildRequests(bidRequests);
       requests.forEach(function (requestItem) {
         expect(requestItem.url).to.match(new RegExp(`${endpointUrl}`));
@@ -113,7 +113,7 @@ describe('integr8AdapterTest', () => {
   describe('interpretResponse', () => {
     const bidRequest = {
       'method': 'POST',
-      'url': 'https://integr8.central.gjirafa.tech/bid',
+      'url': 'https://central.sea.integr8.digital/bid',
       'data': {
         'sizes': '728x90',
         'adUnitId': 'hb-leaderboard',


### PR DESCRIPTION
Integr8 Bid Adapter: Updated endpoint URL

## Type of change
- [x] Code style update (formatting, local variables)

## Description of change
This pull request updates the Integr8 Bid Adapter to use a new default endpoint URL. It also allows the endpoint URL to be specified in the bid request params, giving more flexibility to users.

Changes made:
- Updated the default endpoint URL to 'https://central.sea.integr8.digital/bid'.
- Added support for specifying the endpoint URL in the bid request params using the 'deliveryUrl' parameter.

In the future, we plan to further enhance the adaptability of the Integr8 Bid Adapter by supporting different endpoints for different regions. This change lays the groundwork for such regional customization while maintaining backward compatibility.

This change improves the adaptability of the Integr8 Bid Adapter to different environments and sets the stage for future enhancements.

## Other information

