### PR TITLE
Appnexus Bid Adapter: added stailamedia as an alias

### DIFF
--- a/libraries/appnexusUtils/anUtils.js
+++ b/libraries/appnexusUtils/anUtils.js
@@ -22,6 +22,7 @@ export const appnexusAliases = [
   { code: 'adasta', gvlid: 32 },
   { code: 'beintoo', gvlid: 618 },
   { code: 'projectagora', gvlid: 1032 },
+  { code: 'stailamedia', gvlid: 32 },
   { code: 'uol', gvlid: 32 },
   { code: 'adzymic', gvlid: 723 },
 ];


### PR DESCRIPTION
## Type of change
- [X] New bidder adapter

## Description of change

Adding stailamedia as bidder adapter alias for appnexus

- Tested in appnexus bidder
- Test parameters for validating bids
```
{
  bidder: "stailamedia",
  params: {
    "placementId": "33037108"
  }
}
```
- contact email of the adapter’s maintainer [prebid@stailamedia.com](mailto:prebid@stailamedia.com)
- official adapter submission

## Other information
- DOCS PR: https://github.com/prebid/prebid.github.io/pull/5448