### PR TITLE
1plusX Rtd Provider : add First Party Cookie ID option

### DIFF
--- a/modules/1plusXRtdProvider.js
+++ b/modules/1plusXRtdProvider.js
@@ -1,5 +1,7 @@
 import { submodule } from '../src/hook.js';
+import { MODULE_TYPE_RTD } from '../src/activities/modules.js';
 import { ajax } from '../src/ajax.js';
+import { getStorageManager, STORAGE_TYPE_COOKIES, STORAGE_TYPE_LOCALSTORAGE } from '../src/storageManager.js';
 import {
   logMessage, logError,
   deepAccess, deepSetValue, mergeDeep,
@@ -13,6 +15,9 @@ const ORTB2_NAME = '1plusX.com'
 const PAPI_VERSION = 'v1.0';
 const LOG_PREFIX = '[1plusX RTD Module]: ';
 const OPE_FPID = 'ope_fpid'
+
+export const fpidStorage = getStorageManager({ moduleType: MODULE_TYPE_RTD, moduleName: MODULE_NAME });
+
 export const segtaxes = {
   // cf. https://github.com/InteractiveAdvertisingBureau/openrtb/pull/108
   AUDIENCE: 526,
@@ -53,7 +58,19 @@ export const extractConfig = (moduleConfig, reqBidsConfigObj) => {
     throw new Error('No bidRequestConfig bidder found in moduleConfig bidders');
   }
 
-  return { customerId, timeout, bidders };
+  const fpidStorageType = deepAccess(moduleConfig, 'params.fpidStorageType',
+    STORAGE_TYPE_LOCALSTORAGE)
+
+  if (
+    fpidStorageType !== STORAGE_TYPE_COOKIES &&
+    fpidStorageType !== STORAGE_TYPE_LOCALSTORAGE
+  ) {
+    throw new Error(
+      `fpidStorageType must be ${STORAGE_TYPE_LOCALSTORAGE} or ${STORAGE_TYPE_COOKIES}`
+    )
+  }
+
+  return { customerId, timeout, bidders, fpidStorageType };
 }
 
 /**
@@ -81,16 +98,19 @@ export const extractConsent = ({ gdpr }) => {
 }
 
 /**
- * Extracts the OPE first party id field from local storage
+ * Extracts the OPE first party id field
  * @returns fpid string if found, else null
  */
-export const extractFpid = () => {
+export const extractFpid = (fpidStorageType) => {
   try {
-    const fpid = window.localStorage.getItem(OPE_FPID);
-    if (fpid) {
-      return fpid;
+    switch (fpidStorageType) {
+      case STORAGE_TYPE_COOKIES: return fpidStorage.getCookie(OPE_FPID)
+      case STORAGE_TYPE_LOCALSTORAGE: return fpidStorage.getDataFromLocalStorage(OPE_FPID)
+      default: {
+        logError(`Got unknown fpidStorageType ${fpidStorageType}. Aborting...`)
+        return null
+      }
     }
-    return null;
   } catch (error) {
     return null;
   }
@@ -231,10 +251,10 @@ const init = (config, userConsent) => {
 const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, userConsent) => {
   try {
     // Get the required config
-    const { customerId, bidders } = extractConfig(moduleConfig, reqBidsConfigObj);
+    const { customerId, bidders, fpidStorageType } = extractConfig(moduleConfig, reqBidsConfigObj);
     const { ortb2Fragments: { bidder: biddersOrtb2 } } = reqBidsConfigObj;
     // Get PAPI URL
-    const papiUrl = getPapiUrl(customerId, extractConsent(userConsent) || {}, extractFpid())
+    const papiUrl = getPapiUrl(customerId, extractConsent(userConsent) || {}, extractFpid(fpidStorageType))
     // Call PAPI
     getTargetingDataFromPapi(papiUrl)
       .then((papiResponse) => {

--- a/modules/1plusXRtdProvider.js
+++ b/modules/1plusXRtdProvider.js
@@ -99,6 +99,7 @@ export const extractConsent = ({ gdpr }) => {
 
 /**
  * Extracts the OPE first party id field
+ * @param {string} fpidStorageType indicates where fpid should be read from
  * @returns fpid string if found, else null
  */
 export const extractFpid = (fpidStorageType) => {

--- a/modules/1plusXRtdProvider.md
+++ b/modules/1plusXRtdProvider.md
@@ -45,14 +45,15 @@ pbjs.setConfig({
 
 ### Parameters 
 
-| Name              | Type          | Description                                                      | Default           |
-| :---------------- | :------------ | :--------------------------------------------------------------- |:----------------- |
-| name              | String        | Real time data module name                                       | Always '1plusX'   |
-| waitForIt         | Boolean       | Should be `true` if there's an `auctionDelay` defined (optional) | `false`           |
-| params            | Object        |                                                                  |                   |
-| params.customerId | String        | Your 1plusX customer id                                          |                   |
-| params.bidders    | Array<string> | List of bidders for which you would like data to be set          |                   |
-| params.timeout    | Integer       | timeout (ms)                                                     | 1000ms            |
+| Name                      | Type          | Description                                                      | Default           |
+| :------------------------ | :------------ | :--------------------------------------------------------------- |:----------------- |
+| name                      | String        | Real time data module name                                       | Always '1plusX'   |
+| waitForIt                 | Boolean       | Should be `true` if there's an `auctionDelay` defined (optional) | `false`           |
+| params                    | Object        |                                                                  |                   |
+| params.customerId         | String        | Your 1plusX customer id                                          |                   |
+| params.bidders            | Array<string> | List of bidders for which you would like data to be set          |                   |
+| params.timeout            | Integer       | timeout (ms)                                                     | 1000ms            |
+| params.fpidStorageType    | String        | Either "html5" (local storage) or "cookie" (first party cookie)  | html5             |
 
 ## Testing 
 

--- a/modules/1plusXRtdProvider.md
+++ b/modules/1plusXRtdProvider.md
@@ -53,8 +53,8 @@ pbjs.setConfig({
 | params.customerId         | String        | Your 1plusX customer id                                          |                   |
 | params.bidders            | Array<string> | List of bidders for which you would like data to be set          |                   |
 | params.timeout            | Integer       | timeout (ms)                                                     | 1000ms            |
-| params.fpidStorageType    | String        | Either "html5" (local storage) or "cookie" (first party cookie)  | html5             |
-
+| params.fpidStorageType    | String        | Specifies where the 1plusX fpid should be read from. Either      | html5             |
+|                           |               | "html5" (local storage) or "cookie" (first party cookie)         |                   |
 ## Testing 
 
 To view an example of how the 1plusX RTD module works :

--- a/test/spec/modules/1plusXRtdProvider_spec.js
+++ b/test/spec/modules/1plusXRtdProvider_spec.js
@@ -12,6 +12,7 @@ import {
   updateBidderConfig,
 } from 'modules/1plusXRtdProvider';
 import {deepClone} from '../../../src/utils.js';
+import { STORAGE_TYPE_COOKIES, STORAGE_TYPE_LOCALSTORAGE } from 'src/storageManager.js';
 
 describe('1plusXRtdProvider', () => {
   // Fake server config
@@ -120,12 +121,16 @@ describe('1plusXRtdProvider', () => {
         }, 100);
       }
     })
+    it('callback is called after getBidRequestData', () => {
+
+    })
   })
 
   describe('extractConfig', () => {
     const customerId = 'test';
     const timeout = 1000;
     const bidders = ['appnexus'];
+    const fpidStorageType = STORAGE_TYPE_LOCALSTORAGE
 
     it('Throws an error if no customerId is specified', () => {
       const moduleConfig = { params: { timeout, bidders } };
@@ -141,13 +146,14 @@ describe('1plusXRtdProvider', () => {
       expect(() => extractConfig(moduleConfig, reqBidsConfigEmpty)).to.throw();
     })
     it('Returns an object containing the parameters specified', () => {
-      const moduleConfig = { params: { customerId, timeout, bidders } };
-      const expectedKeys = ['customerId', 'timeout', 'bidders']
+      const moduleConfig = { params: { customerId, timeout, bidders, fpidStorageType } };
+      const expectedKeys = ['customerId', 'timeout', 'bidders', 'fpidStorageType']
       const extractedConfig = extractConfig(moduleConfig, reqBidsConfigObj);
       expect(extractedConfig).to.be.an('object').and.to.have.all.keys(expectedKeys);
       expect(extractedConfig.customerId).to.equal(customerId);
       expect(extractedConfig.timeout).to.equal(timeout);
       expect(extractedConfig.bidders).to.deep.equal(bidders);
+      expect(extractedConfig.fpidStorageType).to.equal(fpidStorageType)
     })
     /* 1plusX RTD module may only use bidders that are both specified in :
         - the bid request configuration
@@ -165,6 +171,20 @@ describe('1plusXRtdProvider', () => {
       const bidders = ['rubicon'];
       const moduleConfig = { params: { customerId, timeout, bidders } };
       expect(() => extractConfig(moduleConfig, reqBidsConfigObj)).to.throw();
+    })
+    it('Throws an error if wrong fpidStorageType is provided', () => {
+      const moduleConfig = { params: { customerId, timeout, bidders, fpidStorageType: 'bogus' } };
+      expect(() => extractConfig(moduleConfig, reqBidsConfigObj).to.throw())
+    })
+    it('Defaults fpidStorageType to localStorage', () => {
+      const moduleConfig = { params: { customerId, timeout, bidders } };
+      const extractedConfig = extractConfig(moduleConfig, reqBidsConfigObj);
+      expect(extractedConfig.fpidStorageType).to.equal(STORAGE_TYPE_LOCALSTORAGE)
+    })
+    it('Correctly instantiates fpidStorageType to cookie store if instructed', () => {
+      const moduleConfig = { params: { customerId, timeout, bidders, fpidStorageType: STORAGE_TYPE_COOKIES } };
+      const extractedConfig = extractConfig(moduleConfig, reqBidsConfigObj);
+      expect(extractedConfig.fpidStorageType).to.equal(STORAGE_TYPE_COOKIES)
     })
   })
 
@@ -281,17 +301,6 @@ describe('1plusXRtdProvider', () => {
           assert(failed, 'Should be throwing an exception')
         }
       }
-    })
-  })
-
-  describe('extractFpid', () => {
-    it('correctly extracts an ope fpid if present', () => {
-      window.localStorage.setItem('ope_fpid', 'oneplusx_test_key')
-      const id1 = extractFpid()
-      window.localStorage.removeItem('ope_fpid')
-      const id2 = extractFpid()
-      expect(id1).to.equal('oneplusx_test_key')
-      expect(id2).to.equal(null)
     })
   })
 

--- a/test/spec/modules/1plusXRtdProvider_spec.js
+++ b/test/spec/modules/1plusXRtdProvider_spec.js
@@ -121,9 +121,6 @@ describe('1plusXRtdProvider', () => {
         }, 100);
       }
     })
-    it('callback is called after getBidRequestData', () => {
-
-    })
   })
 
   describe('extractConfig', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

- This module used to get our first party identifier via local storage. Adding an option so that it can also read it out from the first party cookie, set by us via JavaScript. By default, we still use LocalStorage.
- Extended unit tests to cover the parsing of the config described above
- Using the prebid storeManager to obtain access to local storage and cookie storage. This seems to be a best practice and makes sense imo to be a small refactoring as part of this PR. LMK if I'm not making proper use of this abstraction in my code.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
