### PR TITLE
Microad Bid Adapter: send gpid and other to our request.

### DIFF
--- a/modules/microadBidAdapter.js
+++ b/modules/microadBidAdapter.js
@@ -115,8 +115,8 @@ export const spec = {
         params['aids'] = JSON.stringify(aidsParams)
       }
 
-      const pbadslot = bid.ortb2Imp?.ext?.data?.pbadslot;
-      const gpid = bid.ortb2Imp?.ext?.gpid || pbadslot;
+      const pbadslot = deepAccess(bid, 'ortb2Imp.ext.data.pbadslot');
+      const gpid = deepAccess(bid, 'ortb2Imp.ext.gpid') || pbadslot;
       if (gpid != null && gpid.length > 0) {
         params['gpid'] = gpid;
       }
@@ -125,12 +125,12 @@ export const spec = {
         params['pbadslot'] = pbadslot;
       }
 
-      const adservname = bid.ortb2Imp?.ext?.data?.adserver?.name;
+      const adservname = deepAccess(bid, 'ortb2Imp.ext.data.adserver.name');
       if (adservname != null && adservname.length > 0) {
         params['adservname'] = adservname;
       }
 
-      const adservadslot = bid.ortb2Imp?.ext?.data?.adserver?.adslot;
+      const adservadslot = deepAccess(bid, 'ortb2Imp.ext.data.adserver.adslot');
       if (adservadslot != null && adservadslot.length > 0) {
         params['adservadslot'] = adservadslot;
       }

