### PR TITLE
33Across User ID Module: encode fp parameter

### DIFF
--- a/modules/33acrossIdSystem.js
+++ b/modules/33acrossIdSystem.js
@@ -80,7 +80,7 @@ function calculateQueryStringParams(pid, gdprConsentData, storageConfig) {
 
   const fp = getStoredValue(STORAGE_FPID_KEY, storageConfig);
   if (fp) {
-    params.fp = fp;
+    params.fp = encodeURIComponent(fp);
   }
 
   return params;

--- a/test/spec/modules/33acrossIdSystem_spec.js
+++ b/test/spec/modules/33acrossIdSystem_spec.js
@@ -493,7 +493,7 @@ describe('33acrossIdSystem', () => {
     });
 
     context('when a first-party ID is present in local storage', () => {
-      it('should call endpoint with the first-party ID included', () => {
+      it('should call endpoint with the encoded first-party ID included', () => {
         const completeCallback = () => {};
         const { callback } = thirthyThreeAcrossIdSubmodule.getId({
           params: {
@@ -506,13 +506,13 @@ describe('33acrossIdSystem', () => {
 
         sinon.stub(storage, 'getDataFromLocalStorage')
           .withArgs('33acrossIdFp')
-          .returns('33acrossIdFpValue');
+          .returns('33acrossIdFpValue+');
 
         callback(completeCallback);
 
         const [request] = server.requests;
 
-        expect(request.url).to.contain('fp=33acrossIdFpValue');
+        expect(request.url).to.contain('fp=33acrossIdFpValue%2B');
 
         storage.getDataFromLocalStorage.restore();
       });


### PR DESCRIPTION
## Type of change
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Encode the `fp` query string parameter
