### PR TITLE
imds Bid Adapter : fix incorrectly named user sync property

### DIFF
--- a/modules/imdsBidAdapter.js
+++ b/modules/imdsBidAdapter.js
@@ -224,7 +224,6 @@ export const spec = {
     };
 
     if (!serverResponse.body || typeof serverResponse.body != 'object') {
-      logWarn('IMDS: server returned empty/non-json response: ' + JSON.stringify(serverResponse.body));
       return;
     }
     const {id, seatbid: seatbids} = serverResponse.body;

--- a/modules/imdsBidAdapter.js
+++ b/modules/imdsBidAdapter.js
@@ -324,7 +324,7 @@ export const spec = {
       });
     } else if (syncOptions.pixelEnabled) {
       syncs.push({
-        type: 'pixel',
+        type: 'image',
         url: `${USER_SYNC_PIXEL_URL}?srv=cs&${queryParams.join('&')}`
       });
     }

--- a/modules/imdsBidAdapter.md
+++ b/modules/imdsBidAdapter.md
@@ -11,11 +11,11 @@ Maintainer: eng-demand@imds.tv
 The iMedia Digital Services adapter requires setup and approval from iMedia Digital Services.
 Please reach out to your account manager for more information.
 
-### DFP Video Creative
-To use video, setup a `VAST redirect` creative within Google AdManager (DFP) with the following VAST tag URL:
+### Google Ad Manager Video Creative
+To use video, setup a `VAST redirect` creative within Google Ad Manager with the following VAST tag URL:
 
-```
-https://track.technoratimedia.com/openrtb/tags?ID=%%PATTERN:hb_cache_id_synacorm%%&AUCTION_PRICE=%%PATTERN:hb_pb_synacormedia%%
+```text
+https://track.technoratimedia.com/openrtb/tags?ID=%%PATTERN:hb_uuid_imds%%&AUCTION_PRICE=%%PATTERN:hb_pb_imds%%
 ```
 
 # Test Parameters

--- a/test/spec/modules/imdsBidAdapter_spec.js
+++ b/test/spec/modules/imdsBidAdapter_spec.js
@@ -1362,17 +1362,17 @@ describe('imdsBidAdapter ', function () {
       expect(usersyncs[0].url).to.contain('https://ad-cdn.technoratimedia.com/html/usersync.html');
     });
 
-    it('should return a pixel usersync when pixels is enabled', function () {
+    it('should return an image usersync when pixels are enabled', function () {
       let usersyncs = spec.getUserSyncs({
         pixelEnabled: true
       }, null);
       expect(usersyncs).to.be.an('array').with.lengthOf(1);
-      expect(usersyncs[0]).to.have.property('type', 'pixel');
+      expect(usersyncs[0]).to.have.property('type', 'image');
       expect(usersyncs[0]).to.have.property('url');
       expect(usersyncs[0].url).to.contain('https://sync.technoratimedia.com/services');
     });
 
-    it('should return an iframe usersync when both iframe and pixels is enabled', function () {
+    it('should return an iframe usersync when both iframe and pixel are enabled', function () {
       let usersyncs = spec.getUserSyncs({
         iframeEnabled: true,
         pixelEnabled: true


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

- This changes the "image" usersync from the incorrectly used "pixel" property. This was preventing the new image user sync from happening and causing a warning in the console with debug enabled of: `WARNING: User sync type "pixel" not supported`.
- Removed a warning being emitted for valid 204 no-bid responses with an empty body.
- There is also a change to the markdown documentation to match https://github.com/prebid/prebid.github.io/pull/4908


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
https://github.com/prebid/prebid.github.io/pull/4908