### PR TITLE
Freewheel ssp bid adapter add ortb2 device

### DIFF
--- a/modules/freewheel-sspBidAdapter.js
+++ b/modules/freewheel-sspBidAdapter.js
@@ -430,6 +430,32 @@ export const spec = {
         requestParams.loc = location;
       }
 
+      // Adds device data to the request,
+      // properties are only added if they are not null
+      const deviceData = bidderRequest?.ortb2?.device;
+      const deviceDataProperties = {
+        ortb2DeviceDevicetype: deviceData?.devicetype,
+        ortb2DeviceMake: deviceData?.make,
+        ortb2DeviceModel: deviceData?.model,
+        ortb2DeviceOs: deviceData?.os,
+        ortb2DeviceOsv: deviceData?.osv,
+        ortb2DeviceH: deviceData?.h,
+        ortb2DeviceW: deviceData?.w,
+        ortb2DevicePxratio: deviceData?.pxratio,
+        ortb2DevicePpi: deviceData?.ppi,
+        ortb2DeviceExtFiftyonedegreesDeviceId: deviceData?.ext?.fiftyonedegrees_deviceId,
+      };
+      const filteredDeviceDataProperties = Object
+        .keys(deviceDataProperties)
+        .reduce((r, key) => {
+          if (deviceDataProperties[key]) {
+            r[key] = deviceDataProperties[key];
+          }
+          return r;
+        }, {});
+
+      requestParams = {...requestParams, ...filteredDeviceDataProperties};
+
       var playerSize = [];
       if (currentBidRequest.mediaTypes.video && currentBidRequest.mediaTypes.video.playerSize) {
         // If mediaTypes is video, get size from mediaTypes.video.playerSize per http://prebid.org/blog/pbjs-3

--- a/test/spec/modules/freewheel-sspBidAdapter_spec.js
+++ b/test/spec/modules/freewheel-sspBidAdapter_spec.js
@@ -269,6 +269,36 @@ describe('freewheelSSP BidAdapter Test', () => {
         url: 'https://ads.stickyadstv.com/auto-user-sync?gpp=abc1234&gpp_sid[]=8'
       }]);
     });
+
+    it('should add ORTB2 device data to the request via bidderRequest.ortb2.device', function () {
+      const bidderRequest = {
+        ortb2: {
+          device: {
+            w: 980,
+            h: 1720,
+            dnt: 0,
+            ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1',
+            language: 'en',
+            devicetype: 1,
+            make: 'Apple',
+            model: 'iPhone 12 Pro Max',
+            os: 'iOS',
+            osv: '17.4',
+          }
+        },
+      };
+
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      const payload = request[0].data;
+
+      expect(payload.ortb2DeviceDevicetype).to.equal(bidderRequest.ortb2.device.devicetype);
+      expect(payload.ortb2DeviceMake).to.equal(bidderRequest.ortb2.device.make);
+      expect(payload.ortb2DeviceModel).to.equal(bidderRequest.ortb2.device.model);
+      expect(payload.ortb2DeviceOs).to.equal(bidderRequest.ortb2.device.os);
+      expect(payload.ortb2DeviceOsv).to.equal(bidderRequest.ortb2.device.osv);
+      expect(payload.ortb2DeviceH).to.equal(bidderRequest.ortb2.device.h);
+      expect(payload.ortb2DeviceW).to.equal(bidderRequest.ortb2.device.w);
+    });
   })
 
   describe('buildRequestsForVideo', () => {


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Updated bidder adapter

## Description of change
This PR enhances the FreeWheel bidder request by incorporating device data from the global ORTB2 object. Existing values in the FreeWheel device object will be overridden if they are also present in the global ORTB2 object. However, values unique to FreeWheel or not found in the global ORTB2 object will remain unchanged.

Parameters are added as GET query parameters, prefixed as `ortb2Device<deviceKeyName>`.

## Motivation
The device object has previously been populated by simplistic parsers, if at all, and was inaccurate as a result. Prebid now benefits from RTD modules such as [51Degrees](https://docs.prebid.org/dev-docs/modules/51DegreesRtdProvider.html) that enrich all the device object fields including Apple iPhone model category and device ID. The PR enables FreeWheelssp’s users to benefit from device object improvements.

## Other information
cc: @xwang202