### PR TITLE
PBjs Utils: Faster Deep Clone

### DIFF
--- a/allowedModules.js
+++ b/allowedModules.js
@@ -7,7 +7,7 @@ module.exports = {
   ],
   'src': [
     'fun-hooks/no-eval',
-    'just-clone',
+    'klona',
     'dlv',
     'dset'
   ],

--- a/modules/browsiRtdProvider.js
+++ b/modules/browsiRtdProvider.js
@@ -57,7 +57,7 @@ export function addBrowsiTag(data) {
   script.setAttribute('prebidbpt', 'true');
   script.setAttribute('id', 'browsi-tag');
   script.setAttribute('src', data.u);
-  script.prebidData = deepClone(data);
+  script.prebidData = deepClone(typeof data === 'string' ? Object(data) : data)
   if (_moduleParams.keyName) {
     script.prebidData.kn = _moduleParams.keyName;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "express": "^4.15.4",
         "fun-hooks": "^0.9.9",
         "gulp-wrap": "^0.15.0",
-        "just-clone": "^1.0.2",
+        "klona": "^2.0.6",
         "live-connect-js": "^6.3.4"
       },
       "devDependencies": {
@@ -19198,11 +19198,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/just-clone": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/just-clone/-/just-clone-1.0.2.tgz",
-      "integrity": "sha512-p93GINPwrve0w3HUzpXmpTl7MyzzWz1B5ag44KEtq/hP1mtK8lA2b9Q0VQaPlnY87352osJcE6uBmN0e8kuFMw=="
-    },
     "node_modules/just-debounce": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.1.0.tgz",
@@ -19675,6 +19670,14 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/konan": {
@@ -43994,11 +43997,6 @@
         "verror": "1.10.0"
       }
     },
-    "just-clone": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/just-clone/-/just-clone-1.0.2.tgz",
-      "integrity": "sha512-p93GINPwrve0w3HUzpXmpTl7MyzzWz1B5ag44KEtq/hP1mtK8lA2b9Q0VQaPlnY87352osJcE6uBmN0e8kuFMw=="
-    },
     "just-debounce": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/just-debounce/-/just-debounce-1.1.0.tgz",
@@ -44381,6 +44379,11 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "dev": true
+    },
+    "klona": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
+      "integrity": "sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA=="
     },
     "konan": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "express": "^4.15.4",
     "fun-hooks": "^0.9.9",
     "gulp-wrap": "^0.15.0",
-    "just-clone": "^1.0.2",
+    "klona": "^2.0.6",
     "live-connect-js": "^6.3.4"
   },
   "optionalDependencies": {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 import {config} from './config.js';
-import clone from 'just-clone';
+import {klona} from 'klona/json';
 import {includes} from './polyfill.js';
 import { EVENTS, S2S } from './constants.js';
 import {GreedyPromise} from './utils/promise.js';
@@ -609,7 +609,7 @@ export function shuffle(array) {
 }
 
 export function deepClone(obj) {
-  return clone(obj);
+  return klona(obj) || {};
 }
 
 export function inIframe() {


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Refactoring (no functional changes, no api changes)



## Description of change
<!-- Describe the change proposed in this pull request -->

Prebid currently uses an outdated version of just-clone for deep cloning objects.

After some [benchmarking](https://github.com/bbaresic/deep-clone-benchmarks), klona seems much more efficient even compared to other libraries or even native JS (`structuredClone` and `JSON.parse/stringify`)

This PR replaces `just-clone`, but the other way of deep-cloning `JSON.parse(JSON.stringify(object))` stays unchanged.
That should be done in a different PR.

This partially addresses [#11399](https://github.com/prebid/Prebid.js/issues/11399).