### PR TITLE
PAAPI/fledgeForGpt: make auction configs available independently from GPT

### DIFF
--- a/integrationExamples/gpt/fledge_example.html
+++ b/integrationExamples/gpt/fledge_example.html
@@ -44,15 +44,11 @@
 
     pbjs.que.push(function() {
       pbjs.setConfig({
-        fledgeForGpt: {
-          enabled: true
-        }
-      });
-
-      pbjs.setBidderConfig({
-        bidders: ['openx'],
-        config: {
-          fledgeEnabled: true
+        paapi: {
+          enabled: true,
+          gpt: {
+              autoconfig: false
+          }
         }
       });
 
@@ -69,6 +65,7 @@
         googletag.cmd.push(function() {
           pbjs.que.push(function() {
             pbjs.setTargetingForGPTAsync();
+            pbjs.setPAAPIConfigForGPT();
             googletag.pubads().refresh();
           });
         });

--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -102,6 +102,9 @@
     "videoModule": [
       "jwplayerVideoProvider",
       "videojsVideoProvider"
+    ],
+    "paapi": [
+      "fledgeForGpt"
     ]
   }
 }

--- a/modules/fledgeForGpt.js
+++ b/modules/fledgeForGpt.js
@@ -56,6 +56,8 @@ export function setPAAPIConfigFactory(
   getPAAPIConfig = (filters) => getGlobal().getPAAPIConfig(filters),
   setGptConfig = setComponentAuction) {
   const PREVIOUSLY_SET = {};
+  const resetMap = (keySet) => Object.fromEntries(Array.from(keySet.values()).map(v => [v, null]));
+
   /**
    * Configure GPT slots with PAAPI auction configs.
    * `filters` are the same filters accepted by `pbjs.getPAAPIConfig`;
@@ -71,7 +73,7 @@ export function setPAAPIConfigFactory(
       const sellers = Object.keys(config);
       let previous = PREVIOUSLY_SET[au] || new Set();
       if (!(filters.reuse ?? true) && (filters.adUnitCode ?? au) === au) {
-        Object.assign(config, Object.fromEntries(Array.from(previous.values()).map(v => [v, null])));
+        config = Object.assign(resetMap(previous), config);
         previous = new Set(sellers);
       } else {
         sellers.forEach(seller => previous.add(seller));
@@ -86,7 +88,8 @@ export function setPAAPIConfigFactory(
       Object.entries(PREVIOUSLY_SET)
         .filter(([au]) => !set.has(au) && (filters.adUnitCode ?? au) === au)
         .forEach(([au, sellers]) => {
-          setGptConfig(au, Object.fromEntries(Array.from(sellers.values()).map(seller => [seller, null])))
+          setGptConfig(au, resetMap(sellers));
+          delete PREVIOUSLY_SET[au];
         })
     }
   }

--- a/modules/fledgeForGpt.js
+++ b/modules/fledgeForGpt.js
@@ -38,9 +38,9 @@ export function setComponentAuction(adUnitCode, auctionConfigs) {
           auctionConfig
         }))
     });
-    logInfo(MODULE, `register component auction configs for: ${adUnitCode}: ${gptSlot.getAdUnitPath()}`, Object.values(auctionConfigs));
+    logInfo(MODULE, `register component auction configs for: ${adUnitCode}: ${gptSlot.getAdUnitPath()}`, auctionConfigs);
   } else {
-    logWarn(MODULE, `unable to register component auction config for ${adUnitCode}`, Object.entries(auctionConfigs));
+    logWarn(MODULE, `unable to register component auction config for ${adUnitCode}`, auctionConfigs);
   }
 }
 

--- a/modules/fledgeForGpt.js
+++ b/modules/fledgeForGpt.js
@@ -61,10 +61,12 @@ export function slotConfigurator() {
 const [setComponentAuction, getConfiguredSlots] = slotConfigurator();
 
 export function onAuctionConfigFactory(setGptConfig = setComponentAuction) {
-  return function onAuctionConfig(auctionId, adUnitCode, auctionConfig, markAsUsed) {
+  return function onAuctionConfig(auctionId, configsByAdUnit, markAsUsed) {
     if (autoconfig) {
-      setGptConfig(adUnitCode, auctionConfig.componentAuctions);
-      markAsUsed();
+      Object.entries(configsByAdUnit).forEach(([adUnitCode, cfg]) => {
+        setGptConfig(adUnitCode, cfg?.componentAuctions ?? []);
+        markAsUsed(adUnitCode);
+      });
     }
   }
 }

--- a/modules/fledgeForGpt.js
+++ b/modules/fledgeForGpt.js
@@ -88,11 +88,13 @@ export function setPAAPIConfigFactory(
     if (set.size === 0) {
       logInfo(`${MODULE}: No component auctions available to set`);
     }
-    getSlots()
-      .filter(au => !set.has(au) && (filters.adUnitCode ?? au) === au)
-      .forEach(au => {
-        setGptConfig(au, [], true);
-      })
+    if (!filters.auctionId) {
+      getSlots()
+        .filter(au => !set.has(au) && (filters.adUnitCode ?? au) === au)
+        .forEach(au => {
+          setGptConfig(au, [], true);
+        })
+    }
   }
 }
 /**

--- a/modules/fledgeForGpt.js
+++ b/modules/fledgeForGpt.js
@@ -1,48 +1,30 @@
 /**
- * Fledge modules is responsible for registering fledged auction configs into the GPT slot;
- * GPT is resposible to run the fledge auction.
+ * GPT-specific slot configuration logic for PAAPI.
  */
-import { config } from '../src/config.js';
-import { getHook } from '../src/hook.js';
-import {deepSetValue, logInfo, logWarn, mergeDeep} from '../src/utils.js';
-import {IMP, PBS, registerOrtbProcessor, RESPONSE} from '../src/pbjsORTB.js';
-import * as events from '../src/events.js'
-import CONSTANTS from '../src/constants.json';
-import {currencyCompare} from '../libraries/currencyUtils/currency.js';
-import {maximum, minimum} from '../src/utils/reducers.js';
+import {submodule} from '../src/hook.js';
+import {deepAccess, logInfo, logWarn} from '../src/utils.js';
 import {getGptSlotForAdUnitCode} from '../libraries/gptUtils/gptUtils.js';
+import {config} from '../src/config.js';
+import {getGlobal} from '../src/prebidGlobal.js';
 
-const MODULE = 'fledgeForGpt'
-const PENDING = {};
+const MODULE = 'fledgeForGpt';
 
-export let isEnabled = false;
+// for backwards compat, we attempt to automatically set GPT configuration as soon as we
+// have the auction configs available. Disabling this allows one to call pbjs.setPAAPIConfigForGPT at their
+// own pace.
+let autoconfig = true;
 
-/**
- * Module init.
- */
-export function init(cfg) {
-  if (cfg && cfg.enabled === true) {
-    if (!isEnabled) {
-      getHook('addComponentAuction').before(addComponentAuctionHook);
-      getHook('makeBidRequests').after(markForFledge);
-      events.on(CONSTANTS.EVENTS.AUCTION_INIT, onAuctionInit);
-      events.on(CONSTANTS.EVENTS.AUCTION_END, onAuctionEnd);
-      isEnabled = true;
-    }
-    logInfo(`${MODULE} enabled (browser ${isFledgeSupported() ? 'supports' : 'does NOT support'} fledge)`, cfg);
-  } else {
-    if (isEnabled) {
-      getHook('addComponentAuction').getHooks({hook: addComponentAuctionHook}).remove();
-      getHook('makeBidRequests').getHooks({hook: markForFledge}).remove()
-      events.off(CONSTANTS.EVENTS.AUCTION_INIT, onAuctionInit);
-      events.off(CONSTANTS.EVENTS.AUCTION_END, onAuctionEnd);
-      isEnabled = false;
-    }
-    logInfo(`${MODULE} disabled`, cfg);
-  }
-}
+Object.entries({
+  [MODULE]: MODULE,
+  'paapi': 'paapi.gpt'
+}).forEach(([topic, ns]) => {
+  const configKey = `${ns}.autoconfig`;
+  config.getConfig(topic, (cfg) => {
+    autoconfig = deepAccess(cfg, configKey, true);
+  });
+});
 
-function setComponentAuction(adUnitCode, auctionConfigs) {
+export function setComponentAuction(adUnitCode, auctionConfigs) {
   const gptSlot = getGptSlotForAdUnitCode(adUnitCode);
   if (gptSlot && gptSlot.setConfig) {
     gptSlot.setConfig({
@@ -57,111 +39,36 @@ function setComponentAuction(adUnitCode, auctionConfigs) {
   }
 }
 
-function onAuctionInit({auctionId}) {
-  PENDING[auctionId] = {};
-}
-
-function getSlotSignals(bidsReceived = [], bidRequests = []) {
-  let bidfloor, bidfloorcur;
-  if (bidsReceived.length > 0) {
-    const bestBid = bidsReceived.reduce(maximum(currencyCompare(bid => [bid.cpm, bid.currency])));
-    bidfloor = bestBid.cpm;
-    bidfloorcur = bestBid.currency;
-  } else {
-    const floors = bidRequests.map(bid => typeof bid.getFloor === 'function' && bid.getFloor()).filter(f => f);
-    const minFloor = floors.length && floors.reduce(minimum(currencyCompare(floor => [floor.floor, floor.currency])))
-    bidfloor = minFloor?.floor;
-    bidfloorcur = minFloor?.currency;
-  }
-  const cfg = {};
-  if (bidfloor) {
-    deepSetValue(cfg, 'auctionSignals.prebid.bidfloor', bidfloor);
-    bidfloorcur && deepSetValue(cfg, 'auctionSignals.prebid.bidfloorcur', bidfloorcur);
-  }
-  return cfg;
-}
-
-function onAuctionEnd({auctionId, bidsReceived, bidderRequests}) {
-  try {
-    const allReqs = bidderRequests?.flatMap(br => br.bids);
-    Object.entries(PENDING[auctionId]).forEach(([adUnitCode, auctionConfigs]) => {
-      const forThisAdUnit = (bid) => bid.adUnitCode === adUnitCode;
-      const slotSignals = getSlotSignals(bidsReceived?.filter(forThisAdUnit), allReqs?.filter(forThisAdUnit));
-      setComponentAuction(adUnitCode, auctionConfigs.map(cfg => mergeDeep({}, slotSignals, cfg)))
-    })
-  } finally {
-    delete PENDING[auctionId];
-  }
-}
-
-function setFPDSignals(auctionConfig, fpd) {
-  auctionConfig.auctionSignals = mergeDeep({}, {prebid: fpd}, auctionConfig.auctionSignals);
-}
-
-export function addComponentAuctionHook(next, request, componentAuctionConfig) {
-  const {adUnitCode, auctionId, ortb2, ortb2Imp} = request;
-  if (PENDING.hasOwnProperty(auctionId)) {
-    setFPDSignals(componentAuctionConfig, {ortb2, ortb2Imp});
-    !PENDING[auctionId].hasOwnProperty(adUnitCode) && (PENDING[auctionId][adUnitCode] = []);
-    PENDING[auctionId][adUnitCode].push(componentAuctionConfig);
-  } else {
-    logWarn(MODULE, `Received component auction config for auction that has closed (auction '${auctionId}', adUnit '${adUnitCode}')`, componentAuctionConfig)
-  }
-  next(request, componentAuctionConfig);
-}
-
-function isFledgeSupported() {
-  return 'runAdAuction' in navigator && 'joinAdInterestGroup' in navigator
-}
-
-export function markForFledge(next, bidderRequests) {
-  if (isFledgeSupported()) {
-    const globalFledgeConfig = config.getConfig('fledgeForGpt');
-    const bidders = globalFledgeConfig?.bidders ?? [];
-    bidderRequests.forEach((bidderReq) => {
-      const useGlobalConfig = globalFledgeConfig?.enabled && (bidders.length === 0 || bidders.includes(bidderReq.bidderCode));
-      config.runWithBidder(bidderReq.bidderCode, () => {
-        const fledgeEnabled = config.getConfig('fledgeEnabled') ?? (useGlobalConfig ? globalFledgeConfig.enabled : undefined);
-        const defaultForSlots = config.getConfig('defaultForSlots') ?? (useGlobalConfig ? globalFledgeConfig?.defaultForSlots : undefined);
-        Object.assign(bidderReq, {fledgeEnabled});
-        bidderReq.bids.forEach(bidReq => { deepSetValue(bidReq, 'ortb2Imp.ext.ae', bidReq.ortb2Imp?.ext?.ae ?? defaultForSlots) })
-      })
-    });
-  }
-  next(bidderRequests);
-}
-
-export function setImpExtAe(imp, bidRequest, context) {
-  if (imp.ext?.ae && !context.bidderRequest.fledgeEnabled) {
-    delete imp.ext?.ae;
-  }
-}
-registerOrtbProcessor({type: IMP, name: 'impExtAe', fn: setImpExtAe});
-
-// to make it easier to share code between the PBS adapter and adapters whose backend is PBS, break up
-// fledge response processing in two steps: first aggregate all the auction configs by their imp...
-
-export function parseExtPrebidFledge(response, ortbResponse, context) {
-  (ortbResponse.ext?.prebid?.fledge?.auctionconfigs || []).forEach((cfg) => {
-    const impCtx = context.impContext[cfg.impid];
-    if (!impCtx?.imp?.ext?.ae) {
-      logWarn('Received fledge auction configuration for an impression that was not in the request or did not ask for it', cfg, impCtx?.imp);
-    } else {
-      impCtx.fledgeConfigs = impCtx.fledgeConfigs || [];
-      impCtx.fledgeConfigs.push(cfg);
+export function onAuctionConfigFactory(setGptConfig = setComponentAuction) {
+  return function onAuctionConfig(auctionId, adUnitCode, auctionConfig) {
+    if (autoconfig) {
+      setGptConfig(adUnitCode, auctionConfig.componentAuctions);
     }
-  })
-}
-registerOrtbProcessor({type: RESPONSE, name: 'extPrebidFledge', fn: parseExtPrebidFledge, dialects: [PBS]});
-
-// ...then, make them available in the adapter's response. This is the client side version, for which the
-// interpretResponse api is {fledgeAuctionConfigs: [{bidId, config}]}
-
-export function setResponseFledgeConfigs(response, ortbResponse, context) {
-  const configs = Object.values(context.impContext)
-    .flatMap((impCtx) => (impCtx.fledgeConfigs || []).map(cfg => ({bidId: impCtx.bidRequest.bidId, config: cfg.config})));
-  if (configs.length > 0) {
-    response.fledgeAuctionConfigs = configs;
   }
 }
-registerOrtbProcessor({type: RESPONSE, name: 'fledgeAuctionConfigs', priority: -1, fn: setResponseFledgeConfigs, dialects: [PBS]})
+
+export function setPAAPIConfigFactory(
+  getPAAPIConfig = (filters) => getGlobal().getPAAPIConfig(filters),
+  setGptConfig = setComponentAuction) {
+  return function(filters) {
+    let some = false;
+    Object.entries(
+      getPAAPIConfig(filters) || {}
+    ).forEach(([au, config]) => {
+      some = true;
+      setGptConfig(au, config.componentAuctions);
+    })
+    if (!some) {
+      logInfo(`${MODULE}: No component auctions available to set`);
+    }
+  }
+}
+/**
+ * Configure GPT slots with PAAPI component auctions. Accepts the same filter arguments as `pbjs.getPAAPIConfig`.
+ */
+getGlobal().setPAAPIConfigForGPT = setPAAPIConfigFactory();
+
+submodule('paapi', {
+  name: 'gpt',
+  onAuctionConfig: onAuctionConfigFactory()
+});

--- a/modules/paapi.js
+++ b/modules/paapi.js
@@ -19,6 +19,7 @@ const USED = new WeakSet();
 
 export function registerSubmodule(submod) {
   submodules.push(submod);
+  submod.init && submod.init({getPAAPIConfig});
 }
 
 module('paapi', registerSubmodule);
@@ -91,7 +92,7 @@ function getSlotSignals(bidsReceived = [], bidRequests = []) {
 function onAuctionEnd({auctionId, bidsReceived, bidderRequests, adUnitCodes}) {
   const allReqs = bidderRequests?.flatMap(br => br.bids);
   const paapiConfigs = {};
-  adUnitCodes?.forEach(au => {
+  (adUnitCodes || []).forEach(au => {
     paapiConfigs[au] = null;
     !latestAuctionForAdUnit.hasOwnProperty(au) && (latestAuctionForAdUnit[au] = null);
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "prebid.js",
-      "version": "8.30.0-pre",
+      "version": "8.31.0-pre",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.7",

--- a/test/helpers/indexStub.js
+++ b/test/helpers/indexStub.js
@@ -1,6 +1,6 @@
 import {AuctionIndex} from '../../src/auctionIndex.js';
 
-export function stubAuctionIndex({bidRequests, bidderRequests, adUnits}) {
+export function stubAuctionIndex({bidRequests, bidderRequests, adUnits, auctionId = 'mock-auction'}) {
   if (adUnits == null) {
     adUnits = []
   }
@@ -15,7 +15,7 @@ export function stubAuctionIndex({bidRequests, bidderRequests, adUnits}) {
   }
   const auction = {
     getAuctionId() {
-      return 'mock-auction'
+      return auctionId;
     },
     getBidRequests() {
       return bidderRequests;

--- a/test/spec/modules/fledgeForGpt_spec.js
+++ b/test/spec/modules/fledgeForGpt_spec.js
@@ -120,14 +120,16 @@ describe('fledgeForGpt module', () => {
             afterEach(() => {
               config.resetConfig();
             });
+
             it(`should ${shouldSetConfig ? '' : 'NOT'} set GPT slot configuration`, () => {
               const auctionConfig = {componentAuctions: [{seller: 'mock1'}, {seller: 'mock2'}]};
               const setGptConfig = sinon.stub();
               const markAsUsed = sinon.stub();
-              onAuctionConfigFactory(setGptConfig)('aid', 'au', auctionConfig, markAsUsed);
+              onAuctionConfigFactory(setGptConfig)('aid', {au1: auctionConfig, au2: null}, markAsUsed);
               if (shouldSetConfig) {
-                sinon.assert.calledWith(setGptConfig, 'au', auctionConfig.componentAuctions);
-                sinon.assert.called(markAsUsed);
+                sinon.assert.calledWith(setGptConfig, 'au1', auctionConfig.componentAuctions);
+                sinon.assert.calledWith(setGptConfig, 'au2', []);
+                sinon.assert.calledWith(markAsUsed, 'au1');
               } else {
                 sinon.assert.notCalled(setGptConfig);
                 sinon.assert.notCalled(markAsUsed);

--- a/test/spec/modules/fledgeForGpt_spec.js
+++ b/test/spec/modules/fledgeForGpt_spec.js
@@ -1,419 +1,114 @@
-import {
-  expect
-} from 'chai';
-import * as fledge from 'modules/fledgeForGpt.js';
-import {config} from '../../../src/config.js';
-import adapterManager from '../../../src/adapterManager.js';
-import * as utils from '../../../src/utils.js';
+import {onAuctionConfigFactory, setComponentAuction, setPAAPIConfigFactory} from 'modules/fledgeForGpt.js';
 import * as gptUtils from '../../../libraries/gptUtils/gptUtils.js';
-import {hook} from '../../../src/hook.js';
 import 'modules/appnexusBidAdapter.js';
 import 'modules/rubiconBidAdapter.js';
-import {parseExtPrebidFledge, setImpExtAe, setResponseFledgeConfigs} from 'modules/fledgeForGpt.js';
-import * as events from 'src/events.js';
-import CONSTANTS from 'src/constants.json';
-import {getGlobal} from '../../../src/prebidGlobal.js';
+import {deepSetValue} from '../../../src/utils.js';
+import {config} from 'src/config.js';
 
 describe('fledgeForGpt module', () => {
-  let sandbox;
+  let sandbox, fledgeAuctionConfig;
 
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
+    fledgeAuctionConfig = {
+      seller: 'bidder',
+      mock: 'config'
+    };
   });
   afterEach(() => {
     sandbox.restore();
   });
-  describe('addComponentAuction', function () {
-    before(() => {
-      fledge.init({enabled: true});
+
+  describe('setComponentAuction', () => {
+    let mockGptSlot;
+    beforeEach(() => {
+      mockGptSlot = {
+        setConfig: sinon.stub(),
+        getAdUnitPath: () => 'mock/gpt/au'
+      };
+      sandbox.stub(gptUtils, 'getGptSlotForAdUnitCode').callsFake(() => mockGptSlot);
     });
-
-    const fledgeAuctionConfig = {
-      seller: 'bidder',
-      mock: 'config'
-    };
-
-    describe('addComponentAuctionHook', function () {
-      let nextFnSpy, mockGptSlot;
-      beforeEach(function () {
-        nextFnSpy = sinon.spy();
-        mockGptSlot = {
-          setConfig: sinon.stub(),
-          getAdUnitPath: () => 'mock/gpt/au'
-        };
-        sandbox.stub(gptUtils, 'getGptSlotForAdUnitCode').callsFake(() => mockGptSlot);
+    it('should set GPT slot config', () => {
+      setComponentAuction('au', [fledgeAuctionConfig]);
+      sinon.assert.calledWith(gptUtils.getGptSlotForAdUnitCode, 'au');
+      sinon.assert.calledWith(mockGptSlot.setConfig, {
+        componentAuction: [{
+          configKey: 'bidder',
+          auctionConfig: fledgeAuctionConfig,
+        }]
       });
-
-      it('should call next()', function () {
-        const request = {auctionId: 'aid', adUnitCode: 'auc'};
-        fledge.addComponentAuctionHook(nextFnSpy, request, fledgeAuctionConfig);
-        sinon.assert.calledWith(nextFnSpy, request, fledgeAuctionConfig);
-      });
-
-      it('should collect auction configs and route them to GPT at end of auction', () => {
-        events.emit(CONSTANTS.EVENTS.AUCTION_INIT, {auctionId: 'aid'});
-        const cf1 = {...fledgeAuctionConfig, id: 1, seller: 'b1'};
-        const cf2 = {...fledgeAuctionConfig, id: 2, seller: 'b2'};
-        fledge.addComponentAuctionHook(nextFnSpy, {auctionId: 'aid', adUnitCode: 'au1'}, cf1);
-        fledge.addComponentAuctionHook(nextFnSpy, {auctionId: 'aid', adUnitCode: 'au2'}, cf2);
-        events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId: 'aid'});
-        sinon.assert.calledWith(gptUtils.getGptSlotForAdUnitCode, 'au1');
-        sinon.assert.calledWith(gptUtils.getGptSlotForAdUnitCode, 'au2');
-        sinon.assert.calledWith(mockGptSlot.setConfig, {
-          componentAuction: [{
-            configKey: 'b1',
-            auctionConfig: cf1,
-          }]
-        });
-        sinon.assert.calledWith(mockGptSlot.setConfig, {
-          componentAuction: [{
-            configKey: 'b2',
-            auctionConfig: cf2,
-          }]
-        });
-      });
-
-      it('should drop auction configs after end of auction', () => {
-        events.emit(CONSTANTS.EVENTS.AUCTION_INIT, {auctionId: 'aid'});
-        events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId: 'aid'});
-        fledge.addComponentAuctionHook(nextFnSpy, {auctionId: 'aid', adUnitCode: 'au'}, fledgeAuctionConfig);
-        events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId: 'aid'});
-        sinon.assert.notCalled(mockGptSlot.setConfig);
-      });
-
-      it('should augment auctionSignals with FPD', () => {
-        events.emit(CONSTANTS.EVENTS.AUCTION_INIT, {auctionId: 'aid'});
-        fledge.addComponentAuctionHook(nextFnSpy, {auctionId: 'aid', adUnitCode: 'au1', ortb2: {fpd: 1}, ortb2Imp: {fpd: 2}}, fledgeAuctionConfig);
-        events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId: 'aid'});
-        sinon.assert.calledWith(mockGptSlot.setConfig, {
-          componentAuction: [{
-            configKey: 'bidder',
-            auctionConfig: {
-              ...fledgeAuctionConfig,
-              auctionSignals: {
-                prebid: {
-                  ortb2: {fpd: 1},
-                  ortb2Imp: {fpd: 2}
-                }
-              }
-            },
-          }]
-        })
-      })
-
-      describe('floor signal', () => {
-        before(() => {
-          if (!getGlobal().convertCurrency) {
-            getGlobal().convertCurrency = () => null;
-            getGlobal().convertCurrency.mock = true;
-          }
-        });
-        after(() => {
-          if (getGlobal().convertCurrency.mock) {
-            delete getGlobal().convertCurrency;
-          }
-        });
-
-        beforeEach(() => {
-          sandbox.stub(getGlobal(), 'convertCurrency').callsFake((amount, from, to) => {
-            if (from === to) return amount;
-            if (from === 'USD' && to === 'JPY') return amount * 100;
-            if (from === 'JPY' && to === 'USD') return amount / 100;
-            throw new Error('unexpected currency conversion');
-          });
-        });
-
+    });
+  });
+  describe('onAuctionConfig', () => {
+    [
+      'fledgeForGpt',
+      'paapi.gpt'
+    ].forEach(namespace => {
+      describe(`using ${namespace} config`, () => {
         Object.entries({
-          'bids': (payload, values) => {
-            payload.bidsReceived = values
-              .map((val) => ({adUnitCode: 'au', cpm: val.amount, currency: val.cur}))
-              .concat([{adUnitCode: 'other', cpm: 10000, currency: 'EUR'}])
-          },
-          'no bids': (payload, values) => {
-            payload.bidderRequests = values
-              .map((val) => ({bids: [{adUnitCode: 'au', getFloor: () => ({floor: val.amount, currency: val.cur})}]}))
-              .concat([{bids: {adUnitCode: 'other', getFloor: () => ({floor: -10000, currency: 'EUR'})}}])
-          }
-        }).forEach(([tcase, setup]) => {
-          describe(`when auction has ${tcase}`, () => {
-            Object.entries({
-              'no currencies': {
-                values: [{amount: 1}, {amount: 100}, {amount: 10}, {amount: 100}],
-                'bids': {
-                  bidfloor: 100,
-                  bidfloorcur: undefined
-                },
-                'no bids': {
-                  bidfloor: 1,
-                  bidfloorcur: undefined,
-                }
-              },
-              'only zero values': {
-                values: [{amount: 0, cur: 'USD'}, {amount: 0, cur: 'JPY'}],
-                'bids': {
-                  bidfloor: undefined,
-                  bidfloorcur: undefined,
-                },
-                'no bids': {
-                  bidfloor: undefined,
-                  bidfloorcur: undefined,
-                }
-              },
-              'matching currencies': {
-                values: [{amount: 10, cur: 'JPY'}, {amount: 100, cur: 'JPY'}],
-                'bids': {
-                  bidfloor: 100,
-                  bidfloorcur: 'JPY',
-                },
-                'no bids': {
-                  bidfloor: 10,
-                  bidfloorcur: 'JPY',
-                }
-              },
-              'mixed currencies': {
-                values: [{amount: 10, cur: 'USD'}, {amount: 10, cur: 'JPY'}],
-                'bids': {
-                  bidfloor: 10,
-                  bidfloorcur: 'USD'
-                },
-                'no bids': {
-                  bidfloor: 10,
-                  bidfloorcur: 'JPY',
-                }
-              }
-            }).forEach(([t, testConfig]) => {
-              const values = testConfig.values;
-              const {bidfloor, bidfloorcur} = testConfig[tcase];
-
-              describe(`with ${t}`, () => {
-                let payload;
-                beforeEach(() => {
-                  payload = {auctionId: 'aid'};
-                  setup(payload, values);
-                });
-
-                it('should populate bidfloor/bidfloorcur', () => {
-                  events.emit(CONSTANTS.EVENTS.AUCTION_INIT, {auctionId: 'aid'});
-                  fledge.addComponentAuctionHook(nextFnSpy, {auctionId: 'aid', adUnitCode: 'au'}, fledgeAuctionConfig);
-                  events.emit(CONSTANTS.EVENTS.AUCTION_END, payload);
-                  sinon.assert.calledWith(mockGptSlot.setConfig, sinon.match(arg => {
-                    return arg.componentAuction.some(au => au.auctionConfig.auctionSignals?.prebid?.bidfloor === bidfloor && au.auctionConfig.auctionSignals?.prebid?.bidfloorcur === bidfloorcur)
-                  }))
-                })
-              });
+          'omitted': [undefined, true],
+          'enabled': [true, true],
+          'disabled': [false, false]
+        }).forEach(([t, [autoconfig, shouldSetConfig]]) => {
+          describe(`when autoconfig is ${t}`, () => {
+            beforeEach(() => {
+              const cfg = {};
+              deepSetValue(cfg, `${namespace}.autoconfig`, autoconfig);
+              config.setConfig(cfg);
             });
+            afterEach(() => {
+              config.resetConfig();
+            });
+            it(`should ${shouldSetConfig ? '' : 'NOT'} set GPT slot configuration`, () => {
+              const auctionConfig = {componentAuctions: ['mock1', 'mock2']};
+              const setGptConfig = sinon.stub();
+              onAuctionConfigFactory(setGptConfig)('aid', 'au', auctionConfig);
+              if (shouldSetConfig) {
+                sinon.assert.calledWith(setGptConfig, 'au', auctionConfig.componentAuctions);
+              } else {
+                sinon.assert.notCalled(setGptConfig);
+              }
+            })
           })
         })
-      });
-    });
+      })
+    })
   });
-
-  describe('fledgeEnabled', function () {
-    const navProps = Object.fromEntries(['runAdAuction', 'joinAdInterestGroup'].map(p => [p, navigator[p]]));
-
-    before(function () {
-      // navigator.runAdAuction & co may not exist, so we can't stub it normally with
-      // sinon.stub(navigator, 'runAdAuction') or something
-      Object.keys(navProps).forEach(p => {
-        navigator[p] = sinon.stub();
-      });
-      hook.ready();
+  describe('setPAAPIConfigForGpt', () => {
+    let getPAAPIConfig, setGptConfig, setPAAPIConfigForGPT;
+    beforeEach(() => {
+      getPAAPIConfig = sinon.stub();
+      setGptConfig = sinon.stub();
+      setPAAPIConfigForGPT = setPAAPIConfigFactory(getPAAPIConfig, setGptConfig);
     });
 
-    after(function () {
-      Object.entries(navProps).forEach(([p, orig]) => navigator[p] = orig);
-    });
-
-    afterEach(function () {
-      config.resetConfig();
-    });
-
-    const adUnits = [{
-      'code': '/19968336/header-bid-tag1',
-      'mediaTypes': {
-        'banner': {
-          'sizes': [[728, 90]]
-        },
-      },
-      'bids': [
-        {
-          'bidder': 'appnexus',
-        },
-        {
-          'bidder': 'rubicon',
-        },
-      ]
-    }];
-    function expectFledgeFlags(...enableFlags) {
-      const bidRequests = adapterManager.makeBidRequests(
-        adUnits,
-        Date.now(),
-        utils.getUniqueIdentifierStr(),
-        function callback() {
-        },
-        []
-      );
-
-      expect(bidRequests[0].bids[0].bidder).equals('appnexus');
-      expect(bidRequests[0].fledgeEnabled).to.eql(enableFlags[0].enabled)
-      bidRequests[0].bids.forEach(bid => expect(bid.ortb2Imp.ext.ae).to.eql(enableFlags[0].ae))
-
-      expect(bidRequests[1].bids[0].bidder).equals('rubicon');
-      expect(bidRequests[1].fledgeEnabled).to.eql(enableFlags[1].enabled)
-      bidRequests[1].bids.forEach(bid => expect(bid.ortb2Imp?.ext?.ae).to.eql(enableFlags[1].ae));
-    }
-
-    describe('with setBidderConfig()', () => {
-      it('should set fledgeEnabled correctly per bidder', function () {
-        config.setConfig({bidderSequence: 'fixed'});
-        config.setBidderConfig({
-          bidders: ['appnexus'],
-          config: {
-            fledgeEnabled: true,
-            defaultForSlots: 1,
-          }
-        });
-        expectFledgeFlags({enabled: true, ae: 1}, {enabled: void 0, ae: void 0});
-      });
-    });
-
-    describe('with setConfig()', () => {
-      it('should set fledgeEnabled correctly per bidder', function () {
-        config.setConfig({
-          bidderSequence: 'fixed',
-          fledgeForGpt: {
-            enabled: true,
-            bidders: ['appnexus'],
-            defaultForSlots: 1,
-          }
-        });
-        expectFledgeFlags({enabled: true, ae: 1}, {enabled: void 0, ae: void 0});
-      });
-
-      it('should set fledgeEnabled correctly for all bidders', function () {
-        config.setConfig({
-          bidderSequence: 'fixed',
-          fledgeForGpt: {
-            enabled: true,
-            defaultForSlots: 1,
-          }
-        });
-        expectFledgeFlags({enabled: true, ae: 1}, {enabled: true, ae: 1});
-      });
-
-      it('should not override pub-defined ext.ae', () => {
-        config.setConfig({
-          bidderSequence: 'fixed',
-          fledgeForGpt: {
-            enabled: true,
-            defaultForSlots: 1,
-          }
-        });
-        Object.assign(adUnits[0], {ortb2Imp: {ext: {ae: 0}}});
-        expectFledgeFlags({enabled: true, ae: 0}, {enabled: true, ae: 0});
+    Object.entries({
+      missing: null,
+      empty: {}
+    }).forEach(([t, configs]) => {
+      it(`does not set GPT slot config when config is ${t}`, () => {
+        getPAAPIConfig.returns(configs);
+        setPAAPIConfigForGPT('mock-filters');
+        sinon.assert.calledWith(getPAAPIConfig, 'mock-filters');
+        sinon.assert.notCalled(setGptConfig);
       })
     });
-  });
 
-  describe('ortb processors for fledge', () => {
-    it('imp.ext.ae should be removed if fledge is not enabled', () => {
-      const imp = {ext: {ae: 1}};
-      setImpExtAe(imp, {}, {bidderRequest: {}});
-      expect(imp.ext.ae).to.not.exist;
-    });
-    it('imp.ext.ae should be left intact if fledge is enabled', () => {
-      const imp = {ext: {ae: 2}};
-      setImpExtAe(imp, {}, {bidderRequest: {fledgeEnabled: true}});
-      expect(imp.ext.ae).to.equal(2);
-    });
-    describe('parseExtPrebidFledge', () => {
-      function packageConfigs(configs) {
-        return {
-          ext: {
-            prebid: {
-              fledge: {
-                auctionconfigs: configs
-              }
-            }
-          }
-        };
+    it('sets GPT slot config for each ad unit that has PAAPI config', () => {
+      const cfg = {
+        au1: {
+          componentAuctions: ['a1', 'a2']
+        },
+        au2: {
+          componentAuctions: ['a3']
+        }
       }
-
-      function generateImpCtx(fledgeFlags) {
-        return Object.fromEntries(Object.entries(fledgeFlags).map(([impid, fledgeEnabled]) => [impid, {imp: {ext: {ae: fledgeEnabled}}}]));
-      }
-
-      function generateCfg(impid, ...ids) {
-        return ids.map((id) => ({impid, config: {id}}));
-      }
-
-      function extractResult(ctx) {
-        return Object.fromEntries(
-          Object.entries(ctx)
-            .map(([impid, ctx]) => [impid, ctx.fledgeConfigs?.map(cfg => cfg.config.id)])
-            .filter(([_, val]) => val != null)
-        );
-      }
-
-      it('should collect fledge configs by imp', () => {
-        const ctx = {
-          impContext: generateImpCtx({e1: 1, e2: 1, d1: 0})
-        };
-        const resp = packageConfigs(
-          generateCfg('e1', 1, 2, 3)
-            .concat(generateCfg('e2', 4)
-              .concat(generateCfg('d1', 5, 6)))
-        );
-        parseExtPrebidFledge({}, resp, ctx);
-        expect(extractResult(ctx.impContext)).to.eql({
-          e1: [1, 2, 3],
-          e2: [4],
-        });
-      });
-      it('should not choke if fledge config references unknown imp', () => {
-        const ctx = {impContext: generateImpCtx({i: 1})};
-        const resp = packageConfigs(generateCfg('unknown', 1));
-        parseExtPrebidFledge({}, resp, ctx);
-        expect(extractResult(ctx.impContext)).to.eql({});
-      });
-    });
-    describe('setResponseFledgeConfigs', () => {
-      it('should set fledgeAuctionConfigs paired with their corresponding bid id', () => {
-        const ctx = {
-          impContext: {
-            1: {
-              bidRequest: {bidId: 'bid1'},
-              fledgeConfigs: [{config: {id: 1}}, {config: {id: 2}}]
-            },
-            2: {
-              bidRequest: {bidId: 'bid2'},
-              fledgeConfigs: [{config: {id: 3}}]
-            },
-            3: {
-              bidRequest: {bidId: 'bid3'}
-            }
-          }
-        };
-        const resp = {};
-        setResponseFledgeConfigs(resp, {}, ctx);
-        expect(resp.fledgeAuctionConfigs).to.eql([
-          {bidId: 'bid1', config: {id: 1}},
-          {bidId: 'bid1', config: {id: 2}},
-          {bidId: 'bid2', config: {id: 3}},
-        ]);
-      });
-      it('should not set fledgeAuctionConfigs if none exist', () => {
-        const resp = {};
-        setResponseFledgeConfigs(resp, {}, {
-          impContext: {
-            1: {
-              fledgeConfigs: []
-            },
-            2: {}
-          }
-        });
-        expect(resp).to.eql({});
-      });
-    });
-  });
+      getPAAPIConfig.returns(cfg);
+      setPAAPIConfigForGPT('mock-filters');
+      sinon.assert.calledWith(getPAAPIConfig, 'mock-filters');
+      Object.entries(cfg).forEach(([au, config]) => {
+        sinon.assert.calledWith(setGptConfig, au, config.componentAuctions);
+      })
+    })
+  })
 });

--- a/test/spec/modules/fledgeForGpt_spec.js
+++ b/test/spec/modules/fledgeForGpt_spec.js
@@ -204,5 +204,16 @@ describe('fledgeForGpt module', () => {
       sinon.assert.calledOnce(setGptConfig);
       sinon.assert.calledWith(setGptConfig, 'au1', [], true);
     });
+
+    it('does not reset untouched slots if filtering by auction', () => {
+      getSlots.returns(['au1', 'au2']);
+      getPAAPIConfig.returns({
+        au1: {
+          componentAuctions: [{seller: 's1'}]
+        }
+      });
+      setPAAPIConfigForGPT({auctionId: 'any-auction'});
+      sinon.assert.neverCalledWith(setGptConfig, 'au2');
+    })
   })
 });

--- a/test/spec/modules/fledgeForGpt_spec.js
+++ b/test/spec/modules/fledgeForGpt_spec.js
@@ -163,6 +163,47 @@ describe('fledgeForGpt module', () => {
         })
       });
 
+      it('only resets sellers that have no fresh config', () => {
+        getPAAPIConfig.returns({
+          au1: {
+            componentAuctions: [{seller: 's1'}, {seller: 's2'}]
+          }
+        });
+        setPAAPIConfigForGPT();
+        setGptConfig.resetHistory();
+        getPAAPIConfig.returns({
+          au1: {
+            componentAuctions: [{seller: 's1'}]
+          }
+        });
+        setPAAPIConfigForGPT({reuse: false})
+        sinon.assert.calledWith(setGptConfig, 'au1', {
+          s1: {seller: 's1'},
+          s2: null
+        })
+      });
+
+      it('does not reset slots that have already been reset', () => {
+        getPAAPIConfig.returns({
+          au1: {
+            componentAuctions: [{seller: 's1'}]
+          },
+          au2: {
+            componentAuctions: [{seller: 's1'}]
+          }
+        });
+        setPAAPIConfigForGPT();
+        getPAAPIConfig.returns({});
+        setPAAPIConfigForGPT({adUnitCode: 'au1', reuse: false});
+        setGptConfig.resetHistory();
+        setPAAPIConfigForGPT({adUnitCode: 'au1', reuse: false});
+        sinon.assert.notCalled(setGptConfig);
+        setPAAPIConfigForGPT({reuse: false});
+        sinon.assert.calledWith(setGptConfig, 'au2', {
+          s1: null
+        })
+      })
+
       it('only resets the given adUnit', () => {
         getPAAPIConfig.returns({
           au1: {

--- a/test/spec/modules/paapi_spec.js
+++ b/test/spec/modules/paapi_spec.js
@@ -1,0 +1,484 @@
+import {
+  expect
+} from 'chai';
+import {config} from '../../../src/config.js';
+import adapterManager from '../../../src/adapterManager.js';
+import * as utils from '../../../src/utils.js';
+import {hook} from '../../../src/hook.js';
+import 'modules/appnexusBidAdapter.js';
+import 'modules/rubiconBidAdapter.js';
+import {
+  parseExtPrebidFledge,
+  setImpExtAe,
+  setResponseFledgeConfigs,
+  addComponentAuctionHook,
+  getPAAPIConfig
+} from 'modules/paapi.js';
+import * as events from 'src/events.js';
+import CONSTANTS from 'src/constants.json';
+import {getGlobal} from '../../../src/prebidGlobal.js';
+import {auctionManager} from '../../../src/auctionManager.js';
+import {stubAuctionIndex} from '../../helpers/indexStub.js';
+import {AuctionIndex} from '../../../src/auctionIndex.js';
+
+describe('paapi module', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('getPAAPIConfig', function () {
+    before(() => {
+      config.setConfig({fledgeForGpt: {enabled: true}})
+    });
+    let nextFnSpy, fledgeAuctionConfig;
+
+    beforeEach(() => {
+      fledgeAuctionConfig = {
+        seller: 'bidder',
+        mock: 'config'
+      };
+      nextFnSpy = sinon.spy();
+    })
+
+    describe('on a single auction', function () {
+      const auctionId = 'aid';
+      beforeEach(function () {
+        sandbox.stub(auctionManager, 'index').value(stubAuctionIndex({auctionId}))
+      });
+
+      it('should call next()', function () {
+        const request = {auctionId, adUnitCode: 'auc'};
+        addComponentAuctionHook(nextFnSpy, request, fledgeAuctionConfig);
+        sinon.assert.calledWith(nextFnSpy, request, fledgeAuctionConfig);
+      });
+
+      describe('should collect auction configs', () => {
+        let cf1, cf2;
+        beforeEach(() => {
+          cf1 = {...fledgeAuctionConfig, id: 1, seller: 'b1'};
+          cf2 = {...fledgeAuctionConfig, id: 2, seller: 'b2'};
+          addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode: 'au1'}, cf1);
+          addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode: 'au2'}, cf2);
+          events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId});
+        });
+
+        it('and make them available at end of auction', () => {
+          sinon.assert.match(getPAAPIConfig({auctionId}), {
+            au1: {
+              componentAuctions: [cf1]
+            },
+            au2: {
+              componentAuctions: [cf2]
+            }
+          })
+        });
+
+        it('and filter them by ad unit', () => {
+          const cfg = getPAAPIConfig({auctionId, adUnitCode: 'au1'});
+          expect(Object.keys(cfg)).to.have.members(['au1']);
+          sinon.assert.match(cfg.au1, {
+            componentAuctions: [cf1]
+          })
+        })
+      })
+
+      it('should drop auction configs after end of auction', () => {
+        events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId});
+        addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode: 'au'}, fledgeAuctionConfig);
+        events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId});
+        expect(getPAAPIConfig({auctionId})).to.eql({});
+      });
+
+      it('should augment auctionSignals with FPD', () => {
+        addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode: 'au1', ortb2: {fpd: 1}, ortb2Imp: {fpd: 2}}, fledgeAuctionConfig);
+        events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId});
+        sinon.assert.match(getPAAPIConfig({auctionId}), {
+          au1: {
+            componentAuctions: [{
+              ...fledgeAuctionConfig,
+              auctionSignals: {
+                prebid: {
+                  ortb2: {fpd: 1},
+                  ortb2Imp: {fpd: 2}
+                }
+              }
+            }]
+          }
+        })
+      })
+
+      describe('floor signal', () => {
+        before(() => {
+          if (!getGlobal().convertCurrency) {
+            getGlobal().convertCurrency = () => null;
+            getGlobal().convertCurrency.mock = true;
+          }
+        });
+        after(() => {
+          if (getGlobal().convertCurrency.mock) {
+            delete getGlobal().convertCurrency;
+          }
+        });
+
+        beforeEach(() => {
+          sandbox.stub(getGlobal(), 'convertCurrency').callsFake((amount, from, to) => {
+            if (from === to) return amount;
+            if (from === 'USD' && to === 'JPY') return amount * 100;
+            if (from === 'JPY' && to === 'USD') return amount / 100;
+            throw new Error('unexpected currency conversion');
+          });
+        });
+
+        Object.entries({
+          'bids': (payload, values) => {
+            payload.bidsReceived = values
+              .map((val) => ({adUnitCode: 'au', cpm: val.amount, currency: val.cur}))
+              .concat([{adUnitCode: 'other', cpm: 10000, currency: 'EUR'}])
+          },
+          'no bids': (payload, values) => {
+            payload.bidderRequests = values
+              .map((val) => ({bids: [{adUnitCode: 'au', getFloor: () => ({floor: val.amount, currency: val.cur})}]}))
+              .concat([{bids: {adUnitCode: 'other', getFloor: () => ({floor: -10000, currency: 'EUR'})}}])
+          }
+        }).forEach(([tcase, setup]) => {
+          describe(`when auction has ${tcase}`, () => {
+            Object.entries({
+              'no currencies': {
+                values: [{amount: 1}, {amount: 100}, {amount: 10}, {amount: 100}],
+                'bids': {
+                  bidfloor: 100,
+                  bidfloorcur: undefined
+                },
+                'no bids': {
+                  bidfloor: 1,
+                  bidfloorcur: undefined,
+                }
+              },
+              'only zero values': {
+                values: [{amount: 0, cur: 'USD'}, {amount: 0, cur: 'JPY'}],
+                'bids': {
+                  bidfloor: undefined,
+                  bidfloorcur: undefined,
+                },
+                'no bids': {
+                  bidfloor: undefined,
+                  bidfloorcur: undefined,
+                }
+              },
+              'matching currencies': {
+                values: [{amount: 10, cur: 'JPY'}, {amount: 100, cur: 'JPY'}],
+                'bids': {
+                  bidfloor: 100,
+                  bidfloorcur: 'JPY',
+                },
+                'no bids': {
+                  bidfloor: 10,
+                  bidfloorcur: 'JPY',
+                }
+              },
+              'mixed currencies': {
+                values: [{amount: 10, cur: 'USD'}, {amount: 10, cur: 'JPY'}],
+                'bids': {
+                  bidfloor: 10,
+                  bidfloorcur: 'USD'
+                },
+                'no bids': {
+                  bidfloor: 10,
+                  bidfloorcur: 'JPY',
+                }
+              }
+            }).forEach(([t, testConfig]) => {
+              const values = testConfig.values;
+              const {bidfloor, bidfloorcur} = testConfig[tcase];
+
+              describe(`with ${t}`, () => {
+                let payload;
+                beforeEach(() => {
+                  payload = {auctionId};
+                  setup(payload, values);
+                });
+
+                it('should populate bidfloor/bidfloorcur', () => {
+                  addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode: 'au'}, fledgeAuctionConfig);
+                  events.emit(CONSTANTS.EVENTS.AUCTION_END, payload);
+                  const signals = getPAAPIConfig({auctionId}).au.componentAuctions[0].auctionSignals;
+                  expect(signals.prebid?.bidfloor).to.eql(bidfloor);
+                  expect(signals.prebid?.bidfloorcur).to.eql(bidfloorcur);
+                })
+              });
+            });
+          })
+        })
+      });
+    });
+
+    describe('with multiple auctions', () => {
+      const AUCTION1 = 'auction1';
+      const AUCTION2 = 'auction2';
+      function mockAuction(auctionId) {
+        return {
+          getAuctionId() {
+            return auctionId;
+          }
+        }
+      }
+
+      function expectAdUnitsFromAuctions(actualConfig, auToAuctionMap) {
+        expect(Object.keys(actualConfig)).to.have.members(Object.keys(auToAuctionMap));
+        Object.entries(actualConfig).forEach(([au, cfg]) => {
+          cfg.componentAuctions.forEach(cmp => expect(cmp.auctionId).to.eql(auToAuctionMap[au]));
+        })
+      }
+
+      let configs;
+      beforeEach(() => {
+        const mockAuctions = [mockAuction(AUCTION1), mockAuction(AUCTION2)];
+        sandbox.stub(auctionManager, 'index').value(new AuctionIndex(() => mockAuctions));
+        configs = {[AUCTION1]: {}, [AUCTION2]: {}}
+        Object.entries({
+          [AUCTION1]: ['au1', 'au2'],
+          [AUCTION2]: ['au2', 'au3'],
+        }).forEach(([auctionId, adUnitCodes]) => {
+          adUnitCodes.forEach(adUnitCode => {
+            const cfg = {...fledgeAuctionConfig, auctionId, adUnitCode};
+            configs[auctionId][adUnitCode] = cfg;
+            addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode}, cfg);
+          });
+          events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId});
+        })
+      });
+
+      it('should filter by auction', () => {
+        expectAdUnitsFromAuctions(getPAAPIConfig({auctionId: AUCTION1}), {au1: AUCTION1, au2: AUCTION1});
+        expectAdUnitsFromAuctions(getPAAPIConfig({auctionId: AUCTION2}), {au2: AUCTION2, au3: AUCTION2});
+      });
+
+      it('should filter by auction and ad unit', () => {
+        expectAdUnitsFromAuctions(getPAAPIConfig({auctionId: AUCTION1, adUnitCode: 'au2'}), {au2: AUCTION1});
+        expectAdUnitsFromAuctions(getPAAPIConfig({auctionId: AUCTION2, adUnitCode: 'au2'}), {au2: AUCTION2});
+      })
+
+      it('should use last auction for each ad unit', () => {
+        expectAdUnitsFromAuctions(getPAAPIConfig(), {au1: AUCTION1, au2: AUCTION2, au3: AUCTION2});
+      });
+
+      it('should filter by ad unit and use latest auction', () => {
+        expectAdUnitsFromAuctions(getPAAPIConfig({adUnitCode: 'au2'}), {au2: AUCTION2});
+      })
+    })
+  });
+
+  describe('markForFledge', function () {
+    const navProps = Object.fromEntries(['runAdAuction', 'joinAdInterestGroup'].map(p => [p, navigator[p]]));
+
+    before(function () {
+      // navigator.runAdAuction & co may not exist, so we can't stub it normally with
+      // sinon.stub(navigator, 'runAdAuction') or something
+      Object.keys(navProps).forEach(p => {
+        navigator[p] = sinon.stub();
+      });
+      hook.ready();
+      config.resetConfig();
+    });
+
+    after(function () {
+      Object.entries(navProps).forEach(([p, orig]) => navigator[p] = orig);
+    });
+
+    afterEach(function () {
+      config.resetConfig();
+    });
+
+    const adUnits = [{
+      'code': '/19968336/header-bid-tag1',
+      'mediaTypes': {
+        'banner': {
+          'sizes': [[728, 90]]
+        },
+      },
+      'bids': [
+        {
+          'bidder': 'appnexus',
+        },
+        {
+          'bidder': 'rubicon',
+        },
+      ]
+    }];
+    function expectFledgeFlags(...enableFlags) {
+      const bidRequests = Object.fromEntries(
+        adapterManager.makeBidRequests(
+          adUnits,
+          Date.now(),
+          utils.getUniqueIdentifierStr(),
+          function callback() {
+          },
+          []
+        ).map(b => [b.bidderCode, b])
+      );
+
+      expect(bidRequests.appnexus.fledgeEnabled).to.eql(enableFlags[0].enabled)
+      bidRequests.appnexus.bids.forEach(bid => expect(bid.ortb2Imp.ext.ae).to.eql(enableFlags[0].ae))
+
+      expect(bidRequests.rubicon.fledgeEnabled).to.eql(enableFlags[1].enabled)
+      bidRequests.rubicon.bids.forEach(bid => expect(bid.ortb2Imp?.ext?.ae).to.eql(enableFlags[1].ae));
+    }
+
+    describe('with setBidderConfig()', () => {
+      it('should set fledgeEnabled correctly per bidder', function () {
+        config.setBidderConfig({
+          bidders: ['appnexus'],
+          config: {
+            defaultForSlots: 1,
+            fledgeEnabled: true
+          }
+        });
+        expectFledgeFlags({enabled: true, ae: 1}, {enabled: void 0, ae: void 0});
+      });
+    });
+
+    describe('with setConfig()', () => {
+      it('should set fledgeEnabled correctly per bidder', function () {
+        config.setConfig({
+          bidderSequence: 'fixed',
+          fledgeForGpt: {
+            enabled: true,
+            bidders: ['appnexus'],
+            defaultForSlots: 1,
+          }
+        });
+        expectFledgeFlags({enabled: true, ae: 1}, {enabled: false, ae: undefined});
+      });
+
+      it('should set fledgeEnabled correctly for all bidders', function () {
+        config.setConfig({
+          bidderSequence: 'fixed',
+          fledgeForGpt: {
+            enabled: true,
+            defaultForSlots: 1,
+          }
+        });
+        expectFledgeFlags({enabled: true, ae: 1}, {enabled: true, ae: 1});
+      });
+
+      it('should not override pub-defined ext.ae', () => {
+        config.setConfig({
+          bidderSequence: 'fixed',
+          fledgeForGpt: {
+            enabled: true,
+            defaultForSlots: 1,
+          }
+        });
+        Object.assign(adUnits[0], {ortb2Imp: {ext: {ae: 0}}});
+        expectFledgeFlags({enabled: true, ae: 0}, {enabled: true, ae: 0});
+      })
+    });
+  });
+
+  describe('ortb processors for fledge', () => {
+    it('imp.ext.ae should be removed if fledge is not enabled', () => {
+      const imp = {ext: {ae: 1}};
+      setImpExtAe(imp, {}, {bidderRequest: {}});
+      expect(imp.ext.ae).to.not.exist;
+    });
+    it('imp.ext.ae should be left intact if fledge is enabled', () => {
+      const imp = {ext: {ae: 2}};
+      setImpExtAe(imp, {}, {bidderRequest: {fledgeEnabled: true}});
+      expect(imp.ext.ae).to.equal(2);
+    });
+    describe('parseExtPrebidFledge', () => {
+      function packageConfigs(configs) {
+        return {
+          ext: {
+            prebid: {
+              fledge: {
+                auctionconfigs: configs
+              }
+            }
+          }
+        };
+      }
+
+      function generateImpCtx(fledgeFlags) {
+        return Object.fromEntries(Object.entries(fledgeFlags).map(([impid, fledgeEnabled]) => [impid, {imp: {ext: {ae: fledgeEnabled}}}]));
+      }
+
+      function generateCfg(impid, ...ids) {
+        return ids.map((id) => ({impid, config: {id}}));
+      }
+
+      function extractResult(ctx) {
+        return Object.fromEntries(
+          Object.entries(ctx)
+            .map(([impid, ctx]) => [impid, ctx.fledgeConfigs?.map(cfg => cfg.config.id)])
+            .filter(([_, val]) => val != null)
+        );
+      }
+
+      it('should collect fledge configs by imp', () => {
+        const ctx = {
+          impContext: generateImpCtx({e1: 1, e2: 1, d1: 0})
+        };
+        const resp = packageConfigs(
+          generateCfg('e1', 1, 2, 3)
+            .concat(generateCfg('e2', 4)
+              .concat(generateCfg('d1', 5, 6)))
+        );
+        parseExtPrebidFledge({}, resp, ctx);
+        expect(extractResult(ctx.impContext)).to.eql({
+          e1: [1, 2, 3],
+          e2: [4],
+        });
+      });
+      it('should not choke if fledge config references unknown imp', () => {
+        const ctx = {impContext: generateImpCtx({i: 1})};
+        const resp = packageConfigs(generateCfg('unknown', 1));
+        parseExtPrebidFledge({}, resp, ctx);
+        expect(extractResult(ctx.impContext)).to.eql({});
+      });
+    });
+    describe('setResponseFledgeConfigs', () => {
+      it('should set fledgeAuctionConfigs paired with their corresponding bid id', () => {
+        const ctx = {
+          impContext: {
+            1: {
+              bidRequest: {bidId: 'bid1'},
+              fledgeConfigs: [{config: {id: 1}}, {config: {id: 2}}]
+            },
+            2: {
+              bidRequest: {bidId: 'bid2'},
+              fledgeConfigs: [{config: {id: 3}}]
+            },
+            3: {
+              bidRequest: {bidId: 'bid3'}
+            }
+          }
+        };
+        const resp = {};
+        setResponseFledgeConfigs(resp, {}, ctx);
+        expect(resp.fledgeAuctionConfigs).to.eql([
+          {bidId: 'bid1', config: {id: 1}},
+          {bidId: 'bid1', config: {id: 2}},
+          {bidId: 'bid2', config: {id: 3}},
+        ]);
+      });
+      it('should not set fledgeAuctionConfigs if none exist', () => {
+        const resp = {};
+        setResponseFledgeConfigs(resp, {}, {
+          impContext: {
+            1: {
+              fledgeConfigs: []
+            },
+            2: {}
+          }
+        });
+        expect(resp).to.eql({});
+      });
+    });
+  });
+});

--- a/test/spec/modules/paapi_spec.js
+++ b/test/spec/modules/paapi_spec.js
@@ -1,6 +1,4 @@
-import {
-  expect
-} from 'chai';
+import {expect} from 'chai';
 import {config} from '../../../src/config.js';
 import adapterManager from '../../../src/adapterManager.js';
 import * as utils from '../../../src/utils.js';
@@ -8,11 +6,13 @@ import {hook} from '../../../src/hook.js';
 import 'modules/appnexusBidAdapter.js';
 import 'modules/rubiconBidAdapter.js';
 import {
+  addComponentAuctionHook,
+  getPAAPIConfig,
   parseExtPrebidFledge,
+  registerSubmodule,
   setImpExtAe,
   setResponseFledgeConfigs,
-  addComponentAuctionHook,
-  getPAAPIConfig
+  unregister
 } from 'modules/paapi.js';
 import * as events from 'src/events.js';
 import CONSTANTS from 'src/constants.json';
@@ -23,7 +23,6 @@ import {AuctionIndex} from '../../../src/auctionIndex.js';
 
 describe('paapi module', () => {
   let sandbox;
-
   beforeEach(() => {
     sandbox = sinon.sandbox.create();
   });
@@ -31,352 +30,402 @@ describe('paapi module', () => {
     sandbox.restore();
   });
 
-  describe('getPAAPIConfig', function () {
-    before(() => {
-      config.setConfig({fledgeForGpt: {enabled: true}})
-    });
-    let nextFnSpy, fledgeAuctionConfig;
-
-    beforeEach(() => {
-      fledgeAuctionConfig = {
-        seller: 'bidder',
-        mock: 'config'
-      };
-      nextFnSpy = sinon.spy();
-    })
-
-    describe('on a single auction', function () {
-      const auctionId = 'aid';
-      beforeEach(function () {
-        sandbox.stub(auctionManager, 'index').value(stubAuctionIndex({auctionId}))
-      });
-
-      it('should call next()', function () {
-        const request = {auctionId, adUnitCode: 'auc'};
-        addComponentAuctionHook(nextFnSpy, request, fledgeAuctionConfig);
-        sinon.assert.calledWith(nextFnSpy, request, fledgeAuctionConfig);
-      });
-
-      describe('should collect auction configs', () => {
-        let cf1, cf2;
-        beforeEach(() => {
-          cf1 = {...fledgeAuctionConfig, id: 1, seller: 'b1'};
-          cf2 = {...fledgeAuctionConfig, id: 2, seller: 'b2'};
-          addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode: 'au1'}, cf1);
-          addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode: 'au2'}, cf2);
-          events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId});
-        });
-
-        it('and make them available at end of auction', () => {
-          sinon.assert.match(getPAAPIConfig({auctionId}), {
-            au1: {
-              componentAuctions: [cf1]
-            },
-            au2: {
-              componentAuctions: [cf2]
-            }
-          })
-        });
-
-        it('and filter them by ad unit', () => {
-          const cfg = getPAAPIConfig({auctionId, adUnitCode: 'au1'});
-          expect(Object.keys(cfg)).to.have.members(['au1']);
-          sinon.assert.match(cfg.au1, {
-            componentAuctions: [cf1]
-          })
-        })
-      })
-
-      it('should drop auction configs after end of auction', () => {
-        events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId});
-        addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode: 'au'}, fledgeAuctionConfig);
-        events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId});
-        expect(getPAAPIConfig({auctionId})).to.eql({});
-      });
-
-      it('should augment auctionSignals with FPD', () => {
-        addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode: 'au1', ortb2: {fpd: 1}, ortb2Imp: {fpd: 2}}, fledgeAuctionConfig);
-        events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId});
-        sinon.assert.match(getPAAPIConfig({auctionId}), {
-          au1: {
-            componentAuctions: [{
-              ...fledgeAuctionConfig,
-              auctionSignals: {
-                prebid: {
-                  ortb2: {fpd: 1},
-                  ortb2Imp: {fpd: 2}
-                }
-              }
-            }]
-          }
-        })
-      })
-
-      describe('floor signal', () => {
+  [
+    'fledgeForGpt',
+    'paapi'
+  ].forEach(configNS => {
+    describe(`using ${configNS} for configuration`, () => {
+      describe('getPAAPIConfig', function () {
+        let nextFnSpy, fledgeAuctionConfig;
         before(() => {
-          if (!getGlobal().convertCurrency) {
-            getGlobal().convertCurrency = () => null;
-            getGlobal().convertCurrency.mock = true;
-          }
+          config.setConfig({[configNS]: {enabled: true}});
         });
-        after(() => {
-          if (getGlobal().convertCurrency.mock) {
-            delete getGlobal().convertCurrency;
-          }
-        });
-
         beforeEach(() => {
-          sandbox.stub(getGlobal(), 'convertCurrency').callsFake((amount, from, to) => {
-            if (from === to) return amount;
-            if (from === 'USD' && to === 'JPY') return amount * 100;
-            if (from === 'JPY' && to === 'USD') return amount / 100;
-            throw new Error('unexpected currency conversion');
-          });
+          fledgeAuctionConfig = {
+            seller: 'bidder',
+            mock: 'config'
+          };
+          nextFnSpy = sinon.spy();
         });
 
-        Object.entries({
-          'bids': (payload, values) => {
-            payload.bidsReceived = values
-              .map((val) => ({adUnitCode: 'au', cpm: val.amount, currency: val.cur}))
-              .concat([{adUnitCode: 'other', cpm: 10000, currency: 'EUR'}])
-          },
-          'no bids': (payload, values) => {
-            payload.bidderRequests = values
-              .map((val) => ({bids: [{adUnitCode: 'au', getFloor: () => ({floor: val.amount, currency: val.cur})}]}))
-              .concat([{bids: {adUnitCode: 'other', getFloor: () => ({floor: -10000, currency: 'EUR'})}}])
-          }
-        }).forEach(([tcase, setup]) => {
-          describe(`when auction has ${tcase}`, () => {
-            Object.entries({
-              'no currencies': {
-                values: [{amount: 1}, {amount: 100}, {amount: 10}, {amount: 100}],
-                'bids': {
-                  bidfloor: 100,
-                  bidfloorcur: undefined
-                },
-                'no bids': {
-                  bidfloor: 1,
-                  bidfloorcur: undefined,
-                }
-              },
-              'only zero values': {
-                values: [{amount: 0, cur: 'USD'}, {amount: 0, cur: 'JPY'}],
-                'bids': {
-                  bidfloor: undefined,
-                  bidfloorcur: undefined,
-                },
-                'no bids': {
-                  bidfloor: undefined,
-                  bidfloorcur: undefined,
-                }
-              },
-              'matching currencies': {
-                values: [{amount: 10, cur: 'JPY'}, {amount: 100, cur: 'JPY'}],
-                'bids': {
-                  bidfloor: 100,
-                  bidfloorcur: 'JPY',
-                },
-                'no bids': {
-                  bidfloor: 10,
-                  bidfloorcur: 'JPY',
-                }
-              },
-              'mixed currencies': {
-                values: [{amount: 10, cur: 'USD'}, {amount: 10, cur: 'JPY'}],
-                'bids': {
-                  bidfloor: 10,
-                  bidfloorcur: 'USD'
-                },
-                'no bids': {
-                  bidfloor: 10,
-                  bidfloorcur: 'JPY',
-                }
-              }
-            }).forEach(([t, testConfig]) => {
-              const values = testConfig.values;
-              const {bidfloor, bidfloorcur} = testConfig[tcase];
+        describe('on a single auction', function () {
+          const auctionId = 'aid';
+          beforeEach(function () {
+            sandbox.stub(auctionManager, 'index').value(stubAuctionIndex({auctionId}));
+          });
 
-              describe(`with ${t}`, () => {
-                let payload;
-                beforeEach(() => {
-                  payload = {auctionId};
-                  setup(payload, values);
-                });
+          it('should call next()', function () {
+            const request = {auctionId, adUnitCode: 'auc'};
+            addComponentAuctionHook(nextFnSpy, request, fledgeAuctionConfig);
+            sinon.assert.calledWith(nextFnSpy, request, fledgeAuctionConfig);
+          });
 
-                it('should populate bidfloor/bidfloorcur', () => {
-                  addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode: 'au'}, fledgeAuctionConfig);
-                  events.emit(CONSTANTS.EVENTS.AUCTION_END, payload);
-                  const signals = getPAAPIConfig({auctionId}).au.componentAuctions[0].auctionSignals;
-                  expect(signals.prebid?.bidfloor).to.eql(bidfloor);
-                  expect(signals.prebid?.bidfloorcur).to.eql(bidfloorcur);
-                })
+          describe('should collect auction configs', () => {
+            let cf1, cf2;
+            beforeEach(() => {
+              cf1 = {...fledgeAuctionConfig, id: 1, seller: 'b1'};
+              cf2 = {...fledgeAuctionConfig, id: 2, seller: 'b2'};
+              addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode: 'au1'}, cf1);
+              addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode: 'au2'}, cf2);
+              events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId});
+            });
+
+            it('and make them available at end of auction', () => {
+              sinon.assert.match(getPAAPIConfig({auctionId}), {
+                au1: {
+                  componentAuctions: [cf1]
+                },
+                au2: {
+                  componentAuctions: [cf2]
+                }
               });
             });
-          })
-        })
-      });
-    });
 
-    describe('with multiple auctions', () => {
-      const AUCTION1 = 'auction1';
-      const AUCTION2 = 'auction2';
-      function mockAuction(auctionId) {
-        return {
-          getAuctionId() {
-            return auctionId;
-          }
-        }
-      }
-
-      function expectAdUnitsFromAuctions(actualConfig, auToAuctionMap) {
-        expect(Object.keys(actualConfig)).to.have.members(Object.keys(auToAuctionMap));
-        Object.entries(actualConfig).forEach(([au, cfg]) => {
-          cfg.componentAuctions.forEach(cmp => expect(cmp.auctionId).to.eql(auToAuctionMap[au]));
-        })
-      }
-
-      let configs;
-      beforeEach(() => {
-        const mockAuctions = [mockAuction(AUCTION1), mockAuction(AUCTION2)];
-        sandbox.stub(auctionManager, 'index').value(new AuctionIndex(() => mockAuctions));
-        configs = {[AUCTION1]: {}, [AUCTION2]: {}}
-        Object.entries({
-          [AUCTION1]: ['au1', 'au2'],
-          [AUCTION2]: ['au2', 'au3'],
-        }).forEach(([auctionId, adUnitCodes]) => {
-          adUnitCodes.forEach(adUnitCode => {
-            const cfg = {...fledgeAuctionConfig, auctionId, adUnitCode};
-            configs[auctionId][adUnitCode] = cfg;
-            addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode}, cfg);
+            it('and filter them by ad unit', () => {
+              const cfg = getPAAPIConfig({auctionId, adUnitCode: 'au1'});
+              expect(Object.keys(cfg)).to.have.members(['au1']);
+              sinon.assert.match(cfg.au1, {
+                componentAuctions: [cf1]
+              });
+            });
           });
-          events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId});
-        })
+
+          it('should drop auction configs after end of auction', () => {
+            events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId});
+            addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode: 'au'}, fledgeAuctionConfig);
+            events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId});
+            expect(getPAAPIConfig({auctionId})).to.eql({});
+          });
+
+          it('should augment auctionSignals with FPD', () => {
+            addComponentAuctionHook(nextFnSpy, {
+              auctionId,
+              adUnitCode: 'au1',
+              ortb2: {fpd: 1},
+              ortb2Imp: {fpd: 2}
+            }, fledgeAuctionConfig);
+            events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId});
+            sinon.assert.match(getPAAPIConfig({auctionId}), {
+              au1: {
+                componentAuctions: [{
+                  ...fledgeAuctionConfig,
+                  auctionSignals: {
+                    prebid: {
+                      ortb2: {fpd: 1},
+                      ortb2Imp: {fpd: 2}
+                    }
+                  }
+                }]
+              }
+            });
+          });
+
+          describe('submodules', () => {
+            let submods;
+            beforeEach(() => {
+              submods = [1, 2].map(i => ({
+                name: `test${i}`,
+                onAuctionConfig: sinon.stub()
+              }));
+              submods.forEach(registerSubmodule);
+            });
+            afterEach(() => {
+              submods.forEach(m => unregister(m.name));
+            });
+
+            describe('onAuctionConfig', () => {
+              const auctionId = 'aid';
+              it('is not invoked when there\'s no config', () => {
+                events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId});
+                submods.forEach(submod => sinon.assert.notCalled(submod.onAuctionConfig));
+              });
+              it('is invoked with relevant config otherwise', () => {
+                addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode: 'au1'}, fledgeAuctionConfig);
+                addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode: 'au2'}, fledgeAuctionConfig);
+                events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId});
+                submods.forEach(submod => {
+                  ['au1', 'au2'].forEach(au => {
+                    sinon.assert.calledWith(submod.onAuctionConfig, auctionId, au, {componentAuctions: [fledgeAuctionConfig]});
+                  });
+                });
+              });
+            });
+          });
+
+          describe('floor signal', () => {
+            before(() => {
+              if (!getGlobal().convertCurrency) {
+                getGlobal().convertCurrency = () => null;
+                getGlobal().convertCurrency.mock = true;
+              }
+            });
+            after(() => {
+              if (getGlobal().convertCurrency.mock) {
+                delete getGlobal().convertCurrency;
+              }
+            });
+
+            beforeEach(() => {
+              sandbox.stub(getGlobal(), 'convertCurrency').callsFake((amount, from, to) => {
+                if (from === to) return amount;
+                if (from === 'USD' && to === 'JPY') return amount * 100;
+                if (from === 'JPY' && to === 'USD') return amount / 100;
+                throw new Error('unexpected currency conversion');
+              });
+            });
+
+            Object.entries({
+              'bids': (payload, values) => {
+                payload.bidsReceived = values
+                  .map((val) => ({adUnitCode: 'au', cpm: val.amount, currency: val.cur}))
+                  .concat([{adUnitCode: 'other', cpm: 10000, currency: 'EUR'}]);
+              },
+              'no bids': (payload, values) => {
+                payload.bidderRequests = values
+                  .map((val) => ({
+                    bids: [{
+                      adUnitCode: 'au',
+                      getFloor: () => ({floor: val.amount, currency: val.cur})
+                    }]
+                  }))
+                  .concat([{bids: {adUnitCode: 'other', getFloor: () => ({floor: -10000, currency: 'EUR'})}}]);
+              }
+            }).forEach(([tcase, setup]) => {
+              describe(`when auction has ${tcase}`, () => {
+                Object.entries({
+                  'no currencies': {
+                    values: [{amount: 1}, {amount: 100}, {amount: 10}, {amount: 100}],
+                    'bids': {
+                      bidfloor: 100,
+                      bidfloorcur: undefined
+                    },
+                    'no bids': {
+                      bidfloor: 1,
+                      bidfloorcur: undefined,
+                    }
+                  },
+                  'only zero values': {
+                    values: [{amount: 0, cur: 'USD'}, {amount: 0, cur: 'JPY'}],
+                    'bids': {
+                      bidfloor: undefined,
+                      bidfloorcur: undefined,
+                    },
+                    'no bids': {
+                      bidfloor: undefined,
+                      bidfloorcur: undefined,
+                    }
+                  },
+                  'matching currencies': {
+                    values: [{amount: 10, cur: 'JPY'}, {amount: 100, cur: 'JPY'}],
+                    'bids': {
+                      bidfloor: 100,
+                      bidfloorcur: 'JPY',
+                    },
+                    'no bids': {
+                      bidfloor: 10,
+                      bidfloorcur: 'JPY',
+                    }
+                  },
+                  'mixed currencies': {
+                    values: [{amount: 10, cur: 'USD'}, {amount: 10, cur: 'JPY'}],
+                    'bids': {
+                      bidfloor: 10,
+                      bidfloorcur: 'USD'
+                    },
+                    'no bids': {
+                      bidfloor: 10,
+                      bidfloorcur: 'JPY',
+                    }
+                  }
+                }).forEach(([t, testConfig]) => {
+                  const values = testConfig.values;
+                  const {bidfloor, bidfloorcur} = testConfig[tcase];
+
+                  describe(`with ${t}`, () => {
+                    let payload;
+                    beforeEach(() => {
+                      payload = {auctionId};
+                      setup(payload, values);
+                    });
+
+                    it('should populate bidfloor/bidfloorcur', () => {
+                      addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode: 'au'}, fledgeAuctionConfig);
+                      events.emit(CONSTANTS.EVENTS.AUCTION_END, payload);
+                      const signals = getPAAPIConfig({auctionId}).au.componentAuctions[0].auctionSignals;
+                      expect(signals.prebid?.bidfloor).to.eql(bidfloor);
+                      expect(signals.prebid?.bidfloorcur).to.eql(bidfloorcur);
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+
+        describe('with multiple auctions', () => {
+          const AUCTION1 = 'auction1';
+          const AUCTION2 = 'auction2';
+
+          function mockAuction(auctionId) {
+            return {
+              getAuctionId() {
+                return auctionId;
+              }
+            };
+          }
+
+          function expectAdUnitsFromAuctions(actualConfig, auToAuctionMap) {
+            expect(Object.keys(actualConfig)).to.have.members(Object.keys(auToAuctionMap));
+            Object.entries(actualConfig).forEach(([au, cfg]) => {
+              cfg.componentAuctions.forEach(cmp => expect(cmp.auctionId).to.eql(auToAuctionMap[au]));
+            });
+          }
+
+          let configs;
+          beforeEach(() => {
+            const mockAuctions = [mockAuction(AUCTION1), mockAuction(AUCTION2)];
+            sandbox.stub(auctionManager, 'index').value(new AuctionIndex(() => mockAuctions));
+            configs = {[AUCTION1]: {}, [AUCTION2]: {}};
+            Object.entries({
+              [AUCTION1]: ['au1', 'au2'],
+              [AUCTION2]: ['au2', 'au3'],
+            }).forEach(([auctionId, adUnitCodes]) => {
+              adUnitCodes.forEach(adUnitCode => {
+                const cfg = {...fledgeAuctionConfig, auctionId, adUnitCode};
+                configs[auctionId][adUnitCode] = cfg;
+                addComponentAuctionHook(nextFnSpy, {auctionId, adUnitCode}, cfg);
+              });
+              events.emit(CONSTANTS.EVENTS.AUCTION_END, {auctionId});
+            });
+          });
+
+          it('should filter by auction', () => {
+            expectAdUnitsFromAuctions(getPAAPIConfig({auctionId: AUCTION1}), {au1: AUCTION1, au2: AUCTION1});
+            expectAdUnitsFromAuctions(getPAAPIConfig({auctionId: AUCTION2}), {au2: AUCTION2, au3: AUCTION2});
+          });
+
+          it('should filter by auction and ad unit', () => {
+            expectAdUnitsFromAuctions(getPAAPIConfig({auctionId: AUCTION1, adUnitCode: 'au2'}), {au2: AUCTION1});
+            expectAdUnitsFromAuctions(getPAAPIConfig({auctionId: AUCTION2, adUnitCode: 'au2'}), {au2: AUCTION2});
+          });
+
+          it('should use last auction for each ad unit', () => {
+            expectAdUnitsFromAuctions(getPAAPIConfig(), {au1: AUCTION1, au2: AUCTION2, au3: AUCTION2});
+          });
+
+          it('should filter by ad unit and use latest auction', () => {
+            expectAdUnitsFromAuctions(getPAAPIConfig({adUnitCode: 'au2'}), {au2: AUCTION2});
+          });
+        });
       });
 
-      it('should filter by auction', () => {
-        expectAdUnitsFromAuctions(getPAAPIConfig({auctionId: AUCTION1}), {au1: AUCTION1, au2: AUCTION1});
-        expectAdUnitsFromAuctions(getPAAPIConfig({auctionId: AUCTION2}), {au2: AUCTION2, au3: AUCTION2});
-      });
+      describe('markForFledge', function () {
+        const navProps = Object.fromEntries(['runAdAuction', 'joinAdInterestGroup'].map(p => [p, navigator[p]]));
 
-      it('should filter by auction and ad unit', () => {
-        expectAdUnitsFromAuctions(getPAAPIConfig({auctionId: AUCTION1, adUnitCode: 'au2'}), {au2: AUCTION1});
-        expectAdUnitsFromAuctions(getPAAPIConfig({auctionId: AUCTION2, adUnitCode: 'au2'}), {au2: AUCTION2});
-      })
+        before(function () {
+          // navigator.runAdAuction & co may not exist, so we can't stub it normally with
+          // sinon.stub(navigator, 'runAdAuction') or something
+          Object.keys(navProps).forEach(p => {
+            navigator[p] = sinon.stub();
+          });
+          hook.ready();
+          config.resetConfig();
+        });
 
-      it('should use last auction for each ad unit', () => {
-        expectAdUnitsFromAuctions(getPAAPIConfig(), {au1: AUCTION1, au2: AUCTION2, au3: AUCTION2});
-      });
+        after(function () {
+          Object.entries(navProps).forEach(([p, orig]) => navigator[p] = orig);
+        });
 
-      it('should filter by ad unit and use latest auction', () => {
-        expectAdUnitsFromAuctions(getPAAPIConfig({adUnitCode: 'au2'}), {au2: AUCTION2});
-      })
-    })
-  });
+        afterEach(function () {
+          config.resetConfig();
+        });
 
-  describe('markForFledge', function () {
-    const navProps = Object.fromEntries(['runAdAuction', 'joinAdInterestGroup'].map(p => [p, navigator[p]]));
-
-    before(function () {
-      // navigator.runAdAuction & co may not exist, so we can't stub it normally with
-      // sinon.stub(navigator, 'runAdAuction') or something
-      Object.keys(navProps).forEach(p => {
-        navigator[p] = sinon.stub();
-      });
-      hook.ready();
-      config.resetConfig();
-    });
-
-    after(function () {
-      Object.entries(navProps).forEach(([p, orig]) => navigator[p] = orig);
-    });
-
-    afterEach(function () {
-      config.resetConfig();
-    });
-
-    const adUnits = [{
-      'code': '/19968336/header-bid-tag1',
-      'mediaTypes': {
-        'banner': {
-          'sizes': [[728, 90]]
-        },
-      },
-      'bids': [
-        {
-          'bidder': 'appnexus',
-        },
-        {
-          'bidder': 'rubicon',
-        },
-      ]
-    }];
-    function expectFledgeFlags(...enableFlags) {
-      const bidRequests = Object.fromEntries(
-        adapterManager.makeBidRequests(
-          adUnits,
-          Date.now(),
-          utils.getUniqueIdentifierStr(),
-          function callback() {
+        const adUnits = [{
+          'code': '/19968336/header-bid-tag1',
+          'mediaTypes': {
+            'banner': {
+              'sizes': [[728, 90]]
+            },
           },
-          []
-        ).map(b => [b.bidderCode, b])
-      );
+          'bids': [
+            {
+              'bidder': 'appnexus',
+            },
+            {
+              'bidder': 'rubicon',
+            },
+          ]
+        }];
 
-      expect(bidRequests.appnexus.fledgeEnabled).to.eql(enableFlags[0].enabled)
-      bidRequests.appnexus.bids.forEach(bid => expect(bid.ortb2Imp.ext.ae).to.eql(enableFlags[0].ae))
+        function expectFledgeFlags(...enableFlags) {
+          const bidRequests = Object.fromEntries(
+            adapterManager.makeBidRequests(
+              adUnits,
+              Date.now(),
+              utils.getUniqueIdentifierStr(),
+              function callback() {
+              },
+              []
+            ).map(b => [b.bidderCode, b])
+          );
 
-      expect(bidRequests.rubicon.fledgeEnabled).to.eql(enableFlags[1].enabled)
-      bidRequests.rubicon.bids.forEach(bid => expect(bid.ortb2Imp?.ext?.ae).to.eql(enableFlags[1].ae));
-    }
+          expect(bidRequests.appnexus.fledgeEnabled).to.eql(enableFlags[0].enabled);
+          bidRequests.appnexus.bids.forEach(bid => expect(bid.ortb2Imp.ext.ae).to.eql(enableFlags[0].ae));
 
-    describe('with setBidderConfig()', () => {
-      it('should set fledgeEnabled correctly per bidder', function () {
-        config.setBidderConfig({
-          bidders: ['appnexus'],
-          config: {
-            defaultForSlots: 1,
-            fledgeEnabled: true
-          }
+          expect(bidRequests.rubicon.fledgeEnabled).to.eql(enableFlags[1].enabled);
+          bidRequests.rubicon.bids.forEach(bid => expect(bid.ortb2Imp?.ext?.ae).to.eql(enableFlags[1].ae));
+        }
+
+        describe('with setBidderConfig()', () => {
+          it('should set fledgeEnabled correctly per bidder', function () {
+            config.setBidderConfig({
+              bidders: ['appnexus'],
+              config: {
+                defaultForSlots: 1,
+                fledgeEnabled: true
+              }
+            });
+            expectFledgeFlags({enabled: true, ae: 1}, {enabled: void 0, ae: void 0});
+          });
         });
-        expectFledgeFlags({enabled: true, ae: 1}, {enabled: void 0, ae: void 0});
+
+        describe('with setConfig()', () => {
+          it('should set fledgeEnabled correctly per bidder', function () {
+            config.setConfig({
+              bidderSequence: 'fixed',
+              [configNS]: {
+                enabled: true,
+                bidders: ['appnexus'],
+                defaultForSlots: 1,
+              }
+            });
+            expectFledgeFlags({enabled: true, ae: 1}, {enabled: false, ae: undefined});
+          });
+
+          it('should set fledgeEnabled correctly for all bidders', function () {
+            config.setConfig({
+              bidderSequence: 'fixed',
+              [configNS]: {
+                enabled: true,
+                defaultForSlots: 1,
+              }
+            });
+            expectFledgeFlags({enabled: true, ae: 1}, {enabled: true, ae: 1});
+          });
+
+          it('should not override pub-defined ext.ae', () => {
+            config.setConfig({
+              bidderSequence: 'fixed',
+              [configNS]: {
+                enabled: true,
+                defaultForSlots: 1,
+              }
+            });
+            Object.assign(adUnits[0], {ortb2Imp: {ext: {ae: 0}}});
+            expectFledgeFlags({enabled: true, ae: 0}, {enabled: true, ae: 0});
+          });
+        });
       });
-    });
-
-    describe('with setConfig()', () => {
-      it('should set fledgeEnabled correctly per bidder', function () {
-        config.setConfig({
-          bidderSequence: 'fixed',
-          fledgeForGpt: {
-            enabled: true,
-            bidders: ['appnexus'],
-            defaultForSlots: 1,
-          }
-        });
-        expectFledgeFlags({enabled: true, ae: 1}, {enabled: false, ae: undefined});
-      });
-
-      it('should set fledgeEnabled correctly for all bidders', function () {
-        config.setConfig({
-          bidderSequence: 'fixed',
-          fledgeForGpt: {
-            enabled: true,
-            defaultForSlots: 1,
-          }
-        });
-        expectFledgeFlags({enabled: true, ae: 1}, {enabled: true, ae: 1});
-      });
-
-      it('should not override pub-defined ext.ae', () => {
-        config.setConfig({
-          bidderSequence: 'fixed',
-          fledgeForGpt: {
-            enabled: true,
-            defaultForSlots: 1,
-          }
-        });
-        Object.assign(adUnits[0], {ortb2Imp: {ext: {ae: 0}}});
-        expectFledgeFlags({enabled: true, ae: 0}, {enabled: true, ae: 0});
-      })
     });
   });
 

--- a/test/spec/modules/paapi_spec.js
+++ b/test/spec/modules/paapi_spec.js
@@ -88,6 +88,22 @@ describe('paapi module', () => {
                 componentAuctions: [cf1]
               });
             });
+
+            it('and not return them again if reuse = false', () => {
+              getPAAPIConfig();
+              const cfg = getPAAPIConfig({reuse: false});
+              expect(cfg).to.eql({});
+            });
+            Object.entries({
+              'true': {reuse: true},
+              'undefined': {}
+            }).forEach(([t, options]) => {
+              it(`and return them again if reuse is ${t}`, () => {
+                const expected = getPAAPIConfig();
+                const cfg = getPAAPIConfig(options);
+                expect(cfg).to.eql(expected);
+              })
+            })
           });
 
           it('should drop auction configs after end of auction', () => {
@@ -315,6 +331,12 @@ describe('paapi module', () => {
 
           it('should filter by ad unit and use latest auction', () => {
             expectAdUnitsFromAuctions(getPAAPIConfig({adUnitCode: 'au2'}), {au2: AUCTION2});
+          });
+
+          it('should keep track of which configs were returned for reuse = false', () => {
+            expectAdUnitsFromAuctions(getPAAPIConfig({auctionId: AUCTION1}), {au1: AUCTION1, au2: AUCTION1});
+            expect(getPAAPIConfig({auctionId: AUCTION1, reuse: false})).to.eql({});
+            expectAdUnitsFromAuctions(getPAAPIConfig({reuse: false}), {au2: AUCTION2, au3: AUCTION2});
           });
         });
       });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

- Split 'fledgeForGpt' into  new 'paapi' module that contains all GPT-independent fledge logic. 'fledgeForGpt' is now a submodule of 'paapi'
- 'paapi' now provides a new API `getPAAPIConfig({auctionId, adUnitCode})`, that returns a map from ad unit code to its PAAPI auction config. currently the only populated field is 'componentAuctions'. `auctionId` and `adUnitCode` are optional filters.
- 'fledgeForGpt' now provides a new API `setPAAPIConfigForGPT({auctionId, adUnitCode})` that sets component auction on GPT slots (auctionId/adUnitCode are still optional filters)
- 'fledgeForGpt' configuration keys are renamed to 'paapi' (e.g. `setConfig({paapi: {enabled: true}})`). 'fledgeForGpt' still works but logs a warning.
- `setConfig({paapi: {gpt: {autoconfig: false}}})` (or `setConfig({fledgeForGpt: {autoconfig: false}})` disables GPT slot auto-configuration, which together with the new APIs above should allow running the prebid auction in parallel with loading of GPT (https://github.com/prebid/Prebid.js/issues/10566)


## Other information

Closes https://github.com/prebid/Prebid.js/issues/10566
Also related: https://github.com/prebid/Prebid.js/issues/10573
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
