### PR TITLE
Appnexus Bid Adapter: added emetriq as an alias

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -106,6 +106,7 @@ export const spec = {
   aliases: [
     { code: 'appnexusAst', gvlid: 32 },
     { code: 'emxdigital', gvlid: 183 },
+    { code: 'emetriq', gvlid: 213 },
     { code: 'pagescience', gvlid: 32 },
     { code: 'gourmetads', gvlid: 32 },
     { code: 'matomy', gvlid: 32 },

--- a/modules/sirdataRtdProvider.js
+++ b/modules/sirdataRtdProvider.js
@@ -30,6 +30,7 @@ const partnerIds = {
   'appnexus': 27446,
   'appnexusAst': 27446,
   'brealtime': 27446,
+  'emetriq': 27446,
   'emxdigital': 27446,
   'pagescience': 27446,
   'gourmetads': 33394,
@@ -353,6 +354,7 @@ export function addSegmentData(reqBids, data, moduleConfig, onDone) {
           case 'appnexus':
           case 'appnexusAst':
           case 'brealtime':
+          case 'emetriq':
           case 'emxdigital':
           case 'pagescience':
           case 'gourmetads':


### PR DESCRIPTION
## Type of change
- [X] New bidder adapter 

## Description of change

Adding projectagora as bidder adapter alias for appnexus

- Tested in appnexus bidder
- Test parameters for validating bids
```
{
  bidder: "emetriq",
  params: {
    "placementId": "32068254"
  }
}
```
- contact email of the adapter’s maintainer [admins@emetriq.com](mailto:admins@emetriq.com)
- official adapter submission

## Other information
- DOCS PR: https://github.com/prebid/prebid.github.io/pull/5246