### PR TITLE
MSPA Activity control support for api keys with v1 suffix

### DIFF
--- a/libraries/mspa/activityControls.js
+++ b/libraries/mspa/activityControls.js
@@ -112,9 +112,9 @@ function flatSection(subsections) {
 }
 
 function getApiSection(parsedSections, api) {
-    if (!parsedSections) return null;
-    const apiKey = Object.keys(parsedSections).find(key => key.startsWith(api));
-    return apiKey ? parsedSections[apiKey] : null;
+  if (!parsedSections) return null;
+  const apiKey = Object.keys(parsedSections).find(key => key.startsWith(api));
+  return apiKey ? parsedSections[apiKey] : null;
 }
 
 export function setupRules(api, sids, normalizeConsent = (c) => c, rules = CONSENT_RULES, registerRule = registerActivityControl, getConsentData = () => gppDataHandler.getConsentData()) {

--- a/test/spec/libraries/mspa/activityControls_spec.js
+++ b/test/spec/libraries/mspa/activityControls_spec.js
@@ -214,7 +214,10 @@ describe('setupRules', () => {
           {
             mock: 'consent'
           }
-        ]
+        ],
+        uscav1: {
+          mock: 'consent2'
+        }
       }
     };
   });
@@ -225,6 +228,12 @@ describe('setupRules', () => {
 
   it('should use flatten section data for the given api', () => {
     runSetup('mockApi', [1]);
+    expect(isAllowed('mockActivity', {})).to.equal(false);
+    sinon.assert.calledWith(rules.mockActivity, {mock: 'consent'})
+  });
+
+  it('should check consent starts with api key prefix', () => {
+    runSetup('usca', [1]);
     expect(isAllowed('mockActivity', {})).to.equal(false);
     sinon.assert.calledWith(rules.mockActivity, {mock: 'consent'})
   });
@@ -245,6 +254,14 @@ describe('setupRules', () => {
     runSetup('mockApi', [1], normalize);
     expect(isAllowed('mockActivity', {})).to.equal(false);
     sinon.assert.calledWith(normalize, {mock: 'consent'});
+    sinon.assert.calledWith(rules.mockActivity, {normalized: 'consent'});
+  });
+
+  it('should not choke when consent is already flattened', () => {
+    const normalize = sinon.stub().returns({normalized: 'consent'})
+    runSetup('usca', [1], normalize);
+    expect(isAllowed('mockActivity', {})).to.equal(false);
+    sinon.assert.calledWith(normalize, {mock: 'consent2'});
     sinon.assert.calledWith(rules.mockActivity, {normalized: 'consent'});
   });
 


### PR DESCRIPTION
The U.S. National Privacy section currently has a discrepancy between the documented client side API prefix and how it is implemented via the GPP stub file.

Some sites use "usca" api prefix while others use "uscav1".

### Sections Prefix table

| State | Number | Code | Description |
|-------|--------|------|-------------|
| California | 8 | usca/uscav1* | US - California section |
| Colorado | 10 | usco/uscov1* | US - Colorado section |
| Connecticut | 12 | usct/usctv1* | US - Connecticut section |
| Utah | 11 | usut/usutv1* | US - Utah section |
| Virginia | 9 | usva/usvav1* | US - Virginia section |
| All other U.S. states | 7 | usnat/usnatv1* | US - national section |


Noted [here ](https://www.uniconsent.com/docs/tutorials/iab-gpp), [here](https://support.cookieinformation.com/en/articles/9104991-setting-up-the-global-privacy-platform-framework-with-support-for-global-privacy-control), and [here](https://sourcepoint-public-api.readme.io/reference/california-privacy-section).

This can also be verified by running the following command to verify supported apis for gpp string.

```js
__gpp("ping", function (data, success) {
  console.log(data);
});
```

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
