### PR TITLE
Pstudio Bid Adapter: initial release

### DIFF
--- a/modules/pstudioBidAdapter.js
+++ b/modules/pstudioBidAdapter.js
@@ -417,12 +417,8 @@ function validateSizes(sizes) {
 }
 
 function getBidFloor(bid) {
-  if (bid.params.floorPrice) {
-    return bid.params.floorPrice;
-  }
-
   if (!isFn(bid.getFloor)) {
-    return null;
+    return bid.params.floorPrice ? bid.params.floorPrice : null;
   }
 
   let floor = bid.getFloor({

--- a/modules/pstudioBidAdapter.js
+++ b/modules/pstudioBidAdapter.js
@@ -216,7 +216,6 @@ function readUserIdFromCookie(key) {
       return storedValue;
     }
   } catch (error) {
-    return;
   }
 }
 

--- a/modules/pstudioBidAdapter.js
+++ b/modules/pstudioBidAdapter.js
@@ -12,7 +12,7 @@ import {
 import { getStorageManager } from '../src/storageManager.js';
 
 const BIDDER_CODE = 'pstudio';
-const ENDPOINT = 'http://localhost:8080/prebid-bid';
+const ENDPOINT = 'https://nft-exchange.pre-prod.pstudio.tadex.id/prebid-bid'
 const TIME_TO_LIVE = 300;
 // in case that the publisher limits number of user syncs, thisse syncs will be discarded from the end of the list
 // so more improtant syncing calls should be at the start of the list

--- a/modules/pstudioBidAdapter.js
+++ b/modules/pstudioBidAdapter.js
@@ -206,7 +206,6 @@ function readUserIdFromCookie(key) {
       return match[matchedUserIdIndex];
     }
   } catch (error) {
-    return;
   }
 }
 

