### PR TITLE
LiveIntent UserId module: Add support for sovrn id

### DIFF
--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -223,6 +223,10 @@ export const liveIntentIdSubmodule = {
         result.pubmatic = { 'id': value.pubmatic, ext: { provider: LI_PROVIDER_DOMAIN } }
       }
 
+      if (value.sovrn) {
+        result.sovrn = { 'id': value.sovrn, ext: { provider: LI_PROVIDER_DOMAIN } }
+      }
+
       return result
     }
 
@@ -339,6 +343,18 @@ export const liveIntentIdSubmodule = {
     },
     'pubmatic': {
       source: 'pubmatic.com',
+      atype: 3,
+      getValue: function(data) {
+        return data.id;
+      },
+      getUidExt: function(data) {
+        if (data.ext) {
+          return data.ext;
+        }
+      }
+    },
+    'sovrn': {
+      source: 'liveintent.sovrn.com',
       atype: 3,
       getValue: function(data) {
         return data.id;

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -238,7 +238,6 @@ describe('eids array generation for known sub-modules', function() {
     });
   });
 
-
   it('sovrn', function() {
     const userId = {
       sovrn: {'id': 'sample_id'}
@@ -261,12 +260,12 @@ describe('eids array generation for known sub-modules', function() {
     const newEids = createEidsArray(userId);
     expect(newEids.length).to.equal(1);
     expect(newEids[0]).to.deep.equal({
-      source: 'media.net',
+      source: 'liveintent.sovrn.com',
       uids: [{
         id: 'sample_id',
         atype: 3,
         ext: {
-          provider: 'liveintent.sovrn.com'
+          provider: 'some.provider.com'
         }
       }]
     });

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -238,6 +238,40 @@ describe('eids array generation for known sub-modules', function() {
     });
   });
 
+
+  it('sovrn', function() {
+    const userId = {
+      sovrn: {'id': 'sample_id'}
+    };
+    const newEids = createEidsArray(userId);
+    expect(newEids.length).to.equal(1);
+    expect(newEids[0]).to.deep.equal({
+      source: 'liveintent.sovrn.com',
+      uids: [{
+        id: 'sample_id',
+        atype: 3
+      }]
+    });
+  });
+
+  it('sovrn with ext', function() {
+    const userId = {
+      sovrn: {'id': 'sample_id', 'ext': {'provider': 'some.provider.com'}}
+    };
+    const newEids = createEidsArray(userId);
+    expect(newEids.length).to.equal(1);
+    expect(newEids[0]).to.deep.equal({
+      source: 'media.net',
+      uids: [{
+        id: 'sample_id',
+        atype: 3,
+        ext: {
+          provider: 'liveintent.sovrn.com'
+        }
+      }]
+    });
+  });
+
   it('magnite', function() {
     const userId = {
       magnite: {'id': 'sample_id'}

--- a/test/spec/modules/liveIntentIdMinimalSystem_spec.js
+++ b/test/spec/modules/liveIntentIdMinimalSystem_spec.js
@@ -261,6 +261,11 @@ describe('LiveIntentMinimalId', function() {
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'medianet': 'bar'}, 'medianet': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
+  it('should decode a sovrn id to a seperate object when present', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', sovrn: 'bar' });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'sovrn': 'bar'}, 'sovrn': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
   it('should decode a magnite id to a seperate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', magnite: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'magnite': 'bar'}, 'magnite': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -388,6 +388,11 @@ describe('LiveIntentId', function() {
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'medianet': 'bar'}, 'medianet': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
+  it('should decode a sovrn id to a seperate object when present', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', sovrn: 'bar' });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'sovrn': 'bar'}, 'sovrn': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
   it('should decode a magnite id to a seperate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', magnite: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'magnite': 'bar'}, 'magnite': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
This pull request adds eid mapping for the sovrn ids that now can be resolved via the LiveIntent UserId module.

## Other information

- repository of the backing live-connect module: https://github.com/LiveIntent/live-connect
- documentation PR: https://github.com/prebid/prebid.github.io/pull/5006
