### PR TITLE
Criteo Bid Adapter: Add missing tmax along the request send to backend

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -674,6 +674,7 @@ function buildCdbRequest(context, bidRequests, bidderRequest) {
   if (bidderRequest && bidderRequest.ortb2?.bapp) {
     request.bapp = bidderRequest.ortb2.bapp;
   }
+  request.tmax = bidderRequest.timeout;
   return request;
 }
 

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -675,6 +675,25 @@ describe('The Criteo bidding adapter', function () {
       expect(ortbRequest.source.tid).to.equal('abc');
     });
 
+    it('should properly transmit tmax if available', function () {
+      const bidRequests = [
+        {
+          bidder: 'criteo',
+          adUnitCode: 'bid-123',
+          transactionId: 'transaction-123',
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
+          params: {}
+        },
+      ];
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const ortbRequest = request.data;
+      expect(ortbRequest.tmax).to.equal(bidderRequest.timeout);
+    });
+
     it('should properly transmit bidId if available', function () {
       const bidderRequest = {
         ortb2: {


### PR DESCRIPTION
## Type of change
- [X] Bugfix
- 
## Description of change
Add missing tmax along the request send to backend