### PR TITLE
PBjs Core : new event fired before add bid response

### DIFF
--- a/modules/rtdModule/index.js
+++ b/modules/rtdModule/index.js
@@ -215,7 +215,8 @@ const setEventsListeners = (function () {
         [CONSTANTS.EVENTS.AUCTION_INIT]: ['onAuctionInitEvent'],
         [CONSTANTS.EVENTS.AUCTION_END]: ['onAuctionEndEvent', getAdUnitTargeting],
         [CONSTANTS.EVENTS.BID_RESPONSE]: ['onBidResponseEvent'],
-        [CONSTANTS.EVENTS.BID_REQUESTED]: ['onBidRequestEvent']
+        [CONSTANTS.EVENTS.BID_REQUESTED]: ['onBidRequestEvent'],
+        [CONSTANTS.EVENTS.BEFORE_ADD_BID_RESPONSE]: ['onBeforeAddBidResponseEvent']
       }).forEach(([ev, [handler, preprocess]]) => {
         events.on(ev, (args) => {
           preprocess && preprocess(args);

--- a/modules/rtdModule/index.js
+++ b/modules/rtdModule/index.js
@@ -216,7 +216,7 @@ const setEventsListeners = (function () {
         [CONSTANTS.EVENTS.AUCTION_END]: ['onAuctionEndEvent', getAdUnitTargeting],
         [CONSTANTS.EVENTS.BID_RESPONSE]: ['onBidResponseEvent'],
         [CONSTANTS.EVENTS.BID_REQUESTED]: ['onBidRequestEvent'],
-        [CONSTANTS.EVENTS.BEFORE_ADD_BID_RESPONSE]: ['onBeforeAddBidResponseEvent']
+        [CONSTANTS.EVENTS.BID_ACCEPTED]: ['onBidAcceptedEvent']
       }).forEach(([ev, [handler, preprocess]]) => {
         events.on(ev, (args) => {
           preprocess && preprocess(args);

--- a/src/auction.js
+++ b/src/auction.js
@@ -451,7 +451,7 @@ export function auctionCallbacks(auctionDone, auctionInstance, {index = auctionM
   function acceptBidResponse(adUnitCode, bid) {
     handleBidResponse(adUnitCode, bid, (done) => {
       let bidResponse = getPreparedBidForAuction(bid);
-
+      events.emit(CONSTANTS.EVENTS.BEFORE_ADD_BID_RESPONSE, bidResponse);
       if (FEATURES.VIDEO && bidResponse.mediaType === VIDEO) {
         tryAddVideoBid(auctionInstance, bidResponse, done);
       } else {

--- a/src/auction.js
+++ b/src/auction.js
@@ -451,7 +451,7 @@ export function auctionCallbacks(auctionDone, auctionInstance, {index = auctionM
   function acceptBidResponse(adUnitCode, bid) {
     handleBidResponse(adUnitCode, bid, (done) => {
       let bidResponse = getPreparedBidForAuction(bid);
-      events.emit(CONSTANTS.EVENTS.BEFORE_ADD_BID_RESPONSE, bidResponse);
+      events.emit(CONSTANTS.EVENTS.BID_ACCEPTED, bidResponse);
       if (FEATURES.VIDEO && bidResponse.mediaType === VIDEO) {
         tryAddVideoBid(auctionInstance, bidResponse, done);
       } else {

--- a/src/constants.json
+++ b/src/constants.json
@@ -46,7 +46,7 @@
     "BID_VIEWABLE": "bidViewable",
     "STALE_RENDER": "staleRender",
     "BILLABLE_EVENT": "billableEvent",
-    "BEFORE_ADD_BID_RESPONSE": "beforeAddBidResponse"
+    "BID_ACCEPTED": "bidAccepted"
   },
   "AD_RENDER_FAILED_REASON": {
     "PREVENT_WRITING_ON_MAIN_DOCUMENT": "preventWritingOnMainDocument",

--- a/src/constants.json
+++ b/src/constants.json
@@ -45,7 +45,8 @@
     "AUCTION_DEBUG": "auctionDebug",
     "BID_VIEWABLE": "bidViewable",
     "STALE_RENDER": "staleRender",
-    "BILLABLE_EVENT": "billableEvent"
+    "BILLABLE_EVENT": "billableEvent",
+    "BEFORE_ADD_BID_RESPONSE": "beforeAddBidResponse"
   },
   "AD_RENDER_FAILED_REASON": {
     "PREVENT_WRITING_ON_MAIN_DOCUMENT": "preventWritingOnMainDocument",

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -2736,10 +2736,10 @@ describe('Unit: Prebid Module', function () {
       events.on.restore();
     });
 
-    it('should emit event EFORE_ADD_BID_RESPONSE when invoked', function () {
+    it('should emit event BID_ACCEPTED when invoked', function () {
       var callback = sinon.spy();
-      $$PREBID_GLOBAL$$.onEvent('beforeAddBidResponse', callback);
-      events.emit(CONSTANTS.EVENTS.BEFORE_ADD_BID_RESPONSE);
+      $$PREBID_GLOBAL$$.onEvent('bidAccepted', callback);
+      events.emit(CONSTANTS.EVENTS.BID_ACCEPTED);
       sinon.assert.calledOnce(callback);
     });
 

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -2736,6 +2736,13 @@ describe('Unit: Prebid Module', function () {
       events.on.restore();
     });
 
+    it('should emit event EFORE_ADD_BID_RESPONSE when invoked', function () {
+      var callback = sinon.spy();
+      $$PREBID_GLOBAL$$.onEvent('beforeAddBidResponse', callback);
+      events.emit(CONSTANTS.EVENTS.BEFORE_ADD_BID_RESPONSE);
+      sinon.assert.calledOnce(callback);
+    });
+
     describe('beforeRequestBids', function () {
       let bidRequestedHandler;
       let beforeRequestBidsHandler;


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Add a new event fired before bids are added to auctions.

## Other information
Based on @karimMourra suggestion in PR https://github.com/prebid/Prebid.js/pull/10191 to add an event before video caching is done. I've assumed a more general event before bids are added to auctions made sense.
