### PR TITLE
Criteo Bid Adapter : add support for grid bid parameters

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -473,6 +473,7 @@ function checkNativeSendId(bidRequest) {
  */
 function buildCdbRequest(context, bidRequests, bidderRequest) {
   let networkId;
+  let pubid;
   let schain;
   let userIdAsEids;
   let regs = Object.assign({}, {
@@ -490,6 +491,7 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
         userIdAsEids = bidRequest.userIdAsEids;
       }
       networkId = bidRequest.params.networkId || networkId;
+      pubid = bidRequest.params.pubid || pubid;
       schain = bidRequest.schain || schain;
       const slot = {
         slotid: bidRequest.bidId,
@@ -580,6 +582,9 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
   };
   if (networkId) {
     request.publisher.networkid = networkId;
+  }
+  if (pubid) {
+    request.publisher.id = pubid;
   }
 
   request.source = {

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -515,6 +515,10 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
       if (bidRequest.nativeOrtbRequest?.assets) {
         slot.ext = Object.assign({}, slot.ext, { assets: bidRequest.nativeOrtbRequest.assets });
       }
+      if (bidRequest.params.uid) {
+        slot.ext = Object.assign({}, slot.ext, { bidder: { uid: bidRequest.params.uid } });
+      }
+
       if (bidRequest.params.publisherSubId) {
         slot.publishersubid = bidRequest.params.publisherSubId;
       }

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -1949,6 +1949,50 @@ describe('The Criteo bidding adapter', function () {
       expect(request.data.slots[0].ext).to.not.have.property('ae');
     });
 
+    it('should properly transmit a pubid if available', function () {
+      const bidderRequest = {};
+      const bidRequests = [
+        {
+          bidder: 'criteo',
+          adUnitCode: 'bid-123',
+          ortb2Imp: {
+            ext: {
+              tid: 'transaction-123',
+            },
+          },
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
+          params: {
+            zoneId: 123,
+          },
+        },
+        {
+          bidder: 'criteo',
+          adUnitCode: 'bid-234',
+          ortb2Imp: {
+            ext: {
+              tid: 'transaction-234',
+            },
+          },
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250], [728, 90]]
+            }
+          },
+          params: {
+            networkId: 456,
+            pubid: "pub-888"
+          },
+        },
+      ];
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const ortbRequest = request.data;
+      expect(ortbRequest.publisher.pubid).to.equal("pub-888");
+    });
+
     it('should properly transmit device.ext.cdep if available', function () {
       const bidderRequest = {
         ortb2: {

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -1949,7 +1949,7 @@ describe('The Criteo bidding adapter', function () {
       expect(request.data.slots[0].ext).to.not.have.property('ae');
     });
 
-    it('should properly transmit a pubid if available', function () {
+    it('should properly transmit the pubid and slot uid if available', function () {
       const bidderRequest = {};
       const bidRequests = [
         {
@@ -1984,13 +1984,16 @@ describe('The Criteo bidding adapter', function () {
           },
           params: {
             networkId: 456,
-            pubid: 'pub-888'
+            pubid: 'pub-888',
+            uid: 'ad-unit-1'
           },
         },
       ];
       const request = spec.buildRequests(bidRequests, bidderRequest);
       const ortbRequest = request.data;
       expect(ortbRequest.publisher.id).to.equal('pub-888');
+      expect(request.data.slots[0].ext.bidder).to.be.undefined;
+      expect(request.data.slots[1].ext.bidder.uid).to.equal('ad-unit-1');
     });
 
     it('should properly transmit device.ext.cdep if available', function () {

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -1985,7 +1985,7 @@ describe('The Criteo bidding adapter', function () {
           params: {
             networkId: 456,
             pubid: 'pub-888',
-            uid: 'ad-unit-1'
+            uid: 888
           },
         },
       ];
@@ -1993,7 +1993,7 @@ describe('The Criteo bidding adapter', function () {
       const ortbRequest = request.data;
       expect(ortbRequest.publisher.id).to.equal('pub-888');
       expect(request.data.slots[0].ext.bidder).to.be.undefined;
-      expect(request.data.slots[1].ext.bidder.uid).to.equal('ad-unit-1');
+      expect(request.data.slots[1].ext.bidder.uid).to.equal(888);
     });
 
     it('should properly transmit device.ext.cdep if available', function () {

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -1984,13 +1984,13 @@ describe('The Criteo bidding adapter', function () {
           },
           params: {
             networkId: 456,
-            pubid: "pub-888"
+            pubid: 'pub-888'
           },
         },
       ];
       const request = spec.buildRequests(bidRequests, bidderRequest);
       const ortbRequest = request.data;
-      expect(ortbRequest.publisher.pubid).to.equal("pub-888");
+      expect(ortbRequest.publisher.id).to.equal('pub-888');
     });
 
     it('should properly transmit device.ext.cdep if available', function () {


### PR DESCRIPTION
- [x] Feature

## Description of change
Adding two optional bid parameters, for backward compatibility with grid publishers.
- `pubid` representing the MediaGrid publisher id (`string`)
- `uid` representing the MediaGrid ad slot id (`integer`)