--- a/modules/microadBidAdapter.js
+++ b/modules/microadBidAdapter.js
@@ -117,21 +117,21 @@ export const spec = {
 
       const pbadslot = deepAccess(bid, 'ortb2Imp.ext.data.pbadslot');
       const gpid = deepAccess(bid, 'ortb2Imp.ext.gpid') || pbadslot;
-      if (gpid != null && gpid.length > 0) {
+      if (gpid) {
         params['gpid'] = gpid;
       }
 
-      if (pbadslot != null && pbadslot.length > 0) {
+      if (pbadslot) {
         params['pbadslot'] = pbadslot;
       }
 
       const adservname = deepAccess(bid, 'ortb2Imp.ext.data.adserver.name');
-      if (adservname != null && adservname.length > 0) {
+      if (adservname) {
         params['adservname'] = adservname;
       }
 
       const adservadslot = deepAccess(bid, 'ortb2Imp.ext.data.adserver.adslot');
-      if (adservadslot != null && adservadslot.length > 0) {
+      if (adservadslot) {
         params['adservadslot'] = adservadslot;
       }
 

--- a/modules/microadBidAdapter.js
+++ b/modules/microadBidAdapter.js
@@ -115,6 +115,26 @@ export const spec = {
         params['aids'] = JSON.stringify(aidsParams)
       }
 
+      const pbadslot = bid.ortb2Imp?.ext?.data?.pbadslot;
+      const gpid = bid.ortb2Imp?.ext?.gpid || pbadslot;
+      if (gpid != null && gpid.length > 0) {
+        params['gpid'] = gpid;
+      }
+
+      if (pbadslot != null && pbadslot.length > 0) {
+        params['pbadslot'] = pbadslot;
+      }
+
+      const adservname = bid.ortb2Imp?.ext?.data?.adserver?.name;
+      if (adservname != null && adservname.length > 0) {
+        params['adservname'] = adservname;
+      }
+
+      const adservadslot = bid.ortb2Imp?.ext?.data?.adserver?.adslot;
+      if (adservadslot != null && adservadslot.length > 0) {
+        params['adservadslot'] = adservadslot;
+      }
+
       requests.push({
         method: 'GET',
         url: ENDPOINT_URLS[ENVIRONMENT],

--- a/test/spec/modules/microadBidAdapter_spec.js
+++ b/test/spec/modules/microadBidAdapter_spec.js
@@ -382,6 +382,196 @@ describe('microadBidAdapter', () => {
         })
       });
     })
+
+    describe('should send gpid', () => {
+      it('from gpid', () => {
+        const bidRequest = Object.assign({}, bidRequestTemplate, {
+          ortb2Imp: {
+            ext: {
+              tid: 'transaction-id',
+              gpid: '1111/2222',
+              data: {
+                pbadslot: '3333/4444'
+              }
+            }
+          }
+        });
+        const requests = spec.buildRequests([bidRequest], bidderRequest)
+        requests.forEach(request => {
+          expect(request.data).to.deep.equal(
+            Object.assign({}, expectedResultTemplate, {
+              cbt: request.data.cbt,
+              gpid: '1111/2222',
+              pbadslot: '3333/4444'
+            })
+          );
+        })
+      })
+
+      it('from pbadslot', () => {
+        const bidRequest = Object.assign({}, bidRequestTemplate, {
+          ortb2Imp: {
+            ext: {
+              tid: 'transaction-id',
+              data: {
+                pbadslot: '3333/4444'
+              }
+            }
+          }
+        });
+        const requests = spec.buildRequests([bidRequest], bidderRequest)
+        requests.forEach(request => {
+          expect(request.data).to.deep.equal(
+            Object.assign({}, expectedResultTemplate, {
+              cbt: request.data.cbt,
+              gpid: '3333/4444',
+              pbadslot: '3333/4444'
+            })
+          );
+        })
+      })
+    })
+
+    const notGettingGpids = {
+      'they are not existing': bidRequestTemplate,
+      'they are blank': {
+        ortb2Imp: {
+          ext: {
+            tid: 'transaction-id',
+            gpid: '',
+            data: {
+              pbadslot: ''
+            }
+          }
+        }
+      }
+    }
+
+    Object.entries(notGettingGpids).forEach(([testTitle, param]) => {
+      it(`should not send gpid because ${testTitle}`, () => {
+        const bidRequest = Object.assign({}, bidRequestTemplate, param);
+        const requests = spec.buildRequests([bidRequest], bidderRequest)
+        requests.forEach(request => {
+          expect(request.data).to.deep.equal(
+            Object.assign({}, expectedResultTemplate, {
+              cbt: request.data.cbt,
+            })
+          );
+          expect(request.data.gpid).to.be.undefined;
+          expect(request.data.pbadslot).to.be.undefined;
+        })
+      })
+    })
+
+    it('should send adservname', () => {
+      const bidRequest = Object.assign({}, bidRequestTemplate, {
+        ortb2Imp: {
+          ext: {
+            tid: 'transaction-id',
+            data: {
+              adserver: {
+                name: 'gam'
+              }
+            }
+          }
+        }
+      });
+      const requests = spec.buildRequests([bidRequest], bidderRequest)
+      requests.forEach(request => {
+        expect(request.data).to.deep.equal(
+          Object.assign({}, expectedResultTemplate, {
+            cbt: request.data.cbt,
+            adservname: 'gam'
+          })
+        );
+      })
+    })
+
+    const notGettingAdservnames = {
+      'it is not existing': bidRequestTemplate,
+      'it is blank': {
+        ortb2Imp: {
+          ext: {
+            tid: 'transaction-id',
+            data: {
+              adserver: {
+                name: ''
+              }
+            }
+          }
+        }
+      }
+    }
+
+    Object.entries(notGettingAdservnames).forEach(([testTitle, param]) => {
+      it(`should not send adservname because ${testTitle}`, () => {
+        const bidRequest = Object.assign({}, bidRequestTemplate, param);
+        const requests = spec.buildRequests([bidRequest], bidderRequest)
+        requests.forEach(request => {
+          expect(request.data).to.deep.equal(
+            Object.assign({}, expectedResultTemplate, {
+              cbt: request.data.cbt,
+            })
+          );
+          expect(request.data.adservname).to.be.undefined;
+        })
+      })
+    })
+
+    it('should send adservadslot', () => {
+      const bidRequest = Object.assign({}, bidRequestTemplate, {
+        ortb2Imp: {
+          ext: {
+            tid: 'transaction-id',
+            data: {
+              adserver: {
+                adslot: '/1111/home'
+              }
+            }
+          }
+        }
+      });
+      const requests = spec.buildRequests([bidRequest], bidderRequest)
+      requests.forEach(request => {
+        expect(request.data).to.deep.equal(
+          Object.assign({}, expectedResultTemplate, {
+            cbt: request.data.cbt,
+            adservadslot: '/1111/home'
+          })
+        );
+      })
+    })
+
+    const notGettingAdservadslots = {
+      'it is not existing': bidRequestTemplate,
+      'it is blank': {
+        ortb2Imp: {
+          ext: {
+            tid: 'transaction-id',
+            data: {
+              adserver: {
+                adslot: ''
+              }
+            }
+          }
+        }
+      }
+    }
+
+    Object.entries(notGettingAdservadslots).forEach(([testTitle, param]) => {
+      it(`should not send adservadslot because ${testTitle}`, () => {
+        const bidRequest = Object.assign({}, bidRequestTemplate, param);
+        const requests = spec.buildRequests([bidRequest], bidderRequest)
+        requests.forEach(request => {
+          expect(request.data).to.deep.equal(
+            Object.assign({}, expectedResultTemplate, {
+              cbt: request.data.cbt,
+            })
+          );
+          expect(request.data.adservadslot).to.be.undefined;
+        })
+      })
+    })
   });
 
   describe('interpretResponse', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

We send new 4 parameters to our request. It's below.
- gpid
- pbadslot
- adservname
- adservadslot

We edit document too. It's below.
https://github.com/prebid/prebid.github.io/pull/5140


<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
