### PR TITLE
Core: Add eventString to error executing handler message

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -80,7 +80,7 @@ const _public = (function () {
       try {
         fn.apply(null, args);
       } catch (e) {
-        utils.logError('Error executing handler:', 'events.js', e);
+        utils.logError('Error executing handler:', 'events.js', e, eventString);
       }
     });
   }

--- a/test/spec/unit/core/events_spec.js
+++ b/test/spec/unit/core/events_spec.js
@@ -1,5 +1,6 @@
 import {config} from 'src/config.js';
-import {emit, clearEvents, getEvents} from '../../../../src/events.js';
+import {emit, clearEvents, getEvents, on, off} from '../../../../src/events.js';
+import * as utils from '../../../../src/utils.js'
 
 describe('events', () => {
   let clock;
@@ -26,5 +27,19 @@ describe('events', () => {
     config.setConfig({eventHistoryTTL: 1000});
     clock.tick(10000);
     expect(getEvents().length).to.eql(1);
-  })
+  });
+
+  it('should include the eventString if a callback fails', () => {
+    const logErrorStub = sinon.stub(utils, 'logError');
+    const eventString = 'bidWon';
+    let fn = function() { throw new Error('Test error'); };
+    on(eventString, fn);
+
+    emit(eventString, {});
+
+    sinon.assert.calledWith(logErrorStub, 'Error executing handler:', 'events.js', sinon.match.instanceOf(Error), eventString);
+
+    off(eventString, fn);
+    logErrorStub.restore();
+  });
 })


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
When events.js fails to execute a callback, the error message it provides isn't very helpful. This adds the `eventString` to the error message so we can at least know what event failed a callback.