### PR TITLE
Outbrain bid adapter add ortb2 device

### DIFF
--- a/modules/outbrainBidAdapter.js
+++ b/modules/outbrainBidAdapter.js
@@ -111,7 +111,7 @@ export const spec = {
     const request = {
       id: bidderRequest.bidderRequestId,
       site: { page, publisher },
-      device: { ua },
+      device: ortb2?.device || { ua },
       source: { fd: 1 },
       cur: [cur],
       tmax: timeout,

--- a/test/spec/modules/outbrainBidAdapter_spec.js
+++ b/test/spec/modules/outbrainBidAdapter_spec.js
@@ -65,6 +65,23 @@ describe('Outbrain Adapter', function () {
       }
     }
 
+    const ortb2WithDeviceData = {
+      ortb2: {
+        device: {
+          w: 980,
+          h: 1720,
+          dnt: 0,
+          ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1',
+          language: 'en',
+          devicetype: 1,
+          make: 'Apple',
+          model: 'iPhone 12 Pro Max',
+          os: 'iOS',
+          osv: '17.4'
+        }
+      }
+    };
+
     describe('isBidRequestValid', function () {
       before(() => {
         config.setConfig({
@@ -619,6 +636,19 @@ describe('Outbrain Adapter', function () {
         let res = spec.buildRequests([bidRequest], commonBidderRequest);
         const resData = JSON.parse(res.data)
         expect(resData.imp[0].native.request).to.equal(JSON.stringify(expectedNativeAssets));
+      });
+
+      it('should pass ortb2 device data', function () {
+        const bidRequest = {
+          ...commonBidRequest,
+          ...nativeBidRequestParams,
+        };
+
+        const res = spec.buildRequests(
+          [bidRequest],
+          {...commonBidderRequest, ...ortb2WithDeviceData},
+        );
+        expect(JSON.parse(res.data).device).to.deep.equal(ortb2WithDeviceData.ortb2.device);
       });
     })
 


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Updated bidder adapter

## Description of change
This PR enhances the Outbrain bidder request by incorporating device data from the global ORTB2 object. Existing values in the Outbrain device object will be overridden if they are also present in the global ORTB2 object. However, values unique to Outbrain or not found in the global ORTB2 object will remain unchanged.

## Motivation
The device object has previously been populated by simplistic parsers, if at all, and was inaccurate as a result. Prebid now benefits from RTD modules such as [51Degrees](https://docs.prebid.org/dev-docs/modules/51DegreesRtdProvider.html) that enrich all the device object fields including Apple iPhone model category and device ID. The PR enables Outbrain’s users to benefit from these eco-system improvements.

## Other information
cc: @markkuhar