### PR TITLE
Rubicon Bid Adapter: update TTL default from 300 to 360

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -201,9 +201,6 @@ export const converter = ortbConverter({
     const imp = buildImp(bidRequest, context);
     imp.id = bidRequest.adUnitCode;
     delete imp.banner;
-    if (config.getConfig('s2sConfig.defaultTtl')) {
-      imp.exp = config.getConfig('s2sConfig.defaultTtl');
-    };
     bidRequest.params.position === 'atf' && imp.video && (imp.video.pos = 1);
     bidRequest.params.position === 'btf' && imp.video && (imp.video.pos = 3);
     delete imp.ext?.prebid?.storedrequest;
@@ -237,7 +234,7 @@ export const converter = ortbConverter({
   },
   context: {
     netRevenue: rubiConf.netRevenue !== false, // If anything other than false, netRev is true
-    ttl: 300,
+    ttl: 360,
   },
   processors: pbsExtensions
 });
@@ -685,7 +682,7 @@ export const spec = {
           creativeId: ad.creative_id || `${ad.network || ''}-${ad.advertiser || ''}`,
           cpm: ad.cpm || 0,
           dealId: ad.deal,
-          ttl: 300, // 5 minutes
+          ttl: 360, // 6 minutes
           netRevenue: rubiConf.netRevenue !== false, // If anything other than false, netRev is true
           rubicon: {
             advertiserId: ad.advertiser, networkId: ad.network

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -2268,17 +2268,6 @@ describe('the rubicon adapter', function () {
             expect(payload.ext.prebid.analytics).to.be.undefined;
           });
 
-          it('should send video exp param correctly when set', function () {
-            const bidderRequest = createVideoBidderRequest();
-            config.setConfig({s2sConfig: {defaultTtl: 600}});
-            let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
-            let post = request.data;
-
-            // should exp set to the right value according to config
-            let imp = post.imp[0];
-            expect(imp.exp).to.equal(600);
-          });
-
           it('should not send video exp at all if not set in s2sConfig config', function () {
             const bidderRequest = createVideoBidderRequest();
             let [request] = spec.buildRequests(bidderRequest.bids, bidderRequest);
@@ -3087,7 +3076,7 @@ describe('the rubicon adapter', function () {
           expect(bids[0].width).to.equal(320);
           expect(bids[0].height).to.equal(50);
           expect(bids[0].cpm).to.equal(0.911);
-          expect(bids[0].ttl).to.equal(300);
+          expect(bids[0].ttl).to.equal(360);
           expect(bids[0].netRevenue).to.equal(true);
           expect(bids[0].rubicon.advertiserId).to.equal(7);
           expect(bids[0].rubicon.networkId).to.equal(8);
@@ -3104,7 +3093,7 @@ describe('the rubicon adapter', function () {
           expect(bids[1].width).to.equal(300);
           expect(bids[1].height).to.equal(250);
           expect(bids[1].cpm).to.equal(0.811);
-          expect(bids[1].ttl).to.equal(300);
+          expect(bids[1].ttl).to.equal(360);
           expect(bids[1].netRevenue).to.equal(true);
           expect(bids[1].rubicon.advertiserId).to.equal(7);
           expect(bids[1].rubicon.networkId).to.equal(8);
@@ -3916,7 +3905,7 @@ describe('the rubicon adapter', function () {
             expect(bids[0].seatBidId).to.equal('0');
             expect(bids[0].creativeId).to.equal('4259970');
             expect(bids[0].cpm).to.equal(2);
-            expect(bids[0].ttl).to.equal(300);
+            expect(bids[0].ttl).to.equal(360);
             expect(bids[0].netRevenue).to.equal(true);
             expect(bids[0].adserverTargeting).to.deep.equal({hb_uuid: '0c498f63-5111-4bed-98e2-9be7cb932a64'});
             expect(bids[0].mediaType).to.equal('video');
@@ -4008,7 +3997,7 @@ describe('the rubicon adapter', function () {
             expect(bids[0].seatBidId).to.equal('0');
             expect(bids[0].creativeId).to.equal('4259970');
             expect(bids[0].cpm).to.equal(2);
-            expect(bids[0].ttl).to.equal(300);
+            expect(bids[0].ttl).to.equal(360);
             expect(bids[0].netRevenue).to.equal(true);
             expect(bids[0].adserverTargeting).to.deep.equal({hb_uuid: '0c498f63-5111-4bed-98e2-9be7cb932a64'});
             expect(bids[0].mediaType).to.equal('video');


### PR DESCRIPTION
## Type of change
- [X] Feature

## Description of change
Update the Rubicon bid adapter to have a default TTL of 360 for banner (currently set at 300).