### PR TITLE
Improve Digital Bid Adapter : remove parsing of addtlConsent

### DIFF
--- a/modules/improvedigitalBidAdapter.js
+++ b/modules/improvedigitalBidAdapter.js
@@ -237,29 +237,6 @@ export const CONVERTER = ortbConverter({
           imp.video.placement = VIDEO_PARAMS.PLACEMENT_TYPE.OUTSTREAM;
         }
       }
-    },
-    request: {
-      gdprAddtlConsent(setAddtlConsent, ortbRequest, bidderRequest) {
-        const additionalConsent = bidderRequest?.gdprConsent?.addtlConsent;
-        if (!additionalConsent) {
-          return;
-        }
-        if (spec.syncStore.extendMode) {
-          setAddtlConsent(ortbRequest, bidderRequest);
-          return;
-        }
-        if (additionalConsent && additionalConsent.indexOf('~') !== -1) {
-          // Google Ad Tech Provider IDs
-          const atpIds = additionalConsent.substring(additionalConsent.indexOf('~') + 1);
-          if (atpIds) {
-            deepSetValue(
-              ortbRequest,
-              'user.ext.consented_providers_settings.consented_providers',
-              atpIds.split('.').map(id => parseInt(id, 10))
-            );
-          }
-        }
-      }
     }
   }
 })

--- a/test/spec/modules/improvedigitalBidAdapter_spec.js
+++ b/test/spec/modules/improvedigitalBidAdapter_spec.js
@@ -405,8 +405,7 @@ describe('Improve Digital Adapter Tests', function () {
       const payload = JSON.parse(spec.buildRequests([bidRequest], syncAddFPDToBidderRequest(bidderRequestGdpr))[0].data);
       expect(payload.regs.ext.gdpr).to.exist.and.to.equal(1);
       expect(payload.user.ext.consent).to.equal('CONSENT');
-      expect(payload.user.ext.ConsentedProvidersSettings).to.not.exist;
-      expect(payload.user.ext.consented_providers_settings.consented_providers).to.exist.and.to.deep.equal([1, 35, 41, 101]);
+      expect(payload.user.ext.ConsentedProvidersSettings.consented_providers).to.exist.and.to.deep.equal('1~1.35.41.101');
     });
 
     it('should not add consented providers when empty', function () {


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
Improve Digital bid adapter: Remove parsing of addtlConsent, falling back to the default logic provided by ortbConverter.