### PR TITLE
Prebid 9: re-whitelist 'oustream' for loadExternalScript

### DIFF
--- a/src/adloader.js
+++ b/src/adloader.js
@@ -7,7 +7,7 @@ const _approvedLoadExternalJSList = [
   // Prebid maintained modules:
   'debugging',
   'outstream',
-  // Bid Modules:
+  // Bid Modules - only exception is on rendering edge cases, to clean up in Prebid 10:
   'improvedigital',
   'showheroes-bs',
   // RTD modules:

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -6,7 +6,8 @@ const _requestCache = new WeakMap();
 const _approvedLoadExternalJSList = [
   // Prebid maintained modules:
   'debugging',
-  // Bid Modules - only exception is on rendering edge cases, to clean up in Prebid 10:
+  'outstream',
+  // Bid Modules:
   'improvedigital',
   'showheroes-bs',
   // RTD modules:


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Re-whitelist 'outstream' for loadExternalScript, used by outstream renderers:

https://github.com/prebid/Prebid.js/blob/dbf981739da6d402b0c09e0aa2289cdbb6e86be1/src/Renderer.js#L65

