### PR TITLE
Sharethrough Bid Adapter: support cdep

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -63,6 +63,11 @@ export const sharethroughAdapterSpec = {
       test: 0,
     };
 
+    if (bidderRequest.ortb2?.device?.ext?.cdep) {
+      req.device.ext = {};
+      req.device.ext.cdep = bidderRequest.ortb2.device.ext.cdep;
+    }
+
     req.user = nullish(firstPartyData.user, {});
     if (!req.user.ext) req.user.ext = {};
     req.user.ext.eids = bidRequests[0].userIdAsEids || [];
@@ -220,9 +225,7 @@ export const sharethroughAdapterSpec = {
     const shouldCookieSync =
       syncOptions.pixelEnabled && deepAccess(serverResponses, '0.body.cookieSyncUrls') !== undefined;
 
-    return shouldCookieSync
-      ? serverResponses[0].body.cookieSyncUrls.map((url) => ({ type: 'image', url: url }))
-      : [];
+    return shouldCookieSync ? serverResponses[0].body.cookieSyncUrls.map((url) => ({ type: 'image', url: url })) : [];
   },
 
   // Empty implementation for prebid core to be able to find it

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -45,6 +45,7 @@ export const sharethroughAdapterSpec = {
         dnt: navigator.doNotTrack === '1' ? 1 : 0,
         h: window.screen.height,
         w: window.screen.width,
+        ext: {},
       },
       regs: {
         coppa: config.getConfig('coppa') === true ? 1 : 0,
@@ -64,8 +65,7 @@ export const sharethroughAdapterSpec = {
     };
 
     if (bidderRequest.ortb2?.device?.ext?.cdep) {
-      req.device.ext = {};
-      req.device.ext.cdep = bidderRequest.ortb2.device.ext.cdep;
+      req.device.ext['cdep'] = bidderRequest.ortb2.device.ext.cdep;
     }
 
     req.user = nullish(firstPartyData.user, {});

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -588,6 +588,33 @@ describe('sharethrough adapter spec', function () {
         });
       });
 
+      describe('cookie deprecation', () => {
+        it('should not add cdep if we do not get it in an impression request', () => {
+          const builtRequests = spec.buildRequests(bidRequests, bidderRequest);
+
+          builtRequests.map((builtRequest) => {
+            const ourCdepValue = builtRequest.data.device?.ext?.cdep;
+            expect(ourCdepValue).to.equal(undefined);
+          });
+        });
+
+        it('should add cdep if we DO get it in an impression request', () => {
+          const builtRequests = spec.buildRequests(bidRequests, {
+            auctionId: 'new-auction-id',
+            ortb2: {
+              device: {
+                ext: {
+                  cdep: 'cdep-value',
+                },
+              },
+            },
+          });
+          builtRequests.map((builtRequest) => {
+            expect(builtRequest.data.device.ext.cdep).to.exist.and.to.be.an('string');
+          });
+        });
+      });
+
       describe('first party data', () => {
         const firstPartyData = {
           site: {

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -595,6 +595,7 @@ describe('sharethrough adapter spec', function () {
           builtRequests.map((builtRequest) => {
             const ourCdepValue = builtRequest.data.device?.ext?.cdep;
             expect(ourCdepValue).to.equal(undefined);
+            expect(builtRequest.data.device.ext.cdep).to.not.exist;
           });
         });
 

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -592,10 +592,9 @@ describe('sharethrough adapter spec', function () {
         it('should not add cdep if we do not get it in an impression request', () => {
           const builtRequests = spec.buildRequests(bidRequests, bidderRequest);
 
-          builtRequests.map((builtRequest) => {
+          builtRequests.every((builtRequest) => {
             const ourCdepValue = builtRequest.data.device?.ext?.cdep;
-            expect(ourCdepValue).to.equal(undefined);
-            expect(builtRequest.data.device.ext.cdep).to.not.exist;
+            expect(ourCdepValue === undefined).to.be.true;
           });
         });
 
@@ -610,8 +609,8 @@ describe('sharethrough adapter spec', function () {
               },
             },
           });
-          builtRequests.map((builtRequest) => {
-            expect(builtRequest.data.device.ext.cdep).to.exist.and.to.be.an('string');
+          builtRequests.every((builtRequest) => {
+            expect(builtRequest.data.device.ext.cdep).to.equal('cdep-value');
           });
         });
       });


### PR DESCRIPTION
## Type of change
- [ x] Feature

## Description of change
An update to the bidder adapter so that it passes along `cdep` if it is present in the request information.

