### PR TITLE
Openweb bid adapter: Make placementId parameter mandatory

### DIFF
--- a/modules/openwebBidAdapter.js
+++ b/modules/openwebBidAdapter.js
@@ -46,6 +46,11 @@ export const spec = {
       return false;
     }
 
+    if (!bidRequest.params.placementId) {
+      logWarn('placementId is a mandatory param for OpenWeb adapter');
+      return false;
+    }
+
     return true;
   },
   buildRequests: function (validBidRequests, bidderRequest) {

--- a/test/spec/modules/openwebBidAdapter_spec.js
+++ b/test/spec/modules/openwebBidAdapter_spec.js
@@ -25,7 +25,8 @@ describe('openwebAdapter', function () {
       'adUnitCode': 'adunit-code',
       'sizes': [['640', '480']],
       'params': {
-        'org': 'jdye8weeyirk00000001'
+        'org': 'jdye8weeyirk00000001',
+        'placementId': '123'
       }
     };
 
@@ -33,11 +34,20 @@ describe('openwebAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
 
-    it('should return false when required params are not found', function () {
+    it('should return false when org param is not found', function () {
       const newBid = Object.assign({}, bid);
       delete newBid.params;
       newBid.params = {
         'org': null
+      };
+      expect(spec.isBidRequestValid(newBid)).to.equal(false);
+    });
+
+    it('should return false when placementId param is not found', function () {
+      const newBid = Object.assign({}, bid);
+      delete newBid.params;
+      newBid.params = {
+        'placementId': null
       };
       expect(spec.isBidRequestValid(newBid)).to.equal(false);
     });
@@ -50,7 +60,8 @@ describe('openwebAdapter', function () {
         'adUnitCode': 'adunit-code',
         'sizes': [[640, 480]],
         'params': {
-          'org': 'jdye8weeyirk00000001'
+          'org': 'jdye8weeyirk00000001',
+          'placementId': '123'
         },
         'bidId': '299ffc8cca0b87',
         'loop': 1,
@@ -103,15 +114,13 @@ describe('openwebAdapter', function () {
     const bidderRequest = {
       bidderCode: 'openweb',
     }
-    const placementId = '12345678';
     const api = [1, 2];
     const mimes = ['application/javascript', 'video/mp4', 'video/quicktime'];
     const protocols = [2, 3, 5, 6];
 
     it('sends the placementId to ENDPOINT via POST', function () {
-      bidRequests[0].params.placementId = placementId;
       const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.bids[0].placementId).to.equal(placementId);
+      expect(request.data.bids[0].placementId).to.equal('123');
     });
 
     it('sends the plcmt to ENDPOINT via POST', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Making placementId parameter mandatory for OpenWeb bid adapter.


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
