### PR TITLE
Livewrapped Analytics Adapter : forward extended parameters

### DIFF
--- a/modules/livewrappedAnalyticsAdapter.js
+++ b/modules/livewrappedAnalyticsAdapter.js
@@ -1,4 +1,4 @@
-import { timestamp, logInfo, getWindowTop } from '../src/utils.js';
+import { timestamp, logInfo } from '../src/utils.js';
 import {ajax} from '../src/ajax.js';
 import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
 import { EVENTS, STATUS } from '../src/constants.js';
@@ -171,7 +171,7 @@ livewrappedAnalyticsAdapter.sendEvents = function() {
     timeouts: getTimeouts(sentRequests.gdpr, sentRequests.auctionIds),
     bidAdUnits: getbidAdUnits(),
     rf: getAdRenderFailed(sentRequests.auctionIds),
-    rcv: getAdblockerRecovered()
+    ext: initOptions.ext
   };
 
   if (events.requests.length == 0 &&
@@ -184,12 +184,6 @@ livewrappedAnalyticsAdapter.sendEvents = function() {
 
   ajax(initOptions.endpoint || URL, undefined, JSON.stringify(events), {method: 'POST'});
 };
-
-function getAdblockerRecovered() {
-  try {
-    return getWindowTop().I12C && getWindowTop().I12C.Morph === 1;
-  } catch (e) {}
-}
 
 function getSentRequests() {
   var sentRequests = [];


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x ] Updated bidder adapter 

## Description of change
Make it possible to forward arbitrary parameters. At the same time remove detection of legacy ad blocker recovery support as this is one of the things that can be forwarded with the extended parameters.
