### PR TITLE
Rubicon Bid Adapter: Provide backwards compatibility for transparency object

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -985,6 +985,13 @@ function applyFPD(bidRequest, mediaType, data) {
               if (param) {
                 param += '~~'
               }
+              const domain = transp.domain || '';
+              let dsaparams = '';
+              if (Array.isArray(transp.dsaparams)) {
+                dsaparams = transp.dsaparams.join('_');
+              } else if (Array.isArray(transp.params)) {
+                dsaparams = transp.params.join('_');
+              }
               return param += `${transp.domain}~${transp.dsaparams.join('_')}`
             }, '')
           }


### PR DESCRIPTION
## Type of change

- [ x] Bugfix


## Description of change
When the property `transparency.params` gets passed in the `ortb2` object, the Rubicon adapter throws an error. 

This change will provide backwards compatibility for the `params` property by adding it to the `dsaparams` property.

If `params` or `dsaparams` does not exist, the value will be turned into an empty string. The same is done for the `domain` property. This ensures that the Bid Adapter will not error if these properties do not exist.
