### PR TITLE
Core & PBS adapter: fix race condition between network timeout and auction timeout

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -478,13 +478,13 @@ export function PrebidServer() {
               adapterMetrics
             });
           }
-          done();
+          done(false);
           doClientSideSyncs(requestedBidders, gdprConsent, uspConsent, gppConsent);
         },
         onError(msg, error) {
           logError(`Prebid server call failed: '${msg}'`, error);
           bidRequests.forEach(bidderRequest => events.emit(CONSTANTS.EVENTS.BIDDER_ERROR, {error, bidderRequest}));
-          done();
+          done(error.timedOut);
         },
         onBid: function ({adUnit, bid}) {
           const metrics = bid.metrics = s2sBidRequest.metrics.fork().renameWith();

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -413,8 +413,10 @@ adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, request
         if (s2sBidRequest.ad_units.length) {
           let doneCbs = uniqueServerRequests.map(bidRequest => {
             bidRequest.start = timestamp();
-            return function () {
-              onTimelyResponse(bidRequest.bidderRequestId);
+            return function (timedOut) {
+              if (!timedOut) {
+                onTimelyResponse(bidRequest.bidderRequestId);
+              }
               doneCb.apply(bidRequest, arguments);
             }
           });
@@ -433,7 +435,7 @@ adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, request
             s2sBidRequest,
             serverBidderRequests,
             addBidResponse,
-            () => doneCbs.forEach(done => done()),
+            (timedOut) => doneCbs.forEach(done => done(timedOut)),
             s2sAjax
           );
         }

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -300,7 +300,9 @@ export function newBidder(spec) {
         },
         // If the server responds with an error, there's not much we can do beside logging.
         onError: (errorMessage, error) => {
-          onTimelyResponse(spec.code);
+          if (!error.timedOut) {
+            onTimelyResponse(spec.code);
+          }
           adapterManager.callBidderError(spec.code, error, bidderRequest)
           events.emit(CONSTANTS.EVENTS.BIDDER_ERROR, { error, bidderRequest });
           logError(`Server call for ${spec.code} failed: ${errorMessage} ${error.status}. Continuing without bids.`);

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -114,7 +114,8 @@ function toXHR({status, statusText = '', headers, url}, responseText) {
     getResponseHeader: (header) => headers?.has(header) ? headers.get(header) : null,
     toJSON() {
       return Object.assign({responseXML: getXML()}, this)
-    }
+    },
+    timedOut: false
   }
 }
 
@@ -130,7 +131,10 @@ export function attachCallbacks(fetchPm, callback) {
     .then(([response, responseText]) => {
       const xhr = toXHR(response, responseText);
       response.ok || response.status === 304 ? success(responseText, xhr) : error(response.statusText, xhr);
-    }, () => error('', toXHR({status: 0}, '')));
+    }, (reason) => error('', Object.assign(
+      toXHR({status: 0}, ''),
+      {reason, timedOut: reason?.name === 'AbortError'}))
+    );
 }
 
 export function ajaxBuilder(timeout = 3000, {request, done} = {}) {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2882,6 +2882,32 @@ describe('S2S Adapter', function () {
       })
     })
 
