### PR TITLE
Release Drafter : add default of maintenance for categories

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,14 +3,15 @@ name-template: 'Prebid $RESOLVED_VERSION Release'
 tag-template: '$RESOLVED_VERSION'
 categories:
   - title: '🚀 New Features'
-    label: 'feature'
+      label: 'feature'
   - title: '🛠 Maintenance'
-    label: 'maintenance'    
+      label: 'maintenance'    
   - title: '🐛 Bug Fixes'
-    labels:
-      - 'fix'
-      - 'bugfix'
-      - 'bug'      
+      labels:
+        - 'fix'
+        - 'bugfix'
+        - 'bug'
+    default: maintenance
 change-template: '- $TITLE (#$NUMBER)'
 version-resolver:
   major:


### PR DESCRIPTION
Update for issue #11953 to make maintenance the default tag for release drafer 