### PR TITLE
Criteo bid adapter: increase default Fledge timeout

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -298,7 +298,7 @@ export const spec = {
         if (!sellerSignals.floor && bidRequest.params.bidFloor) {
           sellerSignals.floor = bidRequest.params.bidFloor;
         }
-        let perBuyerTimeout = { '*': 50 };
+        let perBuyerTimeout = { '*': 500 };
         if (sellerSignals.perBuyerTimeout) {
           for (const buyer in sellerSignals.perBuyerTimeout) {
             perBuyerTimeout[buyer] = sellerSignals.perBuyerTimeout[buyer];

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -2644,7 +2644,7 @@ describe('The Criteo bidding adapter', function () {
             },
           },
           perBuyerTimeout: {
-            '*': 50,
+            '*': 500,
             'buyer1': 100,
             'buyer2': 200
           },
@@ -2687,7 +2687,7 @@ describe('The Criteo bidding adapter', function () {
             },
           },
           perBuyerTimeout: {
-            '*': 50,
+            '*': 500,
             'buyer1': 100,
             'buyer2': 200
           },


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Increase default timeout value from 50ms to 500ms