### PR TITLE
Core & fledgeForGpt: backport customSlotMatching

### DIFF
--- a/src/targeting.js
+++ b/src/targeting.js
@@ -21,7 +21,7 @@ import {ADPOD} from './mediaTypes.js';
 import {hook} from './hook.js';
 import {bidderSettings} from './bidderSettings.js';
 import {find, includes} from './polyfill.js';
-import { BID_STATUS, JSON_MAPPING, DEFAULT_TARGETING_KEYS, TARGETING_KEYS, NATIVE_KEYS, STATUS } from './constants.js';
+import {BID_STATUS, DEFAULT_TARGETING_KEYS, JSON_MAPPING, NATIVE_KEYS, STATUS, TARGETING_KEYS} from './constants.js';
 import {getHighestCpm, getOldestHighestCpmBid} from './utils/reducers.js';
 import {getTTL} from './bidTTL.js';
 
@@ -125,6 +125,22 @@ export function sortByDealAndPriceBucketOrCpm(useCpm = false) {
 }
 
 /**
+ * Return a map where each code in `adUnitCodes` maps to a list of GPT slots that match it.
+ *
+ * @param {Array<String>} adUnitCodes
+ * @param customSlotMatching
+ * @param getSlots
+ * @return {{[p: string]: any}}
+ */
+export function getGPTSlotsForAdUnits(adUnitCodes, customSlotMatching, getSlots = () => window.googletag.pubads().getSlots()) {
+  return getSlots().reduce((auToSlots, slot) => {
+    const customMatch = isFn(customSlotMatching) && customSlotMatching(slot);
+    Object.keys(auToSlots).filter(isFn(customMatch) ? customMatch : isAdUnitCodeMatchingSlot(slot)).forEach(au => auToSlots[au].push(slot));
+    return auToSlots;
+  }, Object.fromEntries(adUnitCodes.map(au => [au, []])));
+}
+
+/**
  * @typedef {Object.<string,string>} targeting
  * @property {string} targeting_key
  */
