### PR TITLE
Prebid Server Bid Adapter : Support for custom headers for XHR call

### DIFF
--- a/modules/ceeIdSystem.js
+++ b/modules/ceeIdSystem.js
@@ -43,7 +43,7 @@ export const ceeIdSubmodule = {
    * performs action to obtain id and return a value
    * @function
    * @returns {(IdResponse|undefined)}
-  */
+   */
   getId(config) {
     const { params = {} } = config;
     const { tokenName, value } = params

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -550,6 +550,7 @@ export const processPBSRequest = hook('sync', function (s2sBidRequest, bidReques
   const requestJson = request && JSON.stringify(request);
   logInfo('BidRequest: ' + requestJson);
   const endpointUrl = getMatchingConsentUrl(s2sBidRequest.s2sConfig.endpoint, gdprConsent);
+  const customHeaders = deepAccess(s2sBidRequest, 's2sConfig.customHeaders', {});
   if (request && requestJson && endpointUrl) {
     const networkDone = s2sBidRequest.metrics.startTiming('net');
     ajax(
@@ -584,7 +585,8 @@ export const processPBSRequest = hook('sync', function (s2sBidRequest, bidReques
       {
         contentType: 'text/plain',
         withCredentials: true,
-        browsingTopics: isActivityAllowed(ACTIVITY_TRANSMIT_UFPD, s2sActivityParams(s2sBidRequest.s2sConfig))
+        browsingTopics: isActivityAllowed(ACTIVITY_TRANSMIT_UFPD, s2sActivityParams(s2sBidRequest.s2sConfig)),
+        customHeaders
       }
     );
   } else {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -825,6 +825,20 @@ describe('S2S Adapter', function () {
         })
       })
     })
+    
+    it('should set customHeaders correctly when publisher has provided it', () => {
+      let configWithCustomHeaders = utils.deepClone(CONFIG);
+      configWithCustomHeaders.customHeaders = { customHeader1: 'customHeader1Value' };
+      config.setConfig({ s2sConfig: configWithCustomHeaders });
+
+      let reqWithNewConfig = utils.deepClone(REQUEST);
+      reqWithNewConfig.s2sConfig = configWithCustomHeaders;
+
+      adapter.callBids(reqWithNewConfig, BID_REQUESTS, addBidResponse, done, ajax);
+      const reqHeaders = server.requests[0].requestHeaders
+      expect(reqHeaders.customHeader1).to.exist;
+      expect(reqHeaders.customHeader1).to.equal('customHeader1Value');
+    });
 
     it('should block request if config did not define p1Consent URL in endpoint object config', function () {
       let badConfig = utils.deepClone(CONFIG);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This PR introduces the capability to include custom headers in the XHR calls made to the Prebid Server bid adapter endpoint. By adding custom headers to the `s2sConfig` under the `customHeader` object, users can ensure that these headers are sent with the requests.

### Usage

```
// If only one server config is given

pbjs.setConfig({
  s2sConfig: {
    endpoint: 'https://prebid-server.example.com/bid',
    customHeader: {
      'Custom-Header': 'value'
    }
  }
});
```

```
// If multiple servers, then something like this

pbjs.setConfig({
    s2sConfig: [
        {
            name: "pbs-appnexus",
            customHeader: {
                'Authorization': 'Bearer token-appnexus',
                'Appnexus-Custom-Header': 'value-appnexus'
            }
        },
        {
            name: "pbs-rubicon",
            customHeader: {
                'Authorization': 'Bearer token-rubicon',
                'Rubicon-Custom-Header': 'value-rubicon'
            }
        },
    ],
});

```

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->

