### PR TITLE
Adagio Bid Adapter: remove useless adrequest fields

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -1020,6 +1020,9 @@ export const spec = {
         }
       }
 
+      // Enforce the organizationId param to be a string
+      bidRequest.params.organizationId = bidRequest.params.organizationId.toString();
+
       // Force the Data Layer key and value to be a String
       if (bidRequest.params.dataLayer) {
         if (isStr(bidRequest.params.dataLayer) || isNumber(bidRequest.params.dataLayer) || isArray(bidRequest.params.dataLayer) || isFn(bidRequest.params.dataLayer)) {
@@ -1120,30 +1123,36 @@ export const spec = {
         bidRequest.gpid = gpid;
       }
 
+      // store the whole bidRequest (adUnit) object in the ADAGIO namespace.
       storeRequestInAdagioNS(bidRequest);
 
-      // Remove these fields at the very end, so we can still use them before.
-      delete bidRequest.transactionId;
-      delete bidRequest.ortb2Imp;
-      delete bidRequest.ortb2;
-      delete bidRequest.sizes;
+      // Remove some params that are not needed on the server side.
+      delete bidRequest.params.siteId;
 
-      return bidRequest;
+      // whitelist the fields that are allowed to be sent to the server.
+      const adUnit = {
+        adUnitCode: bidRequest.adUnitCode,
+        auctionId: bidRequest.auctionId,
+        bidder: bidRequest.bidder,
+        bidId: bidRequest.bidId,
+        params: bidRequest.params,
+        features: bidRequest.features,
+        gpid: bidRequest.gpid,
+        mediaTypes: bidRequest.mediaTypes,
+        nativeParams: bidRequest.nativeParams,
+        score: bidRequest.score,
+        transactionId: bidRequest.transactionId,
+      }
+
+      return adUnit;
     });
 
     // Group ad units by organizationId
     const groupedAdUnits = adUnits.reduce((groupedAdUnits, adUnit) => {
-      const adUnitCopy = deepClone(adUnit);
-      adUnitCopy.params.organizationId = adUnitCopy.params.organizationId.toString();
+      const organizationId = adUnit.params.organizationId
 
-      // remove useless props
-      delete adUnitCopy.floorData;
-      delete adUnitCopy.params.siteId;
-      delete adUnitCopy.userId;
-      delete adUnitCopy.userIdAsEids;
-
-      groupedAdUnits[adUnitCopy.params.organizationId] = groupedAdUnits[adUnitCopy.params.organizationId] || [];
-      groupedAdUnits[adUnitCopy.params.organizationId].push(adUnitCopy);
+      groupedAdUnits[organizationId] = groupedAdUnits[organizationId] || [];
+      groupedAdUnits[organizationId].push(adUnit);
 
       return groupedAdUnits;
     }, {});

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -861,11 +861,6 @@ describe('Adagio bid adapter', () => {
         }
         const requests = spec.buildRequests([bid01], bidderRequest);
 
-        expect(requests[0].data.adUnits[0].floors.length).to.equal(3);
-        expect(requests[0].data.adUnits[0].floors[0]).to.deep.equal({f: 1, mt: 'banner', s: '300x250'});
-        expect(requests[0].data.adUnits[0].floors[1]).to.deep.equal({f: 1, mt: 'banner', s: '300x600'});
-        expect(requests[0].data.adUnits[0].floors[2]).to.deep.equal({f: 1, mt: 'video', s: '600x480'});
-
         expect(requests[0].data.adUnits[0].mediaTypes.banner.sizes.length).to.equal(2);
         expect(requests[0].data.adUnits[0].mediaTypes.banner.bannerSizes[0]).to.deep.equal({size: [300, 250], floor: 1});
         expect(requests[0].data.adUnits[0].mediaTypes.banner.bannerSizes[1]).to.deep.equal({size: [300, 600], floor: 1});
@@ -890,10 +885,6 @@ describe('Adagio bid adapter', () => {
         }
         const requests = spec.buildRequests([bid01], bidderRequest);
 
-        expect(requests[0].data.adUnits[0].floors.length).to.equal(2);
-        expect(requests[0].data.adUnits[0].floors[0]).to.deep.equal({f: 1, mt: 'video'});
-        expect(requests[0].data.adUnits[0].floors[1]).to.deep.equal({f: 1, mt: 'native'});
-
         expect(requests[0].data.adUnits[0].mediaTypes.video.floor).to.equal(1);
         expect(requests[0].data.adUnits[0].mediaTypes.native.floor).to.equal(1);
       });
@@ -913,8 +904,6 @@ describe('Adagio bid adapter', () => {
         }
         const requests = spec.buildRequests([bid01], bidderRequest);
 
-        expect(requests[0].data.adUnits[0].floors.length).to.equal(1);
-        expect(requests[0].data.adUnits[0].floors[0]).to.deep.equal({mt: 'video'});
         expect(requests[0].data.adUnits[0].mediaTypes.video.floor).to.be.undefined;
       });
     });


### PR DESCRIPTION
## Type of change

- [x] Refactoring (no functional changes, no api changes)

## Description of change

The purpose of this PR is to save bandwidth cost by sending only what we need at `request.adUnit[]` level.
