### PR TITLE
Mobian RTD Module: remove reference to garm in output of mobian brand-safety

### DIFF
--- a/modules/mobianRtdProvider.js
+++ b/modules/mobianRtdProvider.js
@@ -40,21 +40,9 @@ function getBidRequestData(bidReqConfig, callback, config) {
           return;
         }
 
-        let mobianGarmRisk = response.garm_risk || 'unknown';
+        let mobianRisk = response.garm_risk || 'unknown';
 
-        if (mobianGarmRisk === 'unknown') {
-          const risks = ['garm_high_risk', 'garm_medium_risk', 'garm_low_risk', 'garm_no_risk'];
-          const riskLevels = ['high', 'medium', 'low', 'none'];
-
-          for (let i = 0; i < risks.length; i++) {
-            if (response[risks[i]]) {
-              mobianGarmRisk = riskLevels[i];
-              break;
-            }
-          }
-        }
-
-        const garmCategories = Object.keys(response)
+        const categories = Object.keys(response)
           .filter(key => key.startsWith('garm_content_category_') && response[key])
           .map(key => key.replace('garm_content_category_', ''));
 
@@ -67,8 +55,8 @@ function getBidRequestData(bidReqConfig, callback, config) {
           .map(key => key.replace('emotion_', ''));
 
         const risk = {
-          'mobianGarmRisk': mobianGarmRisk,
-          'garmContentCategories': garmCategories,
+          'risk': mobianRisk,
+          'contentCategories': categories,
           'sentiment': sentiment,
           'emotions': emotions
         };

--- a/test/spec/modules/mobianRtdProvider_spec.js
+++ b/test/spec/modules/mobianRtdProvider_spec.js
@@ -23,87 +23,7 @@ describe('Mobian RTD Submodule', function () {
     ajaxStub.restore();
   });
 
-  it('should return no_risk when server responds with garm_no_risk', function () {
-    ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
-      callbacks.success(JSON.stringify({
-        garm_no_risk: true,
-        garm_low_risk: false,
-        garm_medium_risk: false,
-        garm_high_risk: false
-      }));
-    });
-
-    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
-      expect(risk).to.have.property('mobianGarmRisk');
-      expect(risk['mobianGarmRisk']).to.equal('none');
-      expect(bidReqConfig.ortb2Fragments.global.site.ext.data.mobian).to.deep.equal(risk);
-    });
-  });
-
-  it('should return low_risk when server responds with garm_low_risk', function () {
-    ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
-      callbacks.success(JSON.stringify({
-        garm_no_risk: false,
-        garm_low_risk: true,
-        garm_medium_risk: false,
-        garm_high_risk: false
-      }));
-    });
-
-    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
-      expect(risk).to.have.property('mobianGarmRisk');
-      expect(risk['mobianGarmRisk']).to.equal('low');
-      expect(bidReqConfig.ortb2Fragments.global.site.ext.data.mobian).to.deep.equal(risk);
-    });
-  });
-
-  it('should return medium_risk when server responds with garm_medium_risk', function () {
-    ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
-      callbacks.success(JSON.stringify({
-        garm_no_risk: false,
-        garm_low_risk: false,
-        garm_medium_risk: true,
-        garm_high_risk: false
-      }));
-    });
-
-    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
-      expect(risk).to.have.property('mobianGarmRisk');
-      expect(risk['mobianGarmRisk']).to.equal('medium');
-      expect(bidReqConfig.ortb2Fragments.global.site.ext.data.mobian).to.deep.equal(risk);
-    });
-  });
-
-  it('should return high_risk when server responds with garm_high_risk', function () {
-    ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
-      callbacks.success(JSON.stringify({
-        garm_no_risk: false,
-        garm_low_risk: false,
-        garm_medium_risk: false,
-        garm_high_risk: true
-      }));
-    });
-
-    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
-      expect(risk).to.have.property('mobianGarmRisk');
-      expect(risk['mobianGarmRisk']).to.equal('high');
-      expect(bidReqConfig.ortb2Fragments.global.site.ext.data.mobian).to.deep.equal(risk);
-    });
-  });
-
-  it('should return empty object when server response is not valid JSON', function () {
-    ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
-      callbacks.success('unexpected output not even of the right type');
-    });
-    const originalConfig = JSON.parse(JSON.stringify(bidReqConfig));
-    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
-      expect(risk).to.deep.equal({});
-      // Check that bidReqConfig hasn't been modified
-      expect(bidReqConfig).to.deep.equal(originalConfig);
-    });
-  });
-
-  it('should handle response with direct garm_risk field', function () {
+  it('should return risk level when server responds with garm_risk', function () {
     ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
       callbacks.success(JSON.stringify({
         garm_risk: 'low',
@@ -114,11 +34,12 @@ describe('Mobian RTD Submodule', function () {
 
     return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
       expect(risk).to.deep.equal({
-        mobianGarmRisk: 'low',
-        garmContentCategories: [],
+        risk: 'low',
+        contentCategories: [],
         sentiment: 'positive',
         emotions: ['joy']
       });
+      expect(bidReqConfig.ortb2Fragments.global.site.ext.data.mobian).to.deep.equal(risk);
     });
   });
 
@@ -136,11 +57,42 @@ describe('Mobian RTD Submodule', function () {
 
     return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
       expect(risk).to.deep.equal({
-        mobianGarmRisk: 'medium',
-        garmContentCategories: ['arms', 'crime'],
+        risk: 'medium',
+        contentCategories: ['arms', 'crime'],
         sentiment: 'negative',
         emotions: ['anger', 'fear']
       });
+      expect(bidReqConfig.ortb2Fragments.global.site.ext.data.mobian).to.deep.equal(risk);
+    });
+  });
+
+  it('should return unknown risk when garm_risk is not present', function () {
+    ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
+      callbacks.success(JSON.stringify({
+        sentiment_neutral: true
+      }));
+    });
+
+    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
+      expect(risk).to.deep.equal({
+        risk: 'unknown',
+        contentCategories: [],
+        sentiment: 'neutral',
+        emotions: []
+      });
+      expect(bidReqConfig.ortb2Fragments.global.site.ext.data.mobian).to.deep.equal(risk);
+    });
+  });
+
+  it('should return empty object when server response is not valid JSON', function () {
+    ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
+      callbacks.success('unexpected output not even of the right type');
+    });
+    const originalConfig = JSON.parse(JSON.stringify(bidReqConfig));
+    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
+      expect(risk).to.deep.equal({});
+      // Check that bidReqConfig hasn't been modified
+      expect(bidReqConfig).to.deep.equal(originalConfig);
     });
   });
 


### PR DESCRIPTION

## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Our product team has asked us not to describe the given output as being created by GARM.

I also removed a loop that used to be necessary to compute the risk from the API output but is now redundant because the API output returns the risk directly.