### PR TITLE
Prebid Core: Configurable maxbid

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -979,9 +979,12 @@ function groupByPlacement(bidsByPlacement, bid) {
 }
 
 /**
- * isValidPrice is price validation function 
+ * isValidPrice is price validation function
  * which checks if price from bid response
  * is not higher than top limit set in config
+ * @type {Function}
+ * @param bid
+ * @returns {boolean}
  */
 function isValidPrice(bid) {
   const maxBidValue = config.getConfig('maxBid');
@@ -990,6 +993,6 @@ function isValidPrice(bid) {
   if (!maxBidValue) return true;
   if (maxBidCurrency && bid.currency && (bid.currency !== maxBidCurrency) && bid.getCpmInNewCurrency) {
     return Number(bid.getCpmInNewCurrency(maxBidCurrency)) <= maxBidValue;
-  }  
+  }
   return maxBidValue >= Number(bid.cpm);
 }

--- a/src/config.js
+++ b/src/config.js
@@ -37,7 +37,6 @@ const DEFAULT_BID_CACHE = false;
 const DEFAULT_DEVICE_ACCESS = true;
 const DEFAULT_MAX_NESTED_IFRAMES = 10;
 const DEFAULT_MAXBID_VALUE = 5000
-const DEFAULT_MAXBID_CURRENCY = 'USD'
 
 const DEFAULT_TIMEOUTBUFFER = 400;
 
@@ -164,8 +163,7 @@ export function newConfig() {
       maxNestedIframes: DEFAULT_MAX_NESTED_IFRAMES,
 
       // default max bid
-      maxBid: DEFAULT_MAXBID_VALUE,
-      maxBidCur: DEFAULT_MAXBID_CURRENCY
+      maxBid: DEFAULT_MAXBID_VALUE
     };
 
     Object.defineProperties(newConfig,

--- a/src/config.js
+++ b/src/config.js
@@ -36,6 +36,8 @@ const DEFAULT_DISABLE_AJAX_TIMEOUT = false;
 const DEFAULT_BID_CACHE = false;
 const DEFAULT_DEVICE_ACCESS = true;
 const DEFAULT_MAX_NESTED_IFRAMES = 10;
+const DEFAULT_MAXBID_VALUE = 5000
+const DEFAULT_MAXBID_CURRENCY = 'USD'
 
 const DEFAULT_TIMEOUTBUFFER = 400;
 
@@ -160,6 +162,10 @@ export function newConfig() {
 
       // default max nested iframes for referer detection
       maxNestedIframes: DEFAULT_MAX_NESTED_IFRAMES,
+
+      // default max bid
+      maxBid: DEFAULT_MAXBID_VALUE,
+      maxBidCur: DEFAULT_MAXBID_CURRENCY
     };
 
     Object.defineProperties(newConfig,

--- a/src/constants.js
+++ b/src/constants.js
@@ -135,7 +135,8 @@ export const REJECTION_REASON = {
   FLOOR_NOT_MET: 'Bid does not meet price floor',
   CANNOT_CONVERT_CURRENCY: 'Unable to convert currency',
   DSA_REQUIRED: 'Bid does not provide required DSA transparency info',
-  DSA_MISMATCH: 'Bid indicates inappropriate DSA rendering method'
+  DSA_MISMATCH: 'Bid indicates inappropriate DSA rendering method',
+  PRICE_TOO_HIGH: 'Bid price exceeds maximum value'
 };
 
 export const PREBID_NATIVE_DATA_KEYS_TO_ORTB = {

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -1471,20 +1471,18 @@ describe('auctionmanager.js', function () {
     });
 
     it('should reject bid for price higher than limit for the same currency', () => {
-      sinon.stub(auction, 'addBidRejected')
+      sinon.stub(auction, 'addBidRejected');
       setCurrencyConfig({ adServerCurrency: 'USD' })
       config.setConfig({
         maxBid: 1,
         maxBidCur: 'USD'
-      })
+      });
 
       auction.callBids();
       sinon.assert.calledWith(auction.addBidRejected, sinon.match({rejectionReason: 'Bid price exceeds maximum value'}));
       setCurrencyConfig({});
     })
-    
   });
-
 
   describe('addBidRequests', function () {
     let createAuctionStub;

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -26,6 +26,7 @@ import { IMAGE as ortbNativeRequest } from 'src/native.js';
 import {PrebidServer} from '../../modules/prebidServerBidAdapter/index.js';
 import '../../modules/currency.js'
 import { setConfig as setCurrencyConfig } from '../../modules/currency.js';
+import { REJECTION_REASON } from '../../src/constants.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -1472,15 +1473,12 @@ describe('auctionmanager.js', function () {
 
     it('should reject bid for price higher than limit for the same currency', () => {
       sinon.stub(auction, 'addBidRejected');
-      setCurrencyConfig({ adServerCurrency: 'USD' })
       config.setConfig({
-        maxBid: 1,
-        maxBidCur: 'USD'
+        maxBid: 1
       });
 
       auction.callBids();
-      sinon.assert.calledWith(auction.addBidRejected, sinon.match({rejectionReason: 'Bid price exceeds maximum value'}));
-      setCurrencyConfig({});
+      sinon.assert.calledWith(auction.addBidRejected, sinon.match({rejectionReason: REJECTION_REASON.PRICE_TOO_HIGH}));
     })
   });
 

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -24,6 +24,8 @@ import {expect} from 'chai';
 import {deepClone} from '../../src/utils.js';
 import { IMAGE as ortbNativeRequest } from 'src/native.js';
 import {PrebidServer} from '../../modules/prebidServerBidAdapter/index.js';
+import '../../modules/currency.js'
+import { setConfig as setCurrencyConfig } from '../../modules/currency.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -1467,7 +1469,22 @@ describe('auctionmanager.js', function () {
       config.getConfig.restore();
       store.store.restore();
     });
+
+    it('should reject bid for price higher than limit for the same currency', () => {
+      sinon.stub(auction, 'addBidRejected')
+      setCurrencyConfig({ adServerCurrency: 'USD' })
+      config.setConfig({
+        maxBid: 1,
+        maxBidCur: 'USD'
+      })
+
+      auction.callBids();
+      sinon.assert.calledWith(auction.addBidRejected, sinon.match({rejectionReason: 'Bid price exceeds maximum value'}));
+      setCurrencyConfig({});
+    })
+    
   });
+
 
   describe('addBidRequests', function () {
     let createAuctionStub;


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
#11252 
