### PR TITLE
Rise Utils: Bugfixes

### DIFF
--- a/libraries/riseUtils/index.js
+++ b/libraries/riseUtils/index.js
@@ -324,6 +324,7 @@ export function generateGeneralParams(generalObject, bidderRequest, adapterVersi
   if (bidderRequest && bidderRequest.refererInfo) {
     generalParams.referrer = deepAccess(bidderRequest, 'refererInfo.ref');
     generalParams.page_url = deepAccess(bidderRequest, 'refererInfo.page') || deepAccess(window, 'location.href');
+    generalParams.page_domain = deepAccess(bidderRequest, 'refererInfo.domain') || deepAccess(window, 'location.hostname');
   }
 
   return generalParams;

--- a/libraries/riseUtils/index.js
+++ b/libraries/riseUtils/index.js
@@ -123,7 +123,7 @@ export function generateBidParameters(bid, bidderRequest) {
     sizes: sizesArray,
     floorPrice: Math.max(getFloor(bid, mediaType), params.floorPrice),
     bidId: getBidIdParameter('bidId', bid),
-    loop: getBidIdParameter('bidderRequestsCount', bid),
+    loop: bid.bidderRequestsCount || 0,
     bidderRequestId: getBidIdParameter('bidderRequestId', bid),
     transactionId: bid.ortb2Imp?.ext?.tid || '',
     coppa: 0,


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
1. Rise server expects `loop` parameter to be an integer, so it should default to 0 instead of an empty string.
2. For `page_domain` parameter, we should get the value from `refererInfo` if present.

Fixes #11289 
