### PR TITLE
GeoEdge RTD module: collect CPM and curency from the winning bid

### DIFF
--- a/modules/geoedgeRtdProvider.js
+++ b/modules/geoedgeRtdProvider.js
@@ -116,7 +116,9 @@ function getMacros(bid, key) {
     '%_hbadomains': bid.meta && bid.meta.advertiserDomains,
     '%%PATTERN:hb_pb%%': bid.pbHg,
     '%%SITE%%': location.hostname,
-    '%_pimp%': PV_ID
+    '%_pimp%': PV_ID,
+    '%_hbCpm!': bid.cpm,
+    '%_hbCurrency!': bid.currency
   };
 }
 

--- a/modules/geoedgeRtdProvider.js
+++ b/modules/geoedgeRtdProvider.js
@@ -103,7 +103,7 @@ export function wrapHtml(wrapper, html) {
  * @param {string} key
  * @return {Object}
  */
-function getMacros(bid, key) {
+export function getMacros(bid, key) {
   return {
     '${key}': key,
     '%%ADUNIT%%': bid.adUnitCode,

--- a/test/spec/modules/geoedgeRtdProvider_spec.js
+++ b/test/spec/modules/geoedgeRtdProvider_spec.js
@@ -6,6 +6,7 @@ import {
   getInPageUrl,
   htmlPlaceholder,
   setWrapper,
+  getMacros,
   wrapper,
   WRAPPER_URL
 } from '../../../modules/geoedgeRtdProvider.js';
@@ -115,6 +116,15 @@ describe('Geoedge RTD module', function () {
       it('should set the wrapper', function () {
         setWrapper(mockWrapper);
         expect(wrapper).to.equal(mockWrapper);
+      });
+    });
+    describe('getMacros', function () {
+      it('return a dictionary of macros replaced with values from bid object', function () {
+        let bid = mockBid('testBidder');
+        let dict = getMacros(bid, key);
+        let hasCpm = dict['%_hbCpm!'] === bid.cpm;
+        let hasCurrency = dict['%_hbCurrency!'] === bid.currency;
+        expect(hasCpm && hasCurrency);
       });
     });
     describe('onBidResponseEvent', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Other

## Description of change
Collect CPM and currency code from the winning bid for reporting purposes. 

## Other information
[GeoEdge module](https://docs.prebid.org/dev-docs/modules/geoedgeRtdProvider.html)
https://github.com/prebid/Prebid.js/pull/5869
https://github.com/prebid/Prebid.js/pull/9267
https://github.com/prebid/Prebid.js/pull/10291