### PR TITLE
JW Player RTD Module : populate content url, title and description

### DIFF
--- a/integrationExamples/realTimeData/jwplayerRtdProvider_example.html
+++ b/integrationExamples/realTimeData/jwplayerRtdProvider_example.html
@@ -26,15 +26,20 @@
           },
           mediaTypes: {
               video: {
-                  sizes: [[320, 460]],
+                sizes: [[320, 460]],
+                mimes :  ["video/mp4"],
+                minduration : 3,
+                maxduration: 30,
+                protocols : [1,2]
               }
           },
           // Replace this object to test a new Adapter!
           bids: [{
-              bidder: 'appnexus',
-              params: {
-                  placementId: 13144370
-              }
+            bidder: 'ix',
+            params: {
+              siteId: '300',
+              video: {}
+            }
           }]
       }];
 

--- a/integrationExamples/realTimeData/jwplayerRtdProvider_example.html
+++ b/integrationExamples/realTimeData/jwplayerRtdProvider_example.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+
+    /* Paste JW Player script tag here */
+
     <script async src="../../build/dev/prebid.js"></script>
-    <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
     <meta charset="UTF-8">
     <title>JW Player RTD Provider Example</title>
     <script>
@@ -10,7 +12,7 @@
       var PREBID_TIMEOUT = 1000;
 
       var adUnits = [{
-          code: 'div-gpt-ad-1460505748561-0',
+          code: 'video-ad-unit',
           ortb2Imp: {
               ext: {
                   data: {
@@ -23,8 +25,8 @@
               }
           },
           mediaTypes: {
-              banner: {
-                  sizes: [[300, 250], [300,600]],
+              video: {
+                  sizes: [[320, 460]],
               }
           },
           // Replace this object to test a new Adapter!
@@ -41,11 +43,6 @@
     </script>
 
     <script>
-      var googletag = googletag || {};
-      googletag.cmd = googletag.cmd || [];
-      googletag.cmd.push(function() {
-        googletag.pubads().disableInitialLoad();
-      });
 
       pbjs.que.push(function() {
         pbjs.setConfig({
@@ -63,44 +60,28 @@
         });
         pbjs.addAdUnits(adUnits);
         pbjs.requestBids({
-          bidsBackHandler: sendAdserverRequest,
+          bidsBackHandler: renderHighestBid,
           timeout: PREBID_TIMEOUT
         });
       });
 
-      function sendAdserverRequest() {
-        if (pbjs.adserverRequestSent) return;
-        pbjs.adserverRequestSent = true;
-        googletag.cmd.push(function() {
-          pbjs.que.push(function() {
-            pbjs.setTargetingForGPTAsync();
-            googletag.pubads().refresh();
-          });
-        });
+      function renderHighestBid() {
+        const highestBids = pbjs.getHighestCpmBids('video-ad-unit');
+        const highestBid = highestBids && highestBids.length && highestBids[0];
+        if (!highestBid) {
+          return;
+        }
+
+        if (highestBid.vastXml) {
+          jwplayer().loadAdXml(highestBid.vastXml);
+        } else if (highestBid.vastUrl) {
+          jwplayer().loadAdTag(highestBid.vastUrl);
+        }
       }
 
-      setTimeout(function() {
-        sendAdserverRequest();
-      }, FAILSAFE_TIMEOUT);
-
-    </script>
-
-    <script>
-      googletag.cmd.push(function () {
-        googletag.defineSlot('/19968336/header-bid-tag-0', [[300, 250], [300, 600]], 'div-gpt-ad-1460505748561-0').addService(googletag.pubads());
-
-        googletag.pubads().enableSingleRequest();
-        googletag.enableServices();
-      });
     </script>
 </head>
 
 <body>
-<h5>Div-1</h5>
-<div id='div-gpt-ad-1460505748561-0'>
-    <script type='text/javascript'>
-      googletag.cmd.push(function() { googletag.display('div-gpt-ad-1460505748561-0'); });
-    </script>
-</div>
 </body>
 </html>

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -38,7 +38,7 @@ export const jwplayerSubmodule = {
   /**
    * add targeting data to bids and signal completion to realTimeData module
    * @function
-   * @param {Obj} bidReqConfig
+   * @param {object} bidReqConfig
    * @param {function} onDone
    */
   getBidRequestData: enrichBidRequest,
@@ -323,10 +323,6 @@ export function getContentData(mediaId, segments) {
 }
 
 export function addOrtbSiteContent(ortb2, contentId, contentData, contentTitle, contentDescription, contentUrl) {
-  if (!contentId && !contentData) {
-    return;
-  }
-
   if (ortb2 == null) {
     ortb2 = {};
   }

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -58,13 +58,7 @@ config.getConfig('realTimeData', ({realTimeData}) => {
     return;
   }
   fetchTargetingInformation(params);
-  if (params.overrideContentId !== undefined) {
-    // For backwards compatibility, default to true unless overriden by Publisher.
-    overrideContentId = params.overrideContentId;
-  }
-  overrideContentUrl = !!params.overrideContentUrl;
-  overrideContentTitle = !!params.overrideContentTitle;
-  overrideContentDescription = !!params.overrideContentDescription;
+  setOverrides(params);
 });
 
 submodule('realTimeData', jwplayerSubmodule);
@@ -81,6 +75,16 @@ export function fetchTargetingInformation(jwTargeting) {
   mediaIDs.forEach(mediaID => {
     fetchTargetingForMediaId(mediaID);
   });
+}
+
+export function setOverrides(params) {
+  if (params.overrideContentId !== undefined) {
+    // For backwards compatibility, default to true unless overriden by Publisher.
+    overrideContentId = params.overrideContentId;
+  }
+  overrideContentUrl = !!params.overrideContentUrl;
+  overrideContentTitle = !!params.overrideContentTitle;
+  overrideContentDescription = !!params.overrideContentDescription;
 }
 
 export function fetchTargetingForMediaId(mediaId) {

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -388,11 +388,11 @@ export function addOrtbSiteContent(ortb2, contentId, contentData, contentTitle, 
 function shouldOverride(currentValue, newValue, configValue) {
   switch (configValue) {
     case ENRICH_ALWAYS:
-      return newValue !== undefined;
+      return !!newValue;
     case ENRICH_NEVER:
       return false;
     case ENRICH_WHEN_EMPTY:
-      return newValue !== undefined && currentValue === undefined;
+      return !!newValue && currentValue === undefined;
     default:
       return false;
   }

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -26,11 +26,12 @@ const JWPLAYER_DOMAIN = SUBMODULE_NAME + '.com';
 const ENRICH_ALWAYS = 'always';
 const ENRICH_WHEN_EMPTY = 'whenEmpty';
 const ENRICH_NEVER = 'never';
+const overrideValidationRegex = /^(always|never|whenEmpty)$/;
 const playlistItemCache = {};
 const pendingRequests = {};
 let activeRequestCount = 0;
 let resumeBidRequest;
-// defaults to True for backwards compatibility
+// defaults to 'always' for backwards compatibility
 let overrideContentId = ENRICH_ALWAYS;
 let overrideContentUrl = ENRICH_WHEN_EMPTY;
 let overrideContentTitle = ENRICH_WHEN_EMPTY;
@@ -81,11 +82,19 @@ export function fetchTargetingInformation(jwTargeting) {
 }
 
 export function setOverrides(params) {
-  // For backwards compatibility, default to always unless overriden by Publisher.
-  overrideContentId = params.overrideContentId || ENRICH_ALWAYS;
-  overrideContentUrl = params.overrideContentUrl || ENRICH_WHEN_EMPTY;
-  overrideContentTitle = params.overrideContentTitle || ENRICH_WHEN_EMPTY;
-  overrideContentDescription = params.overrideContentDescription || ENRICH_WHEN_EMPTY;
+  // For backwards compatibility, default to always unless overridden by Publisher.
+  overrideContentId = sanitizeOverrideParam(params.overrideContentId, ENRICH_ALWAYS);
+  overrideContentUrl = sanitizeOverrideParam(params.overrideContentUrl, ENRICH_WHEN_EMPTY);
+  overrideContentTitle = sanitizeOverrideParam(params.overrideContentTitle, ENRICH_WHEN_EMPTY);
+  overrideContentDescription = sanitizeOverrideParam(params.overrideContentDescription, ENRICH_WHEN_EMPTY);
+}
+
+function sanitizeOverrideParam(overrideParam, defaultValue) {
+  if (overrideValidationRegex.test(overrideParam)) {
+    return overrideParam;
+  }
+
+  return defaultValue;
 }
 
 export function fetchTargetingForMediaId(mediaId) {

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -223,13 +223,32 @@ export function getVatFromCache(mediaID) {
     return null;
   }
 
+  let mediaUrl = item.file;
+  if (!mediaUrl) {
+    mediaUrl = getFileFromSources(item);
+  }
+
   return {
     segments: item.jwpseg,
     title: item.title,
     description: item.description,
-    mediaUrl: item.file,
+    mediaUrl,
     mediaID
   };
+}
+
+function getFileFromSources(playlistItem) {
+  const sources = playlistItem.sources;
+  if (!sources || !sources.length) {
+    return;
+  }
+
+  const validSource = sources.find(source => !!source.file);
+  if (!validSource) {
+    return;
+  }
+
+  return validSource.file;
 }
 
 export function getVatFromPlayer(playerDivId, mediaID) {

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -223,10 +223,7 @@ export function getVatFromCache(mediaID) {
     return null;
   }
 
-  let mediaUrl = item.file;
-  if (!mediaUrl) {
-    mediaUrl = getFileFromSources(item);
-  }
+const mediaUrl = item.file ?? getFileFromSources(item);
 
   return {
     segments: item.jwpseg,

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -32,6 +32,7 @@ const pendingRequests = {};
 let activeRequestCount = 0;
 let resumeBidRequest;
 // defaults to 'always' for backwards compatibility
+// TODO: Prebid 9 - replace with ENRICH_WHEN_EMPTY
 let overrideContentId = ENRICH_ALWAYS;
 let overrideContentUrl = ENRICH_WHEN_EMPTY;
 let overrideContentTitle = ENRICH_WHEN_EMPTY;
@@ -83,6 +84,7 @@ export function fetchTargetingInformation(jwTargeting) {
 
 export function setOverrides(params) {
   // For backwards compatibility, default to always unless overridden by Publisher.
+  // TODO: Prebid 9 - replace with ENRICH_WHEN_EMPTY
   overrideContentId = sanitizeOverrideParam(params.overrideContentId, ENRICH_ALWAYS);
   overrideContentUrl = sanitizeOverrideParam(params.overrideContentUrl, ENRICH_WHEN_EMPTY);
   overrideContentTitle = sanitizeOverrideParam(params.overrideContentTitle, ENRICH_WHEN_EMPTY);

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -235,17 +235,7 @@ const mediaUrl = item.file ?? getFileFromSources(item);
 }
 
 function getFileFromSources(playlistItem) {
-  const sources = playlistItem.sources;
-  if (!sources || !sources.length) {
-    return;
-  }
-
-  const validSource = sources.find(source => !!source.file);
-  if (!validSource) {
-    return;
-  }
-
-  return validSource.file;
+return playlistItem.sources?.find?.(source => source.file)?.file;
 }
 
 export function getVatFromPlayer(playerDivId, mediaID) {

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -27,6 +27,11 @@ const playlistItemCache = {};
 const pendingRequests = {};
 let activeRequestCount = 0;
 let resumeBidRequest;
+// defaults to True for backwards compatibility
+let overrideContentId = true;
+let overrideContentUrl = false;
+let overrideContentTitle = false;
+let overrideContentDescription = false;
 
 /** @type {RtdSubmodule} */
 export const jwplayerSubmodule = {
@@ -53,6 +58,13 @@ config.getConfig('realTimeData', ({realTimeData}) => {
     return;
   }
   fetchTargetingInformation(params);
+  if (params.overrideContentId !== undefined) {
+    // For backwards compatibility, default to true unless overriden by Publisher.
+    overrideContentId = params.overrideContentId;
+  }
+  overrideContentUrl = !!params.overrideContentUrl;
+  overrideContentTitle = !!params.overrideContentTitle;
+  overrideContentDescription = !!params.overrideContentDescription;
 });
 
 submodule('realTimeData', jwplayerSubmodule);
@@ -336,19 +348,24 @@ export function addOrtbSiteContent(ortb2, contentId, contentData, contentTitle, 
   let site = ortb2.site = ortb2.site || {};
   let content = site.content = site.content || {};
 
-  if (contentId) {
+  const shouldSetContentId = !content.id || overrideContentId;
+  if (contentId && shouldSetContentId) {
     content.id = contentId;
   }
 
-  if (contentUrl) {
+  const shouldSetContentUrl = !content.url || overrideContentUrl;
+  if (contentUrl && shouldSetContentUrl) {
     content.url = contentUrl;
   }
 
-  if (contentTitle) {
+  const shouldSetContentTitle = !content.title || overrideContentTitle;
+  if (contentTitle && shouldSetContentTitle) {
     content.title = contentTitle;
   }
 
-  if (contentDescription) {
+  const isDescriptionSet = content.ext && content.ext.description;
+  const shouldSetContentDescription = !isDescriptionSet || overrideContentDescription;
+  if (contentDescription && shouldSetContentDescription) {
     content.ext = content.ext || {};
     content.ext.description = contentDescription;
   }

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -343,10 +343,11 @@ export function addOrtbSiteContent(ortb2, contentId, contentData, contentTitle, 
   }
 
   if (contentDescription) {
-    content.ext = { description: contentDescription };
+    content.ext = content.ext || {};
+    content.ext.description = contentDescription;
   }
 
-  const currentData = content.data = content.data || [];
+  const currentData = content.data || [];
   // remove old jwplayer data
   const data = currentData.filter(datum => datum.name !== JWPLAYER_DOMAIN);
 
@@ -354,7 +355,9 @@ export function addOrtbSiteContent(ortb2, contentId, contentData, contentTitle, 
     data.push(contentData);
   }
 
-  content.data = data;
+  if (data.length) {
+    content.data = data;
+  }
 
   return ortb2;
 }

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -167,7 +167,7 @@ export function enrichAdUnits(adUnits, ortb2Fragments = {}) {
       const contentData = getContentData(mediaId, contentSegments);
       const targeting = formatTargetingResponse(vat);
       enrichBids(adUnit.bids, targeting, contentId, contentData);
-      addOrtbSiteContent(ortb2Fragments.global, contentId, contentData, vat.title, vat.description);
+      addOrtbSiteContent(ortb2Fragments.global, contentId, contentData, vat.title, vat.description, vat.mediaUrl);
     };
     loadVat(jwTargeting, onVatResponse);
   });

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -223,7 +223,7 @@ export function getVatFromCache(mediaID) {
     return null;
   }
 
-const mediaUrl = item.file ?? getFileFromSources(item);
+  const mediaUrl = item.file ?? getFileFromSources(item);
 
   return {
     segments: item.jwpseg,
@@ -235,7 +235,7 @@ const mediaUrl = item.file ?? getFileFromSources(item);
 }
 
 function getFileFromSources(playlistItem) {
-return playlistItem.sources?.find?.(source => source.file)?.file;
+  return playlistItem.sources?.find?.(source => !!source.file)?.file;
 }
 
 export function getVatFromPlayer(playerDivId, mediaID) {

--- a/modules/jwplayerRtdProvider.md
+++ b/modules/jwplayerRtdProvider.md
@@ -78,6 +78,19 @@ realTimeData = {
 };
 ```
 
+## Configuration syntax
+
+| Name  |Type | Description   | Notes  |
+| :------------ | :------------ | :------------ |:------------ |
+| name | String | Real time data module name | Always 'jwplayer' |
+| waitForIt | Boolean | Required to ensure that the auction is delayed until prefetch is complete | Optional. Defaults to false |
+| params | Object | | |
+| params.mediaIDs | Array of Strings | Media Ids for prefetching | Optional |
+| params.overrideContentId | String enum: 'always', 'whenEmpty' or 'never' | Determines when the module should update the oRTB site.content.id  | Defaults to 'always' |
+| params.overrideContentUrl | String enum: 'always', 'whenEmpty' or 'never' | Determines when the module should update the oRTB site.content.url | Defaults to 'whenEmpty' |
+| params.overrideContentTitle | String enum: 'always', 'whenEmpty' or 'never' | Determines when the module should update the oRTB site.content.title | Defaults to 'whenEmpty' |
+| params.overrideContentDescription | String enum: 'always', 'whenEmpty' or 'never' | Determines when the module should update the oRTB site.content.ext.description | Defaults to 'whenEmpty' |
+
 # Usage for Bid Adapters:
 
 Implement the `buildRequests` function. When it is called, the `bidRequests` param will be an array of bids.

--- a/modules/jwplayerRtdProvider.md
+++ b/modules/jwplayerRtdProvider.md
@@ -94,6 +94,8 @@ Example:
         site: {
             content: {
                 id: 'jw_abc123',
+                title: 'media title',
+                url: 'https:www.cdn.com/media.mp4',
                 data: [{
                     name: 'jwplayer.com',
                     ext: {
@@ -105,7 +107,10 @@ Example:
                     }, { 
                         id: '456'
                     }]
-                }]
+                }],
+                ext: {
+                  description: 'media description'
+              }
             }
         }   
     }
@@ -116,7 +121,10 @@ where:
 - `ortb2` is an object containing first party data
   - `site` is an object containing page specific information
     - `content` is an object containing metadata for the media. It may contain the following information: 
-      - `id` is a unique identifier for the specific media asset
+      - `id` is a unique identifier for the specific media asset,
+      - `title` is the title of the media content
+      - `url` is the url of the media asset
+      - `ext.description` is the description of the media content
       - `data` is an array containing segment taxonomy objects that have the following parameters:
         - `name` is the `jwplayer.com` string indicating the provider name
         - `ext.segtax` whose `502` value is the unique identifier for JW Player's proprietary taxonomy

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -150,26 +150,41 @@ describe('jwplayerRtdProvider', function() {
     describe('When jwplayer.js is on page', function () {
       const playlistItemWithSegmentMock = {
         mediaid: mediaIdWithSegment,
+        title: 'Media With Segment',
+        description: 'The media has segments',
+        file: 'mediaWithSegments.mp4',
         jwpseg: validSegments
       };
 
       const targetingForMediaWithSegment = {
         segments: validSegments,
-        mediaID: mediaIdWithSegment
+        mediaID: mediaIdWithSegment,
+        title: 'Media With Segment',
+        description: 'The media has segments',
+        mediaUrl: 'mediaWithSegments.mp4',
       };
 
       const playlistItemNoSegmentMock = {
-        mediaid: mediaIdNoSegment
+        mediaid: mediaIdNoSegment,
+        title: 'Media Without Segment',
+        description: 'The media has no segments',
+        file: 'mediaWithoutSegments.mp4',
       };
 
       const currentItemSegments = ['test_seg_3', 'test_seg_4'];
       const currentPlaylistItemMock = {
         mediaid: mediaIdForCurrentItem,
-        jwpseg: currentItemSegments
+        jwpseg: currentItemSegments,
+        title: 'Current Item',
+        description: 'The current playlist item',
+        file: 'currentItem.mp4',
       };
       const targetingForCurrentItem = {
         segments: currentItemSegments,
-        mediaID: mediaIdForCurrentItem
+        mediaID: mediaIdForCurrentItem,
+        title: 'Current Item',
+        description: 'The current playlist item',
+        mediaUrl: 'currentItem.mp4',
       };
 
       const playerInstanceMock = {
@@ -225,10 +240,11 @@ describe('jwplayerRtdProvider', function() {
 
       it('returns undefined segments when segments are absent', function () {
         const targeting = getVatFromPlayer(validPlayerID, mediaIdNoSegment);
-        expect(targeting).to.deep.equal({
-          mediaID: mediaIdNoSegment,
-          segments: undefined
-        });
+        expect(targeting.segments).to.be.undefined;
+        expect(targeting.mediaID).to.equal(mediaIdNoSegment);
+        expect(targeting.title).to.equal('Media Without Segment');
+        expect(targeting.description).to.equal('The media has no segments');
+        expect(targeting.mediaUrl).to.equal('mediaWithoutSegments.mp4');
       });
 
       describe('Get Bid Request Data', function () {

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -1098,7 +1098,6 @@ describe('jwplayerRtdProvider', function() {
     });
 
     it('should keep previous content title by default when new value is not available', function () {
-
       const ortb2 = {
         site: {
           content: {
@@ -1125,7 +1124,7 @@ describe('jwplayerRtdProvider', function() {
         }
       };
 
-      addOrtbSiteContent(ortb2, null, 'newTitle');
+      addOrtbSiteContent(ortb2, null, null, 'newTitle');
       expect(ortb2).to.have.nested.property('site.content.title', 'newTitle');
     });
 
@@ -1223,7 +1222,7 @@ describe('jwplayerRtdProvider', function() {
         }
       };
 
-      addOrtbSiteContent(ortb2,null, null, 'newTitle');
+      addOrtbSiteContent(ortb2, null, null, 'newTitle');
       expect(ortb2.site.content.title).to.be.undefined;
     });
 
@@ -1335,7 +1334,7 @@ describe('jwplayerRtdProvider', function() {
       };
 
       addOrtbSiteContent(ortb2);
-      expect(ortb2.site.content.ext.description).to.be.undefined;
+      expect(ortb2.site.content.ext).to.be.undefined;
     });
 
     it('should keep previous content description when override is set to never', function () {
@@ -1369,10 +1368,8 @@ describe('jwplayerRtdProvider', function() {
       };
 
       addOrtbSiteContent(ortb2);
-      expect(ortb2.site.content.ext.description).to.be.undefined;
+      expect(ortb2.site.content.ext).to.be.undefined;
     });
-
-
 
     it('should set content url by default when absent from ortb2', function () {
       const ortb2 = {};
@@ -1405,7 +1402,7 @@ describe('jwplayerRtdProvider', function() {
       };
 
       addOrtbSiteContent(ortb2, null, null, null, null, 'newUrl');
-      expect(ortb2).to.have.nested.property('site.content.title', 'oldUrl');
+      expect(ortb2).to.have.nested.property('site.content.url', 'oldUrl');
     });
 
     it('should override content url when override is always', function () {
@@ -1474,7 +1471,7 @@ describe('jwplayerRtdProvider', function() {
       };
 
       addOrtbSiteContent(ortb2, null, null, null, null, 'newUrl');
-      expect(ortb2).to.have.nested.property('site.content.title', 'oldUrl');
+      expect(ortb2).to.have.nested.property('site.content.url', 'oldUrl');
     });
 
     it('should keep previous content url when override is whenEmpty and new value is not available', function () {
@@ -1507,7 +1504,7 @@ describe('jwplayerRtdProvider', function() {
       };
 
       addOrtbSiteContent(ortb2, null, null, null, null, 'newUrl');
-      expect(ortb2).to.have.nested.property('site.content.title', 'oldUrl');
+      expect(ortb2).to.have.nested.property('site.content.url', 'oldUrl');
     });
 
     it('should not populate content url when override is set to never', function () {

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -1373,148 +1373,6 @@ describe('jwplayerRtdProvider', function() {
     });
 
 
-    it('should keep previous content title by default when already defined', function () {
-      const ortb2 = {
-        site: {
-          content: {
-            title: 'oldTitle'
-          }
-        }
-      };
-
-      addOrtbSiteContent(ortb2, null, null, 'newTitle');
-      expect(ortb2).to.have.nested.property('site.content.title', 'oldTitle');
-    });
-
-    it('should keep previous content title by default when new value is not available', function () {
-
-      const ortb2 = {
-        site: {
-          content: {
-            title: 'oldTitle',
-            data: [{ datum: 'first_datum' }]
-          }
-        }
-      };
-
-      addOrtbSiteContent(ortb2, null, { datum: 'new_datum' });
-      expect(ortb2).to.have.nested.property('site.content.title', 'oldTitle');
-    });
-
-    it('should override content title when override is always', function () {
-      setOverrides({
-        overrideContentTitle: 'always',
-      });
-
-      const ortb2 = {
-        site: {
-          content: {
-            title: 'oldTitle'
-          }
-        }
-      };
-
-      addOrtbSiteContent(ortb2, null, 'newTitle');
-      expect(ortb2).to.have.nested.property('site.content.title', 'newTitle');
-    });
-
-    it('should keep previous content title when override is always and new value is not available', function () {
-      setOverrides({
-        overrideContentTitle: 'always',
-      });
-
-      const ortb2 = {
-        site: {
-          content: {
-            title: 'oldTitle'
-          }
-        }
-      };
-
-      addOrtbSiteContent(ortb2);
-      expect(ortb2).to.have.nested.property('site.content.title', 'oldTitle');
-    });
-
-    it('should populate content title when override is whenEmpty and value is empty', function () {
-      setOverrides({
-        overrideContentTitle: 'whenEmpty',
-      });
-
-      const ortb2 = {
-        site: {
-          content: {
-          }
-        }
-      };
-
-      addOrtbSiteContent(ortb2, null, null, 'newTitle');
-      expect(ortb2).to.have.nested.property('site.content.title', 'newTitle');
-    });
-
-    it('should keep previous content title when override is whenEmpty and value is already populated', function () {
-      setOverrides({
-        overrideContentTitle: 'whenEmpty',
-      });
-
-      const ortb2 = {
-        site: {
-          content: {
-            title: 'oldTitle'
-          }
-        }
-      };
-
-      addOrtbSiteContent(ortb2, null, null, 'newTitle');
-      expect(ortb2).to.have.nested.property('site.content.title', 'oldTitle');
-    });
-
-    it('should keep previous content title when override is whenEmpty and new value is not available', function () {
-      setOverrides({
-        overrideContentTitle: 'whenEmpty',
-      });
-
-      const ortb2 = {
-        site: {
-          content: {
-          }
-        }
-      };
-
-      addOrtbSiteContent(ortb2);
-      expect(ortb2.site.content.title).to.be.undefined;
-    });
-
-    it('should keep previous content title when override is set to never', function () {
-      setOverrides({
-        overrideContentTitle: 'never',
-      });
-
-      const ortb2 = {
-        site: {
-          content: {
-            title: 'oldTitle'
-          }
-        }
-      };
-
-      addOrtbSiteContent(ortb2, null, null, 'newTitle');
-      expect(ortb2).to.have.nested.property('site.content.title', 'oldTitle');
-    });
-
-    it('should not populate content title when override is set to never', function () {
-      setOverrides({
-        overrideContentTitle: 'never',
-      });
-
-      const ortb2 = {
-        site: {
-          content: {}
-        }
-      };
-
-      addOrtbSiteContent(ortb2,null, null, 'newTitle');
-      expect(ortb2.site.content.title).to.be.undefined;
-    });
 
     it('should set content url by default when absent from ortb2', function () {
       const ortb2 = {};
@@ -1523,15 +1381,42 @@ describe('jwplayerRtdProvider', function() {
       expect(ortb2).to.have.nested.property('site.content.url', expectedUrl);
     });
 
-    it('should override content url when configured to do so', function () {
+    it('should keep previous content url by default when new value is not available', function () {
+      const ortb2 = {
+        site: {
+          content: {
+            url: 'oldUrl',
+            data: [{ datum: 'first_datum' }]
+          }
+        }
+      };
+
+      addOrtbSiteContent(ortb2, null, { datum: 'new_datum' });
+      expect(ortb2).to.have.nested.property('site.content.url', 'oldUrl');
+    });
+
+    it('should keep previous content url by default when already defined', function () {
+      const ortb2 = {
+        site: {
+          content: {
+            url: 'oldUrl',
+          }
+        }
+      };
+
+      addOrtbSiteContent(ortb2, null, null, null, null, 'newUrl');
+      expect(ortb2).to.have.nested.property('site.content.title', 'oldUrl');
+    });
+
+    it('should override content url when override is always', function () {
       setOverrides({
-        overrideContentUrl: true
+        overrideContentUrl: 'always',
       });
 
       const ortb2 = {
         site: {
           content: {
-            url: 'oldUrl'
+            url: 'oldUrl',
           }
         }
       };
@@ -1541,33 +1426,103 @@ describe('jwplayerRtdProvider', function() {
       expect(ortb2).to.have.nested.property('site.content.url', expectedUrl);
     });
 
-    it('should keep previous content url by default when new value is not available', function () {
+    it('should keep previous content url when override is always and new value is not available', function () {
+      setOverrides({
+        overrideContentUrl: 'always',
+      });
 
       const ortb2 = {
         site: {
           content: {
             url: 'oldUrl',
-            data: [{ datum: 'first_datum' }]
           }
         }
       };
 
-      addOrtbSiteContent(ortb2, null, { datum: 'new_datum' });
+      addOrtbSiteContent(ortb2);
       expect(ortb2).to.have.nested.property('site.content.url', 'oldUrl');
     });
 
-    it('should keep previous content url when not set', function () {
+    it('should populate content url when override is whenEmpty and value is empty', function () {
+      setOverrides({
+        overrideContentUrl: 'whenEmpty',
+      });
+
       const ortb2 = {
         site: {
           content: {
-            url: 'oldUrl',
-            data: [{ datum: 'first_datum' }]
           }
         }
       };
 
-      addOrtbSiteContent(ortb2, null, { datum: 'new_datum' });
-      expect(ortb2).to.have.nested.property('site.content.url', 'oldUrl');
+      const expectedUrl = 'expectedUrl';
+      addOrtbSiteContent(ortb2, null, null, null, null, expectedUrl);
+      expect(ortb2).to.have.nested.property('site.content.url', expectedUrl);
+    });
+
+    it('should keep previous content url when override is whenEmpty and value is already populated', function () {
+      setOverrides({
+        overrideContentUrl: 'whenEmpty',
+      });
+
+      const ortb2 = {
+        site: {
+          content: {
+            url: 'oldUrl',
+          }
+        }
+      };
+
+      addOrtbSiteContent(ortb2, null, null, null, null, 'newUrl');
+      expect(ortb2).to.have.nested.property('site.content.title', 'oldUrl');
+    });
+
+    it('should keep previous content url when override is whenEmpty and new value is not available', function () {
+      setOverrides({
+        overrideContentUrl: 'whenEmpty',
+      });
+
+      const ortb2 = {
+        site: {
+          content: {
+          }
+        }
+      };
+
+      addOrtbSiteContent(ortb2);
+      expect(ortb2.site.content.url).to.be.undefined;
+    });
+
+    it('should keep previous content url when override is set to never', function () {
+      setOverrides({
+        overrideContentUrl: 'never',
+      });
+
+      const ortb2 = {
+        site: {
+          content: {
+            url: 'oldUrl',
+          }
+        }
+      };
+
+      addOrtbSiteContent(ortb2, null, null, null, null, 'newUrl');
+      expect(ortb2).to.have.nested.property('site.content.title', 'oldUrl');
+    });
+
+    it('should not populate content url when override is set to never', function () {
+      setOverrides({
+        overrideContentUrl: 'never',
+      });
+
+      const ortb2 = {
+        site: {
+          content: {}
+        }
+      };
+
+      addOrtbSiteContent(ortb2, null, null, null, null, 'newUrl');
+      expect(ortb2.site.content.url).to.be.undefined;
     });
   });
 

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -67,6 +67,40 @@ describe('jwplayerRtdProvider', function() {
 
         expect(targetingInfo).to.deep.equal(validTargeting);
       });
+
+      it('should obtain file from sources', function () {
+        request.respond(
+          200,
+          responseHeader,
+          JSON.stringify({
+            playlist: [
+              {
+                sources: [{
+                  label: 'missing file',
+                }, {
+                  file: 'source.mp4',
+                  label: 'valid file'
+                }],
+                jwpseg: validSegments,
+                title: 'test',
+                description: 'this is a test'
+              }
+            ]
+          })
+        );
+
+        const targetingInfo = getVatFromCache(testIdForSuccess);
+
+        const validTargeting = {
+          segments: validSegments,
+          mediaID: testIdForSuccess,
+          mediaUrl: 'source.mp4',
+          title: 'test',
+          description: 'this is a test'
+        };
+
+        expect(targetingInfo).to.deep.equal(validTargeting);
+      });
     });
 
     describe('Fetch fails', function () {

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -11,6 +11,7 @@ import {
   getContentSegments,
   getVatFromCache,
   getVatFromPlayer,
+  setOverrides,
   jwplayerSubmodule
 } from 'modules/jwplayerRtdProvider.js';
 import {server} from 'test/mocks/xhr.js';
@@ -798,6 +799,15 @@ describe('jwplayerRtdProvider', function() {
   });
 
   describe(' Add Ortb Site Content', function () {
+    beforeEach(() => {
+      setOverrides({
+        overrideContentId: true,
+        overrideContentUrl: false,
+        overrideContentTitle: false,
+        overrideContentDescription: false
+      });
+    });
+
     it('should maintain object structure when id and data params are empty', function () {
       const ortb2 = {
         site: {
@@ -879,7 +889,7 @@ describe('jwplayerRtdProvider', function() {
       expect(ortb2).to.have.nested.property('site.content.id', expectedId);
     });
 
-    it('should override content id', function () {
+    it('should override content id by default', function () {
       const ortb2 = {
         site: {
           content: {
@@ -893,7 +903,24 @@ describe('jwplayerRtdProvider', function() {
       expect(ortb2).to.have.nested.property('site.content.id', expectedId);
     });
 
-    it('should keep previous content id when not set', function () {
+    it('should not override content id when overrideContentId is false', function () {
+      setOverrides({
+        overrideContentId: false,
+      });
+
+      const ortb2 = {
+        site: {
+          content: {
+            id: 'oldId'
+          }
+        }
+      };
+
+      addOrtbSiteContent(ortb2, 'newId');
+      expect(ortb2).to.have.nested.property('site.content.id', 'oldId');
+    });
+
+    it('should keep previous content id when new value is not available', function () {
       const previousId = 'oldId';
       const ortb2 = {
         site: {
@@ -951,14 +978,31 @@ describe('jwplayerRtdProvider', function() {
       expect(ortb2).to.have.nested.property('site.content.id', expectedId);
     });
 
-    it('should set content title', function () {
+    it('should set content title by default when absent from ortb2', function () {
       const ortb2 = {};
       const expectedTitle = 'expectedTitle';
       addOrtbSiteContent(ortb2, null, null, expectedTitle);
       expect(ortb2).to.have.nested.property('site.content.title', expectedTitle);
     });
 
-    it('should override content title', function () {
+    it('should not set content title by defaullt when already defined', function () {
+      const ortb2 = {
+        site: {
+          content: {
+            title: 'oldTitle'
+          }
+        }
+      };
+
+      addOrtbSiteContent(ortb2, null, null, 'newTitle');
+      expect(ortb2).to.have.nested.property('site.content.title', 'oldTitle');
+    });
+
+    it('should override content title when configured to do so', function () {
+      setOverrides({
+        overrideContentTitle: true
+      });
+
       const ortb2 = {
         site: {
           content: {
@@ -972,7 +1016,11 @@ describe('jwplayerRtdProvider', function() {
       expect(ortb2).to.have.nested.property('site.content.title', expectedTitle);
     });
 
-    it('should keep previous content title when not set', function () {
+    it('should keep previous content title when new value is not available', function () {
+      setOverrides({
+        overrideContentTitle: true
+      });
+
       const ortb2 = {
         site: {
           content: {
@@ -986,14 +1034,33 @@ describe('jwplayerRtdProvider', function() {
       expect(ortb2).to.have.nested.property('site.content.title', 'oldTitle');
     });
 
-    it('should set content description', function () {
+    it('should set content description by default when absent from ortb2', function () {
       const ortb2 = {};
       const expectedDescription = 'expectedDescription';
       addOrtbSiteContent(ortb2, null, null, null, expectedDescription);
       expect(ortb2).to.have.nested.property('site.content.ext.description', expectedDescription);
     });
 
-    it('should override content description', function () {
+    it('should not set content description by default when already defined', function () {
+      const ortb2 = {
+        site: {
+          content: {
+            ext: {
+              description: 'oldDescription'
+            }
+          }
+        }
+      };
+
+      addOrtbSiteContent(ortb2, null, null, null, 'newDescription');
+      expect(ortb2).to.have.nested.property('site.content.ext.description', 'oldDescription');
+    });
+
+    it('should override content description when configured to do so', function () {
+      setOverrides({
+        overrideContentDescription: true
+      });
+
       const ortb2 = {
         site: {
           content: {
@@ -1009,7 +1076,11 @@ describe('jwplayerRtdProvider', function() {
       expect(ortb2).to.have.nested.property('site.content.ext.description', expectedDescription);
     });
 
-    it('should keep previous content description when not set', function () {
+    it('should keep previous content description when new value is not available', function () {
+      setOverrides({
+        overrideContentDescription: true
+      });
+
       const ortb2 = {
         site: {
           content: {
@@ -1032,7 +1103,11 @@ describe('jwplayerRtdProvider', function() {
       expect(ortb2).to.have.nested.property('site.content.url', expectedUrl);
     });
 
-    it('should override content url', function () {
+    it('should override content url when configured to do so', function () {
+      setOverrides({
+        overrideContentUrl: true
+      });
+
       const ortb2 = {
         site: {
           content: {

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -223,7 +223,7 @@ describe('jwplayerRtdProvider', function() {
       it('caches segments when media ID matches a playist item with segments', function () {
         getVatFromPlayer(validPlayerID, mediaIdWithSegment);
         const vat = getVatFromCache(mediaIdWithSegment);
-        expect(vat.segments).to.deep.equal(validSegments);
+        expect(vat).to.deep.equal(targetingForMediaWithSegment);
       });
 
       it('returns segments of current item when media ID is missing', function () {

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -215,23 +215,23 @@ describe('jwplayerRtdProvider', function() {
         expect(targeting).to.be.null;
       });
 
-      it('returns segments when media ID matches a playlist item with segments', function () {
+      it('returns targeting when media ID matches a playlist item', function () {
         const targeting = getVatFromPlayer(validPlayerID, mediaIdWithSegment);
         expect(targeting).to.deep.equal(targetingForMediaWithSegment);
       });
 
-      it('caches segments when media ID matches a playist item with segments', function () {
+      it('caches item when media ID matches a valid playist item', function () {
         getVatFromPlayer(validPlayerID, mediaIdWithSegment);
         const vat = getVatFromCache(mediaIdWithSegment);
         expect(vat).to.deep.equal(targetingForMediaWithSegment);
       });
 
-      it('returns segments of current item when media ID is missing', function () {
+      it('returns targeting of current item when media ID is missing', function () {
         const targeting = getVatFromPlayer(validPlayerID);
         expect(targeting).to.deep.equal(targetingForCurrentItem);
       });
 
-      it('caches segments from the current item', function () {
+      it('caches metadata from the current item', function () {
         getVatFromPlayer(validPlayerID);
 
         window.jwplayer = null;
@@ -506,7 +506,9 @@ describe('jwplayerRtdProvider', function() {
           playlist: [
             {
               file: 'test.mp4',
-              jwpseg: validSegments
+              jwpseg: validSegments,
+              title: 'test title',
+              description: 'test description',
             }
           ]
         })
@@ -515,6 +517,9 @@ describe('jwplayerRtdProvider', function() {
       expect(ortb2Fragments.global).to.have.property('site');
       expect(ortb2Fragments.global.site).to.have.property('content');
       expect(ortb2Fragments.global.site.content).to.have.property('id', 'jw_' + testIdForSuccess);
+      expect(ortb2Fragments.global.site.content).to.have.property('url', 'test.mp4');
+      expect(ortb2Fragments.global.site.content).to.have.property('title', 'test title');
+      expect(ortb2Fragments.global.site.content.ext).to.have.property('description', 'test description');
       expect(ortb2Fragments.global.site.content).to.have.property('data');
       const data = ortb2Fragments.global.site.content.data;
       expect(data).to.have.length(1);

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -47,7 +47,9 @@ describe('jwplayerRtdProvider', function() {
             playlist: [
               {
                 file: 'test.mp4',
-                jwpseg: validSegments
+                jwpseg: validSegments,
+                title: 'test',
+                description: 'this is a test'
               }
             ]
           })
@@ -57,7 +59,10 @@ describe('jwplayerRtdProvider', function() {
 
         const validTargeting = {
           segments: validSegments,
-          mediaID: testIdForSuccess
+          mediaID: testIdForSuccess,
+          mediaUrl: 'test.mp4',
+          title: 'test',
+          description: 'this is a test'
         };
 
         expect(targetingInfo).to.deep.equal(validTargeting);
@@ -82,16 +87,12 @@ describe('jwplayerRtdProvider', function() {
         expect(targetingInfo).to.be.null;
       });
 
-      it('should not write to cache when segments are absent', function() {
+      it('should not write to cache when playlist is empty', function() {
         request.respond(
           200,
           responseHeader,
           JSON.stringify({
-            playlist: [
-              {
-                file: 'test.mp4'
-              }
-            ]
+            playlist: []
           })
         );
         const targetingInfo = getVatFromCache(testIdForFailure);

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -783,9 +783,15 @@ describe('jwplayerRtdProvider', function() {
     it('should create a structure compliant with the oRTB 2 spec', function() {
       const ortb2 = {}
       const expectedId = 'expectedId';
+      const expectedUrl = 'expectedUrl';
+      const expectedTitle = 'expectedTitle';
+      const expectedDescription = 'expectedDescription';
       const expectedData = { datum: 'datum' };
-      addOrtbSiteContent(ortb2, expectedId, expectedData);
+      addOrtbSiteContent(ortb2, expectedId, expectedData, expectedTitle, expectedDescription, expectedUrl);
       expect(ortb2).to.have.nested.property('site.content.id', expectedId);
+      expect(ortb2).to.have.nested.property('site.content.url', expectedUrl);
+      expect(ortb2).to.have.nested.property('site.content.title', expectedTitle);
+      expect(ortb2).to.have.nested.property('site.content.ext.description', expectedDescription);
       expect(ortb2).to.have.nested.property('site.content.data');
       expect(ortb2.site.content.data[0]).to.be.deep.equal(expectedData);
     });
@@ -794,11 +800,14 @@ describe('jwplayerRtdProvider', function() {
       const ortb2 = {
         site: {
           content: {
-            id: 'oldId'
+            id: 'oldId',
+            ext: {
+              random_field: 'randomField'
+            }
           },
           random: {
             random_sub: 'randomSub'
-          }
+          },
         },
         app: {
           content: {
@@ -808,11 +817,18 @@ describe('jwplayerRtdProvider', function() {
       };
 
       const expectedId = 'expectedId';
+      const expectedUrl = 'expectedUrl';
+      const expectedTitle = 'expectedTitle';
+      const expectedDescription = 'expectedDescription';
       const expectedData = { datum: 'datum' };
-      addOrtbSiteContent(ortb2, expectedId, expectedData);
+      addOrtbSiteContent(ortb2, expectedId, expectedData, expectedTitle, expectedDescription, expectedUrl);
       expect(ortb2).to.have.nested.property('site.random.random_sub', 'randomSub');
       expect(ortb2).to.have.nested.property('app.content.id', 'appId');
+      expect(ortb2).to.have.nested.property('site.content.ext.random_field', 'randomField');
       expect(ortb2).to.have.nested.property('site.content.id', expectedId);
+      expect(ortb2).to.have.nested.property('site.content.url', expectedUrl);
+      expect(ortb2).to.have.nested.property('site.content.title', expectedTitle);
+      expect(ortb2).to.have.nested.property('site.content.ext.description', expectedDescription);
       expect(ortb2).to.have.nested.property('site.content.data');
       expect(ortb2.site.content.data[0]).to.be.deep.equal(expectedData);
     });
@@ -894,6 +910,115 @@ describe('jwplayerRtdProvider', function() {
       expect(ortb2.site.content.data).to.have.length(1);
       expect(ortb2.site.content.data[0]).to.be.deep.equal(expectedData);
       expect(ortb2).to.have.nested.property('site.content.id', expectedId);
+    });
+
+    it('should set content title', function () {
+      const ortb2 = {};
+      const expectedTitle = 'expectedTitle';
+      addOrtbSiteContent(ortb2, null, null, expectedTitle);
+      expect(ortb2).to.have.nested.property('site.content.title', expectedTitle);
+    });
+
+    it('should override content title', function () {
+      const ortb2 = {
+        site: {
+          content: {
+            title: 'oldTitle'
+          }
+        }
+      };
+
+      const expectedTitle = 'expectedTitle';
+      addOrtbSiteContent(ortb2, null, null, expectedTitle);
+      expect(ortb2).to.have.nested.property('site.content.title', expectedTitle);
+    });
+
+    it('should keep previous content title when not set', function () {
+      const ortb2 = {
+        site: {
+          content: {
+            title: 'oldTitle',
+            data: [{ datum: 'first_datum' }]
+          }
+        }
+      };
+
+      addOrtbSiteContent(ortb2, null, { datum: 'new_datum' });
+      expect(ortb2).to.have.nested.property('site.content.title', 'oldTitle');
+    });
+
+    it('should set content description', function () {
+      const ortb2 = {};
+      const expectedDescription = 'expectedDescription';
+      addOrtbSiteContent(ortb2, null, null, null, expectedDescription);
+      expect(ortb2).to.have.nested.property('site.content.ext.description', expectedDescription);
+    });
+
+    it('should override content description', function () {
+      const ortb2 = {
+        site: {
+          content: {
+            ext: {
+              description: 'oldDescription'
+            }
+          }
+        }
+      };
+
+      const expectedDescription = 'expectedDescription';
+      addOrtbSiteContent(ortb2, null, null, null, expectedDescription);
+      expect(ortb2).to.have.nested.property('site.content.ext.description', expectedDescription);
+    });
+
+    it('should keep previous content description when not set', function () {
+      const ortb2 = {
+        site: {
+          content: {
+            data: [{ datum: 'first_datum' }],
+            ext: {
+              description: 'oldDescription'
+            }
+          }
+        }
+      };
+
+      addOrtbSiteContent(ortb2, null, { datum: 'new_datum' });
+      expect(ortb2).to.have.nested.property('site.content.ext.description', 'oldDescription');
+    });
+
+    it('should set content url', function () {
+      const ortb2 = {};
+      const expectedUrl = 'expectedUrl';
+      addOrtbSiteContent(ortb2, null, null, null, null, expectedUrl);
+      expect(ortb2).to.have.nested.property('site.content.url', expectedUrl);
+    });
+
+    it('should override content url', function () {
+      const ortb2 = {
+        site: {
+          content: {
+            url: 'oldUrl'
+          }
+        }
+      };
+
+      const expectedUrl = 'expectedUrl';
+      addOrtbSiteContent(ortb2, null, null, null, null, expectedUrl);
+      expect(ortb2).to.have.nested.property('site.content.url', expectedUrl);
+    });
+
+    it('should keep previous content url when not set', function () {
+      const ortb2 = {
+        site: {
+          content: {
+            url: 'oldUrl',
+            data: [{ datum: 'first_datum' }]
+          }
+        }
+      };
+
+      addOrtbSiteContent(ortb2, null, { datum: 'new_datum' });
+      expect(ortb2).to.have.nested.property('site.content.url', 'oldUrl');
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Includes content url, title and description when enriching the `ortb.site.content`.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
Docs PR: https://github.com/prebid/prebid.github.io/pull/5190