### PR TITLE
Teads Bid Adapter : support fledgeEnabled boolean

### DIFF
--- a/modules/teadsBidAdapter.js
+++ b/modules/teadsBidAdapter.js
@@ -47,6 +47,8 @@ export const spec = {
     const bids = validBidRequests.map(buildRequestObject);
     const topWindow = window.top;
 
+    const fledgeEnabled = 'runAdAuction' in navigator && 'joinAdInterestGroup' in navigator;
+
     const payload = {
       referrer: getReferrerInfo(bidderRequest),
       pageReferrer: document.referrer,
@@ -63,6 +65,7 @@ export const spec = {
       hardwareConcurrency: topWindow.navigator?.hardwareConcurrency,
       deviceMemory: topWindow.navigator?.deviceMemory,
       hb_version: '$prebid.version$',
+      fledgeEnabled: fledgeEnabled,
       ...getSharedViewerIdParameters(validBidRequests),
       ...getFirstPartyTeadsIdParameter(validBidRequests)
     };

--- a/test/spec/modules/teadsBidAdapter_spec.js
+++ b/test/spec/modules/teadsBidAdapter_spec.js
@@ -407,6 +407,24 @@ describe('teadsBidAdapter', () => {
       });
     });
 
+    it('should add fledgeEnabled info to payload when runAdAuction and joinAdInterestGroup are defined', function () {
+      navigator.runAdAuction = 'Function implementation';
+      navigator.joinAdInterestGroup = 'Function implementation';
+      const request1 = spec.buildRequests(bidRequests, bidderRequestDefault);
+      const payload1 = JSON.parse(request1.data);
+
+      expect(payload1.fledgeEnabled).to.exist;
+      expect(payload1.fledgeEnabled).to.deep.equal(true);
+
+      delete navigator.runAdAuction;
+      delete navigator.joinAdInterestGroup;
+      const request2 = spec.buildRequests(bidRequests, bidderRequestDefault);
+      const payload2 = JSON.parse(request2.data);
+
+      expect(payload2.fledgeEnabled).to.exist;
+      expect(payload2.fledgeEnabled).to.deep.equal(false);
+    });
+
     it('should add timeToFirstByte info to payload', function () {
       const request = spec.buildRequests(bidRequests, bidderRequestDefault);
       const payload = JSON.parse(request.data);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

This adapts Teads bid adapter to send a boolean named fledgeEnabled that describes if fledge is supported on the browser.

Related PR for documentation : https://github.com/prebid/prebid.github.io/pull/5075

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
