### PR TITLE
Adagio Bid Adapter: fix floor prices module support

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -1,6 +1,5 @@
 import {find} from '../src/polyfill.js';
 import {
-  _map,
   cleanObj,
   deepAccess,
   deepClone,
@@ -570,6 +569,7 @@ function _parseNativeBidResponse(bid) {
   bid.native = native
 }
 
+// bidRequest param must be the `bidRequest` object with the original `auctionId` value.
 function _getFloors(bidRequest) {
   if (!isFn(bidRequest.getFloor)) {
     return false;
@@ -996,7 +996,7 @@ export const spec = {
 
     const aucId = generateUUID()
 
-    const adUnits = _map(validBidRequests, (rawBidRequest) => {
+    const adUnits = validBidRequests.map(rawBidRequest => {
       const bidRequest = deepClone(rawBidRequest);
 
       // Fix https://github.com/prebid/Prebid.js/issues/9781
@@ -1068,7 +1068,10 @@ export const spec = {
       });
 
       // Handle priceFloors module
-      const computedFloors = _getFloors(bidRequest);
+      // We need to use `rawBidRequest` as param because:
+      // - adagioBidAdapter generates its own auctionId due to transmitTid activity limitation (see https://github.com/prebid/Prebid.js/pull/10079)
+      // - the priceFloors.getFloor() uses a `_floorDataForAuction` map to store the floors based on the auctionId.
+      const computedFloors = _getFloors(rawBidRequest);
       if (isArray(computedFloors) && computedFloors.length) {
         bidRequest.floors = computedFloors
 
@@ -1149,7 +1152,7 @@ export const spec = {
     });
 
     // Build one request per organizationId
-    const requests = _map(Object.keys(groupedAdUnits), organizationId => {
+    const requests = Object.keys(groupedAdUnits).map(organizationId => {
       return {
         method: 'POST',
         url: ENDPOINT,


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description of change

This PR is about to fix a problem originated in our adapter when we chose to generate a custom `auctionId` to bypass the `transmitTid` activity introduced in Prebid.js 8 (see #10079).

## Other information

N/A