### PR TITLE
Sirdata RTD Module : New lint rule for Prebid 9 fix

### DIFF
--- a/modules/sirdataRtdProvider.js
+++ b/modules/sirdataRtdProvider.js
@@ -284,7 +284,7 @@ export function removePII(content) {
  * @returns {Object} - The sanitized content
  */
 export function sanitizeContent(content) {
-  if (content && content.documentElement.innerText && content.documentElement.innerText.length > 500) {
+  if (content && content.documentElement.textContent && content.documentElement.textContent.length > 500) {
     // Reduce size by removing useless content
     // Allowed tags
     const allowedTags = [


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Use "textContent" instead of "innerText" to avoid merging failing the new lint rule https://github.com/prebid/Prebid.js/issues/11233 for Prebid 9.

The bug has been raised here : https://github.com/prebid/Prebid.js/pull/11524#issuecomment-2136659759