### PR TITLE
Discovery Bid Adapter : not filter params

### DIFF
--- a/modules/discoveryBidAdapter.js
+++ b/modules/discoveryBidAdapter.js
@@ -511,7 +511,7 @@ export const spec = {
     if (bid.params.badv) {
       globals['badv'] = Array.isArray(bid.params.badv) ? bid.params.badv : [];
     }
-    return !!(bid.params.token && bid.params.publisher && bid.params.tagid);
+    return true;
   },
 
   /**
@@ -522,6 +522,8 @@ export const spec = {
    * @return ServerRequest Info describing the request to the server.
    */
   buildRequests: function (validBidRequests, bidderRequest) {
+    if (!globals['token']) return;
+
     let payload = getParam(validBidRequests, bidderRequest);
 
     const payloadString = JSON.stringify(payload);

--- a/test/spec/modules/discoveryBidAdapter_spec.js
+++ b/test/spec/modules/discoveryBidAdapter_spec.js
@@ -170,7 +170,7 @@ describe('discovery:BidAdapterTests', function () {
         bidder: 'discovery',
         params: {},
       })
-    ).to.equal(true);
+    ).to.be.undefined;
   });
 
   it('discovery:validate_generated_params', function () {

--- a/test/spec/modules/discoveryBidAdapter_spec.js
+++ b/test/spec/modules/discoveryBidAdapter_spec.js
@@ -164,25 +164,19 @@ describe('discovery:BidAdapterTests', function () {
     ).to.equal(true);
   });
 
-  it('discovery:no params', function () {
+  it('isBidRequestValid:no_params', function () {
     expect(
       spec.isBidRequestValid({
         bidder: 'discovery',
         params: {},
       })
-    ).to.be.undefined;
+    ).to.equal(true);
   });
 
   it('discovery:validate_generated_params', function () {
     request = spec.buildRequests(bidRequestData.bids, bidRequestData);
     let req_data = JSON.parse(request.data);
     expect(req_data.imp).to.have.lengthOf(1);
-  });
-
-  it('discovery:no_params', function () {
-    request = spec.buildRequests(bidRequestDataNoParams.bids, bidRequestData);
-    let req_data = JSON.parse(request.data);
-    expect(req_data.imp).to.have.lengthOf(0);
   });
 
   describe('discovery: buildRequests', function() {

--- a/test/spec/modules/discoveryBidAdapter_spec.js
+++ b/test/spec/modules/discoveryBidAdapter_spec.js
@@ -179,7 +179,6 @@ describe('discovery:BidAdapterTests', function () {
     expect(req_data.imp).to.have.lengthOf(1);
   });
 
-
   it('discovery:no_params', function () {
     request = spec.buildRequests(bidRequestDataNoParams.bids, bidRequestData);
     let req_data = JSON.parse(request.data);

--- a/test/spec/modules/discoveryBidAdapter_spec.js
+++ b/test/spec/modules/discoveryBidAdapter_spec.js
@@ -80,6 +80,77 @@ describe('discovery:BidAdapterTests', function () {
   };
   let request = [];
 
+  let bidRequestDataNoParams = {
+    bidderCode: 'discovery',
+    auctionId: 'ff66e39e-4075-4d18-9854-56fde9b879ac',
+    bidderRequestId: '4fec04e87ad785',
+    bids: [
+      {
+        bidder: 'discovery',
+        params: {
+          referrer: 'https://discovery.popin.cc',
+        },
+        refererInfo: {
+          page: 'https://discovery.popin.cc',
+          stack: [
+            'a.com',
+            'b.com'
+          ]
+        },
+        mediaTypes: {
+          banner: {
+            sizes: [[300, 250]],
+            pos: 'left',
+          },
+        },
+        ortb2: {
+          user: {
+            ext: {
+              data: {
+                CxSegments: []
+              }
+            }
+          },
+          site: {
+            domain: 'discovery.popin.cc',
+            publisher: {
+              domain: 'discovery.popin.cc'
+            },
+            page: 'https://discovery.popin.cc',
+            cat: ['IAB-19', 'IAB-20'],
+          },
+        },
+        ortb2Imp: {
+          ext: {
+            gpid: 'adslot_gpid',
+            tid: 'tid_01',
+            data: {
+              browsi: {
+                browsiViewability: 'NA',
+              },
+              adserver: {
+                name: 'adserver_name',
+                adslot: 'adslot_name',
+              },
+              keywords: ['travel', 'sport'],
+              pbadslot: '202309999'
+            }
+          }
+        },
+        adUnitCode: 'regular_iframe',
+        transactionId: 'd163f9e2-7ecd-4c2c-a3bd-28ceb52a60ee',
+        sizes: [[300, 250]],
+        bidId: '276092a19e05eb',
+        bidderRequestId: '1fadae168708b',
+        auctionId: 'ff66e39e-4075-4d18-9854-56fde9b879ac',
+        src: 'client',
+        bidRequestsCount: 1,
+        bidderRequestsCount: 1,
+        bidderWinsCount: 0,
+      },
+    ],
+  };
+
   it('discovery:validate_pub_params', function () {
     expect(
       spec.isBidRequestValid({
@@ -93,10 +164,26 @@ describe('discovery:BidAdapterTests', function () {
     ).to.equal(true);
   });
 
+  it('discovery:no params', function () {
+    expect(
+      spec.isBidRequestValid({
+        bidder: 'discovery',
+        params: {},
+      })
+    ).to.equal(true);
+  });
+
   it('discovery:validate_generated_params', function () {
     request = spec.buildRequests(bidRequestData.bids, bidRequestData);
     let req_data = JSON.parse(request.data);
     expect(req_data.imp).to.have.lengthOf(1);
+  });
+
+
+  it('discovery:no_params', function () {
+    request = spec.buildRequests(bidRequestDataNoParams.bids, bidRequestData);
+    let req_data = JSON.parse(request.data);
+    expect(req_data.imp).to.have.lengthOf(0);
   });
 
   describe('discovery: buildRequests', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
just filter token once. not filter publisher and tagid

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
