### PR TITLE
Core: Add Session Storage Manager & Contxtful RTD Provider: use session storage

### DIFF
--- a/modules/contxtfulRtdProvider.js
+++ b/modules/contxtfulRtdProvider.js
@@ -39,7 +39,6 @@ function getRxEngineReceptivity(requester) {
 }
 
 function getItemFromSessionStorage(key) {
-
   let value = null;
   try {
     // Use the Storage Manager
@@ -48,11 +47,9 @@ function getItemFromSessionStorage(key) {
   }
 
   return value;
-
 }
 
 function loadSessionReceptivity(requester) {
-
   let sessionStorageValue = getItemFromSessionStorage(requester);
   if (!sessionStorageValue) {
     return null;
@@ -71,7 +68,6 @@ function loadSessionReceptivity(requester) {
   } catch {
     return null;
   }
-
 }
 
 /**

--- a/modules/contxtfulRtdProvider.js
+++ b/modules/contxtfulRtdProvider.js
@@ -18,13 +18,17 @@ import {
 } from '../src/utils.js';
 import { loadExternalScript } from '../src/adloader.js';
 import { getStorageManager } from '../src/storageManager.js';
+import { MODULE_TYPE_RTD } from '../src/activities/modules.js';
 
 const MODULE_NAME = 'contxtful';
 const MODULE = `${MODULE_NAME}RtdProvider`;
 
 const CONTXTFUL_RECEPTIVITY_DOMAIN = 'api.receptivity.io';
 
-const storageManager = getStorageManager({ bidderCode: MODULE_NAME });
+const storageManager = getStorageManager({
+  moduleType: MODULE_TYPE_RTD,
+  moduleName: MODULE_NAME
+});
 
 let rxApi = null;
 let isFirstBidRequestCall = true;

--- a/modules/contxtfulRtdProvider.js
+++ b/modules/contxtfulRtdProvider.js
@@ -17,11 +17,14 @@ import {
   isArray,
 } from '../src/utils.js';
 import { loadExternalScript } from '../src/adloader.js';
+import { getStorageManager } from '../src/storageManager.js';
 
 const MODULE_NAME = 'contxtful';
 const MODULE = `${MODULE_NAME}RtdProvider`;
 
 const CONTXTFUL_RECEPTIVITY_DOMAIN = 'api.receptivity.io';
+
+const storageManager = getStorageManager({ bidderCode: MODULE_NAME });
 
 let rxApi = null;
 let isFirstBidRequestCall = true;
@@ -35,10 +38,22 @@ function getRxEngineReceptivity(requester) {
   return rxApi?.receptivity(requester);
 }
 
+function getItemFromSessionStorage(key) {
+
+  let value = null;
+  try {
+    // Use the Storage Manager
+    value = storageManager.getDataFromSessionStorage(key, null);
+  } catch (error) {
+  }
+
+  return value;
+
+}
+
 function loadSessionReceptivity(requester) {
-  // TODO: commented out because of rule violations
-  /*
-  let sessionStorageValue = sessionStorage.getItem(requester);
+
+  let sessionStorageValue = getItemFromSessionStorage(requester);
   if (!sessionStorageValue) {
     return null;
   }
@@ -56,7 +71,7 @@ function loadSessionReceptivity(requester) {
   } catch {
     return null;
   }
-   */
+
 }
 
 /**

--- a/modules/contxtfulRtdProvider.md
+++ b/modules/contxtfulRtdProvider.md
@@ -59,10 +59,31 @@ pbjs.setConfig({
           "adServerTargeting": true, // Optional, default: true
         }
       }
-    ]
+    ],
+    userSync: {
+    userIds: [
+      {
+        name: "contxtful",
+        storage: {
+          type: "html5",
+        },
+      },
+    ],
+  },
   }
 });
 ```
+
+The Contxtful RTD Module uses browser session storage. The access to it must be explicitly set as such:
+```js
+// https://docs.prebid.org/dev-docs/publisher-api-reference/bidderSettings.html
+pbjs.bidderSettings = {
+  contxtful: {
+    storageAllowed: true
+  }
+}
+```
+
 ## Parameters
 
 | Name                | Type     | Scope    | Description                                |

--- a/modules/contxtfulRtdProvider.md
+++ b/modules/contxtfulRtdProvider.md
@@ -61,21 +61,22 @@ pbjs.setConfig({
       }
     ],
     userSync: {
-    userIds: [
-      {
-        name: "contxtful",
-        storage: {
-          type: "html5",
+      userIds: [
+        {
+          name: "contxtful",
+          storage: {
+            type: "html5",
+          },
         },
-      },
-    ],
-  },
+      ],
+    },
   }
 });
 ```
 
 The Contxtful RTD Module uses browser session storage. The access to it must be explicitly set as such:
-```js
+
+```javascript
 // https://docs.prebid.org/dev-docs/publisher-api-reference/bidderSettings.html
 pbjs.bidderSettings = {
   contxtful: {

--- a/modules/contxtfulRtdProvider.md
+++ b/modules/contxtfulRtdProvider.md
@@ -59,31 +59,12 @@ pbjs.setConfig({
           "adServerTargeting": true, // Optional, default: true
         }
       }
-    ],
-    userSync: {
-      userIds: [
-        {
-          name: "contxtful",
-          storage: {
-            type: "html5",
-          },
-        },
-      ],
-    },
+    ]
   }
 });
 ```
 
-The Contxtful RTD Module uses browser session storage. The access to it must be explicitly set as such:
-
-```javascript
-// https://docs.prebid.org/dev-docs/publisher-api-reference/bidderSettings.html
-pbjs.bidderSettings = {
-  contxtful: {
-    storageAllowed: true
-  }
-}
-```
+The Contxtful RTD Module uses browser session storage. The access to storage must be set at the bidder level as documented in [pbjs.bidderSettings](https://docs.prebid.org/dev-docs/publisher-api-reference/bidderSettings.html).
 
 ## Parameters
 

--- a/modules/contxtfulRtdProvider.md
+++ b/modules/contxtfulRtdProvider.md
@@ -64,8 +64,6 @@ pbjs.setConfig({
 });
 ```
 
-The Contxtful RTD Module uses browser session storage. The access to storage must be set at the bidder level as documented in [pbjs.bidderSettings](https://docs.prebid.org/dev-docs/publisher-api-reference/bidderSettings.html).
-
 ## Parameters
 
 | Name                | Type     | Scope    | Description                                |

--- a/src/storageManager.js
+++ b/src/storageManager.js
@@ -179,6 +179,83 @@ export function newStorageManager({moduleName, moduleType} = {}, {isAllowed = is
   }
 
   /**
+   * @returns {boolean}
+   */
+  const sessionStorageIsEnabled = function (done) {
+    let cb = function (result) {
+      if (result && result.valid) {
+        try {
+          sessionStorage.setItem('prebid.cookieTest', '1');
+          return sessionStorage.getItem('prebid.cookieTest') === '1';
+        } catch (error) {
+        } finally {
+          try {
+            sessionStorage.removeItem('prebid.cookieTest');
+          } catch (error) {}
+        }
+      }
+      return false;
+    }
+    return schedule(cb, STORAGE_TYPE_LOCALSTORAGE, done);
+  }
+
+  /**
+   * @param {string} key
+   * @param {string} value
+   */
+  const setDataInSessionStorage = function (key, value, done) {
+    let cb = function (result) {
+      if (result && result.valid && hasSessionStorage()) {
+        window.sessionStorage.setItem(key, value);
+      }
+    }
+    return schedule(cb, STORAGE_TYPE_LOCALSTORAGE, done);
+  }
+
+  /**
+   * @param {string} key
+   * @returns {(string|null)}
+   */
+  const getDataFromSessionStorage = function (key, done) {
+    let cb = function (result) {
+      if (result && result.valid && hasSessionStorage()) {
+        return window.sessionStorage.getItem(key);
+      }
+      return null;
+    }
+    return schedule(cb, STORAGE_TYPE_LOCALSTORAGE, done);
+  }
+
+  /**
+   * @param {string} key
+   */
+  const removeDataFromSessionStorage = function (key, done) {
+    let cb = function (result) {
+      if (result && result.valid && hasSessionStorage()) {
+        window.sessionStorage.removeItem(key);
+      }
+    }
+    return schedule(cb, STORAGE_TYPE_LOCALSTORAGE, done);
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  const hasSessionStorage = function (done) {
+    let cb = function (result) {
+      if (result && result.valid) {
+        try {
+          return !!window.sessionStorage;
+        } catch (e) {
+          logError('Session storage api disabled');
+        }
+      }
+      return false;
+    }
+    return schedule(cb, STORAGE_TYPE_LOCALSTORAGE, done);
+  }
+
+  /**
    * Returns all cookie values from the jar whose names contain the `keyLike`
    * Needs to exist in `utils.js` as it follows the StorageHandler interface defined in live-connect-js. If that module were to be removed, this function can go as well.
    * @param {string} keyLike
@@ -217,6 +294,11 @@ export function newStorageManager({moduleName, moduleType} = {}, {isAllowed = is
     getDataFromLocalStorage,
     removeDataFromLocalStorage,
     hasLocalStorage,
+    sessionStorageIsEnabled,
+    setDataInSessionStorage,
+    getDataFromSessionStorage,
+    removeDataFromSessionStorage,
+    hasSessionStorage,
     findSimilarCookies
   }
 }

--- a/test/spec/unit/core/storageManager_spec.js
+++ b/test/spec/unit/core/storageManager_spec.js
@@ -137,7 +137,6 @@ describe('storage manager', function() {
       expect(val).to.be.null;
       sinon.assert.calledThrice(errorLogSpy);
     })
-
   })
 
   describe('sessionstorage forbidden access in 3rd-party context', function() {
@@ -166,7 +165,6 @@ describe('storage manager', function() {
       expect(val).to.be.null;
       sinon.assert.calledThrice(errorLogSpy);
     })
-
   })
 
   describe('localstorage is enabled', function() {


### PR DESCRIPTION
## Type of change
- [ x ] Maintenance

## Description of change

- This PR adds sessionStorage functions in the Prebid Storage Manager
- The Contxtful RTD Provider leverages these to read from sessionStorage.

In our use case, we don't rely on localStorage because sessionStorage is more volatile and don't persist and suits perfectly as we don't want any kind of tracking.

We cannot simply override or extend the storage manager to add this functionality; so we propose to make it available in the storage manager.

## Other information
- RTD Provider Documentation does not need updating.