### PR TITLE
Taboola bid adapter add ortb2 device

### DIFF
--- a/modules/taboolaBidAdapter.js
+++ b/modules/taboolaBidAdapter.js
@@ -276,7 +276,7 @@ function getSiteProperties({publisherId}, refererInfo, ortb2) {
 function fillTaboolaReqData(bidderRequest, bidRequest, data) {
   const {refererInfo, gdprConsent = {}, uspConsent} = bidderRequest;
   const site = getSiteProperties(bidRequest.params, refererInfo, bidderRequest.ortb2);
-  deepSetValue(data, 'device.ua', navigator.userAgent);
+  deepSetValue(data, 'device', bidderRequest?.ortb2?.device || {ua: navigator.userAgent});
   const extractedUserId = userData.getUserId(gdprConsent, uspConsent);
   if (data.user == undefined) {
     data.user = {

--- a/modules/taboolaBidAdapter.js
+++ b/modules/taboolaBidAdapter.js
@@ -276,7 +276,7 @@ function getSiteProperties({publisherId}, refererInfo, ortb2) {
 function fillTaboolaReqData(bidderRequest, bidRequest, data) {
   const {refererInfo, gdprConsent = {}, uspConsent} = bidderRequest;
   const site = getSiteProperties(bidRequest.params, refererInfo, bidderRequest.ortb2);
-  deepSetValue(data, 'device', bidderRequest?.ortb2?.device || {ua: navigator.userAgent});
+  deepSetValue(data, 'device', bidderRequest?.ortb2?.device);
   const extractedUserId = userData.getUserId(gdprConsent, uspConsent);
   if (data.user == undefined) {
     data.user = {

--- a/test/spec/modules/taboolaBidAdapter_spec.js
+++ b/test/spec/modules/taboolaBidAdapter_spec.js
@@ -365,6 +365,18 @@ describe('Taboola Adapter', function () {
             wlang: ['de'],
             user: {
               id: 'externalUserIdPassed'
+            },
+            device: {
+              w: 980,
+              h: 1720,
+              dnt: 0,
+              ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1',
+              language: 'en',
+              devicetype: 1,
+              make: 'Apple',
+              model: 'iPhone 12 Pro Max',
+              os: 'iOS',
+              osv: '17.4'
             }
           }
         }
@@ -373,6 +385,7 @@ describe('Taboola Adapter', function () {
         expect(res.data.badv).to.deep.equal(bidderRequest.ortb2.badv)
         expect(res.data.wlang).to.deep.equal(bidderRequest.ortb2.wlang)
         expect(res.data.user.id).to.deep.equal(bidderRequest.ortb2.user.id)
+        expect(res.data.device).to.deep.equal(bidderRequest.ortb2.device);
       });
 
       it('should pass user entities', function () {

--- a/test/spec/modules/taboolaBidAdapter_spec.js
+++ b/test/spec/modules/taboolaBidAdapter_spec.js
@@ -173,6 +173,11 @@ describe('Taboola Adapter', function () {
         page: 'https://example.com/ref',
         ref: 'https://ref',
         domain: 'example.com',
+      },
+      ortb2: {
+        device: {
+          ua: navigator.userAgent,
+        },
       }
     }
 
@@ -197,9 +202,9 @@ describe('Taboola Adapter', function () {
           'bidfloorcur': 'USD',
           'ext': {}
         }],
-        id: 'mock-uuid',
-        'test': 0,
         'device': {'ua': navigator.userAgent},
+        'id': 'mock-uuid',
+        'test': 0,
         'user': {
           'buyeruid': 0,
           'ext': {},


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Updated bidder adapter

## Description of change
This PR enhances the Taboola bidder request by incorporating device data from the global ORTB2 object. Existing values in the Taboola device object will be overridden if they are also present in the global ORTB2 object. However, values unique to Taboola or not found in the global ORTB2 object will remain unchanged.

## Motivation
The device object has previously been populated by simplistic parsers, if at all, and was inaccurate as a result. Prebid now benefits from RTD modules such as [51Degrees](https://docs.prebid.org/dev-docs/modules/51DegreesRtdProvider.html) that enrich all the device object fields including Apple iPhone model category and device ID. The PR enables Taboola users to benefit from these eco-system improvements.

## Other information
cc: @mikizi @ahmadlob @barRubi