### PR TITLE
Rise Bid Adapter: Add ORTB2 device data to request payload

### DIFF
--- a/modules/riseBidAdapter.js
+++ b/modules/riseBidAdapter.js
@@ -63,6 +63,7 @@ export const spec = {
 
     combinedRequestsObject.params = generateGeneralParams(generalObject, bidderRequest);
     combinedRequestsObject.bids = generateBidsParams(validBidRequests, bidderRequest);
+    combinedRequestsObject.device = generateDeviceParams(bidderRequest?.ortb2);
 
     return {
       method: 'POST',
@@ -491,4 +492,13 @@ function generateGeneralParams(generalObject, bidderRequest) {
   }
 
   return generalParams;
+}
+
+/**
+ * Generate device params
+ * @param {Object} ortb2Data
+ * @returns {Object} device params object
+ */
+function generateDeviceParams(ortb2Data) {
+  return ortb2Data?.device || {};
 }

--- a/test/spec/modules/riseBidAdapter_spec.js
+++ b/test/spec/modules/riseBidAdapter_spec.js
@@ -434,6 +434,31 @@ describe('riseAdapter', function () {
       expect(request.data.bids[0].sua).to.not.exist;
     });
 
+    it('should send ORTB2 device data in bid request', function() {
+      const ortb2 = {
+        device: {
+          w: 980,
+          h: 1720,
+          dnt: 0,
+          ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1',
+          language: 'en',
+          devicetype: 1,
+          make: 'Apple',
+          model: 'iPhone 12 Pro Max',
+          os: 'iOS',
+          osv: '17.4',
+          ext: {fiftyonedegrees_deviceId: '17595-133085-133468-18092'},
+        },
+      };
+
+      const request = spec.buildRequests(bidRequests, {
+        ...bidderRequest,
+        ortb2,
+      });
+
+      expect(request.data.device).to.deep.equal(ortb2.device);
+    });
+
     describe('COPPA Param', function() {
       it('should set coppa equal 0 in bid request if coppa is set to false', function() {
         const request = spec.buildRequests(bidRequests, bidderRequest);


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Updated bidder adapter

## Description of change
This PR enhances the Rise bid request by incorporating device data from the global ORTB2 object.

The device object has previously been populated by simplistic parsers, if at all, and was inaccurate as a result. Prebid now benefits from RTD modules such as 51Degrees that enrich all the device object fields including Apple iPhone model category and device ID. The PR enables Rise’s users to benefit from device object improvements.

## Other information
cc: @lasloche