### PR TITLE
Prebid Core: Adding onAdRenderSucceeded to bidder spec

### DIFF
--- a/src/adRendering.js
+++ b/src/adRendering.js
@@ -18,6 +18,7 @@ import {getCreativeRenderer} from './creativeRenderers.js';
 import {hook} from './hook.js';
 import {fireNativeTrackers} from './native.js';
 import {GreedyPromise} from './utils/promise.js';
+import adapterManager from './adapterManager.js';
 
 const { AD_RENDER_FAILED, AD_RENDER_SUCCEEDED, STALE_RENDER, BID_WON } = EVENTS;
 const { EXCEPTION } = AD_RENDER_FAILED_REASON;
@@ -67,6 +68,8 @@ export function emitAdRenderSucceeded({ doc, bid, id }) {
   const data = { doc };
   if (bid) data.bid = bid;
   if (id) data.adId = id;
+
+  adapterManager.callAdRenderSucceededBidder(bid.adapterCode || bid.bidder, bid);
 
   events.emit(AD_RENDER_SUCCEEDED, data);
 }

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -688,6 +688,10 @@ adapterManager.callBidderError = function(bidder, error, bidderRequest) {
   tryCallBidderMethod(bidder, 'onBidderError', param);
 };
 
+adapterManager.callAdRenderSucceededBidder = function (bidder, bid) {
+  tryCallBidderMethod(bidder, 'onAdRenderSucceeded', bid);
+}
+
 function resolveAlias(alias) {
   const seen = new Set();
   while (_aliasRegistry.hasOwnProperty(alias) && !seen.has(alias)) {

--- a/test/spec/unit/adRendering_spec.js
+++ b/test/spec/unit/adRendering_spec.js
@@ -1,7 +1,7 @@
 import * as events from 'src/events.js';
 import * as utils from 'src/utils.js';
 import {
-  doRender, getBidToRender,
+  doRender, emitAdRenderSucceeded, getBidToRender,
   getRenderingData,
   handleCreativeEvent,
   handleNativeMessage,
@@ -12,6 +12,7 @@ import {expect} from 'chai/index.mjs';
 import {config} from 'src/config.js';
 import {VIDEO} from '../../../src/mediaTypes.js';
 import {auctionManager} from '../../../src/auctionManager.js';
+import adapterManager from '../../../src/adapterManager.js';
 
 describe('adRendering', () => {
   let sandbox;
@@ -267,4 +268,29 @@ describe('adRendering', () => {
       sinon.assert.calledWith(fireTrackers, data, bid);
     })
   })
+
+  describe('onAdRenderSucceeded', () => {
+    let mockAdapterSpec, bids;
+    beforeEach(() => {
+      mockAdapterSpec = {
+        onAdRenderSucceeded: sinon.stub()
+      };
+      adapterManager.bidderRegistry['mockBidder'] = {
+        bidder: 'mockBidder',
+        getSpec: function () { return mockAdapterSpec; },
+      };
+      bids = [
+        { bidder: 'mockBidder', params: { placementId: 'id' } },
+      ];
+    });
+
+    afterEach(function () {
+      delete adapterManager.bidderRegistry['mockBidder'];
+    });
+
+    it('should invoke onAddRenderSucceeded on emitAdRenderSucceeded', () => {
+      emitAdRenderSucceeded({ bid: bids[0] });
+      sinon.assert.called(mockAdapterSpec.onAdRenderSucceeded);
+    });
+  });
 });

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -428,6 +428,16 @@ describe('adapterManager tests', function () {
         sinon.assert.notCalled(criteoSpec.onBidViewable);
       })
     });
+
+    describe('onAdRenderSucceeded', function () {
+      beforeEach(() => {
+        criteoSpec.onAdRenderSucceeded = sinon.stub()
+      });
+      it('should call spec\'s onAdRenderSucceeded callback', function () {
+        adapterManager.callAdRenderSucceededBidder(bids[0].bidder, bids[0]);
+        sinon.assert.called(criteoSpec.onAdRenderSucceeded);
+      });
+    });
   })
   describe('onBidderError', function () {
     const bidder = 'appnexus';


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
#9573 