### PR TITLE
GrowthCode RTD: bounce requests when the PID is missing

### DIFF
--- a/modules/growthCodeRtdProvider.js
+++ b/modules/growthCodeRtdProvider.js
@@ -60,7 +60,11 @@ function init(config, userConsent) {
 
   items = tryParse(storage.getDataFromLocalStorage(RTD_CACHE_KEY, null));
 
-  return callServer(configParams, items, expiresAt, userConsent);
+  if (configParams.pid === undefined) {
+    return true; // Die gracefully
+  } else {
+    return callServer(configParams, items, expiresAt, userConsent);
+  }
 }
 function callServer(configParams, items, expiresAt, userConsent) {
   // Expire Cache


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Updated RTD module to not perform a server call with the PID missing in the config
