### PR TITLE
ViantOrtb Bid Adapter : called replaceAuctionMacro to replace Auction_Price

### DIFF
--- a/modules/viantOrtbBidAdapter.js
+++ b/modules/viantOrtbBidAdapter.js
@@ -51,10 +51,10 @@ export const spec = {
   onBidWon: function (bid) {
     if (bid.burl) {
       utils.triggerPixel(bid.burl);
-      utils.replaceAuctionPrice(bid.burl, bid.price);
+      utils.triggerPixel(utils.replaceAuctionPrice(bid.burl, bid.originalCpm || bid.cpm || bid.price));
     } else if (bid.nurl) {
       utils.triggerPixel(bid.nurl);
-      utils.replaceAuctionPrice(bid.nurl, bid.price);
+      utils.triggerPixel(utils.replaceAuctionPrice(bid.nurl, bid.originalCpm || bid.cpm || bid.price));
     }
   }
 }

--- a/modules/viantOrtbBidAdapter.js
+++ b/modules/viantOrtbBidAdapter.js
@@ -51,10 +51,10 @@ export const spec = {
   onBidWon: function (bid) {
     if (bid.burl) {
       utils.triggerPixel(bid.burl);
-      utils.triggerPixel(utils.replaceAuctionPrice(bid.burl, bid.originalCpm || bid.cpm || bid.price));
+      utils.triggerPixel(utils.replaceAuctionPrice(bid.burl, bid.originalCpm || bid.cpm));
     } else if (bid.nurl) {
       utils.triggerPixel(bid.nurl);
-      utils.triggerPixel(utils.replaceAuctionPrice(bid.nurl, bid.originalCpm || bid.cpm || bid.price));
+      utils.triggerPixel(utils.replaceAuctionPrice(bid.nurl, bid.originalCpm || bid.cpm));
     }
   }
 }


### PR DESCRIPTION
Called replaceAuctionMacro in viantOrtbBidAdapter to replace Auction_Price

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Auction price macro was not getting expanded for bids won with Viant Adapter. Explicitly called replaceAuctionPrice method from utils.js to get the correct value.