### PR TITLE
Ozone Adapter 2.9.1 - Alias Support Added

### DIFF
--- a/modules/ozoneBidAdapter.js
+++ b/modules/ozoneBidAdapter.js
@@ -22,10 +22,10 @@ const AUCTIONURI = '/openrtb2/auction';
 const OZONECOOKIESYNC = '/static/load-cookie.html';
 const OZONE_RENDERER_URL = 'https://prebid.the-ozone-project.com/ozone-renderer.js';
 const ORIGIN_DEV = 'https://test.ozpr.net';
-const OZONEVERSION = '2.9.0';
+const OZONEVERSION = '2.9.1';
 export const spec = {
   gvlid: 524,
-  aliases: [{code: 'lmc', gvlid: 524}],
+  aliases: [{code: 'lmc', gvlid: 524}, {code: 'venatus', gvlid: 524}],
   version: OZONEVERSION,
   code: BIDDER_CODE,
   supportedMediaTypes: [VIDEO, BANNER],
@@ -78,6 +78,9 @@ export const spec = {
     if (bidderConfig.hasOwnProperty('batchRequests')) {
       this.propertyBag.whitelabel.batchRequests = bidderConfig.batchRequests;
     }
+    if (arr.hasOwnProperty('batchRequests')) {
+      this.propertyBag.whitelabel.batchRequests = true;
+    }
     try {
       if (arr.hasOwnProperty('auction') && arr.auction === 'dev') {
         logInfo('GET: auction=dev');
@@ -100,6 +103,7 @@ export const spec = {
     return this.propertyBag.whitelabel.rendererUrl;
   },
   isBatchRequests() {
+    logInfo('isBatchRequests going to return ', this.propertyBag.whitelabel.batchRequests);
     return this.propertyBag.whitelabel.batchRequests;
   },
   isBidRequestValid(bid) {

--- a/test/spec/modules/ozoneBidAdapter_spec.js
+++ b/test/spec/modules/ozoneBidAdapter_spec.js
@@ -2069,6 +2069,19 @@ describe('ozone Adapter', function () {
       expect(request.length).to.equal(3);
       config.resetConfig();
     });
+    it('should not batch into 10s if config is set to false and singleRequest is true', function () {
+      config.setConfig({ozone: {'batchRequests': false, 'singleRequest': true}});
+      var specMock = utils.deepClone(spec);
+      let arrReq = [];
+      for (let i = 0; i < 15; i++) {
+        let b = validBidRequests[0];
+        b.adUnitCode += i;
+        arrReq.push(b);
+      }
+      const request = specMock.buildRequests(arrReq, validBidderRequest);
+      expect(request.method).to.equal('POST');
+      config.resetConfig();
+    });
     it('should use GET values auction=dev & cookiesync=dev if set', function() {
       var specMock = utils.deepClone(spec);
       specMock.getGetParametersAsObject = function() {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x ] Other

## Description of change
added 'venatus' alias support onto adapter. Minor refactoring of bidAdapter code and spec tests.
