### PR TITLE
dsaControl module: Reject bids without meta.dsa when required

### DIFF
--- a/libraries/ortbConverter/processors/default.js
+++ b/libraries/ortbConverter/processors/default.js
@@ -97,6 +97,9 @@ export const DEFAULT_PROCESSORS = {
         if (bid.adomain) {
           bidResponse.meta.advertiserDomains = bid.adomain;
         }
+        if (bid.ext?.dsa) {
+          bidResponse.meta.dsa = bid.ext.dsa;
+        }
       }
     }
   }

--- a/modules/dsaControl.js
+++ b/modules/dsaControl.js
@@ -1,4 +1,3 @@
-import {BID_RESPONSE, registerOrtbProcessor} from '../src/pbjsORTB.js';
 import {config} from '../src/config.js';
 import {auctionManager} from '../src/auctionManager.js';
 import {timedBidResponseHook} from '../src/utils/perfMetrics.js';
@@ -50,16 +49,3 @@ toggleHooks(true);
 config.getConfig('consentManagement', (cfg) => {
   toggleHooks(cfg.consentManagement?.dsa?.validateBids ?? true);
 });
-
-export function setMetaDsa(bidResponse, bid) {
-  if (bid.ext?.dsa) {
-    bidResponse.meta.dsa = bidResponse.meta.dsa ?? bid.ext.dsa;
-  }
-}
-
-registerOrtbProcessor({
-  name: 'metaDsa',
-  type: BID_RESPONSE,
-  fn: setMetaDsa,
-  priority: -1 // run after 'meta' init
-})

--- a/modules/dsaControl.js
+++ b/modules/dsaControl.js
@@ -1,0 +1,65 @@
+import {BID_RESPONSE, registerOrtbProcessor} from '../src/pbjsORTB.js';
+import {config} from '../src/config.js';
+import {auctionManager} from '../src/auctionManager.js';
+import {timedBidResponseHook} from '../src/utils/perfMetrics.js';
+import CONSTANTS from '../src/constants.json';
+import {getHook} from '../src/hook.js';
+import {logInfo, logWarn} from '../src/utils.js';
+
+let expiryHandle;
+let dsaAuctions = {};
+
+export const addBidResponseHook = timedBidResponseHook('dsa', function (fn, adUnitCode, bid, reject) {
+  if (!dsaAuctions.hasOwnProperty(bid.auctionId)) {
+    dsaAuctions[bid.auctionId] = auctionManager.index.getAuction(bid)?.getFPD?.()?.global?.regs?.ext?.dsa?.required
+  }
+  const required = dsaAuctions[bid.auctionId];
+  if (!bid.meta?.dsa) {
+    if (required === 1) {
+      logWarn(`dsaControl: ${CONSTANTS.REJECTION_REASON.DSA_REQUIRED}; will still be accepted as regs.ext.dsa.required = 1`, bid);
+    } else if ([2, 3].includes(required)) {
+      reject(CONSTANTS.REJECTION_REASON.DSA_REQUIRED);
+      return;
+    }
+  }
+  return fn.call(this, adUnitCode, bid, reject);
+});
+
+function toggleHooks(enabled) {
+  if (enabled && expiryHandle == null) {
+    getHook('addBidResponse').before(addBidResponseHook);
+    expiryHandle = auctionManager.onExpiry(auction => {
+      delete dsaAuctions[auction.getAuctionId()];
+    });
+    logInfo('dsaControl: DSA bid validation is enabled')
+  } else if (!enabled && expiryHandle != null) {
+    getHook('addBidResponse').getHooks({hook: addBidResponseHook}).remove();
+    expiryHandle();
+    expiryHandle = null;
+    logInfo('dsaControl: DSA bid validation is disabled')
+  }
+}
+
+export function reset() {
+  toggleHooks(false);
+  dsaAuctions = {};
+}
+
+toggleHooks(true);
+
+config.getConfig('consentManagement', (cfg) => {
+  toggleHooks(cfg.consentManagement?.dsa?.validateBids ?? true);
+});
+
+export function setMetaDsa(bidResponse, bid) {
+  if (bid.ext?.dsa) {
+    bidResponse.meta.dsa = bidResponse.meta.dsa ?? bid.ext.dsa;
+  }
+}
+
+registerOrtbProcessor({
+  name: 'metaDsa',
+  type: BID_RESPONSE,
+  fn: setMetaDsa,
+  priority: -1 // run after 'meta' init
+})

