### PR TITLE
Setupad adapter: param change and minor fixes

### DIFF
--- a/modules/setupadBidAdapter.js
+++ b/modules/setupadBidAdapter.js
@@ -230,8 +230,6 @@ export const spec = {
 
     if (!placementIds) return;
 
-    let extraBidParams = '';
-
     // find the winning bidder by using creativeId as identification
     if (biddersCreativeIds.hasOwnProperty(bid.creativeId) && biddersCreativeIds[bid.creativeId]) {
       bidder = biddersCreativeIds[bid.creativeId];

--- a/modules/setupadBidAdapter.js
+++ b/modules/setupadBidAdapter.js
@@ -262,21 +262,15 @@ function getBidders(serverResponse) {
 }
 
 function getAd(bid) {
-  let ad, adUrl;
+  const { adm, nurl } = bid;
+  let ad = adm;
 
-  switch (deepAccess(bid, 'ext.prebid.type')) {
-    default:
-      if (bid.adm && bid.nurl) {
-        ad = bid.adm;
-        ad += createTrackPixelHtml(decodeURIComponent(bid.nurl));
-      } else if (bid.adm) {
-        ad = bid.adm;
-      } else if (bid.nurl) {
-        adUrl = bid.nurl;
-      }
+  if (nurl) {
+    const trackingPixel = createTrackPixelHtml(decodeURIComponent(nurl));
+    ad += trackingPixel;
   }
 
-  return { ad, adUrl };
+  return { ad };
 }
 
 registerBidder(spec);

--- a/modules/setupadBidAdapter.md
+++ b/modules/setupadBidAdapter.md
@@ -26,7 +26,7 @@ const adUnits = [
         bidder: 'setupad',
         params: {
           placement_id: '123', //required
-          account_id: '123', //optional
+          account_id: '123', //required
         },
       },
     ],

--- a/test/spec/modules/setupadBidAdapter_spec.js
+++ b/test/spec/modules/setupadBidAdapter_spec.js
@@ -92,11 +92,26 @@ describe('SetupadAdapter', function () {
       bidder: 'setupad',
       params: {
         placement_id: '123',
+        account_id: '123',
       },
     };
+
     it('should return true when required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
+
+    it('should return false when placement_id is missing', function () {
+      const bidWithoutPlacementId = { ...bid };
+      delete bidWithoutPlacementId.params.placement_id;
+      expect(spec.isBidRequestValid(bidWithoutPlacementId)).to.equal(false);
+    });
+
+    it('should return false when account_id is missing', function () {
+      const bidWithoutAccountId = { ...bid };
+      delete bidWithoutAccountId.params.account_id;
+      expect(spec.isBidRequestValid(bidWithoutAccountId)).to.equal(false);
+    });
+
     it('should return false when required params are not passed', function () {
       delete bid.params.placement_id;
       expect(spec.isBidRequestValid(bid)).to.equal(false);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Changed account_id param from optional to required, updated tests accordingly and made a minor bug fix related to URL encoding for REPORT_ENDPOINT. &currency and &timestamp params were encoded as "¤cy=" and "×tamp=" during bundling process.

## Other information
SETUPAD prebid.github.io PR: [prebid/prebid.github.io#5411](https://github.com/prebid/prebid.github.io/pull/5411)
