### PR TITLE
JW Player RTD Adapter: 9.0 migration

### DIFF
--- a/integrationExamples/realTimeData/jwplayerRtdProvider_example.html
+++ b/integrationExamples/realTimeData/jwplayerRtdProvider_example.html
@@ -65,7 +65,11 @@
               waitForIt: true,
               params: {
                 // Note: the following media Ids are placeholders and should be replaced with your Ids.
-                mediaIDs: ['abc', 'def', 'ghi', 'jkl']
+                mediaIDs: ['abc', 'def', 'ghi', 'jkl'],
+                overrideContentId: 'always',
+                overrideContentUrl: 'always',
+                overrideContentTitle: 'always',
+                overrideContentDescription: 'always'
               }
             }]
           }

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -31,9 +31,7 @@ const playlistItemCache = {};
 const pendingRequests = {};
 let activeRequestCount = 0;
 let resumeBidRequest;
-// defaults to 'always' for backwards compatibility
-// TODO: Prebid 9 - replace with ENRICH_WHEN_EMPTY
-let overrideContentId = ENRICH_ALWAYS;
+let overrideContentId = ENRICH_WHEN_EMPTY;
 let overrideContentUrl = ENRICH_WHEN_EMPTY;
 let overrideContentTitle = ENRICH_WHEN_EMPTY;
 let overrideContentDescription = ENRICH_WHEN_EMPTY;
