### PR TITLE
PulsePoint bid adapter: Removing deprecated method

### DIFF
--- a/modules/pulsepointBidAdapter.js
+++ b/modules/pulsepointBidAdapter.js
@@ -1,7 +1,6 @@
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import {isArray} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
-import {convertTypes} from '../libraries/transformParamsUtils/convertTypes.js';
 
 const DEFAULT_CURRENCY = 'USD';
 const KNOWN_PARAMS = ['cp', 'ct', 'cf', 'battr', 'deals'];

--- a/modules/pulsepointBidAdapter.js
+++ b/modules/pulsepointBidAdapter.js
@@ -58,13 +58,6 @@ export const spec = {
         url: 'https://bh.contextweb.com/visitormatch/prebid'
       }];
     }
-  },
-  transformBidParams: function(params) {
-    return convertTypes({
-      'cf': 'string',
-      'cp': 'number',
-      'ct': 'number'
-    }, params);
   }
 };
 


### PR DESCRIPTION
Removing the `transformBidParams` method that has been deprecated for 9.0