### PR TITLE
Pubmatic: Contribute vendor details for Prebid server adapter

### DIFF
--- a/modules/prebidServerBidAdapter/config.js
+++ b/modules/prebidServerBidAdapter/config.js
@@ -38,5 +38,14 @@ export const S2S_VENDORS = {
       noP1Consent: 'https://prebid.openx.net/cookie_sync'
     },
     timeout: 1000
+  },
+  'openwrap': {
+    adapter: 'prebidServer',
+    enabled: true,
+    endpoint: {
+      p1Consent: 'http://ow.pubmatic.com/openrtb2/auction?source=pbjs',
+      noP1Consent: 'http://ow.pubmatic.com/openrtb2/auction?source=pbjs'
+    },
+    timeout: 1000
   }
 }

--- a/modules/prebidServerBidAdapter/config.js
+++ b/modules/prebidServerBidAdapter/config.js
@@ -43,9 +43,9 @@ export const S2S_VENDORS = {
     adapter: 'prebidServer',
     enabled: true,
     endpoint: {
-      p1Consent: 'http://ow.pubmatic.com/openrtb2/auction?source=pbjs',
-      noP1Consent: 'http://ow.pubmatic.com/openrtb2/auction?source=pbjs'
+      p1Consent: 'https://ow.pubmatic.com/openrtb2/auction?source=pbjs',
+      noP1Consent: 'https://ow.pubmatic.com/openrtb2/auction?source=pbjs'
     },
-    timeout: 1000
+    timeout: 500
   }
 }

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -3780,8 +3780,8 @@ describe('S2S Adapter', function () {
       expect(vendorConfig.bidders).to.deep.equal(['pubmatic']);
       expect(vendorConfig.enabled).to.be.true;
       expect(vendorConfig.endpoint).to.deep.equal({
-        p1Consent: 'http://ow.pubmatic.com/openrtb2/auction?source=pbjs',
-        noP1Consent: 'http://ow.pubmatic.com/openrtb2/auction?source=pbjs'
+        p1Consent: 'https://ow.pubmatic.com/openrtb2/auction?source=pbjs',
+        noP1Consent: 'https://ow.pubmatic.com/openrtb2/auction?source=pbjs'
       });
       expect(vendorConfig).to.have.property('timeout', 1000);
     });
@@ -3802,8 +3802,8 @@ describe('S2S Adapter', function () {
         'defaultVendor': 'openwrap',
         'enabled': true,
         'endpoint': {
-          p1Consent: 'http://ow.pubmatic.com/openrtb2/auction?source=pbjs',
-          noP1Consent: 'http://ow.pubmatic.com/openrtb2/auction?source=pbjs'
+          p1Consent: 'https://ow.pubmatic.com/openrtb2/auction?source=pbjs',
+          noP1Consent: 'https://ow.pubmatic.com/openrtb2/auction?source=pbjs'
         },
         'timeout': 750
       })
@@ -3826,8 +3826,8 @@ describe('S2S Adapter', function () {
         bidders: ['pubmatic'],
         defaultVendor: 'openwrap',
         endpoint: {
-          p1Consent: 'http://ow.pubmatic.com/openrtb2/auction?source=pbjs',
-          noP1Consent: 'http://ow.pubmatic.com/openrtb2/auction?source=pbjs'
+          p1Consent: 'https://ow.pubmatic.com/openrtb2/auction?source=pbjs',
+          noP1Consent: 'https://ow.pubmatic.com/openrtb2/auction?source=pbjs'
         },
       })
     });

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -3764,6 +3764,74 @@ describe('S2S Adapter', function () {
       })
     });
 
