### PR TITLE
Adnuntius Bid Adaptor: Handle voidAuIds from server response

### DIFF
--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -15,39 +15,146 @@ const GVLID = 855;
 const DEFAULT_VAST_VERSION = 'vast4'
 const MAXIMUM_DEALS_LIMIT = 5;
 const VALID_BID_TYPES = ['netBid', 'grossBid'];
+const META_DATA_KEY = 'adn.metaData';
 
-const checkSegment = function (segment) {
-  if (isStr(segment)) return segment;
-  if (segment.id) return segment.id
-}
+export const misc = {
+  getUnixTimestamp: function(addDays, asMinutes) {
+    const multiplication = addDays / (asMinutes ? 1440 : 1);
+    return Date.now() + (addDays && addDays > 0 ? (1000 * 60 * 60 * 24 * multiplication) : 0);
+  }
+};
 
-const getSegmentsFromOrtb = function (ortb2) {
-  const userData = deepAccess(ortb2, 'user.data');
-  let segments = [];
-  if (userData) {
-    userData.forEach(userdat => {
-      if (userdat.segment) {
-        segments.push(...userdat.segment.filter(checkSegment).map(checkSegment));
+const storageTool = (function() {
+  const storage = getStorageManager({bidderCode: BIDDER_CODE});
+  let metaInternal;
+
+  const getMetaInternal = function() {
+    if (!storage.localStorageIsEnabled()) {
+      return {};
+    }
+
+    let parsedJson;
+    try {
+      parsedJson = JSON.parse(storage.getDataFromLocalStorage(META_DATA_KEY));
+    } catch (e) {
+      return {};
+    }
+
+    let filteredEntries = parsedJson ? parsedJson.filter((datum) => {
+      if (datum.key === 'voidAuIds' && Array.isArray(datum.value)) {
+        return true;
+      }
+      return datum.key && datum.value && datum.exp && datum.exp > misc.getUnixTimestamp();
+    }) : [];
+    const voidAuIdsEntry = filteredEntries.find(entry => entry.key === 'voidAuIds');
+    if (voidAuIdsEntry) {
+      const now = misc.getUnixTimestamp();
+      voidAuIdsEntry.value = voidAuIdsEntry.value.filter(voidAuId => voidAuId.auId && voidAuId.exp > now);
+      if (!voidAuIdsEntry.value.length) {
+        filteredEntries = filteredEntries.filter(entry => entry.key !== 'voidAuIds');
+      }
+    }
+    return filteredEntries;
+  };
+
+  const setMetaInternal = function(apiResponse) {
+    if (!storage.localStorageIsEnabled()) {
+      return;
+    }
+
+    const updateVoidAuIds = function(currentVoidAuIds, auIdsAsString) {
+      const newAuIds = auIdsAsString ? auIdsAsString.split(';') : [];
+      const notNewExistingAuIds = currentVoidAuIds.filter(auIdObj => {
+        return newAuIds.indexOf(auIdObj.value) < -1;
+      }) || [];
+      const oneDayFromNow = misc.getUnixTimestamp(1);
+      const apiIdsArray = newAuIds.map(auId => {
+        return {exp: oneDayFromNow, auId: auId};
+      }) || [];
+      return notNewExistingAuIds.concat(apiIdsArray) || [];
+    }
+
+    const metaAsObj = getMetaInternal().reduce((a, entry) => ({...a, [entry.key]: {value: entry.value, exp: entry.exp}}), {});
+    for (const key in apiResponse) {
+      if (key !== 'voidAuIds') {
+        metaAsObj[key] = {
+          value: apiResponse[key],
+          exp: misc.getUnixTimestamp(100)
+        }
+      }
+    }
+    const currentAuIds = updateVoidAuIds(metaAsObj.voidAuIds || [], apiResponse.voidAuIds || []);
+    if (currentAuIds.length > 0) {
+      metaAsObj.voidAuIds = {value: currentAuIds};
+    }
+    const metaDataForSaving = Object.entries(metaAsObj).map((entrySet) => {
+      if (entrySet[0] === 'voidAuIds') {
+        return {
+          key: entrySet[0],
+          value: entrySet[1].value
+        };
+      }
+      return {
+        key: entrySet[0],
+        value: entrySet[1].value,
+        exp: entrySet[1].exp
       }
     });
-  }
-  return segments
-}
+    storage.setDataInLocalStorage(META_DATA_KEY, JSON.stringify(metaDataForSaving));
+  };
 
-const handleMeta = function () {
-  const storage = getStorageManager({ bidderCode: BIDDER_CODE })
-  let adnMeta = null
-  if (storage.localStorageIsEnabled()) {
-    adnMeta = JSON.parse(storage.getDataFromLocalStorage('adn.metaData'))
+  const getUsi = function(meta, ortb2) {
+    let usi = (meta && meta.usi) ? meta.usi : false;
+    if (ortb2 && ortb2.user && ortb2.user.id) {
+      usi = ortb2.user.id
+    }
+    return usi;
   }
-  return (adnMeta !== null) ? adnMeta.reduce((acc, cur) => { return { ...acc, [cur.key]: cur.value } }, {}) : {}
-}
 
-const getUsi = function (meta, ortb2, bidderRequest) {
-  let usi = (meta !== null && meta.usi) ? meta.usi : false;
-  if (ortb2 && ortb2.user && ortb2.user.id) { usi = ortb2.user.id }
-  return usi
-}
+  const getSegmentsFromOrtb = function (ortb2) {
+    const userData = deepAccess(ortb2, 'user.data');
+    let segments = [];
+    if (userData) {
+      userData.forEach(userdat => {
+        if (userdat.segment) {
+          segments.push(...userdat.segment.map((segment) => {
+            if (isStr(segment)) return segment;
+            if (isStr(segment.id)) return segment.id;
+          }).filter((seg) => !!seg));
+        }
+      });
+    }
+    return segments
+  }
+
+  return {
+    refreshStorage: function(bidderRequest) {
+      const ortb2 = bidderRequest.ortb2 || {};
+      metaInternal = getMetaInternal().reduce((a, entry) => ({...a, [entry.key]: entry.value}), {});
+      metaInternal.usi = getUsi(metaInternal, ortb2);
+      if (!metaInternal.usi) {
+        delete metaInternal.usi;
+      }
+      if (metaInternal.voidAuIds) {
+        metaInternal.voidAuIdsArray = metaInternal.voidAuIds.map((voidAuId) => {
+          return voidAuId.auId;
+        });
+      }
+      metaInternal.segments = getSegmentsFromOrtb(ortb2);
+    },
+    saveToStorage: function(serverData) {
+      setMetaInternal(serverData);
+    },
+    getUrlRelatedData: function() {
+      const {segments, usi, voidAuIdsArray} = metaInternal;
+      return {segments, usi, voidAuIdsArray};
+    },
+    getPayloadRelatedData: function() {
+      const {segments, usi, userId, voidAuIdsArray, voidAuIds, ...payloadRelatedData} = metaInternal;
+      return payloadRelatedData;
+    }
+  };
+})();
 
 const validateBidType = function(bidTypeOption) {
   return VALID_BID_TYPES.indexOf(bidTypeOption || '') > -1 ? bidTypeOption : 'bid';
@@ -67,34 +174,34 @@ export const spec = {
   },
 
   buildRequests: function (validBidRequests, bidderRequest) {
-    const networks = {};
-    const bidRequests = {};
-    const requests = [];
-    const request = [];
-    const ortb2 = bidderRequest.ortb2 || {};
-    const bidderConfig = config.getConfig();
+    const queryParamsAndValues = [];
+    queryParamsAndValues.push('tzo=' + new Date().getTimezoneOffset())
+    queryParamsAndValues.push('format=json')
 
-    const adnMeta = handleMeta()
-    const usi = getUsi(adnMeta, ortb2, bidderRequest)
-    const segments = getSegmentsFromOrtb(ortb2);
-    const tzo = new Date().getTimezoneOffset();
     const gdprApplies = deepAccess(bidderRequest, 'gdprConsent.gdprApplies');
     const consentString = deepAccess(bidderRequest, 'gdprConsent.consentString');
+    if (gdprApplies !== undefined) queryParamsAndValues.push('consentString=' + consentString);
 
-    request.push('tzo=' + tzo)
-    request.push('format=json')
+    storageTool.refreshStorage(bidderRequest);
 
-    if (gdprApplies !== undefined) request.push('consentString=' + consentString);
-    if (segments.length > 0) request.push('segments=' + segments.join(','));
-    if (usi) request.push('userId=' + usi);
-    if (bidderConfig.useCookie === false) request.push('noCookies=true');
-    if (bidderConfig.maxDeals > 0) request.push('ds=' + Math.min(bidderConfig.maxDeals, MAXIMUM_DEALS_LIMIT));
+    const urlRelatedMetaData = storageTool.getUrlRelatedData();
+    if (urlRelatedMetaData.segments.length > 0) queryParamsAndValues.push('segments=' + urlRelatedMetaData.segments.join(','));
+    if (urlRelatedMetaData.usi) queryParamsAndValues.push('userId=' + urlRelatedMetaData.usi);
+
+    const bidderConfig = config.getConfig();
+    if (bidderConfig.useCookie === false) queryParamsAndValues.push('noCookies=true');
+    if (bidderConfig.maxDeals > 0) queryParamsAndValues.push('ds=' + Math.min(bidderConfig.maxDeals, MAXIMUM_DEALS_LIMIT));
+
+    const bidRequests = {};
+    const networks = {};
     for (let i = 0; i < validBidRequests.length; i++) {
-      const bid = validBidRequests[i]
-      let network = bid.params.network || 'network';
-      const maxDeals = Math.max(0, Math.min(bid.params.maxDeals || 0, MAXIMUM_DEALS_LIMIT));
-      const targeting = bid.params.targeting || {};
+      const bid = validBidRequests[i];
+      if ((urlRelatedMetaData.voidAuIdsArray && (urlRelatedMetaData.voidAuIdsArray.indexOf(bid.params.auId) > -1 || urlRelatedMetaData.voidAuIdsArray.indexOf(bid.params.auId.padStart(16, '0')) > -1))) {
+        // This auId is void. Do NOT waste time and energy sending a request to the server
+        continue;
+      }
 
+      let network = bid.params.network || 'network';
       if (bid.mediaTypes && bid.mediaTypes.video && bid.mediaTypes.video.context !== 'outstream') {
         network += '_video'
       }
@@ -105,21 +212,31 @@ export const spec = {
       networks[network] = networks[network] || {};
       networks[network].adUnits = networks[network].adUnits || [];
       if (bidderRequest && bidderRequest.refererInfo) networks[network].context = bidderRequest.refererInfo.page;
-      if (adnMeta) networks[network].metaData = adnMeta;
-      const adUnit = { ...targeting, auId: bid.params.auId, targetId: bid.bidId, maxDeals: maxDeals }
+
+      const payloadRelatedData = storageTool.getPayloadRelatedData();
+      if (Object.keys(payloadRelatedData).length > 0) {
+        networks[network].metaData = payloadRelatedData;
+      }
+
+      const targeting = bid.params.targeting || {};
+      const adUnit = { ...targeting, auId: bid.params.auId, targetId: bid.params.targetId || bid.bidId };
+      const maxDeals = Math.max(0, Math.min(bid.params.maxDeals || 0, MAXIMUM_DEALS_LIMIT));
+      if (maxDeals > 0) {
+        adUnit.maxDeals = maxDeals;
+      }
       if (bid.mediaTypes && bid.mediaTypes.banner && bid.mediaTypes.banner.sizes) adUnit.dimensions = bid.mediaTypes.banner.sizes
       networks[network].adUnits.push(adUnit);
     }
 
+    const requests = [];
     const networkKeys = Object.keys(networks)
     for (let j = 0; j < networkKeys.length; j++) {
       const network = networkKeys[j];
-      const networkRequest = [...request]
-      if (network.indexOf('_video') > -1) { networkRequest.push('tt=' + DEFAULT_VAST_VERSION) }
+      if (network.indexOf('_video') > -1) { queryParamsAndValues.push('tt=' + DEFAULT_VAST_VERSION) }
       const requestURL = gdprApplies ? ENDPOINT_URL_EUROPE : ENDPOINT_URL
       requests.push({
         method: 'POST',
-        url: requestURL + '?' + networkRequest.join('&'),
+        url: requestURL + '?' + queryParamsAndValues.join('&'),
         data: JSON.stringify(networks[network]),
         bid: bidRequests[network]
       });
@@ -129,6 +246,9 @@ export const spec = {
   },
 
   interpretResponse: function (serverResponse, bidRequest) {
+    if (serverResponse.body.metaData) {
+      storageTool.saveToStorage(serverResponse.body.metaData);
+    }
     const adUnits = serverResponse.body.adUnits;
 
     let validatedBidType = validateBidType(config.getConfig().bidType);

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -10,9 +10,10 @@ import {getGlobal} from '../../../src/prebidGlobal';
 describe('adnuntiusBidAdapter', function() {
   const URL = 'https://ads.adnuntius.delivery/i?tzo=';
   const EURO_URL = 'https://europe.delivery.adnuntius.com/i?tzo=';
-  const GVLID = 855;
   const usi = utils.generateUUID()
-  const meta = [{key: 'usi', value: usi}]
+
+  const meta = [{key: 'valueless'}, {value: 'keyless'}, {key: 'voidAuIds'}, {key: 'voidAuIds', value: [{auId: '11118b6bc', exp: misc.getUnixTimestamp()}, {exp: misc.getUnixTimestamp(1)}]}, {key: 'valid', value: 'also-valid', exp: misc.getUnixTimestamp(1)}, {key: 'expired', value: 'fwefew', exp: misc.getUnixTimestamp()}, {key: 'usi', value: 'should be skipped because timestamp', exp: misc.getUnixTimestamp()}, {key: 'usi', value: usi, exp: misc.getUnixTimestamp(100)}, {key: 'usi', value: 'should be skipped because timestamp', exp: misc.getUnixTimestamp()}]
+  let storage;
 
   before(() => {
     getGlobal().bidderSettings = {
@@ -20,8 +21,11 @@ describe('adnuntiusBidAdapter', function() {
         storageAllowed: true
       }
     };
-    const storage = getStorageManager({bidderCode: 'adnuntius'})
-    storage.setDataInLocalStorage('adn.metaData', JSON.stringify(meta))
+    storage = getStorageManager({bidderCode: 'adnuntius'});
+  });
+
+  beforeEach(() => {
+    storage.setDataInLocalStorage('adn.metaData', JSON.stringify(meta));
   });
 
   after(() => {
@@ -47,6 +51,7 @@ describe('adnuntiusBidAdapter', function() {
       bidder: 'adnuntius',
       params: {
         auId: '000000000008b6bc',
+        targetId: '123',
         network: 'adnuntius',
         maxDeals: 1
       },
@@ -459,7 +464,78 @@ describe('adnuntiusBidAdapter', function() {
       expect(request[0]).to.have.property('url');
       expect(request[0].url).to.equal(ENDPOINT_URL);
       expect(request[0]).to.have.property('data');
-      expect(request[0].data).to.equal('{"adUnits":[{"auId":"000000000008b6bc","targetId":"adn-000000000008b6bc","maxDeals":1,"dimensions":[[640,480],[600,400]]},{"auId":"0000000000000551","targetId":"adn-0000000000000551","maxDeals":0,"dimensions":[[1640,1480],[1600,1400]]}],"metaData":{"usi":"' + usi + '"}}');
+      expect(request[0].data).to.equal('{"adUnits":[{"auId":"000000000008b6bc","targetId":"123","maxDeals":1,"dimensions":[[640,480],[600,400]]},{"auId":"0000000000000551","targetId":"adn-0000000000000551","dimensions":[[1640,1480],[1600,1400]]}],"metaData":{"valid":"also-valid"}}');
+    });
+
+    it('Test requests with no local storage', function() {
+      storage.setDataInLocalStorage('adn.metaData', JSON.stringify([{}]));
+      const request = spec.buildRequests(bidderRequests, {});
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('bid');
+      const bid = request[0].bid[0]
+      expect(bid).to.have.property('bidId');
+      expect(request[0]).to.have.property('url');
+      expect(request[0].url).to.equal(ENDPOINT_URL_BASE);
+      expect(request[0]).to.have.property('data');
+      expect(request[0].data).to.equal('{"adUnits":[{"auId":"000000000008b6bc","targetId":"123","maxDeals":1,"dimensions":[[640,480],[600,400]]},{"auId":"0000000000000551","targetId":"adn-0000000000000551","dimensions":[[1640,1480],[1600,1400]]}]}');
+
+      localStorage.removeItem('adn.metaData');
+      const request2 = spec.buildRequests(bidderRequests, {});
+      expect(request2.length).to.equal(1);
+      expect(request2[0]).to.have.property('url');
+      expect(request2[0].url).to.equal(ENDPOINT_URL_BASE);
+    });
+
+    it('Test request changes for voided au ids', function() {
+      storage.setDataInLocalStorage('adn.metaData', JSON.stringify([{key: 'voidAuIds', value: [{auId: '11118b6bc', exp: misc.getUnixTimestamp(1)}, {auId: '0000000000000023', exp: misc.getUnixTimestamp(1)}]}]));
+      const bRequests = bidderRequests.concat([{
+        bidId: 'adn-11118b6bc',
+        bidder: 'adnuntius',
+        params: {
+          auId: '11118b6bc',
+          network: 'adnuntius',
+        },
+        mediaTypes: {
+          banner: {
+            sizes: [[1640, 1480], [1600, 1400]],
+          }
+        },
+      }]);
+      bRequests.push({
+        bidId: 'adn-23',
+        bidder: 'adnuntius',
+        params: {
+          auId: '23',
+          network: 'adnuntius',
+        },
+        mediaTypes: {
+          banner: {
+            sizes: [[1640, 1480], [1600, 1400]],
+          }
+        },
+      });
+      bRequests.push({
+        bidId: 'adn-13',
+        bidder: 'adnuntius',
+        params: {
+          auId: '13',
+          network: 'adnuntius',
+        },
+        mediaTypes: {
+          banner: {
+            sizes: [[164, 140], [10, 1400]],
+          }
+        },
+      });
+      const request = spec.buildRequests(bRequests, {});
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('bid');
+      const bid = request[0].bid[0]
+      expect(bid).to.have.property('bidId');
+      expect(request[0]).to.have.property('url');
+      expect(request[0].url).to.equal(ENDPOINT_URL_BASE);
+      expect(request[0]).to.have.property('data');
+      expect(request[0].data).to.equal('{"adUnits":[{"auId":"000000000008b6bc","targetId":"123","maxDeals":1,"dimensions":[[640,480],[600,400]]},{"auId":"0000000000000551","targetId":"adn-0000000000000551","dimensions":[[1640,1480],[1600,1400]]},{"auId":"13","targetId":"adn-13","dimensions":[[164,140],[10,1400]]}]}');
     });
 
     it('Test Video requests', function() {
@@ -477,7 +553,7 @@ describe('adnuntiusBidAdapter', function() {
         user: {
           data: [{
             name: 'adnuntius',
-            segment: [{id: 'segment1'}, {id: 'segment2'}]
+            segment: [{id: 'segment1'}, {id: 'segment2'}, {invalidSegment: 'invalid'}, {id: 123}, {id: ['3332']}]
           },
           {
             name: 'other',
@@ -660,7 +736,7 @@ describe('adnuntiusBidAdapter', function() {
       expect(bidderRequests[0].params.maxDeals).to.equal(1);
       expect(data.adUnits[0].maxDeals).to.equal(bidderRequests[0].params.maxDeals);
       expect(bidderRequests[1].params).to.not.have.property('maxBids');
-      expect(data.adUnits[1].maxDeals).to.equal(0);
+      expect(data.adUnits[1].maxDeals).to.equal(undefined);
     });
     it('Should allow a maximum of 5 deals.', function() {
       config.setBidderConfig({
@@ -706,7 +782,7 @@ describe('adnuntiusBidAdapter', function() {
       expect(request[0]).to.have.property('data');
       const data = JSON.parse(request[0].data);
       expect(data.adUnits.length).to.equal(1);
-      expect(data.adUnits[0].maxDeals).to.equal(0);
+      expect(data.adUnits[0].maxDeals).to.equal(undefined);
     });
     it('Should set max deals using bidder config.', function() {
       config.setBidderConfig({
@@ -794,6 +870,33 @@ describe('adnuntiusBidAdapter', function() {
       expect(interpretedResponse[1].ttl).to.equal(360);
       expect(interpretedResponse[1].dealId).to.equal('not-in-deal-array-here');
       expect(interpretedResponse[1].dealCount).to.equal(0);
+
+      const results = JSON.parse(storage.getDataFromLocalStorage('adn.metaData'));
+      const usiEntry = results.find(entry => entry.key === 'usi');
+      expect(usiEntry.key).to.equal('usi');
+      expect(usiEntry.value).to.equal('from-api-server dude');
+      expect(usiEntry.exp).to.be.greaterThan(misc.getUnixTimestamp(90));
+
+      const voidAuIdsEntry = results.find(entry => entry.key === 'voidAuIds');
+      expect(voidAuIdsEntry.key).to.equal('voidAuIds');
+      expect(voidAuIdsEntry.exp).to.equal(undefined);
+      expect(voidAuIdsEntry.value[0].auId).to.equal('00000000000abcde');
+      expect(voidAuIdsEntry.value[0].exp).to.be.greaterThan(misc.getUnixTimestamp());
+      expect(voidAuIdsEntry.value[0].exp).to.be.lessThan(misc.getUnixTimestamp(2));
+      expect(voidAuIdsEntry.value[1].auId).to.equal('00000000000fffff');
+      expect(voidAuIdsEntry.value[1].exp).to.be.greaterThan(misc.getUnixTimestamp());
+      expect(voidAuIdsEntry.value[1].exp).to.be.lessThan(misc.getUnixTimestamp(2));
+
+      const validEntry = results.find(entry => entry.key === 'valid');
+      expect(validEntry.key).to.equal('valid');
+      expect(validEntry.value).to.equal('also-valid');
+      expect(validEntry.exp).to.be.greaterThan(misc.getUnixTimestamp());
+      expect(validEntry.exp).to.be.lessThan(misc.getUnixTimestamp(2));
+
+      const randomApiEntry = results.find(entry => entry.key === 'randomApiKey');
+      expect(randomApiEntry.key).to.equal('randomApiKey');
+      expect(randomApiEntry.value).to.equal('randomApiValue');
+      expect(randomApiEntry.exp).to.be.greaterThan(misc.getUnixTimestamp(90));
     });
 
     it('should not process valid response when passed alt bidder that is an adndeal', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
- invalid ad units are put into a voidAuIds array in the ad server response
- this changeset stores those void ad units IDs into local storage and prevents calling to those same ad units.
- also stores any values from metaData from the adserver response into local storage and sends it with subsequent requests
- also some general refactoring


<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
