### PR TITLE
Rubicon Bid Adapter: fix handling of default settings for outstream renderer

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -829,7 +829,14 @@ function renderBid(bid) {
   hideSmartAdServerIframe(adUnitElement);
 
   // configure renderer
-  const config = bid.renderer.getConfig();
+  const defaultConfig = {
+    align: 'center',
+    position: 'append',
+    closeButton: false,
+    label: undefined,
+    collapse: true
+  };
+  const config = { ...defaultConfig, ...bid.renderer.getConfig() };
   bid.renderer.push(() => {
     window.MagniteApex.renderAd({
       width: bid.width,
@@ -837,12 +844,12 @@ function renderBid(bid) {
       vastUrl: bid.vastUrl,
       placement: {
         attachTo: adUnitElement,
-        align: config.align || 'center',
-        position: config.position || 'append'
+        align: config.align,
+        position: config.position
       },
-      closeButton: config.closeButton || false,
-      label: config.label || undefined,
-      collapse: config.collapse || true
+      closeButton: config.closeButton,
+      label: config.label,
+      collapse: config.collapse
     });
   });
 }

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -3899,7 +3899,8 @@ describe('the rubicon adapter', function () {
             config.setConfig({rubicon: {
               rendererConfig: {
                 align: 'left',
-                closeButton: true
+                closeButton: true,
+                collapse: false
               },
               rendererUrl: 'https://example.test/renderer.js'
             }});
@@ -3971,7 +3972,8 @@ describe('the rubicon adapter', function () {
             expect(typeof bids[0].renderer).to.equal('object');
             expect(bids[0].renderer.getConfig()).to.deep.equal({
               align: 'left',
-              closeButton: true
+              closeButton: true,
+              collapse: false
             });
             expect(bids[0].renderer.url).to.equal('https://example.test/renderer.js');
           });
@@ -4025,7 +4027,7 @@ describe('the rubicon adapter', function () {
             const renderCall = window.MagniteApex.renderAd.getCall(0);
             expect(renderCall.args[0]).to.deep.equal({
               closeButton: true,
-              collapse: true,
+              collapse: false,
               height: 320,
               label: undefined,
               placement: {
@@ -4094,7 +4096,7 @@ describe('the rubicon adapter', function () {
             const renderCall = window.MagniteApex.renderAd.getCall(0);
             expect(renderCall.args[0]).to.deep.equal({
               closeButton: true,
-              collapse: true,
+              collapse: false,
               height: 480,
               label: undefined,
               placement: {


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Fix handling of default configuration for the outstream renderer in the Rubicon bid adapter, so parameters set to `false` are properly passed.
