### PR TITLE
Real Time Data Module: Mobian Brand Safety

### DIFF
--- a/modules/mobianRtdProvider.js
+++ b/modules/mobianRtdProvider.js
@@ -1,19 +1,19 @@
 import { submodule } from '../src/hook.js';
 import { ajaxBuilder } from '../src/ajax.js';
-
 export const MOBIAN_URL = 'http://impact-analytics-staging.themobian.com';
 
 export const mobianBrandSafetySubmodule = {
   name: 'mobianBrandSafety',
   gvlid: null,
   init: init,
-  getTargetingData: getTargetingData
+  getBidRequestData: getBidRequestData
 };
 
 function init() {
   return true;
 }
-function getTargetingData() {
+function getBidRequestData(bidReqConfig, callback, config) {
+  const { site: ortb2Site } = bidReqConfig.ortb2Fragments.global;
   const pageUrl = encodeURIComponent(getPageUrl());
   const requestUrl = `${MOBIAN_URL}?url=${pageUrl}`;
 
@@ -32,12 +32,11 @@ function getTargetingData() {
             break;
           }
         }
-
-        const targeting = {
+        const risk = {
           'mobianGarmRisk': mobianGarmRisk
         };
-
-        resolve(targeting);
+        resolve(risk);
+        ortb2Site.ext.data['mobian'] = risk
       },
       error: function () {
         resolve({});

--- a/modules/mobianRtdProvider.js
+++ b/modules/mobianRtdProvider.js
@@ -1,0 +1,53 @@
+import { submodule } from '../src/hook.js';
+import { ajaxBuilder } from '../src/ajax.js';
+
+export const MOBIAN_URL = 'http://impact-analytics-staging.themobian.com';
+
+export const mobianBrandSafetySubmodule = {
+  name: 'mobianBrandSafety',
+  gvlid: null,
+  init: init,
+  getTargetingData: getTargetingData
+};
+
+function init() {
+  return true;
+}
+function getTargetingData() {
+  const pageUrl = encodeURIComponent(getPageUrl());
+  const requestUrl = `${MOBIAN_URL}?url=${pageUrl}`;
+
+  const ajax = ajaxBuilder();
+
+  return new Promise((resolve) => {
+    ajax(requestUrl, {
+      success: function(response) {
+        const risks = ['garm_high_risk', 'garm_medium_risk', 'garm_low_risk', 'garm_no_risk'];
+        const riskLevels = ['high_risk', 'medium_risk', 'low_risk', 'no_risk'];
+
+        let mobianGarmRisk = 'unknown';
+        for (let i = 0; i < risks.length; i++) {
+          if (response[risks[i]]) {
+            mobianGarmRisk = riskLevels[i];
+            break;
+          }
+        }
+
+        const targeting = {
+          'mobianGarmRisk': mobianGarmRisk
+        };
+
+        resolve(targeting);
+      },
+      error: function () {
+        resolve({});
+      }
+    });
+  });
+}
+
+function getPageUrl() {
+  return window.location.href;
+}
+
+submodule('realTimeData', mobianBrandSafetySubmodule);

--- a/modules/mobianRtdProvider.md
+++ b/modules/mobianRtdProvider.md
@@ -1,0 +1,11 @@
+# Overview
+
+Module Name: Mobian Rtd Provider
+Module Type: Rtd Provider
+Maintainer: rich.rodriguez@themobian.com
+
+# Description
+
+RTD provider for themobian Brand Safety determinations. Publishers
+should use this to get Mobian's GARM Risk evaluations for
+a URL. 

--- a/test/spec/modules/mobianRtdProvider_spec.js
+++ b/test/spec/modules/mobianRtdProvider_spec.js
@@ -5,6 +5,21 @@ import * as ajax from 'src/ajax.js';
 
 describe('Mobian RTD Submodule', function () {
   let ajaxStub;
+  let bidReqConfig;
+
+  beforeEach(function () {
+    bidReqConfig = {
+      ortb2Fragments: {
+        global: {
+          site: {
+            ext: {
+              data: {}
+            }
+          }
+        }
+      }
+    };
+  });
 
   afterEach(function () {
     ajaxStub.restore();
@@ -20,13 +35,14 @@ describe('Mobian RTD Submodule', function () {
       });
     });
 
-    return mobianBrandSafetySubmodule.getTargetingData().then((targeting) => {
-      expect(targeting).to.have.property('mobianGarmRisk');
-      expect(targeting['mobianGarmRisk']).to.equal('no_risk');
+    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
+      expect(risk).to.have.property('mobianGarmRisk');
+      expect(risk['mobianGarmRisk']).to.equal('no_risk');
+      expect(bidReqConfig.ortb2Fragments.global.site.ext.data.mobian).to.deep.equal(risk);
     });
   });
 
-  it('should return low_risk when server responds with garm_low_risk', function () {
+  it('should return low_risk when server responds with garm_no_risk', function () {
     ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
       callbacks.success({
         garm_no_risk: false,
@@ -36,9 +52,10 @@ describe('Mobian RTD Submodule', function () {
       });
     });
 
-    return mobianBrandSafetySubmodule.getTargetingData().then((targeting) => {
-      expect(targeting).to.have.property('mobianGarmRisk');
-      expect(targeting['mobianGarmRisk']).to.equal('low_risk');
+    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
+      expect(risk).to.have.property('mobianGarmRisk');
+      expect(risk['mobianGarmRisk']).to.equal('low_risk');
+      expect(bidReqConfig.ortb2Fragments.global.site.ext.data.mobian).to.deep.equal(risk);
     });
   });
 
@@ -52,9 +69,10 @@ describe('Mobian RTD Submodule', function () {
       });
     });
 
-    return mobianBrandSafetySubmodule.getTargetingData().then((targeting) => {
-      expect(targeting).to.have.property('mobianGarmRisk');
-      expect(targeting['mobianGarmRisk']).to.equal('medium_risk');
+    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
+      expect(risk).to.have.property('mobianGarmRisk');
+      expect(risk['mobianGarmRisk']).to.equal('medium_risk');
+      expect(bidReqConfig.ortb2Fragments.global.site.ext.data.mobian).to.deep.equal(risk);
     });
   });
 
