### PR TITLE
Insticator Bid Adaptor:  add support for bidder video params

### DIFF
--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -120,6 +120,7 @@ function buildVideo(bidRequest) {
   }
 
   const bidRequestVideo = deepAccess(bidRequest, 'mediaTypes.video');
+  const videoBidderParams = deepAccess(bidRequest, 'params.video', {});
   let optionalParams = {};
   for (const param in OPTIONAL_VIDEO_PARAMS) {
     if (bidRequestVideo[param]) {
@@ -132,7 +133,8 @@ function buildVideo(bidRequest) {
     mimes,
     w,
     h,
-    ...optionalParams
+    ...optionalParams,
+    ...videoBidderParams
   }
 
   if (plcmt) {
@@ -384,7 +386,12 @@ function validateBanner(bid) {
 }
 
 function validateVideo(bid) {
-  const video = deepAccess(bid, 'mediaTypes.video');
+  const videoParams = deepAccess(bid, 'mediaTypes.video');
+  const videoBidderParams = deepAccess(bid, 'params.video', {});
+  let video = {
+    ...videoParams,
+    ...videoBidderParams
+  }
 
   if (video === undefined) {
     return true;

--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -134,7 +134,7 @@ function buildVideo(bidRequest) {
     w,
     h,
     ...optionalParams,
-    ...videoBidderParams
+    ...videoBidderParams // bidder specific overrides for video
   }
 
   if (plcmt) {
@@ -390,9 +390,8 @@ function validateVideo(bid) {
   const videoBidderParams = deepAccess(bid, 'params.video', {});
   let video = {
     ...videoParams,
-    ...videoBidderParams
+    ...videoBidderParams // bidder specific overrides for video
   }
-
   if (video === undefined) {
     return true;
   }

--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -393,8 +393,9 @@ function validateVideo(bid) {
     ...videoBidderParams // bidder specific overrides for video
   }
   // Check if the merged video object is empty
-  if (Object.keys(video).length === 0) {
-    return true; // or handle the case where video parameters are undefined or empty
+  if (Object.keys(video).length === 0 || video === undefined) {
+    logError('insticator: video object is empty');
+    return false; // or handle the case where video parameters are undefined or empty
   }
 
   let w = deepAccess(bid, 'mediaTypes.video.w');

--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -386,14 +386,15 @@ function validateBanner(bid) {
 }
 
 function validateVideo(bid) {
-  const videoParams = deepAccess(bid, 'mediaTypes.video');
+  const videoParams = deepAccess(bid, 'mediaTypes.video', {});
   const videoBidderParams = deepAccess(bid, 'params.video', {});
   let video = {
     ...videoParams,
     ...videoBidderParams // bidder specific overrides for video
   }
-  if (video === undefined) {
-    return true;
+  // Check if the merged video object is empty
+  if (Object.keys(video).length === 0) {
+    return true; // or handle the case where video parameters are undefined or empty
   }
 
   let w = deepAccess(bid, 'mediaTypes.video.w');

--- a/test/spec/modules/insticatorBidAdapter_spec.js
+++ b/test/spec/modules/insticatorBidAdapter_spec.js
@@ -286,6 +286,36 @@ describe('InsticatorBidAdapter', function () {
         }
       })).to.be.false;
     });
+
+    it('should return true when video bidder params override bidRequest video params', () => {
+      expect(spec.isBidRequestValid({
+        ...bidRequest,
+        ...{
+          mediaTypes: {
+            video: {
+              mimes: [
+                'video/mp4',
+                'video/mpeg',
+              ],
+              playerSize: [250, 300],
+              placement: 1,
+            },
+          }
+        },
+        params: {
+          ...bidRequest.params,
+          video: {
+            mimes: [
+              'video/mp4',
+              'video/mpeg',
+              'video/x-flv',
+              'video/webm',
+            ],
+            placement: 2,
+          },
+        }
+      })).to.be.true;
+    });
   });
 
   describe('buildRequests', function () {
@@ -461,6 +491,40 @@ describe('InsticatorBidAdapter', function () {
     });
     it('should return empty array if no valid requests are passed', function () {
       expect(spec.buildRequests([], bidderRequest)).to.be.an('array').that.have.lengthOf(0);
+    });
+
+    it('should have bidRequest params override bidRequest mediatypes', function () {
+      const tempBiddRequest = {
+        ...bidRequest,
+        params: {
+          ...bidRequest.params,
+          video: {
+            mimes: [
+              'video/mp4',
+              'video/mpeg',
+              'video/x-flv',
+              'video/webm',
+              'video/ogg',
+            ],
+            plcmt: 4,
+            w: 640,
+            h: 480,
+          }
+        }
+      }
+      const requests = spec.buildRequests([tempBiddRequest], bidderRequest);
+      const data = JSON.parse(requests[0].data);
+      expect(data.imp[0].video.mimes).to.deep.equal([
+        'video/mp4',
+        'video/mpeg',
+        'video/x-flv',
+        'video/webm',
+        'video/ogg',
+      ])
+      expect(data.imp[0].video.placement).to.equal(2);
+      expect(data.imp[0].video.plcmt).to.equal(4);
+      expect(data.imp[0].video.w).to.equal(640);
+      expect(data.imp[0].video.h).to.equal(480);
     });
   });
 

--- a/test/spec/modules/insticatorBidAdapter_spec.js
+++ b/test/spec/modules/insticatorBidAdapter_spec.js
@@ -493,7 +493,7 @@ describe('InsticatorBidAdapter', function () {
       expect(spec.buildRequests([], bidderRequest)).to.be.an('array').that.have.lengthOf(0);
     });
 
-    it('should have bidRequest params override bidRequest mediatypes', function () {
+    it('should have bidder params override bidRequest mediatypes', function () {
       const tempBiddRequest = {
         ...bidRequest,
         params: {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
