### PR TITLE
Criteo Bid Adapter: converted adapter to oRTB 2.5

### DIFF
--- a/libraries/ortb2.5Translator/translator.js
+++ b/libraries/ortb2.5Translator/translator.js
@@ -1,10 +1,12 @@
 import {deepAccess, deepSetValue, logError} from '../../src/utils.js';
 
 export const EXT_PROMOTIONS = [
+  'device.sua',
   'source.schain',
   'regs.gdpr',
   'regs.us_privacy',
   'regs.gpp',
+  'regs.gpp_sid',
   'user.consent',
   'user.eids'
 ];

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -1,14 +1,14 @@
-import { deepAccess, generateUUID, isArray, logError, logWarn, parseUrl } from '../src/utils.js';
-import { registerBidder } from '../src/adapters/bidderFactory.js';
-import { config } from '../src/config.js';
-import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
-
-import { getStorageManager } from '../src/storageManager.js';
-import { getRefererInfo } from '../src/refererDetection.js';
-import { hasPurpose1Consent } from '../src/utils/gpdr.js';
-import { Renderer } from '../src/Renderer.js';
-import { OUTSTREAM } from '../src/video.js';
-import { ajax } from '../src/ajax.js';
+import {deepAccess, deepSetValue, isArray, logError, logWarn, parseUrl} from '../src/utils.js';
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
+import {getStorageManager} from '../src/storageManager.js';
+import {getRefererInfo} from '../src/refererDetection.js';
+import {hasPurpose1Consent} from '../src/utils/gpdr.js';
+import {Renderer} from '../src/Renderer.js';
+import {OUTSTREAM} from '../src/video.js';
+import {ajax} from '../src/ajax.js';
+import {ortbConverter} from '../libraries/ortbConverter/converter.js';
+import {ortb25Translator} from '../libraries/ortb2.5Translator/translator.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -19,19 +19,198 @@ import { ajax } from '../src/ajax.js';
  */
 
 const GVLID = 91;
-export const ADAPTER_VERSION = 36;
+export const ADAPTER_VERSION = 37;
 const BIDDER_CODE = 'criteo';
-const CDB_ENDPOINT = 'https://bidder.criteo.com/cdb';
+const CDB_ENDPOINT = 'https://bidder.criteo.com/openrtb_2_5/pbjs/auction/request';
 const PROFILE_ID_INLINE = 207;
-export const PROFILE_ID_PUBLISHERTAG = 185;
 export const storage = getStorageManager({ bidderCode: BIDDER_CODE });
 const LOG_PREFIX = 'Criteo: ';
+const TRANSLATOR = ortb25Translator();
 
 const PUBLISHER_TAG_OUTSTREAM_SRC = 'https://static.criteo.net/js/ld/publishertag.renderer.js'
 const OPTOUT_COOKIE_NAME = 'cto_optout';
 const BUNDLE_COOKIE_NAME = 'cto_bundle';
 const GUID_RETENTION_TIME_HOUR = 24 * 30 * 13; // 13 months
 const OPTOUT_RETENTION_TIME_HOUR = 5 * 12 * 30 * 24; // 5 years
