### PR TITLE
OpenWeb Bid Adapter: Remove Multi Currency Support

### DIFF
--- a/modules/openwebBidAdapter.js
+++ b/modules/openwebBidAdapter.js
@@ -286,7 +286,6 @@ function generateBidParameters(bid, bidderRequest) {
   const {params} = bid;
   const mediaType = isBanner(bid) ? BANNER : VIDEO;
   const sizesArray = getSizesArray(bid, mediaType);
-  const currency = params.currency || config.getConfig('currency.adServerCurrency') || DEFAULT_CURRENCY;
 
   // fix floor price in case of NAN
   if (isNaN(params.floorPrice)) {
@@ -297,8 +296,7 @@ function generateBidParameters(bid, bidderRequest) {
     mediaType,
     adUnitCode: getBidIdParameter('adUnitCode', bid),
     sizes: sizesArray,
-    currency: currency,
-    floorPrice: Math.max(getFloor(bid, mediaType, currency), params.floorPrice),
+    floorPrice: Math.max(getFloor(bid, mediaType), params.floorPrice),
     bidId: getBidIdParameter('bidId', bid),
     loop: getBidIdParameter('bidderRequestsCount', bid),
     bidderRequestId: getBidIdParameter('bidderRequestId', bid),

--- a/modules/openwebBidAdapter.js
+++ b/modules/openwebBidAdapter.js
@@ -141,16 +141,16 @@ registerBidder(spec);
  * @param bid {bid}
  * @returns {Number}
  */
-function getFloor(bid, mediaType, currency) {
+function getFloor(bid, mediaType) {
   if (!isFn(bid.getFloor)) {
     return 0;
   }
   let floorResult = bid.getFloor({
-    currency: currency,
+    currency: DEFAULT_CURRENCY,
     mediaType: mediaType,
     size: '*'
   });
-  return floorResult.currency === currency && floorResult.floor ? floorResult.floor : 0;
+  return floorResult.currency === DEFAULT_CURRENCY && floorResult.floor ? floorResult.floor : 0;
 }
 
 /**

--- a/modules/openwebBidAdapter.md
+++ b/modules/openwebBidAdapter.md
@@ -24,8 +24,6 @@ The adapter supports Video and Display demand.
 | `floorPrice` | optional | Number |  Minimum price in USD. Misuse of this parameter can impact revenue | 2.00
 | `placementId` | optional | String |  A unique placement identifier  | "12345678"
 | `testMode` | optional | Boolean |  This activates the test mode  | false
-| `currency` | optional | String | 3 letters currency | "EUR"
-
 
 # Test Parameters
 ```javascript

--- a/test/spec/modules/openwebBidAdapter_spec.js
+++ b/test/spec/modules/openwebBidAdapter_spec.js
@@ -178,16 +178,6 @@ describe('openwebAdapter', function () {
       expect(request.data.bids[1].mediaType).to.equal(BANNER)
     });
 
-    it('should send the correct currency in bid request', function () {
-      const bid = utils.deepClone(bidRequests[0]);
-      bid.params = {
-        'currency': 'EUR'
-      };
-      const expectedCurrency = bid.params.currency;
-      const request = spec.buildRequests([bid], bidderRequest);
-      expect(request.data.bids[0].currency).to.equal(expectedCurrency);
-    });
-
     it('should respect syncEnabled option', function() {
       config.setConfig({
         userSync: {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
OpenWeb supports only USD in their ad server for now.