### PR TITLE
adspiritBidAdapter - fix lint errors in unit test file

### DIFF
--- a/test/spec/modules/adspiritBidAdapter_spec.js
+++ b/test/spec/modules/adspiritBidAdapter_spec.js
@@ -7,7 +7,6 @@ const RTB_URL = '/rtb/getbid.php?rtbprovider=prebid';
 const SCRIPT_URL = '/adasync.min.js';
 
 describe('Adspirit Bidder Spec', function () {
-  
   // isBidRequestValid ---case
   describe('isBidRequestValid', function () {
     it('should return true if the bid request is valid', function () {
@@ -217,7 +216,6 @@ describe('Adspirit Bidder Spec', function () {
         impressionTrackers: ['view_tracker_url']
       });
     });
-
 
     const bannerBidRequestMock = {
       bidRequest: {


### PR DESCRIPTION

## Type of change
- [x] Other

## Description of change
When PR https://github.com/prebid/Prebid.js/pull/10939 was merged, it seems there were some lint errors in the unit test file that broke the master circleci test runs.

This PR should fix the lint issues.