### PR TITLE
fledgeForGpt: use `imp.ext.ae` instead of `defaultForSlots`; add `prebid.ortb2` and `prebid.ortb2Imp` auction signals

### DIFF
--- a/modules/fledgeForGpt.js
+++ b/modules/fledgeForGpt.js
@@ -96,14 +96,15 @@ function onAuctionEnd({auctionId, bidsReceived, bidderRequests}) {
   }
 }
 
-export function addComponentAuctionHook(next, auctionId, adUnitCode, componentAuctionConfig) {
+export function addComponentAuctionHook(next, request, componentAuctionConfig) {
+  const {adUnitCode, auctionId} = request;
   if (PENDING.hasOwnProperty(auctionId)) {
     !PENDING[auctionId].hasOwnProperty(adUnitCode) && (PENDING[auctionId][adUnitCode] = []);
     PENDING[auctionId][adUnitCode].push(componentAuctionConfig);
   } else {
     logWarn(MODULE, `Received component auction config for auction that has closed (auction '${auctionId}', adUnit '${adUnitCode}')`, componentAuctionConfig)
   }
-  next(auctionId, adUnitCode, componentAuctionConfig);
+  next(request, componentAuctionConfig);
 }
 
 function isFledgeSupported() {

--- a/modules/fledgeForGpt.js
+++ b/modules/fledgeForGpt.js
@@ -96,9 +96,14 @@ function onAuctionEnd({auctionId, bidsReceived, bidderRequests}) {
   }
 }
 
+function setFPDSignals(auctionConfig, fpd) {
+  auctionConfig.auctionSignals = mergeDeep({}, {prebid: fpd}, auctionConfig.auctionSignals);
+}
+
 export function addComponentAuctionHook(next, request, componentAuctionConfig) {
-  const {adUnitCode, auctionId} = request;
+  const {adUnitCode, auctionId, ortb2, ortb2Imp} = request;
   if (PENDING.hasOwnProperty(auctionId)) {
+    setFPDSignals(componentAuctionConfig, {ortb2, ortb2Imp});
     !PENDING[auctionId].hasOwnProperty(adUnitCode) && (PENDING[auctionId][adUnitCode] = []);
     PENDING[auctionId][adUnitCode].push(componentAuctionConfig);
   } else {

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -503,8 +503,8 @@ export function PrebidServer() {
             }
           }
         },
-        onFledge: ({adUnitCode, config}) => {
-          addComponentAuction(bidRequests[0].auctionId, adUnitCode, config);
+        onFledge: (params) => {
+          addComponentAuction({auctionId: bidRequests[0].auctionId, ...params}, params.config);
         }
       })
     }

