### PR TITLE
 Adagio Bid Adapter|Analytics Adapter: use rtd uid as auctionid

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -724,7 +724,6 @@ export const spec = {
     // Those params are not sent to the server.
     // They are used for further operations on analytics adapter.
     validBidRequests.forEach(rawBidRequest => {
-      rawBidRequest.params.adagioAuctionId = aucId
       rawBidRequest.params.pageviewId = pageviewId
     });
 

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -277,8 +277,6 @@ describe('Adagio bid adapter', () => {
     it('should send bid request to ENDPOINT_PB via POST', function() {
       sandbox.stub(_internal, 'getDevice').returns({ a: 'a' });
       sandbox.stub(_internal, 'getSite').returns({ domain: 'adagio.io', 'page': 'https://adagio.io/hb' });
-      // sandbox.stub(_internal, 'getPageviewId').returns('1234-567');
-      // sandbox.stub(utils, 'generateUUID').returns('blabla');
 
       const bid01 = new BidRequestBuilder().withParams().build();
       const bidderRequest = new BidderRequestBuilder().build();
@@ -292,7 +290,31 @@ describe('Adagio bid adapter', () => {
       expect(requests[0].data).to.have.all.keys(expectedDataKeys);
     });
 
-    it('should use a custom generated auctionId and remove transactionId', function() {
+    it('should use a custom generated auctionId from ortb2.site.ext.data.adg_rtd.uid when available', function() {
+      const expectedAuctionId = '373bcda7-9794-4f1c-be2c-0d223d11d579'
+
+      const bid01 = new BidRequestBuilder().withParams().build();
+      let ortb = {
+        ortb2: {
+          site: {
+            ext: {
+              data: {
+                adg_rtd: {
+                  uid: expectedAuctionId
+                }
+              }
+            }
+          }
+        }
+      }
+      const bidderRequest = new BidderRequestBuilder(ortb).build();
+
+      const requests = spec.buildRequests([bid01], bidderRequest);
+      expect(requests[0].data.adUnits[0].auctionId).eq(expectedAuctionId);
+      expect(requests[0].data.adUnits[0].transactionId).to.not.exist;
+    });
+
+    it('should use a custom generated auctionId when ortb2.site.ext.data.adg_rtd.uid is absent and remove transactionId', function() {
       const expectedAuctionId = '373bcda7-9794-4f1c-be2c-0d223d11d579'
       sandbox.stub(utils, 'generateUUID').returns(expectedAuctionId);
 
@@ -305,9 +327,7 @@ describe('Adagio bid adapter', () => {
     });
 
     it('should enrich prebid bid requests params', function() {
-      const expectedAuctionId = '373bcda7-9794-4f1c-be2c-0d223d11d579'
       const expectedPageviewId = '56befc26-8cf0-472d-b105-73896df8eb89';
-      sandbox.stub(utils, 'generateUUID').returns(expectedAuctionId);
       sandbox.stub(_internal, 'getAdagioNs').returns({ pageviewId: expectedPageviewId });
 
       const bid01 = new BidRequestBuilder().withParams().build();
@@ -315,7 +335,6 @@ describe('Adagio bid adapter', () => {
 
       spec.buildRequests([bid01], bidderRequest);
 
-      expect(bid01.params.adagioAuctionId).eq(expectedAuctionId);
       expect(bid01.params.pageviewId).eq(expectedPageviewId);
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 


## Description of change
<!-- Describe the change proposed in this pull request -->
Harmonize the use of our RTD generated uid as auction ID for our bid adapter & analytics adapter
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
