### PR TITLE
Prebid 9: gptPreAuction: use GPID by default

### DIFF
--- a/modules/ceeIdSystem.js
+++ b/modules/ceeIdSystem.js
@@ -44,7 +44,7 @@ export const ceeIdSubmodule = {
    * performs action to obtain id and return a value
    * @function
    * @returns {(IdResponse|undefined)}
-  */
+   */
   getId() {
     const ceeIdToken = readId();
 

--- a/modules/gptPreAuction.js
+++ b/modules/gptPreAuction.js
@@ -160,7 +160,7 @@ const handleSetGptConfig = moduleConfig => {
       typeof customGptSlotMatching === 'function' && customGptSlotMatching,
     'customPbAdSlot', customPbAdSlot => typeof customPbAdSlot === 'function' && customPbAdSlot,
     'customPreAuction', customPreAuction => typeof customPreAuction === 'function' && customPreAuction,
-    'useDefaultPreAuction', useDefaultPreAuction => useDefaultPreAuction === true,
+    'useDefaultPreAuction', useDefaultPreAuction => useDefaultPreAuction ?? true,
   ]);
 
   if (_currentConfig.enabled) {

--- a/test/spec/modules/gptPreAuction_spec.js
+++ b/test/spec/modules/gptPreAuction_spec.js
@@ -188,7 +188,7 @@ describe('GPT pre-auction module', () => {
         customGptSlotMatching: false,
         customPbAdSlot: false,
         customPreAuction: false,
-        useDefaultPreAuction: false
+        useDefaultPreAuction: true
       });
     });
   });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change

`gptPreAuction` has a [`useDefaultPreAuction`](https://docs.prebid.org/dev-docs/modules/gpt-pre-auction.html#configuration) option that, when enabled, prefers GPID over pbadslot (although in practice they often end up being the same either way). 

This toggles the default so that GPID is preferred.

## Other information

Related: https://github.com/prebid/Prebid.js/issues/10239
