### PR TITLE
Core: add option to turn off `Sec-Browsing-Topics` header

### DIFF
--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -457,7 +457,7 @@ export const processBidderRequests = hook('sync', function (spec, bids, bidderRe
       return Object.assign(defaults, ro, {
         browsingTopics: ro?.hasOwnProperty('browsingTopics') && !ro.browsingTopics
           ? false
-          : isActivityAllowed(ACTIVITY_TRANSMIT_UFPD, activityParams(MODULE_TYPE_BIDDER, spec.code))
+          : (bidderSettings.get(spec.code, 'topicsHeader') ?? true) && isActivityAllowed(ACTIVITY_TRANSMIT_UFPD, activityParams(MODULE_TYPE_BIDDER, spec.code))
       })
     }
     switch (request.method) {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

This adds a `bidderSettings[<bidder>].topicsHeader` option that, when set to false, disables the [`Sec-Browsing-Topics` header](https://github.com/prebid/Prebid.js/pull/10340) on bidder requests.

