### PR TITLE
AMX Bid Adapter: add support for overriding bidderCode (allowAlternateBidderCodes)

### DIFF
--- a/modules/amxBidAdapter.js
+++ b/modules/amxBidAdapter.js
@@ -455,7 +455,7 @@ export const spec = {
     }
 
     const bidderSettings = config.getConfig('bidderSettings');
-    const settings = bidderSettings?.amx ?? bidderSettings?.standard ?? {};;
+    const settings = bidderSettings?.amx ?? bidderSettings?.standard ?? {};
     const allowAlternateBidderCodes = !!settings.allowAlternateBidderCodes;
 
     return flatMap(Object.keys(response.r), (bidID) => {
@@ -473,7 +473,7 @@ export const spec = {
           const { bc: bidderCode, ds: demandSource } = bid.ext ?? {};
 
           return {
-            ...(bidderCode != null && allowAlternateBidderCodes ?  { bidderCode } : {}),
+            ...(bidderCode != null && allowAlternateBidderCodes ? { bidderCode } : {}),
             requestId: bidID,
             cpm: bid.price,
             width: size[0],

--- a/modules/amxBidAdapter.js
+++ b/modules/amxBidAdapter.js
@@ -454,6 +454,10 @@ export const spec = {
       setUIDSafe(response.am);
     }
 
+    const bidderSettings = config.getConfig('bidderSettings');
+    const settings = bidderSettings?.amx ?? bidderSettings?.standard ?? {};;
+    const allowAlternateBidderCodes = !!settings.allowAlternateBidderCodes;
+
     return flatMap(Object.keys(response.r), (bidID) => {
       return flatMap(response.r[bidID], (siteBid) =>
         siteBid.b.map((bid) => {
@@ -466,8 +470,10 @@ export const spec = {
 
           const size = resolveSize(bid, request.data, bidID);
           const defaultExpiration = mediaType === BANNER ? 240 : 300;
+          const { bc: bidderCode, ds: demandSource } = bid.ext ?? {};
 
           return {
+            ...(bidderCode != null && allowAlternateBidderCodes ?  { bidderCode } : {}),
             requestId: bidID,
             cpm: bid.price,
             width: size[0],
@@ -479,6 +485,7 @@ export const spec = {
             meta: {
               advertiserDomains: bid.adomain,
               mediaType,
+              ...(demandSource != null ? { demandSource } : {}),
             },
             mediaType,
             ttl: typeof bid.exp === 'number' ? bid.exp : defaultExpiration,


### PR DESCRIPTION
…AMX Bid adapter

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Adding the ability to override the bidderCode, when publisher enables `allowAlternateBidderCodes`. Also allows setting `meta.demandSource` as an alternative (for use in reporting/key-values).

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
