### PR TITLE
33Across User ID Module: Enable 1PID addressability by default

### DIFF
--- a/modules/33acrossIdSystem.js
+++ b/modules/33acrossIdSystem.js
@@ -25,6 +25,7 @@ const CALLER_NAME = 'pbjs';
 const GVLID = 58;
 
 const STORAGE_FPID_KEY = '33acrossIdFp';
+const DEFAULT_1PID_SUPPORT = true;
 
 export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME });
 
@@ -164,7 +165,7 @@ export const thirthyThreeAcrossIdSubmodule = {
       return;
     }
 
-    const { pid, storeFpid, apiUrl = API_URL } = params;
+    const { pid, storeFpid = DEFAULT_1PID_SUPPORT, apiUrl = API_URL } = params;
 
     return {
       callback(cb) {

--- a/modules/33acrossIdSystem.md
+++ b/modules/33acrossIdSystem.md
@@ -51,4 +51,4 @@ The following settings are available in the `params` property in `userSync.userI
 | Param name | Scope | Type | Description | Example |
 | --- | --- | --- | --- | --- |
 | pid | Required | String | Partner ID provided by 33Across | `"0010b00002GYU4eBAH"` |
-| storeFpid | Optional | Boolean | Indicates whether a supplemental first-party ID may be stored to improve addressability | `false` (default) or `true` |
+| storeFpid | Optional | Boolean | Indicates whether a supplemental first-party ID may be stored to improve addressability, this feature is enabled by default | `true` (default) or `false` |


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [X] Other

## Description of change
Enable by default the use of first party ID for addressability purposes.

## Other information
This change was discussed here -> https://github.com/prebid/Prebid.js/pull/10714/files#r1433061489
and it should be part of the 9.0 release