### PR TITLE
Core: fix missing AD_RENDER_SUCCEDED for outstream renderers

### DIFF
--- a/src/adRendering.js
+++ b/src/adRendering.js
@@ -19,7 +19,10 @@ const {AD_RENDER_FAILED, AD_RENDER_SUCCEEDED, STALE_RENDER, BID_WON} = constants
  */
 export function emitAdRenderFail({ reason, message, bid, id }) {
   const data = { reason, message };
-  if (bid) data.bid = bid;
+  if (bid) {
+    data.bid = bid;
+    data.adId = bid.adId;
+  }
   if (id) data.adId = id;
 
   logError(`Error rendering ad (id: ${id}): ${message}`);
@@ -64,6 +67,7 @@ export function handleRender(renderFn, {adId, options, bidResponse, doc}) {
     // rendering for outstream safeframe
     if (isRendererRequired(renderer)) {
       executeRenderer(renderer, bidResponse, doc);
+      emitAdRenderSucceeded({doc, bid: bidResponse, id: adId})
     } else if (adId) {
       if (mediaType === VIDEO) {
         emitAdRenderFail({


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fixes a bug where AD_RENDER_SUCCEEDED is not fired for bids that have a renderer.

