### PR TITLE
Yieldmo Bid Adapter: Prevent Consent Override and Eids fix

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -177,7 +177,7 @@ export const spec = {
         serverRequest.topics = topicsData;
       }
       if (eids.length) {
-        serverRequest.user = { eids };
+        deepSetValue(serverRequest, 'user.eids', eids);
       };
       serverRequests.push({
         method: 'POST',

--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -177,7 +177,7 @@ export const spec = {
         serverRequest.topics = topicsData;
       }
       if (eids.length) {
-        deepSetValue(serverRequest, 'user.eids', eids);
+        deepSetValue(serverRequest, 'user.ext.eids', eids);
       };
       serverRequests.push({
         method: 'POST',

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -264,7 +264,11 @@ describe('YieldmoAdapter', function () {
           vendorData: {blerp: 1},
           gdprApplies: true,
         };
-        const data = buildAndGetData([mockBannerBid()], 0, mockBidderRequest({gdprConsent}));
+        const data = buildAndGetData(
+          [mockBannerBid()],
+          0,
+          mockBidderRequest({ gdprConsent })
+        );
         expect(data.userConsent).equal(
           JSON.stringify({
             gdprApplies: true,
@@ -638,6 +642,45 @@ describe('YieldmoAdapter', function () {
           ext: { data: { pbadslot: '/6355419/Travel/Europe/France/Paris' } },
         };
         expect(buildAndGetData([mockVideoBid({ortb2Imp})]).imp[0].ext.gpid).to.be.equal(ortb2Imp.ext.data.pbadslot);
+      });
+
+      it('should pass consent in video bid along with eids', () => {
+        const params = {
+          userIdAsEids: [
+            {
+              source: 'pubcid.org',
+              uids: [
+                {
+                  id: 'fake_pubcid',
+                  atype: 1,
+                },
+              ],
+            },
+          ],
+          fakeUserIdAsEids: [
+            {
+              source: 'pubcid.org',
+              uids: [
+                {
+                  id: 'fake_pubcid',
+                  atype: 1,
+                },
+              ],
+            },
+          ],
+        };
+        let videoBidder = mockBidderRequest(
+          {
+            gdprConsent: {
+              gdprApplies: 1,
+              consentString: 'BOJ/P2HOJ/P2HABABMAAAAAZ+A==',
+            },
+          },
+          [mockVideoBid()]
+        );
+        let payload = buildAndGetData([mockVideoBid({...params})], 0, videoBidder);
+        expect(payload.user.ext.consent).to.equal('BOJ/P2HOJ/P2HABABMAAAAAZ+A==');
+        expect(payload.user.eids).to.eql(params.fakeUserIdAsEids);
       });
 
       it('should add eids to the video bid request', function () {

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -680,7 +680,7 @@ describe('YieldmoAdapter', function () {
         );
         let payload = buildAndGetData([mockVideoBid({...params})], 0, videoBidder);
         expect(payload.user.ext.consent).to.equal('BOJ/P2HOJ/P2HABABMAAAAAZ+A==');
-        expect(payload.user.eids).to.eql(params.fakeUserIdAsEids);
+        expect(payload.user.ext.eids).to.eql(params.fakeUserIdAsEids);
       });
 
       it('should add eids to the video bid request', function () {
@@ -702,7 +702,7 @@ describe('YieldmoAdapter', function () {
             }]
           }]
         };
-        expect(buildAndGetData([mockVideoBid({...params})]).user.eids).to.eql(params.fakeUserIdAsEids);
+        expect(buildAndGetData([mockVideoBid({...params})]).user.ext.eids).to.eql(params.fakeUserIdAsEids);
       });
 
       it('should add topics to the bid request', function () {


### PR DESCRIPTION
Bug fix where we do not override user consent with eids.

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
