### PR TITLE
viantOrtb Bid Adapter : add test case for native

### DIFF
--- a/test/spec/modules/viantOrtbBidAdapter_spec.js
+++ b/test/spec/modules/viantOrtbBidAdapter_spec.js
@@ -109,6 +109,49 @@ describe('viantOrtbBidAdapter', function () {
         });
       });
     });
+
+    describe('native', function () {
+      describe('and request config uses mediaTypes', () => {
+        function makeBid() {
+          return {
+            'bidder': 'viant',
+            'params': {
+              'unit': '12345678',
+              'delDomain': 'test-del-domain',
+              'publisherId': '464',
+              'placementId': 'some-PlacementId_2'
+            },
+            'mediaTypes': {
+              'video': {
+                'context': 'instream',
+                'playerSize': [[640, 480]],
+                'mimes': ['video/mp4'],
+                'protocols': [1, 2, 3, 4, 5, 6, 7, 8],
+                'api': [1, 3],
+                'skip': 1,
+                'skipafter': 5,
+                'minduration': 10,
+                'maxduration': 30
+              }
+            },
+            'adUnitCode': 'adunit-code',
+            'bidId': '30b31c1838de1e',
+            'bidderRequestId': '22edbae2733bf6',
+            'auctionId': '1d1a030790a475',
+            'transactionId': '4008d88a-8137-410b-aa35-fbfdabcb478e'
+          }
+        }
+        it('should return true when required params found', function () {
+          expect(spec.isBidRequestValid(makeBid())).to.equal(true);
+        });
+
+        it('should return false when required params are not passed', function () {
+          let nativeBidWithMediaTypes = Object.assign({}, makeBid());
+          nativeBidWithMediaTypes.params = {};
+          expect(spec.isBidRequestValid(nativeBidWithMediaTypes)).to.equal(false);
+        });
+      });
+    });
   });
 
   describe('buildRequests-banner', function () {


### PR DESCRIPTION
Added a test case for native ads

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
