### PR TITLE
Medianet Bid Adapter: added gvlid for trustedstack alias.

### DIFF
--- a/modules/medianetBidAdapter.js
+++ b/modules/medianetBidAdapter.js
@@ -57,7 +57,7 @@ mnData.urlData = {
 };
 
 const aliases = [
-  { code: TRUSTEDSTACK_CODE },
+  { code: TRUSTEDSTACK_CODE, gvlid: 1288 },
 ];
 
 getGlobal().medianetGlobals = getGlobal().medianetGlobals || {};


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
contact email of the adapter’s maintainer: [prebid-support@media.net](mailto:prebid-support@media.net)