@@ -83,9 +81,7 @@ export function fetchTargetingInformation(jwTargeting) {
 }
 
 export function setOverrides(params) {
-  // For backwards compatibility, default to always unless overridden by Publisher.
-  // TODO: Prebid 9 - replace with ENRICH_WHEN_EMPTY
-  overrideContentId = sanitizeOverrideParam(params.overrideContentId, ENRICH_ALWAYS);
+  overrideContentId = sanitizeOverrideParam(params.overrideContentId, ENRICH_WHEN_EMPTY);
   overrideContentUrl = sanitizeOverrideParam(params.overrideContentUrl, ENRICH_WHEN_EMPTY);
   overrideContentTitle = sanitizeOverrideParam(params.overrideContentTitle, ENRICH_WHEN_EMPTY);
   overrideContentDescription = sanitizeOverrideParam(params.overrideContentDescription, ENRICH_WHEN_EMPTY);

--- a/modules/jwplayerRtdProvider.md
+++ b/modules/jwplayerRtdProvider.md
@@ -12,16 +12,20 @@ Publishers must register JW Player as a real time data provider by setting up a 
 following structure:
 
 ```javascript
-const jwplayerDataProvider = {
-  name: "jwplayer"
-};
-
 pbjs.setConfig({
     ...,
     realTimeData: {
-      dataProviders: [
-          jwplayerDataProvider
-      ]
+      dataProviders: [{
+        name: 'jwplayer',
+        waitForIt: true,
+        params: {
+          mediaIDs: ['abc', 'def', 'ghi', 'jkl'],
+          overrideContentId: 'always',
+          overrideContentUrl: 'always',
+          overrideContentTitle: 'always',
+          overrideContentDescription: 'always'
+        }
+      }]
     }
 });
 ```
@@ -155,7 +159,7 @@ To view an example:
 
 - in your browser, navigate to:
 
-`http://localhost:9999/integrationExamples/gpt/jwplayerRtdProvider_example.html`
+`http://localhost:9999/integrationExamples/realTimeData/jwplayerRtdProvider_example.html`
 
 **Note:** the mediaIds in the example are placeholder values; replace them with your existing IDs.
 

--- a/modules/jwplayerRtdProvider.md
+++ b/modules/jwplayerRtdProvider.md
@@ -86,7 +86,7 @@ realTimeData = {
 | waitForIt | Boolean | Required to ensure that the auction is delayed until prefetch is complete | Optional. Defaults to false |
 | params | Object | | |
 | params.mediaIDs | Array of Strings | Media Ids for prefetching | Optional |
-| params.overrideContentId | String enum: 'always', 'whenEmpty' or 'never' | Determines when the module should update the oRTB site.content.id  | Defaults to 'always' |
+| params.overrideContentId | String enum: 'always', 'whenEmpty' or 'never' | Determines when the module should update the oRTB site.content.id  | Defaults to 'whenEmpty' |
 | params.overrideContentUrl | String enum: 'always', 'whenEmpty' or 'never' | Determines when the module should update the oRTB site.content.url | Defaults to 'whenEmpty' |
 | params.overrideContentTitle | String enum: 'always', 'whenEmpty' or 'never' | Determines when the module should update the oRTB site.content.title | Defaults to 'whenEmpty' |
 | params.overrideContentDescription | String enum: 'always', 'whenEmpty' or 'never' | Determines when the module should update the oRTB site.content.ext.description | Defaults to 'whenEmpty' |

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -629,7 +629,7 @@ describe('jwplayerRtdProvider', function() {
 
       expect(ortb2Fragments.global).to.have.property('site');
       expect(ortb2Fragments.global.site).to.have.property('content');
-      expect(ortb2Fragments.global.site.content).to.have.property('id', 'jw_' + testIdForSuccess);
+      expect(ortb2Fragments.global.site.content).to.have.property('id', 'randomContentId');
       expect(ortb2Fragments.global.site.content).to.have.property('data');
       const data = ortb2Fragments.global.site.content.data;
       expect(data).to.have.length(3);
@@ -801,7 +801,7 @@ describe('jwplayerRtdProvider', function() {
   describe(' Add Ortb Site Content', function () {
     beforeEach(() => {
       setOverrides({
-        overrideContentId: 'always',
+        overrideContentId: 'whenEmpty',
         overrideContentUrl: 'whenEmpty',
         overrideContentTitle: 'whenEmpty',
         overrideContentDescription: 'whenEmpty'
@@ -865,16 +865,16 @@ describe('jwplayerRtdProvider', function() {
         }
       };
 
-      const expectedId = 'expectedId';
+      const newId = 'newId';
       const expectedUrl = 'expectedUrl';
       const expectedTitle = 'expectedTitle';
       const expectedDescription = 'expectedDescription';
       const expectedData = { datum: 'datum' };
-      addOrtbSiteContent(ortb2, expectedId, expectedData, expectedTitle, expectedDescription, expectedUrl);
+      addOrtbSiteContent(ortb2, newId, expectedData, expectedTitle, expectedDescription, expectedUrl);
       expect(ortb2).to.have.nested.property('site.random.random_sub', 'randomSub');
       expect(ortb2).to.have.nested.property('app.content.id', 'appId');
       expect(ortb2).to.have.nested.property('site.content.ext.random_field', 'randomField');
-      expect(ortb2).to.have.nested.property('site.content.id', expectedId);
+      expect(ortb2).to.have.nested.property('site.content.id', 'oldId');
       expect(ortb2).to.have.nested.property('site.content.url', expectedUrl);
       expect(ortb2).to.have.nested.property('site.content.title', expectedTitle);
       expect(ortb2).to.have.nested.property('site.content.ext.description', expectedDescription);
@@ -889,7 +889,7 @@ describe('jwplayerRtdProvider', function() {
       expect(ortb2).to.have.nested.property('site.content.id', expectedId);
     });
 
-    it('should override content id by default', function () {
+    it('should keep old content id by default', function () {
       const ortb2 = {
         site: {
           content: {
@@ -898,9 +898,8 @@ describe('jwplayerRtdProvider', function() {
         }
       };
 
-      const expectedId = 'expectedId';
-      addOrtbSiteContent(ortb2, expectedId);
-      expect(ortb2).to.have.nested.property('site.content.id', expectedId);
+      addOrtbSiteContent(ortb2, 'newId');
+      expect(ortb2).to.have.nested.property('site.content.id', 'oldId');
     });
 
     it('should keep previous content id when new value is not available', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Breaking API change for 9.0
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
A TODO was left to update the default behavior of content ID override from 'always' to 'whenEmpty'



## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Docs PR: https://github.com/prebid/prebid.github.io/pull/5393