### PR TITLE
Prebid 9: TCF: use publisher consent for vendorless modules

### DIFF
--- a/src/consentHandler.js
+++ b/src/consentHandler.js
@@ -10,14 +10,6 @@ import {config} from './config.js';
  */
 export const VENDORLESS_GVLID = Object.freeze({});
 
-/**
- * Placeholder gvlid for when device.ext.cdep is present (Privacy Sandbox cookie deprecation label). When this value is used as gvlid, the gdpr
- * enforcement module will look to see that publisher consent was given.
- *
- * see https://github.com/prebid/Prebid.js/issues/10516
- */
-export const FIRST_PARTY_GVLID = Object.freeze({});
-
 export class ConsentHandler {
   #enabled;
   #data;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

For vendorless (first party) modules, use publisher consent and LI instead of purpose consent and LI.

Closes https://github.com/prebid/Prebid.js/issues/10622

