### PR TITLE
Yieldmo Bid Adapter: Adding tmax to banner bid requests

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -78,14 +78,17 @@ export const spec = {
         bust: new Date().getTime().toString(),
         dnt: getDNT(),
         description: getPageDescription(),
+        tmax: bidderRequest.timeout || 400,
         userConsent: JSON.stringify({
           // case of undefined, stringify will remove param
-          gdprApplies: deepAccess(bidderRequest, 'gdprConsent.gdprApplies') || '',
+          gdprApplies:
+            deepAccess(bidderRequest, 'gdprConsent.gdprApplies') || '',
           cmp: deepAccess(bidderRequest, 'gdprConsent.consentString') || '',
           gpp: deepAccess(bidderRequest, 'gppConsent.gppString') || '',
-          gpp_sid: deepAccess(bidderRequest, 'gppConsent.applicableSections') || []
+          gpp_sid:
+            deepAccess(bidderRequest, 'gppConsent.applicableSections') || [],
         }),
-        us_privacy: deepAccess(bidderRequest, 'uspConsent') || ''
+        us_privacy: deepAccess(bidderRequest, 'uspConsent') || '',
       };
 
       if (canAccessTopWindow()) {

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -74,7 +74,6 @@ describe('YieldmoAdapter', function () {
     bidderRequestId: '14c4ede8c693f',
     bids,
     auctionStart: 1520001292880,
-    timeout: 3000,
     start: 1520001292884,
     doneCbCallCount: 0,
     refererInfo: {
@@ -169,6 +168,14 @@ describe('YieldmoAdapter', function () {
         expect(requests[0].url).to.be.equal(BANNER_ENDPOINT);
       });
 
+      it('should pass default timeout in bid request', function () {
+        const requests = build([mockBannerBid()]);
+        expect(requests[0].data.tmax).to.equal(400);
+      });
+      it('should pass tmax to bid request', function () {
+        const requests = build([mockBannerBid()], mockBidderRequest({timeout: 1000}));
+        expect(requests[0].data.tmax).to.equal(1000);
+      });
       it('should not blow up if crumbs is undefined', function () {
         expect(function () {
           build([mockBannerBid({crumbs: undefined})]);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add timeout (tmax) for Banner bid requests

