### PR TITLE
Reduce log spamming

### DIFF
--- a/modules/utiqIdSystem.js
+++ b/modules/utiqIdSystem.js
@@ -27,11 +27,6 @@ function getUtiqFromStorage() {
   let utiqPassStorage = JSON.parse(
     storage.getDataFromLocalStorage('utiqPass')
   );
-  logInfo(
-    `${LOG_PREFIX}: Local storage utiqPass: ${JSON.stringify(
-      utiqPassStorage
-    )}`
-  );
 
   if (
     utiqPassStorage &&
@@ -40,12 +35,19 @@ function getUtiqFromStorage() {
     utiqPassStorage.connectId.idGraph.length > 0
   ) {
     utiqPass = utiqPassStorage.connectId.idGraph[0];
+
+    logInfo(
+      `${LOG_PREFIX}: Local storage utiqPass: ${JSON.stringify(
+        utiqPassStorage
+      )}`
+    );
+
+    logInfo(
+      `${LOG_PREFIX}: Graph of utiqPass: ${JSON.stringify(
+        utiqPass
+      )}`
+    );
   }
-  logInfo(
-    `${LOG_PREFIX}: Graph of utiqPass: ${JSON.stringify(
-      utiqPass
-    )}`
-  );
 
   return {
     utiq:


### PR DESCRIPTION
The utiq module uses busy waiting to provide the `eid` values. Every busy waiting round it logs messages that are not actionable.

## Type of change

- [x] Refactoring (no functional changes, no api changes)

## Description of change

The utiq module uses busy waiting to provide the `eid` values. Every busy waiting round it logs messages that are not actionable.

## Other information

FYI @jkthomas 
