### PR TITLE
Adquery Bid Adapter: removed ad data from bidWon event handler

### DIFF
--- a/modules/adqueryBidAdapter.js
+++ b/modules/adqueryBidAdapter.js
@@ -116,7 +116,10 @@ export const spec = {
   onBidWon: (bid) => {
     logInfo('onBidWon', bid);
     const bidString = JSON.stringify(bid);
-    const encodedBuf = window.btoa(bidString);
+    let copyOfBid = JSON.parse(bidString);
+    delete copyOfBid.ad;
+    const shortBidString = JSON.stringify(copyOfBid);
+    const encodedBuf = window.btoa(shortBidString);
 
     let params = {
       q: encodedBuf,

--- a/modules/adqueryBidAdapter.js
+++ b/modules/adqueryBidAdapter.js
@@ -115,9 +115,8 @@ export const spec = {
    */
   onBidWon: (bid) => {
     logInfo('onBidWon', bid);
-    const bidString = JSON.stringify(bid);
-    let copyOfBid = JSON.parse(bidString);
-    delete copyOfBid.ad;
+    let copyOfBid = { ...bid }
+    delete copyOfBid.ad
     const shortBidString = JSON.stringify(copyOfBid);
     const encodedBuf = window.btoa(shortBidString);
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Remove ad data from bidWon event