### PR TITLE
Magnite Analytics Adapter: Add PBS ARs flag to adUnit

### DIFF
--- a/modules/magniteAnalyticsAdapter.js
+++ b/modules/magniteAnalyticsAdapter.js
@@ -905,6 +905,8 @@ magniteAdapter.track = ({ eventType, args }) => {
           'source', () => bid.src === 's2s' ? 'server' : 'client',
           'status', () => 'no-bid'
         ]);
+        // add a pbs flag if one of the bids has a server source
+        if (adUnit.bids[bid.bidId].source === 'server') adUnit.pbsRequest = 1;
         // set acct site zone id on adunit
         if ((!adUnit.siteId || !adUnit.zoneId) && rubiconAliases.indexOf(bid.bidder) !== -1) {
           if (deepAccess(bid, 'params.accountId') == accountId) {

--- a/test/spec/modules/magniteAnalyticsAdapter_spec.js
+++ b/test/spec/modules/magniteAnalyticsAdapter_spec.js
@@ -1520,6 +1520,8 @@ describe('magnite analytics adapter', function () {
 
       // bid source should be 'server'
       expectedMessage.auctions[0].adUnits[0].bids[0].source = 'server';
+      // if one of bids.source === server should add pbsRequest flag to adUnit
+      expectedMessage.auctions[0].adUnits[0].pbsRequest = 1;
       expectedMessage.bidsWon[0].source = 'server';
       expect(message).to.deep.equal(expectedMessage);
     });


### PR DESCRIPTION
## Type of change

- [X] Feature

## Description of change
Added a way to report on ARs to PBS from a web wrapper in PBA: for any adunitcode with 1 or more bidders that are source = server, added a flag to to indicate a call to PBS was made (flag = pbsRequest)