### PR TITLE
Yieldmo Bid Adapter: Adding gpc in the bid request

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -100,6 +100,10 @@ export const spec = {
       if (topicsData) {
         serverRequest.topics = topicsData;
       }
+      const gpc = getGPCSignal(bidderRequest);
+      if (gpc) {
+        serverRequest.gpc = gpc;
+      }
 
       if (canAccessTopWindow()) {
         serverRequest.pr = (LOCAL_WINDOW.document && LOCAL_WINDOW.document.referrer) || '';
@@ -417,12 +421,20 @@ function openRtbRequest(bidRequests, bidderRequest) {
   if (schain) {
     openRtbRequest.schain = schain;
   }
-
+  const gpc = getGPCSignal(bidderRequest);
+  if (gpc) {
+    deepSetValue(openRtbRequest, 'regs.ext.gpc', gpc);
+  }
   if (bidRequests[0].auctionId) {
     openRtbRequest.auctionId = bidRequests[0].auctionId;
   }
   populateOpenRtbGdpr(openRtbRequest, bidderRequest);
   return openRtbRequest;
+}
+
+function getGPCSignal(bidderRequest) {
+  const gpc = deepAccess(bidderRequest, 'ortb2.regs.ext.gpc');
+  return gpc;
 }
 
 function getTopics(bidderRequest) {

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -413,6 +413,22 @@ describe('YieldmoAdapter', function () {
         });
       });
 
+      it('should send gpc in the banner bid request', function () {
+        const biddata = build(
+          [mockBannerBid()],
+          mockBidderRequest({
+            ortb2: {
+              regs: {
+                ext: {
+                  gpc: '1'
+                },
+              },
+            },
+          })
+        );
+        expect(biddata[0].data.gpc).to.equal('1');
+      });
+
       it('should add eids to the banner bid request', function () {
         const params = {
           userIdAsEids: [{
@@ -665,6 +681,23 @@ describe('YieldmoAdapter', function () {
           classifier: '2206021246',
           topics: [7, 8, 9],
         });
+      });
+
+      it('should send gpc in the bid request', function () {
+        let videoBidder = mockBidderRequest(
+          {
+            ortb2: {
+              regs: {
+                ext: {
+                  gpc: '1',
+                },
+              },
+            },
+          },
+          [mockVideoBid()]
+        );
+        let payload = buildAndGetData([mockVideoBid()], 0, videoBidder);
+        expect(payload.regs.ext.gpc).to.equal('1');
       });
 
       it('should add device info to payload if available', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Passing GPC Value in the Bid Request.
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
