### PR TITLE
mediasquare Bid Adapter: minor change with floors

### DIFF
--- a/modules/mediasquareBidAdapter.js
+++ b/modules/mediasquareBidAdapter.js
@@ -62,6 +62,8 @@ export const spec = {
             if (tmpFloor != {}) { floor[value.join('x')] = tmpFloor; }
           });
         }
+        let tmpFloor = adunitValue.getFloor({currency: 'USD', mediaType: '*', size: '*'});
+        if (tmpFloor != {}) { floor['*'] = tmpFloor; }
       }
       codes.push({
         owner: adunitValue.params.owner,

--- a/test/spec/modules/mediasquareBidAdapter_spec.js
+++ b/test/spec/modules/mediasquareBidAdapter_spec.js
@@ -173,6 +173,7 @@ describe('MediaSquare bid adapter tests', function () {
     const responsefloor = JSON.parse(requestfloor.data);
     expect(responsefloor.codes[0]).to.have.property('floor').exist;
     expect(responsefloor.codes[0].floor).to.have.property('300x250').and.to.have.property('floor').and.to.equal(1);
+    expect(responsefloor.codes[0].floor).to.have.property('*');
   });
 
   it('Verify parse response', function () {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
If an adunit had no size - such as native - the floor was not sent. Now getting remnant informations using the wildcard