+    it('should configure the s2sConfig object with openwrap vendor defaults unless specified by user', function () {
+      const options = {
+        accountId: '1234',
+        bidders: ['pubmatic'],
+        defaultVendor: 'openwrap'
+      };
+
+      config.setConfig({ s2sConfig: options });
+      sinon.assert.notCalled(logErrorSpy);
+
+      let vendorConfig = config.getConfig('s2sConfig');
+      expect(vendorConfig).to.have.property('accountId', '1234');
+      expect(vendorConfig).to.have.property('adapter', 'prebidServer');
+      expect(vendorConfig.bidders).to.deep.equal(['pubmatic']);
+      expect(vendorConfig.enabled).to.be.true;
+      expect(vendorConfig.endpoint).to.deep.equal({
+        p1Consent: 'http://ow.pubmatic.com/openrtb2/auction?source=pbjs',
+        noP1Consent: 'http://ow.pubmatic.com/openrtb2/auction?source=pbjs'
+      });
+      expect(vendorConfig).to.have.property('timeout', 1000);
+    });
+
+    it('should return proper defaults', function () {
+      const options = {
+        accountId: '1234',
+        bidders: ['pubmatic'],
+        defaultVendor: 'openwrap',
+        timeout: 750
+      };
+
+      config.setConfig({ s2sConfig: options });
+      expect(config.getConfig('s2sConfig')).to.deep.equal({
+        'accountId': '1234',
+        'adapter': 'prebidServer',
+        'bidders': ['pubmatic'],
+        'defaultVendor': 'openwrap',
+        'enabled': true,
+        'endpoint': {
+          p1Consent: 'http://ow.pubmatic.com/openrtb2/auction?source=pbjs',
+          noP1Consent: 'http://ow.pubmatic.com/openrtb2/auction?source=pbjs'
+        },
+        'timeout': 750
+      })
+    });
+
+    it('should return default adapterOptions if not set', function () {
+      config.setConfig({
+        s2sConfig: {
+          accountId: '1234',
+          bidders: ['pubmatic'],
+          defaultVendor: 'openwrap',
+          timeout: 750
+        }
+      });
+      expect(config.getConfig('s2sConfig')).to.deep.equal({
+        enabled: true,
+        timeout: 750,
+        adapter: 'prebidServer',
+        accountId: '1234',
+        bidders: ['pubmatic'],
+        defaultVendor: 'openwrap',
+        endpoint: {
+          p1Consent: 'http://ow.pubmatic.com/openrtb2/auction?source=pbjs',
+          noP1Consent: 'http://ow.pubmatic.com/openrtb2/auction?source=pbjs'
+        },
+      })
+    });
+
     it('should set adapterOptions', function () {
       config.setConfig({
         s2sConfig: {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -3783,7 +3783,7 @@ describe('S2S Adapter', function () {
         p1Consent: 'https://ow.pubmatic.com/openrtb2/auction?source=pbjs',
         noP1Consent: 'https://ow.pubmatic.com/openrtb2/auction?source=pbjs'
       });
-      expect(vendorConfig).to.have.property('timeout', 1000);
+      expect(vendorConfig).to.have.property('timeout', 500);
     });
 
     it('should return proper defaults', function () {
@@ -3791,7 +3791,7 @@ describe('S2S Adapter', function () {
         accountId: '1234',
         bidders: ['pubmatic'],
         defaultVendor: 'openwrap',
-        timeout: 750
+        timeout: 500
       };
 
       config.setConfig({ s2sConfig: options });
@@ -3805,7 +3805,7 @@ describe('S2S Adapter', function () {
           p1Consent: 'https://ow.pubmatic.com/openrtb2/auction?source=pbjs',
           noP1Consent: 'https://ow.pubmatic.com/openrtb2/auction?source=pbjs'
         },
-        'timeout': 750
+        'timeout': 500
       })
     });
 
@@ -3815,12 +3815,12 @@ describe('S2S Adapter', function () {
           accountId: '1234',
           bidders: ['pubmatic'],
           defaultVendor: 'openwrap',
-          timeout: 750
+          timeout: 500
         }
       });
       expect(config.getConfig('s2sConfig')).to.deep.equal({
         enabled: true,
-        timeout: 750,
+        timeout: 500,
         adapter: 'prebidServer',
         accountId: '1234',
         bidders: ['pubmatic'],


### PR DESCRIPTION

## Type of change
- [x] Feature

## Description of change
This is to contribute **OpenWrap** as a **vendor for Prebid server adapter**.
When publisher will use openwrap as defaultVendor, it will include options in the config with vendor’s default values, e.g. adapter, timeout, endpoint.
Example: 
```
s2sConfig: {
          enabled: true,
          bidders: ['pubmatic'],
          defaultVendor: 'openwrap',
          extPrebid: { 
		bidderparams: {
              		pubmatic: {
                		publisherId: publisherId,
                		wrapper: {
                  			profileid: profileId,
                  			versionid: versionId

```
