### PR TITLE
Mobian RTD Module: reduce cardinality of fields added to site.ext.data

### DIFF
--- a/modules/mobianRtdProvider.js
+++ b/modules/mobianRtdProvider.js
@@ -22,6 +22,7 @@ export const mobianBrandSafetySubmodule = {
 function init() {
   return true;
 }
+
 function getBidRequestData(bidReqConfig, callback, config) {
   const { site: ortb2Site } = bidReqConfig.ortb2Fragments.global;
   const pageUrl = encodeURIComponent(getPageUrl());
@@ -41,7 +42,7 @@ function getBidRequestData(bidReqConfig, callback, config) {
 
         let mobianRisk = response.garm_risk || 'unknown';
 
-        const categories = Object.keys(response)
+        const contentCategories = Object.keys(response)
           .filter(key => key.startsWith('garm_content_category_') && response[key])
           .map(key => key.replace('garm_content_category_', ''));
 
@@ -53,46 +54,19 @@ function getBidRequestData(bidReqConfig, callback, config) {
           .filter(key => key.startsWith('emotion_') && response[key])
           .map(key => key.replace('emotion_', ''));
 
-        const categoryFlags = {
-          adult: categories.includes('adult'),
-          arms: categories.includes('arms'),
-          crime: categories.includes('crime'),
-          death_injury: categories.includes('death_injury'),
-          piracy: categories.includes('piracy'),
-          hate_speech: categories.includes('hate_speech'),
-          obscenity: categories.includes('obscenity'),
-          drugs: categories.includes('drugs'),
-          spam: categories.includes('spam'),
-          terrorism: categories.includes('terrorism'),
-          debated_issue: categories.includes('debated_issue')
-        };
-
-        const emotionFlags = {
-          love: emotions.includes('love'),
-          joy: emotions.includes('joy'),
-          anger: emotions.includes('anger'),
-          surprise: emotions.includes('surprise'),
-          sadness: emotions.includes('sadness'),
-          fear: emotions.includes('fear')
+        const risk = {
+          risk: mobianRisk,
+          contentCategories: contentCategories,
+          sentiment: sentiment,
+          emotions: emotions
         };
 
         deepSetValue(ortb2Site.ext, 'data.mobianRisk', mobianRisk);
+        deepSetValue(ortb2Site.ext, 'data.mobianContentCategories', contentCategories);
         deepSetValue(ortb2Site.ext, 'data.mobianSentiment', sentiment);
+        deepSetValue(ortb2Site.ext, 'data.mobianEmotions', emotions);
 
-        Object.entries(categoryFlags).forEach(([category, value]) => {
-          deepSetValue(ortb2Site.ext, `data.mobianCategory${category.charAt(0).toUpperCase() + category.slice(1)}`, value);
-        });
-
-        Object.entries(emotionFlags).forEach(([emotion, value]) => {
-          deepSetValue(ortb2Site.ext, `data.mobianEmotion${emotion.charAt(0).toUpperCase() + emotion.slice(1)}`, value);
-        });
-
-        resolve({
-          risk: mobianRisk,
-          sentiment: sentiment,
-          categoryFlags: categoryFlags,
-          emotionFlags: emotionFlags
-        });
+        resolve(risk);
         callback();
       },
       error: function () {
@@ -102,6 +76,7 @@ function getBidRequestData(bidReqConfig, callback, config) {
     });
   });
 }
+
 function getPageUrl() {
   return window.location.href;
 }

--- a/test/spec/modules/mobianRtdProvider_spec.js
+++ b/test/spec/modules/mobianRtdProvider_spec.js
@@ -25,7 +25,7 @@ describe('Mobian RTD Submodule', function () {
     ajaxStub.restore();
   });
 
-  it('should set individual key-value pairs when server responds with garm_risk', function () {
+  it('should set key-value pairs when server responds with garm_risk', function () {
     ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
       callbacks.success(JSON.stringify({
         garm_risk: 'low',
@@ -37,33 +37,15 @@ describe('Mobian RTD Submodule', function () {
     return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((result) => {
       expect(result).to.deep.equal({
         risk: 'low',
+        contentCategories: [],
         sentiment: 'positive',
-        categoryFlags: {
-          adult: false,
-          arms: false,
-          crime: false,
-          death_injury: false,
-          piracy: false,
-          hate_speech: false,
-          obscenity: false,
-          drugs: false,
-          spam: false,
-          terrorism: false,
-          debated_issue: false
-        },
-        emotionFlags: {
-          love: false,
-          joy: true,
-          anger: false,
-          surprise: false,
-          sadness: false,
-          fear: false
-        }
+        emotions: ['joy']
       });
       expect(bidReqConfig.ortb2Fragments.global.site.ext.data).to.deep.include({
         mobianRisk: 'low',
+        mobianContentCategories: [],
         mobianSentiment: 'positive',
-        mobianEmotionJoy: true
+        mobianEmotions: ['joy']
       });
     });
   });
@@ -83,36 +65,15 @@ describe('Mobian RTD Submodule', function () {
     return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((result) => {
       expect(result).to.deep.equal({
         risk: 'medium',
+        contentCategories: ['arms', 'crime'],
         sentiment: 'negative',
-        categoryFlags: {
-          adult: false,
-          arms: true,
-          crime: true,
-          death_injury: false,
-          piracy: false,
-          hate_speech: false,
-          obscenity: false,
-          drugs: false,
-          spam: false,
-          terrorism: false,
-          debated_issue: false
-        },
-        emotionFlags: {
-          love: false,
-          joy: false,
-          anger: true,
-          surprise: false,
-          sadness: false,
-          fear: true
-        }
+        emotions: ['anger', 'fear']
       });
       expect(bidReqConfig.ortb2Fragments.global.site.ext.data).to.deep.include({
         mobianRisk: 'medium',
+        mobianContentCategories: ['arms', 'crime'],
         mobianSentiment: 'negative',
-        mobianCategoryArms: true,
-        mobianCategoryCrime: true,
-        mobianEmotionAnger: true,
-        mobianEmotionFear: true
+        mobianEmotions: ['anger', 'fear']
       });
     });
   });
@@ -127,32 +88,15 @@ describe('Mobian RTD Submodule', function () {
     return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((result) => {
       expect(result).to.deep.equal({
         risk: 'unknown',
+        contentCategories: [],
         sentiment: 'neutral',
-        categoryFlags: {
-          adult: false,
-          arms: false,
-          crime: false,
-          death_injury: false,
-          piracy: false,
-          hate_speech: false,
-          obscenity: false,
-          drugs: false,
-          spam: false,
-          terrorism: false,
-          debated_issue: false
-        },
-        emotionFlags: {
-          love: false,
-          joy: false,
-          anger: false,
-          surprise: false,
-          sadness: false,
-          fear: false
-        }
+        emotions: []
       });
       expect(bidReqConfig.ortb2Fragments.global.site.ext.data).to.deep.include({
         mobianRisk: 'unknown',
-        mobianSentiment: 'neutral'
+        mobianContentCategories: [],
+        mobianSentiment: 'neutral',
+        mobianEmotions: []
       });
     });
   });


### PR DESCRIPTION


## Type of change
- [x] Bugfix

## Description of change
Contra our remark in PR #12082 , the third-party tooling can indeed accept lists in site.ext.data, just not substructures. This alternative is more compact and adds only four total keys.  (As before, the change is not backwards compatible but the only current user is paying close attention to this structure.)