### PR TITLE
Onetag Bid Adapter: add reading of ortb2Imp field

### DIFF
--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -291,6 +291,7 @@ function setGeneralInfo(bidRequest) {
   this['gpid'] = deepAccess(bidRequest, 'ortb2Imp.ext.gpid') || deepAccess(bidRequest, 'ortb2Imp.ext.data.pbadslot');
   this['pubId'] = params.pubId;
   this['ext'] = params.ext;
+  this['ortb2Imp'] = deepAccess(bidRequest, 'ortb2Imp');
   if (params.pubClick) {
     this['click'] = params.pubClick;
   }

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -226,6 +226,7 @@ describe('onetag', function () {
             'bidId',
             'bidderRequestId',
             'pubId',
+            'ortb2Imp',
             'transactionId',
             'context',
             'playerSize',
@@ -240,6 +241,7 @@ describe('onetag', function () {
             'bidId',
             'bidderRequestId',
             'pubId',
+            'ortb2Imp',
             'transactionId',
             'mediaTypeInfo',
             'sizes',
@@ -270,6 +272,7 @@ describe('onetag', function () {
       expect(payload.bids).to.exist.and.to.have.length(1);
       expect(payload.bids[0].auctionId).to.equal(bannerBid.ortb2.source.tid);
       expect(payload.bids[0].transactionId).to.equal(bannerBid.ortb2Imp.ext.tid);
+      expect(payload.bids[0].ortb2Imp).to.deep.equal(bannerBid.ortb2Imp);
     });
     it('should send GDPR consent data', function () {
       let consentString = 'consentString';


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add reading of ortb2Imp field

