### PR TITLE
ortbConverter: do not override EIDS provided as first party data

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -1196,7 +1196,7 @@ module('userId', attachIdSystem, { postInstallAllowed: true });
 export function setOrtbUserExtEids(ortbRequest, bidderRequest, context) {
   const eids = deepAccess(context, 'bidRequests.0.userIdAsEids');
   if (eids && Object.keys(eids).length > 0) {
-    deepSetValue(ortbRequest, 'user.ext.eids', eids);
+    deepSetValue(ortbRequest, 'user.ext.eids', eids.concat(ortbRequest.user?.ext?.eids || []));
   }
 }
 registerOrtbProcessor({type: REQUEST, name: 'userExtEids', fn: setOrtbUserExtEids});

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1025,7 +1025,7 @@ describe('OpenxRtbAdapter', function () {
           // enrich bid request with userId key/value
 
           const request = spec.buildRequests(bidRequestsWithUserId, mockBidderRequest);
-          expect(request[0].data.user.ext.eids).to.equal(userIdAsEids);
+          expect(request[0].data.user.ext.eids).to.eql(userIdAsEids);
         });
 
         it(`when no user ids are available, it should not send any extended ids`, function () {

--- a/test/spec/modules/trafficgateBidAdapter_spec.js
+++ b/test/spec/modules/trafficgateBidAdapter_spec.js
@@ -1006,7 +1006,7 @@ describe('TrafficgateOpenxRtbAdapter', function () {
           // enrich bid request with userId key/value
 
           const request = spec.buildRequests(bidRequestsWithUserId, mockBidderRequest);
-          expect(request[0].data.user.ext.eids).to.equal(userIdAsEids);
+          expect(request[0].data.user.ext.eids).to.eql(userIdAsEids);
         });
 
         it(`when no user ids are available, it should not send any extended ids`, function () {

--- a/test/spec/ortbConverter/userId_spec.js
+++ b/test/spec/ortbConverter/userId_spec.js
@@ -6,12 +6,33 @@ describe('pbjs - ortb user eids', () => {
     setOrtbUserExtEids(req, {}, {
       bidRequests: [
         {
-          userIdAsEids: {e: 'id'}
+          userIdAsEids: [{e: 'id'}]
         }
       ]
     });
-    expect(req.user.ext.eids).to.eql({e: 'id'});
+    expect(req.user.ext.eids).to.eql([{e: 'id'}]);
   });
+
+  it('should not override eids from fpd', () => {
+    const req = {
+      user: {
+        ext: {
+          eids: [{existing: 'id'}]
+        }
+      }
+    };
+    setOrtbUserExtEids(req, {}, {
+      bidRequests: [
+        {
+          userIdAsEids: [{nw: 'id'}]
+        }
+      ]
+    });
+    expect(req.user.ext.eids).to.eql([
+      {nw: 'id'},
+      {existing: 'id'},
+    ])
+  })
 
   it('has no effect if requests have no eids', () => {
     const req = {};


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Update ortbConverter to extend, not override, EIDs provided as first party data

## Other information

Related to https://github.com/prebid/Prebid.js/issues/11954
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
