### PR TITLE
Adagio Bid Adapter: Add full ORTB2 device data to request payload

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -5,7 +5,6 @@ import {
   deepAccess,
   deepClone,
   generateUUID,
-  getDNT,
   getWindowSelf,
   isArray,
   isArrayOfNums,
@@ -16,6 +15,7 @@ import {
   logError,
   logInfo,
   logWarn,
+  mergeDeep,
 } from '../src/utils.js';
 import { getRefererInfo, parseDomain } from '../src/refererDetection.js';
 import { OUTSTREAM } from '../src/video.js';
@@ -74,19 +74,33 @@ export const ORTB_VIDEO_PARAMS = {
 };
 
 /**
- * Returns the window.ADAGIO global object used to store Adagio data.
- * This object is created in window.top if possible, otherwise in window.self.
+ * Get device data object, with some properties
+ * deviated from the OpenRTB spec.
+ * @param {Object} ortb2Data
+ * @returns {Object} Device data object
  */
-function getDevice() {
+function getDevice(ortb2Data) {
+  const _device = {};
+
+  // Merge the device object from ORTB2 data.
+  if (ortb2Data?.device) {
+    mergeDeep(_device, ortb2Data.device);
+  }
+
+  // If the geo object is not defined, create it.
+  if (!_device.geo) {
+    _device.geo = {};
+  }
+
   const language = navigator.language ? 'language' : 'userLanguage';
-  return {
+  mergeDeep(_device, {
     userAgent: navigator.userAgent,
     language: navigator[language],
-    dnt: getDNT() ? 1 : 0,
-    geo: {},
     js: 1
-  };
-};
+  });
+
+  return _device;
+}
 
 function getSite(bidderRequest) {
   const { refererInfo } = bidderRequest;
@@ -542,7 +556,7 @@ export const spec = {
     validBidRequests = convertOrtbRequestToProprietaryNative(validBidRequests);
 
     const secure = (location.protocol === 'https:') ? 1 : 0;
-    const device = _internal.getDevice();
+    const device = _internal.getDevice(bidderRequest?.ortb2);
     const site = _internal.getSite(bidderRequest);
     const pageviewId = _internal.getAdagioNs().pageviewId;
     const gdprConsent = _getGdprConsent(bidderRequest) || {};

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -1043,6 +1043,40 @@ describe('Adagio bid adapter', () => {
         expect(requests[0].data.regs.dsa).to.be.undefined;
       });
     })
+
+    describe('with ORTB2', function() {
+      it('should add ortb2 device data to the request', function() {
+        const ortb2 = {
+          device: {
+            w: 980,
+            h: 1720,
+            dnt: 0,
+            ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1',
+            language: 'en',
+            devicetype: 1,
+            make: 'Apple',
+            model: 'iPhone 12 Pro Max',
+            os: 'iOS',
+            osv: '17.4',
+            ext: {fiftyonedegrees_deviceId: '17595-133085-133468-18092'},
+          },
+        };
+
+        const bid01 = new BidRequestBuilder().withParams().build();
+        const bidderRequest = new BidderRequestBuilder({ortb2}).build();
+        const requests = spec.buildRequests([bid01], bidderRequest);
+
+        const expectedData = {
+          ...ortb2.device,
+          language: navigator[navigator.language ? 'language' : 'userLanguage'],
+          js: 1,
+          geo: {},
+          userAgent: navigator.userAgent,
+        };
+
+        expect(requests[0].data.device).to.deep.equal(expectedData);
+      });
+    });
   });
 
   describe('interpretResponse()', function() {


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Updated bidder adapter

## Description of change
This PR enhances the Adagio bid request by incorporating device data from the global ORTB2 object. Existing values in the Adagio device object won't be replaced (e.g. language, userAgent, js).

The device object has previously been populated by simplistic parsers, if at all, and was inaccurate as a result. Prebid now benefits from RTD modules such as 51Degrees that enrich all the device object fields including Apple iPhone model category and device ID. The PR enables Adagio’s users to benefit from device object improvements.

## Other information
cc: @osazos