### PR TITLE
Tead Bid Adapter: support ad slot name in code parameter of ad unit

### DIFF
--- a/modules/teadsBidAdapter.js
+++ b/modules/teadsBidAdapter.js
@@ -262,7 +262,7 @@ function buildRequestObject(bid) {
   reqObj.bidderRequestId = getBidIdParameter('bidderRequestId', bid);
   reqObj.placementId = parseInt(placementId, 10);
   reqObj.pageId = parseInt(pageId, 10);
-  reqObj.adUnitCode = getBidIdParameter('adUnitCode', bid);
+  reqObj.adUnitCode = getValue(bid.params, 'adUnitCode') || getBidIdParameter('adUnitCode', bid);
   reqObj.transactionId = bid.ortb2Imp?.ext?.tid || '';
   if (gpid) { reqObj.gpid = gpid; }
   if (videoPlcmt) { reqObj.videoPlcmt = videoPlcmt; }


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
This workarround will support usage of ad slot name next to div element ID according to official documentation. See https://docs.prebid.org/dev-docs/adunit-reference.html#adunit code parameter description:
An identifier you create and assign to this ad unit. Generally this is set to the ad slot name or the div element ID. 

We will also contact the maintainer of this adapter about this issue, mentioned in https://github.com/prebid/Prebid.js/blob/master/modules/teadsBidAdapter.md. This pull request can be a reference for a fully fledged change request

## Other information
https://github.com/prebid/Prebid.js/issues/10824
