### PR TITLE
core: allow bid adapters to return null fledgeAuctionConfigs

### DIFF
--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -89,8 +89,8 @@ import {ACTIVITY_TRANSMIT_TID, ACTIVITY_TRANSMIT_UFPD} from '../activities/activ
 /**
  * @typedef {object} BidderAuctionResponse An object encapsulating an adapter response for current Auction
  *
- * @property {Array<Bid>} bids Contextual bids returned by this adapter, if any
- * @property {object|null} fledgeAuctionConfigs Optional FLEDGE response, as a map of impid -> auction_config
+ * @property {Array<Bid>} bids? Contextual bids returned by this adapter, if any
+ * @property {Array<{bidId: String, config: {}}>} paapiAuctionConfigs? Array of paapi auction configs, each scoped to a particular bidId
  */
 
 /**
@@ -361,6 +361,18 @@ export function newBidder(spec) {
   }
 }
 
+// Transition from 'fledge' to 'paapi'
+// TODO: remove this in prebid 9
+const PAAPI_RESPONSE_PROPS = ['paapiAuctionConfigs', 'fledgeAuctionConfigs'];
+const RESPONSE_PROPS = ['bids'].concat(PAAPI_RESPONSE_PROPS);
+function getPaapiConfigs(adapterResponse) {
+  const [paapi, fledge] = PAAPI_RESPONSE_PROPS.map(prop => adapterResponse[prop]);
+  if (paapi != null && fledge != null) {
+    throw new Error(`Adapter response should use ${PAAPI_RESPONSE_PROPS[0]} over ${PAAPI_RESPONSE_PROPS[1]}, not both`);
+  }
+  return paapi ?? fledge;
+}
+
 /**
  * Run a set of bid requests - that entails converting them to HTTP requests, sending
  * them over the network, and parsing the responses.
@@ -425,12 +437,12 @@ export const processBidderRequests = hook('sync', function (spec, bids, bidderRe
       // adapters can reply with:
       // a single bid
       // an array of bids
-      // an object with {bids: [*], fledgeAuctionConfigs: [*]}
+      // a BidderAuctionResponse object ({bids: [*], paapiAuctionConfigs: [*]})
 
-      const RESPONSE_PROPS = ['bids', 'fledgeAuctionConfigs'];
       let bids, paapiConfigs;
       if (response && !Object.keys(response).some(key => !RESPONSE_PROPS.includes(key))) {
-        [bids, paapiConfigs] = RESPONSE_PROPS.map(k => response[k]);
+        bids = response.bids;
+        paapiConfigs = getPaapiConfigs(response);
       } else {
         bids = response;
       }

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -1462,6 +1462,26 @@ describe('bidderFactory', () => {
           foo: 'bar'
         }
       }
+
+      it('should unwrap bids', function() {
+        const bidder = newBidder(spec);
+        spec.interpretResponse.returns({
+          bids: bids,
+        });
+        bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
+        sinon.assert.calledWith(addBidResponseStub, 'mock/placement', sinon.match(bids[0]));
+      });
+
+      it('does not unwrap bids from a bid that happens to have a "bids" property', () => {
+        const bidder = newBidder(spec);
+        const bid = Object.assign({
+          bids: ['a', 'b']
+        }, bids[0]);
+        spec.interpretResponse.returns(bid);
+        bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
+        sinon.assert.calledWith(addBidResponseStub, 'mock/placement', sinon.match(bid));
+      })
+
       describe('when response has FLEDGE auction config', function() {
         let fledgeStub;
 
@@ -1479,17 +1499,6 @@ describe('bidderFactory', () => {
 
         beforeEach(function () {
           fledgeStub = sinon.stub();
-        });
-
-        it('should unwrap bids', function() {
-          const bidder = newBidder(spec);
-          spec.interpretResponse.returns({
-            bids: bids,
-            fledgeAuctionConfigs: []
-          });
-          bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
-          expect(addBidResponseStub.calledOnce).to.equal(true);
-          expect(addBidResponseStub.firstCall.args[0]).to.equal('mock/placement');
         });
 
         it('should call fledgeManager with FLEDGE configs', function() {

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -1501,7 +1501,17 @@ describe('bidderFactory', () => {
           paapiStub = sinon.stub();
         });
 
-        ['fledgeAuctionConfigs', 'paapiAuctionConfigs'].forEach(paapiProp => {
+        const PAAPI_PROPS = ['fledgeAuctionConfigs', 'paapiAuctionConfigs'];
+
+        it(`should not accept both ${PAAPI_PROPS.join(' and ')}`, () => {
+          const bidder = newBidder(spec);
+          spec.interpretResponse.returns(Object.fromEntries(PAAPI_PROPS.map(prop => [prop, [paapiConfig]])))
+          expect(() => {
+            bidder.callBids(bidRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
+          }).to.throw;
+        })
+
+        PAAPI_PROPS.forEach(paapiProp => {
           describe(`using ${paapiProp}`, () => {
             it('should call paapi hook with PAAPI configs', function() {
               const bidder = newBidder(spec);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Allow adapters to return an object with null/undefined paapi configs (e.g. `{bids: [...]}`), to avoid boilerplate that unwraps return values from ortbConverter.