--- a/modules/pstudioBidAdapter.js
+++ b/modules/pstudioBidAdapter.js
@@ -1,0 +1,413 @@
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import { deepAccess, isArray, isNumber, generateUUID } from '../src/utils.js';
+
+const BIDDER_CODE = 'pstudio';
+const ENDPOINT = 'https://nft-exchange.pre-prod.pstudio.tadex.id/prebid-bid'
+const TIME_TO_LIVE = 300;
+// in case that the publisher limits number of user syncs, thisse syncs will be discarded from the end of the list
+// so more improtant syncing calls should be at the start of the list
+const USER_SYNCS = [
+  // PARTNER_UID is a partner user id
+  {
+    type: 'img',
+    url: 'https://match.adsrvr.org/track/cmf/generic?ttd_pid=k1on5ig&ttd_tpi=1&ttd_puid=%PARTNER_UID%&dsp=ttd',
+    macro: '%PARTNER_UID%',
+  },
+  {
+    type: 'img',
+    url: 'https://dsp.myads.telkomsel.com/api/v1/pixel?uid=%USERID%',
+    macro: '%USERID%',
+  },
+];
+const COOKIE_NAME = '__tadexid';
+const COOKIE_TTL_DAYS = 365;
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const SUPPORTED_MEDIA_TYPES = [BANNER, VIDEO];
+const VIDEO_PARAMS = [
+  'mimes',
+  'minduration',
+  'maxduration',
+  'protocols',
+  'startdelay',
+  'placement',
+  'skip',
+  'skipafter',
+  'minbitrate',
+  'maxbitrate',
+  'delivery',
+  'playbackmethod',
+  'api',
+  'linearity',
+];
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: SUPPORTED_MEDIA_TYPES,
+
+  isBidRequestValid: function (bid) {
+    const params = bid.params || {};
+    return !!params.pubid && !!params.floorPrice && isVideoRequestValid(bid);
+  },
+
+  buildRequests: function (validBidRequests, bidderRequest) {
+    return validBidRequests.map((bid) => ({
+      method: 'POST',
+      url: ENDPOINT,
+      data: JSON.stringify(buildRequestData(bid, bidderRequest)),
+      options: {
+        contentType: 'application/json',
+        withCredentials: true,
+      },
+    }));
+  },
+
+  interpretResponse: function (serverResponse, bidRequest) {
+    const bidResponses = [];
+
+    if (!serverResponse.body.bids) return [];
+    const { id } = JSON.parse(bidRequest.data);
+
+    serverResponse.body.bids.map((bid) => {
+      const { cpm, width, height, currency, ad, meta } = bid;
+      let bidResponse = {
+        requestId: id,
+        cpm,
+        width,
+        height,
+        creativeId: bid.creative_id,
+        currency,
+        netRevenue: bid.net_revenue,
+        ttl: TIME_TO_LIVE,
+        meta: {
+          advertiserDomains: meta.advertiser_domains,
+        },
+      };
+
+      if (bid.vast_url || bid.vast_xml) {
+        bidResponse.vastUrl = bid.vast_url;
+        bidResponse.vastXml = bid.vast_xml;
+        bidResponse.mediaType = VIDEO;
+      } else {
+        bidResponse.ad = ad;
+      }
+
+      bidResponses.push(bidResponse);
+    });
+
+    return bidResponses;
+  },
+
+  getUserSyncs(_optionsType, _serverResponse, _gdprConsent, _uspConsent) {
+    const syncs = [];
+
+    let userId = readUserIdFromCookie(COOKIE_NAME);
+
+    if (!userId) {
+      userId = generateId();
+      writeIdToCookie(COOKIE_NAME, userId);
+    }
+
+    USER_SYNCS.map((userSync) => {
+      if (userSync.type === 'img') {
+        syncs.push({
+          type: 'image',
+          url: userSync.url.replace(userSync.macro, userId),
+        });
+      }
+    });
+
+    return syncs;
+  },
+};
+
+function buildRequestData(bid, bidderRequest) {
+  let payloadObject = buildBaseObject(bid, bidderRequest);
+
+  if (bid.mediaTypes.banner) {
+    return buildBannerObject(bid, payloadObject);
+  } else if (bid.mediaTypes.video) {
+    return buildVideoObject(bid, payloadObject);
+  }
+}
+
+function buildBaseObject(bid, bidderRequest) {
+  const firstPartyData = prepareFirstPartyData(bidderRequest.ortb2);
+  const { pubid, floorPrice, bcat, badv, bapp } = bid.params;
+  const { userId } = bid;
+  const uid2Token = userId?.uid2?.id;
+
+  if (uid2Token) {
+    if (firstPartyData.user) {
+      firstPartyData.user.uid2_token = uid2Token;
+    } else {
+      firstPartyData.user = { uid2_token: uid2Token };
+    }
+  }
+  const userCookieId = readUserIdFromCookie(COOKIE_NAME);
+  if (userCookieId) {
+    if (firstPartyData.user) {
+      firstPartyData.user.id = userCookieId;
+    } else {
+      firstPartyData.user = { id: userCookieId };
+    }
+  }
+
+  return {
+    id: bid.bidId,
+    pubid,
+    floor_price: floorPrice,
+    adtagid: bid.adUnitCode,
+    ...(bcat && { bcat }),
+    ...(badv && { badv }),
+    ...(bapp && { bapp }),
+    ...firstPartyData,
+  };
+}
+
+function buildBannerObject(bid, payloadObject) {
+  const { sizes, pos, name } = bid.mediaTypes.banner;
+
+  payloadObject.banner_properties = {
+    name,
+    sizes,
+    pos,
+  };
+
+  return payloadObject;
+}
+
+function buildVideoObject(bid, payloadObject) {
+  const { context, playerSize, w, h } = bid.mediaTypes.video;
+
+  payloadObject.video_properties = {
+    context,
+    w: w || playerSize[0][0],
+    h: h || playerSize[0][1],
+  };
+
+  for (const param of VIDEO_PARAMS) {
+    const paramValue = deepAccess(bid, `mediaTypes.video.${param}`);
+
+    if (paramValue) {
+      payloadObject.video_properties[param] = paramValue;
+    }
+  }
+
+  return payloadObject;
+}
+
+function readUserIdFromCookie(key) {
+  try {
+    const re = new RegExp(`^(.*;\\s*)?${key}=([^;]+)(;.*)?$`);
+    const match = document.cookie.match(re);
+    if (match !== null) {
+      const matchedUserIdIndex = 2;
+      return match[matchedUserIdIndex];
+    }
+  } catch (error) {
+    return;
+  }
+}
+
+function generateId() {
+  return generateUUID();
+}
+
+function daysToMs(days) {
+  return days * DAY_IN_MS;
+}
+
+function writeIdToCookie(key, value) {
+  const expires = new Date(
+    Date.now() + daysToMs(parseInt(COOKIE_TTL_DAYS))
+  ).toUTCString();
+
+  document.cookie = `${key}=${value};Expires=${expires};`;
+}
+
+function prepareFirstPartyData({ user, device, site, app, regs }) {
+  let userData;
+  let deviceData;
+  let siteData;
+  let appData;
+  let regsData;
+
+  if (user) {
+    userData = {
+      yob: user.yob,
+      gender: user.gender,
+    };
+  }
+
+  if (device) {
+    deviceData = {
+      ua: device.ua,
+      dnt: device.dnt,
+      lmt: device.lmt,
+      ip: device.ip,
+      ipv6: device.ipv6,
+      devicetype: device.devicetype,
+      make: device.make,
+      model: device.model,
+      os: device.os,
+      osv: device.osv,
+      js: device.js,
+      language: device.language,
+      carrier: device.carrier,
+      connectiontype: device.connectiontype,
+      ifa: device.ifa,
+      ...(device.geo && {
+        geo: {
+          lat: device.geo.lat,
+          lon: device.geo.lon,
+          country: device.geo.country,
+          region: device.geo.region,
+          regionfips104: device.geo.regionfips104,
+          metro: device.geo.metro,
+          city: device.geo.city,
+          zip: device.geo.zip,
+          type: device.geo.type,
+        },
+      }),
+      ...(device.ext && {
+        ext: {
+          ifatype: device.ext.ifatype,
+        },
+      }),
+    };
+  }
+
+  if (site) {
+    siteData = {
+      id: site.id,
+      name: site.name,
+      domain: site.domain,
+      page: site.page,
+      cat: site.cat,
+      sectioncat: site.sectioncat,
+      pagecat: site.pagecat,
+      ref: site.ref,
+      ...(site.publisher && {
+        publisher: {
+          name: site.publisher.name,
+          cat: site.publisher.cat,
+          domain: site.publisher.domain,
+        },
+      }),
+      ...(site.content && {
+        content: {
+          id: site.content.id,
+          episode: site.content.episode,
+          title: site.content.title,
+          series: site.content.series,
+          artist: site.content.artist,
+          genre: site.content.genre,
+          album: site.content.album,
+          isrc: site.content.isrc,
+          season: site.content.season,
+        },
+      }),
+      mobile: site.mobile,
+    };
+  }
+
+  if (app) {
+    appData = {
+      id: app.id,
+      name: app.name,
+      bundle: app.bundle,
+      domain: app.domain,
+      storeurl: app.storeurl,
+      cat: app.cat,
+      sectioncat: app.sectioncat,
+      pagecat: app.pagecat,
+      ver: app.ver,
+      privacypolicy: app.privacypolicy,
+      paid: app.paid,
+      ...(app.publisher && {
+        publisher: {
+          name: app.publisher.name,
+          cat: app.publisher.cat,
+          domain: app.publisher.domain,
+        },
+      }),
+      keywords: app.keywords,
+      ...(app.content && {
+        content: {
+          id: app.content.id,
+          episode: app.content.episode,
+          title: app.content.title,
+          series: app.content.series,
+          artist: app.content.artist,
+          genre: app.content.genre,
+          album: app.content.album,
+          isrc: app.content.isrc,
+          season: app.content.season,
+        },
+      }),
+    };
+  }
+
+  if (regs) {
+    regsData = { coppa: regs.coppa };
+  }
+
+  return cleanObject({
+    user: userData,
+    device: deviceData,
+    site: siteData,
+    app: appData,
+    regs: regsData,
+  });
+}
+
+function cleanObject(data) {
+  for (let key in data) {
+    if (typeof data[key] == 'object') {
+      cleanObject(data[key]);
+
+      if (isEmptyObject(data[key])) delete data[key];
+    }
+
+    if (data[key] === undefined) delete data[key];
+  }
+
+  return data;
+}
+
+function isEmptyObject(object) {
+  return Object.keys(object).length === 0;
+}
+
+function isVideoRequestValid(bidRequest) {
+  if (bidRequest.mediaTypes.video) {
+    const { w, h, playerSize, mimes, protocols } = deepAccess(
+      bidRequest,
+      'mediaTypes.video',
+      {}
+    );
+
+    const areSizesValid =
+      (isNumber(w) && isNumber(h)) || validateSizes(playerSize);
+    const areMimesValid = isArray(mimes) && mimes.length > 0;
+    const areProtocolsValid =
+      isArray(protocols) && protocols.length > 0 && protocols.every(isNumber);
+
+    return areSizesValid && areMimesValid && areProtocolsValid;
+  }
+
+  return true;
+}
+
+function validateSizes(sizes) {
+  return (
+    isArray(sizes) &&
+    sizes.length > 0 &&
+    sizes.every(
+      (size) => isArray(size) && size.length === 2 && size.every(isNumber)
+    )
+  );
+}
+
+registerBidder(spec);

