### PR TITLE
Seedtag Bid Adapter : add geom to bidRequest

### DIFF
--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -107,7 +107,6 @@ function buildBidRequest(validBidRequest) {
       return mediaTypesMap[pbjsType];
     }
   );
-
   const bidRequest = {
     id: validBidRequest.bidId,
     transactionId: validBidRequest.ortb2Imp?.ext?.tid,
@@ -115,6 +114,7 @@ function buildBidRequest(validBidRequest) {
     supplyTypes: mediaTypes,
     adUnitId: params.adUnitId,
     adUnitCode: validBidRequest.adUnitCode,
+    geom: geom(validBidRequest.adUnitCode),
     placement: params.placement,
     requestCount: validBidRequest.bidderRequestsCount || 1, // FIXME : in unit test the parameter bidderRequestsCount is undefined
   };
@@ -198,6 +198,27 @@ function ttfb() {
   return ttfb >= 0 && ttfb <= performance.now() ? ttfb : 0;
 }
 
+function geom(adunitCode) {
+  const slot = document.getElementById(adunitCode);
+  if (slot) {
+    const scrollY = window.scrollY;
+    const { top, left, width, height } = slot.getBoundingClientRect();
+    const viewport = {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    };
+
+    return {
+      scrollY,
+      top,
+      left,
+      width,
+      height,
+      viewport,
+    };
+  }
+}
+
 export function getTimeoutUrl(data) {
   let queryParams = '';
   if (
@@ -277,13 +298,13 @@ export const spec = {
     if (bidderRequest.gppConsent) {
       payload.gppConsent = {
         gppString: bidderRequest.gppConsent.gppString,
-        applicableSections: bidderRequest.gppConsent.applicableSections
-      }
+        applicableSections: bidderRequest.gppConsent.applicableSections,
+      };
     } else if (bidderRequest.ortb2?.regs?.gpp) {
       payload.gppConsent = {
         gppString: bidderRequest.ortb2.regs.gpp,
-        applicableSections: bidderRequest.ortb2.regs.gpp_sid
-      }
+        applicableSections: bidderRequest.ortb2.regs.gpp_sid,
+      };
     }
 
     const payloadString = JSON.stringify(payload);

--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -298,13 +298,13 @@ export const spec = {
     if (bidderRequest.gppConsent) {
       payload.gppConsent = {
         gppString: bidderRequest.gppConsent.gppString,
-        applicableSections: bidderRequest.gppConsent.applicableSections,
-      };
+        applicableSections: bidderRequest.gppConsent.applicableSections
+      }
     } else if (bidderRequest.ortb2?.regs?.gpp) {
       payload.gppConsent = {
         gppString: bidderRequest.ortb2.regs.gpp,
-        applicableSections: bidderRequest.ortb2.regs.gpp_sid,
-      };
+        applicableSections: bidderRequest.ortb2.regs.gpp_sid
+      }
     }
 
     const payloadString = JSON.stringify(payload);

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -9,6 +9,17 @@ const ADUNIT_ID = '000000';
 
 const adUnitCode = '/19968336/header-bid-tag-0'
 
+// create a default adunit
+const slot = document.createElement('div');
+slot.id = adUnitCode;
+slot.style.width = '300px'
+slot.style.height = '250px'
+slot.style.position = 'absolute'
+slot.style.top = '10px'
+slot.style.left = '20px'
+
+document.body.appendChild(slot);
+
 function getSlotConfigs(mediaTypes, params) {
   return {
     params: params,
@@ -50,16 +61,6 @@ const createBannerSlotConfig = (placement, mediatypes) => {
 
 describe('Seedtag Adapter', function () {
   beforeEach(function () {
-    // create the adunit slot
-    const slot = document.createElement('div');
-    slot.id = adUnitCode;
-    slot.style.width = '300px'
-    slot.style.height = '250px'
-    slot.style.position = 'absolute'
-    slot.style.top = '10px'
-    slot.style.left = '20px'
-
-    document.body.appendChild(slot);
     mockGpt.reset();
   });
 

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -2,9 +2,12 @@ import { expect } from 'chai';
 import { spec, getTimeoutUrl } from 'modules/seedtagBidAdapter.js';
 import * as utils from 'src/utils.js';
 import { config } from '../../../src/config.js';
+import * as mockGpt from 'test/spec/integration/faker/googletag.js';
 
 const PUBLISHER_ID = '0000-0000-01';
 const ADUNIT_ID = '000000';
+
+const adUnitCode = '/19968336/header-bid-tag-0'
 
 function getSlotConfigs(mediaTypes, params) {
   return {
@@ -25,7 +28,7 @@ function getSlotConfigs(mediaTypes, params) {
         tid: 'd704d006-0d6e-4a09-ad6c-179e7e758096',
       }
     },
-    adUnitCode: 'adunit-code',
+    adUnitCode: adUnitCode,
   };
 }
 
@@ -45,7 +48,20 @@ const createBannerSlotConfig = (placement, mediatypes) => {
   });
 };
 
+
+
 describe('Seedtag Adapter', function () {
+  beforeEach(function () {
+    // create the adunit slot
+    const slot = document.createElement('div');
+    slot.id = adUnitCode;
+    document.body.appendChild(slot);
+    mockGpt.reset();
+  });
+
+  afterEach(function () {
+    mockGpt.enable();
+  });
   describe('isBidRequestValid method', function () {
     describe('returns true', function () {
       describe('when banner slot config has all mandatory params', () => {
@@ -277,7 +293,7 @@ describe('Seedtag Adapter', function () {
       expect(data.auctionStart).to.be.greaterThanOrEqual(now);
       expect(data.ttfb).to.be.greaterThanOrEqual(0);
 
-      expect(data.bidRequests[0].adUnitCode).to.equal('adunit-code');
+      expect(data.bidRequests[0].adUnitCode).to.equal(adUnitCode);
     });
 
     describe('GDPR params', function () {
@@ -374,6 +390,27 @@ describe('Seedtag Adapter', function () {
         expect(videoBid.sizes[1][1]).to.equal(600);
         expect(videoBid.requestCount).to.equal(1);
       });
+
+      it('should have geom parameters if slot is available', function() {
+        const request = spec.buildRequests(validBidRequests, bidderRequest);
+        const data = JSON.parse(request.data);
+        const bidRequests = data.bidRequests;
+        const bannerBid = bidRequests[0];
+        expect(bannerBid).to.have.property('geom')
+
+        const params = ['top', 'left', 'width', 'height', 'scrollY']
+        params.forEach(param => {
+          expect(bannerBid.geom).to.have.property(param)
+          expect(bannerBid.geom[param]).to.be.a('number')
+        })
+
+        expect(bannerBid.geom).to.have.property('viewport')
+        const viewportParams = ['width', 'height']
+        viewportParams.forEach(param => {
+          expect(bannerBid.geom.viewport).to.have.property(param)
+          expect(bannerBid.geom.viewport[param]).to.be.a('number')
+        })
+      })
     });
 
     describe('COPPA param', function () {

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -401,21 +401,28 @@ describe('Seedtag Adapter', function () {
         const data = JSON.parse(request.data);
         const bidRequests = data.bidRequests;
         const bannerBid = bidRequests[0];
-        expect(bannerBid).to.have.property('geom')
 
-        const params = [['width', 300], ['height', 250], ['top', 10], ['left', 20], ['scrollY', 0]]
-        params.forEach(([param, value]) => {
-          expect(bannerBid.geom).to.have.property(param)
-          expect(bannerBid.geom[param]).to.be.a('number')
-          expect(bannerBid.geom[param]).to.be.equal(value)
-        })
+        // on some CI, the DOM is not initialized, so we need to check if the slot is available
+        const slot = document.getElementById(adUnitCode)
+        if (slot) {
+          expect(bannerBid).to.have.property('geom')
 
-        expect(bannerBid.geom).to.have.property('viewport')
-        const viewportParams = ['width', 'height']
-        viewportParams.forEach(param => {
-          expect(bannerBid.geom.viewport).to.have.property(param)
-          expect(bannerBid.geom.viewport[param]).to.be.a('number')
-        })
+          const params = [['width', 300], ['height', 250], ['top', 10], ['left', 20], ['scrollY', 0]]
+          params.forEach(([param, value]) => {
+            expect(bannerBid.geom).to.have.property(param)
+            expect(bannerBid.geom[param]).to.be.a('number')
+            expect(bannerBid.geom[param]).to.be.equal(value)
+          })
+
+          expect(bannerBid.geom).to.have.property('viewport')
+          const viewportParams = ['width', 'height']
+          viewportParams.forEach(param => {
+            expect(bannerBid.geom.viewport).to.have.property(param)
+            expect(bannerBid.geom.viewport[param]).to.be.a('number')
+          })
+        } else {
+          expect(bannerBid).to.not.have.property('geom')
+        }
       })
     });
 

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -48,13 +48,17 @@ const createBannerSlotConfig = (placement, mediatypes) => {
   });
 };
 
-
-
 describe('Seedtag Adapter', function () {
   beforeEach(function () {
     // create the adunit slot
     const slot = document.createElement('div');
     slot.id = adUnitCode;
+    slot.style.width = '300px'
+    slot.style.height = '250px'
+    slot.style.position = 'absolute'
+    slot.style.top = '10px'
+    slot.style.left = '20px'
+
     document.body.appendChild(slot);
     mockGpt.reset();
   });
@@ -398,10 +402,11 @@ describe('Seedtag Adapter', function () {
         const bannerBid = bidRequests[0];
         expect(bannerBid).to.have.property('geom')
 
-        const params = ['top', 'left', 'width', 'height', 'scrollY']
-        params.forEach(param => {
+        const params = [['width', 300], ['height', 250], ['top', 10], ['left', 20], ['scrollY', 0]]
+        params.forEach(([param, value]) => {
           expect(bannerBid.geom).to.have.property(param)
           expect(bannerBid.geom[param]).to.be.a('number')
+          expect(bannerBid.geom[param]).to.be.equal(value)
         })
 
         expect(bannerBid.geom).to.have.property('viewport')


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
add a `geom` object in the bid request to get slot size information

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
