### PR TITLE
Greenbids Analytics Adapter: define split between exploratory and non exploratory sides of the sampling

### DIFF
--- a/test/spec/modules/greenbidsAnalyticsAdapter_spec.js
+++ b/test/spec/modules/greenbidsAnalyticsAdapter_spec.js
@@ -404,16 +404,24 @@ describe('Greenbids Prebid AnalyticsAdapter Testing', function () {
 
   describe('isSampled', function() {
     it('should return true for invalid sampling rates', function() {
-      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', -1)).to.be.true;
-      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 1.2)).to.be.true;
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', -1, 0.0)).to.be.true;
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 1.2, 0.0)).to.be.true;
     });
 
     it('should return determinist falsevalue for valid sampling rate given the predifined id and rate', function() {
-      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 0.0001)).to.be.false;
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 0.0001, 0.0)).to.be.false;
     });
 
     it('should return determinist true value for valid sampling rate given the predifined id and rate', function() {
-      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 0.9999)).to.be.true;
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 0.9999, 0.0)).to.be.true;
+    });
+
+    it('should return determinist true value for valid sampling rate given the predifined id and rate when we split to non exploration first', function() {
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 0.9999, 0.0, 1.0)).to.be.true;
+    });
+
+    it('should return determinist false value for valid sampling rate given the predifined id and rate when we split to non exploration first', function() {
+      expect(isSampled('ce1f3692-632c-4cfd-9e40-0c2ad625ec56', 0.0001, 0.0, 1.0)).to.be.false;
     });
   });
 });


### PR DESCRIPTION


<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Small fix related to a bug on Greenbids side to have a fixed split in the deterministic sampling.

A debug parameter flag has been added to to module' configuration but doesn't require documentation update as the parameter shouldn't be directly changed by end users.
