### PR TITLE
consentManagementUsp: fix bug where data deletion events are triggered when CMP does not support `registerDeletion`

### DIFF
--- a/modules/consentManagementUsp.js
+++ b/modules/consentManagementUsp.js
@@ -90,7 +90,7 @@ function lookupUspConsent({onSuccess, onError}) {
 
   cmp({
     command: 'registerDeletion',
-    callback: adapterManager.callDataDeletionRequest
+    callback: (res, success) => (success == null || success) && adapterManager.callDataDeletionRequest(res)
   }).catch(e => {
     logError('Error invoking CMP `registerDeletion`:', e);
   });

--- a/test/spec/modules/consentManagementUsp_spec.js
+++ b/test/spec/modules/consentManagementUsp_spec.js
@@ -522,6 +522,19 @@ describe('consentManagement', function () {
         setConsentConfig(goodConfig);
         expect(uspDataHandler.getConsentData()).to.eql('string');
       });
+
+      it('does not invoke registerDeletion if the CMP calls back with an error', () => {
+        sandbox.stub(window, '__uspapi').callsFake((cmd, _, cb) => {
+          if (cmd === 'registerDeletion') {
+            cb(null, false);
+          } else {
+            // eslint-disable-next-line standard/no-callback-literal
+            cb({uspString: 'string'}, true);
+          }
+        });
+        setConsentConfig(goodConfig);
+        sinon.assert.notCalled(adapterManager.callDataDeletionRequest);
+      })
     });
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Some CMPs do not suport USPAPI `registerDeletion` and immediately invoke the callback to signal an error, which Prebid erroneously interprets as a request to trigger data deletion.


