### PR TITLE
Pubmatic bid adapter add ortb2 device

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -1285,6 +1285,11 @@ export const spec = {
       }
     }
 
+    // if present, merge device object from ortb2 into `payload.device`
+    if (bidderRequest?.ortb2?.device) {
+      mergeDeep(payload.device, bidderRequest.ortb2.device);
+    }
+
     if (commonFpd.ext?.prebid?.bidderparams?.[bidderRequest.bidderCode]?.acat) {
       const acatParams = commonFpd.ext.prebid.bidderparams[bidderRequest.bidderCode].acat;
       _allowedIabCategoriesValidation(payload, acatParams);

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -2378,6 +2378,40 @@ describe('PubMatic adapter', function () {
         expect(data.device.ext).to.deep.equal(cdepObj);
       });
 
+      it('should pass enriched device data from ortb2 object if present in bidderRequest fpd', function () {
+        const fpdBidderRequest = {
+          auctionId: 'new-auction-id',
+          ortb2: {
+            device: {
+              w: 980,
+              h: 1720,
+              dnt: 0,
+              ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1',
+              language: 'en',
+              devicetype: 1,
+              make: 'Apple',
+              model: 'iPhone 12 Pro Max',
+              os: 'iOS',
+              osv: '17.4',
+            }
+          },
+        };
+
+        const request = spec.buildRequests(multipleMediaRequests, fpdBidderRequest);
+        const data = JSON.parse(request.data);
+
+        expect(data.device.w).to.equal(fpdBidderRequest.ortb2.device.w);
+        expect(data.device.h).to.equal(fpdBidderRequest.ortb2.device.h);
+        expect(data.device.dnt).to.equal(fpdBidderRequest.ortb2.device.dnt);
+        expect(data.device.ua).to.equal(fpdBidderRequest.ortb2.device.ua);
+        expect(data.device.language).to.equal(fpdBidderRequest.ortb2.device.language);
+        expect(data.device.devicetype).to.equal(fpdBidderRequest.ortb2.device.devicetype);
+        expect(data.device.make).to.equal(fpdBidderRequest.ortb2.device.make);
+        expect(data.device.model).to.equal(fpdBidderRequest.ortb2.device.model);
+        expect(data.device.os).to.equal(fpdBidderRequest.ortb2.device.os);
+        expect(data.device.osv).to.equal(fpdBidderRequest.ortb2.device.osv);
+      });
+
       it('Request params should have valid native bid request for all valid params', function () {
         let request = spec.buildRequests(nativeBidRequests, {
           auctionId: 'new-auction-id'


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Updated bidder adapter

## Description of change
This PR enhances the Pubmatic bidder request by incorporating device data from the global ORTB2 object. Existing values in the Pubmatic device object will be overridden if they are also present in the global ORTB2 object. However, values unique to Pubmatic or not found in the global ORTB2 object will remain unchanged.

## Motivation
The device object has previously been populated by simplistic parsers, if at all, and was inaccurate as a result. Prebid now benefits from RTD modules such as [51Degrees](https://docs.prebid.org/dev-docs/modules/51DegreesRtdProvider.html) that enrich all the device object fields including Apple iPhone model category and device ID. The PR enables Pubmatic’s users to benefit from device object improvements.

## Other information
cc: @PubMatic-OpenWrap @pm-azhar-mulla @pm-priyanka-deshmane @pm-nitin-shirsat
