### PR TITLE
fledgeForGpt: automatically import paapi for NPM consumers

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -295,8 +295,7 @@ function bundle(dev, moduleArr) {
   [coreFile].concat(moduleFiles).map(name => path.basename(name)).forEach((file) => {
     (depGraph[file] || []).forEach((dep) => dependencies.add(helpers.getBuiltPath(dev, dep)));
   });
-
-  const entries = [coreFile].concat(Array.from(dependencies), moduleFiles);
+  const entries = _.uniq([coreFile].concat(Array.from(dependencies), moduleFiles));
 
   var outputFileName = argv.bundleName ? argv.bundleName : 'prebid.js';
 

--- a/modules/fledgeForGpt.js
+++ b/modules/fledgeForGpt.js
@@ -7,6 +7,11 @@ import {getGptSlotForAdUnitCode} from '../libraries/gptUtils/gptUtils.js';
 import {config} from '../src/config.js';
 import {getGlobal} from '../src/prebidGlobal.js';
 
+// import parent module to keep backwards-compat for NPM consumers after paapi was split from fledgeForGpt
+// there's a special case in webpack.conf.js to avoid duplicating build output on non-npm builds
+// TODO: remove this in prebid 9
+// eslint-disable-next-line prebid/validate-imports
+import './paapi.js';
 const MODULE = 'fledgeForGpt';
 
 let getPAAPIConfig;

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -128,10 +128,31 @@ module.exports = {
               return [lib, def];
             })
         );
+        const core = path.resolve('./src');
+        const paapiMod = path.resolve('./modules/paapi.js');
+        const nodeModules = path.resolve('./node_modules');
+
         return Object.assign(libraries, {
+          core: {
+            name: 'chunk-core',
+            test: (module) => {
+              return module.resource?.startsWith(core) || module.resource?.startsWith(nodeModules);
+            }
+          },
+          paapi: {
+            // fledgeForGpt imports paapi to keep backwards compat for NPM consumers
+            // this makes the paapi module its own chunk, pulled in by both paapi and fledgeForGpt entry points,
+            // to avoid duplication
+            // TODO: remove this in prebid 9
+            name: 'chunk-paapi',
+            test: (module) => {
+              return module.resource === paapiMod;
+            }
+          }
+        }, {
           default: false,
           defaultVendors: false
-        })
+        });
       })()
     }
   },


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

With https://github.com/prebid/Prebid.js/pull/10930, `fledgeForGpt` was made a submodule of `paapi`. The build automatically includes submodules' parent modules, but this is not the case for NPM consumers.

This also fixes webpack's `splitChunk` configuration to avoid other, unrelated output duplication - logic that's not pulled in from `src/prebid.js`, but imported from modules, is duplicated for each module.
