### PR TITLE
ConsentManagementGpp module: throw error on some invalid sections

### DIFF
--- a/modules/consentManagementGpp.js
+++ b/modules/consentManagementGpp.js
@@ -423,12 +423,11 @@ function processCmpData(consentData) {
   ) {
     throw new GPPError('CMP returned unexpected value during lookup process.', consentData);
   }
-  if (
-    (consentData?.parsedSections != null && isPlainObject(consentData.parsedSections.usnatv1)) ||
-    (consentData?.parsedSections != null && isPlainObject(consentData.parsedSections.uscav1))
-  ) {
-    logWarn('CMP returned invalid section during lookup process.', consentData);
-  }
+  ['usnatv1', 'uscav1'].forEach(section => {
+    if (consentData?.parsedSections?.[section]) {
+      logWarn(`Received invalid section from cmp: '${section}'. Some functionality may not work as expected`, consentData)
+    }
+  })
   return storeConsentData(consentData);
 }
 

--- a/modules/consentManagementGpp.js
+++ b/modules/consentManagementGpp.js
@@ -423,6 +423,12 @@ function processCmpData(consentData) {
   ) {
     throw new GPPError('CMP returned unexpected value during lookup process.', consentData);
   }
+  if (
+    (consentData?.parsedSections != null && isPlainObject(consentData.parsedSections.usnatv1)) ||
+    (consentData?.parsedSections != null && !isPlainObject(consentData.parsedSections.uscav1))
+  ) {
+    throw new GPPError('CMP returned invalid section during lookup process.', consentData);
+  } 
   return storeConsentData(consentData);
 }
 

--- a/modules/consentManagementGpp.js
+++ b/modules/consentManagementGpp.js
@@ -425,7 +425,7 @@ function processCmpData(consentData) {
   }
   if (
     (consentData?.parsedSections != null && isPlainObject(consentData.parsedSections.usnatv1)) ||
-    (consentData?.parsedSections != null && !isPlainObject(consentData.parsedSections.uscav1))
+    (consentData?.parsedSections != null && isPlainObject(consentData.parsedSections.uscav1))
   ) {
     throw new GPPError('CMP returned invalid section during lookup process.', consentData);
   } 

--- a/modules/consentManagementGpp.js
+++ b/modules/consentManagementGpp.js
@@ -427,7 +427,7 @@ function processCmpData(consentData) {
     (consentData?.parsedSections != null && isPlainObject(consentData.parsedSections.usnatv1)) ||
     (consentData?.parsedSections != null && isPlainObject(consentData.parsedSections.uscav1))
   ) {
-    throw new GPPError('CMP returned invalid section during lookup process.', consentData);
+    logWarn('CMP returned invalid section during lookup process.', consentData);
   }
   return storeConsentData(consentData);
 }

--- a/modules/consentManagementGpp.js
+++ b/modules/consentManagementGpp.js
@@ -428,7 +428,7 @@ function processCmpData(consentData) {
     (consentData?.parsedSections != null && isPlainObject(consentData.parsedSections.uscav1))
   ) {
     throw new GPPError('CMP returned invalid section during lookup process.', consentData);
-  } 
+  }
   return storeConsentData(consentData);
 }
 


### PR DESCRIPTION
I know we can't check for every string under the sun and validating the list will inevitably lead to a stale list, but these invalid section name strings are causing real and widespread problems now. 

Fixes https://github.com/prebid/Prebid.js/issues/11384