### PR TITLE
Datawrkz bid adapter : removed use of deprecated video.placement

### DIFF
--- a/modules/datawrkzBidAdapter.js
+++ b/modules/datawrkzBidAdapter.js
@@ -227,7 +227,6 @@ function buildVideoRequest(bidRequest, bidderRequest) {
     maxbitrate: deepAccess(bidRequest, 'mediaTypes.video.maxbitrate'),
     delivery: deepAccess(bidRequest, 'mediaTypes.video.delivery'),
     linearity: deepAccess(bidRequest, 'mediaTypes.video.linearity'),
-    placement: deepAccess(bidRequest, 'mediaTypes.video.placement'),
     skip: deepAccess(bidRequest, 'mediaTypes.video.skip'),
     skipafter: deepAccess(bidRequest, 'mediaTypes.video.skipafter')
   };


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Removed of deprecated video.placement as per #10452