### PR TITLE
orbidderBidAdapter.js: remove mediaType video to avoid broken requests

### DIFF
--- a/modules/orbidderBidAdapter.js
+++ b/modules/orbidderBidAdapter.js
@@ -93,6 +93,9 @@ export const spec = {
       if (bidderRequest && bidderRequest.refererInfo) {
         referer = bidderRequest.refererInfo.page || '';
       }
+      if (bidRequest?.mediaTypes?.video) {
+        delete bidderRequest.mediaTypes.video;
+      }
 
       bidRequest.params.bidfloor = getBidFloor(bidRequest);
 

--- a/modules/orbidderBidAdapter.js
+++ b/modules/orbidderBidAdapter.js
@@ -94,7 +94,7 @@ export const spec = {
         referer = bidderRequest.refererInfo.page || '';
       }
       if (bidRequest?.mediaTypes?.video) {
-        delete bidderRequest.mediaTypes.video;
+        delete bidRequest.mediaTypes.video;
       }
 
       bidRequest.params.bidfloor = getBidFloor(bidRequest);


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [ ] Updated bidder adapter

## Description of change
The bidder seems to not support multiType bidrequests containing video. It then always throws a 400.
Our contact told us, the bidder doesn't support video at all, so we updated the bidder to remove definitions for video on bidRequests.

## Other information
Recently changes to the bidder has been done by @arneschulz1984 and @hendrikiseke1979.
To ensure this change suits the bidder it would be great if one of those could do the review please
