### PR TITLE
JW Player RTD Module : fallback to lone player on page

### DIFF
--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -12,7 +12,7 @@
 import {submodule} from '../src/hook.js';
 import {config} from '../src/config.js';
 import {ajaxBuilder} from '../src/ajax.js';
-import {deepAccess, logError} from '../src/utils.js';
+import { deepAccess, logError, logWarn } from '../src/utils.js'
 import {find} from '../src/polyfill.js';
 import {getGlobal} from '../src/prebidGlobal.js';
 
@@ -436,10 +436,18 @@ function getPlayer(playerDivId) {
     return;
   }
 
-  const player = jwplayer(playerDivId);
-  if (!player || !player.getPlaylist) {
-    logError('player ID did not match any players');
-    return;
+  let player = jwplayer(playerDivId);
+  if (player && player.getPlaylist) {
+    return player;
   }
-  return player;
+
+  let errorMessage = `player Div ID ${playerID} did not match any players.`;
+  player = jwplayer();
+
+  if (player && player.getPlaylist) {
+    logWarn(`${errorMessage} Targeting player Div ID ${player.id} instead`);
+    return player;
+  }
+
+  logError(errorMessage);
 }

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -447,7 +447,8 @@ function getPlayer(playerDivId) {
     return;
   }
 
-  let errorMessage = `player Div ID ${playerID} did not match any players.`;
+  let errorMessage = `player Div ID ${playerDivId} did not match any players.`;
+
   // If there are multiple instances on the page, we cannot guess which one should be targeted.
   if (playerOnPageCount > 1) {
     logError(errorMessage);

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -429,7 +429,7 @@ export function addTargetingToBid(bid, targeting) {
   bid.rtd = Object.assign({}, rtd, jwRtd);
 }
 
-function getPlayer(playerDivId) {
+export function getPlayer(playerDivId) {
   const jwplayer = window.jwplayer;
   if (!jwplayer) {
     logError(SUBMODULE_NAME + '.js was not found on page');

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -441,9 +441,20 @@ function getPlayer(playerDivId) {
     return player;
   }
 
-  let errorMessage = `player Div ID ${playerID} did not match any players.`;
-  player = jwplayer();
+  const playerOnPageCount = document.getElementsByClassName('jwplayer').length;
+  if (playerOnPageCount === 0) {
+    logError('No JWPlayer instances have been detected on the page');
+    return;
+  }
 
+  let errorMessage = `player Div ID ${playerID} did not match any players.`;
+  // If there are multiple instances on the page, we cannot guess which one should be targeted.
+  if (playerOnPageCount > 1) {
+    logError(errorMessage);
+    return;
+  }
+
+  player = jwplayer();
   if (player && player.getPlaylist) {
     logWarn(`${errorMessage} Targeting player Div ID ${player.id} instead`);
     return player;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
This is a convenience for Publishers using the wrong Player Div Id.
When there is only 1 instance of a JW Player on the page, the module picks that player instance for targeting and logs a warning.
If multiple players are on the page, and none match the Player Div Id, then none are used. 

