### PR TITLE
Sovrn Bid Adapter: make minduration optional

### DIFF
--- a/modules/sovrnBidAdapter.js
+++ b/modules/sovrnBidAdapter.js
@@ -44,7 +44,6 @@ const ORTB_VIDEO_PARAMS = {
 const REQUIRED_VIDEO_PARAMS = {
   context: (value) => value !== ADPOD,
   mimes: ORTB_VIDEO_PARAMS.mimes,
-  minduration: ORTB_VIDEO_PARAMS.minduration,
   maxduration: ORTB_VIDEO_PARAMS.maxduration,
   protocols: ORTB_VIDEO_PARAMS.protocols
 }

--- a/test/spec/modules/sovrnBidAdapter_spec.js
+++ b/test/spec/modules/sovrnBidAdapter_spec.js
@@ -64,6 +64,29 @@ describe('sovrnBidAdapter', function() {
 
       expect(spec.isBidRequestValid(bidRequest)).to.equal(false)
     })
+
+    it('should return true when minduration is not passed', function() {
+      const width = 300
+      const height = 250
+      const mimes = ['video/mp4', 'application/javascript']
+      const protocols = [2, 5]
+      const maxduration = 60
+      const startdelay = 0
+      const videoBidRequest = {
+        ...baseBidRequest,
+        mediaTypes: {
+          video: {
+            mimes,
+            protocols,
+            playerSize: [[width, height], [360, 240]],
+            maxduration,
+            startdelay
+          }
+        }
+      }
+
+      expect(spec.isBidRequestValid(videoBidRequest)).to.equal(true)
+    })
   })
 
   describe('buildRequests', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Purpose of this PR is to make minduration optional parameter


## Other information
[Docs PR](https://github.com/prebid/prebid.github.io/pull/4915)
