### PR TITLE
GPID追加対応

### DIFF
--- a/modules/microadBidAdapter.js
+++ b/modules/microadBidAdapter.js
@@ -115,6 +115,26 @@ export const spec = {
         params['aids'] = JSON.stringify(aidsParams)
       }
 
+      const pbadslot = bid.ortb2Imp?.ext?.data?.pbadslot;
+      const gpid = bid.ortb2Imp?.ext?.gpid || pbadslot;
+      if (gpid != null && gpid.length > 0) {
+        params['gpid'] = gpid;
+      }
+
+      if (pbadslot != null && pbadslot.length > 0) {
+        params['pbadslot'] = pbadslot;
+      }
+
+      const adservname = bid.ortb2Imp?.ext?.data?.adserver?.name;
+      if (adservname != null && adservname.length > 0) {
+        params['adservname'] = adservname;
+      }
+
+      const adservadslot = bid.ortb2Imp?.ext?.data?.adserver?.adslot;
+      if (adservadslot != null && adservadslot.length > 0) {
+        params['adservadslot'] = adservadslot;
+      }
+
       requests.push({
         method: 'GET',
         url: ENDPOINT_URLS[ENVIRONMENT],

--- a/test/spec/modules/microadBidAdapter_spec.js
+++ b/test/spec/modules/microadBidAdapter_spec.js
@@ -382,6 +382,196 @@ describe('microadBidAdapter', () => {
         })
       });
     })
