### PR TITLE
[JW Player RTD Module] Deprecate playerID

### DIFF
--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -192,18 +192,22 @@ export function extractPublisherParams(adUnit, fallback) {
 }
 
 function loadVat(params, onCompletion) {
-  const { playerID, mediaID } = params;
+  let { playerID, playerDivId, mediaID } = params;
+  if (!playerDivId) {
+    playerDivId = playerID;
+  }
+
   if (pendingRequests[mediaID] !== undefined) {
-    loadVatForPendingRequest(playerID, mediaID, onCompletion);
+    loadVatForPendingRequest(playerDivId, mediaID, onCompletion);
     return;
   }
 
-  const vat = getVatFromCache(mediaID) || getVatFromPlayer(playerID, mediaID) || { mediaID };
+  const vat = getVatFromCache(mediaID) || getVatFromPlayer(playerDivId, mediaID) || { mediaID };
   onCompletion(vat);
 }
 
-function loadVatForPendingRequest(playerID, mediaID, callback) {
-  const vat = getVatFromPlayer(playerID, mediaID);
+function loadVatForPendingRequest(playerDivId, mediaID, callback) {
+  const vat = getVatFromPlayer(playerDivId, mediaID);
   if (vat) {
     callback(vat);
   } else {
@@ -225,8 +229,8 @@ export function getVatFromCache(mediaID) {
   };
 }
 
-export function getVatFromPlayer(playerID, mediaID) {
-  const player = getPlayer(playerID);
+export function getVatFromPlayer(playerDivId, mediaID) {
+  const player = getPlayer(playerDivId);
   if (!player) {
     return null;
   }
@@ -362,14 +366,14 @@ export function addTargetingToBid(bid, targeting) {
   bid.rtd = Object.assign({}, rtd, jwRtd);
 }
 
-function getPlayer(playerID) {
+function getPlayer(playerDivId) {
   const jwplayer = window.jwplayer;
   if (!jwplayer) {
     logError(SUBMODULE_NAME + '.js was not found on page');
     return;
   }
 
-  const player = jwplayer(playerID);
+  const player = jwplayer(playerDivId);
   if (!player || !player.getPlaylist) {
     logError('player ID did not match any players');
     return;

--- a/modules/jwplayerRtdProvider.md
+++ b/modules/jwplayerRtdProvider.md
@@ -36,7 +36,7 @@ const adUnit = {
       data: {
         jwTargeting: {
           // Note: the following Ids are placeholders and should be replaced with your Ids.
-          playerID: 'abcd',
+          playerDivId: 'abcd',
           mediaID: '1234'
         }
       }
@@ -51,7 +51,7 @@ pbjs.que.push(function() {
     });
 });
 ``` 
-**Note**: The player ID is the ID of the HTML div element used when instantiating the player. 
+**Note**: The player Div ID is the ID of the HTML div element used when instantiating the player. 
 You can retrieve this ID by calling `player.id`, where player is the JW Player instance variable.
 
 **Note**: You may also include `jwTargeting` information in the prebid config's `ortb2.site.ext.data`. Information provided in the adUnit will always supersede, and information in the config will be used as a fallback.

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -244,6 +244,41 @@ describe('jwplayerRtdProvider', function() {
                 data: {
                   jwTargeting: {
                     mediaID: mediaIdWithSegment,
+                    playerDivId: validPlayerID
+                  }
+                }
+              }
+            },
+            bids: [
+              bid
+            ]
+          };
+          const expectedContentId = 'jw_' + mediaIdWithSegment;
+          const expectedTargeting = {
+            segments: validSegments,
+            content: {
+              id: expectedContentId
+            }
+          };
+          jwplayerSubmodule.getBidRequestData({ adUnits: [adUnit] }, bidRequestSpy);
+          expect(bidRequestSpy.calledOnce).to.be.true;
+          expect(bid.rtd.jwplayer).to.have.deep.property('targeting', expectedTargeting);
+          server.respond();
+          expect(bidRequestSpy.calledOnce).to.be.true;
+        });
+
+        it('includes backwards support for playerID when playerDivId is not set', function () {
+          const bidRequestSpy = sinon.spy();
+
+          fetchTargetingForMediaId(mediaIdWithSegment);
+
+          const bid = {};
+          const adUnit = {
+            ortb2Imp: {
+              ext: {
+                data: {
+                  jwTargeting: {
+                    mediaID: mediaIdWithSegment,
                     playerID: validPlayerID
                   }
                 }
@@ -605,23 +640,23 @@ describe('jwplayerRtdProvider', function() {
     it('should prioritize adUnit properties ', function () {
       const expectedMediaID = 'test_media_id';
       const expectedPlayerID = 'test_player_id';
-      const config = { playerID: 'bad_id', mediaID: 'bad_id' };
+      const config = { playerDivId: 'bad_id', mediaID: 'bad_id' };
 
-      const adUnit = { ortb2Imp: { ext: { data: { jwTargeting: { mediaID: expectedMediaID, playerID: expectedPlayerID } } } } };
+      const adUnit = { ortb2Imp: { ext: { data: { jwTargeting: { mediaID: expectedMediaID, playerDivId: expectedPlayerID } } } } };
       const targeting = extractPublisherParams(adUnit, config);
       expect(targeting).to.have.property('mediaID', expectedMediaID);
-      expect(targeting).to.have.property('playerID', expectedPlayerID);
+      expect(targeting).to.have.property('playerDivId', expectedPlayerID);
     });
 
     it('should use config properties as fallbacks', function () {
       const expectedMediaID = 'test_media_id';
       const expectedPlayerID = 'test_player_id';
-      const config = { playerID: expectedPlayerID, mediaID: 'bad_id' };
+      const config = { playerDivId: expectedPlayerID, mediaID: 'bad_id' };
 
       const adUnit = { ortb2Imp: { ext: { data: { jwTargeting: { mediaID: expectedMediaID } } } } };
       const targeting = extractPublisherParams(adUnit, config);
       expect(targeting).to.have.property('mediaID', expectedMediaID);
-      expect(targeting).to.have.property('playerID', expectedPlayerID);
+      expect(targeting).to.have.property('playerDivId', expectedPlayerID);
     });
 
     it('should return undefined when Publisher Params are absent', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] API Deprecation

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Deprecate `playerID` config param in favor of `playerDivId`. 
this is required to distinguish from other player IDs in the JW Player ecosystem.
Backwards compatibility for `playerID` is included.

Docs PR: https://github.com/prebid/prebid.github.io/pull/5190

