### PR TITLE
PBS Adapter: Add PBS_ANALYTICS Event

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -475,8 +475,8 @@ export function PrebidServer() {
           if (isValid) {
             bidRequests.forEach(bidderRequest => events.emit(EVENTS.BIDDER_DONE, bidderRequest));
           }
-          const { emitSeatNonBid, emitAtag } = shouldEmitAnalyticsEvent(s2sBidRequest.s2sConfig, response)
-          if (emitSeatNonBid) {
+          const { seatNonBidData, atagData } = getAnalyticsFlags(s2sBidRequest.s2sConfig, response)
+          if (seatNonBidData) {
             events.emit(EVENTS.SEAT_NON_BID, {
               seatnonbid: response.ext.seatnonbid,
               auctionId: bidRequests[0].auctionId,
@@ -486,10 +486,10 @@ export function PrebidServer() {
             });
           }
           // pbs analytics event
-          if (emitSeatNonBid || emitAtag) {
+          if (seatNonBidData || atagData) {
             const data = {
-              seatnonbid: emitSeatNonBid ? response.ext.seatnonbid : undefined,
-              atag: emitAtag ? response.ext.prebid.analytics.tags : undefined,
+              seatnonbid: seatNonBidData,
+              atag: atagData,
               auctionId: bidRequests[0].auctionId,
               requestedBidders,
               response,
@@ -614,17 +614,17 @@ export const processPBSRequest = hook('sync', function (s2sBidRequest, bidReques
   }
 }, 'processPBSRequest');
 
-function shouldEmitAnalyticsEvent(s2sConfig, response) {
+function getAnalyticsFlags(s2sConfig, response) {
   return {
-    emitAtag: shouldEmitAtag(response),
-    emitSeatNonBid: shouldEmitNonbids(s2sConfig, response)
+    atagData: getAtagData(response),
+    seatNonBidData: getNonbidData(s2sConfig, response)
   }
 }
-function shouldEmitNonbids(s2sConfig, response) {
-  return s2sConfig?.extPrebid?.returnallbidstatus && response?.ext?.seatnonbid;
+function getNonbidData(s2sConfig, response) {
+  return s2sConfig?.extPrebid?.returnallbidstatus ? response?.ext?.seatnonbid: undefined;
 }
 
-function shouldEmitAtag(response) {
+function getAtagData(response) {
   return response?.ext?.prebid?.analytics?.tags;
 }
 

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -621,7 +621,7 @@ function getAnalyticsFlags(s2sConfig, response) {
   }
 }
 function getNonbidData(s2sConfig, response) {
-  return s2sConfig?.extPrebid?.returnallbidstatus ? response?.ext?.seatnonbid: undefined;
+  return s2sConfig?.extPrebid?.returnallbidstatus ? response?.ext?.seatnonbid : undefined;
 }
 
 function getAtagData(response) {

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -617,10 +617,10 @@ export const processPBSRequest = hook('sync', function (s2sBidRequest, bidReques
 function getAnalyticsFlags(s2sConfig, response) {
   return {
     atagData: getAtagData(response),
-    seatNonBidData: getNonbidData(s2sConfig, response)
+    seatNonBidData: getNonBidData(s2sConfig, response)
   }
 }
-function getNonbidData(s2sConfig, response) {
+function getNonBidData(s2sConfig, response) {
   return s2sConfig?.extPrebid?.returnallbidstatus ? response?.ext?.seatnonbid : undefined;
 }
 

--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -475,7 +475,8 @@ export function PrebidServer() {
           if (isValid) {
             bidRequests.forEach(bidderRequest => events.emit(EVENTS.BIDDER_DONE, bidderRequest));
           }
-          if (shouldEmitNonbids(s2sBidRequest.s2sConfig, response)) {
+          const { emitSeatNonBid, emitAtag } = shouldEmitAnalyticsEvent(s2sBidRequest.s2sConfig, response)
+          if (emitSeatNonBid) {
             events.emit(EVENTS.SEAT_NON_BID, {
               seatnonbid: response.ext.seatnonbid,
               auctionId: bidRequests[0].auctionId,
@@ -483,6 +484,18 @@ export function PrebidServer() {
               response,
               adapterMetrics
             });
+          }
+          // pbs analytics event
+          if (emitSeatNonBid || emitAtag) {
+            const data = {
+              seatnonbid: emitSeatNonBid ? response.ext.seatnonbid : undefined,
+              atag: emitAtag ? response.ext.prebid.analytics.tags : undefined,
+              auctionId: bidRequests[0].auctionId,
+              requestedBidders,
+              response,
+              adapterMetrics
+            }
+            events.emit(EVENTS.PBS_ANALYTICS, data);
           }
           done(false);
           doClientSideSyncs(requestedBidders, gdprConsent, uspConsent, gppConsent);
@@ -601,8 +614,18 @@ export const processPBSRequest = hook('sync', function (s2sBidRequest, bidReques
   }
 }, 'processPBSRequest');
 
+function shouldEmitAnalyticsEvent(s2sConfig, response) {
+  return {
+    emitAtag: shouldEmitAtag(response),
+    emitSeatNonBid: shouldEmitNonbids(s2sConfig, response)
+  }
+}
 function shouldEmitNonbids(s2sConfig, response) {
   return s2sConfig?.extPrebid?.returnallbidstatus && response?.ext?.seatnonbid;
+}
+
+function shouldEmitAtag(response) {
+  return response?.ext?.prebid?.analytics?.tags;
 }
 
 /**

--- a/src/constants.js
+++ b/src/constants.js
@@ -43,6 +43,7 @@ export const EVENTS = {
   BILLABLE_EVENT: 'billableEvent',
   BID_ACCEPTED: 'bidAccepted',
   RUN_PAAPI_AUCTION: 'paapiRunAuction',
+  PBS_ANALYTICS: 'pbsAnalytics',
   PAAPI_BID: 'paapiBid',
   PAAPI_NO_BID: 'paapiNoBid',
   PAAPI_ERROR: 'paapiError',

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -3155,6 +3155,39 @@ describe('S2S Adapter', function () {
       expect(event[1].response).to.deep.equal(responding);
     });
 
+    it('emits the PBS_ANALYTICS event and captures seatnonbid responses', function () {
+      const original = CONFIG;
+      CONFIG.extPrebid = { returnallbidstatus: true };
+      const nonbidResponse = {...RESPONSE_OPENRTB, ext: {seatnonbid: [{}]}};
+      config.setConfig({ CONFIG });
+      CONFIG = original;
+      adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
+      const responding = deepClone(nonbidResponse);
+      Object.assign(responding.ext.seatnonbid, [{auctionId: 2}])
+      server.requests[0].respond(200, {}, JSON.stringify(responding));
+      const event = events.emit.thirdCall.args;
+      expect(event[0]).to.equal(EVENTS.PBS_ANALYTICS);
+      expect(event[1].seatnonbid[0]).to.have.property('auctionId', 2);
+      expect(event[1].requestedBidders).to.deep.equal(['appnexus']);
+      expect(event[1].response).to.deep.equal(responding);
+    });
+
+    it('emits the PBS_ANALYTICS event and captures atag responses', function () {
+      const original = CONFIG;
+      CONFIG.extPrebid = { returnallbidstatus: true };
+      const atagResponse = {...RESPONSE_OPENRTB, ext: {prebid: {analytics: {tags: ['data']}}}};
+      config.setConfig({ CONFIG });
+      CONFIG = original;
+      adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
+      const responding = deepClone(atagResponse);
+      Object.assign(responding.ext.prebid.analytics.tags, ['stuff'])
+      server.requests[0].respond(200, {}, JSON.stringify(responding));
+      const event = events.emit.secondCall.args;
+      expect(event[0]).to.equal(EVENTS.PBS_ANALYTICS);
+      expect(event[1].atag[0]).to.deep.equal('stuff');
+      expect(event[1].response).to.deep.equal(responding);
+    });
+
     it('respects defaultTtl', function () {
       const s2sConfig = Object.assign({}, CONFIG, {
         defaultTtl: 30


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->

- [ x ] Feature


## Description of change
<!-- Describe the change proposed in this pull request -->
Add PBS_ANALYTICS event and pass ATAG data through it

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Supercedes https://github.com/prebid/Prebid.js/pull/12015
