### PR TITLE
Ix Bid Adapter: pass through paapi imp extension [PB-2799]

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -974,6 +974,7 @@ function addImpressions(impressions, impKeys, r, adUnitIndex) {
   const tid = impressions[impKeys[adUnitIndex]].tid;
   const sid = impressions[impKeys[adUnitIndex]].sid;
   const auctionEnvironment = impressions[impKeys[adUnitIndex]].ae;
+  const paapi = impressions[impKeys[adUnitIndex]].paapi;
   const bannerImpressions = impressionObjects.filter(impression => BANNER in impression);
   const otherImpressions = impressionObjects.filter(impression => !(BANNER in impression));
 
@@ -1023,7 +1024,7 @@ function addImpressions(impressions, impKeys, r, adUnitIndex) {
         _bannerImpression.banner.pos = position;
       }
 
-      if (dfpAdUnitCode || gpid || tid || sid || auctionEnvironment || externalID) {
+      if (dfpAdUnitCode || gpid || tid || sid || auctionEnvironment || externalID || paapi) {
         _bannerImpression.ext = {};
 
         _bannerImpression.ext.dfp_ad_unit_code = dfpAdUnitCode;
@@ -1035,6 +1036,7 @@ function addImpressions(impressions, impKeys, r, adUnitIndex) {
         // enable fledge auction
         if (auctionEnvironment == 1) {
           _bannerImpression.ext.ae = 1;
+          _bannerImpression.ext.paapi = paapi;
         }
       }
 
@@ -1440,6 +1442,10 @@ function createBannerImps(validBidRequest, missingBannerSizes, bannerImps, bidde
   const fledgeEnabled = deepAccess(bidderRequest, 'fledgeEnabled')
   if (fledgeEnabled) {
     const auctionEnvironment = deepAccess(validBidRequest, 'ortb2Imp.ext.ae')
+    const paapi = deepAccess(validBidRequest, 'ortb2Imp.ext.paapi')
+    if (paapi) {
+      bannerImps[validBidRequest.adUnitCode].paapi = paapi
+    }
     if (auctionEnvironment) {
       if (isInteger(auctionEnvironment)) {
         bannerImps[validBidRequest.adUnitCode].ae = auctionEnvironment;

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -3517,6 +3517,22 @@ describe('IndexexchangeAdapter', function () {
       expect(logWarnSpy.calledWith('error setting auction environment flag - must be an integer')).to.be.true;
       logWarnSpy.restore();
     });
+
+    it('impression should have paapi extension when passed', function () {
+      const bidderRequest = deepClone(DEFAULT_OPTION_FLEDGE_ENABLED);
+      let bid = utils.deepClone(DEFAULT_BANNER_VALID_BID_WITH_FLEDGE_ENABLED[0]);
+      bid.ortb2Imp.ext.ae = 1
+      bid.ortb2Imp.ext.paapi = {
+        requestedSize: {
+          width: 300,
+          height: 250
+        }
+      }
+      const requestBidFloor = spec.buildRequests([bid], bidderRequest)[0];
+      const impression = extractPayload(requestBidFloor).imp[0];
+      expect(impression.ext.paapi.requestedSize.width).to.equal(300);
+      expect(impression.ext.paapi.requestedSize.height).to.equal(250);
+    });
   });
 
   describe('integration through exchangeId and externalId', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Pass through imp.ext.paapi extension

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
