### PR TITLE
Grid Bid Adapter : do not send topics along requests to the backend

### DIFF
--- a/modules/gridBidAdapter.js
+++ b/modules/gridBidAdapter.js
@@ -466,6 +466,7 @@ export const spec = {
   },
 
   ajaxCall: function(url, cb, data, options) {
+    options.browsingTopics = false;
     return ajax(url, cb, data, options);
   },
 


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
We don't expect to get topics sent along the request on grid backend.