### PR TITLE
Liveintent Identity Module: Refactor the TTD usage and add test

### DIFF
--- a/libraries/uid1Eids/uid1Eids.js
+++ b/libraries/uid1Eids/uid1Eids.js
@@ -1,0 +1,16 @@
+export const UID1_EIDS = {
+  'tdid': {
+    source: 'adserver.org',
+    atype: 1,
+    getValue: function(data) {
+      if (data.id) {
+        return data.id;
+      } else {
+        return data;
+      }
+    },
+    getUidExt: function(data) {
+      return {...{rtiPartner: 'TDID'}, ...data.ext}
+    }
+  }
+}

--- a/modules/liveIntentIdSystem.js
+++ b/modules/liveIntentIdSystem.js
@@ -11,6 +11,7 @@ import { LiveConnect } from 'live-connect-js'; // eslint-disable-line prebid/val
 import { gdprDataHandler, uspDataHandler, gppDataHandler } from '../src/adapterManager.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
+import {UID1_EIDS} from '../libraries/uid1Eids/uid1Eids.js';
 import {UID2_EIDS} from '../libraries/uid2Eids/uid2Eids.js';
 import { getRefererInfo } from '../src/refererDetection.js';
 
@@ -236,7 +237,9 @@ export const liveIntentIdSubmodule = {
       }
 
       if (value.thetradedesk) {
-        result.thetradedesk = { 'id': value.thetradedesk, ext: { provider: getRefererInfo().domain || LI_PROVIDER_DOMAIN } }
+        result.lipb = {...result.lipb, tdid: value.thetradedesk}
+        result.tdid = { 'id': value.thetradedesk, ext: { rtiPartner: 'TDID', provider: getRefererInfo().domain || LI_PROVIDER_DOMAIN } }
+        delete result.lipb.thetradedesk
       }
 
       return result