--- a/src/auctionManager.js
+++ b/src/auctionManager.js
@@ -60,7 +60,9 @@ export function newAuctionManager() {
     }
   })
 
-  const auctionManager = {};
+  const auctionManager = {
+    onExpiry: _auctions.onExpiry
+  };
 
   function getAuction(auctionId) {
     for (const auction of _auctions) {

--- a/src/constants.json
+++ b/src/constants.json
@@ -131,7 +131,8 @@
     "BIDDER_DISALLOWED": "Bidder code is not allowed by allowedAlternateBidderCodes / allowUnknownBidderCodes",
     "FLOOR_NOT_MET": "Bid does not meet price floor",
     "CANNOT_CONVERT_CURRENCY": "Unable to convert currency",
-    "DSA_REQUIRED": "Bid does not provide required DSA transparency info"
+    "DSA_REQUIRED": "Bid does not provide required DSA transparency info",
+    "DSA_MISMATCH": "Bid indicates inappropriate DSA rendering method"
   },
   "PREBID_NATIVE_DATA_KEYS_TO_ORTB": {
     "body": "desc",

--- a/src/constants.json
+++ b/src/constants.json
@@ -130,7 +130,8 @@
     "INVALID_REQUEST_ID": "Invalid request ID",
     "BIDDER_DISALLOWED": "Bidder code is not allowed by allowedAlternateBidderCodes / allowUnknownBidderCodes",
     "FLOOR_NOT_MET": "Bid does not meet price floor",
-    "CANNOT_CONVERT_CURRENCY": "Unable to convert currency"
+    "CANNOT_CONVERT_CURRENCY": "Unable to convert currency",
+    "DSA_REQUIRED": "Bid does not provide required DSA transparency info"
   },
   "PREBID_NATIVE_DATA_KEYS_TO_ORTB": {
     "body": "desc",

--- a/test/spec/modules/dsaControl_spec.js
+++ b/test/spec/modules/dsaControl_spec.js
@@ -71,19 +71,4 @@ describe('DSA transparency', () => {
     })
     it('should accept bids regardless of dsa when "required" any other value')
   });
-
-  describe('setMetaDsa', () => {
-    it('does nothing if bid has no ext.dsa', () => {
-      const resp = {};
-      setMetaDsa(resp, {});
-      expect(resp).to.eql({});
-    });
-
-    it('carries over ext.dsa into meta.dsa', () => {
-      const dsa = {transparency: 'info'};
-      const resp = {meta: {}};
-      setMetaDsa(resp, {ext: {dsa}});
-      expect(resp.meta.dsa).to.eql(dsa);
-    })
-  })
 });

--- a/test/spec/modules/dsaControl_spec.js
+++ b/test/spec/modules/dsaControl_spec.js
@@ -1,0 +1,89 @@
+import {addBidResponseHook, setMetaDsa, reset} from '../../../modules/dsaControl.js';
+import CONSTANTS from 'src/constants.json';
+import {auctionManager} from '../../../src/auctionManager.js';
+import {AuctionIndex} from '../../../src/auctionIndex.js';
+
+describe('DSA transparency', () => {
+  let sandbox;
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create();
+  });
+  afterEach(() => {
+    sandbox.restore();
+    reset();
+  });
+
+  describe('addBidResponseHook', () => {
+    const auctionId = 'auction-id';
+    let bid, auction, fpd, next, reject;
+    beforeEach(() => {
+      next = sinon.stub();
+      reject = sinon.stub();
+      fpd = {};
+      bid = {
+        auctionId
+      }
+      auction = {
+        getAuctionId: () => auctionId,
+        getFPD: () => ({global: fpd})
+      }
+      sandbox.stub(auctionManager, 'index').get(() => new AuctionIndex(() => [auction]));
+    });
+
+    [2, 3].forEach(required => {
+      describe(`when regs.ext.dsa.required is ${required} (required)`, () => {
+        beforeEach(() => {
+          fpd = {
+            regs: {ext: {dsa: {required}}}
+          };
+        });
+
+        it('should reject bids that have no meta.dsa', () => {
+          addBidResponseHook(next, 'adUnit', bid, reject);
+          sinon.assert.calledWith(reject, CONSTANTS.REJECTION_REASON.DSA_REQUIRED);
+          sinon.assert.notCalled(next);
+        });
+
+        it('should accept bids that do', () => {
+          bid.meta = {dsa: {}};
+          addBidResponseHook(next, 'adUnit', bid, reject);
+          sinon.assert.notCalled(reject);
+          sinon.assert.calledWith(next, 'adUnit', bid, reject);
+        });
+      });
+    });
+    [undefined, 'garbage', 0, 1].forEach(required => {
+      describe(`when regs.ext.dsa is ${required}`, () => {
+        beforeEach(() => {
+          if (required != null) {
+            fpd = {
+              regs: {ext: {dsa: {required}}}
+            }
+          }
+        });
+
+        it('should accept bids regardless of their meta.dsa', () => {
+          addBidResponseHook(next, 'adUnit', bid, reject);
+          sinon.assert.notCalled(reject);
+          sinon.assert.calledWith(next, 'adUnit', bid, reject);
+        })
+      })
+    })
+    it('should accept bids regardless of dsa when "required" any other value')
+  });
+
+  describe('setMetaDsa', () => {
+    it('does nothing if bid has no ext.dsa', () => {
+      const resp = {};
+      setMetaDsa(resp, {});
+      expect(resp).to.eql({});
+    });
+
+    it('carries over ext.dsa into meta.dsa', () => {
+      const dsa = {transparency: 'info'};
+      const resp = {meta: {}};
+      setMetaDsa(resp, {ext: {dsa}});
+      expect(resp.meta.dsa).to.eql(dsa);
+    })
+  })
+});

