### PR TITLE
33Across User ID sub-module: Introduce a new supplemental ID

### DIFF
--- a/modules/33acrossIdSystem.js
+++ b/modules/33acrossIdSystem.js
@@ -25,7 +25,9 @@ const CALLER_NAME = 'pbjs';
 const GVLID = 58;
 
 const STORAGE_FPID_KEY = '33acrossIdFp';
+const STORAGE_TPID_KEY = '33acrossIdTp';
 const DEFAULT_1PID_SUPPORT = true;
+const DEFAULT_TPID_SUPPORT = true;
 
 export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME });
 
@@ -47,7 +49,8 @@ function calculateResponseObj(response) {
 
   return {
     envelope: response.data.envelope,
-    fp: response.data.fp
+    fp: response.data.fp,
+    tp: response.data.tp
   };
 }
 
@@ -84,6 +87,11 @@ function calculateQueryStringParams(pid, gdprConsentData, storageConfig) {
     params.fp = encodeURIComponent(fp);
   }
 
+  const tp = getStoredValue(STORAGE_TPID_KEY, storageConfig);
+  if (tp) {
+    params.tp = encodeURIComponent(tp);
+  }
+
   return params;
 }
 
@@ -116,10 +124,10 @@ function getStoredValue(key, storageConfig = {}) {
   }
 }
 
-function handleFpId(fpId, storageConfig = {}) {
-  fpId
-    ? storeValue(STORAGE_FPID_KEY, fpId, storageConfig)
-    : deleteFromStorage(STORAGE_FPID_KEY);
+function handleSupplementalId(key, id, storageConfig = {}) {
+  id
+    ? storeValue(key, id, storageConfig)
+    : deleteFromStorage(key);
 }
 
 /** @type {Submodule} */
@@ -165,7 +173,7 @@ export const thirthyThreeAcrossIdSubmodule = {
       return;
     }
 
-    const { pid, storeFpid = DEFAULT_1PID_SUPPORT, apiUrl = API_URL } = params;
+    const { pid, storeFpid = DEFAULT_1PID_SUPPORT, storeTpid = DEFAULT_TPID_SUPPORT, apiUrl = API_URL } = params;
 
     return {
       callback(cb) {
@@ -184,7 +192,11 @@ export const thirthyThreeAcrossIdSubmodule = {
             }
 
             if (storeFpid) {
-              handleFpId(responseObj.fp, storageConfig);
+              handleSupplementalId(STORAGE_FPID_KEY, responseObj.fp, storageConfig);
+            }
+
+            if (storeTpid) {
+              handleSupplementalId(STORAGE_TPID_KEY, responseObj.tp, storageConfig);
             }
 
             cb(responseObj.envelope);

--- a/modules/33acrossIdSystem.md
+++ b/modules/33acrossIdSystem.md
@@ -52,3 +52,4 @@ The following settings are available in the `params` property in `userSync.userI
 | --- | --- | --- | --- | --- |
 | pid | Required | String | Partner ID provided by 33Across | `"0010b00002GYU4eBAH"` |
 | storeFpid | Optional | Boolean | Indicates whether a supplemental first-party ID may be stored to improve addressability, this feature is enabled by default | `true` (default) or `false` |
+| storeTpid | Optional | Boolean | Indicates whether a supplemental third-party ID may be stored to improve addressability, this feature is enabled by default | `true` (default) or `false` |


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter
- [ ] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Enhance the 33Across User ID sub-module to support setting a third-party supplemental ID in addition to the primary ID envelope.

## Other information
https://github.com/prebid/prebid.github.io/pull/5361