--- a/modules/prebidServerBidAdapter/ortbConverter.js
+++ b/modules/prebidServerBidAdapter/ortbConverter.js
@@ -240,7 +240,16 @@ const PBS_CONVERTER = ortbConverter({
       },
       fledgeAuctionConfigs(orig, response, ortbResponse, context) {
         const configs = Object.values(context.impContext)
-          .flatMap((impCtx) => (impCtx.fledgeConfigs || []).map(cfg => ({adUnitCode: impCtx.adUnit.code, config: cfg.config})));
+          .flatMap((impCtx) => (impCtx.fledgeConfigs || []).map(cfg => {
+            const bidderReq = impCtx.actualBidderRequests.find(br => br.bidderCode === cfg.bidder);
+            const bidReq = impCtx.actualBidRequests.get(cfg.bidder);
+            return {
+              adUnitCode: impCtx.adUnit.code,
+              ortb2: bidderReq?.ortb2,
+              ortb2Imp: bidReq?.ortb2Imp,
+              config: cfg.config
+            };
+          }));
         if (configs.length > 0) {
           response.fledgeAuctionConfigs = configs;
         }

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -292,7 +292,7 @@ export function newBidder(spec) {
           fledgeAuctionConfigs.forEach((fledgeAuctionConfig) => {
             const bidRequest = bidRequestMap[fledgeAuctionConfig.bidId];
             if (bidRequest) {
-              addComponentAuction(bidRequest.auctionId, bidRequest.adUnitCode, fledgeAuctionConfig.config);
+              addComponentAuction(bidRequest, fledgeAuctionConfig.config);
             } else {
               logWarn('Received fledge auction configuration for an unknown bidId', fledgeAuctionConfig);
             }
@@ -525,7 +525,7 @@ export const registerSyncInner = hook('async', function(spec, responses, gdprCon
   }
 }, 'registerSyncs')
 
-export const addComponentAuction = hook('sync', (adUnitCode, fledgeAuctionConfig) => {
+export const addComponentAuction = hook('sync', (request, fledgeAuctionConfig) => {
 }, 'addComponentAuction');
 
 // check that the bid has a width and height set

--- a/test/spec/modules/fledgeForGpt_spec.js
+++ b/test/spec/modules/fledgeForGpt_spec.js
@@ -81,6 +81,26 @@ describe('fledgeForGpt module', () => {
         sinon.assert.notCalled(mockGptSlot.setConfig);
       });
 
+      it('should augment auctionSignals with FPD', () => {
+        events.emit(CONSTANTS.EVENTS.AUCTION_INIT, {auctionId: 'aid'});
+        fledge.addComponentAuctionHook(nextFnSpy, {auctionId: 'aid', adUnitCode: 'au1', ortb2: {fpd: 1}, ortb2Imp: {fpd: 2}}, fledgeAuctionConfig);
+        events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId: 'aid'});
+        sinon.assert.calledWith(mockGptSlot.setConfig, {
+          componentAuction: [{
+            configKey: 'bidder',
+            auctionConfig: {
+              ...fledgeAuctionConfig,
+              auctionSignals: {
+                prebid: {
+                  ortb2: {fpd: 1},
+                  ortb2Imp: {fpd: 2}
+                }
+              }
+            },
+          }]
+        })
+      })
+
       describe('floor signal', () => {
         before(() => {
           if (!getGlobal().convertCurrency) {

--- a/test/spec/modules/fledgeForGpt_spec.js
+++ b/test/spec/modules/fledgeForGpt_spec.js
@@ -45,16 +45,17 @@ describe('fledgeForGpt module', () => {
       });
 
       it('should call next()', function () {
-        fledge.addComponentAuctionHook(nextFnSpy, 'aid', 'auc', fledgeAuctionConfig);
-        sinon.assert.calledWith(nextFnSpy, 'aid', 'auc', fledgeAuctionConfig);
+        const request = {auctionId: 'aid', adUnitCode: 'auc'};
+        fledge.addComponentAuctionHook(nextFnSpy, request, fledgeAuctionConfig);
+        sinon.assert.calledWith(nextFnSpy, request, fledgeAuctionConfig);
       });
 
       it('should collect auction configs and route them to GPT at end of auction', () => {
         events.emit(CONSTANTS.EVENTS.AUCTION_INIT, {auctionId: 'aid'});
         const cf1 = {...fledgeAuctionConfig, id: 1, seller: 'b1'};
         const cf2 = {...fledgeAuctionConfig, id: 2, seller: 'b2'};
-        fledge.addComponentAuctionHook(nextFnSpy, 'aid', 'au1', cf1);
-        fledge.addComponentAuctionHook(nextFnSpy, 'aid', 'au2', cf2);
+        fledge.addComponentAuctionHook(nextFnSpy, {auctionId: 'aid', adUnitCode: 'au1'}, cf1);
+        fledge.addComponentAuctionHook(nextFnSpy, {auctionId: 'aid', adUnitCode: 'au2'}, cf2);
         events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId: 'aid'});
         sinon.assert.calledWith(gptUtils.getGptSlotForAdUnitCode, 'au1');
         sinon.assert.calledWith(gptUtils.getGptSlotForAdUnitCode, 'au2');
@@ -75,7 +76,7 @@ describe('fledgeForGpt module', () => {
       it('should drop auction configs after end of auction', () => {
         events.emit(CONSTANTS.EVENTS.AUCTION_INIT, {auctionId: 'aid'});
         events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId: 'aid'});
-        fledge.addComponentAuctionHook(nextFnSpy, 'aid', 'au', fledgeAuctionConfig);
+        fledge.addComponentAuctionHook(nextFnSpy, {auctionId: 'aid', adUnitCode: 'au'}, fledgeAuctionConfig);
         events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId: 'aid'});
         sinon.assert.notCalled(mockGptSlot.setConfig);
       });
@@ -173,7 +174,7 @@ describe('fledgeForGpt module', () => {
 
                 it('should populate bidfloor/bidfloorcur', () => {
                   events.emit(CONSTANTS.EVENTS.AUCTION_INIT, {auctionId: 'aid'});
-                  fledge.addComponentAuctionHook(nextFnSpy, 'aid', 'au', fledgeAuctionConfig);
+                  fledge.addComponentAuctionHook(nextFnSpy, {auctionId: 'aid', adUnitCode: 'au'}, fledgeAuctionConfig);
                   events.emit(CONSTANTS.EVENTS.AUCTION_END, payload);
                   sinon.assert.calledWith(mockGptSlot.setConfig, sinon.match(arg => {
                     return arg.componentAuction.some(au => au.auctionConfig.auctionSignals?.prebid?.bidfloor === bidfloor && au.auctionConfig.auctionSignals?.prebid?.bidfloorcur === bidfloorcur)

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -3489,7 +3489,6 @@ describe('S2S Adapter', function () {
         request.ad_units.forEach(au => deepSetValue(au, 'ortb2Imp.ext.ae', 1));
       });
 
-
       function expectFledgeCalls() {
         const auctionId = bidderRequests[0].auctionId;
         sinon.assert.calledWith(fledgeStub, sinon.match({auctionId, adUnitCode: AU, ortb2: bidderRequests[0].ortb2, ortb2Imp: bidderRequests[0].bids[0].ortb2Imp}), {id: 1})

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -3425,6 +3425,32 @@ describe('S2S Adapter', function () {
       });
     });
     describe('when the response contains ext.prebid.fledge', () => {
+      const AU = 'div-gpt-ad-1460505748561-0';
+      const FLEDGE_RESP = {
+        ext: {
+          prebid: {
+            fledge: {
+              auctionconfigs: [
+                {
+                  impid: AU,
+                  bidder: 'appnexus',
+                  config: {
+                    id: 1
+                  }
+                },
+                {
+                  impid: AU,
+                  bidder: 'other',
+                  config: {
+                    id: 2
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+
       let fledgeStub, request, bidderRequests;
 
       function fledgeHook(next, ...args) {
@@ -3442,50 +3468,46 @@ describe('S2S Adapter', function () {
       beforeEach(function () {
         fledgeStub = sinon.stub();
         config.setConfig({CONFIG});
+        bidderRequests = deepClone(BID_REQUESTS);
+        AU
+        bidderRequests.forEach(req => {
+          Object.assign(req, {
+            fledgeEnabled: true,
+            ortb2: {
+              fpd: 1
+            }
+          })
+          req.bids.forEach(bid => {
+            Object.assign(bid, {
+              ortb2Imp: {
+                fpd: 2
+              }
+            })
+          })
+        });
         request = deepClone(REQUEST);
         request.ad_units.forEach(au => deepSetValue(au, 'ortb2Imp.ext.ae', 1));
-        bidderRequests = deepClone(BID_REQUESTS);
-        bidderRequests.forEach(req => req.fledgeEnabled = true);
       });
 
-      const AU = 'div-gpt-ad-1460505748561-0';
-      const FLEDGE_RESP = {
-        ext: {
-          prebid: {
-            fledge: {
-              auctionconfigs: [
-                {
-                  impid: AU,
-                  config: {
-                    id: 1
-                  }
-                },
-                {
-                  impid: AU,
-                  config: {
-                    id: 2
-                  }
-                }
-              ]
-            }
-          }
-        }
+
+      function expectFledgeCalls() {
+        const auctionId = bidderRequests[0].auctionId;
+        sinon.assert.calledWith(fledgeStub, sinon.match({auctionId, adUnitCode: AU, ortb2: bidderRequests[0].ortb2, ortb2Imp: bidderRequests[0].bids[0].ortb2Imp}), {id: 1})
+        sinon.assert.calledWith(fledgeStub, sinon.match({auctionId, adUnitCode: AU, ortb2: undefined, ortb2Imp: undefined}), {id: 2})
       }
 
       it('calls addComponentAuction alongside addBidResponse', function () {
         adapter.callBids(request, bidderRequests, addBidResponse, done, ajax);
         server.requests[0].respond(200, {}, JSON.stringify(mergeDeep({}, RESPONSE_OPENRTB, FLEDGE_RESP)));
         expect(addBidResponse.called).to.be.true;
-        sinon.assert.calledWith(fledgeStub, bidderRequests[0].auctionId, AU, {id: 1});
-        sinon.assert.calledWith(fledgeStub, bidderRequests[0].auctionId, AU, {id: 2});
+        expectFledgeCalls();
       });
 
       it('calls addComponentAuction when there is no bid in the response', () => {
         adapter.callBids(request, bidderRequests, addBidResponse, done, ajax);
         server.requests[0].respond(200, {}, JSON.stringify(FLEDGE_RESP));
         expect(addBidResponse.called).to.be.false;
-        sinon.assert.calledWith(fledgeStub, bidderRequests[0].auctionId, AU, {id: 1});
-        sinon.assert.calledWith(fledgeStub, bidderRequests[0].auctionId, AU, {id: 2});
+        expectFledgeCalls();
       })
     });
   });

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -1448,7 +1448,7 @@ describe('bidderFactory', () => {
           bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
           expect(fledgeStub.calledOnce).to.equal(true);
-          sinon.assert.calledWith(fledgeStub, bidRequest.auctionId, 'mock/placement', fledgeAuctionConfig.config);
+          sinon.assert.calledWith(fledgeStub, bidRequest.bids[0], fledgeAuctionConfig.config);
           expect(addBidResponseStub.calledOnce).to.equal(true);
           expect(addBidResponseStub.firstCall.args[0]).to.equal('mock/placement');
         })
@@ -1462,7 +1462,7 @@ describe('bidderFactory', () => {
           bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
 
           expect(fledgeStub.calledOnce).to.be.true;
-          sinon.assert.calledWith(fledgeStub, bidRequest.auctionId, 'mock/placement', fledgeAuctionConfig.config);
+          sinon.assert.calledWith(fledgeStub, bidRequest.bids[0], fledgeAuctionConfig.config);
           expect(addBidResponseStub.calledOnce).to.equal(false);
         })
       })


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

 - Update fledge logic to set `ortb2Imp.ext.ae` on bid requests when appropriate instead of `defaultForSlots`
 - Add `prebid.ortb2` and `prebid.ortb2Imp` to fledge `auctionSignals`

Closes https://github.com/prebid/Prebid.js/issues/10419
