### PR TITLE
Sharethrough Bid Adapter: revise getUserSyncs method

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -220,22 +220,9 @@ export const sharethroughAdapterSpec = {
     const shouldCookieSync =
       syncOptions.pixelEnabled && deepAccess(serverResponses, '0.body.cookieSyncUrls') !== undefined;
 
-    let syncurl = '';
-
-    // Attaching GDPR Consent Params in UserSync url
-    if (gdprConsent) {
-      syncurl += '&gdpr=' + (gdprConsent.gdprApplies ? 1 : 0);
-      syncurl += '&gdpr_consent=' + encodeURIComponent(gdprConsent.consentString || '');
-    }
-    if (gppConsent) {
-      syncurl += '&gpp=' + encodeURIComponent(gppConsent?.gppString);
-      syncurl += '&gpp_sid=' + encodeURIComponent(gppConsent?.applicableSections?.join(','));
-    }
-
-    return shouldCookieSync ? serverResponses[0].body.cookieSyncUrls.map((url) => (
-      { type: 'image',
-        url: url + syncurl
-      })) : [];
+    return shouldCookieSync
+      ? serverResponses[0].body.cookieSyncUrls.map((url) => ({ type: 'image', url: url + syncurl }))
+      : [];
   },
 
   // Empty implementation for prebid core to be able to find it

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -216,12 +216,12 @@ export const sharethroughAdapterSpec = {
     });
   },
 
-  getUserSyncs: (syncOptions, serverResponses, gdprConsent, gppConsent) => {
+  getUserSyncs: (syncOptions, serverResponses) => {
     const shouldCookieSync =
       syncOptions.pixelEnabled && deepAccess(serverResponses, '0.body.cookieSyncUrls') !== undefined;
 
     return shouldCookieSync
-      ? serverResponses[0].body.cookieSyncUrls.map((url) => ({ type: 'image', url: url + syncurl }))
+      ? serverResponses[0].body.cookieSyncUrls.map((url) => ({ type: 'image', url: url }))
       : [];
   },
 

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -409,12 +409,12 @@ describe('sharethrough adapter spec', function () {
           it('should properly attach GPP information to the request when applicable', () => {
             bidderRequest.gppConsent = {
               gppString: 'some-gpp-string',
-              applicableSections: [3, 5]
+              applicableSections: [3, 5],
             };
 
             const openRtbReq = spec.buildRequests(bidRequests, bidderRequest)[0].data;
-            expect(openRtbReq.regs.gpp).to.equal(bidderRequest.gppConsent.gppString)
-            expect(openRtbReq.regs.gpp_sid).to.equal(bidderRequest.gppConsent.applicableSections)
+            expect(openRtbReq.regs.gpp).to.equal(bidderRequest.gppConsent.gppString);
+            expect(openRtbReq.regs.gpp_sid).to.equal(bidderRequest.gppConsent.applicableSections);
           });
 
           it('should populate request accordingly when gpp explicitly does not apply', function () {
@@ -618,7 +618,7 @@ describe('sharethrough adapter spec', function () {
           badv: ['domain1.com', 'domain2.com'],
           regs: {
             gpp: 'gpp_string',
-            gpp_sid: [7]
+            gpp_sid: [7],
           },
         };
 
@@ -869,25 +869,6 @@ describe('sharethrough adapter spec', function () {
       it('returns an empty array if pixels are not enabled', function () {
         const syncArray = spec.getUserSyncs({ pixelEnabled: false }, serverResponses);
         expect(syncArray).to.be.an('array').that.is.empty;
-      });
-
-      it('returns GDPR Consent Params in UserSync url', function () {
-        const syncArray = spec.getUserSyncs({ pixelEnabled: true }, serverResponses, { gdprApplies: true,
-          consentString: 'consent' });
-        expect(syncArray).to.deep.equal([
-          { type: 'image', url: 'cookieUrl1&gdpr=1&gdpr_consent=consent' },
-          { type: 'image', url: 'cookieUrl2&gdpr=1&gdpr_consent=consent' },
-          { type: 'image', url: 'cookieUrl3&gdpr=1&gdpr_consent=consent' },
-        ]);
-      });
-
-      it('returns GPP Consent Params in UserSync url', function () {
-        const syncArray = spec.getUserSyncs({ pixelEnabled: true }, serverResponses, {}, {gppString: 'gpp-string', applicableSections: [1, 2]});
-        expect(syncArray).to.deep.equal([
-          { type: 'image', url: 'cookieUrl1&gdpr=0&gdpr_consent=&gpp=gpp-string&gpp_sid=1%2C2' },
-          { type: 'image', url: 'cookieUrl2&gdpr=0&gdpr_consent=&gpp=gpp-string&gpp_sid=1%2C2' },
-          { type: 'image', url: 'cookieUrl3&gdpr=0&gdpr_consent=&gpp=gpp-string&gpp_sid=1%2C2' },
-        ]);
       });
     });
   });


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Removing some params and query-string additions in our `getUserSyncs()` method that we thought we needed for GDPR and GPP but which turned out to be unnecessary.  (_Our ad-server team already gets that info through bid requests_.)  No functional change.
