### PR TITLE
greenbids analytics adapter force split determinist sampling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "prebid.js",
-      "version": "8.35.0-pre",
+      "version": "8.37.0-pre",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.16.7",
@@ -11651,8 +11651,10 @@
       }
     },
     "node_modules/eslint-plugin-prebid": {
-      "resolved": "plugins/eslint",
-      "link": true
+      "version": "1.0.0",
+      "resolved": "file:plugins/eslint",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/eslint-plugin-promise": {
       "version": "5.2.0",
@@ -29214,12 +29216,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "plugins/eslint": {
-      "name": "eslint-plugin-prebid",
-      "version": "1.0.0",
-      "dev": true,
-      "license": "Apache-2.0"
     }
   },
   "dependencies": {
@@ -38092,7 +38088,8 @@
       }
     },
     "eslint-plugin-prebid": {
-      "version": "file:plugins/eslint"
+      "version": "1.0.0",
+      "dev": true
     },
     "eslint-plugin-promise": {
       "version": "5.2.0",

--- a/test/spec/modules/greenbidsAnalyticsAdapter_spec.js
+++ b/test/spec/modules/greenbidsAnalyticsAdapter_spec.js
@@ -404,16 +404,24 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
 
   describe('isSampled', function() {
     it('should return true for invalid sampling rates', function() {
-      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', -1)).to.be.true;
-      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 1.2)).to.be.true;
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', -1, 1.0)).to.be.true;
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 1.2, 1.0)).to.be.true;
     });
 
-    it('should return determinist falsevalue for valid sampling rate given the predifined id and rate', function() {
-      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 0.0001)).to.be.false;
+    it('should return determinist false value for valid sampling rate given the predifined id and rate', function() {
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 0.0001, 1.0)).to.be.false;
     });
 
     it('should return determinist true value for valid sampling rate given the predifined id and rate', function() {
-      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 0.9999)).to.be.true;
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 0.9999, 1.0)).to.be.true;
+    });
+
+    it('should return determinist false value for valid sampling rate given the predifined id and rate when we split to non exploration', function() {
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 0.9999, 0.0)).to.be.false;
+    });
+
+    it('should return determinist true value for valid sampling rate given the predifined id and rate when we split to non exploration', function() {
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 0.0001, 0.0)).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature

## Description of change
Small feature to fix a bug on Greenbids side to have a fixed split in the deterministic sampling.

A debug parameter flag has been added to to module but doesn't require documentation update as the parameter shouldn't be directly changed by end users.

