### PR TITLE
Prebid core: cached bids should contain the ID of the auction they actually won

### DIFF
--- a/src/targeting.js
+++ b/src/targeting.js
@@ -464,19 +464,17 @@ export function newTargeting(auctionManager) {
       if (typeof filterFunction === 'function') {
         bidsReceived = bidsReceived.filter(bid => latestAuctionForAdUnit[bid.adUnitCode] === bid.auctionId || !!filterFunction(bid))
       }
-
-      bidsReceived = bidsReceived
-        .map(bid => {
-          if (latestAuctionForAdUnit[bid.adUnitCode] !== bid.auctionId) {
-            bid.latestAuctionForAdUnit = latestAuctionForAdUnit[bid.adUnitCode];
-          }
-          return bid;
-        });
     }
 
     bidsReceived = bidsReceived
       .filter(bid => deepAccess(bid, 'video.context') !== ADPOD)
       .filter(isBidUsable);
+
+    bidsReceived
+      .forEach(bid => {
+        bid.latestTargetedAuctionId = latestAuctionForAdUnit[bid.adUnitCode];
+        return bid;
+      });
 
     return getHighestCpmBidsFromBidPool(bidsReceived, getOldestHighestCpmBid);
   }

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -464,6 +464,14 @@ export function newTargeting(auctionManager) {
       if (typeof filterFunction === 'function') {
         bidsReceived = bidsReceived.filter(bid => latestAuctionForAdUnit[bid.adUnitCode] === bid.auctionId || !!filterFunction(bid))
       }
+
+      bidsReceived = bidsReceived
+        .map(bid => {
+          if (latestAuctionForAdUnit[bid.adUnitCode] !== bid.auctionId) {
+            bid.latestAuctionForAdUnit = latestAuctionForAdUnit[bid.adUnitCode];
+          }
+          return bid;
+        });
     }
 
     bidsReceived = bidsReceived

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -955,6 +955,7 @@ describe('targeting tests', function () {
 
         expect(bids.length).to.equal(1);
         expect(bids[0].adId).to.equal('adid-1');
+        expect(bids[0].latestAuctionForAdUnit).to.equal(2);
 
         useBidCache = false;
 
@@ -962,6 +963,7 @@ describe('targeting tests', function () {
 
         expect(bids.length).to.equal(1);
         expect(bids[0].adId).to.equal('adid-2');
+        expect(bids[0].latestAuctionForAdUnit).to.equal(undefined);
       });
 
       it('should use bidCacheFilterFunction', function() {
@@ -989,9 +991,13 @@ describe('targeting tests', function () {
 
         expect(bids.length).to.equal(4);
         expect(bids[0].adId).to.equal('adid-1');
+        expect(bids[0].latestAuctionForAdUnit).to.equal(2);
         expect(bids[1].adId).to.equal('adid-4');
+        expect(bids[1].latestAuctionForAdUnit).to.equal(undefined);
         expect(bids[2].adId).to.equal('adid-5');
+        expect(bids[2].latestAuctionForAdUnit).to.equal(2);
         expect(bids[3].adId).to.equal('adid-8');
+        expect(bids[3].latestAuctionForAdUnit).to.equal(undefined);
 
         // Bid Caching Off, No Filter Function
         useBidCache = false;
@@ -1000,9 +1006,13 @@ describe('targeting tests', function () {
 
         expect(bids.length).to.equal(4);
         expect(bids[0].adId).to.equal('adid-2');
+        expect(bids[0].latestAuctionForAdUnit).to.equal(undefined);
         expect(bids[1].adId).to.equal('adid-4');
+        expect(bids[1].latestAuctionForAdUnit).to.equal(undefined);
         expect(bids[2].adId).to.equal('adid-6');
+        expect(bids[2].latestAuctionForAdUnit).to.equal(undefined);
         expect(bids[3].adId).to.equal('adid-8');
+        expect(bids[3].latestAuctionForAdUnit).to.equal(undefined);
 
         // Bid Caching On AGAIN, No Filter Function (should be same as first time)
         useBidCache = true;
@@ -1011,9 +1021,13 @@ describe('targeting tests', function () {
 
         expect(bids.length).to.equal(4);
         expect(bids[0].adId).to.equal('adid-1');
+        expect(bids[0].latestAuctionForAdUnit).to.equal(2);
         expect(bids[1].adId).to.equal('adid-4');
+        expect(bids[1].latestAuctionForAdUnit).to.equal(undefined);
         expect(bids[2].adId).to.equal('adid-5');
+        expect(bids[2].latestAuctionForAdUnit).to.equal(2);
         expect(bids[3].adId).to.equal('adid-8');
+        expect(bids[3].latestAuctionForAdUnit).to.equal(undefined);
 
         // Bid Caching On, with Filter Function to Exclude video
         useBidCache = true;
@@ -1026,9 +1040,13 @@ describe('targeting tests', function () {
 
         expect(bids.length).to.equal(4);
         expect(bids[0].adId).to.equal('adid-1');
+        expect(bids[0].latestAuctionForAdUnit).to.equal(2);
         expect(bids[1].adId).to.equal('adid-4');
+        expect(bids[1].latestAuctionForAdUnit).to.equal(undefined);
         expect(bids[2].adId).to.equal('adid-6');
+        expect(bids[2].latestAuctionForAdUnit).to.equal(undefined);
         expect(bids[3].adId).to.equal('adid-8');
+        expect(bids[3].latestAuctionForAdUnit).to.equal(undefined);
         // filter function should have been called for each cached bid (4 times)
         expect(bcffCalled).to.equal(4);
 
@@ -1044,9 +1062,13 @@ describe('targeting tests', function () {
 
         expect(bids.length).to.equal(4);
         expect(bids[0].adId).to.equal('adid-2');
+        expect(bids[0].latestAuctionForAdUnit).to.equal(undefined);
         expect(bids[1].adId).to.equal('adid-4');
+        expect(bids[1].latestAuctionForAdUnit).to.equal(undefined);
         expect(bids[2].adId).to.equal('adid-6');
+        expect(bids[2].latestAuctionForAdUnit).to.equal(undefined);
         expect(bids[3].adId).to.equal('adid-8');
+        expect(bids[3].latestAuctionForAdUnit).to.equal(undefined);
         // filter function should not have been called
         expect(bcffCalled).to.equal(0);
       });

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -955,7 +955,7 @@ describe('targeting tests', function () {
 
         expect(bids.length).to.equal(1);
         expect(bids[0].adId).to.equal('adid-1');
-        expect(bids[0].latestAuctionForAdUnit).to.equal(2);
+        expect(bids[0].latestTargetedAuctionId).to.equal(2);
 
         useBidCache = false;
 
@@ -963,7 +963,7 @@ describe('targeting tests', function () {
 
         expect(bids.length).to.equal(1);
         expect(bids[0].adId).to.equal('adid-2');
-        expect(bids[0].latestAuctionForAdUnit).to.equal(undefined);
+        expect(bids[0].latestTargetedAuctionId).to.equal(2);
       });
 
       it('should use bidCacheFilterFunction', function() {
@@ -991,13 +991,13 @@ describe('targeting tests', function () {
 
         expect(bids.length).to.equal(4);
         expect(bids[0].adId).to.equal('adid-1');
-        expect(bids[0].latestAuctionForAdUnit).to.equal(2);
+        expect(bids[0].latestTargetedAuctionId).to.equal(2);
         expect(bids[1].adId).to.equal('adid-4');
-        expect(bids[1].latestAuctionForAdUnit).to.equal(undefined);
+        expect(bids[1].latestTargetedAuctionId).to.equal(2);
         expect(bids[2].adId).to.equal('adid-5');
-        expect(bids[2].latestAuctionForAdUnit).to.equal(2);
+        expect(bids[2].latestTargetedAuctionId).to.equal(2);
         expect(bids[3].adId).to.equal('adid-8');
-        expect(bids[3].latestAuctionForAdUnit).to.equal(undefined);
+        expect(bids[3].latestTargetedAuctionId).to.equal(2);
 
         // Bid Caching Off, No Filter Function
         useBidCache = false;
@@ -1006,13 +1006,13 @@ describe('targeting tests', function () {
 
         expect(bids.length).to.equal(4);
         expect(bids[0].adId).to.equal('adid-2');
-        expect(bids[0].latestAuctionForAdUnit).to.equal(undefined);
+        expect(bids[0].latestTargetedAuctionId).to.equal(2);
         expect(bids[1].adId).to.equal('adid-4');
-        expect(bids[1].latestAuctionForAdUnit).to.equal(undefined);
+        expect(bids[1].latestTargetedAuctionId).to.equal(2);
         expect(bids[2].adId).to.equal('adid-6');
-        expect(bids[2].latestAuctionForAdUnit).to.equal(undefined);
+        expect(bids[2].latestTargetedAuctionId).to.equal(2);
         expect(bids[3].adId).to.equal('adid-8');
-        expect(bids[3].latestAuctionForAdUnit).to.equal(undefined);
+        expect(bids[3].latestTargetedAuctionId).to.equal(2);
 
         // Bid Caching On AGAIN, No Filter Function (should be same as first time)
         useBidCache = true;
@@ -1021,13 +1021,13 @@ describe('targeting tests', function () {
 
         expect(bids.length).to.equal(4);
         expect(bids[0].adId).to.equal('adid-1');
-        expect(bids[0].latestAuctionForAdUnit).to.equal(2);
+        expect(bids[0].latestTargetedAuctionId).to.equal(2);
         expect(bids[1].adId).to.equal('adid-4');
-        expect(bids[1].latestAuctionForAdUnit).to.equal(undefined);
+        expect(bids[1].latestTargetedAuctionId).to.equal(2);
         expect(bids[2].adId).to.equal('adid-5');
-        expect(bids[2].latestAuctionForAdUnit).to.equal(2);
+        expect(bids[2].latestTargetedAuctionId).to.equal(2);
         expect(bids[3].adId).to.equal('adid-8');
-        expect(bids[3].latestAuctionForAdUnit).to.equal(undefined);
+        expect(bids[3].latestTargetedAuctionId).to.equal(2);
 
         // Bid Caching On, with Filter Function to Exclude video
         useBidCache = true;
@@ -1040,13 +1040,13 @@ describe('targeting tests', function () {
 
         expect(bids.length).to.equal(4);
         expect(bids[0].adId).to.equal('adid-1');
-        expect(bids[0].latestAuctionForAdUnit).to.equal(2);
+        expect(bids[0].latestTargetedAuctionId).to.equal(2);
         expect(bids[1].adId).to.equal('adid-4');
-        expect(bids[1].latestAuctionForAdUnit).to.equal(undefined);
+        expect(bids[1].latestTargetedAuctionId).to.equal(2);
         expect(bids[2].adId).to.equal('adid-6');
-        expect(bids[2].latestAuctionForAdUnit).to.equal(undefined);
+        expect(bids[2].latestTargetedAuctionId).to.equal(2);
         expect(bids[3].adId).to.equal('adid-8');
-        expect(bids[3].latestAuctionForAdUnit).to.equal(undefined);
+        expect(bids[3].latestTargetedAuctionId).to.equal(2);
         // filter function should have been called for each cached bid (4 times)
         expect(bcffCalled).to.equal(4);
 
@@ -1062,13 +1062,13 @@ describe('targeting tests', function () {
 
         expect(bids.length).to.equal(4);
         expect(bids[0].adId).to.equal('adid-2');
-        expect(bids[0].latestAuctionForAdUnit).to.equal(undefined);
+        expect(bids[0].latestTargetedAuctionId).to.equal(2);
         expect(bids[1].adId).to.equal('adid-4');
-        expect(bids[1].latestAuctionForAdUnit).to.equal(undefined);
+        expect(bids[1].latestTargetedAuctionId).to.equal(2);
         expect(bids[2].adId).to.equal('adid-6');
-        expect(bids[2].latestAuctionForAdUnit).to.equal(undefined);
+        expect(bids[2].latestTargetedAuctionId).to.equal(2);
         expect(bids[3].adId).to.equal('adid-8');
-        expect(bids[3].latestAuctionForAdUnit).to.equal(undefined);
+        expect(bids[3].latestTargetedAuctionId).to.equal(2);
         // filter function should not have been called
         expect(bcffCalled).to.equal(0);
       });

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -25,6 +25,7 @@ import {stubAuctionIndex} from '../../helpers/indexStub.js';
 import {createBid} from '../../../src/bidfactory.js';
 import {enrichFPD} from '../../../src/fpd/enrichment.js';
 import {mockFpdEnrichments} from '../../helpers/fpd.js';
+import {generateUUID} from '../../../src/utils.js';
 var assert = require('chai').assert;
 var expect = require('chai').expect;
 
@@ -42,11 +43,12 @@ var adUnits = getAdUnits();
 var adUnitCodes = getAdUnits().map(unit => unit.code);
 var bidsBackHandler = function() {};
 const timeout = 2000;
+const auctionId = generateUUID();
 let auction;
 
 function resetAuction() {
   if (auction == null) {
-    auction = auctionManager.createAuction({adUnits, adUnitCodes, callback: bidsBackHandler, cbTimeout: timeout});
+    auction = auctionManager.createAuction({adUnits, adUnitCodes, callback: bidsBackHandler, cbTimeout: timeout, labels: undefined, auctionId: auctionId});
   }
   $$PREBID_GLOBAL$$.setConfig({ enableSendAllBids: false });
   auction.getBidRequests = getBidRequests;
@@ -3302,16 +3304,20 @@ describe('Unit: Prebid Module', function () {
       const highestBid = $$PREBID_GLOBAL$$.getHighestUnusedBidResponseForAdUnitCode('/19968336/header-bid-tag-0');
       expect(highestBid).to.deep.equal(_bidsReceived[2])
     })
-  })
+  });
 
-  describe('getHighestCpm', () => {
+  describe('getHighestCpmBids', () => {
     after(() => {
       resetAuction();
     });
     it('returns an array containing the highest bid object for the given adUnitCode', function () {
-      const highestCpmBids = $$PREBID_GLOBAL$$.getHighestCpmBids('/19968336/header-bid-tag-0');
+      const adUnitcode = '/19968336/header-bid-tag-0';
+      targeting.setLatestAuctionForAdUnit(adUnitcode, auctionId)
+      const highestCpmBids = $$PREBID_GLOBAL$$.getHighestCpmBids(adUnitcode);
       expect(highestCpmBids.length).to.equal(1);
-      expect(highestCpmBids[0]).to.deep.equal(auctionManager.getBidsReceived()[1]);
+      const expectedBid = auctionManager.getBidsReceived()[1];
+      expectedBid.latestAuctionForAdUnit = auctionId;
+      expect(highestCpmBids[0]).to.deep.equal(expectedBid);
     });
 
     it('returns an empty array when the given adUnit is not found', function () {

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -3316,7 +3316,7 @@ describe('Unit: Prebid Module', function () {
       const highestCpmBids = $$PREBID_GLOBAL$$.getHighestCpmBids(adUnitcode);
       expect(highestCpmBids.length).to.equal(1);
       const expectedBid = auctionManager.getBidsReceived()[1];
-      expectedBid.latestAuctionForAdUnit = auctionId;
+      expectedBid.latestTargetedAuctionId = auctionId;
       expect(highestCpmBids[0]).to.deep.equal(expectedBid);
     });
 


### PR DESCRIPTION
## Type of change
- Feature

## Description of change
Cached bids should contain the ID of the auctions that they actually won so that this information is available through `BID_WON` events.

## Other information
More information about the motivation for this PR can be found here: https://github.com/prebid/Prebid.js/issues/10540
