### PR TITLE
ID5 UserId module : use userId storage mechanism to store request number

### DIFF
--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -13,14 +13,13 @@ import {
   isPlainObject,
   logError,
   logInfo,
-  logWarn,
-  safeJSONParse
+  logWarn
 } from '../src/utils.js';
 import {fetch} from '../src/ajax.js';
 import {submodule} from '../src/hook.js';
 import {getRefererInfo} from '../src/refererDetection.js';
 import {getStorageManager} from '../src/storageManager.js';
-import {uspDataHandler, gppDataHandler} from '../src/adapterManager.js';
+import {gppDataHandler, uspDataHandler} from '../src/adapterManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 import {GreedyPromise} from '../src/utils/promise.js';
 import {loadExternalScript} from '../src/adloader.js';
@@ -34,18 +33,11 @@ import {loadExternalScript} from '../src/adloader.js';
 
 const MODULE_NAME = 'id5Id';
 const GVLID = 131;
-const NB_EXP_DAYS = 30;
 export const ID5_STORAGE_NAME = 'id5id';
-export const ID5_PRIVACY_STORAGE_NAME = `${ID5_STORAGE_NAME}_privacy`;
-const LOCAL_STORAGE = 'html5';
 const LOG_PREFIX = 'User ID - ID5 submodule: ';
 const ID5_API_CONFIG_URL = 'https://id5-sync.com/api/config/prebid';
 const ID5_DOMAIN = 'id5-sync.com';
 const TRUE_LINK_SOURCE = 'true-link-id5-sync.com';
-
-// order the legacy cookie names in reverse priority order so the last
-// cookie in the array is the most preferred to use
-const LEGACY_COOKIE_NAMES = ['pbjs-id5id', 'id5id.1st', 'id5id'];
 
 export const storage = getStorageManager({moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME});
 
