### PR TITLE
identityLink Id System : fix 3p call to always use tcf consent type 4 

### DIFF
--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -54,7 +54,6 @@ export const identityLinkSubmodule = {
     }
     const hasGdpr = (consentData && typeof consentData.gdprApplies === 'boolean' && consentData.gdprApplies) ? 1 : 0;
     const gdprConsentString = hasGdpr ? consentData.consentString : '';
-    const tcfPolicyV2 = utils.deepAccess(consentData, 'vendorData.tcfPolicyVersion') === 2;
     // use protocol relative urls for http or https
     if (hasGdpr && (!gdprConsentString || gdprConsentString === '')) {
       utils.logInfo('identityLink: Consent string is required to call envelope API.');
@@ -64,7 +63,7 @@ export const identityLinkSubmodule = {
     const gppString = gppData && gppData.gppString ? gppData.gppString : false;
     const gppSectionId = gppData && gppData.gppString && gppData.applicableSections.length > 0 && gppData.applicableSections[0] !== -1 ? gppData.applicableSections[0] : false;
     const hasGpp = gppString && gppSectionId;
-    const url = `https://api.rlcdn.com/api/identity/envelope?pid=${configParams.pid}${hasGdpr ? (tcfPolicyV2 ? '&ct=4&cv=' : '&ct=1&cv=') + gdprConsentString : ''}${hasGpp ? '&gpp=' + gppString + '&gpp_sid=' + gppSectionId : ''}`;
+    const url = `https://api.rlcdn.com/api/identity/envelope?pid=${configParams.pid}${hasGdpr ? '&ct=4&cv=' + gdprConsentString : ''}${hasGpp ? '&gpp=' + gppString + '&gpp_sid=' + gppSectionId : ''}`;
     let resp;
     resp = function (callback) {
       // Check ats during callback so it has a chance to initialise.

--- a/test/spec/modules/identityLinkIdSystem_spec.js
+++ b/test/spec/modules/identityLinkIdSystem_spec.js
@@ -75,24 +75,6 @@ describe('IdentityLinkId tests', function () {
     expect(submoduleCallback).to.be.undefined;
   });
 
-  it('should call the LiveRamp envelope endpoint with IAB consent string v1', function () {
-    let callBackSpy = sinon.spy();
-    let consentData = {
-      gdprApplies: true,
-      consentString: 'BOkIpDSOkIpDSADABAENCc-AAAApOAFAAMAAsAMIAcAA_g'
-    };
-    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams, consentData).callback;
-    submoduleCallback(callBackSpy);
-    let request = server.requests[0];
-    expect(request.url).to.be.eq('https://api.rlcdn.com/api/identity/envelope?pid=14&ct=1&cv=BOkIpDSOkIpDSADABAENCc-AAAApOAFAAMAAsAMIAcAA_g');
-    request.respond(
-      200,
-      responseHeader,
-      JSON.stringify({})
-    );
-    expect(callBackSpy.calledOnce).to.be.true;
-  });
-
   it('should call the LiveRamp envelope endpoint with IAB consent string v2', function () {
     let callBackSpy = sinon.spy();
     let consentData = {


### PR DESCRIPTION
## Type of change

- [X] Bugfix

## Description of change
identityLinkIdSystem - Liveramp - bug fix. Fix 3p call to always use tcf consent type 4. 

We have removed logic where we were checking tcfPolicyVersion since back in a days we needed to know which version to send to our api because of backward compatibility. Since our back-end now only allows ct=4 parameter we need to change this, since tcfPolicyVersion been increased (now is 4) so now because of this logic, we always set ct parameter to 1, which is incorrect and causes error on http request. 

