### PR TITLE
OpenX Bid Adapter: remove use of deprecated video.placement

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -144,9 +144,6 @@ const converter = ortbConverter({
             bidRequest = {...bidRequest, mediaTypes: {[VIDEO]: videoParams}}
           }
           orig(imp, bidRequest, context);
-          if (imp.video && videoParams?.context === 'outstream') {
-            imp.video.placement = imp.video.placement || 4;
-          }
         }
       }
     }

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1087,7 +1087,6 @@ describe('OpenxRtbAdapter', function () {
             skipafter: 4,
             minduration: 10,
             maxduration: 30,
-            placement: 4,
             protocols: [8],
             w: 300,
             h: 250


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Deprecation of video.placement as it has been replaced with video.plcmt

background: https://github.com/prebid/Prebid.js/issues/10452