### PR TITLE
greenbidsAnalyticsAdapter: fix double sampling bug

### DIFF
--- a/modules/greenbidsAnalyticsAdapter.js
+++ b/modules/greenbidsAnalyticsAdapter.js
@@ -33,7 +33,6 @@ export const isSampled = function(greenbidsId, samplingRate) {
     return true;
   }
   const hashInt = parseInt(greenbidsId.slice(-4), 16);
-
   return hashInt < samplingRate * (0xFFFF + 1);
 }
 
@@ -59,8 +58,6 @@ export const greenbidsAnalyticsAdapter = Object.assign(adapter({ANALYTICS_SERVER
     if (typeof analyticsOptions.options.sampling === 'number') {
       logWarn('"options.sampling" is deprecated, please use "greenbidsSampling" instead.');
       analyticsOptions.options.greenbidsSampling = analyticsOptions.options.sampling;
-      // Set sampling to null to prevent prebid analytics integrated sampling to happen
-      analyticsOptions.options.sampling = null;
     }
 
     /**
@@ -228,6 +225,10 @@ greenbidsAnalyticsAdapter.originEnableAnalytics = greenbidsAnalyticsAdapter.enab
 
 greenbidsAnalyticsAdapter.enableAnalytics = function(config) {
   this.initConfig(config);
+  if (typeof config.options.sampling === 'number') {
+    // Set sampling to 1 to prevent prebid analytics integrated sampling to happen
+    config.options.sampling = 1;
+  }
   logInfo('loading greenbids analytics');
   greenbidsAnalyticsAdapter.originEnableAnalytics(config);
 };


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
The way we inactivated internal analytics sampling when using legacy parameter `sampling` wasn't working and the sampling was done twice. This fixes the place where the override is done.
