### PR TITLE
Adnuntius Bid Adapter: network-scope metadata from adserver.

### DIFF
--- a/integrationExamples/gpt/adnuntius_example.html
+++ b/integrationExamples/gpt/adnuntius_example.html
@@ -17,7 +17,7 @@
                     bidder: 'adnuntius',
                     params: {
                         auId: "201208",
-                        network: "adnuntius",
+                        network: "1287",
                         bidType: 'netBid'
                     }
                 }]
@@ -49,6 +49,12 @@
                     bidType: 'netBid'
                 }
             });
+
+            pbjs.bidderSettings = {
+                standard: {
+                    storageAllowed: true
+                }
+            };
 
             pbjs.addAdUnits(adUnits);
             pbjs.requestBids({bidsBackHandler: initAdserver});

--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -15,7 +15,8 @@ const GVLID = 855;
 const DEFAULT_VAST_VERSION = 'vast4'
 const MAXIMUM_DEALS_LIMIT = 5;
 const VALID_BID_TYPES = ['netBid', 'grossBid'];
-const META_DATA_KEY = 'adn.metaData';
+const METADATA_KEY = 'adn.metaData';
+const METADATA_KEY_SEPARATOR = '@@@';
 
 export const misc = {
   getUnixTimestamp: function (addDays, asMinutes) {
@@ -28,23 +29,28 @@ const storageTool = (function () {
   const storage = getStorageManager({ bidderCode: BIDDER_CODE });
   let metaInternal;
 
-  const getMetaInternal = function () {
+  const getMetaDataFromLocalStorage = function (pNetwork) {
     if (!storage.localStorageIsEnabled()) {
       return [];
     }
 
     let parsedJson;
     try {
-      parsedJson = JSON.parse(storage.getDataFromLocalStorage(META_DATA_KEY));
+      parsedJson = JSON.parse(storage.getDataFromLocalStorage(METADATA_KEY));
     } catch (e) {
       return [];
+    }
+
+    let network = pNetwork;
+    if (Array.isArray(pNetwork)) {
+      network = (pNetwork.find((p) => p.network) || {}).network;
     }
 
     let filteredEntries = parsedJson ? parsedJson.filter((datum) => {
       if (datum.key === 'voidAuIds' && Array.isArray(datum.value)) {
         return true;
       }
-      return datum.key && datum.value && datum.exp && datum.exp > misc.getUnixTimestamp();
+      return datum.key && datum.value && datum.exp && datum.exp > misc.getUnixTimestamp() && (!network || network === datum.network);
     }) : [];
     const voidAuIdsEntry = filteredEntries.find(entry => entry.key === 'voidAuIds');
     if (voidAuIdsEntry) {
@@ -57,7 +63,7 @@ const storageTool = (function () {
     return filteredEntries;
   };
 
-  const setMetaInternal = function (apiResponse) {
+  const setMetaInternal = function (apiRespMetadata, network) {
     if (!storage.localStorageIsEnabled()) {
       return;
     }
@@ -74,41 +80,48 @@ const storageTool = (function () {
       return notNewExistingAuIds.concat(apiIdsArray) || [];
     }
 
-    const metaAsObj = getMetaInternal().reduce((a, entry) => ({ ...a, [entry.key]: { value: entry.value, exp: entry.exp } }), {});
-    for (const key in apiResponse) {
+    // use the metadata key separator to distinguish the same key for different networks.
+    const metaAsObj = getMetaDataFromLocalStorage().reduce((a, entry) => ({ ...a, [entry.key + METADATA_KEY_SEPARATOR + (entry.network ? entry.network : '')]: { value: entry.value, exp: entry.exp, network: entry.network } }), {});
+    for (const key in apiRespMetadata) {
       if (key !== 'voidAuIds') {
-        metaAsObj[key] = {
-          value: apiResponse[key],
-          exp: misc.getUnixTimestamp(100)
+        metaAsObj[key + METADATA_KEY_SEPARATOR + network] = {
+          value: apiRespMetadata[key],
+          exp: misc.getUnixTimestamp(100),
+          network: network
         }
       }
     }
-    const currentAuIds = updateVoidAuIds(metaAsObj.voidAuIds || [], apiResponse.voidAuIds);
+    const currentAuIds = updateVoidAuIds(metaAsObj.voidAuIds || [], apiRespMetadata.voidAuIds);
     if (currentAuIds.length > 0) {
       metaAsObj.voidAuIds = { value: currentAuIds };
     }
     const metaDataForSaving = Object.entries(metaAsObj).map((entrySet) => {
-      if (entrySet[0] === 'voidAuIds') {
+      if (entrySet.length !== 2) {
+        return {};
+      }
+      const key = entrySet[0].split(METADATA_KEY_SEPARATOR)[0];
+      if (key === 'voidAuIds') {
         return {
-          key: entrySet[0],
+          key: key,
           value: entrySet[1].value
         };
       }
       return {
-        key: entrySet[0],
+        key: key,
         value: entrySet[1].value,
-        exp: entrySet[1].exp
+        exp: entrySet[1].exp,
+        network: entrySet[1].network
       }
-    });
-    storage.setDataInLocalStorage(META_DATA_KEY, JSON.stringify(metaDataForSaving));
+    }).filter(entry => entry.key);
+    storage.setDataInLocalStorage(METADATA_KEY, JSON.stringify(metaDataForSaving));
   };
 
-  const getUsi = function (meta, ortb2, bidderRequest) {
+  const getUsi = function (meta, ortb2, bidParams) {
     // Fetch user id from parameters.
-    for (let i = 0; i < (bidderRequest.bids || []).length; i++) {
-      const bid = bidderRequest.bids[i];
-      if (bid.params && bid.params.userId) {
-        return bid.params.userId;
+    for (let i = 0; i < bidParams.length; i++) {
+      const bidParam = bidParams[i];
+      if (bidParam.userId) {
+        return bidParam.userId;
       }
     }
     if (ortb2 && ortb2.user && ortb2.user.id) {
@@ -136,8 +149,11 @@ const storageTool = (function () {
   return {
     refreshStorage: function (bidderRequest) {
       const ortb2 = bidderRequest.ortb2 || {};
-      metaInternal = getMetaInternal().reduce((a, entry) => ({ ...a, [entry.key]: entry.value }), {});
-      metaInternal.usi = getUsi(metaInternal, ortb2, bidderRequest);
+      const bidParams = (bidderRequest.bids || []).map((b) => {
+        return b.params ? b.params : {};
+      });
+      metaInternal = getMetaDataFromLocalStorage(bidParams).reduce((a, entry) => ({ ...a, [entry.key]: entry.value }), {});
+      metaInternal.usi = getUsi(metaInternal, ortb2, bidParams);
       if (!metaInternal.usi) {
         delete metaInternal.usi;
       }
@@ -148,15 +164,17 @@ const storageTool = (function () {
       }
       metaInternal.segments = getSegmentsFromOrtb(ortb2);
     },
-    saveToStorage: function (serverData) {
-      setMetaInternal(serverData);
+    saveToStorage: function (serverData, network) {
+      setMetaInternal(serverData, network);
     },
     getUrlRelatedData: function () {
+      // getting the URL information is theoretically not network-specific
       const { segments, usi, voidAuIdsArray } = metaInternal;
       return { segments, usi, voidAuIdsArray };
     },
-    getPayloadRelatedData: function () {
-      const { segments, usi, userId, voidAuIdsArray, voidAuIds, ...payloadRelatedData } = metaInternal;
+    getPayloadRelatedData: function (network) {
+      // getting the payload data should be network-specific
+      const { segments, usi, userId, voidAuIdsArray, voidAuIds, ...payloadRelatedData } = getMetaDataFromLocalStorage(network).reduce((a, entry) => ({...a, [entry.key]: entry.value}), {});
       return payloadRelatedData;
     }
   };
@@ -223,7 +241,7 @@ export const spec = {
       networks[network].adUnits = networks[network].adUnits || [];
       if (bidderRequest && bidderRequest.refererInfo) networks[network].context = bidderRequest.refererInfo.page;
 
-      const payloadRelatedData = storageTool.getPayloadRelatedData();
+      const payloadRelatedData = storageTool.getPayloadRelatedData(bid.params.network);
       if (Object.keys(payloadRelatedData).length > 0) {
         networks[network].metaData = payloadRelatedData;
       }
@@ -239,7 +257,7 @@ export const spec = {
     }
 
     const requests = [];
-    const networkKeys = Object.keys(networks)
+    const networkKeys = Object.keys(networks);
     for (let j = 0; j < networkKeys.length; j++) {
       const network = networkKeys[j];
       if (network.indexOf('_video') > -1) { queryParamsAndValues.push('tt=' + DEFAULT_VAST_VERSION) }
@@ -257,7 +275,7 @@ export const spec = {
 
   interpretResponse: function (serverResponse, bidRequest) {
     if (serverResponse.body.metaData) {
-      storageTool.saveToStorage(serverResponse.body.metaData);
+      storageTool.saveToStorage(serverResponse.body.metaData, serverResponse.body.network);
     }
     const adUnits = serverResponse.body.adUnits;
 

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -12,7 +12,7 @@ describe('adnuntiusBidAdapter', function() {
   const EURO_URL = 'https://europe.delivery.adnuntius.com/i?tzo=';
   const usi = utils.generateUUID()
 
-  const meta = [{key: 'valueless'}, {value: 'keyless'}, {key: 'voidAuIds'}, {key: 'voidAuIds', value: [{auId: '11118b6bc', exp: misc.getUnixTimestamp()}, {exp: misc.getUnixTimestamp(1)}]}, {key: 'valid', value: 'also-valid', exp: misc.getUnixTimestamp(1)}, {key: 'expired', value: 'fwefew', exp: misc.getUnixTimestamp()}, {key: 'usi', value: 'should be skipped because timestamp', exp: misc.getUnixTimestamp()}, {key: 'usi', value: usi, exp: misc.getUnixTimestamp(100)}, {key: 'usi', value: 'should be skipped because timestamp', exp: misc.getUnixTimestamp()}]
+  const meta = [{key: 'valueless'}, {value: 'keyless'}, {key: 'voidAuIds'}, {key: 'voidAuIds', value: [{auId: '11118b6bc', exp: misc.getUnixTimestamp()}, {exp: misc.getUnixTimestamp(1)}]}, {key: 'valid-withnetwork', value: 'also-valid-network', network: 'the-network', exp: misc.getUnixTimestamp(1)}, {key: 'valid', value: 'also-valid', exp: misc.getUnixTimestamp(1)}, {key: 'expired', value: 'fwefew', exp: misc.getUnixTimestamp()}, {key: 'usi', value: 'should be skipped because timestamp', exp: misc.getUnixTimestamp(), network: 'adnuntius'}, {key: 'usi', value: usi, exp: misc.getUnixTimestamp(100), network: 'adnuntius'}, {key: 'usi', value: 'should be skipped because timestamp', exp: misc.getUnixTimestamp()}]
   let storage;
 
   before(() => {
@@ -257,7 +257,8 @@ describe('adnuntiusBidAdapter', function() {
         'usi': 'from-api-server dude',
         'voidAuIds': '00000000000abcde;00000000000fffff',
         'randomApiKey': 'randomApiValue'
-      }
+      },
+      'network': 'some-network-id'
     }
   }
   const serverVideoResponse = {
@@ -464,7 +465,7 @@ describe('adnuntiusBidAdapter', function() {
       expect(request[0]).to.have.property('url');
       expect(request[0].url).to.equal(ENDPOINT_URL);
       expect(request[0]).to.have.property('data');
-      expect(request[0].data).to.equal('{"adUnits":[{"auId":"000000000008b6bc","targetId":"123","maxDeals":1,"dimensions":[[640,480],[600,400]]},{"auId":"0000000000000551","targetId":"adn-0000000000000551","dimensions":[[1640,1480],[1600,1400]]}],"metaData":{"valid":"also-valid"}}');
+      expect(request[0].data).to.equal('{"adUnits":[{"auId":"000000000008b6bc","targetId":"123","maxDeals":1,"dimensions":[[640,480],[600,400]]},{"auId":"0000000000000551","targetId":"adn-0000000000000551","dimensions":[[1640,1480],[1600,1400]]}]}');
     });
 
     it('Test requests with no local storage', function() {
@@ -695,7 +696,7 @@ describe('adnuntiusBidAdapter', function() {
             network: 'adnuntius'
           }
         }
-      ]
+      ];
       const request = config.runWithBidder('adnuntius', () => spec.buildRequests(req, { bids: req }));
       expect(request.length).to.equal(1);
       expect(request[0]).to.have.property('url')
@@ -913,10 +914,11 @@ describe('adnuntiusBidAdapter', function() {
       expect(interpretedResponse[1].dealCount).to.equal(0);
 
       const results = JSON.parse(storage.getDataFromLocalStorage('adn.metaData'));
-      const usiEntry = results.find(entry => entry.key === 'usi');
+      const usiEntry = results.find(entry => entry.key === 'usi' && entry.network === 'some-network-id');
       expect(usiEntry.key).to.equal('usi');
       expect(usiEntry.value).to.equal('from-api-server dude');
       expect(usiEntry.exp).to.be.greaterThan(misc.getUnixTimestamp(90));
+      expect(usiEntry.network).to.equal('some-network-id')
 
       const voidAuIdsEntry = results.find(entry => entry.key === 'voidAuIds');
       expect(voidAuIdsEntry.key).to.equal('voidAuIds');
@@ -937,6 +939,7 @@ describe('adnuntiusBidAdapter', function() {
       const randomApiEntry = results.find(entry => entry.key === 'randomApiKey');
       expect(randomApiEntry.key).to.equal('randomApiKey');
       expect(randomApiEntry.value).to.equal('randomApiValue');
+      expect(randomApiEntry.network).to.equal('some-network-id');
       expect(randomApiEntry.exp).to.be.greaterThan(misc.getUnixTimestamp(90));
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Code style update (formatting, local variables)

## Description of change
<!-- Describe the change proposed in this pull request -->
Metadata from the adserver is saved into local storage, when permitted, to be used in future requests.

This metadata has not been network-scoped so different customers running off the same page would contaminate each others' metadata. This change fixes that problem.
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
