### PR TITLE
Rubicon Bid Adapter: Pass SUA data if available

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -1002,7 +1002,6 @@ function applyFPD(bidRequest, mediaType, data) {
         }
       ])
     }
-
   } else {
     if (Object.keys(impExt).length) {
       mergeDeep(data.imp[0].ext, impExt);


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change
Rubicon Bid Adapter now will look for device.sua object and pass along necessary client hints where applicable.

Option to disable included (default is enabled)