### PR TITLE
Seedtag Bid Adapter : allows sending bcat and badv ortb2 params in request payload

### DIFF
--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -324,6 +324,14 @@ export const spec = {
       payload.user.eids = validBidRequests[0].userIdAsEids
     }
 
+    if (bidderRequest.ortb2?.bcat) {
+      payload.bcat = bidderRequest.ortb2?.bcat
+    }
+
+    if (bidderRequest.ortb2?.badv) {
+      payload.badv = bidderRequest.ortb2?.badv
+    }
+
     const payloadString = JSON.stringify(payload);
 
     return {

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -590,6 +590,42 @@ describe('Seedtag Adapter', function () {
         expect(data.user.eids).to.deep.equal(userIdAsEids);
       })
     });
+
+    describe('Blocking params', function () {
+      it('should add bcat param to payload when bidderRequest has ortb2 bcat info', function () {
+        const blockedCategories = ['IAB1', 'IAB2']
+        var ortb2 = {
+          bcat: blockedCategories
+        }
+        bidderRequest['ortb2'] = ortb2
+
+        const request = spec.buildRequests(validBidRequests, bidderRequest);
+        const data = JSON.parse(request.data);
+        expect(data.bcat).to.deep.equal(blockedCategories);
+      });
+
+      it('should add badv param to payload when bidderRequest has ortb2 badv info', function () {
+        const blockedAdvertisers = ['blocked.com']
+        var ortb2 = {
+          badv: blockedAdvertisers
+        }
+        bidderRequest['ortb2'] = ortb2
+
+        const request = spec.buildRequests(validBidRequests, bidderRequest);
+        const data = JSON.parse(request.data);
+        expect(data.badv).to.deep.equal(blockedAdvertisers);
+      });
+
+      it('should not add bcat and badv params to payload when bidderRequest does not have ortb2 badv and bcat info', function () {
+        var ortb2 = {}
+        bidderRequest['ortb2'] = ortb2
+
+        const request = spec.buildRequests(validBidRequests, bidderRequest);
+        const data = JSON.parse(request.data);
+        expect(data.bcat).to.be.undefined;
+        expect(data.badv).to.be.undefined;
+      });
+    });
   })
   describe('interpret response method', function () {
     it('should return a void array, when the server response are not correct.', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->

- [x] Feature
## Description of change
Allows sending bcat and badv ortb2 parameters into request payload

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
