### PR TITLE
identityLinkIdSystem: include gpp in 3p envelope retrieval

### DIFF
--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -10,6 +10,7 @@ import { ajax } from '../src/ajax.js';
 import { submodule } from '../src/hook.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
+import { gppDataHandler } from '../src/adapterManager.js';
 
 const MODULE_NAME = 'identityLink';
 
@@ -59,12 +60,16 @@ export const identityLinkSubmodule = {
       utils.logInfo('identityLink: Consent string is required to call envelope API.');
       return;
     }
-    const url = `https://api.rlcdn.com/api/identity/envelope?pid=${configParams.pid}${hasGdpr ? (tcfPolicyV2 ? '&ct=4&cv=' : '&ct=1&cv=') + gdprConsentString : ''}`;
+    const gppData = gppDataHandler.getConsentData();
+    const gppString = gppData && gppData.gppString ? gppData.gppString : false;
+    const gppSectionId = gppData && gppData.gppString && gppData.applicableSections.length > 0 && gppData.applicableSections[0] !== -1 ? gppData.applicableSections[0] : false;
+    const hasGpp = gppString && gppSectionId;
+    const url = `https://api.rlcdn.com/api/identity/envelope?pid=${configParams.pid}${hasGdpr ? (tcfPolicyV2 ? '&ct=4&cv=' : '&ct=1&cv=') + gdprConsentString : ''}${hasGpp ? '&gpp=' + gppString + '&gpp_sid=' + gppSectionId : ''}`;
     let resp;
     resp = function (callback) {
       // Check ats during callback so it has a chance to initialise.
       // If ats library is available, use it to retrieve envelope. If not use standard third party endpoint
-      if (window.ats) {
+      if (window.ats && window.ats.retrieveEnvelope) {
         utils.logInfo('identityLink: ATS exists!');
         window.ats.retrieveEnvelope(function (envelope) {
           if (envelope) {

--- a/test/spec/modules/identityLinkIdSystem_spec.js
+++ b/test/spec/modules/identityLinkIdSystem_spec.js
@@ -3,6 +3,7 @@ import * as utils from 'src/utils.js';
 import {server} from 'test/mocks/xhr.js';
 import {getCoreStorageManager} from '../../../src/storageManager.js';
 import {stub} from 'sinon';
+import { gppDataHandler } from '../../../src/adapterManager.js';
 
 const storage = getCoreStorageManager();
 
@@ -20,6 +21,7 @@ function setTestEnvelopeCookie () {
 
 describe('IdentityLinkId tests', function () {
   let logErrorStub;
+  let gppConsentDataStub;
 
   beforeEach(function () {
     defaultConfigParams = { params: {pid: pid} };
@@ -110,6 +112,48 @@ describe('IdentityLinkId tests', function () {
       JSON.stringify({})
     );
     expect(callBackSpy.calledOnce).to.be.true;
+  });
+
+  it('should call the LiveRamp envelope endpoint with GPP consent string', function() {
+    gppConsentDataStub = sinon.stub(gppDataHandler, 'getConsentData');
+    gppConsentDataStub.returns({
+      ready: true,
+      gppString: 'DBABLA~BVVqAAAACqA.QA',
+      applicableSections: [7]
+    });
+    let callBackSpy = sinon.spy();
+    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams).callback;
+    submoduleCallback(callBackSpy);
+    let request = server.requests[0];
+    expect(request.url).to.be.eq('https://api.rlcdn.com/api/identity/envelope?pid=14&gpp=DBABLA~BVVqAAAACqA.QA&gpp_sid=7');
+    request.respond(
+      200,
+      responseHeader,
+      JSON.stringify({})
+    );
+    expect(callBackSpy.calledOnce).to.be.true;
+    gppConsentDataStub.restore();
+  });
+
+  it('should NOT call the LiveRamp envelope endpoint if GPP applies but no consent string', function () {
+    gppConsentDataStub = sinon.stub(gppDataHandler, 'getConsentData');
+    gppConsentDataStub.returns({
+      ready: true,
+      gppString: '',
+      applicableSections: [7]
+    });
+    let callBackSpy = sinon.spy();
+    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams).callback;
+    submoduleCallback(callBackSpy);
+    let request = server.requests[0];
+    expect(request.url).to.be.eq('https://api.rlcdn.com/api/identity/envelope?pid=14');
+    request.respond(
+      200,
+      responseHeader,
+      JSON.stringify({})
+    );
+    expect(callBackSpy.calledOnce).to.be.true;
+    gppConsentDataStub.restore();
   });
 
   it('should not throw Uncaught TypeError when envelope endpoint returns empty response', function () {


### PR DESCRIPTION
identityLink - Liveramp

## Type of change
- [ ] Feature
- [ ] Bugfix


## Description of change
Add logic to get gpp consent string using Prebid consent management module and include gpp consent string and section id in 3p http request in order to get envelope.

