### PR TITLE
User ID: rename deprecated googletag function

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -716,14 +716,14 @@ function registerSignalSources() {
   if (!isGptPubadsDefined()) {
     return;
   }
-  window.googletag.encryptedSignalProviders = window.googletag.encryptedSignalProviders || [];
+  window.googletag.secureSignalProviders = window.googletag.secureSignalProviders || [];
   const encryptedSignalSources = config.getConfig('userSync.encryptedSignalSources');
   if (encryptedSignalSources) {
     const registerDelay = encryptedSignalSources.registerDelay || 0;
     setTimeout(() => {
       encryptedSignalSources['sources'] && encryptedSignalSources['sources'].forEach(({ source, encrypt, customFunc }) => {
         source.forEach((src) => {
-          window.googletag.encryptedSignalProviders.push({
+          window.googletag.secureSignalProviders.push({
             id: src,
             collectorFunction: () => getEncryptedEidsForSource(src, encrypt, customFunc)
           });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
User ID module used googletag.encryptedSignalProviders function which has been deprecated, I renamed it to the supported googletag.secureSignalProviders function.

Screenshot of google console warning message:
![image](https://github.com/prebid/Prebid.js/assets/65354776/c29aacd6-a625-4cbd-9ccb-4eea4dc1e860)

