### PR TITLE
Core: ORTB video params validation (work on dupe)

### DIFF
--- a/libraries/ortbConverter/processors/video.js
+++ b/libraries/ortbConverter/processors/video.js
@@ -1,30 +1,7 @@
 import {deepAccess, isEmpty, logWarn, mergeDeep, sizesToSizeTuples, sizeTupleToRtbSize} from '../../../src/utils.js';
 import {VIDEO} from '../../../src/mediaTypes.js';
 
-// parameters that share the same name & semantics between pbjs adUnits and imp.video
-const ORTB_VIDEO_PARAMS = new Set([
-  'pos',
-  'placement',
-  'plcmt',
-  'api',
-  'mimes',
-  'protocols',
-  'playbackmethod',
-  'minduration',
-  'maxduration',
-  'w',
-  'h',
-  'startdelay',
-  'placement',
-  'linearity',
-  'skip',
-  'skipmin',
-  'skipafter',
-  'minbitrate',
-  'maxbitrate',
-  'delivery',
-  'playbackend'
-]);
+import {ORTB_VIDEO_PARAMS} from '../../../src/video.js';
 
 export function fillVideoImp(imp, bidRequest, context) {
   if (context.mediaType && context.mediaType !== VIDEO) return;
@@ -32,6 +9,7 @@ export function fillVideoImp(imp, bidRequest, context) {
   const videoParams = deepAccess(bidRequest, 'mediaTypes.video');
   if (!isEmpty(videoParams)) {
     const video = Object.fromEntries(
+      // Parameters that share the same name & semantics between pbjs adUnits and imp.video
       Object.entries(videoParams)
         .filter(([name]) => ORTB_VIDEO_PARAMS.has(name))
     );

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -180,8 +180,8 @@ function _buildVideoBidRequest(bidRequest) {
     videoParams.playerName = getPlayerName(bidRequest);
   }
 
-  validateOrtbVideoFields(videoParams)
   bidRequest.mediaTypes.video = videoParams;
+  validateOrtbVideoFields(bidRequest);
 }
 
 function _parseNativeBidResponse(bid) {

--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -8,9 +8,7 @@ import {
   getDNT,
   getWindowSelf,
   isArray,
-  isArrayOfNums,
   isFn,
-  isInteger,
   isNumber,
   isStr,
   logError,
@@ -18,7 +16,7 @@ import {
   logWarn,
 } from '../src/utils.js';
 import { getRefererInfo, parseDomain } from '../src/refererDetection.js';
-import { OUTSTREAM } from '../src/video.js';
+import { OUTSTREAM, validateOrtbVideoFields } from '../src/video.js';
 import { Renderer } from '../src/Renderer.js';
 import { _ADAGIO } from '../libraries/adagioUtils/adagioUtils.js';
 import { config } from '../src/config.js';
@@ -39,39 +37,6 @@ const BB_RENDERER_DEFAULT = 'renderer';
 export const BB_RENDERER_URL = `https://${BB_PUBLICATION}.bbvms.com/r/$RENDERER.js`;
 
 const CURRENCY = 'USD';
-
-// This provide a whitelist and a basic validation of OpenRTB 2.5 options used by the Adagio SSP.
-// Accept all options but 'protocol', 'companionad', 'companiontype', 'ext'
-// https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf
-export const ORTB_VIDEO_PARAMS = {
-  'mimes': (value) => Array.isArray(value) && value.length > 0 && value.every(v => typeof v === 'string'),
-  'minduration': (value) => isInteger(value),
-  'maxduration': (value) => isInteger(value),
-  'protocols': (value) => isArrayOfNums(value),
-  'w': (value) => isInteger(value),
-  'h': (value) => isInteger(value),
-  'startdelay': (value) => isInteger(value),
-  'placement': (value) => {
-    logWarn(LOG_PREFIX, 'The OpenRTB video param `placement` is deprecated and should not be used anymore.');
-    return isInteger(value)
-  },
-  'plcmt': (value) => isInteger(value),
-  'linearity': (value) => isInteger(value),
-  'skip': (value) => [1, 0].includes(value),
-  'skipmin': (value) => isInteger(value),
-  'skipafter': (value) => isInteger(value),
-  'sequence': (value) => isInteger(value),
-  'battr': (value) => isArrayOfNums(value),
-  'maxextended': (value) => isInteger(value),
-  'minbitrate': (value) => isInteger(value),
-  'maxbitrate': (value) => isInteger(value),
-  'boxingallowed': (value) => isInteger(value),
-  'playbackmethod': (value) => isArrayOfNums(value),
-  'playbackend': (value) => isInteger(value),
-  'delivery': (value) => isArrayOfNums(value),
-  'pos': (value) => isInteger(value),
-  'api': (value) => isArrayOfNums(value)
-};
 
 /**
  * Returns the window.ADAGIO global object used to store Adagio data.
@@ -186,6 +151,12 @@ function _getEids(bidRequest) {
   }
 }
 
+/**
+ * Merge and compute video params set at mediaTypes and bidder params level
+ *
+ * @param {object} bidRequest - copy of the original bidRequest object.
+ * @returns {void}
+ */
 function _buildVideoBidRequest(bidRequest) {
   const videoAdUnitParams = deepAccess(bidRequest, 'mediaTypes.video', {});
   const videoBidderParams = deepAccess(bidRequest, 'params.video', {});
@@ -206,22 +177,11 @@ function _buildVideoBidRequest(bidRequest) {
   };
 
   if (videoParams.context && videoParams.context === OUTSTREAM) {
-    bidRequest.mediaTypes.video.playerName = getPlayerName(bidRequest);
+    videoParams.playerName = getPlayerName(bidRequest);
   }
 
-  // Only whitelisted OpenRTB options need to be validated.
-  // Other options will still remain in the `mediaTypes.video` object
-  // sent in the ad-request, but will be ignored by the SSP.
-  Object.keys(ORTB_VIDEO_PARAMS).forEach(paramName => {
-    if (videoParams.hasOwnProperty(paramName)) {
-      if (ORTB_VIDEO_PARAMS[paramName](videoParams[paramName])) {
-        bidRequest.mediaTypes.video[paramName] = videoParams[paramName];
-      } else {
-        delete bidRequest.mediaTypes.video[paramName];
-        logWarn(`${LOG_PREFIX} The OpenRTB video param ${paramName} has been skipped due to misformating. Please refer to OpenRTB 2.5 spec.`);
-      }
-    }
-  });
+  validateOrtbVideoFields(videoParams)
+  bidRequest.mediaTypes.video = videoParams;
 }
 
 function _parseNativeBidResponse(bid) {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -134,7 +134,7 @@ function validateVideoMediaType(adUnit) {
       delete validatedAdUnit.mediaTypes.video.playerSize;
     }
   }
-  validateOrtbVideoFields(video);
+  validateOrtbVideoFields(validatedAdUnit);
   return validatedAdUnit;
 }
 

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -41,7 +41,7 @@ import {enrichFPD} from './fpd/enrichment.js';
 import {allConsent} from './consentHandler.js';
 import {insertLocatorFrame, renderAdDirect} from './adRendering.js';
 import {getHighestCpm} from './utils/reducers.js';
-import {fillVideoDefaults} from './video.js';
+import {fillVideoDefaults, validateOrtbVideoFields} from './video.js';
 
 const pbjsInstance = getGlobal();
 const { triggerUserSyncs } = userSync;
@@ -134,6 +134,7 @@ function validateVideoMediaType(adUnit) {
       delete validatedAdUnit.mediaTypes.video.playerSize;
     }
   }
+  validateOrtbVideoFields(video);
   return validatedAdUnit;
 }
 

--- a/src/video.js
+++ b/src/video.js
@@ -7,44 +7,44 @@ export const OUTSTREAM = 'outstream';
 export const INSTREAM = 'instream';
 
 /**
- * Basic validation of OpenRTB 2.x video object properties.
+ * List of OpenRTB 2.x video object properties with simple validators.
  * Not included: `companionad`, `durfloors`, `ext`
  * reference: https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md
  */
 export const ORTB_VIDEO_PARAMS = new Map([
-  [ 'mimes', { validate: (value) => Array.isArray(value) && value.length > 0 && value.every(v => typeof v === 'string') } ],
-  [ 'minduration', { validate: (value) => isInteger(value) } ],
-  [ 'maxduration', { validate: (value) => isInteger(value) } ],
-  [ 'startdelay', { validate: (value) => isInteger(value) } ],
-  [ 'maxseq', { validate: (value) => isInteger(value) } ],
-  [ 'poddur', { validate: (value) => isInteger(value) } ],
-  [ 'protocols', { validate: (value) => isArrayOfNums(value) } ],
-  [ 'w', { validate: (value) => isInteger(value) } ],
-  [ 'h', { validate: (value) => isInteger(value) } ],
-  [ 'podid', { validate: (value) => isStr(value) } ],
-  [ 'podseq', { validate: (value) => isInteger(value) } ],
-  [ 'rqddurs', { validate: (value) => isArrayOfNums(value) } ],
-  [ 'placement', { validate: (value) => isInteger(value) } ], // deprecated, see plcmt
-  [ 'plcmt', { validate: (value) => isInteger(value) } ],
-  [ 'linearity', { validate: (value) => isInteger(value) } ],
-  [ 'skip', { validate: (value) => [1, 0].includes(value) } ],
-  [ 'skipmin', { validate: (value) => isInteger(value) } ],
-  [ 'skipafter', { validate: (value) => isInteger(value) } ],
-  [ 'sequence', { validate: (value) => isInteger(value) } ], // deprecated
-  [ 'slotinpod', { validate: (value) => isInteger(value) } ],
-  [ 'mincpmpersec', { validate: (value) => isNumber(value) } ],
-  [ 'battr', { validate: (value) => isArrayOfNums(value) } ],
-  [ 'maxextended', { validate: (value) => isInteger(value) } ],
-  [ 'minbitrate', { validate: (value) => isInteger(value) } ],
-  [ 'maxbitrate', { validate: (value) => isInteger(value) } ],
-  [ 'boxingallowed', { validate: (value) => isInteger(value) } ],
-  [ 'playbackmethod', { validate: (value) => isArrayOfNums(value) } ],
-  [ 'playbackend', { validate: (value) => isInteger(value) } ],
-  [ 'delivery', { validate: (value) => isArrayOfNums(value) } ],
-  [ 'pos', { validate: (value) => isInteger(value) } ],
-  [ 'api', { validate: (value) => isArrayOfNums(value) } ],
-  [ 'companiontype', { validate: (value) => isArrayOfNums(value) } ],
-  [ 'poddedupe', { validate: (value) => isArrayOfNums(value) } ],
+  [ 'mimes', value => Array.isArray(value) && value.length > 0 && value.every(v => typeof v === 'string') ],
+  [ 'minduration', isInteger ],
+  [ 'maxduration', isInteger ],
+  [ 'startdelay', isInteger ],
+  [ 'maxseq', isInteger ],
+  [ 'poddur', isInteger ],
+  [ 'protocols', isArrayOfNums ],
+  [ 'w', isInteger ],
+  [ 'h', isInteger ],
+  [ 'podid', isStr ],
+  [ 'podseq', isInteger ],
+  [ 'rqddurs', isArrayOfNums ],
+  [ 'placement', isInteger ], // deprecated, see plcmt
+  [ 'plcmt', isInteger ],
+  [ 'linearity', isInteger ],
+  [ 'skip', value => [1, 0].includes(value) ],
+  [ 'skipmin', isInteger ],
+  [ 'skipafter', isInteger ],
+  [ 'sequence', isInteger ], // deprecated
+  [ 'slotinpod', isInteger ],
+  [ 'mincpmpersec', isNumber ],
+  [ 'battr', isArrayOfNums ],
+  [ 'maxextended', isInteger ],
+  [ 'minbitrate', isInteger ],
+  [ 'maxbitrate', isInteger ],
+  [ 'boxingallowed', isInteger ],
+  [ 'playbackmethod', isArrayOfNums ],
+  [ 'playbackend', isInteger ],
+  [ 'delivery', isArrayOfNums ],
+  [ 'pos', isInteger ],
+  [ 'api', isArrayOfNums ],
+  [ 'companiontype', isArrayOfNums ],
+  [ 'poddedupe', isArrayOfNums ]
 ]);
 
 export function fillVideoDefaults(adUnit) {
@@ -81,8 +81,8 @@ export function validateOrtbVideoFields(adUnit, onInvalidParam) {
         if (!ORTB_VIDEO_PARAMS.has(key)) {
           return
         }
-        const valid = ORTB_VIDEO_PARAMS.get(key).validate(value);
-        if (!valid) {
+        const isValid = ORTB_VIDEO_PARAMS.get(key)(value);
+        if (!isValid) {
           if (typeof onInvalidParam === 'function') {
             onInvalidParam(key, value, adUnit);
           } else {

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -603,7 +603,6 @@ describe('Adagio bid adapter', () => {
         const requests = spec.buildRequests([bid01], bidderRequest);
         expect(requests).to.have.lengthOf(1);
         expect(requests[0].data.adUnits[0].mediaTypes.video).to.deep.equal(expected);
-        sinon.assert.calledTwice(utils.logWarn.withArgs(sinon.match(new RegExp(/^Adagio: The OpenRTB/))));
       });
     });
 

--- a/test/spec/video_spec.js
+++ b/test/spec/video_spec.js
@@ -1,4 +1,4 @@
-import {fillVideoDefaults, isValidVideoBid} from 'src/video.js';
+import {fillVideoDefaults, isValidVideoBid, validateOrtbVideoFields} from 'src/video.js';
 import {hook} from '../../src/hook.js';
 import {stubAuctionIndex} from '../helpers/indexStub.js';
 
@@ -75,6 +75,64 @@ describe('video.js', function () {
         })
       })
     })
