### PR TITLE
IX Bid Adapter: add support for signaling privacy sandbox (fledge) auction requests [PB-1841]

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -1377,15 +1377,15 @@ function createBannerImps(validBidRequest, missingBannerSizes, bannerImps, bidde
   // Add Fledge flag if enabled
   const fledgeEnabled = deepAccess(bidderRequest, 'fledgeEnabled')
   if (fledgeEnabled) {
-    if (bidderRequest.defaultForSlots == 1) {
-      bannerImps[validBidRequest.adUnitCode].ae = 1
-    } else {
-      const auctionEnvironment = deepAccess(validBidRequest, 'ortb2Imp.ext.ae')
+    const auctionEnvironment = deepAccess(validBidRequest, 'ortb2Imp.ext.ae')
+    if (auctionEnvironment) {
       if (isInteger(auctionEnvironment)) {
         bannerImps[validBidRequest.adUnitCode].ae = auctionEnvironment;
       } else {
         logWarn('error setting auction environment flag - must be an integer')
       }
+    } else if (deepAccess(bidderRequest, 'defaultForSlots') == 1) {
+      bannerImps[validBidRequest.adUnitCode].ae = 1
     }
   }
 

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -993,12 +993,12 @@ function addImpressions(impressions, impKeys, r, adUnitIndex) {
       }
 
       if (dfpAdUnitCode || gpid || tid || sid || fledgeEnabled) {
-        _bannerImpression.ext = _bannerImpression.ext || {};
+        _bannerImpression.ext = {};
 
-        if (dfpAdUnitCode) _bannerImpression.ext.dfp_ad_unit_code = dfpAdUnitCode;
-        if (gpid) _bannerImpression.ext.gpid = gpid;
-        if (tid) _bannerImpression.ext.tid = tid;
-        if (sid) _bannerImpression.ext.sid = sid;
+        _bannerImpression.ext.dfp_ad_unit_code = dfpAdUnitCode;
+        _bannerImpression.ext.gpid = gpid;
+        _bannerImpression.ext.tid = tid;
+        _bannerImpression.ext.sid = sid;
 
         // enable fledge auction
         if (fledgeEnabled) _bannerImpression.ext.ae = 1;

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -953,7 +953,7 @@ function addImpressions(impressions, impKeys, r, adUnitIndex) {
   const dfpAdUnitCode = impressions[impKeys[adUnitIndex]].dfp_ad_unit_code;
   const tid = impressions[impKeys[adUnitIndex]].tid;
   const sid = impressions[impKeys[adUnitIndex]].sid;
-  const fledgeEnabled = impressions[impKeys[adUnitIndex]].ae;
+  const auctionEnvironment = impressions[impKeys[adUnitIndex]].ae;
   const bannerImpressions = impressionObjects.filter(impression => BANNER in impression);
   const otherImpressions = impressionObjects.filter(impression => !(BANNER in impression));
 
@@ -993,7 +993,7 @@ function addImpressions(impressions, impKeys, r, adUnitIndex) {
         _bannerImpression.banner.pos = position;
       }
 
-      if (dfpAdUnitCode || gpid || tid || sid || fledgeEnabled) {
+      if (dfpAdUnitCode || gpid || tid || sid || auctionEnvironment) {
         _bannerImpression.ext = {};
 
         _bannerImpression.ext.dfp_ad_unit_code = dfpAdUnitCode;
@@ -1002,7 +1002,9 @@ function addImpressions(impressions, impKeys, r, adUnitIndex) {
         _bannerImpression.ext.sid = sid;
 
         // enable fledge auction
-        if (fledgeEnabled) _bannerImpression.ext.ae = 1;
+        if (auctionEnvironment == 1) {
+          _bannerImpression.ext.ae = 1;
+        }
       }
 
       if ('bidfloor' in bannerImps[0]) {

--- a/modules/ixBidAdapter.md
+++ b/modules/ixBidAdapter.md
@@ -469,6 +469,11 @@ pbjs.setConfig({
 
 The timeout value must be a positive whole number in milliseconds.
 
+Protected Audience API (FLEDGE)
+===========================
+
+In order to enable receiving [Protected Audience API](https://developer.chrome.com/en/docs/privacy-sandbox/fledge/) traffic, follow Prebid's documentation on [fledgeForGpt](https://docs.prebid.org/dev-docs/modules/fledgeForGpt.html) module to build and enable Fledge.
+
 Additional Information
 ======================
 

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -3219,16 +3219,16 @@ describe('IndexexchangeAdapter', function () {
   });
 
   describe('buildRequestFledge', function () {
-    it('impression should have ae=1 in ext when fledge is enabled through ad unit', function () {
+    it('impression should have ae=1 in ext when fledge module is enabled and ae is set in ad unit', function () {
       const bidderRequest = deepClone(DEFAULT_OPTION_FLEDGE_ENABLED);
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID_WITH_FLEDGE_ENABLED[0]);
       const requestBidFloor = spec.buildRequests([bid], bidderRequest)[0];
       const impression = extractPayload(requestBidFloor).imp[0];
 
-      expect(impression.ext.ae).to.equal(1); // Check that ae=1 is added to the impression ext
+      expect(impression.ext.ae).to.equal(1);
     });
 
-    it('impression should have ae=1 in ext when fledge is enabled globaly through setConfig', function () {
+    it('impression should have ae=1 in ext when fledge module is enabled globally and default is set through setConfig', function () {
       const bidderRequest = deepClone(DEFAULT_OPTION_FLEDGE_ENABLED_GLOBALLY);
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       const requestBidFloor = spec.buildRequests([bid], bidderRequest)[0];
@@ -3237,8 +3237,26 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.ext.ae).to.equal(1);
     });
 
-    it('impression should not have ae=1 in ext when fledge is enabled globaly through setConfig but overriden at ad unit level', function () {
+    it('impression should have ae=1 in ext when fledge module is enabled globally but no default set through setConfig but set at ad unit level', function () {
       const bidderRequest = deepClone(DEFAULT_OPTION_FLEDGE_ENABLED);
+      const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID_WITH_FLEDGE_ENABLED[0]);
+      const requestBidFloor = spec.buildRequests([bid], bidderRequest)[0];
+      const impression = extractPayload(requestBidFloor).imp[0];
+
+      expect(impression.ext.ae).to.equal(1);
+    });
+
+    it('impression should not have ae=1 in ext when fledge module is enabled globally through setConfig but overidden at ad unit level', function () {
+      const bidderRequest = deepClone(DEFAULT_OPTION_FLEDGE_ENABLED);
+      const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
+      const requestBidFloor = spec.buildRequests([bid], bidderRequest)[0];
+      const impression = extractPayload(requestBidFloor).imp[0];
+
+      expect(impression.ext.ae).to.be.undefined;
+    });
+
+    it('impression should not have ae=1 in ext when fledge module is disabled', function () {
+      const bidderRequest = deepClone(DEFAULT_OPTION);
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       const requestBidFloor = spec.buildRequests([bid], bidderRequest)[0];
       const impression = extractPayload(requestBidFloor).imp[0];

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -3275,7 +3275,7 @@ describe('IndexexchangeAdapter', function () {
     it('should log warning for non integer auction environment in ad unit for fledge', () => {
       const logWarnSpy = sinon.spy(utils, 'logWarn');
       const bid = DEFAULT_BANNER_VALID_BID_WITH_FLEDGE_ENABLED[0];
-      bid.ortb2Imp.ext.ae = "malformed"
+      bid.ortb2Imp.ext.ae = 'malformed'
       const bidderRequestWithFledgeEnabled = deepClone(DEFAULT_OPTION_FLEDGE_ENABLED);
       spec.buildRequests([bid], bidderRequestWithFledgeEnabled);
       expect(logWarnSpy.calledWith('error setting auction environment flag - must be an integer')).to.be.true;

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -3271,6 +3271,16 @@ describe('IndexexchangeAdapter', function () {
       const diagObj = extractPayload(request[0]).ext.ixdiag;
       expect(diagObj.ae).to.equal(true);
     });
+
+    it('should log warning for non integer auction environment in ad unit for fledge', () => {
+      const logWarnSpy = sinon.spy(utils, 'logWarn');
+      const bid = DEFAULT_BANNER_VALID_BID_WITH_FLEDGE_ENABLED[0];
+      bid.ortb2Imp.ext.ae = "malformed"
+      const bidderRequestWithFledgeEnabled = deepClone(DEFAULT_OPTION_FLEDGE_ENABLED);
+      spec.buildRequests([bid], bidderRequestWithFledgeEnabled);
+      expect(logWarnSpy.calledWith('error setting auction environment flag - must be an integer')).to.be.true;
+      logWarnSpy.restore();
+    });
   });
 
   describe('interpretResponse', function () {

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -3220,21 +3220,7 @@ describe('IndexexchangeAdapter', function () {
 
   describe('buildRequestFledge', function () {
     it('impression should have ae=1 in ext when fledge is enabled through ad unit', function () {
-      config.setConfig({
-        fledgeForGpt: {
-          enabled: true
-        }
-      });
-
-      config.setBidderConfig({
-        bidders: ['ix'],
-        config: {
-          fledgeEnabled: true,
-        }
-      });
-
       const bidderRequest = deepClone(DEFAULT_OPTION_FLEDGE_ENABLED);
-
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID_WITH_FLEDGE_ENABLED[0]);
       const requestBidFloor = spec.buildRequests([bid], bidderRequest)[0];
       const impression = extractPayload(requestBidFloor).imp[0];
@@ -3243,23 +3229,7 @@ describe('IndexexchangeAdapter', function () {
     });
 
     it('impression should have ae=1 in ext when fledge is enabled globaly through setConfig', function () {
-      config.setConfig({
-        fledgeForGpt: {
-          enabled: true,
-          defaultForSlots: 1
-        }
-      });
-
-      config.setBidderConfig({
-        bidders: ['ix'],
-        config: {
-          fledgeEnabled: true,
-          defaultForSlots: 1
-        }
-      });
-
       const bidderRequest = deepClone(DEFAULT_OPTION_FLEDGE_ENABLED_GLOBALLY);
-
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
       const requestBidFloor = spec.buildRequests([bid], bidderRequest)[0];
       const impression = extractPayload(requestBidFloor).imp[0];
@@ -3267,24 +3237,21 @@ describe('IndexexchangeAdapter', function () {
       expect(impression.ext.ae).to.equal(1);
     });
 
-    it('should contain correct IXdiag ae property for Fledge', function () {
-      config.setConfig({
-        fledgeForGpt: {
-          enabled: true
-        }
-      });
+    it('impression should not have ae=1 in ext when fledge is enabled globaly through setConfig but overriden at ad unit level', function () {
+      const bidderRequest = deepClone(DEFAULT_OPTION_FLEDGE_ENABLED);
+      const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID[0]);
+      const requestBidFloor = spec.buildRequests([bid], bidderRequest)[0];
+      const impression = extractPayload(requestBidFloor).imp[0];
 
-      config.setBidderConfig({
-        bidders: ['ix'],
-        config: {
-          fledgeEnabled: true,
-          defaultForSlots: 1
-        }
-      });
+      expect(impression.ext.ae).to.be.undefined;
+    });
+
+    it('should contain correct IXdiag ae property for Fledge', function () {
       const bid = DEFAULT_BANNER_VALID_BID_WITH_FLEDGE_ENABLED[0];
-      const request = spec.buildRequests([bid], {});
+      const bidderRequestWithFledgeEnabled = deepClone(DEFAULT_OPTION_FLEDGE_ENABLED);
+      const request = spec.buildRequests([bid], bidderRequestWithFledgeEnabled);
       const diagObj = extractPayload(request[0]).ext.ixdiag;
-      expect(diagObj.ae).to.equal(true); // Check if Fledge flag is set to true
+      expect(diagObj.ae).to.equal(true);
     });
   });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

- Adds support for signalling Protected Audience (FLEDGE) flag and receiving PA demand.
- In order to enable receiving [Protected Audience API](https://developer.chrome.com/en/docs/privacy-sandbox/fledge/) traffic, follow Prebid's documentation on [fledgeForGpt](https://docs.prebid.org/dev-docs/modules/fledgeForGpt.html) module to build and enable Protected Audience (Fledge) auctions.

Note: receiving actually PA demand is TBD.

## Other information
For more information please contact shahin.rahbariasl@indexexchange.com. 