@@ -68,9 +86,10 @@ describe('Mobian RTD Submodule', function () {
       });
     });
 
-    return mobianBrandSafetySubmodule.getTargetingData().then((targeting) => {
-      expect(targeting).to.have.property('mobianGarmRisk');
-      expect(targeting['mobianGarmRisk']).to.equal('high_risk');
+    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
+      expect(risk).to.have.property('mobianGarmRisk');
+      expect(risk['mobianGarmRisk']).to.equal('high_risk');
+      expect(bidReqConfig.ortb2Fragments.global.site.ext.data.mobian).to.deep.equal(risk);
     });
   });
 
@@ -79,9 +98,10 @@ describe('Mobian RTD Submodule', function () {
       callbacks.success('unexpected output not even of the right type');
     });
 
-    return mobianBrandSafetySubmodule.getTargetingData().then((targeting) => {
-      expect(targeting).to.have.property('mobianGarmRisk');
-      expect(targeting['mobianGarmRisk']).to.equal('unknown');
+    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
+      expect(risk).to.have.property('mobianGarmRisk');
+      expect(risk['mobianGarmRisk']).to.equal('unknown');
+      expect(bidReqConfig.ortb2Fragments.global.site.ext.data.mobian).to.deep.equal(risk);
     });
   });
 });

--- a/test/spec/modules/mobianRtdProvider_spec.js
+++ b/test/spec/modules/mobianRtdProvider_spec.js
@@ -1,0 +1,87 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mobianBrandSafetySubmodule, MOBIAN_URL } from 'modules/mobianRtdProvider.js';
+import * as ajax from 'src/ajax.js';
+
+describe('Mobian RTD Submodule', function () {
+  let ajaxStub;
+
+  afterEach(function () {
+    ajaxStub.restore();
+  });
+
+  it('should return no_risk when server responds with garm_no_risk', function () {
+    ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
+      callbacks.success({
+        garm_no_risk: true,
+        garm_low_risk: false,
+        garm_medium_risk: false,
+        garm_high_risk: false
+      });
+    });
+
+    return mobianBrandSafetySubmodule.getTargetingData().then((targeting) => {
+      expect(targeting).to.have.property('mobianGarmRisk');
+      expect(targeting['mobianGarmRisk']).to.equal('no_risk');
+    });
+  });
+
+  it('should return low_risk when server responds with garm_low_risk', function () {
+    ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
+      callbacks.success({
+        garm_no_risk: false,
+        garm_low_risk: true,
+        garm_medium_risk: false,
+        garm_high_risk: false
+      });
+    });
+
+    return mobianBrandSafetySubmodule.getTargetingData().then((targeting) => {
+      expect(targeting).to.have.property('mobianGarmRisk');
+      expect(targeting['mobianGarmRisk']).to.equal('low_risk');
+    });
+  });
+
+  it('should return medium_risk when server responds with garm_medium_risk', function () {
+    ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
+      callbacks.success({
+        garm_no_risk: false,
+        garm_low_risk: false,
+        garm_medium_risk: true,
+        garm_high_risk: false
+      });
+    });
+
+    return mobianBrandSafetySubmodule.getTargetingData().then((targeting) => {
+      expect(targeting).to.have.property('mobianGarmRisk');
+      expect(targeting['mobianGarmRisk']).to.equal('medium_risk');
+    });
+  });
+
+  it('should return high_risk when server responds with garm_high_risk', function () {
+    ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
+      callbacks.success({
+        garm_no_risk: false,
+        garm_low_risk: false,
+        garm_medium_risk: false,
+        garm_high_risk: true
+      });
+    });
+
+    return mobianBrandSafetySubmodule.getTargetingData().then((targeting) => {
+      expect(targeting).to.have.property('mobianGarmRisk');
+      expect(targeting['mobianGarmRisk']).to.equal('high_risk');
+    });
+  });
+
+  it('should return unknown when server response is not of the expected shape', function () {
+    ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
+      callbacks.success('unexpected output not even of the right type');
+    });
+
+    return mobianBrandSafetySubmodule.getTargetingData().then((targeting) => {
+      expect(targeting).to.have.property('mobianGarmRisk');
+      expect(targeting['mobianGarmRisk']).to.equal('unknown');
+    });
+  });
+});


### PR DESCRIPTION
<!--

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
- [x ] Feature

## Description of change
This is a new RTD module which populates data from Mobian's brand safety API into the prebid environment for advertisers to use. There is a related documentation PR here: https://github.com/prebid/prebid.github.io/pull/5420