### PR TITLE
ID5 UserId module - integrate with TrueLink Id

### DIFF
--- a/modules/id5IdSystem.md
+++ b/modules/id5IdSystem.md
@@ -37,7 +37,7 @@ pbjs.setConfig({
         type: 'html5',           // "html5" is the required storage type
         name: 'id5id',           // "id5id" is the required storage name
         expires: 90,             // storage lasts for 90 days
-        refreshInSeconds: 8*3600 // refresh ID every 8 hours to ensure it's fresh
+        refreshInSeconds: 7200   // refresh ID every 2 hours to ensure it's fresh
       }
     }],
     auctionDelay: 50             // 50ms maximum auction delay, applies to all userId modules
@@ -61,7 +61,7 @@ pbjs.setConfig({
 | storage.type | Required | String | This is where the results of the user ID will be stored. ID5 **requires** `"html5"`.                                                                                                                                                                                           | `"html5"` |
 | storage.name | Required | String | The name of the local storage where the user ID will be stored. ID5 **requires** `"id5id"`.                                                                                                                                                                                    | `"id5id"` |
 | storage.expires | Optional | Integer | How long (in days) the user ID information will be stored. ID5 recommends `90`.                                                                                                                                                                                                | `90` |
-| storage.refreshInSeconds | Optional | Integer | How many seconds until the ID5 ID will be refreshed. ID5 strongly recommends 8 hours between refreshes                                                                                                                                                                         | `8*3600` |
+| storage.refreshInSeconds | Optional | Integer | How many seconds until the ID5 ID will be refreshed. ID5 strongly recommends 2 hours between refreshes                                                                                                                                                                         | `7200` |
 
 **ATTENTION:** As of Prebid.js v4.14.0, ID5 requires `storage.type` to be `"html5"` and `storage.name` to be `"id5id"`. Using other values will display a warning today, but in an upcoming release, it will prevent the ID5 module from loading. This change is to ensure the ID5 module in Prebid.js interoperates properly with the [ID5 API](https://github.com/id5io/id5-api.js) and to reduce the size of publishers' first-party cookies that are sent to their web servers. If you have any questions, please reach out to us at [prebid@id5.io](mailto:prebid@id5.io).
 
@@ -125,7 +125,7 @@ The id from `uidapi.com` will be available if the partner that is used in ID5 us
 
 ### Providing TrueLinkId as a Google PPID
 
-TrueLinkId can be provided as a PPID - to use it the `true-link-id5-sync.com` needs to be provided as a ppid source in prebid userSync configuration:
+TrueLinkId can be provided as a PPID - to use, it the `true-link-id5-sync.com` needs to be provided as a ppid source in prebid userSync configuration:
 
 ```javascript
 pbjs.setConfig({

--- a/modules/id5IdSystem.md
+++ b/modules/id5IdSystem.md
@@ -73,3 +73,68 @@ To turn on A/B Testing, simply edit the configuration (see above table) to enabl
 
 ### A Note on Using Multiple Wrappers
 If you or your monetization partners are deploying multiple Prebid wrappers on your websites, you should make sure you add the ID5 ID User ID module to *every* wrapper. Only the bidders configured in the Prebid wrapper where the ID5 ID User ID module is installed and configured will be able to pick up the ID5 ID. Bidders from other Prebid instances will not be able to pick up the ID5 ID.
+
+### Provided eids
+The module provides following eids:
+
+```
+[
+  {
+    source: 'id5-sync.com',
+    uids: [
+      {
+        id: 'some-random-id-value',
+        atype: 1,
+        ext: {
+          linkType: 2,
+          abTestingControlGroup: false
+        }
+      }
+    ]
+  },
+  {
+    source: 'true-link-id5-sync.com',
+    uids: [
+      {
+        id: 'some-publisher-true-link-id',
+        atype: 1
+      }
+    ]
+  },
+  {
+    source: 'uidapi.com',
+    uids: [
+      {
+        id: 'some-uid2',
+        atype: 3,
+        ext: {
+          provider: 'id5-sync.com'
+        }
+      }
+    ]
+  }
+]
+```
+
+The id from `id5-sync.com` should be always present (though the id provided will be '0' in case of no consent or optout)
+
+The id from `true-link-id5-sync.com` will be available if the page is integrated with TrueLink (if you are an ID5 partner you can learn more at https://wiki.id5.io/en/identitycloud/retrieve-id5-ids/true-link-integration)
+
+The id from `uidapi.com` will be available if the partner that is used in ID5 user module has the EUID2 integration enabled (it has to be enabled on the ID5 side)
+
+
+### Providing TrueLinkId as a Google PPID
+
+TrueLinkId can be provided as a PPID - to use it the `true-link-id5-sync.com` needs to be provided as a ppid source in prebid userSync configuration:
+
+```javascript
+pbjs.setConfig({
+  userSync: {
+    ppid: 'true-link-id5-sync.com',
+    userIds: [],  //userIds modules should be configured here
+  }
+});
+```
+
+
+

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -26,6 +26,7 @@ describe('ID5 ID System', function () {
   const ID5_MODULE_NAME = 'id5Id';
   const ID5_EIDS_NAME = ID5_MODULE_NAME.toLowerCase();
   const ID5_SOURCE = 'id5-sync.com';
+  const TRUE_LINK_SOURCE = 'true-link-id5-sync.com';
   const ID5_TEST_PARTNER_ID = 173;
   const ID5_ENDPOINT = `https://id5-sync.com/g/v2/${ID5_TEST_PARTNER_ID}.json`;
   const ID5_API_CONFIG_URL = `https://id5-sync.com/api/config/prebid`;
@@ -48,10 +49,8 @@ describe('ID5 ID System', function () {
   const EUID_STORED_ID = 'EUID_1';
   const EUID_SOURCE = 'uidapi.com';
   const ID5_STORED_OBJ_WITH_EUID = {
-    'universal_uid': ID5_STORED_ID,
-    'signature': ID5_STORED_SIGNATURE,
+    ...ID5_STORED_OBJ,
     'ext': {
-      'linkType': ID5_STORED_LINK_TYPE,
       'euid': {
         'source': EUID_SOURCE,
         'uids': [{
@@ -60,6 +59,11 @@ describe('ID5 ID System', function () {
         }]
       }
     }
+  };
+  const TRUE_LINK_STORED_ID = 'TRUE_LINK_1';
+  const ID5_STORED_OBJ_WITH_TRUE_LINK = {
+    ...ID5_STORED_OBJ,
+    publisherTrueLinkId: TRUE_LINK_STORED_ID
   };
   const ID5_RESPONSE_ID = 'newid5id';
   const ID5_RESPONSE_SIGNATURE = 'abcdef';
@@ -146,6 +150,16 @@ describe('ID5 ID System', function () {
         resolve(response);
       });
     });
+  }
+
+  function wrapAsyncExpects(done, expectsFn) {
+    return function () {
+      try {
+        expectsFn();
+      } catch (err) {
+        done(err);
+      }
+    }
   }
 
   class XhrServerMock {
@@ -837,6 +851,38 @@ describe('ID5 ID System', function () {
         id5System.id5IdSubmodule.getId(getId5FetchConfig());
       });
     });
+
+    it('should pass true link info to ID5 server even when true link is not booted', function () {
+      let xhrServerMock = new XhrServerMock(server);
+      let submoduleResponse = callSubmoduleGetId(getId5FetchConfig(), undefined, ID5_STORED_OBJ);
+
+      return xhrServerMock.expectFetchRequest()
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(requestBody.true_link).is.deep.equal({booted: false});
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse;
+        });
+    });
+
+    it('should pass full true link info to ID5 server when true link is booted', function () {
+      let xhrServerMock = new XhrServerMock(server);
+      let trueLinkResponse = {booted: true, redirected: true, id: 'TRUE_LINK_ID'};
+      window.id5Bootstrap = {
+        getTrueLinkInfo: function () {
+          return trueLinkResponse;
+        }
+      };
+      let submoduleResponse = callSubmoduleGetId(getId5FetchConfig(), undefined, ID5_STORED_OBJ);
+
+      return xhrServerMock.expectFetchRequest()
+        .then(fetchRequest => {
+          let requestBody = JSON.parse(fetchRequest.requestBody);
+          expect(requestBody.true_link).is.deep.equal(trueLinkResponse);
+          fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
+          return submoduleResponse;
+        });
+    });
   });
 
   describe('Local storage', () => {
@@ -950,6 +996,31 @@ describe('ID5 ID System', function () {
       }, {adUnits});
     });
 