@@ -278,6 +281,7 @@ export const liveIntentIdSubmodule = {
     return { callback: result };
   },
   eids: {
+    ...UID1_EIDS,
     ...UID2_EIDS,
     'lipb': {
       getValue: function(data) {
@@ -367,18 +371,6 @@ export const liveIntentIdSubmodule = {
     },
     'sovrn': {
       source: 'liveintent.sovrn.com',
-      atype: 3,
-      getValue: function(data) {
-        return data.id;
-      },
-      getUidExt: function(data) {
-        if (data.ext) {
-          return data.ext;
-        }
-      }
-    },
-    'thetradedesk': {
-      source: 'adserver.org',
       atype: 3,
       getValue: function(data) {
         return data.id;

--- a/modules/unifiedIdSystem.js
+++ b/modules/unifiedIdSystem.js
@@ -8,6 +8,7 @@
 import { logError } from '../src/utils.js';
 import {ajax} from '../src/ajax.js';
 import {submodule} from '../src/hook.js'
+import {UID1_EIDS} from '../libraries/uid1Eids/uid1Eids.js';
 
 /**
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
@@ -74,17 +75,7 @@ export const unifiedIdSubmodule = {
     };
     return {callback: resp};
   },
-  eids: {
-    'tdid': {
-      source: 'adserver.org',
-      atype: 1,
-      getUidExt: function() {
-        return {
-          rtiPartner: 'TDID'
-        };
-      }
-    },
-  }
+  eids: {...UID1_EIDS}
 };
 
 submodule('userId', unifiedIdSubmodule);

--- a/modules/userId/eids.md
+++ b/modules/userId/eids.md
@@ -31,7 +31,8 @@ userIdAsEids = [
             id: 'some-random-id-value',
             atype: 1,
             ext: {
-                rtiPartner: 'TDID'
+                rtiPartner: 'TDID',
+                provider: 'liveintent.com'
             }
         }]
     },
@@ -173,17 +174,6 @@ userIdAsEids = [
         }]
     },
     
-    {
-        source: 'adserver.org',
-        uids: [{
-            id: 'some-random-id-value',
-            atype: 3,
-            ext: {
-                provider: 'liveintent.com'
-            }
-        }]
-    },
-
     {
         source: 'rubiconproject.com',
         uids: [{

--- a/test/spec/modules/eids_spec.js
+++ b/test/spec/modules/eids_spec.js
@@ -29,6 +29,18 @@ describe('eids array generation for known sub-modules', function() {
     });
   });
 
+  it('unifiedId: ext generation with provider', function() {
+    const userId = {
+      tdid: {'id': 'some-sample_id', 'ext': {'provider': 'some.provider.com'}}
+    };
+    const newEids = createEidsArray(userId);
+    expect(newEids.length).to.equal(1);
+    expect(newEids[0]).to.deep.equal({
+      source: 'adserver.org',
+      uids: [{id: 'some-sample_id', atype: 1, ext: { rtiPartner: 'TDID', provider: 'some.provider.com' }}]
+    });
+  });
+
   describe('id5Id', function() {
     it('does not include an ext if not provided', function() {
       const userId = {
@@ -393,39 +405,6 @@ describe('eids array generation for known sub-modules', function() {
     expect(newEids.length).to.equal(1);
     expect(newEids[0]).to.deep.equal({
       source: 'pubmatic.com',
-      uids: [{
-        id: 'sample_id',
-        atype: 3,
-        ext: {
-          provider: 'some.provider.com'
-        }
-      }]
-    });
-  });
-
-  it('thetradedesk', function() {
-    const userId = {
-      thetradedesk: {'id': 'sample_id'}
-    };
-    const newEids = createEidsArray(userId);
-    expect(newEids.length).to.equal(1);
-    expect(newEids[0]).to.deep.equal({
-      source: 'adserver.org',
-      uids: [{
-        id: 'sample_id',
-        atype: 3
-      }]
-    });
-  });
-
-  it('thetradedesk with ext', function() {
-    const userId = {
-      thetradedesk: {'id': 'sample_id', 'ext': {'provider': 'some.provider.com'}}
-    };
-    const newEids = createEidsArray(userId);
-    expect(newEids.length).to.equal(1);
-    expect(newEids[0]).to.deep.equal({
-      source: 'adserver.org',
       uids: [{
         id: 'sample_id',
         atype: 3,

--- a/test/spec/modules/liveIntentIdMinimalSystem_spec.js
+++ b/test/spec/modules/liveIntentIdMinimalSystem_spec.js
@@ -294,7 +294,7 @@ describe('LiveIntentMinimalId', function() {
     const provider = 'liveintent.com'
     refererInfoStub.returns({domain: provider})
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', thetradedesk: 'bar' });
-    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'thetradedesk': 'bar'}, 'thetradedesk': {'id': 'bar', 'ext': {'provider': provider}}});
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'tdid': 'bar'}, 'tdid': {'id': 'bar', 'ext': {'rtiPartner': 'TDID', 'provider': provider}}});
   });
 
   it('should allow disabling nonId resolution', function() {

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -432,7 +432,7 @@ describe('LiveIntentId', function() {
     const provider = 'liveintent.com'
     refererInfoStub.returns({domain: provider})
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', thetradedesk: 'bar' });
-    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'thetradedesk': 'bar'}, 'thetradedesk': {'id': 'bar', 'ext': {'provider': provider}}});
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'tdid': 'bar'}, 'tdid': {'id': 'bar', 'ext': {'rtiPartner': 'TDID', 'provider': provider}}});
   });
 
   it('should allow disabling nonId resolution', function() {

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -12,6 +12,7 @@ import {
   setSubmoduleRegistry,
   syncDelay,
 } from 'modules/userId/index.js';
+import {UID1_EIDS} from 'libraries/uid1Eids/uid1Eids.js';
 import {createEidsArray, EID_CONFIG} from 'modules/userId/eids.js';
 import {config} from 'src/config.js';
 import * as utils from 'src/utils.js';
@@ -96,6 +97,25 @@ describe('User ID', function () {
       },
       aliasName,
       eids
+    }
+  }
+
+  function createMockEid(name, source) {
+    return {
+      [name]: {
+        source: source || `${name}Source`,
+        atype: 3,
+        getValue: function(data) {
+          if (data.id) {
+            return data.id;
+          } else {
+            return data;
+          }
+        },
+        getUidExt: function(data) {
+          return data.ext
+        }
+      }
     }
   }
 
@@ -644,10 +664,10 @@ describe('User ID', function () {
     it('pbjs.getUserIdsAsEids should prioritize user ids according to config available to core', () => {
       init(config);
       setSubmoduleRegistry([
-        createMockIdSubmodule('mockId1Module', {id: {uid2: {id: 'uid2_value'}}}),
-        createMockIdSubmodule('mockId2Module', {id: {pubcid: 'pubcid_value', lipb: {lipbid: 'lipbid_value_from_mockId2Module'}}}),
-        createMockIdSubmodule('mockId3Module', {id: {uid2: {id: 'uid2_value_from_mockId3Module'}, pubcid: 'pubcid_value_from_mockId3Module', lipb: {lipbid: 'lipbid_value'}, merkleId: {id: 'merkleId_value_from_mockId3Module'}}}),
-        createMockIdSubmodule('mockId4Module', {id: {merkleId: {id: 'merkleId_value'}}})
+        createMockIdSubmodule('mockId1Module', {id: {uid2: {id: 'uid2_value'}}}, null, createMockEid('uid2')),
+        createMockIdSubmodule('mockId2Module', {id: {pubcid: 'pubcid_value', lipb: {lipbid: 'lipbid_value_from_mockId2Module'}}}, null, createMockEid('pubcid')),
+        createMockIdSubmodule('mockId3Module', {id: {uid2: {id: 'uid2_value_from_mockId3Module'}, pubcid: 'pubcid_value_from_mockId3Module', lipb: {lipbid: 'lipbid_value'}, merkleId: {id: 'merkleId_value_from_mockId3Module'}}}, null, {...createMockEid('uid2'), ...createMockEid('merkleId'), ...createMockEid('lipb')}),
+        createMockIdSubmodule('mockId4Module', {id: {merkleId: {id: 'merkleId_value'}}}, null, createMockEid('merkleId'))
       ]);
       config.setConfig({
         userSync: {
@@ -677,6 +697,38 @@ describe('User ID', function () {
         const expected = createEidsArray(ids);
         expect(eids).to.deep.equal(expected);
       });
+    });
+
+    it('pbjs.getUserIdsAsEids should prioritize the uid1 according to config available to core', () => {
+      init(config);
+      setSubmoduleRegistry([
+        createMockIdSubmodule('mockId1Module', {id: {tdid: {id: 'uid1_value'}}}, null, UID1_EIDS),
+        createMockIdSubmodule('mockId2Module', {id: {tdid: {id: 'uid1Id_value_from_mockId2Module'}}}, null, UID1_EIDS),
+        createMockIdSubmodule('mockId3Module', {id: {tdid: {id: 'uid1Id_value_from_mockId3Module'}}}, null, UID1_EIDS)
+      ]);
+      config.setConfig({
+        userSync: {
+          idPriority: {
+            tdid: ['mockId2Module', 'mockId3Module', 'mockId1Module']
+          },
+          auctionDelay: 10, // with auctionDelay > 0, no auction is needed to complete init
+          userIds: [
+            { name: 'mockId1Module' },
+            { name: 'mockId2Module' },
+            { name: 'mockId3Module' }
+          ]
+        }
+      });
+
+      const ids = {
+        'tdid': { id: 'uid1Id_value_from_mockId2Module' },
+      };
+
+      return getGlobal().getUserIdsAsync().then(() => {
+        const eids = getGlobal().getUserIdsAsEids();
+        const expected = createEidsArray(ids);
+        expect(eids).to.deep.equal(expected);
+      })
     });
 
     describe('EID updateConfig', () => {
@@ -3554,11 +3606,16 @@ describe('User ID', function () {
 
       it('pbjs.getUserIdsAsEidBySource with priority config available to core', () => {
         init(config);
+        const uid2Eids = createMockEid('uid2', 'uidapi.com')
+        const pubcEids = createMockEid('pubcid', 'pubcid.org')
+        const liveIntentEids = createMockEid('lipb', 'liveintent.com')
+        const merkleEids = createMockEid('merkleId', 'merkleinc.com')
+
         setSubmoduleRegistry([
-          createMockIdSubmodule('mockId1Module', {id: {uid2: {id: 'uid2_value'}}}),
-          createMockIdSubmodule('mockId2Module', {id: {pubcid: 'pubcid_value', lipb: {lipbid: 'lipbid_value_from_mockId2Module'}}}),
-          createMockIdSubmodule('mockId3Module', {id: {uid2: {id: 'uid2_value_from_mockId3Module'}, pubcid: 'pubcid_value_from_mockId3Module', lipb: {lipbid: 'lipbid_value'}, merkleId: {id: 'merkleId_value_from_mockId3Module'}}}),
-          createMockIdSubmodule('mockId4Module', {id: {merkleId: {id: 'merkleId_value'}}})
+          createMockIdSubmodule('mockId1Module', {id: {uid2: {id: 'uid2_value'}}}, null, uid2Eids),
+          createMockIdSubmodule('mockId2Module', {id: {pubcid: 'pubcid_value', lipb: {lipbid: 'lipbid_value_from_mockId2Module'}}}, null, {...pubcEids, ...liveIntentEids}),
+          createMockIdSubmodule('mockId3Module', {id: {uid2: {id: 'uid2_value_from_mockId3Module'}, pubcid: 'pubcid_value_from_mockId3Module', lipb: {lipbid: 'lipbid_value'}, merkleId: {id: 'merkleId_value_from_mockId3Module'}}}, null, {...uid2Eids, ...pubcEids, ...liveIntentEids}),
+          createMockIdSubmodule('mockId4Module', {id: {merkleId: {id: 'merkleId_value'}}}, null, merkleEids)
         ]);
         config.setConfig({
           userSync: {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
* Define `uid1Eids` for the trade desk identifier and refactor its usages.
* Add a check in the userId test for the uid1 when it is set in different modules to ensure that it respects the priority. (to address this comment: https://github.com/prebid/Prebid.js/pull/11119/files#r1496636311) 
* The eids was missing in the mocked module in `userId_spec`:
   * Current behavior: `getGlobal().getUserIdsAsEids()` returns `[]` and the expected values (`createEidsArray(ids)`) were also empty as the module didn’t require to resolve the eids. That’s why the test passed before (`[] == []`)

   * Note: The functionality works correctly, so I only added the eids in the mocked modules.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
