### PR TITLE
Rubicon Bid Adapter: pass DSA fields

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -916,6 +916,7 @@ function applyFPD(bidRequest, mediaType, data) {
   let impExtData = deepAccess(bidRequest.ortb2Imp, 'ext.data') || {};
 
   const gpid = deepAccess(bidRequest, 'ortb2Imp.ext.gpid');
+  const dsa = deepAccess(fpd, 'regs.ext.dsa');
   const SEGTAX = {user: [4], site: [1, 2, 5, 6]};
   const MAP = {user: 'tg_v.', site: 'tg_i.', adserver: 'tg_i.dfp_ad_unit_code', pbadslot: 'tg_i.pbadslot', keywords: 'kw'};
   const validate = function(prop, key, parentName) {
@@ -969,6 +970,26 @@ function applyFPD(bidRequest, mediaType, data) {
     // add in gpid
     if (gpid) {
       data['p_gpid'] = gpid;
+    }
+
+    // add dsa signals
+    if (dsa && Object.keys(dsa).length) {
+      pick(dsa, [
+        'dsainfo', (dsainfo) => data['dsainfo'] = dsainfo,
+        'required', (required) => data['dsarequired'] = required,
+        'pubrender', (pubrender) => data['dsapubrender'] = pubrender,
+        'datatopub', (datatopub) => data['dsadatatopubs'] = datatopub,
+        'transparency', (transparency) => {
+          if (Array.isArray(transparency) && transparency.length) {
+            data['dsatransparency'] = transparency.reduce((param, transp) => {
+              if (param) {
+                param += '~~'
+              }
+              return param += `${transp.domain}~${transp.params.join('_')}`
+            }, '')
+          }
+        }
+      ])
     }
 
     // only send one of pbadslot or dfp adunit code (prefer pbadslot)

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -694,6 +694,10 @@ export const spec = {
           bid.mediaType = ad.creative_type;
         }
 
+        if (ad.dsa && Object.keys(ad.dsa).length) {
+          bid.meta.dsa = ad.dsa;
+        }
+
         if (ad.adomain) {
           bid.meta.advertiserDomains = Array.isArray(ad.adomain) ? ad.adomain : [ad.adomain];
         }

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -976,7 +976,7 @@ function applyFPD(bidRequest, mediaType, data) {
     if (dsa && Object.keys(dsa).length) {
       pick(dsa, [
         'dsainfo', (dsainfo) => data['dsainfo'] = dsainfo,
-        'required', (required) => data['dsarequired'] = required,
+        'dsarequired', (required) => data['dsarequired'] = required,
         'pubrender', (pubrender) => data['dsapubrender'] = pubrender,
         'datatopub', (datatopub) => data['dsadatatopubs'] = datatopub,
         'transparency', (transparency) => {
@@ -985,7 +985,7 @@ function applyFPD(bidRequest, mediaType, data) {
               if (param) {
                 param += '~~'
               }
-              return param += `${transp.domain}~${transp.params.join('_')}`
+              return param += `${transp.domain}~${transp.dsaparams.join('_')}`
             }, '')
           }
         }

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1575,7 +1575,7 @@ describe('the rubicon adapter', function () {
           describe('UserID catchall support', function () {
             it('should send user id with generic format', function () {
               const clonedBid = utils.deepClone(bidderRequest.bids[0]);
-              // Hardcoding userIdAsEids since createEidsArray returns empty array if source not found in eids.js
+              // Hardcoding userIdAsEids since createEirray returns empty array if source not found in eids.js
               clonedBid.userIdAsEids = [{
                 source: 'catchall',
                 uids: [{
@@ -1591,7 +1591,7 @@ describe('the rubicon adapter', function () {
 
             it('should send rubiconproject special case', function () {
               const clonedBid = utils.deepClone(bidderRequest.bids[0]);
-              // Hardcoding userIdAsEids since createEidsArray returns empty array if source not found in eids.js
+              // Hardcoding userIdAsEids since createEirray returns empty array if source not found in eids.js
               clonedBid.userIdAsEids = [{
                 source: 'rubiconproject.com',
                 uids: [{
@@ -1717,17 +1717,17 @@ describe('the rubicon adapter', function () {
               regs: {
                 ext: {
                   dsa: {
-                    required: 3,
+                    dsarequired: 3,
                     pubrender: 0,
                     datatopub: 2,
                     transparency: [
                       {
                         domain: 'testdomain.com',
-                        params: [1],
+                        dsaparams: [1],
                       },
                       {
                         domain: 'testdomain2.com',
-                        params: [1, 2]
+                        dsaparams: [1, 2]
                       }
                     ]
                   }
@@ -1745,7 +1745,7 @@ describe('the rubicon adapter', function () {
               expect(data).to.have.property('dsadatatopubs');
               expect(data).to.have.property('dsatransparency');
 
-              expect(data['dsarequired']).to.equal(ortb2.regs.ext.dsa.required.toString());
+              expect(data['dsarequired']).to.equal(ortb2.regs.ext.dsa.dsarequired.toString());
               expect(data['dsapubrender']).to.equal(ortb2.regs.ext.dsa.pubrender.toString());
               expect(data['dsadatatopubs']).to.equal(ortb2.regs.ext.dsa.datatopub.toString());
               expect(data['dsatransparency']).to.equal(expectedTransparency)

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1575,7 +1575,7 @@ describe('the rubicon adapter', function () {
           describe('UserID catchall support', function () {
             it('should send user id with generic format', function () {
               const clonedBid = utils.deepClone(bidderRequest.bids[0]);
-              // Hardcoding userIdAsEids since createEirray returns empty array if source not found in eids.js
+              // Hardcoding userIdAsEids since createEidsArray returns empty array if source not found in eids.js
               clonedBid.userIdAsEids = [{
                 source: 'catchall',
                 uids: [{
@@ -1591,7 +1591,7 @@ describe('the rubicon adapter', function () {
 
             it('should send rubiconproject special case', function () {
               const clonedBid = utils.deepClone(bidderRequest.bids[0]);
-              // Hardcoding userIdAsEids since createEirray returns empty array if source not found in eids.js
+              // Hardcoding userIdAsEids since createEidsArray returns empty array if source not found in eids.js
               clonedBid.userIdAsEids = [{
                 source: 'rubiconproject.com',
                 uids: [{
@@ -3407,11 +3407,6 @@ describe('the rubicon adapter', function () {
               }
             ]
           };
-          // config.setConfig({
-          //   rubicon: {
-          //     netRevenue: false
-          //   }
-          // });
           let bids = spec.interpretResponse({body: response}, {
             bidRequest: bidderRequest.bids[0]
           });

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -3338,6 +3338,91 @@ describe('the rubicon adapter', function () {
           expect(bids[0].cpm).to.be.equal(0);
         });
 
+        it('should handle DSA object from response', function() {
+          let response = {
+            'status': 'ok',
+            'account_id': 14062,
+            'site_id': 70608,
+            'zone_id': 530022,
+            'size_id': 15,
+            'alt_size_ids': [
+              43
+            ],
+            'tracking': '',
+            'inventory': {},
+            'ads': [
+              {
+                'status': 'ok',
+                'impression_id': '153dc240-8229-4604-b8f5-256933b9374c',
+                'size_id': '15',
+                'ad_id': '6',
+                'adomain': ['test.com'],
+                'advertiser': 7,
+                'network': 8,
+                'creative_id': 'crid-9',
+                'type': 'script',
+                'script': 'alert(\'foo\')',
+                'campaign_id': 10,
+                'cpm': 0.811,
+                'targeting': [
+                  {
+                    'key': 'rpfl_14062',
+                    'values': [
+                      '15_tier_all_test'
+                    ]
+                  }
+                ],
+                'dsa': {
+                  'behalf': 'Advertiser',
+                  'paid': 'Advertiser',
+                  'transparency': [{
+                    'domain': 'dsp1domain.com',
+                    'dsaparams': [1, 2]
+                  }],
+                  'adrender': 1
+                }
+              },
+              {
+                'status': 'ok',
+                'impression_id': '153dc240-8229-4604-b8f5-256933b9374d',
+                'size_id': '43',
+                'ad_id': '7',
+                'adomain': ['test.com'],
+                'advertiser': 7,
+                'network': 8,
+                'creative_id': 'crid-9',
+                'type': 'script',
+                'script': 'alert(\'foo\')',
+                'campaign_id': 10,
+                'cpm': 0.911,
+                'targeting': [
+                  {
+                    'key': 'rpfl_14062',
+                    'values': [
+                      '43_tier_all_test'
+                    ]
+                  }
+                ],
+                'dsa': {}
+              }
+            ]
+          };
+          // config.setConfig({
+          //   rubicon: {
+          //     netRevenue: false
+          //   }
+          // });
+          let bids = spec.interpretResponse({body: response}, {
+            bidRequest: bidderRequest.bids[0]
+          });
+          expect(bids).to.be.lengthOf(2);
+          expect(bids[1].meta.dsa).to.have.property('behalf');
+          expect(bids[1].meta.dsa).to.have.property('paid');
+
+          // if we dont have dsa field in response or the dsa object is empty
+          expect(bids[0].meta).to.not.have.property('dsa');
+        })
+
         it('should create bids with matching requestIds if imp id matches', function () {
           let bidRequests = [{
             'bidder': 'rubicon',


### PR DESCRIPTION
## Type of change
- [X] Feature

## Description of change
The rubicon prebid.js adapter must be able to pass publisher-specified DSA fields through the fastlane.json GET interface.