### PR TITLE
Insticator Bid Adapter : update adapter for deprecated placement field

### DIFF
--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -102,7 +102,7 @@ function buildVideo(bidRequest) {
   let w = deepAccess(bidRequest, 'mediaTypes.video.w');
   let h = deepAccess(bidRequest, 'mediaTypes.video.h');
   const mimes = deepAccess(bidRequest, 'mediaTypes.video.mimes');
-  const placement = deepAccess(bidRequest, 'mediaTypes.video.placement') || 3;
+  const placement = deepAccess(bidRequest, 'mediaTypes.video.placement');
   const plcmt = deepAccess(bidRequest, 'mediaTypes.video.plcmt') || undefined;
   const playerSize = deepAccess(bidRequest, 'mediaTypes.video.playerSize');
   const context = deepAccess(bidRequest, 'mediaTypes.video.context');
@@ -136,6 +136,10 @@ function buildVideo(bidRequest) {
     }
   }
 
+  if (placement && typeof placement !== 'undefined' && typeof placement === 'number') {
+    optionalParams['placement'] = placement;
+  }
+
   if (plcmt) {
     optionalParams['plcmt'] = plcmt;
   }
@@ -145,7 +149,6 @@ function buildVideo(bidRequest) {
   }
 
   let videoObj = {
-    placement,
     mimes,
     w,
     h,
@@ -592,13 +595,6 @@ function validateVideo(bid) {
 
   if (!Array.isArray(mimes) || mimes.length === 0) {
     logError('insticator: mimes not specified');
-    return false;
-  }
-
-  const placement = deepAccess(bid, 'mediaTypes.video.placement');
-
-  if (typeof placement !== 'undefined' && typeof placement !== 'number') {
-    logError('insticator: video placement is not a number');
     return false;
   }
 

--- a/test/spec/modules/insticatorBidAdapter_spec.js
+++ b/test/spec/modules/insticatorBidAdapter_spec.js
@@ -175,25 +175,6 @@ describe('InsticatorBidAdapter', function () {
       })).to.be.true;
     })
 
-    it('should return false if video placement is not a number', () => {
-      expect(spec.isBidRequestValid({
-        ...bidRequest,
-        ...{
-          mediaTypes: {
-            video: {
-              mimes: [
-                'video/mp4',
-                'video/mpeg',
-              ],
-              w: 250,
-              h: 300,
-              placement: 'NaN',
-            },
-          }
-        }
-      })).to.be.false;
-    });
-
     it('should return false if video plcmt is not a number', () => {
       expect(spec.isBidRequestValid({
         ...bidRequest,
@@ -224,7 +205,7 @@ describe('InsticatorBidAdapter', function () {
                 'video/mpeg',
               ],
               playerSize: [250, 300],
-              placement: 1,
+              plcmt: 1,
             },
           }
         }
@@ -293,7 +274,7 @@ describe('InsticatorBidAdapter', function () {
                 'video/mpeg',
               ],
               playerSize: [250, 300],
-              placement: 1,
+              plcmt: 1,
             },
           }
         },
@@ -306,7 +287,7 @@ describe('InsticatorBidAdapter', function () {
               'video/x-flv',
               'video/webm',
             ],
-            placement: 2,
+            plcmt: 2,
           },
         }
       })).to.be.true;


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
