### PR TITLE
Adagio Rtd Provider: ensure fallback when adUnit.ortb2Imp is missing

### DIFF
--- a/test/spec/modules/adagioRtdProvider_spec.js
+++ b/test/spec/modules/adagioRtdProvider_spec.js
@@ -436,6 +436,18 @@ describe('Adagio Rtd Provider', function () {
         expect(bidRequest.adUnits[0]).to.have.property('ortb2Imp');
         expect(bidRequest.adUnits[0].ortb2Imp.ext.data.placement).to.not.exist;
       });
+
+      it('ensure we create the `ortb2Imp` object if it does not exist', function() {
+        const configCopy = utils.deepClone(config);
+        configCopy.params.placementSource = PLACEMENT_SOURCES.ADUNITCODE;
+
+        const bidRequest = utils.deepClone(bidReqConfig);
+        delete bidRequest.adUnits[0].ortb2Imp;
+
+        adagioRtdSubmodule.getBidRequestData(bidRequest, cb, configCopy);
+        expect(bidRequest.adUnits[0]).to.have.property('ortb2Imp');
+        expect(bidRequest.adUnits[0].ortb2Imp.ext.data.placement).to.equal('div-gpt-ad-1460505748561-0');
+      });
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Create the `adUnits[].ortb2Imp` property if it not exists when calling the getBidRequestData() callback.