### PR TITLE
Zeta Global SSP Bid Adapter : pass user.geo and device.geo to payload

### DIFF
--- a/modules/zeta_global_sspBidAdapter.js
+++ b/modules/zeta_global_sspBidAdapter.js
@@ -147,6 +147,18 @@ export const spec = {
     payload.device.w = screen.width;
     payload.device.h = screen.height;
 
+    if (bidderRequest.ortb2?.user?.geo && bidderRequest.ortb2?.device?.geo) {
+      payload.device.geo = { ...payload.device.geo, ...bidderRequest.ortb2?.device.geo };
+      payload.user.geo = { ...payload.user.geo, ...bidderRequest.ortb2?.user.geo };
+    } else {
+      if (bidderRequest.ortb2?.user?.geo) {
+        payload.user.geo = payload.device.geo = { ...payload.user.geo, ...bidderRequest.ortb2?.user.geo };
+      }
+      if (bidderRequest.ortb2?.device?.geo) {
+        payload.user.geo = payload.device.geo = { ...payload.user.geo, ...bidderRequest.ortb2?.device.geo };
+      }
+    }
+
     if (bidderRequest?.ortb2?.device?.sua) {
       payload.device.sua = bidderRequest.ortb2.device.sua;
     }

--- a/test/spec/modules/zeta_global_sspBidAdapter_spec.js
+++ b/test/spec/modules/zeta_global_sspBidAdapter_spec.js
@@ -155,7 +155,17 @@ describe('Zeta Ssp Bid Adapter', function () {
               { id: '59' }
             ]
           }
-        ]
+        ],
+        geo: {
+          lat: 40.0,
+          lon: -80.0,
+          type: 2,
+          country: 'USA',
+          region: 'NY',
+          metro: '501',
+          city: 'New York',
+          zip: '10001',
+        }
       }
     }
   }];
@@ -658,10 +668,35 @@ describe('Zeta Ssp Bid Adapter', function () {
     expect(payload.device.sua.platform.brand).to.eql('Chrome');
     expect(payload.device.sua.platform.version[0]).to.eql('102');
 
+    // expecting the same values for user.geo and device.geo
+    expect(payload.device.geo.type).to.eql(2);
+    expect(payload.device.geo.lat).to.eql(40.0);
+    expect(payload.device.geo.lon).to.eql(-80.0);
+    expect(payload.device.geo.country).to.eql('USA');
+    expect(payload.device.geo.region).to.eql('NY');
+    expect(payload.device.geo.metro).to.eql('501');
+    expect(payload.device.geo.city).to.eql('New York');
+    expect(payload.device.geo.zip).to.eql('10001');
+
     expect(payload.device.ua).to.not.be.undefined;
     expect(payload.device.language).to.not.be.undefined;
     expect(payload.device.w).to.not.be.undefined;
     expect(payload.device.h).to.not.be.undefined;
+  });
+
+  it('Test provide user params', function () {
+    const request = spec.buildRequests(bannerRequest, bannerRequest[0]);
+    const payload = JSON.parse(request.data);
+
+    // expecting the same values for user.geo and device.geo
+    expect(payload.user.geo.type).to.eql(2);
+    expect(payload.user.geo.lat).to.eql(40.0);
+    expect(payload.user.geo.lon).to.eql(-80.0);
+    expect(payload.user.geo.country).to.eql('USA');
+    expect(payload.user.geo.region).to.eql('NY');
+    expect(payload.user.geo.metro).to.eql('501');
+    expect(payload.user.geo.city).to.eql('New York');
+    expect(payload.user.geo.zip).to.eql('10001');
   });
 
   it('Test that all empties are removed', function () {


### PR DESCRIPTION


## Type of change
- [x] Feature

## Description of change

Passing both user.geo and device.geo to the payload. If one of them does not exist, the data is merged.