@@ -231,7 +223,7 @@ export const id5IdSubmodule = {
    * @param {SubmoduleConfig} config
    * @param {ConsentData|undefined} consentData
    * @param {Object} cacheIdObj - existing id, if any
-   * @return {(IdResponse|function(callback:function))} A response object that contains id and/or callback.
+   * @return {IdResponse} A response object that contains id.
    */
   extendId(config, consentData, cacheIdObj) {
     if (!hasWriteConsentToLocalStorage(consentData)) {
@@ -239,10 +231,10 @@ export const id5IdSubmodule = {
       return cacheIdObj;
     }
 
-    const partnerId = validateConfig(config) ? config.params.partner : 0;
-    incrementNb(partnerId);
-
     logInfo(LOG_PREFIX + 'using cached ID', cacheIdObj);
+    if (cacheIdObj) {
+      cacheIdObj.nbPage = incrementNb(cacheIdObj)
+    }
     return cacheIdObj;
   },
   eids: {
@@ -401,8 +393,8 @@ export class IdFetchFlow {
     const params = this.submoduleConfig.params;
     const hasGdpr = (this.gdprConsentData && typeof this.gdprConsentData.gdprApplies === 'boolean' && this.gdprConsentData.gdprApplies) ? 1 : 0;
     const referer = getRefererInfo();
-    const signature = (this.cacheIdObj && this.cacheIdObj.signature) ? this.cacheIdObj.signature : getLegacyCookieSignature();
-    const nbPage = incrementAndResetNb(params.partner);
+    const signature = this.cacheIdObj ? this.cacheIdObj.signature : undefined;
+    const nbPage = incrementNb(this.cacheIdObj);
     const trueLinkInfo = window.id5Bootstrap ? window.id5Bootstrap.getTrueLinkInfo() : {booted: false};
 
     const data = {
@@ -456,7 +448,6 @@ export class IdFetchFlow {
   #processFetchCallResponse(fetchCallResponse) {
     try {
       if (fetchCallResponse.privacy) {
-        storeInLocalStorage(ID5_PRIVACY_STORAGE_NAME, JSON.stringify(fetchCallResponse.privacy), NB_EXP_DAYS);
         if (window.id5Bootstrap && window.id5Bootstrap.setPrivacy) {
           window.id5Bootstrap.setPrivacy(fetchCallResponse.privacy);
         }
@@ -507,89 +498,19 @@ function validateConfig(config) {
     logError(LOG_PREFIX + 'storage required to be set');
     return false;
   }
-
-  // in a future release, we may return false if storage type or name are not set as required
-  if (config.storage.type !== LOCAL_STORAGE) {
-    logWarn(LOG_PREFIX + `storage type recommended to be '${LOCAL_STORAGE}'. In a future release this may become a strict requirement`);
-  }
-  // in a future release, we may return false if storage type or name are not set as required
   if (config.storage.name !== ID5_STORAGE_NAME) {
-    logWarn(LOG_PREFIX + `storage name recommended to be '${ID5_STORAGE_NAME}'. In a future release this may become a strict requirement`);
+    logWarn(LOG_PREFIX + `storage name recommended to be '${ID5_STORAGE_NAME}'.`);
   }
 
   return true;
 }
 
-export function expDaysStr(expDays) {
-  return (new Date(Date.now() + (1000 * 60 * 60 * 24 * expDays))).toUTCString();
-}
-
-export function nbCacheName(partnerId) {
-  return `${ID5_STORAGE_NAME}_${partnerId}_nb`;
-}
-
-export function storeNbInCache(partnerId, nb) {
-  storeInLocalStorage(nbCacheName(partnerId), nb, NB_EXP_DAYS);
-}
-
-export function getNbFromCache(partnerId) {
-  let cacheNb = getFromLocalStorage(nbCacheName(partnerId));
-  return (cacheNb) ? parseInt(cacheNb) : 0;
-}
-
-function incrementNb(partnerId) {
-  const nb = (getNbFromCache(partnerId) + 1);
-  storeNbInCache(partnerId, nb);
-  return nb;
-}
-
-function incrementAndResetNb(partnerId) {
-  const result = incrementNb(partnerId);
-  storeNbInCache(partnerId, 0);
-  return result;
-}
-
-function getLegacyCookieSignature() {
-  let legacyStoredValue;
-  LEGACY_COOKIE_NAMES.forEach(function (cookie) {
-    if (storage.getCookie(cookie)) {
-      legacyStoredValue = safeJSONParse(storage.getCookie(cookie)) || legacyStoredValue;
-    }
-  });
-  return (legacyStoredValue && legacyStoredValue.signature) || '';
-}
-
-/**
- * This will make sure we check for expiration before accessing local storage
- * @param {string} key
- */
-export function getFromLocalStorage(key) {
-  const storedValueExp = storage.getDataFromLocalStorage(`${key}_exp`);
-  // empty string means no expiration set
-  if (storedValueExp === '') {
-    return storage.getDataFromLocalStorage(key);
-  } else if (storedValueExp) {
-    if ((new Date(storedValueExp)).getTime() - Date.now() > 0) {
-      return storage.getDataFromLocalStorage(key);
-    }
+function incrementNb(cachedObj) {
+  if (cachedObj && cachedObj.nbPage !== undefined) {
+    return cachedObj.nbPage + 1;
+  } else {
+    return 1;
   }
-  // if we got here, then we have an expired item or we didn't set an
-  // expiration initially somehow, so we need to remove the item from the
-  // local storage
-  storage.removeDataFromLocalStorage(key);
-  return null;
-}
-
-/**
- * Ensure that we always set an expiration in local storage since
- * by default it's not required
- * @param {string} key
- * @param {any} value
- * @param {number} expDays
- */
-export function storeInLocalStorage(key, value, expDays) {
-  storage.setDataInLocalStorage(`${key}_exp`, expDaysStr(expDays));
-  storage.setDataInLocalStorage(`${key}`, value);
 }
 
 /**

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -93,6 +93,15 @@ describe('ID5 ID System', function () {
     'Content-Type': 'application/json'
   };
 
+  function expDaysStr(expDays) {
+    return (new Date(Date.now() + (1000 * 60 * 60 * 24 * expDays))).toUTCString();
+  }
+
+  function storeInStorage(key, value, expDays) {
+    id5System.storage.setDataInLocalStorage(`${key}_exp`, expDaysStr(expDays));
+    id5System.storage.setDataInLocalStorage(`${key}`, value);
+  }
+
   function getId5FetchConfig(partner = ID5_TEST_PARTNER_ID, storageName = id5System.ID5_STORAGE_NAME, storageType = 'html5') {
     return {
       name: ID5_MODULE_NAME,
@@ -637,8 +646,6 @@ describe('ID5 ID System', function () {
 
     it('should call the ID5 server with nb=1 when no stored value exists and reset after', async function () {
       const xhrServerMock = new XhrServerMock(server);
-      const TEST_PARTNER_ID = 189;
-      coreStorage.removeDataFromLocalStorage(id5System.nbCacheName(TEST_PARTNER_ID));
 
       // Trigger the fetch but we await on it later
       const submoduleResponsePromise = callSubmoduleGetId(getId5FetchConfig(), undefined, ID5_STORED_OBJ);
@@ -648,28 +655,28 @@ describe('ID5 ID System', function () {
       expect(requestBody.nbPage).is.eq(1);
 
       fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
-      await submoduleResponsePromise;
+      const response = await submoduleResponsePromise;
 
-      expect(id5System.getNbFromCache(TEST_PARTNER_ID)).is.eq(0);
+      expect(response.nbPage).is.undefined;
     });
 
     it('should call the ID5 server with incremented nb when stored value exists and reset after', async function () {
       const xhrServerMock = new XhrServerMock(server);
       const TEST_PARTNER_ID = 189;
       const config = getId5FetchConfig(TEST_PARTNER_ID);
-      id5System.storeNbInCache(TEST_PARTNER_ID, 1);
+      const storedObj = {...ID5_STORED_OBJ, nbPage: 1};
 
       // Trigger the fetch but we await on it later
-      const submoduleResponsePromise = callSubmoduleGetId(config, undefined, ID5_STORED_OBJ);
+      const submoduleResponsePromise = callSubmoduleGetId(config, undefined, storedObj);
 
       const fetchRequest = await xhrServerMock.expectFetchRequest();
       const requestBody = JSON.parse(fetchRequest.requestBody);
       expect(requestBody.nbPage).is.eq(2);
 
       fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
-      await submoduleResponsePromise;
+      const response = await submoduleResponsePromise;
 
-      expect(id5System.getNbFromCache(TEST_PARTNER_ID)).is.eq(0);
+      expect(response.nbPage).is.undefined;
     });
 
     it('should call the ID5 server with ab_testing object when abTesting is turned on', async function () {
@@ -718,45 +725,6 @@ describe('ID5 ID System', function () {
 
       fetchRequest.respond(200, responseHeader, JSON.stringify(ID5_JSON_RESPONSE));
       await submoduleResponsePromise;
-    });
-
-    it('should store the privacy object from the ID5 server response', async function () {
-      const xhrServerMock = new XhrServerMock(server);
-
-      // Trigger the fetch but we await on it later
-      const submoduleResponsePromise = callSubmoduleGetId(getId5FetchConfig(), undefined, ID5_STORED_OBJ);
-
-      const privacy = {
-        jurisdiction: 'gdpr',
-        id5_consent: true
-      };
-
-      const fetchRequest = await xhrServerMock.expectFetchRequest();
-      const responseObject = utils.deepClone(ID5_JSON_RESPONSE);
-      responseObject.privacy = privacy;
-
-      fetchRequest.respond(200, responseHeader, JSON.stringify(responseObject));
-      await submoduleResponsePromise;
-
-      expect(id5System.getFromLocalStorage(id5System.ID5_PRIVACY_STORAGE_NAME)).is.eq(JSON.stringify(privacy));
-      coreStorage.removeDataFromLocalStorage(id5System.ID5_PRIVACY_STORAGE_NAME);
-    });
-
-    it('should not store a privacy object if not part of ID5 server response', async function () {
-      const xhrServerMock = new XhrServerMock(server);
-      coreStorage.removeDataFromLocalStorage(id5System.ID5_PRIVACY_STORAGE_NAME);
-
-      // Trigger the fetch but we await on it later
-      const submoduleResponsePromise = callSubmoduleGetId(getId5FetchConfig(), undefined, ID5_STORED_OBJ);
-
-      const fetchRequest = await xhrServerMock.expectFetchRequest();
-      const responseObject = utils.deepClone(ID5_JSON_RESPONSE);
-      responseObject.privacy = undefined;
-
-      fetchRequest.respond(200, responseHeader, JSON.stringify(responseObject));
-      await submoduleResponsePromise;
-
-      expect(id5System.getFromLocalStorage(id5System.ID5_PRIVACY_STORAGE_NAME)).is.null;
     });
 
     describe('with successful external module call', function () {
@@ -926,7 +894,6 @@ describe('ID5 ID System', function () {
       sinon.stub(events, 'getEvents').returns([]);
       coreStorage.removeDataFromLocalStorage(id5System.ID5_STORAGE_NAME);
       coreStorage.removeDataFromLocalStorage(`${id5System.ID5_STORAGE_NAME}_last`);
-      coreStorage.removeDataFromLocalStorage(id5System.nbCacheName(ID5_TEST_PARTNER_ID));
       coreStorage.setDataInLocalStorage(id5System.ID5_STORAGE_NAME + '_cst', getConsentHash());
       adUnits = [getAdUnitMock()];
     });
@@ -934,19 +901,18 @@ describe('ID5 ID System', function () {
       events.getEvents.restore();
       coreStorage.removeDataFromLocalStorage(id5System.ID5_STORAGE_NAME);
       coreStorage.removeDataFromLocalStorage(`${id5System.ID5_STORAGE_NAME}_last`);
-      coreStorage.removeDataFromLocalStorage(id5System.nbCacheName(ID5_TEST_PARTNER_ID));
       coreStorage.removeDataFromLocalStorage(id5System.ID5_STORAGE_NAME + '_cst');
       sandbox.restore();
     });
 
     it('should add stored ID from cache to bids', function (done) {
-      id5System.storeInLocalStorage(id5System.ID5_STORAGE_NAME, JSON.stringify(ID5_STORED_OBJ), 1);
+      storeInStorage(id5System.ID5_STORAGE_NAME, JSON.stringify(ID5_STORED_OBJ), 1);
 
       init(config);
       setSubmoduleRegistry([id5System.id5IdSubmodule]);
       config.setConfig(getFetchLocalStorageConfig());
 
-      requestBidsHook(function () {
+      requestBidsHook(wrapAsyncExpects(done, () => {
         adUnits.forEach(unit => {
           unit.bids.forEach(bid => {
             expect(bid).to.have.deep.nested.property(`userId.${ID5_EIDS_NAME}`);
@@ -964,11 +930,11 @@ describe('ID5 ID System', function () {
           });
         });
         done();
-      }, {adUnits});
+      }), {adUnits});
     });
 
     it('should add stored EUID from cache to bids', function (done) {
-      id5System.storeInLocalStorage(id5System.ID5_STORAGE_NAME, JSON.stringify(ID5_STORED_OBJ_WITH_EUID), 1);
+      storeInStorage(id5System.ID5_STORAGE_NAME, JSON.stringify(ID5_STORED_OBJ_WITH_EUID), 1);
 
       init(config);
       setSubmoduleRegistry([id5System.id5IdSubmodule]);
@@ -997,7 +963,7 @@ describe('ID5 ID System', function () {
     });
 
     it('should add stored TRUE_LINK_ID from cache to bids', function (done) {
-      id5System.storeInLocalStorage(id5System.ID5_STORAGE_NAME, JSON.stringify(ID5_STORED_OBJ_WITH_TRUE_LINK), 1);
+      storeInStorage(id5System.ID5_STORAGE_NAME, JSON.stringify(ID5_STORED_OBJ_WITH_TRUE_LINK), 1);
 
       init(config);
       setSubmoduleRegistry([id5System.id5IdSubmodule]);
@@ -1041,48 +1007,20 @@ describe('ID5 ID System', function () {
       }, {adUnits});
     });
 
-    it('should set nb=1 in cache when no stored nb value exists and cached ID', function (done) {
-      id5System.storeInLocalStorage(id5System.ID5_STORAGE_NAME, JSON.stringify(ID5_STORED_OBJ), 1);
-      coreStorage.removeDataFromLocalStorage(id5System.nbCacheName(ID5_TEST_PARTNER_ID));
-
-      init(config);
-      setSubmoduleRegistry([id5System.id5IdSubmodule]);
-      config.setConfig(getFetchLocalStorageConfig());
-
-      requestBidsHook((adUnitConfig) => {
-        expect(id5System.getNbFromCache(ID5_TEST_PARTNER_ID)).is.eq(1);
-        done();
-      }, {adUnits});
-    });
-
-    it('should increment nb in cache when stored nb value exists and cached ID', function (done) {
-      id5System.storeInLocalStorage(id5System.ID5_STORAGE_NAME, JSON.stringify(ID5_STORED_OBJ), 1);
-      id5System.storeNbInCache(ID5_TEST_PARTNER_ID, 1);
-
-      init(config);
-      setSubmoduleRegistry([id5System.id5IdSubmodule]);
-      config.setConfig(getFetchLocalStorageConfig());
-
-      requestBidsHook(() => {
-        expect(id5System.getNbFromCache(ID5_TEST_PARTNER_ID)).is.eq(2);
-        done();
-      }, {adUnits});
-    });
-
     it('should call ID5 servers with signature and incremented nb post auction if refresh needed', function () {
       const xhrServerMock = new XhrServerMock(server);
-      const initialLocalStorageValue = JSON.stringify(ID5_STORED_OBJ);
-      id5System.storeInLocalStorage(id5System.ID5_STORAGE_NAME, initialLocalStorageValue, 1);
-      id5System.storeInLocalStorage(`${id5System.ID5_STORAGE_NAME}_last`, id5System.expDaysStr(-1), 1);
+      let storedObject = ID5_STORED_OBJ;
+      storedObject.nbPage = 1;
+      const initialLocalStorageValue = JSON.stringify(storedObject);
+      storeInStorage(id5System.ID5_STORAGE_NAME, initialLocalStorageValue, 1);
+      storeInStorage(`${id5System.ID5_STORAGE_NAME}_last`, expDaysStr(-1), 1);
 
-      id5System.storeNbInCache(ID5_TEST_PARTNER_ID, 1);
       let id5Config = getFetchLocalStorageConfig();
       id5Config.userSync.userIds[0].storage.refreshInSeconds = 2;
       id5Config.userSync.auctionDelay = 0; // do not trigger callback before auction
       init(config);
       setSubmoduleRegistry([id5System.id5IdSubmodule]);
       config.setConfig(id5Config);
-
       return new Promise((resolve) => {
         requestBidsHook(() => {
           resolve();
@@ -1095,18 +1033,7 @@ describe('ID5 ID System', function () {
         const requestBody = JSON.parse(request.requestBody);
         expect(requestBody.s).is.eq(ID5_STORED_SIGNATURE);
         expect(requestBody.nbPage).is.eq(2);
-        expect(id5System.getNbFromCache(ID5_TEST_PARTNER_ID)).is.eq(0);
         request.respond(200, HEADERS_CONTENT_TYPE_JSON, JSON.stringify(ID5_JSON_RESPONSE));
-
-        return new Promise(function (resolve) {
-          (function waitForCondition() {
-            if (id5System.getFromLocalStorage(id5System.ID5_STORAGE_NAME) !== initialLocalStorageValue) return resolve();
-            setTimeout(waitForCondition, 30);
-          })();
-        });
-      }).then(() => {
-        expect(decodeURIComponent(id5System.getFromLocalStorage(id5System.ID5_STORAGE_NAME))).is.eq(JSON.stringify(ID5_JSON_RESPONSE));
-        expect(id5System.getNbFromCache(ID5_TEST_PARTNER_ID)).is.eq(0);
       });
     });
   });


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->
To better adhere to Prebid user configuration (mentioned in https://github.com/prebid/Prebid.js/issues/10710) id5id module no longer stores any data on itself, and will only use the storage provided by Prebid userId module
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Docs PR: https://github.com/prebid/prebid.github.io/pull/5498
