### PR TITLE
Adnuntius Bid Adapter : merge targeting from multiple sources

### DIFF
--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -130,31 +130,6 @@ const storageTool = (function () {
     return (meta && meta.usi) ? meta.usi : false
   }
 
-  const getSegmentsFromOrtb = function (ortb2) {
-    const userData = deepAccess(ortb2, 'user.data');
-    let segments = [];
-    if (userData) {
-      userData.forEach(userdat => {
-        if (userdat.segment) {
-          segments.push(...userdat.segment.map((segment) => {
-            if (isStr(segment)) return segment;
-            if (isStr(segment.id)) return segment.id;
-          }).filter((seg) => !!seg));
-        }
-      });
-    }
-    return segments
-  }
-
-  const getKvsFromOrtb = function (ortb2) {
-    const siteData = deepAccess(ortb2, 'site.ext.data');
-    if (siteData) {
-      return siteData
-    } else {
-      return null
-    }
-  }
-
   return {
     refreshStorage: function (bidderRequest) {
       const ortb2 = bidderRequest.ortb2 || {};
@@ -171,23 +146,67 @@ const storageTool = (function () {
           return voidAuId.auId;
         });
       }
-      metaInternal.segments = getSegmentsFromOrtb(ortb2);
-      metaInternal.kv = getKvsFromOrtb(ortb2);
     },
     saveToStorage: function (serverData, network) {
       setMetaInternal(serverData, network);
     },
     getUrlRelatedData: function () {
       // getting the URL information is theoretically not network-specific
-      const { segments, kv, usi, voidAuIdsArray } = metaInternal;
-      return { segments, kv, usi, voidAuIdsArray };
+      const { usi, voidAuIdsArray } = metaInternal;
+      return { usi, voidAuIdsArray };
     },
     getPayloadRelatedData: function (network) {
       // getting the payload data should be network-specific
-      const { segments, kv, usi, userId, voidAuIdsArray, voidAuIds, ...payloadRelatedData } = getMetaDataFromLocalStorage(network).reduce((a, entry) => ({ ...a, [entry.key]: entry.value }), {});
+      const { segments, usi, userId, voidAuIdsArray, voidAuIds, ...payloadRelatedData } = getMetaDataFromLocalStorage(network).reduce((a, entry) => ({ ...a, [entry.key]: entry.value }), {});
       return payloadRelatedData;
     }
   };
+})();
+
+const targetingTool = (function() {
+  const getSegmentsFromOrtb = function(bidderRequest) {
+    const userData = deepAccess(bidderRequest.ortb2 || {}, 'user.data');
+    let segments = [];
+    if (userData) {
+      userData.forEach(userdat => {
+        if (userdat.segment) {
+          segments.push(...userdat.segment.map((segment) => {
+            if (isStr(segment)) return segment;
+            if (isStr(segment.id)) return segment.id;
+          }).filter((seg) => !!seg));
+        }
+      });
+    }
+    return segments
+  };
+
+  const getKvsFromOrtb = function(bidderRequest) {
+    return deepAccess(bidderRequest.ortb2 || {}, 'site.ext.data');
+  };
+
+  return {
+    addSegmentsToUrlData: function (validBids, bidderRequest, existingUrlRelatedData) {
+      let segments = getSegmentsFromOrtb(bidderRequest || {});
+
+      for (let i = 0; i < validBids.length; i++) {
+        const bid = validBids[i];
+        const targeting = bid.params.targeting || {};
+        if (Array.isArray(targeting.segments)) {
+          segments = segments.concat(targeting.segments);
+          delete bid.params.targeting.segments;
+        }
+      }
+
+      existingUrlRelatedData.segments = segments;
+    },
+    mergeKvsFromOrtb: function(bidTargeting, bidderRequest) {
+      const kv = getKvsFromOrtb(bidderRequest || {});
+      if (!kv) {
+        return;
+      }
+      bidTargeting.kv = {...kv, ...bidTargeting.kv};
+    }
+  }
 })();
 
 const validateBidType = function (bidTypeOption) {
@@ -227,6 +246,7 @@ export const spec = {
     storageTool.refreshStorage(bidderRequest);
 
     const urlRelatedMetaData = storageTool.getUrlRelatedData();
+    targetingTool.addSegmentsToUrlData(validBidRequests, bidderRequest, urlRelatedMetaData);
     if (urlRelatedMetaData.segments.length > 0) queryParamsAndValues.push('segments=' + urlRelatedMetaData.segments.join(','));
     if (urlRelatedMetaData.usi) queryParamsAndValues.push('userId=' + urlRelatedMetaData.usi);
 
@@ -261,9 +281,9 @@ export const spec = {
         networks[network].metaData = payloadRelatedData;
       }
 
-      const targeting = bid.params.targeting || {};
-      if (urlRelatedMetaData.kv) targeting.kv = urlRelatedMetaData.kv;
-      const adUnit = { ...targeting, auId: bid.params.auId, targetId: bid.params.targetId || bid.bidId };
+      const bidTargeting = {...bid.params.targeting || {}};
+      targetingTool.mergeKvsFromOrtb(bidTargeting, bidderRequest);
+      const adUnit = { ...bidTargeting, auId: bid.params.auId, targetId: bid.params.targetId || bid.bidId };
       const maxDeals = Math.max(0, Math.min(bid.params.maxDeals || 0, MAXIMUM_DEALS_LIMIT));
       if (maxDeals > 0) {
         adUnit.maxDeals = maxDeals;


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Allows targeting from ortb and directly on the bid to merge rather than have one overwrite the other.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
