### PR TITLE
PBjs Core : expire stale bids directly from auction object to prevent long TTL bid

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -163,10 +163,16 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
   let _nonBids = [];
 
   function addBidRequests(bidderRequests) { _bidderRequests = _bidderRequests.concat(bidderRequests); }
-  function addBidReceived(bidsReceived) { _bidsReceived = _bidsReceived.concat(bidsReceived); }
+  function addBidReceived(bidResponse) { _bidsReceived = _bidsReceived.concat(bidResponse); purgeBidOnExpiration(bidResponse); }
   function addBidRejected(bidsRejected) { _bidsRejected = _bidsRejected.concat(bidsRejected); }
   function addNoBid(noBid) { _noBids = _noBids.concat(noBid); }
   function addNonBids(seatnonbids) { _nonBids = _nonBids.concat(seatnonbids); }
+
+  function purgeBidOnExpiration(bidResponse) {
+    setTimeout(() => {
+      _bidsReceived = _bidsReceived.filter(bid => bid.adId !== bidResponse.adId);
+    }, bidResponse.ttl * 1000);
+  }
 
   function getProperties() {
     return {


### PR DESCRIPTION
## Type of change

- [x ] Feature

## Description of change

By expiring bids after their TTL has elapsed directly in the auction object we prevent bids with long TTLs from hogging memory. At the moment when there is a long TTL bid in an auction, all the other bids are kept long after their expiry.

## Relevant Issue

https://github.com/prebid/Prebid.js/issues/11310