### PR TITLE
Smaato Bid Adapter : add DOOH support

### DIFF
--- a/modules/smaatoBidAdapter.js
+++ b/modules/smaatoBidAdapter.js
@@ -212,15 +212,19 @@ const converter = ortbConverter({
       return bidderRequest.gdprConsent && bidderRequest.gdprConsent.gdprApplies;
     }
 
+    function setPublisherId(node) {
+      deepSetValue(node, 'publisher.id', bidRequest.params.publisherId);
+    }
+
     const request = buildRequest(imps, bidderRequest, context);
     const bidRequest = context.bidRequests[0];
-    let siteContent;
+    let content;
     const mediaType = context.mediaType;
     if (mediaType === VIDEO) {
       const videoParams = bidRequest.mediaTypes[VIDEO];
       if (videoParams.context === ADPOD) {
         request.imp = createAdPodImp(request.imp[0], videoParams);
-        siteContent = addOptionalAdpodParameters(videoParams);
+        content = addOptionalAdpodParameters(videoParams);
       }
     }
 
@@ -242,19 +246,26 @@ const converter = ortbConverter({
 
     if (request.site) {
       request.site.id = window.location.hostname
-      if (siteContent) {
-        request.site.content = siteContent;
+      if (content) {
+        request.site.content = content;
       }
+      setPublisherId(request.site);
+    } else if (request.dooh) {
+      request.dooh.id = window.location.hostname
+      if (content) {
+        request.dooh.content = content;
+      }
+      setPublisherId(request.dooh);
     } else {
       request.site = {
         id: window.location.hostname,
         domain: bidderRequest.refererInfo.domain || window.location.hostname,
         page: bidderRequest.refererInfo.page || window.location.href,
         ref: bidderRequest.refererInfo.ref,
-        content: siteContent || null
+        content: content || null
       }
+      setPublisherId(request.site);
     }
-    deepSetValue(request.site, 'publisher.id', bidRequest.params.publisherId);
 
     if (request.regs) {
       if (isGdprApplicable()) {

--- a/test/spec/modules/smaatoBidAdapter_spec.js
+++ b/test/spec/modules/smaatoBidAdapter_spec.js
@@ -296,6 +296,33 @@ describe('smaatoBidAdapterTest', () => {
         expect(req.site.page).to.equal(page);
         expect(req.site.ref).to.equal(ref);
         expect(req.site.publisher.id).to.equal('publisherId');
+        expect(req.dooh).to.be.undefined;
+      })
+
+      it('sends correct dooh from ortb2', () => {
+        const name = 'name';
+        const domain = 'domain';
+        const keywords = 'keyword1,keyword2';
+        const venuetypetax = 1;
+        const ortb2 = {
+          dooh: {
+            name: name,
+            domain: domain,
+            keywords: keywords,
+            venuetypetax: venuetypetax
+          },
+        };
+
+        const reqs = spec.buildRequests([singleBannerBidRequest], {...defaultBidderRequest, ortb2});
+
+        const req = extractPayloadOfFirstAndOnlyRequest(reqs);
+        expect(req.dooh.id).to.exist.and.to.be.a('string');
+        expect(req.dooh.name).to.equal(name);
+        expect(req.dooh.domain).to.equal(domain);
+        expect(req.dooh.keywords).to.equal(keywords);
+        expect(req.dooh.venuetypetax).to.equal(venuetypetax);
+        expect(req.dooh.publisher.id).to.equal('publisherId');
+        expect(req.site).to.be.undefined;
       })
 
       it('sends correct device from ortb2', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Adding DOOH support for Smaato adapter
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
