### PR TITLE
PBjs Core: bugfix - accessing array instead of adUnit

### DIFF
--- a/integrationExamples/videoModule/jwplayer/bidsBackHandlerOverride.html
+++ b/integrationExamples/videoModule/jwplayer/bidsBackHandlerOverride.html
@@ -119,7 +119,9 @@
               });
 
               bid.vastUrl = videoUrl;
-              pbjs.videoModule.renderBid('player', bid);
+              pbjs.renderAd(null, bid.adId);
+              // Alternatively you can use:
+              // pbjs.videoModule.renderBid('player', bid);
             });
           }
         });

--- a/libraries/creativeRender/direct.js
+++ b/libraries/creativeRender/direct.js
@@ -35,12 +35,13 @@ export function renderAdDirect(doc, adId, options) {
     } else {
       bid = auctionManager.findBidByAdId(adId);
 
-      if (FEATURES.VIDEO) {
+      if (FEATURES.VIDEO && bid.mediaType === 'video') {
         // TODO: could the video module implement this as a custom renderer, rather than a special case in here?
         const adUnit = bid && auctionManager.index.getAdUnit(bid);
         const videoModule = getGlobal().videoModule;
-        if (adUnit?.video && videoModule) {
-          videoModule.renderBid(adUnit.video.divId, bid);
+        const divId = adUnit && adUnit.video && adUnit.video.divId;
+        if (divId && videoModule) {
+          videoModule.renderBid(divId, bid);
           return;
         }
       }

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1476,6 +1476,25 @@ describe('Unit: Prebid Module', function () {
       $$PREBID_GLOBAL$$.offEvent(CONSTANTS.EVENTS.STALE_RENDER, onStaleEvent);
       configObj.setConfig({'auctionOptions': {}});
     });
+
+    if (FEATURES.VIDEO) {
+      it('should render in the Video Module when mediaType is video and the AdUnit includes a video config', function () {
+        const adUnit = {
+          video: {
+            divId: 'playerDivId'
+          }
+        };
+        sinon.stub(auctionManager.index, 'getAdUnit').callsFake(() => adUnit);
+        pushBidResponseToAuction({
+          mediaType: 'video'
+        });
+        const renderBidSpy = sinon.spy($$PREBID_GLOBAL$$.videoModule, 'renderBid');
+        $$PREBID_GLOBAL$$.renderAd(null, bidId);
+        assert.ok(renderBidSpy.calledOnce, 'videoModule.renderBid should be called when adUnit is configured for Video Module');
+        const args = renderBidSpy.getCall(0).args;
+        assert.ok(args[0] === 'playerDivId', 'divId from adUnit must be passed as an argument');
+      });
+    }
   });
 
   describe('requestBids', function () {

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1206,6 +1206,8 @@ describe('Unit: Prebid Module', function () {
     var spyAddWinningBid;
     var inIframe = true;
     var triggerPixelStub;
+    let indexStub;
+    let auctionManagerInstance;
 
     function pushBidResponseToAuction(obj) {
       adResponse = Object.assign({
@@ -1251,6 +1253,10 @@ describe('Unit: Prebid Module', function () {
       inIframe = true;
       sinon.stub(utils, 'inIframe').callsFake(() => inIframe);
       triggerPixelStub = sinon.stub(utils.internal, 'triggerPixel');
+
+      indexStub = sinon.stub(auctionManager, 'index');
+      auctionManagerInstance = newAuctionManager();
+      indexStub.get(() => auctionManagerInstance.index);
     });
 
     afterEach(function () {
@@ -1261,6 +1267,7 @@ describe('Unit: Prebid Module', function () {
       utils.inIframe.restore();
       triggerPixelStub.restore();
       spyAddWinningBid.restore();
+      indexStub.restore();
     });
 
     it('should require doc and id params', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
`pbjsInstance.adUnits.filter` returns an array yet the code was expecting an actual ad unit. This fix uses `auctionManager.index.getAdUnit` to get the ad unit and adds a check for the `divId` before attempting to render the ad. 
Integration example has been updated.


## Other information
fixes issue #10505
