### PR TITLE
AppNexus Bid Adapter: stop suppressing user syncs on any gpp string with section > 5

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -439,11 +439,7 @@ export const spec = {
 
   getUserSyncs: function (syncOptions, responses, gdprConsent, uspConsent, gppConsent) {
     function checkGppStatus(gppConsent) {
-      // this is a temporary measure to supress usersync in US-based GPP regions
-      // this logic will be revised when proper signals (akin to purpose1 from TCF2) can be determined for US GPP
-      if (gppConsent && Array.isArray(gppConsent.applicableSections)) {
-        return gppConsent.applicableSections.every(sec => typeof sec === 'number' && sec <= 5);
-      }
+      // user sync suppression for adapters is handled in activity controls and not needed in adapters
       return true;
     }
 


### PR DESCRIPTION
Activity controls should be sufficient to take care of this, or the AppNexus adapter should examine the strings. 