### PR TITLE
Invibes bid adapter add ortb2 device

### DIFF
--- a/modules/invibesBidAdapter.js
+++ b/modules/invibesBidAdapter.js
@@ -182,6 +182,32 @@ function buildRequest(bidRequests, bidderRequest) {
     isInfiniteScrollPage: isInfiniteScrollPage
   };
 
+  // Adds device data to the request,
+  // the properties are only added if they are not null
+  const deviceData = bidderRequest?.ortb2?.device;
+  const deviceDataProperties = {
+    ortb2DeviceDevicetype: deviceData?.devicetype,
+    ortb2DeviceMake: deviceData?.make,
+    ortb2DeviceModel: deviceData?.model,
+    ortb2DeviceOs: deviceData?.os,
+    ortb2DeviceOsv: deviceData?.osv,
+    ortb2DeviceH: deviceData?.h,
+    ortb2DeviceW: deviceData?.w,
+    ortb2DevicePxratio: deviceData?.pxratio,
+    ortb2DevicePpi: deviceData?.ppi,
+    ortb2DeviceExtFiftyonedegreesDeviceId: deviceData?.ext?.fiftyonedegrees_deviceId,
+  };
+  const filteredDeviceDataProperties = Object
+    .keys(deviceDataProperties)
+    .reduce((r, key) => {
+      if (deviceDataProperties[key]) {
+        r[key] = deviceDataProperties[key];
+      }
+      return r;
+    }, {});
+
+  data = {...data, ...filteredDeviceDataProperties};
+
   if (bidderRequest.refererInfo && bidderRequest.refererInfo.ref) {
     data.pageReferrer = bidderRequest.refererInfo.ref.substring(0, 300);
   }

--- a/test/spec/modules/invibesBidAdapter_spec.js
+++ b/test/spec/modules/invibesBidAdapter_spec.js
@@ -1172,6 +1172,37 @@ describe('invibesBidAdapter:', function () {
       let request = spec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.oi).to.equal(0);
     });
+
+    it('should send ORTB2 device data if available', function () {
+      const bidderRequest = {
+        ortb2: {
+          device: {
+            w: 980,
+            h: 1720,
+            dnt: 0,
+            ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1',
+            language: 'en',
+            devicetype: 1,
+            make: 'Apple',
+            model: 'iPhone 12 Pro Max',
+            os: 'iOS',
+            osv: '17.4'
+          },
+        },
+        refererInfo: {
+          page: 'https://randomWeb.com?someFakePara=fakeValue&secondParam=secondValue'
+        },
+      };
+
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.ortb2DeviceDevicetype).to.equal(bidderRequest.ortb2.device.devicetype);
+      expect(request.data.ortb2DeviceMake).to.equal(bidderRequest.ortb2.device.make);
+      expect(request.data.ortb2DeviceModel).to.equal(bidderRequest.ortb2.device.model);
+      expect(request.data.ortb2DeviceOs).to.equal(bidderRequest.ortb2.device.os);
+      expect(request.data.ortb2DeviceOsv).to.equal(bidderRequest.ortb2.device.osv);
+      expect(request.data.ortb2DeviceH).to.equal(bidderRequest.ortb2.device.h);
+      expect(request.data.ortb2DeviceW).to.equal(bidderRequest.ortb2.device.w);
+    });
   });
 
   describe('interpretResponse', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Updated bidder adapter

## Description of change
This PR enhances the Invibes bidder request by incorporating device data from the global ORTB2 object. Existing values in the Invibes device object will be overridden if they are also present in the global ORTB2 object. However, values unique to Invibes or not found in the global ORTB2 object will remain unchanged.

Parameters are added as GET query parameters, prefixed as `ortb2Device<deviceKeyName>`.

## Motivation
The device object has previously been populated by simplistic parsers, if at all, and was inaccurate as a result. Prebid now benefits from RTD modules such as [51Degrees](https://docs.prebid.org/dev-docs/modules/51DegreesRtdProvider.html) that enrich all the device object fields including Apple iPhone model category and device ID. The PR enables Invibes' users to benefit from these eco-system improvements.

## Other information
cc: @rcheptanariu