### PR TITLE
Appnexus Bid Adapter : adding 'adzymic' as a new alias

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -110,6 +110,7 @@ export const spec = {
     { code: 'beintoo', gvlid: 618 },
     { code: 'projectagora', gvlid: 1032 },
     { code: 'uol', gvlid: 32 },
+    { code: 'adzymic', gvlid: 32 },
   ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
## Description of change
<!-- Describe the change proposed in this pull request -->
Adzymic is an aliased bidder on Appnexus adapter.
Maintainer emails:
anil@adzymic.co
travis@adzymic.co

Test params for testing the integration:
```
{
    bidder: 'adzymic',
    params: {
                    placementId: 13144370
                }
}
```
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Docs PR: https://github.com/prebid/prebid.github.io/pull/4946
