### PR TITLE
LiveIntent UserId module: Expose shared id

### DIFF
--- a/libraries/pubcidEids/pubcidEids.js
+++ b/libraries/pubcidEids/pubcidEids.js
@@ -1,0 +1,18 @@
+export const PUBCID_EIDS = {
+  'pubcid': {
+    source: 'pubcid.org',
+    atype: 1,
+    getValue: function(data) {
+      if (data.id) {
+        return data.id;
+      } else {
+        return data;
+      }
+    },
+    getUidExt: function(data) {
+      if (data.ext) {
+        return data.ext;
+      }
+    }
+  }
+};

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -8,10 +8,11 @@ import { triggerPixel, logError } from '../src/utils.js';
 import { ajaxBuilder } from '../src/ajax.js';
 import { submodule } from '../src/hook.js';
 import { LiveConnect } from 'live-connect-js'; // eslint-disable-line prebid/validate-imports
-import { gdprDataHandler, uspDataHandler, gppDataHandler } from '../src/adapterManager.js';
-import {getStorageManager} from '../src/storageManager.js';
-import {MODULE_TYPE_UID} from '../src/activities/modules.js';
-import {UID2_EIDS} from '../libraries/uid2Eids/uid2Eids.js';
+import { gdprDataHandler, uspDataHandler, gppDataHandler, coppaDataHandler } from '../src/adapterManager.js';
+import { getStorageManager } from '../src/storageManager.js';
+import { MODULE_TYPE_UID } from '../src/activities/modules.js';
+import { UID2_EIDS } from '../libraries/uid2Eids/uid2Eids.js';
+import { PUBCID_EIDS } from '../libraries/pubcidEids/pubcidEids.js';
 import { getRefererInfo } from '../src/refererDetection.js';
 
 /**
@@ -20,12 +21,12 @@ import { getRefererInfo } from '../src/refererDetection.js';
  * @typedef {import('../modules/userId/index.js').IdResponse} IdResponse
  */
 
-const DEFAULT_AJAX_TIMEOUT = 5000
-const EVENTS_TOPIC = 'pre_lips'
+const DEFAULT_AJAX_TIMEOUT = 5000;
+const EVENTS_TOPIC = 'pre_lips';
 const MODULE_NAME = 'liveIntentId';
 const LI_PROVIDER_DOMAIN = 'liveintent.com';
 export const storage = getStorageManager({moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME});
