### PR TITLE
Ozone Bid Adapter: Add full ORTB2 device data to request payload

### DIFF
--- a/modules/ozoneBidAdapter.js
+++ b/modules/ozoneBidAdapter.js
@@ -227,7 +227,7 @@ export const spec = {
     const getParams = this.getGetParametersAsObject();
     const wlOztestmodeKey = whitelabelPrefix + 'testmode';
     const isTestMode = getParams[wlOztestmodeKey] || null; // this can be any string, it's used for testing ads
-    ozoneRequest.device = {'w': window.innerWidth, 'h': window.innerHeight};
+    ozoneRequest.device = bidderRequest?.ortb2?.device || {};
     let placementIdOverrideFromGetParam = this.getPlacementIdOverrideFromGetParam(); // null or string
     let schain = null;
     let tosendtags = validBidRequests.map(ozoneBidRequest => {

--- a/test/spec/modules/ozoneBidAdapter_spec.js
+++ b/test/spec/modules/ozoneBidAdapter_spec.js
@@ -2445,6 +2445,27 @@ describe('ozone Adapter', function () {
       const payload = JSON.parse(request.data);
       expect(payload.imp[0].ext.ae).to.equal(1);
     });
+    it('should handle ortb2 device data', function () {
+      const bidderRequest = JSON.parse(JSON.stringify(validBidderRequest));
+      bidderRequest.ortb2 = {
+        device: {
+          w: 980,
+          h: 1720,
+          dnt: 0,
+          ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1',
+          language: 'en',
+          devicetype: 1,
+          make: 'Apple',
+          model: 'iPhone 12 Pro Max',
+          os: 'iOS',
+          osv: '17.4',
+          ext: {fiftyonedegrees_deviceId: '17595-133085-133468-18092'},
+        },
+      };
+      const request = spec.buildRequests(validBidRequests, bidderRequest);
+      const payload = JSON.parse(request.data);
+      expect(payload.device).to.deep.equal(bidderRequest.ortb2.device);
+    });
   });
   describe('interpretResponse', function () {
     beforeEach(function () {


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Updated bidder adapter

## Description of change
This PR enhances the Ozone bid request by incorporating device data from the global ORTB2 object.

The device object has previously been populated by simplistic parsers, if at all, and was inaccurate as a result. Prebid now benefits from RTD modules such as 51Degrees that enrich all the device object fields including Apple iPhone model category and device ID. The PR enables Ozone's users to benefit from the device object.

## Other information
cc: @AskRupert-DM