### PR TITLE
Consumable Bid Adapter: fix us privacy format and make gpp applicable sections optional

### DIFF
--- a/modules/consumableBidAdapter.js
+++ b/modules/consumableBidAdapter.js
@@ -196,8 +196,11 @@ export const spec = {
           syncUrl = appendUrlParam(syncUrl, `gdpr=0&gdpr_consent=${encodeURIComponent(gdprConsent.consentString) || ''}`);
         }
       }
-      if (gppConsent && gppConsent.gppString && gppConsent.applicableSections) {
-        syncUrl = appendUrlParam(syncUrl, `gpp=${encodeURIComponent(gppConsent.gppString)}&gpp_sid=${encodeURIComponent(gppConsent.applicableSections.join(','))}`);
+      if (gppConsent && gppConsent.gppString) {
+        syncUrl = appendUrlParam(syncUrl, `gpp=${encodeURIComponent(gppConsent.gppString)}`);
+        if (gppConsent.applicableSections && gppConsent.applicableSections.length > 0) {
+          syncUrl = appendUrlParam(syncUrl, `gpp_sid=${encodeURIComponent(gppConsent.applicableSections.join(','))}`);
+        }
       }
 
       if (uspConsent) {

--- a/modules/consumableBidAdapter.js
+++ b/modules/consumableBidAdapter.js
@@ -191,17 +191,17 @@ export const spec = {
     if (syncOptions.iframeEnabled) {
       if (gdprConsent && gdprConsent.consentString) {
         if (typeof gdprConsent.gdprApplies === 'boolean') {
-          syncUrl = appendUrlParam(syncUrl, `gdpr=${Number(gdprConsent.gdprApplies)}&gdpr_consent=${gdprConsent.consentString}`);
+          syncUrl = appendUrlParam(syncUrl, `gdpr=${Number(gdprConsent.gdprApplies)}&gdpr_consent=${encodeURIComponent(gdprConsent.consentString) || ''}`);
         } else {
-          syncUrl = appendUrlParam(syncUrl, `gdpr=0&gdpr_consent=${gdprConsent.consentString}`);
+          syncUrl = appendUrlParam(syncUrl, `gdpr=0&gdpr_consent=${encodeURIComponent(gdprConsent.consentString) || ''}`);
         }
       }
-      if (gppConsent && gppConsent.gppString) {
-        syncUrl = appendUrlParam(syncUrl, `gpp=${gppConsent.gppString}&gpp_sid=${gppConsent.applicableSections}`);
+      if (gppConsent && gppConsent.gppString && gppConsent.applicableSections) {
+        syncUrl = appendUrlParam(syncUrl, `gpp=${encodeURIComponent(gppConsent.gppString)}&gpp_sid=${encodeURIComponent(gppConsent.applicableSections.join(','))}`);
       }
 
-      if (uspConsent && uspConsent.consentString) {
-        syncUrl = appendUrlParam(syncUrl, `us_privacy=${uspConsent.consentString}`);
+      if (uspConsent) {
+        syncUrl = appendUrlParam(syncUrl, `us_privacy=${encodeURIComponent(uspConsent)}`);
       }
 
       if (!serverResponses || serverResponses.length === 0 || !serverResponses[0].body.bdr || serverResponses[0].body.bdr !== 'cx') {

--- a/test/spec/modules/consumableBidAdapter_spec.js
+++ b/test/spec/modules/consumableBidAdapter_spec.js
@@ -656,16 +656,14 @@ describe('Consumable BidAdapter', function () {
         applicableSections: [1, 2],
         gppString: 'GPP_CONSENT_STRING'
       }
-      let opts = spec.getUserSyncs(syncOptions, [AD_SERVER_RESPONSE], {}, {}, gppConsent);
+      let opts = spec.getUserSyncs(syncOptions, [AD_SERVER_RESPONSE], {}, '', gppConsent);
 
       expect(opts.length).to.equal(1);
-      expect(opts[0].url).to.equal('https://sync.serverbid.com/ss/730181.html?gpp=GPP_CONSENT_STRING&gpp_sid=1,2');
+      expect(opts[0].url).to.equal('https://sync.serverbid.com/ss/730181.html?gpp=GPP_CONSENT_STRING&gpp_sid=1%2C2');
     })
 
     it('should return a sync url if iframe syncs are enabled and USP applies', function () {
-      let uspConsent = {
-        consentString: 'USP_CONSENT_STRING',
-      }
+      let uspConsent = 'USP_CONSENT_STRING';
       let opts = spec.getUserSyncs(syncOptions, [AD_SERVER_RESPONSE], {}, uspConsent);
 
       expect(opts.length).to.equal(1);
@@ -677,9 +675,7 @@ describe('Consumable BidAdapter', function () {
         consentString: 'GDPR_CONSENT_STRING',
         gdprApplies: true,
       }
-      let uspConsent = {
-        consentString: 'USP_CONSENT_STRING',
-      }
+      let uspConsent = 'USP_CONSENT_STRING';
       let opts = spec.getUserSyncs(syncOptions, [AD_SERVER_RESPONSE], gdprConsent, uspConsent);
 
       expect(opts.length).to.equal(1);
@@ -704,50 +700,22 @@ describe('Consumable BidAdapter', function () {
       sandbox.restore();
     });
 
-    it('Request should have unifiedId config params', function() {
+    it('Request should have EIDs', function() {
       bidderRequest.bidRequest[0].userId = {};
       bidderRequest.bidRequest[0].userId.tdid = 'TTD_ID';
-      bidderRequest.bidRequest[0].userIdAsEids = createEidsArray(bidderRequest.bidRequest[0].userId);
-      let request = spec.buildRequests(bidderRequest.bidRequest, BIDDER_REQUEST_1);
-      let data = JSON.parse(request.data);
-      expect(data.user.eids).to.deep.equal([{
+      bidderRequest.bidRequest[0].userIdAsEids = [{
         'source': 'adserver.org',
         'uids': [{
-          'id': 'TTD_ID',
+          'id': 'TTD_ID_FROM_USER_ID_MODULE',
           'atype': 1,
           'ext': {
             'rtiPartner': 'TDID'
           }
         }]
-      }]);
-    });
-
-    it('Request should have adsrvrOrgId from UserId Module if config and userId module both have TTD ID', function() {
-      sandbox.stub(config, 'getConfig').callsFake((key) => {
-        var config = {
-          adsrvrOrgId: {
-            'TDID': 'TTD_ID_FROM_CONFIG',
-            'TDID_LOOKUP': 'TRUE',
-            'TDID_CREATED_AT': '2022-06-21T09:47:00'
-          }
-        };
-        return config[key];
-      });
-      bidderRequest.bidRequest[0].userId = {};
-      bidderRequest.bidRequest[0].userId.tdid = 'TTD_ID';
-      bidderRequest.bidRequest[0].userIdAsEids = createEidsArray(bidderRequest.bidRequest[0].userId);
+      }];
       let request = spec.buildRequests(bidderRequest.bidRequest, BIDDER_REQUEST_1);
       let data = JSON.parse(request.data);
-      expect(data.user.eids).to.deep.equal([{
-        'source': 'adserver.org',
-        'uids': [{
-          'id': 'TTD_ID',
-          'atype': 1,
-          'ext': {
-            'rtiPartner': 'TDID'
-          }
-        }]
-      }]);
+      expect(data.user.eids).to.deep.equal(bidderRequest.bidRequest[0].userIdAsEids);
     });
 
     it('Request should NOT have adsrvrOrgId params if userId is NOT object', function() {

--- a/test/spec/modules/consumableBidAdapter_spec.js
+++ b/test/spec/modules/consumableBidAdapter_spec.js
@@ -651,7 +651,7 @@ describe('Consumable BidAdapter', function () {
       expect(opts[0].url).to.equal('https://sync.serverbid.com/ss/730181.html?gdpr=0&gdpr_consent=GDPR_CONSENT_STRING');
     })
 
-    it('should return a sync url if iframe syncs are enabled and GPP applies', function () {
+    it('should return a sync url if iframe syncs are enabled and has GPP consent with applicable sections', function () {
       let gppConsent = {
         applicableSections: [1, 2],
         gppString: 'GPP_CONSENT_STRING'
@@ -660,6 +660,17 @@ describe('Consumable BidAdapter', function () {
 
       expect(opts.length).to.equal(1);
       expect(opts[0].url).to.equal('https://sync.serverbid.com/ss/730181.html?gpp=GPP_CONSENT_STRING&gpp_sid=1%2C2');
+    })
+
+    it('should return a sync url if iframe syncs are enabled and has GPP consent without applicable sections', function () {
+      let gppConsent = {
+        applicableSections: [],
+        gppString: 'GPP_CONSENT_STRING'
+      }
+      let opts = spec.getUserSyncs(syncOptions, [AD_SERVER_RESPONSE], {}, '', gppConsent);
+
+      expect(opts.length).to.equal(1);
+      expect(opts[0].url).to.equal('https://sync.serverbid.com/ss/730181.html?gpp=GPP_CONSENT_STRING');
     })
 
     it('should return a sync url if iframe syncs are enabled and USP applies', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix

## Description of change
Incorrectly treated `us_privacy` as an object, now fixed as a string.
Also updated to treat gpp applicable sections as optional and removed duplicate EID test

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
