### PR TITLE
Consent Management : cleanup references to allowAuctionWithoutConsent

### DIFF
--- a/integrationExamples/gpt/gdpr_hello_world.html
+++ b/integrationExamples/gpt/gdpr_hello_world.html
@@ -54,8 +54,7 @@
           pbjs.setConfig({
             consentManagement: {
               cmpApi: 'iab',
-              timeout: 5000,
-              allowAuctionWithoutConsent: true
+              timeout: 5000
             },
             pubcid: {
               enable: false

--- a/modules/consentManagement.js
+++ b/modules/consentManagement.js
@@ -250,7 +250,7 @@ export function resetConsentData() {
 
 /**
  * A configuration function that initializes some module variables, as well as add a hook into the requestBids function
- * @param {{cmp:string, timeout:number, allowAuctionWithoutConsent:boolean, defaultGdprScope:boolean}} config required; consentManagement module config settings; cmp (string), timeout (int), allowAuctionWithoutConsent (boolean)
+ * @param {{cmp:string, timeout:number, defaultGdprScope:boolean}} config required; consentManagement module config settings; cmp (string), timeout (int))
  */
 export function setConsentConfig(config) {
   // if `config.gdpr`, `config.usp` or `config.gpp` exist, assume new config format.

--- a/modules/consentManagementGpp.js
+++ b/modules/consentManagementGpp.js
@@ -455,7 +455,7 @@ export function resetConsentData() {
 
 /**
  * A configuration function that initializes some module variables, as well as add a hook into the requestBids function
- * @param {{cmp:string, timeout:number, allowAuctionWithoutConsent:boolean, defaultGdprScope:boolean}} config required; consentManagement module config settings; cmp (string), timeout (int), allowAuctionWithoutConsent (boolean)
+ * @param {{cmp:string, timeout:number, defaultGdprScope:boolean}} config required; consentManagement module config settings; cmp (string), timeout (int))
  */
 export function setConsentConfig(config) {
   config = config && config.gpp;

--- a/modules/consentManagementUsp.js
+++ b/modules/consentManagementUsp.js
@@ -202,7 +202,7 @@ export function resetConsentData() {
 
 /**
  * A configuration function that initializes some module variables, as well as add a hook into the requestBids function
- * @param {object} config required; consentManagementUSP module config settings; usp (string), timeout (int), allowAuctionWithoutConsent (boolean)
+ * @param {object} config required; consentManagementUSP module config settings; usp (string), timeout (int)
  */
 export function setConsentConfig(config) {
   config = config && config.usp;

--- a/test/pages/consent_mgt_gdpr.html
+++ b/test/pages/consent_mgt_gdpr.html
@@ -150,7 +150,6 @@
         consentManagement: {
           gdpr: {
             cmpApi: 'static',
-            allowAuctionWithoutConsent: true,
             consentData: {
               getConsentData: {
                 'gdprApplies': true,

--- a/test/spec/modules/gdprEnforcement_spec.js
+++ b/test/spec/modules/gdprEnforcement_spec.js
@@ -37,7 +37,6 @@ describe('gdpr enforcement', function () {
   let staticConfig = {
     cmpApi: 'static',
     timeout: 7500,
-    allowAuctionWithoutConsent: false,
     consentData: {
       getTCData: {
         'tcString': 'COuqj-POu90rDBcBkBENAZCgAPzAAAPAACiQFwwBAABAA1ADEAbQC4YAYAAgAxAG0A',
@@ -894,7 +893,6 @@ describe('gdpr enforcement', function () {
       setEnforcementConfig({
         gdpr: {
           cmpApi: 'iab',
-          allowAuctionWithoutConsent: true,
           timeout: 5000
         }
       });


### PR DESCRIPTION
## Type of change
cleanup

## Description of change
The docs committee noticed that people still search for the ancient allowAuctionWithoutConsent flag. Noticed that references to it are still peppered through the PBJS codebase. Cleaning up the core items. There are a number of bid adapters that refer to it as well, but not touching them here.
