### PR TITLE
Prebid 9: Prevent from Events system import in bidders

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -96,5 +96,15 @@ module.exports = {
     // code in other packages (such as plugins/eslint) is not "seen" by babel and its parser will complain.
     files: 'plugins/*/**/*.js',
     parser: 'esprima'
+  }, 
+  {
+    files: '**BidAdapter.js',
+    rules: {
+      'no-restricted-imports': [
+        'error', {
+          patterns: ["**/src/events.js"]
+        }
+      ]
+    }
   }])
 };

--- a/modules/holidBidAdapter.js
+++ b/modules/holidBidAdapter.js
@@ -5,8 +5,6 @@ import {
   logMessage,
   triggerPixel,
 } from '../src/utils.js';
-import * as events from '../src/events.js';
-import { EVENTS } from '../src/constants.js';
 import {BANNER} from '../src/mediaTypes.js';
 
 import {registerBidder} from '../src/adapters/bidderFactory.js';
@@ -18,8 +16,6 @@ const COOKIE_SYNC_ENDPOINT = 'https://null.holid.io/sync.html'
 const TIME_TO_LIVE = 300
 const TMAX = 500
 let wurlMap = {}
-
-events.on(EVENTS.BID_WON, bidWonHandler)
 
 export const spec = {
   code: BIDDER_CODE,
@@ -120,6 +116,15 @@ export const spec = {
 
     return syncs
   },
+
+  onBidWon(bid) {
+    const wurl = getWurl(bid.requestId)
+    if (wurl) {
+      logMessage(`Invoking image pixel for wurl on BID_WIN: "${wurl}"`)
+      triggerPixel(wurl)
+      removeWurl(bid.requestId)
+    }
+  }
 }
 
 function getImp(bid) {
@@ -173,15 +178,6 @@ function removeWurl(requestId) {
 function getWurl(requestId) {
   if (isStr(requestId)) {
     return wurlMap[requestId]
-  }
-}
-
-function bidWonHandler(bid) {
-  const wurl = getWurl(bid.requestId)
-  if (wurl) {
-    logMessage(`Invoking image pixel for wurl on BID_WIN: "${wurl}"`)
-    triggerPixel(wurl)
-    removeWurl(bid.requestId)
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
#11071 