### PR TITLE
Mobian RTD module: ensure object to modify exists

### DIFF
--- a/modules/mobianRtdProvider.js
+++ b/modules/mobianRtdProvider.js
@@ -1,10 +1,22 @@
+/**
+ * This module adds the Mobian RTD provider to the real time data module
+ * The {@link module:modules/realTimeData} module is required
+ * @module modules/anonymisedRtdProvider
+ * @requires module:modules/realTimeData
+ */
 import { submodule } from '../src/hook.js';
 import { ajaxBuilder } from '../src/ajax.js';
+import { deepSetValue } from '../src/utils.js';
+
+/**
+ * @typedef {import('../modules/rtdModule/index.js').RtdSubmodule} RtdSubmodule
+ */
+
 export const MOBIAN_URL = 'https://impact-api-prod.themobian.com/brand_safety';
 
+/** @type {RtdSubmodule} */
 export const mobianBrandSafetySubmodule = {
   name: 'mobianBrandSafety',
-  gvlid: null,
   init: init,
   getBidRequestData: getBidRequestData
 };
@@ -36,10 +48,12 @@ function getBidRequestData(bidReqConfig, callback, config) {
           'mobianGarmRisk': mobianGarmRisk
         };
         resolve(risk);
-        ortb2Site.ext.data['mobian'] = risk
+        deepSetValue(ortb2Site.ext, 'data.mobian', risk);
+        callback()
       },
       error: function () {
         resolve({});
+        callback()
       }
     });
   });

--- a/test/spec/modules/mobianRtdProvider_spec.js
+++ b/test/spec/modules/mobianRtdProvider_spec.js
@@ -12,9 +12,7 @@ describe('Mobian RTD Submodule', function () {
       ortb2Fragments: {
         global: {
           site: {
-            ext: {
-              data: {}
-            }
+            ext: {}
           }
         }
       }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x ] Bugfix

## Description of change
The Mobian RTD submodule modifies site.ext.data in the ortb2 object, but this may not exist. We now create that object when it doesn't otherwise exist. The unit test is changed to verify that the module behaves as expected even when the object doesn't exist. (Also added some type comments and removed an unnecessary instantiation, I can revert those if we are strict about the one-change-per PR policy!)
