### PR TITLE
OpenX Bid Adapter: remove transformBidParams

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -18,8 +18,7 @@ export const spec = {
   isBidRequestValid,
   buildRequests,
   interpretResponse,
-  getUserSyncs,
-  transformBidParams
+  getUserSyncs
 };
 
 registerBidder(spec);
@@ -152,13 +151,6 @@ const converter = ortbConverter({
     }
   }
 });
-
-function transformBidParams(params, isOpenRtb) {
-  return convertTypes({
-    'unit': 'string',
-    'customFloor': 'number'
-  }, params);
-}
 
 function isBidRequestValid(bidRequest) {
   const hasDelDomainOrPlatform = bidRequest.params.delDomain ||

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -4,7 +4,6 @@ import * as utils from '../src/utils.js';
 import {mergeDeep} from '../src/utils.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {ortbConverter} from '../libraries/ortbConverter/converter.js';
-import {convertTypes} from '../libraries/transformParamsUtils/convertTypes.js';
 
 const bidderConfig = 'hb_pb_ortb';
 const bidderVersion = '2.0';


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter

## Description of change
Removing transformBidParams as it will be deprecated in Prebid.js 9.0