### PR TITLE
Index Exchange Bid Adapter: Add full ORTB2 device data to request payload

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -746,7 +746,7 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
 
     const isLastAdUnit = adUnitIndex === impKeys.length - 1;
 
-    r = addDeviceInfo(r);
+    r = addDeviceInfo(r, bidderRequest?.ortb2);
     r = deduplicateImpExtFields(r);
     r = removeSiteIDs(r);
 
@@ -2079,14 +2079,21 @@ function isValidAuctionConfig(config) {
 }
 
 /**
- * Adds device.w / device.h info
+ * Adds device info from ORTB2 data to the request
  * @param {object} r
+ * @param {object} ortb2Data
  * @returns object
  */
-export function addDeviceInfo(r) {
-  if (r.device == undefined) {
-    r.device = {};
+export function addDeviceInfo(r, ortb2Data) {
+  // add device object if not present
+  r.device = r.device || {};
+
+  // if present, merge device object from ortb2Data
+  if (ortb2Data?.device) {
+    mergeDeep(r.device, ortb2Data.device);
   }
+
+  // override screen width and height with window.screen values
   r.device.h = window.screen.height;
   r.device.w = window.screen.width;
 

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -5379,16 +5379,42 @@ describe('IndexexchangeAdapter', function () {
         device: {
           ip: '127.0.0.1'
         }
-      }
-      r = addDeviceInfo(r);
+      };
+      r = addDeviceInfo(r, {device: {}});
       expect(r.device.w).to.exist;
       expect(r.device.h).to.exist;
     });
     it('should add device to request when device doesnt exist', () => {
-      let r = {}
-      r = addDeviceInfo(r);
+      let r = {};
+      r = addDeviceInfo(r, {device: {}});
       expect(r.device.w).to.exist;
       expect(r.device.h).to.exist;
+    });
+    it('should send all available device info', () => {
+      const _deviceData = {
+        w: 980,
+        h: 1720,
+        dnt: 0,
+        ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1',
+        language: 'en',
+        devicetype: 1,
+        make: 'Apple',
+        model: 'iPhone 12 Pro Max',
+        os: 'iOS',
+        osv: '17.4'
+      };
+      let r = {};
+      r = addDeviceInfo(r, {
+        device: _deviceData,
+      });
+      // ensure that the screen width and height are used in the request,
+      // instead of viewport size
+      const _expectedDeviceData = {
+        ..._deviceData,
+        w: window.screen.width,
+        h: window.screen.height,
+      };
+      expect(r.device).to.deep.equal(_expectedDeviceData);
     });
   });
 });


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Updated bidder adapter

## Description of change
This PR enhances the Index Exchange bid request by incorporating device data from the global ORTB2 object. Existing values in the IX device object won't be replaced (e.g. screen size).

The device object has previously been populated by simplistic parsers, if at all, and was inaccurate as a result. Prebid now benefits from RTD modules such as 51Degrees that enrich all the device object fields including Apple iPhone model category and device ID. The PR enables Index Exchange’s users to benefit from device object improvements.

## Other information
cc: @ccorbo