### PR TITLE
PBjs Utils/Module Change: Replace JSON.parse/stringify with Efficient Deep Clone Method

### DIFF
--- a/modules/aidemBidAdapter.js
+++ b/modules/aidemBidAdapter.js
@@ -1,4 +1,4 @@
-import {deepAccess, deepSetValue, isBoolean, isNumber, isStr, logError, logInfo} from '../src/utils.js';
+import {deepAccess, deepClone, deepSetValue, isBoolean, isNumber, isStr, logError, logInfo} from '../src/utils.js';
 import {config} from '../src/config.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
@@ -132,7 +132,7 @@ function getRegs(bidderRequest) {
 }
 
 function setPrebidRequestEnvironment(payload) {
-  const __navigator = JSON.parse(JSON.stringify(recur(navigator)));
+  const __navigator = deepClone(recur(navigator));
   delete __navigator.plugins;
   deepSetValue(payload, 'environment.ri', getRefererInfo());
   deepSetValue(payload, 'environment.hl', window.history.length);

--- a/modules/apacdexBidAdapter.js
+++ b/modules/apacdexBidAdapter.js
@@ -1,4 +1,4 @@
-import { deepAccess, isPlainObject, isArray, replaceAuctionPrice, isFn, logError } from '../src/utils.js';
+import { deepAccess, isPlainObject, isArray, replaceAuctionPrice, isFn, logError, deepClone } from '../src/utils.js';
 import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import {hasPurpose1Consent} from '../src/utils/gpdr.js';
@@ -85,7 +85,7 @@ export const spec = {
         bidReq.bidFloor = bidFloor;
       }
 
-      bids.push(JSON.parse(JSON.stringify(bidReq)));
+      bids.push(deepClone(bidReq));
     });
 
     const payload = {};

--- a/modules/asteriobidAnalyticsAdapter.js
+++ b/modules/asteriobidAnalyticsAdapter.js
@@ -1,4 +1,4 @@
-import { generateUUID, getParameterByName, logError, logInfo, parseUrl } from '../src/utils.js'
+import { generateUUID, getParameterByName, logError, logInfo, parseUrl, deepClone, hasNonSerializableProperty } from '../src/utils.js'
 import { ajaxBuilder } from '../src/ajax.js'
 import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js'
 import adapterManager from '../src/adapterManager.js'
@@ -192,10 +192,10 @@ function handleEvent(eventType, eventArgs) {
     return
   }
 
