### PR TITLE
Utils.js (Warning in Integration Tests): add back getWindowFromDocument

### DIFF
--- a/modules/tpmnBidAdapter.js
+++ b/modules/tpmnBidAdapter.js
@@ -184,7 +184,7 @@ function createRenderer(bid) {
 
 function outstreamRender(bid, doc) {
   bid.renderer.push(() => {
-    const win = utils.getWindowFromDocument(doc) || window;
+    const win = (doc) ? doc.defaultView : window;
     win.ANOutstreamVideo.renderAd({
       sizes: [bid.playerWidth, bid.playerHeight],
       targetId: bid.adUnitCode,

--- a/src/utils.js
+++ b/src/utils.js
@@ -181,6 +181,15 @@ export function getWindowLocation() {
 }
 
 /**
+ * returns a window object, which holds the provided document or null
+ * @param {Document} doc
+ * @returns {Window}
+ */
+export function getWindowFromDocument(doc) {
+  return (doc) ? doc.defaultView : null;
+}
+
+/**
  * Wrappers to console.(log | info | warn | error). Takes N arguments, the same as the native methods
  */
 export function logMessage() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -181,15 +181,6 @@ export function getWindowLocation() {
 }
 
 /**
- * returns a window object, which holds the provided document or null
- * @param {Document} doc
- * @returns {Window}
- */
-export function getWindowFromDocument(doc) {
-  return (doc) ? doc.defaultView : null;
-}
-
-/**
  * Wrappers to console.(log | info | warn | error). Takes N arguments, the same as the native methods
  */
 export function logMessage() {


### PR DESCRIPTION
When cleaning out utils.js looks like getWindowFromDocument was removed but one bid adapter seems to still reference it and looks to be throwing a warning during integration tests. Not sure if we want to add it back to utils as done in this or or remove the function from the TPMN adapter?