### PR TITLE
BLIINK Bid Adapter: hotfix gvlid parameter in release 8.19.0

### DIFF
--- a/modules/bliinkBidAdapter.js
+++ b/modules/bliinkBidAdapter.js
@@ -4,6 +4,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js'
 import { config } from '../src/config.js'
 import { _each, deepAccess, deepSetValue, getWindowSelf, getWindowTop } from '../src/utils.js'
 export const BIDDER_CODE = 'bliink'
+export const GVL_ID = 658
 export const BLIINK_ENDPOINT_ENGINE = 'https://engine.bliink.io/prebid'
 
 export const BLIINK_ENDPOINT_COOKIE_SYNC_IFRAME = 'https://tag.bliink.io/usersync.html'
@@ -343,6 +344,7 @@ const getUserSyncs = (syncOptions, serverResponses, gdprConsent, uspConsent) => 
  */
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVL_ID,
   aliases: aliasBidderCode,
   supportedMediaTypes: supportedMediaTypes,
   isBidRequestValid,

--- a/test/spec/modules/bliinkBidAdapter_spec.js
+++ b/test/spec/modules/bliinkBidAdapter_spec.js
@@ -8,6 +8,7 @@ import {
   getEffectiveConnectionType,
   getUserIds,
   getDomLoadingDuration,
+  GVL_ID,
 } from 'modules/bliinkBidAdapter.js';
 import { config } from 'src/config.js';
 
@@ -1167,4 +1168,8 @@ describe('getEffectiveConnectionType', () => {
       expect(result).to.equal('unsupported');
     });
   }
+});
+
+it('should expose gvlid', function () {
+  expect(spec.gvlid).to.equal(GVL_ID);
 });


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
This pull request resolves a TCF2 compliance issue that has been identified with our Prebid adapter for 'bidder.bliink', which prevents bids from being fetched due to lack of consent configuration. The problem is indicated by the warning message received:

`WARNING: Activity control: TCF2 denied 'fetchBids' for 'bidder.bliink'`

This was observed following the release of version 8.19.0 where the required `gvlid` parameter was inadvertently omitted. 

Considering the importance of this fix for GDPR compliance and the functionality of the adapter, I propose the following:
- Integrate this hotfix into the master branch.
- If possible, create a patched release (e.g., 8.19.1) that includes this critical fix, ensuring users who rely on release 8.19.0 can update to a version with the issue resolved.

I understand that modifying existing releases is not standard practice. However, given the impact on GDPR compliance, I believe an exception might be warranted in this case.

Thank you for your prompt attention to this matter.