### PR TITLE
yandex ID: Use error-prone reference to crypto module

### DIFF
--- a/modules/yandexIdSystem.js
+++ b/modules/yandexIdSystem.js
@@ -128,7 +128,7 @@ class YandexUidGenerator {
   }
 
   _getRandomGenerator() {
-    if (crypto) {
+    if (window.crypto) {
       return () => {
         const buffer = new Uint32Array(1);
         crypto.getRandomValues(buffer);

--- a/test/spec/modules/yandexIdSystem_spec.js
+++ b/test/spec/modules/yandexIdSystem_spec.js
@@ -110,12 +110,17 @@ describe('YandexId module', () => {
 
     describe('crypto', () => {
       it('uses Math.random when crypto is not available', () => {
-        sandbox.stub(window, 'crypto').value(undefined);
+        const cryptoTmp = window.crypto;
+
+        // @ts-expect-error -- Crypto is always defined in modern JS. TS yells when trying to delete non-nullable property.
+        delete window.crypto;
 
         yandexIdSubmodule.getId(CORRECT_SUBMODULE_CONFIG);
 
         expect(randomStub.calledOnce).to.be.true;
         expect(getCryptoRandomValuesStub.called).to.be.false;
+
+        window.crypto = cryptoTmp;
       });
 
       it('uses crypto when it is available', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->

There was an implicit issue for browsers that do not have `crypto` available globally, we would get a `ReferenceError` when trying to reference `crypto` without `window.` prefix. I've updated the code and changed the tests to reflect the changes.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
