### PR TITLE
pb9: Organize adloader.js

### DIFF
--- a/src/adloader.js
+++ b/src/adloader.js
@@ -6,6 +6,7 @@ const _requestCache = new WeakMap();
 const _approvedLoadExternalJSList = [
   // Prebid maintained modules:
   'debugging',
+  'outstream',
   // Bid Modules:
   'adagio',
   'improvedigital',

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -6,14 +6,14 @@ const _requestCache = new WeakMap();
 const _approvedLoadExternalJSList = [
   // Prebid maintained modules:
   'debugging',
-  // Bid Modules: 
+  // Bid Modules:
   'adagio',
   'improvedigital',
   'lucead',
   // RTD modules:
   'aaxBlockmeter',
   'adloox',
-  'akamaidap',  
+  'akamaidap',
   'arcspan',
   'airgrid',
   'browsi',

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -4,35 +4,36 @@ import { logError, logWarn, insertElement, setScriptAttributes } from './utils.j
 const _requestCache = new WeakMap();
 // The below list contains modules or vendors whom Prebid allows to load external JS.
 const _approvedLoadExternalJSList = [
+  // Prebid maintained modules:
   'debugging',
-  'adloox',
-  'criteo',
-  'outstream',
+  // Bid Modules: 
   'adagio',
-  'browsi',
-  'brandmetrics',
-  'justtag',
-  'tncId',
-  'akamaidap',
-  'ftrackId',
-  'inskin',
-  'hadron',
-  'medianet',
   'improvedigital',
-  'azerionedge',
+  'lucead',
+  // RTD modules:
   'aaxBlockmeter',
-  'confiant',
+  'adloox',
+  'akamaidap',  
   'arcspan',
   'airgrid',
+  'browsi',
+  'brandmetrics',
   'clean.io',
+  'confiant',
+  'contxtful',
+  'hadron',
+  'mediafilter',
+  'medianet',
+  'azerionedge',
   'a1Media',
   'geoedge',
-  'mediafilter',
   'qortex',
   'dynamicAdBoost',
-  'contxtful',
+  // UserId Submodules
+  'justtag',
+  'tncId',
+  'ftrackId',
   'id5',
-  'lucead',
 ];
 
 /**

--- a/test/spec/adloader_spec.js
+++ b/test/spec/adloader_spec.js
@@ -23,19 +23,19 @@ describe('adLoader', function () {
     });
 
     it('only allows whitelisted vendors to load scripts', function () {
-      adLoader.loadExternalScript('someURL', 'criteo');
+      adLoader.loadExternalScript('someURL', 'debugging');
       expect(utilsLogErrorStub.called).to.be.false;
       expect(utilsinsertElementStub.called).to.be.true;
     });
 
     it('should not load cached script again', function() {
-      adLoader.loadExternalScript('someURL', 'criteo');
+      adLoader.loadExternalScript('someURL', 'debugging');
       expect(utilsinsertElementStub.called).to.be.false;
     });
 
     it('callback function can be passed to the function', function() {
       let callback = function() {};
-      adLoader.loadExternalScript('someURL1', 'criteo', callback);
+      adLoader.loadExternalScript('someURL1', 'debugging', callback);
       expect(utilsinsertElementStub.called).to.be.true;
     });
 
@@ -61,11 +61,11 @@ describe('adLoader', function () {
       }
       const doc1 = getDocSpec();
       const doc2 = getDocSpec();
-      adLoader.loadExternalScript('someURL', 'criteo', () => {}, doc1);
-      adLoader.loadExternalScript('someURL', 'criteo', () => {}, doc1);
-      adLoader.loadExternalScript('someURL', 'criteo', () => {}, doc1);
-      adLoader.loadExternalScript('someURL', 'criteo', () => {}, doc2);
-      adLoader.loadExternalScript('someURL', 'criteo', () => {}, doc2);
+      adLoader.loadExternalScript('someURL', 'debugging', () => {}, doc1);
+      adLoader.loadExternalScript('someURL', 'debugging', () => {}, doc1);
+      adLoader.loadExternalScript('someURL', 'debugging', () => {}, doc1);
+      adLoader.loadExternalScript('someURL', 'debugging', () => {}, doc2);
+      adLoader.loadExternalScript('someURL', 'debugging', () => {}, doc2);
       expect(utilsinsertElementStub.callCount).to.equal(2);
     });
   });
@@ -88,7 +88,7 @@ describe('adLoader', function () {
         }
       },
       attrs = {'z': 'A', 'y': 2};
-    let script = adLoader.loadExternalScript('someUrl', 'criteo', undefined, doc, attrs);
+    let script = adLoader.loadExternalScript('someUrl', 'debugging', undefined, doc, attrs);
     expect(script.z).to.equal('A');
     expect(script.y).to.equal(2);
   });


### PR DESCRIPTION
goal is to prepare for a linting rule that does not allow bidders to use loadexternalurl

removes a couple (criteo, spotx) that no longer are on the list. Also removed 'outstream' as I could not find a module matching that string. 