+
+    describe('should send gpid', () => {
+      it('from gpid', () => {
+        const bidRequest = Object.assign({}, bidRequestTemplate, {
+          ortb2Imp: {
+            ext: {
+              tid: 'transaction-id',
+              gpid: '1111/2222',
+              data: {
+                pbadslot: '3333/4444'
+              }
+            }
+          }
+        });
+        const requests = spec.buildRequests([bidRequest], bidderRequest)
+        requests.forEach(request => {
+          expect(request.data).to.deep.equal(
+            Object.assign({}, expectedResultTemplate, {
+              cbt: request.data.cbt,
+              gpid: '1111/2222',
+              pbadslot: '3333/4444'
+            })
+          );
+        })
+      })
+
+      it('from pbadslot', () => {
+        const bidRequest = Object.assign({}, bidRequestTemplate, {
+          ortb2Imp: {
+            ext: {
+              tid: 'transaction-id',
+              data: {
+                pbadslot: '3333/4444'
+              }
+            }
+          }
+        });
+        const requests = spec.buildRequests([bidRequest], bidderRequest)
+        requests.forEach(request => {
+          expect(request.data).to.deep.equal(
+            Object.assign({}, expectedResultTemplate, {
+              cbt: request.data.cbt,
+              gpid: '3333/4444',
+              pbadslot: '3333/4444'
+            })
+          );
+        })
+      })
+    })
+
+    const notGettingGpids = {
+      'they are not existing': bidRequestTemplate,
+      'they are blank': {
+        ortb2Imp: {
+          ext: {
+            tid: 'transaction-id',
+            gpid: '',
+            data: {
+              pbadslot: ''
+            }
+          }
+        }
+      }
+    }
+
+    Object.entries(notGettingGpids).forEach(([testTitle, param]) => {
+      it(`should not send gpid because ${testTitle}`, () => {
+        const bidRequest = Object.assign({}, bidRequestTemplate, param);
+        const requests = spec.buildRequests([bidRequest], bidderRequest)
+        requests.forEach(request => {
+          expect(request.data).to.deep.equal(
+            Object.assign({}, expectedResultTemplate, {
+              cbt: request.data.cbt,
+            })
+          );
+          expect(request.data.gpid).to.be.undefined;
+          expect(request.data.pbadslot).to.be.undefined;
+        })
+      })
+    })
+
+    it('should send adservname', () => {
+      const bidRequest = Object.assign({}, bidRequestTemplate, {
+        ortb2Imp: {
+          ext: {
+            tid: 'transaction-id',
+            data: {
+              adserver: {
+                name: 'gam'
+              }
+            }
+          }
+        }
+      });
+      const requests = spec.buildRequests([bidRequest], bidderRequest)
+      requests.forEach(request => {
+        expect(request.data).to.deep.equal(
+          Object.assign({}, expectedResultTemplate, {
+            cbt: request.data.cbt,
+            adservname: 'gam'
+          })
+        );
+      })
+    })
+
+    const notGettingAdservnames = {
+      'it is not existing': bidRequestTemplate,
+      'it is blank': {
+        ortb2Imp: {
+          ext: {
+            tid: 'transaction-id',
+            data: {
+              adserver: {
+                name: ''
+              }
+            }
+          }
+        }
+      }
+    }
+
+    Object.entries(notGettingAdservnames).forEach(([testTitle, param]) => {
+      it(`should not send adservname because ${testTitle}`, () => {
+        const bidRequest = Object.assign({}, bidRequestTemplate, param);
+        const requests = spec.buildRequests([bidRequest], bidderRequest)
+        requests.forEach(request => {
+          expect(request.data).to.deep.equal(
+            Object.assign({}, expectedResultTemplate, {
+              cbt: request.data.cbt,
+            })
+          );
+          expect(request.data.adservname).to.be.undefined;
+        })
+      })
+    })
+
+    it('should send adservadslot', () => {
+      const bidRequest = Object.assign({}, bidRequestTemplate, {
+        ortb2Imp: {
+          ext: {
+            tid: 'transaction-id',
+            data: {
+              adserver: {
+                adslot: '/1111/home'
+              }
+            }
+          }
+        }
+      });
+      const requests = spec.buildRequests([bidRequest], bidderRequest)
+      requests.forEach(request => {
+        expect(request.data).to.deep.equal(
+          Object.assign({}, expectedResultTemplate, {
+            cbt: request.data.cbt,
+            adservadslot: '/1111/home'
+          })
+        );
+      })
+    })
+
+    const notGettingAdservadslots = {
+      'it is not existing': bidRequestTemplate,
+      'it is blank': {
+        ortb2Imp: {
+          ext: {
+            tid: 'transaction-id',
+            data: {
+              adserver: {
+                adslot: ''
+              }
+            }
+          }
+        }
+      }
+    }
+
+    Object.entries(notGettingAdservadslots).forEach(([testTitle, param]) => {
+      it(`should not send adservadslot because ${testTitle}`, () => {
+        const bidRequest = Object.assign({}, bidRequestTemplate, param);
+        const requests = spec.buildRequests([bidRequest], bidderRequest)
+        requests.forEach(request => {
+          expect(request.data).to.deep.equal(
+            Object.assign({}, expectedResultTemplate, {
+              cbt: request.data.cbt,
+            })
+          );
+          expect(request.data.adservadslot).to.be.undefined;
+        })
+      })
+    })
   });
 
   describe('interpretResponse', () => {


### PR DESCRIPTION
### 概要
GPID追加対応を行いました。

### 変更点
- /prebidに追加された4つのパラメータに対応。プロパティが取得できない or 空文字の場合パラメータ自体を付与しないようにする。
- gpid
  - `ortb2Imp.ext.gpid`が取得できればそれを送る。取得できなければ`ortb2Imp.ext.data.pbadslot`を送る。
- pbadslot
  - `ortb2Imp.ext.data.pbadslot`が取得できればそれを送る。
- adservname
  - `ortb2Imp.ext.data.adserver.name`が取得できればそれを送る。
- adservadslot
  - `ortb2Imp.ext.data.adserver.adslot`が取得できればそれを送る。

### 参考
- テストケース: https://microad.atlassian.net/wiki/spaces/COM/pages/3447129254/TEST+MNL-3614+Prebid.js+GPID
- リクエスト項目仕様: https://microad.atlassian.net/wiki/spaces/COM/pages/427230062/COMPASS
- マイクロアドPrebid.js仕様: 