### PR TITLE
[DFP Ad Server Video]: Bugfix - Encode description url

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -249,7 +249,9 @@ export function buildAdpodVideoUrl({code, params, callback} = {}) {
  */
 function buildUrlFromAdserverUrlComponents(components, bid, options) {
   const descriptionUrl = getDescriptionUrl(bid, components, 'search');
-  if (descriptionUrl) { components.search.description_url = descriptionUrl; }
+  if (descriptionUrl) {
+    components.search.description_url = descriptionUrl;
+  }
 
   components.search.cust_params = getCustParams(bid, options, components.search.cust_params);
   return buildUrl(components);
@@ -264,7 +266,7 @@ function buildUrlFromAdserverUrlComponents(components, bid, options) {
  * @return {string | undefined} The encoded vast url if it exists, or undefined
  */
 function getDescriptionUrl(bid, components, prop) {
-  return deepAccess(components, `${prop}.description_url`) || dep.ri().page;
+  return deepAccess(components, `${prop}.description_url`) || encodeURIComponent(dep.ri().page);
 }
 
 /**

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -58,8 +58,18 @@ describe('The DFP video support module', function () {
         }, options)));
         const prm = utils.parseQS(url.query);
         expect(prm.description_url).to.eql('example.com');
+      });
+
+      it('should use a URI encode page location as default for description_url', () => {
+        sandbox.stub(dep, 'ri').callsFake(() => ({page: 'https://example.com?iu=/99999999/news&cust_params=current_hour%3D12%26newscat%3Dtravel&pbjs_debug=true'}));
+        const url = parse(buildDfpVideoUrl(Object.assign({
+          adUnit: adUnit,
+          bid: bid,
+        }, options)));
+        const prm = utils.parseQS(url.query);
+        expect(prm.description_url).to.eql('https%3A%2F%2Fexample.com%3Fiu%3D%2F99999999%2Fnews%26cust_params%3Dcurrent_hour%253D12%2526newscat%253Dtravel%26pbjs_debug%3Dtrue');
       })
-    })
+    });
   })
 
   it('should make a legal request URL when given the required params', function () {

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -60,7 +60,7 @@ describe('The DFP video support module', function () {
         expect(prm.description_url).to.eql('example.com');
       });
 
-      it('should use a URI encode page location as default for description_url', () => {
+      it('should use a URI encoded page location as default for description_url', () => {
         sandbox.stub(dep, 'ri').callsFake(() => ({page: 'https://example.com?iu=/99999999/news&cust_params=current_hour%3D12%26newscat%3Dtravel&pbjs_debug=true'}));
         const url = parse(buildDfpVideoUrl(Object.assign({
           adUnit: adUnit,
@@ -68,7 +68,7 @@ describe('The DFP video support module', function () {
         }, options)));
         const prm = utils.parseQS(url.query);
         expect(prm.description_url).to.eql('https%3A%2F%2Fexample.com%3Fiu%3D%2F99999999%2Fnews%26cust_params%3Dcurrent_hour%253D12%2526newscat%253Dtravel%26pbjs_debug%3Dtrue');
-      })
+      });
     });
   })
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
The DFP module uses the page url as a fallback when populating the `description_url` query param. If said URL has query params and they are not encoded, the ad tag breaks.
The fix consists of calling URI encoding the page url before setting it as a query param. 

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