+    describe('calls done', () => {
+      let success, error;
+      beforeEach(() => {
+        const mockAjax = function (_, callback) {
+          ({success, error} = callback);
+        }
+        config.setConfig({ s2sConfig: CONFIG });
+        adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, mockAjax);
+      })
+
+      it('passing timedOut = false on succcess', () => {
+        success({});
+        sinon.assert.calledWith(done, false);
+      });
+
+      Object.entries({
+        'timeouts': true,
+        'other errors': false
+      }).forEach(([t, timedOut]) => {
+        it(`passing timedOut = ${timedOut} on ${t}`, () => {
+          error('', {timedOut});
+          sinon.assert.calledWith(done, timedOut);
+        })
+      })
+    })
+
     // TODO: test dependent on pbjs_api_spec.  Needs to be isolated
     it('does not call addBidResponse and calls done when ad unit not set', function () {
       config.setConfig({ s2sConfig: CONFIG });

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -964,25 +964,42 @@ describe('adapterManager tests', function () {
       'start': 1462918897460
     }];
 
-    it('invokes callBids on the S2S adapter', function () {
-      const done = sinon.stub();
-      const onTimelyResponse = sinon.stub();
-      prebidServerAdapterMock.callBids.callsFake((_1, _2, _3, done) => {
-        done();
+    describe('invokes callBids on the S2S adapter', () => {
+      let onTimelyResponse, timedOut, done;
+      beforeEach(() => {
+        done = sinon.stub();
+        onTimelyResponse = sinon.stub();
+        prebidServerAdapterMock.callBids.callsFake((_1, _2, _3, done) => {
+          done(timedOut);
+        });
+      })
+
+      function runTest() {
+        adapterManager.callBids(
+          getAdUnits(),
+          bidRequests,
+          () => {},
+          done,
+          undefined,
+          undefined,
+          onTimelyResponse
+        );
+        sinon.assert.calledTwice(prebidServerAdapterMock.callBids);
+        sinon.assert.calledTwice(done);
+      }
+
+      it('and marks requests as timely if the adapter says timedOut = false', function () {
+        timedOut = false;
+        runTest();
+        bidRequests.forEach(br => sinon.assert.calledWith(onTimelyResponse, br.bidderRequestId));
       });
-      adapterManager.callBids(
-        getAdUnits(),
-        bidRequests,
-        () => {},
-        done,
-        undefined,
-        undefined,
-        onTimelyResponse
-      );
-      sinon.assert.calledTwice(prebidServerAdapterMock.callBids);
-      sinon.assert.calledTwice(done);
-      bidRequests.forEach(br => sinon.assert.calledWith(onTimelyResponse, br.bidderRequestId));
-    });
+
+      it('and does NOT mark them as timely if it says timedOut = true', () => {
+        timedOut = true;
+        runTest();
+        sinon.assert.notCalled(onTimelyResponse);
+      })
+    })
 
     // Enable this test when prebidServer adapter is made 1.0 compliant
     it('invokes callBids with only s2s bids', function () {

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -38,10 +38,6 @@ const MOCK_BIDS_REQUEST = {
   ]
 }
 
-function onTimelyResponseStub() {
-
-}
-
 before(() => {
   hook.ready();
 });
@@ -49,6 +45,10 @@ before(() => {
 let wrappedCallback = config.callbackWithBidder(CODE);
 
 describe('bidderFactory', () => {
+  let onTimelyResponseStub;
+  beforeEach(() => {
+    onTimelyResponseStub = sinon.stub();
+  })
   describe('bidders created by newBidder', function () {
     let spec;
     let bidder;
@@ -582,6 +582,14 @@ describe('bidderFactory', () => {
         utils.logError.restore();
       });
 
+      it('should call onTimelyResponse', () => {
+        const bidder = newBidder(spec);
+        spec.isBidRequestValid.returns(true);
+        spec.buildRequests.returns({method: 'POST', url: 'test', data: {}});
+        bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
+        sinon.assert.called(onTimelyResponseStub);
+      })
+
       it('should call spec.interpretResponse() with the response content', function () {
         const bidder = newBidder(spec);
 
@@ -800,12 +808,13 @@ describe('bidderFactory', () => {
       let ajaxStub;
       let callBidderErrorStub;
       let eventEmitterStub;
-      let xhrErrorMock = {
-        status: 500,
-        statusText: 'Internal Server Error'
-      };
+      let xhrErrorMock;
 
       beforeEach(function () {
+        xhrErrorMock = {
+          status: 500,
+          statusText: 'Internal Server Error'
+        };
         ajaxStub = sinon.stub(ajax, 'ajax').callsFake(function(url, callbacks) {
           callbacks.error('ajax call failed.', xhrErrorMock);
         });
@@ -820,6 +829,20 @@ describe('bidderFactory', () => {
         callBidderErrorStub.restore();
         eventEmitterStub.restore();
       });
+
+      Object.entries({
+        'timeouts': true,
+        'other errors': false
+      }).forEach(([t, timedOut]) => {
+        it(`should ${timedOut ? 'NOT ' : ''}call onTimelyResponse on ${t}`, () => {
+          Object.assign(xhrErrorMock, {timedOut});
+          const bidder = newBidder(spec);
+          spec.isBidRequestValid.returns(true);
+          spec.buildRequests.returns({method: 'POST', url: 'test', data: {}});
+          bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
+          sinon.assert[timedOut ? 'notCalled' : 'called'](onTimelyResponseStub);
+        })
+      })
 
       it('should not spec.interpretResponse()', function () {
         const bidder = newBidder(spec);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

This fixes a bug where request timeouts sometimes do not result in a `bidTimeout` event.

Overview of the problem (assuming for this example that timeout is set to 1s):

 1. when an auction starts we schedule a task to run after 1s;
 2. then we queue all network requests, each with timeout also set to 1s;
 3. as the responses come back, we mark their requests as "timely";
 4. if 1s passes before all requests are done, the task from <span>#</span>1 runs, checks whether there are any requests that are not "timely", and if so emits a BID_TIMEOUT event.

The bug is that when a request times out it still looks like a response to our logic and we still mark it as timely, so if the response processing happens to run before task <span>#</span>1 it won't pick up the timeout.