+  })
+
+  describe('validateOrtbVideoFields', () => {
+    function validate(videoMediaType = {}) {
+      const adUnit = {
+        mediaTypes: { video: videoMediaType }
+      };
+      const video = adUnit.mediaTypes.video;
+      validateOrtbVideoFields(video);
+      return adUnit.mediaTypes.video;
+    }
+
+    it('remove incorrect ortb properties, and keep non ortb ones', () => {
+      const mt = {
+        content: 'outstream',
+
+        mimes: ['video/mp4'],
+        minduration: 5,
+        maxduration: 15,
+        startdelay: 0,
+        maxseq: 0,
+        poddur: 0,
+        protocols: [7],
+        w: 600,
+        h: 480,
+        podid: 'an-id',
+        podseq: 0,
+        rqddurs: [5],
+        placement: 1,
+        plcmt: 1,
+        linearity: 1,
+        skip: 0,
+        skipmin: 3,
+        skipafter: 3,
+        sequence: 0,
+        slotinpod: 0,
+        mincpmpersec: 2.5,
+        battr: [6, 7],
+        maxextended: 0,
+        minbitrate: 800,
+        maxbitrate: 1000,
+        boxingallowed: 1,
+        playbackmethod: [1],
+        playbackend: 1,
+        delivery: [2],
+        pos: 0,
+        api: 6, // -- INVALID
+        companiontype: [1, 2, 3],
+        poddedupe: [1],
+
+        otherOne: 'test',
+      };
+
+      const expected = {...mt};
+      delete expected.api;
+
+      expect(validate(mt)).to.eql(expected)
+    });
   })
 
   describe('isValidVideoBid', () => {


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)

## Description of change
This is part of the work currently done to remove dupe code and any feedback would be appreciated.

The PR
- add a core helper function to validate (and remove if necessary) ORTB Video fields
- use it during the `validateVideoMediaType()` call to ensure only valid params are passed along the auction
- use it for the Adagio Bid Adapter in order to remove some duplicated code

It could be a starting point to address the following point:
There are a lot of adapters that use the pretty same logic which is to get the video params from an adUnit _(at mediaTypes and/or bids{}.params level)_ ensure they are matching the Ortb spec and remove them if not during the buildRequests() function.
Note this PR is not dedicated to fix all of them, just to try to introduce a common way for now.
