### PR TITLE
Core: use same transaction ID for twin ad units

### DIFF
--- a/modules/contxtfulRtdProvider.js
+++ b/modules/contxtfulRtdProvider.js
@@ -121,7 +121,7 @@ function getReceptivity() {
  * @param { [String] } adUnits
  * @param {*} _config
  * @param {*} _userConsent
-*  @return {{ code: { ReceptivityState: String } }}
+ *  @return {{ code: { ReceptivityState: String } }}
  */
 function getTargetingData(adUnits, _config, _userConsent) {
   logInfo(MODULE, 'getTargetingData');

--- a/modules/dsp_genieeBidAdapter.js
+++ b/modules/dsp_genieeBidAdapter.js
@@ -42,21 +42,21 @@ export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: [BANNER],
   /**
-     * Determines whether or not the given bid request is valid.
-     *
-     * @param {BidRequest} - The bid params to validate.
-     * @return boolean True if this is a valid bid, and false otherwise.
-     */
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} - The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
   isBidRequestValid: function (_) {
     return true;
   },
   /**
-     * Make a server request from the list of BidRequests.
-     *
-     * @param {validBidRequests[]} - an array of bids
-     * @param {bidderRequest} - the master bidRequest object
-     * @return ServerRequest Info describing the request to the server.
-     */
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @param {bidderRequest} - the master bidRequest object
+   * @return ServerRequest Info describing the request to the server.
+   */
   buildRequests: function (validBidRequests, bidderRequest) {
     if (deepAccess(bidderRequest, 'gdprConsent.gdprApplies') || // gdpr
             USPConsent(bidderRequest.uspConsent) || // usp
@@ -84,12 +84,12 @@ export const spec = {
     };
   },
   /**
-     * Unpack the response from the server into a list of bids.
-     *
-     * @param {ServerResponse} serverResponse A successful response from the server.
-     * @param {BidRequest} bidRequest - the master bidRequest object
-     * @return {bids} - An array of bids which were nested inside the server.
-     */
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @param {BidRequest} bidRequest - the master bidRequest object
+   * @return {bids} - An array of bids which were nested inside the server.
+   */
   interpretResponse: function (serverResponse, bidRequest) {
     if (!serverResponse.body) { // empty response (no bids)
       return [];
@@ -99,12 +99,12 @@ export const spec = {
   },
 
   /**
-     * Register the user sync pixels which should be dropped after the auction.
-     *
-     * @param {SyncOptions} syncOptions Which user syncs are allowed?
-     * @param {ServerResponse[]} serverResponses List of server's responses.
-     * @return {UserSync[]} The user syncs which should be dropped.
-     */
+   * Register the user sync pixels which should be dropped after the auction.
+   *
+   * @param {SyncOptions} syncOptions Which user syncs are allowed?
+   * @param {ServerResponse[]} serverResponses List of server's responses.
+   * @return {UserSync[]} The user syncs which should be dropped.
+   */
   getUserSyncs: function (syncOptions, serverResponses, gdprConsent, uspConsent) {
     const syncs = [];
     // gdpr & usp

--- a/modules/prebidServerBidAdapter/ortbConverter.js
+++ b/modules/prebidServerBidAdapter/ortbConverter.js
@@ -118,6 +118,7 @@ const PBS_CONVERTER = ortbConverter({
         src: CONSTANTS.S2S.SRC,
         bidId: bidRequest ? (bidRequest.bidId || bidRequest.bid_Id) : null,
         transactionId: context.adUnit.transactionId,
+        adUnitId: context.adUnit.adUnitId,
         auctionId: context.bidderRequest.auctionId,
       }), bidResponse),
       adUnit: context.adUnit.code

--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -94,8 +94,8 @@ const getHostname = (() => {
 })();
 
 // First look into bidRequest!
-function getGptSlotFromAdUnit(transactionId, {index = auctionManager.index} = {}) {
-  const adUnit = index.getAdUnit({transactionId});
+function getGptSlotFromAdUnit(adUnitId, {index = auctionManager.index} = {}) {
+  const adUnit = index.getAdUnit({adUnitId});
   const isGam = deepAccess(adUnit, 'ortb2Imp.ext.data.adserver.name') === 'gam';
   return isGam && adUnit.ortb2Imp.ext.data.adserver.adslot;
 }
@@ -111,7 +111,7 @@ export let fieldMatchingFunctions = {
   [SYN_FIELD]: () => '*',
   'size': (bidRequest, bidResponse) => parseGPTSingleSizeArray(bidResponse.size) || '*',
   'mediaType': (bidRequest, bidResponse) => bidResponse.mediaType || 'banner',
-  'gptSlot': (bidRequest, bidResponse) => getGptSlotFromAdUnit((bidRequest || bidResponse).transactionId) || getGptSlotInfoForAdUnitCode(getAdUnitCode(bidRequest, bidResponse)).gptSlot,
+  'gptSlot': (bidRequest, bidResponse) => getGptSlotFromAdUnit((bidRequest || bidResponse).adUnitId) || getGptSlotInfoForAdUnitCode(getAdUnitCode(bidRequest, bidResponse)).gptSlot,
   'domain': getHostname,
   'adUnitCode': (bidRequest, bidResponse) => getAdUnitCode(bidRequest, bidResponse)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "prebid.js",
-      "version": "8.31.0-pre",
+      "version": "8.32.0-pre",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.7",

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -115,6 +115,7 @@ function getBids({bidderCode, auctionId, bidderRequestId, adUnits, src, metrics}
         bids.push(Object.assign({}, bid, {
           adUnitCode: adUnit.code,
           transactionId: adUnit.transactionId,
+          adUnitId: adUnit.adUnitId,
           sizes: deepAccess(mediaTypes, 'banner.sizes') || deepAccess(mediaTypes, 'video.playerSize') || [],
           bidId: bid.bid_id || getUniqueIdentifierStr(),
           bidderRequestId,

--- a/src/auction.js
+++ b/src/auction.js
@@ -361,7 +361,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
   }
 
   function addWinningBid(winningBid) {
-    const winningAd = adUnits.find(adUnit => adUnit.transactionId === winningBid.transactionId);
+    const winningAd = adUnits.find(adUnit => adUnit.adUnitId === winningBid.adUnitId);
     _winningBids = _winningBids.concat(winningBid);
     callBurl(winningBid);
     adapterManager.callBidWonBidder(winningBid.adapterCode || winningBid.bidder, winningBid, adUnits);
@@ -548,7 +548,7 @@ function tryAddVideoBid(auctionInstance, bidResponse, afterBidAdded, {index = au
   const videoMediaType = deepAccess(
     index.getMediaTypes({
       requestId: bidResponse.originalRequestId || bidResponse.requestId,
-      transactionId: bidResponse.transactionId
+      adUnitId: bidResponse.adUnitId
     }), 'video');
   const context = videoMediaType && deepAccess(videoMediaType, 'context');
   const useCacheKey = videoMediaType && deepAccess(videoMediaType, 'useCacheKey');

--- a/src/auctionIndex.js
+++ b/src/auctionIndex.js
@@ -5,7 +5,8 @@
 export function AuctionIndex(getAuctions) {
   Object.assign(this, {
     /**
-     * @param auctionId
+     * @param {Object} filter
+     * @param filter.auctionId
      * @returns {*} Auction instance for `auctionId`
      */
     getAuction({auctionId}) {
@@ -16,40 +17,43 @@ export function AuctionIndex(getAuctions) {
     },
     /**
      * NOTE: you should prefer {@link #getMediaTypes} for looking up bid media types.
-     * @param transactionId
-     * @returns adUnit object for `transactionId`
+     * @param {Object} filter
+     * @param filter.adUnitId
+     * @returns adUnit object for `adUnitId`
      */
-    getAdUnit({transactionId}) {
-      if (transactionId != null) {
+    getAdUnit({adUnitId}) {
+      if (adUnitId != null) {
         return getAuctions()
           .flatMap(a => a.getAdUnits())
-          .find(au => au.transactionId === transactionId);
+          .find(au => au.adUnitId === adUnitId);
       }
     },
     /**
-     * @param transactionId
-     * @param requestId?
-     * @returns {*} mediaTypes object from bidRequest (through requestId) falling back to the adUnit (through transactionId).
+     * @param {Object} filter
+     * @param filter.adUnitId
+     * @param filter.requestId
+     * @returns {*} mediaTypes object from bidRequest (through requestId) falling back to the adUnit (through adUnitId).
      *
      * The bidRequest is given precedence because its mediaTypes can differ from the adUnit's (if bidder-specific labels are in use).
      * Bids that have no associated request do not have labels either, and use the adUnit's mediaTypes.
      */
-    getMediaTypes({transactionId, requestId}) {
+    getMediaTypes({adUnitId, requestId}) {
       if (requestId != null) {
         const req = this.getBidRequest({requestId});
-        if (req != null && (transactionId == null || req.transactionId === transactionId)) {
+        if (req != null && (adUnitId == null || req.adUnitId === adUnitId)) {
           return req.mediaTypes;
         }
-      } else if (transactionId != null) {
-        const au = this.getAdUnit({transactionId});
+      } else if (adUnitId != null) {
+        const au = this.getAdUnit({adUnitId});
         if (au != null) {
           return au.mediaTypes;
         }
       }
     },
     /**
-     * @param requestId?
-     * @param bidderRequestId?
+     * @param {Object} filter
+     * @param filter.requestId
+     * @param filter.bidderRequestId
      * @returns {*} bidderRequest that matches both requestId and bidderRequestId (if either or both are provided).
      *
      * NOTE: Bid responses are not guaranteed to have a corresponding request.
@@ -68,7 +72,8 @@ export function AuctionIndex(getAuctions) {
       }
     },
     /**
-     * @param requestId
+     * @param {Object} filter
+     * @param filter.requestId
      * @returns {*} bidRequest object for requestId
      *
      * NOTE: Bid responses are not guaranteed to have a corresponding request.

--- a/src/bidfactory.js
+++ b/src/bidfactory.js
@@ -14,20 +14,23 @@ import { getUniqueIdentifierStr } from './utils.js';
  dealId,
  priceKeyString;
  */
-function Bid(statusCode, {src = 'client', bidder = '', bidId, transactionId, auctionId} = {}) {
+function Bid(statusCode, {src = 'client', bidder = '', bidId, transactionId, adUnitId, auctionId} = {}) {
   var _bidSrc = src;
   var _statusCode = statusCode || 0;
 
-  this.bidderCode = bidder;
-  this.width = 0;
-  this.height = 0;
-  this.statusMessage = _getStatus();
-  this.adId = getUniqueIdentifierStr();
-  this.requestId = bidId;
-  this.transactionId = transactionId;
-  this.auctionId = auctionId;
-  this.mediaType = 'banner';
-  this.source = _bidSrc;
+  Object.assign(this, {
+    bidderCode: bidder,
+    width: 0,
+    height: 0,
+    statusMessage: _getStatus(),
+    adId: getUniqueIdentifierStr(),
+    requestId: bidId,
+    transactionId,
+    adUnitId,
+    auctionId,
+    mediaType: 'banner',
+    source: _bidSrc
+  })
 
   function _getStatus() {
     switch (_statusCode) {
@@ -57,6 +60,7 @@ function Bid(statusCode, {src = 'client', bidder = '', bidId, transactionId, auc
       bidder: this.bidderCode,
       bidId: this.requestId,
       transactionId: this.transactionId,
+      adUnitId: this.adUnitId,
       auctionId: this.auctionId
     }
   };

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -552,6 +552,8 @@ export const startAuction = hook('async', function ({ bidsBackHandler, timeout: 
     defer.resolve({bids, timedOut, auctionId})
   }
 
+  const tids = {};
+
   /*
    * for a given adunit which supports a set of mediaTypes
    * and a given bidder which supports a set of mediaTypes
@@ -568,14 +570,17 @@ export const startAuction = hook('async', function ({ bidsBackHandler, timeout: 
 
     const bidders = allBidders.filter(bidder => !s2sBidders.has(bidder));
     adUnit.adUnitId = generateUUID();
-    const tid = adUnit.ortb2Imp?.ext?.tid || generateUUID();
-    adUnit.transactionId = tid;
+    const tid = adUnit.ortb2Imp?.ext?.tid;
+    if (tid) {
+      if (tids.hasOwnProperty(adUnit.code)) {
+        logWarn(`Multiple distinct ortb2Imp.ext.tid were provided for twin ad units '${adUnit.code}'`)
+      } else {
+        tids[adUnit.code] = tid;
+      }
+    }
     if (ttlBuffer != null && !adUnit.hasOwnProperty('ttlBuffer')) {
       adUnit.ttlBuffer = ttlBuffer;
     }
-    // Populate ortb2Imp.ext.tid with transactionId. Specifying a transaction ID per item in the ortb impression array, lets multiple transaction IDs be transmitted in a single bid request.
-    deepSetValue(adUnit, 'ortb2Imp.ext.tid', tid);
-
     bidders.forEach(bidder => {
       const adapter = bidderRegistry[bidder];
       const spec = adapter && adapter.getSpec && adapter.getSpec();
@@ -594,11 +599,18 @@ export const startAuction = hook('async', function ({ bidsBackHandler, timeout: 
     });
     adunitCounter.incrementRequestsCounter(adUnit.code);
   });
-
   if (!adUnits || adUnits.length === 0) {
     logMessage('No adUnits configured. No bids requested.');
     auctionDone();
   } else {
+    adUnits.forEach(au => {
+      const tid = au.ortb2Imp?.ext?.tid || tids[au.code] || generateUUID();
+      if (!tids.hasOwnProperty(au.code)) {
+        tids[au.code] = tid;
+      }
+      au.transactionId = tid;
+      deepSetValue(au, 'ortb2Imp.ext.tid', tid);
+    });
     const auction = auctionManager.createAuction({
       adUnits,
       adUnitCodes,

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -567,7 +567,7 @@ export const startAuction = hook('async', function ({ bidsBackHandler, timeout: 
     const bidderRegistry = adapterManager.bidderRegistry;
 
     const bidders = allBidders.filter(bidder => !s2sBidders.has(bidder));
-
+    adUnit.adUnitId = generateUUID();
     const tid = adUnit.ortb2Imp?.ext?.tid || generateUUID();
     adUnit.transactionId = tid;
     if (ttlBuffer != null && !adUnit.hasOwnProperty('ttlBuffer')) {

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -57,6 +57,7 @@ function mockBid(opts) {
     'bidderCode': bidderCode || BIDDER_CODE,
     'requestId': utils.getUniqueIdentifierStr(),
     'transactionId': (opts && opts.transactionId) || ADUNIT_CODE,
+    adUnitId: (opts && opts.adUnitId) || ADUNIT_CODE,
     'creativeId': 'id',
     'currency': 'USD',
     'netRevenue': true,
@@ -114,6 +115,7 @@ function mockBidRequest(bid, opts) {
         },
         'adUnitCode': adUnitCode || ADUNIT_CODE,
         'transactionId': bid.transactionId,
+        adUnitId: bid.adUnitId,
         'sizes': [[300, 250], [300, 600]],
         'bidId': bid.requestId,
         'bidderRequestId': requestId,
@@ -791,7 +793,7 @@ describe('auctionmanager.js', function () {
       });
       adUnits = [{
         code: ADUNIT_CODE,
-        transactionId: ADUNIT_CODE,
+        adUnitId: ADUNIT_CODE,
         bids: [
           {bidder: BIDDER_CODE},
         ]
@@ -849,11 +851,11 @@ describe('auctionmanager.js', function () {
         bids = [
           {
             adUnitCode: ADUNIT_CODE,
-            transactionId: ADUNIT_CODE,
+            adUnitId: ADUNIT_CODE,
             ttl: 10
           }, {
             adUnitCode: ADUNIT_CODE,
-            transactionId: ADUNIT_CODE,
+            adUnitId: ADUNIT_CODE,
             ttl: 100
           }
         ];
@@ -882,7 +884,7 @@ describe('auctionmanager.js', function () {
         'bids': {
           bd: [{
             adUnitCode: ADUNIT_CODE,
-            transactionId: ADUNIT_CODE,
+            adUnitId: ADUNIT_CODE,
             ttl: 10
           }],
           entries: () => auctionManager.getBidsReceived()
@@ -933,7 +935,7 @@ describe('auctionmanager.js', function () {
             }
           },
           code: ADUNIT_CODE,
-          transactionId: ADUNIT_CODE,
+          adUnitId: ADUNIT_CODE,
           bids: [
             {bidder: BIDDER_CODE, params: {placementId: 'id'}},
           ]
@@ -1134,7 +1136,7 @@ describe('auctionmanager.js', function () {
           }, bidRequests[0].bids[0]);
           Object.assign(bidRequests[0].bids[0], {
             adUnitCode: ADUNIT_CODE1,
-            transactionId: ADUNIT_CODE1,
+            adUnitId: ADUNIT_CODE1,
           });
 
           makeRequestsStub.returns(bidRequests);
@@ -1186,6 +1188,7 @@ describe('auctionmanager.js', function () {
         adUnits = [{
           code: ADUNIT_CODE,
           transactionId: ADUNIT_CODE,
+          adUnitId: ADUNIT_CODE,
           bids: [
             {bidder: BIDDER_CODE, params: {placementId: 'id'}},
             {bidder: BIDDER_CODE1, params: {placementId: 'id'}},
@@ -1357,12 +1360,14 @@ describe('auctionmanager.js', function () {
       adUnits = [{
         code: ADUNIT_CODE,
         transactionId: ADUNIT_CODE,
+        adUnitId: ADUNIT_CODE,
         bids: [
           {bidder: BIDDER_CODE, params: {placementId: 'id'}},
         ]
       }, {
         code: ADUNIT_CODE1,
         transactionId: ADUNIT_CODE1,
+        adUnitId: ADUNIT_CODE1,
         bids: [
           {bidder: BIDDER_CODE1, params: {placementId: 'id'}},
         ]
@@ -1570,6 +1575,7 @@ describe('auctionmanager.js', function () {
         const adUnits = [{
           code: ADUNIT_CODE,
           transactionId: ADUNIT_CODE,
+          adUnitId: ADUNIT_CODE,
           bids: [
             {bidder: BIDDER_CODE, params: {placementId: 'id'}},
           ],
@@ -1702,7 +1708,7 @@ describe('auctionmanager.js', function () {
   function mockAuction(getBidRequests, start = 1) {
     return {
       getBidRequests: getBidRequests,
-      getAdUnits: () => getBidRequests().flatMap(br => br.bids).map(br => ({ code: br.adUnitCode, transactionId: br.transactionId, mediaTypes: br.mediaTypes })),
+      getAdUnits: () => getBidRequests().flatMap(br => br.bids).map(br => ({ code: br.adUnitCode, transactionId: br.transactionId, adUnitId: br.adUnitId, mediaTypes: br.mediaTypes })),
       getAuctionId: () => '1',
       addBidReceived: () => true,
       addBidRejected: () => true,
@@ -1773,8 +1779,8 @@ describe('auctionmanager.js', function () {
         let ADUNIT_CODE2 = 'adUnitCode2';
         let BIDDER_CODE2 = 'sampleBidder2';
 
-        let bids1 = [mockBid({ bidderCode: BIDDER_CODE1, transactionId: ADUNIT_CODE1 })];
-        let bids2 = [mockBid({ bidderCode: BIDDER_CODE2, transactionId: ADUNIT_CODE2 })];
+        let bids1 = [mockBid({ bidderCode: BIDDER_CODE1, adUnitId: ADUNIT_CODE1 })];
+        let bids2 = [mockBid({ bidderCode: BIDDER_CODE2, adUnitId: ADUNIT_CODE2 })];
         bidRequests = [
           mockBidRequest(bids[0]),
           mockBidRequest(bids1[0], { adUnitCode: ADUNIT_CODE1 }),

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -91,6 +91,7 @@ const REQUEST = {
         }
       },
       'transactionId': '4ef956ad-fd83-406d-bd35-e4bb786ab86c',
+      'adUnitId': 'au-id-1',
       'bids': [
         {
           'bid_id': '123',

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -116,7 +116,8 @@ describe('the price floors module', function () {
     bidder: 'rubicon',
     adUnitCode: 'test_div_1',
     auctionId: '1234-56-789',
-    transactionId: 'tr_test_div_1'
+    transactionId: 'tr_test_div_1',
+    adUnitId: 'tr_test_div_1',
   };
 
   function getAdUnitMock(code = 'adUnit-code') {
@@ -618,8 +619,8 @@ describe('the price floors module', function () {
         });
       });
       it('picks the gptSlot from the adUnit and does not call the slotMatching', function () {
-        const newBidRequest1 = { ...basicBidRequest, transactionId: 'au1' };
-        adUnits = [{code: newBidRequest1.code, transactionId: 'au1'}];
+        const newBidRequest1 = { ...basicBidRequest, adUnitId: 'au1' };
+        adUnits = [{code: newBidRequest1.adUnitCode, adUnitId: 'au1'}];
         utils.deepSetValue(adUnits[0], 'ortb2Imp.ext.data.adserver', {
           name: 'gam',
           adslot: '/12345/news/politics'
@@ -632,8 +633,8 @@ describe('the price floors module', function () {
           matchingRule: '/12345/news/politics'
         });
 
-        const newBidRequest2 = { ...basicBidRequest, adUnitCode: 'test_div_2', transactionId: 'au2' };
-        adUnits = [{code: newBidRequest2.adUnitCode, transactionId: newBidRequest2.transactionId}];
+        const newBidRequest2 = { ...basicBidRequest, adUnitCode: 'test_div_2', adUnitId: 'au2' };
+        adUnits = [{code: newBidRequest2.adUnitCode, adUnitId: newBidRequest2.adUnitId}];
         utils.deepSetValue(adUnits[0], 'ortb2Imp.ext.data.adserver', {
           name: 'gam',
           adslot: '/12345/news/weather'
@@ -2345,7 +2346,7 @@ describe('the price floors module', function () {
     }
 
     const resp = {
-      transactionId: req.transactionId,
+      adUnitId: req.adUnitId,
       size: [100, 100],
       mediaType: 'banner',
     }
@@ -2356,7 +2357,7 @@ describe('the price floors module', function () {
         adUnits: [
           {
             code: req.adUnitCode,
-            transactionId: req.transactionId,
+            adUnitId: req.adUnitId,
             ortb2Imp: {ext: {data: {adserver: {name: 'gam', adslot: 'slot'}}}}
           }
         ]

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -19,7 +19,7 @@ const utils = require('src/utils');
 
 const bid = {
   adId: '123',
-  transactionId: 'au',
+  adUnitId: 'au',
   native: {
     title: 'Native Creative',
     body: 'Cool description great stuff',
@@ -49,7 +49,7 @@ const bid = {
 
 const ortbBid = {
   adId: '123',
-  transactionId: 'au',
+  adUnitId: 'au',
   native: {
     ortb: {
       assets: [
@@ -106,7 +106,7 @@ const ortbBid = {
 
 const completeNativeBid = {
   adId: '123',
-  transactionId: 'au',
+  adUnitId: 'au',
   native: {
     ...bid.native,
     ...ortbBid.native
@@ -157,7 +157,7 @@ const ortbRequest = {
 }
 
 const bidWithUndefinedFields = {
-  transactionId: 'au',
+  adUnitId: 'au',
   native: {
     title: 'Native Creative',
     body: undefined,
@@ -209,7 +209,7 @@ describe('native.js', function () {
 
   it('sends placeholders for configured assets', function () {
     const adUnit = {
-      transactionId: 'au',
+      adUnitId: 'au',
       nativeParams: {
         body: { sendId: true },
         clickUrl: { sendId: true },
@@ -246,7 +246,7 @@ describe('native.js', function () {
 
   it('should only include native targeting keys with values', function () {
     const adUnit = {
-      transactionId: 'au',
+      adUnitId: 'au',
       nativeParams: {
         body: { sendId: true },
         clickUrl: { sendId: true },
@@ -273,7 +273,7 @@ describe('native.js', function () {
 
   it('should only include targeting that has sendTargetingKeys set to true', function () {
     const adUnit = {
-      transactionId: 'au',
+      adUnitId: 'au',
       nativeParams: {
         image: {
           required: true,
@@ -294,7 +294,7 @@ describe('native.js', function () {
 
   it('should only include targeting if sendTargetingKeys not set to false', function () {
     const adUnit = {
-      transactionId: 'au',
+      adUnitId: 'au',
       nativeParams: {
         image: {
           required: true,
@@ -347,7 +347,7 @@ describe('native.js', function () {
 
   it('should copy over rendererUrl to bid object and include it in targeting', function () {
     const adUnit = {
-      transactionId: 'au',
+      adUnitId: 'au',
       nativeParams: {
         image: {
           required: true,
@@ -382,7 +382,7 @@ describe('native.js', function () {
 
   it('should copy over adTemplate to bid object and include it in targeting', function () {
     const adUnit = {
-      transactionId: 'au',
+      adUnitId: 'au',
       nativeParams: {
         image: {
           required: true,
@@ -724,7 +724,7 @@ describe('validate native openRTB', function () {
 
 describe('validate native', function () {
   const adUnit = {
-    transactionId: 'test_adunit',
+    adUnitId: 'test_adunit',
     mediaTypes: {
       native: {
         title: {
@@ -749,7 +749,7 @@ describe('validate native', function () {
   let validBid = {
     adId: 'abc123',
     requestId: 'test_bid_id',
-    transactionId: 'test_adunit',
+    adUnitId: 'test_adunit',
     adUnitCode: '123/prebid_native_adunit',
     bidder: 'test_bidder',
     native: {
@@ -776,7 +776,7 @@ describe('validate native', function () {
   let noIconDimBid = {
     adId: 'abc234',
     requestId: 'test_bid_id',
-    transactionId: 'test_adunit',
+    adUnitId: 'test_adunit',
     adUnitCode: '123/prebid_native_adunit',
     bidder: 'test_bidder',
     native: {
@@ -799,7 +799,7 @@ describe('validate native', function () {
   let noImgDimBid = {
     adId: 'abc345',
     requestId: 'test_bid_id',
-    transactionId: 'test_adunit',
+    adUnitId: 'test_adunit',
     adUnitCode: '123/prebid_native_adunit',
     bidder: 'test_bidder',
     native: {
@@ -836,7 +836,7 @@ describe('validate native', function () {
 
   it('should convert from old-style native to OpenRTB request', () => {
     const adUnit = {
-      transactionId: 'test_adunit',
+      adUnitId: 'test_adunit',
       mediaTypes: {
         native: {
           title: {
@@ -1043,7 +1043,7 @@ describe('validate native', function () {
       const validBidRequests = [{
         bidId: 'bidId3',
         adUnitCode: 'adUnitCode3',
-        transactionId: 'transactionId3',
+        adUnitId: 'transactionId3',
         mediaTypes: {
           banner: {}
         },

--- a/test/spec/unit/core/auctionIndex_spec.js
+++ b/test/spec/unit/core/auctionIndex_spec.js
@@ -38,22 +38,22 @@ describe('auction index', () => {
     let adUnits;
 
     beforeEach(() => {
-      adUnits = [{transactionId: 'au1'}, {transactionId: 'au2'}];
+      adUnits = [{adUnitId: 'au1'}, {adUnitId: 'au2'}];
       auctions = [
         mockAuction('a1', [adUnits[0], {}]),
         mockAuction('a2', [adUnits[1]])
       ];
     });
 
-    it('should find adUnits by transactionId', () => {
-      expect(index.getAdUnit({transactionId: 'au2'})).to.equal(adUnits[1]);
+    it('should find adUnits by adUnitId', () => {
+      expect(index.getAdUnit({adUnitId: 'au2'})).to.equal(adUnits[1]);
     });
 
     it('should return undefined if adunit is missing', () => {
-      expect(index.getAdUnit({transactionId: 'missing'})).to.be.undefined;
+      expect(index.getAdUnit({adUnitId: 'missing'})).to.be.undefined;
     });
 
-    it('should return undefined if no transactionId is provided', () => {
+    it('should return undefined if no adUnitId is provided', () => {
       expect(index.getAdUnit({})).to.be.undefined;
     });
   });
@@ -87,12 +87,12 @@ describe('auction index', () => {
     beforeEach(() => {
       mediaTypes = [{mockMT: '1'}, {mockMT: '2'}, {mockMT: '3'}, {mockMT: '4'}]
       adUnits = [
-        {transactionId: 'au1', mediaTypes: mediaTypes[0]},
-        {transactionId: 'au2', mediaTypes: mediaTypes[1]}
+        {adUnitId: 'au1', mediaTypes: mediaTypes[0]},
+        {adUnitId: 'au2', mediaTypes: mediaTypes[1]}
       ]
       bidderRequests = [
-        {bidderRequestId: 'ber1', bids: [{bidId: 'b1', mediaTypes: mediaTypes[2], transactionId: 'au1'}, {}]},
-        {bidderRequestId: 'ber2', bids: [{bidId: 'b2', mediaTypes: mediaTypes[3], transactionId: 'au2'}]}
+        {bidderRequestId: 'ber1', bids: [{bidId: 'b1', mediaTypes: mediaTypes[2], adUnitId: 'au1'}, {}]},
+        {bidderRequestId: 'ber2', bids: [{bidId: 'b2', mediaTypes: mediaTypes[3], adUnitId: 'au2'}]}
       ]
       auctions = [
         mockAuction('a1', [adUnits[0]], [bidderRequests[0], {}]),
@@ -100,8 +100,8 @@ describe('auction index', () => {
       ]
     });
 
-    it('should find mediaTypes by transactionId', () => {
-      expect(index.getMediaTypes({transactionId: 'au2'})).to.equal(mediaTypes[1]);
+    it('should find mediaTypes by adUnitId', () => {
+      expect(index.getMediaTypes({adUnitId: 'au2'})).to.equal(mediaTypes[1]);
     });
 
     it('should find mediaTypes by requestId', () => {
@@ -109,18 +109,18 @@ describe('auction index', () => {
     });
 
     it('should give precedence to request.mediaTypes over adUnit.mediaTypes', () => {
-      expect(index.getMediaTypes({requestId: 'b2', transactionId: 'au2'})).to.equal(mediaTypes[3]);
+      expect(index.getMediaTypes({requestId: 'b2', adUnitId: 'au2'})).to.equal(mediaTypes[3]);
     });
 
-    it('should return undef if requestId and transactionId do not match', () => {
-      expect(index.getMediaTypes({requestId: 'b1', transactionId: 'au2'})).to.be.undefined;
+    it('should return undef if requestId and adUnitId do not match', () => {
+      expect(index.getMediaTypes({requestId: 'b1', adUnitId: 'au2'})).to.be.undefined;
     });
 
     it('should return undef if no params are provided', () => {
       expect(index.getMediaTypes({})).to.be.undefined;
     });
 
-    ['requestId', 'transactionId'].forEach(param => {
+    ['requestId', 'adUnitId'].forEach(param => {
       it(`should return undef if ${param} is missing`, () => {
         expect(index.getMediaTypes({[param]: 'missing'})).to.be.undefined;
       });

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -1086,7 +1086,7 @@ describe('bidderFactory', () => {
     if (FEATURES.NATIVE) {
       it('should add native bids that do have required assets', function () {
         adUnits = [{
-          transactionId: 'au',
+          adUnitId: 'au',
           nativeParams: {
             title: {'required': true},
           }
@@ -1097,7 +1097,7 @@ describe('bidderFactory', () => {
             bidId: '1',
             auctionId: 'first-bid-id',
             adUnitCode: 'mock/placement',
-            transactionId: 'au',
+            adUnitId: 'au',
             params: {
               param: 5
             },

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -556,6 +556,7 @@ describe('Unit: Prebid Module', function () {
             'bidderRequestId': '331f3cf3f1d9c8',
             'auctionId': '20882439e3238c',
             'transactionId': 'trdiv-gpt-ad-1460505748561-0',
+            'adUnitId': 'audiv-gpt-ad-1460505748561-0',
           }
         ],
         'auctionStart': 1505250713622,
@@ -573,6 +574,7 @@ describe('Unit: Prebid Module', function () {
       let auctionManagerInstance = newAuctionManager();
       targeting = newTargeting(auctionManagerInstance);
       let adUnits = [{
+        adUnitId: 'audiv-gpt-ad-1460505748561-0',
         transactionId: 'trdiv-gpt-ad-1460505748561-0',
         code: 'div-gpt-ad-1460505748561-0',
         sizes: [[300, 250], [300, 600]],
@@ -718,6 +720,7 @@ describe('Unit: Prebid Module', function () {
 
       const adUnit = {
         transactionId: `tr${code}`,
+        adUnitId: `au${code}`,
         code: code,
         sizes: [[300, 250], [300, 600]],
         bids: [{
@@ -820,6 +823,7 @@ describe('Unit: Prebid Module', function () {
               },
               'adUnitCode': 'div-gpt-ad-1460505748561-0',
               'transactionId': 'trdiv-gpt-ad-1460505748561-0',
+              'adUnitId': 'audiv-gpt-ad-1460505748561-0',
               'sizes': [
                 [
                   300,
@@ -1532,6 +1536,7 @@ describe('Unit: Prebid Module', function () {
           }
         },
         transactionId: 'mock-tid',
+        adUnitId: 'mock-au',
         bids: [
           {bidder: BIDDER_CODE, params: {placementId: 'id'}},
         ]
@@ -1606,6 +1611,7 @@ describe('Unit: Prebid Module', function () {
         height: 250,
         adUnitCode: bidRequests[0].bids[0].adUnitCode,
         transactionId: 'mock-tid',
+        adUnitId: 'mock-au',
         adserverTargeting: {
           'hb_bidder': BIDDER_CODE,
           'hb_adid': bidId,
@@ -1684,7 +1690,8 @@ describe('Unit: Prebid Module', function () {
             const bid = {
               bidder: 'mock-bidder',
               adUnitCode: adUnits[0].code,
-              transactionId: adUnits[0].transactionId
+              transactionId: adUnits[0].transactionId,
+              adUnitId: adUnits[0].adUnitId,
             }
             requestBids({
               adUnits,
@@ -1968,6 +1975,34 @@ describe('Unit: Prebid Module', function () {
           .and.not.to.equal('d0676a3c-ff32-45a5-af65-8175a8e7ddca');
         expect(auctionArgs.adUnits[1]).to.have.property('transactionId')
           .and.to.match(/[a-f0-9\-]{36}/i);
+      });
+
+      it('should generate unique adUnitId', () => {
+        $$PREBID_GLOBAL$$.requestBids({
+          adUnits: [
+            {
+              code: 'single',
+              mediaTypes: { banner: { sizes: [] } },
+              bids: []
+            }, {
+              code: 'twin',
+              mediaTypes: { banner: { sizes: [] } },
+              bids: []
+            },
+            {
+              code: 'twin',
+              mediaTypes: { banner: { sizes: [] } },
+              bids: []
+            }
+          ]
+        });
+
+        const ids = new Set();
+        auctionArgs.adUnits.forEach(au => {
+          expect(au.adUnitId).to.exist;
+          ids.add(au.adUnitId);
+        });
+        expect(ids.size).to.eql(3);
       });
 
       describe('transactionId', () => {
@@ -3546,7 +3581,7 @@ describe('Unit: Prebid Module', function () {
       {
         code: 'adUnit-code-1',
         mediaTypes: { banner: { sizes: [[300, 250], [300, 600]] } },
-        transactionId: '1234567890',
+        adUnitId: '1234567890',
         bids: [
           { bidder: 'pubmatic', params: {placementId: '10433394'}, adUnitCode: 'adUnit-code-1' }
         ]
@@ -3555,15 +3590,15 @@ describe('Unit: Prebid Module', function () {
         code: 'adUnit-code-2',
         deferBilling: true,
         mediaTypes: { banner: { sizes: [[300, 250], [300, 600]] } },
-        transactionId: '0987654321',
+        adUnitId: '0987654321',
         bids: [
           { bidder: 'pubmatic', params: {placementId: '10433394'}, adUnitCode: 'adUnit-code-2' }
         ]
       }
     ];
 
-    let winningBid1 = { adapterCode: 'pubmatic', bidder: 'pubmatic', params: {placementId: '10433394'}, adUnitCode: 'adUnit-code-1', transactionId: '1234567890', adId: 'abcdefg' }
-    let winningBid2 = { adapterCode: 'pubmatic', bidder: 'pubmatic', params: {placementId: '10433394'}, adUnitCode: 'adUnit-code-2', transactionId: '0987654321' }
+    let winningBid1 = { adapterCode: 'pubmatic', bidder: 'pubmatic', params: {placementId: '10433394'}, adUnitCode: 'adUnit-code-1', adUnitId: '1234567890', adId: 'abcdefg' }
+    let winningBid2 = { adapterCode: 'pubmatic', bidder: 'pubmatic', params: {placementId: '10433394'}, adUnitCode: 'adUnit-code-2', adUnitId: '0987654321' }
     let adUnitCodes = ['adUnit-code-1', 'adUnit-code-2'];
     let auction = auctionModule.newAuction({adUnits, adUnitCodes, callback: function() {}, cbTimeout: 2000});
 

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1977,6 +1977,74 @@ describe('Unit: Prebid Module', function () {
           .and.to.match(/[a-f0-9\-]{36}/i);
       });
 
+      it('should use the same transactionID for ad units with the same code', () => {
+        $$PREBID_GLOBAL$$.requestBids({
+          adUnits: [
+            {
+              code: 'twin',
+              mediaTypes: { banner: { sizes: [] } },
+              bids: []
+            }, {
+              code: 'twin',
+              mediaTypes: { banner: { sizes: [] } },
+              bids: []
+            }
+          ]
+        });
+        const tid = auctionArgs.adUnits[0].transactionId;
+        expect(tid).to.exist;
+        expect(auctionArgs.adUnits[1].transactionId).to.eql(tid);
+      });
+
+      it('should re-use pub-provided transaction ID for ad units with the same code', () => {
+        $$PREBID_GLOBAL$$.requestBids({
+          adUnits: [
+            {
+              code: 'twin',
+              mediaTypes: { banner: { sizes: [] } },
+              bids: [],
+            }, {
+              code: 'twin',
+              mediaTypes: { banner: { sizes: [] } },
+              bids: [],
+              ortb2Imp: {
+                ext: {
+                  tid: 'pub-tid'
+                }
+              }
+            }
+          ]
+        });
+        expect(auctionArgs.adUnits.map(au => au.transactionId)).to.eql(['pub-tid', 'pub-tid']);
+      });
+
+      it('should use pub-provided TIDs when they conflict for ad units with the same code', () => {
+        $$PREBID_GLOBAL$$.requestBids({
+          adUnits: [
+            {
+              code: 'twin',
+              mediaTypes: { banner: { sizes: [] } },
+              bids: [],
+              ortb2Imp: {
+                ext: {
+                  tid: 't1'
+                }
+              }
+            }, {
+              code: 'twin',
+              mediaTypes: { banner: { sizes: [] } },
+              bids: [],
+              ortb2Imp: {
+                ext: {
+                  tid: 't2'
+                }
+              }
+            }
+          ]
+        });
+        expect(auctionArgs.adUnits.map(au => au.transactionId)).to.eql(['t1', 't2']);
+      });
+
       it('should generate unique adUnitId', () => {
         $$PREBID_GLOBAL$$.requestBids({
           adUnits: [

--- a/test/spec/video_spec.js
+++ b/test/spec/video_spec.js
@@ -82,10 +82,10 @@ describe('video.js', function () {
       const bid = {
         adId: '456xyz',
         vastUrl: 'http://www.example.com/vastUrl',
-        transactionId: 'au'
+        adUnitId: 'au'
       };
       const adUnits = [{
-        transactionId: 'au',
+        adUnitId: 'au',
         mediaTypes: {
           video: {context: 'instream'}
         }
@@ -96,10 +96,10 @@ describe('video.js', function () {
 
     it('catches invalid instream bids', function () {
       const bid = {
-        transactionId: 'au'
+        adUnitId: 'au'
       };
       const adUnits = [{
-        transactionId: 'au',
+        adUnitId: 'au',
         mediaTypes: {
           video: {context: 'instream'}
         }
@@ -110,26 +110,26 @@ describe('video.js', function () {
 
     it('catches invalid bids when prebid-cache is disabled', function () {
       const adUnits = [{
-        transactionId: 'au',
+        adUnitId: 'au',
         bidder: 'vastOnlyVideoBidder',
         mediaTypes: {video: {}},
       }];
 
-      const valid = isValidVideoBid({ transactionId: 'au', vastXml: '<xml>vast</xml>' }, {index: stubAuctionIndex({adUnits})});
+      const valid = isValidVideoBid({ adUnitId: 'au', vastXml: '<xml>vast</xml>' }, {index: stubAuctionIndex({adUnits})});
 
       expect(valid).to.equal(false);
     });
 
     it('validates valid outstream bids', function () {
       const bid = {
-        transactionId: 'au',
+        adUnitId: 'au',
         renderer: {
           url: 'render.url',
           render: () => true,
         }
       };
       const adUnits = [{
-        transactionId: 'au',
+        adUnitId: 'au',
         mediaTypes: {
           video: {context: 'outstream'}
         }
@@ -140,10 +140,10 @@ describe('video.js', function () {
 
     it('validates valid outstream bids with a publisher defined renderer', function () {
       const bid = {
-        transactionId: 'au',
+        adUnitId: 'au',
       };
       const adUnits = [{
-        transactionId: 'au',
+        adUnitId: 'au',
         mediaTypes: {
           video: {
             context: 'outstream',
@@ -160,10 +160,10 @@ describe('video.js', function () {
 
     it('catches invalid outstream bids', function () {
       const bid = {
-        transactionId: 'au',
+        adUnitId: 'au',
       };
       const adUnits = [{
-        transactionId: 'au',
+        adUnitId: 'au',
         mediaTypes: {
           video: {context: 'outstream'}
         }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fixes https://github.com/prebid/Prebid.js/issues/10858

Note that:

- `transactionId` was used internally as a unique identifier for the ad unit; this is now replaced by a new `adUnitId`;
- `adUnitId` is not protected by the `transmitTid` activity, and exchanges could in theory use it to correlate requests. My reasoning is that since adapters would have to go out of their way to do so - picking up this new field that is only useful to break rules - we can avoid the additional overhead to gate this under the activity. I can be convinced otherwise.
- there are several appnexus clones with [this copy-pasted piece of logic](https://github.com/search?q=repo%3Aprebid%2FPrebid.js+%22TODO%3A+why+does+this+need+to+iterate+through+every+ad+unit%22&type=code) that is broken by this change. However, it's also broken by turning off TIDs (which is the default since 8), and those adapters are already waiting for a fix.

