### PR TITLE
GreenbidsAnalyticsAdapter and GreenbidsRtdProvider: Rework greenbids sampling and improve transparency

### DIFF
--- a/modules/greenbidsAnalyticsAdapter.md
+++ b/modules/greenbidsAnalyticsAdapter.md
@@ -1,23 +1,24 @@
-# Overview
+#### Registration
 
-```
-Module Name: Greenbids Analytics Adapter
-Module Type: Analytics Adapter
-Maintainer: jb@greenbids.ai
-```
+The Greenbids Analytics adapter requires setup and approval from the
+Greenbids team. Please reach out to our team for more information [greenbids.ai](https://greenbids.ai).
 
-# Description
+#### Analytics Options
 
-Analytics adapter for Greenbids
+{: .table .table-bordered .table-striped }
+| Name         | Scope              | Description                                                                                                                 | Example                                                                             | Type             |
+|-------------|---------|--------------------|-----------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|------------------|
+| pbuid | required  | The Greenbids Publisher ID | greenbids-publisher-1  | string |
+| greenbidsSampling | optional  | sampling factor [0-1] (a value of 0.1 will filter 90% of the traffic) | 1.0  | float |
 
-# Test Parameters
+### Example Configuration
 
-```
-{
-  provider: 'greenbids',
-  options: {
-    pbuid: "PBUID_FROM_GREENBIDS"
-    sampling: 1.0
-  }
-}
+```javascript
+    pbjs.enableAnalytics({
+        provider: 'greenbids',
+        options: {
+            pbuid: "greenbids-publisher-1" // please contact Greenbids to get a pbuid for yourself
+            greenbidsSampling: 1.0
+        }
+    });
 ```

--- a/modules/greenbidsRtdProvider.js
+++ b/modules/greenbidsRtdProvider.js
@@ -1,4 +1,4 @@
-import { logError, deepClone, generateUUID, deepSetValue } from '../src/utils.js';
+import { logError, deepClone, generateUUID, deepSetValue, deepAccess } from '../src/utils.js';
 import { ajax } from '../src/ajax.js';
 import { submodule } from '../src/hook.js';
 import * as events from '../src/events.js';
@@ -24,12 +24,17 @@ function init(moduleConfig) {
 
 function onAuctionInitEvent(auctionDetails) {
   /* Emitting one billing event per auction */
-  events.emit(CONSTANTS.EVENTS.BILLABLE_EVENT, {
-    type: 'auction',
-    billingId: generateUUID(),
-    auctionId: auctionDetails.auctionId,
-    vendor: MODULE_NAME
-  });
+  let defaultId = 'default_id';
+  let greenbidsId = deepAccess(auctionDetails.adUnits[0], 'ortb2Imp.ext.greenbids.greenbidsId', defaultId);
+  /* greenbids was successfully called so we emit the event */
+  if (greenbidsId !== defaultId) {
+    events.emit(CONSTANTS.EVENTS.BILLABLE_EVENT, {
+      type: 'auction',
+      billingId: generateUUID(),
+      auctionId: auctionDetails.auctionId,
+      vendor: MODULE_NAME
+    });
+  }
 }
 
 function getBidRequestData(reqBidsConfigObj, callback, config, userConsent) {

--- a/modules/greenbidsRtdProvider.js
+++ b/modules/greenbidsRtdProvider.js
@@ -1,12 +1,13 @@
-import { logError } from '../src/utils.js';
+import { logError, deepClone, generateUUID, deepSetValue } from '../src/utils.js';
 import { ajax } from '../src/ajax.js';
 import { submodule } from '../src/hook.js';
+import * as events from '../src/events.js';
+import CONSTANTS from '../src/constants.json';
 
 const MODULE_NAME = 'greenbidsRtdProvider';
-const MODULE_VERSION = '1.0.0';
+const MODULE_VERSION = '2.0.0';
 const ENDPOINT = 'https://t.greenbids.ai';
 
-const auctionInfo = {};
 const rtdOptions = {};
 
 function init(moduleConfig) {
@@ -16,22 +17,28 @@ function init(moduleConfig) {
     return false;
   } else {
     rtdOptions.pbuid = params?.pbuid;
-    rtdOptions.targetTPR = params?.targetTPR || 0.99;
     rtdOptions.timeout = params?.timeout || 200;
     return true;
   }
 }
 
 function onAuctionInitEvent(auctionDetails) {
-  auctionInfo.auctionId = auctionDetails.auctionId;
+  /* Emitting one billing event per auction */
+  events.emit(CONSTANTS.EVENTS.BILLABLE_EVENT, {
+    type: 'auction',
+    billingId: generateUUID(),
+    auctionId: auctionDetails.auctionId,
+    vendor: MODULE_NAME
+  });
 }
 
 function getBidRequestData(reqBidsConfigObj, callback, config, userConsent) {
-  let promise = createPromise(reqBidsConfigObj);
+  let greenbidsId = generateUUID();
+  let promise = createPromise(reqBidsConfigObj, greenbidsId);
   promise.then(callback);
 }
 
-function createPromise(reqBidsConfigObj) {
+function createPromise(reqBidsConfigObj, greenbidsId) {
   return new Promise((resolve) => {
     const timeoutId = setTimeout(() => {
       resolve(reqBidsConfigObj);
@@ -40,7 +47,7 @@ function createPromise(reqBidsConfigObj) {
       ENDPOINT,
       {
         success: (response) => {
-          processSuccessResponse(response, timeoutId, reqBidsConfigObj);
+          processSuccessResponse(response, timeoutId, reqBidsConfigObj, greenbidsId);
           resolve(reqBidsConfigObj);
         },
         error: () => {
@@ -48,24 +55,35 @@ function createPromise(reqBidsConfigObj) {
           resolve(reqBidsConfigObj);
         },
       },
-      createPayload(reqBidsConfigObj),
-      { contentType: 'application/json' }
+      createPayload(reqBidsConfigObj, greenbidsId),
+      {
+        contentType: 'application/json',
+        customHeaders: {
+          'Greenbids-Pbuid': rtdOptions.pbuid
+        }
+      }
     );
   });
 }
 
-function processSuccessResponse(response, timeoutId, reqBidsConfigObj) {
+function processSuccessResponse(response, timeoutId, reqBidsConfigObj, greenbidsId) {
   clearTimeout(timeoutId);
   const responseAdUnits = JSON.parse(response);
-
-  updateAdUnitsBasedOnResponse(reqBidsConfigObj.adUnits, responseAdUnits);
+  updateAdUnitsBasedOnResponse(reqBidsConfigObj.adUnits, responseAdUnits, greenbidsId);
 }
 
-function updateAdUnitsBasedOnResponse(adUnits, responseAdUnits) {
+function updateAdUnitsBasedOnResponse(adUnits, responseAdUnits, greenbidsId) {
   adUnits.forEach((adUnit) => {
     const matchingAdUnit = findMatchingAdUnit(responseAdUnits, adUnit.code);
     if (matchingAdUnit) {
-      removeFalseBidders(adUnit, matchingAdUnit);
+      deepSetValue(adUnit, 'ortb2Imp.ext.greenbids', {
+        greenbidsId: greenbidsId,
+        keptInAuction: matchingAdUnit.bidders,
+        isExploration: matchingAdUnit.isExploration
+      });
+      if (!matchingAdUnit.isExploration) {
+        removeFalseBidders(adUnit, matchingAdUnit);
+      }
     }
   });
 }
@@ -85,14 +103,24 @@ function getFalseBidders(bidders) {
     .map(([bidder]) => bidder);
 }
 
-function createPayload(reqBidsConfigObj) {
+function stripAdUnits(adUnits) {
+  const stripedAdUnits = deepClone(adUnits);
+  return stripedAdUnits.map(adUnit => {
+    adUnit.bids = adUnit.bids.map(bid => {
+      return { bidder: bid.bidder };
+    });
+    return adUnit;
+  });
+}
+
+function createPayload(reqBidsConfigObj, greenbidsId) {
   return JSON.stringify({
-    auctionId: auctionInfo.auctionId,
     version: MODULE_VERSION,
+    ...rtdOptions,
     referrer: window.location.href,
     prebid: '$prebid.version$',
-    rtdOptions: rtdOptions,
-    adUnits: reqBidsConfigObj.adUnits,
+    greenbidsId: greenbidsId,
+    adUnits: stripAdUnits(reqBidsConfigObj.adUnits),
   });
 }
 
@@ -105,6 +133,7 @@ export const greenbidsSubmodule = {
   findMatchingAdUnit: findMatchingAdUnit,
   removeFalseBidders: removeFalseBidders,
   getFalseBidders: getFalseBidders,
+  stripAdUnits: stripAdUnits,
 };
 
 submodule('realTimeData', greenbidsSubmodule);

--- a/modules/greenbidsRtdProvider.md
+++ b/modules/greenbidsRtdProvider.md
@@ -2,6 +2,7 @@
 
 ```
 Module Name: Greenbids RTD Provider
+Module Version: 2.0.0
 Module Type: RTD Provider
 Maintainer: jb@greenbids.ai
 ```
@@ -21,7 +22,6 @@ This module is configured as part of the `realTimeData.dataProviders` object.
 | `waitForIt `     | required (mandatory true value) | Tells prebid auction to wait for the result of this module | `'true'`   | `boolean` |
 | `params`      | required |  | | `Object` |
 | `params.pbuid`      | required | The client site id provided by Greenbids. | `'TEST_FROM_GREENBIDS'` | `string` |
-| `params.targetTPR`      | optional (default 0.95) | Target True positive rate for the throttling model | `0.99` | `[0-1]` |
 | `params.timeout`      | optional (default 200) | Maximum amount of milliseconds allowed for module to finish working (has to be <= to the realTimeData.auctionDelay property) | `200` | `number` |
 
 #### Example

--- a/test/spec/modules/greenbidsAnalyticsAdapter_spec.js
+++ b/test/spec/modules/greenbidsAnalyticsAdapter_spec.js
@@ -1,8 +1,11 @@
 import {
-  greenbidsAnalyticsAdapter, parseBidderCode,
+  greenbidsAnalyticsAdapter,
+  isSampled,
   ANALYTICS_VERSION, BIDDER_STATUS
 } from 'modules/greenbidsAnalyticsAdapter.js';
-
+import {
+  generateUUID,
+} from '../../../src/utils.js';
 import {expect} from 'chai';
 import sinon from 'sinon';
 
@@ -13,13 +16,12 @@ const pbuid = 'pbuid-AA778D8A796AEA7A0843E2BBEB677766';
 const auctionId = 'b0b39610-b941-4659-a87c-de9f62d3e13e';
 
 describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
-  describe('event tracking and message cache manager', function () {
+  describe('enableAnalytics and config parser', function () {
+    const configOptions = {
+      pbuid: pbuid,
+      greenbidsSampling: 0,
+    };
     beforeEach(function () {
-      const configOptions = {
-        pbuid: pbuid,
-        sampling: 0,
-      };
-
       greenbidsAnalyticsAdapter.enableAnalytics({
         provider: 'greenbidsAnalytics',
         options: configOptions
@@ -30,41 +32,36 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
       greenbidsAnalyticsAdapter.disableAnalytics();
     });
 
-    describe('#parseBidderCode()', function() {
-      it('should get lower case bidder code from bidderCode field value', function() {
-        const receivedBids = [
-          {
-            auctionId: auctionId,
-            adUnitCode: 'adunit_1',
-            bidder: 'greenbids',
-            bidderCode: 'GREENBIDS',
-            requestId: 'a1b2c3d4',
-            timeToRespond: 72,
-            cpm: 0.1,
-            currency: 'USD',
-            ad: '<html>fake ad1</html>'
-          },
-        ];
-        const result = parseBidderCode(receivedBids[0]);
-        expect(result).to.equal('greenbids');
+    it('should parse config correctly with optional values', function () {
+      expect(greenbidsAnalyticsAdapter.getAnalyticsOptions().options).to.deep.equal(configOptions);
+      expect(greenbidsAnalyticsAdapter.getAnalyticsOptions().pbuid).to.equal(configOptions.pbuid);
+    });
+
+    it('should not enable Analytics when pbuid is missing', function () {
+      const configOptions = {
+        options: {
+        }
+      };
+      const validConfig = greenbidsAnalyticsAdapter.initConfig(configOptions);
+      expect(validConfig).to.equal(false);
+    });
+  });
+
+  describe('event tracking and message cache manager', function () {
+    beforeEach(function () {
+      const configOptions = {
+        pbuid: pbuid,
+        greenbidsSampling: 0,
+      };
+
+      greenbidsAnalyticsAdapter.enableAnalytics({
+        provider: 'greenbidsAnalytics',
+        options: configOptions
       });
-      it('should get lower case bidder code from bidder field value as bidderCode field is missing', function() {
-        const receivedBids = [
-          {
-            auctionId: auctionId,
-            adUnitCode: 'adunit_1',
-            bidder: 'greenbids',
-            bidderCode: '',
-            requestId: 'a1b2c3d4',
-            timeToRespond: 72,
-            cpm: 0.1,
-            currency: 'USD',
-            ad: '<html>fake ad1</html>'
-          },
-        ];
-        const result = parseBidderCode(receivedBids[0]);
-        expect(result).to.equal('greenbids');
-      });
+    });
+
+    afterEach(function () {
+      greenbidsAnalyticsAdapter.disableAnalytics();
     });
 
     describe('#getCachedAuction()', function() {
@@ -330,7 +327,7 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
             timeout: 3000,
             auctionEnd: 1234567990,
             bidsReceived: receivedBids,
-            noBids: noBids
+            noBids: noBids,
           }];
 
           greenbidsAnalyticsAdapter.handleBidTimeout(args);
@@ -353,7 +350,7 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
   describe('greenbids Analytics Adapter track handler ', function () {
     const configOptions = {
       pbuid: pbuid,
-      sampling: 1,
+      greenbidsSampling: 1,
     };
 
     beforeEach(function () {
@@ -369,6 +366,13 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
       events.getEvents.restore();
     });
 
+    it('should call handleAuctionInit as AUCTION_INIT trigger event', function() {
+      sinon.spy(greenbidsAnalyticsAdapter, 'handleAuctionInit');
+      events.emit(constants.EVENTS.AUCTION_INIT, {});
+      sinon.assert.callCount(greenbidsAnalyticsAdapter.handleAuctionInit, 1);
+      greenbidsAnalyticsAdapter.handleAuctionInit.restore();
+    });
+
     it('should call handleBidTimeout as BID_TIMEOUT trigger event', function() {
       sinon.spy(greenbidsAnalyticsAdapter, 'handleBidTimeout');
       events.emit(constants.EVENTS.BID_TIMEOUT, {});
@@ -382,37 +386,32 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
       sinon.assert.callCount(greenbidsAnalyticsAdapter.handleAuctionEnd, 1);
       greenbidsAnalyticsAdapter.handleAuctionEnd.restore();
     });
+
+    it('should call handleBillable as BILLABLE_EVENT trigger event', function() {
+      sinon.spy(greenbidsAnalyticsAdapter, 'handleBillable');
+      events.emit(constants.EVENTS.BILLABLE_EVENT, {
+        type: 'auction',
+        billingId: generateUUID(),
+        auctionId: 'auctionID-1',
+        vendor: 'greenbidsRtdProvider'
+      });
+      sinon.assert.callCount(greenbidsAnalyticsAdapter.handleBillable, 1);
+      greenbidsAnalyticsAdapter.handleBillable.restore();
+    });
   });
 
-  describe('enableAnalytics and config parser', function () {
-    const configOptions = {
-      pbuid: pbuid,
-      sampling: 0,
-    };
-
-    beforeEach(function () {
-      greenbidsAnalyticsAdapter.enableAnalytics({
-        provider: 'greenbidsAnalytics',
-        options: configOptions
-      });
+  describe('isSampled', function() {
+    it('should return true for invalid sampling rates', function() {
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', -1)).to.be.true;
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 1.2)).to.be.true;
     });
 
-    afterEach(function () {
-      greenbidsAnalyticsAdapter.disableAnalytics();
+    it('should return determinist falsevalue for valid sampling rate given the predifined id and rate', function() {
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 0.0001)).to.be.false;
     });
 
-    it('should parse config correctly with optional values', function () {
-      expect(greenbidsAnalyticsAdapter.getAnalyticsOptions().options).to.deep.equal(configOptions);
-      expect(greenbidsAnalyticsAdapter.getAnalyticsOptions().pbuid).to.equal(configOptions.pbuid);
-    });
-
-    it('should not enable Analytics when pbuid is missing', function () {
-      const configOptions = {
-        options: {
-        }
-      };
-      const validConfig = greenbidsAnalyticsAdapter.initConfig(configOptions);
-      expect(validConfig).to.equal(false);
+    it('should return determinist true value for valid sampling rate given the predifined id and rate', function() {
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 0.9999)).to.be.true;
     });
   });
 });

--- a/test/spec/modules/greenbidsAnalyticsAdapter_spec.js
+++ b/test/spec/modules/greenbidsAnalyticsAdapter_spec.js
@@ -19,7 +19,7 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
   describe('enableAnalytics and config parser', function () {
     const configOptions = {
       pbuid: pbuid,
-      greenbidsSampling: 0,
+      greenbidsSampling: 1,
     };
     beforeEach(function () {
       greenbidsAnalyticsAdapter.enableAnalytics({
@@ -51,7 +51,7 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
     beforeEach(function () {
       const configOptions = {
         pbuid: pbuid,
-        greenbidsSampling: 0,
+        greenbidsSampling: 1,
       };
 
       greenbidsAnalyticsAdapter.enableAnalytics({
@@ -143,7 +143,7 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
           auctionId: auctionId,
           pbuid: pbuid,
           referrer: window.location.href,
-          sampling: 0,
+          sampling: 1,
           prebid: '$prebid.version$',
         });
       }
@@ -257,7 +257,9 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
             noBids: noBids
           };
 
+          sinon.stub(greenbidsAnalyticsAdapter, 'getCachedAuction').returns({timeoutBids: timeoutBids});
           const result = greenbidsAnalyticsAdapter.createBidMessage(args, timeoutBids);
+          greenbidsAnalyticsAdapter.getCachedAuction.restore();
 
           assertHavingRequiredMessageFields(result);
           expect(result).to.deep.include({
@@ -368,21 +370,21 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
 
     it('should call handleAuctionInit as AUCTION_INIT trigger event', function() {
       sinon.spy(greenbidsAnalyticsAdapter, 'handleAuctionInit');
-      events.emit(constants.EVENTS.AUCTION_INIT, {});
+      events.emit(constants.EVENTS.AUCTION_INIT, {auctionId: 'auctionId'});
       sinon.assert.callCount(greenbidsAnalyticsAdapter.handleAuctionInit, 1);
       greenbidsAnalyticsAdapter.handleAuctionInit.restore();
     });
 
     it('should call handleBidTimeout as BID_TIMEOUT trigger event', function() {
       sinon.spy(greenbidsAnalyticsAdapter, 'handleBidTimeout');
-      events.emit(constants.EVENTS.BID_TIMEOUT, {});
+      events.emit(constants.EVENTS.BID_TIMEOUT, {auctionId: 'auctionId'});
       sinon.assert.callCount(greenbidsAnalyticsAdapter.handleBidTimeout, 1);
       greenbidsAnalyticsAdapter.handleBidTimeout.restore();
     });
 
     it('should call handleAuctionEnd as AUCTION_END trigger event', function() {
       sinon.spy(greenbidsAnalyticsAdapter, 'handleAuctionEnd');
-      events.emit(constants.EVENTS.AUCTION_END, {});
+      events.emit(constants.EVENTS.AUCTION_END, {auctionId: 'auctionId'});
       sinon.assert.callCount(greenbidsAnalyticsAdapter.handleAuctionEnd, 1);
       greenbidsAnalyticsAdapter.handleAuctionEnd.restore();
     });
@@ -392,7 +394,7 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
       events.emit(constants.EVENTS.BILLABLE_EVENT, {
         type: 'auction',
         billingId: generateUUID(),
-        auctionId: 'auctionID-1',
+        auctionId: 'auctionId',
         vendor: 'greenbidsRtdProvider'
       });
       sinon.assert.callCount(greenbidsAnalyticsAdapter.handleBillable, 1);

--- a/test/spec/modules/greenbidsRtdProvider_spec.js
+++ b/test/spec/modules/greenbidsRtdProvider_spec.js
@@ -6,7 +6,7 @@ import {
 import {
   greenbidsSubmodule
 } from 'modules/greenbidsRtdProvider.js';
-import {server} from '../../mocks/xhr.js';
+import { server } from '../../mocks/xhr.js';
 import * as events from '../../../src/events.js';
 import CONSTANTS from '../../../src/constants.json';
 
@@ -166,7 +166,7 @@ describe('greenbidsRtdProvider', () => {
       setTimeout(() => {
         server.requests[0].respond(
           200,
-          {'Content-Type': 'application/json'},
+          { 'Content-Type': 'application/json' },
           JSON.stringify(SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED)
         );
       }, 50);
@@ -199,7 +199,7 @@ describe('greenbidsRtdProvider', () => {
       setTimeout(() => {
         server.requests[0].respond(
           200,
-          {'Content-Type': 'application/json'},
+          { 'Content-Type': 'application/json' },
           JSON.stringify(SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED)
         );
         done();
@@ -226,8 +226,8 @@ describe('greenbidsRtdProvider', () => {
       setTimeout(() => {
         server.requests[0].respond(
           500,
-          {'Content-Type': 'application/json'},
-          JSON.stringify({'failure': 'fail'})
+          { 'Content-Type': 'application/json' },
+          JSON.stringify({ 'failure': 'fail' })
         );
       }, 50);
 
@@ -243,8 +243,8 @@ describe('greenbidsRtdProvider', () => {
     });
   });
 
-  describe('stripAdUnits', function() {
-    it('should strip all properties except bidder from each bid in adUnits', function() {
+  describe('stripAdUnits', function () {
+    it('should strip all properties except bidder from each bid in adUnits', function () {
       const adUnits =
         [
           {
@@ -252,7 +252,7 @@ describe('greenbidsRtdProvider', () => {
               { bidder: 'bidder1', otherProp: 'value1' },
               { bidder: 'bidder2', otherProp: 'value2' }
             ],
-            mediaTypes: {'banner': {prop: 'value3'}}
+            mediaTypes: { 'banner': { prop: 'value3' } }
           }
         ];
       const expectedOutput = [
@@ -261,7 +261,7 @@ describe('greenbidsRtdProvider', () => {
             { bidder: 'bidder1' },
             { bidder: 'bidder2' }
           ],
-          mediaTypes: {'banner': {prop: 'value3'}}
+          mediaTypes: { 'banner': { prop: 'value3' } }
         }
       ];
 
@@ -270,7 +270,7 @@ describe('greenbidsRtdProvider', () => {
       expect(output).to.deep.equal(expectedOutput);
     });
 
-    it('should strip all properties except bidder from each bid in adUnits but keep ortb2Imp', function() {
+    it('should strip all properties except bidder from each bid in adUnits but keep ortb2Imp', function () {
       const adUnits =
         [
           {
@@ -278,7 +278,7 @@ describe('greenbidsRtdProvider', () => {
               { bidder: 'bidder1', otherProp: 'value1' },
               { bidder: 'bidder2', otherProp: 'value2' }
             ],
-            mediaTypes: {'banner': {prop: 'value3'}},
+            mediaTypes: { 'banner': { prop: 'value3' } },
             ortb2Imp: {
               ext: {
                 greenbids: {
@@ -294,7 +294,7 @@ describe('greenbidsRtdProvider', () => {
             { bidder: 'bidder1' },
             { bidder: 'bidder2' }
           ],
-          mediaTypes: {'banner': {prop: 'value3'}},
+          mediaTypes: { 'banner': { prop: 'value3' } },
           ortb2Imp: {
             ext: {
               greenbids: {
@@ -311,8 +311,26 @@ describe('greenbidsRtdProvider', () => {
     });
   });
 
-  describe('onAuctionInitEvent', function() {
-    it('should emit billable events', function (done) {
+  describe('onAuctionInitEvent', function () {
+    it('should not emit billable event if greenbids hasn\'t set the adunit.ext value', function () {
+      sinon.spy(events, 'emit');
+      greenbidsSubmodule.onAuctionInitEvent({
+        auctionId: 'test',
+        adUnits: [
+          {
+            bids: [
+              { bidder: 'bidder1', otherProp: 'value1' },
+              { bidder: 'bidder2', otherProp: 'value2' }
+            ],
+            mediaTypes: { 'banner': { prop: 'value3' } },
+          }
+        ]
+      });
+      sinon.assert.callCount(events.emit, 0);
+      events.emit.restore();
+    });
+
+    it('should  emit billable event if greenbids has set the adunit.ext value', function (done) {
       let counter = 0;
       events.on(CONSTANTS.EVENTS.BILLABLE_EVENT, function (event) {
         if (event.vendor === 'greenbidsRtdProvider' && event.type === 'auction') {
@@ -321,7 +339,19 @@ describe('greenbidsRtdProvider', () => {
         expect(counter).to.equal(1);
         done();
       });
-      greenbidsSubmodule.onAuctionInitEvent({auctionId: 'test'});
+      greenbidsSubmodule.onAuctionInitEvent({
+        auctionId: 'test',
+        adUnits: [
+          {
+            bids: [
+              { bidder: 'bidder1', otherProp: 'value1' },
+              { bidder: 'bidder2', otherProp: 'value2' }
+            ],
+            mediaTypes: { 'banner': { prop: 'value3' } },
+            ortb2Imp: { ext: { greenbids: { greenbidsId: 'b0b39610-b941-4659-a87c-de9f62d3e13e' } } }
+          }
+        ]
+      });
     });
   });
 });

--- a/test/spec/modules/greenbidsRtdProvider_spec.js
+++ b/test/spec/modules/greenbidsRtdProvider_spec.js
@@ -7,6 +7,8 @@ import {
   greenbidsSubmodule
 } from 'modules/greenbidsRtdProvider.js';
 import {server} from '../../mocks/xhr.js';
+import * as events from '../../../src/events.js';
+import CONSTANTS from '../../../src/constants.json';
 
 describe('greenbidsRtdProvider', () => {
   const endPoint = 't.greenbids.ai';
@@ -39,14 +41,15 @@ describe('greenbidsRtdProvider', () => {
       }]
   };
 
-  const SAMPLE_RESPONSE_ADUNITS = [
+  const SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED = [
     {
       code: 'adUnit1',
       bidders: {
         'appnexus': true,
         'rubicon': false,
         'ix': true
-      }
+      },
+      isExploration: false
     },
     {
       code: 'adUnit2',
@@ -54,7 +57,30 @@ describe('greenbidsRtdProvider', () => {
         'appnexus': false,
         'rubicon': true,
         'openx': true
-      }
+      },
+      isExploration: false
+
+    }];
+
+  const SAMPLE_RESPONSE_ADUNITS_EXPLORED = [
+    {
+      code: 'adUnit1',
+      bidders: {
+        'appnexus': true,
+        'rubicon': false,
+        'ix': true
+      },
+      isExploration: true
+    },
+    {
+      code: 'adUnit2',
+      bidders: {
+        'appnexus': false,
+        'rubicon': true,
+        'openx': true
+      },
+      isExploration: true
+
     }];
 
   describe('init', () => {
@@ -70,22 +96,37 @@ describe('greenbidsRtdProvider', () => {
   });
 
   describe('updateAdUnitsBasedOnResponse', () => {
-    it('should update ad units based on response', () => {
+    it('should update ad units based on response if not exploring', () => {
       const adUnits = JSON.parse(JSON.stringify(SAMPLE_REQUEST_BIDS_CONFIG_OBJ.adUnits));
-      greenbidsSubmodule.updateAdUnitsBasedOnResponse(adUnits, SAMPLE_RESPONSE_ADUNITS);
+      greenbidsSubmodule.updateAdUnitsBasedOnResponse(adUnits, SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED);
 
       expect(adUnits[0].bids).to.have.length(2);
       expect(adUnits[1].bids).to.have.length(2);
+    });
+
+    it('should not update ad units based on response if exploring', () => {
+      const adUnits = JSON.parse(JSON.stringify(SAMPLE_REQUEST_BIDS_CONFIG_OBJ.adUnits));
+      greenbidsSubmodule.updateAdUnitsBasedOnResponse(adUnits, SAMPLE_RESPONSE_ADUNITS_EXPLORED);
+
+      expect(adUnits[0].bids).to.have.length(3);
+      expect(adUnits[1].bids).to.have.length(3);
+      expect(adUnits[0].ortb2Imp.ext.greenbids.greenbidsId).to.be.a.string;
+      expect(adUnits[1].ortb2Imp.ext.greenbids.greenbidsId).to.be.a.string;
+      expect(adUnits[0].ortb2Imp.ext.greenbids.greenbidsId).to.equal(adUnits[0].ortb2Imp.ext.greenbids.greenbidsId);
+      expect(adUnits[0].ortb2Imp.ext.greenbids.keptInAuction).to.deep.equal(SAMPLE_RESPONSE_ADUNITS_EXPLORED[0].bidders);
+      expect(adUnits[1].ortb2Imp.ext.greenbids.keptInAuction).to.deep.equal(SAMPLE_RESPONSE_ADUNITS_EXPLORED[1].bidders);
+      expect(adUnits[0].ortb2Imp.ext.greenbids.isExploration).to.equal(SAMPLE_RESPONSE_ADUNITS_EXPLORED[0].isExploration);
+      expect(adUnits[1].ortb2Imp.ext.greenbids.isExploration).to.equal(SAMPLE_RESPONSE_ADUNITS_EXPLORED[1].isExploration);
     });
   });
 
   describe('findMatchingAdUnit', () => {
     it('should find matching ad unit by code', () => {
-      const matchingAdUnit = greenbidsSubmodule.findMatchingAdUnit(SAMPLE_RESPONSE_ADUNITS, 'adUnit1');
-      expect(matchingAdUnit).to.deep.equal(SAMPLE_RESPONSE_ADUNITS[0]);
+      const matchingAdUnit = greenbidsSubmodule.findMatchingAdUnit(SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED, 'adUnit1');
+      expect(matchingAdUnit).to.deep.equal(SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED[0]);
     });
     it('should return undefined if no matching ad unit is found', () => {
-      const matchingAdUnit = greenbidsSubmodule.findMatchingAdUnit(SAMPLE_RESPONSE_ADUNITS, 'nonexistent');
+      const matchingAdUnit = greenbidsSubmodule.findMatchingAdUnit(SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED, 'nonexistent');
       expect(matchingAdUnit).to.be.undefined;
     });
   });
@@ -93,7 +134,7 @@ describe('greenbidsRtdProvider', () => {
   describe('removeFalseBidders', () => {
     it('should remove bidders with false value', () => {
       const adUnit = JSON.parse(JSON.stringify(SAMPLE_REQUEST_BIDS_CONFIG_OBJ.adUnits[0]));
-      const matchingAdUnit = SAMPLE_RESPONSE_ADUNITS[0];
+      const matchingAdUnit = SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED[0];
       greenbidsSubmodule.removeFalseBidders(adUnit, matchingAdUnit);
       expect(adUnit.bids).to.have.length(2);
       expect(adUnit.bids.map((bid) => bid.bidder)).to.not.include('rubicon');
@@ -126,13 +167,14 @@ describe('greenbidsRtdProvider', () => {
         server.requests[0].respond(
           200,
           {'Content-Type': 'application/json'},
-          JSON.stringify(SAMPLE_RESPONSE_ADUNITS)
+          JSON.stringify(SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED)
         );
       }, 50);
 
       setTimeout(() => {
         const requestUrl = new URL(server.requests[0].url);
         expect(requestUrl.host).to.be.eq(endPoint);
+        expect(requestBids.greenbidsId).to.be.a.string;
         expect(requestBids.adUnits[0].bids).to.have.length(2);
         expect(requestBids.adUnits[0].bids.map((bid) => bid.bidder)).to.not.include('rubicon');
         expect(requestBids.adUnits[0].bids.map((bid) => bid.bidder)).to.include('ix');
@@ -158,7 +200,7 @@ describe('greenbidsRtdProvider', () => {
         server.requests[0].respond(
           200,
           {'Content-Type': 'application/json'},
-          JSON.stringify(SAMPLE_RESPONSE_ADUNITS)
+          JSON.stringify(SAMPLE_RESPONSE_ADUNITS_NOT_EXPLORED)
         );
         done();
       }, 300);
@@ -166,6 +208,7 @@ describe('greenbidsRtdProvider', () => {
       setTimeout(() => {
         const requestUrl = new URL(server.requests[0].url);
         expect(requestUrl.host).to.be.eq(endPoint);
+        expect(requestBids.greenbidsId).to.be.a.string;
         expect(requestBids.adUnits[0].bids).to.have.length(3);
         expect(requestBids.adUnits[1].bids).to.have.length(3);
         expect(callback.calledOnce).to.be.true;
@@ -191,11 +234,94 @@ describe('greenbidsRtdProvider', () => {
       setTimeout(() => {
         const requestUrl = new URL(server.requests[0].url);
         expect(requestUrl.host).to.be.eq(endPoint);
+        expect(requestBids.greenbidsId).to.be.a.string;
         expect(requestBids.adUnits[0].bids).to.have.length(3);
         expect(requestBids.adUnits[1].bids).to.have.length(3);
         expect(callback.calledOnce).to.be.true;
         done();
       }, 60);
+    });
+  });
+
+  describe('stripAdUnits', function() {
+    it('should strip all properties except bidder from each bid in adUnits', function() {
+      const adUnits =
+        [
+          {
+            bids: [
+              { bidder: 'bidder1', otherProp: 'value1' },
+              { bidder: 'bidder2', otherProp: 'value2' }
+            ],
+            mediaTypes: {'banner': {prop: 'value3'}}
+          }
+        ];
+      const expectedOutput = [
+        {
+          bids: [
+            { bidder: 'bidder1' },
+            { bidder: 'bidder2' }
+          ],
+          mediaTypes: {'banner': {prop: 'value3'}}
+        }
+      ];
+
+      // Perform the test
+      const output = greenbidsSubmodule.stripAdUnits(adUnits);
+      expect(output).to.deep.equal(expectedOutput);
+    });
+
+    it('should strip all properties except bidder from each bid in adUnits but keep ortb2Imp', function() {
+      const adUnits =
+        [
+          {
+            bids: [
+              { bidder: 'bidder1', otherProp: 'value1' },
+              { bidder: 'bidder2', otherProp: 'value2' }
+            ],
+            mediaTypes: {'banner': {prop: 'value3'}},
+            ortb2Imp: {
+              ext: {
+                greenbids: {
+                  greenbidsId: 'test'
+                }
+              }
+            }
+          }
+        ];
+      const expectedOutput = [
+        {
+          bids: [
+            { bidder: 'bidder1' },
+            { bidder: 'bidder2' }
+          ],
+          mediaTypes: {'banner': {prop: 'value3'}},
+          ortb2Imp: {
+            ext: {
+              greenbids: {
+                greenbidsId: 'test'
+              }
+            }
+          }
+        }
+      ];
+
+      // Perform the test
+      const output = greenbidsSubmodule.stripAdUnits(adUnits);
+      expect(output).to.deep.equal(expectedOutput);
+    });
+  });
+
+  describe('onAuctionInitEvent', function() {
+    it('should emit billable events', function (done) {
+      let counter = 0;
+      events.on(CONSTANTS.EVENTS.BILLABLE_EVENT, function (event) {
+        if (event.vendor === 'greenbidsRtdProvider' && event.type === 'auction') {
+          counter += 1;
+        }
+        expect(counter).to.equal(1);
+        done();
+      });
+      greenbidsSubmodule.onAuctionInitEvent({auctionId: 'test'});
     });
   });
 });


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
This PR changes the way Greenbids handles sampling in the AnalyticsAdapter. Instead of being independent from the rtdProvider, we use a uuid created during the RTD processing to decide on the sampling.

This allows several things:
- the sampled analytics traffic will be a mathematical subset of the RTD exploration (same id used)
- we are able to enrich the `adUnit.ext` with information from the greenbidsRtdProvider that bidders can access if they want visibility on Greenbids impact on their traffic.
- we are able to emit a BillableEvent with vendor `greenbidsRtdProvider` in the rtd module for each auction handled by Greenbids. We listen for it in the analytics module for internal statistic but this Billable event can be listen to by prebid wrappers licensing Greenbids for direct billing


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Documentation update https://github.com/prebid/prebid.github.io/pull/5010
