### PR TITLE
Onetag Bid Adapter: add DSA support

### DIFF
--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -127,6 +127,9 @@ function interpretResponse(serverResponse, bidderRequest) {
       },
       ttl: bid.ttl || 300
     };
+    if (bid.dsa) {
+      responseBid.meta.dsa = bid.dsa;
+    }
     if (bid.mediaType === BANNER) {
       responseBid.ad = bid.ad;
     } else if (bid.mediaType === VIDEO) {

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -396,47 +396,75 @@ describe('onetag', function () {
       expect(payload.ortb2).to.exist;
       expect(payload.ortb2).to.exist.and.to.deep.equal(firtPartyData);
     });
-  });
-  it('Should send FLEDGE eligibility flag when FLEDGE is enabled', function () {
-    let bidderRequest = {
-      'bidderCode': 'onetag',
-      'auctionId': '1d1a030790a475',
-      'bidderRequestId': '22edbae2733bf6',
-      'timeout': 3000,
-      'fledgeEnabled': true
-    };
-    let serverRequest = spec.buildRequests([bannerBid], bidderRequest);
-    const payload = JSON.parse(serverRequest.data);
+    it('Should send DSA (ortb2 field)', function () {
+      const dsa = {
+        'regs': {
+          'ext': {
+            'dsa': {
+              'required': 1,
+              'pubrender': 0,
+              'datatopub': 1,
+              'transparency': [{
+                'domain': 'dsa-domain',
+                'params': [1, 2]
+              }]
+            }
+          }
+        }
+      };
+      let bidderRequest = {
+        'bidderCode': 'onetag',
+        'auctionId': '1d1a030790a475',
+        'bidderRequestId': '22edbae2733bf6',
+        'timeout': 3000,
+        'ortb2': dsa
+      }
+      let serverRequest = spec.buildRequests([bannerBid], bidderRequest);
+      const payload = JSON.parse(serverRequest.data);
+      expect(payload.ortb2).to.exist;
+      expect(payload.ortb2).to.exist.and.to.deep.equal(dsa);
+    });
+    it('Should send FLEDGE eligibility flag when FLEDGE is enabled', function () {
+      let bidderRequest = {
+        'bidderCode': 'onetag',
+        'auctionId': '1d1a030790a475',
+        'bidderRequestId': '22edbae2733bf6',
+        'timeout': 3000,
+        'fledgeEnabled': true
+      };
+      let serverRequest = spec.buildRequests([bannerBid], bidderRequest);
+      const payload = JSON.parse(serverRequest.data);
 
-    expect(payload.fledgeEnabled).to.exist;
-    expect(payload.fledgeEnabled).to.exist.and.to.equal(bidderRequest.fledgeEnabled);
-  });
-  it('Should send FLEDGE eligibility flag when FLEDGE is not enabled', function () {
-    let bidderRequest = {
-      'bidderCode': 'onetag',
-      'auctionId': '1d1a030790a475',
-      'bidderRequestId': '22edbae2733bf6',
-      'timeout': 3000,
-      'fledgeEnabled': false
-    };
-    let serverRequest = spec.buildRequests([bannerBid], bidderRequest);
-    const payload = JSON.parse(serverRequest.data);
+      expect(payload.fledgeEnabled).to.exist;
+      expect(payload.fledgeEnabled).to.exist.and.to.equal(bidderRequest.fledgeEnabled);
+    });
+    it('Should send FLEDGE eligibility flag when FLEDGE is not enabled', function () {
+      let bidderRequest = {
+        'bidderCode': 'onetag',
+        'auctionId': '1d1a030790a475',
+        'bidderRequestId': '22edbae2733bf6',
+        'timeout': 3000,
+        'fledgeEnabled': false
+      };
+      let serverRequest = spec.buildRequests([bannerBid], bidderRequest);
+      const payload = JSON.parse(serverRequest.data);
 
-    expect(payload.fledgeEnabled).to.exist;
-    expect(payload.fledgeEnabled).to.exist.and.to.equal(bidderRequest.fledgeEnabled);
-  });
-  it('Should send FLEDGE eligibility flag set to false when fledgeEnabled is not defined', function () {
-    let bidderRequest = {
-      'bidderCode': 'onetag',
-      'auctionId': '1d1a030790a475',
-      'bidderRequestId': '22edbae2733bf6',
-      'timeout': 3000,
-    };
-    let serverRequest = spec.buildRequests([bannerBid], bidderRequest);
-    const payload = JSON.parse(serverRequest.data);
+      expect(payload.fledgeEnabled).to.exist;
+      expect(payload.fledgeEnabled).to.exist.and.to.equal(bidderRequest.fledgeEnabled);
+    });
+    it('Should send FLEDGE eligibility flag set to false when fledgeEnabled is not defined', function () {
+      let bidderRequest = {
+        'bidderCode': 'onetag',
+        'auctionId': '1d1a030790a475',
+        'bidderRequestId': '22edbae2733bf6',
+        'timeout': 3000,
+      };
+      let serverRequest = spec.buildRequests([bannerBid], bidderRequest);
+      const payload = JSON.parse(serverRequest.data);
 
-    expect(payload.fledgeEnabled).to.exist;
-    expect(payload.fledgeEnabled).to.exist.and.to.equal(false);
+      expect(payload.fledgeEnabled).to.exist;
+      expect(payload.fledgeEnabled).to.exist.and.to.equal(false);
+    });
   });
   describe('interpretResponse', function () {
     const request = getBannerVideoRequest();
@@ -485,6 +513,21 @@ describe('onetag', function () {
     it('Returns an empty array if response is not valid', function () {
       const serverResponses = spec.interpretResponse('invalid_response', { data: '{}' });
       expect(serverResponses).to.be.an('array').that.is.empty;
+    });
+    it('Returns meta dsa field if dsa field is present in response', function () {
+      const dsaResponseObj = {
+        'behalf': 'Advertiser',
+        'paid': 'Advertiser',
+        'transparency': {
+          'domain': 'dsp1domain.com',
+          'params': [1, 2]
+        },
+        'adrender': 1
+      };
+      const responseWithDsa = {...response};
+      responseWithDsa.body.bids.forEach(bid => bid.dsa = {...dsaResponseObj});
+      const serverResponse = spec.interpretResponse(responseWithDsa, request);
+      serverResponse.forEach(bid => expect(bid.meta.dsa).to.deep.equals(dsaResponseObj));
     });
   });
   describe('getUserSyncs', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
Feature
## Description of change
This PR adds support for the Digital Services Act (DSA) feature for the Onetag bid adapter. In specific, it supplies the DSA relevant response values into the `bid.meta` field for Prebid.js core to further process/surface to the publisher/interested party listening for that data.
## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
