### PR TITLE
Called replaceAuctionMacro in  viantOrtbBidAdapter to replace Auction_Price

### DIFF
--- a/modules/viantOrtbBidAdapter.js
+++ b/modules/viantOrtbBidAdapter.js
@@ -51,8 +51,10 @@ export const spec = {
   onBidWon: function (bid) {
     if (bid.burl) {
       utils.triggerPixel(bid.burl);
+      utils.replaceAuctionPrice(bid.burl,bid.price);
     } else if (bid.nurl) {
       utils.triggerPixel(bid.nurl);
+      utils.replaceAuctionPrice(bid.nurl,bid.price);
     }
   }
 }

--- a/modules/viantOrtbBidAdapter.js
+++ b/modules/viantOrtbBidAdapter.js
@@ -51,10 +51,10 @@ export const spec = {
   onBidWon: function (bid) {
     if (bid.burl) {
       utils.triggerPixel(bid.burl);
-      utils.replaceAuctionPrice(bid.burl,bid.price);
+      utils.replaceAuctionPrice(bid.burl, bid.price);
     } else if (bid.nurl) {
       utils.triggerPixel(bid.nurl);
-      utils.replaceAuctionPrice(bid.nurl,bid.price);
+      utils.replaceAuctionPrice(bid.nurl, bid.price);
     }
   }
 }


### PR DESCRIPTION
Called replaceAuctionMacro in  viantOrtbBidAdapter to replace Auction_Price

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Auction price macro was not getting expanded for bids won with Viant Adapter. Explicitly called replaceAuctionPrice method from utils.js to get the correct value.