### PR TITLE
Criteo Bid Adapter : fix invalid DSA adrender field mapping

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -255,8 +255,8 @@ export const spec = {
           if (slot.ext?.meta?.networkName) {
             bid.meta = Object.assign({}, bid.meta, { networkName: slot.ext.meta.networkName })
           }
-          if (slot.ext?.dsa?.adrender) {
-            bid.meta = Object.assign({}, bid.meta, { adrender: slot.ext.dsa.adrender })
+          if (slot.ext?.dsa) {
+            bid.meta = Object.assign({}, bid.meta, { dsa: slot.ext.dsa })
           }
           if (slot.native) {
             if (bidRequest.params.nativeCallback) {

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -2060,7 +2060,7 @@ describe('The Criteo bidding adapter', function () {
       };
       const bids = spec.interpretResponse(response, request);
       expect(bids).to.have.lengthOf(1);
-      expect(bids[0].meta.adrender).to.equal(1);
+      expect(bids[0].meta.dsa.adrender).to.equal(1);
     });
 
     it('should properly parse a bid response with a networkId with twin ad unit banner win', function () {


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
The Criteo bid adapter is not mapping DSA adrender property to where DSA  control expects to read it.