### PR TITLE
Adnuntius Bid Adapter: fix for bids without userId specified

### DIFF
--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -105,15 +105,16 @@ const storageTool = (function () {
 
   const getUsi = function (meta, ortb2, bidderRequest) {
     // Fetch user id from parameters.
-    const paramUsi = (bidderRequest.bids) ? bidderRequest.bids.find(bid => {
-      if (bid.params && bid.params.userId) return true
-    }).params.userId : false
-    let usi = (meta && meta.usi) ? meta.usi : false
-    if (ortb2 && ortb2.user && ortb2.user.id) {
-      usi = ortb2.user.id
+    for (let i = 0; i < (bidderRequest.bids || []).length; i++) {
+      const bid = bidderRequest.bids[i];
+      if (bid.params && bid.params.userId) {
+        return bid.params.userId;
+      }
     }
-    if (paramUsi) usi = paramUsi
-    return usi;
+    if (ortb2 && ortb2.user && ortb2.user.id) {
+      return ortb2.user.id
+    }
+    return (meta && meta.usi) ? meta.usi : false
   }
 
   const getSegmentsFromOrtb = function (ortb2) {

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -681,6 +681,26 @@ describe('adnuntiusBidAdapter', function() {
       expect(request[0]).to.have.property('url')
       expect(request[0].url).to.equal(`${ENDPOINT_URL_BASE}&userId=different_user_id`);
     });
+
+    it('should handle no user specified', function () {
+      config.setBidderConfig({
+        bidders: ['adnuntius'],
+      });
+      const req = [
+        {
+          bidId: 'adn-000000000008b6bc',
+          bidder: 'adnuntius',
+          params: {
+            auId: '000000000008b6bc',
+            network: 'adnuntius'
+          }
+        }
+      ]
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(req, { bids: req }));
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(ENDPOINT_URL);
+    });
   });
 
   describe('user privacy', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
## Description of change
<!-- Describe the change proposed in this pull request -->
Bug fix on bid params without a user ID specified.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
