### PR TITLE
Limelight Digital Bid Adapter: add sua field

### DIFF
--- a/modules/limelightDigitalBidAdapter.js
+++ b/modules/limelightDigitalBidAdapter.js
@@ -62,7 +62,7 @@ export const spec = {
     }
     const placements = groupBy(validBidRequests.map(bidRequest => buildPlacement(bidRequest)), 'host')
     return Object.keys(placements)
-      .map(host => buildRequest(winTop, host, placements[host].map(placement => placement.adUnit)));
+      .map(host => buildRequest(winTop, host, placements[host].map(placement => placement.adUnit), bidderRequest));
   },
 
   /**
@@ -119,7 +119,7 @@ export const spec = {
 
 registerBidder(spec);
 
-function buildRequest(winTop, host, adUnits) {
+function buildRequest(winTop, host, adUnits, bidderRequest) {
   return {
     method: 'POST',
     url: `https://${host}/hb`,
@@ -127,7 +127,8 @@ function buildRequest(winTop, host, adUnits) {
       secure: (location.protocol === 'https:'),
       deviceWidth: winTop.screen.width,
       deviceHeight: winTop.screen.height,
-      adUnits: adUnits
+      adUnits: adUnits,
+      sua: bidderRequest?.ortb2?.device?.sua
     }
   }
 }

--- a/test/spec/modules/limelightDigitalBidAdapter_spec.js
+++ b/test/spec/modules/limelightDigitalBidAdapter_spec.js
@@ -208,7 +208,19 @@ describe('limelightDigitalAdapter', function () {
   }
 
   describe('buildRequests', function () {
-    const serverRequests = spec.buildRequests([bid1, bid2, bid3, bid4])
+    const bidderRequest = {
+      ortb2: {
+        device: {
+          sua: {
+            browsers: [],
+            platform: [],
+            mobile: 1,
+            architecture: 'arm'
+          }
+        }
+      }
+    }
+    const serverRequests = spec.buildRequests([bid1, bid2, bid3, bid4], bidderRequest)
     it('Creates two ServerRequests', function() {
       expect(serverRequests).to.exist
       expect(serverRequests).to.have.lengthOf(2)
@@ -230,7 +242,8 @@ describe('limelightDigitalAdapter', function () {
           'deviceWidth',
           'deviceHeight',
           'secure',
-          'adUnits'
+          'adUnits',
+          'sua'
         );
         expect(data.deviceWidth).to.be.a('number');
         expect(data.deviceHeight).to.be.a('number');
@@ -266,6 +279,10 @@ describe('limelightDigitalAdapter', function () {
           expect(adUnit.custom5).to.be.a('string');
           expect(adUnit.page).to.be.a('string');
         })
+        expect(data.sua.browsers).to.be.a('array');
+        expect(data.sua.platform).to.be.a('array');
+        expect(data.sua.mobile).to.be.a('number');
+        expect(data.sua.architecture).to.be.a('string');
       })
     })
     it('Returns valid URL', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

We send sua in request

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
