### PR TITLE
LiveIntent UserId module: Add support for openpath

### DIFF
--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -12,6 +12,7 @@ import { gdprDataHandler, uspDataHandler, gppDataHandler } from '../src/adapterM
 import {getStorageManager} from '../src/storageManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 import {UID2_EIDS} from '../libraries/uid2Eids/uid2Eids.js';
+import { getRefererInfo } from '../src/refererDetection.js';
 
 /**
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
@@ -234,6 +235,10 @@ export const liveIntentIdSubmodule = {
         result.sovrn = { 'id': value.sovrn, ext: { provider: LI_PROVIDER_DOMAIN } }
       }
 
+      if (value.thetradedesk) {
+        result.thetradedesk = { 'id': value.thetradedesk, ext: { provider: getRefererInfo().domain || LI_PROVIDER_DOMAIN } }
+      }
+
       return result
     }
 
@@ -362,6 +367,18 @@ export const liveIntentIdSubmodule = {
     },
     'sovrn': {
       source: 'liveintent.sovrn.com',
+      atype: 3,
+      getValue: function(data) {
+        return data.id;
+      },
+      getUidExt: function(data) {
+        if (data.ext) {
+          return data.ext;
+        }
+      }
+    },
+    'thetradedesk': {
+      source: 'adserver.org',
       atype: 3,
       getValue: function(data) {
         return data.id;

--- a/modules/userId/eids.md
+++ b/modules/userId/eids.md
@@ -172,6 +172,17 @@ userIdAsEids = [
             }
         }]
     },
+    
+    {
+        source: 'adserver.org',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 3,
+            ext: {
+                provider: 'liveintent.com'
+            }
+        }]
+    },
 
     {
         source: 'rubiconproject.com',

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -403,6 +403,39 @@ describe('eids array generation for known sub-modules', function() {
     });
   });
 
+  it('thetradedesk', function() {
+    const userId = {
+      thetradedesk: {'id': 'sample_id'}
+    };
+    const newEids = createEidsArray(userId);
+    expect(newEids.length).to.equal(1);
+    expect(newEids[0]).to.deep.equal({
+      source: 'adserver.org',
+      uids: [{
+        id: 'sample_id',
+        atype: 3
+      }]
+    });
+  });
+
+  it('thetradedesk with ext', function() {
+    const userId = {
+      thetradedesk: {'id': 'sample_id', 'ext': {'provider': 'some.provider.com'}}
+    };
+    const newEids = createEidsArray(userId);
+    expect(newEids.length).to.equal(1);
+    expect(newEids[0]).to.deep.equal({
+      source: 'adserver.org',
+      uids: [{
+        id: 'sample_id',
+        atype: 3,
+        ext: {
+          provider: 'some.provider.com'
+        }
+      }]
+    });
+  });
+
   it('liveIntentId; getValue call and NO ext', function() {
     const userId = {
       lipb: {

--- a/test/spec/modules/liveIntentIdMinimalSystem_spec.js
+++ b/test/spec/modules/liveIntentIdMinimalSystem_spec.js
@@ -2,6 +2,7 @@ import * as utils from 'src/utils.js';
 import { gdprDataHandler, uspDataHandler } from '../../../src/adapterManager.js';
 import { server } from 'test/mocks/xhr.js';
 import { liveIntentIdSubmodule, reset as resetLiveIntentIdSubmodule, storage } from 'modules/liveIntentIdSystem.js';
+import * as refererDetection from '../../../src/refererDetection.js';
 
 const PUBLISHER_ID = '89899';
 const defaultConfigParams = { params: {publisherId: PUBLISHER_ID} };
@@ -14,6 +15,7 @@ describe('LiveIntentMinimalId', function() {
   let getCookieStub;
   let getDataFromLocalStorageStub;
   let imgStub;
+  let refererInfoStub;
 
   beforeEach(function() {
     liveIntentIdSubmodule.setModuleMode('minimal');
@@ -23,6 +25,7 @@ describe('LiveIntentMinimalId', function() {
     logErrorStub = sinon.stub(utils, 'logError');
     uspConsentDataStub = sinon.stub(uspDataHandler, 'getConsentData');
     gdprConsentDataStub = sinon.stub(gdprDataHandler, 'getConsentData');
+    refererInfoStub = sinon.stub(refererDetection, 'getRefererInfo');
   });
 
   afterEach(function() {
@@ -32,6 +35,7 @@ describe('LiveIntentMinimalId', function() {
     logErrorStub.restore();
     uspConsentDataStub.restore();
     gdprConsentDataStub.restore();
+    refererInfoStub.restore();
     liveIntentIdSubmodule.setModuleMode('minimal');
     resetLiveIntentIdSubmodule();
   });
@@ -241,7 +245,7 @@ describe('LiveIntentMinimalId', function() {
     expect(callBackSpy.calledOnce).to.be.true;
   });
 
-  it('should decode a uid2 to a seperate object when present', function() {
+  it('should decode a uid2 to a separate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', uid2: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'uid2': 'bar'}, 'uid2': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
@@ -251,39 +255,46 @@ describe('LiveIntentMinimalId', function() {
     expect(result).to.eql({'uid2': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
-  it('should decode a bidswitch id to a seperate object when present', function() {
+  it('should decode a bidswitch id to a separate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', bidswitch: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'bidswitch': 'bar'}, 'bidswitch': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
-  it('should decode a medianet id to a seperate object when present', function() {
+  it('should decode a medianet id to a separate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', medianet: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'medianet': 'bar'}, 'medianet': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
-  it('should decode a sovrn id to a seperate object when present', function() {
+  it('should decode a sovrn id to a separate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', sovrn: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'sovrn': 'bar'}, 'sovrn': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
-  it('should decode a magnite id to a seperate object when present', function() {
+  it('should decode a magnite id to a separate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', magnite: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'magnite': 'bar'}, 'magnite': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
-  it('should decode an index id to a seperate object when present', function() {
+  it('should decode an index id to a separate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', index: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'index': 'bar'}, 'index': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
-  it('should decode an openx id to a seperate object when present', function () {
+  it('should decode an openx id to a separate object when present', function () {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', openx: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'openx': 'bar'}, 'openx': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
-  it('should decode an pubmatic id to a seperate object when present', function() {
+  it('should decode an pubmatic id to a separate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', pubmatic: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'pubmatic': 'bar'}, 'pubmatic': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
+  it('should decode a thetradedesk id to a separate object when present', function() {
+    const provider = 'liveintent.com'
+    refererInfoStub.returns({domain: provider})
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', thetradedesk: 'bar' });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'thetradedesk': 'bar'}, 'thetradedesk': {'id': 'bar', 'ext': {'provider': provider}}});
   });
 
   it('should allow disabling nonId resolution', function() {

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -2,6 +2,8 @@ import { liveIntentIdSubmodule, reset as resetLiveIntentIdSubmodule, storage } f
 import * as utils from 'src/utils.js';
 import { gdprDataHandler, uspDataHandler, gppDataHandler } from '../../../src/adapterManager.js';
 import { server } from 'test/mocks/xhr.js';
+import * as refererDetection from '../../../src/refererDetection.js';
+
 resetLiveIntentIdSubmodule();
 liveIntentIdSubmodule.setModuleMode('standard')
 const PUBLISHER_ID = '89899';
@@ -16,6 +18,7 @@ describe('LiveIntentId', function() {
   let getCookieStub;
   let getDataFromLocalStorageStub;
   let imgStub;
+  let refererInfoStub;
 
   beforeEach(function() {
     liveIntentIdSubmodule.setModuleMode('standard');
@@ -26,6 +29,7 @@ describe('LiveIntentId', function() {
     uspConsentDataStub = sinon.stub(uspDataHandler, 'getConsentData');
     gdprConsentDataStub = sinon.stub(gdprDataHandler, 'getConsentData');
     gppConsentDataStub = sinon.stub(gppDataHandler, 'getConsentData');
+    refererInfoStub = sinon.stub(refererDetection, 'getRefererInfo');
   });
 
   afterEach(function() {
@@ -36,6 +40,7 @@ describe('LiveIntentId', function() {
     uspConsentDataStub.restore();
     gdprConsentDataStub.restore();
     gppConsentDataStub.restore();
+    refererInfoStub.restore();
     resetLiveIntentIdSubmodule();
   });
 
@@ -421,6 +426,13 @@ describe('LiveIntentId', function() {
   it('should decode an pubmatic id to a separate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', pubmatic: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'pubmatic': 'bar'}, 'pubmatic': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
+  it('should decode a thetradedesk id to a separate object when present', function() {
+    const provider = 'liveintent.com'
+    refererInfoStub.returns({domain: provider})
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', thetradedesk: 'bar' });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'thetradedesk': 'bar'}, 'thetradedesk': {'id': 'bar', 'ext': {'provider': provider}}});
   });
 
   it('should allow disabling nonId resolution', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Add eid mapping for the trade desk (TDD) ids that can be resolved via the LiveIntent UserId module.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Documentation PR: https://github.com/prebid/prebid.github.io/pull/5164