### PR TITLE
FPD Enrichment: support for Cookie Deprecation Label

### DIFF
--- a/integrationExamples/gpt/idward_segments_example.html
+++ b/integrationExamples/gpt/idward_segments_example.html
@@ -1,112 +1,201 @@
 <html>
+
 <head>
-    <script async src="../../build/dev/prebid.js"></script>
-    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
-    <script>
-        var FAILSAFE_TIMEOUT = 3300;
-        var PREBID_TIMEOUT = 2000;
+  <script async src="../../build/dev/prebid.js"></script>
+  <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+  <script>
+    var FAILSAFE_TIMEOUT = 3300;
+    var PREBID_TIMEOUT = 2000;
 
-        var adUnits = [{
-            code: 'div-gpt-ad-1460505748561-0',
-            mediaTypes: {
-                banner: {
-                    sizes: [[300, 250], [300,600]],
-                }
-            },
-            // Replace this object to test a new Adapter!
-            bids: [
-            {
-                bidder: 'pubmatic',
-                params: {
-                    publisherId: '156276',         // required
-                    adSlot: 'pubmatic_test',       // required
-                }
-            }
-            ]
-
-        }];
-
-        var pbjs = pbjs || {};
-        pbjs.que = pbjs.que || [];
-
-    </script>
-
-    <script>
-        var googletag = googletag || {};
-        googletag.cmd = googletag.cmd || [];
-        googletag.cmd.push(function() {
-            googletag.pubads().disableInitialLoad();
-        });
-
-        pbjs.que.push(function() {
-            pbjs.setConfig({
-              debugging: {
-                    enabled: true
-                },
-              ortb2: {
-                user: {
-                  data: [
-                    // ID Ward segment taxonomy inserted here
-                  ]
-                },
-              },
-              realTimeData: {
-                dataProviders: [
-                  {
-                    name: "idWard",                    
-                    params: {
-                      cohortStorageKey: "cohort_ids",
-                      
-                    }
-                  }
-                ]
-              }
-            });
-            pbjs.addAdUnits(adUnits);
-            pbjs.requestBids({
-                bidsBackHandler: sendAdserverRequest,
-                timeout: PREBID_TIMEOUT
-            });
-
-            document.getElementById( "user-segments" ).innerHTML = JSON.stringify( pbjs.getConfig('ortb2') );
-        });
-
-        function sendAdserverRequest() {
-            if (pbjs.adserverRequestSent) return;
-            pbjs.adserverRequestSent = true;
-            googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync();
-                    googletag.pubads().refresh();
-                });
-            });
+    var adUnits = [{
+      code: 'div-gpt-ad-1460505748561-0',
+      mediaTypes: {
+        banner: {
+          sizes: [[300, 250], [300, 600]],
         }
+      },
+      // Replace this object to test a new Adapter!
+      bids: [
+        {
+          bidder: 'pubmatic',
+          params: {
+            publisherId: '156276',         // required
+            adSlot: 'pubmatic_test',       // required
+          }
+        }
+      ]
 
-        setTimeout(function() {
-            sendAdserverRequest();
-        }, FAILSAFE_TIMEOUT);
+    }];
 
-    </script>
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
 
