### PR TITLE
Build system: fix source maps

### DIFF
--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -15,8 +15,7 @@ function newWebpackConfig(codeCoverage, disableFeatures) {
     mode: 'development',
     devtool: 'inline-source-map',
   });
-
-  delete webpackConfig.entry;
+  ['entry', 'optimization'].forEach(prop => delete webpackConfig[prop]);
 
   webpackConfig.module.rules
     .flatMap((r) => r.use)

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -133,10 +133,16 @@ module.exports = {
         const nodeModules = path.resolve('./node_modules');
 
         return Object.assign(libraries, {
+          common_deps: {
+            name: 'common_deps',
+            test(module) {
+              return module.resource?.startsWith(nodeModules);
+            }
+          },
           core: {
             name: 'chunk-core',
             test: (module) => {
-              return module.resource?.startsWith(core) || module.resource?.startsWith(nodeModules);
+              return module.resource?.startsWith(core);
             }
           },
           paapi: {

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -135,7 +135,6 @@ module.exports = {
         return Object.assign(libraries, {
           common_deps: {
             name: 'common_deps',
-            chunks: 'all',
             test(module) {
               return module.resource?.startsWith(nodeModules);
             }

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -135,6 +135,7 @@ module.exports = {
         return Object.assign(libraries, {
           common_deps: {
             name: 'common_deps',
+            chunks: 'all',
             test(module) {
               return module.resource?.startsWith(nodeModules);
             }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes

## Description of change

Some source maps were broken with #11269, and apparently splitting npm dependencies into their own chunk fixes them.

