### PR TITLE
Onetag Bid Adapter: add reading of addtlConsent GDPR field

### DIFF
--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -63,7 +63,8 @@ function buildRequests(validBidRequests, bidderRequest) {
   if (bidderRequest && bidderRequest.gdprConsent) {
     payload.gdprConsent = {
       consentString: bidderRequest.gdprConsent.consentString,
-      consentRequired: bidderRequest.gdprConsent.gdprApplies
+      consentRequired: bidderRequest.gdprConsent.gdprApplies,
+      addtlConsent: bidderRequest.gdprConsent.addtlConsent
     };
   }
   if (bidderRequest && bidderRequest.gppConsent) {

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -273,6 +273,7 @@ describe('onetag', function () {
     });
     it('should send GDPR consent data', function () {
       let consentString = 'consentString';
+      let addtlConsent = '2~1.35.41.101~dv.9.21.81';
       let bidderRequest = {
         'bidderCode': 'onetag',
         'auctionId': '1d1a030790a475',
@@ -280,7 +281,8 @@ describe('onetag', function () {
         'timeout': 3000,
         'gdprConsent': {
           consentString: consentString,
-          gdprApplies: true
+          gdprApplies: true,
+          addtlConsent: addtlConsent
         }
       };
       let serverRequest = spec.buildRequests([bannerBid], bidderRequest);
@@ -289,6 +291,7 @@ describe('onetag', function () {
       expect(payload).to.exist;
       expect(payload.gdprConsent).to.exist;
       expect(payload.gdprConsent.consentString).to.exist.and.to.equal(consentString);
+      expect(payload.gdprConsent.addtlConsent).to.exist.and.to.equal(addtlConsent);
       expect(payload.gdprConsent.consentRequired).to.exist.and.to.be.true;
     });
     it('Should send GPP consent data', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add reading of `addtlConsent` field inside `gdprConsent` object