### PR TITLE
Sonobi Bid Adapter : remove experian data from bid endpoint

### DIFF
--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -98,11 +98,6 @@ export const spec = {
       'iqid': bidderSettings.get(BIDDER_CODE, 'storageAllowed') ? JSON.stringify(loadOrCreateFirstPartyData()) : null,
     };
 
-    if (deepAccess(bidderRequest, 'ortb2.experianRtidData') && deepAccess(bidderRequest, 'ortb2.experianRtidKey')) {
-      payload.expData = deepAccess(bidderRequest, 'ortb2.experianRtidData');
-      payload.expKey = deepAccess(bidderRequest, 'ortb2.experianRtidKey');
-    }
-
     const fpd = bidderRequest.ortb2;
 
     if (fpd) {

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -495,14 +495,6 @@ describe('SonobiBidAdapter', function () {
       expect(bidRequests.data.hfa).to.equal('hfakey')
     })
 
-    it('should return a properly formatted request with expData and expKey', function () {
-      bidderRequests.ortb2.experianRtidData = 'IkhlbGxvLCB3b3JsZC4gSGVsbG8sIHdvcmxkLiBIZWxsbywgd29ybGQuIg==';
-      bidderRequests.ortb2.experianRtidKey = 'sovrn-encryption-key-1';
-      const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
-      expect(bidRequests.data.expData).to.equal('IkhlbGxvLCB3b3JsZC4gSGVsbG8sIHdvcmxkLiBIZWxsbywgd29ybGQuIg==');
-      expect(bidRequests.data.expKey).to.equal('sovrn-encryption-key-1');
-    });
-
     it('should return a properly formatted request with experianRtidData and exexperianRtidKeypKey omitted from fpd', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests)
       expect(bidRequests.data.fpd.indexOf('experianRtidData')).to.equal(-1);


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Experian RTID Data can be so large that it exceeds the URI length limit on Sonobi's bid endpoint. We want to remove this data from the bid endpoint for now.


