### PR TITLE
Luponmedia Bid Adapter (9.0 fixes) : remove discontinued fpd.context, remove unused onBid…

### DIFF
--- a/modules/luponmediaBidAdapter.js
+++ b/modules/luponmediaBidAdapter.js
@@ -14,7 +14,6 @@ import {
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {config} from '../src/config.js';
 import {BANNER} from '../src/mediaTypes.js';
-import {ajax} from '../src/ajax.js';
 
 const BIDDER_CODE = 'luponmedia';
 const ENDPOINT_URL = 'https://rtb.adxpremium.services/openrtb2/auction';
@@ -220,19 +219,6 @@ export const spec = {
 
     hasSynced = true;
     return allUserSyncs;
-  },
-  onBidWon: bid => {
-    const bidString = JSON.stringify(bid);
-    spec.sendWinningsToServer(bidString);
-  },
-  sendWinningsToServer: data => {
-    let mutation = `mutation {createWin(input: {win: {eventData: "${window.btoa(data)}"}}) {win {createTime } } }`;
-    let dataToSend = JSON.stringify({ query: mutation });
-
-    ajax('https://analytics.adxpremium.services/graphql', null, dataToSend, {
-      contentType: 'application/json',
-      method: 'POST'
-    });
   }
 };
 
@@ -469,9 +455,7 @@ function newOrtbBidRequest(bidRequest, bidderRequest, currentImps) {
     deepSetValue(data, 'ext.prebid.bidderconfig.0', bidderData);
   }
 
-  // TODO: bidRequest.fpd is not the right place for pbadslot - who's filling that in, if anyone?
-  // is this meant to be bidRequest.ortb2Imp.ext.data.pbadslot?
-  const pbAdSlot = deepAccess(bidRequest, 'fpd.context.pbAdSlot');
+  const pbAdSlot = deepAccess(bidRequest, 'ortb2Imp.ext.data.pbadslot');
   if (typeof pbAdSlot === 'string' && pbAdSlot) {
     deepSetValue(data.imp[0].ext, 'context.data.adslot', pbAdSlot);
   }

--- a/test/spec/modules/luponmediaBidAdapter_spec.js
+++ b/test/spec/modules/luponmediaBidAdapter_spec.js
@@ -385,49 +385,4 @@ describe('luponmediaBidAdapter', function () {
       expect(checkSchain).to.equal(false);
     });
   });
-
-  describe('onBidWon', function () {
-    const bidWonEvent = {
-      'bidderCode': 'luponmedia',
-      'width': 300,
-      'height': 250,
-      'statusMessage': 'Bid available',
-      'adId': '105bbf8c54453ff',
-      'requestId': '934b8752185955',
-      'mediaType': 'banner',
-      'source': 'client',
-      'cpm': 0.364,
-      'creativeId': '443801010',
-      'currency': 'USD',
-      'netRevenue': false,
-      'ttl': 300,
-      'referrer': '',
-      'ad': '',
-      'auctionId': '926a8ea3-3dd4-4bf2-95ab-c85c2ce7e99b',
-      'responseTimestamp': 1598527728026,
-      'requestTimestamp': 1598527727629,
-      'bidder': 'luponmedia',
-      'adUnitCode': 'div-gpt-ad-1533155193780-5',
-      'timeToRespond': 397,
-      'size': '300x250',
-      'status': 'rendered'
-    };
-
-    let ajaxStub;
-
-    beforeEach(() => {
-      ajaxStub = sinon.stub(spec, 'sendWinningsToServer')
-    })
-
-    afterEach(() => {
-      ajaxStub.restore()
-    })
-
-    it('calls luponmedia\'s callback endpoint', () => {
-      const result = spec.onBidWon(bidWonEvent);
-      expect(result).to.equal(undefined);
-      expect(ajaxStub.calledOnce).to.equal(true);
-      expect(ajaxStub.firstCall.args[0]).to.deep.equal(JSON.stringify(bidWonEvent));
-    });
-  });
 });


### PR DESCRIPTION
Removed discontinued fpd.context as requested in 9.0 fixes spreadsheet, additionally we removed onBidWon event since we don't use it anymore. 

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
