### PR TITLE
PAAPI: emit addComponentAuction event

### DIFF
--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -549,6 +549,7 @@ export const registerSyncInner = hook('async', function(spec, responses, gdprCon
 }, 'registerSyncs')
 
 export const addComponentAuction = hook('sync', (request, fledgeAuctionConfig) => {
+  events.emit(CONSTANTS.EVENTS.ADD_COMPONENT_AUCTION, request, fledgeAuctionConfig);
 }, 'addComponentAuction');
 
 // check that the bid has a width and height set

--- a/src/constants.json
+++ b/src/constants.json
@@ -51,7 +51,8 @@
     "BID_VIEWABLE": "bidViewable",
     "STALE_RENDER": "staleRender",
     "BILLABLE_EVENT": "billableEvent",
-    "BID_ACCEPTED": "bidAccepted"
+    "BID_ACCEPTED": "bidAccepted",
+    "ADD_COMPONENT_AUCTION": "addComponentAuction"
   },
   "AD_RENDER_FAILED_REASON": {
     "PREVENT_WRITING_ON_MAIN_DOCUMENT": "preventWritingOnMainDocument",

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -1588,4 +1588,29 @@ describe('bidderFactory', () => {
       });
     })
   });
+
+  describe('addComponentAuction', () => {
+    let requestStub
+    let fledgeAuctionConfigStub
+    let eventEmitterSpy
+
+    beforeEach(() => {
+      eventEmitterSpy = sinon.spy(events, 'emit');
+      requestStub = sinon.stub();
+      fledgeAuctionConfigStub = sinon.stub();
+    })
+
+    afterEach(() => {
+      eventEmitterSpy.restore();
+    })
+
+    it(`should emit an addComponentAuction event`, () => {
+      addComponentAuction(requestStub, fledgeAuctionConfigStub);
+      const eventCall = eventEmitterSpy.withArgs(CONSTANTS.EVENTS.ADD_COMPONENT_AUCTION).getCalls()[0];
+      const [event, request, fledgeAuctionConfig] = eventCall.args;
+      assert.equal(event, CONSTANTS.EVENTS.ADD_COMPONENT_AUCTION)
+      assert.equal(request, requestStub);
+      assert.equal(fledgeAuctionConfig, fledgeAuctionConfigStub);
+    })
+  });
 })


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Component Auction Configs appear to be entirely contained within the
PAAPI + fledgeForGPT modules. This event provides a way to access
those configs from outside of those 2 modules.
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
