### PR TITLE
User id module: adds a catch to greedy promise

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -488,6 +488,7 @@ function idSystemInitializer({delay = GreedyPromise.timeout} = {}) {
     }
     cancel = defer();
     return GreedyPromise.race([promise, cancel.promise])
+      .catch(() => logWarn(`${MODULE_NAME} - cancelled promise`))
       .finally(initMetrics.startTiming('userId.total'))
   }
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
 Errors that occur currently throw an Uncaught promise error on page. This adds a catch to avoid the error and logs as well for debugging

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
