### PR TITLE
LiveIntent UserId module:  Use openx.net as source for the openx id

### DIFF
--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -330,7 +330,7 @@ export const liveIntentIdSubmodule = {
       }
     },
     'openx': {
-      source: 'openx.com',
+      source: 'openx.net',
       atype: 3,
       getValue: function(data) {
         return data.id;

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -344,7 +344,7 @@ describe('eids array generation for known sub-modules', function() {
     const newEids = createEidsArray(userId);
     expect(newEids.length).to.equal(1);
     expect(newEids[0]).to.deep.equal({
-      source: 'openx.com',
+      source: 'openx.net',
       uids: [{
         id: 'sample_id',
         atype: 3
@@ -359,7 +359,7 @@ describe('eids array generation for known sub-modules', function() {
     const newEids = createEidsArray(userId);
     expect(newEids.length).to.equal(1);
     expect(newEids[0]).to.deep.equal({
-      source: 'openx.com',
+      source: 'openx.net',
       uids: [{
         id: 'sample_id',
         atype: 3,


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
This pull request changes the source of the opex id from openx.com to openx.net when generating an eid for this type of ids.

## Other information

- repository of the backing live-connect module: https://github.com/LiveIntent/live-connect

