### PR TITLE
Criteo Bid Adapter: send pubid in the proper publisher.id request field

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -621,9 +621,6 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
   if (networkId) {
     request.publisher.networkid = networkId;
   }
-  if (pubid) {
-    request.publisher.id = pubid;
-  }
 
   request.source = {
     tid: bidderRequest.ortb2?.source?.tid
@@ -637,6 +634,12 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
   request.user = bidderRequest.ortb2?.user || {};
   request.site = bidderRequest.ortb2?.site || {};
   request.app = bidderRequest.ortb2?.app || {};
+
+  if (pubid) {
+    request.site.publisher = {...request.site.publisher, ...{ id: pubid }};
+    request.app.publisher = {...request.app.publisher, ...{ id: pubid }};
+  }
+
   request.device = bidderRequest.ortb2?.device || {};
   if (bidderRequest && bidderRequest.ceh) {
     request.user.ceh = bidderRequest.ceh;

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -2009,7 +2009,15 @@ describe('The Criteo bidding adapter', function () {
     });
 
     it('should properly transmit the pubid and slot uid if available', function () {
-      const bidderRequest = {};
+      const bidderRequest = {
+        ortb2: {
+          site: {
+            publisher: {
+              id: 'pub-777'
+            }
+          }
+        }
+      };
       const bidRequests = [
         {
           bidder: 'criteo',
@@ -2050,7 +2058,8 @@ describe('The Criteo bidding adapter', function () {
       ];
       const request = spec.buildRequests(bidRequests, bidderRequest);
       const ortbRequest = request.data;
-      expect(ortbRequest.publisher.id).to.equal('pub-888');
+      expect(ortbRequest.publisher.id).to.be.undefined;
+      expect(ortbRequest.site.publisher.id).to.equal('pub-888');
       expect(request.data.slots[0].ext.bidder).to.be.undefined;
       expect(request.data.slots[1].ext.bidder.uid).to.equal(888);
     });


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Our PBJS adapter is currenltly sending our bidder params "pubid" into an invalid field to our backend. This PR aims at fixing this.