### PR TITLE
HadronId Module: implementing user consent in backend calls

### DIFF
--- a/modules/hadronIdSystem.js
+++ b/modules/hadronIdSystem.js
@@ -9,8 +9,11 @@ import {ajax} from '../src/ajax.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {submodule} from '../src/hook.js';
 import {isFn, isStr, isPlainObject, logError, logInfo} from '../src/utils.js';
+import { config } from '../src/config.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
+import { gdprDataHandler, uspDataHandler, gppDataHandler } from '../src/adapterManager.js';
 
+const LOG_PREFIX = '[hadronIdSystem]';
 const HADRONID_LOCAL_NAME = 'auHadronId';
 const MODULE_NAME = 'hadronId';
 const AU_GVLID = 561;
@@ -41,6 +44,8 @@ function paramOrDefault(param, defaultVal, arg) {
 const urlAddParams = (url, params) => {
   return url + (url.indexOf('?') > -1 ? '&' : '?') + params
 }
+
+const isDebug = config.getConfig('debug') || false;
 
 /** @type {Submodule} */
 export const hadronIdSubmodule = {
@@ -88,7 +93,7 @@ export const hadronIdSubmodule = {
             } catch (error) {
               logError(error);
             }
-            logInfo(`Response from backend is ${responseObj}`);
+            logInfo(LOG_PREFIX, `Response from backend is ${response}`, responseObj);
             hadronId = responseObj['hadronId'];
             storage.setDataInLocalStorage(HADRONID_LOCAL_NAME, hadronId);
             responseObj = {id: {hadronId}};
@@ -100,13 +105,34 @@ export const hadronIdSubmodule = {
           callback();
         }
       };
-      logInfo('HadronId not found in storage, calling backend...');
-      const url = urlAddParams(
+      let url = urlAddParams(
         // config.params.url and config.params.urlArg are not documented
         // since their use is for debugging purposes only
         paramOrDefault(config.params.url, DEFAULT_HADRON_URL_ENDPOINT, config.params.urlArg),
-        `partner_id=${partnerId}&_it=prebid`
+        `partner_id=${partnerId}&_it=prebid&t=1&src=id` // src=id => the backend was called from getId
       );
+      if (isDebug) {
+        url += '&debug=1'
+      }
+      const gdprConsent = gdprDataHandler.getConsentData()
+      if (gdprConsent) {
+        url += `${gdprConsent.consentString ? '&gdprString=' + encodeURIComponent(gdprConsent.consentString) : ''}`;
+        url += `&gdpr=${gdprConsent.gdprApplies === true ? 1 : 0}`;
+      }
+
+      const usPrivacyString = uspDataHandler.getConsentData();
+      if (usPrivacyString) {
+        url += `&us_privacy=${encodeURIComponent(usPrivacyString)}`;
+      }
+
+      const gppConsent = gppDataHandler.getConsentData();
+      if (gppConsent) {
+        url += `${gppConsent.gppString ? '&gpp=' + encodeURIComponent(gppConsent.gppString) : ''}`;
+        url += `${gppConsent.applicableSections ? '&gpp_sid=' + encodeURIComponent(gppConsent.applicableSections) : ''}`;
+      }
+
+      logInfo(LOG_PREFIX, `hadronId not found in storage, calling home (${url})`);
+
       ajax(url, callbacks, undefined, {method: 'GET'});
     };
     return {callback: resp};

--- a/test/spec/modules/hadronIdSystem_spec.js
+++ b/test/spec/modules/hadronIdSystem_spec.js
@@ -22,7 +22,7 @@ describe('HadronIdSystem', function () {
       const callback = hadronIdSubmodule.getId(config).callback;
       callback(callbackSpy);
       const request = server.requests[0];
-      expect(request.url).to.eq(`https://id.hadron.ad.gt/api/v1/pbhid?partner_id=0&_it=prebid`);
+      expect(request.url).to.match(/^https:\/\/id\.hadron\.ad\.gt\/api\/v1\/pbhid/);
       request.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify({ hadronId: 'testHadronId1' }));
       expect(callbackSpy.lastCall.lastArg).to.deep.equal({ id: { hadronId: 'testHadronId1' } });
     });
@@ -47,7 +47,7 @@ describe('HadronIdSystem', function () {
       const callback = hadronIdSubmodule.getId(config).callback;
       callback(callbackSpy);
       const request = server.requests[0];
-      expect(request.url).to.eq('https://hadronid.publync.com/?partner_id=0&_it=prebid');
+      expect(request.url).to.match(/^https:\/\/hadronid\.publync\.com\//);
       request.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify({ hadronId: 'testHadronId1' }));
       expect(callbackSpy.lastCall.lastArg).to.deep.equal({ id: { hadronId: 'testHadronId1' } });
     });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
So far our module is not aware of the user consent, with this change we'll be able to detect user consent string in the backend and proceed accordingly. 

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
