### PR TITLE
Rise Bid Adapter: Add ORTB2 device data to request payload

### DIFF
--- a/libraries/riseUtils/index.js
+++ b/libraries/riseUtils/index.js
@@ -217,6 +217,15 @@ export function generateBidParameters(bid, bidderRequest) {
   return bidObject;
 }
 
+/**
+ * Generate device params
+ * @param {Object} ortb2Data
+ * @returns {Object} device params object
+ */
+export function generateDeviceParams(ortb2Data) {
+  return ortb2Data.device;
+}
+
 export function buildBidResponse(adUnit, DEFAULT_CURRENCY, TTL, VIDEO, BANNER) {
   const bidResponse = {
     requestId: adUnit.requestId,

--- a/libraries/riseUtils/index.js
+++ b/libraries/riseUtils/index.js
@@ -217,15 +217,6 @@ export function generateBidParameters(bid, bidderRequest) {
   return bidObject;
 }
 
-/**
- * Generate device params
- * @param {Object} ortb2Data
- * @returns {Object} device params object
- */
-export function generateDeviceParams(ortb2Data) {
-  return ortb2Data.device;
-}
-
 export function buildBidResponse(adUnit, DEFAULT_CURRENCY, TTL, VIDEO, BANNER) {
   const bidResponse = {
     requestId: adUnit.requestId,
@@ -296,6 +287,10 @@ export function generateGeneralParams(generalObject, bidderRequest, adapterVersi
   }
   if (ortb2Metadata.user) {
     generalParams.user_metadata = JSON.stringify(ortb2Metadata.user);
+  }
+
+  if (ortb2Metadata.device) {
+    generalParams.device = ortb2Metadata.device;
   }
 
   if (syncEnabled) {

--- a/modules/riseBidAdapter.js
+++ b/modules/riseBidAdapter.js
@@ -10,6 +10,7 @@ import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import {
   getEndpoint,
   generateBidsParams,
+  generateDeviceParams,
   generateGeneralParams,
   buildBidResponse,
 } from '../libraries/riseUtils/index.js';
@@ -58,6 +59,7 @@ export const spec = {
 
     combinedRequestsObject.params = generateGeneralParams(generalObject, bidderRequest);
     combinedRequestsObject.bids = generateBidsParams(validBidRequests, bidderRequest);
+    combinedRequestsObject.device = generateDeviceParams(bidderRequest.ortb2);
 
     return {
       method: 'POST',

--- a/modules/riseBidAdapter.js
+++ b/modules/riseBidAdapter.js
@@ -10,7 +10,6 @@ import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import {
   getEndpoint,
   generateBidsParams,
-  generateDeviceParams,
   generateGeneralParams,
   buildBidResponse,
 } from '../libraries/riseUtils/index.js';
@@ -59,7 +58,6 @@ export const spec = {
 
     combinedRequestsObject.params = generateGeneralParams(generalObject, bidderRequest);
     combinedRequestsObject.bids = generateBidsParams(validBidRequests, bidderRequest);
-    combinedRequestsObject.device = generateDeviceParams(bidderRequest.ortb2);
 
     return {
       method: 'POST',

--- a/test/spec/modules/riseBidAdapter_spec.js
+++ b/test/spec/modules/riseBidAdapter_spec.js
@@ -457,7 +457,7 @@ describe('riseAdapter', function () {
         ortb2,
       });
 
-      expect(request.data.device).to.deep.equal(ortb2.device);
+      expect(request.data.params.device).to.deep.equal(ortb2.device);
     });
 
     describe('COPPA Param', function() {

--- a/test/spec/modules/riseBidAdapter_spec.js
+++ b/test/spec/modules/riseBidAdapter_spec.js
@@ -111,6 +111,7 @@ describe('riseAdapter', function () {
 
     const bidderRequest = {
       bidderCode: 'rise',
+      ortb2: {device: {}},
     }
     const placementId = '12345678';
     const api = [1, 2];
@@ -432,6 +433,31 @@ describe('riseAdapter', function () {
       expect(data.bids[0].sua).to.deep.equal(sua);
       const request = spec.buildRequests(bidRequests, bidderRequest);
       expect(request.data.bids[0].sua).to.not.exist;
+    });
+
+    it('should send ORTB2 device data in bid request', function() {
+      const ortb2 = {
+        device: {
+          w: 980,
+          h: 1720,
+          dnt: 0,
+          ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1',
+          language: 'en',
+          devicetype: 1,
+          make: 'Apple',
+          model: 'iPhone 12 Pro Max',
+          os: 'iOS',
+          osv: '17.4',
+          ext: {fiftyonedegrees_deviceId: '17595-133085-133468-18092'},
+        },
+      };
+
+      const request = spec.buildRequests(bidRequests, {
+        ...bidderRequest,
+        ortb2,
+      });
+
+      expect(request.data.device).to.deep.equal(ortb2.device);
     });
 
     describe('COPPA Param', function() {


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Updated bidder adapter

## Description of change
This PR enhances the Rise bid request by incorporating device data from the global ORTB2 object.

The device object has previously been populated by simplistic parsers, if at all, and was inaccurate as a result. Prebid now benefits from RTD modules such as 51Degrees that enrich all the device object fields including Apple iPhone model category and device ID. The PR enables Rise's users to benefit from the device object.

In the spirit of other "generate" functions a `generateDeviceParams` function has been introduced - it serves to encapsulate the extraction of the device data from the upstream source and any customizations that might be needed. The device data seems to be added into various parts of the request, such as `request.data.bids[n].sua`, `request.data.params.ua`, `request.data.params.device_type`, and similar fields. We have consolidated all the device data under the `request.data.device` keypath. **Please let us know if this keypath works or should a different one be used, s.a. `request.data.params.device`, or perhaps fields of the `device` object must be all copied under `request.data.params`.**

## Other information
cc: @lasloche