### PR TITLE
Rubicon Bid Adapter: Do not require API for video requests

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -1183,8 +1183,7 @@ export function hasValidVideoParams(bid) {
   var requiredParams = {
     mimes: arrayType,
     protocols: arrayType,
-    linearity: numberType,
-    api: arrayType
+    linearity: numberType
   }
   // loop through each param and verify it has the correct
   Object.keys(requiredParams).forEach(function(param) {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -2381,16 +2381,6 @@ describe('the rubicon adapter', function () {
             bidderRequest = createVideoBidderRequest();
             delete bidderRequest.bids[0].mediaTypes.video.linearity;
             expect(spec.isBidRequestValid(bidderRequest.bids[0])).to.equal(false);
-
-            // change api to an string, no good
-            bidderRequest = createVideoBidderRequest();
-            bidderRequest.bids[0].mediaTypes.video.api = 'string';
-            expect(spec.isBidRequestValid(bidderRequest.bids[0])).to.equal(false);
-
-            // delete api, no good
-            bidderRequest = createVideoBidderRequest();
-            delete bidderRequest.bids[0].mediaTypes.video.api;
-            expect(spec.isBidRequestValid(bidderRequest.bids[0])).to.equal(false);
           });
 
           it('bid request is valid when video context is outstream', function () {


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change
We do not want to force users to have `mediaTypes.video.api` defined any longer