### PR TITLE
Price Floors: Failure to Account for 'data.skipRate'

### DIFF
--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -347,7 +347,7 @@ export function updateAdUnitsForAuction(adUnits, floorData, auctionId) {
       bid.auctionId = auctionId;
       bid.floorData = {
         skipped: floorData.skipped,
-        skipRate: floorData.skipRate,
+        skipRate: deepAccess(floorData, 'data.skipRate') ?? floorData.skipRate,
         floorMin: floorData.floorMin,
         modelVersion: deepAccess(floorData, 'data.modelVersion'),
         modelWeight: deepAccess(floorData, 'data.modelWeight'),
@@ -396,7 +396,7 @@ export function createFloorsDataForAuction(adUnits, auctionId) {
     resolvedFloorsData.skipped = true;
   } else {
     // determine the skip rate now
-    const auctionSkipRate = getParameterByName('pbjs_skipRate') || resolvedFloorsData.skipRate;
+    const auctionSkipRate = getParameterByName('pbjs_skipRate') || (deepAccess(resolvedFloorsData, 'data.skipRate') ?? resolvedFloorsData.skipRate);
     const isSkipped = Math.random() * 100 < parseFloat(auctionSkipRate);
     resolvedFloorsData.skipped = isSkipped;
   }

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -12,7 +12,7 @@ import {
   isFloorsDataValid,
   addBidResponseHook,
   fieldMatchingFunctions,
-  allowedFields, parseFloorData, normalizeDefault, getFloorDataFromAdUnits
+  allowedFields, parseFloorData, normalizeDefault, getFloorDataFromAdUnits, updateAdUnitsForAuction, createFloorsDataForAuction
 } from 'modules/priceFloors.js';
 import * as events from 'src/events.js';
 import * as mockGpt from '../integration/faker/googletag.js';
@@ -648,6 +648,90 @@ describe('the price floors module', function () {
       });
     });
   });
+
+  describe('updateAdUnitsForAuction', function() {
+    let inputFloorData;
+    let adUnits;
+
+    beforeEach(function() {
+      adUnits = [getAdUnitMock()];
+      inputFloorData = utils.deepClone(minFloorConfigLow);
+      inputFloorData.skipRate = 0.5;
+    });
+
+    it('should set the skipRate in the bid floorData if it exists in the data property of the floorData', function() {
+      utils.deepSetValue(inputFloorData, 'data', {
+        skipRate: 0.7
+      });
+      updateAdUnitsForAuction(adUnits, inputFloorData, 'id');
+
+      const skipRate = utils.deepAccess(adUnits, '0.bids.0.floorData.skipRate');
+      expect(skipRate).to.equal(0.7);
+    });
+
+    it('should set the skipRate in the bid floorData directly from the floor data if it does not exist in the data property of floorData', function() {
+      updateAdUnitsForAuction(adUnits, inputFloorData, 'id');
+
+      const skipRate = utils.deepAccess(adUnits, '0.bids.0.floorData.skipRate');
+      expect(skipRate).to.equal(0.5);
+    });
+
+    it('should set the skipRate in the bid floorData to undefined if both skipRate and skipRate in the data property are undefined', function() {
+      inputFloorData.skipRate = undefined;
+      utils.deepSetValue(inputFloorData, 'data', {
+        skipRate: undefined,
+      });
+      updateAdUnitsForAuction(adUnits, inputFloorData, 'id');
+
+      const skipRate = utils.deepAccess(adUnits, '0.bids.0.floorData.skipRate');
+      expect(skipRate).to.equal(undefined);
+    });
+  });
+
+  describe('createFloorsDataForAuction', function() {
+    let adUnits;
+    let floorConfig;
+
+    beforeEach(function() {
+      adUnits = [getAdUnitMock()];
+      floorConfig = utils.deepClone(basicFloorConfig);
+    });
+
+    it('should return skipRate as 0 if both skipRate and skipRate in the data property are undefined', function() {
+      floorConfig.skipRate = undefined;
+      floorConfig.data.skipRate = undefined;
+      handleSetFloorsConfig({
+        ...floorConfig,
+      });
+      const floorData = createFloorsDataForAuction(adUnits, 'id');
+
+      expect(floorData.skipRate).to.equal(0);
+      expect(floorData.skipped).to.equal(false);
+    });
+
+    it('should properly set skipRate if it is available in the data property', function() {
+      // this will force skipped to be true
+      floorConfig.skipRate = 101;
+      floorConfig.data.skipRate = 201;
+      handleSetFloorsConfig(floorConfig);
+
+      const floorData = createFloorsDataForAuction(adUnits, 'id');
+
+      expect(floorData.data.skipRate).to.equal(201);
+      expect(floorData.skipped).to.equal(true);
+    });
+
+    it('should should use the skipRate if its not available in the data property ', function() {
+      // this will force skipped to be true
+      floorConfig.skipRate = 101;
+      handleSetFloorsConfig(floorConfig);
+      const floorData = createFloorsDataForAuction(adUnits, 'id');
+
+      expect(floorData.skipRate).to.equal(101);
+      expect(floorData.skipped).to.equal(true);
+    });
+  });
+
   describe('pre-auction tests', function () {
     let exposedAdUnits;
     const validateBidRequests = (getFloorExpected, FloorDataExpected) => {

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -659,7 +659,7 @@ describe('the price floors module', function () {
       inputFloorData.skipRate = 0.5;
     });
 
-    it('should set the skipRate in the bid floorData if it exists in the data property of the floorData', function() {
+    it('should set the skipRate to the skipRate from the data property before using the skipRate from floorData directly', function() {
       utils.deepSetValue(inputFloorData, 'data', {
         skipRate: 0.7
       });
@@ -669,7 +669,7 @@ describe('the price floors module', function () {
       expect(skipRate).to.equal(0.7);
     });
 
-    it('should set the skipRate in the bid floorData directly from the floor data if it does not exist in the data property of floorData', function() {
+    it('should set the skipRate to the skipRate from floorData directly if it does not exist in the data property of floorData', function() {
       updateAdUnitsForAuction(adUnits, inputFloorData, 'id');
 
       const skipRate = utils.deepAccess(adUnits, '0.bids.0.floorData.skipRate');
@@ -700,9 +700,8 @@ describe('the price floors module', function () {
     it('should return skipRate as 0 if both skipRate and skipRate in the data property are undefined', function() {
       floorConfig.skipRate = undefined;
       floorConfig.data.skipRate = undefined;
-      handleSetFloorsConfig({
-        ...floorConfig,
-      });
+      handleSetFloorsConfig(floorConfig);
+
       const floorData = createFloorsDataForAuction(adUnits, 'id');
 
       expect(floorData.skipRate).to.equal(0);
@@ -725,6 +724,7 @@ describe('the price floors module', function () {
       // this will force skipped to be true
       floorConfig.skipRate = 101;
       handleSetFloorsConfig(floorConfig);
+
       const floorData = createFloorsDataForAuction(adUnits, 'id');
 
       expect(floorData.skipRate).to.equal(101);


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
According to the documentation on the [Price Floor Module](https://docs.prebid.org/dev-docs/modules/floors.html), if the "skipRate" exists in the data object within the floors module, it should take precedence over the root-level "skipRate."

This implementation includes checks to prioritize the "skipRate" in the data object, if present.