### PR TITLE
Conversant Bid Adapter: fix response handling

### DIFF
--- a/modules/conversantBidAdapter.js
+++ b/modules/conversantBidAdapter.js
@@ -94,7 +94,10 @@ const converter = ortbConverter({
     const bidResponse = buildBidResponse(bid, context);
     return bidResponse;
   },
-
+  response(buildResponse, bidResponses, ortbResponse, context) {
+    const response = buildResponse(bidResponses, ortbResponse, context);
+    return response.bids;
+  },
   overrides: {
     imp: {
       banner(fillBannerImp, imp, bidRequest, context) {

--- a/test/spec/modules/conversantBidAdapter_spec.js
+++ b/test/spec/modules/conversantBidAdapter_spec.js
@@ -465,7 +465,7 @@ describe('Conversant adapter tests', function() {
 
     before(() => {
       request = spec.buildRequests(bidRequests, {});
-      response = spec.interpretResponse(bidResponses, request).bids;
+      response = spec.interpretResponse(bidResponses, request);
     });
 
     it('Banner', function() {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ X] Bugfix

## Description of change
Adapter was missing the response function leading fromORTB to return an object where prebid couldn't match the request to the response

