### PR TITLE
Taboola Bid Adapter: fix ortb2 user override issue

### DIFF
--- a/modules/taboolaBidAdapter.js
+++ b/modules/taboolaBidAdapter.js
@@ -64,6 +64,7 @@ export const userData = {
         return tblaId;
       }
     }
+    return undefined;
   },
   getCookieDataByKey(cookieData, key) {
     if (!cookieData) {
@@ -78,6 +79,7 @@ export const userData = {
     if (hasLocalStorage() && localStorageIsEnabled()) {
       return getDataFromLocalStorage(STORAGE_KEY);
     }
+    return undefined;
   },
   getFromTRC() {
     return window.TRC ? window.TRC.user_id : 0;
@@ -271,35 +273,38 @@ function getSiteProperties({publisherId}, refererInfo, ortb2) {
 function fillTaboolaReqData(bidderRequest, bidRequest, data) {
   const {refererInfo, gdprConsent = {}, uspConsent} = bidderRequest;
   const site = getSiteProperties(bidRequest.params, refererInfo, bidderRequest.ortb2);
-  const device = {ua: navigator.userAgent};
-  let user = {
-    buyeruid: userData.getUserId(gdprConsent, uspConsent),
-    ext: {}
-  };
-  if (bidderRequest && bidderRequest.ortb2 && bidderRequest.ortb2.user) {
-    user.data = bidderRequest.ortb2.user.data;
+  deepSetValue(data, 'device.ua', navigator.userAgent);
+  const extractedUserId = userData.getUserId(gdprConsent, uspConsent);
+  if (data.user == undefined) {
+    data.user = {
+      buyeruid: 0,
+      ext: {}
+    }
   }
-  const regs = {
-    coppa: 0,
-    ext: {}
-  };
-
+  if (extractedUserId && extractedUserId !== 0) {
+    deepSetValue(data, 'user.buyeruid', extractedUserId);
+  }
+  if (data.regs?.ext == undefined) {
+    data.regs = {
+      ext: {}
+    }
+  }
+  deepSetValue(data, 'regs.coppa', 0);
   if (gdprConsent.gdprApplies) {
-    user.ext.consent = bidderRequest.gdprConsent.consentString;
-    regs.ext.gdpr = 1;
+    deepSetValue(data, 'user.ext.consent', bidderRequest.gdprConsent.consentString);
+    deepSetValue(data, 'regs.ext.gdpr', 1);
   }
-
   if (uspConsent) {
-    regs.ext.us_privacy = uspConsent;
+    deepSetValue(data, 'regs.ext.us_privacy', uspConsent);
   }
 
   if (bidderRequest.ortb2?.regs?.gpp) {
-    regs.ext.gpp = bidderRequest.ortb2.regs.gpp;
-    regs.ext.gpp_sid = bidderRequest.ortb2.regs.gpp_sid;
+    deepSetValue(data, 'regs.ext.gpp', bidderRequest.ortb2.regs.gpp);
+    deepSetValue(data, 'regs.ext.gpp_sid', bidderRequest.ortb2.regs.gpp_sid);
   }
 
   if (config.getConfig('coppa')) {
-    regs.coppa = 1;
+    deepSetValue(data, 'regs.coppa', 1);
   }
 
   const ortb2 = bidderRequest.ortb2 || {
@@ -308,16 +313,14 @@ function fillTaboolaReqData(bidderRequest, bidRequest, data) {
     wlang: []
   };
 
+  deepSetValue(data, 'source.fd', 1);
+
   data.id = bidderRequest.bidderRequestId;
   data.site = site;
-  data.device = device;
-  data.source = {fd: 1};
   data.tmax = (bidderRequest.timeout == undefined) ? undefined : parseInt(bidderRequest.timeout);
   data.bcat = ortb2.bcat || bidRequest.params.bcat || [];
   data.badv = ortb2.badv || bidRequest.params.badv || [];
   data.wlang = ortb2.wlang || bidRequest.params.wlang || [];
-  data.user = user;
-  data.regs = regs;
   deepSetValue(data, 'ext.pageType', ortb2?.ext?.data?.pageType || ortb2?.ext?.data?.section || bidRequest.params.pageType);
   deepSetValue(data, 'ext.prebid.version', '$prebid.version$');
 }

--- a/test/spec/modules/taboolaBidAdapter_spec.js
+++ b/test/spec/modules/taboolaBidAdapter_spec.js
@@ -375,6 +375,23 @@ describe('Taboola Adapter', function () {
         expect(res.data.user.id).to.deep.equal(bidderRequest.ortb2.user.id)
       });
 
+      it('should pass user entities', function () {
+        const bidderRequest = {
+          ...commonBidderRequest,
+          ortb2: {
+            user: {
+              id: 'userid',
+              buyeruid: 'buyeruid',
+              yob: 1990
+            }
+          }
+        }
+        const res = spec.buildRequests([defaultBidRequest], bidderRequest);
+        expect(res.data.user.id).to.deep.equal(bidderRequest.ortb2.user.id)
+        expect(res.data.user.buyeruid).to.deep.equal(bidderRequest.ortb2.user.buyeruid)
+        expect(res.data.user.yob).to.deep.equal(bidderRequest.ortb2.user.yob)
+      });
+
       it('should pass pageType if exists in ortb2', function () {
         const bidderRequest = {
           ...commonBidderRequest,
@@ -504,6 +521,28 @@ describe('Taboola Adapter', function () {
           ...commonBidderRequest
         };
         const res = spec.buildRequests([defaultBidRequest], bidderRequest);
+        expect(res.data.user.buyeruid).to.equal('12121212');
+      });
+
+      it('should get buyeruid from cookie as priority and external user id from ortb2 object', function () {
+        getDataFromLocalStorage.returns(51525152);
+        hasLocalStorage.returns(false);
+        localStorageIsEnabled.returns(false);
+        cookiesAreEnabled.returns(true);
+        getCookie.returns('taboola%20global%3Auser-id=12121212');
+
+        const bidderRequest = {
+          ...commonBidderRequest,
+          ortb2: {
+            user: {
+              id: 'userid',
+              buyeruid: 'buyeruid',
+              yob: 1990
+            }
+          }
+        };
+        const res = spec.buildRequests([defaultBidRequest], bidderRequest);
+        expect(res.data.user.id).to.deep.equal('userid')
         expect(res.data.user.buyeruid).to.equal('12121212');
       });
 

--- a/test/spec/modules/taboolaBidAdapter_spec.js
+++ b/test/spec/modules/taboolaBidAdapter_spec.js
@@ -199,6 +199,13 @@ describe('Taboola Adapter', function () {
         }],
         id: 'mock-uuid',
         'test': 0,
+        'device': {'ua': navigator.userAgent},
+        'user': {
+          'buyeruid': 0,
+          'ext': {},
+        },
+        'regs': {'ext': {}, 'coppa': 0},
+        'source': {'fd': 1},
         'site': {
           'id': commonBidRequest.params.publisherId,
           'name': commonBidRequest.params.publisherId,
@@ -208,16 +215,9 @@ describe('Taboola Adapter', function () {
           'publisher': {'id': commonBidRequest.params.publisherId},
           'content': {'language': navigator.language}
         },
-        'device': {'ua': navigator.userAgent},
-        'source': {'fd': 1},
         'bcat': [],
         'badv': [],
         'wlang': [],
-        'user': {
-          'buyeruid': 0,
-          'ext': {},
-        },
-        'regs': {'coppa': 0, 'ext': {}},
         'ext': {
           'prebid': {
             'version': '$prebid.version$'
@@ -363,12 +363,16 @@ describe('Taboola Adapter', function () {
             bcat: ['EX1', 'EX2', 'EX3'],
             badv: ['site.com'],
             wlang: ['de'],
+            user: {
+              id: 'externalUserId'
+            }
           }
         }
         const res = spec.buildRequests([defaultBidRequest], bidderRequest);
         expect(res.data.bcat).to.deep.equal(bidderRequest.ortb2.bcat)
         expect(res.data.badv).to.deep.equal(bidderRequest.ortb2.badv)
         expect(res.data.wlang).to.deep.equal(bidderRequest.ortb2.wlang)
+        expect(res.data.user.id).to.deep.equal(bidderRequest.ortb2.user.id)
       });
 
       it('should pass pageType if exists in ortb2', function () {

--- a/test/spec/modules/taboolaBidAdapter_spec.js
+++ b/test/spec/modules/taboolaBidAdapter_spec.js
@@ -364,7 +364,7 @@ describe('Taboola Adapter', function () {
             badv: ['site.com'],
             wlang: ['de'],
             user: {
-              id: 'externalUserId'
+              id: 'externalUserIdPassed'
             }
           }
         }


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
user object entities in first party data (ortb2) not passed within the server generated request.
In this PR, fixed the override issue and passing what the ortb convertor generated "user" field as it is
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
