### PR TITLE
Onetag Bid Adapter: read auctionId/transactionId from related ortb2 fields

### DIFF
--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -267,9 +267,8 @@ function setGeneralInfo(bidRequest) {
   this['adUnitCode'] = bidRequest.adUnitCode;
   this['bidId'] = bidRequest.bidId;
   this['bidderRequestId'] = bidRequest.bidderRequestId;
-  // TODO: fix auctionId leak: https://github.com/prebid/Prebid.js/issues/9781
-  this['auctionId'] = bidRequest.auctionId;
-  this['transactionId'] = bidRequest.ortb2Imp?.ext?.tid;
+  this['auctionId'] = deepAccess(bidRequest, 'ortb2.source.tid');
+  this['transactionId'] = deepAccess(bidRequest, 'ortb2Imp.ext.tid');
   this['gpid'] = deepAccess(bidRequest, 'ortb2Imp.ext.gpid') || deepAccess(bidRequest, 'ortb2Imp.ext.data.pbadslot');
   this['pubId'] = params.pubId;
   this['ext'] = params.ext;

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -15,9 +15,14 @@ describe('onetag', function () {
       'bidId': '30b31c1838de1e',
       'bidderRequestId': '22edbae2733bf6',
       'auctionId': '1d1a030790a475',
-      ortb2Imp: {
-        ext: {
-          tid: 'qwerty123'
+      'ortb2Imp': {
+        'ext': {
+          'tid': '0000'
+        }
+      },
+      'ortb2': {
+        'source': {
+          'tid': '1111'
         }
       },
       'schain': {
@@ -255,6 +260,15 @@ describe('onetag', function () {
         let dataObj = JSON.parse(dataString);
         expect(dataObj.bids).to.be.an('array').that.is.empty;
       } catch (e) { }
+    });
+    it('Should pick each bid\'s auctionId and transactionId from ortb2 related fields', function () {
+      const serverRequest = spec.buildRequests([bannerBid]);
+      const payload = JSON.parse(serverRequest.data);
+
+      expect(payload).to.exist;
+      expect(payload.bids).to.exist.and.to.have.length(1);
+      expect(payload.bids[0].auctionId).to.equal(bannerBid.ortb2.source.tid);
+      expect(payload.bids[0].transactionId).to.equal(bannerBid.ortb2Imp.ext.tid);
     });
     it('should send GDPR consent data', function () {
       let consentString = 'consentString';


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Read `auctionId` and `transactionId` from `ortb2.source.tid` `ortb2Imp.ext.tid`.

## Other information
Addresses #9781.
