### PR TITLE
Missena Bid Adapter: add session identifier

### DIFF
--- a/modules/missenaBidAdapter.js
+++ b/modules/missenaBidAdapter.js
@@ -1,6 +1,7 @@
 import {
   buildUrl,
   formatQS,
+  generateUUID,
   isFn,
   logInfo,
   safeJSONParse,
@@ -24,6 +25,7 @@ const EVENTS_DOMAIN = 'events.missena.io';
 const EVENTS_DOMAIN_DEV = 'events.staging.missena.xyz';
 
 export const storage = getStorageManager({ bidderCode: BIDDER_CODE });
+window.msna_ik = window.msna_ik || generateUUID();
 
 /* Get Floor price information */
 function getFloor(bidRequest) {
@@ -79,6 +81,7 @@ export const spec = {
     return validBidRequests.map((bidRequest) => {
       const payload = {
         adunit: bidRequest.adUnitCode,
+        ik: window.msna_ik,
         request_id: bidRequest.bidId,
         timeout: bidderRequest.timeout,
       };

--- a/test/spec/modules/missenaBidAdapter_spec.js
+++ b/test/spec/modules/missenaBidAdapter_spec.js
@@ -137,6 +137,10 @@ describe('Missena Adapter', function () {
       expect(payloadNoFloor.floor).to.equal(undefined);
       expect(payloadNoFloor.floor_currency).to.equal(undefined);
     });
+    it('should send the idempotency key', function () {
+      expect(window.msna_ik).to.not.equal(undefined);
+      expect(payload.ik).to.equal(window.msna_ik);
+    });
 
     getDataFromLocalStorageStub.restore();
     getDataFromLocalStorageStub = sinon.stub(


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
We need a way to identify individual page visits across multiple auctions in the context of prebid auction refresh. 