--- a/test/spec/ortbConverter/common_spec.js
+++ b/test/spec/ortbConverter/common_spec.js
@@ -1,0 +1,29 @@
+import {DEFAULT_PROCESSORS} from '../../../libraries/ortbConverter/processors/default.js';
+import {BID_RESPONSE} from '../../../src/pbjsORTB.js';
+
+describe('common processors', () => {
+  describe('bid response properties', () => {
+    const responseProps = DEFAULT_PROCESSORS[BID_RESPONSE].props.fn;
+    let context;
+
+    beforeEach(() => {
+      context = {
+        ortbResponse: {}
+      }
+    })
+
+    describe('meta.dsa', () => {
+      const MOCK_DSA = {transparency: 'info'};
+      it('is not set if bid has no meta.dsa', () => {
+        const resp = {};
+        responseProps(resp, {}, context);
+        expect(resp.meta?.dsa).to.not.exist;
+      });
+      it('is set to ext.dsa otherwise', () => {
+        const resp = {};
+        responseProps(resp, {ext: {dsa: MOCK_DSA}}, context);
+        expect(resp.meta.dsa).to.eql(MOCK_DSA);
+      })
+    })
+  })
+})

--- a/test/spec/unit/utils/ttlCollection_spec.js
+++ b/test/spec/unit/utils/ttlCollection_spec.js
@@ -67,6 +67,33 @@ describe('ttlCollection', () => {
           });
         });
 
+        it('should run onExpiry when items are cleared', () => {
+          const i1 = {ttl: 1000, some: 'data'};
+          const i2 = {ttl: 2000, some: 'data'};
+          coll.add(i1);
+          coll.add(i2);
+          const cb = sinon.stub();
+          coll.onExpiry(cb);
+          return waitForPromises().then(() => {
+            clock.tick(500);
+            sinon.assert.notCalled(cb);
+            clock.tick(SLACK + 500);
+            sinon.assert.calledWith(cb, i1);
+            clock.tick(3000);
+            sinon.assert.calledWith(cb, i2);
+          })
+        });
+
+        it('should allow unregistration of onExpiry callbacks', () => {
+          const cb = sinon.stub();
+          coll.add({ttl: 500});
+          coll.onExpiry(cb)();
+          return waitForPromises().then(() => {
+            clock.tick(500 + SLACK);
+            sinon.assert.notCalled(cb);
+          })
+        })
+
         it('should not wait too long if a shorter ttl shows up', () => {
           coll.add({ttl: 4000});
           coll.add({ttl: 1000});


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

Update ortbConverter to to carry ORTB response `seatbid[].bid[].ext.dsa` into bid responses' `meta.dsa`; also, add a new `dsaControl` module that:

 - rejects bids that do not provide `meta.dsa` if the auction had `ortb2.regs.ext.dsa.required` set to either 2 ("Required, bid responses without DSA object will not be accepted") or 3 ("Required, bid responses without DSA object will not be accepted, Publisher is an Online Platform")
 - logs a warning for bids that do not provide `meta.dsa` if required was set to 1 ("Supported, bid responses with or without DSA object will be accepted")

## Other information

Closes https://github.com/prebid/Prebid.js/issues/10957
ORTB DSA reference: https://github.com/InteractiveAdvertisingBureau/openrtb/blob/main/extensions/community_extensions/dsa_transparency.md