+
+/**
+ * Defines the generic oRTB converter and all customization functions.
+ */
+const CONVERTER = ortbConverter({
+  context: {
+    netRevenue: true,
+    ttl: 60
+  },
+  imp,
+  request,
+  bidResponse,
+  response
+});
+
+/**
+ * Builds an impression object for the ORTB 2.5 request.
+ *
+ * @param {function} buildImp - The function for building an imp object.
+ * @param {Object} bidRequest - The bid request object.
+ * @param {Object} context - The context object.
+ * @returns {Object} The ORTB 2.5 imp object.
+ */
+function imp(buildImp, bidRequest, context) {
+  let imp = buildImp(bidRequest, context);
+  const params = bidRequest.params;
+
+  imp.tagid = bidRequest.adUnitCode;
+  deepSetValue(imp, 'ext', {
+    ...bidRequest.params.ext,
+    ...imp.ext,
+    rwdd: imp.rwdd,
+    floors: getFloors(bidRequest),
+    bidder: {
+      publishersubid: params?.publisherSubId,
+      zoneid: params?.zoneId,
+      uid: params?.uid,
+    },
+  });
+
+  delete imp.rwdd // oRTB 2.6 field moved to ext
+
+  if (!context.fledgeEnabled && imp.ext.igs?.ae) {
+    delete imp.ext.igs.ae;
+  }
+
+  if (hasVideoMediaType(bidRequest)) {
+    const paramsVideo = bidRequest.params.video;
+    if (paramsVideo !== undefined) {
+      deepSetValue(imp, 'video', {
+        ...imp.video,
+        skip: imp.video.skip || paramsVideo.skip || 0,
+        placement: imp.video.placement || paramsVideo.placement,
+        minduration: imp.video.minduration || paramsVideo.minduration,
+        playbackmethod: imp.video.playbackmethod || paramsVideo.playbackmethod,
+        startdelay: imp.video.startdelay || paramsVideo.startdelay || 0,
+      })
+    }
+    deepSetValue(imp, 'video.ext', {
+      context: bidRequest.mediaTypes.video.context,
+      playersizes: parseSizes(deepAccess(bidRequest, 'mediaTypes.video.playerSize'), parseSize),
+      plcmt: bidRequest.mediaTypes.video.plcmt,
+      poddur: bidRequest.mediaTypes.video.adPodDurationSec,
+      rqddurs: bidRequest.mediaTypes.video.durationRangeSec,
+    })
+  }
+
+  if (imp.native && typeof imp.native.request !== 'undefined') {
+    let requestNative = JSON.parse(imp.native.request);
+
+    // We remove the native asset requirements if we used the bypass to generate the imp
+    const hasAssetRequirements = requestNative.assets &&
+      (requestNative.assets.length !== 1 || Object.keys(requestNative.assets[0]).length);
+    if (!hasAssetRequirements) {
+      delete requestNative.assets;
+    }
+
+    deepSetValue(imp, 'native.request_native', requestNative);
+    delete imp.native.request;
+  }
+
+  return imp;
+}
+
+/**
+ * Builds a request object for the ORTB 2.5 request.
+ *
+ * @param {function} buildRequest - The function for building a request object.
+ * @param {Array} imps - An array of ORTB 2.5 impression objects.
+ * @param {Object} bidderRequest - The bidder request object.
+ * @param {Object} context - The context object.
+ * @returns {Object} The ORTB 2.5 request object.
+ */
+function request(buildRequest, imps, bidderRequest, context) {
+  let request = buildRequest(imps, bidderRequest, context);
+
+  // params.pubid should override publisher id
+  if (typeof context.publisherId !== 'undefined') {
+    if (typeof request.app !== 'undefined') {
+      deepSetValue(request, 'app.publisher.id', context.publisherId);
+    } else {
+      deepSetValue(request, 'site.publisher.id', context.publisherId);
+    }
+  }
+
+  if (bidderRequest && bidderRequest.gdprConsent) {
+    deepSetValue(request, 'regs.ext.gdprversion', bidderRequest.gdprConsent.apiVersion);
+  }
+
+  // Translate 2.6 OpenRTB request into 2.5 OpenRTB request
+  request = TRANSLATOR(request);
+
+  return request;
+}
+
+/**
+ * Build bid from oRTB 2.5 bid.
+ *
+ * @param buildBidResponse
+ * @param bid
+ * @param context
+ * @returns {*}
+ */
+function bidResponse(buildBidResponse, bid, context) {
+  context.mediaType = deepAccess(bid, 'ext.mediatype');
+  if (context.mediaType === NATIVE && typeof bid.adm_native !== 'undefined') {
+    bid.adm = bid.adm_native;
+    delete bid.adm_native;
+  }
+
+  let bidResponse = buildBidResponse(bid, context);
+  const {bidRequest} = context;
+
+  bidResponse.currency = deepAccess(bid, 'ext.cur')
+
+  if (typeof deepAccess(bid, 'ext.meta') !== 'undefined') {
+    deepSetValue(bidResponse, 'meta', {
+      ...bidResponse.meta,
+      ...bid.ext.meta
+    });
+  }
+  if (typeof deepAccess(bid, 'ext.paf.content_id') !== 'undefined') {
+    deepSetValue(bidResponse, 'meta.paf.content_id', bid.ext.paf.content_id)
+  }
+
+  if (bidResponse.mediaType === VIDEO) {
+    bidResponse.vastUrl = bid.ext?.displayurl;
+    // if outstream video, add a default render for it.
+    if (deepAccess(bidRequest, 'mediaTypes.video.context') === OUTSTREAM) {
+      bidResponse.renderer = createOutstreamVideoRenderer(bid);
+    }
+  }
+
+  return bidResponse;
+}
+
+/**
+ * Builds bid response from the oRTB 2.5 bid response.
+ *
+ * @param buildResponse
+ * @param bidResponses
+ * @param ortbResponse
+ * @param context
+ * @returns *
+ */
+function response(buildResponse, bidResponses, ortbResponse, context) {
+  let response = buildResponse(bidResponses, ortbResponse, context);
+
+  const pafTransmission = deepAccess(ortbResponse, 'ext.paf.transmission');
+  response.bids.forEach(bid => {
+    if (typeof pafTransmission !== 'undefined' && typeof deepAccess(bid, 'meta.paf.content_id') !== 'undefined') {
+      deepSetValue(bid, 'meta.paf.transmission', pafTransmission);
+    } else {
+      delete bid.meta.paf;
+    }
+  });
+
+  return response;
+}
 
 /** @type {BidderSpec} */
 export const spec = {
@@ -170,19 +349,25 @@ export const spec = {
    * @return {ServerRequest}
    */
   buildRequests: (bidRequests, bidderRequest) => {
-    let url;
-    let data;
-    let fpd = bidderRequest.ortb2 || {};
+    bidRequests.forEach(bidRequest => {
+      if (hasNativeMediaType(bidRequest)) {
+        if (!checkNativeSendId(bidRequest)) {
+          logWarn(LOG_PREFIX + 'all native assets containing URL should be sent as placeholders with sendId(icon, image, clickUrl, displayUrl, privacyLink, privacyIcon)');
+        }
 
-    Object.assign(bidderRequest, {
-      publisherExt: fpd.site?.ext,
-      userExt: fpd.user?.ext,
-      ceh: config.getConfig('criteo.ceh'),
-      coppa: config.getConfig('coppa')
+        // We support native request without assets requirements because we can fill them later on.
+        // This is a trick to fool oRTB converter isOpenRTBBidRequestValid(ortb) fn because it needs
+        // nativeOrtbRequest.assets to be non-empty.
+        if (deepAccess(bidRequest, 'nativeOrtbRequest.assets') == null) {
+          logWarn(LOG_PREFIX + 'native asset requirements are missing');
+          deepSetValue(bidRequest, 'nativeOrtbRequest.assets', [{}]);
+        }
+      }
     });
+
     const context = buildContext(bidRequests, bidderRequest);
-    url = buildCdbUrl(context);
-    data = buildCdbRequest(context, bidRequests, bidderRequest);
+    const url = buildCdbUrl(context);
+    const data = CONVERTER.toORTB({bidderRequest, bidRequests, context});
 
     if (data) {
       return { method: 'POST', url, data, bidRequests };
@@ -195,77 +380,16 @@ export const spec = {
    * @return {Bid[] | {bids: Bid[], fledgeAuctionConfigs: object[]}}
    */
   interpretResponse: (response, request) => {
-    const body = response.body || response;
-
-    const bids = [];
-    const fledgeAuctionConfigs = [];
-
-    if (body && body.slots && isArray(body.slots)) {
-      body.slots.forEach(slot => {
-        const bidRequest = getAssociatedBidRequest(request.bidRequests, slot);
-        if (bidRequest) {
-          const bidId = bidRequest.bidId;
-          const bid = {
-            requestId: bidId,
-            cpm: slot.cpm,
-            currency: slot.currency,
-            netRevenue: true,
-            ttl: slot.ttl || 60,
-            creativeId: slot.creativecode,
-            width: slot.width,
-            height: slot.height,
-            dealId: slot.deal,
-          };
-          if (body.ext?.paf?.transmission && slot.ext?.paf?.content_id) {
-            const pafResponseMeta = {
-              content_id: slot.ext.paf.content_id,
-              transmission: response.ext.paf.transmission
-            };
-            bid.meta = Object.assign({}, bid.meta, { paf: pafResponseMeta });
-          }
-          if (slot.adomain) {
-            bid.meta = Object.assign({}, bid.meta, { advertiserDomains: [slot.adomain].flat() });
-          }
-          if (slot.ext?.meta?.networkName) {
-            bid.meta = Object.assign({}, bid.meta, { networkName: slot.ext.meta.networkName })
-          }
-          if (slot.ext?.dsa) {
-            bid.meta = Object.assign({}, bid.meta, { dsa: slot.ext.dsa })
-          }
-          if (slot.native) {
-            if (bidRequest.params.nativeCallback) {
-              bid.ad = createNativeAd(bidId, slot.native, bidRequest.params.nativeCallback);
-            } else {
-              bid.native = createPrebidNativeAd(slot.native);
-              bid.mediaType = NATIVE;
-            }
-          } else if (slot.video) {
-            bid.vastUrl = slot.displayurl;
-            bid.mediaType = VIDEO;
-            const context = deepAccess(bidRequest, 'mediaTypes.video.context');
-            // if outstream video, add a default render for it.
-            if (context === OUTSTREAM) {
-              bid.renderer = createOutstreamVideoRenderer(slot);
-            }
-          } else {
-            bid.ad = slot.creative;
-          }
-          bids.push(bid);
-        }
-      });
+    if (typeof response?.body == 'undefined') {
+      return []; // no bid
     }
 
-    if (isArray(body.ext?.igi)) {
-      body.ext.igi.forEach((igi) => {
-        if (isArray(igi?.igs)) {
-          igi.igs.forEach((igs) => {
-            fledgeAuctionConfigs.push(igs);
-          });
-        }
-      });
-    }
+    const interpretedResponse = CONVERTER.fromORTB({response: response.body, request: request.data});
+    const bids = interpretedResponse.bids || [];
 
-    if (fledgeAuctionConfigs.length) {
+    const fledgeAuctionConfigs = deepAccess(response.body, 'ext.igi')?.filter(igi => isArray(igi?.igs))
+      .flatMap(igi => igi.igs);
+    if (fledgeAuctionConfigs?.length) {
       return {
         bids,
         fledgeAuctionConfigs,
@@ -319,30 +443,21 @@ function deleteFromAllStorages(name) {
  * @param bidderRequest
  */
 function buildContext(bidRequests, bidderRequest) {
-  let referrer = '';
-  if (bidderRequest && bidderRequest.refererInfo) {
-    referrer = bidderRequest.refererInfo.page;
-  }
   const queryString = parseUrl(bidderRequest?.refererInfo?.topmostLocation).search;
 
-  const context = {
-    url: referrer,
+  return {
+    url: bidderRequest?.refererInfo?.page || '',
     debug: queryString['pbt_debug'] === '1',
     noLog: queryString['pbt_nolog'] === '1',
-    amp: false,
+    fledgeEnabled: bidderRequest.fledgeEnabled,
+    amp: bidRequests.some(bidRequest => bidRequest.params.integrationMode === 'amp'),
+    networkId: bidRequests.find(bidRequest => bidRequest.params?.networkId)?.params.networkId,
+    publisherId: bidRequests.find(bidRequest => bidRequest.params?.pubid)?.params.pubid,
   };
-
-  bidRequests.forEach(bidRequest => {
-    if (bidRequest.params.integrationMode === 'amp') {
-      context.amp = true;
-    }
-  });
-
-  return context;
 }
 
 /**
- * @param {CriteoContext} context
+ * @param {Object} context
  * @return {string}
  */
 function buildCdbUrl(context) {
@@ -378,6 +493,10 @@ function buildCdbUrl(context) {
     url += `&optout=1`;
   }
 
+  if (context.networkId) {
+    url += `&networkId=` + context.networkId;
+  }
+
   return url;
 }
 
@@ -391,184 +510,6 @@ function checkNativeSendId(bidRequest) {
       (bidRequest.nativeParams.privacyLink && ((bidRequest.nativeParams.privacyLink.sendId !== true || bidRequest.nativeParams.privacyLink.sendTargetingKeys === true))) ||
       (bidRequest.nativeParams.privacyIcon && ((bidRequest.nativeParams.privacyIcon.sendId !== true || bidRequest.nativeParams.privacyIcon.sendTargetingKeys === true)))
     ));
-}
-
-/**
- * @param {CriteoContext} context
- * @param {BidRequest[]} bidRequests
- * @param bidderRequest
- * @return {*}
- */
-function buildCdbRequest(context, bidRequests, bidderRequest) {
-  let networkId;
-  let pubid;
-  let schain;
-  let userIdAsEids;
-  let regs = Object.assign({}, {
-    coppa: bidderRequest.coppa === true ? 1 : (bidderRequest.coppa === false ? 0 : undefined)
-  }, bidderRequest.ortb2?.regs);
-  const request = {
-    id: generateUUID(),
-    publisher: {
-      url: context.url,
-      ext: bidderRequest.publisherExt,
-    },
-    regs: regs,
-    slots: bidRequests.map(bidRequest => {
-      if (!userIdAsEids) {
-        userIdAsEids = bidRequest.userIdAsEids;
-      }
-      networkId = bidRequest.params.networkId || networkId;
-      pubid = bidRequest.params.pubid || pubid;
-      schain = bidRequest.schain || schain;
-      const slot = {
-        slotid: bidRequest.bidId,
-        impid: bidRequest.adUnitCode,
-        transactionid: bidRequest.ortb2Imp?.ext?.tid
-      };
-      if (bidRequest.params.zoneId) {
-        slot.zoneid = bidRequest.params.zoneId;
-      }
-      if (deepAccess(bidRequest, 'ortb2Imp.ext')) {
-        slot.ext = bidRequest.ortb2Imp.ext;
-      }
-
-      if (deepAccess(bidRequest, 'ortb2Imp.rwdd')) {
-        slot.rwdd = bidRequest.ortb2Imp.rwdd;
-      }
-
-      if (bidRequest.params.ext) {
-        slot.ext = Object.assign({}, slot.ext, bidRequest.params.ext);
-      }
-      if (bidRequest.nativeOrtbRequest?.assets) {
-        slot.ext = Object.assign({}, slot.ext, { assets: bidRequest.nativeOrtbRequest.assets });
-      }
-      if (bidRequest.params.uid) {
-        slot.ext = Object.assign({}, slot.ext, { bidder: { uid: bidRequest.params.uid } });
-      }
-
-      if (bidRequest.params.publisherSubId) {
-        slot.publishersubid = bidRequest.params.publisherSubId;
-      }
-
-      if (bidRequest.params.nativeCallback || hasNativeMediaType(bidRequest)) {
-        slot.native = true;
-        if (!checkNativeSendId(bidRequest)) {
-          logWarn(LOG_PREFIX + 'all native assets containing URL should be sent as placeholders with sendId(icon, image, clickUrl, displayUrl, privacyLink, privacyIcon)');
-        }
-      }
-
-      if (hasBannerMediaType(bidRequest)) {
-        slot.sizes = parseSizes(deepAccess(bidRequest, 'mediaTypes.banner.sizes'), parseSize);
-      } else {
-        slot.sizes = [];
-      }
-
-      if (hasVideoMediaType(bidRequest)) {
-        const video = {
-          context: bidRequest.mediaTypes.video.context,
-          playersizes: parseSizes(deepAccess(bidRequest, 'mediaTypes.video.playerSize'), parseSize),
-          mimes: bidRequest.mediaTypes.video.mimes,
-          protocols: bidRequest.mediaTypes.video.protocols,
-          maxduration: bidRequest.mediaTypes.video.maxduration,
-          api: bidRequest.mediaTypes.video.api,
-          skip: bidRequest.mediaTypes.video.skip,
-          placement: bidRequest.mediaTypes.video.placement,
-          minduration: bidRequest.mediaTypes.video.minduration,
-          playbackmethod: bidRequest.mediaTypes.video.playbackmethod,
-          startdelay: bidRequest.mediaTypes.video.startdelay,
-          plcmt: bidRequest.mediaTypes.video.plcmt,
-          w: bidRequest.mediaTypes.video.w,
-          h: bidRequest.mediaTypes.video.h,
-          linearity: bidRequest.mediaTypes.video.linearity,
-          skipmin: bidRequest.mediaTypes.video.skipmin,
-          skipafter: bidRequest.mediaTypes.video.skipafter,
-          minbitrate: bidRequest.mediaTypes.video.minbitrate,
-          maxbitrate: bidRequest.mediaTypes.video.maxbitrate,
-          delivery: bidRequest.mediaTypes.video.delivery,
-          pos: bidRequest.mediaTypes.video.pos,
-          playbackend: bidRequest.mediaTypes.video.playbackend,
-          adPodDurationSec: bidRequest.mediaTypes.video.adPodDurationSec,
-          durationRangeSec: bidRequest.mediaTypes.video.durationRangeSec,
-        };
-        const paramsVideo = bidRequest.params.video;
-        if (paramsVideo !== undefined) {
-          video.skip = video.skip || paramsVideo.skip || 0;
-          video.placement = video.placement || paramsVideo.placement;
-          video.minduration = video.minduration || paramsVideo.minduration;
-          video.playbackmethod = video.playbackmethod || paramsVideo.playbackmethod;
-          video.startdelay = video.startdelay || paramsVideo.startdelay || 0;
-        }
-
-        slot.video = video;
-      }
-
-      enrichSlotWithFloors(slot, bidRequest);
-
-      if (!bidderRequest.fledgeEnabled && slot.ext?.ae) {
-        delete slot.ext.ae;
-      }
-
-      return slot;
-    }),
-  };
-  if (networkId) {
-    request.publisher.networkid = networkId;
-  }
-
-  request.source = {
-    tid: bidderRequest.ortb2?.source?.tid
-  };
-
-  if (schain) {
-    request.source.ext = {
-      schain: schain
-    };
-  };
-  request.user = bidderRequest.ortb2?.user || {};
-  request.site = bidderRequest.ortb2?.site || {};
-  request.app = bidderRequest.ortb2?.app || {};
-
-  if (pubid) {
-    request.site.publisher = {...request.site.publisher, ...{ id: pubid }};
-    request.app.publisher = {...request.app.publisher, ...{ id: pubid }};
-  }
-  request.device = bidderRequest.ortb2?.device || {};
-  if (bidderRequest && bidderRequest.ceh) {
-    request.user.ceh = bidderRequest.ceh;
-  }
-  if (bidderRequest && bidderRequest.gdprConsent) {
-    request.gdprConsent = {};
-    if (typeof bidderRequest.gdprConsent.gdprApplies !== 'undefined') {
-      request.gdprConsent.gdprApplies = !!(bidderRequest.gdprConsent.gdprApplies);
-    }
-    request.gdprConsent.version = bidderRequest.gdprConsent.apiVersion;
-    if (typeof bidderRequest.gdprConsent.consentString !== 'undefined') {
-      request.gdprConsent.consentData = bidderRequest.gdprConsent.consentString;
-    }
-  }
-  if (bidderRequest && bidderRequest.uspConsent) {
-    request.user.uspIab = bidderRequest.uspConsent;
-  }
-  if (bidderRequest && bidderRequest.ortb2?.device?.sua) {
-    request.user.ext = request.user.ext || {};
-    request.user.ext.sua = bidderRequest.ortb2?.device?.sua || {};
-  }
-  if (userIdAsEids) {
-    request.user.ext = request.user.ext || {};
-    request.user.ext.eids = [...userIdAsEids];
-  }
-  if (bidderRequest && bidderRequest.ortb2?.bcat) {
-    request.bcat = bidderRequest.ortb2.bcat;
-  }
-  if (bidderRequest && bidderRequest.ortb2?.badv) {
-    request.badv = bidderRequest.ortb2.badv;
-  }
-  if (bidderRequest && bidderRequest.ortb2?.bapp) {
-    request.bapp = bidderRequest.ortb2.bapp;
-  }
-  request.tmax = bidderRequest.timeout;
-  return request;
 }
 
 function parseSizes(sizes, parser = s => s) {
@@ -587,10 +528,6 @@ function parseSize(size) {
 
 function hasVideoMediaType(bidRequest) {
   return deepAccess(bidRequest, 'mediaTypes.video') !== undefined;
-}
-
-function hasBannerMediaType(bidRequest) {
-  return deepAccess(bidRequest, 'mediaTypes.banner') !== undefined;
 }
 
 function hasNativeMediaType(bidRequest) {
@@ -612,54 +549,6 @@ function hasValidVideoMediaType(bidRequest) {
   return isValid;
 }
 
-/**
- * Create prebid compatible native ad with native payload
- * @param {*} payload
- * @returns prebid native ad assets
- */
-function createPrebidNativeAd(payload) {
-  return {
-    sendTargetingKeys: false, // no key is added to KV by default
-    title: payload.products[0].title,
-    body: payload.products[0].description,
-    sponsoredBy: payload.advertiser.description,
-    icon: payload.advertiser.logo,
-    image: payload.products[0].image,
-    clickUrl: payload.products[0].click_url,
-    privacyLink: payload.privacy.optout_click_url,
-    privacyIcon: payload.privacy.optout_image_url,
-    cta: payload.products[0].call_to_action,
-    price: payload.products[0].price,
-    impressionTrackers: payload.impression_pixels.map(pix => pix.url)
-  };
-}
-
-/**
- * @param {string} id
- * @param {*} payload
- * @param {*} callback
- * @return {string}
- */
-function createNativeAd(id, payload, callback) {
-  // Store the callback and payload in a global object to be later accessed from the creative
-  var slotsName = 'criteo_prebid_native_slots';
-  window[slotsName] = window[slotsName] || {};
-  window[slotsName][id] = { callback, payload };
-
-  // The creative is in an iframe so we have to get the callback and payload
-  // from the parent window (doesn't work with safeframes)
-  return `
-<script type="text/javascript">
-for (var i = 0; i < 10; ++i) {
- var slots = window.parent.${slotsName};
-  if(!slots){continue;}
-  var responseSlot = slots["${id}"];
-  responseSlot.callback(responseSlot.payload);
-  break;
-}
-</script>`;
-}
-
 function pickAvailableGetFloorFunc(bidRequest) {
   if (bidRequest.getFloor) {
     return bidRequest.getFloor;
@@ -678,92 +567,63 @@ function pickAvailableGetFloorFunc(bidRequest) {
   return undefined;
 }
 
-function enrichSlotWithFloors(slot, bidRequest) {
+function getFloors(bidRequest) {
   try {
-    const slotFloors = {};
+    const floors = {};
 
     const getFloor = pickAvailableGetFloorFunc(bidRequest);
 
     if (getFloor) {
       if (bidRequest.mediaTypes?.banner) {
-        slotFloors.banner = {};
+        floors.banner = {};
         const bannerSizes = parseSizes(deepAccess(bidRequest, 'mediaTypes.banner.sizes'))
-        bannerSizes.forEach(bannerSize => slotFloors.banner[parseSize(bannerSize).toString()] = getFloor.call(bidRequest, { size: bannerSize, mediaType: BANNER }));
+        bannerSizes.forEach(bannerSize => floors.banner[parseSize(bannerSize).toString()] = getFloor.call(bidRequest, { size: bannerSize, mediaType: BANNER }));
       }
 
       if (bidRequest.mediaTypes?.video) {
-        slotFloors.video = {};
+        floors.video = {};
         const videoSizes = parseSizes(deepAccess(bidRequest, 'mediaTypes.video.playerSize'))
-        videoSizes.forEach(videoSize => slotFloors.video[parseSize(videoSize).toString()] = getFloor.call(bidRequest, { size: videoSize, mediaType: VIDEO }));
+        videoSizes.forEach(videoSize => floors.video[parseSize(videoSize).toString()] = getFloor.call(bidRequest, { size: videoSize, mediaType: VIDEO }));
       }
 
       if (bidRequest.mediaTypes?.native) {
-        slotFloors.native = {};
-        slotFloors.native['*'] = getFloor.call(bidRequest, { size: '*', mediaType: NATIVE });
+        floors.native = {};
+        floors.native['*'] = getFloor.call(bidRequest, { size: '*', mediaType: NATIVE });
       }
 
-      if (Object.keys(slotFloors).length > 0) {
-        if (!slot.ext) {
-          slot.ext = {}
-        }
-        Object.assign(slot.ext, {
-          floors: slotFloors
-        });
-      }
+      return floors;
     }
   } catch (e) {
     logError('Could not parse floors from Prebid: ' + e);
   }
 }
 
-function createOutstreamVideoRenderer(slot) {
-  if (slot.ext.videoPlayerConfig === undefined || slot.ext.videoPlayerType === undefined) {
+function createOutstreamVideoRenderer(bid) {
+  if (bid.ext?.videoPlayerConfig === undefined || bid.ext?.videoPlayerType === undefined) {
     return undefined;
   }
 
   const config = {
-    documentResolver: (bid, sourceDocument, renderDocument) => {
+    documentResolver: (_, sourceDocument, renderDocument) => {
       return renderDocument ?? sourceDocument;
     }
   }
 
-  const render = (bid, renderDocument) => {
+  const render = (_, renderDocument) => {
     let payload = {
-      slotid: slot.impid,
-      vastUrl: slot.displayurl,
-      vastXml: slot.creative,
+      slotid: bid.id,
+      vastUrl: bid.ext?.displayurl,
+      vastXml: bid.adm,
       documentContext: renderDocument,
     };
 
-    let outstreamConfig = slot.ext.videoPlayerConfig;
-
-    window.CriteoOutStream[slot.ext.videoPlayerType].play(payload, outstreamConfig)
+    let outstreamConfig = bid.ext.videoPlayerConfig;
+    window.CriteoOutStream[bid.ext.videoPlayerType].play(payload, outstreamConfig)
   };
 
   const renderer = Renderer.install({ url: PUBLISHER_TAG_OUTSTREAM_SRC, config: config });
   renderer.setRender(render);
   return renderer;
-}
-
-function getAssociatedBidRequest(bidRequests, slot) {
-  for (const request of bidRequests) {
-    if (request.adUnitCode === slot.impid) {
-      if (request.params.zoneId && parseInt(request.params.zoneId) === slot.zoneid) {
-        return request;
-      } else if (slot.native) {
-        if (request.mediaTypes?.native || request.nativeParams) {
-          return request;
-        }
-      } else if (slot.video) {
-        if (request.mediaTypes?.video) {
-          return request;
-        }
-      } else if (request.mediaTypes?.banner || request.sizes) {
-        return request;
-      }
-    }
-  }
-  return undefined;
 }
 
 registerBidder(spec);

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -1,17 +1,20 @@
 import { expect } from 'chai';
 import {
-  tryGetCriteoFastBid,
   spec,
   storage,
-  PROFILE_ID_PUBLISHERTAG,
-  ADAPTER_VERSION,
-  canFastBid, getFastBidUrl, FAST_BID_VERSION_CURRENT
 } from 'modules/criteoBidAdapter.js';
 import * as utils from 'src/utils.js';
 import * as refererDetection from 'src/refererDetection.js';
 import * as ajax from 'src/ajax.js';
 import { config } from '../../../src/config.js';
 import { BANNER, NATIVE, VIDEO } from '../../../src/mediaTypes.js';
+import {syncAddFPDToBidderRequest} from '../../helpers/fpd';
+import 'modules/userId/index.js';
+import 'modules/consentManagement.js';
+import 'modules/consentManagementUsp.js';
+import 'modules/consentManagementGpp.js';
+import 'modules/schain.js';
+import {hook} from '../../../src/hook';
 
 describe('The Criteo bidding adapter', function () {
   let utilsMock, sandbox, ajaxStub;
@@ -594,8 +597,8 @@ describe('The Criteo bidding adapter', function () {
       },
       timeout: 3000,
       gdprConsent: {
-        gdprApplies: 1,
-        consentString: 'concentDataString',
+        gdprApplies: true,
+        consentString: 'consentDataString',
         vendorData: {
           vendorConsents: {
             '91': 1
@@ -606,6 +609,10 @@ describe('The Criteo bidding adapter', function () {
     };
 
     let localStorageIsEnabledStub;
+
+    before(() => {
+      hook.ready();
+    });
 
     this.beforeEach(function () {
       localStorageIsEnabledStub = sinon.stub(storage, 'localStorageIsEnabled');
@@ -620,13 +627,11 @@ describe('The Criteo bidding adapter', function () {
     it('should properly build a request using random uuid as auction id', function () {
       const generateUUIDStub = sinon.stub(utils, 'generateUUID');
       generateUUIDStub.returns('def');
-      const bidderRequest = {
-      };
+      const bidderRequest = {};
       const bidRequests = [
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
@@ -635,7 +640,7 @@ describe('The Criteo bidding adapter', function () {
           params: {}
         },
       ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
       const ortbRequest = request.data;
       expect(ortbRequest.id).to.equal('def');
       generateUUIDStub.restore();
@@ -653,7 +658,6 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
@@ -662,7 +666,7 @@ describe('The Criteo bidding adapter', function () {
           params: {}
         },
       ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
       const ortbRequest = request.data;
       expect(ortbRequest.source.tid).to.equal('abc');
     });
@@ -681,25 +685,18 @@ describe('The Criteo bidding adapter', function () {
           params: {}
         },
       ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
       const ortbRequest = request.data;
       expect(ortbRequest.tmax).to.equal(bidderRequest.timeout);
     });
 
     it('should properly transmit bidId if available', function () {
-      const bidderRequest = {
-        ortb2: {
-          source: {
-            tid: 'abc'
-          }
-        }
-      };
+      const bidderRequest = {};
       const bidRequests = [
         {
           bidId: 'bidId',
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
@@ -708,33 +705,9 @@ describe('The Criteo bidding adapter', function () {
           params: {}
         },
       ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
       const ortbRequest = request.data;
-      expect(ortbRequest.slots[0].slotid).to.equal('bidId');
-    });
-
-    it('should properly build a request if refererInfo is not provided', function () {
-      const bidderRequest = {};
-      const bidRequests = [
-        {
-          bidder: 'criteo',
-          adUnitCode: 'bid-123',
-          ortb2Imp: {
-            ext: {
-              tid: 'transaction-123',
-            },
-          },
-          mediaTypes: {
-            banner: {
-              sizes: [[728, 90]]
-            }
-          },
-          params: {}
-        },
-      ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      const ortbRequest = request.data;
-      expect(ortbRequest.publisher.url).to.equal('');
+      expect(ortbRequest.imp[0].id).to.equal('bidId');
     });
 
     it('should properly build a zoneId request', function () {
@@ -755,77 +728,24 @@ describe('The Criteo bidding adapter', function () {
           params: {
             zoneId: 123,
             publisherSubId: '123',
-            nativeCallback: function () { },
             integrationMode: 'amp'
           },
         },
       ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.url).to.match(/^https:\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&wv=[^&]+&cb=\d+&lsavail=1&im=1&debug=1&nolog=1/);
+      const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+      expect(request.url).to.match(/^https:\/\/bidder\.criteo\.com\/openrtb_2_5\/pbjs\/auction\/request\?profileId=207&av=\d+&wv=[^&]+&cb=\d+&lsavail=[01]&im=1&debug=[01]&nolog=[01]$/);
       expect(request.method).to.equal('POST');
       const ortbRequest = request.data;
-      expect(ortbRequest.publisher.url).to.equal(refererUrl);
-      expect(ortbRequest.slots).to.have.lengthOf(1);
-      expect(ortbRequest.slots[0].impid).to.equal('bid-123');
-      expect(ortbRequest.slots[0].transactionid).to.equal('transaction-123');
-      expect(ortbRequest.slots[0].sizes).to.have.lengthOf(1);
-      expect(ortbRequest.slots[0].sizes[0]).to.equal('728x90');
-      expect(ortbRequest.slots[0].zoneid).to.equal(123);
-      expect(ortbRequest.gdprConsent.consentData).to.equal('concentDataString');
-      expect(ortbRequest.gdprConsent.gdprApplies).to.equal(true);
-      expect(ortbRequest.gdprConsent.version).to.equal(1);
-    });
-
-    it('should keep undefined sizes for non native banner', function () {
-      const bidRequests = [
-        {
-          mediaTypes: {
-            banner: {
-              sizes: [[undefined, undefined]]
-            }
-          },
-          params: {},
-        },
-      ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      const ortbRequest = request.data;
-      expect(ortbRequest.slots[0].sizes).to.have.lengthOf(1);
-      expect(ortbRequest.slots[0].sizes[0]).to.equal('undefinedxundefined');
-    });
-
-    it('should keep undefined size for non native banner', function () {
-      const bidRequests = [
-        {
-          mediaTypes: {
-            banner: {
-              sizes: [undefined, undefined]
-            }
-          },
-          params: {},
-        },
-      ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      const ortbRequest = request.data;
-      expect(ortbRequest.slots[0].sizes).to.have.lengthOf(1);
-      expect(ortbRequest.slots[0].sizes[0]).to.equal('undefinedxundefined');
-    });
-
-    it('should properly detect and forward native flag', function () {
-      const bidRequests = [
-        {
-          mediaTypes: {
-            banner: {
-              sizes: [[undefined, undefined]]
-            }
-          },
-          params: {
-            nativeCallback: function () { }
-          },
-        },
-      ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      const ortbRequest = request.data;
-      expect(ortbRequest.slots[0].native).to.equal(true);
+      expect(ortbRequest.site.page).to.equal(refererUrl);
+      expect(ortbRequest.imp).to.have.lengthOf(1);
+      expect(ortbRequest.imp[0].tagid).to.equal('bid-123');
+      expect(ortbRequest.imp[0].banner.format).to.have.lengthOf(1);
+      expect(ortbRequest.imp[0].banner.format[0].w).to.equal(728);
+      expect(ortbRequest.imp[0].banner.format[0].h).to.equal(90);
+      expect(ortbRequest.imp[0].ext.bidder.zoneid).to.equal(123);
+      expect(ortbRequest.user.ext.consent).to.equal('consentDataString');
+      expect(ortbRequest.regs.ext.gdpr).to.equal(1);
+      expect(ortbRequest.regs.ext.gdprversion).to.equal(1);
     });
 
     it('should properly forward eids', function () {
@@ -833,7 +753,6 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
@@ -851,7 +770,7 @@ describe('The Criteo bidding adapter', function () {
           params: {}
         },
       ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
       const ortbRequest = request.data;
       expect(ortbRequest.user.ext.eids).to.deep.equal([
         {
@@ -864,79 +783,81 @@ describe('The Criteo bidding adapter', function () {
       ]);
     });
 
-    it('should properly detect and forward native flag', function () {
-      const bidRequests = [
-        {
-          mediaTypes: {
-            banner: {
-              sizes: [undefined, undefined]
-            }
+    if (FEATURES.NATIVE) {
+      it('should properly build a native request without assets', function () {
+        const bidRequests = [
+          {
+            mediaTypes: {
+              native: {}
+            },
+            params: {}
           },
-          params: {
-            nativeCallback: function () { }
-          },
-        },
-      ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      const ortbRequest = request.data;
-      expect(ortbRequest.slots[0].native).to.equal(true);
-    });
+        ];
+        const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+        const ortbRequest = request.data;
+        expect(ortbRequest.imp[0].native.request_native).to.not.be.null;
+        expect(ortbRequest.imp[0].native.request_native.assets).to.be.undefined;
+      });
+    }
 
-    it('should map ortb native assets to slot ext assets', function () {
-      const assets = [{
-        required: 1,
-        id: 1,
-        img: {
-          type: 3,
-          wmin: 100,
-          hmin: 100,
-        }
-      },
-      {
-        required: 1,
-        id: 2,
-        title: {
-          len: 140,
-        }
-      },
-      {
-        required: 1,
-        id: 3,
-        data: {
-          type: 1,
-        }
-      },
-      {
-        required: 0,
-        id: 4,
-        data: {
-          type: 2,
-        }
-      },
-      {
-        required: 0,
-        id: 5,
-        img: {
-          type: 1,
-          wmin: 20,
-          hmin: 20,
-        }
-      }];
-      const bidRequests = [
-        {
-          nativeOrtbRequest: {
-            assets: assets
-          },
-          params: {
-            nativeCallback: function () { }
-          },
+    if (FEATURES.NATIVE) {
+      it('should properly build a native request with assets', function () {
+        const assets = [{
+          required: 1,
+          id: 1,
+          img: {
+            type: 3,
+            wmin: 100,
+            hmin: 100,
+          }
         },
-      ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      const ortbRequest = request.data;
-      expect(ortbRequest.slots[0].native).to.equal(true);
-      expect(ortbRequest.slots[0].ext.assets).to.deep.equal(assets);
-    });
+        {
+          required: 1,
+          id: 2,
+          title: {
+            len: 140,
+          }
+        },
+        {
+          required: 1,
+          id: 3,
+          data: {
+            type: 1,
+          }
+        },
+        {
+          required: 0,
+          id: 4,
+          data: {
+            type: 2,
+          }
+        },
+        {
+          required: 0,
+          id: 5,
+          img: {
+            type: 1,
+            wmin: 20,
+            hmin: 20,
+          }
+        }];
+        const bidRequests = [
+          {
+            mediaTypes: {
+              native: {}
+            },
+            nativeOrtbRequest: {
+              assets: assets
+            },
+            params: {}
+          },
+        ];
+        const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+        const ortbRequest = request.data;
+        expect(ortbRequest.imp[0].native.request_native).to.not.be.null;
+        expect(ortbRequest.imp[0].native.request_native.assets).to.deep.equal(assets);
+      });
+    }
 
     it('should properly build a networkId request', function () {
       const bidderRequest = {
@@ -946,7 +867,7 @@ describe('The Criteo bidding adapter', function () {
         },
         timeout: 3000,
         gdprConsent: {
-          gdprApplies: 0,
+          gdprApplies: false,
           consentString: undefined,
           vendorData: {
             vendorConsents: {
@@ -974,23 +895,23 @@ describe('The Criteo bidding adapter', function () {
           },
         },
       ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.url).to.match(/^https:\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&wv=[^&]+&cb=\d/);
+      const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+      expect(request.url).to.match(/^https:\/\/bidder\.criteo\.com\/openrtb_2_5\/pbjs\/auction\/request\?profileId=207&av=\d+&wv=[^&]+&cb=\d+&lsavail=[01]&debug=[01]&nolog=[01]&networkId=456$/);
       expect(request.method).to.equal('POST');
       const ortbRequest = request.data;
-      expect(ortbRequest.publisher.url).to.equal(refererUrl);
-      expect(ortbRequest.publisher.networkid).to.equal(456);
-      expect(ortbRequest.slots).to.have.lengthOf(1);
-      expect(ortbRequest.slots[0].impid).to.equal('bid-123');
-      expect(ortbRequest.slots[0].transactionid).to.equal('transaction-123');
-      expect(ortbRequest.slots[0].sizes).to.have.lengthOf(2);
-      expect(ortbRequest.slots[0].sizes[0]).to.equal('300x250');
-      expect(ortbRequest.slots[0].sizes[1]).to.equal('728x90');
-      expect(ortbRequest.gdprConsent.consentData).to.equal(undefined);
-      expect(ortbRequest.gdprConsent.gdprApplies).to.equal(false);
+      expect(ortbRequest.site.page).to.equal(refererUrl);
+      expect(ortbRequest.imp).to.have.lengthOf(1);
+      expect(ortbRequest.imp[0].tagid).to.equal('bid-123');
+      expect(ortbRequest.imp[0].banner.format).to.have.lengthOf(2);
+      expect(ortbRequest.imp[0].banner.format[0].w).to.equal(300);
+      expect(ortbRequest.imp[0].banner.format[0].h).to.equal(250);
+      expect(ortbRequest.imp[0].banner.format[1].w).to.equal(728);
+      expect(ortbRequest.imp[0].banner.format[1].h).to.equal(90);
+      expect(ortbRequest.user?.ext?.consent).to.equal(undefined);
+      expect(ortbRequest.regs.ext.gdpr).to.equal(0);
     });
 
-    it('should properly build a mixed request', function () {
+    it('should properly build a mixed request with both a zoneId and a networkId', function () {
       const bidderRequest = {
         refererInfo: {
           page: refererUrl,
@@ -1034,23 +955,26 @@ describe('The Criteo bidding adapter', function () {
           },
         },
       ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.url).to.match(/^https:\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&wv=[^&]+&cb=\d/);
+      const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+      expect(request.url).to.match(/^https:\/\/bidder\.criteo\.com\/openrtb_2_5\/pbjs\/auction\/request\?profileId=207&av=\d+&wv=[^&]+&cb=\d+&lsavail=[01]&debug=[01]&nolog=[01]&networkId=456$/);
       expect(request.method).to.equal('POST');
       const ortbRequest = request.data;
-      expect(ortbRequest.publisher.url).to.equal(refererUrl);
-      expect(ortbRequest.publisher.networkid).to.equal(456);
-      expect(ortbRequest.slots).to.have.lengthOf(2);
-      expect(ortbRequest.slots[0].impid).to.equal('bid-123');
-      expect(ortbRequest.slots[0].transactionid).to.equal('transaction-123');
-      expect(ortbRequest.slots[0].sizes).to.have.lengthOf(1);
-      expect(ortbRequest.slots[0].sizes[0]).to.equal('728x90');
-      expect(ortbRequest.slots[1].impid).to.equal('bid-234');
-      expect(ortbRequest.slots[1].transactionid).to.equal('transaction-234');
-      expect(ortbRequest.slots[1].sizes).to.have.lengthOf(2);
-      expect(ortbRequest.slots[1].sizes[0]).to.equal('300x250');
-      expect(ortbRequest.slots[1].sizes[1]).to.equal('728x90');
-      expect(ortbRequest.gdprConsent).to.equal(undefined);
+      expect(ortbRequest.site.page).to.equal(refererUrl);
+      expect(ortbRequest.imp).to.have.lengthOf(2);
+      expect(ortbRequest.imp[0].tagid).to.equal('bid-123');
+      expect(ortbRequest.imp[0].banner.format).to.have.lengthOf(1);
+      expect(ortbRequest.imp[0].banner.format[0].w).to.equal(728);
+      expect(ortbRequest.imp[0].banner.format[0].h).to.equal(90);
+      expect(ortbRequest.imp[0].ext.tid).to.equal('transaction-123');
+      expect(ortbRequest.imp[0].ext.bidder.zoneid).to.equal(123);
+      expect(ortbRequest.imp[1].tagid).to.equal('bid-234');
+      expect(ortbRequest.imp[1].banner.format).to.have.lengthOf(2);
+      expect(ortbRequest.imp[1].banner.format[0].w).to.equal(300);
+      expect(ortbRequest.imp[1].banner.format[0].h).to.equal(250);
+      expect(ortbRequest.imp[1].banner.format[1].w).to.equal(728);
+      expect(ortbRequest.imp[1].banner.format[1].h).to.equal(90);
+      expect(ortbRequest.imp[1].ext.tid).to.equal('transaction-234');
+      expect(ortbRequest.user?.ext?.consent).to.equal(undefined);
     });
 
     it('should properly build a request with undefined gdpr consent fields when they are not provided', function () {
@@ -1058,7 +982,6 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
@@ -1074,9 +997,9 @@ describe('The Criteo bidding adapter', function () {
         gdprConsent: {},
       };
 
-      const ortbRequest = spec.buildRequests(bidRequests, bidderRequest).data;
-      expect(ortbRequest.gdprConsent.consentData).to.equal(undefined);
-      expect(ortbRequest.gdprConsent.gdprApplies).to.equal(undefined);
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.user?.ext?.consent).to.equal(undefined);
+      expect(ortbRequest.regs?.ext?.gdpr).to.equal(undefined);
     });
 
     it('should properly build a request with ccpa consent field', function () {
@@ -1084,7 +1007,6 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
@@ -1100,42 +1022,43 @@ describe('The Criteo bidding adapter', function () {
         uspConsent: '1YNY',
       };
 
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.user).to.not.be.null;
-      expect(request.data.user.uspIab).to.equal('1YNY');
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.regs.ext.us_privacy).to.equal('1YNY');
     });
 
-    it('should properly build a request with site and app ortb fields', function () {
-      const bidRequests = [];
-      let app = {
-        publisher: {
-          id: 'appPublisherId'
-        }
-      };
-      let site = {
-        publisher: {
-          id: 'sitePublisherId'
-        }
-      };
-      const bidderRequest = {
-        ortb2: {
-          app: app,
-          site: site
-        }
-      };
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-
-      expect(request.data.app).to.equal(app);
-      expect(request.data.site).to.equal(site);
-    });
-
-    it('should properly build a request with device sua field', function () {
-      const sua = {}
+    it('should properly build a request with overridden tmax', function () {
       const bidRequests = [
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
+          mediaTypes: {
+            banner: {
+              sizes: [[728, 90]]
+            }
+          },
+          params: {
+            zoneId: 123,
+          },
+        },
+      ];
+      const bidderRequest = {
+        timeout: 1234
+      };
+
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.tmax).to.equal(1234);
+    });
+
+    it('should properly build a request with device sua field', function () {
+      const sua = {
+        platform: {
+          brand: 'abc'
+        }
+      }
+      const bidRequests = [
+        {
+          bidder: 'criteo',
+          adUnitCode: 'bid-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
@@ -1156,9 +1079,9 @@ describe('The Criteo bidding adapter', function () {
         }
       };
 
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.user.ext.sua).to.not.be.null;
-      expect(request.data.user.ext.sua).to.equal(sua);
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.device.ext.sua).not.to.be.null;
+      expect(ortbRequest.device.ext.sua.platform.brand).to.equal('abc');
     });
 
     it('should properly build a request with gpp consent field', function () {
@@ -1166,7 +1089,6 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
@@ -1184,10 +1106,9 @@ describe('The Criteo bidding adapter', function () {
         }
       };
 
-      const request = spec.buildRequests(bidRequests, { ...bidderRequest, ortb2 });
-      expect(request.data.regs).to.not.be.null;
-      expect(request.data.regs.gpp).to.equal('gpp_consent_string');
-      expect(request.data.regs.gpp_sid).to.deep.equal([0, 1, 2]);
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest({ ...bidderRequest, ortb2 })).data;
+      expect(ortbRequest.regs.ext.gpp).to.equal('gpp_consent_string');
+      expect(ortbRequest.regs.ext.gpp_sid).to.deep.equal([0, 1, 2]);
     });
 
     it('should properly build a request with dsa object', function () {
@@ -1195,7 +1116,6 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
@@ -1226,10 +1146,8 @@ describe('The Criteo bidding adapter', function () {
         }
       };
 
-      const request = spec.buildRequests(bidRequests, { ...bidderRequest, ortb2 });
-      expect(request.data.regs).to.not.be.null;
-      expect(request.data.regs.ext).to.not.be.null;
-      expect(request.data.regs.ext.dsa).to.deep.equal(dsa);
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest({ ...bidderRequest, ortb2 })).data;
+      expect(ortbRequest.regs.ext.dsa).to.deep.equal(dsa);
     });
 
     it('should properly build a request with schain object', function () {
@@ -1241,7 +1159,6 @@ describe('The Criteo bidding adapter', function () {
           bidder: 'criteo',
           schain: expectedSchain,
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
@@ -1253,8 +1170,8 @@ describe('The Criteo bidding adapter', function () {
         },
       ];
 
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.source.ext.schain).to.equal(expectedSchain);
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.source.ext.schain).to.equal(expectedSchain);
     });
 
     it('should properly build a request with bcat field', function () {
@@ -1263,7 +1180,6 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
@@ -1280,9 +1196,8 @@ describe('The Criteo bidding adapter', function () {
         }
       };
 
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.bcat).to.not.be.null;
-      expect(request.data.bcat).to.equal(bcat);
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.bcat).to.deep.equal(bcat);
     });
 
     it('should properly build a request with badv field', function () {
@@ -1291,7 +1206,6 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
@@ -1308,9 +1222,8 @@ describe('The Criteo bidding adapter', function () {
         }
       };
 
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.badv).to.not.be.null;
-      expect(request.data.badv).to.equal(badv);
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.badv).to.deep.equal(badv);
     });
 
     it('should properly build a request with bapp field', function () {
@@ -1319,7 +1232,6 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
@@ -1336,225 +1248,178 @@ describe('The Criteo bidding adapter', function () {
         }
       };
 
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.bapp).to.not.be.null;
-      expect(request.data.bapp).to.equal(bapp);
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.bapp).to.deep.equal(bapp);
     });
 
-    it('should properly build a request with if ccpa consent field is not provided', function () {
-      const bidRequests = [
-        {
-          bidder: 'criteo',
-          adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
-          mediaTypes: {
-            banner: {
-              sizes: [[728, 90]]
-            }
+    if (FEATURES.VIDEO) {
+      it('should properly build a video request', function () {
+        const bidRequests = [
+          {
+            bidder: 'criteo',
+            adUnitCode: 'bid-123',
+            sizes: [[640, 480]],
+            mediaTypes: {
+              video: {
+                context: 'inbanner',
+                playerSize: [640, 480],
+                mimes: ['video/mp4', 'video/x-flv'],
+                maxduration: 30,
+                api: [1, 2],
+                protocols: [2, 3],
+                plcmt: 3,
+                w: 640,
+                h: 480,
+                linearity: 1,
+                skipmin: 30,
+                skipafter: 30,
+                minbitrate: 10000,
+                maxbitrate: 48000,
+                delivery: [1, 2, 3],
+                pos: 1,
+                playbackend: 1,
+                adPodDurationSec: 30,
+                durationRangeSec: [1, 30],
+              }
+            },
+            params: {
+              zoneId: 123,
+              video: {
+                skip: 1,
+                minduration: 5,
+                startdelay: 5,
+                playbackmethod: [1, 3],
+                placement: 2
+              }
+            },
           },
-          params: {
-            zoneId: 123,
-          },
-        },
-      ];
-      const bidderRequest = {
-        timeout: 3000
-      };
-
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.user).to.not.be.null;
-      expect(request.data.user.uspIab).to.equal(undefined);
-    });
-
-    it('should properly build a video request', function () {
-      const bidRequests = [
-        {
-          bidder: 'criteo',
-          adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
-          sizes: [[640, 480]],
-          mediaTypes: {
-            video: {
-              context: 'instream',
-              playerSize: [640, 480],
-              mimes: ['video/mp4', 'video/x-flv'],
-              maxduration: 30,
-              api: [1, 2],
-              protocols: [2, 3],
-              plcmt: 3,
-              w: 640,
-              h: 480,
-              linearity: 1,
-              skipmin: 30,
-              skipafter: 30,
-              minbitrate: 10000,
-              maxbitrate: 48000,
-              delivery: [1, 2, 3],
-              pos: 1,
-              playbackend: 1,
-              adPodDurationSec: 30,
-              durationRangeSec: [1, 30],
-            }
-          },
-          params: {
-            zoneId: 123,
-            video: {
-              skip: 1,
-              minduration: 5,
-              startdelay: 5,
-              playbackmethod: [1, 3],
-              placement: 2
-            }
-          },
-        },
-      ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.url).to.match(/^https:\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&wv=[^&]+&cb=\d/);
-      expect(request.method).to.equal('POST');
-      const ortbRequest = request.data;
-      expect(ortbRequest.slots[0].video.context).to.equal('instream');
-      expect(ortbRequest.slots[0].video.mimes).to.deep.equal(['video/mp4', 'video/x-flv']);
-      expect(ortbRequest.slots[0].sizes).to.deep.equal([]);
-      expect(ortbRequest.slots[0].video.playersizes).to.deep.equal(['640x480']);
-      expect(ortbRequest.slots[0].video.maxduration).to.equal(30);
-      expect(ortbRequest.slots[0].video.api).to.deep.equal([1, 2]);
-      expect(ortbRequest.slots[0].video.protocols).to.deep.equal([2, 3]);
-      expect(ortbRequest.slots[0].video.skip).to.equal(1);
-      expect(ortbRequest.slots[0].video.minduration).to.equal(5);
-      expect(ortbRequest.slots[0].video.startdelay).to.equal(5);
-      expect(ortbRequest.slots[0].video.playbackmethod).to.deep.equal([1, 3]);
-      expect(ortbRequest.slots[0].video.placement).to.equal(2);
-      expect(ortbRequest.slots[0].video.plcmt).to.equal(3);
-      expect(ortbRequest.slots[0].video.w).to.equal(640);
-      expect(ortbRequest.slots[0].video.h).to.equal(480);
-      expect(ortbRequest.slots[0].video.linearity).to.equal(1);
-      expect(ortbRequest.slots[0].video.skipmin).to.equal(30);
-      expect(ortbRequest.slots[0].video.skipafter).to.equal(30);
-      expect(ortbRequest.slots[0].video.minbitrate).to.equal(10000);
-      expect(ortbRequest.slots[0].video.maxbitrate).to.equal(48000);
-      expect(ortbRequest.slots[0].video.delivery).to.deep.equal([1, 2, 3]);
-      expect(ortbRequest.slots[0].video.pos).to.equal(1);
-      expect(ortbRequest.slots[0].video.playbackend).to.equal(1);
-      expect(ortbRequest.slots[0].video.adPodDurationSec).to.equal(30);
-      expect(ortbRequest.slots[0].video.durationRangeSec).to.deep.equal([1, 30]);
-    });
-
-    it('should properly build a video request with more than one player size', function () {
-      const bidRequests = [
-        {
-          bidder: 'criteo',
-          adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
-          sizes: [[640, 480], [800, 600]],
-          mediaTypes: {
-            video: {
-              playerSize: [[640, 480], [800, 600]],
-              mimes: ['video/mp4', 'video/x-flv'],
-              maxduration: 30,
-              api: [1, 2],
-              protocols: [2, 3]
-            }
-          },
-          params: {
-            zoneId: 123,
-            video: {
-              skip: 1,
-              minduration: 5,
-              startdelay: 5,
-              playbackmethod: [1, 3],
-              placement: 2
-            }
-          },
-        },
-      ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.url).to.match(/^https:\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&wv=[^&]+&cb=\d/);
-      expect(request.method).to.equal('POST');
-      const ortbRequest = request.data;
-      expect(ortbRequest.slots[0].sizes).to.deep.equal([]);
-      expect(ortbRequest.slots[0].video.mimes).to.deep.equal(['video/mp4', 'video/x-flv']);
-      expect(ortbRequest.slots[0].video.playersizes).to.deep.equal(['640x480', '800x600']);
-      expect(ortbRequest.slots[0].video.maxduration).to.equal(30);
-      expect(ortbRequest.slots[0].video.api).to.deep.equal([1, 2]);
-      expect(ortbRequest.slots[0].video.protocols).to.deep.equal([2, 3]);
-      expect(ortbRequest.slots[0].video.skip).to.equal(1);
-      expect(ortbRequest.slots[0].video.minduration).to.equal(5);
-      expect(ortbRequest.slots[0].video.startdelay).to.equal(5);
-      expect(ortbRequest.slots[0].video.playbackmethod).to.deep.equal([1, 3]);
-      expect(ortbRequest.slots[0].video.placement).to.equal(2);
-    });
-
-    it('should properly build a video request when mediaTypes.video.skip=0', function () {
-      const bidRequests = [
-        {
-          bidder: 'criteo',
-          adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
-          sizes: [[300, 250]],
-          mediaTypes: {
-            video: {
-              playerSize: [[300, 250]],
-              mimes: ['video/mp4', 'video/MPV', 'video/H264', 'video/webm', 'video/ogg'],
-              minduration: 1,
-              maxduration: 30,
-              playbackmethod: [2, 3, 4, 5, 6],
-              api: [1, 2, 3, 4, 5, 6],
-              protocols: [1, 2, 3, 4, 5, 6, 7, 8],
-              skip: 0
-            }
-          },
-          params: {
-            networkId: 123
-          }
-        }
-      ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.url).to.match(/^https:\/\/bidder\.criteo\.com\/cdb\?profileId=207&av=\d+&wv=[^&]+&cb=\d/);
-      expect(request.method).to.equal('POST');
-      const ortbRequest = request.data;
-      expect(ortbRequest.slots[0].sizes).to.deep.equal([]);
-      expect(ortbRequest.slots[0].video.playersizes).to.deep.equal(['300x250']);
-      expect(ortbRequest.slots[0].video.mimes).to.deep.equal(['video/mp4', 'video/MPV', 'video/H264', 'video/webm', 'video/ogg']);
-      expect(ortbRequest.slots[0].video.minduration).to.equal(1);
-      expect(ortbRequest.slots[0].video.maxduration).to.equal(30);
-      expect(ortbRequest.slots[0].video.playbackmethod).to.deep.equal([2, 3, 4, 5, 6]);
-      expect(ortbRequest.slots[0].video.api).to.deep.equal([1, 2, 3, 4, 5, 6]);
-      expect(ortbRequest.slots[0].video.protocols).to.deep.equal([1, 2, 3, 4, 5, 6, 7, 8]);
-      expect(ortbRequest.slots[0].video.skip).to.equal(0);
-    });
-
-    it('should properly build a request with ceh', function () {
-      const bidRequests = [
-        {
-          bidder: 'criteo',
-          adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
-          mediaTypes: {
-            banner: {
-              sizes: [[728, 90]]
-            }
-          },
-          params: {
-            zoneId: 123,
-          },
-        },
-      ];
-      config.setConfig({
-        criteo: {
-          ceh: 'hashedemail'
-        }
+        ];
+        const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+        expect(request.url).to.match(/^https:\/\/bidder\.criteo\.com\/openrtb_2_5\/pbjs\/auction\/request\?profileId=207&av=\d+&wv=[^&]+&cb=\d+&lsavail=[01]&debug=[01]&nolog=[01]$/);
+        expect(request.method).to.equal('POST');
+        const ortbRequest = request.data;
+        expect(ortbRequest.imp).to.have.lengthOf(1);
+        expect(ortbRequest.imp[0].video.mimes).to.deep.equal(['video/mp4', 'video/x-flv']);
+        expect(ortbRequest.imp[0].video.maxduration).to.equal(30);
+        expect(ortbRequest.imp[0].video.api).to.deep.equal([1, 2]);
+        expect(ortbRequest.imp[0].video.protocols).to.deep.equal([2, 3]);
+        expect(ortbRequest.imp[0].video.skip).to.equal(1);
+        expect(ortbRequest.imp[0].video.minduration).to.equal(5);
+        expect(ortbRequest.imp[0].video.startdelay).to.equal(5);
+        expect(ortbRequest.imp[0].video.playbackmethod).to.deep.equal([1, 3]);
+        expect(ortbRequest.imp[0].video.placement).to.equal(2);
+        expect(ortbRequest.imp[0].video.w).to.equal(640);
+        expect(ortbRequest.imp[0].video.h).to.equal(480);
+        expect(ortbRequest.imp[0].video.linearity).to.equal(1);
+        expect(ortbRequest.imp[0].video.skipmin).to.equal(30);
+        expect(ortbRequest.imp[0].video.skipafter).to.equal(30);
+        expect(ortbRequest.imp[0].video.minbitrate).to.equal(10000);
+        expect(ortbRequest.imp[0].video.maxbitrate).to.equal(48000);
+        expect(ortbRequest.imp[0].video.delivery).to.deep.equal([1, 2, 3]);
+        expect(ortbRequest.imp[0].video.pos).to.equal(1);
+        expect(ortbRequest.imp[0].video.playbackend).to.equal(1);
+        expect(ortbRequest.imp[0].video.ext.context).to.equal('inbanner');
+        expect(ortbRequest.imp[0].video.ext.playersizes).to.deep.equal(['640x480']);
+        expect(ortbRequest.imp[0].video.ext.plcmt).to.equal(3);
+        expect(ortbRequest.imp[0].video.ext.poddur).to.equal(30);
+        expect(ortbRequest.imp[0].video.ext.rqddurs).to.deep.equal([1, 30]);
       });
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.user).to.not.be.null;
-      expect(request.data.user.ceh).to.equal('hashedemail');
-    });
+    }
+
+    if (FEATURES.VIDEO) {
+      it('should properly build a video request with more than one player size', function () {
+        const bidRequests = [
+          {
+            bidder: 'criteo',
+            adUnitCode: 'bid-123',
+            sizes: [[640, 480], [800, 600]],
+            mediaTypes: {
+              video: {
+                playerSize: [[640, 480], [800, 600]],
+                mimes: ['video/mp4', 'video/x-flv'],
+                maxduration: 30,
+                api: [1, 2],
+                protocols: [2, 3]
+              }
+            },
+            params: {
+              zoneId: 123,
+              video: {
+                skip: 1,
+                minduration: 5,
+                startdelay: 5,
+                playbackmethod: [1, 3],
+                placement: 2
+              }
+            },
+          },
+        ];
+        const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+        expect(request.url).to.match(/^https:\/\/bidder\.criteo\.com\/openrtb_2_5\/pbjs\/auction\/request\?profileId=207&av=\d+&wv=[^&]+&cb=\d+&lsavail=[01]&debug=[01]&nolog=[01]$/);
+        expect(request.method).to.equal('POST');
+        const ortbRequest = request.data;
+        expect(ortbRequest.imp[0].video.mimes).to.deep.equal(['video/mp4', 'video/x-flv']);
+        expect(ortbRequest.imp[0].video.maxduration).to.equal(30);
+        expect(ortbRequest.imp[0].video.api).to.deep.equal([1, 2]);
+        expect(ortbRequest.imp[0].video.protocols).to.deep.equal([2, 3]);
+        expect(ortbRequest.imp[0].video.skip).to.equal(1);
+        expect(ortbRequest.imp[0].video.minduration).to.equal(5);
+        expect(ortbRequest.imp[0].video.startdelay).to.equal(5);
+        expect(ortbRequest.imp[0].video.playbackmethod).to.deep.equal([1, 3]);
+        expect(ortbRequest.imp[0].video.placement).to.equal(2);
+        expect(ortbRequest.imp[0].video.w).to.equal(640);
+        expect(ortbRequest.imp[0].video.h).to.equal(480);
+        expect(ortbRequest.imp[0].video.ext.playersizes).to.deep.equal(['640x480', '800x600']);
+        expect(ortbRequest.imp[0].ext.bidder.zoneid).to.equal(123);
+      });
+    }
+
+    if (FEATURES.VIDEO) {
+      it('should properly build a video request when mediaTypes.video.skip=0', function () {
+        const bidRequests = [
+          {
+            bidder: 'criteo',
+            adUnitCode: 'bid-123',
+            sizes: [[300, 250]],
+            mediaTypes: {
+              video: {
+                playerSize: [[300, 250]],
+                mimes: ['video/mp4', 'video/MPV', 'video/H264', 'video/webm', 'video/ogg'],
+                minduration: 1,
+                maxduration: 30,
+                playbackmethod: [2, 3, 4, 5, 6],
+                api: [1, 2, 3, 4, 5, 6],
+                protocols: [1, 2, 3, 4, 5, 6, 7, 8],
+                skip: 0
+              }
+            },
+            params: {
+              networkId: 456
+            }
+          }
+        ];
+        const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+        expect(request.url).to.match(/^https:\/\/bidder\.criteo\.com\/openrtb_2_5\/pbjs\/auction\/request\?profileId=207&av=\d+&wv=[^&]+&cb=\d+&lsavail=[01]&debug=[01]&nolog=[01]&networkId=456$/);
+        expect(request.method).to.equal('POST');
+        const ortbRequest = request.data;
+        expect(ortbRequest.imp[0].video.mimes).to.deep.equal(['video/mp4', 'video/MPV', 'video/H264', 'video/webm', 'video/ogg']);
+        expect(ortbRequest.imp[0].video.minduration).to.equal(1);
+        expect(ortbRequest.imp[0].video.maxduration).to.equal(30);
+        expect(ortbRequest.imp[0].video.playbackmethod).to.deep.equal([2, 3, 4, 5, 6]);
+        expect(ortbRequest.imp[0].video.api).to.deep.equal([1, 2, 3, 4, 5, 6]);
+        expect(ortbRequest.imp[0].video.protocols).to.deep.equal([1, 2, 3, 4, 5, 6, 7, 8]);
+        expect(ortbRequest.imp[0].video.skip).to.equal(0);
+        expect(ortbRequest.imp[0].video.w).to.equal(300);
+        expect(ortbRequest.imp[0].video.h).to.equal(250);
+        expect(ortbRequest.imp[0].video.ext.playersizes).to.deep.equal(['300x250']);
+      });
+    }
 
     it('should properly build a request without first party data', function () {
       const bidRequests = [
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
@@ -1566,37 +1431,17 @@ describe('The Criteo bidding adapter', function () {
         },
       ];
 
-      const request = spec.buildRequests(bidRequests, { ...bidderRequest, ortb2: {} });
-      expect(request.data.publisher.ext).to.equal(undefined);
-      expect(request.data.user.ext).to.equal(undefined);
-      expect(request.data.slots[0].ext).to.equal(undefined);
-    });
-
-    it('should properly build a request with criteo specific ad unit first party data', function () {
-      // TODO: this test does not do what it says
-      const bidRequests = [
-        {
-          bidder: 'criteo',
-          adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
-          mediaTypes: {
-            banner: {
-              sizes: [[728, 90]]
-            }
-          },
-          params: {
-            zoneId: 123,
-            ext: {
-              bidfloor: 0.75
-            }
-          }
-        },
-      ];
-
-      const request = spec.buildRequests(bidRequests, { ...bidderRequest, ortb2: {} });
-      expect(request.data.slots[0].ext).to.deep.equal({
-        bidfloor: 0.75,
-      });
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest({ ...bidderRequest, ortb2: {} })).data;
+      expect(ortbRequest.site.page).to.equal(refererUrl);
+      expect(ortbRequest.imp).to.have.lengthOf(1);
+      expect(ortbRequest.imp[0].tagid).to.equal('bid-123');
+      expect(ortbRequest.imp[0].banner.format).to.have.lengthOf(1);
+      expect(ortbRequest.imp[0].banner.format[0].w).to.equal(728);
+      expect(ortbRequest.imp[0].banner.format[0].h).to.equal(90);
+      expect(ortbRequest.imp[0].ext.bidder.zoneid).to.equal(123);
+      expect(ortbRequest.user.ext.consent).to.equal('consentDataString');
+      expect(ortbRequest.regs.ext.gdpr).to.equal(1);
+      expect(ortbRequest.regs.ext.gdprversion).to.equal(1);
     });
 
     it('should properly build a request with first party data', function () {
@@ -1642,7 +1487,6 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
@@ -1669,41 +1513,34 @@ describe('The Criteo bidding adapter', function () {
         user: userData
       };
 
-      const request = spec.buildRequests(bidRequests, { ...bidderRequest, ortb2 });
-      expect(request.data.publisher.ext).to.deep.equal({ data: { pageType: 'article' } });
-      expect(request.data.user).to.deep.equal(userData);
-      expect(request.data.site).to.deep.equal(siteData);
-      expect(request.data.slots[0].ext).to.deep.equal({
-        bidfloor: 0.75,
-        data: {
-          someContextAttribute: 'abc'
-        }
-      });
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest({ ...bidderRequest, ortb2 })).data;
+      expect(ortbRequest.user).to.deep.equal({ ...userData, ext: { ...userData.ext, consent: 'consentDataString' } });
+      expect(ortbRequest.site).to.deep.equal({ ...siteData, page: refererUrl, domain: 'criteo.com', publisher: { ...ortbRequest.site.publisher, domain: 'criteo.com' } });
+      expect(ortbRequest.imp[0].ext.bidfloor).to.equal(0.75);
+      expect(ortbRequest.imp[0].ext.data.someContextAttribute).to.equal('abc')
     });
 
     it('should properly build a request when coppa flag is true', function () {
       const bidRequests = [];
       const bidderRequest = {};
       config.setConfig({ coppa: true });
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.regs.coppa).to.not.be.undefined;
-      expect(request.data.regs.coppa).to.equal(1);
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.regs.coppa).to.equal(1);
     });
 
     it('should properly build a request when coppa flag is false', function () {
       const bidRequests = [];
       const bidderRequest = {};
       config.setConfig({ coppa: false });
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.regs.coppa).to.not.be.undefined;
-      expect(request.data.regs.coppa).to.equal(0);
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.regs.coppa).to.equal(0);
     });
 
     it('should properly build a request when coppa flag is not defined', function () {
       const bidRequests = [];
       const bidderRequest = {};
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.regs.coppa).to.be.undefined;
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.regs?.coppa).to.be.undefined;
     });
 
     it('should properly build a banner request with floors', function () {
@@ -1711,7 +1548,6 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[300, 250], [728, 90]]
@@ -1739,8 +1575,8 @@ describe('The Criteo bidding adapter', function () {
         },
       ];
       const bidderRequest = {};
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.slots[0].ext.floors).to.deep.equal({
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.imp[0].ext.floors).to.deep.equal({
         'banner': {
           '300x250': { 'currency': 'USD', 'floor': 1 },
           '728x90': { 'currency': 'USD', 'floor': 2 }
@@ -1753,7 +1589,6 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[300, 250], [728, 90]]
@@ -1767,8 +1602,8 @@ describe('The Criteo bidding adapter', function () {
         },
       ];
       const bidderRequest = {};
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.slots[0].ext.floors).to.deep.equal({
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.imp[0].ext.floors).to.deep.equal({
         'banner': {
           '300x250': { 'currency': 'EUR', 'floor': 1 },
           '728x90': { 'currency': 'EUR', 'floor': 1 }
@@ -1781,7 +1616,6 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             video: {
               playerSize: [[300, 250], [728, 90]]
@@ -1809,8 +1643,8 @@ describe('The Criteo bidding adapter', function () {
         },
       ];
       const bidderRequest = {};
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.slots[0].ext.floors).to.deep.equal({
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.imp[0].ext.floors).to.deep.equal({
         'video': {
           '300x250': { 'currency': 'USD', 'floor': 1 },
           '728x90': { 'currency': 'USD', 'floor': 2 }
@@ -1818,75 +1652,79 @@ describe('The Criteo bidding adapter', function () {
       });
     });
 
-    it('should properly build a multi format request with floors', function () {
-      const bidRequests = [
-        {
-          bidder: 'criteo',
-          adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
-          mediaTypes: {
-            banner: {
-              sizes: [[300, 250], [728, 90]]
+    if (FEATURES.VIDEO && FEATURES.NATIVE) {
+      it('should properly build a multi format request with floors', function () {
+        const bidRequests = [
+          {
+            bidder: 'criteo',
+            adUnitCode: 'bid-123',
+            mediaTypes: {
+              banner: {
+                sizes: [[300, 250], [728, 90]]
+              },
+              video: {
+                playerSize: [640, 480],
+              },
+              native: {}
             },
-            video: {
-              playerSize: [640, 480],
+            params: {
+              networkId: 456,
             },
-            native: {}
-          },
-          params: {
-            networkId: 456,
-          },
-          ortb2Imp: {
-            ext: {
-              data: {
-                someContextAttribute: 'abc'
+            ortb2Imp: {
+              ext: {
+                data: {
+                  someContextAttribute: 'abc'
+                }
+              }
+            },
+
+            getFloor: inputParams => {
+              if (inputParams.mediaType === BANNER && inputParams.size[0] === 300 && inputParams.size[1] === 250) {
+                return {
+                  currency: 'USD',
+                  floor: 1.0
+                };
+              } else if (inputParams.mediaType === BANNER && inputParams.size[0] === 728 && inputParams.size[1] === 90) {
+                return {
+                  currency: 'USD',
+                  floor: 2.0
+                };
+              } else if (inputParams.mediaType === VIDEO && inputParams.size[0] === 640 && inputParams.size[1] === 480) {
+                return {
+                  currency: 'EUR',
+                  floor: 3.2
+                };
+              } else if (inputParams.mediaType === NATIVE && inputParams.size === '*') {
+                return {
+                  currency: 'YEN',
+                  floor: 4.99
+                };
+              } else {
+                return {}
               }
             }
           },
-
-          getFloor: inputParams => {
-            if (inputParams.mediaType === BANNER && inputParams.size[0] === 300 && inputParams.size[1] === 250) {
-              return {
-                currency: 'USD',
-                floor: 1.0
-              };
-            } else if (inputParams.mediaType === BANNER && inputParams.size[0] === 728 && inputParams.size[1] === 90) {
-              return {
-                currency: 'USD',
-                floor: 2.0
-              };
-            } else if (inputParams.mediaType === VIDEO && inputParams.size[0] === 640 && inputParams.size[1] === 480) {
-              return {
-                currency: 'EUR',
-                floor: 3.2
-              };
-            } else if (inputParams.mediaType === NATIVE && inputParams.size === '*') {
-              return {
-                currency: 'YEN',
-                floor: 4.99
-              };
-            } else {
-              return {}
-            }
+        ];
+        const bidderRequest = {};
+        const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+        expect(ortbRequest.imp[0].banner).not.to.be.null;
+        expect(ortbRequest.imp[0].video).not.to.be.null;
+        expect(ortbRequest.imp[0].native.request_native).not.to.be.null;
+        expect(ortbRequest.imp[0].ext.data.someContextAttribute).to.deep.equal('abc');
+        expect(ortbRequest.imp[0].ext.floors).to.deep.equal({
+          'banner': {
+            '300x250': { 'currency': 'USD', 'floor': 1 },
+            '728x90': { 'currency': 'USD', 'floor': 2 }
+          },
+          'video': {
+            '640x480': { 'currency': 'EUR', 'floor': 3.2 }
+          },
+          'native': {
+            '*': { 'currency': 'YEN', 'floor': 4.99 }
           }
-        },
-      ];
-      const bidderRequest = {};
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.slots[0].ext.data.someContextAttribute).to.deep.equal('abc');
-      expect(request.data.slots[0].ext.floors).to.deep.equal({
-        'banner': {
-          '300x250': { 'currency': 'USD', 'floor': 1 },
-          '728x90': { 'currency': 'USD', 'floor': 2 }
-        },
-        'video': {
-          '640x480': { 'currency': 'EUR', 'floor': 3.2 }
-        },
-        'native': {
-          '*': { 'currency': 'YEN', 'floor': 4.99 }
-        }
+        });
       });
-    });
+    }
 
     it('should properly build a request when imp.rwdd is present', function () {
       const bidderRequest = {};
@@ -1894,32 +1732,22 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
             }
           },
           params: {
-            zoneId: 123,
-            ext: {
-              bidfloor: 0.75
-            }
+            zoneId: 123
           },
           ortb2Imp: {
-            rwdd: 1,
-            ext: {
-              data: {
-                someContextAttribute: 'abc'
-              }
-            }
+            rwdd: 1
           }
         },
       ];
 
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.slots[0].rwdd).to.be.not.null;
-      expect(request.data.slots[0].rwdd).to.equal(1);
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.imp[0].ext.rwdd).to.equal(1);
     });
 
     it('should properly build a request when imp.rwdd is false', function () {
@@ -1928,31 +1756,22 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
             }
           },
           params: {
-            zoneId: 123,
-            ext: {
-              bidfloor: 0.75
-            }
+            zoneId: 123
           },
           ortb2Imp: {
-            rwdd: 0,
-            ext: {
-              data: {
-                someContextAttribute: 'abc'
-              }
-            }
+            rwdd: 0
           }
         },
       ];
 
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.slots[0].rwdd).to.be.undefined;
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.imp[0].ext?.rwdd).to.equal(0);
     });
 
     it('should properly build a request when FLEDGE is enabled', function () {
@@ -1963,28 +1782,26 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
             }
           },
           params: {
-            zoneId: 123,
-            ext: {
-              bidfloor: 0.75
-            }
+            zoneId: 123
           },
           ortb2Imp: {
             ext: {
-              ae: 1
+              igs: {
+                ae: 1
+              }
             }
           }
         },
       ];
 
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.slots[0].ext.ae).to.equal(1);
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.imp[0].ext.igs.ae).to.equal(1);
     });
 
     it('should properly build a request when FLEDGE is disabled', function () {
@@ -1995,28 +1812,26 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           mediaTypes: {
             banner: {
               sizes: [[728, 90]]
             }
           },
           params: {
-            zoneId: 123,
-            ext: {
-              bidfloor: 0.75
-            }
+            zoneId: 123
           },
           ortb2Imp: {
             ext: {
-              ae: 1
+              igs: {
+                ae: 1
+              }
             }
           }
         },
       ];
 
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.slots[0].ext).to.not.have.property('ae');
+      const ortbRequest = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest)).data;
+      expect(ortbRequest.imp[0].ext.igs?.ae).to.be.undefined;
     });
 
     it('should properly transmit the pubid and slot uid if available', function () {
@@ -2067,12 +1882,11 @@ describe('The Criteo bidding adapter', function () {
           },
         },
       ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
       const ortbRequest = request.data;
-      expect(ortbRequest.publisher.id).to.be.undefined;
       expect(ortbRequest.site.publisher.id).to.equal('pub-888');
-      expect(request.data.slots[0].ext.bidder).to.be.undefined;
-      expect(request.data.slots[1].ext.bidder.uid).to.equal(888);
+      expect(ortbRequest.imp[0].ext.bidder.uid).to.be.undefined;
+      expect(ortbRequest.imp[1].ext.bidder.uid).to.equal(888);
     });
 
     it('should properly transmit device.ext.cdep if available', function () {
@@ -2086,131 +1900,202 @@ describe('The Criteo bidding adapter', function () {
         }
       };
       const bidRequests = [];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
       const ortbRequest = request.data;
       expect(ortbRequest.device.ext.cdep).to.equal('cookieDeprecationLabel');
     });
   });
 
   describe('interpretResponse', function () {
-    it('should return an empty array when parsing a no bid response', function () {
+    const refererUrl = 'https://criteo.com?pbt_debug=1&pbt_nolog=1';
+    const bidderRequest = {
+      refererInfo: {
+        page: refererUrl,
+        topmostLocation: refererUrl
+      },
+      timeout: 3000,
+      gdprConsent: {
+        gdprApplies: true,
+        consentString: 'consentDataString',
+        vendorData: {
+          vendorConsents: {
+            '91': 1
+          },
+        },
+        apiVersion: 1,
+      },
+    };
+
+    function mockResponse(winningBidId, mediaType) {
+      return {
+        id: 'test-requestId',
+        seatbid: [
+          {
+            seat: 'criteo',
+            bid: [
+              {
+                id: 'test-bidderId',
+                impid: winningBidId,
+                price: 1.23,
+                adomain: ['criteo.com'],
+                bundle: '',
+                iurl: 'http://some_image/',
+                cid: '123456',
+                crid: 'test-crId',
+                dealid: 'deal-code',
+                w: 728,
+                h: 90,
+                adm: 'test-ad',
+                adm_native: mediaType === NATIVE ? {
+                  ver: '1.2',
+                  assets: [
+                    {
+                      id: 10,
+                      title: {
+                        text: 'Some product'
+                      }
+                    },
+                    {
+                      id: 11,
+                      img: {
+                        type: 3,
+                        url: 'https://main_image_url.com',
+                        w: 400,
+                        h: 400
+                      }
+                    },
+                    {
+                      id: 12,
+                      data: {
+                        value: 'Some product'
+                      }
+                    },
+                    {
+                      id: 13,
+                      data: {
+                        value: '1,499 TL'
+                      }
+                    },
+                    {
+                      id: 15,
+                      data: {
+                        value: 'CTA'
+                      },
+                      link: {
+                        url: 'https://cta_url.com'
+                      }
+                    },
+                    {
+                      id: 17,
+                      img: {
+                        type: 1,
+                        url: 'https://main_image_url.com',
+                        w: 200,
+                        h: 200
+                      },
+                      link: {
+                        url: 'https://icon_image_url.com'
+                      }
+                    },
+                    {
+                      id: 16,
+                      data: {
+                        value: 'Some brand'
+                      }
+                    }
+                  ],
+                  eventtrackers: [
+                    {
+                      event: 1,
+                      method: 1,
+                      url: 'https://eventtrackers.com'
+                    },
+                    {
+                      event: 1,
+                      method: 1,
+                      url: 'https://test_in_isolation.criteo.com/tpd?dd=HTlW9l9xTEZqRHVlSHFiSWx5Q2VQMlEwSTJhNCUyQkxNazQ1Y29LR3ZmS2VTSDFsUGdkRHNoWjQ2UWp0SGtVZ1RTbHI0TFRpTlVqNWxiUkZOeGVFNjVraW53R0loRVJQNDJOY2R1eWxVdjBBQ1BEdVFvTyUyRlg3aWJaeUFha3UyemNNVGpmJTJCS1prc0FwRjZRJTJCQ2dpaFBJeVhZRmQlMkZURVZocUFRdm03OTdFZHZSbURNZWt4Uzh2M1NSUUxmTmhaTnNnRXd4VkZlOTdJOXdnNGZjaVolMkZWYmdYVjJJMkQ0eGxQaFIwQmVtWk1sQ09tNXlGY0Nwc09GTDladzExJTJGVExGNXJsdGpneERDeTMlMkJuNUlUcEU4NDFLMTZPc2ZoWFUwMmpGbDFpVjBPZUVtTlEwaWNOeHRyRFYyenRKd0lpJTJGTTElMkY1WGZ3Smo3aTh0bUJzdzZRdlZUSXppanNkamo3ekZNZjhKdjl2VDJ5eHV1YnVzdmdRdk5iWnprNXVFMVdmbGs0QU1QY0ozZQ'
+                    }
+                  ],
+                  privacy: 'https://cta_url.com',
+                  ext: {
+                    privacy: {
+                      imageurl: 'https://icon_image_url.com',
+                      clickurl: 'https://cta_url.com',
+                      longlegaltext: ''
+                    }
+                  }
+                } : undefined,
+                ext: {
+                  mediatype: mediaType,
+                  displayurl: mediaType === VIDEO ? 'http://test-ad' : undefined,
+                  dsa: {
+                    adrender: 1
+                  },
+                  meta: {
+                    networkName: 'Criteo'
+                  },
+                  videoPlayerType: mediaType === VIDEO ? 'RadiantMediaPlayer' : undefined,
+                  videoPlayerConfig: mediaType === VIDEO ? {} : undefined,
+                  cur: 'CUR'
+                }
+              }
+            ]
+          }
+        ]
+      };
+    }
+
+    it('should return an empty array when parsing an empty bid response', function () {
+      const bidRequests = [];
       const response = {};
-      const request = { bidRequests: [] };
+      const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
       const bids = spec.interpretResponse(response, request);
       expect(bids).to.have.lengthOf(0);
     });
 
-    it('should properly parse a bid response with a networkId', function () {
-      const response = {
-        body: {
-          slots: [{
-            impid: 'test-requestId',
-            cpm: 1.23,
-            creative: 'test-ad',
-            creativecode: 'test-crId',
-            width: 728,
-            height: 90,
-            deal: 'myDealCode',
-            adomain: ['criteo.com'],
-            ext: {
-              meta: {
-                networkName: 'Criteo'
-              }
-            }
-          }],
-        },
-      };
-      const request = {
-        bidRequests: [{
-          adUnitCode: 'test-requestId',
-          bidId: 'test-bidId',
-          mediaTypes: {
-            banner: {
-              sizes: [[728, 90]]
-            }
-          },
-          params: {
-            networkId: 456,
-          }
-        }]
-      };
-      const bids = spec.interpretResponse(response, request);
-      expect(bids).to.have.lengthOf(1);
-      expect(bids[0].requestId).to.equal('test-bidId');
-      expect(bids[0].cpm).to.equal(1.23);
-      expect(bids[0].ad).to.equal('test-ad');
-      expect(bids[0].creativeId).to.equal('test-crId');
-      expect(bids[0].width).to.equal(728);
-      expect(bids[0].height).to.equal(90);
-      expect(bids[0].dealId).to.equal('myDealCode');
-      expect(bids[0].meta.advertiserDomains[0]).to.equal('criteo.com');
-      expect(bids[0].meta.networkName).to.equal('Criteo');
+    it('should return an empty array when parsing a well-formed no bid response', function () {
+      const bidRequests = [];
+      const response = { seatbid: [] };
+      const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+      const bids = spec.interpretResponse({ body: response }, request);
+      expect(bids).to.have.lengthOf(0);
     });
 
-    it('should properly parse a bid response with dsa', function () {
-      const response = {
-        body: {
-          slots: [{
-            impid: 'test-requestId',
-            cpm: 1.23,
-            creative: 'test-ad',
-            creativecode: 'test-crId',
-            width: 728,
-            height: 90,
-            deal: 'myDealCode',
-            adomain: ['criteo.com'],
-            ext: {
-              dsa: {
-                adrender: 1
-              },
-              meta: {
-                networkName: 'Criteo'
-              }
-            }
-          }],
-        },
-      };
-      const request = {
-        bidRequests: [{
-          adUnitCode: 'test-requestId',
-          bidId: 'test-bidId',
-          mediaTypes: {
-            banner: {
-              sizes: [[728, 90]]
-            }
-          },
-          params: {
-            networkId: 456,
+    it('should properly parse a banner bid response', function () {
+      const bidRequests = [{
+        adUnitCode: 'test-requestId',
+        bidId: 'test-bidId',
+        mediaTypes: {
+          banner: {
+            sizes: [[728, 90]]
           }
-        }]
-      };
-      const bids = spec.interpretResponse(response, request);
+        },
+        params: {
+          networkId: 456,
+        }
+      }];
+      const response = mockResponse('test-bidId', BANNER);
+      const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+      const bids = spec.interpretResponse({ body: response }, request);
       expect(bids).to.have.lengthOf(1);
+      expect(bids[0].mediaType).to.equal(BANNER);
+      expect(bids[0].requestId).to.equal('test-bidId');
+      expect(bids[0].seatBidId).to.equal('test-bidderId')
+      expect(bids[0].cpm).to.equal(1.23);
+      expect(bids[0].currency).to.equal('CUR');
+      expect(bids[0].width).to.equal(728);
+      expect(bids[0].height).to.equal(90);
+      expect(bids[0].ad).to.equal('test-ad');
+      expect(bids[0].creativeId).to.equal('test-crId');
+      expect(bids[0].dealId).to.equal('deal-code');
+      expect(bids[0].meta.advertiserDomains[0]).to.equal('criteo.com');
+      expect(bids[0].meta.networkName).to.equal('Criteo');
       expect(bids[0].meta.dsa.adrender).to.equal(1);
     });
 
-    it('should properly parse a bid response with a networkId with twin ad unit banner win', function () {
-      const response = {
-        body: {
-          slots: [{
-            impid: 'test-requestId',
-            cpm: 1.23,
-            creative: 'test-ad',
-            creativecode: 'test-crId',
-            width: 728,
-            height: 90,
-            deal: 'myDealCode',
-            adomain: ['criteo.com'],
-            ext: {
-              meta: {
-                networkName: 'Criteo'
-              }
-            }
-          }],
-        },
-      };
-      const request = {
-        bidRequests: [{
+    if (FEATURES.VIDEO) {
+      it('should properly parse a bid response with a video', function () {
+        const bidRequests = [{
           adUnitCode: 'test-requestId',
           bidId: 'test-bidId',
           mediaTypes: {
@@ -2224,63 +2109,36 @@ describe('The Criteo bidding adapter', function () {
             }
           },
           params: {
-            networkId: 456,
+            zoneId: 123,
           },
-        }, {
-          adUnitCode: 'test-requestId',
-          bidId: 'test-bidId2',
-          mediaTypes: {
-            banner: {
-              sizes: [[728, 90]]
-            }
-          },
-          params: {
-            networkId: 456,
-          }
-        }]
-      };
-      const bids = spec.interpretResponse(response, request);
-      expect(bids).to.have.lengthOf(1);
-      expect(bids[0].requestId).to.equal('test-bidId2');
-      expect(bids[0].cpm).to.equal(1.23);
-      expect(bids[0].ad).to.equal('test-ad');
-      expect(bids[0].creativeId).to.equal('test-crId');
-      expect(bids[0].width).to.equal(728);
-      expect(bids[0].height).to.equal(90);
-      expect(bids[0].dealId).to.equal('myDealCode');
-      expect(bids[0].meta.advertiserDomains[0]).to.equal('criteo.com');
-      expect(bids[0].meta.networkName).to.equal('Criteo');
-    });
+        }];
+        const response = mockResponse('test-bidId', VIDEO);
+        const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+        const bids = spec.interpretResponse({ body: response }, request);
+        expect(bids).to.have.lengthOf(1);
+        expect(bids[0].mediaType).to.equal(VIDEO);
+        expect(bids[0].requestId).to.equal('test-bidId');
+        expect(bids[0].seatBidId).to.equal('test-bidderId')
+        expect(bids[0].cpm).to.equal(1.23);
+        expect(bids[0].currency).to.equal('CUR');
+        expect(bids[0].vastUrl).to.equal('http://test-ad');
+        expect(bids[0].vastXml).to.equal('test-ad');
+        expect(bids[0].playerWidth).to.equal(640);
+        expect(bids[0].playerHeight).to.equal(480);
+        expect(bids[0].renderer).to.equal(undefined);
+      });
+    }
 
-    it('should properly parse a bid response with a networkId with twin ad unit video win', function () {
-      const response = {
-        body: {
-          slots: [{
-            impid: 'test-requestId',
-            bidId: 'abc123',
-            cpm: 1.23,
-            displayurl: 'http://test-ad',
-            width: 728,
-            height: 90,
-            zoneid: 123,
-            video: true,
-            ext: {
-              meta: {
-                networkName: 'Criteo'
-              }
-            }
-          }],
-        },
-      };
-      const request = {
-        bidRequests: [{
+    if (FEATURES.VIDEO) {
+      it('should properly parse a bid response with an outstream video', function () {
+        const bidRequests = [{
           adUnitCode: 'test-requestId',
           bidId: 'test-bidId',
           mediaTypes: {
             video: {
-              context: 'instream',
+              context: 'outstream',
               mimes: ['video/mpeg'],
-              playerSize: [728, 90],
+              playerSize: [640, 480],
               protocols: [5, 6],
               maxduration: 30,
               api: [1, 2]
@@ -2289,6 +2147,124 @@ describe('The Criteo bidding adapter', function () {
           params: {
             networkId: 456,
           },
+        }];
+        const response = mockResponse('test-bidId', VIDEO);
+        const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+        const bids = spec.interpretResponse({ body: response }, request);
+        expect(bids).to.have.lengthOf(1);
+        expect(bids[0].mediaType).to.equal(VIDEO);
+        expect(bids[0].requestId).to.equal('test-bidId');
+        expect(bids[0].seatBidId).to.equal('test-bidderId')
+        expect(bids[0].cpm).to.equal(1.23);
+        expect(bids[0].currency).to.equal('CUR');
+        expect(bids[0].vastUrl).to.equal('http://test-ad');
+        expect(bids[0].vastXml).to.equal('test-ad');
+        expect(bids[0].playerWidth).to.equal(640);
+        expect(bids[0].playerHeight).to.equal(480);
+        expect(bids[0].renderer.url).to.equal('https://static.criteo.net/js/ld/publishertag.renderer.js');
+        expect(typeof bids[0].renderer.config.documentResolver).to.equal('function');
+        expect(typeof bids[0].renderer._render).to.equal('function');
+      });
+    }
+
+    if (FEATURES.NATIVE) {
+      it('should properly parse a native bid response', function () {
+        const bidRequests = [{
+          adUnitCode: 'test-requestId',
+          bidId: 'test-bidId',
+          params: {
+            zoneId: '123',
+          },
+          native: true,
+        }];
+        const response = mockResponse('test-bidId', NATIVE);
+        const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+        const bids = spec.interpretResponse({ body: response }, request);
+        expect(bids).to.have.lengthOf(1);
+        expect(bids[0].mediaType).to.equal(NATIVE);
+        expect(bids[0].requestId).to.equal('test-bidId');
+        expect(bids[0].seatBidId).to.equal('test-bidderId')
+        expect(bids[0].cpm).to.equal(1.23);
+        expect(bids[0].currency).to.equal('CUR');
+        expect(bids[0].width).to.equal(728);
+        expect(bids[0].height).to.equal(90);
+        expect(bids[0].ad).to.equal(undefined);
+        expect(bids[0].native.ortb).not.to.be.null;
+        expect(bids[0].native.ortb).to.equal(response.seatbid[0].bid[0].adm); // adm_native field was moved to adm
+        expect(bids[0].creativeId).to.equal('test-crId');
+        expect(bids[0].dealId).to.equal('deal-code');
+        expect(bids[0].meta.advertiserDomains[0]).to.equal('criteo.com');
+        expect(bids[0].meta.networkName).to.equal('Criteo');
+        expect(bids[0].meta.dsa.adrender).to.equal(1);
+      });
+    }
+
+    it('should properly parse a bid response when banner win with twin ad units', function () {
+      const bidRequests = [{
+        adUnitCode: 'test-requestId',
+        bidId: 'test-bidId',
+        mediaTypes: {
+          video: {
+            context: 'instream',
+            mimes: ['video/mpeg'],
+            playerSize: [640, 480],
+            protocols: [5, 6],
+            maxduration: 30,
+            api: [1, 2]
+          }
+        },
+        params: {
+          networkId: 456,
+        },
+      }, {
+        adUnitCode: 'test-requestId',
+        bidId: 'test-bidId2',
+        mediaTypes: {
+          banner: {
+            sizes: [[728, 90]]
+          }
+        },
+        params: {
+          networkId: 456,
+        }
+      }];
+      const response = mockResponse('test-bidId2', BANNER);
+      const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+      const bids = spec.interpretResponse({ body: response }, request);
+      expect(bids).to.have.lengthOf(1);
+      expect(bids[0].mediaType).to.equal(BANNER);
+      expect(bids[0].requestId).to.equal('test-bidId2');
+      expect(bids[0].seatBidId).to.equal('test-bidderId')
+      expect(bids[0].cpm).to.equal(1.23);
+      expect(bids[0].currency).to.equal('CUR');
+      expect(bids[0].width).to.equal(728);
+      expect(bids[0].height).to.equal(90);
+      expect(bids[0].ad).to.equal('test-ad');
+      expect(bids[0].creativeId).to.equal('test-crId');
+      expect(bids[0].dealId).to.equal('deal-code');
+      expect(bids[0].meta.advertiserDomains[0]).to.equal('criteo.com');
+      expect(bids[0].meta.networkName).to.equal('Criteo');
+      expect(bids[0].meta.dsa.adrender).to.equal(1);
+    });
+
+    if (FEATURES.VIDEO) {
+      it('should properly parse a bid response when video win with twin ad units', function () {
+        const bidRequests = [{
+          adUnitCode: 'test-requestId',
+          bidId: 'test-bidId',
+          mediaTypes: {
+            video: {
+              context: 'instream',
+              mimes: ['video/mpeg'],
+              playerSize: [640, 480],
+              protocols: [5, 6],
+              maxduration: 30,
+              api: [1, 2]
+            }
+          },
+          params: {
+            zoneId: '123'
+          },
         }, {
           adUnitCode: 'test-requestId',
           bidId: 'test-bidId2',
@@ -2300,63 +2276,27 @@ describe('The Criteo bidding adapter', function () {
           params: {
             networkId: 456,
           }
-        }]
-      };
-      const bids = spec.interpretResponse(response, request);
-      expect(bids).to.have.lengthOf(1);
-      expect(bids[0].requestId).to.equal('test-bidId');
-      expect(bids[0].cpm).to.equal(1.23);
-      expect(bids[0].vastUrl).to.equal('http://test-ad');
-      expect(bids[0].mediaType).to.equal(VIDEO);
-    });
+        }];
+        const response = mockResponse('test-bidId', VIDEO);
+        const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+        const bids = spec.interpretResponse({ body: response }, request);
+        expect(bids).to.have.lengthOf(1);
+        expect(bids[0].mediaType).to.equal(VIDEO);
+        expect(bids[0].requestId).to.equal('test-bidId');
+        expect(bids[0].seatBidId).to.equal('test-bidderId')
+        expect(bids[0].cpm).to.equal(1.23);
+        expect(bids[0].currency).to.equal('CUR');
+        expect(bids[0].vastUrl).to.equal('http://test-ad');
+        expect(bids[0].vastXml).to.equal('test-ad');
+        expect(bids[0].playerWidth).to.equal(640);
+        expect(bids[0].playerHeight).to.equal(480);
+        expect(bids[0].renderer).to.equal(undefined);
+      });
+    }
 
-    it('should properly parse a bid response with a networkId with twin ad unit native win', function () {
-      const response = {
-        body: {
-          slots: [{
-            impid: 'test-requestId',
-            cpm: 1.23,
-            creative: 'test-ad',
-            creativecode: 'test-crId',
-            width: 728,
-            height: 90,
-            deal: 'myDealCode',
-            adomain: ['criteo.com'],
-            native: {
-              'products': [{
-                'sendTargetingKeys': false,
-                'title': 'Product title',
-                'description': 'Product desc',
-                'price': '100',
-                'click_url': 'https://product.click',
-                'image': {
-                  'url': 'https://publisherdirect.criteo.com/publishertag/preprodtest/creative.png',
-                  'height': 300,
-                  'width': 300
-                },
-                'call_to_action': 'Try it now!'
-              }],
-              'advertiser': {
-                'description': 'sponsor',
-                'domain': 'criteo.com',
-                'logo': { 'url': 'https://www.criteo.com/images/criteo-logo.svg', 'height': 300, 'width': 300 }
-              },
-              'privacy': {
-                'optout_click_url': 'https://info.criteo.com/privacy/informations',
-                'optout_image_url': 'https://static.criteo.net/flash/icon/nai_small.png',
-              },
-              'impression_pixels': [{ 'url': 'https://my-impression-pixel/test/impression' }, { 'url': 'https://cas.com/lg.com' }]
-            },
-            ext: {
-              meta: {
-                networkName: 'Criteo'
-              }
-            }
-          }],
-        },
-      };
-      const request = {
-        bidRequests: [{
+    if (FEATURES.NATIVE) {
+      it('should properly parse a bid response when native win with twin ad units', function () {
+        const bidRequests = [{
           adUnitCode: 'test-requestId',
           bidId: 'test-bidId',
           mediaTypes: {
@@ -2376,292 +2316,138 @@ describe('The Criteo bidding adapter', function () {
           params: {
             networkId: 456,
           }
-        }]
-      };
-      const bids = spec.interpretResponse(response, request);
-      expect(bids).to.have.lengthOf(1);
-      expect(bids[0].requestId).to.equal('test-bidId');
-      expect(bids[0].cpm).to.equal(1.23);
-      expect(bids[0].mediaType).to.equal(NATIVE);
-    });
-
-    it('should properly parse a bid response with a zoneId', function () {
-      const response = {
-        body: {
-          slots: [{
-            impid: 'test-requestId',
-            bidId: 'abc123',
-            cpm: 1.23,
-            creative: 'test-ad',
-            width: 728,
-            height: 90,
-            zoneid: 123,
-          }],
-        },
-      };
-      const request = {
-        bidRequests: [{
-          adUnitCode: 'test-requestId',
-          bidId: 'test-bidId',
-          params: {
-            zoneId: 123,
-          },
-        }]
-      };
-      const bids = spec.interpretResponse(response, request);
-      expect(bids).to.have.lengthOf(1);
-      expect(bids[0].requestId).to.equal('test-bidId');
-      expect(bids[0].cpm).to.equal(1.23);
-      expect(bids[0].ad).to.equal('test-ad');
-      expect(bids[0].width).to.equal(728);
-      expect(bids[0].height).to.equal(90);
-    });
-
-    it('should properly parse a bid response with a video', function () {
-      const response = {
-        body: {
-          slots: [{
-            impid: 'test-requestId',
-            bidId: 'abc123',
-            cpm: 1.23,
-            displayurl: 'http://test-ad',
-            width: 728,
-            height: 90,
-            zoneid: 123,
-            video: true
-          }],
-        },
-      };
-      const request = {
-        bidRequests: [{
-          adUnitCode: 'test-requestId',
-          bidId: 'test-bidId',
-          params: {
-            zoneId: 123,
-          },
-        }]
-      };
-      const bids = spec.interpretResponse(response, request);
-      expect(bids).to.have.lengthOf(1);
-      expect(bids[0].requestId).to.equal('test-bidId');
-      expect(bids[0].cpm).to.equal(1.23);
-      expect(bids[0].vastUrl).to.equal('http://test-ad');
-      expect(bids[0].mediaType).to.equal(VIDEO);
-    });
-
-    it('should properly parse a bid response with a outstream video', function () {
-      const response = {
-        body: {
-          slots: [{
-            impid: 'test-requestId',
-            bidId: 'abc123',
-            cpm: 1.23,
-            displayurl: 'http://test-ad',
-            width: 728,
-            height: 90,
-            zoneid: 123,
-            video: true,
-            ext: {
-              videoPlayerType: 'RadiantMediaPlayer',
-              videoPlayerConfig: {
-
-              }
-            }
-          }],
-        },
-      };
-      const request = {
-        bidRequests: [{
-          adUnitCode: 'test-requestId',
-          bidId: 'test-bidId',
-          params: {
-            zoneId: 123,
-          },
-          mediaTypes: {
-            video: {
-              context: 'outstream'
-            }
-          }
-        }]
-      };
-      const bids = spec.interpretResponse(response, request);
-      expect(bids).to.have.lengthOf(1);
-      expect(bids[0].requestId).to.equal('test-bidId');
-      expect(bids[0].cpm).to.equal(1.23);
-      expect(bids[0].vastUrl).to.equal('http://test-ad');
-      expect(bids[0].renderer.url).to.equal('https://static.criteo.net/js/ld/publishertag.renderer.js');
-      expect(typeof bids[0].renderer.config.documentResolver).to.equal('function');
-      expect(typeof bids[0].renderer._render).to.equal('function');
-    });
-
-    it('should properly parse a bid response with native', function () {
-      const response = {
-        body: {
-          slots: [{
-            impid: 'test-requestId',
-            bidId: 'abc123',
-            cpm: 1.23,
-            width: 728,
-            height: 90,
-            zoneid: 123,
-            native: {
-              'products': [{
-                'sendTargetingKeys': false,
-                'title': 'Product title',
-                'description': 'Product desc',
-                'price': '100',
-                'click_url': 'https://product.click',
-                'image': {
-                  'url': 'https://publisherdirect.criteo.com/publishertag/preprodtest/creative.png',
-                  'height': 300,
-                  'width': 300
-                },
-                'call_to_action': 'Try it now!'
-              }],
-              'advertiser': {
-                'description': 'sponsor',
-                'domain': 'criteo.com',
-                'logo': { 'url': 'https://www.criteo.com/images/criteo-logo.svg', 'height': 300, 'width': 300 }
-              },
-              'privacy': {
-                'optout_click_url': 'https://info.criteo.com/privacy/informations',
-                'optout_image_url': 'https://static.criteo.net/flash/icon/nai_small.png',
-              },
-              'impression_pixels': [{ 'url': 'https://my-impression-pixel/test/impression' }, { 'url': 'https://cas.com/lg.com' }]
-            }
-          }],
-        },
-      };
-      const request = {
-        bidRequests: [{
-          adUnitCode: 'test-requestId',
-          bidId: 'test-bidId',
-          params: {
-            zoneId: 123,
-          },
-          native: true,
-        }]
-      };
-      const bids = spec.interpretResponse(response, request);
-      expect(bids).to.have.lengthOf(1);
-      expect(bids[0].requestId).to.equal('test-bidId');
-      expect(bids[0].cpm).to.equal(1.23);
-      expect(bids[0].mediaType).to.equal(NATIVE);
-    });
-
-    it('should warn only once if sendTargetingKeys set to true on required fields for native bidRequest', () => {
-      const bidderRequest = {};
-      const bidRequests = [
-        {
-          bidder: 'criteo',
-          adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
-          sizes: [[728, 90]],
-          params: {
-            zoneId: 123,
-            publisherSubId: '123',
-            nativeCallback: function () { }
-          },
-        },
-        {
-          bidder: 'criteo',
-          adUnitCode: 'bid-456',
-          transactionId: 'transaction-456',
-          sizes: [[728, 90]],
-          params: {
-            zoneId: 456,
-            publisherSubId: '456',
-            nativeCallback: function () { }
-          },
-        },
-      ];
-
-      const nativeParamsWithSendTargetingKeys = [
-        {
-          nativeParams: {
-            image: {
-              sendTargetingKeys: true
-            },
-          }
-        },
-        {
-          nativeParams: {
-            icon: {
-              sendTargetingKeys: true
-            },
-          }
-        },
-        {
-          nativeParams: {
-            clickUrl: {
-              sendTargetingKeys: true
-            },
-          }
-        },
-        {
-          nativeParams: {
-            displayUrl: {
-              sendTargetingKeys: true
-            },
-          }
-        },
-        {
-          nativeParams: {
-            privacyLink: {
-              sendTargetingKeys: true
-            },
-          }
-        },
-        {
-          nativeParams: {
-            privacyIcon: {
-              sendTargetingKeys: true
-            },
-          }
-        }
-      ];
-
-      utilsMock.expects('logWarn')
-        .withArgs('Criteo: all native assets containing URL should be sent as placeholders with sendId(icon, image, clickUrl, displayUrl, privacyLink, privacyIcon)')
-        .exactly(nativeParamsWithSendTargetingKeys.length * bidRequests.length);
-      nativeParamsWithSendTargetingKeys.forEach(nativeParams => {
-        let transformedBidRequests = { ...bidRequests };
-        transformedBidRequests = [Object.assign(transformedBidRequests[0], nativeParams), Object.assign(transformedBidRequests[1], nativeParams)];
-        spec.buildRequests(transformedBidRequests, bidderRequest);
+        }];
+        const response = mockResponse('test-bidId', NATIVE);
+        const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+        const bids = spec.interpretResponse({ body: response }, request);
+        expect(bids).to.have.lengthOf(1);
+        expect(bids[0].mediaType).to.equal(NATIVE);
+        expect(bids[0].requestId).to.equal('test-bidId');
+        expect(bids[0].seatBidId).to.equal('test-bidderId')
+        expect(bids[0].cpm).to.equal(1.23);
+        expect(bids[0].currency).to.equal('CUR');
+        expect(bids[0].width).to.equal(728);
+        expect(bids[0].height).to.equal(90);
+        expect(bids[0].ad).to.equal(undefined);
+        expect(bids[0].native.ortb).not.to.be.null;
+        expect(bids[0].native.ortb).to.equal(response.seatbid[0].bid[0].adm); // adm_native field was moved to adm
+        expect(bids[0].creativeId).to.equal('test-crId');
+        expect(bids[0].dealId).to.equal('deal-code');
+        expect(bids[0].meta.advertiserDomains[0]).to.equal('criteo.com');
+        expect(bids[0].meta.networkName).to.equal('Criteo');
+        expect(bids[0].meta.dsa.adrender).to.equal(1);
       });
-      utilsMock.verify();
-    });
+    }
 
-    it('should properly parse a bid response with a zoneId passed as a string', function () {
-      const response = {
-        body: {
-          slots: [{
-            impid: 'test-requestId',
-            cpm: 1.23,
-            creative: 'test-ad',
-            width: 728,
-            height: 90,
-            zoneid: 123,
-          }],
-        },
-      };
-      const request = {
-        bidRequests: [{
-          adUnitCode: 'test-requestId',
-          bidId: 'test-bidId',
-          params: {
-            zoneId: '123',
+    if (FEATURES.NATIVE) {
+      it('should warn only once if sendTargetingKeys set to true on required fields for native bidRequest', () => {
+        const bidRequests = [
+          {
+            bidder: 'criteo',
+            adUnitCode: 'bid-123',
+            mediaTypes: {
+              native: {}
+            },
+            nativeOrtbRequest: {
+              assets: [{
+                required: 1,
+                id: 1,
+                img: {
+                  type: 3,
+                  wmin: 100,
+                  hmin: 100,
+                }
+              }]
+            },
+            transactionId: 'transaction-123',
+            sizes: [[728, 90]],
+            params: {
+              zoneId: 123,
+              publisherSubId: '123'
+            },
           },
-        }]
-      };
-      const bids = spec.interpretResponse(response, request);
-      expect(bids).to.have.lengthOf(1);
-      expect(bids[0].requestId).to.equal('test-bidId');
-      expect(bids[0].cpm).to.equal(1.23);
-      expect(bids[0].ad).to.equal('test-ad');
-      expect(bids[0].width).to.equal(728);
-      expect(bids[0].height).to.equal(90);
-    });
+          {
+            bidder: 'criteo',
+            adUnitCode: 'bid-456',
+            mediaTypes: {
+              native: {}
+            },
+            nativeOrtbRequest: {
+              assets: [{
+                required: 1,
+                id: 1,
+                img: {
+                  type: 3,
+                  wmin: 100,
+                  hmin: 100,
+                }
+              }]
+            },
+            transactionId: 'transaction-456',
+            sizes: [[728, 90]],
+            params: {
+              zoneId: 456,
+              publisherSubId: '456'
+            },
+          },
+        ];
+
+        const nativeParamsWithSendTargetingKeys = [
+          {
+            nativeParams: {
+              image: {
+                sendTargetingKeys: true
+              },
+            }
+          },
+          {
+            nativeParams: {
+              icon: {
+                sendTargetingKeys: true
+              },
+            }
+          },
+          {
+            nativeParams: {
+              clickUrl: {
+                sendTargetingKeys: true
+              },
+            }
+          },
+          {
+            nativeParams: {
+              displayUrl: {
+                sendTargetingKeys: true
+              },
+            }
+          },
+          {
+            nativeParams: {
+              privacyLink: {
+                sendTargetingKeys: true
+              },
+            }
+          },
+          {
+            nativeParams: {
+              privacyIcon: {
+                sendTargetingKeys: true
+              },
+            }
+          }
+        ];
+
+        utilsMock.expects('logWarn')
+          .withArgs('Criteo: all native assets containing URL should be sent as placeholders with sendId(icon, image, clickUrl, displayUrl, privacyLink, privacyIcon)')
+          .exactly(nativeParamsWithSendTargetingKeys.length * bidRequests.length);
+        nativeParamsWithSendTargetingKeys.forEach(nativeParams => {
+          let transformedBidRequests = { ...bidRequests };
+          transformedBidRequests = [Object.assign(transformedBidRequests[0], nativeParams), Object.assign(transformedBidRequests[1], nativeParams)];
+          spec.buildRequests(transformedBidRequests, syncAddFPDToBidderRequest(bidderRequest));
+        });
+        utilsMock.verify();
+      });
+    }
 
     it('should properly parse a bid response with FLEDGE auction configs', function () {
       let auctionConfig1 = {
@@ -2742,34 +2528,6 @@ describe('The Criteo bidding adapter', function () {
         },
         sellerCurrency: '???'
       };
-      const response = {
-        body: {
-          ext: {
-            igi: [{
-              impid: 'test-bidId',
-              igs: [{
-                impid: 'test-bidId',
-                bidId: 'test-bidId',
-                config: auctionConfig1
-              }]
-            }, {
-              impid: 'test-bidId-2',
-              igs: [{
-                impid: 'test-bidId-2',
-                bidId: 'test-bidId-2',
-                config: auctionConfig2
-              }]
-            }]
-          },
-        },
-      };
-      const bidderRequest = {
-        ortb2: {
-          source: {
-            tid: 'abc'
-          }
-        }
-      };
       const bidRequests = [
         {
           bidId: 'test-bidId',
@@ -2802,8 +2560,27 @@ describe('The Criteo bidding adapter', function () {
           }
         },
       ];
-      const request = spec.buildRequests(bidRequests, bidderRequest);
-      const interpretedResponse = spec.interpretResponse(response, request);
+      const response = {
+        ext: {
+          igi: [{
+            impid: 'test-bidId',
+            igs: [{
+              impid: 'test-bidId',
+              bidId: 'test-bidId',
+              config: auctionConfig1
+            }]
+          }, {
+            impid: 'test-bidId-2',
+            igs: [{
+              impid: 'test-bidId-2',
+              bidId: 'test-bidId-2',
+              config: auctionConfig2
+            }]
+          }]
+        },
+      };
+      const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+      const interpretedResponse = spec.interpretResponse({ body: response }, request);
       expect(interpretedResponse).to.have.property('bids');
       expect(interpretedResponse).to.have.property('fledgeAuctionConfigs');
       expect(interpretedResponse.bids).to.have.lengthOf(0);
@@ -2839,59 +2616,65 @@ describe('The Criteo bidding adapter', function () {
       hasBidResponseLevelPafData: false,
       hasBidResponseBidLevelPafData: false,
       shouldContainsBidMetaPafData: false
-    }].forEach(testCase => {
-      const bidPafContentId = 'abcdef';
-      const pafTransmission = {
-        version: '12'
-      };
-      const response = {
-        slots: [
-          {
-            width: 300,
-            height: 250,
-            cpm: 10,
-            impid: 'adUnitId',
-            ext: (testCase.hasBidResponseBidLevelPafData ? {
-              paf: {
-                content_id: bidPafContentId
-              }
-            } : undefined)
-          }
-        ],
-        ext: (testCase.hasBidResponseLevelPafData ? {
-          paf: {
-            transmission: pafTransmission
-          }
-        } : undefined)
-      };
-
-      const request = {
-        bidRequests: [{
+    }].forEach(testCase =>
+      it('should properly forward or not meta paf data', () => {
+        const bidPafContentId = 'abcdef';
+        const pafTransmission = {
+          version: '12'
+        };
+        const bidRequests = [{
+          bidId: 'test-bidId',
           adUnitCode: 'adUnitId',
           sizes: [[300, 250]],
           params: {
             networkId: 456,
           }
-        }]
-      };
+        }];
+        const response = {
+          id: 'test-requestId',
+          seatbid: [{
+            seat: 'criteo',
+            bid: [
+              {
+                id: 'test-bidderId',
+                impid: 'test-bidId',
+                w: 728,
+                h: 90,
+                ext: {
+                  mediatype: BANNER,
+                  paf: testCase.hasBidResponseBidLevelPafData ? {
+                    content_id: bidPafContentId
+                  } : undefined
+                }
+              }
+            ]
+          }],
+          ext: (testCase.hasBidResponseLevelPafData ? {
+            paf: {
+              transmission: pafTransmission
+            }
+          } : undefined)
+        };
 
-      const bids = spec.interpretResponse(response, request);
+        const request = spec.buildRequests(bidRequests, syncAddFPDToBidderRequest(bidderRequest));
+        const bids = spec.interpretResponse({ body: response }, request);
 
-      expect(bids).to.have.lengthOf(1);
+        expect(bids).to.have.lengthOf(1);
 
-      const theoreticalBidMetaPafData = {
-        paf: {
-          content_id: bidPafContentId,
-          transmission: pafTransmission
+        const expectedBidMetaPafData = {
+          paf: {
+            content_id: bidPafContentId,
+            transmission: pafTransmission
+          }
+        };
+
+        if (testCase.shouldContainsBidMetaPafData) {
+          expect(bids[0].meta).to.deep.equal(expectedBidMetaPafData);
+        } else {
+          expect(bids[0].meta).not.to.deep.equal(expectedBidMetaPafData);
         }
-      };
-
-      if (testCase.shouldContainsBidMetaPafData) {
-        expect(bids[0].meta).to.deep.equal(theoreticalBidMetaPafData);
-      } else {
-        expect(bids[0].meta).not.to.deep.equal(theoreticalBidMetaPafData);
-      }
-    });
+      })
+    )
   });
 
   describe('when pubtag prebid adapter is not available', function () {
@@ -2901,12 +2684,24 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
           sizes: [[728, 90]],
+          mediaTypes: {
+            native: {}
+          },
+          nativeOrtbRequest: {
+            assets: [{
+              required: 1,
+              id: 1,
+              img: {
+                type: 3,
+                wmin: 100,
+                hmin: 100,
+              }
+            }]
+          },
           params: {
             zoneId: 123,
-            publisherSubId: '123',
-            nativeCallback: function () { }
+            publisherSubId: '123'
           },
           nativeParams: {
             image: {
@@ -2932,7 +2727,7 @@ describe('The Criteo bidding adapter', function () {
       ];
 
       utilsMock.expects('logWarn').withArgs('Criteo: all native assets containing URL should be sent as placeholders with sendId(icon, image, clickUrl, displayUrl, privacyLink, privacyIcon)').never();
-      const request = spec.buildRequests(bidRequestsWithSendId, bidderRequest);
+      const request = spec.buildRequests(bidRequestsWithSendId, syncAddFPDToBidderRequest(bidderRequest));
       utilsMock.verify();
     });
 
@@ -2942,23 +2737,46 @@ describe('The Criteo bidding adapter', function () {
         {
           bidder: 'criteo',
           adUnitCode: 'bid-123',
-          transactionId: 'transaction-123',
-          sizes: [[728, 90]],
+          mediaTypes: {
+            native: {}
+          },
+          nativeOrtbRequest: {
+            assets: [{
+              required: 1,
+              id: 1,
+              img: {
+                type: 3,
+                wmin: 100,
+                hmin: 100,
+              }
+            }]
+          },
           params: {
             zoneId: 123,
-            publisherSubId: '123',
-            nativeCallback: function () { }
+            publisherSubId: '123'
           },
         },
         {
           bidder: 'criteo',
           adUnitCode: 'bid-456',
           transactionId: 'transaction-456',
-          sizes: [[728, 90]],
+          mediaTypes: {
+            native: {}
+          },
+          nativeOrtbRequest: {
+            assets: [{
+              required: 1,
+              id: 1,
+              img: {
+                type: 3,
+                wmin: 100,
+                hmin: 100,
+              }
+            }]
+          },
           params: {
             zoneId: 456,
-            publisherSubId: '456',
-            nativeCallback: function () { }
+            publisherSubId: '456'
           },
         },
       ];
@@ -3014,7 +2832,7 @@ describe('The Criteo bidding adapter', function () {
       nativeParamsWithoutSendId.forEach(nativeParams => {
         let transformedBidRequests = { ...bidRequests };
         transformedBidRequests = [Object.assign(transformedBidRequests[0], nativeParams), Object.assign(transformedBidRequests[1], nativeParams)];
-        spec.buildRequests(transformedBidRequests, bidderRequest);
+        spec.buildRequests(transformedBidRequests, syncAddFPDToBidderRequest(bidderRequest));
       });
       utilsMock.verify();
     });


### PR DESCRIPTION
## Type of change

- [X] Updated bidder adapter

## Description of change

- Modified request and response models to comply with OpenRTB 2.5 (using the oRTB converter).
- Changed the endpoint to forward requests to a new oRTB 2.5 compliant endpoint.
- Dropped support of undefined sized banner trick in favor of built-in `native` media type.
- Dropped support of native callback in favor of built-in rendering fn.

## Breaking changes and how to migrate (for publishers)

- If you were using undefined sized banner to get native bids:
  - Remove the undefined sized banner from `mediaTypes`.
  - Define a `native` object in `mediaTypes`.

- If you were previously using a native callback:
  - Define the render fn by following [Prebid Documentation](https://docs.prebid.org/prebid/native-implementation.html#433-define-the-render-javascript).
  - Define a `native` object in `mediaTypes`.

## Additional notes
Even though native requests without asset requirements should be supported, we strongly advised to define some native asset requirements.