### PR TITLE
RTBHouse Bid Adapter: prevent buyer list overwrite

### DIFF
--- a/modules/rtbhouseBidAdapter.js
+++ b/modules/rtbhouseBidAdapter.js
@@ -165,6 +165,7 @@ export const spec = {
   interpretResponse: function (serverResponse, originalRequest) {
     let bids;
 
+    const fledgeInterestGroupBuyers = config.getConfig('fledgeConfig.interestGroupBuyers') || [];
     const responseBody = serverResponse.body;
     let fledgeAuctionConfigs = null;
 
@@ -186,7 +187,7 @@ export const spec = {
           {
             seller,
             decisionLogicUrl,
-            interestGroupBuyers: Object.keys(perBuyerSignals),
+            interestGroupBuyers: [...fledgeInterestGroupBuyers, ...Object.keys(perBuyerSignals)],
             perBuyerSignals,
           },
           sellerTimeout


### PR DESCRIPTION
Fixes a bug where full buyer list is overwritten with buyer list with pbs (in this case, can only be one) 