### PR TITLE
Cwire Bid Adapter support domainId and deprecate placementId

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -219,9 +219,9 @@ export const converter = ortbConverter({
     const {bidRequest} = context;
 
     let [parseSizeWidth, parseSizeHeight] = bidRequest.mediaTypes.video?.context === 'outstream' ? parseSizes(bidRequest, VIDEO) : [undefined, undefined];
-
-    bidResponse.width = bid.w || parseSizeWidth || bidResponse.playerWidth;
-    bidResponse.height = bid.h || parseSizeHeight || bidResponse.playerHeight;
+    // 0 by default to avoid undefined size
+    bidResponse.width = bid.w || parseSizeWidth || bidResponse.playerWidth || 0;
+    bidResponse.height = bid.h || parseSizeHeight || bidResponse.playerHeight || 0;
 
     if (bidResponse.mediaType === VIDEO && bidRequest.mediaTypes.video.context === 'outstream') {
       bidResponse.renderer = outstreamRenderer(bidResponse);

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -3987,6 +3987,16 @@ describe('the rubicon adapter', function () {
             let bids = spec.interpretResponse({body: response}, {data: request});
             expect(bids).to.have.nested.property('[0].native');
           });
+          it('should set 0 to bids width and height if `w` and `h` in response object not defined', () => {
+            const nativeBidderRequest = addNativeToBidRequest(bidderRequest);
+            const request = converter.toORTB({bidderRequest: nativeBidderRequest, bidRequests: nativeBidderRequest.bids});
+            let response = getNativeResponse({impid: request.imp[0].id});
+            delete response.seatbid[0].bid[0].w;
+            delete response.seatbid[0].bid[0].h
+            let bids = spec.interpretResponse({body: response}, {data: request});
+            expect(bids[0].width).to.equal(0);
+            expect(bids[0].height).to.equal(0);
+          })
         });
       }
 


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter

## Description of change

Updating our prebid adapter to include domainId and make placementId optional (deprecated), while leaving the old params for compatibility purposes.