### PR TITLE
Criteo bid adapter: add device object to backend request

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -609,6 +609,7 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
   request.user = bidderRequest.ortb2?.user || {};
   request.site = bidderRequest.ortb2?.site || {};
   request.app = bidderRequest.ortb2?.app || {};
+  request.device = bidderRequest.ortb2?.device || {};
   if (bidderRequest && bidderRequest.ceh) {
     request.user.ceh = bidderRequest.ceh;
   }

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -1906,6 +1906,22 @@ describe('The Criteo bidding adapter', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.slots[0].ext).to.not.have.property('ae');
     });
+
+    it('should properly transmit device.ext.cdep if available', function () {
+      const bidderRequest = {
+        ortb2: {
+          device: {
+            ext: {
+              cdep: 'cookieDeprecationLabel'
+            }
+          }
+        }
+      };
+      const bidRequests = [];
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const ortbRequest = request.data;
+      expect(ortbRequest.device.ext.cdep).to.equal('cookieDeprecationLabel');
+    });
   });
 
   describe('interpretResponse', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Add a device object in the backend request created with `buildCdbRequest`, this is used to transmit `device.ext.cdep` value.