### PR TITLE
Navegg UserID Submodule: conform with pub storage configuration

### DIFF
--- a/modules/naveggIdSystem.js
+++ b/modules/naveggIdSystem.js
@@ -6,9 +6,9 @@
  */
 import { isStr, isPlainObject, logError } from '../src/utils.js';
 import { submodule } from '../src/hook.js';
-import * as ajaxLib from '../src/ajax.js';
-import {getStorageManager} from '../src/storageManager.js';
-import {MODULE_TYPE_UID} from '../src/activities/modules.js';
+import { ajaxBuilder } from '../src/ajax.js';
+import { getStorageManager } from '../src/storageManager.js';
+import { MODULE_TYPE_UID } from '../src/activities/modules.js';
 
 /**
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
@@ -24,7 +24,7 @@ export const storage = getStorageManager({moduleType: MODULE_TYPE_UID, moduleNam
 
 function getIdFromAPI() {
   const resp = function (callback) {
-    ajaxLib.ajaxBuilder()(
+    ajaxBuilder()(
       BASE_URL,
       response => {
         if (response) {

--- a/modules/naveggIdSystem.js
+++ b/modules/naveggIdSystem.js
@@ -7,7 +7,7 @@
 import { isStr, isPlainObject, logError } from '../src/utils.js';
 import { submodule } from '../src/hook.js';
 import { ajax } from '../src/ajax.js';
-import {getStorageManager} from '../src/storageManager.js';
+import {getStorageManager, STORAGE_TYPE_COOKIES, STORAGE_TYPE_LOCALSTORAGE} from '../src/storageManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 
 /**
@@ -24,55 +24,59 @@ const INVALID_EXPIRE = 3600 * 1000;
 
 export const storage = getStorageManager({moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME});
 
-function getNaveggIdFromApi() {
-  const callbacks = {
-    success: response => {
-      if (response) {
-        try {
-          const responseObj = JSON.parse(response);
-          writeCookie(NAVEGG_ID, responseObj[NAVEGG_ID]);
-        } catch (error) {
-          logError(error);
+/* eslint-disable no-console */
+function getIdFromAPI(toStore, storedName) {
+  const resp = function (callback) {
+    ajax(BASE_URL, {
+      success: response => {
+        if (response) {
+          try {
+            const responseObj = {'nvggid': 'bmF2ZWdnaWQK'} // JSON.parse(response);
+            console.log('responseObj: ' + responseObj)
+            callback(responseObj[NAVEGG_ID])
+          } catch (error) {
+            logError(error);
+            callback()
+          }
         }
+      },
+      error: error => {
+        logError('Navegg ID fetch encountered an error', error);
       }
     },
-    error: error => {
-      logError('Navegg ID fetch encountered an error', error);
-    }
-  };
-  ajax(BASE_URL, callbacks, undefined, { method: 'GET', withCredentials: false });
-}
-
-function writeCookie(key, value) {
-  try {
-    if (storage.cookiesAreEnabled) {
-      let expTime = new Date();
-      const expires = value ? DEFAULT_EXPIRE : INVALID_EXPIRE;
-      expTime.setTime(expTime.getTime() + expires);
-      storage.setCookie(key, value, expTime.toUTCString(), 'none');
-    }
-  } catch (e) {
-    logError(e);
+    undefined, { method: 'GET', withCredentials: false });
   }
+  return resp
 }
 
