### PR TITLE
Prebid Core: pass document instance to custom renderer

### DIFF
--- a/libraries/creativeRender/direct.js
+++ b/libraries/creativeRender/direct.js
@@ -52,7 +52,7 @@ export function renderAdDirect(doc, adId, options) {
           message: `renderAd was prevented from writing to the main document.`
         })
       } else {
-        handleRender(renderFn, {adId, options: {clickUrl: options?.clickThrough}, bidResponse: bid});
+        handleRender(renderFn, {adId, options: {clickUrl: options?.clickThrough}, bidResponse: bid, doc});
       }
     }
   } catch (e) {

--- a/src/adRendering.js
+++ b/src/adRendering.js
@@ -43,7 +43,7 @@ export function emitAdRenderSucceeded({ doc, bid, id }) {
   events.emit(AD_RENDER_SUCCEEDED, data);
 }
 
-export function handleRender(renderFn, {adId, options, bidResponse}) {
+export function handleRender(renderFn, {adId, options, bidResponse, doc}) {
   if (bidResponse == null) {
     emitAdRenderFail({
       reason: constants.AD_RENDER_FAILED_REASON.CANNOT_FIND_AD,
@@ -63,7 +63,7 @@ export function handleRender(renderFn, {adId, options, bidResponse}) {
     const {adId, ad, adUrl, width, height, renderer, cpm, originalCpm, mediaType} = bidResponse;
     // rendering for outstream safeframe
     if (isRendererRequired(renderer)) {
-      executeRenderer(renderer, bidResponse);
+      executeRenderer(renderer, bidResponse, doc);
     } else if (adId) {
       if (mediaType === VIDEO) {
         emitAdRenderFail({


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ x] Bugfix

## Description of change
it seems the new implementation for rendering creative's isn't passing the document instance called via renderAd, to the (custom)Render, causing custom renderers which require the document instance of the calling function (iframe) to complete the render.
