### PR TITLE
Relevant Digital Bid Adapter : remove 'transformBidParams'

### DIFF
--- a/modules/relevantdigitalBidAdapter.js
+++ b/modules/relevantdigitalBidAdapter.js
@@ -200,24 +200,6 @@ export const spec = {
     });
     return syncs;
   },
-
-  /** If server side, transform bid params if needed */
-  transformBidParams(params, isOrtb, adUnit, bidRequests) {
-    if (!params.placementId) {
-      return;
-    }
-    const bid = bidRequests.flatMap(req => req.adUnitsS2SCopy || []).flatMap((adUnit) => adUnit.bids).find((bid) => bid.params?.placementId === params.placementId);
-    if (!bid) {
-      return;
-    }
-    const cfg = getBidderConfig([bid]);
-    FIELDS.forEach(({ name }) => {
-      if (cfg[name] && !params[name]) {
-        params[name] = cfg[name];
-      }
-    });
-    return params;
-  },
 };
 
 registerBidder(spec);

--- a/test/spec/modules/relevantdigitalBidAdapter_spec.js
+++ b/test/spec/modules/relevantdigitalBidAdapter_spec.js
@@ -1,10 +1,5 @@
 import {spec, resetBidderConfigs} from 'modules/relevantdigitalBidAdapter.js';
-import { parseUrl, deepClone } from 'src/utils.js';
-import { config } from 'src/config.js';
-import { S2S } from 'src/constants.js';
-
-import adapterManager, {
-} from 'src/adapterManager.js';
+import { parseUrl } from 'src/utils.js';
 
 const expect = require('chai').expect;
 
@@ -13,17 +8,6 @@ const PLACEMENT_ID = 'example_placement_id';
 const ACCOUNT_ID = 'example_account_id';
 const TEST_DOMAIN = 'example.com';
 const TEST_PAGE = `https://${TEST_DOMAIN}/page.html`;
-
-const CONFIG = {
-  enabled: true,
-  endpoint: S2S.DEFAULT_ENDPOINT,
-  timeout: 1000,
-  maxBids: 1,
-  adapter: 'prebidServer',
-  bidders: ['relevantdigital'],
-  accountId: 'abc'
-};
-
 const ADUNIT_CODE = '/19968336/header-bid-tag-0';
 
 const BID_PARAMS = {
@@ -312,64 +296,4 @@ describe('Relevant Digital Bid Adaper', function () {
       expect(allSyncs).to.deep.equal(expectedResult)
     });
   });
-  describe('transformBidParams', function () {
-    beforeEach(() => {
-      config.setConfig({
-        s2sConfig: CONFIG,
-      });
-    });
-    afterEach(() => {
-      config.resetConfig();
-    });
-
-    const adUnit = (params) => ({
-      code: ADUNIT_CODE,
-      bids: [
-        {
-          bidder: 'relevantdigital',
-          adUnitCode: ADUNIT_CODE,
-          params,
-        }
-      ]
-    });
-
-    const request = (params) => adapterManager.makeBidRequests([adUnit(params)], 123, 'auction-id', 123, [], {})[0];
-
-    it('transforms adunit bid params and config params correctly', function () {
-      config.setConfig({
-        relevantdigital: {
-          pbsHost: PBS_HOST,
-          accountId: ACCOUNT_ID,
-        },
-      });
-      const adUnitParams = { placementId: PLACEMENT_ID };
-      const expextedTransformedBidParams = {
-        ...BID_PARAMS.params, pbsHost: `https://${BID_PARAMS.params.pbsHost}`, 'pbsBufferMs': 250
-      };
-      expect(spec.transformBidParams(adUnitParams, null, null, [request(adUnitParams)])).to.deep.equal(expextedTransformedBidParams);
-    });
-    it('transforms adunit bid params correctly', function () {
-      const adUnitParams = { ...BID_PARAMS.params, pbsHost: 'host.relevant-digital.com', pbsBufferMs: 500 };
-      const expextedTransformedBidParams = {
-        ...BID_PARAMS.params, pbsHost: 'host.relevant-digital.com', pbsBufferMs: 500
-      };
-      expect(spec.transformBidParams(adUnitParams, null, null, [request(adUnitParams)])).to.deep.equal(expextedTransformedBidParams);
-    });
-    it('transforms adunit bid params correctly', function () {
-      const adUnitParams = { ...BID_PARAMS.params, pbsHost: 'host.relevant-digital.com', pbsBufferMs: 500 };
-      const expextedTransformedBidParams = {
-        ...BID_PARAMS.params, pbsHost: 'host.relevant-digital.com', pbsBufferMs: 500
-      };
-      expect(spec.transformBidParams(adUnitParams, null, null, [request(adUnitParams)])).to.deep.equal(expextedTransformedBidParams);
-    });
-    it('does not transform bid params if placementId is missing', function () {
-      const adUnitParams = { ...BID_PARAMS.params, placementId: null };
-      expect(spec.transformBidParams(adUnitParams, null, null, [request(adUnitParams)])).to.equal(undefined);
-    });
-    it('does not transform bid params s2s config is missing', function () {
-      config.resetConfig();
-      const adUnitParams = BID_PARAMS.params;
-      expect(spec.transformBidParams(adUnitParams, null, null, [request(adUnitParams)])).to.equal(undefined);
-    });
-  })
 });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

This PR removes `transformBidParams` from our bid adapter in preparation for Prebid 9. This can be done as it only affects a very unusual use-case which there is an easy workaround for - provide the required settings inside `params` instead of using `pbjs.setConfig()` as described [here](https://docs.prebid.org/dev-docs/bidders/relevantdigital.html#example-setup-using-pbjssetconfig), when using S2S. 

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->
