### PR TITLE
OpenX Bid Adapter: add ortb2Imp to PAAPI auctionSignals

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -109,7 +109,7 @@ const converter = ortbConverter({
           bidId,
           config: mergeDeep(Object.assign({}, cfg), {
             auctionSignals: {
-              ortb2Imp: context.impContext[bidId]?.ortbRequest?.imp?.[0],
+              ortb2Imp: context.impContext[bidId]?.imp,
             },
           }),
         }

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -107,9 +107,11 @@ const converter = ortbConverter({
       fledgeAuctionConfigs = Object.entries(fledgeAuctionConfigs).map(([bidId, cfg]) => {
         return {
           bidId,
-          config: Object.assign({
-            auctionSignals: {},
-          }, cfg)
+          config: mergeDeep(Object.assign({}, cfg), {
+            auctionSignals: {
+              ortb2Imp: context.impContext[bidId]?.ortbRequest?.imp?.[0],
+            },
+          }),
         }
       });
       return {

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1508,6 +1508,25 @@ describe('OpenxRtbAdapter', function () {
         expect(response.fledgeAuctionConfigs.length).to.equal(1);
         expect(response.fledgeAuctionConfigs[0].bidId).to.equal('test-bid-id');
       });
+
+      it('should inject ortb2Imp in auctionSignals', function () {
+        const auctionConfig = response.fledgeAuctionConfigs[0].config;
+        expect(auctionConfig).to.deep.include({
+          auctionSignals: {
+            ortb2Imp: {
+              id: 'test-bid-id',
+              tagid: '12345678',
+              banner: {
+                topframe: 0,
+                format: bidRequestConfigs[0].mediaTypes.banner.sizes.map(([w, h]) => ({w, h}))
+              },
+              ext: {
+                divid: 'adunit-code',
+              }
+            }
+          }
+        });
+      })
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Feature
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Inject the OpenRTB `imp` request object into PAAPI `auctionSignals.ortb2Imp`, to expose contextual slot information such as `banner.formats` to all PAAPI component buyers under the OpenX seller.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
