### PR TITLE
UID2: Remove obsolete optout-check code for EUID

### DIFF
--- a/modules/euidIdSystem.js
+++ b/modules/euidIdSystem.js
@@ -103,7 +103,6 @@ export const euidIdSubmodule = {
       mappedConfig.cstg = {
         serverPublicKey: config?.params?.serverPublicKey,
         subscriptionId: config?.params?.subscriptionId,
-        optoutCheck: 1,
         ...extractIdentityFromParams(config?.params ?? {})
       }
     }

--- a/modules/euidIdSystem.js
+++ b/modules/euidIdSystem.js
@@ -14,6 +14,13 @@ import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 // eslint-disable-next-line prebid/validate-imports
 import { Uid2GetId, Uid2CodeVersion, extractIdentityFromParams } from './uid2IdSystem_shared.js';
 
+/**
+ * @typedef {import('../modules/userId/index.js').Submodule} Submodule
+ * @typedef {import('../modules/userId/index.js').SubmoduleConfig} SubmoduleConfig
+ * @typedef {import('../modules/userId/index.js').ConsentData} ConsentData
+ * @typedef {import('../modules/userId/index.js').IdResponse} IdResponse
+ */
+
 const MODULE_NAME = 'euid';
 const MODULE_REVISION = Uid2CodeVersion;
 const PREBID_VERSION = '$prebid.version$';
@@ -75,9 +82,9 @@ export const euidIdSubmodule = {
   /**
    * performs action to obtain id and return a value.
    * @function
-   * @param {SubmoduleConfig} [configparams]
+   * @param {SubmoduleConfig} [config]
    * @param {ConsentData|undefined} consentData
-   * @returns {euidId}
+   * @returns {IdResponse}
    */
   getId(config, consentData) {
     if (consentData?.gdprApplies !== true) {

--- a/modules/uid2IdSystem_shared.js
+++ b/modules/uid2IdSystem_shared.js
@@ -393,7 +393,6 @@ if (FEATURES.UID2_CSTG) {
       this._baseUrl = opts.baseUrl;
       this._serverPublicKey = opts.cstg.serverPublicKey;
       this._subscriptionId = opts.cstg.subscriptionId;
-      this._optoutCheck = opts.cstg.optoutCheck;
       this._logInfo = logInfo;
       this._logWarn = logWarn;
     }
@@ -451,8 +450,7 @@ if (FEATURES.UID2_CSTG) {
     }
 
     async generateToken(cstgIdentity) {
-      const requestIdentity = await this.generateCstgRequest(cstgIdentity);
-      const request = { optout_check: this._optoutCheck, ...requestIdentity };
+      const request = await this.generateCstgRequest(cstgIdentity);
       this._logInfo('Building CSTG request for', request);
       const box = await UID2CstgBox.build(
         this.stripPublicKeyPrefix(this._serverPublicKey)


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
This change reverts the optout-check parameter that was added in https://github.com/prebid/Prebid.js/pull/11075.  This is no longer an optional parameter and its functionality is now the default for EUID.  This PR leaves the handling of the new optout return status but removes references to the CSTG parameter.

## Other information
This change reverts the optout-check parameter that was added in https://github.com/prebid/Prebid.js/pull/11075
