### PR TITLE
priceFloors: Prevent warning when floor price value is 0

### DIFF
--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -748,7 +748,7 @@ export const addBidResponseHook = timedBidResponseHook('priceFloors', function a
   let floorInfo = getFirstMatchingFloor(floorData.data, matchingBidRequest, {...bid, size: [bid.width, bid.height]});
 
   if (!floorInfo.matchingFloor) {
-    logWarn(`${MODULE_NAME}: unable to determine a matching price floor for bidResponse`, bid);
+    if (floorInfo.matchingFloor !== 0) logWarn(`${MODULE_NAME}: unable to determine a matching price floor for bidResponse`, bid);
     return fn.call(this, adUnitCode, bid, reject);
   }
 

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -2011,6 +2011,12 @@ describe('the price floors module', function () {
       expect(returnedBidResponse).to.not.haveOwnProperty('floorData');
       expect(logWarnSpy.calledOnce).to.equal(true);
     });
+    it('if it finds a rule with a floor price of zero it should not call log warn', function () {
+      _floorDataForAuction[AUCTION_ID] = utils.deepClone(basicFloorConfig);
+      _floorDataForAuction[AUCTION_ID].data.values = { '*': 0 };
+      runBidResponse();
+      expect(logWarnSpy.calledOnce).to.equal(false);
+    });
     it('if it finds a rule and floors should update the bid accordingly', function () {
       _floorDataForAuction[AUCTION_ID] = utils.deepClone(basicFloorConfig);
       _floorDataForAuction[AUCTION_ID].data.values = { 'banner': 1.0 };


### PR DESCRIPTION

## Type of change
- [x] Bugfix

## Description of change

Prevent the `unable to determine a matching price floor for bidResponse` warning from showing up when the price floor is `0`
I opted to just adding an additional check to the warning line rather than changing the previous if condition since
`0` is the only `falsy` and letting the floorPrice module run when we know the floor price will be met would be inefficient
