### PR TITLE
MobianRtdModule: add mobian contextual variables directly to site.ext.data 

### DIFF
--- a/modules/mobianRtdProvider.js
+++ b/modules/mobianRtdProvider.js
@@ -22,7 +22,6 @@ export const mobianBrandSafetySubmodule = {
 function init() {
   return true;
 }
-
 function getBidRequestData(bidReqConfig, callback, config) {
   const { site: ortb2Site } = bidReqConfig.ortb2Fragments.global;
   const pageUrl = encodeURIComponent(getPageUrl());
@@ -54,25 +53,55 @@ function getBidRequestData(bidReqConfig, callback, config) {
           .filter(key => key.startsWith('emotion_') && response[key])
           .map(key => key.replace('emotion_', ''));
 
-        const risk = {
-          'risk': mobianRisk,
-          'contentCategories': categories,
-          'sentiment': sentiment,
-          'emotions': emotions
+        const categoryFlags = {
+          adult: categories.includes('adult'),
+          arms: categories.includes('arms'),
+          crime: categories.includes('crime'),
+          death_injury: categories.includes('death_injury'),
+          piracy: categories.includes('piracy'),
+          hate_speech: categories.includes('hate_speech'),
+          obscenity: categories.includes('obscenity'),
+          drugs: categories.includes('drugs'),
+          spam: categories.includes('spam'),
+          terrorism: categories.includes('terrorism'),
+          debated_issue: categories.includes('debated_issue')
         };
 
-        resolve(risk);
-        deepSetValue(ortb2Site.ext, 'data.mobian', risk);
-        callback()
+        const emotionFlags = {
+          love: emotions.includes('love'),
+          joy: emotions.includes('joy'),
+          anger: emotions.includes('anger'),
+          surprise: emotions.includes('surprise'),
+          sadness: emotions.includes('sadness'),
+          fear: emotions.includes('fear')
+        };
+
+        deepSetValue(ortb2Site.ext, 'data.mobianRisk', mobianRisk);
+        deepSetValue(ortb2Site.ext, 'data.mobianSentiment', sentiment);
+
+        Object.entries(categoryFlags).forEach(([category, value]) => {
+          deepSetValue(ortb2Site.ext, `data.mobianCategory${category.charAt(0).toUpperCase() + category.slice(1)}`, value);
+        });
+
+        Object.entries(emotionFlags).forEach(([emotion, value]) => {
+          deepSetValue(ortb2Site.ext, `data.mobianEmotion${emotion.charAt(0).toUpperCase() + emotion.slice(1)}`, value);
+        });
+
+        resolve({
+          risk: mobianRisk,
+          sentiment: sentiment,
+          categoryFlags: categoryFlags,
+          emotionFlags: emotionFlags
+        });
+        callback();
       },
       error: function () {
         resolve({});
-        callback()
+        callback();
       }
     });
   });
 }
-
 function getPageUrl() {
   return window.location.href;
 }

