### PR TITLE
PubMatic Bid Adapter: Support for cookie deprecation label

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -1232,6 +1232,10 @@ export const spec = {
       payload.device.sua = device?.sua;
     }
 
+    if (device?.ext?.cdep) {
+      deepSetValue(payload, 'device.ext.cdep', device.ext.cdep);
+    }
+
     if (user?.geo && device?.geo) {
       payload.device.geo = { ...payload.device.geo, ...device.geo };
       payload.user.geo = { ...payload.user.geo, ...user.geo };

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -2311,6 +2311,23 @@ describe('PubMatic adapter', function () {
         expect(data.device.sua).to.deep.equal(suaObject);
       });
 
+      it('should pass device.ext.cdep if present in bidderRequest fpd ortb2 object', function () {
+        const cdepObj = {
+          cdep: 'example_label_1'
+        };
+        let request = spec.buildRequests(multipleMediaRequests, {
+          auctionId: 'new-auction-id',
+          ortb2: {
+            device: {
+              ext: cdepObj
+            }
+          }
+        });
+        let data = JSON.parse(request.data);
+        expect(data.device.ext.cdep).to.exist.and.to.be.an('string');
+        expect(data.device.ext).to.deep.equal(cdepObj);
+      });
+
       it('Request params should have valid native bid request for all valid params', function () {
         let request = spec.buildRequests(nativeBidRequests, {
           auctionId: 'new-auction-id'


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
- Support for the PubMatic bid adapter to capture the Privacy Sandbox cookie deprecation label from `device.ext.cdep` (if it is present).

## Other information
Relates to:
- https://github.com/prebid/Prebid.js/issues/10516
- https://github.com/prebid/Prebid.js/pull/10683