### PR TITLE
yahooAdsBidAdapter.js: add gvl to alias

### DIFF
--- a/modules/yahooAdsBidAdapter.js
+++ b/modules/yahooAdsBidAdapter.js
@@ -9,8 +9,8 @@ const INTEGRATION_METHOD = 'prebid.js';
 const BIDDER_CODE = 'yahooAds';
 const GVLID = 25;
 const BIDDER_ALIASES = [
- { code: 'yahoossp', gvlid: 25 },
- { code: 'yahooAdvertising', gvlid: 25 }
+  { code: 'yahoossp', gvlid: 25 },
+  { code: 'yahooAdvertising', gvlid: 25 }
 ];
 const ADAPTER_VERSION = '1.1.0';
 const PREBID_VERSION = '$prebid.version$';

--- a/modules/yahooAdsBidAdapter.js
+++ b/modules/yahooAdsBidAdapter.js
@@ -9,8 +9,8 @@ const INTEGRATION_METHOD = 'prebid.js';
 const BIDDER_CODE = 'yahooAds';
 const GVLID = 25;
 const BIDDER_ALIASES = [
-  { code: 'yahoossp', gvlid: 25 },
-  { code: 'yahooAdvertising', gvlid: 25 }
+  { code: 'yahoossp', gvlid: GVLID },
+  { code: 'yahooAdvertising', gvlid: GVLID }
 ];
 const ADAPTER_VERSION = '1.1.0';
 const PREBID_VERSION = '$prebid.version$';

--- a/modules/yahooAdsBidAdapter.js
+++ b/modules/yahooAdsBidAdapter.js
@@ -9,8 +9,8 @@ const INTEGRATION_METHOD = 'prebid.js';
 const BIDDER_CODE = 'yahooAds';
 const GVLID = 25;
 const BIDDER_ALIASES = [
-    { code: 'yahoossp', gvlid: 25 },
-    { code: 'yahooAdvertising', gvlid: 25 }
+ { code: 'yahoossp', gvlid: 25 },
+ { code: 'yahooAdvertising', gvlid: 25 }
 ];
 const ADAPTER_VERSION = '1.1.0';
 const PREBID_VERSION = '$prebid.version$';

--- a/modules/yahooAdsBidAdapter.js
+++ b/modules/yahooAdsBidAdapter.js
@@ -7,8 +7,11 @@ import {hasPurpose1Consent} from '../src/utils/gpdr.js';
 
 const INTEGRATION_METHOD = 'prebid.js';
 const BIDDER_CODE = 'yahooAds';
-const BIDDER_ALIASES = ['yahoossp', 'yahooAdvertising']
 const GVLID = 25;
+const BIDDER_ALIASES = [
+    { code: 'yahoossp', gvlid: 25 },
+    { code: 'yahooAdvertising', gvlid: 25 }
+];
 const ADAPTER_VERSION = '1.1.0';
 const PREBID_VERSION = '$prebid.version$';
 const DEFAULT_BID_TTL = 300;

--- a/test/spec/modules/yahooAdsBidAdapter_spec.js
+++ b/test/spec/modules/yahooAdsBidAdapter_spec.js
@@ -193,7 +193,7 @@ describe('Yahoo Advertising Bid Adapter:', () => {
     });
 
     it('should define the correct bidder aliases', () => {
-      expect(spec.aliases).to.deep.equal(['yahoossp', 'yahooAdvertising']);
+      expect(spec.aliases).to.deep.equal([{ 'code': 'yahoossp', 'gvlid': 25 },{ 'code': 'yahooAdvertising', 'gvlid': 25 }]);
     });
 
     it('should define the correct vendor ID', () => {

--- a/test/spec/modules/yahooAdsBidAdapter_spec.js
+++ b/test/spec/modules/yahooAdsBidAdapter_spec.js
@@ -193,7 +193,7 @@ describe('Yahoo Advertising Bid Adapter:', () => {
     });
 
     it('should define the correct bidder aliases', () => {
-      expect(spec.aliases).to.deep.equal([{ 'code': 'yahoossp', 'gvlid': 25 },{ 'code': 'yahooAdvertising', 'gvlid': 25 }]);
+      expect(spec.aliases).to.deep.equal([{ 'code': 'yahoossp', 'gvlid': 25 }, { 'code': 'yahooAdvertising', 'gvlid': 25 }]);
     });
 
     it('should define the correct vendor ID', () => {


### PR DESCRIPTION
add gvlid for aliases

cc @slimkrazy 

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
