### PR TITLE
Consumable Bid Adapter: add language to request

### DIFF
--- a/modules/consumableBidAdapter.js
+++ b/modules/consumableBidAdapter.js
@@ -61,7 +61,8 @@ export const spec = {
       source: [{
         'name': 'prebidjs',
         'version': '$prebid.version$'
-      }]
+      }],
+      lang: (navigator && navigator.language) ? navigator.language.split('-')[0] : ''
     }, validBidRequests[0].params);
 
     if (bidderRequest && bidderRequest.gdprConsent) {

--- a/modules/consumableBidAdapter.js
+++ b/modules/consumableBidAdapter.js
@@ -62,7 +62,7 @@ export const spec = {
         'name': 'prebidjs',
         'version': '$prebid.version$'
       }],
-      lang: (navigator && navigator.language) ? navigator.language.split('-')[0] : ''
+      lang: bidderRequest.ortb2.device.language,
     }, validBidRequests[0].params);
 
     if (bidderRequest && bidderRequest.gdprConsent) {

--- a/test/spec/modules/consumableBidAdapter_spec.js
+++ b/test/spec/modules/consumableBidAdapter_spec.js
@@ -519,6 +519,12 @@ describe('Consumable BidAdapter', function () {
       expect(data1.placements[0].bidfloor).to.equal(0.05);
       expect(data2.placements[0].bidfloor).to.equal(0.15);
     });
+    it('should contain the language param', function () {
+      let request = spec.buildRequests(BIDDER_REQUEST_1.bidRequest, BIDDER_REQUEST_1);
+      let data = JSON.parse(request.data);
+
+      expect(data.lang).to.be.a('string');
+    });
   });
   describe('interpretResponse validation', function () {
     it('response should have valid bidderCode', function () {

--- a/test/spec/modules/consumableBidAdapter_spec.js
+++ b/test/spec/modules/consumableBidAdapter_spec.js
@@ -66,6 +66,11 @@ const BIDDER_REQUEST_1 = {
       'http://example.com/iframe1.html',
       'http://example.com/iframe2.html'
     ]
+  },
+  ortb2: {
+    device: {
+      language: 'en'
+    }
   }
 };
 
@@ -130,6 +135,11 @@ const BIDDER_REQUEST_2 = {
       'http://example.com/iframe1.html',
       'http://example.com/iframe2.html'
     ]
+  },
+  ortb2: {
+    device: {
+      language: 'en'
+    }
   }
 };
 
@@ -177,6 +187,11 @@ const BIDDER_REQUEST_VIDEO = {
       'http://example.com/iframe1.html',
       'http://example.com/iframe2.html'
     ]
+  },
+  ortb2: {
+    device: {
+      language: 'en'
+    }
   }
 };
 
@@ -188,6 +203,11 @@ const BIDDER_REQUEST_EMPTY = {
   gdprConsent: {
     consentString: 'consent-test',
     gdprApplies: false
+  },
+  ortb2: {
+    device: {
+      language: 'en'
+    }
   }
 };
 
@@ -523,7 +543,7 @@ describe('Consumable BidAdapter', function () {
       let request = spec.buildRequests(BIDDER_REQUEST_1.bidRequest, BIDDER_REQUEST_1);
       let data = JSON.parse(request.data);
 
-      expect(data.lang).to.be.a('string');
+      expect(data.lang).to.equal('en');
     });
   });
   describe('interpretResponse validation', function () {


### PR DESCRIPTION
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 

## Description of change
This retrieves the user's browser language from the `Navigator` object and populates the request param `lang`.

