### PR TITLE
PubxAI Rtd module update: Make the endpoint call optional; read from local storage. 

### DIFF
--- a/modules/pubxaiRtdProvider.js
+++ b/modules/pubxaiRtdProvider.js
@@ -115,7 +115,7 @@ export const fetchFloorRules = async (provider) => {
     } else {
       // Fetch from local storage
       try {
-        const localData = storage.getDataFromLocalStorage('pubx:dynamicFloors') || window.__pubxDynamicFloors__;
+        const localData = storage.getDataFromSessionStorage('pubx:dynamicFloors') || window.__pubxDynamicFloors__;
         if (localData) {
           resolve(JSON.parse(localData));
         } else {

--- a/modules/pubxaiRtdProvider.js
+++ b/modules/pubxaiRtdProvider.js
@@ -2,6 +2,7 @@ import { ajax } from '../src/ajax.js';
 import { config } from '../src/config.js';
 import { submodule } from '../src/hook.js';
 import { deepAccess } from '../src/utils.js';
+import { MODULE_TYPE_RTD } from '../src/activities/modules.js';
 import { getStorageManager } from '../src/storageManager.js';
 /**
  * This RTD module has a dependency on the priceFloors module.
@@ -17,7 +18,7 @@ export const FloorsApiStatus = Object.freeze({
   SUCCESS: 'SUCCESS',
   ERROR: 'ERROR',
 });
-const storage = getStorageManager({ moduleType: MODULE_TYPE_ANALYTICS, moduleName: adapterCode });
+const storage = getStorageManager({ moduleType: MODULE_TYPE_RTD, moduleName: SUBMODULE_NAME });
 export const FLOORS_EVENT_HANDLE = 'floorsApi';
 export const FLOORS_END_POINT = 'https://floor.pbxai.com/';
 export const FLOOR_PROVIDER = 'PubxFloorProvider';

--- a/modules/pubxaiRtdProvider.js
+++ b/modules/pubxaiRtdProvider.js
@@ -18,7 +18,7 @@ export const FloorsApiStatus = Object.freeze({
   SUCCESS: 'SUCCESS',
   ERROR: 'ERROR',
 });
-const storage = getStorageManager({ moduleType: MODULE_TYPE_RTD, moduleName: SUBMODULE_NAME });
+export const storage = getStorageManager({ moduleType: MODULE_TYPE_RTD, moduleName: SUBMODULE_NAME });
 export const FLOORS_EVENT_HANDLE = 'floorsApi';
 export const FLOORS_END_POINT = 'https://floor.pbxai.com/';
 export const FLOOR_PROVIDER = 'PubxFloorProvider';

--- a/modules/pubxaiRtdProvider.md
+++ b/modules/pubxaiRtdProvider.md
@@ -32,7 +32,7 @@ pbjs.setConfig({
 	...,
 	realTimeData: {
 		auctionDelay: AUCTION_DELAY,
-		dataProviders: {
+		dataProviders: [{
 			name: "pubxai",
 			waitForIt: true,
 			params: {
@@ -42,7 +42,7 @@ pbjs.setConfig({
 				enforcement: `<enforcement>`, // (optional)
 				data: `<defaultConfig>` // (optional)
 			}
-		}
+		}]
 	}
 	// rest of the config
 	...,

--- a/test/spec/modules/pubxaiRtdProvider_spec.js
+++ b/test/spec/modules/pubxaiRtdProvider_spec.js
@@ -142,7 +142,7 @@ describe('pubxaiRtdProvider', () => {
     let storageStub;
 
     beforeEach(() => {
-      storageStub = sinon.stub(getStorageManager({ moduleType: 'rtd', moduleName: 'pubxai' }), 'getDataFromLocalStorage');
+      storageStub = sinon.stub(getStorageManager({ moduleType: 'rtd', moduleName: 'pubxai' }), 'getDataFromSessionStorage');
     });
 
     afterEach(() => {

--- a/test/spec/modules/pubxaiRtdProvider_spec.js
+++ b/test/spec/modules/pubxaiRtdProvider_spec.js
@@ -1,6 +1,7 @@
 import * as priceFloors from '../../../modules/priceFloors';
 import {
   FLOORS_END_POINT,
+  storage,
   FLOORS_EVENT_HANDLE,
   FloorsApiStatus,
   beforeInit,
@@ -16,7 +17,6 @@ import {
 import { config } from '../../../src/config';
 import * as hook from '../../../src/hook.js';
 import { server } from '../../mocks/xhr.js';
-import { getStorageManager } from '../../../src/storageManager.js';
 
 const getConfig = () => ({
   params: {
@@ -142,7 +142,7 @@ describe('pubxaiRtdProvider', () => {
     let storageStub;
 
     beforeEach(() => {
-      storageStub = sinon.stub(getStorageManager({ moduleType: 'rtd', moduleName: 'pubxai' }), 'getDataFromSessionStorage');
+      storageStub = sinon.stub(storage, 'getDataFromSessionStorage');
     });
 
     afterEach(() => {
@@ -417,9 +417,7 @@ describe('pubxaiRtdProvider', () => {
       expect(FLOORS_END_POINT).to.equal('https://floor.pbxai.com/');
     });
     it('standard case', () => {
-      expect(getUrl(provider)).to.equal(
-        `https://floor.pbxai.com/?pubxId=12345&page=${window.location.href}`
-      );
+      expect(getUrl(provider)).to.equal(null);
     });
     it('custom url provided', () => {
       provider.params.endpoint = 'https://custom.floor.com/';

--- a/test/spec/modules/pubxaiRtdProvider_spec.js
+++ b/test/spec/modules/pubxaiRtdProvider_spec.js
@@ -16,6 +16,7 @@ import {
 import { config } from '../../../src/config';
 import * as hook from '../../../src/hook.js';
 import { server } from '../../mocks/xhr.js';
+import { getStorageManager } from '../../../src/storageManager.js';
 
 const getConfig = () => ({
   params: {
@@ -45,6 +46,7 @@ const resetGlobals = () => {
   window.__pubxFloorsConfig__ = undefined;
   window.__pubxFloorsApiStatus__ = undefined;
   window.__pubxFloorRulesPromise__ = null;
+  localStorage.removeItem('pubx:dynamicFloors');
 };
 
 const fakeServer = (
@@ -119,7 +121,7 @@ describe('pubxaiRtdProvider', () => {
       stub.restore();
     });
     it('createFloorsDataForAuction called once before and once after __pubxFloorRulesPromise__. Also getBidRequestData executed only once', async () => {
-      pubxaiSubmodule.getBidRequestData(reqBidsConfigObj, () => {});
+      pubxaiSubmodule.getBidRequestData(reqBidsConfigObj, () => { });
       assert(priceFloors.createFloorsDataForAuction.calledOnce);
       await window.__pubxFloorRulesPromise__;
       assert(priceFloors.createFloorsDataForAuction.calledTwice);
@@ -129,7 +131,7 @@ describe('pubxaiRtdProvider', () => {
           reqBidsConfigObj.auctionId
         )
       );
-      pubxaiSubmodule.getBidRequestData(reqBidsConfigObj, () => {});
+      pubxaiSubmodule.getBidRequestData(reqBidsConfigObj, () => { });
       await window.__pubxFloorRulesPromise__;
       assert(priceFloors.createFloorsDataForAuction.calledTwice);
     });
@@ -137,6 +139,16 @@ describe('pubxaiRtdProvider', () => {
   describe('fetchFloorRules', () => {
     const providerConfig = getConfig();
     const floorsResponse = getFloorsResponse();
+    let storageStub;
+
+    beforeEach(() => {
+      storageStub = sinon.stub(getStorageManager({ moduleType: 'rtd', moduleName: 'pubxai' }), 'getDataFromLocalStorage');
+    });
+
+    afterEach(() => {
+      storageStub.restore();
+    });
+
     it('success with floors response', (done) => {
       const promise = fetchFloorRules(providerConfig);
       fakeServer(floorsResponse);
@@ -145,6 +157,7 @@ describe('pubxaiRtdProvider', () => {
         done();
       });
     });
+
     it('success with no floors response', (done) => {
       const promise = fetchFloorRules(providerConfig);
       fakeServer(undefined);
@@ -153,6 +166,7 @@ describe('pubxaiRtdProvider', () => {
         done();
       });
     });
+
     it('API call error', (done) => {
       const promise = fetchFloorRules(providerConfig);
       fakeServer(undefined, undefined, 404);
@@ -167,6 +181,7 @@ describe('pubxaiRtdProvider', () => {
           done();
         });
     });
+
     it('Wrong API response', (done) => {
       const promise = fetchFloorRules(providerConfig);
       fakeServer('floorsResponse');
@@ -180,6 +195,25 @@ describe('pubxaiRtdProvider', () => {
         .finally(() => {
           done();
         });
+    });
+
+    it('success with local data response', (done) => {
+      const localFloorsResponse = getFloorsResponse();
+      storageStub.withArgs('pubx:dynamicFloors').returns(JSON.stringify(localFloorsResponse));
+      const promise = fetchFloorRules({ params: {} });
+      promise.then((res) => {
+        expect(res).to.deep.equal(localFloorsResponse);
+        done();
+      });
+    });
+
+    it('no local data response', (done) => {
+      storageStub.withArgs('pubx:dynamicFloors').returns(null);
+      const promise = fetchFloorRules({ params: {} });
+      promise.then((res) => {
+        expect(res).to.deep.equal(null);
+        done();
+      });
     });
   });
   describe('setPriceFloors', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Feature


## Description of change
The endpoint param of the RTD module has been made optional. When the endpoint is not provided, look for available data in the session storage or in a global window object. 

