### PR TITLE
9.0: Update gumgumBidAdapter.js

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -374,14 +374,6 @@ function buildRequests(validBidRequests, bidderRequest) {
       data.fpc = currency;
     }
 
-    if (params.iriscat && typeof params.iriscat === 'string') {
-      data.iriscat = params.iriscat;
-    }
-
-    if (params.irisid && typeof params.irisid === 'string') {
-      data.irisid = params.irisid;
-    }
-
     if (params.zone || params.pubId) {
       params.zone ? (data.t = params.zone) : (data.pubId = params.pubId);
 

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -254,36 +254,6 @@ describe('gumgumAdapter', function () {
       expect(legReq.data.si).to.equal(invalidSlotId);
     });
 
-    it('should set the iriscat param when found', function () {
-      const request = { ...bidRequests[0], params: { iriscat: 'abc123' } }
-      const bidRequest = spec.buildRequests([request])[0];
-      expect(bidRequest.data).to.have.property('iriscat');
-    });
-
-    it('should not set the iriscat param when not found', function () {
-      const request = { ...bidRequests[0] }
-      const bidRequest = spec.buildRequests([request])[0];
-      expect(bidRequest.data).to.not.have.property('iriscat');
-    });
-
-    it('should set the irisid param when found', function () {
-      const request = { ...bidRequests[0], params: { irisid: 'abc123' } }
-      const bidRequest = spec.buildRequests([request])[0];
-      expect(bidRequest.data).to.have.property('irisid');
-    });
-
-    it('should not set the irisid param when not found', function () {
-      const request = { ...bidRequests[0] }
-      const bidRequest = spec.buildRequests([request])[0];
-      expect(bidRequest.data).to.not.have.property('irisid');
-    });
-
-    it('should not set the irisid param when not of type string', function () {
-      const request = { ...bidRequests[0], params: { irisid: 123456 } }
-      const bidRequest = spec.buildRequests([request])[0];
-      expect(bidRequest.data).to.not.have.property('irisid');
-    });
-
     it('should set the global placement id (gpid) if in adserver property', function () {
       const req = { ...bidRequests[0],
         ortb2Imp: {

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -393,25 +393,6 @@ describe('gumgumAdapter', function () {
       expect(bidRequest.data).to.include.any.keys('t');
       expect(bidRequest.data).to.include.any.keys('fp');
     });
-    it('should set iriscat parameter if iriscat param is found and is of type string', function () {
-      const iriscat = 'segment';
-      const request = { ...bidRequests[0] };
-      request.params = { ...request.params, iriscat };
-      const bidRequest = spec.buildRequests([request])[0];
-      expect(bidRequest.data.iriscat).to.equal(iriscat);
-    });
-    it('should not send iriscat parameter if iriscat param is not found', function () {
-      const request = { ...bidRequests[0] };
-      const bidRequest = spec.buildRequests([request])[0];
-      expect(bidRequest.data.iriscat).to.be.undefined;
-    });
-    it('should not send iriscat parameter if iriscat param is not of type string', function () {
-      const iriscat = 123;
-      const request = { ...bidRequests[0] };
-      request.params = { ...request.params, iriscat };
-      const bidRequest = spec.buildRequests([request])[0];
-      expect(bidRequest.data.iriscat).to.be.undefined;
-    });
     it('should send pubId if inScreenPubID param is specified', function () {
       const request = Object.assign({}, bidRequests[0]);
       delete request.params;


### PR DESCRIPTION
enforcing standard request object locations must also be supported when a param is offered.

see prebid 9 related discussion on #10861 
