### PR TITLE
beOp Bid Adapter : add DNT, SH and SW in requests

### DIFF
--- a/modules/beopBidAdapter.js
+++ b/modules/beopBidAdapter.js
@@ -61,6 +61,14 @@ export const spec = {
     const gdpr = bidderRequest.gdprConsent;
     const firstSlot = slots[0];
     const kwdsFromRequest = firstSlot.kwds;
+    const dnt = navigator.doNotTrack === '1' ||
+    window.doNotTrack === '1' ||
+    navigator.msDoNotTrack === '1' ||
+    navigator.doNotTrack === 'yes'
+      ? 1
+      : 0;
+    const sh = screen.height;
+    const sw = screen.width;
     let keywords = getAllOrtbKeywords(bidderRequest.ortb2, kwdsFromRequest);
 
     const payloadObject = {
@@ -79,6 +87,9 @@ export const spec = {
       gdpr_applies: gdpr ? gdpr.gdprApplies : false,
       tc_string: (gdpr && gdpr.gdprApplies) ? gdpr.consentString : null,
       eids: firstSlot.eids,
+      dnt: dnt,
+      sh: sh,
+      sw: sw
     };
 
     const payloadString = JSON.stringify(payloadObject);

--- a/test/spec/modules/beopBidAdapter_spec.js
+++ b/test/spec/modules/beopBidAdapter_spec.js
@@ -330,4 +330,25 @@ describe('BeOp Bid Adapter tests', () => {
       expect(payload.eids[0].source).to.equal('provider.com');
     });
   })
+
+  describe('Ensure dnt, sw and sh are get', function() {
+    let bidRequests = [];
+    afterEach(function () {
+      bidRequests = [];
+    });
+
+    it(`should get dnt from navigator, sh and sw from screen`, function () {
+      let bid = Object.assign({}, validBid);
+      bidRequests.push(bid);
+
+      const request = spec.buildRequests(bidRequests, {});
+      const payload = JSON.parse(request.data);
+      expect(payload.dnt).to.exist;
+      expect(payload.sh).to.exist;
+      expect(payload.sw).to.exist;
+      expect(payload.dnt).to.equal(0);
+      expect(payload.sh).to.be.greaterThan(300);
+      expect(payload.sw).to.be.greaterThan(300);
+    });
+  })
 });


### PR DESCRIPTION
## Type of change

- [x] Feature


## Description of change
Just need to get new parameters from our Prebid.js delivery as we have added them in our own tag delivery