--- a/test/spec/modules/mobianRtdProvider_spec.js
+++ b/test/spec/modules/mobianRtdProvider_spec.js
@@ -12,7 +12,9 @@ describe('Mobian RTD Submodule', function () {
       ortb2Fragments: {
         global: {
           site: {
-            ext: {}
+            ext: {
+              data: {}
+            }
           }
         }
       }
@@ -23,7 +25,7 @@ describe('Mobian RTD Submodule', function () {
     ajaxStub.restore();
   });
 
-  it('should return risk level when server responds with garm_risk', function () {
+  it('should set individual key-value pairs when server responds with garm_risk', function () {
     ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
       callbacks.success(JSON.stringify({
         garm_risk: 'low',
@@ -32,14 +34,37 @@ describe('Mobian RTD Submodule', function () {
       }));
     });
 
-    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
-      expect(risk).to.deep.equal({
+    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((result) => {
+      expect(result).to.deep.equal({
         risk: 'low',
-        contentCategories: [],
         sentiment: 'positive',
-        emotions: ['joy']
+        categoryFlags: {
+          adult: false,
+          arms: false,
+          crime: false,
+          death_injury: false,
+          piracy: false,
+          hate_speech: false,
+          obscenity: false,
+          drugs: false,
+          spam: false,
+          terrorism: false,
+          debated_issue: false
+        },
+        emotionFlags: {
+          love: false,
+          joy: true,
+          anger: false,
+          surprise: false,
+          sadness: false,
+          fear: false
+        }
       });
-      expect(bidReqConfig.ortb2Fragments.global.site.ext.data.mobian).to.deep.equal(risk);
+      expect(bidReqConfig.ortb2Fragments.global.site.ext.data).to.deep.include({
+        mobianRisk: 'low',
+        mobianSentiment: 'positive',
+        mobianEmotionJoy: true
+      });
     });
   });
 
@@ -55,14 +80,40 @@ describe('Mobian RTD Submodule', function () {
       }));
     });
 
-    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
-      expect(risk).to.deep.equal({
+    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((result) => {
+      expect(result).to.deep.equal({
         risk: 'medium',
-        contentCategories: ['arms', 'crime'],
         sentiment: 'negative',
-        emotions: ['anger', 'fear']
+        categoryFlags: {
+          adult: false,
+          arms: true,
+          crime: true,
+          death_injury: false,
+          piracy: false,
+          hate_speech: false,
+          obscenity: false,
+          drugs: false,
+          spam: false,
+          terrorism: false,
+          debated_issue: false
+        },
+        emotionFlags: {
+          love: false,
+          joy: false,
+          anger: true,
+          surprise: false,
+          sadness: false,
+          fear: true
+        }
       });
-      expect(bidReqConfig.ortb2Fragments.global.site.ext.data.mobian).to.deep.equal(risk);
+      expect(bidReqConfig.ortb2Fragments.global.site.ext.data).to.deep.include({
+        mobianRisk: 'medium',
+        mobianSentiment: 'negative',
+        mobianCategoryArms: true,
+        mobianCategoryCrime: true,
+        mobianEmotionAnger: true,
+        mobianEmotionFear: true
+      });
     });
   });
 
@@ -73,14 +124,36 @@ describe('Mobian RTD Submodule', function () {
       }));
     });
 
-    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
-      expect(risk).to.deep.equal({
+    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((result) => {
+      expect(result).to.deep.equal({
         risk: 'unknown',
-        contentCategories: [],
         sentiment: 'neutral',
-        emotions: []
+        categoryFlags: {
+          adult: false,
+          arms: false,
+          crime: false,
+          death_injury: false,
+          piracy: false,
+          hate_speech: false,
+          obscenity: false,
+          drugs: false,
+          spam: false,
+          terrorism: false,
+          debated_issue: false
+        },
+        emotionFlags: {
+          love: false,
+          joy: false,
+          anger: false,
+          surprise: false,
+          sadness: false,
+          fear: false
+        }
       });
-      expect(bidReqConfig.ortb2Fragments.global.site.ext.data.mobian).to.deep.equal(risk);
+      expect(bidReqConfig.ortb2Fragments.global.site.ext.data).to.deep.include({
+        mobianRisk: 'unknown',
+        mobianSentiment: 'neutral'
+      });
     });
   });
 
@@ -89,8 +162,8 @@ describe('Mobian RTD Submodule', function () {
       callbacks.success('unexpected output not even of the right type');
     });
     const originalConfig = JSON.parse(JSON.stringify(bidReqConfig));
-    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
-      expect(risk).to.deep.equal({});
+    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((result) => {
+      expect(result).to.deep.equal({});
       // Check that bidReqConfig hasn't been modified
       expect(bidReqConfig).to.deep.equal(originalConfig);
     });
@@ -101,8 +174,8 @@ describe('Mobian RTD Submodule', function () {
       callbacks.error();
     });
 
-    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((risk) => {
-      expect(risk).to.deep.equal({});
+    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((result) => {
+      expect(result).to.deep.equal({});
     });
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Our client is using Magnite for importing k-v pairs from site.ext.data, and Magnite isn't able to reach into site.ext.data.mobian, so we are "bringing everything up a layer." 