### PR TITLE
dgkeyword: use ortb2

### DIFF
--- a/modules/dgkeywordRtdProvider.js
+++ b/modules/dgkeywordRtdProvider.js
@@ -6,8 +6,7 @@
  * @module modules/dgkeywordProvider
  * @requires module:modules/realTimeData
  */
-
-import {logMessage, deepSetValue, logError, logInfo, mergeDeep} from '../src/utils.js';
+import { logMessage, deepSetValue, logError, logInfo, isStr, isArray } from '../src/utils.js';
 import { ajax } from '../src/ajax.js';
 import { submodule } from '../src/hook.js';
 import { getGlobal } from '../src/prebidGlobal.js';
@@ -57,19 +56,11 @@ export function getDgKeywordsAndSet(reqBidsConfigObj, callback, moduleConfig, us
             if (Object.keys(keywords).length > 0) {
               const targetBidKeys = {};
               for (let bid of setKeywordTargetBidders) {
-                // set keywords to params
-                bid.params.keywords = keywords;
+                // set keywords to ortb2Imp
+                deepSetValue(bid, 'ortb2Imp.ext.data.keywords', convertKeywordsToString(keywords));
                 if (!targetBidKeys[bid.bidder]) {
                   targetBidKeys[bid.bidder] = true;
                 }
-              }
-
-              if (!reqBidsConfigObj._ignoreSetOrtb2) {
-                // set keywrods to ortb2
-                let addOrtb2 = {};
-                deepSetValue(addOrtb2, 'site.keywords', keywords);
-                deepSetValue(addOrtb2, 'user.keywords', keywords);
-                mergeDeep(reqBidsConfigObj.ortb2Fragments.bidder, Object.fromEntries(Object.keys(targetBidKeys).map(bidder => [bidder, addOrtb2])));
               }
             }
           }
@@ -156,4 +147,32 @@ function init(moduleConfig) {
 function registerSubModule() {
   submodule('realTimeData', dgkeywordSubmodule);
 }
+
+// keywords: { 'genre': ['rock', 'pop'], 'pets': ['dog'] } goes to 'genre=rock,genre=pop,pets=dog'
+export function convertKeywordsToString(keywords) {
+  let result = '';
+  Object.keys(keywords).forEach(key => {
+    // if 'text' or ''
+    if (isStr(keywords[key])) {
+      if (keywords[key] !== '') {
+        result += `${key}=${keywords[key]},`
+      } else {
+        result += `${key},`;
+      }
+    } else if (isArray(keywords[key])) {
+      if (keywords[key][0] === '') {
+        result += `${key},`
+      } else {
+        keywords[key].forEach(val => {
+          result += `${key}=${val},`
+        });
+      }
+    }
+  });
+
+  // remove last trailing comma
+  result = result.substring(0, result.length - 1);
+  return result;
+}
+
 registerSubModule();

--- a/test/spec/modules/dgkeywordRtdProvider_spec.js
+++ b/test/spec/modules/dgkeywordRtdProvider_spec.js
@@ -242,16 +242,16 @@ describe('Digital Garage Keyword Module', function () {
           expect(targets[1].bidder).to.be.equal('dg2');
           expect(targets[1].params.placementId).to.be.equal(99999998);
           expect(targets[1].params.dgkeyword).to.be.an('undefined');
-          expect(targets[1].params.keywords).to.be.an('undefined');
+          expect(targets[1].params.ortb2Imp).to.be.an('undefined');
           targets = pbjs.adUnits[1].bids;
           expect(targets[0].bidder).to.be.equal('dg');
           expect(targets[0].params.placementId).to.be.equal(99999996);
           expect(targets[0].params.dgkeyword).to.be.an('undefined');
-          expect(targets[0].params.keywords).to.be.an('undefined');
+          expect(targets[0].params.ortb2Imp).to.be.an('undefined');
           expect(targets[2].bidder).to.be.equal('dg3');
           expect(targets[2].params.placementId).to.be.equal(99999994);
           expect(targets[2].params.dgkeyword).to.be.an('undefined');
-          expect(targets[2].params.keywords).to.be.an('undefined');
+          expect(targets[2].params.ortb2Imp).to.be.an('undefined');
 
           expect(pbjs.getBidderConfig()).to.be.deep.equal({});
 
@@ -275,16 +275,16 @@ describe('Digital Garage Keyword Module', function () {
           expect(targets[1].bidder).to.be.equal('dg2');
           expect(targets[1].params.placementId).to.be.equal(99999998);
           expect(targets[1].params.dgkeyword).to.be.an('undefined');
-          expect(targets[1].params.keywords).to.be.an('undefined');
+          expect(targets[1].params.ortb2Imp).to.be.an('undefined');
           targets = pbjs.adUnits[1].bids;
           expect(targets[0].bidder).to.be.equal('dg');
           expect(targets[0].params.placementId).to.be.equal(99999996);
           expect(targets[0].params.dgkeyword).to.be.an('undefined');
-          expect(targets[0].params.keywords).to.be.an('undefined');
+          expect(targets[0].params.ortb2Imp).to.be.an('undefined');
           expect(targets[2].bidder).to.be.equal('dg3');
           expect(targets[2].params.placementId).to.be.equal(99999994);
           expect(targets[2].params.dgkeyword).to.be.an('undefined');
-          expect(targets[2].params.keywords).to.be.an('undefined');
+          expect(targets[2].params.ortb2Imp).to.be.an('undefined');
 
           expect(pbjs.getBidderConfig()).to.be.deep.equal({});
 
@@ -318,16 +318,16 @@ describe('Digital Garage Keyword Module', function () {
           expect(targets[1].bidder).to.be.equal('dg2');
           expect(targets[1].params.placementId).to.be.equal(99999998);
           expect(targets[1].params.dgkeyword).to.be.an('undefined');
-          expect(targets[1].params.keywords).to.be.deep.equal(SUCCESS_RESULT);
+          expect(targets[1].ortb2Imp.ext.data.keywords).to.be.deep.equal(dgRtd.convertKeywordsToString(SUCCESS_RESULT));
           targets = pbjs.adUnits[1].bids;
           expect(targets[0].bidder).to.be.equal('dg');
           expect(targets[0].params.placementId).to.be.equal(99999996);
           expect(targets[0].params.dgkeyword).to.be.an('undefined');
-          expect(targets[0].params.keywords).to.be.deep.equal(SUCCESS_RESULT);
+          expect(targets[0].ortb2Imp.ext.data.keywords).to.be.deep.equal(dgRtd.convertKeywordsToString(SUCCESS_RESULT));
           expect(targets[2].bidder).to.be.equal('dg3');
           expect(targets[2].params.placementId).to.be.equal(99999994);
           expect(targets[2].params.dgkeyword).to.be.an('undefined');
-          expect(targets[2].params.keywords).to.be.an('undefined');
+          expect(targets[2].ortb2Imp).to.be.an('undefined');
 
           if (!IGNORE_SET_ORTB2) {
             expect(pbjs.getBidderConfig()).to.be.deep.equal({


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

### Purpose
dgkeyword submodule to be compatible with Prebid >8.0.0

### Changes
- use ortb2 on setting keywords
- prevent to use keywords for specified websites or specified users, because to use keywords or not is related to ad-units  

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->