--- a/modules/pstudioBidAdapter.md
+++ b/modules/pstudioBidAdapter.md
@@ -1,0 +1,148 @@
+# Overview
+
+```
+Module Name: PStudio Bid Adapter
+Module Type: Bidder Adapter
+Maintainer: pstudio@telkomsel.com 
+```
+
+# Description
+
+Currently module supports banner as well as instream video mediaTypes.
+
+
+# Test parameters
+
+Those parameters should be used to get test responses from the adapter.
+
+```js
+var adUnits = [
+  // Banner ad unit
+  {
+    code: 'test-div-1',
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]],
+      },
+    },
+    bids: [
+      {
+        bidder: 'pstudio',
+        params: {
+          // id of test publisher
+          pubid: '22430f9d-9610-432c-aabe-6134256f11af',
+          floorPrice: 1.25,
+        },
+      },
+    ],
+  },
+  // Instream video ad unit
+  {
+    code: 'test-div-2',
+    mediaTypes: {
+      video: {
+        context: 'instream',
+        playerSize: [640, 480],
+        mimes: ['video/mp4'],
+        protocols: [3],
+      },
+    },
+    bids: [
+      {
+        bidder: 'pstudio',
+        params: {
+          // id of test publisher
+          pubid: '22430f9d-9610-432c-aabe-6134256f11af',
+          floorPrice: 1.25,
+        },
+      },
+    ],
+  },
+];
+```
+
+# Sample Banner Ad Unit
+
+```js
+var adUnits = [
+  {
+    code: 'test-div-1',
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]],
+        pos: 0,
+        name: 'test-name',
+      },
+    },
+    bids: [
+      {
+        bidder: 'pstudio',
+        params: {
+          pubid: '22430f9d-9610-432c-aabe-6134256f11af', // required
+          floorPrice: 1.15, // required
+          bcat: ['IAB1-1', 'IAB1-3'], // optional
+          badv: ['nike.com'], // optional
+          bapp: ['com.foo.mygame'], // optional
+        },
+      },
+    ],
+  },
+];
+```
+
+# Sample Video Ad Unit
+
+```js
+var videoAdUnits = [
+  {
+    code: 'test-instream-video',
+    mediaTypes: {
+      video: {
+        context: 'instream', // required (only instream accepted)
+        playerSize: [640, 480], // required (alternatively it could be pair of `w` and `h` parameters)
+        mimes: ['video/mp4'], // required (only choices `video/mp4`, `application/javascript`, `video/webm` and `video/ogg` supported)
+        protocols: [2, 3], // 1 required (only choices 2 and 3 supported)
+        minduration: 5, // optional
+        maxduration: 30, // optional
+        startdelay: 5, // optional
+        placement: 1, // optional (only 1 accepted, as it is instream placement)
+        skip: 1, // optional
+        skipafter: 1, // optional
+        minbitrate: 10, // optional
+        maxbitrate: 10, // optional
+        delivery: 1, // optional
+        playbackmethod: [1, 3], // optional
+        api: [2], // optional (only choice 2 supported)
+        linearity: 1, // optional
+      },
+    },
+    bids: [
+      {
+        bidder: 'pstudio',
+        params: {
+          pubid: '22430f9d-9610-432c-aabe-6134256f11af',
+          floorPrice: 1.25,
+          badv: ['adidas.com'],
+        },
+      },
+    ],
+  },
+];
+```
+
+# Configuration for video
+
+### Prebid cache
+
+For video ads, Prebid cache must be enabled, as the demand partner does not support caching of video content.
+
+```js
+pbjs.setConfig({
+  cache: {
+    url: 'https://prebid.adnxs.com/pbc/v1/cache',
+  },
+});
+```
+
+Please provide Prebid Cache of your choice. This example uses AppNexus cache, but if you use other cache, change it according to your needs.
+

