### PR TITLE
Missena Bid Adapter: add capping support

### DIFF
--- a/modules/missenaBidAdapter.js
+++ b/modules/missenaBidAdapter.js
@@ -8,11 +8,14 @@ import {
 import { config } from '../src/config.js';
 import { BANNER } from '../src/mediaTypes.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { getStorageManager } from '../src/storageManager.js';
 
 const BIDDER_CODE = 'missena';
 const ENDPOINT_URL = 'https://bid.missena.io/';
 const EVENTS_DOMAIN = 'events.missena.io';
 const EVENTS_DOMAIN_DEV = 'events.staging.missena.xyz';
+
+const storage = getStorageManager({ bidderCode: BIDDER_CODE });
 
 /* Get Floor price information */
 function getFloor(bidRequest) {
@@ -22,7 +25,7 @@ function getFloor(bidRequest) {
 
   const bidFloors = bidRequest.getFloor({
     currency: 'USD',
-    mediaType: BANNER
+    mediaType: BANNER,
   });
 
   if (!isNaN(bidFloors.floor)) {
@@ -53,6 +56,16 @@ export const spec = {
    * @return ServerRequest Info describing the request to the server.
    */
   buildRequests: function (validBidRequests, bidderRequest) {
+    const capKey = `missena.missena.capper.remove-bubble.${validBidRequests[0]?.params.apiKey}`;
+    const capping = JSON.parse(storage.getDataFromLocalStorage(capKey));
+    if (
+      typeof capping?.expiry === 'number' &&
+      new Date().getTime() < capping?.expiry
+    ) {
+      logInfo('Missena - Capped');
+      return [];
+    }
+
     return validBidRequests.map((bidRequest) => {
       const payload = {
         adunit: bidRequest.adUnitCode,


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Some of our publishing partners requested a mechanism to cap the participation in prebid auctions if the user closed our ad. This is particularly relevant in the context of a page that refreshes the ad auctions periodically (e.g. every 15 seconds).  
The PR implements the code that checks for the saved capping information and skips the participation if within the capped time frame. 

