### PR TITLE
CORE: prevent unbound growth of suspendedTimeouts and possible NaN values

### DIFF
--- a/src/utils/focusTimeout.js
+++ b/src/utils/focusTimeout.js
@@ -6,7 +6,7 @@ function trackTimeOutOfFocus() {
   if (document.hidden) {
     outOfFocusStart = Date.now()
   } else {
-    timeOutOfFocus += Date.now() - (outOfFocusStart); // when the page is loaded in hidden state outOfFocusStart is undefined, which results in timeoutOffset being NaN
+    timeOutOfFocus += Date.now() - (outOfFocusStart ?? 0); // when the page is loaded in hidden state outOfFocusStart is undefined, which results in timeoutOffset being NaN
     outOfFocusStart = null;
     suspendedTimeouts.forEach(({ callback, startTime, setTimerId }) => setTimerId(setFocusTimeout(callback, timeOutOfFocus - startTime)()));
     suspendedTimeouts = [];

--- a/src/utils/focusTimeout.js
+++ b/src/utils/focusTimeout.js
@@ -2,15 +2,26 @@ let outOfFocusStart = null; // enforce null otherwise it could be undefined and 
 let timeOutOfFocus = 0;
 let suspendedTimeouts = [];
 
-document.addEventListener('visibilitychange', () => {
+function trackTimeOutOfFocus() {
   if (document.hidden) {
     outOfFocusStart = Date.now()
   } else {
-    timeOutOfFocus += Date.now() - (outOfFocusStart ?? 0); // when the page is loaded in hidden state outOfFocusStart is undefined, which results in timeoutOffset being NaN
-    outOfFocusStart = null; // out of focus time should be cleared prior looping the suspendedTimeouts, as the callbacks could reached their timelimit and could be executed immediately
+    timeOutOfFocus += Date.now() - (outOfFocusStart); // when the page is loaded in hidden state outOfFocusStart is undefined, which results in timeoutOffset being NaN
+    outOfFocusStart = null;
     suspendedTimeouts.forEach(({ callback, startTime, setTimerId }) => setTimerId(setFocusTimeout(callback, timeOutOfFocus - startTime)()));
+    suspendedTimeouts = [];
   }
-});
+}
+
+document.addEventListener('visibilitychange', trackTimeOutOfFocus);
+
+export function reset() {
+  outOfFocusStart = null;
+  timeOutOfFocus = 0;
+  suspendedTimeouts = [];
+  document.removeEventListener('visibilitychange', trackTimeOutOfFocus);
+  document.addEventListener('visibilitychange', trackTimeOutOfFocus);
+}
 
 /**
  * Wraps native setTimeout function in order to count time only when page is focused
@@ -19,9 +30,8 @@ document.addEventListener('visibilitychange', () => {
  * @param {number} [milliseconds] - Minimum duration (in milliseconds) that the callback will be executed after
  * @returns {function(*): (number)} - Getter function for current timer id
  */
-export default function setFocusTimeout(callback, milliseconds) {
+export function setFocusTimeout(callback, milliseconds) {
   const startTime = timeOutOfFocus;
-  suspendedTimeouts = suspendedTimeouts.filter((cbObj) => cbObj.callback !== callback); // remove the callback from the suspendedTimeouts, to prevent unbounded growth of the array
   let timerId = setTimeout(() => {
     if (timeOutOfFocus === startTime && outOfFocusStart == null) {
       callback();

--- a/src/utils/ttlCollection.js
+++ b/src/utils/ttlCollection.js
@@ -1,6 +1,6 @@
 import {GreedyPromise} from './promise.js';
 import {binarySearch, logError, timestamp} from '../utils.js';
-import setFocusTimeout from './focusTimeout.js';
+import {setFocusTimeout} from './focusTimeout.js';
 
 /**
  * Create a set-like collection that automatically forgets items after a certain time.


### PR DESCRIPTION
## Type of change
- [x ] Bugfix

## Description of change
We have publishers complain about high memory usage caused by the focusTimeout handler for cleaning up expired bids, introduced by; https://github.com/prebid/Prebid.js/pull/11803 . this is because the values in suspendedTimeouts are never cleared. in addition to this if you open a page, and really quickly tab away the value timeOutOfFocus can become NaN when outOfFocusStart isn't set. 

in addition it would be nice this feature is optional, e.g. to allow the configure the old behaviour, e.g. in case you want todo ad-reloads in the background, but still clean them up.
