### PR TITLE
LiveIntent UserId module: Add missing EID examples

### DIFF
--- a/modules/userId/eids.md
+++ b/modules/userId/eids.md
@@ -102,8 +102,7 @@ userIdAsEids = [
             id: 'some-random-id-value',
             atype: 1
         }],
-            segments: ['s1', 's2']
-        }
+        segments: ['s1', 's2']
     },
     
     {
@@ -117,6 +116,50 @@ userIdAsEids = [
         }]
     },
     
+    {
+        source: 'liveintent.indexexchange.com',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 3,
+            ext: {
+                provider: 'liveintent.com'
+            }
+        }]
+    },
+
+    {
+        source: 'liveintent.sovrn.com'',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 3,
+            ext: {
+                provider: 'liveintent.com'
+            }
+        }]
+    },
+
+    {
+        source: 'openx.net'',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 3,
+            ext: {
+                provider: 'liveintent.com'
+            }
+        }]
+    },
+
+    {
+        source: 'pubmatic.com'',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 3,
+            ext: {
+                provider: 'liveintent.com'
+            }
+        }]
+    },   
+
     {
         source: 'media.net',
         uids: [{

--- a/modules/userId/eids.md
+++ b/modules/userId/eids.md
@@ -77,6 +77,7 @@ userIdAsEids = [
         uids: [{
             id: 'the-ids-object-stringified',
             atype: 1
+        }]
     },
 
     {
@@ -101,7 +102,6 @@ userIdAsEids = [
             id: 'some-random-id-value',
             atype: 1
         }],
-        ext: {
             segments: ['s1', 's2']
         }
     },

--- a/modules/userId/eids.md
+++ b/modules/userId/eids.md
@@ -102,7 +102,9 @@ userIdAsEids = [
             id: 'some-random-id-value',
             atype: 1
         }],
-        segments: ['s1', 's2']
+        ext: {
+            segments: ['s1', 's2']
+        }
     },
     
     {


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
Adds examples of EIDs for index, sovrn, openx, pubmatic id exposed by the LiveIntent UserId module. 