@@ -144,22 +160,13 @@ export function newTargeting(auctionManager) {
   targeting.resetPresetTargeting = function(adUnitCode, customSlotMatching) {
     if (isGptPubadsDefined()) {
       const adUnitCodes = getAdUnitCodes(adUnitCode);
-      const adUnits = auctionManager.getAdUnits().filter(adUnit => includes(adUnitCodes, adUnit.code));
       let unsetKeys = pbTargetingKeys.reduce((reducer, key) => {
         reducer[key] = null;
         return reducer;
       }, {});
-      window.googletag.pubads().getSlots().forEach(slot => {
-        let customSlotMatchingFunc = isFn(customSlotMatching) && customSlotMatching(slot);
-        // reset only registered adunits
-        adUnits.forEach(unit => {
-          if (unit.code === slot.getAdUnitPath() ||
-              unit.code === slot.getSlotElementId() ||
-              (isFn(customSlotMatchingFunc) && customSlotMatchingFunc(unit.code))) {
-            slot.updateTargetingFromMap(unsetKeys);
-          }
-        });
-      });
+      Object.values(getGPTSlotsForAdUnits(adUnitCodes, customSlotMatching)).forEach((slots) => {
+        slots.forEach(slot => slot.updateTargetingFromMap(unsetKeys))
+      })
     }
   };
 
@@ -420,20 +427,19 @@ export function newTargeting(auctionManager) {
    * @param {Object.<string,Object.<string,string>>} targetingConfig
    */
   targeting.setTargetingForGPT = function(targetingConfig, customSlotMatching) {
-    window.googletag.pubads().getSlots().forEach(slot => {
-      Object.keys(targetingConfig).filter(customSlotMatching ? customSlotMatching(slot) : isAdUnitCodeMatchingSlot(slot))
-        .forEach(targetId => {
-          Object.keys(targetingConfig[targetId]).forEach(key => {
-            let value = targetingConfig[targetId][key];
-            if (typeof value === 'string' && value.indexOf(',') !== -1) {
-              // due to the check the array will be formed only if string has ',' else plain string will be assigned as value
-              value = value.split(',');
-            }
-            targetingConfig[targetId][key] = value;
-          });
-          logMessage(`Attempting to set targeting-map for slot: ${slot.getSlotElementId()} with targeting-map:`, targetingConfig[targetId]);
-          slot.updateTargetingFromMap(targetingConfig[targetId])
-        })
+    Object.entries(getGPTSlotsForAdUnits(Object.keys(targetingConfig), customSlotMatching)).forEach(([targetId, slots]) => {
+      slots.forEach(slot => {
+        Object.keys(targetingConfig[targetId]).forEach(key => {
+          let value = targetingConfig[targetId][key];
+          if (typeof value === 'string' && value.indexOf(',') !== -1) {
+            // due to the check the array will be formed only if string has ',' else plain string will be assigned as value
+            value = value.split(',');
+          }
+          targetingConfig[targetId][key] = value;
+        });
+        logMessage(`Attempting to set targeting-map for slot: ${slot.getSlotElementId()} with targeting-map:`, targetingConfig[targetId]);
+        slot.updateTargetingFromMap(targetingConfig[targetId])
+      })
     })
   };
 

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -1,5 +1,6 @@
 import {expect} from 'chai';
 import {
+  getGPTSlotsForAdUnits,
   filters,
   getHighestCpmBidsFromBidPool,
   sortByDealAndPriceBucketOrCpm,
@@ -1310,6 +1311,17 @@ describe('targeting tests', function () {
   describe('setTargetingForAst', function () {
     let sandbox,
       apnTagStub;
+
+    before(() => {
+      if (window.apntag?.setKeywords == null) {
+        const orig = window.apntag;
+        window.apntag = {setKeywords: () => {}}
+        after(() => {
+          window.apntag = orig;
+        })
+      }
+    });
+
     beforeEach(function() {
       sandbox = sinon.createSandbox();
       sandbox.stub(targetingInstance, 'resetPresetTargetingAST');
@@ -1346,4 +1358,62 @@ describe('targeting tests', function () {
       expect(apnTagStub.getCall(1).args[1]).to.deep.equal({HB_BIDDER: 'appnexus'});
     });
   });
+
+  describe('getGPTSlotsForAdUnits', () => {
+    function mockSlot(path, elId) {
+      return {
+        getAdUnitPath() {
+          return path;
+        },
+        getSlotElementId() {
+          return elId;
+        }
+      }
+    }
+
+    let slots;
+
+    beforeEach(() => {
+      slots = [
+        mockSlot('slot/1', 'div-1'),
+        mockSlot('slot/2', 'div-2'),
+      ]
+    });
+
+    Object.entries({
+      'ad unit path': ['slot/1', 'slot/2'],
+      'element id': ['div-1', 'div-2']
+    }).forEach(([t, adUnitCodes]) => {
+      it(`can find slots by ${t}`, () => {
+        expect(getGPTSlotsForAdUnits(adUnitCodes, null, () => slots)).to.eql(Object.fromEntries(adUnitCodes.map((au, i) => [au, [slots[i]]])));
+      })
+    });
+
+    it('returns empty list on no match', () => {
+      expect(getGPTSlotsForAdUnits(['missing', 'slot/2'], null, () => slots)).to.eql({
+        missing: [],
+        'slot/2': [slots[1]]
+      });
+    });
+
+    it('can use customSlotMatching', () => {
+      const csm = (slot) => {
+        if (slot.getAdUnitPath() === 'slot/1') {
+          return (au) => {
+            return au === 'custom'
+          }
+        }
+      }
+      expect(getGPTSlotsForAdUnits(['div-2', 'custom'], csm, () => slots)).to.eql({
+        'custom': [slots[0]],
+        'div-2': [slots[1]]
+      })
+    });
+
+    it('can handle repeated adUnitCodes', () => {
+      expect(getGPTSlotsForAdUnits(['div-1', 'div-1'], null, () => slots)).to.eql({
+        'div-1': [slots[0]]
+      })
+    })
+  })
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

Partial backport of https://github.com/prebid/Prebid.js/issues/11934. Adds support for `customSlotMatching`, but since there's no way to pass it to the legacy `autoconfig` behavior, it's only supported when used directly with `setPAAPIConfigForGpt`.

Closes https://github.com/prebid/Prebid.js/issues/11934

