### PR TITLE
Adagio Rtd Provider: add placementSource param

### DIFF
--- a/modules/adagioRtdProvider.md
+++ b/modules/adagioRtdProvider.md
@@ -30,6 +30,7 @@ pbjs.setConfig({
       params: {
         organizationId: '1000' // Required. Provided by Adagio
         site: 'my-site' // Required. Provided by Adagio
+        placementSource: 'ortb' // Optional. Where to find the "placement" value. Possible values: 'ortb'<default> | 'code' | 'gpid'
       }
     }]
   }


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Updated RTD provider  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 

## Description of change
- Add a config param to define a source to programmatically set the value of `ortb2Imp.ext.data.placement` signal
- Remove the behavior that was to always fallback on the ad-unit code value, but only when reading the Adagio params in adUnits[].bids[]

## Other information
Updated doc: https://github.com/prebid/prebid.github.io/pull/5415