### PR TITLE
Build system: fix e2e tests

### DIFF
--- a/test/fake-server/fixtures/basic-outstream/request.json
+++ b/test/fake-server/fixtures/basic-outstream/request.json
@@ -19,6 +19,7 @@
         "prebid": true,
         "disable_psa": true,
         "video": {
+          "context": 4,
           "skippable": true,
           "playback_method": 2
         },
@@ -39,6 +40,7 @@
         "prebid": true,
         "disable_psa": true,
         "video": {
+          "context": 4,
           "skippable": true,
           "playback_method": 2
         },


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

In a rather embarassing turn of events, an innocous update to the [appnexus adapter](https://github.com/prebid/Prebid.js/pull/11244) broke our end-to-end tests (which, despite the name, involve mocking the appnexus response).
 
