### PR TITLE
Qortex RTD Provider: add module to submodules.json

### DIFF
--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -75,6 +75,7 @@
       "oneKeyRtdProvider",
       "optimeraRtdProvider",
       "permutiveRtdProvider",
+      "qortexRtdProvider",
       "reconciliationRtdProvider",
       "sirdataRtdProvider",
       "timeoutRtdProvider",


### PR DESCRIPTION
After our code was merged, we realized that this file was missing from the PR. In its current state, the download page does not add the required rtdModule into the generated prebid build, leading to errors when implemented on publisher pages.

Please advise if this should resolve the issue and thank you for the help!