+    it('should add stored TRUE_LINK_ID from cache to bids', function (done) {
+      id5System.storeInLocalStorage(id5System.ID5_STORAGE_NAME, JSON.stringify(ID5_STORED_OBJ_WITH_TRUE_LINK), 1);
+
+      init(config);
+      setSubmoduleRegistry([id5System.id5IdSubmodule]);
+      config.setConfig(getFetchLocalStorageConfig());
+
+      requestBidsHook(wrapAsyncExpects(done, function () {
+        adUnits.forEach(unit => {
+          unit.bids.forEach(bid => {
+            expect(bid).to.have.deep.nested.property(`userId.trueLinkId`);
+            expect(bid.userId.trueLinkId.uid).is.equal(TRUE_LINK_STORED_ID);
+            expect(bid.userIdAsEids[1]).is.deep.equal({
+              source: TRUE_LINK_SOURCE,
+              uids: [{
+                id: TRUE_LINK_STORED_ID,
+                atype: 1,
+              }]
+            });
+          });
+        });
+        done();
+      }), {adUnits});
+    });
+
     it('should add config value ID to bids', function (done) {
       init(config);
       setSubmoduleRegistry([id5System.id5IdSubmodule]);
@@ -1054,6 +1125,11 @@ describe('ID5 ID System', function () {
         'source': EUID_SOURCE,
         'uid': EUID_STORED_ID,
         'ext': {'provider': ID5_SOURCE}
+      });
+    });
+    it('should decode trueLinkId from a stored object with trueLinkId', function () {
+      expect(id5System.id5IdSubmodule.decode(ID5_STORED_OBJ_WITH_TRUE_LINK, getId5FetchConfig()).trueLinkId).is.deep.equal({
+        'uid': TRUE_LINK_STORED_ID
       });
     });
   });


### PR DESCRIPTION
## Type of change
- [x] Feature

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
ID5 offers an option for publishers to integrate a TrueLink Id on the pages. If it's present on the page, we want to capture it and pass it to the server side. We also want to expose it as a EID so its later usable as a PPID
