### PR TITLE
Insticator adapter update with publisherId param

### DIFF
--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -439,6 +439,10 @@ function buildRequest(validBidRequests, bidderRequest) {
     deepSetValue(req, 'user.ext.consent', bidderRequest.gdprConsent.consentString);
   }
 
+  if (validBidRequests[0]?.params?.publisherId) {
+    deepSetValue(req, 'site.publisher.id', validBidRequests[0].params.publisherId);
+  }
+
   return req;
 }
 

--- a/test/spec/modules/insticatorBidAdapter_spec.js
+++ b/test/spec/modules/insticatorBidAdapter_spec.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { spec, storage } from '../../../modules/insticatorBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js'
-import { logInfo } from '../../../src/utils.js';
 
 const USER_ID_KEY = 'hb_insticator_uid';
 const USER_ID_DUMMY_VALUE = '74f78609-a92d-4cf1-869f-1b244bbfb5d2';
@@ -18,7 +17,6 @@ describe('InsticatorBidAdapter', function () {
     adUnitCode: 'adunit-code',
     params: {
       adUnitId: '1a2b3c4d5e6f1a2b3c4d',
-      publisherId: '1a2b3c4d5e6f1a2b3c4d',
       user: {
         yob: 1984,
         gender: 'M'
@@ -388,8 +386,6 @@ describe('InsticatorBidAdapter', function () {
       expect(data.site.domain).not.to.be.empty;
       expect(data.site.page).not.to.be.empty;
       expect(data.site.ref).to.equal(bidderRequest.refererInfo.ref);
-      expect(data.site.publisher).to.be.an('object');
-      expect(data.site.publisher.id).to.equal(bidRequest.params.publisherId);
       expect(data.device).to.be.an('object');
       expect(data.device.w).to.equal(window.innerWidth);
       expect(data.device.h).to.equal(window.innerHeight);
@@ -769,6 +765,24 @@ describe('InsticatorBidAdapter', function () {
       expect(data.regs.ext).to.have.property('gdpr');
       expect(data.regs.ext).to.have.property('us_privacy');
       expect(data.regs.ext).to.have.property('gppSid');
+    });
+
+    it('should return true if publisherId is absent', () => {
+      expect(spec.isBidRequestValid(bidRequest)).to.be.true;
+    })
+
+    it('should have publisher object with id in site object, if publisherId present in params', function () {
+      const tempBiddRequest = {
+        ...bidRequest,
+      }
+      tempBiddRequest.params = {
+        ...tempBiddRequest.params,
+        publisherId: '86dd03a1-053f-4e3e-90e7-389070a0c62c'
+      }
+      const requests = spec.buildRequests([tempBiddRequest], bidderRequest);
+      const data = JSON.parse(requests[0].data);
+      expect(data.site.publisher).to.be.an('object');
+      expect(data.site.publisher.id).to.equal(tempBiddRequest.params.publisherId)
     });
   });
 

--- a/test/spec/modules/insticatorBidAdapter_spec.js
+++ b/test/spec/modules/insticatorBidAdapter_spec.js
@@ -784,6 +784,19 @@ describe('InsticatorBidAdapter', function () {
       expect(data.site.publisher).to.be.an('object');
       expect(data.site.publisher.id).to.equal(tempBiddRequest.params.publisherId)
     });
+
+    it('should have publisher object should be empty, if publisherId is empty string', function () {
+      const tempBiddRequest = {
+        ...bidRequest,
+      }
+      tempBiddRequest.params = {
+        ...tempBiddRequest.params,
+        publisherId: ''
+      }
+      const requests = spec.buildRequests([tempBiddRequest], bidderRequest);
+      const data = JSON.parse(requests[0].data);
+      expect(data.site.publisher).to.not.an('object');
+    });
   });
 
   describe('interpretResponse', function () {

--- a/test/spec/modules/insticatorBidAdapter_spec.js
+++ b/test/spec/modules/insticatorBidAdapter_spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { spec, storage } from '../../../modules/insticatorBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js'
+import { logInfo } from '../../../src/utils.js';
 
 const USER_ID_KEY = 'hb_insticator_uid';
 const USER_ID_DUMMY_VALUE = '74f78609-a92d-4cf1-869f-1b244bbfb5d2';
@@ -17,6 +18,7 @@ describe('InsticatorBidAdapter', function () {
     adUnitCode: 'adunit-code',
     params: {
       adUnitId: '1a2b3c4d5e6f1a2b3c4d',
+      publisherId: '1a2b3c4d5e6f1a2b3c4d',
       user: {
         yob: 1984,
         gender: 'M'
@@ -386,6 +388,8 @@ describe('InsticatorBidAdapter', function () {
       expect(data.site.domain).not.to.be.empty;
       expect(data.site.page).not.to.be.empty;
       expect(data.site.ref).to.equal(bidderRequest.refererInfo.ref);
+      expect(data.site.publisher).to.be.an('object');
+      expect(data.site.publisher.id).to.equal(bidRequest.params.publisherId);
       expect(data.device).to.be.an('object');
       expect(data.device.w).to.equal(window.innerWidth);
       expect(data.device.h).to.equal(window.innerHeight);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
