### PR TITLE
Pubmatic Analytics Adapter : skip duplicate data for pubmatic bids in logger and tracker

### DIFF
--- a/modules/pubmaticAnalyticsAdapter.js
+++ b/modules/pubmaticAnalyticsAdapter.js
@@ -9,6 +9,7 @@ import {getGptSlotInfoForAdUnitCode} from '../libraries/gptUtils/gptUtils.js';
 
 /// /////////// CONSTANTS //////////////
 const ADAPTER_CODE = 'pubmatic';
+const VENDOR_OPENWRAP = 'openwrap';
 const SEND_TIMEOUT = 2000;
 const END_POINT_HOST = 'https://t.pubmatic.com/';
 const END_POINT_BID_LOGGER = END_POINT_HOST + 'wl?';
@@ -258,12 +259,27 @@ function isS2SBidder(bidder) {
   return (s2sBidders.indexOf(bidder) > -1) ? 1 : 0
 }
 
+function isOWPubmaticBid(adapterName) {
+  let s2sConf = config.getConfig('s2sConfig');
+  let s2sConfArray = isArray(s2sConf) ? s2sConf : [s2sConf];
+  return s2sConfArray.some(conf => {
+    if (adapterName === ADAPTER_CODE && conf.defaultVendor === VENDOR_OPENWRAP &&
+      conf.bidders.indexOf(ADAPTER_CODE) > -1) {
+      return true;
+    }
+  })
+}
+
 function gatherPartnerBidsForAdUnitForLogger(adUnit, adUnitId, highestBid) {
   highestBid = (highestBid && highestBid.length > 0) ? highestBid[0] : null;
   return Object.keys(adUnit.bids).reduce(function(partnerBids, bidId) {
     adUnit.bids[bidId].forEach(function(bid) {
+      let adapterName = getAdapterNameForAlias(bid.adapterCode || bid.bidder);
+      if (isOWPubmaticBid(adapterName) && isS2SBidder(bid.bidder)) {
+        return;
+      }
       partnerBids.push({
-        'pn': getAdapterNameForAlias(bid.adapterCode || bid.bidder),
+        'pn': adapterName,
         'bc': bid.bidderCode || bid.bidder,
         'bidid': bid.bidId || bidId,
         'db': bid.bidResponse ? 0 : 1,
@@ -419,13 +435,20 @@ function executeBidsLoggerCall(e, highestCpmBids) {
 function executeBidWonLoggerCall(auctionId, adUnitId) {
   const winningBidId = cache.auctions[auctionId].adUnitCodes[adUnitId].bidWon;
   const winningBids = cache.auctions[auctionId].adUnitCodes[adUnitId].bids[winningBidId];
-  let winningBid = winningBids[0];
+  if (!winningBids) {
+    logWarn(LOG_PRE_FIX + 'Could not find winningBids for : ', auctionId);
+    return;
+  }
 
+  let winningBid = winningBids[0];
   if (winningBids.length > 1) {
     winningBid = winningBids.filter(bid => bid.adId === cache.auctions[auctionId].adUnitCodes[adUnitId].bidWonAdId)[0];
   }
 
   const adapterName = getAdapterNameForAlias(winningBid.adapterCode || winningBid.bidder);
+  if (isOWPubmaticBid(adapterName) && isS2SBidder(winningBid.bidder)) {
+    return;
+  }
   let origAdUnit = getAdUnit(cache.auctions[auctionId].origAdUnits, adUnitId) || {};
   let auctionCache = cache.auctions[auctionId];
   let floorData = auctionCache.floorData;
@@ -479,7 +502,10 @@ function executeBidWonLoggerCall(auctionId, adUnitId) {
 function auctionInitHandler(args) {
   s2sBidders = (function() {
     let s2sConf = config.getConfig('s2sConfig');
-    return (s2sConf && isArray(s2sConf.bidders)) ? s2sConf.bidders : [];
+    let s2sBidders = [];
+    (s2sConf || []) &&
+      isArray(s2sConf) ? s2sConf.map(conf => s2sBidders.push(...conf.bidders)) : s2sBidders.push(...s2sConf.bidders);
+    return s2sBidders || [];
   }());
   let cacheEntry = pick(args, [
     'timestamp',
@@ -513,6 +539,10 @@ function bidRequestedHandler(args) {
 }
 
 function bidResponseHandler(args) {
+  if (!args.requestId) {
+    logWarn(LOG_PRE_FIX + 'Got null requestId in bidResponseHandler');
+    return;
+  }
   let bid = cache.auctions[args.auctionId].adUnitCodes[args.adUnitCode].bids[args.requestId][0];
   if (!bid) {
     logError(LOG_PRE_FIX + 'Could not find associated bid request for bid response with requestId: ', args.requestId);
@@ -577,7 +607,7 @@ function auctionEndHandler(args) {
   let highestCpmBids = getGlobal().getHighestCpmBids() || [];
   setTimeout(() => {
     executeBidsLoggerCall.call(this, args, highestCpmBids);
-  }, (cache.auctions[args.auctionId].bidderDonePendingCount === 0 ? 500 : SEND_TIMEOUT));
+  }, (cache.auctions[args.auctionId]?.bidderDonePendingCount === 0 ? 500 : SEND_TIMEOUT));
 }
 
 function bidTimeoutHandler(args) {

--- a/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
@@ -1,4 +1,4 @@
-import pubmaticAnalyticsAdapter, {getMetadata} from 'modules/pubmaticAnalyticsAdapter.js';
+import pubmaticAnalyticsAdapter, { getMetadata } from 'modules/pubmaticAnalyticsAdapter.js';
 import adapterManager from 'src/adapterManager.js';
 import CONSTANTS from 'src/constants.json';
 import { config } from 'src/config.js';
@@ -316,6 +316,208 @@ describe('pubmatic analytics adapter', function () {
     expect(utils.logError.called).to.equal(true);
   });
 
+  describe('OW S2S', function() {
+    this.beforeEach(function() {
+      pubmaticAnalyticsAdapter.enableAnalytics({
+        options: {
+          publisherId: 9999,
+          profileId: 1111,
+          profileVersionId: 20
+        }
+      });
+      config.setConfig({
+        s2sConfig: {
+          accountId: '1234',
+          bidders: ['pubmatic'],
+          defaultVendor: 'openwrap',
+          timeout: 500
+        }
+      });
+    });
+
+    this.afterEach(function() {
+      pubmaticAnalyticsAdapter.disableAnalytics();
+    });
+
+    it('Pubmatic Won: No tracker fired', function() {
+      this.timeout(5000)
+
+      sandbox.stub($$PREBID_GLOBAL$$, 'getHighestCpmBids').callsFake((key) => {
+        return [MOCK.BID_RESPONSE[0], MOCK.BID_RESPONSE[1]]
+      });
+
+      config.setConfig({
+        testGroupId: 15
+      });
+
+      events.emit(AUCTION_INIT, MOCK.AUCTION_INIT);
+      events.emit(BID_REQUESTED, MOCK.BID_REQUESTED);
+      events.emit(BID_RESPONSE, MOCK.BID_RESPONSE[0]);
+      events.emit(BIDDER_DONE, MOCK.BIDDER_DONE);
+      events.emit(AUCTION_END, MOCK.AUCTION_END);
+      events.emit(SET_TARGETING, MOCK.SET_TARGETING);
+      events.emit(BID_WON, MOCK.BID_WON[0]);
+
+      clock.tick(2000 + 1000);
+      expect(requests.length).to.equal(1); // only logger is fired
+      let request = requests[0];
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      let data = getLoggerJsonFromRequest(request.requestBody);
+      expect(data.pubid).to.equal('9999');
+      expect(data.pid).to.equal('1111');
+      expect(data.pdvid).to.equal('20');
+    });
+
+    it('Non-pubmatic won: logger, tracker fired', function() {
+      const APPNEXUS_BID = Object.assign({}, BID, {
+        'bidder': 'appnexus',
+        'adserverTargeting': {
+          'hb_bidder': 'appnexus',
+          'hb_adid': '2ecff0db240757',
+          'hb_pb': 1.20,
+          'hb_size': '640x480',
+          'hb_source': 'server'
+        }
+      });
+
+      const MOCK_AUCTION_INIT_APPNEXUS = {
+        'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
+        'timestamp': 1519767010567,
+        'auctionStatus': 'inProgress',
+        'adUnits': [ {
+          'code': '/19968336/header-bid-tag-1',
+          'sizes': [[640, 480]],
+          'bids': [ {
+            'bidder': 'appnexus',
+            'params': {
+              'publisherId': '1001'
+            }
+          } ],
+          'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014'
+        }
+        ],
+        'adUnitCodes': ['/19968336/header-bid-tag-1'],
+        'bidderRequests': [ {
+          'bidderCode': 'appnexus',
+          'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
+          'bidderRequestId': '1be65d7958826a',
+          'bids': [ {
+            'bidder': 'appnexus',
+            'params': {
+              'publisherId': '1001',
+              'kgpv': 'this-is-a-kgpv'
+            },
+            'mediaTypes': {
+              'banner': {
+                'sizes': [[640, 480]]
+              }
+            },
+            'adUnitCode': '/19968336/header-bid-tag-1',
+            'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
+            'sizes': [[640, 480]],
+            'bidId': '2ecff0db240757',
+            'bidderRequestId': '1be65d7958826a',
+            'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
+            'src': 'client',
+            'bidRequestsCount': 1
+          }
+          ],
+          'timeout': 3000,
+          'refererInfo': {
+            'topmostLocation': 'http://www.test.com/page.html', 'reachedTop': true, 'numIframes': 0, 'stack': ['http://www.test.com/page.html']
+          }
+        }
+        ],
+        'bidsReceived': [],
+        'winningBids': [],
+        'timeout': 3000
+      };
+
+      const MOCK_BID_REQUESTED_APPNEXUS = {
+        'bidder': 'appnexus',
+        'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa',
+        'bidderRequestId': '1be65d7958826a',
+        'bids': [
+          {
+            'bidder': 'appnexus',
+            'adapterCode': 'appnexus',
+            'bidderCode': 'appnexus',
+            'params': {
+              'publisherId': '1001',
+              'video': {
+                'minduration': 30,
+                'skippable': true
+              }
+            },
+            'mediaType': 'video',
+            'adUnitCode': '/19968336/header-bid-tag-0',
+            'transactionId': 'ca4af27a-6d02-4f90-949d-d5541fa12014',
+            'sizes': [[640, 480]],
+            'bidId': '2ecff0db240757',
+            'bidderRequestId': '1be65d7958826a',
+            'auctionId': '25c6d7f5-699a-4bfc-87c9-996f915341fa'
+          }
+        ],
+        'auctionStart': 1519149536560,
+        'timeout': 5000,
+        'start': 1519149562216,
+        'refererInfo': {
+          'topmostLocation': 'http://www.test.com/page.html', 'reachedTop': true, 'numIframes': 0, 'stack': ['http://www.test.com/page.html']
+        },
+        'gdprConsent': {
+          'consentString': 'here-goes-gdpr-consent-string',
+          'gdprApplies': true
+        }
+      };
+
+      this.timeout(5000)
+
+      sandbox.stub($$PREBID_GLOBAL$$, 'getHighestCpmBids').callsFake((key) => {
+        return [APPNEXUS_BID]
+      });
+
+      events.emit(AUCTION_INIT, MOCK_AUCTION_INIT_APPNEXUS);
+      events.emit(BID_REQUESTED, MOCK_BID_REQUESTED_APPNEXUS);
+      events.emit(BID_RESPONSE, APPNEXUS_BID);
+      events.emit(BIDDER_DONE, {
+        'bidderCode': 'appnexus',
+        'bids': [
+          APPNEXUS_BID,
+          Object.assign({}, APPNEXUS_BID, {
+            'serverResponseTimeMs': 42,
+          })
+        ]
+      });
+      events.emit(AUCTION_END, MOCK.AUCTION_END);
+      events.emit(SET_TARGETING, {
+        [APPNEXUS_BID.adUnitCode]: APPNEXUS_BID.adserverTargeting,
+      });
+      events.emit(BID_WON, Object.assign({}, APPNEXUS_BID, {
+        'status': 'rendered'
+      }));
+
+      clock.tick(2000 + 1000);
+      expect(requests.length).to.equal(2); // logger as well as tracker is fired
+      let request = requests[1]; // logger is executed late, trackers execute first
+      expect(request.url).to.equal('https://t.pubmatic.com/wl?pubid=9999');
+      let data = getLoggerJsonFromRequest(request.requestBody);
+      expect(data.pubid).to.equal('9999');
+      expect(data.pid).to.equal('1111');
+      expect(data.pdvid).to.equal('20');
+
+      let firstTracker = requests[0].url;
+      expect(firstTracker.split('?')[0]).to.equal('https://t.pubmatic.com/wt');
+      firstTracker.split('?')[1].split('&').map(e => e.split('=')).forEach(e => data[e[0]] = e[1]);
+      expect(data.pubid).to.equal('9999');
+      expect(decodeURIComponent(data.purl)).to.equal('http://www.test.com/page.html');
+
+      expect(data.s).to.be.an('array');
+      expect(data.s.length).to.equal(1);
+      expect(data.s[0].ps[0].pn).to.equal('appnexus');
+      expect(data.s[0].ps[0].bc).to.equal('appnexus');
+    })
+  });
+
   describe('when handling events', function() {
     beforeEach(function () {
       pubmaticAnalyticsAdapter.enableAnalytics({
@@ -374,14 +576,14 @@ describe('pubmatic analytics adapter', function () {
       // slot 1
       expect(data.s[0].sn).to.equal('/19968336/header-bid-tag-0');
       expect(data.s[0].fskp).to.equal(0);
-	  expect(data.s[0].sid).not.to.be.undefined;
-	  expect(data.s[0].ffs).to.equal(1);
-	  expect(data.s[0].fsrc).to.equal(2);
-	  expect(data.s[0].fp).to.equal('pubmatic');
+      expect(data.s[0].sid).not.to.be.undefined;
+      expect(data.s[0].ffs).to.equal(1);
+      expect(data.s[0].fsrc).to.equal(2);
+      expect(data.s[0].fp).to.equal('pubmatic');
       expect(data.s[0].sz).to.deep.equal(['640x480']);
       expect(data.s[0].ps).to.be.an('array');
-	  expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
-	  expect(data.s[0].ps.length).to.equal(1);
+      expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
+      expect(data.s[0].ps.length).to.equal(1);
       expect(data.s[0].ps[0].pn).to.equal('pubmatic');
       expect(data.s[0].ps[0].bc).to.equal('pubmatic');
       expect(data.s[0].ps[0].bidid).to.equal('2ecff0db240757');
@@ -394,8 +596,8 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[0].ps[0].en).to.equal(1.23);
       expect(data.s[0].ps[0].di).to.equal('-1');
       expect(data.s[0].ps[0].dc).to.equal('');
-	  expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].l1).to.equal(944);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[0].ps[0].l2).to.equal(0);
       expect(data.s[0].ps[0].ss).to.equal(1);
       expect(data.s[0].ps[0].t).to.equal(0);
@@ -407,10 +609,10 @@ describe('pubmatic analytics adapter', function () {
       // slot 2
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].fskp).to.equal(0);
-	  expect(data.s[1].sid).not.to.be.undefined;
-	  expect(data.s[1].ffs).to.equal(1);
-	  expect(data.s[1].fsrc).to.equal(2);
-	  expect(data.s[1].fp).to.equal('pubmatic');
+      expect(data.s[1].sid).not.to.be.undefined;
+      expect(data.s[1].ffs).to.equal(1);
+      expect(data.s[1].fsrc).to.equal(2);
+      expect(data.s[1].fp).to.equal('pubmatic');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
@@ -429,7 +631,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);
@@ -467,7 +669,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.af).to.equal('video');
     });
 
-    it('Logger: do not log floor fields when prebids floor shows noData in location property', function() {
+    it('Logger : do not log floor fields when prebids floor shows noData in location property', function() {
       const BID_REQUESTED_COPY = utils.deepClone(MOCK.BID_REQUESTED);
       BID_REQUESTED_COPY['bids'][1]['floorData']['location'] = 'noData';
 
@@ -591,13 +793,13 @@ describe('pubmatic analytics adapter', function () {
       // slot 1
       expect(data.s[0].sn).to.equal('/19968336/header-bid-tag-0');
       expect(data.s[0].fskp).to.equal(0);
-	  expect(data.s[0].sid).not.to.be.undefined;
-	  expect(data.s[0].ffs).to.equal(1);
-	  expect(data.s[0].fsrc).to.equal(2);
-	  expect(data.s[0].fp).to.equal('pubmatic');
+      expect(data.s[0].sid).not.to.be.undefined;
+      expect(data.s[0].ffs).to.equal(1);
+      expect(data.s[0].fsrc).to.equal(2);
+      expect(data.s[0].fp).to.equal('pubmatic');
       expect(data.s[0].sz).to.deep.equal(['640x480']);
       expect(data.s[0].ps).to.be.an('array');
-	  expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
+      expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
       expect(data.s[0].ps.length).to.equal(1);
       expect(data.s[0].ps[0].pn).to.equal('pubmatic');
       expect(data.s[0].ps[0].bc).to.equal('pubmatic');
@@ -671,7 +873,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[0].sz).to.deep.equal(['640x480']);
       expect(data.s[0].ps).to.be.an('array');
       expect(data.s[0].ps.length).to.equal(1);
-	  expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
+      expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
       expect(data.s[0].ps[0].pn).to.equal('pubmatic');
       expect(data.s[0].ps[0].bc).to.equal('pubmatic');
       expect(data.s[0].ps[0].bidid).to.equal('2ecff0db240757');
@@ -715,11 +917,11 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].fskp).to.equal(0);
 
-	  expect(data.s[1].sid).not.to.be.undefined;
+      expect(data.s[1].sid).not.to.be.undefined;
 
-	  expect(data.s[1].ffs).to.equal(1);
-	  expect(data.s[1].fsrc).to.equal(2);
-	  expect(data.s[1].fp).to.equal('pubmatic');
+      expect(data.s[1].ffs).to.equal(1);
+      expect(data.s[1].fsrc).to.equal(2);
+      expect(data.s[1].fp).to.equal('pubmatic');
 
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
       expect(data.s[1].ps).to.be.an('array');
@@ -803,10 +1005,10 @@ describe('pubmatic analytics adapter', function () {
       let data = getLoggerJsonFromRequest(request.requestBody);
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].fskp).to.equal(0);
-	  expect(data.s[1].sid).not.to.be.undefined;
-	  expect(data.s[1].ffs).to.equal(1);
-	  expect(data.s[1].fsrc).to.equal(2);
-	  expect(data.s[1].fp).to.equal('pubmatic');
+      expect(data.s[1].sid).not.to.be.undefined;
+      expect(data.s[1].ffs).to.equal(1);
+      expect(data.s[1].fsrc).to.equal(2);
+      expect(data.s[1].fp).to.equal('pubmatic');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
@@ -823,8 +1025,8 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].dc).to.equal('PMP');
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
-	  expect(data.s[0].ps[0].l1).to.equal(0);
-	  expect(data.s[0].ps[0].ol1).to.equal(0);
+      expect(data.s[0].ps[0].l1).to.equal(0);
+      expect(data.s[0].ps[0].ol1).to.equal(0);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(1);
@@ -869,7 +1071,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
       expect(data.s[1].ps).to.be.an('array');
-	  expect(data.s[1].sid).not.to.be.undefined;
+      expect(data.s[1].sid).not.to.be.undefined;
       expect(data.s[1].ps.length).to.equal(1);
       expect(data.s[1].ps[0].pn).to.equal('pubmatic');
       expect(data.s[1].ps[0].bc).to.equal('pubmatic');
@@ -885,7 +1087,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);
@@ -917,10 +1119,10 @@ describe('pubmatic analytics adapter', function () {
       let data = getLoggerJsonFromRequest(request.requestBody);
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].fskp).to.equal(0);
-	  expect(data.s[1].sid).not.to.be.undefined;
-	  expect(data.s[1].ffs).to.equal(1);
-	  expect(data.s[1].fsrc).to.equal(2);
-	  expect(data.s[1].fp).to.equal('pubmatic');
+      expect(data.s[1].sid).not.to.be.undefined;
+      expect(data.s[1].ffs).to.equal(1);
+      expect(data.s[1].fsrc).to.equal(2);
+      expect(data.s[1].fp).to.equal('pubmatic');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
@@ -938,7 +1140,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);
@@ -980,7 +1182,7 @@ describe('pubmatic analytics adapter', function () {
       let data = getLoggerJsonFromRequest(request.requestBody);
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
-	  expect(data.s[1].sid).not.to.be.undefined;
+      expect(data.s[1].sid).not.to.be.undefined;
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
       expect(data.s[1].ps[0].pn).to.equal('pubmatic');
@@ -997,7 +1199,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);
@@ -1035,10 +1237,10 @@ describe('pubmatic analytics adapter', function () {
       let data = getLoggerJsonFromRequest(request.requestBody);
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].fskp).to.equal(0);
-	  expect(data.s[1].sid).not.to.be.undefined;
-	  expect(data.s[1].ffs).to.equal(1);
-	  expect(data.s[1].fsrc).to.equal(2);
-	  expect(data.s[1].fp).to.equal('pubmatic');
+      expect(data.s[1].sid).not.to.be.undefined;
+      expect(data.s[1].ffs).to.equal(1);
+      expect(data.s[1].fsrc).to.equal(2);
+      expect(data.s[1].fp).to.equal('pubmatic');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
@@ -1056,7 +1258,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);
@@ -1096,7 +1298,7 @@ describe('pubmatic analytics adapter', function () {
       let data = getLoggerJsonFromRequest(request.requestBody);
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
-	  expect(data.s[1].sid).not.to.be.undefined;
+      expect(data.s[1].sid).not.to.be.undefined;
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
       expect(data.s[1].ps[0].pn).to.equal('pubmatic');
@@ -1113,7 +1315,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);
@@ -1155,11 +1357,11 @@ describe('pubmatic analytics adapter', function () {
       // Testing only for rejected bid as other scenarios will be covered under other TCs
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].fskp).to.equal(0);
-	  expect(data.s[1].ffs).to.equal(1);
-	  expect(data.s[1].fsrc).to.equal(2);
-	  expect(data.s[1].fp).to.equal('pubmatic');
+      expect(data.s[1].ffs).to.equal(1);
+      expect(data.s[1].fsrc).to.equal(2);
+      expect(data.s[1].fp).to.equal('pubmatic');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
-	  expect(data.s[1].sid).not.to.be.undefined;
+      expect(data.s[1].sid).not.to.be.undefined;
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
       expect(data.s[1].ps[0].pn).to.equal('pubmatic');
@@ -1177,7 +1379,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);
@@ -1234,13 +1436,13 @@ describe('pubmatic analytics adapter', function () {
       // slot 1
       expect(data.s[0].sn).to.equal('/19968336/header-bid-tag-0');
       expect(data.s[0].fskp).to.equal(0);
-	  expect(data.s[0].ffs).to.equal(1);
-	  expect(data.s[0].fsrc).to.equal(2);
-	  expect(data.s[0].fp).to.equal('pubmatic');
+      expect(data.s[0].ffs).to.equal(1);
+      expect(data.s[0].fsrc).to.equal(2);
+      expect(data.s[0].fp).to.equal('pubmatic');
       expect(data.s[0].sz).to.deep.equal(['640x480']);
-	  expect(data.s[0].sid).not.to.be.undefined;
+      expect(data.s[0].sid).not.to.be.undefined;
       expect(data.s[0].ps).to.be.an('array');
-	    expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
+      expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
       expect(data.s[0].ps.length).to.equal(1);
       expect(data.s[0].ps[0].pn).to.equal('pubmatic');
       expect(data.s[0].ps[0].bc).to.equal('pubmatic_alias');
@@ -1255,7 +1457,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[0].ps[0].di).to.equal('-1');
       expect(data.s[0].ps[0].dc).to.equal('');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[0].ps[0].l2).to.equal(0);
       expect(data.s[0].ps[0].ss).to.equal(0);
       expect(data.s[0].ps[0].t).to.equal(0);
@@ -1268,11 +1470,11 @@ describe('pubmatic analytics adapter', function () {
       // slot 2
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].fskp).to.equal(0);
-	  expect(data.s[1].ffs).to.equal(1);
-	  expect(data.s[1].fsrc).to.equal(2);
-	  expect(data.s[1].fp).to.equal('pubmatic');
+      expect(data.s[1].ffs).to.equal(1);
+      expect(data.s[1].fsrc).to.equal(2);
+      expect(data.s[1].fp).to.equal('pubmatic');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
-	  expect(data.s[1].sid).not.to.be.undefined;
+      expect(data.s[1].sid).not.to.be.undefined;
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
       expect(data.s[1].ps[0].pn).to.equal('pubmatic');
@@ -1289,8 +1491,8 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].dc).to.equal('PMP');
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
-	  expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].l1).to.equal(944);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);
@@ -1364,13 +1566,13 @@ describe('pubmatic analytics adapter', function () {
       // slot 1
       expect(data.s[0].sn).to.equal('/19968336/header-bid-tag-0');
       expect(data.s[0].fskp).to.equal(0);
-	  expect(data.s[0].ffs).to.equal(1);
-	  expect(data.s[0].fsrc).to.equal(2);
-	  expect(data.s[0].fp).to.equal('pubmatic');
+      expect(data.s[0].ffs).to.equal(1);
+      expect(data.s[0].fsrc).to.equal(2);
+      expect(data.s[0].fp).to.equal('pubmatic');
       expect(data.s[0].sz).to.deep.equal(['640x480']);
-	  expect(data.s[0].sid).not.to.be.undefined;
+      expect(data.s[0].sid).not.to.be.undefined;
       expect(data.s[0].ps).to.be.an('array');
-	    expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
+      expect(data.s[0].au).to.equal('/19968336/header-bid-tag-0');
       expect(data.s[0].ps.length).to.equal(1);
       expect(data.s[0].ps[0].pn).to.equal('pubmatic');
       expect(data.s[0].ps[0].bc).to.equal('groupm');
@@ -1385,7 +1587,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[0].ps[0].di).to.equal('-1');
       expect(data.s[0].ps[0].dc).to.equal('');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[0].ps[0].l2).to.equal(0);
       expect(data.s[0].ps[0].ss).to.equal(0);
       expect(data.s[0].ps[0].t).to.equal(0);
@@ -1398,7 +1600,7 @@ describe('pubmatic analytics adapter', function () {
       // slot 2
       expect(data.s[1].sn).to.equal('/19968336/header-bid-tag-1');
       expect(data.s[1].sz).to.deep.equal(['1000x300', '970x250', '728x90']);
-	  expect(data.s[1].sid).not.to.be.undefined;
+      expect(data.s[1].sid).not.to.be.undefined;
       expect(data.s[1].ps).to.be.an('array');
       expect(data.s[1].ps.length).to.equal(1);
       expect(data.s[1].ps[0].pn).to.equal('pubmatic');
@@ -1416,7 +1618,7 @@ describe('pubmatic analytics adapter', function () {
       expect(data.s[1].ps[0].mi).to.equal('matched-impression');
       expect(data.s[1].ps[0].adv).to.equal('example.com');
       expect(data.s[0].ps[0].l1).to.equal(944);
-	  expect(data.s[0].ps[0].ol1).to.equal(3214);
+      expect(data.s[0].ps[0].ol1).to.equal(3214);
       expect(data.s[1].ps[0].l2).to.equal(0);
       expect(data.s[1].ps[0].ss).to.equal(1);
       expect(data.s[1].ps[0].t).to.equal(0);


### PR DESCRIPTION

## Type of change
- [x] Feature

## Description of change
With this change, when publisher is using openwrap meta adapter with pubmatic analytics adapter, the duplicate data of pubmatic bid from logger is skipped and tracker will not be fired in case pubmatic wins auction(this will be taken care by server side tracker)