### PR TITLE
Optable Bid Adapter: initial release

### DIFF
--- a/modules/optableBidAdapter.js
+++ b/modules/optableBidAdapter.js
@@ -1,0 +1,42 @@
+import * as utils from '../src/utils.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { config } from '../src/config.js';
+import { BANNER } from '../src/mediaTypes.js';
+import { ortbConverter } from '../libraries/ortbConverter/converter.js'
+const converter = ortbConverter({
+  context: { netRevenue: true, ttl: 300 },
+  imp(buildImp, bidRequest, context) {
+    const imp = buildImp(bidRequest, context);
+    utils.mergeDeep(imp, {
+      tagid: bidRequest.params.site,
+    });
+    return imp;
+  }
+});
+const BIDDER_CODE = 'optable';
+const DEFAULT_REGION = 'ca'
+const DEFAULT_ORIGIN = 'https://ads.optable.co'
+
+export const spec = {
+  code: BIDDER_CODE,
+  isBidRequestValid: function(bid) { return !!bid.params?.site },
+  buildRequests: function(bidRequests, bidderRequest) {
+    const region = config.getConfig('optable.region') ?? DEFAULT_REGION
+    const origin = config.getConfig('optable.origin') ?? DEFAULT_ORIGIN
+    const requestURL = `${origin}/${region}/ortb2/v1/ssp/bid`
+    const data = converter.toORTB({ bidRequests, bidderRequest, context: { mediaType: BANNER } });
+
+    return { method: 'POST', url: requestURL, data }
+  },
+  interpretResponse: function(response, request) {
+    const bids = converter.fromORTB({ response: response.body, request: request.data }).bids
+    const auctionConfigs = (response.body.ext?.optable?.fledge?.auctionconfigs ?? []).map((cfg) => {
+      const { impid, ...config } = cfg;
+      return { bidId: impid, config }
+    })
+
+    return { bids, fledgeAuctionConfigs: auctionConfigs }
+  },
+  supportedMediaTypes: [BANNER]
+}
+registerBidder(spec);

--- a/modules/optableBidAdapter.md
+++ b/modules/optableBidAdapter.md
@@ -1,0 +1,41 @@
+# Overview
+
+```
+Module Name: Optable Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: prebid@optable.co
+```
+
+# Description
+
+Module that connects to Optable's demand sources.
+
+# Bid Parameters
+## Banner
+
+| Name | Scope | Type | Description | Example
+| ---- | ----- | ---- | ----------- | -------
+| `site` | required | String | Optable site ID provided by your Optable representative. | "aaaaaaaa"
+
+## Video
+
+Not supported at the moment.
+
+# Example
+```javascript
+var adUnits = [
+  {
+    code: 'test-div',
+    sizes: [[728, 90]],  // a display size
+    mediaTypes: {'banner': {}},
+    bids: [
+      {
+        bidder: 'optable',
+        params: {
+          site: 'aaaaaaaa',
+        },
+      },
+    ],
+  },
+];
+```

--- a/test/spec/modules/optableBidAdapter_spec.js
+++ b/test/spec/modules/optableBidAdapter_spec.js
@@ -1,0 +1,89 @@
+import { expect } from 'chai';
+import { spec } from 'modules/optableBidAdapter';
+import { newBidder } from 'src/adapters/bidderFactory.js';
+
+describe('optableBidAdapter', function() {
+  const adapter = newBidder(spec);
+
+  describe('isBidRequestValid', function() {
+    const validBid = {
+      bidder: 'optable',
+      params: { site: '123' },
+    };
+
+    it('should return true when required params are present', function() {
+      expect(spec.isBidRequestValid(validBid)).to.be.true;
+    });
+
+    it('should return false when site is missing', function() {
+      const invalidBid = { ...validBid };
+      delete invalidBid.params.site;
+      expect(spec.isBidRequestValid(invalidBid)).to.be.false;
+    });
+  });
+
+  describe('buildRequests', function() {
+    const validBid = {
+      bidder: 'optable',
+      params: {
+        site: '123',
+      },
+    };
+
+    const bidderRequest = {
+      bidderRequestId: 'bid123',
+      refererInfo: {
+        domain: 'example.com',
+        page: 'https://example.com/page',
+        ref: 'https://referrer.com'
+      },
+    };
+
+    it('should include site as tagid in imp', function() {
+      const request = spec.buildRequests([validBid], bidderRequest);
+      expect(request.url).to.equal('https://ads.optable.co/ca/ortb2/v1/ssp/bid');
+      expect(request.method).to.equal('POST');
+      expect(request.data.imp[0].tagid).to.equal('123')
+    });
+  });
+
+  describe('interpretResponse', function() {
+    const validBid = {
+      bidder: 'optable',
+      params: {
+        site: '123',
+      },
+    };
+
+    const bidderRequest = {
+      bidderRequestId: 'bid123',
+      refererInfo: {
+        domain: 'example.com',
+        page: 'https://example.com/page',
+        ref: 'https://referrer.com'
+      },
+    };
+
+    const response = {
+      body: {
+        ext: {
+          optable: {
+            fledge: {
+              auctionconfigs: [
+                { impid: 'bid123', seller: 'https://ads.optable.co' },
+              ]
+            }
+          }
+        }
+      }
+    };
+
+    it('maps fledgeAuctionConfigs from ext.optable.fledge.auctionconfigs', function() {
+      const request = spec.buildRequests([validBid], bidderRequest);
+      const result = spec.interpretResponse(response, request);
+      expect(result.fledgeAuctionConfigs).to.deep.equal([
+        { bidId: 'bid123', config: { seller: 'https://ads.optable.co' } }
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

This introduces a first version of Optable's PAAPI-only bid adapter. It integrates sell side for now by emitting fledgeAuctionConfigs until https://github.com/prebid/Prebid.js/pull/11277 makes it in, at which point we may integrate as direct buyer as well.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer: prebid@optable.co
- test parameters for validating bids:
```
{
  bidder: 'optable',
  params: {
    site: 'site'
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
