### PR TITLE
Currency module: fix bug where changing currency configs causes currency logic to run multiple times

### DIFF
--- a/modules/currency.js
+++ b/modules/currency.js
@@ -155,36 +155,35 @@ function loadRates() {
 
 function initCurrency() {
   conversionCache = {};
-  currencySupportEnabled = true;
-
-  logInfo('Installing addBidResponse decorator for currency module', arguments);
-
-  // Adding conversion function to prebid global for external module and on page use
-  getGlobal().convertCurrency = (cpm, fromCurrency, toCurrency) => parseFloat(cpm) * getCurrencyConversion(fromCurrency, toCurrency);
-  getHook('addBidResponse').before(addBidResponseHook, 100);
-  getHook('responsesReady').before(responsesReadyHook);
-  onEvent(EVENTS.AUCTION_TIMEOUT, rejectOnAuctionTimeout);
-  onEvent(EVENTS.AUCTION_INIT, loadRates);
-  loadRates();
+  if (!currencySupportEnabled) {
+    currencySupportEnabled = true;
+    // Adding conversion function to prebid global for external module and on page use
+    getGlobal().convertCurrency = (cpm, fromCurrency, toCurrency) => parseFloat(cpm) * getCurrencyConversion(fromCurrency, toCurrency);
+    getHook('addBidResponse').before(addBidResponseHook, 100);
+    getHook('responsesReady').before(responsesReadyHook);
+    onEvent(EVENTS.AUCTION_TIMEOUT, rejectOnAuctionTimeout);
+    onEvent(EVENTS.AUCTION_INIT, loadRates);
+    loadRates();
+  }
 }
 
 function resetCurrency() {
-  logInfo('Uninstalling addBidResponse decorator for currency module', arguments);
+  if (currencySupportEnabled) {
+    getHook('addBidResponse').getHooks({hook: addBidResponseHook}).remove();
+    getHook('responsesReady').getHooks({hook: responsesReadyHook}).remove();
+    offEvent(EVENTS.AUCTION_TIMEOUT, rejectOnAuctionTimeout);
+    offEvent(EVENTS.AUCTION_INIT, loadRates);
+    delete getGlobal().convertCurrency;
 
-  getHook('addBidResponse').getHooks({hook: addBidResponseHook}).remove();
-  getHook('responsesReady').getHooks({hook: responsesReadyHook}).remove();
-  offEvent(EVENTS.AUCTION_TIMEOUT, rejectOnAuctionTimeout);
-  offEvent(EVENTS.AUCTION_INIT, loadRates);
-  delete getGlobal().convertCurrency;
-
-  adServerCurrency = 'USD';
-  conversionCache = {};
-  currencySupportEnabled = false;
-  currencyRatesLoaded = false;
-  needToCallForCurrencyFile = true;
-  currencyRates = {};
-  bidderCurrencyDefault = {};
-  responseReady = defer();
+    adServerCurrency = 'USD';
+    conversionCache = {};
+    currencySupportEnabled = false;
+    currencyRatesLoaded = false;
+    needToCallForCurrencyFile = true;
+    currencyRates = {};
+    bidderCurrencyDefault = {};
+    responseReady = defer();
+  }
 }
 
 function responsesReadyHook(next, ready) {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fix a bug where multiple `setConfig({currency})` cause the currency module to run its event handlers multiple times.