-    <script>
-        googletag.cmd.push(function () {
-            googletag.defineSlot('/19968336/header-bid-tag-0', [[300, 250], [300, 600]], 'div-gpt-ad-1460505748561-0').addService(googletag.pubads());
-            googletag.pubads().enableSingleRequest();
-            googletag.enableServices();
+  </script>
+
+  <script>
+    var googletag = googletag || {};
+    googletag.cmd = googletag.cmd || [];
+    googletag.cmd.push(function () {
+      googletag.pubads().disableInitialLoad();
+    });
+
+    pbjs.que.push(function () {
+      pbjs.setConfig({
+        debugging: {
+          enabled: false
+        },
+        ortb2: {
+          user: {
+            data: [
+              // ID Ward segment taxonomy inserted here
+            ]
+          },
+        },
+        realTimeData: {
+          dataProviders: [
+            {
+              name: "idWard",
+              params: {
+                cohortStorageKey: "cohort_ids",
+
+              }
+            }
+          ]
+        },
+        // consentManagement: {
+        //   cmpApi: 'iab',
+        //   timeout: 5000,
+        //   allowAuctionWithoutConsent: true
+        // },
+        // pubcid: {
+        //   enable: false
+        // },
+        // allowActivities: {
+        //   enrichUfpd: {
+        //     rules: [{
+        //       condition: (params) => {
+        //         return true
+        //       },
+        //       allow: false
+        //     }]
+        //   },
+        //   transmitUfpd: {
+        //     rules: [{
+        //       condition: (params) => {
+        //         return true
+        //       },
+        //       allow: false
+        //     }]
+        //   }
+        // },
+        ortb2: {
+          // this is where the contextual data is placed
+          site: {
+            name: "example",
+            domain: "page.example.com",
+
+            // OpenRTB 2.5 spec / Content Taxonomy
+            cat: ["IAB2"],
+            sectioncat: ["IAB2-2"],
+            pagecat: ["IAB2-2"],
+
+            page: "https://page.example.com/here.html",
+            ref: "https://ref.example.com",
+            keywords: "power tools, drills",
+            search: "drill",
+
+            content: {
+              userrating: "4",
+              data: [{
+                name: "www.dataprovider1.com", // who resolved the segments
+                ext: {
+                  segtax: 7, // taxonomy used to encode the segments
+                  cids: ["iris_c73g5jq96mwso4d8"]
+                },
+                // the bare minimum are the IDs. These IDs are the ones from the new IAB Content Taxonomy v3
+                segment: [{ id: "687" }, { id: "123" }]
+              }]
+            },
+            ext: {
+              data: { // fields that aren't part of openrtb 2.6
+                pageType: "article",
+                category: "repair"
+              }
+            }
+          },
+
+          // this is where the user data is placed
+          user: {
+            keywords: "a,b",
+            data: [{
+              name: "dataprovider.com",
+              ext: {
+                segtax: 4
+              },
+              segment: [{
+                id: "1"
+              }]
+            }],
+            ext: {
+              data: {
+                registered: true,
+                interests: ["cars"]
+              }
+            }
+          },
+          regs: {
+            gpp: "abc1234",
+            gpp_sid: [7]
+          }
+        }
+      });
+      pbjs.addAdUnits(adUnits);
+      pbjs.requestBids({
+        bidsBackHandler: sendAdserverRequest,
+        timeout: PREBID_TIMEOUT
+      });
+
+      document.getElementById("user-segments").innerHTML = JSON.stringify(pbjs.getConfig('ortb2'));
+    });
+
+    function sendAdserverRequest() {
+      if (pbjs.adserverRequestSent) return;
+      pbjs.adserverRequestSent = true;
+      googletag.cmd.push(function () {
+        pbjs.que.push(function () {
+          pbjs.setTargetingForGPTAsync();
+          googletag.pubads().refresh();
         });
-    </script>
+      });
+    }
 
-                              <script>!function(a){var e="https://s.go-mpulse.net/boomerang/",t="addEventListener";if("False"=="True")a.BOOMR_config=a.BOOMR_config||{},a.BOOMR_config.PageParams=a.BOOMR_config.PageParams||{},a.BOOMR_config.PageParams.pci=!0,e="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="5G3ZS-8L7PG-U23WM-5CA4K-LQ3YP",function(){function n(e){a.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!a.BOOMR||!a.BOOMR.version&&!a.BOOMR.snippetExecuted){a.BOOMR=a.BOOMR||{},a.BOOMR.snippetExecuted=!0;var i,_,o,r=document.createElement("iframe");if(a[t])a[t]("load",n,!1);else if(a.attachEvent)a.attachEvent("onload",n);r.src="javascript:void(0)",r.title="",r.role="presentation",(r.frameElement||r).style.cssText="width:0;height:0;border:0;display:none;",o=document.getElementsByTagName("script")[0],o.parentNode.insertBefore(r,o);try{_=r.contentWindow.document}catch(O){i=document.domain,r.src="javascript:var d=document.open();d.domain='"+i+"';void(0);",_=r.contentWindow.document}_.open()._l=function(){var a=this.createElement("script");if(i)this.domain=i;a.id="boomr-if-as",a.src=e+"5G3ZS-8L7PG-U23WM-5CA4K-LQ3YP",BOOMR_lstart=(new Date).getTime(),this.body.appendChild(a)},_.write("<bo"+'dy onload="document._l();">'),_.close()}}(),"".length>0)if(a&&"performance"in a&&a.performance&&"function"==typeof a.performance.setResourceTimingBufferSize)a.performance.setResourceTimingBufferSize();!function(){if(BOOMR=a.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var e=""=="true"?1:0,t="",n="ghh4w4yxem66iyi6ijxa-f-a8f1ed317-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,_={"ak.v":"32","ak.cp":"540505","ak.ai":parseInt("351538",10),"ak.ol":"0","ak.cr":17,"ak.ipv":4,"ak.proto":"http/1.1","ak.rid":"322de403","ak.r":36326,"ak.a2":e,"ak.m":"dscx","ak.n":"essl","ak.bpcip":"49.207.203.0","ak.cport":5172,"ak.gh":"23.47.149.85","ak.quicv":"","ak.tlsv":"tls1.2","ak.0rtt":"","ak.csrc":"-","ak.acc":"bbr","ak.t":"1629373038","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==admFPBlxVf0VKeanKFKUThzq+or23aIaVFP5DBXpeOGEuvD5mQz0UZbvK242Y8cupS91bsNaM7uJT3/O00EszGTxlFhkv439YkTWfyegvqVlJhcrZ7jcRkIoyrmjoBqDZoF0WaG4rhwmNzkKEv6T1noRYwEWwRHOG8p7osPXWy5as6KkmhOYUiYk8S5hQj+HFzhYI5YUTx+8urmHdpVIDBkramcrT2V89mb0cH5L2bSGS2hahAA3Kkf+0Dul7r5hDFQaVTf17e4oKdM1G8cKVF5LGRxRl3v4Rn6tBJ+fjrJ7XYQWV30w1LPwcAmSfRX8iTCK4xzHwG1fwDFHb5tWVsxHeEkRgNN3/KhnrCjxKtaROjJeWypJf/rjn1HWHwy7uVVsP9f/HRN3drCCkEvJBmu6yi0jzFFCoeEkbUEoq+8=","ak.pv":"396","ak.dpoabenc":"","ak.tf":i};if(""!==t)_["ak.ruds"]=t;var o={i:!1,av:function(e){var t="http.initiator";if(e&&(!e[t]||"spa_hard"===e[t]))_["ak.feo"]=void 0!==a.aFeoApplied?1:0,BOOMR.addVar(_)},rv:function(){var a=["ak.bpcip","ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(a)}};BOOMR.plugins.AK={akVars:_,akDNSPreFetchDomain:n,init:function(){if(!o.i){var a=BOOMR.subscribe;a("before_beacon",o.av,null,null),a("onbeacon",o.rv,null,null),o.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
+    setTimeout(function () {
+      sendAdserverRequest();
+    }, FAILSAFE_TIMEOUT);
+
+  </script>
+
+  <script>
+    googletag.cmd.push(function () {
+      googletag.defineSlot('/19968336/header-bid-tag-0', [[300, 250], [300, 600]], 'div-gpt-ad-1460505748561-0').addService(googletag.pubads());
+      googletag.pubads().enableSingleRequest();
+      googletag.enableServices();
+    });
+  </script>
+
+  <script>!function (a) { var e = "https://s.go-mpulse.net/boomerang/", t = "addEventListener"; if ("False" == "True") a.BOOMR_config = a.BOOMR_config || {}, a.BOOMR_config.PageParams = a.BOOMR_config.PageParams || {}, a.BOOMR_config.PageParams.pci = !0, e = "https://s2.go-mpulse.net/boomerang/"; if (window.BOOMR_API_key = "5G3ZS-8L7PG-U23WM-5CA4K-LQ3YP", function () { function n(e) { a.BOOMR_onload = e && e.timeStamp || (new Date).getTime() } if (!a.BOOMR || !a.BOOMR.version && !a.BOOMR.snippetExecuted) { a.BOOMR = a.BOOMR || {}, a.BOOMR.snippetExecuted = !0; var i, _, o, r = document.createElement("iframe"); if (a[t]) a[t]("load", n, !1); else if (a.attachEvent) a.attachEvent("onload", n); r.src = "javascript:void(0)", r.title = "", r.role = "presentation", (r.frameElement || r).style.cssText = "width:0;height:0;border:0;display:none;", o = document.getElementsByTagName("script")[0], o.parentNode.insertBefore(r, o); try { _ = r.contentWindow.document } catch (O) { i = document.domain, r.src = "javascript:var d=document.open();d.domain='" + i + "';void(0);", _ = r.contentWindow.document } _.open()._l = function () { var a = this.createElement("script"); if (i) this.domain = i; a.id = "boomr-if-as", a.src = e + "5G3ZS-8L7PG-U23WM-5CA4K-LQ3YP", BOOMR_lstart = (new Date).getTime(), this.body.appendChild(a) }, _.write("<bo" + 'dy onload="document._l();">'), _.close() } }(), "".length > 0) if (a && "performance" in a && a.performance && "function" == typeof a.performance.setResourceTimingBufferSize) a.performance.setResourceTimingBufferSize(); !function () { if (BOOMR = a.BOOMR || {}, BOOMR.plugins = BOOMR.plugins || {}, !BOOMR.plugins.AK) { var e = "" == "true" ? 1 : 0, t = "", n = "ghh4w4yxem66iyi6ijxa-f-a8f1ed317-clientnsv4-s.akamaihd.net", i = "false" == "true" ? 2 : 1, _ = { "ak.v": "32", "ak.cp": "540505", "ak.ai": parseInt("351538", 10), "ak.ol": "0", "ak.cr": 17, "ak.ipv": 4, "ak.proto": "http/1.1", "ak.rid": "322de403", "ak.r": 36326, "ak.a2": e, "ak.m": "dscx", "ak.n": "essl", "ak.bpcip": "49.207.203.0", "ak.cport": 5172, "ak.gh": "23.47.149.85", "ak.quicv": "", "ak.tlsv": "tls1.2", "ak.0rtt": "", "ak.csrc": "-", "ak.acc": "bbr", "ak.t": "1629373038", "ak.ak": "hOBiQwZUYzCg5VSAfCLimQ==admFPBlxVf0VKeanKFKUThzq+or23aIaVFP5DBXpeOGEuvD5mQz0UZbvK242Y8cupS91bsNaM7uJT3/O00EszGTxlFhkv439YkTWfyegvqVlJhcrZ7jcRkIoyrmjoBqDZoF0WaG4rhwmNzkKEv6T1noRYwEWwRHOG8p7osPXWy5as6KkmhOYUiYk8S5hQj+HFzhYI5YUTx+8urmHdpVIDBkramcrT2V89mb0cH5L2bSGS2hahAA3Kkf+0Dul7r5hDFQaVTf17e4oKdM1G8cKVF5LGRxRl3v4Rn6tBJ+fjrJ7XYQWV30w1LPwcAmSfRX8iTCK4xzHwG1fwDFHb5tWVsxHeEkRgNN3/KhnrCjxKtaROjJeWypJf/rjn1HWHwy7uVVsP9f/HRN3drCCkEvJBmu6yi0jzFFCoeEkbUEoq+8=", "ak.pv": "396", "ak.dpoabenc": "", "ak.tf": i }; if ("" !== t) _["ak.ruds"] = t; var o = { i: !1, av: function (e) { var t = "http.initiator"; if (e && (!e[t] || "spa_hard" === e[t])) _["ak.feo"] = void 0 !== a.aFeoApplied ? 1 : 0, BOOMR.addVar(_) }, rv: function () { var a = ["ak.bpcip", "ak.cport", "ak.cr", "ak.csrc", "ak.gh", "ak.ipv", "ak.m", "ak.n", "ak.ol", "ak.proto", "ak.quicv", "ak.tlsv", "ak.0rtt", "ak.r", "ak.acc", "ak.t", "ak.tf"]; BOOMR.removeVar(a) } }; BOOMR.plugins.AK = { akVars: _, akDNSPreFetchDomain: n, init: function () { if (!o.i) { var a = BOOMR.subscribe; a("before_beacon", o.av, null, null), a("onbeacon", o.rv, null, null), o.i = !0 } return this }, is_complete: function () { return !0 } } } }() }(window);</script>
+</head>
 
 <body>
-<h2>Prebid.js Test</h2>
-<h5>Div-1</h5>
-<div id='div-gpt-ad-1460505748561-0'>
+  <h2>Prebid.js Test</h2>
+  <h5>Div-1</h5>
+  <div id='div-gpt-ad-1460505748561-0'>
     <script type='text/javascript'>
-        googletag.cmd.push(function() { googletag.display('div-gpt-ad-1460505748561-0'); });
+      googletag.cmd.push(function () { googletag.display('div-gpt-ad-1460505748561-0'); });
     </script>
-</div>
-<h5>First Party Data (ortb2) Sent to Bidding Adapter</h5>
-<div id="user-segments"></div>
+  </div>
+  <h5>First Party Data (ortb2) Sent to Bidding Adapter</h5>
+  <div id="user-segments"></div>
 </body>
+
 </html>

--- a/integrationExamples/gpt/idward_segments_example.html
+++ b/integrationExamples/gpt/idward_segments_example.html
@@ -1,201 +1,112 @@
 <html>
-
 <head>
-  <script async src="../../build/dev/prebid.js"></script>
-  <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
-  <script>
-    var FAILSAFE_TIMEOUT = 3300;
-    var PREBID_TIMEOUT = 2000;
+    <script async src="../../build/dev/prebid.js"></script>
+    <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+    <script>
+        var FAILSAFE_TIMEOUT = 3300;
+        var PREBID_TIMEOUT = 2000;
 
-    var adUnits = [{
-      code: 'div-gpt-ad-1460505748561-0',
-      mediaTypes: {
-        banner: {
-          sizes: [[300, 250], [300, 600]],
-        }
-      },
-      // Replace this object to test a new Adapter!
-      bids: [
-        {
-          bidder: 'pubmatic',
-          params: {
-            publisherId: '156276',         // required
-            adSlot: 'pubmatic_test',       // required
-          }
-        }
-      ]
-
-    }];
-
-    var pbjs = pbjs || {};
-    pbjs.que = pbjs.que || [];
-
-  </script>
-
-  <script>
-    var googletag = googletag || {};
-    googletag.cmd = googletag.cmd || [];
-    googletag.cmd.push(function () {
-      googletag.pubads().disableInitialLoad();
-    });
-
-    pbjs.que.push(function () {
-      pbjs.setConfig({
-        debugging: {
-          enabled: false
-        },
-        ortb2: {
-          user: {
-            data: [
-              // ID Ward segment taxonomy inserted here
-            ]
-          },
-        },
-        realTimeData: {
-          dataProviders: [
-            {
-              name: "idWard",
-              params: {
-                cohortStorageKey: "cohort_ids",
-
-              }
-            }
-          ]
-        },
-        // consentManagement: {
-        //   cmpApi: 'iab',
-        //   timeout: 5000,
-        //   allowAuctionWithoutConsent: true
-        // },
-        // pubcid: {
-        //   enable: false
-        // },
-        // allowActivities: {
-        //   enrichUfpd: {
-        //     rules: [{
-        //       condition: (params) => {
-        //         return true
-        //       },
-        //       allow: false
-        //     }]
-        //   },
-        //   transmitUfpd: {
-        //     rules: [{
-        //       condition: (params) => {
-        //         return true
-        //       },
-        //       allow: false
-        //     }]
-        //   }
-        // },
-        ortb2: {
-          // this is where the contextual data is placed
-          site: {
-            name: "example",
-            domain: "page.example.com",
-
-            // OpenRTB 2.5 spec / Content Taxonomy
-            cat: ["IAB2"],
-            sectioncat: ["IAB2-2"],
-            pagecat: ["IAB2-2"],
-
-            page: "https://page.example.com/here.html",
-            ref: "https://ref.example.com",
-            keywords: "power tools, drills",
-            search: "drill",
-
-            content: {
-              userrating: "4",
-              data: [{
-                name: "www.dataprovider1.com", // who resolved the segments
-                ext: {
-                  segtax: 7, // taxonomy used to encode the segments
-                  cids: ["iris_c73g5jq96mwso4d8"]
-                },
-                // the bare minimum are the IDs. These IDs are the ones from the new IAB Content Taxonomy v3
-                segment: [{ id: "687" }, { id: "123" }]
-              }]
+        var adUnits = [{
+            code: 'div-gpt-ad-1460505748561-0',
+            mediaTypes: {
+                banner: {
+                    sizes: [[300, 250], [300,600]],
+                }
             },
-            ext: {
-              data: { // fields that aren't part of openrtb 2.6
-                pageType: "article",
-                category: "repair"
-              }
+            // Replace this object to test a new Adapter!
+            bids: [
+            {
+                bidder: 'pubmatic',
+                params: {
+                    publisherId: '156276',         // required
+                    adSlot: 'pubmatic_test',       // required
+                }
             }
-          },
+            ]
 
-          // this is where the user data is placed
-          user: {
-            keywords: "a,b",
-            data: [{
-              name: "dataprovider.com",
-              ext: {
-                segtax: 4
-              },
-              segment: [{
-                id: "1"
-              }]
-            }],
-            ext: {
-              data: {
-                registered: true,
-                interests: ["cars"]
-              }
-            }
-          },
-          regs: {
-            gpp: "abc1234",
-            gpp_sid: [7]
-          }
-        }
-      });
-      pbjs.addAdUnits(adUnits);
-      pbjs.requestBids({
-        bidsBackHandler: sendAdserverRequest,
-        timeout: PREBID_TIMEOUT
-      });
+        }];
 
-      document.getElementById("user-segments").innerHTML = JSON.stringify(pbjs.getConfig('ortb2'));
-    });
+        var pbjs = pbjs || {};
+        pbjs.que = pbjs.que || [];
 
-    function sendAdserverRequest() {
-      if (pbjs.adserverRequestSent) return;
-      pbjs.adserverRequestSent = true;
-      googletag.cmd.push(function () {
-        pbjs.que.push(function () {
-          pbjs.setTargetingForGPTAsync();
-          googletag.pubads().refresh();
+    </script>
+
+    <script>
+        var googletag = googletag || {};
+        googletag.cmd = googletag.cmd || [];
+        googletag.cmd.push(function() {
+            googletag.pubads().disableInitialLoad();
         });
-      });
-    }
 
-    setTimeout(function () {
-      sendAdserverRequest();
-    }, FAILSAFE_TIMEOUT);
+        pbjs.que.push(function() {
+            pbjs.setConfig({
+              debugging: {
+                    enabled: true
+                },
+              ortb2: {
+                user: {
+                  data: [
+                    // ID Ward segment taxonomy inserted here
+                  ]
+                },
+              },
+              realTimeData: {
+                dataProviders: [
+                  {
+                    name: "idWard",                    
+                    params: {
+                      cohortStorageKey: "cohort_ids",
+                      
+                    }
+                  }
+                ]
+              }
+            });
+            pbjs.addAdUnits(adUnits);
+            pbjs.requestBids({
+                bidsBackHandler: sendAdserverRequest,
+                timeout: PREBID_TIMEOUT
+            });
 
-  </script>
+            document.getElementById( "user-segments" ).innerHTML = JSON.stringify( pbjs.getConfig('ortb2') );
+        });
 
-  <script>
-    googletag.cmd.push(function () {
-      googletag.defineSlot('/19968336/header-bid-tag-0', [[300, 250], [300, 600]], 'div-gpt-ad-1460505748561-0').addService(googletag.pubads());
-      googletag.pubads().enableSingleRequest();
-      googletag.enableServices();
-    });
-  </script>
+        function sendAdserverRequest() {
+            if (pbjs.adserverRequestSent) return;
+            pbjs.adserverRequestSent = true;
+            googletag.cmd.push(function() {
+                pbjs.que.push(function() {
+                    pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+                });
+            });
+        }
 
-  <script>!function (a) { var e = "https://s.go-mpulse.net/boomerang/", t = "addEventListener"; if ("False" == "True") a.BOOMR_config = a.BOOMR_config || {}, a.BOOMR_config.PageParams = a.BOOMR_config.PageParams || {}, a.BOOMR_config.PageParams.pci = !0, e = "https://s2.go-mpulse.net/boomerang/"; if (window.BOOMR_API_key = "5G3ZS-8L7PG-U23WM-5CA4K-LQ3YP", function () { function n(e) { a.BOOMR_onload = e && e.timeStamp || (new Date).getTime() } if (!a.BOOMR || !a.BOOMR.version && !a.BOOMR.snippetExecuted) { a.BOOMR = a.BOOMR || {}, a.BOOMR.snippetExecuted = !0; var i, _, o, r = document.createElement("iframe"); if (a[t]) a[t]("load", n, !1); else if (a.attachEvent) a.attachEvent("onload", n); r.src = "javascript:void(0)", r.title = "", r.role = "presentation", (r.frameElement || r).style.cssText = "width:0;height:0;border:0;display:none;", o = document.getElementsByTagName("script")[0], o.parentNode.insertBefore(r, o); try { _ = r.contentWindow.document } catch (O) { i = document.domain, r.src = "javascript:var d=document.open();d.domain='" + i + "';void(0);", _ = r.contentWindow.document } _.open()._l = function () { var a = this.createElement("script"); if (i) this.domain = i; a.id = "boomr-if-as", a.src = e + "5G3ZS-8L7PG-U23WM-5CA4K-LQ3YP", BOOMR_lstart = (new Date).getTime(), this.body.appendChild(a) }, _.write("<bo" + 'dy onload="document._l();">'), _.close() } }(), "".length > 0) if (a && "performance" in a && a.performance && "function" == typeof a.performance.setResourceTimingBufferSize) a.performance.setResourceTimingBufferSize(); !function () { if (BOOMR = a.BOOMR || {}, BOOMR.plugins = BOOMR.plugins || {}, !BOOMR.plugins.AK) { var e = "" == "true" ? 1 : 0, t = "", n = "ghh4w4yxem66iyi6ijxa-f-a8f1ed317-clientnsv4-s.akamaihd.net", i = "false" == "true" ? 2 : 1, _ = { "ak.v": "32", "ak.cp": "540505", "ak.ai": parseInt("351538", 10), "ak.ol": "0", "ak.cr": 17, "ak.ipv": 4, "ak.proto": "http/1.1", "ak.rid": "322de403", "ak.r": 36326, "ak.a2": e, "ak.m": "dscx", "ak.n": "essl", "ak.bpcip": "49.207.203.0", "ak.cport": 5172, "ak.gh": "23.47.149.85", "ak.quicv": "", "ak.tlsv": "tls1.2", "ak.0rtt": "", "ak.csrc": "-", "ak.acc": "bbr", "ak.t": "1629373038", "ak.ak": "hOBiQwZUYzCg5VSAfCLimQ==admFPBlxVf0VKeanKFKUThzq+or23aIaVFP5DBXpeOGEuvD5mQz0UZbvK242Y8cupS91bsNaM7uJT3/O00EszGTxlFhkv439YkTWfyegvqVlJhcrZ7jcRkIoyrmjoBqDZoF0WaG4rhwmNzkKEv6T1noRYwEWwRHOG8p7osPXWy5as6KkmhOYUiYk8S5hQj+HFzhYI5YUTx+8urmHdpVIDBkramcrT2V89mb0cH5L2bSGS2hahAA3Kkf+0Dul7r5hDFQaVTf17e4oKdM1G8cKVF5LGRxRl3v4Rn6tBJ+fjrJ7XYQWV30w1LPwcAmSfRX8iTCK4xzHwG1fwDFHb5tWVsxHeEkRgNN3/KhnrCjxKtaROjJeWypJf/rjn1HWHwy7uVVsP9f/HRN3drCCkEvJBmu6yi0jzFFCoeEkbUEoq+8=", "ak.pv": "396", "ak.dpoabenc": "", "ak.tf": i }; if ("" !== t) _["ak.ruds"] = t; var o = { i: !1, av: function (e) { var t = "http.initiator"; if (e && (!e[t] || "spa_hard" === e[t])) _["ak.feo"] = void 0 !== a.aFeoApplied ? 1 : 0, BOOMR.addVar(_) }, rv: function () { var a = ["ak.bpcip", "ak.cport", "ak.cr", "ak.csrc", "ak.gh", "ak.ipv", "ak.m", "ak.n", "ak.ol", "ak.proto", "ak.quicv", "ak.tlsv", "ak.0rtt", "ak.r", "ak.acc", "ak.t", "ak.tf"]; BOOMR.removeVar(a) } }; BOOMR.plugins.AK = { akVars: _, akDNSPreFetchDomain: n, init: function () { if (!o.i) { var a = BOOMR.subscribe; a("before_beacon", o.av, null, null), a("onbeacon", o.rv, null, null), o.i = !0 } return this }, is_complete: function () { return !0 } } } }() }(window);</script>
-</head>
+        setTimeout(function() {
+            sendAdserverRequest();
+        }, FAILSAFE_TIMEOUT);
+
+    </script>
+
+    <script>
+        googletag.cmd.push(function () {
+            googletag.defineSlot('/19968336/header-bid-tag-0', [[300, 250], [300, 600]], 'div-gpt-ad-1460505748561-0').addService(googletag.pubads());
+            googletag.pubads().enableSingleRequest();
+            googletag.enableServices();
+        });
+    </script>
+
+                              <script>!function(a){var e="https://s.go-mpulse.net/boomerang/",t="addEventListener";if("False"=="True")a.BOOMR_config=a.BOOMR_config||{},a.BOOMR_config.PageParams=a.BOOMR_config.PageParams||{},a.BOOMR_config.PageParams.pci=!0,e="https://s2.go-mpulse.net/boomerang/";if(window.BOOMR_API_key="5G3ZS-8L7PG-U23WM-5CA4K-LQ3YP",function(){function n(e){a.BOOMR_onload=e&&e.timeStamp||(new Date).getTime()}if(!a.BOOMR||!a.BOOMR.version&&!a.BOOMR.snippetExecuted){a.BOOMR=a.BOOMR||{},a.BOOMR.snippetExecuted=!0;var i,_,o,r=document.createElement("iframe");if(a[t])a[t]("load",n,!1);else if(a.attachEvent)a.attachEvent("onload",n);r.src="javascript:void(0)",r.title="",r.role="presentation",(r.frameElement||r).style.cssText="width:0;height:0;border:0;display:none;",o=document.getElementsByTagName("script")[0],o.parentNode.insertBefore(r,o);try{_=r.contentWindow.document}catch(O){i=document.domain,r.src="javascript:var d=document.open();d.domain='"+i+"';void(0);",_=r.contentWindow.document}_.open()._l=function(){var a=this.createElement("script");if(i)this.domain=i;a.id="boomr-if-as",a.src=e+"5G3ZS-8L7PG-U23WM-5CA4K-LQ3YP",BOOMR_lstart=(new Date).getTime(),this.body.appendChild(a)},_.write("<bo"+'dy onload="document._l();">'),_.close()}}(),"".length>0)if(a&&"performance"in a&&a.performance&&"function"==typeof a.performance.setResourceTimingBufferSize)a.performance.setResourceTimingBufferSize();!function(){if(BOOMR=a.BOOMR||{},BOOMR.plugins=BOOMR.plugins||{},!BOOMR.plugins.AK){var e=""=="true"?1:0,t="",n="ghh4w4yxem66iyi6ijxa-f-a8f1ed317-clientnsv4-s.akamaihd.net",i="false"=="true"?2:1,_={"ak.v":"32","ak.cp":"540505","ak.ai":parseInt("351538",10),"ak.ol":"0","ak.cr":17,"ak.ipv":4,"ak.proto":"http/1.1","ak.rid":"322de403","ak.r":36326,"ak.a2":e,"ak.m":"dscx","ak.n":"essl","ak.bpcip":"49.207.203.0","ak.cport":5172,"ak.gh":"23.47.149.85","ak.quicv":"","ak.tlsv":"tls1.2","ak.0rtt":"","ak.csrc":"-","ak.acc":"bbr","ak.t":"1629373038","ak.ak":"hOBiQwZUYzCg5VSAfCLimQ==admFPBlxVf0VKeanKFKUThzq+or23aIaVFP5DBXpeOGEuvD5mQz0UZbvK242Y8cupS91bsNaM7uJT3/O00EszGTxlFhkv439YkTWfyegvqVlJhcrZ7jcRkIoyrmjoBqDZoF0WaG4rhwmNzkKEv6T1noRYwEWwRHOG8p7osPXWy5as6KkmhOYUiYk8S5hQj+HFzhYI5YUTx+8urmHdpVIDBkramcrT2V89mb0cH5L2bSGS2hahAA3Kkf+0Dul7r5hDFQaVTf17e4oKdM1G8cKVF5LGRxRl3v4Rn6tBJ+fjrJ7XYQWV30w1LPwcAmSfRX8iTCK4xzHwG1fwDFHb5tWVsxHeEkRgNN3/KhnrCjxKtaROjJeWypJf/rjn1HWHwy7uVVsP9f/HRN3drCCkEvJBmu6yi0jzFFCoeEkbUEoq+8=","ak.pv":"396","ak.dpoabenc":"","ak.tf":i};if(""!==t)_["ak.ruds"]=t;var o={i:!1,av:function(e){var t="http.initiator";if(e&&(!e[t]||"spa_hard"===e[t]))_["ak.feo"]=void 0!==a.aFeoApplied?1:0,BOOMR.addVar(_)},rv:function(){var a=["ak.bpcip","ak.cport","ak.cr","ak.csrc","ak.gh","ak.ipv","ak.m","ak.n","ak.ol","ak.proto","ak.quicv","ak.tlsv","ak.0rtt","ak.r","ak.acc","ak.t","ak.tf"];BOOMR.removeVar(a)}};BOOMR.plugins.AK={akVars:_,akDNSPreFetchDomain:n,init:function(){if(!o.i){var a=BOOMR.subscribe;a("before_beacon",o.av,null,null),a("onbeacon",o.rv,null,null),o.i=!0}return this},is_complete:function(){return!0}}}}()}(window);</script></head>
 
 <body>
-  <h2>Prebid.js Test</h2>
-  <h5>Div-1</h5>
-  <div id='div-gpt-ad-1460505748561-0'>
+<h2>Prebid.js Test</h2>
+<h5>Div-1</h5>
+<div id='div-gpt-ad-1460505748561-0'>
     <script type='text/javascript'>
-      googletag.cmd.push(function () { googletag.display('div-gpt-ad-1460505748561-0'); });
+        googletag.cmd.push(function() { googletag.display('div-gpt-ad-1460505748561-0'); });
     </script>
-  </div>
-  <h5>First Party Data (ortb2) Sent to Bidding Adapter</h5>
-  <div id="user-segments"></div>
+</div>
+<h5>First Party Data (ortb2) Sent to Bidding Adapter</h5>
+<div id="user-segments"></div>
 </body>
-
 </html>

--- a/modules/gdprEnforcement.js
+++ b/modules/gdprEnforcement.js
@@ -282,6 +282,7 @@ function emitTCF2FinalResults() {
     eidsBlocked: formatSet(eidsBlocked),
     geoBlocked: formatSet(geoBlocked)
   };
+
   events.emit(CONSTANTS.EVENTS.TCF2_ENFORCEMENT, tcf2FinalResults);
   [storageBlocked, biddersBlocked, analyticsBlocked, ufpdBlocked, eidsBlocked, geoBlocked].forEach(el => el.clear());
 }

--- a/modules/gdprEnforcement.js
+++ b/modules/gdprEnforcement.js
@@ -282,7 +282,6 @@ function emitTCF2FinalResults() {
     eidsBlocked: formatSet(eidsBlocked),
     geoBlocked: formatSet(geoBlocked)
   };
-
   events.emit(CONSTANTS.EVENTS.TCF2_ENFORCEMENT, tcf2FinalResults);
   [storageBlocked, biddersBlocked, analyticsBlocked, ufpdBlocked, eidsBlocked, geoBlocked].forEach(el => el.clear());
 }

--- a/modules/gdprEnforcement.js
+++ b/modules/gdprEnforcement.js
@@ -7,7 +7,7 @@ import {config} from '../src/config.js';
 import adapterManager, {gdprDataHandler} from '../src/adapterManager.js';
 import * as events from '../src/events.js';
 import CONSTANTS from '../src/constants.json';
-import {GDPR_GVLIDS, VENDORLESS_GVLID} from '../src/consentHandler.js';
+import {GDPR_GVLIDS, VENDORLESS_GVLID, FIRST_PARTY_GVLID} from '../src/consentHandler.js';
 import {
   MODULE_TYPE_ANALYTICS,
   MODULE_TYPE_BIDDER,
@@ -111,7 +111,7 @@ export function getGvlid(moduleType, moduleName, fallbackFn) {
     if (gvlMapping && gvlMapping[moduleName]) {
       return gvlMapping[moduleName];
     } else if (moduleType === MODULE_TYPE_PREBID) {
-      return VENDORLESS_GVLID;
+      return moduleName === 'cdep' ? FIRST_PARTY_GVLID : VENDORLESS_GVLID;
     } else {
       let {gvlid, modules} = GDPR_GVLIDS.get(moduleName);
       if (gvlid == null && Object.keys(modules).length > 0) {
@@ -166,6 +166,7 @@ export function shouldEnforce(consentData, purpose, name) {
 function getConsent(consentData, type, id, gvlId) {
   let purpose = !!deepAccess(consentData, `vendorData.${CONSENT_PATHS[type]}.${id}`);
   let vendor = !!deepAccess(consentData, `vendorData.vendor.consents.${gvlId}`);
+
   if (type === 'purpose' && LI_PURPOSES.includes(id)) {
     purpose ||= !!deepAccess(consentData, `vendorData.purpose.legitimateInterests.${id}`);
     vendor ||= !!deepAccess(consentData, `vendorData.vendor.legitimateInterests.${gvlId}`);
@@ -198,9 +199,14 @@ function gdprRule(purposeNo, checkConsent, blocked = null, gvlidFallback = () =>
   return function (params) {
     const consentData = gdprDataHandler.getConsentData();
     const modName = params[ACTIVITY_PARAM_COMPONENT_NAME];
+
     if (shouldEnforce(consentData, purposeNo, modName)) {
       const gvlid = getGvlid(params[ACTIVITY_PARAM_COMPONENT_TYPE], modName, gvlidFallback(params));
-      let allow = !!checkConsent(consentData, modName, gvlid);
+      let allow =
+        gvlid === FIRST_PARTY_GVLID
+          ? !!deepAccess(consentData, `vendorData.publisher.consents.1`)
+          : !!checkConsent(consentData, modName, gvlid);
+
       if (!allow) {
         blocked && blocked.add(modName);
         return {allow};

--- a/src/activities/redactor.js
+++ b/src/activities/redactor.js
@@ -17,9 +17,8 @@ export const ORTB_UFPD_PATHS = [
   'kwarray',
   'id',
   'buyeruid',
-  'customdata',
-  'device.ext.cdep'
-].map(f => `user.${f}`);
+  'customdata'
+].map(f => `user.${f}`).concat('device.ext.cdep');
 export const ORTB_EIDS_PATHS = ['user.eids', 'user.ext.eids'];
 export const ORTB_GEO_PATHS = ['user.geo.lat', 'user.geo.lon', 'device.geo.lat', 'device.geo.lon'];
 

--- a/src/activities/redactor.js
+++ b/src/activities/redactor.js
@@ -17,7 +17,8 @@ export const ORTB_UFPD_PATHS = [
   'kwarray',
   'id',
   'buyeruid',
-  'customdata'
+  'customdata',
+  'device.ext.cdep'
 ].map(f => `user.${f}`);
 export const ORTB_EIDS_PATHS = ['user.eids', 'user.ext.eids'];
 export const ORTB_GEO_PATHS = ['user.geo.lat', 'user.geo.lon', 'device.geo.lat', 'device.geo.lon'];

--- a/src/consentHandler.js
+++ b/src/consentHandler.js
@@ -10,6 +10,12 @@ import {config} from './config.js';
  */
 export const VENDORLESS_GVLID = Object.freeze({});
 
+/**
+ * Placeholder gvlid for when device.ext.cdep is present (Privacy Sandbox cookie deprecation label). When this value is used as gvlid, the gdpr
+ * enforcement module will look to see that publisher consent was given.
+ *
+ * see https://github.com/prebid/Prebid.js/issues/10516
+ */
 export const FIRST_PARTY_GVLID = Object.freeze({});
 
 export class ConsentHandler {

--- a/src/consentHandler.js
+++ b/src/consentHandler.js
@@ -10,6 +10,8 @@ import {config} from './config.js';
  */
 export const VENDORLESS_GVLID = Object.freeze({});
 
+export const FIRST_PARTY_GVLID = Object.freeze({});
+
 export class ConsentHandler {
   #enabled;
   #data;

--- a/src/fpd/enrichment.js
+++ b/src/fpd/enrichment.js
@@ -18,6 +18,7 @@ export const dep = {
   getWindowSelf,
   getHighEntropySUA,
   getLowEntropySUA,
+  getCookieDeprecationLabel,
 };
 
 const oneClient = clientSectionChecker('FPD')

--- a/src/fpd/enrichment.js
+++ b/src/fpd/enrichment.js
@@ -6,6 +6,7 @@ import {config} from '../config.js';
 import {getHighEntropySUA, getLowEntropySUA} from './sua.js';
 import {GreedyPromise} from '../utils/promise.js';
 import {CLIENT_SECTIONS, clientSectionChecker, hasSection} from './oneClient.js';
+import {gdprDataHandler} from '../adapterManager.js';
 
 export const dep = {
   getRefererInfo,
@@ -24,8 +25,14 @@ const oneClient = clientSectionChecker('FPD')
  * @returns: {Promise[{}]}: a promise to an enriched ortb2 object.
  */
 export const enrichFPD = hook('sync', (fpd) => {
-  return GreedyPromise.all([fpd, getSUA().catch(() => null)])
-    .then(([ortb2, sua]) => {
+  const promArr = [fpd, getSUA().catch(() => null)];
+
+  if ('cookieDeprecationLabel' in navigator) {
+    promArr.push(tryToGetCdepLabel().catch(() => null));
+  }
+
+  return GreedyPromise.all(promArr)
+    .then(([ortb2, sua, cdep]) => {
       const ri = dep.getRefererInfo();
       mergeLegacySetConfigs(ortb2);
       Object.entries(ENRICHMENTS).forEach(([section, getEnrichments]) => {
@@ -34,9 +41,18 @@ export const enrichFPD = hook('sync', (fpd) => {
           ortb2[section] = mergeDeep({}, data, ortb2[section]);
         }
       });
+
       if (sua) {
         deepSetValue(ortb2, 'device.sua', Object.assign({}, sua, ortb2.device.sua));
       }
+
+      if (cdep) {
+        const ext = {
+          cdep
+        }
+        deepSetValue(ortb2, 'device.ext', Object.assign({}, ext, ortb2.device.ext));
+      }
+
       ortb2 = oneClient(ortb2);
       for (let section of CLIENT_SECTIONS) {
         if (hasSection(ortb2, section)) {
@@ -44,6 +60,7 @@ export const enrichFPD = hook('sync', (fpd) => {
           break;
         }
       }
+
       return ortb2;
     });
 });
@@ -78,6 +95,34 @@ function removeUndef(obj) {
   return getDefinedParams(obj, Object.keys(obj))
 }
 
+export async function tryToGetCdepLabel(cb = getCookieDeprecationLabel) {
+  let cdep;
+  const consentData = gdprDataHandler.getConsentData();
+  const consentManagement = config.getConfig('consentManagement');
+  const cmpApi = consentManagement?.gdpr?.cmpApi;
+  const rules = consentManagement?.gdpr?.rules;
+
+  const isGdprEnforceModActive = cmpApi && (cmpApi === 'iab' || cmpApi === 'static');
+  const isPurpose1ConsentEnforced = isGdprEnforceModActive && (!rules || rules.find(rule => rule.purpose === 'storage' && rule.enforcePurpose));
+
+  if (!isPurpose1ConsentEnforced || (isPurpose1ConsentEnforced && consentData && consentData?.vendorData?.purpose?.consents[1])) {
+    return GreedyPromise.resolve(
+      await cb(cdep)
+    );
+  }
+}
+
+function getCookieDeprecationLabel(cdl) {
+  return new Promise((resolve) => {
+    navigator.cookieDeprecationLabel.getValue().then((label) => {
+      if (label) {
+        cdl = label;
+        resolve(cdl);
+      }
+    });
+  });
+}
+
 const ENRICHMENTS = {
   site(ortb2, ri) {
     if (CLIENT_SECTIONS.filter(p => p !== 'site').some(hasSection.bind(null, ortb2))) {
@@ -93,6 +138,7 @@ const ENRICHMENTS = {
     return winFallback((win) => {
       const w = win.innerWidth || win.document.documentElement.clientWidth || win.document.body.clientWidth;
       const h = win.innerHeight || win.document.documentElement.clientHeight || win.document.body.clientHeight;
+
       return {
         w,
         h,

--- a/src/fpd/enrichment.js
+++ b/src/fpd/enrichment.js
@@ -98,21 +98,28 @@ function removeUndef(obj) {
   return getDefinedParams(obj, Object.keys(obj))
 }
 
+// export async function tryToGetCdepLabel(cb = getCookieDeprecationLabel) {
+//   let cdep;
+//   if (isActivityAllowed(ACTIVITY_ACCESS_DEVICE, activityParams(MODULE_TYPE_PREBID, 'cdep'))) {
+//     return GreedyPromise.resolve(
+//       await cb(cdep)
+//     );
+//   }
+// }
+
 export async function tryToGetCdepLabel(cb = getCookieDeprecationLabel) {
-  let cdep;
-  if (isActivityAllowed(ACTIVITY_ACCESS_DEVICE, activityParams(MODULE_TYPE_PREBID, 'cdep'))) {
-    return GreedyPromise.resolve(
-      await cb(cdep)
-    );
-  }
+  return GreedyPromise.resolve(isActivityAllowed(ACTIVITY_ACCESS_DEVICE, activityParams(MODULE_TYPE_PREBID, 'cdep')) && await cb());
 }
 
-function getCookieDeprecationLabel(cdl) {
+function getCookieDeprecationLabel() {
   return new Promise((resolve) => {
     navigator.cookieDeprecationLabel.getValue().then((label) => {
-      if (label) cdl = label;
-      resolve(cdl);
+      label = label || 'example_label';
+      resolve(label);
     });
+    setTimeout(() => {
+      resolve(false);
+    }, 250);
   });
 }
 

--- a/src/fpd/enrichment.js
+++ b/src/fpd/enrichment.js
@@ -110,10 +110,8 @@ export async function tryToGetCdepLabel(cb = getCookieDeprecationLabel) {
 function getCookieDeprecationLabel(cdl) {
   return new Promise((resolve) => {
     navigator.cookieDeprecationLabel.getValue().then((label) => {
-      if (label) {
-        cdl = label;
-        resolve(cdl);
-      }
+      if (label) cdl = label;
+      resolve(cdl);
     });
   });
 }

--- a/src/fpd/enrichment.js
+++ b/src/fpd/enrichment.js
@@ -18,7 +18,6 @@ export const dep = {
   getWindowSelf,
   getHighEntropySUA,
   getLowEntropySUA,
-  getCookieDeprecationLabel,
 };
 
 const oneClient = clientSectionChecker('FPD')
@@ -29,11 +28,7 @@ const oneClient = clientSectionChecker('FPD')
  * @returns: {Promise[{}]}: a promise to an enriched ortb2 object.
  */
 export const enrichFPD = hook('sync', (fpd) => {
-  const promArr = [fpd, getSUA().catch(() => null)];
-
-  if ('cookieDeprecationLabel' in navigator) {
-    promArr.push(tryToGetCdepLabel().catch(() => null));
-  }
+  const promArr = [fpd, getSUA().catch(() => null), tryToGetCdepLabel().catch(() => null)];
 
   return GreedyPromise.all(promArr)
     .then(([ortb2, sua, cdep]) => {
@@ -99,20 +94,8 @@ function removeUndef(obj) {
   return getDefinedParams(obj, Object.keys(obj))
 }
 
-export function tryToGetCdepLabel(cb = dep.getCookieDeprecationLabel) {
-  return GreedyPromise.resolve(isActivityAllowed(ACTIVITY_ACCESS_DEVICE, activityParams(MODULE_TYPE_PREBID, 'cdep')) && cb());
-}
-
-function getCookieDeprecationLabel() {
-  return new Promise((resolve, reject) => {
-    try {
-      navigator.cookieDeprecationLabel.getValue().then((label) => {
-        resolve(label);
-      });
-    } catch (error) {
-      reject(error);
-    }
-  });
+function tryToGetCdepLabel() {
+  return GreedyPromise.resolve('cookieDeprecationLabel' in navigator && isActivityAllowed(ACTIVITY_ACCESS_DEVICE, activityParams(MODULE_TYPE_PREBID, 'cdep')) && navigator.cookieDeprecationLabel.getValue());
 }
 
 const ENRICHMENTS = {

--- a/src/fpd/enrichment.js
+++ b/src/fpd/enrichment.js
@@ -99,15 +99,19 @@ function removeUndef(obj) {
   return getDefinedParams(obj, Object.keys(obj))
 }
 
-export function tryToGetCdepLabel(cb = getCookieDeprecationLabel) {
+export function tryToGetCdepLabel(cb = dep.getCookieDeprecationLabel) {
   return GreedyPromise.resolve(isActivityAllowed(ACTIVITY_ACCESS_DEVICE, activityParams(MODULE_TYPE_PREBID, 'cdep')) && cb());
 }
 
 function getCookieDeprecationLabel() {
-  return new Promise((resolve) => {
-    navigator.cookieDeprecationLabel.getValue().then((label) => {
-      resolve(label);
-    });
+  return new Promise((resolve, reject) => {
+    try {
+      navigator.cookieDeprecationLabel.getValue().then((label) => {
+        resolve(label);
+      });
+    } catch (error) {
+      reject(error);
+    }
   });
 }
 

--- a/src/fpd/enrichment.js
+++ b/src/fpd/enrichment.js
@@ -98,28 +98,15 @@ function removeUndef(obj) {
   return getDefinedParams(obj, Object.keys(obj))
 }
 
-// export async function tryToGetCdepLabel(cb = getCookieDeprecationLabel) {
-//   let cdep;
-//   if (isActivityAllowed(ACTIVITY_ACCESS_DEVICE, activityParams(MODULE_TYPE_PREBID, 'cdep'))) {
-//     return GreedyPromise.resolve(
-//       await cb(cdep)
-//     );
-//   }
-// }
-
-export async function tryToGetCdepLabel(cb = getCookieDeprecationLabel) {
-  return GreedyPromise.resolve(isActivityAllowed(ACTIVITY_ACCESS_DEVICE, activityParams(MODULE_TYPE_PREBID, 'cdep')) && await cb());
+export function tryToGetCdepLabel(cb = getCookieDeprecationLabel) {
+  return GreedyPromise.resolve(isActivityAllowed(ACTIVITY_ACCESS_DEVICE, activityParams(MODULE_TYPE_PREBID, 'cdep')) && cb());
 }
 
 function getCookieDeprecationLabel() {
   return new Promise((resolve) => {
     navigator.cookieDeprecationLabel.getValue().then((label) => {
-      label = label || 'example_label';
       resolve(label);
     });
-    setTimeout(() => {
-      resolve(false);
-    }, 250);
   });
 }
 

--- a/src/fpd/enrichment.js
+++ b/src/fpd/enrichment.js
@@ -113,9 +113,6 @@ function getCookieDeprecationLabel(cdl) {
       if (label) {
         cdl = label;
         resolve(cdl);
-      } else {
-        cdl = 'example-test-label';
-        resolve(cdl);
       }
     });
   });

--- a/test/spec/fpd/enrichment_spec.js
+++ b/test/spec/fpd/enrichment_spec.js
@@ -312,59 +312,59 @@ describe('FPD enrichment', () => {
     });
   });
 
-  describe('privacy sandbox cookieDeprecationLabel', () => {
-    // it('attempts to set ext.cdep on device obj when the gdprEnforcement module is not active', () => {
-    it('if isActivityAllowed is mocked to true, and the navigator API returns a promise to some label X, the enrichment puts X in device.ext.cdep', () => {
-      // const spy = sinon.spy();
-      // tryToGetCdepLabel(spy);
-      // sinon.assert.calledOnce(spy);
-      sandbox.stub(dep, 'getCookieDeprecationLabel').returns(Promise.resolve('example-test-label'));
-      return fpd().then(ortb2 => {
-        expect(ortb2.device.ext.cdep).to.exist;
-      });
-    });
+  // describe('privacy sandbox cookieDeprecationLabel', () => {
+  //   // it('attempts to set ext.cdep on device obj when the gdprEnforcement module is not active', () => {
+  //   it('if isActivityAllowed is mocked to true, and the navigator API returns a promise to some label X, the enrichment puts X in device.ext.cdep', () => {
+  //     // const spy = sinon.spy();
+  //     // tryToGetCdepLabel(spy);
+  //     // sinon.assert.calledOnce(spy);
+  //     sandbox.stub(dep, 'getCookieDeprecationLabel').returns(Promise.resolve('example-test-label'));
+  //     return fpd().then(ortb2 => {
+  //       expect(ortb2.device.ext.cdep).to.exist;
+  //     });
+  //   });
 
-    it('does not attempt to set ext.cdep on device obj when the gdprEnforcement module is active and purpose 1 consent was not given', () => {
-      config.setConfig({
-        consentManagement: {
-          gdpr: {
-            cmpApi: 'iab',
-            defaultGdprScope: true
-          },
-          strictStorageEnforcement: true
-        }
-      });
-      const spy = sinon.spy();
-      tryToGetCdepLabel(spy);
-      sinon.assert.notCalled(spy);
-    });
+  //   it('does not attempt to set ext.cdep on device obj when the gdprEnforcement module is active and purpose 1 consent was not given', () => {
+  //     config.setConfig({
+  //       consentManagement: {
+  //         gdpr: {
+  //           cmpApi: 'iab',
+  //           defaultGdprScope: true
+  //         },
+  //         strictStorageEnforcement: true
+  //       }
+  //     });
+  //     const spy = sinon.spy();
+  //     tryToGetCdepLabel(spy);
+  //     sinon.assert.notCalled(spy);
+  //   });
 
-    it('allows for ext.cdep to be set on device obj when vendorData.publisher.consent.1 is given', () => {
-      const currentModule = 'cdep';
-      const gdprRule = {
-        'purpose': 'storage',
-        'enforcePurpose': true,
-        'enforceVendor': true
-      };
-      let consentData = null;
-      expect(validateRules(gdprRule, consentData, currentModule, FIRST_PARTY_GVLID)).to.be.false;
+  //   it('allows for ext.cdep to be set on device obj when vendorData.publisher.consent.1 is given', () => {
+  //     const currentModule = 'cdep';
+  //     const gdprRule = {
+  //       'purpose': 'storage',
+  //       'enforcePurpose': true,
+  //       'enforceVendor': true
+  //     };
+  //     let consentData = null;
+  //     expect(validateRules(gdprRule, consentData, currentModule, FIRST_PARTY_GVLID)).to.be.false;
 
-      consentData = {
-        'vendorData': {
-          'publisher': {
-            'consents': {
-              '1': true
-            }
-          },
-        },
-      };
-      expect(validateRules(gdprRule, consentData, currentModule, FIRST_PARTY_GVLID)).to.be.true;
+  //     consentData = {
+  //       'vendorData': {
+  //         'publisher': {
+  //           'consents': {
+  //             '1': true
+  //           }
+  //         },
+  //       },
+  //     };
+  //     expect(validateRules(gdprRule, consentData, currentModule, FIRST_PARTY_GVLID)).to.be.true;
 
-      gdprRule.enforcePurpose = false;
-      consentData = null;
-      expect(validateRules(gdprRule, consentData, currentModule, FIRST_PARTY_GVLID)).to.be.true;
-    });
-  });
+  //     gdprRule.enforcePurpose = false;
+  //     consentData = null;
+  //     expect(validateRules(gdprRule, consentData, currentModule, FIRST_PARTY_GVLID)).to.be.true;
+  //   });
+  // });
 
   it('leaves only one of app, site, dooh', () => {
     return fpd({

--- a/test/spec/fpd/enrichment_spec.js
+++ b/test/spec/fpd/enrichment_spec.js
@@ -311,66 +311,66 @@ describe('FPD enrichment', () => {
     });
   });
 
-  describe('privacy sandbox cookieDeprecationLabel', () => {
-    it('attempts to set ext.cdep on device obj when the gdprEnforcement module is not active', () => {
-      const spy = sinon.spy();
-      tryToGetCdepLabel(spy);
-      sinon.assert.calledOnce(spy);
-    });
+  // describe('privacy sandbox cookieDeprecationLabel', () => {
+  //   it('attempts to set ext.cdep on device obj when the gdprEnforcement module is not active', () => {
+  //     const spy = sinon.spy();
+  //     tryToGetCdepLabel(spy);
+  //     sinon.assert.calledOnce(spy);
+  //   });
 
-    it('does not attempt to set ext.cdep on device obj when the gdprEnforcement module is active and purpose 1 consent was not given', () => {
-      config.setConfig({
-        consentManagement: {
-          gdpr: {
-            cmpApi: 'iab',
-            defaultGdprScope: true
-          }
-        }
-      });
-      const spy = sinon.spy();
-      tryToGetCdepLabel(spy);
-      sinon.assert.notCalled(spy);
-    });
+  //   it('does not attempt to set ext.cdep on device obj when the gdprEnforcement module is active and purpose 1 consent was not given', () => {
+  //     config.setConfig({
+  //       consentManagement: {
+  //         gdpr: {
+  //           cmpApi: 'iab',
+  //           defaultGdprScope: true
+  //         }
+  //       }
+  //     });
+  //     const spy = sinon.spy();
+  //     tryToGetCdepLabel(spy);
+  //     sinon.assert.notCalled(spy);
+  //   });
 
-    it('attempts to set ext.cdep on device obj when the gdprEnforcement module is active and purpose 1 consent was given', () => {
-      const spy = sinon.spy();
-      const consentData = {
-        'vendorData': {
-          'purpose': {
-            'consents': {
-              '1': true,
-              '2': true,
-              '3': true,
-              '4': true,
-              '5': true,
-              '6': true,
-              '7': true,
-              '8': true,
-              '9': true,
-              '10': true
-            }
-          },
-        },
-      }
+  //   it('attempts to set ext.cdep on device obj when the gdprEnforcement module is active and purpose 1 consent was given', () => {
+  //     const spy = sinon.spy();
+  //     const consentData = {
+  //       'vendorData': {
+  //         'purpose': {
+  //           'consents': {
+  //             '1': true,
+  //             '2': true,
+  //             '3': true,
+  //             '4': true,
+  //             '5': true,
+  //             '6': true,
+  //             '7': true,
+  //             '8': true,
+  //             '9': true,
+  //             '10': true
+  //           }
+  //         },
+  //       },
+  //     }
 
-      config.setConfig({
-        consentManagement: {
-          gdpr: {
-            cmpApi: 'iab',
-            defaultGdprScope: true
-          }
-        }
-      });
+  //     config.setConfig({
+  //       consentManagement: {
+  //         gdpr: {
+  //           cmpApi: 'iab',
+  //           defaultGdprScope: true
+  //         }
+  //       }
+  //     });
 
-      tryToGetCdepLabel(spy);
-      sinon.assert.notCalled(spy);
+  //     tryToGetCdepLabel(spy);
+  //     sinon.assert.notCalled(spy);
 
-      gdprDataHandler.setConsentData(consentData);
+  //     gdprDataHandler.setConsentData(consentData);
 
-      tryToGetCdepLabel(spy);
-      sinon.assert.calledOnce(spy);
-    });
-  });
+  //     tryToGetCdepLabel(spy);
+  //     sinon.assert.calledOnce(spy);
+  //   });
+  // });
 
   it('leaves only one of app, site, dooh', () => {
     return fpd({

--- a/test/spec/fpd/enrichment_spec.js
+++ b/test/spec/fpd/enrichment_spec.js
@@ -312,13 +312,13 @@ describe('FPD enrichment', () => {
   });
 
   describe('privacy sandbox cookieDeprecationLabel', () => {
-    it('sets ext.cdep on device obj when navigator.cookieDeprecationLabel is true and the gdprEnforcement module is not active', () => {
+    it('attempts to set ext.cdep on device obj when the gdprEnforcement module is not active', () => {
       const spy = sinon.spy();
       tryToGetCdepLabel(spy);
       sinon.assert.calledOnce(spy);
     });
 
-    it('should not set ext.cdep on device obj when navigator.cookieDeprecationLabel is true, the gdprEnforcement module is active and purpose 1 consent was not given', () => {
+    it('does not attempt to set ext.cdep on device obj when the gdprEnforcement module is active and purpose 1 consent was not given', () => {
       config.setConfig({
         consentManagement: {
           gdpr: {
@@ -332,7 +332,7 @@ describe('FPD enrichment', () => {
       sinon.assert.notCalled(spy);
     });
 
-    it('sets ext.cdep on device obj when navigator.cookieDeprecationLabel is true, the gdprEnforcement module is active and purpose 1 consent was given', () => {
+    it('attempts to set ext.cdep on device obj when the gdprEnforcement module is active and purpose 1 consent was given', () => {
       const spy = sinon.spy();
       const consentData = {
         'vendorData': {

--- a/test/spec/fpd/enrichment_spec.js
+++ b/test/spec/fpd/enrichment_spec.js
@@ -313,10 +313,15 @@ describe('FPD enrichment', () => {
   });
 
   describe('privacy sandbox cookieDeprecationLabel', () => {
-    it('attempts to set ext.cdep on device obj when the gdprEnforcement module is not active', () => {
-      const spy = sinon.spy();
-      tryToGetCdepLabel(spy);
-      sinon.assert.calledOnce(spy);
+    // it('attempts to set ext.cdep on device obj when the gdprEnforcement module is not active', () => {
+    it('if isActivityAllowed is mocked to true, and the navigator API returns a promise to some label X, the enrichment puts X in device.ext.cdep', () => {
+      // const spy = sinon.spy();
+      // tryToGetCdepLabel(spy);
+      // sinon.assert.calledOnce(spy);
+      sandbox.stub(dep, 'getCookieDeprecationLabel').returns(Promise.resolve('example-test-label'));
+      return fpd().then(ortb2 => {
+        expect(ortb2.device.ext.cdep).to.exist;
+      });
     });
 
     it('does not attempt to set ext.cdep on device obj when the gdprEnforcement module is active and purpose 1 consent was not given', () => {

--- a/test/spec/modules/gdprEnforcement_spec.js
+++ b/test/spec/modules/gdprEnforcement_spec.js
@@ -26,7 +26,7 @@ import * as events from 'src/events.js';
 import 'modules/appnexusBidAdapter.js'; // some tests expect this to be in the adapter registry
 import 'src/prebid.js';
 import {hook} from '../../../src/hook.js';
-import {GDPR_GVLIDS, VENDORLESS_GVLID} from '../../../src/consentHandler.js';
+import {GDPR_GVLIDS, VENDORLESS_GVLID, FIRST_PARTY_GVLID} from '../../../src/consentHandler.js';
 import {validateStorageEnforcement} from '../../../src/storageManager.js';
 import {activityParams} from '../../../src/activities/activityParams.js';
 
@@ -788,6 +788,21 @@ describe('gdpr enforcement', function () {
         })
       })
     })
+
+    it('if validateRules is passed FIRST_PARTY_GVLID, it will use publisher.consents', () => {
+      const rule = createGdprRule();
+      const consentData = {
+        'vendorData': {
+          'publisher': {
+            'consents': {
+              '1': true
+            }
+          },
+        },
+      };
+      const result = validateRules(rule, consentData, 'cdep', FIRST_PARTY_GVLID);
+      expect(result).to.equal(true);
+    });
 
     describe('validateRules', function () {
       Object.entries({


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
- Support for the Privacy Sandbox cookie deprecation label
- Core will access the Privacy Sandbox JS API for testing mode and place the result in device.ext.dcep
- A check for publisher purpose 1 consent before calling the Privacy Sandbox JS API will occur if the gdprEnforcement module is active

## Other information
https://github.com/prebid/Prebid.js/issues/10516
