### PR TITLE
LiveIntent UserId module: update LiveConnect dependency; fix caching bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "express": "^4.15.4",
         "fun-hooks": "^0.9.9",
         "just-clone": "^1.0.2",
-        "live-connect-js": "6.2.3"
+        "live-connect-js": "^6.2.4"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.16.5",
@@ -16242,9 +16242,9 @@
       }
     },
     "node_modules/live-connect-js": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.2.3.tgz",
-      "integrity": "sha512-+q+rFCHzHyVTexFsf+nHRLSo039Iuz3fP8+2RXaytG/ikhAzJ1oOJ2u9Kzy0EDdKOKy8C4WcBlGMmH+DzXLmzw==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.2.4.tgz",
+      "integrity": "sha512-fjNzKxbtmHSCsPT27UANOf66fVizJkhgSzAj5Ej9X6sYRiox+NClM2VdRSf4eL54BabJznPLEWzWT/s4ZVVWsQ==",
       "dependencies": {
         "live-connect-common": "^v3.0.2",
         "tiny-hashes": "1.0.1"
@@ -37892,9 +37892,9 @@
       "integrity": "sha512-K3LNKd9CpREDJbXGdwKqPojjQaxd4G6c7OAD6Yzp3wsCWTH2hV8xNAbUksSOpOcVyyOT9ilteEFXIJQJrbODxQ=="
     },
     "live-connect-js": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.2.3.tgz",
-      "integrity": "sha512-+q+rFCHzHyVTexFsf+nHRLSo039Iuz3fP8+2RXaytG/ikhAzJ1oOJ2u9Kzy0EDdKOKy8C4WcBlGMmH+DzXLmzw==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.2.4.tgz",
+      "integrity": "sha512-fjNzKxbtmHSCsPT27UANOf66fVizJkhgSzAj5Ej9X6sYRiox+NClM2VdRSf4eL54BabJznPLEWzWT/s4ZVVWsQ==",
       "requires": {
         "live-connect-common": "^v3.0.2",
         "tiny-hashes": "1.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "express": "^4.15.4",
         "fun-hooks": "^0.9.9",
         "just-clone": "^1.0.2",
-        "live-connect-js": "^6.0.1"
+        "live-connect-js": "6.2.3"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.16.5",
@@ -15471,14 +15471,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -16242,32 +16234,19 @@
       "dev": true
     },
     "node_modules/live-connect-common": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-3.0.0.tgz",
-      "integrity": "sha512-pa1SuzCg8ovsB6OziAQZpDid/OT8k37VgWFQkE8OUmG52Kf9PUtJM8wqaGdMXd/rNAe/NH8m+Kxx9MZuOvn5zg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-3.0.2.tgz",
+      "integrity": "sha512-K3LNKd9CpREDJbXGdwKqPojjQaxd4G6c7OAD6Yzp3wsCWTH2hV8xNAbUksSOpOcVyyOT9ilteEFXIJQJrbODxQ==",
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/live-connect-handlers": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/live-connect-handlers/-/live-connect-handlers-2.1.0.tgz",
-      "integrity": "sha512-uABe9D6yRp7HRgO6vhdIM5j88l17/ROzYGIOHc2Rv1TacLFH6IJ8sbmunY5mIJ9L6ArOVmL4WHY+QgOIkabhxg==",
-      "dependencies": {
-        "js-cookie": "^3.0.5",
-        "live-connect-common": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/live-connect-js": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.0.1.tgz",
-      "integrity": "sha512-+TwM7cjgyutqaMNlTQKNY9nJFDPpSWfoazSHmlWxOPlimp10PSZGABIbtulNGGpYbR/Zxgc+C/uW5OxqcNEPXg==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.2.3.tgz",
+      "integrity": "sha512-+q+rFCHzHyVTexFsf+nHRLSo039Iuz3fP8+2RXaytG/ikhAzJ1oOJ2u9Kzy0EDdKOKy8C4WcBlGMmH+DzXLmzw==",
       "dependencies": {
-        "live-connect-common": "^3.0.0",
-        "live-connect-handlers": "^2.1.0",
+        "live-connect-common": "^v3.0.2",
         "tiny-hashes": "1.0.1"
       },
       "engines": {
@@ -37287,11 +37266,6 @@
         }
       }
     },
-    "js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -37913,26 +37887,16 @@
       "dev": true
     },
     "live-connect-common": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-3.0.0.tgz",
-      "integrity": "sha512-pa1SuzCg8ovsB6OziAQZpDid/OT8k37VgWFQkE8OUmG52Kf9PUtJM8wqaGdMXd/rNAe/NH8m+Kxx9MZuOvn5zg=="
-    },
-    "live-connect-handlers": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/live-connect-handlers/-/live-connect-handlers-2.1.0.tgz",
-      "integrity": "sha512-uABe9D6yRp7HRgO6vhdIM5j88l17/ROzYGIOHc2Rv1TacLFH6IJ8sbmunY5mIJ9L6ArOVmL4WHY+QgOIkabhxg==",
-      "requires": {
-        "js-cookie": "^3.0.5",
-        "live-connect-common": "^3.0.0"
-      }
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-3.0.2.tgz",
+      "integrity": "sha512-K3LNKd9CpREDJbXGdwKqPojjQaxd4G6c7OAD6Yzp3wsCWTH2hV8xNAbUksSOpOcVyyOT9ilteEFXIJQJrbODxQ=="
     },
     "live-connect-js": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.0.1.tgz",
-      "integrity": "sha512-+TwM7cjgyutqaMNlTQKNY9nJFDPpSWfoazSHmlWxOPlimp10PSZGABIbtulNGGpYbR/Zxgc+C/uW5OxqcNEPXg==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.2.3.tgz",
+      "integrity": "sha512-+q+rFCHzHyVTexFsf+nHRLSo039Iuz3fP8+2RXaytG/ikhAzJ1oOJ2u9Kzy0EDdKOKy8C4WcBlGMmH+DzXLmzw==",
       "requires": {
-        "live-connect-common": "^3.0.0",
-        "live-connect-handlers": "^2.1.0",
+        "live-connect-common": "^v3.0.2",
         "tiny-hashes": "1.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "express": "^4.15.4",
     "fun-hooks": "^0.9.9",
     "just-clone": "^1.0.2",
-    "live-connect-js": "6.2.3"
+    "live-connect-js": "^6.2.4"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "express": "^4.15.4",
     "fun-hooks": "^0.9.9",
     "just-clone": "^1.0.2",
-    "live-connect-js": "^6.0.1"
+    "live-connect-js": "6.2.3"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Resolution result caching had a bug that under certain circumstances lead to resolving the wrong set of ids in cases where multiple LiveConnect instances were present on a page. The bug has been fixed in the live-connect module. In Prebid, only the module version pump but no code changes are required. 

## Other information
- PR for fixing the cache: https://github.com/LiveIntent/live-connect/pull/215
