### PR TITLE
Orbidder changes: send all Prebid.JS bidRequests fields to orbidder

### DIFF
--- a/modules/orbidderBidAdapter.js
+++ b/modules/orbidderBidAdapter.js
@@ -99,15 +99,7 @@ export const spec = {
         data: {
           v: getGlobal().version,
           pageUrl: referer,
-          bidId: bidRequest.bidId,
-          auctionId: bidRequest.auctionId,
-          // TODO: fix auctionId leak: https://github.com/prebid/Prebid.js/issues/9781
-          transactionId: bidRequest.ortb2Imp?.ext?.tid,
-          adUnitCode: bidRequest.adUnitCode,
-          bidRequestCount: bidRequest.bidRequestCount,
-          params: bidRequest.params,
-          sizes: bidRequest.sizes,
-          mediaTypes: bidRequest.mediaTypes
+          ...bidRequest // get all data provided by bid request
         }
       };
 

--- a/test/spec/modules/orbidderBidAdapter_spec.js
+++ b/test/spec/modules/orbidderBidAdapter_spec.js
@@ -9,39 +9,57 @@ describe('orbidderBidAdapter', () => {
   const defaultBidRequestBanner = {
     bidId: 'd66fa86787e0b0ca900a96eacfd5f0bb',
     auctionId: 'ccc4c7cdfe11cfbd74065e6dd28413d8',
-    ortb2Imp: {
-      ext: {
-        tid: 'd58851660c0c4461e4aa06344fc9c0c6',
-      }
-    },
+    transactionId: 'd58851660c0c4461e4aa06344fc9c0c6',
     bidRequestCount: 1,
     adUnitCode: 'adunit-code',
     sizes: [[300, 250], [300, 600]],
     params: {
       'accountId': 'string1',
-      'placementId': 'string2'
+      'placementId': 'string2',
+      'bidfloor': 1.23
     },
     mediaTypes: {
       banner: {
-        sizes: [[300, 250], [300, 600]],
+        sizes: [[300, 250], [300, 600]]
       }
-    }
+    },
+    userId: {
+      'id5id': {
+        'uid': 'ID5*XXXXXXXXXXXXX',
+        'ext': {
+          'linkType': 2,
+          'pba': 'XXXXXXXXXXXX=='
+        }
+      }
+    },
+    userIdAsEids: [
+      {
+        'source': 'id5-sync.com',
+        'uids': [
+          {
+            'id': 'ID5*XXXXXXXXXXXXX',
+            'atype': 1,
+            'ext': {
+              'linkType': 2,
+              'pba': 'XXXXXXXXXXXX=='
+            }
+          }
+        ]
+      }
+    ]
   };
 
   const defaultBidRequestNative = {
     bidId: 'd66fa86787e0b0ca900a96eacfd5f0bc',
     auctionId: 'ccc4c7cdfe11cfbd74065e6dd28413d9',
-    ortb2Imp: {
-      ext: {
-        tid: 'd58851660c0c4461e4aa06344fc9c0c7',
-      }
-    },
+    transactionId: 'd58851660c0c4461e4aa06344fc9c0c6',
     bidRequestCount: 1,
     adUnitCode: 'adunit-code-native',
     sizes: [],
     params: {
       'accountId': 'string3',
-      'placementId': 'string4'
+      'placementId': 'string4',
+      'bidfloor': 2.34
     },
     mediaTypes: {
       native: {
@@ -56,7 +74,31 @@ describe('orbidderBidAdapter', () => {
           required: true
         }
       }
-    }
+    },
+    userId: {
+      'id5id': {
+        'uid': 'ID5*YYYYYYYYYYYYYYY',
+        'ext': {
+          'linkType': 2,
+          'pba': 'YYYYYYYYYYYYY=='
+        }
+      }
+    },
+    userIdAsEids: [
+      {
+        'source': 'id5-sync.com',
+        'uids': [
+          {
+            'id': 'ID5*YYYYYYYYYYYYYYY',
+            'atype': 1,
+            'ext': {
+              'linkType': 2,
+              'pba': 'YYYYYYYYYYYYY=='
+            }
+          }
+        ]
+      }
+    ]
   };
 
   const deepClone = function(val) {
@@ -179,34 +221,20 @@ describe('orbidderBidAdapter', () => {
       // we add two, because we add pageUrl and version from bidderRequest object
       expect(Object.keys(request.data).length).to.equal(Object.keys(defaultBidRequestBanner).length + 2);
 
-      expect(request.data.bidId).to.equal(defaultBidRequestBanner.bidId);
-      expect(request.data.auctionId).to.equal(defaultBidRequestBanner.auctionId);
-      expect(request.data.transactionId).to.equal(defaultBidRequestBanner.ortb2Imp.ext.tid);
-      expect(request.data.bidRequestCount).to.equal(defaultBidRequestBanner.bidRequestCount);
-      expect(request.data.adUnitCode).to.equal(defaultBidRequestBanner.adUnitCode);
-      expect(request.data.pageUrl).to.equal('https://localhost:9876/');
-      expect(request.data.v).to.equal($$PREBID_GLOBAL$$.version);
-      expect(request.data.sizes).to.equal(defaultBidRequestBanner.sizes);
-
-      expect(_.isEqual(request.data.params, defaultBidRequestBanner.params)).to.be.true;
-      expect(_.isEqual(request.data.mediaTypes, defaultBidRequestBanner.mediaTypes)).to.be.true;
+      const expectedBidRequest = deepClone(defaultBidRequestBanner);
+      expectedBidRequest.pageUrl = 'https://localhost:9876/';
+      expectedBidRequest.v = $$PREBID_GLOBAL$$.version;
+      expect(request.data).to.deep.equal(expectedBidRequest);
     });
 
     it('native: sends correct bid parameters', () => {
       // we add two, because we add pageUrl and version from bidderRequest object
       expect(Object.keys(nativeRequest.data).length).to.equal(Object.keys(defaultBidRequestNative).length + 2);
 
-      expect(nativeRequest.data.bidId).to.equal(defaultBidRequestNative.bidId);
-      expect(nativeRequest.data.auctionId).to.equal(defaultBidRequestNative.auctionId);
-      expect(nativeRequest.data.transactionId).to.equal(defaultBidRequestNative.ortb2Imp.ext.tid);
-      expect(nativeRequest.data.bidRequestCount).to.equal(defaultBidRequestNative.bidRequestCount);
-      expect(nativeRequest.data.adUnitCode).to.equal(defaultBidRequestNative.adUnitCode);
-      expect(nativeRequest.data.pageUrl).to.equal('https://localhost:9876/');
-      expect(nativeRequest.data.v).to.equal($$PREBID_GLOBAL$$.version);
-      expect(nativeRequest.data.sizes).to.be.empty;
-
-      expect(_.isEqual(nativeRequest.data.params, defaultBidRequestNative.params)).to.be.true;
-      expect(_.isEqual(nativeRequest.data.mediaTypes, defaultBidRequestNative.mediaTypes)).to.be.true;
+      const expectedBidRequest = deepClone(defaultBidRequestNative);
+      expectedBidRequest.pageUrl = 'https://localhost:9876/';
+      expectedBidRequest.v = $$PREBID_GLOBAL$$.version;
+      expect(nativeRequest.data).to.deep.equal(expectedBidRequest);
     });
 
     it('banner: handles empty gdpr object', () => {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Orbidder likes to support to userId module. For this the behaviour, the bid request generation has to be changed.
From now on, Orbidder likes to receive alle bid request fields and not only predefined fields.
With this change there are as well no changes needed, when Orbidder likes to support other features.

