### PR TITLE
GrowthCode RTD: fixed TCF string passing

### DIFF
--- a/modules/growthCodeRtdProvider.js
+++ b/modules/growthCodeRtdProvider.js
@@ -81,8 +81,8 @@ function callServer(configParams, items, expiresAt, userConsent) {
     url = tryAppendQueryString(url, 'pid', configParams.pid);
     url = tryAppendQueryString(url, 'u', window.location.href);
     url = tryAppendQueryString(url, 'gcid', gcid);
-    if ((userConsent !== null) && (userConsent.gdpr !== null) && (userConsent.gdpr.consentData.getTCData.tcString)) {
-      url = tryAppendQueryString(url, 'tcf', userConsent.gdpr.consentData.getTCData.tcString)
+    if ((userConsent !== null) && (userConsent.gdpr !== null) && (userConsent.gdpr.consentString)) {
+      url = tryAppendQueryString(url, 'tcf', userConsent.gdpr.consentString)
     }
 
     ajax.ajaxBuilder()(url, {


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ x ] Bugfix

## Description of change
When accessing the TCF it is pulling from the wrong location, use 'userConsent.gdpr.consentString'