-  try {
-    eventArgs = eventArgs ? JSON.parse(JSON.stringify(eventArgs)) : {}
-  } catch (e) {
-    // keep eventArgs as is
+  if (eventArgs) {
+    eventArgs = hasNonSerializableProperty(eventArgs) ? eventArgs : deepClone(eventArgs)
+  } else {
+    eventArgs = {}
   }
 
   const pmEvent = {}

--- a/modules/bidwatchAnalyticsAdapter.js
+++ b/modules/bidwatchAnalyticsAdapter.js
@@ -3,6 +3,7 @@ import adapterManager from '../src/adapterManager.js';
 import { EVENTS } from '../src/constants.js';
 import { ajax } from '../src/ajax.js';
 import { getRefererInfo } from '../src/refererDetection.js';
+import { deepClone } from '../src/utils.js';
 
 const analyticsType = 'endpoint';
 const url = 'URL_TO_SERVER_ENDPOINT';
@@ -113,7 +114,7 @@ function addTimeout(args) {
   let stringArgs = JSON.parse(dereferenceWithoutRenderer(args));
   argsDereferenced = stringArgs;
   argsDereferenced.forEach((attr) => {
-    argsCleaned.push(filterAttributes(JSON.parse(JSON.stringify(attr)), false));
+    argsCleaned.push(filterAttributes(deepClone(attr), false));
   });
   if (auctionEnd[eventType] == undefined) { auctionEnd[eventType] = [] }
   auctionEnd[eventType].push(argsCleaned);

--- a/modules/debugging/bidInterceptor.js
+++ b/modules/debugging/bidInterceptor.js
@@ -1,9 +1,9 @@
 import {
   deepAccess,
   deepClone,
-  deepEqual,
   delayExecution,
-  mergeDeep
+  mergeDeep,
+  hasNonSerializableProperty
 } from '../../src/utils.js';
 
 /**
@@ -22,9 +22,9 @@ Object.assign(BidInterceptor.prototype, {
   },
   serializeConfig(ruleDefs) {
     const isSerializable = (ruleDef, i) => {
-      const serializable = deepEqual(ruleDef, JSON.parse(JSON.stringify(ruleDef)), {checkTypes: true});
+      const serializable = !hasNonSerializableProperty(ruleDef);
       if (!serializable && !deepAccess(ruleDef, 'options.suppressWarnings')) {
-        this.logger.logWarn(`Bid interceptor rule definition #${i + 1} is not serializable and will be lost after a refresh. Rule definition: `, ruleDef);
+        this.logger.logWarn(`Bid interceptor rule definition #${i + 1} contains non-serializable properties and will be lost after a refresh. Rule definition: `, ruleDef);
       }
       return serializable;
     }

--- a/modules/etargetBidAdapter.js
+++ b/modules/etargetBidAdapter.js
@@ -1,4 +1,4 @@
-import { deepSetValue, isFn, isPlainObject } from '../src/utils.js';
+import { deepClone, deepSetValue, isFn, isPlainObject } from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 
@@ -28,7 +28,7 @@ export const spec = {
   buildRequests: function (validBidRequests, bidderRequest) {
     var i, l, bid, reqParams, netRevenue, gdprObject;
     var request = [];
-    var bids = JSON.parse(JSON.stringify(validBidRequests));
+    var bids = deepClone(validBidRequests);
     var lastCountry = 'sk';
     var floors = [];
     for (i = 0, l = bids.length; i < l; i++) {

--- a/modules/growthCodeAnalyticsAdapter.js
+++ b/modules/growthCodeAnalyticsAdapter.js
@@ -31,7 +31,7 @@ let analyticsType = 'endpoint';
 
 let growthCodeAnalyticsAdapter = Object.assign(adapter({url: url, analyticsType}), {
   track({eventType, args}) {
-    let eventData = args ? JSON.parse(JSON.stringify(args)) : {};
+    let eventData = args ? utils.deepClone(args) : {};
     let data = {};
     if (!trackEvents.includes(eventType)) return;
     switch (eventType) {

--- a/modules/hadronAnalyticsAdapter.js
+++ b/modules/hadronAnalyticsAdapter.js
@@ -53,7 +53,7 @@ let analyticsType = 'endpoint';
 
 let hadronAnalyticsAdapter = Object.assign(adapter({url: HADRON_ANALYTICS_URL, analyticsType}), {
   track({eventType, args}) {
-    args = args ? JSON.parse(JSON.stringify(args)) : {};
+    args = args ? utils.deepClone(args) : {};
     var data = {};
     if (!eventsToTrack.includes(eventType)) return;
     switch (eventType) {

--- a/modules/interactiveOffersBidAdapter.js
+++ b/modules/interactiveOffersBidAdapter.js
@@ -1,4 +1,4 @@
-import {isNumber, logWarn} from '../src/utils.js';
+import {deepClone, isNumber, logWarn} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER} from '../src/mediaTypes.js';
 
@@ -80,7 +80,7 @@ function parseRequestPrebidjsToOpenRTB(prebidRequest, bidderRequest) {
   let pageURL = window.location.href;
   let domain = window.location.hostname;
   let secure = (window.location.protocol == 'https:' ? 1 : 0);
-  let openRTBRequest = JSON.parse(JSON.stringify(DEFAULT['OpenRTBBidRequest']));
+  let openRTBRequest = deepClone(DEFAULT['OpenRTBBidRequest']);
   openRTBRequest.id = bidderRequest.bidderRequestId;
   openRTBRequest.ext = {
     // TODO: please do not send internal data structures over the network
@@ -89,36 +89,36 @@ function parseRequestPrebidjsToOpenRTB(prebidRequest, bidderRequest) {
     auctionId: prebidRequest.auctionId
   };
 
-  openRTBRequest.site = JSON.parse(JSON.stringify(DEFAULT['OpenRTBBidRequestSite']));
+  openRTBRequest.site = deepClone(DEFAULT['OpenRTBBidRequestSite']);
   openRTBRequest.site.id = domain;
   openRTBRequest.site.name = domain;
   openRTBRequest.site.domain = domain;
   openRTBRequest.site.page = pageURL;
   openRTBRequest.site.ref = prebidRequest.refererInfo.ref;
 
-  openRTBRequest.site.publisher = JSON.parse(JSON.stringify(DEFAULT['OpenRTBBidRequestSitePublisher']));
+  openRTBRequest.site.publisher = deepClone(DEFAULT['OpenRTBBidRequestSitePublisher']);
   openRTBRequest.site.publisher.id = 0;
   openRTBRequest.site.publisher.name = prebidRequest.refererInfo.domain;
   openRTBRequest.site.publisher.domain = domain;
   openRTBRequest.site.publisher.domain = domain;
 
-  openRTBRequest.site.content = JSON.parse(JSON.stringify(DEFAULT['OpenRTBBidRequestSiteContent']));
+  openRTBRequest.site.content = deepClone(DEFAULT['OpenRTBBidRequestSiteContent']);
 
-  openRTBRequest.source = JSON.parse(JSON.stringify(DEFAULT['OpenRTBBidRequestSource']));
+  openRTBRequest.source = deepClone(DEFAULT['OpenRTBBidRequestSource']);
   openRTBRequest.source.fd = 0;
   openRTBRequest.source.tid = prebidRequest.ortb2?.source?.tid;
   openRTBRequest.source.pchain = '';
 
-  openRTBRequest.device = JSON.parse(JSON.stringify(DEFAULT['OpenRTBBidRequestDevice']));
+  openRTBRequest.device = deepClone(DEFAULT['OpenRTBBidRequestDevice']);
 
-  openRTBRequest.user = JSON.parse(JSON.stringify(DEFAULT['OpenRTBBidRequestUser']));
+  openRTBRequest.user = deepClone(DEFAULT['OpenRTBBidRequestUser']);
 
   openRTBRequest.imp = [];
   prebidRequest.bids.forEach(function(bid) {
     if (!ret.partnerId) {
       ret.partnerId = bid.params.partnerId;
     }
-    let imp = JSON.parse(JSON.stringify(DEFAULT['OpenRTBBidRequestImp']));
+    let imp = deepClone(DEFAULT['OpenRTBBidRequestImp']);
     imp.id = bid.bidId;
     imp.secure = secure;
     imp.tagid = bid.adUnitCode;
@@ -131,7 +131,7 @@ function parseRequestPrebidjsToOpenRTB(prebidRequest, bidderRequest) {
 
     Object.keys(bid.mediaTypes).forEach(function(mediaType) {
       if (mediaType == 'banner') {
-        imp.banner = JSON.parse(JSON.stringify(DEFAULT['OpenRTBBidRequestImpBanner']));
+        imp.banner = deepClone(DEFAULT['OpenRTBBidRequestImpBanner']);
         imp.banner.w = 0;
         imp.banner.h = 0;
         imp.banner.format = [];
@@ -156,7 +156,7 @@ function parseResponseOpenRTBToPrebidjs(openRTBResponse) {
       response.seatbid.forEach(function(seatbid) {
         if (seatbid.bid && seatbid.bid.forEach) {
           seatbid.bid.forEach(function(bid) {
-            let prebid = JSON.parse(JSON.stringify(DEFAULT['PrebidBid']));
+            let prebid = deepClone(DEFAULT['PrebidBid']);
             prebid.requestId = bid.impid;
             prebid.ad = bid.adm;
             prebid.creativeId = bid.crid;

--- a/modules/invisiblyAnalyticsAdapter.js
+++ b/modules/invisiblyAnalyticsAdapter.js
@@ -5,7 +5,7 @@ import { ajaxBuilder } from '../src/ajax.js';
 import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
 import adapterManager from '../src/adapterManager.js';
 
-import { generateUUID, logInfo } from '../src/utils.js';
+import { deepClone, hasNonSerializableProperty, generateUUID, logInfo } from '../src/utils.js';
 import { EVENTS } from '../src/constants.js';
 
 const DEFAULT_EVENT_URL = 'https://api.pymx5.com/v1/' + 'sites/events';
@@ -133,7 +133,12 @@ function flush() {
 }
 
 function handleEvent(eventType, eventArgs) {
-  eventArgs = eventArgs ? JSON.parse(JSON.stringify(eventArgs)) : {};
+  if (eventArgs) {
+    eventArgs = hasNonSerializableProperty(eventArgs) ? eventArgs : deepClone(eventArgs)
+  } else {
+    eventArgs = {}
+  }
+
   let invisiblyEvent = {};
 
   switch (eventType) {

--- a/modules/newspassidBidAdapter.js
+++ b/modules/newspassidBidAdapter.js
@@ -1,4 +1,5 @@
 import {
+  deepClone,
   logInfo,
   logError,
   deepAccess,
@@ -33,12 +34,12 @@ export const spec = {
   },
   loadConfiguredData(bid) {
     if (this.propertyBag.config) { return; }
-    this.propertyBag.config = JSON.parse(JSON.stringify(this.config_defaults));
+    this.propertyBag.config = deepClone(this.config_defaults);
     let bidder = bid.bidder || 'newspassid';
     this.propertyBag.config.logId = bidder.toUpperCase();
     this.propertyBag.config.bidder = bidder;
     let bidderConfig = config.getConfig(bidder) || {};
-    logInfo('got bidderConfig: ', JSON.parse(JSON.stringify(bidderConfig)));
+    logInfo('got bidderConfig: ', deepClone(bidderConfig));
     let arrGetParams = this.getGetParametersAsObject();
     if (bidderConfig.endpointOverride) {
       if (bidderConfig.endpointOverride.origin) {
@@ -131,7 +132,7 @@ export const spec = {
   buildRequests(validBidRequests, bidderRequest) {
     this.loadConfiguredData(validBidRequests[0]);
     this.propertyBag.buildRequestsStart = new Date().getTime();
-    logInfo(`buildRequests time: ${this.propertyBag.buildRequestsStart} v ${NEWSPASSVERSION} validBidRequests`, JSON.parse(JSON.stringify(validBidRequests)), 'bidderRequest', JSON.parse(JSON.stringify(bidderRequest)));
+    logInfo(`buildRequests time: ${this.propertyBag.buildRequestsStart} v ${NEWSPASSVERSION} validBidRequests`, deepClone(validBidRequests), 'bidderRequest', deepClone(bidderRequest));
     if (this.blockTheRequest()) {
       return [];
     }
@@ -281,7 +282,7 @@ export const spec = {
         data: JSON.stringify(npRequest),
         bidderRequest: bidderRequest
       };
-      logInfo('buildRequests request data for single = ', JSON.parse(JSON.stringify(npRequest)));
+      logInfo('buildRequests request data for single = ', deepClone(npRequest));
       this.propertyBag.buildRequestsEnd = new Date().getTime();
       logInfo(`buildRequests going to return for single at time ${this.propertyBag.buildRequestsEnd} (took ${this.propertyBag.buildRequestsEnd - this.propertyBag.buildRequestsStart}ms): `, ret);
       return ret;
@@ -309,7 +310,7 @@ export const spec = {
     if (request && request.bidderRequest && request.bidderRequest.bids) { this.loadConfiguredData(request.bidderRequest.bids[0]); }
     let startTime = new Date().getTime();
     logInfo(`interpretResponse time: ${startTime}. buildRequests done -> interpretResponse start was ${startTime - this.propertyBag.buildRequestsEnd}ms`);
-    logInfo(`serverResponse, request`, JSON.parse(JSON.stringify(serverResponse)), JSON.parse(JSON.stringify(request)));
+    logInfo(`serverResponse, request`, deepClone(serverResponse), deepClone(request));
     serverResponse = serverResponse.body || {};
     let aucId = serverResponse.id; // this will be correct for single requests and non-single
     if (!serverResponse.hasOwnProperty('seatbid')) {

--- a/modules/nobidAnalyticsAdapter.js
+++ b/modules/nobidAnalyticsAdapter.js
@@ -241,7 +241,7 @@ window.nobidCarbonizer = {
       adunit.bids = allowedBidders;
     }
     for (const adunit of adunits) {
-      if (!nobidAnalytics.originalAdUnits[adunit.code]) nobidAnalytics.originalAdUnits[adunit.code] = JSON.parse(JSON.stringify(adunit));
+      if (!nobidAnalytics.originalAdUnits[adunit.code]) nobidAnalytics.originalAdUnits[adunit.code] = deepClone(adunit);
     };
     if (this.isActive()) {
       // 5% of the time do not block;

--- a/modules/oxxionAnalyticsAdapter.js
+++ b/modules/oxxionAnalyticsAdapter.js
@@ -3,6 +3,7 @@ import adapterManager from '../src/adapterManager.js';
 import { EVENTS } from '../src/constants.js';
 import { ajax } from '../src/ajax.js';
 import { getRefererInfo } from '../src/refererDetection.js';
+import { deepClone } from '../src/utils.js';
 
 const analyticsType = 'endpoint';
 const url = 'URL_TO_SERVER_ENDPOINT';
@@ -125,7 +126,7 @@ function addTimeout(args) {
   let stringArgs = JSON.parse(dereferenceWithoutRenderer(args));
   argsDereferenced = stringArgs;
   argsDereferenced.forEach((attr) => {
-    argsCleaned.push(filterAttributes(JSON.parse(JSON.stringify(attr)), false));
+    argsCleaned.push(filterAttributes(deepClone(attr), false));
   });
   if (auctionEnd[eventType] == undefined) { auctionEnd[eventType] = [] }
   auctionEnd[eventType].push(argsCleaned);

--- a/modules/ozoneBidAdapter.js
+++ b/modules/ozoneBidAdapter.js
@@ -1,4 +1,5 @@
 import {
+  deepClone,
   logInfo,
   logError,
   deepAccess,
@@ -42,12 +43,12 @@ export const spec = {
   },
   loadWhitelabelData(bid) {
     if (this.propertyBag.whitelabel) { return; }
-    this.propertyBag.whitelabel = JSON.parse(JSON.stringify(this.whitelabel_defaults));
+    this.propertyBag.whitelabel = deepClone(this.whitelabel_defaults);
     let bidder = bid.bidder || 'ozone'; // eg. ozone
     this.propertyBag.whitelabel.logId = bidder.toUpperCase();
     this.propertyBag.whitelabel.bidder = bidder;
     let bidderConfig = config.getConfig(bidder) || {};
-    logInfo('got bidderConfig: ', JSON.parse(JSON.stringify(bidderConfig)));
+    logInfo('got bidderConfig: ', deepClone(bidderConfig));
     if (bidderConfig.kvpPrefix) {
       this.propertyBag.whitelabel.keyPrefix = bidderConfig.kvpPrefix;
     }
@@ -177,7 +178,7 @@ export const spec = {
     this.propertyBag.buildRequestsStart = new Date().getTime();
     let whitelabelBidder = this.propertyBag.whitelabel.bidder; // by default = ozone
     let whitelabelPrefix = this.propertyBag.whitelabel.keyPrefix;
-    logInfo(`buildRequests time: ${this.propertyBag.buildRequestsStart} v ${OZONEVERSION} validBidRequests`, JSON.parse(JSON.stringify(validBidRequests)), 'bidderRequest', JSON.parse(JSON.stringify(bidderRequest)));
+    logInfo(`buildRequests time: ${this.propertyBag.buildRequestsStart} v ${OZONEVERSION} validBidRequests`, deepClone(validBidRequests), 'bidderRequest', deepClone(bidderRequest));
     if (this.blockTheRequest()) {
       return [];
     }
@@ -403,7 +404,7 @@ export const spec = {
         data: JSON.stringify(ozoneRequest),
         bidderRequest: bidderRequest
       };
-      logInfo('buildRequests request data for single = ', JSON.parse(JSON.stringify(ozoneRequest)));
+      logInfo('buildRequests request data for single = ', deepClone(ozoneRequest));
       this.propertyBag.buildRequestsEnd = new Date().getTime();
       logInfo(`buildRequests going to return for single at time ${this.propertyBag.buildRequestsEnd} (took ${this.propertyBag.buildRequestsEnd - this.propertyBag.buildRequestsStart}ms): `, ret);
       return ret;
@@ -444,7 +445,7 @@ export const spec = {
     if (mediaTypesSizes.native) {
       ret.native = bidRequestRef.getFloor({mediaType: 'native', currency: 'USD', size: mediaTypesSizes.native});
     }
-    logInfo('getFloorObjectForAuction returning : ', JSON.parse(JSON.stringify(ret)));
+    logInfo('getFloorObjectForAuction returning : ', deepClone(ret));
     return ret;
   },
   interpretResponse(serverResponse, request) {
@@ -453,7 +454,7 @@ export const spec = {
     let whitelabelBidder = this.propertyBag.whitelabel.bidder; // by default = ozone
     let whitelabelPrefix = this.propertyBag.whitelabel.keyPrefix;
     logInfo(`interpretResponse time: ${startTime} . Time between buildRequests done and interpretResponse start was ${startTime - this.propertyBag.buildRequestsEnd}ms`);
-    logInfo(`serverResponse, request`, JSON.parse(JSON.stringify(serverResponse)), JSON.parse(JSON.stringify(request)));
+    logInfo(`serverResponse, request`, deepClone(serverResponse), deepClone(request));
     serverResponse = serverResponse.body || {};
     let aucId = serverResponse.id; // this will be correct for single requests and non-single
     if (!serverResponse.hasOwnProperty('seatbid')) {
@@ -573,7 +574,7 @@ export const spec = {
     }
     let endTime = new Date().getTime();
     logInfo(`interpretResponse going to return at time ${endTime} (took ${endTime - startTime}ms) Time from buildRequests Start -> interpretRequests End = ${endTime - this.propertyBag.buildRequestsStart}ms`);
-    logInfo('interpretResponse arrAllBids (serialised): ', JSON.parse(JSON.stringify(arrAllBids))); // this is ok to log because the renderer has not been attached yet
+    logInfo('interpretResponse arrAllBids (serialised): ', deepClone(arrAllBids)); // this is ok to log because the renderer has not been attached yet
     return arrAllBids;
   },
   setBidMediaTypeIfNotExist(thisBid, mediaType) {
@@ -1039,7 +1040,7 @@ function newRenderer(adUnitCode, rendererOptions = {}) {
 }
 function outstreamRender(bid) {
   logInfo('outstreamRender called. Going to push the call to window.ozoneVideo.outstreamRender(bid) bid = (first static, then reference)');
-  logInfo(JSON.parse(JSON.stringify(spec.getLoggableBidObject(bid))));
+  logInfo(deepClone(spec.getLoggableBidObject(bid)));
   bid.renderer.push(() => {
     logInfo('Going to execute window.ozoneVideo.outstreamRender');
     window.ozoneVideo.outstreamRender(bid);

--- a/modules/prebidmanagerAnalyticsAdapter.js
+++ b/modules/prebidmanagerAnalyticsAdapter.js
@@ -1,4 +1,4 @@
-import { generateUUID, getParameterByName, logError, parseUrl, logInfo } from '../src/utils.js';
+import { deepClone, generateUUID, getParameterByName, hasNonSerializableProperty, logError, parseUrl, logInfo } from '../src/utils.js';
 import {ajaxBuilder} from '../src/ajax.js';
 import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
 import adapterManager from '../src/adapterManager.js';
@@ -199,10 +199,10 @@ function trimBidderRequest(bidderRequest) {
 }
 
 function handleEvent(eventType, eventArgs) {
-  try {
-    eventArgs = eventArgs ? JSON.parse(JSON.stringify(eventArgs)) : {};
-  } catch (e) {
-    // keep eventArgs as is
+  if (eventArgs) {
+    eventArgs = hasNonSerializableProperty(eventArgs) ? eventArgs : deepClone(eventArgs)
+  } else {
+    eventArgs = {}
   }
 
   const pmEvent = {};

--- a/modules/sovrnAnalyticsAdapter.js
+++ b/modules/sovrnAnalyticsAdapter.js
@@ -1,4 +1,4 @@
-import {logError, timestamp} from '../src/utils.js';
+import {deepClone, logError, timestamp} from '../src/utils.js';
 import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
 import adaptermanager from '../src/adapterManager.js';
 import { EVENTS } from '../src/constants.js';
@@ -99,7 +99,7 @@ class BidWinner {
     // eslint-disable-next-line no-undef
     this.body.prebidVersion = $$REPO_AND_VERSION$$
     this.body.sovrnId = sovrnId
-    this.body.winningBid = JSON.parse(JSON.stringify(event))
+    this.body.winningBid = deepClone(event)
     this.body.url = rootURL
     this.body.payload = 'winner'
     delete this.body.winningBid.ad
@@ -156,7 +156,7 @@ class AuctionData {
    * @param {*} event - the args object from the auction event
    */
   bidRequested(event) {
-    const eventCopy = JSON.parse(JSON.stringify(event))
+    const eventCopy = deepClone(event)
     delete eventCopy.doneCbCallCount
     delete eventCopy.auctionId
     this.auction.requests.push(eventCopy)
@@ -170,13 +170,13 @@ class AuctionData {
   findBid(event) {
     const bidder = find(this.auction.requests, r => (r.bidderCode === event.bidderCode))
     if (!bidder) {
-      this.auction.unsynced.push(JSON.parse(JSON.stringify(event)))
+      this.auction.unsynced.push(deepClone(event))
     }
     let bid = find(bidder.bids, b => (b.bidId === event.requestId))
 
     if (!bid) {
       event.unmatched = true
-      bidder.bids.push(JSON.parse(JSON.stringify(event)))
+      bidder.bids.push(deepClone(event))
     }
     return bid
   }
@@ -190,7 +190,7 @@ class AuctionData {
   originalBid(event) {
     let bid = this.findBid(event)
     if (bid) {
-      Object.assign(bid, JSON.parse(JSON.stringify(event)))
+      Object.assign(bid, deepClone(event))
       this.dropBidFields.forEach((f) => delete bid[f])
     }
   }

--- a/modules/widespaceBidAdapter.js
+++ b/modules/widespaceBidAdapter.js
@@ -1,6 +1,6 @@
 import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
-import {parseQueryStringParameters, parseSizesInput} from '../src/utils.js';
+import {deepClone, parseQueryStringParameters, parseSizesInput} from '../src/utils.js';
 import {find, includes} from '../src/polyfill.js';
 import {getStorageManager} from '../src/storageManager.js';
 
@@ -212,7 +212,7 @@ function getLcuid() {
 }
 
 function encodedParamValue(value) {
-  const requiredStringify = typeof JSON.parse(JSON.stringify(value)) === 'object';
+  const requiredStringify = typeof deepClone(value) === 'object';
   return encodeURIComponent(requiredStringify ? JSON.stringify(value) : value);
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1150,3 +1150,42 @@ export function binarySearch(arr, el, key = (el) => el) {
   }
   return left;
 }
+
+/**
+ * Checks if an object has non-serializable properties.
+ * Non-serializable properties are functions and RegExp objects.
+ *
+ * @param {Object} obj - The object to check.
+ * @param {Set} checkedObjects - A set of properties that have already been checked.
+ * @returns {boolean} - Returns true if the object has non-serializable properties, false otherwise.
+ */
+export function hasNonSerializableProperty(obj, checkedObjects = new Set()) {
+  for (const key in obj) {
+    const value = obj[key];
+    const type = typeof value;
+
+    if (
+      value === undefined ||
+      type === 'function' ||
+      type === 'symbol' ||
+      value instanceof RegExp ||
+      value instanceof Map ||
+      value instanceof Set ||
+      value instanceof Date ||
+      (value !== null && type === 'object' && value.hasOwnProperty('toJSON'))
+    ) {
+      return true;
+    }
+    if (value !== null && type === 'object' && value.constructor === Object) {
+      if (checkedObjects.has(value)) {
+        // circular reference, means we have a non-serializable property
+        return true;
+      }
+      checkedObjects.add(value);
+      if (hasNonSerializableProperty(value, checkedObjects)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/test/helpers/index_adapter_utils.js
+++ b/test/helpers/index_adapter_utils.js
@@ -1,3 +1,5 @@
+import { deepClone } from '../../src/utils';
+
 var AllowedAdUnits = [[728, 90], [120, 600], [300, 250], [160, 600], [336, 280], [234, 60], [300, 600], [300, 50], [320, 50], [970, 250], [300, 1050], [970, 90], [180, 150]];
 var UnsupportedAdUnits = [[700, 100], [100, 600], [300, 200], [100, 600], [300, 200], [200, 60], [900, 200], [300, 1000], [900, 90], [100, 100]];
 
@@ -117,7 +119,7 @@ exports.getExpectedIndexSlots = function(bids) {
 }
 
 function clone(x) {
-  return JSON.parse(JSON.stringify(x));
+  return deepClone(x);
 }
 
 // returns the difference(lhs, rhs), difference(rhs,lhs), and intersection(lhs, rhs) based on the object keys

--- a/test/spec/modules/debugging_mod_spec.js
+++ b/test/spec/modules/debugging_mod_spec.js
@@ -37,7 +37,12 @@ describe('bid interceptor', () => {
   describe('serializeConfig', () => {
     Object.entries({
       regexes: /pat/,
-      functions: () => ({})
+      functions: () => ({}),
+      'undefined': undefined,
+      date: new Date(),
+      symbol: Symbol('test'),
+      map: new Map(),
+      set: new Set(),
     }).forEach(([test, arg]) => {
       it(`should filter out ${test}`, () => {
         const valid = [{key1: 'value'}, {key2: 'value'}];


### PR DESCRIPTION
## Type of change

- [x] Refactoring (no functional changes, no api changes)



## Description of change
This replaces all the `JSON.parse/stringify` instances with the faster `deepClone (klona)`.

`JSON.parse/stringify` comes with many caveats:
- it is slower than some other methods of doing deep cloning
- both `parse` and `stringifiy` can throw, and many places in code do not address this
- it has many implicit behaviors, like casting dates to strings, or removing properties that are empty

## Other information
Related: #11399, #11418 