--- a/test/spec/modules/pstudioBidAdapter_spec.js
+++ b/test/spec/modules/pstudioBidAdapter_spec.js
@@ -1,0 +1,501 @@
+import { assert } from 'chai';
+import { spec } from 'modules/pstudioBidAdapter.js';
+import { deepClone } from '../../../src/utils.js';
+
+const uuidRegex =
+  /[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}/;
+
+describe('PStudioAdapter', function () {
+  const bannerBid = {
+    bidder: 'pstudio',
+    params: {
+      pubid: '258c2a8d-d2ad-4c31-a2a5-e63001186456',
+      floorPrice: 1.15,
+    },
+    adUnitCode: 'test-div-1',
+    mediaTypes: {
+      banner: {
+        sizes: [
+          [300, 250],
+          [300, 600],
+        ],
+        pos: 0,
+        name: 'some-name',
+      },
+    },
+    bidId: '30b31c1838de1e',
+  };
+
+  const videoBid = {
+    bidder: 'pstudio',
+    params: {
+      pubid: '258c2a8d-d2ad-4c31-a2a5-e63001186456',
+      floorPrice: 1.15,
+    },
+    adUnitCode: 'test-div-1',
+    mediaTypes: {
+      video: {
+        playerSize: [[300, 250]],
+        mimes: ['video/mp4'],
+        minduration: 5,
+        maxduration: 30,
+        protocols: [2, 3],
+        startdelay: 5,
+        placement: 2,
+        skip: 1,
+        skipafter: 1,
+        minbitrate: 10,
+        maxbitrate: 10,
+        delivery: 1,
+        playbackmethod: [1, 3],
+        api: [2],
+        linearity: 1,
+      },
+    },
+    bidId: '30b31c1838de1e',
+  };
+
+  const bidWithOptionalParams = deepClone(bannerBid);
+  bidWithOptionalParams.params['bcat'] = ['IAB17-18', 'IAB7-42'];
+  bidWithOptionalParams.params['badv'] = ['ford.com'];
+  bidWithOptionalParams.params['bapp'] = ['com.foo.mygame'];
+  bidWithOptionalParams.params['regs'] = {
+    coppa: 1,
+  };
+
+  bidWithOptionalParams.userId = {
+    uid2: {
+      id: '7505e78e-4a9b-4011-8901-0e00c3f55ea9',
+    },
+  };
+
+  const emptyOrtb2BidderRequest = { ortb2: {} };
+
+  const baseBidderRequest = {
+    ortb2: {
+      device: {
+        w: 1680,
+        h: 342,
+      },
+    },
+  };
+
+  const extendedBidderRequest = deepClone(baseBidderRequest);
+  extendedBidderRequest.ortb2['device'] = {
+    dnt: 0,
+    ua: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36',
+    lmt: 0,
+    ip: '192.0.0.1',
+    ipv6: '2001:0000:130F:0000:0000:09C0:876A:130B',
+    devicetype: 2,
+    make: 'some_producer',
+    model: 'some_model',
+    os: 'some_os',
+    osv: 'some_version',
+    js: 1,
+    language: 'en',
+    carrier: 'WiFi',
+    connectiontype: 0,
+    ifa: 'some_ifa',
+    geo: {
+      lat: 50.4,
+      lon: 40.2,
+      country: 'some_country_code',
+      region: 'some_region_code',
+      regionfips104: 'some_fips_code',
+      metro: 'metro_code',
+      city: 'city_code',
+      zip: 'zip_code',
+      type: 2,
+    },
+    ext: {
+      ifatype: 'dpid',
+    },
+  };
+  extendedBidderRequest.ortb2['site'] = {
+    id: 'some_id',
+    name: 'example',
+    domain: 'page.example.com',
+    cat: ['IAB2'],
+    sectioncat: ['IAB2-2'],
+    pagecat: ['IAB2-2'],
+    page: 'https://page.example.com/here.html',
+    ref: 'https://ref.example.com',
+    publisher: {
+      name: 'some_name',
+      cat: ['IAB2'],
+      domain: 'https://page.example.com/here.html',
+    },
+    content: {
+      id: 'some_id',
+      episode: 22,
+      title: 'New episode.',
+      series: 'New series.',
+      artist: 'New artist',
+      genre: 'some genre',
+      album: 'New album',
+      isrc: 'AA-6Q7-20-00047',
+      season: 'New season',
+    },
+    mobile: 0,
+  };
+  extendedBidderRequest.ortb2['app'] = {
+    id: 'some_id',
+    name: 'example',
+    bundle: 'some_bundle',
+    domain: 'page.example.com',
+    storeurl: 'https://store.example.com',
+    cat: ['IAB2'],
+    sectioncat: ['IAB2-2'],
+    pagecat: ['IAB2-2'],
+    ver: 'some_version',
+    privacypolicy: 0,
+    paid: 0,
+    keywords: 'some, example, keywords',
+    publisher: {
+      name: 'some_name',
+      cat: ['IAB2'],
+      domain: 'https://page.example.com/here.html',
+    },
+    content: {
+      id: 'some_id',
+      episode: 22,
+      title: 'New episode.',
+      series: 'New series.',
+      artist: 'New artist',
+      genre: 'some genre',
+      album: 'New album',
+      isrc: 'AA-6Q7-20-00047',
+      season: 'New season',
+    },
+  };
+  extendedBidderRequest.ortb2['user'] = {
+    yob: 1992,
+    gender: 'M',
+  };
+  extendedBidderRequest.ortb2['regs'] = {
+    coppa: 0,
+  };
+
+  describe('isBidRequestValid', function () {
+    it('should return true when publisher id found', function () {
+      expect(spec.isBidRequestValid(bannerBid)).to.equal(true);
+    });
+
+    it('should return true for video bid', () => {
+      expect(spec.isBidRequestValid(videoBid)).to.equal(true);
+    });
+
+    it('should return false when publisher id not found', function () {
+      const localBid = deepClone(bannerBid);
+      delete localBid.params.pubid;
+      delete localBid.params.floorPrice;
+
+      expect(spec.isBidRequestValid(localBid)).to.equal(false);
+    });
+
+    it('should return false when playerSize in video not found', () => {
+      const localBid = deepClone(videoBid);
+      delete localBid.mediaTypes.video.playerSize;
+
+      expect(spec.isBidRequestValid(localBid)).to.equal(false);
+    });
+
+    it('should return false when mimes in video not found', () => {
+      const localBid = deepClone(videoBid);
+      delete localBid.mediaTypes.video.mimes;
+
+      expect(spec.isBidRequestValid(localBid)).to.equal(false);
+    });
+
+    it('should return false when protocols in video not found', () => {
+      const localBid = deepClone(videoBid);
+      delete localBid.mediaTypes.video.protocols;
+
+      expect(spec.isBidRequestValid(localBid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', function () {
+    const bannerRequest = spec.buildRequests([bannerBid], baseBidderRequest);
+    const bannerPayload = JSON.parse(bannerRequest[0].data);
+    const videoRequest = spec.buildRequests([videoBid], baseBidderRequest);
+    const videoPayload = JSON.parse(videoRequest[0].data);
+
+    it('should properly map ids in request payload', function () {
+      expect(bannerPayload.id).to.equal(bannerBid.bidId);
+      expect(bannerPayload.adtagid).to.equal(bannerBid.adUnitCode);
+    });
+
+    it('should properly map banner mediaType in request payload', function () {
+      expect(bannerPayload.banner_properties).to.deep.equal({
+        name: bannerBid.mediaTypes.banner.name,
+        sizes: bannerBid.mediaTypes.banner.sizes,
+        pos: bannerBid.mediaTypes.banner.pos,
+      });
+    });
+
+    it('should properly map video mediaType in request payload', () => {
+      expect(videoPayload.video_properties).to.deep.equal({
+        w: videoBid.mediaTypes.video.playerSize[0][0],
+        h: videoBid.mediaTypes.video.playerSize[0][1],
+        mimes: videoBid.mediaTypes.video.mimes,
+        minduration: videoBid.mediaTypes.video.minduration,
+        maxduration: videoBid.mediaTypes.video.maxduration,
+        protocols: videoBid.mediaTypes.video.protocols,
+        startdelay: videoBid.mediaTypes.video.startdelay,
+        placement: videoBid.mediaTypes.video.placement,
+        skip: videoBid.mediaTypes.video.skip,
+        skipafter: videoBid.mediaTypes.video.skipafter,
+        minbitrate: videoBid.mediaTypes.video.minbitrate,
+        maxbitrate: videoBid.mediaTypes.video.maxbitrate,
+        delivery: videoBid.mediaTypes.video.delivery,
+        playbackmethod: videoBid.mediaTypes.video.playbackmethod,
+        api: videoBid.mediaTypes.video.api,
+        linearity: videoBid.mediaTypes.video.linearity,
+      });
+    });
+
+    it('should properly set required bidder params in request payload', function () {
+      expect(bannerPayload.pubid).to.equal(bannerBid.params.pubid);
+      expect(bannerPayload.floor_price).to.equal(bannerBid.params.floorPrice);
+    });
+
+    it('should omit optional bidder params or first-party data from bid request if they are not provided', function () {
+      assert.isUndefined(bannerPayload.bcat);
+      assert.isUndefined(bannerPayload.badv);
+      assert.isUndefined(bannerPayload.bapp);
+      assert.isUndefined(bannerPayload.user);
+      assert.isUndefined(bannerPayload.device);
+      assert.isUndefined(bannerPayload.site);
+      assert.isUndefined(bannerPayload.app);
+      assert.isUndefined(bannerPayload.user_ids);
+      assert.isUndefined(bannerPayload.regs);
+    });
+
+    it('should properly set optional bidder parameters', function () {
+      const request = spec.buildRequests(
+        [bidWithOptionalParams],
+        baseBidderRequest
+      );
+      const payload = JSON.parse(request[0].data);
+
+      expect(payload.bcat).to.deep.equal(['IAB17-18', 'IAB7-42']);
+      expect(payload.badv).to.deep.equal(['ford.com']);
+      expect(payload.bapp).to.deep.equal(['com.foo.mygame']);
+    });
+
+    it('should properly set optional user_ids', function () {
+      const request = spec.buildRequests(
+        [bidWithOptionalParams],
+        baseBidderRequest
+      );
+      const {
+        user: { uid2_token },
+      } = JSON.parse(request[0].data);
+      const expectedUID = '7505e78e-4a9b-4011-8901-0e00c3f55ea9';
+
+      expect(uid2_token).to.equal(expectedUID);
+    });
+
+    it('should properly set optional user_ids when no first party data is provided', function () {
+      const request = spec.buildRequests(
+        [bidWithOptionalParams],
+        emptyOrtb2BidderRequest
+      );
+      const {
+        user: { uid2_token },
+      } = JSON.parse(request[0].data);
+      const expectedUID = '7505e78e-4a9b-4011-8901-0e00c3f55ea9';
+
+      expect(uid2_token).to.equal(expectedUID);
+    });
+
+    it('should properly handle first-party data', function () {
+      const request = spec.buildRequests([bannerBid], extendedBidderRequest);
+      const payload = JSON.parse(request[0].data);
+
+      expect(payload.user).to.deep.equal(extendedBidderRequest.ortb2.user);
+      expect(payload.device).to.deep.equal(extendedBidderRequest.ortb2.device);
+      expect(payload.site).to.deep.equal(extendedBidderRequest.ortb2.site);
+      expect(payload.app).to.deep.equal(extendedBidderRequest.ortb2.app);
+      expect(payload.regs).to.deep.equal(extendedBidderRequest.ortb2.regs);
+    });
+
+    it('should not set first-party data if nothing is provided in ORTB2 param', function () {
+      const request = spec.buildRequests([bannerBid], emptyOrtb2BidderRequest);
+      const payload = JSON.parse(request[0].data);
+
+      expect(payload).not.to.haveOwnProperty('user');
+      expect(payload).not.to.haveOwnProperty('device');
+      expect(payload).not.to.haveOwnProperty('site');
+      expect(payload).not.to.haveOwnProperty('app');
+      expect(payload).not.to.haveOwnProperty('regs');
+    });
+
+    it('should set user id if proper cookie is present', function () {
+      const cookie = '157bc918-b961-4216-ac72-29fc6363edcb';
+      document.cookie = `__tadexid=${cookie}`;
+
+      const request = spec.buildRequests([bannerBid], emptyOrtb2BidderRequest);
+      const payload = JSON.parse(request[0].data);
+
+      expect(payload.user.id).to.equal(cookie);
+    });
+
+    it('should not set user id if proper cookie not present', function () {
+      document.cookie = '__tadexid=';
+
+      const request = spec.buildRequests([bannerBid], emptyOrtb2BidderRequest);
+      const payload = JSON.parse(request[0].data);
+
+      expect(payload).not.to.haveOwnProperty('user');
+    });
+  });
+
+  describe('interpretResponse', function () {
+    const serverResponse = {
+      body: {
+        id: '123141241231',
+        bids: [
+          {
+            cpm: 1.02,
+            width: 300,
+            height: 600,
+            currency: 'USD',
+            ad: '<h1>Hello ad</h1>',
+            creative_id: 'crid12345',
+            net_revenue: true,
+            meta: {
+              advertiser_domains: ['https://advertiser.com'],
+            },
+          },
+        ],
+      },
+    };
+
+    const serverVideoResponse = {
+      body: {
+        id: '123141241231',
+        bids: [
+          {
+            vast_url: 'https://v.a/st.xml',
+            cpm: 5,
+            width: 640,
+            height: 480,
+            currency: 'USD',
+            creative_id: 'crid12345',
+            net_revenue: true,
+            meta: {
+              advertiser_domains: ['https://advertiser.com'],
+            },
+          },
+        ],
+      },
+    };
+
+    const bidRequest = {
+      method: 'POST',
+      url: 'test-url',
+      data: JSON.stringify({
+        id: '12345',
+        pubid: 'somepubid',
+      }),
+    };
+
+    it('should properly parse response from server', function () {
+      const expectedResponse = {
+        requestId: JSON.parse(bidRequest.data).id,
+        cpm: serverResponse.body.bids[0].cpm,
+        width: serverResponse.body.bids[0].width,
+        height: serverResponse.body.bids[0].height,
+        ad: serverResponse.body.bids[0].ad,
+        currency: serverResponse.body.bids[0].currency,
+        creativeId: serverResponse.body.bids[0].creative_id,
+        netRevenue: serverResponse.body.bids[0].net_revenue,
+        meta: {
+          advertiserDomains:
+            serverResponse.body.bids[0].meta.advertiser_domains,
+        },
+        ttl: 300,
+      };
+      const parsedResponse = spec.interpretResponse(serverResponse, bidRequest);
+
+      expect(parsedResponse[0]).to.deep.equal(expectedResponse);
+    });
+
+    it('should properly parse video response from server', function () {
+      const expectedResponse = {
+        requestId: JSON.parse(bidRequest.data).id,
+        cpm: serverVideoResponse.body.bids[0].cpm,
+        width: serverVideoResponse.body.bids[0].width,
+        height: serverVideoResponse.body.bids[0].height,
+        currency: serverVideoResponse.body.bids[0].currency,
+        creativeId: serverVideoResponse.body.bids[0].creative_id,
+        netRevenue: serverVideoResponse.body.bids[0].net_revenue,
+        mediaType: 'video',
+        vastUrl: serverVideoResponse.body.bids[0].vast_url,
+        vastXml: undefined,
+        meta: {
+          advertiserDomains:
+            serverVideoResponse.body.bids[0].meta.advertiser_domains,
+        },
+        ttl: 300,
+      };
+      const parsedResponse = spec.interpretResponse(
+        serverVideoResponse,
+        bidRequest
+      );
+
+      expect(parsedResponse[0]).to.deep.equal(expectedResponse);
+    });
+
+    it('should return empty array if no bids are returned', function () {
+      const emptyResponse = deepClone(serverResponse);
+      emptyResponse.body.bids = undefined;
+
+      const parsedResponse = spec.interpretResponse(emptyResponse, bidRequest);
+
+      expect(parsedResponse).to.deep.equal([]);
+    });
+  });
+
+  describe('getUserSyncs', function () {
+    it('should return sync object with correctly injected user id', function () {
+      document.cookie = '__tadexid=testid;Expires=120000';
+      const result = spec.getUserSyncs({}, {}, {}, {});
+
+      expect(result).to.deep.equal([
+        {
+          type: 'image',
+          url: 'https://match.adsrvr.org/track/cmf/generic?ttd_pid=k1on5ig&ttd_tpi=1&ttd_puid=testid&dsp=ttd',
+        },
+        {
+          type: 'image',
+          url: 'https://dsp.myads.telkomsel.com/api/v1/pixel?uid=testid',
+        },
+      ]);
+    });
+
+    it('should generate user id and put it into sync object', function () {
+      const result = spec.getUserSyncs({}, {}, {}, {});
+      const re = new RegExp(`^(.*;\\s*)?__tadexid=([^;]+)(;.*)?$`);
+
+      const newUUID = document.cookie.match(re)[2];
+
+      expect(newUUID).match(uuidRegex);
+      expect(result[0]).deep.equal({
+        type: 'image',
+        url: `https://match.adsrvr.org/track/cmf/generic?ttd_pid=k1on5ig&ttd_tpi=1&ttd_puid=${newUUID}&dsp=ttd`,
+      });
+      expect(result[1]).deep.equal({
+        type: 'image',
+        url: `https://dsp.myads.telkomsel.com/api/v1/pixel?uid=${newUUID}`,
+      });
+    });
+
+    afterEach(function () {
+      document.cookie = '__tadexid=';
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter  documentation PR https://github.com/prebid/prebid.github.io/pull/5095 

## Description of change

This is initial PR with PStudio bid adapter
Currently module supports banner as well as instream video mediaTypes.

- contact email of the adapter’s maintainer
pstudio@telkomsel.com 

- test parameters for validating bids:

# Test parameters

Those parameters should be used to get test responses from the adapter.

```js
var adUnits = [
  // Banner ad unit
  {
    code: 'test-div-1',
    mediaTypes: {
      banner: {
        sizes: [[300, 250]],
      },
    },
    bids: [
      {
        bidder: 'pstudio',
        params: {
          // id of test publisher
          pubid: '22430f9d-9610-432c-aabe-6134256f11af',
          floorPrice: 1.25,
        },
      },
    ],
  },
  // Instream video ad unit
  {
    code: 'test-div-2',
    mediaTypes: {
      video: {
        context: 'instream',
        playerSize: [640, 480],
        mimes: ['video/mp4'],
        protocols: [3],
      },
    },
    bids: [
      {
        bidder: 'pstudio',
        params: {
          // id of test publisher
          pubid: '22430f9d-9610-432c-aabe-6134256f11af',
          floorPrice: 1.25,
        },
      },
    ],
  },
];
```


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
