### PR TITLE
Sovrn bid adapter add ortb2 device

### DIFF
--- a/modules/sovrnBidAdapter.js
+++ b/modules/sovrnBidAdapter.js
@@ -6,7 +6,10 @@ import {
   logError,
   deepAccess,
   isInteger,
-  logWarn, getBidIdParameter, isEmptyStr
+  logWarn,
+  getBidIdParameter,
+  isEmptyStr,
+  mergeDeep
 } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js'
 import {
@@ -195,6 +198,12 @@ export const spec = {
       if (bidderRequest.gppConsent) {
         deepSetValue(sovrnBidReq, 'regs.gpp', bidderRequest.gppConsent.gppString);
         deepSetValue(sovrnBidReq, 'regs.gpp_sid', bidderRequest.gppConsent.applicableSections);
+      }
+
+      // if present, merge device object from ortb2 into `sovrnBidReq.device`
+      if (bidderRequest?.ortb2?.device) {
+        sovrnBidReq.device = sovrnBidReq.device || {};
+        mergeDeep(sovrnBidReq.device, bidderRequest.ortb2.device);
       }
 
       if (eids) {

--- a/test/spec/modules/sovrnBidAdapter_spec.js
+++ b/test/spec/modules/sovrnBidAdapter_spec.js
@@ -419,6 +419,31 @@ describe('sovrnBidAdapter', function() {
       expect(regs.gpp_sid).to.include(8)
     })
 
+    it('should add ORTB2 device data to the request', function () {
+      const bidderRequest = {
+        ...baseBidderRequest,
+        ortb2: {
+          device: {
+            w: 980,
+            h: 1720,
+            dnt: 0,
+            ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1',
+            language: 'en',
+            devicetype: 1,
+            make: 'Apple',
+            model: 'iPhone 12 Pro Max',
+            os: 'iOS',
+            osv: '17.4',
+          },
+        },
+      };
+
+      const request = spec.buildRequests([baseBidRequest], bidderRequest);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.device).to.deep.equal(bidderRequest.ortb2.device);
+    });
+
     it('should not send gpp info when gppConsent is not defined', function () {
       const bidderRequest = {
         ...baseBidderRequest,


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Updated bidder adapter

## Description of change
This PR enhances the Sovrn bidder request by incorporating device data from the global ORTB2 object. Existing values in the Sovrn device object will be overridden if they are also present in the global ORTB2 object. However, values unique to Sovrn or not found in the global ORTB2 object will remain unchanged.

## Motivation
The device object has previously been populated by simplistic parsers, if at all, and was inaccurate as a result. Prebid now benefits from RTD modules such as [51Degrees](https://docs.prebid.org/dev-docs/modules/51DegreesRtdProvider.html) that enrich all the device object fields including Apple iPhone model category and device ID. The PR enables Sovrn’s users to benefit from device object improvements.

## Other information
cc: @TWrightSovrn