-function readnaveggIdFromLocalStorage() {
+/**
+ * @returns {string | null}
+ */
+function readNaveggIdFromLocalStorage() {
   return storage.localStorageIsEnabled ? storage.getDataFromLocalStorage(NAVEGG_ID) : null;
 }
-
-function readnaveggIDFromCookie() {
+/**
+ * @returns {string | null}
+ */
+function readNaveggIdFromCookie() {
   return storage.cookiesAreEnabled ? storage.getCookie(NAVEGG_ID) : null;
 }
-
-function readoldnaveggIDFromCookie() {
+/**
+ * @returns {string | null}
+ */
+function readOldNaveggIdFromCookie() {
   return storage.cookiesAreEnabled ? storage.getCookie(OLD_NAVEGG_ID) : null;
 }
-
-function readnvgIDFromCookie() {
+/**
+ * @returns {string | null}
+ */
+function readNvgIdFromCookie() {
   return storage.cookiesAreEnabled ? (storage.findSimilarCookies('nvg') ? storage.findSimilarCookies('nvg')[0] : null) : null;
 }
-
-function readnavIDFromCookie() {
+/**
+ * @returns {string | null}
+ */
+function readNavIdFromCookie() {
   return storage.cookiesAreEnabled ? (storage.findSimilarCookies('nav') ? storage.findSimilarCookies('nav')[0] : null) : null;
 }
 
@@ -90,28 +94,45 @@ export const naveggIdSubmodule = {
    * @return { Object | string | undefined }
    */
   decode(value) {
+    console.log('decode value: ' + value)
     const naveggIdVal = value ? isStr(value) ? value : isPlainObject(value) ? value.id : undefined : undefined;
     return naveggIdVal ? {
       'naveggId': naveggIdVal.split('|')[0]
     } : undefined;
   },
+
   /**
    * performs action to obtain id and return a value in the callback's response argument
    * @function
    * @param {SubmoduleConfig} config
    * @return {{id: string | undefined } | undefined}
    */
-  getId() {
-    const naveggIdString = readnaveggIdFromLocalStorage() || readnaveggIDFromCookie() || getNaveggIdFromApi() || readoldnaveggIDFromCookie() || readnvgIDFromCookie() || readnavIDFromCookie();
+  getId({ name, enabledStorageTypes = [], storage: storageConfig = {} }) {
+    const resp = getIdFromAPI(enabledStorageTypes, storageConfig.name)
 
-    if (typeof naveggIdString == 'string' && naveggIdString) {
-      try {
-        return { id: naveggIdString };
-      } catch (error) {
-        logError(error);
-      }
-    }
-    return undefined;
+    // const naveggIdOldString = readOldNaveggIdFromCookie() || readNvgIdFromCookie() || readNavIdFromCookie()
+    // const naveggIdLocalStorage = readNaveggIdFromLocalStorage()
+    // const naveggIdCookie = readNaveggIdFromCookie()
+    // let toStore = []
+
+    // if (!naveggIdLocalStorage && enabledStorageTypes.indexOf(STORAGE_TYPE_LOCALSTORAGE) > -1) { toStore.push(STORAGE_TYPE_LOCALSTORAGE) }
+    // if (!naveggIdCookie && enabledStorageTypes.indexOf(STORAGE_TYPE_COOKIES) > -1) { toStore.push(STORAGE_TYPE_COOKIES) }
+    // saveNaveggIdFromApi(toStore, storageConfig.name)
+
+    // const naveggIdString = readNaveggIdFromCookie() || readNaveggIdFromLocalStorage();
+
+    // console.log('naveggIdString: ' + naveggIdString)
+    // console.log('----------------------------')
+
+    // if (typeof naveggIdString == 'string' && naveggIdString) {
+    //   try {
+    //     return { id: naveggIdString };
+    //   } catch (error) {
+    //     logError(error);
+    //   }
+    // }
+    // return undefined;
+    return {callback: resp}
   },
   eids: {
     'naveggId': {

--- a/modules/naveggIdSystem.js
+++ b/modules/naveggIdSystem.js
@@ -34,7 +34,7 @@ function getIdFromAPI() {
           } catch (error) {
             logError(error);
             const fallbackValue = getNaveggIdFromLocalStorage() || getOldCookie();
-            callback(fallbackValue)
+            callback(fallbackValue);
           }
 
           if (responseObj && responseObj[NAVEGG_ID]) {
@@ -48,11 +48,11 @@ function getIdFromAPI() {
       error => {
         logError('Navegg ID fetch encountered an error', error);
         const fallbackValue = getNaveggIdFromLocalStorage() || getOldCookie();
-        callback(fallbackValue)
+        callback(fallbackValue);
       },
       {method: 'GET', withCredentials: false});
   };
-  return resp
+  return resp;
 }
 
 /**

--- a/modules/naveggIdSystem.md
+++ b/modules/naveggIdSystem.md
@@ -10,6 +10,11 @@ pbjs.setConfig({
     userSync: {
         userIds: [{
             name: 'naveggId',
+            storage: {
+                name : 'nvggid',
+                type : 'cookie&html5',
+                expires: 8
+            }
         }]
     }
 });
@@ -20,3 +25,6 @@ The below parameters apply only to the naveggID integration.
 | Param under usersync.userIds[] | Scope | Type | Description | Example |
 | --- | --- | --- | --- | --- |
 | name | Required | String | ID of the module - `"naveggId"` | `"naveggId"` |
+| storage.name | Required | String | The name of the cookie or html5 local storage where the user ID will be stored.	 | `"nvggid"` |
+| storage.type | Required | String | Must be "`cookie`", "`html5`" or "`cookie&html5`". This is where the results of the user ID will be stored.	| `"cookie&html5"` |
+| storage.expires | Required | Integer | How long (in days) the user ID information will be stored. | `8` |

--- a/test/spec/modules/naveggIdSystem_spec.js
+++ b/test/spec/modules/naveggIdSystem_spec.js
@@ -1,45 +1,155 @@
-import { naveggIdSubmodule, storage } from 'modules/naveggIdSystem.js';
+import { naveggIdSubmodule, storage, getIdFromAPI } from 'modules/naveggIdSystem.js';
+import * as utils from '../../../src/utils.js';
+import { server } from 'test/mocks/xhr.js';
+import * as ajaxLib from 'src/ajax.js';
 
-describe('naveggId', function () {
-  let sandbox;
-  beforeEach(() => {
-    sandbox = sinon.sandbox.create();
-    sandbox.stub(storage, 'getDataFromLocalStorage');
+const NAVEGGID_CONFIG_COOKIE_HTML5 = {
+  name: 'naveggId',
+  storage: {
+    name: 'nvggid',
+    type: 'cookie&html5',
+    expires: 8
+  }
+}
+
+const NAVEGGID_CONFIG_COOKIE = {
+  name: 'naveggId',
+  storage: {
+    name: 'nvggid',
+    type: 'cookie',
+    expires: 8
+  }
+}
+
+const NAVEGGID_CONFIG_HTML5 = {
+  name: 'naveggId',
+  storage: {
+    name: 'nvggid',
+    type: 'html5',
+    expires: 8
+  }
+}
+
+const MOCK_RESPONSE = {
+  nvggid: 'test_nvggid'
+}
+
+const MOCK_RESPONSE_NULL = {
+  nvggid: null
+}
+
+function mockResponse(responseText, isSuccess = true) {
+  return function(url, callbacks) {
+    if (isSuccess) {
+      callbacks.success(responseText)
+    } else {
+      callbacks.error(new Error('Mock Error'))
+    }
+  }
+}
+
+function deleteAllCookies() {
+  document.cookie.split(';').forEach(cookie => {
+    const eqPos = cookie.indexOf('=');
+    const name = eqPos > -1 ? cookie.substring(0, eqPos) : cookie;
+    document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:00 GMT';
   });
-  afterEach(() => {
-    sandbox.restore();
+}
+
+/* eslint-disable no-console */
+describe('getId', function () {
+  let ajaxStub, ajaxBuilderStub;
+
+  beforeEach(function() {
+    ajaxStub = sinon.stub()
+    ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(ajaxStub);
   });
 
-  it('should NOT find navegg id', function () {
-    let id = naveggIdSubmodule.getId();
-
-    expect(id).to.be.undefined;
+  afterEach(function() {
+    ajaxBuilderStub.restore();
+    deleteAllCookies();
   });
 
-  it('getId() should return "test-nid" id from cookie OLD_NAVEGG_ID', function() {
-    sinon.stub(storage, 'getCookie').withArgs('nid').returns('test-nid');
-    let id = naveggIdSubmodule.getId();
-    expect(id).to.be.deep.equal({id: 'test-nid'})
-  })
+  it('should get the value from a nid cookie', function() {
+    storage.setCookie('nid', 'old_nid_cookie', storage.expires)
 
-  it('getId() should return "test-nvggid" id from local storage NAVEGG_ID', function() {
-    storage.getDataFromLocalStorage.callsFake(() => 'test-ninvggidd')
+    const callback = sinon.spy();
+    const apiCallback = naveggIdSubmodule.getId(NAVEGGID_CONFIG_COOKIE_HTML5).callback;
 
-    let id = naveggIdSubmodule.getId();
-    expect(id).to.be.deep.equal({id: 'test-ninvggidd'})
-  })
+    ajaxStub.callsFake((url, successCallbacks, errorCallback, options) => {
+      if (successCallbacks && typeof successCallbacks === 'function') {
+        successCallbacks(JSON.stringify(MOCK_RESPONSE_NULL));
+      }
+    });
+    apiCallback(callback)
 
-  it('getId() should return "test-nvggid" id from local storage NAV0', function() {
-    storage.getDataFromLocalStorage.callsFake(() => 'nvgid-nav0')
+    expect(callback.calledOnce).to.be.true;
+    expect(callback.calledWith('old_nid_cookie')).to.be.true;
+  });
 
-    let id = naveggIdSubmodule.getId();
-    expect(id).to.be.deep.equal({id: 'nvgid-nav0'})
-  })
+  it('should get the value from a nav cookie', function() {
+    storage.setCookie('navId', 'old_nav_cookie', storage.expires)
 
-  it('getId() should return "test-nvggid" id from local storage NVG0', function() {
-    storage.getDataFromLocalStorage.callsFake(() => 'nvgid-nvg0')
+    const callback = sinon.spy();
+    const apiCallback = naveggIdSubmodule.getId(NAVEGGID_CONFIG_COOKIE_HTML5).callback;
 
-    let id = naveggIdSubmodule.getId();
-    expect(id).to.be.deep.equal({id: 'nvgid-nvg0'})
-  })
+    ajaxStub.callsFake((url, successCallbacks, errorCallback, options) => {
+      if (successCallbacks && typeof successCallbacks === 'function') {
+        successCallbacks(JSON.stringify(MOCK_RESPONSE_NULL));
+      }
+    });
+    apiCallback(callback)
+
+    expect(callback.calledOnce).to.be.true;
+    expect(callback.calledWith('old_nav_cookie')).to.be.true;
+  });
+
+  it('should get the value from an old nvg cookie', function() {
+    storage.setCookie('nvgid', 'old_nvg_cookie', storage.expires)
+
+    const callback = sinon.spy();
+    const apiCallback = naveggIdSubmodule.getId(NAVEGGID_CONFIG_COOKIE_HTML5).callback;
+
+    ajaxStub.callsFake((url, successCallbacks, errorCallback, options) => {
+      if (successCallbacks && typeof successCallbacks === 'function') {
+        successCallbacks(JSON.stringify(MOCK_RESPONSE_NULL));
+      }
+    });
+    apiCallback(callback)
+
+    expect(callback.calledOnce).to.be.true;
+    expect(callback.calledWith('old_nvg_cookie')).to.be.true;
+  });
+
+  it('should return correct value from API response', function(done) {
+    const callback = sinon.spy();
+    const apiCallback = naveggIdSubmodule.getId(NAVEGGID_CONFIG_COOKIE_HTML5).callback;
+
+    ajaxStub.callsFake((url, successCallbacks, errorCallback, options) => {
+      if (successCallbacks && typeof successCallbacks === 'function') {
+        successCallbacks(JSON.stringify(MOCK_RESPONSE));
+      }
+    });
+    apiCallback(callback)
+
+    expect(callback.calledOnce).to.be.true;
+    expect(callback.calledWith('test_nvggid')).to.be.true;
+    done();
+  });
+
+  it('should return no value from API response', function(done) {
+    const callback = sinon.spy();
+    const apiCallback = naveggIdSubmodule.getId(NAVEGGID_CONFIG_COOKIE_HTML5).callback;
+
+    ajaxStub.callsFake((url, successCallbacks, errorCallback, options) => {
+      if (successCallbacks && typeof successCallbacks === 'function') {
+        successCallbacks(JSON.stringify(MOCK_RESPONSE_NULL));
+      }
+    });
+    apiCallback(callback)
+    console.log('result: ' + callback.lastCall.lastArg)
+    expect(callback.calledOnce).to.be.true;
+    expect(callback.calledWith(undefined)).to.be.true;
+    done();
+  });
 });

--- a/test/spec/modules/naveggIdSystem_spec.js
+++ b/test/spec/modules/naveggIdSystem_spec.js
@@ -1,5 +1,4 @@
 import { naveggIdSubmodule, storage, getIdFromAPI } from 'modules/naveggIdSystem.js';
-import * as utils from '../../../src/utils.js';
 import { server } from 'test/mocks/xhr.js';
 import * as ajaxLib from 'src/ajax.js';
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Other

## Description of change
Fixing the problems described at https://github.com/prebid/Prebid.js/issues/10710.
We are now saving the ID in cookie or html5, respecting the storage.type parameter. 
We also changed our logic to get the ID from our API.
