### PR TITLE
Yieldmo Bid Adapter : adding support for video.plcmt

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -29,7 +29,7 @@ const VIDEO_PATH = '/exchange/prebidvideo';
 const STAGE_DOMAIN = 'https://ads-stg.yieldmo.com';
 const PROD_DOMAIN = 'https://ads.yieldmo.com';
 const OUTSTREAM_VIDEO_PLAYER_URL = 'https://prebid-outstream.yieldmo.com/bundle.js';
-const OPENRTB_VIDEO_BIDPARAMS = ['mimes', 'startdelay', 'placement', 'startdelay', 'skipafter', 'protocols', 'api',
+const OPENRTB_VIDEO_BIDPARAMS = ['mimes', 'startdelay', 'placement', 'plcmt', 'skipafter', 'protocols', 'api',
   'playbackmethod', 'maxduration', 'minduration', 'pos', 'skip', 'skippable'];
 const OPENRTB_VIDEO_SITEPARAMS = ['name', 'domain', 'cat', 'keywords'];
 const LOCAL_WINDOW = getWindowTop();
@@ -449,7 +449,7 @@ function openRtbImpression(bidRequest) {
     imp.video.skip = 1;
     delete imp.video.skippable;
   }
-  if (imp.video.placement !== 1) {
+  if (imp.video.plcmt !== 1 || imp.video.placement !== 1) {
     imp.video.startdelay = DEFAULT_START_DELAY;
     imp.video.playbackmethod = [ DEFAULT_PLAYBACK_METHOD ];
   }

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -47,7 +47,7 @@ describe('YieldmoAdapter', function () {
       video: {
         playerSize: [640, 480],
         context: 'instream',
-        mimes: ['video/mp4']
+        mimes: ['video/mp4'],
       },
     },
     params: {
@@ -61,11 +61,11 @@ describe('YieldmoAdapter', function () {
         api: [2, 3],
         skipppable: true,
         playbackmethod: [1, 2],
-        ...videoParams
-      }
+        ...videoParams,
+      },
     },
     transactionId: '54a58774-7a41-494e-8cbc-fa7b79164f0c',
-    ...rootParams
+    ...rootParams,
   });
 
   const mockBidderRequest = (params = {}, bids = [mockBannerBid()]) => ({
@@ -458,6 +458,16 @@ describe('YieldmoAdapter', function () {
       it('should add mediaTypes.video.mimes prop to the imp.video', function () {
         utils.deepAccess(videoBid, 'mediaTypes.video')['minduration'] = ['video/mp4'];
         expect(buildVideoBidAndGetVideoParam().minduration).to.deep.equal(['video/mp4']);
+      });
+
+      it('should add plcmt value to the imp.video', function () {
+        const videoBid = mockVideoBid({}, {}, { plcmt: 1 });
+        expect(utils.deepAccess(videoBid, 'params.video')['plcmt']).to.equal(1);
+      });
+
+      it('should add start delay if plcmt value is not 1', function () {
+        const videoBid = mockVideoBid({}, {}, { plcmt: 2 });
+        expect(build([videoBid])[0].data.imp[0].video.startdelay).to.equal(0);
       });
 
       it('should override mediaTypes.video.mimes prop if params.video.mimes is present', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Adding support for video.plcmt parameter

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
