### PR TITLE
33Across User ID module: Change ID expiration from 90 to 30 days

### DIFF
--- a/modules/33acrossIdSystem.md
+++ b/modules/33acrossIdSystem.md
@@ -15,7 +15,7 @@ pbjs.setConfig({
         storage: {
           name: "33acrossId",
           type: "html5",
-          expires: 90,
+          expires: 30,
           refreshInSeconds: 8*3600
         },
         params: {
@@ -41,7 +41,7 @@ The following settings are available for the `storage` property in the `userSync
 | --- | --- | --- | --- | --- |
 | name | Required | String| Name of the cookie or HTML5 local storage where the user ID will be stored | `"33acrossId"` |
 | type | Required | String | `"html5"` (preferred)  or `"cookie"` | `"html5"` |
-| expires | Strongly Recommended | Number | How long (in days) the user ID information will be stored. 33Across recommends `90`. | `90` |
+| expires | Strongly Recommended | Number | How long (in days) the user ID information will be stored. 33Across recommends `30`. | `30` |
 | refreshInSeconds | Strongly Recommended | Number | The interval (in seconds) for refreshing the user ID. 33Across recommends no more than 8 hours between refreshes. | `8*3600` |
 
 ### Params

--- a/test/spec/modules/33acrossIdSystem_spec.js
+++ b/test/spec/modules/33acrossIdSystem_spec.js
@@ -63,7 +63,7 @@ describe('33acrossIdSystem', () => {
               },
               storage: {
                 type: 'cookie',
-                expires: 90
+                expires: 30
               }
             });
 
@@ -184,7 +184,7 @@ describe('33acrossIdSystem', () => {
             },
             storage: {
               type: 'cookie',
-              expires: 90
+              expires: 30
             }
           });
 


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [X] Other

## Description of change
Change the recommended (and default) expiration from 90 to 30 days.

Documentation: https://github.com/prebid/prebid.github.io/pull/5171
