### PR TITLE
Adagio Analytics Adapter: fix failing tests

### DIFF
--- a/test/spec/modules/adagioAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adagioAnalyticsAdapter_spec.js
@@ -182,7 +182,7 @@ const AUCTION_ID_ADAGIO = '6fc53663-bde5-427b-ab63-baa9ed296f47'
 const AUCTION_ID_CACHE = 'b43d24a0-13d4-406d-8176-3181402bafc4';
 const AUCTION_ID_CACHE_ADAGIO = 'a9cae98f-efb5-477e-9259-27350044f8db';
 
-const BID_ADAGIO = Object.assign({}, BID_ADAGIO, {
+const BID_ADAGIO = {
   bidder: 'adagio',
   auctionId: AUCTION_ID,
   adUnitCode: '/19968336/header-bid-tag-1',
@@ -215,9 +215,9 @@ const BID_ADAGIO = Object.assign({}, BID_ADAGIO, {
     sid: '42',
     e_pba_test: true
   }
-});
+};
 
-const BID_ANOTHER = Object.assign({}, BID_ANOTHER, {
+const BID_ANOTHER = {
   bidder: 'another',
   auctionId: AUCTION_ID,
   adUnitCode: '/19968336/header-bid-tag-1',
@@ -246,12 +246,11 @@ const BID_ANOTHER = Object.assign({}, BID_ANOTHER, {
   meta: {
     advertiserDomains: ['example.com']
   }
-});
+};
 
-const BID_CACHED = Object.assign({}, BID_ADAGIO, {
-  auctionId: AUCTION_ID_CACHE,
-  latestTargetedAuctionId: BID_ADAGIO.auctionId,
-});
+const BID_CACHED = utils.deepClone(BID_ADAGIO);
+BID_CACHED.auctionId = AUCTION_ID_CACHE;
+BID_CACHED.latestTargetedAuctionId = BID_ADAGIO.auctionId;
 
 const PARAMS_ADG = {
   organizationId: '1001',


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Should fix and closes #11635 

Note that I was not able to reproduce the bug locally as I have a up to date MacOS version. The one used in the issue (10.15.7) is obsolete.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->
