### PR TITLE
IX Bid Adapter: add check for fledge autoconfig to ixdiag

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -721,10 +721,10 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
   let r = createRequest(validBidRequests);
 
   // Add FTs to be requested from Exchange
-  r = addRequestedFeatureToggles(r, FEATURE_TOGGLES.REQUESTED_FEATURE_TOGGLES)
+  r = addRequestedFeatureToggles(r, FEATURE_TOGGLES.REQUESTED_FEATURE_TOGGLES);
 
   // getting ixdiags for adunits of the video, outstream & multi format (MF) style
-  const fledgeEnabled = deepAccess(bidderRequest, 'fledgeEnabled')
+  const fledgeEnabled = deepAccess(bidderRequest, 'fledgeEnabled');
   let ixdiag = buildIXDiag(validBidRequests, fledgeEnabled);
   for (let key in ixdiag) {
     r.ext.ixdiag[key] = ixdiag[key];
@@ -1332,6 +1332,7 @@ function buildIXDiag(validBidRequests, fledgeEnabled) {
     url: window.location.href.split('?')[0],
     vpd: defaultVideoPlacement,
     ae: fledgeEnabled,
+    fac: checkFledgeAutoConfig(),
     eidLength: allEids.length
   };
 
@@ -1369,6 +1370,16 @@ function buildIXDiag(validBidRequests, fledgeEnabled) {
   }
 
   return ixdiag;
+}
+
+// Function to check the fledgeAutoConfig settings in pbjs config
+function checkFledgeAutoConfig() {
+  const pbjsConfig = config.getConfig();
+
+  const autoConfigPaapi = deepAccess(pbjsConfig, 'paapi.gpt.autoconfig', false);
+  const autoConfigFledge = deepAccess(pbjsConfig, 'fledgeForGpt.autoconfig', false);
+
+  return autoConfigPaapi || autoConfigFledge;
 }
 
 /**

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -3455,6 +3455,10 @@ describe('IndexexchangeAdapter', function () {
   });
 
   describe('buildRequestFledge', function () {
+    afterEach(() => {
+      config.resetConfig();
+    });
+
     it('impression should have ae=1 in ext when fledge module is enabled and ae is set in ad unit', function () {
       const bidderRequest = deepClone(DEFAULT_OPTION_FLEDGE_ENABLED);
       const bid = utils.deepClone(DEFAULT_BANNER_VALID_BID_WITH_FLEDGE_ENABLED[0]);
@@ -3506,6 +3510,29 @@ describe('IndexexchangeAdapter', function () {
       const request = spec.buildRequests([bid], bidderRequestWithFledgeEnabled);
       const diagObj = extractPayload(request[0]).ext.ixdiag;
       expect(diagObj.ae).to.equal(true);
+    });
+
+    it('should set ixDiag property correctly for fledgeAutoConfig', function () {
+      config.setConfig({
+        paapi: {
+          gpt: {
+            autoconfig: true
+          }
+        }
+      });
+      const bid = DEFAULT_BANNER_VALID_BID_WITH_FLEDGE_ENABLED[0];
+      const bidderRequestWithFledgeEnabled = deepClone(DEFAULT_OPTION_FLEDGE_ENABLED);
+      const request = spec.buildRequests([bid], bidderRequestWithFledgeEnabled);
+      const diagObj = extractPayload(request[0]).ext.ixdiag;
+      expect(diagObj.fac).to.equal(true);
+    });
+
+    it('should set ixDiag property correctly for fledgeAutoConfig when its not set', function () {
+      const bid = DEFAULT_BANNER_VALID_BID[0];
+      const bidderRequest = deepClone(DEFAULT_OPTION);
+      const request = spec.buildRequests([bid], bidderRequest);
+      const diagObj = extractPayload(request[0]).ext.ixdiag;
+      expect(diagObj.fac).to.equal(false);
     });
 
     it('should log warning for non integer auction environment in ad unit for fledge', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
- Adds check for determining if PAAPI (Fledge) autoconfig option is enabled to IX diagnostic object.

## Other information
For more information, contact shahin.rahbariasl@indexexchange.com
