### PR TITLE
Kobler adapter: Fix to avoid bidding with third-party creatives requiring consent or legitimate interest.

### DIFF
--- a/test/spec/modules/koblerBidAdapter_spec.js
+++ b/test/spec/modules/koblerBidAdapter_spec.js
@@ -13,7 +13,8 @@ function createBidderRequest(auctionId, timeout, pageUrl, addGdprConsent) {
       purpose: {
         consents: {
           1: false,
-          2: true
+          2: true,
+          3: false
         }
       },
       publisher: {
@@ -308,27 +309,6 @@ describe('KoblerAdapter', function () {
 
       const openRtbRequest = JSON.parse(result.data);
       expect(openRtbRequest.site.page).to.be.equal('example.com');
-      expect(openRtbRequest.test).to.be.equal(1);
-    });
-
-    it('should read pageUrl from config when testing', function () {
-      config.setConfig({
-        pageUrl: 'https://testing-url.com'
-      });
-      const validBidRequests = [
-        createValidBidRequest(
-          {
-            test: true
-          }
-        )
-      ];
-      const bidderRequest = createBidderRequest();
-
-      const result = spec.buildRequests(validBidRequests, bidderRequest);
-      expect(result.url).to.be.equal('https://bid-service.dev.essrtb.com/bid/prebid_rtb_call');
-
-      const openRtbRequest = JSON.parse(result.data);
-      expect(openRtbRequest.site.page).to.be.equal('https://testing-url.com');
       expect(openRtbRequest.test).to.be.equal(1);
     });
 

--- a/test/spec/modules/koblerBidAdapter_spec.js
+++ b/test/spec/modules/koblerBidAdapter_spec.js
@@ -5,14 +5,36 @@ import {config} from 'src/config.js';
 import * as utils from 'src/utils.js';
 import {getRefererInfo} from 'src/refererDetection.js';
 
-function createBidderRequest(auctionId, timeout, pageUrl) {
+function createBidderRequest(auctionId, timeout, pageUrl, addGdprConsent) {
+  const gdprConsent = addGdprConsent ? {
+    consentString: 'BOtmiBKOtmiBKABABAENAFAAAAACeAAA',
+    apiVersion: 2,
+    vendorData: {
+      purpose: {
+        consents: {
+          1: false,
+          2: true
+        }
+      },
+      publisher: {
+        restrictions: {
+          '2': {
+            // require consent
+            '11': 1
+          }
+        }
+      }
+    },
+    gdprApplies: true
+  } : {};
   return {
     bidderRequestId: 'mock-uuid',
     auctionId: auctionId || 'c1243d83-0bed-4fdb-8c76-42b456be17d0',
     timeout: timeout || 2000,
     refererInfo: {
       page: pageUrl || 'example.com'
-    }
+    },
+    gdprConsent: gdprConsent
   };
 }
 
@@ -439,7 +461,8 @@ describe('KoblerAdapter', function () {
       const bidderRequest = createBidderRequest(
         '9ff580cf-e10e-4b66-add7-40ac0c804e21',
         4500,
-        'bid.kobler.no'
+        'bid.kobler.no',
+        true
       );
 
       const result = spec.buildRequests(validBidRequests, bidderRequest);
@@ -529,7 +552,13 @@ describe('KoblerAdapter', function () {
         site: {
           page: 'bid.kobler.no'
         },
-        test: 0
+        test: 0,
+        ext: {
+          kobler: {
+            tcf_purpose_2_given: true,
+            tcf_purpose_3_given: false
+          }
+        }
       };
 
       expect(openRtbRequest).to.deep.equal(expectedOpenRtbRequest);
@@ -702,14 +731,12 @@ describe('KoblerAdapter', function () {
       spec.onTimeout([
         {
           adUnitCode: 'adunit-code',
-          auctionId: 'a1fba829-dd41-409f-acfb-b7b0ac5f30c6',
           bidId: 'ef236c6c-e934-406b-a877-d7be8e8a839a',
           timeout: 100,
           params: [],
         },
         {
           adUnitCode: 'adunit-code-2',
-          auctionId: 'a1fba829-dd41-409f-acfb-b7b0ac5f30c6',
           bidId: 'ca4121c8-9a4a-46ba-a624-e9b64af206f2',
           timeout: 100,
           params: [],
@@ -719,13 +746,11 @@ describe('KoblerAdapter', function () {
       expect(utils.triggerPixel.callCount).to.be.equal(2);
       expect(utils.triggerPixel.getCall(0).args[0]).to.be.equal(
         'https://bid.essrtb.com/notify/prebid_timeout?ad_unit_code=adunit-code&' +
-        'auction_id=a1fba829-dd41-409f-acfb-b7b0ac5f30c6&bid_id=ef236c6c-e934-406b-a877-d7be8e8a839a&timeout=100&' +
-        'page_url=' + encodeURIComponent(getRefererInfo().page)
+        'bid_id=ef236c6c-e934-406b-a877-d7be8e8a839a&timeout=100&page_url=' + encodeURIComponent(getRefererInfo().page)
       );
       expect(utils.triggerPixel.getCall(1).args[0]).to.be.equal(
         'https://bid.essrtb.com/notify/prebid_timeout?ad_unit_code=adunit-code-2&' +
-        'auction_id=a1fba829-dd41-409f-acfb-b7b0ac5f30c6&bid_id=ca4121c8-9a4a-46ba-a624-e9b64af206f2&timeout=100&' +
-        'page_url=' + encodeURIComponent(getRefererInfo().page)
+        'bid_id=ca4121c8-9a4a-46ba-a624-e9b64af206f2&timeout=100&page_url=' + encodeURIComponent(getRefererInfo().page)
       );
     });
   });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [X] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Kobler, a contextual advertising provider, does not process any personal data itself, so it is not part of TCF/GVL. However, it supports using select third-party creatives in its platform, some of which require certain permissions in order to be shown. Kobler's bidder checks if necessary permissions are present to avoid bidding with ineligible creatives. This PR makes this check possible.
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
