### PR TITLE
Liveintent & UID2 ID systems: share EID configuration

### DIFF
--- a/libraries/uid2Eids/uid2Eids.js
+++ b/libraries/uid2Eids/uid2Eids.js
@@ -1,0 +1,14 @@
+export const UID2_EIDS = {
+  'uid2': {
+    source: 'uidapi.com',
+    atype: 3,
+    getValue: function(data) {
+      return data.id;
+    },
+    getUidExt: function(data) {
+      if (data.ext) {
+        return data.ext;
+      }
+    }
+  }
+}

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -11,6 +11,7 @@ import { LiveConnect } from 'live-connect-js'; // eslint-disable-line prebid/val
 import { gdprDataHandler, uspDataHandler } from '../src/adapterManager.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
+import {UID2_EIDS} from '../libraries/uid2Eids/uid2Eids.js';
 
 const DEFAULT_AJAX_TIMEOUT = 5000
 const EVENTS_TOPIC = 'pre_lips'
@@ -249,6 +250,7 @@ export const liveIntentIdSubmodule = {
     return { callback: result };
   },
   eids: {
+    ...UID2_EIDS,
     'lipb': {
       getValue: function(data) {
         return data.lipbid;

--- a/modules/uid2IdSystem.js
+++ b/modules/uid2IdSystem.js
@@ -14,6 +14,7 @@ import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 // RE below lint exception: UID2 and EUID are separate modules, but the protocol is the same and shared code makes sense here.
 // eslint-disable-next-line prebid/validate-imports
 import { Uid2GetId, Uid2CodeVersion } from './uid2IdSystem_shared.js';
+import {UID2_EIDS} from '../libraries/uid2Eids/uid2Eids.js';
 
 const MODULE_NAME = 'uid2';
 const MODULE_REVISION = Uid2CodeVersion;
@@ -83,20 +84,7 @@ export const uid2IdSubmodule = {
     _logInfo(`UID2 getId returned`, result);
     return result;
   },
-  eids: {
-    'uid2': {
-      source: 'uidapi.com',
-      atype: 3,
-      getValue: function(data) {
-        return data.id;
-      },
-      getUidExt: function(data) {
-        if (data.ext) {
-          return data.ext;
-        }
-      }
-    },
-  },
+  eids: UID2_EIDS
 };
 
 function decodeImpl(value) {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

The LiveIntent ID module can provide UID2 modules, but after https://github.com/prebid/Prebid.js/pull/10229 it needs the UID2 module to also be installed or the relevant EID formatting logic will be missing. This refactors both modules to share it.

## Other information

See https://github.com/prebid/Prebid.js/pull/10229/files#r1334349319

