### PR TITLE
Insticator Bid Adapter: Fix bid validation for non-video requests

### DIFF
--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -128,6 +128,10 @@ function buildVideo(bidRequest) {
     }
   }
 
+  if (plcmt) {
+    optionalParams['plcmt'] = plcmt;
+  }
+
   let videoObj = {
     placement,
     mimes,
@@ -137,9 +141,6 @@ function buildVideo(bidRequest) {
     ...videoBidderParams // bidder specific overrides for video
   }
 
-  if (plcmt) {
-    videoObj['plcmt'] = plcmt;
-  }
   return videoObj
 }
 
@@ -386,16 +387,16 @@ function validateBanner(bid) {
 }
 
 function validateVideo(bid) {
-  const videoParams = deepAccess(bid, 'mediaTypes.video', {});
-  const videoBidderParams = deepAccess(bid, 'params.video', {});
+  const videoParams = deepAccess(bid, 'mediaTypes.video');
+  const videoBidderParams = deepAccess(bid, 'params.video');
   let video = {
     ...videoParams,
     ...videoBidderParams // bidder specific overrides for video
   }
-  // Check if the merged video object is empty
-  if (Object.keys(video).length === 0 || video === undefined) {
-    logError('insticator: video object is empty');
-    return false; // or handle the case where video parameters are undefined or empty
+
+  // Check if the video object is undefined
+  if (videoParams === undefined) {
+    return true;
   }
 
   let w = deepAccess(bid, 'mediaTypes.video.w');

--- a/test/spec/modules/insticatorBidAdapter_spec.js
+++ b/test/spec/modules/insticatorBidAdapter_spec.js
@@ -161,6 +161,19 @@ describe('InsticatorBidAdapter', function () {
       })).to.be.false;
     });
 
+    it('should return true if video object is absent/undefined', () => {
+      expect(spec.isBidRequestValid({
+        ...bidRequest,
+        ...{
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250], [300, 600]],
+            },
+          }
+        }
+      })).to.be.true;
+    })
+
     it('should return false if video placement is not a number', () => {
       expect(spec.isBidRequestValid({
         ...bidRequest,


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