-const defaultRequestedAttributes = {'nonId': true}
+const defaultRequestedAttributes = {'nonId': true};
 const calls = {
   ajaxGet: (url, onSuccess, onError, timeout) => {
     ajaxBuilder(timeout)(
@@ -52,10 +53,10 @@ let liveConnect = null;
  */
 export function reset() {
   if (window && window.liQ_instances) {
-    window.liQ_instances.forEach(i => i.eventBus.off(EVENTS_TOPIC, setEventFiredFlag))
+    window.liQ_instances.forEach(i => i.eventBus.off(EVENTS_TOPIC, setEventFiredFlag));
     window.liQ_instances = [];
   }
-  liveIntentIdSubmodule.setModuleMode(null)
+  liveIntentIdSubmodule.setModuleMode(null);
   eventFired = false;
   liveConnect = null;
 }
@@ -69,7 +70,7 @@ export function setEventFiredFlag() {
 
 function parseLiveIntentCollectorConfig(collectConfig) {
   const config = {};
-  collectConfig = collectConfig || {}
+  collectConfig = collectConfig || {};
   collectConfig.appId && (config.appId = collectConfig.appId);
   collectConfig.fpiStorageStrategy && (config.storageStrategy = collectConfig.fpiStorageStrategy);
   collectConfig.fpiExpirationDays && (config.expirationDays = collectConfig.fpiExpirationDays);
@@ -85,21 +86,30 @@ function parseLiveIntentCollectorConfig(collectConfig) {
  * @returns {Array}
  */
 function parseRequestedAttributes(overrides) {
+  function renameAttribute(attribute) {
+    if (attribute === 'sharedId') {
+      return 'idCookie';
+    } else {
+      return attribute;
+    };
+  }
   function createParameterArray(config) {
-    return Object.entries(config).flatMap(([k, v]) => (typeof v === 'boolean' && v) ? [k] : []);
+    return Object.entries(config).flatMap(([k, v]) => (typeof v === 'boolean' && v) ? [renameAttribute(k)] : []);
   }
   if (typeof overrides === 'object') {
-    return createParameterArray({...defaultRequestedAttributes, ...overrides})
+    return createParameterArray({...defaultRequestedAttributes, ...overrides});
   } else {
     return createParameterArray(defaultRequestedAttributes);
   }
 }
 
 function initializeLiveConnect(configParams) {
-  configParams = configParams || {};
   if (liveConnect) {
     return liveConnect;
   }
+
+  configParams = configParams || {};
+  const sharedIdConfig = configParams.sharedId || {};
 
   const publisherId = configParams.publisherId || 'any';
   const identityResolutionConfig = {
@@ -107,8 +117,8 @@ function initializeLiveConnect(configParams) {
     requestedAttributes: parseRequestedAttributes(configParams.requestedAttributesOverrides)
   };
   if (configParams.url) {
-    identityResolutionConfig.url = configParams.url
-  }
+    identityResolutionConfig.url = configParams.url;
+  };
 
   identityResolutionConfig.ajaxTimeout = configParams.ajaxTimeout || DEFAULT_AJAX_TIMEOUT;
 
@@ -118,7 +128,7 @@ function initializeLiveConnect(configParams) {
     liveConnectConfig.distributorId = configParams.distributorId;
     identityResolutionConfig.source = configParams.distributorId;
   } else {
-    identityResolutionConfig.source = configParams.partner || 'prebid'
+    identityResolutionConfig.source = configParams.partner || 'prebid';
   }
 
   liveConnectConfig.wrapperName = 'prebid';
@@ -126,11 +136,16 @@ function initializeLiveConnect(configParams) {
   liveConnectConfig.identityResolutionConfig = identityResolutionConfig;
   liveConnectConfig.identifiersToResolve = configParams.identifiersToResolve || [];
   liveConnectConfig.fireEventDelay = configParams.fireEventDelay;
+
+  liveConnectConfig.idCookie = {};
+  liveConnectConfig.idCookie.name = sharedIdConfig.name;
+  liveConnectConfig.idCookie.strategy = sharedIdConfig.strategy == 'html5' ? 'localStorage' : sharedIdConfig.strategy;
+
   const usPrivacyString = uspDataHandler.getConsentData();
   if (usPrivacyString) {
     liveConnectConfig.usPrivacyString = usPrivacyString;
   }
-  const gdprConsent = gdprDataHandler.getConsentData()
+  const gdprConsent = gdprDataHandler.getConsentData();
   if (gdprConsent) {
     liveConnectConfig.gdprApplies = gdprConsent.gdprApplies;
     liveConnectConfig.gdprConsent = gdprConsent.consentString;
@@ -144,21 +159,21 @@ function initializeLiveConnect(configParams) {
   // The third param is the ajax and pixel object, the ajax and pixel use PBJS
   liveConnect = liveIntentIdSubmodule.getInitializer()(liveConnectConfig, storage, calls);
   if (configParams.emailHash) {
-    liveConnect.push({ hash: configParams.emailHash })
+    liveConnect.push({ hash: configParams.emailHash });
   }
   return liveConnect;
 }
 
 function tryFireEvent() {
   if (!eventFired && liveConnect) {
-    const eventDelay = liveConnect.config.fireEventDelay || 500
+    const eventDelay = liveConnect.config.fireEventDelay || 500;
     setTimeout(() => {
-      const instances = window.liQ_instances
-      instances.forEach(i => i.eventBus.once(EVENTS_TOPIC, setEventFiredFlag))
+      const instances = window.liQ_instances;
+      instances.forEach(i => i.eventBus.once(EVENTS_TOPIC, setEventFiredFlag));
       if (!eventFired && liveConnect) {
         liveConnect.fire();
       }
-    }, eventDelay)
+    }, eventDelay);
   }
 }
 
@@ -172,10 +187,10 @@ export const liveIntentIdSubmodule = {
   name: MODULE_NAME,
 
   setModuleMode(mode) {
-    this.moduleMode = mode
+    this.moduleMode = mode;
   },
   getInitializer() {
-    return (liveConnectConfig, storage, calls) => LiveConnect(liveConnectConfig, storage, calls, this.moduleMode)
+    return (liveConnectConfig, storage, calls) => LiveConnect(liveConnectConfig, storage, calls, this.moduleMode);
   },
 
   /**
@@ -193,46 +208,54 @@ export const liveIntentIdSubmodule = {
       const result = {};
 
       // old versions stored lipbid in unifiedId. Ensure that we can still read the data.
-      const lipbid = value.nonId || value.unifiedId
+      const lipbid = value.nonId || value.unifiedId;
       if (lipbid) {
-        value.lipbid = lipbid
-        delete value.unifiedId
-        result.lipb = value
+        const lipb = { ...value, lipbid };
+        delete lipb.unifiedId;
+        result.lipb = lipb;
       }
 
       // Lift usage of uid2 by exposing uid2 if we were asked to resolve it.
       // As adapters are applied in lexicographical order, we will always
       // be overwritten by the 'proper' uid2 module if it is present.
       if (value.uid2) {
-        result.uid2 = { 'id': value.uid2, ext: { provider: LI_PROVIDER_DOMAIN } }
+        result.uid2 = { 'id': value.uid2, ext: { provider: LI_PROVIDER_DOMAIN } };
       }
 
       if (value.bidswitch) {
-        result.bidswitch = { 'id': value.bidswitch, ext: { provider: LI_PROVIDER_DOMAIN } }
+        result.bidswitch = { 'id': value.bidswitch, ext: { provider: LI_PROVIDER_DOMAIN } };
       }
 
       if (value.medianet) {
-        result.medianet = { 'id': value.medianet, ext: { provider: LI_PROVIDER_DOMAIN } }
+        result.medianet = { 'id': value.medianet, ext: { provider: LI_PROVIDER_DOMAIN } };
       }
 
       if (value.magnite) {
-        result.magnite = { 'id': value.magnite, ext: { provider: LI_PROVIDER_DOMAIN } }
+        result.magnite = { 'id': value.magnite, ext: { provider: LI_PROVIDER_DOMAIN } };
       }
 
       if (value.index) {
-        result.index = { 'id': value.index, ext: { provider: LI_PROVIDER_DOMAIN } }
+        result.index = { 'id': value.index, ext: { provider: LI_PROVIDER_DOMAIN } };
       }
 
       if (value.openx) {
-        result.openx = { 'id': value.openx, ext: { provider: LI_PROVIDER_DOMAIN } }
+        result.openx = { 'id': value.openx, ext: { provider: LI_PROVIDER_DOMAIN } };
       }
 
       if (value.pubmatic) {
-        result.pubmatic = { 'id': value.pubmatic, ext: { provider: LI_PROVIDER_DOMAIN } }
+        result.pubmatic = { 'id': value.pubmatic, ext: { provider: LI_PROVIDER_DOMAIN } };
       }
 
       if (value.sovrn) {
-        result.sovrn = { 'id': value.sovrn, ext: { provider: LI_PROVIDER_DOMAIN } }
+        result.sovrn = { 'id': value.sovrn, ext: { provider: LI_PROVIDER_DOMAIN } };
+      }
+
+      if (value.idCookie) {
+        if (!coppaDataHandler.getCoppa()) {
+          result.lipb = { ...result.lipb, pubcid: value.idCookie };
+          result.pubcid = { 'id': value.idCookie, ext: { provider: LI_PROVIDER_DOMAIN } };
+        }
+        delete result.lipb.idCookie;
       }
 
       if (value.thetradedesk) {
@@ -279,6 +302,7 @@ export const liveIntentIdSubmodule = {
   },
   eids: {
     ...UID2_EIDS,
+    ...PUBCID_EIDS,
     'lipb': {
       getValue: function(data) {
         return data.lipbid;

--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -12,6 +12,7 @@ import {getStorageManager} from '../src/storageManager.js';
 import {VENDORLESS_GVLID} from '../src/consentHandler.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 import {domainOverrideToRootDomain} from '../libraries/domainOverrideToRootDomain/index.js';
+import {PUBCID_EIDS} from '../libraries/pubcidEids/pubcidEids.js';
 
 /**
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
@@ -183,10 +184,7 @@ export const sharedIdSystemSubmodule = {
 
   domainOverride: domainOverrideToRootDomain(storage, 'sharedId'),
   eids: {
-    'pubcid': {
-      source: 'pubcid.org',
-      atype: 1
-    },
+    ...PUBCID_EIDS
   }
 };
 

--- a/modules/userId/eids.md
+++ b/modules/userId/eids.md
@@ -106,7 +106,7 @@ userIdAsEids = [
             segments: ['s1', 's2']
         }
     },
-    
+
     {
         source: 'bidswitch.net',
         uids: [{
@@ -117,7 +117,7 @@ userIdAsEids = [
             }
         }]
     },
-    
+
     {
         source: 'liveintent.indexexchange.com',
         uids: [{
@@ -160,7 +160,7 @@ userIdAsEids = [
                 provider: 'liveintent.com'
             }
         }]
-    },   
+    },
 
     {
         source: 'media.net',
@@ -189,6 +189,17 @@ userIdAsEids = [
         uids: [{
             id: 'some-random-id-value',
             atype: 3,
+            ext: {
+                provider: 'liveintent.com'
+            }
+        }]
+    },
+
+    {
+        source: 'pubcid.org',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 1,
             ext: {
                 provider: 'liveintent.com'
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "fun-hooks": "^0.9.9",
         "gulp-wrap": "^0.15.0",
         "just-clone": "^1.0.2",
-        "live-connect-js": "^6.3.4"
+        "live-connect-js": "^6.6.0"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.16.5",
@@ -19839,19 +19839,19 @@
       "dev": true
     },
     "node_modules/live-connect-common": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-3.0.3.tgz",
-      "integrity": "sha512-ZPycT04ROBUvPiksnLTunrKC3ROhBSeO99fQ+4qMIkgKwP2CvS44L7fK+0WFV4nAi+65KbzSng7JWcSlckfw8w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-3.1.1.tgz",
+      "integrity": "sha512-sV0oUvJnaTN41f30hOo3wDjZL2y8TYu5BQKvlxmek7Agpe2AGGN/dsPA8i2sHkessRKpcTfrPjmpnG2bIxq7Gg==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/live-connect-js": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.3.4.tgz",
-      "integrity": "sha512-lg2XeCaj/eEbK66QGGDEdz9IdT/K3ExZ83Qo6xGVLdP5XJ33xAUCk/gds34rRTmpIwUfAnboOpyj3UoYtS3QUQ==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.6.0.tgz",
+      "integrity": "sha512-007CQoS/ebr0iv1Bvj1D9YK5nOkQG6GJXBHnHtT2CRAwFs7Da+wequFnfpZ5I9TwhzCwZ+oPuInRp7qaSwfVvQ==",
       "dependencies": {
-        "live-connect-common": "^v3.0.3",
+        "live-connect-common": "^v3.1.1",
         "tiny-hashes": "1.0.1"
       },
       "engines": {
@@ -44518,16 +44518,16 @@
       "dev": true
     },
     "live-connect-common": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-3.0.3.tgz",
-      "integrity": "sha512-ZPycT04ROBUvPiksnLTunrKC3ROhBSeO99fQ+4qMIkgKwP2CvS44L7fK+0WFV4nAi+65KbzSng7JWcSlckfw8w=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/live-connect-common/-/live-connect-common-3.1.1.tgz",
+      "integrity": "sha512-sV0oUvJnaTN41f30hOo3wDjZL2y8TYu5BQKvlxmek7Agpe2AGGN/dsPA8i2sHkessRKpcTfrPjmpnG2bIxq7Gg=="
     },
     "live-connect-js": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.3.4.tgz",
-      "integrity": "sha512-lg2XeCaj/eEbK66QGGDEdz9IdT/K3ExZ83Qo6xGVLdP5XJ33xAUCk/gds34rRTmpIwUfAnboOpyj3UoYtS3QUQ==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-6.6.0.tgz",
+      "integrity": "sha512-007CQoS/ebr0iv1Bvj1D9YK5nOkQG6GJXBHnHtT2CRAwFs7Da+wequFnfpZ5I9TwhzCwZ+oPuInRp7qaSwfVvQ==",
       "requires": {
-        "live-connect-common": "^v3.0.3",
+        "live-connect-common": "^v3.1.1",
         "tiny-hashes": "1.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "fun-hooks": "^0.9.9",
     "gulp-wrap": "^0.15.0",
     "just-clone": "^1.0.2",
-    "live-connect-js": "^6.3.4"
+    "live-connect-js": "^6.6.0"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -1,7 +1,7 @@
 import {createEidsArray} from 'modules/userId/eids.js';
 import {expect} from 'chai';
 
-//  Note: In unit tets cases for bidders, call the createEidsArray function over userId object that is used for calling fetchBids
+//  Note: In unit test cases for bidders, call the createEidsArray function over userId object that is used for calling fetchBids
 //      this way the request will stay consistent and unit test cases will not need lots of changes.
 
 describe('eids array generation for known sub-modules', function() {
@@ -447,6 +447,54 @@ describe('eids array generation for known sub-modules', function() {
     expect(newEids[0]).to.deep.equal({
       source: 'liveintent.com',
       uids: [{id: 'some-random-id-value', atype: 3}]
+    });
+  });
+
+  it('pubcid', function() {
+    const userId = {
+      pubcid: {'id': 'sample_id'}
+    };
+    const newEids = createEidsArray(userId);
+    expect(newEids.length).to.equal(1);
+    expect(newEids[0]).to.deep.equal({
+      source: 'pubcid.org',
+      uids: [{
+        id: 'sample_id',
+        atype: 1
+      }]
+    });
+  });
+
+  it('pubcid flat', function() {
+    const userId = {
+      pubcid: 'sample_id'
+    };
+    const newEids = createEidsArray(userId);
+    expect(newEids.length).to.equal(1);
+    expect(newEids[0]).to.deep.equal({
+      source: 'pubcid.org',
+      uids: [{
+        id: 'sample_id',
+        atype: 1
+      }]
+    });
+  });
+
+  it('pubcid with ext', function() {
+    const userId = {
+      pubcid: {'id': 'sample_id', 'ext': {'provider': 'some.provider.com'}}
+    };
+    const newEids = createEidsArray(userId);
+    expect(newEids.length).to.equal(1);
+    expect(newEids[0]).to.deep.equal({
+      source: 'pubcid.org',
+      uids: [{
+        id: 'sample_id',
+        atype: 1,
+        ext: {
+          provider: 'some.provider.com'
+        }
+      }]
     });
   });
 

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -1,13 +1,13 @@
 import { liveIntentIdSubmodule, reset as resetLiveIntentIdSubmodule, storage } from 'modules/liveIntentIdSystem.js';
 import * as utils from 'src/utils.js';
-import { gdprDataHandler, uspDataHandler, gppDataHandler } from '../../../src/adapterManager.js';
+import { gdprDataHandler, uspDataHandler, gppDataHandler, coppaDataHandler } from '../../../src/adapterManager.js';
 import { server } from 'test/mocks/xhr.js';
 import * as refererDetection from '../../../src/refererDetection.js';
 
 resetLiveIntentIdSubmodule();
 liveIntentIdSubmodule.setModuleMode('standard')
 const PUBLISHER_ID = '89899';
-const defaultConfigParams = { params: {publisherId: PUBLISHER_ID, fireEventDelay: 1} };
+const defaultConfigParams = {publisherId: PUBLISHER_ID, fireEventDelay: 1};
 const responseHeader = {'Content-Type': 'application/json'}
 
 describe('LiveIntentId', function() {
@@ -18,6 +18,7 @@ describe('LiveIntentId', function() {
   let getCookieStub;
   let getDataFromLocalStorageStub;
   let imgStub;
+  let coppaConsentDataStub;
   let refererInfoStub;
 
   beforeEach(function() {
@@ -29,6 +30,7 @@ describe('LiveIntentId', function() {
     uspConsentDataStub = sinon.stub(uspDataHandler, 'getConsentData');
     gdprConsentDataStub = sinon.stub(gdprDataHandler, 'getConsentData');
     gppConsentDataStub = sinon.stub(gppDataHandler, 'getConsentData');
+    coppaConsentDataStub = sinon.stub(coppaDataHandler, 'getCoppa');
     refererInfoStub = sinon.stub(refererDetection, 'getRefererInfo');
   });
 
@@ -40,11 +42,12 @@ describe('LiveIntentId', function() {
     uspConsentDataStub.restore();
     gdprConsentDataStub.restore();
     gppConsentDataStub.restore();
+    coppaConsentDataStub.restore();
     refererInfoStub.restore();
     resetLiveIntentIdSubmodule();
   });
 
-  it('should initialize LiveConnect with a privacy string when getId, and include it in the resolution request', function () {
+  it('should initialize LiveConnect with a privacy string when getId but not send request', function () {
     uspConsentDataStub.returns('1YNY');
     gdprConsentDataStub.returns({
       gdprApplies: true,
@@ -55,35 +58,25 @@ describe('LiveIntentId', function() {
       applicableSections: [1, 2]
     })
     let callBackSpy = sinon.spy();
-    let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
+    let submoduleCallback = liveIntentIdSubmodule.getId({ params: defaultConfigParams }).callback;
     submoduleCallback(callBackSpy);
-    let request = server.requests[0];
-    expect(request.url).to.match(/.*us_privacy=1YNY.*&gdpr=1&n3pc=1&gdpr_consent=consentDataString.*&gpp_s=gppConsentDataString&gpp_as=1%2C2.*/);
-    const response = {
-      unifiedId: 'a_unified_id',
-      segments: [123, 234]
-    }
-    request.respond(
-      200,
-      responseHeader,
-      JSON.stringify(response)
-    );
-    expect(callBackSpy.calledOnceWith(response)).to.be.true;
+    expect(server.requests).to.be.empty;
+    expect(callBackSpy.notCalled).to.be.true;
   });
 
-  it('should fire an event when getId', function(done) {
+  it('should fire an event without privacy setting when getId', function(done) {
     uspConsentDataStub.returns('1YNY');
     gdprConsentDataStub.returns({
-      gdprApplies: true,
+      gdprApplies: false,
       consentString: 'consentDataString'
     })
     gppConsentDataStub.returns({
       gppString: 'gppConsentDataString',
       applicableSections: [1]
     })
-    liveIntentIdSubmodule.getId(defaultConfigParams);
+    liveIntentIdSubmodule.getId({ params: defaultConfigParams });
     setTimeout(() => {
-      expect(server.requests[0].url).to.match(/https:\/\/rp.liadm.com\/j\?.*&us_privacy=1YNY.*&wpn=prebid.*&gdpr=1&n3pc=1&n3pct=1&nb=1&gdpr_consent=consentDataString&gpp_s=gppConsentDataString&gpp_as=1.*/);
+      expect(server.requests[0].url).to.match(/https:\/\/rp.liadm.com\/j\?.*&us_privacy=1YNY.*&wpn=prebid.*&gdpr=0&gdpr_consent=consentDataString&gpp_s=gppConsentDataString&gpp_as=1.*/);
       done();
     }, 200);
   });
@@ -100,9 +93,7 @@ describe('LiveIntentId', function() {
   });
 
   it('should initialize LiveConnect and forward the prebid version when decode and emit an event', function(done) {
-    liveIntentIdSubmodule.decode({}, { params: {
-      ...defaultConfigParams
-    }});
+    liveIntentIdSubmodule.decode({}, { params: defaultConfigParams });
     setTimeout(() => {
       expect(server.requests[0].url).to.contain('tv=$prebid.version$')
       done();
@@ -111,7 +102,7 @@ describe('LiveIntentId', function() {
 
   it('should initialize LiveConnect with the config params when decode and emit an event', function (done) {
     liveIntentIdSubmodule.decode({}, { params: {
-      ...defaultConfigParams.params,
+      ...defaultConfigParams,
       ...{
         url: 'https://dummy.liveintent.com',
         liCollectConfig: {
@@ -153,7 +144,7 @@ describe('LiveIntentId', function() {
       gppString: 'gppConsentDataString',
       applicableSections: [1]
     })
-    liveIntentIdSubmodule.decode({}, defaultConfigParams);
+    liveIntentIdSubmodule.decode({}, { params: defaultConfigParams });
     setTimeout(() => {
       expect(server.requests[0].url).to.match(/.*us_privacy=1YNY.*&gdpr=0&gdpr_consent=consentDataString.*&gpp_s=gppConsentDataString&gpp_as=1.*/);
       done();
@@ -162,7 +153,7 @@ describe('LiveIntentId', function() {
 
   it('should fire an event when decode and a hash is provided', function(done) {
     liveIntentIdSubmodule.decode({}, { params: {
-      ...defaultConfigParams.params,
+      ...defaultConfigParams,
       emailHash: '58131bc547fb87af94cebdaf3102321f'
     }});
     setTimeout(() => {
@@ -177,7 +168,7 @@ describe('LiveIntentId', function() {
   });
 
   it('should fire an event when decode', function(done) {
-    liveIntentIdSubmodule.decode({}, defaultConfigParams);
+    liveIntentIdSubmodule.decode({}, { params: defaultConfigParams });
     setTimeout(() => {
       expect(server.requests[0].url).to.be.not.null
       done();
@@ -185,10 +176,10 @@ describe('LiveIntentId', function() {
   });
 
   it('should initialize LiveConnect and send data only once', function(done) {
-    liveIntentIdSubmodule.getId(defaultConfigParams);
-    liveIntentIdSubmodule.decode({}, defaultConfigParams);
-    liveIntentIdSubmodule.getId(defaultConfigParams);
-    liveIntentIdSubmodule.decode({}, defaultConfigParams);
+    liveIntentIdSubmodule.getId({ params: defaultConfigParams });
+    liveIntentIdSubmodule.decode({}, { params: defaultConfigParams });
+    liveIntentIdSubmodule.getId({ params: defaultConfigParams });
+    liveIntentIdSubmodule.decode({}, { params: defaultConfigParams });
     setTimeout(() => {
       expect(server.requests.length).to.be.eq(1);
       done();
@@ -198,7 +189,7 @@ describe('LiveIntentId', function() {
   it('should call the custom URL of the LiveIntent Identity Exchange endpoint', function() {
     getCookieStub.returns(null);
     let callBackSpy = sinon.spy();
-    let submoduleCallback = liveIntentIdSubmodule.getId({ params: {...defaultConfigParams.params, ...{'url': 'https://dummy.liveintent.com/idex'}} }).callback;
+    let submoduleCallback = liveIntentIdSubmodule.getId({ params: {...defaultConfigParams, ...{'url': 'https://dummy.liveintent.com/idex'}} }).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
     expect(request.url).to.be.eq('https://dummy.liveintent.com/idex/prebid/89899?cd=.localhost&resolve=nonId');
@@ -241,7 +232,7 @@ describe('LiveIntentId', function() {
     getCookieStub.returns(null);
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId({ params: {
-      ...defaultConfigParams.params,
+      ...defaultConfigParams,
       ...{
         'url': 'https://dummy.liveintent.com/idex',
         'partner': 'rubicon'
@@ -261,7 +252,7 @@ describe('LiveIntentId', function() {
   it('should call the LiveIntent Identity Exchange endpoint, with no additional query params', function() {
     getCookieStub.returns(null);
     let callBackSpy = sinon.spy();
-    let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
+    let submoduleCallback = liveIntentIdSubmodule.getId({ params: defaultConfigParams }).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
     expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?cd=.localhost&resolve=nonId');
@@ -276,7 +267,7 @@ describe('LiveIntentId', function() {
   it('should log an error and continue to callback if ajax request errors', function() {
     getCookieStub.returns(null);
     let callBackSpy = sinon.spy();
-    let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
+    let submoduleCallback = liveIntentIdSubmodule.getId({ params: defaultConfigParams }).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
     expect(request.url).to.be.eq('https://idx.liadm.com/idex/prebid/89899?cd=.localhost&resolve=nonId');
@@ -293,7 +284,7 @@ describe('LiveIntentId', function() {
     const oldCookie = 'a-xxxx--123e4567-e89b-12d3-a456-426655440000'
     getCookieStub.withArgs('_lc2_fpi').returns(oldCookie)
     let callBackSpy = sinon.spy();
-    let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
+    let submoduleCallback = liveIntentIdSubmodule.getId({ params: defaultConfigParams }).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
     expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?duid=${oldCookie}&cd=.localhost&resolve=nonId`);
@@ -310,7 +301,7 @@ describe('LiveIntentId', function() {
     getCookieStub.withArgs('_lc2_fpi').returns(oldCookie);
     getDataFromLocalStorageStub.withArgs('_thirdPC').returns('third-pc');
     const configParams = { params: {
-      ...defaultConfigParams.params,
+      ...defaultConfigParams,
       ...{
         'identifiersToResolve': ['_thirdPC']
       }
@@ -332,7 +323,7 @@ describe('LiveIntentId', function() {
     getCookieStub.returns(null);
     getDataFromLocalStorageStub.withArgs('_thirdPC').returns({'key': 'value'});
     const configParams = { params: {
-      ...defaultConfigParams.params,
+      ...defaultConfigParams,
       ...{
         'identifiersToResolve': ['_thirdPC']
       }
@@ -352,7 +343,7 @@ describe('LiveIntentId', function() {
 
   it('should send an error when the cookie jar throws an unexpected error', function() {
     getCookieStub.throws('CookieError', 'A message');
-    liveIntentIdSubmodule.getId(defaultConfigParams);
+    liveIntentIdSubmodule.getId({ params: defaultConfigParams });
     expect(imgStub.getCall(0).args[0]).to.match(/.*ae=.+/);
   });
 
@@ -369,7 +360,7 @@ describe('LiveIntentId', function() {
   it('should resolve extra attributes', function() {
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId({ params: {
-      ...defaultConfigParams.params,
+      ...defaultConfigParams,
       ...{ requestedAttributesOverrides: { 'foo': true, 'bar': false } }
     } }).callback;
     submoduleCallback(callBackSpy);
@@ -438,7 +429,7 @@ describe('LiveIntentId', function() {
   it('should allow disabling nonId resolution', function() {
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId({ params: {
-      ...defaultConfigParams.params,
+      ...defaultConfigParams,
       ...{ requestedAttributesOverrides: { 'nonId': false, 'uid2': true } }
     } }).callback;
     submoduleCallback(callBackSpy);
@@ -451,4 +442,47 @@ describe('LiveIntentId', function() {
     );
     expect(callBackSpy.calledOnce).to.be.true;
   });
-});
+
+  it('should decode a idCookie as sharedId if it exists and coppa is false', function() {
+    coppaConsentDataStub.returns(false)
+    const result = liveIntentIdSubmodule.decode({nonId: 'foo', idCookie: 'bar'})
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'pubcid': 'bar'}, 'pubcid': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}})
+  });
+
+  it('should not decode a idCookie as sharedId if it exists and coppa is true', function() {
+    coppaConsentDataStub.returns(true)
+    const result = liveIntentIdSubmodule.decode({nonId: 'foo', idCookie: 'bar'})
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo'}})
+  });
+
+  it('should parse sharedId to pubcid', async function() {
+    const expectedValue = 'someValue'
+    const cookieName = 'testcookie'
+    getCookieStub.withArgs(cookieName).returns(expectedValue)
+    const config = { params: {
+      ...defaultConfigParams,
+      sharedId: { 'strategy': 'cookie', 'name': cookieName },
+      requestedAttributesOverrides: { 'sharedId': true } }
+    }
+    const submoduleCallback = liveIntentIdSubmodule.getId(config).callback;
+    const decodedResult = new Promise(resolve => {
+      submoduleCallback((x) => resolve(liveIntentIdSubmodule.decode(x, config)));
+    });
+    const request = server.requests[0];
+    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?cd=.localhost&ic=someValue&resolve=nonId`);
+    request.respond(
+      200,
+      responseHeader,
+      JSON.stringify({})
+    );
+
+    const result = await decodedResult
+    expect(result).to.be.eql({
+      lipb: { 'pubcid': expectedValue },
+      pubcid: {
+        ext: { 'provider': 'liveintent.com' },
+        id: expectedValue
+      }
+    });
+  });
+})


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
This PR introduces a new feature that will allow to provide the shared id via the LiveIntent user id module. The configuration below shows how to configure the location from which to pull the shared id: 

```
"params": {
    "sharedId": {
      "strategy": "cookie", // or 'html5'
      "name": "foobar"
    },
    "requestedAttributesOverrides": {'sharedId': true}
}
```

The shared id will be exposed by the LiveIntent user id module as a separate id. There is also support for translation into EIDs. In case more than one module exposes shared ids, module prioritization should be used to define priority. For example:

```
{
    //...
    "idPriority": {
        pubcid: ['sharedId', 'liveIntentId']
    }
    //...
}
```

## Other information
- based on the latest version of LiveConnect: https://www.npmjs.com/package/live-connect-js
  [Release Notes](https://github.com/LiveIntent/live-connect/releases/tag/v6.6.0):
  - [CM-1155] Send raw idcookie (https://github.com/LiveIntent/live-connect/pull/328) (https://github.com/LiveIntent/live-connect/commit/4dc32a913da478e5be26f93e81781e1c214fb5e2)
  - Bump the npm-packages group with 8 updates (https://github.com/LiveIntent/live-connect/pull/327) (https://github.com/LiveIntent/live-connect/commit/f93738dd851c97c8e442aae0ddd3072af9d59cff)
  - Bump the npm-packages group with 4 updates (https://github.com/LiveIntent/live-connect/pull/325) (https://github.com/LiveIntent/live-connect/commit/6fcc6b220e3c211fb4706c1dcc91b56fc0c785e6)
  - Bump the npm-packages group with 1 update (https://github.com/LiveIntent/live-connect/pull/324) (https://github.com/LiveIntent/live-connect/commit/de91e1ec556d3a4cbcdbc6df59d8704240ee50e9)
- documentation changes: https://github.com/prebid/prebid.github.io/pull/5163
