### PR TITLE
Sharethrough bid adapter add ortb2 device

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -68,6 +68,11 @@ export const sharethroughAdapterSpec = {
       req.device.ext['cdep'] = bidderRequest.ortb2.device.ext.cdep;
     }
 
+    // if present, merge device object from ortb2 into `req.device`
+    if (bidderRequest?.ortb2?.device) {
+      mergeDeep(req.device, bidderRequest.ortb2.device);
+    }
+
     req.user = nullish(firstPartyData.user, {});
     if (!req.user.ext) req.user.ext = {};
     req.user.ext.eids = bidRequests[0].userIdAsEids || [];

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -346,6 +346,41 @@ describe('sharethrough adapter spec', function () {
 
           expect(openRtbReq.user.ext.eids).to.deep.equal([]);
         });
+
+        it('should add ORTB2 device data to the request', () => {
+          const bidderRequestWithOrtb2Device = {
+            ...bidderRequest,
+            ...{
+              ortb2: {
+                device: {
+                  w: 980,
+                  h: 1720,
+                  dnt: 0,
+                  ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1',
+                  language: 'en',
+                  devicetype: 1,
+                  make: 'Apple',
+                  model: 'iPhone 12 Pro Max',
+                  os: 'iOS',
+                  osv: '17.4',
+                },
+              },
+            },
+          };
+
+          const [request] = spec.buildRequests(bidRequests, bidderRequestWithOrtb2Device);
+
+          expect(request.data.device.w).to.equal(bidderRequestWithOrtb2Device.ortb2.device.w);
+          expect(request.data.device.h).to.equal(bidderRequestWithOrtb2Device.ortb2.device.h);
+          expect(request.data.device.dnt).to.equal(bidderRequestWithOrtb2Device.ortb2.device.dnt);
+          expect(request.data.device.ua).to.equal(bidderRequestWithOrtb2Device.ortb2.device.ua);
+          expect(request.data.device.language).to.equal(bidderRequestWithOrtb2Device.ortb2.device.language);
+          expect(request.data.device.devicetype).to.equal(bidderRequestWithOrtb2Device.ortb2.device.devicetype);
+          expect(request.data.device.make).to.equal(bidderRequestWithOrtb2Device.ortb2.device.make);
+          expect(request.data.device.model).to.equal(bidderRequestWithOrtb2Device.ortb2.device.model);
+          expect(request.data.device.os).to.equal(bidderRequestWithOrtb2Device.ortb2.device.os);
+          expect(request.data.device.osv).to.equal(bidderRequestWithOrtb2Device.ortb2.device.osv);
+        });
       });
 
       describe('no referer provided', () => {


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Updated bidder adapter

## Description of change
This PR enhances the Sharethrough bidder request by incorporating device data from the global ORTB2 object. Existing values in the Sharethrough device object will be overridden if they are also present in the global ORTB2 object. However, values unique to Sharethrough or not found in the global ORTB2 object will remain unchanged.

## Motivation
The device object has previously been populated by simplistic parsers, if at all, and was inaccurate as a result. Prebid now benefits from RTD modules such as [51Degrees](https://docs.prebid.org/dev-docs/modules/51DegreesRtdProvider.html) that enrich all the device object fields including Apple iPhone model category and device ID. The PR enables Sharethrough’s users to benefit from device object improvements.

## Other information
cc: @jefftmahoney