### PR TITLE
Snigel bid adapter: include query string in page field (7.54.x-legacy)

### DIFF
--- a/modules/snigelBidAdapter.js
+++ b/modules/snigelBidAdapter.js
@@ -105,7 +105,7 @@ registerBidder(spec);
 
 function getPage(bidderRequest) {
   return (
-    getConfig(`${BIDDER_CODE}.page`) || deepAccess(bidderRequest, 'refererInfo.canonicalUrl') || window.location.href
+    getConfig(`${BIDDER_CODE}.page`) || deepAccess(bidderRequest, 'refererInfo.page') || window.location.href
   );
 }
 

--- a/test/spec/modules/snigelBidAdapter_spec.js
+++ b/test/spec/modules/snigelBidAdapter_spec.js
@@ -23,6 +23,7 @@ const BASE_BIDDER_REQUEST = {
   auctionId: 'test',
   bidderRequestId: 'test',
   refererInfo: {
+    page: 'https://localhost',
     canonicalUrl: 'https://localhost',
   },
 };


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->

Just a tiny bit of maintenance.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->
