### PR TITLE
Outbrain bid adapter: pass GPP consent

### DIFF
--- a/modules/outbrainBidAdapter.js
+++ b/modules/outbrainBidAdapter.js
@@ -149,6 +149,13 @@ export const spec = {
     if (config.getConfig('coppa') === true) {
       deepSetValue(request, 'regs.coppa', config.getConfig('coppa') & 1)
     }
+    if (bidderRequest.gppConsent) {
+      deepSetValue(request, 'regs.ext.gpp', bidderRequest.gppConsent.gppString)
+      deepSetValue(request, 'regs.ext.gpp_sid', bidderRequest.gppConsent.applicableSections)
+    } else if (deepAccess(bidderRequest, 'ortb2.regs.gpp')) {
+      deepSetValue(request, 'regs.ext.gpp', bidderRequest.ortb2.regs.gpp)
+      deepSetValue(request, 'regs.ext.gpp_sid', bidderRequest.ortb2.regs.gpp_sid)
+    }
 
     if (eids) {
       deepSetValue(request, 'user.ext.eids', eids);
@@ -212,7 +219,7 @@ export const spec = {
       }
     }).filter(Boolean);
   },
-  getUserSyncs: (syncOptions, responses, gdprConsent, uspConsent) => {
+  getUserSyncs: (syncOptions, responses, gdprConsent, uspConsent, gppConsent) => {
     const syncs = [];
     let syncUrl = config.getConfig('outbrain.usersyncUrl');
 
@@ -224,6 +231,10 @@ export const spec = {
       }
       if (uspConsent) {
         query.push('us_privacy=' + encodeURIComponent(uspConsent));
+      }
+      if (gppConsent) {
+        query.push('gpp=' + encodeURIComponent(gppConsent.gppString));
+        query.push('gpp_sid=' + encodeURIComponent(gppConsent.applicableSections.join(',')));
       }
 
       syncs.push({

--- a/test/spec/modules/outbrainBidAdapter_spec.js
+++ b/test/spec/modules/outbrainBidAdapter_spec.js
@@ -427,7 +427,7 @@ describe('Outbrain Adapter', function () {
         expect(resData.badv).to.deep.equal(['bad-advertiser'])
       });
 
-      it('first party data', function () {
+      it('should pass first party data', function () {
         const bidRequest = {
           ...commonBidRequest,
           ...nativeBidRequestParams,
@@ -506,6 +506,28 @@ describe('Outbrain Adapter', function () {
         expect(resData.regs.coppa).to.equal(1)
 
         config.resetConfig()
+      });
+
+      it('should pass gpp information', function () {
+        const bidRequest = {
+          ...commonBidRequest,
+          ...nativeBidRequestParams,
+        };
+        const bidderRequest = {
+          ...commonBidderRequest,
+          'gppConsent': {
+            'gppString': 'abc12345',
+            'applicableSections': [8]
+          }
+        }
+
+        const res = spec.buildRequests([bidRequest], bidderRequest);
+        const resData = JSON.parse(res.data);
+
+        expect(resData.regs.ext.gpp).to.exist;
+        expect(resData.regs.ext.gpp_sid).to.exist;
+        expect(resData.regs.ext.gpp).to.equal('abc12345');
+        expect(resData.regs.ext.gpp_sid).to.deep.equal([8]);
       });
 
       it('should pass extended ids', function () {
@@ -859,6 +881,12 @@ describe('Outbrain Adapter', function () {
     it('should pass GDPR and US consent', function () {
       expect(spec.getUserSyncs({ pixelEnabled: true }, {}, { gdprApplies: true, consentString: 'foo' }, '1NYN')).to.deep.equal([{
         type: 'image', url: `${usersyncUrl}?gdpr=1&gdpr_consent=foo&us_privacy=1NYN`
+      }]);
+    });
+
+    it('should pass gpp consent', function () {
+      expect(spec.getUserSyncs({ pixelEnabled: true }, {}, undefined, '', { gppString: 'abc12345', applicableSections: [1, 2] })).to.deep.equal([{
+        type: 'image', url: `${usersyncUrl}?gpp=abc12345&gpp_sid=1%2C2`
       }]);
     });
   })


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Pass GPP consent to in bid requests and in user sync calls.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
