### PR TITLE
Adnuntius Bid Adapter: send script-override parameter to ad server

### DIFF
--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -209,6 +209,11 @@ export const spec = {
       queryParamsAndValues.push('gdpr=' + flag);
     }
 
+    const searchParams = new URLSearchParams(window.location.search);
+    if (searchParams.has('script-override')) {
+      queryParamsAndValues.push('so=' + searchParams.get('script-override'));
+    }
+
     storageTool.refreshStorage(bidderRequest);
 
     const urlRelatedMetaData = storageTool.getUrlRelatedData();


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Pass on script-override parameter from the URL to the adserver for testing purposes. This enables loading the internal Adnuntius ad-loading script from a separate location that is editable.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
