### PR TITLE
permutiveRtd : transform integers to strings

### DIFF
--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -95,7 +95,8 @@ export function getModuleConfig(customModuleConfig) {
 /**
  * Sets ortb2 config for ac bidders
  * @param {Object} bidderOrtb2 - The ortb2 object for the all bidders
- * @param {Object} customModuleConfig - Publisher config for module
+ * @param {Object} moduleConfig - Publisher config for module
+ * @param {Object} segmentData - Segment data grouped by bidder or type
  */
 export function setBidderRtb (bidderOrtb2, moduleConfig, segmentData) {
   const acBidders = deepAccess(moduleConfig, 'params.acBidders')
@@ -129,7 +130,7 @@ export function setBidderRtb (bidderOrtb2, moduleConfig, segmentData) {
 
 /**
  * Updates `user.data` object in existing bidder config with Permutive segments
- * @param string bidder - The bidder
+ * @param {string} bidder - The bidder identifier
  * @param {Object} currConfig - Current bidder config
  * @param {Object[]} transformationConfigs - array of objects with `id` and `config` properties, used to determine
  *                                           the transformations on user data to include the ORTB2 object
@@ -442,7 +443,7 @@ function iabSegmentId(permutiveSegmentId, iabIds) {
  * Pull the latest configuration and cohort information and update accordingly.
  *
  * @param reqBidsConfigObj - Bidder provided config for request
- * @param customModuleConfig - Publisher provide config
+ * @param moduleConfig - Publisher provided config
  */
 export function readAndSetCohorts(reqBidsConfigObj, moduleConfig) {
   const segmentData = getSegments(deepAccess(moduleConfig, 'params.maxSegs'))

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -132,11 +132,11 @@ export function setBidderRtb (bidderOrtb2, moduleConfig, segmentData) {
  * Updates `user.data` object in existing bidder config with Permutive segments
  * @param {string} bidder - The bidder identifier
  * @param {Object} currConfig - Current bidder config
- * @param {Object[]} transformationConfigs - array of objects with `id` and `config` properties, used to determine
- *                                           the transformations on user data to include the ORTB2 object
  * @param {string[]} segmentIDs - Permutive segment IDs
  * @param {string[]} sspSegmentIDs - Permutive SSP segment IDs
  * @param {Object} topics - Privacy Sandbox Topics, keyed by IAB taxonomy version (600, 601, etc.)
+ * @param {Object[]} transformationConfigs - array of objects with `id` and `config` properties, used to determine
+ *                                           the transformations on user data to include the ORTB2 object
  * @param {Object} segmentData - The segments available for targeting
  * @return {Object} Merged ortb2 object
  */


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix


## Description of change

Segments were read from persistence and used _as is_. We now safely transform all values read to a string.

This was causing issues when exposing segments into ortb2 that expected the segment IDs to be of type `string` ([see open rtd spec section 3.2.21 and 3.2.22)](https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf).

Added tests to ensure that values read from persistence are parsed safely.


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
