### PR TITLE
Core: deferred rendering

### DIFF
--- a/libraries/dfpUtils/dfpUtils.js
+++ b/libraries/dfpUtils/dfpUtils.js
@@ -1,3 +1,5 @@
+import {gdprDataHandler} from '../../src/consentHandler.js';
+
 /** Safe defaults which work on pretty much all video calls. */
 export const DEFAULT_DFP_PARAMS = {
   env: 'vp',
@@ -12,9 +14,13 @@ export const DFP_ENDPOINT = {
   pathname: '/gampad/ads'
 }
 
-export const setGdprConsent = (gdprConsent, queryParams) => {
-  if (!gdprConsent) { return; }
-  if (typeof gdprConsent.gdprApplies === 'boolean') { queryParams.gdpr = Number(gdprConsent.gdprApplies); }
-  if (gdprConsent.consentString) { queryParams.gdpr_consent = gdprConsent.consentString; }
-  if (gdprConsent.addtlConsent) { queryParams.addtl_consent = gdprConsent.addtlConsent; }
+export function gdprParams() {
+  const gdprConsent = gdprDataHandler.getConsentData();
+  const params = {};
+  if (gdprConsent) {
+    if (typeof gdprConsent.gdprApplies === 'boolean') { params.gdpr = Number(gdprConsent.gdprApplies); }
+    if (gdprConsent.consentString) { params.gdpr_consent = gdprConsent.consentString; }
+    if (gdprConsent.addtlConsent) { params.addtl_consent = gdprConsent.addtlConsent; }
+  }
+  return params;
 }

--- a/modules/bidViewability.js
+++ b/modules/bidViewability.js
@@ -67,7 +67,6 @@ export let logWinningBidNotFound = (slot) => {
 
 export let impressionViewableHandler = (globalModuleConfig, slot, event) => {
   let respectiveBid = getMatchingWinningBidForGPTSlot(globalModuleConfig, slot);
-  let respectiveDeferredAdUnit = getGlobal().adUnits.find(adUnit => adUnit.deferBilling && respectiveBid.adUnitCode === adUnit.code);
 
   if (respectiveBid === null) {
     logWinningBidNotFound(slot);
@@ -77,8 +76,8 @@ export let impressionViewableHandler = (globalModuleConfig, slot, event) => {
     // trigger respective bidder's onBidViewable handler
     adapterManager.callBidViewableBidder(respectiveBid.adapterCode || respectiveBid.bidder, respectiveBid);
 
-    if (respectiveDeferredAdUnit) {
-      adapterManager.callBidBillableBidder(respectiveBid);
+    if (respectiveBid.deferBilling) {
+      adapterManager.triggerBilling(respectiveBid);
     }
 
     // emit the BID_VIEWABLE event with bid details, this event can be consumed by bidders and analytics pixels

--- a/modules/bidViewability.js
+++ b/modules/bidViewability.js
@@ -4,11 +4,12 @@
 
 import {config} from '../src/config.js';
 import * as events from '../src/events.js';
-import { EVENTS } from '../src/constants.js';
+import {EVENTS} from '../src/constants.js';
 import {isFn, logWarn, triggerPixel} from '../src/utils.js';
 import {getGlobal} from '../src/prebidGlobal.js';
-import adapterManager, {gdprDataHandler, uspDataHandler, gppDataHandler} from '../src/adapterManager.js';
+import adapterManager, {gppDataHandler, uspDataHandler} from '../src/adapterManager.js';
 import {find} from '../src/polyfill.js';
+import {gdprParams} from '../libraries/dfpUtils/dfpUtils.js';
 
 const MODULE_NAME = 'bidViewability';
 const CONFIG_ENABLED = 'enabled';
@@ -32,14 +33,7 @@ export let getMatchingWinningBidForGPTSlot = (globalModuleConfig, slot) => {
 
 export let fireViewabilityPixels = (globalModuleConfig, bid) => {
   if (globalModuleConfig[CONFIG_FIRE_PIXELS] === true && bid.hasOwnProperty(BID_VURL_ARRAY)) {
-    let queryParams = {};
-
-    const gdprConsent = gdprDataHandler.getConsentData();
-    if (gdprConsent) {
-      if (typeof gdprConsent.gdprApplies === 'boolean') { queryParams.gdpr = Number(gdprConsent.gdprApplies); }
-      if (gdprConsent.consentString) { queryParams.gdpr_consent = gdprConsent.consentString; }
-      if (gdprConsent.addtlConsent) { queryParams.addtl_consent = gdprConsent.addtlConsent; }
-    }
+    let queryParams = gdprParams();
 
     const uspConsent = uspDataHandler.getConsentData();
     if (uspConsent) { queryParams.us_privacy = uspConsent; }

--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -2,10 +2,8 @@
  * This module adds [DFP support]{@link https://www.doubleclickbygoogle.com/} for Video to Prebid.
  */
 
-import { DEFAULT_DFP_PARAMS, DFP_ENDPOINT, setGdprConsent } from '../libraries/dfpUtils/dfpUtils.js';
 import { getSignals } from '../libraries/gptUtils/gptUtils.js';
 import { registerVideoSupport } from '../src/adServerManager.js';
-import { gdprDataHandler } from '../src/adapterManager.js';
 import { getPPID } from '../src/adserver.js';
 import { auctionManager } from '../src/auctionManager.js';
 import { config } from '../src/config.js';
@@ -24,6 +22,7 @@ import {
   parseSizesInput,
   parseUrl
 } from '../src/utils.js';
+import {DEFAULT_DFP_PARAMS, DFP_ENDPOINT, gdprParams} from '../libraries/dfpUtils/dfpUtils.js';
 /**
  * @typedef {Object} DfpVideoParams
  *
@@ -108,13 +107,12 @@ export function buildDfpVideoUrl(options) {
     urlComponents.search,
     derivedParams,
     options.params,
-    { cust_params: encodedCustomParams }
+    { cust_params: encodedCustomParams },
+    gdprParams()
   );
 
   const descriptionUrl = getDescriptionUrl(bid, options, 'params');
   if (descriptionUrl) { queryParams.description_url = descriptionUrl; }
-  const gdprConsent = gdprDataHandler.getConsentData();
-  setGdprConsent(gdprConsent, queryParams);
 
   if (!queryParams.ppid) {
     const ppid = getPPID();

--- a/modules/dfpAdpod.js
+++ b/modules/dfpAdpod.js
@@ -1,8 +1,7 @@
 import {submodule} from '../src/hook.js';
 import {buildUrl, deepAccess, formatQS, logError, parseSizesInput} from '../src/utils.js';
 import {auctionManager} from '../src/auctionManager.js';
-import {DEFAULT_DFP_PARAMS, DFP_ENDPOINT, setGdprConsent} from '../libraries/dfpUtils/dfpUtils.js';
-import {gdprDataHandler} from '../src/consentHandler.js';
+import {DEFAULT_DFP_PARAMS, DFP_ENDPOINT, gdprParams} from '../libraries/dfpUtils/dfpUtils.js';
 import {registerVideoSupport} from '../src/adServerManager.js';
 
 export const adpodUtils = {};
@@ -75,11 +74,9 @@ export function buildAdpodVideoUrl({code, params, callback} = {}) {
       DEFAULT_DFP_PARAMS,
       derivedParams,
       params,
-      { cust_params: encodedCustomParams }
+      { cust_params: encodedCustomParams },
+      gdprParams(),
     );
-
-    const gdprConsent = gdprDataHandler.getConsentData();
-    setGdprConsent(gdprConsent, queryParams);
 
     const masterTag = buildUrl({
       ...DFP_ENDPOINT,

--- a/modules/prebidServerBidAdapter/ortbConverter.js
+++ b/modules/prebidServerBidAdapter/ortbConverter.js
@@ -122,7 +122,10 @@ const PBS_CONVERTER = ortbConverter({
         transactionId: context.adUnit.transactionId,
         adUnitId: context.adUnit.adUnitId,
         auctionId: context.bidderRequest.auctionId,
-      }), bidResponse),
+      }), bidResponse, {
+        deferRendering: !!context.adUnit.deferBilling,
+        deferBilling: !!context.adUnit.deferBilling
+      }),
       adUnit: context.adUnit.code
     };
   },

--- a/modules/topLevelPaapi.js
+++ b/modules/topLevelPaapi.js
@@ -96,7 +96,6 @@ export function getRenderingDataHook(next, bid, options) {
 
 export function markWinningBidHook(next, bid) {
   if (isPaapiBid(bid)) {
-    bid.status = BID_STATUS.RENDERED;
     emit(EVENTS.BID_WON, bid);
     next.bail();
   } else {

--- a/src/adRendering.js
+++ b/src/adRendering.js
@@ -19,6 +19,7 @@ import {hook} from './hook.js';
 import {fireNativeTrackers} from './native.js';
 import {GreedyPromise} from './utils/promise.js';
 import adapterManager from './adapterManager.js';
+import {useMetrics} from './utils/perfMetrics.js';
 
 const { AD_RENDER_FAILED, AD_RENDER_SUCCEEDED, STALE_RENDER, BID_WON } = EVENTS;
 const { EXCEPTION } = AD_RENDER_FAILED_REASON;
@@ -167,32 +168,70 @@ doRender.before(function (next, args) {
 }, 100)
 
 export function handleRender({renderFn, resizeFn, adId, options, bidResponse, doc}) {
-  if (bidResponse == null) {
-    emitAdRenderFail({
-      reason: AD_RENDER_FAILED_REASON.CANNOT_FIND_AD,
-      message: `Cannot find ad '${adId}'`,
-      id: adId
-    });
-    return;
-  }
-  if (bidResponse.status === BID_STATUS.RENDERED) {
-    logWarn(`Ad id ${adId} has been rendered before`);
-    events.emit(STALE_RENDER, bidResponse);
-    if (deepAccess(config.getConfig('auctionOptions'), 'suppressStaleRender')) {
+  deferRendering(bidResponse, () => {
+    if (bidResponse == null) {
+      emitAdRenderFail({
+        reason: AD_RENDER_FAILED_REASON.CANNOT_FIND_AD,
+        message: `Cannot find ad '${adId}'`,
+        id: adId
+      });
       return;
     }
+    if (bidResponse.status === BID_STATUS.RENDERED) {
+      logWarn(`Ad id ${adId} has been rendered before`);
+      events.emit(STALE_RENDER, bidResponse);
+      if (deepAccess(config.getConfig('auctionOptions'), 'suppressStaleRender')) {
+        return;
+      }
+    }
+    try {
+      doRender({renderFn, resizeFn, bidResponse, options, doc});
+    } catch (e) {
+      emitAdRenderFail({
+        reason: AD_RENDER_FAILED_REASON.EXCEPTION,
+        message: e.message,
+        id: adId,
+        bid: bidResponse
+      });
+    }
+  })
+}
+
+export function markBidAsRendered(bidResponse) {
+  const metrics = useMetrics(bidResponse.metrics);
+  metrics.checkpoint('bidRender');
+  metrics.timeBetween('bidWon', 'bidRender', 'render.deferred');
+  metrics.timeBetween('auctionEnd', 'bidRender', 'render.pending');
+  metrics.timeBetween('requestBids', 'bidRender', 'render.e2e');
+  bidResponse.status = BID_STATUS.RENDERED;
+}
+
+const DEFERRED_RENDER = new WeakMap();
+const WINNERS = new WeakSet();
+
+export function deferRendering(bidResponse, renderFn) {
+  if (bidResponse == null) {
+    // if the bid is missing, let renderFn deal with it now
+    renderFn();
+    return;
   }
-  try {
-    doRender({renderFn, resizeFn, bidResponse, options, doc});
-  } catch (e) {
-    emitAdRenderFail({
-      reason: AD_RENDER_FAILED_REASON.EXCEPTION,
-      message: e.message,
-      id: adId,
-      bid: bidResponse
-    });
+  DEFERRED_RENDER.set(bidResponse, renderFn);
+  if (!bidResponse.deferRendering) {
+    renderIfDeferred(bidResponse);
   }
-  markWinningBid(bidResponse);
+  if (!WINNERS.has(bidResponse)) {
+    WINNERS.add(bidResponse);
+    markWinningBid(bidResponse);
+  }
+}
+
+export function renderIfDeferred(bidResponse) {
+  const renderFn = DEFERRED_RENDER.get(bidResponse);
+  if (renderFn) {
+    renderFn();
+    markBidAsRendered(bidResponse);
+    DEFERRED_RENDER.delete(bidResponse);
+  }
 }
 
 export function renderAdDirect(doc, adId, options) {

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -134,6 +134,7 @@ function getBids({bidderCode, auctionId, bidderRequestId, adUnits, src, metrics}
           bidRequestsCount: getRequestsCounter(adUnit.code),
           bidderRequestsCount: getBidderRequestsCounter(adUnit.code, bid.bidder),
           bidderWinsCount: getBidderWinsCounter(adUnit.code, bid.bidder),
+          deferBilling: !!adUnit.deferBilling
         }));
         return bids;
       }, [])

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -10,6 +10,7 @@ import {
   getUniqueIdentifierStr,
   getUserConfiguredParams,
   groupBy,
+  internal,
   isArray,
   isPlainObject,
   isValidMediaTypes,
@@ -30,13 +31,15 @@ import {find, includes} from './polyfill.js';
 import {
   getBidderRequestsCounter,
   getBidderWinsCounter,
-  getRequestsCounter, incrementBidderRequestsCounter,
-  incrementBidderWinsCounter, incrementRequestsCounter
+  getRequestsCounter,
+  incrementBidderRequestsCounter,
+  incrementBidderWinsCounter,
+  incrementRequestsCounter
 } from './adUnits.js';
 import {getRefererInfo} from './refererDetection.js';
 import {GDPR_GVLIDS, gdprDataHandler, gppDataHandler, uspDataHandler, } from './consentHandler.js';
 import * as events from './events.js';
-import { EVENTS, S2S } from './constants.js';
+import {EVENTS, S2S} from './constants.js';
 import {useMetrics} from './utils/perfMetrics.js';
 import {auctionManager} from './auctionManager.js';
 import {MODULE_TYPE_ANALYTICS, MODULE_TYPE_BIDDER, MODULE_TYPE_PREBID} from './activities/modules.js';
@@ -643,7 +646,7 @@ function invokeBidderMethod(bidder, method, spec, fn, ...params) {
 }
 
 function tryCallBidderMethod(bidder, method, param) {
-  if (param?.src !== S2S.SRC) {
+  if (param?.source !== S2S.SRC) {
     const target = getBidderMethod(bidder, method);
     if (target != null) {
       invokeBidderMethod(bidder, method, ...target, param);
@@ -672,9 +675,18 @@ adapterManager.callBidWonBidder = function(bidder, bid, adUnits) {
   tryCallBidderMethod(bidder, 'onBidWon', bid);
 };
 
-adapterManager.callBidBillableBidder = function(bid) {
-  tryCallBidderMethod(bid.bidder, 'onBidBillable', bid);
-};
+adapterManager.triggerBilling = (() => {
+  const BILLED = new WeakSet();
+  return (bid) => {
+    if (!BILLED.has(bid)) {
+      BILLED.add(bid);
+      if (bid.source === S2S.SRC && bid.burl) {
+        internal.triggerPixel(bid.burl);
+      }
+      tryCallBidderMethod(bid.bidder, 'onBidBillable', bid);
+    }
+  }
+})();
 
 adapterManager.callSetTargetingBidder = function(bidder, bid) {
   tryCallBidderMethod(bidder, 'onSetTargeting', bid);

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -323,6 +323,8 @@ export function newBidder(spec) {
             bid.originalCpm = bid.cpm;
             bid.originalCurrency = bid.currency;
             bid.meta = bid.meta || Object.assign({}, bid[bidRequest.bidder]);
+            bid.deferBilling = bidRequest.deferBilling;
+            bid.deferRendering = bid.deferBilling && (bid.deferRendering ?? typeof spec.onBidBillable !== 'function');
             const prebidBid = Object.assign(createBid(STATUS.GOOD, bidRequest), bid, pick(bidRequest, TIDS));
             addBidWithCode(bidRequest.adUnitCode, prebidBid);
           } else {

--- a/src/auction.js
+++ b/src/auction.js
@@ -66,7 +66,6 @@
  */
 
 import {
-  callBurl,
   deepAccess,
   generateUUID,
   getValue,
@@ -370,11 +369,11 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
   }
 
   function addWinningBid(winningBid) {
-    const winningAd = adUnits.find(adUnit => adUnit.adUnitId === winningBid.adUnitId);
     _winningBids = _winningBids.concat(winningBid);
-    callBurl(winningBid);
     adapterManager.callBidWonBidder(winningBid.adapterCode || winningBid.bidder, winningBid, adUnits);
-    if (winningAd && !winningAd.deferBilling) adapterManager.callBidBillableBidder(winningBid);
+    if (!winningBid.deferBilling) {
+      adapterManager.triggerBilling(winningBid)
+    }
   }
 
   function setBidTargeting(bid) {

--- a/src/auctionManager.js
+++ b/src/auctionManager.js
@@ -73,11 +73,10 @@ export function newAuctionManager() {
   auctionManager.addWinningBid = function(bid) {
     const metrics = useMetrics(bid.metrics);
     metrics.checkpoint('bidWon');
-    metrics.timeBetween('auctionEnd', 'bidWon', 'render.pending');
-    metrics.timeBetween('requestBids', 'bidWon', 'render.e2e');
+    metrics.timeBetween('auctionEnd', 'bidWon', 'adserver.pending');
+    metrics.timeBetween('requestBids', 'bidWon', 'adserver.e2e');
     const auction = getAuction(bid.auctionId);
     if (auction) {
-      bid.status = BID_STATUS.RENDERED;
       auction.addWinningBid(bid);
     } else {
       logWarn(`Auction not found when adding winning bid`);

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -39,7 +39,7 @@ import {newMetrics, useMetrics} from './utils/perfMetrics.js';
 import {defer, GreedyPromise} from './utils/promise.js';
 import {enrichFPD} from './fpd/enrichment.js';
 import {allConsent} from './consentHandler.js';
-import {insertLocatorFrame, renderAdDirect} from './adRendering.js';
+import {insertLocatorFrame, markBidAsRendered, renderAdDirect} from './adRendering.js';
 import {getHighestCpm} from './utils/reducers.js';
 import {fillVideoDefaults, validateOrtbVideoFields} from './video.js';
 
@@ -894,6 +894,7 @@ if (FEATURES.VIDEO) {
     }
     if (bids.length > 0) {
       auctionManager.addWinningBid(bids[0]);
+      markBidAsRendered(bids[0])
     }
   }
 }

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -39,7 +39,7 @@ import {newMetrics, useMetrics} from './utils/perfMetrics.js';
 import {defer, GreedyPromise} from './utils/promise.js';
 import {enrichFPD} from './fpd/enrichment.js';
 import {allConsent} from './consentHandler.js';
-import {insertLocatorFrame, markBidAsRendered, renderAdDirect} from './adRendering.js';
+import {insertLocatorFrame, markBidAsRendered, renderAdDirect, renderIfDeferred} from './adRendering.js';
 import {getHighestCpm} from './utils/reducers.js';
 import {fillVideoDefaults, validateOrtbVideoFields} from './video.js';
 
@@ -983,7 +983,10 @@ pbjsInstance.processQueue = function () {
 pbjsInstance.triggerBilling = ({adId, adUnitCode}) => {
   auctionManager.getAllWinningBids()
     .filter((bid) => bid.adId === adId || (adId == null && bid.adUnitCode === adUnitCode))
-    .forEach((bid) => adapterManager.triggerBilling(bid));
+    .forEach((bid) => {
+      adapterManager.triggerBilling(bid);
+      renderIfDeferred(bid);
+    });
 };
 
 export default pbjsInstance;

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -7,7 +7,7 @@ import {getAllAssetsMessage, getAssetMessage} from './native.js';
 import {BID_STATUS, MESSAGES} from './constants.js';
 import {isApnGetTagDefined, isGptPubadsDefined, logError, logWarn} from './utils.js';
 import {find, includes} from './polyfill.js';
-import {getBidToRender, handleCreativeEvent, handleNativeMessage, handleRender, markWinningBid} from './adRendering.js';
+import {deferRendering, getBidToRender, handleCreativeEvent, handleNativeMessage, handleRender} from './adRendering.js';
 import {getCreativeRendererSource} from './creativeRenderers.js';
 
 const { REQUEST, RESPONSE, NATIVE, EVENT } = MESSAGES;
@@ -103,16 +103,12 @@ function handleNativeRequest(reply, data, adObject) {
     return;
   }
 
-  if (adObject.status !== BID_STATUS.RENDERED) {
-    markWinningBid(adObject);
-  }
-
   switch (data.action) {
     case 'assetRequest':
-      reply(getAssetMessage(data, adObject));
+      deferRendering(adObject, () => reply(getAssetMessage(data, adObject)));
       break;
     case 'allAssetRequest':
-      reply(getAllAssetsMessage(data, adObject));
+      deferRendering(adObject, () => reply(getAllAssetsMessage(data, adObject)));
       break;
     default:
       handleNativeMessage(data, adObject, {resizeFn: getResizer(adObject)})

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 import {config} from './config.js';
 import {klona} from 'klona/json';
 import {includes} from './polyfill.js';
-import { EVENTS, S2S } from './constants.js';
+import {EVENTS} from './constants.js';
 import {GreedyPromise} from './utils/promise.js';
 import {getGlobal} from './prebidGlobal.js';
 import { default as deepAccess } from 'dlv/index.js';
@@ -472,12 +472,6 @@ export function triggerPixel(url, done, timeout) {
     waitForElementToLoad(img, timeout).then(done);
   }
   img.src = url;
-}
-
-export function callBurl({ source, burl }) {
-  if (source === S2S.SRC && burl) {
-    internal.triggerPixel(burl);
-  }
 }
 
 /**

--- a/test/spec/modules/bidViewability_spec.js
+++ b/test/spec/modules/bidViewability_spec.js
@@ -245,7 +245,7 @@ describe('#bidViewability', function() {
     let logWinningBidNotFoundSpy;
     let callBidViewableBidderSpy;
     let winningBidsArray;
-    let callBidBillableBidderSpy;
+    let triggerBillingSpy;
     let adUnits = [
       {
         'code': 'abc123',
@@ -262,7 +262,7 @@ describe('#bidViewability', function() {
       triggerPixelSpy = sandbox.spy(utils, ['triggerPixel']);
       eventsEmitSpy = sandbox.spy(events, ['emit']);
       callBidViewableBidderSpy = sandbox.spy(adapterManager, ['callBidViewableBidder']);
-      callBidBillableBidderSpy = sandbox.spy(adapterManager, ['callBidBillableBidder']);
+      triggerBillingSpy = sandbox.spy(adapterManager, ['triggerBilling']);
       // mocking winningBidsArray
       winningBidsArray = [];
       sandbox.stub(prebidGlobal, 'getGlobal').returns({
@@ -307,22 +307,16 @@ describe('#bidViewability', function() {
       expect(eventsEmitSpy.callCount).to.equal(0);
     });
 
-    it('should call the callBidBillableBidder function if the viewable bid is associated with an ad unit with deferBilling set to true', function() {
+    it('should call the triggerBilling function if the viewable bid has deferBilling set to true', function() {
       let moduleConfig = {};
-      const deferredBillingAdUnit = {
-        'code': '/harshad/Jan/2021/',
-        'deferBilling': true,
-        'bids': [
-          {
-            'bidder': 'pubmatic'
-          }
-        ]
-      };
-      adUnits.push(deferredBillingAdUnit);
-      winningBidsArray.push(PBJS_WINNING_BID);
+      const bid = {
+        ...PBJS_WINNING_BID,
+        deferBilling: true
+      }
+      winningBidsArray.push(bid);
       bidViewability.impressionViewableHandler(moduleConfig, GPT_SLOT, null);
-      expect(callBidBillableBidderSpy.callCount).to.equal(1);
-      sinon.assert.calledWith(callBidBillableBidderSpy, PBJS_WINNING_BID);
+      expect(triggerBillingSpy.callCount).to.equal(1);
+      sinon.assert.calledWith(triggerBillingSpy, bid);
     });
   });
 });

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -3475,6 +3475,18 @@ describe('S2S Adapter', function () {
       expect(response).to.have.property('adapterCode', 'appnexus2');
     });
 
+    it('should set deferBilling and deferRendering to true when request has deferBilling = true', () => {
+      config.setConfig({ CONFIG });
+      const req = deepClone(REQUEST);
+      req.ad_units.forEach(au => au.deferBilling = true);
+      adapter.callBids(req, BID_REQUESTS, addBidResponse, done, ajax);
+      server.requests[0].respond(200, {}, JSON.stringify(RESPONSE_OPENRTB));
+      sinon.assert.match(addBidResponse.firstCall.args[1], {
+        deferBilling: true,
+        deferRendering: true
+      });
+    });
+
     describe('on sync requested with no cookie', () => {
       let cfg, req, csRes;
 

--- a/test/spec/modules/topLevelPaapi_spec.js
+++ b/test/spec/modules/topLevelPaapi_spec.js
@@ -489,7 +489,6 @@ describe('topLevelPaapi', () => {
         markWinningBidHook(next, bid);
         sinon.assert.notCalled(next);
         sinon.assert.called(next.bail);
-        expect(bid.status).to.eql(BID_STATUS.RENDERED);
         sinon.assert.calledWith(events.emit, EVENTS.BID_WON, bid);
       });
       it('ignores non-paapi bids', () => {

--- a/test/spec/unit/adRendering_spec.js
+++ b/test/spec/unit/adRendering_spec.js
@@ -2,7 +2,7 @@ import * as events from 'src/events.js';
 import * as utils from 'src/utils.js';
 import {
   deferRendering,
-  doRender, 
+  doRender,
   getBidToRender,
   emitAdRenderSucceeded,
   getRenderingData,

--- a/test/spec/unit/adRendering_spec.js
+++ b/test/spec/unit/adRendering_spec.js
@@ -1,11 +1,14 @@
 import * as events from 'src/events.js';
 import * as utils from 'src/utils.js';
 import {
-  doRender, emitAdRenderSucceeded, getBidToRender,
+  deferRendering,
+  doRender, 
+  getBidToRender,
+  emitAdRenderSucceeded,
   getRenderingData,
   handleCreativeEvent,
   handleNativeMessage,
-  handleRender
+  handleRender, markWinningBid, renderIfDeferred
 } from '../../../src/adRendering.js';
 import { AD_RENDER_FAILED_REASON, BID_STATUS, EVENTS } from 'src/constants.js';
 import {expect} from 'chai/index.mjs';
@@ -164,6 +167,91 @@ describe('adRendering', () => {
       })
     });
 
+    describe('deferRendering', () => {
+      let fn, markWin;
+      function markWinHook(next, bidResponse) {
+        markWin(bidResponse);
+      }
+      before(() => {
+        markWinningBid.before(markWinHook);
+      })
+      after(() => {
+        markWinningBid.getHooks({hook: markWinHook}).remove();
+      })
+      beforeEach(() => {
+        fn = sinon.stub();
+        markWin = sinon.stub();
+      });
+
+      [null, undefined].forEach((bidResponse) => {
+        it(`should run fn immediately if bidResponse is ${bidResponse}`, () => {
+          deferRendering(bidResponse, fn);
+          sinon.assert.called(fn);
+        });
+      });
+
+      [undefined, false].forEach(defer => {
+        describe(`when bid has deferRendering = ${defer}`, () => {
+          if (defer != null) {
+            beforeEach(() => { bidResponse.deferRendering = defer })
+          }
+          it('should run fn and mark bid as rendered', () => {
+            deferRendering(bidResponse, fn);
+            sinon.assert.called(fn);
+            expect(bidResponse.status).to.equal(BID_STATUS.RENDERED);
+          });
+        });
+      });
+
+      describe('when bid is marked for deferred rendering', () => {
+        beforeEach(() => {
+          bidResponse.deferRendering = true;
+        });
+        it('should not run fn and not mark bid as rendered', () => {
+          deferRendering(bidResponse, fn);
+          sinon.assert.notCalled(fn);
+          expect(bidResponse.status).to.not.equal(BID_STATUS.RENDERED);
+        });
+
+        it('should render on subsequent call to renderIfDeferred', () => {
+          deferRendering(bidResponse, fn);
+          renderIfDeferred(bidResponse);
+          sinon.assert.called(fn);
+          expect(bidResponse.status).to.eql(BID_STATUS.RENDERED);
+        });
+
+        it('should not render again if renderIfDeferred is called multiple times', () => {
+          deferRendering(bidResponse, fn);
+          renderIfDeferred(bidResponse);
+          renderIfDeferred(bidResponse);
+          sinon.assert.calledOnce(fn);
+        });
+      });
+
+      it('should run fn if bid is not marked for deferral', () => {
+        deferRendering(bidResponse, fn);
+      });
+      [true, false].forEach(defer => {
+        it(`should mark bid as winning (deferRendering = ${defer})`, () => {
+          bidResponse.deferRendering = defer;
+          deferRendering(bidResponse, fn);
+          sinon.assert.calledWith(markWin, bidResponse);
+        });
+
+        it('should not mark a winner twice', () => {
+          bidResponse.deferRendering = defer;
+          deferRendering(bidResponse, fn);
+          deferRendering(bidResponse, fn);
+          sinon.assert.calledOnce(markWin);
+        })
+      })
+    });
+    describe('renderIfDeferred', () => {
+      it('should not choke on unmarked bids', () => {
+        renderIfDeferred(bidResponse);
+        expect(bidResponse.status).to.not.equal(BID_STATUS.RENDERED);
+      })
+    });
     describe('handleRender', () => {
       let doRenderStub
       function doRenderHook(next, ...args) {
@@ -210,12 +298,6 @@ describe('adRendering', () => {
           sinon.assert.notCalled(doRenderStub);
         })
       });
-
-      it('should mark bid as won and emit BID_WON', () => {
-        handleRender({renderFn, bidResponse});
-        sinon.assert.calledWith(events.emit, EVENTS.BID_WON, bidResponse);
-        sinon.assert.calledWith(auctionManager.addWinningBid, bidResponse);
-      })
     })
   })
 

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1736,6 +1736,14 @@ describe('adapterManager tests', function () {
       expect(sizes1).not.to.deep.equal(sizes2);
     });
 
+    it('should transfer deferBilling from ad unit', () => {
+      adUnits[0].deferBilling = true;
+      const requests = makeBidRequests();
+      requests.flatMap(req => req.bids).forEach(bidRequest => {
+        expect(bidRequest.deferBilling).to.equal(bidRequest.adUnitCode === adUnits[0].code);
+      })
+    })
+
     it('should set and increment bidRequestsCounter', () => {
       const [au1, au2] = adUnits;
       makeBidRequests([au1, au2]).flatMap(br => br.bids).forEach(bid => {

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -639,48 +639,103 @@ describe('bidderFactory', () => {
         expect(doneStub.calledOnce).to.equal(true);
       });
 
-      it('should only add bids for valid adUnit code into the auction, even if the bidder doesn\'t bid on all of them', function () {
-        const bidder = newBidder(spec);
+      describe('when interpretResponse returns a bid', () => {
+        let bid, bidderRequest;
+        beforeEach(() => {
+          bid = {
+            creativeId: 'creative-id',
+            requestId: '1',
+            ad: 'ad-url.com',
+            cpm: 0.5,
+            height: 200,
+            width: 300,
+            adUnitCode: 'mock/placement',
+            currency: 'USD',
+            netRevenue: true,
+            ttl: 300,
+            bidderCode: 'sampleBidder',
+            sampleBidder: {advertiserId: '12345', networkId: '111222'}
+          }
+          bidderRequest = utils.deepClone(MOCK_BIDS_REQUEST);
+          bidderRequest.bids[0].bidder = 'sampleBidder';
+        })
 
-        const bid = {
-          creativeId: 'creative-id',
-          requestId: '1',
-          ad: 'ad-url.com',
-          cpm: 0.5,
-          height: 200,
-          width: 300,
-          adUnitCode: 'mock/placement',
-          currency: 'USD',
-          netRevenue: true,
-          ttl: 300,
-          bidderCode: 'sampleBidder',
-          sampleBidder: {advertiserId: '12345', networkId: '111222'}
-        };
-        const bidderRequest = Object.assign({}, MOCK_BIDS_REQUEST);
-        bidderRequest.bids[0].bidder = 'sampleBidder';
-        spec.isBidRequestValid.returns(true);
-        spec.buildRequests.returns({
-          method: 'POST',
-          url: 'test.url.com',
-          data: {}
+        function getAuctionBid() {
+          const bidder = newBidder(spec);
+          spec.isBidRequestValid.returns(true);
+          spec.buildRequests.returns({
+            method: 'POST',
+            url: 'test.url.com',
+            data: {}
+          });
+          spec.getUserSyncs.returns([]);
+          spec.interpretResponse.returns(bid);
+          bidder.callBids(bidderRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
+          return addBidResponseStub.firstCall.args[1];
+        }
+
+        function setDeferredBilling(deferredBilling = true) {
+          bidderRequest.bids.forEach(bid => { bid.deferBilling = deferredBilling });
+        }
+
+        it('should only add bids for valid adUnit code into the auction, even if the bidder doesn\'t bid on all of them', function () {
+          const auctionBid = getAuctionBid();
+          expect(addBidResponseStub.calledOnce).to.equal(true);
+          expect(addBidResponseStub.firstCall.args[0]).to.equal('mock/placement');
+          // checking the fields added by our code
+          expect(auctionBid.originalCpm).to.equal(bid.cpm);
+          expect(auctionBid.originalCurrency).to.equal(bid.currency);
+          expect(doneStub.calledOnce).to.equal(true);
+          expect(logErrorSpy.callCount).to.equal(0);
+          expect(auctionBid.meta).to.exist;
+          expect(auctionBid.meta).to.deep.equal({advertiserId: '12345', networkId: '111222'});
         });
-        spec.getUserSyncs.returns([]);
 
-        spec.interpretResponse.returns(bid);
+        describe('if request has deferBilling = true', () => {
+          beforeEach(() => setDeferredBilling(true));
 
-        bidder.callBids(bidderRequest, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);
+          it('should set response.deferBilling = true, regardless of what the adapter says', () => {
+            bid.deferBilling = false;
+            expect(getAuctionBid().deferBilling).to.be.true;
+          });
+          [
+            {
+              shouldDefer: true
+            },
+            {
+              deferRendering: false,
+              shouldDefer: false
+            },
+            {
+              onBidBillable: true,
+              shouldDefer: false,
+            },
+            {
+              onBidBillable: true,
+              deferRendering: true,
+              shouldDefer: true
+            }
+          ].forEach(({onBidBillable, deferRendering, shouldDefer}) => {
+            it(`sets response deferRendering = ${shouldDefer} when adapter ${onBidBillable ? 'supports' : 'does not support'} onBidBillable, and sayd deferRender = ${deferRendering}`, () => {
+              if (onBidBillable) {
+                spec.onBidBillable = sinon.stub();
+              }
+              bid.deferRendering = deferRendering;
+              expect(getAuctionBid().deferRendering).to.equal(shouldDefer);
+            });
+          })
+        });
 
-        expect(addBidResponseStub.calledOnce).to.equal(true);
-        expect(addBidResponseStub.firstCall.args[0]).to.equal('mock/placement');
-        let bidObject = addBidResponseStub.firstCall.args[1];
-        // checking the fields added by our code
-        expect(bidObject.originalCpm).to.equal(bid.cpm);
-        expect(bidObject.originalCurrency).to.equal(bid.currency);
-        expect(doneStub.calledOnce).to.equal(true);
-        expect(logErrorSpy.callCount).to.equal(0);
-        expect(bidObject.meta).to.exist;
-        expect(bidObject.meta).to.deep.equal({advertiserId: '12345', networkId: '111222'});
-      });
+        describe('if request has deferBilling = false', () => {
+          beforeEach(() => setDeferredBilling(false));
+          [true, false].forEach(deferredRender => {
+            it(`should set deferRendering = false when adapter says deferRendering = ${deferredRender}`, () => {
+              bid.deferRendering = deferredRender;
+              expect(getAuctionBid().deferRendering).to.be.false;
+            });
+          });
+        });
+      })
 
       it('should call spec.getUserSyncs() with the response', function () {
         const bidder = newBidder(spec);

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1413,18 +1413,14 @@ describe('Unit: Prebid Module', function () {
         spyAddWinningBid.resetHistory();
         onWonEvent.resetHistory();
         onStaleEvent.resetHistory();
-
-        // Second render should have a warning but still added to winning bids
+        doc.write.resetHistory();
         return renderAd(doc, bidId);
       }).then(() => {
+        // Second render should have a warning but still be rendered
         sinon.assert.calledWith(spyLogMessage, message);
         sinon.assert.calledWith(spyLogWarn, warning);
-
-        sinon.assert.calledOnce(spyAddWinningBid);
-        sinon.assert.calledWith(spyAddWinningBid, adResponse);
-
-        sinon.assert.calledWith(onWonEvent, adResponse);
         sinon.assert.calledWith(onStaleEvent, adResponse);
+        sinon.assert.called(doc.write);
 
         // Clean up
         $$PREBID_GLOBAL$$.offEvent(EVENTS.BID_WON, onWonEvent);

--- a/test/spec/unit/secureCreatives_spec.js
+++ b/test/spec/unit/secureCreatives_spec.js
@@ -209,11 +209,8 @@ describe('secureCreatives', () => {
           return receive(ev);
         }).then(() => {
           sinon.assert.calledWith(spyLogWarn, warning);
-          sinon.assert.calledOnce(spyAddWinningBid);
-          sinon.assert.calledWith(spyAddWinningBid, adResponse);
           sinon.assert.calledOnce(adResponse.renderer.render);
           sinon.assert.calledWith(adResponse.renderer.render, adResponse);
-          sinon.assert.calledWith(stubEmit, EVENTS.BID_WON, adResponse);
           sinon.assert.calledWith(stubEmit, EVENTS.STALE_RENDER, adResponse);
         });
       });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

This introduces the ability to defer rendering of bids until their billing is explicitly triggered through `pbjs.triggerBilling`. This is to allow "pre-rendering" (in formats like interstitial) of bids that fire billing pixels when rendered.

* update the `pbjs.triggerBilling` API to accept ad units in addition to specific bids (e.g. `triggerBilling({adUnitCode: '...'})` will trigger whichever bids won for that ad unit)
* bids on ad units that have `deferBilling: true`, but whose bid adapter does not define a billing method (`onBidBillable`), are marked for deferred rendering.
* when either a remote creative or a call to `pbjs.renderAd` attempts to render such a bid, it is marked as winning (`BID_WON` is emitted, it's added to `pbjs.getAllWinningBids()`, etc), but it is not actually rendered.
* the actual rendering only happens when `pbjs.triggerBilling` is called.

## Other information

Closes https://github.com/prebid/Prebid.js/issues/10594
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
