### PR TITLE
smartxBidAdapter: Using plcmt instead of placement

### DIFF
--- a/modules/smartxBidAdapter.js
+++ b/modules/smartxBidAdapter.js
@@ -120,10 +120,10 @@ export const spec = {
       const api = getBidIdParameter('api', bid.params) || [2];
       const protocols = getBidIdParameter('protocols', bid.params) || [2, 3, 5, 6];
       var contextcustom = deepAccess(bid, 'mediaTypes.video.context');
-      var placement = 1;
+      var plcmt = 1;
 
       if (contextcustom === 'outstream') {
-        placement = 3;
+        plcmt = 3;
       }
 
       let smartxReq = [{
@@ -144,7 +144,7 @@ export const spec = {
           maxbitrate: maxbitrate,
           delivery: delivery,
           pos: pos,
-          placement: placement,
+          plcmt: plcmt,
           api: api,
           ext: ext
         },

--- a/test/spec/modules/smartxBidAdapter_spec.js
+++ b/test/spec/modules/smartxBidAdapter_spec.js
@@ -178,7 +178,7 @@ describe('The smartx adapter', function () {
           2, 3, 5, 6
         ],
         startdelay: 0,
-        placement: 1,
+        plcmt: 1,
         pos: 1
       });
 
@@ -209,7 +209,7 @@ describe('The smartx adapter', function () {
       });
 
       expect(request.data.imp[0].video).to.contain({
-        placement: 1
+        plcmt: 1
       });
 
       bid.mediaTypes.video.context = 'outstream';
@@ -252,7 +252,7 @@ describe('The smartx adapter', function () {
       expect(request.data.imp[0].video.startdelay).to.equal(1);
 
       expect(request.data.imp[0].video).to.contain({
-        placement: 3
+        plcmt: 3
       });
 
       expect(request.data.imp[0].bidfloor).to.equal(55);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
smartxBidAdapter: Using plcmt instead of placement

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
