### PR TITLE
User id module: Ability to store user IDs in cookie and localStorage simultaneously

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -315,7 +315,9 @@ function deleteValueFromLocalStorage(submodule) {
 }
 
 export function deleteStoredValue(submodule) {
-  calculateEnabledStorageTypes(submodule).forEach(storageType => {
+  populateEnabledStorageTypes(submodule);
+
+  submodule.enabledStorageTypes.forEach(storageType => {
     switch (storageType) {
       case COOKIE:
         deleteValueFromCookie(submodule);
@@ -881,9 +883,7 @@ function initSubmodules(dest, submodules, forceRefresh = false) {
   return uidMetrics().fork().measureTime('userId.init.modules', function () {
     if (!submodules.length) return []; // to simplify log messages from here on
 
-    submodules.forEach(submod => {
-      submod.enabledStorageTypes = calculateEnabledStorageTypes(submod);
-    });
+    submodules.forEach(submod => populateEnabledStorageTypes(submod));
 
     /**
      * filter out submodules that:
@@ -1005,10 +1005,14 @@ function canUseCookies(submodule) {
   return true
 }
 
-function calculateEnabledStorageTypes(submodule) {
+function populateEnabledStorageTypes(submodule) {
+  if (submodule.enabledStorageTypes) {
+    return;
+  }
+
   const storageTypes = getConfiguredStorageTypes(submodule.config);
 
-  return storageTypes.filter(type => {
+  submodule.enabledStorageTypes = storageTypes.filter(type => {
     switch (type) {
       case LOCAL_STORAGE:
         return canUseLocalStorage(submodule);

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -275,11 +275,17 @@ export function setStoredValue(submodule, value) {
   try {
     const expiresStr = (new Date(Date.now() + (storage.expires * (60 * 60 * 24 * 1000)))).toUTCString();
     const valueStr = isPlainObject(value) ? JSON.stringify(value) : value;
-    if (storage.type === COOKIE) {
-      setValueInCookie(submodule, valueStr, expiresStr);
-    } else if (storage.type === LOCAL_STORAGE) {
-      setValueInLocalStorage(submodule, valueStr, expiresStr);
-    }
+
+    submodule.enabledStorageTypes.forEach(storageType => {
+      switch (storageType) {
+        case COOKIE:
+          setValueInCookie(submodule, valueStr, expiresStr);
+          break;
+        case LOCAL_STORAGE:
+          setValueInLocalStorage(submodule, valueStr, expiresStr);
+          break;
+      }
+    });
   } catch (error) {
     logError(error);
   }
@@ -309,13 +315,16 @@ function deleteValueFromLocalStorage(submodule) {
 }
 
 export function deleteStoredValue(submodule) {
-  const storageType = submodule.config?.storage?.type;
-
-  if (storageType === COOKIE) {
-    deleteValueFromCookie(submodule);
-  } else if (storageType === LOCAL_STORAGE) {
-    deleteValueFromLocalStorage(submodule);
-  }
+  calculateEnabledStorageTypes(submodule).forEach(storageType => {
+    switch (storageType) {
+      case COOKIE:
+        deleteValueFromCookie(submodule);
+        break;
+      case LOCAL_STORAGE:
+        deleteValueFromLocalStorage(submodule);
+        break;
+    }
+  });
 }
 
 function setPrebidServerEidPermissions(initializedSubmodules) {
@@ -352,11 +361,19 @@ function getStoredValue(submodule, key = undefined) {
   const storedKey = key ? `${storage.name}_${key}` : storage.name;
   let storedValue;
   try {
-    if (storage.type === COOKIE) {
-      storedValue = getValueFromCookie(submodule, storedKey);
-    } else if (storage.type === LOCAL_STORAGE) {
-      storedValue = getValueFromLocalStorage(submodule, storedKey);
-    }
+    submodule.enabledStorageTypes.find(storageType => {
+      switch (storageType) {
+        case COOKIE:
+          storedValue = getValueFromCookie(submodule, storedKey);
+          break;
+        case LOCAL_STORAGE:
+          storedValue = getValueFromLocalStorage(submodule, storedKey);
+          break;
+      }
+
+      return !!storedValue;
+    });
+
     // support storing a string or a stringified object
     if (typeof storedValue === 'string' && storedValue.trim().charAt(0) === '{') {
       storedValue = JSON.parse(storedValue);
@@ -804,8 +821,10 @@ function populateSubmoduleId(submodule, forceRefresh, allSubmodules) {
     }
 
     if (!storedId || refreshNeeded || forceRefresh || consentChanged(submodule)) {
+      const extendedConfig = Object.assign({ enabledStorageTypes: submodule.enabledStorageTypes }, submodule.config);
+
       // No id previously saved, or a refresh is needed, or consent has changed. Request a new id from the submodule.
-      response = submodule.submodule.getId(submodule.config, gdprConsent, storedId);
+      response = submodule.submodule.getId(extendedConfig, gdprConsent, storedId);
     } else if (typeof submodule.submodule.extendId === 'function') {
       // If the id exists already, give submodule a chance to decide additional actions that need to be taken
       response = submodule.submodule.extendId(submodule.config, gdprConsent, storedId);
@@ -862,6 +881,10 @@ function initSubmodules(dest, submodules, forceRefresh = false) {
   return uidMetrics().fork().measureTime('userId.init.modules', function () {
     if (!submodules.length) return []; // to simplify log messages from here on
 
+    submodules.forEach(submod => {
+      submod.enabledStorageTypes = calculateEnabledStorageTypes(submod);
+    });
+
     /**
      * filter out submodules that:
      *
@@ -912,6 +935,16 @@ function updateInitializedSubmodules(dest, submodule) {
   }
 }
 
+function getConfiguredStorageTypes(config) {
+  return config?.storage?.type?.trim().split(/\s*&\s*/) || [];
+}
+
+function hasValidStorageTypes(config) {
+  const storageTypes = getConfiguredStorageTypes(config);
+
+  return storageTypes.every(storageType => ALL_STORAGE_TYPES.has(storageType));
+}
+
 /**
  * list of submodule configurations with valid 'storage' or 'value' obj definitions
  * storage config: contains values for storing/retrieving User ID data in browser storage
@@ -933,7 +966,7 @@ function getValidSubmoduleConfigs(configRegistry) {
     if (config.storage &&
       !isEmptyStr(config.storage.type) &&
       !isEmptyStr(config.storage.name) &&
-      ALL_STORAGE_TYPES.has(config.storage.type)) {
+      hasValidStorageTypes(config)) {
       carry.push(config);
     } else if (isPlainObject(config.value)) {
       carry.push(config);
@@ -972,15 +1005,23 @@ function canUseCookies(submodule) {
   return true
 }
 
-function canUseStorage(submodule) {
-  const storageType = submodule?.config?.storage?.type;
-  if (storageType === COOKIE) {
-    return canUseCookies(submodule);
-  } else if (storageType === LOCAL_STORAGE) {
-    return canUseLocalStorage(submodule);
-  }
+function calculateEnabledStorageTypes(submodule) {
+  const storageTypes = getConfiguredStorageTypes(submodule.config);
 
-  return false;
+  return storageTypes.filter(type => {
+    switch (type) {
+      case LOCAL_STORAGE:
+        return canUseLocalStorage(submodule);
+      case COOKIE:
+        return canUseCookies(submodule);
+    }
+
+    return false;
+  });
+}
+
+function canUseStorage(submodule) {
+  return !!submodule.enabledStorageTypes.length;
 }
 
 function updateEIDConfig(submodules) {

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -1837,6 +1837,88 @@ describe('User ID', function () {
         }, {adUnits});
       });
 
+      it('test hook from pubcommonid cookie&html5', function (done) {
+        const expiration = new Date(Date.now() + 100000).toUTCString();
+        coreStorage.setCookie('pubcid', 'testpubcid', expiration);
+        localStorage.setItem('pubcid', 'testpubcid');
+        localStorage.setItem('pubcid_exp', expiration);
+
+        init(config);
+        setSubmoduleRegistry([sharedIdSystemSubmodule]);
+        config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie&html5']));
+
+        requestBidsHook(function () {
+          adUnits.forEach(unit => {
+            unit.bids.forEach(bid => {
+              expect(bid).to.have.deep.nested.property('userId.pubcid');
+              expect(bid.userId.pubcid).to.equal('testpubcid');
+              expect(bid.userIdAsEids[0]).to.deep.equal({
+                source: 'pubcid.org',
+                uids: [{id: 'testpubcid', atype: 1}]
+              });
+            });
+          });
+
+          coreStorage.setCookie('pubcid', '', EXPIRED_COOKIE_DATE);
+          localStorage.removeItem('pubcid');
+          localStorage.removeItem('pubcid_exp');
+
+          done();
+        }, {adUnits});
+      });
+
+      it('test hook from pubcommonid cookie&html5, no cookie present', function (done) {
+        localStorage.setItem('pubcid', 'testpubcid');
+        localStorage.setItem('pubcid_exp', new Date(Date.now() + 100000).toUTCString());
+
+        init(config);
+        setSubmoduleRegistry([sharedIdSystemSubmodule]);
+        config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie&html5']));
+
+        requestBidsHook(function () {
+          adUnits.forEach(unit => {
+            unit.bids.forEach(bid => {
+              expect(bid).to.have.deep.nested.property('userId.pubcid');
+              expect(bid.userId.pubcid).to.equal('testpubcid');
+              expect(bid.userIdAsEids[0]).to.deep.equal({
+                source: 'pubcid.org',
+                uids: [{id: 'testpubcid', atype: 1}]
+              });
+            });
+          });
+
+          localStorage.removeItem('pubcid');
+          localStorage.removeItem('pubcid_exp');
+
+          done();
+        }, {adUnits});
+      });
+
+      it('test hook from pubcommonid cookie&html5, no local storage entry', function (done) {
+        coreStorage.setCookie('pubcid', 'testpubcid', (new Date(Date.now() + 100000).toUTCString()));
+
+        init(config);
+        setSubmoduleRegistry([sharedIdSystemSubmodule]);
+        config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie&html5']));
+
+        requestBidsHook(function () {
+          adUnits.forEach(unit => {
+            unit.bids.forEach(bid => {
+              expect(bid).to.have.deep.nested.property('userId.pubcid');
+              expect(bid.userId.pubcid).to.equal('testpubcid');
+              expect(bid.userIdAsEids[0]).to.deep.equal({
+                source: 'pubcid.org',
+                uids: [{id: 'testpubcid', atype: 1}]
+              });
+            });
+          });
+
+          coreStorage.setCookie('pubcid', '', EXPIRED_COOKIE_DATE);
+
+          done();
+        }, {adUnits});
+      });
+
       it('test hook from pubcommonid config value object', function (done) {
         init(config);
         setSubmoduleRegistry([sharedIdSystemSubmodule]);
@@ -3197,7 +3279,8 @@ describe('User ID', function () {
           },
           storageMgr: {
             setCookie: sinon.stub()
-          }
+          },
+          enabledStorageTypes: [ 'cookie' ]
         }
         setStoredValue(submodule, 'bar');
         expect(submodule.storageMgr.setCookie.getCall(0).args[4]).to.equal('foo.com');
@@ -3214,7 +3297,8 @@ describe('User ID', function () {
           },
           storageMgr: {
             setCookie: sinon.stub()
-          }
+          },
+          enabledStorageTypes: [ 'cookie' ]
         }
         setStoredValue(submodule, 'bar');
         expect(submodule.storageMgr.setCookie.getCall(0).args[4]).to.equal(null);
@@ -3361,6 +3445,20 @@ describe('User ID', function () {
           sinon.assert.calledOnce(mockExtendId);
         });
       });
+
+      it('calls getId with the list of enabled storage types', function() {
+        setStorage({lastDelta: 1000});
+        config.setConfig(userIdConfig);
+
+        let innerAdUnits;
+        return runBidsHook((config) => {
+          innerAdUnits = config.adUnits
+        }, {adUnits}).then(() => {
+          sinon.assert.calledOnce(mockGetId);
+
+          expect(mockGetId.getCall(0).args[0].enabledStorageTypes).to.deep.equal([ userIdConfig.userSync.userIds[0].storage.type ]);
+        });
+      });
     });
 
     describe('requestDataDeletion', () => {
@@ -3376,21 +3474,23 @@ describe('User ID', function () {
           onDataDeletionRequest: sinon.stub()
         }
       }
-      let mod1, mod2, mod3, cfg1, cfg2, cfg3;
+      let mod1, mod2, mod3, mod4, cfg1, cfg2, cfg3, cfg4;
 
       beforeEach(() => {
         init(config);
         mod1 = idMod('id1', 'val1');
         mod2 = idMod('id2', 'val2');
         mod3 = idMod('id3', 'val3');
+        mod4 = idMod('id4', 'val4');
         cfg1 = getStorageMock('id1', 'id1', 'cookie');
         cfg2 = getStorageMock('id2', 'id2', 'html5');
-        cfg3 = {name: 'id3', value: {id3: 'val3'}};
-        setSubmoduleRegistry([mod1, mod2, mod3]);
+        cfg3 = getStorageMock('id3', 'id3', 'cookie&html5');
+        cfg4 = {name: 'id4', value: {id4: 'val4'}};
+        setSubmoduleRegistry([mod1, mod2, mod3, mod4]);
         config.setConfig({
           auctionDelay: 1,
           userSync: {
-            userIds: [cfg1, cfg2, cfg3]
+            userIds: [cfg1, cfg2, cfg3, cfg4]
           }
         });
         return getGlobal().refreshUserIds();
@@ -3399,16 +3499,21 @@ describe('User ID', function () {
       it('deletes stored IDs', () => {
         expect(coreStorage.getCookie('id1')).to.exist;
         expect(coreStorage.getDataFromLocalStorage('id2')).to.exist;
+        expect(coreStorage.getCookie('id3')).to.exist;
+        expect(coreStorage.getDataFromLocalStorage('id3')).to.exist;
         requestDataDeletion(sinon.stub());
         expect(coreStorage.getCookie('id1')).to.not.exist;
         expect(coreStorage.getDataFromLocalStorage('id2')).to.not.exist;
+        expect(coreStorage.getCookie('id3')).to.not.exist;
+        expect(coreStorage.getDataFromLocalStorage('id3')).to.not.exist;
       });
 
       it('invokes onDataDeletionRequest', () => {
         requestDataDeletion(sinon.stub());
         sinon.assert.calledWith(mod1.onDataDeletionRequest, cfg1, {id1: 'val1'});
-        sinon.assert.calledWith(mod2.onDataDeletionRequest, cfg2, {id2: 'val2'})
-        sinon.assert.calledWith(mod3.onDataDeletionRequest, cfg3, {id3: 'val3'})
+        sinon.assert.calledWith(mod2.onDataDeletionRequest, cfg2, {id2: 'val2'});
+        sinon.assert.calledWith(mod3.onDataDeletionRequest, cfg3, {id3: 'val3'});
+        sinon.assert.calledWith(mod4.onDataDeletionRequest, cfg4, {id4: 'val4'});
       });
 
       describe('does not choke when onDataDeletionRequest', () => {
@@ -3423,6 +3528,7 @@ describe('User ID', function () {
             requestDataDeletion(next, arg);
             sinon.assert.calledOnce(mod2.onDataDeletionRequest);
             sinon.assert.calledOnce(mod3.onDataDeletionRequest);
+            sinon.assert.calledOnce(mod4.onDataDeletionRequest);
             sinon.assert.calledWith(next, arg);
           })
         })


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter 
- [ ] Updated bidder adapter 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Introduce a third storage method that saves IDs to both cookie and localStorage. Details can be found in the issue link below.

## Other information
Issue: https://github.com/prebid/Prebid.js/issues/11274
Documentation: https://github.com/prebid/prebid.github.io/pull/5315
