### PR TITLE
NextMillennium Bid Adapter: support for GPP consent string, `site.pagecat`, `site.content.cat` and `site.content.language`

### DIFF
--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -104,8 +104,8 @@ export const spec = {
       };
 
       postBody.imp.push(getImp(bid, id));
-      setConsentStrings(postBody, bidderRequest)
-      setOrtb2Parameters(postBody, bidderRequest?.ortb2)
+      setConsentStrings(postBody, bidderRequest);
+      setOrtb2Parameters(postBody, bidderRequest?.ortb2);
 
       const urlParameters = parseUrl(getWindowTop().location.href).search;
       const isTest = urlParameters['pbs'] && urlParameters['pbs'] === 'test';

--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -260,7 +260,7 @@ export const spec = {
         syncUrlQuery.push('gpp=' + gppConsent.gppString + '&gpp_sid=' + gppConsent?.applicableSections?.join(','));
       }
 
-      const type = syncOptions.iframeEnabled && 'iframe' || 'image';
+      const type = (syncOptions.iframeEnabled && 'iframe') || 'image';
       syncUrlQuery.push('type=' + type);
       pixels.push({
         type,

--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -305,7 +305,7 @@ export function setConsentStrings(postBody = {}, bidderRequest) {
 };
 
 export function setOrtb2Parameters(postBody, ortb2 = {}) {
-  for(let parameter of ALLOWED_ORTB2_PARAMETERS) {
+  for (let parameter of ALLOWED_ORTB2_PARAMETERS) {
     const value = deepAccess(ortb2, parameter)
     if (value) deepSetValue(postBody, parameter, value)
   }

--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -30,6 +30,7 @@ const TEST_ENDPOINT = 'https://test.pbs.nextmillmedia.com/openrtb2/auction';
 const SYNC_ENDPOINT = 'https://cookies.nextmillmedia.com/sync?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&type={{.TYPE_PIXEL}}';
 const REPORT_ENDPOINT = 'https://report2.hb.brainlyads.com/statistics/metric';
 const TIME_TO_LIVE = 360;
+
 const VIDEO_PARAMS = [
   'api',
   'linearity',

--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -2,6 +2,7 @@ import {
   _each,
   createTrackPixelHtml,
   deepAccess,
+  deepSetValue,
   getBidIdParameter,
   getDefinedParams,
   getWindowTop,
@@ -22,6 +23,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {getRefererInfo} from '../src/refererDetection.js';
 
 const NM_VERSION = '3.0.0'
+const GVLID = 1060;
 const BIDDER_CODE = 'nextMillennium';
 const ENDPOINT = 'https://pbs.nextmillmedia.com/openrtb2/auction';
 const TEST_ENDPOINT = 'https://test.pbs.nextmillmedia.com/openrtb2/auction';
@@ -40,7 +42,11 @@ const VIDEO_PARAMS = [
   'startdelay',
 ];
 
-const GVLID = 1060;
+const ALLOWED_ORTB2_PARAMETERS = [
+  'site.pagecat',
+  'site.content.cat',
+  'site.content.language',
+]
 
 const sendingDataStatistic = initSendingDataStatistic();
 events.on(CONSTANTS.EVENTS.AUCTION_INIT, auctionInitHandler);
@@ -99,6 +105,7 @@ export const spec = {
 
       postBody.imp.push(getImp(bid, id));
       setConsentStrings(postBody, bidderRequest)
+      setOrtb2Parameters(postBody, bidderRequest?.ortb2)
 
       const urlParameters = parseUrl(getWindowTop().location.href).search;
       const isTest = urlParameters['pbs'] && urlParameters['pbs'] === 'test';
@@ -296,6 +303,13 @@ export function setConsentStrings(postBody = {}, bidderRequest) {
     };
   };
 };
+
+export function setOrtb2Parameters(postBody, ortb2 = {}) {
+  for(let parameter of ALLOWED_ORTB2_PARAMETERS) {
+    const value = deepAccess(ortb2, parameter)
+    if (value) deepSetValue(postBody, parameter, value)
+  }
+}
 
 export function replaceUsersyncMacros(url, gdprConsent = {}, uspConsent = '', gppConsent = {}, type = '') {
   const { consentString = '', gdprApplies = false } = gdprConsent;

--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -22,7 +22,7 @@ import * as events from '../src/events.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {getRefererInfo} from '../src/refererDetection.js';
 
-const NM_VERSION = '3.0.0'
+const NM_VERSION = '3.0.0';
 const GVLID = 1060;
 const BIDDER_CODE = 'nextMillennium';
 const ENDPOINT = 'https://pbs.nextmillmedia.com/openrtb2/auction';
@@ -46,7 +46,7 @@ const ALLOWED_ORTB2_PARAMETERS = [
   'site.pagecat',
   'site.content.cat',
   'site.content.language',
-]
+];
 
 const sendingDataStatistic = initSendingDataStatistic();
 events.on(CONSTANTS.EVENTS.AUCTION_INIT, auctionInitHandler);
@@ -100,7 +100,7 @@ export const spec = {
 
         device,
         site,
-        imp: []
+        imp: [],
       };
 
       postBody.imp.push(getImp(bid, id));
@@ -156,8 +156,8 @@ export const spec = {
           netRevenue: true,
           ttl: TIME_TO_LIVE,
           meta: {
-            advertiserDomains: bid.adomain || []
-          }
+            advertiserDomains: bid.adomain || [],
+          },
         };
 
         if (vastUrl || vastXml) {
@@ -306,8 +306,8 @@ export function setConsentStrings(postBody = {}, bidderRequest) {
 
 export function setOrtb2Parameters(postBody, ortb2 = {}) {
   for (let parameter of ALLOWED_ORTB2_PARAMETERS) {
-    const value = deepAccess(ortb2, parameter)
-    if (value) deepSetValue(postBody, parameter, value)
+    const value = deepAccess(ortb2, parameter);
+    if (value) deepSetValue(postBody, parameter, value);
   }
 }
 

--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -118,7 +118,7 @@ export const spec = {
         data: JSON.stringify(postBody),
         options: {
           contentType: 'text/plain',
-          withCredentials: true
+          withCredentials: true,
         },
 
         bidId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "prebid.js",
-      "version": "8.24.0-pre",
+      "version": "8.25.0-pre",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prebid.js",
-  "version": "8.27.0-pre",
+  "version": "8.25.0-pre",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prebid.js",
-  "version": "8.25.0-pre",
+  "version": "8.27.0-pre",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "prebid.js",
-      "version": "8.25.0-pre",
+      "version": "8.24.0-pre",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.7",

--- a/test/spec/modules/nextMillenniumBidAdapter_spec.js
+++ b/test/spec/modules/nextMillenniumBidAdapter_spec.js
@@ -1,9 +1,10 @@
 import { expect } from 'chai';
 import {
-  spec,
   getImp,
-  setConsentStrings,
   replaceUsersyncMacros,
+  setConsentStrings,
+  setOrtb2Parameters,
+  spec,
 } from 'modules/nextMillenniumBidAdapter.js';
 
 describe('nextMillenniumBidAdapterTests', () => {
@@ -349,6 +350,58 @@ describe('nextMillenniumBidAdapterTests', () => {
         const {syncOptions, responses, gdprConsent, uspConsent, gppConsent} = data;
         const pixels = spec.getUserSyncs(syncOptions, responses, gdprConsent, uspConsent, gppConsent);
         expect(pixels).to.deep.equal(expected);
+      });
+    }
+  });
+
+  describe('function setOrtb2Parameters', () => {
+    const dataTests = [
+      {
+        title: 'site.pagecat, site.content.cat and site.content.language',
+        data: {
+          postBody: {},
+          ortb2: {site: {
+            pagecat: ['IAB2-11', 'IAB2-12', 'IAB2-14'],
+            content: {cat: ['IAB2-11', 'IAB2-12', 'IAB2-14'], language: 'EN'},
+          }},
+        },
+
+        expected: {site: {
+          pagecat: ['IAB2-11', 'IAB2-12', 'IAB2-14'],
+          content: {cat: ['IAB2-11', 'IAB2-12', 'IAB2-14'], language: 'EN'},
+        }},
+      },
+
+      {
+        title: 'only site.content.language',
+        data: {
+          postBody: {site: {domain: 'some.domain'}},
+          ortb2: {site: {
+            content: {language: 'EN'},
+          }},
+        },
+
+        expected: {site: {
+          domain: 'some.domain',
+          content: {language: 'EN'},
+        }},
+      },
+
+      {
+        title: 'object ortb2 is empty',
+        data: {
+          postBody: {imp: []},
+        },
+
+        expected: {imp: []},
+      },
+    ];
+
+    for (let {title, data, expected} of dataTests) {
+      it(title, () => {
+        const {postBody, ortb2} = data;
+        setOrtb2Parameters(postBody, ortb2);
+        expect(postBody).to.deep.equal(expected);
       });
     }
   });

--- a/test/spec/modules/nextMillenniumBidAdapter_spec.js
+++ b/test/spec/modules/nextMillenniumBidAdapter_spec.js
@@ -1,66 +1,384 @@
 import { expect } from 'chai';
-import { spec } from 'modules/nextMillenniumBidAdapter.js';
+import {
+  spec,
+  getImp,
+  setConsentStrings,
+  replaceUsersyncMacros,
+} from 'modules/nextMillenniumBidAdapter.js';
 
-describe('nextMillenniumBidAdapterTests', function() {
-  const bidRequestData = [
-    {
-      adUnitCode: 'test-div',
-      bidId: 'bid1234',
-      auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
-      bidder: 'nextMillennium',
-      params: { placement_id: '-1' },
-      sizes: [[300, 250]],
-      uspConsent: '1---',
-      gppConsent: {
-        gppString: 'DBACNYA~CPXxRfAPXxR',
-        applicableSections: [7],
+describe('nextMillenniumBidAdapterTests', () => {
+  describe('function getImp', () => {
+    const dataTests = [
+      {
+        title: 'imp - banner',
+        data: {
+          id: '123',
+          bid: {
+            mediaTypes: {banner: {sizes: [[300, 250], [320, 250]]}},
+            adUnitCode: 'test-banner-1',
+          },
+        },
+
+        expected: {
+          id: 'test-banner-1',
+          ext: {prebid: {storedrequest: {id: '123'}}},
+          banner: {format: [{w: 300, h: 250}, {w: 320, h: 250}]},
+        },
       },
 
-      gdprConsent: {
-        consentString: 'kjfdniwjnifwenrif3',
-        gdprApplies: true
+      {
+        title: 'imp - video',
+        data: {
+          id: '234',
+          bid: {
+            mediaTypes: {video: {playerSize: [400, 300]}},
+            adUnitCode: 'test-video-1',
+          },
+        },
+
+        expected: {
+          id: 'test-video-1',
+          ext: {prebid: {storedrequest: {id: '234'}}},
+          video: {w: 400, h: 300},
+        },
+      },
+    ];
+
+    for (let {title, data, expected} of dataTests) {
+      it(title, () => {
+        const {bid, id} = data;
+        const imp = getImp(bid, id);
+        expect(imp).to.deep.equal(expected);
+      });
+    }
+  });
+
+  describe('function setConsentStrings', () => {
+    const dataTests = [
+      {
+        title: 'full: uspConsent, gdprConsent and gppConsent',
+        data: {
+          postBody: {},
+          bidderRequest: {
+            uspConsent: '1---',
+            gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7]},
+            gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: true},
+            ortb2: {regs: {gpp: 'DSFHFHWEUYVDC', gpp_sid: [8, 9, 10]}},
+          },
+        },
+
+        expected: {
+          user: {ext: {consent: 'kjfdniwjnifwenrif3'}},
+          regs: {
+            gpp: 'DBACNYA~CPXxRfAPXxR',
+            gpp_sid: [7],
+            ext: {gdpr: 1, us_privacy: '1---'},
+          },
+        },
       },
 
-      ortb2: {
-        device: {
-          w: 1500,
-          h: 1000
+      {
+        title: 'gdprConsent(false) and ortb2(gpp)',
+        data: {
+          postBody: {},
+          bidderRequest: {
+            gdprConsent: {consentString: 'ewtewbefbawyadexv', gdprApplies: false},
+            ortb2: {regs: {gpp: 'DSFHFHWEUYVDC', gpp_sid: [8, 9, 10]}},
+          },
         },
 
-        site: {
-          domain: 'example.com',
-          page: 'http://example.com'
-        }
-      }
-    }];
+        expected: {
+          user: {ext: {consent: 'ewtewbefbawyadexv'}},
+          regs: {
+            gpp: 'DSFHFHWEUYVDC',
+            gpp_sid: [8, 9, 10],
+            ext: {gdpr: 0},
+          },
+        },
+      },
 
-  const bidRequestData2 = [
-    {
-      adUnitCode: 'test-div',
-      bidId: 'bid1234',
-      auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
-      bidder: 'nextMillennium',
-      params: { placement_id: '-1' },
-      sizes: [[300, 250]],
-
-      ortb2: {
-        device: {
-          w: 1500,
-          h: 1000
+      {
+        title: 'gdprConsent(false)',
+        data: {
+          postBody: {},
+          bidderRequest: {gdprConsent: {gdprApplies: false}},
         },
 
-        site: {
-          domain: 'example.com',
-          page: 'http://example.com'
+        expected: {
+          regs: {ext: {gdpr: 0}},
+        },
+      },
+
+      {
+        title: 'empty',
+        data: {
+          postBody: {},
+          bidderRequest: {},
         },
 
-        regs: {
-          gpp: 'DBACNYA~CPXxRfAPXxR',
-          gpp_sid: [7, 8],
+        expected: {},
+      },
+    ];
+
+    for (let {title, data, expected} of dataTests) {
+      it(title, () => {
+        const {postBody, bidderRequest} = data;
+        setConsentStrings(postBody, bidderRequest);
+        expect(postBody).to.deep.equal(expected);
+      });
+    }
+  });
+
+  describe('function replaceUsersyncMacros', () => {
+    const dataTests = [
+      {
+        title: 'url with all macroses - consents full: uspConsent, gdprConsent and gppConsent',
+        data: {
+          url: 'https://some.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&type={{.TYPE_PIXEL}}',
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: true},
+          type: 'image',
         },
+
+        expected: 'https://some.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8&type=image',
+      },
+
+      {
+        title: 'url with some macroses - consents full: uspConsent, gdprConsent and gppConsent',
+        data: {
+          url: 'https://some.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&type={{.TYPE_PIXEL}}',
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: false},
+          type: 'iframe',
+        },
+
+        expected: 'https://some.url?gdpr=0&gdpr_consent=kjfdniwjnifwenrif3&type=iframe',
+      },
+
+      {
+        title: 'url without macroses - consents full: uspConsent, gdprConsent and gppConsent',
+        data: {
+          url: 'https://some.url?param1=value1&param2=value2',
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: false},
+          type: 'iframe',
+        },
+
+        expected: 'https://some.url?param1=value1&param2=value2',
+      },
+
+      {
+        title: 'url with all macroses - consents are empty',
+        data: {
+          url: 'https://some.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}&type={{.TYPE_PIXEL}}',
+        },
+
+        expected: 'https://some.url?gdpr=0&gdpr_consent=&us_privacy=&gpp=&gpp_sid=&type=',
+      },
+    ];
+
+    for (let {title, data, expected} of dataTests) {
+      it(title, () => {
+        const {url, gdprConsent, uspConsent, gppConsent, type} = data;
+        const newUrl = replaceUsersyncMacros(url, gdprConsent, uspConsent, gppConsent, type);
+        expect(newUrl).to.equal(expected);
+      });
+    }
+  });
+
+  describe('function spec.getUserSyncs', () => {
+    const dataTests = [
+      {
+        title: 'pixels from responses ({iframeEnabled: true, pixelEnabled: true})',
+        data: {
+          syncOptions: {iframeEnabled: true, pixelEnabled: true},
+          responses: [
+            {body: {ext: {sync: {
+              image: [
+                'https://some.1.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.2.url?us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.3.url?param=1234',
+              ],
+
+              iframe: [
+                'https://some.4.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.5.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}',
+              ],
+            }}}},
+
+            {body: {ext: {sync: {
+              iframe: [
+                'https://some.6.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.7.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}',
+              ],
+            }}}},
+
+            {body: {ext: {sync: {
+              image: [
+                'https://some.8.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+              ],
+            }}}},
+          ],
+
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: true},
+        },
+
+        expected: [
+          {type: 'image', url: 'https://some.1.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8'},
+          {type: 'image', url: 'https://some.2.url?us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8'},
+          {type: 'image', url: 'https://some.3.url?param=1234'},
+          {type: 'iframe', url: 'https://some.4.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8'},
+          {type: 'iframe', url: 'https://some.5.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---'},
+          {type: 'iframe', url: 'https://some.6.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8'},
+          {type: 'iframe', url: 'https://some.7.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---'},
+          {type: 'image', url: 'https://some.8.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8'},
+        ],
+      },
+
+      {
+        title: 'pixels from responses ({iframeEnabled: true, pixelEnabled: false})',
+        data: {
+          syncOptions: {iframeEnabled: true, pixelEnabled: false},
+          responses: [
+            {body: {ext: {sync: {
+              image: [
+                'https://some.1.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.2.url?us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.3.url?param=1234',
+              ],
+
+              iframe: [
+                'https://some.4.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.5.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}',
+              ],
+            }}}},
+          ],
+
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: true},
+        },
+
+        expected: [
+          {type: 'iframe', url: 'https://some.4.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8'},
+          {type: 'iframe', url: 'https://some.5.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---'},
+        ],
+      },
+
+      {
+        title: 'pixels from responses ({iframeEnabled: false, pixelEnabled: true})',
+        data: {
+          syncOptions: {iframeEnabled: false, pixelEnabled: true},
+          responses: [
+            {body: {ext: {sync: {
+              image: [
+                'https://some.1.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.2.url?us_privacy={{.USPrivacy}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.3.url?param=1234',
+              ],
+
+              iframe: [
+                'https://some.4.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&gpp={{.GPP}}&gpp_sid={{.GPPSID}}',
+                'https://some.5.url?gdpr={{.GDPR}}&gdpr_consent={{.GDPRConsent}}&us_privacy={{.USPrivacy}}',
+              ],
+            }}}},
+          ],
+
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: true},
+        },
+
+        expected: [
+          {type: 'image', url: 'https://some.1.url?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8'},
+          {type: 'image', url: 'https://some.2.url?us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8'},
+          {type: 'image', url: 'https://some.3.url?param=1234'},
+        ],
+      },
+
+      {
+        title: 'pixels - responses is empty ({iframeEnabled: true, pixelEnabled: true})',
+        data: {
+          syncOptions: {iframeEnabled: true, pixelEnabled: true},
+          responses: [],
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: true},
+        },
+
+        expected: [
+          {type: 'image', url: 'https://cookies.nextmillmedia.com/sync?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8&type=image'},
+          {type: 'iframe', url: 'https://cookies.nextmillmedia.com/sync?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8&type=iframe'},
+        ],
+      },
+
+      {
+        title: 'pixels - responses is empty ({iframeEnabled: true, pixelEnabled: false})',
+        data: {
+          syncOptions: {iframeEnabled: true, pixelEnabled: false},
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: true},
+        },
+
+        expected: [
+          {type: 'iframe', url: 'https://cookies.nextmillmedia.com/sync?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7,8&type=iframe'},
+        ],
+      },
+
+      {
+        title: 'pixels - responses is empty ({iframeEnabled: false, pixelEnabled: false})',
+        data: {
+          syncOptions: {iframeEnabled: false, pixelEnabled: false},
+          uspConsent: '1---',
+          gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7, 8]},
+          gdprConsent: {consentString: 'kjfdniwjnifwenrif3', gdprApplies: true},
+        },
+
+        expected: [],
+      },
+    ];
+
+    for (let {title, data, expected} of dataTests) {
+      it(title, () => {
+        const {syncOptions, responses, gdprConsent, uspConsent, gppConsent} = data;
+        const pixels = spec.getUserSyncs(syncOptions, responses, gdprConsent, uspConsent, gppConsent);
+        expect(pixels).to.deep.equal(expected);
+      });
+    }
+  });
+
+  const bidRequestData = [{
+    adUnitCode: 'test-div',
+    bidId: 'bid1234',
+    auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+    bidder: 'nextMillennium',
+    params: { placement_id: '-1' },
+    sizes: [[300, 250]],
+    uspConsent: '1---',
+    gppConsent: {gppString: 'DBACNYA~CPXxRfAPXxR', applicableSections: [7]},
+    gdprConsent: {
+      consentString: 'kjfdniwjnifwenrif3',
+      gdprApplies: true
+    },
+
+    ortb2: {
+      device: {
+        w: 1500,
+        h: 1000
+      },
+
+      site: {
+        domain: 'example.com',
+        page: 'http://example.com'
       }
     }
-  ];
+  }];
 
   const serverResponse = {
     body: {
@@ -151,69 +469,6 @@ describe('nextMillenniumBidAdapterTests', function() {
     },
   ];
 
-  it('Request params check with GDPR and USP Consent and GPP Consent', function () {
-    const request = spec.buildRequests(bidRequestData, bidRequestData[0]);
-    expect(JSON.parse(request[0].data).user.ext.consent).to.equal('kjfdniwjnifwenrif3');
-    expect(JSON.parse(request[0].data).regs.ext.us_privacy).to.equal('1---');
-    expect(JSON.parse(request[0].data).regs.ext.gdpr).to.equal(1);
-    expect(JSON.parse(request[0].data).regs.gpp).to.equal('DBACNYA~CPXxRfAPXxR');
-    expect(JSON.stringify(JSON.parse(request[0].data).regs.gpp_sid)).to.equal('[7]');
-
-    const request2 = spec.buildRequests(bidRequestData2, bidRequestData2[0]);
-    expect(JSON.parse(request2[0].data).regs.gpp).to.equal('DBACNYA~CPXxRfAPXxR');
-    expect(JSON.stringify(JSON.parse(request2[0].data).regs.gpp_sid)).to.equal('[7,8]');
-  });
-
-  it('Test getUserSyncs function', function () {
-    const {gdprConsent, uspConsent, gppConsent} = bidRequestData[0];
-    const syncOptions = {
-      'iframeEnabled': false,
-      'pixelEnabled': true
-    }
-
-    let userSync = spec.getUserSyncs(syncOptions, [serverResponse], gdprConsent, uspConsent, gppConsent);
-    expect(userSync).to.be.an('array').with.lengthOf(1);
-    expect(userSync[0].type).to.equal('image');
-    expect(userSync[0].url).to.equal('urlA?gdpr=1&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7');
-
-    syncOptions.iframeEnabled = true;
-    syncOptions.pixelEnabled = false;
-    userSync = spec.getUserSyncs(syncOptions, [serverResponse], gdprConsent, uspConsent);
-    expect(userSync).to.be.an('array').with.lengthOf(1);
-    expect(userSync[0].type).to.equal('iframe');
-    expect(userSync[0].url).to.equal('urlB');
-  });
-
-  it('Test getUserSyncs with no response', function () {
-    const syncOptions = {
-      'iframeEnabled': true,
-      'pixelEnabled': false
-    }
-    let userSync = spec.getUserSyncs(syncOptions, [], bidRequestData[0].gdprConsent, bidRequestData[0].uspConsent, bidRequestData[0].gppConsent);
-    expect(userSync).to.be.an('array')
-    expect(userSync[0].type).to.equal('iframe')
-    expect(userSync[0].url).to.equal('https://cookies.nextmillmedia.com/sync?gdpr=1&gdpr_consent=kjfdniwjnifwenrif3&us_privacy=1---&gpp=DBACNYA~CPXxRfAPXxR&gpp_sid=7&type=iframe')
-  })
-
-  it('Test getUserSyncs function if GDPR is undefined', function () {
-    const syncOptions = {
-      'iframeEnabled': false,
-      'pixelEnabled': true
-    }
-
-    let userSync = spec.getUserSyncs(syncOptions, [serverResponse], undefined, bidRequestData[0].uspConsent);
-    expect(userSync).to.be.an('array').with.lengthOf(1);
-    expect(userSync[0].type).to.equal('image');
-    expect(userSync[0].url).to.equal('urlA?gdpr=0&gpp={{.GPP}}&gpp_sid={{.GPPSID}}');
-  });
-
-  it('Request params check without GDPR Consent', function () {
-    delete bidRequestData[0].gdprConsent
-    const request = spec.buildRequests(bidRequestData, bidRequestData[0]);
-    expect(JSON.parse(request[0].data).regs.ext.gdpr).to.be.undefined;
-    expect(JSON.parse(request[0].data).regs.ext.us_privacy).to.equal('1---');
-  });
-
   it('validate_generated_params', function() {
     const request = spec.buildRequests(bidRequestData, {bidderRequestId: 'mock-uuid'});
     expect(request[0].bidId).to.equal('bid1234');
@@ -232,7 +487,7 @@ describe('nextMillenniumBidAdapterTests', function() {
 
   it('Check if refresh_count param is incremented', function() {
     const request = spec.buildRequests(bidRequestData);
-    expect(JSON.parse(request[0].data).ext.nextMillennium.refresh_count).to.equal(4);
+    expect(JSON.parse(request[0].data).ext.nextMillennium.refresh_count).to.equal(1);
   });
 
   it('Check if domain was added', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
- GPP Consent String support
- Supplemented test coverage of existing functionality
- Added support for Openrtb 2.5 parameters: `site.pagecat`, `site.content.cat` and `site.content.language` (Added to the adapter description. PR: https://github.com/prebid/prebid.github.io/pull/4994)
- Fixed a bug with video ad sizes
- Rewritten getUserSync function
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
