### PR TITLE
Yandex Bid Adapter: Add rtt (roud trip time) tracking via nurl

### DIFF
--- a/modules/yandexBidAdapter.js
+++ b/modules/yandexBidAdapter.js
@@ -140,7 +140,7 @@ export const spec = {
   interpretResponse: interpretResponse,
 
   onBidWon: function (bid) {
-    const nurl = bid['nurl'];
+    const nurl = addRTT(bid['nurl'], bid.timeToRespond);
 
     if (!nurl) {
       return;
@@ -376,6 +376,26 @@ function replaceAuctionPrice(url, price, currency) {
   return url
     .replace(/\${AUCTION_PRICE}/, price)
     .replace(/\${AUCTION_CURRENCY}/, currency);
+}
+
+function addRTT(url, rtt) {
+  if (!url) return;
+
+  if (url.indexOf(`\${RTT}`) > -1) {
+    return url.replace(/\${RTT}/, rtt ?? -1);
+  }
+
+  let urlObj = new URL(url);
+
+  if (Number.isInteger(rtt)) {
+    urlObj.searchParams.set('rtt', rtt);
+  } else {
+    urlObj.searchParams.delete('rtt');
+  }
+
+  url = urlObj.toString();
+
+  return url;
 }
 
 registerBidder(spec);

--- a/modules/yandexBidAdapter.js
+++ b/modules/yandexBidAdapter.js
@@ -385,7 +385,7 @@ function addRTT(url, rtt) {
     return url.replace(/\${RTT}/, rtt ?? -1);
   }
 
-  let urlObj = new URL(url);
+  const urlObj = new URL(url);
 
   if (Number.isInteger(rtt)) {
     urlObj.searchParams.set('rtt', rtt);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature


## Description of change
<!-- Describe the change proposed in this pull request -->

Code added for yandex bid adapter to track timeToRespond via sending rtt param to nurl.
