### PR TITLE
Adnuntius Bid Adapter: allow dev end point option for adserver calls

### DIFF
--- a/integrationExamples/gpt/adnuntius_example.html
+++ b/integrationExamples/gpt/adnuntius_example.html
@@ -16,8 +16,8 @@
                 bids: [{
                     bidder: 'adnuntius',
                     params: {
-                        auId: "201208",
-                        network: "1287",
+                        auId: "4d0",
+                        network: "60",
                         bidType: 'netBid'
                     }
                 }]
@@ -46,7 +46,8 @@
             pbjs.setBidderConfig({
                 bidders: ['adnuntius'],
                 config: {
-                    bidType: 'netBid'
+                    bidType: 'netBid',
+                    env: 'dev'
                 }
             });
 

--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -9,6 +9,7 @@ const BIDDER_CODE_DEAL_ALIAS_BASE = 'adndeal';
 const BIDDER_CODE_DEAL_ALIASES = [1, 2, 3, 4, 5].map(num => {
   return BIDDER_CODE_DEAL_ALIAS_BASE + num;
 });
+const DEV_ENDPOINT_URL = 'https://adserver.dev.adnuntius.com/i';
 const ENDPOINT_URL = 'https://ads.adnuntius.delivery/i';
 const ENDPOINT_URL_EUROPE = 'https://europe.delivery.adnuntius.com/i';
 const GVLID = 855;
@@ -258,10 +259,11 @@ export const spec = {
 
     const requests = [];
     const networkKeys = Object.keys(networks);
+    const devEnv = config.getConfig().env === 'dev';
     for (let j = 0; j < networkKeys.length; j++) {
       const network = networkKeys[j];
       if (network.indexOf('_video') > -1) { queryParamsAndValues.push('tt=' + DEFAULT_VAST_VERSION) }
-      const requestURL = gdprApplies ? ENDPOINT_URL_EUROPE : ENDPOINT_URL
+      const requestURL = devEnv ? DEV_ENDPOINT_URL : gdprApplies ? ENDPOINT_URL_EUROPE : ENDPOINT_URL
       requests.push({
         method: 'POST',
         url: requestURL + '?' + queryParamsAndValues.join('&'),

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -9,6 +9,7 @@ import {getGlobal} from '../../../src/prebidGlobal';
 
 describe('adnuntiusBidAdapter', function() {
   const URL = 'https://ads.adnuntius.delivery/i?tzo=';
+  const DEV_URL = 'https://adserver.dev.adnuntius.com/i?tzo=';
   const EURO_URL = 'https://europe.delivery.adnuntius.com/i?tzo=';
   const usi = utils.generateUUID()
 
@@ -39,6 +40,7 @@ describe('adnuntiusBidAdapter', function() {
   const tzo = new Date().getTimezoneOffset();
   const ENDPOINT_URL_BASE = `${URL}${tzo}&format=prebid`;
   const ENDPOINT_URL = `${ENDPOINT_URL_BASE}&userId=${usi}`;
+  const DEV_ENDPOINT_URL = `${DEV_URL}${tzo}&format=prebid&userId=${usi}`;
   const ENDPOINT_URL_VIDEO = `${ENDPOINT_URL_BASE}&userId=${usi}&tt=vast4`;
   const ENDPOINT_URL_NOCOOKIE = `${ENDPOINT_URL_BASE}&userId=${usi}&noCookies=true`;
   const ENDPOINT_URL_SEGMENTS = `${ENDPOINT_URL_BASE}&segments=segment1,segment2,segment3&userId=${usi}`;
@@ -456,6 +458,25 @@ describe('adnuntiusBidAdapter', function() {
   });
 
   describe('buildRequests', function() {
+    it('Test dev requests', function() {
+      config.setBidderConfig({
+        bidders: ['adnuntius'],
+        config: {
+          env: 'dev'
+        }
+      });
+
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidderRequests, {}));
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('bid');
+      const bid = request[0].bid[0]
+      expect(bid).to.have.property('bidId');
+      expect(request[0]).to.have.property('url');
+      expect(request[0].url).to.equal(DEV_ENDPOINT_URL);
+      expect(request[0]).to.have.property('data');
+      expect(request[0].data).to.equal('{"adUnits":[{"auId":"000000000008b6bc","targetId":"123","maxDeals":1,"dimensions":[[640,480],[600,400]]},{"auId":"0000000000000551","targetId":"adn-0000000000000551","dimensions":[[1640,1480],[1600,1400]]}],"metaData":{"valid":"also-valid"}}');
+    });
+
     it('Test requests', function() {
       const request = spec.buildRequests(bidderRequests, {});
       expect(request.length).to.equal(1);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Enable using the dev adserver for ad delivery for testing purposes.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
