### PR TITLE
OpenX BidAdapter: remove PAF, bugfix for PAAPI igi support

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -80,11 +80,6 @@ const converter = ortbConverter({
       bidResponse.meta.advertiserId = bid.ext.buyer_id;
       bidResponse.meta.brandId = bid.ext.brand_id;
     }
-    const {ortbResponse} = context;
-    if (ortbResponse.ext && ortbResponse.ext.paf) {
-      bidResponse.meta.paf = Object.assign({}, ortbResponse.ext.paf);
-      bidResponse.meta.paf.content_id = utils.deepAccess(bid, 'ext.paf.content_id');
-    }
     return bidResponse;
   },
   response(buildResponse, bidResponses, ortbResponse, context) {
@@ -117,7 +112,7 @@ const converter = ortbConverter({
         paapi: fledgeAuctionConfigs,
       }
     } else {
-      return response.bids
+      return response
     }
   },
   overrides: {

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1109,7 +1109,7 @@ describe('OpenxRtbAdapter', function () {
     let bid;
 
     context('when there is an nbr response', function () {
-      let bids;
+      let response;
       beforeEach(function () {
         bidRequestConfigs = [{
           bidder: 'openx',
@@ -1131,16 +1131,16 @@ describe('OpenxRtbAdapter', function () {
         bidRequest = spec.buildRequests(bidRequestConfigs, {refererInfo: {}})[0];
 
         bidResponse = {nbr: 0}; // Unknown error
-        bids = spec.interpretResponse({body: bidResponse}, bidRequest);
+        response = spec.interpretResponse({body: bidResponse}, bidRequest);
       });
 
       it('should not return any bids', function () {
-        expect(bids.length).to.equal(0);
+        expect(response.bids.length).to.equal(0);
       });
     });
 
     context('when no seatbid in response', function () {
-      let bids;
+      let response;
       beforeEach(function () {
         bidRequestConfigs = [{
           bidder: 'openx',
@@ -1162,16 +1162,16 @@ describe('OpenxRtbAdapter', function () {
         bidRequest = spec.buildRequests(bidRequestConfigs, {refererInfo: {}})[0];
 
         bidResponse = {ext: {}, id: 'test-bid-id'};
-        bids = spec.interpretResponse({body: bidResponse}, bidRequest);
+        response = spec.interpretResponse({body: bidResponse}, bidRequest);
       });
 
       it('should not return any bids', function () {
-        expect(bids.length).to.equal(0);
+        expect(response.bids.length).to.equal(0);
       });
     });
 
     context('when there is no response', function () {
-      let bids;
+      let response;
       beforeEach(function () {
         bidRequestConfigs = [{
           bidder: 'openx',
@@ -1193,11 +1193,11 @@ describe('OpenxRtbAdapter', function () {
         bidRequest = spec.buildRequests(bidRequestConfigs, {refererInfo: {}})[0];
 
         bidResponse = ''; // Unknown error
-        bids = spec.interpretResponse({body: bidResponse}, bidRequest);
+        response = spec.interpretResponse({body: bidResponse}, bidRequest);
       });
 
       it('should not return any bids', function () {
-        expect(bids.length).to.equal(0);
+        expect(response.bids.length).to.equal(0);
       });
     });
 
@@ -1232,19 +1232,11 @@ describe('OpenxRtbAdapter', function () {
           ext: {
             dsp_id: '123',
             buyer_id: '456',
-            brand_id: '789',
-            paf: {
-              content_id: 'paf_content_id'
-            }
+            brand_id: '789'
           }
         }]
       }],
-      cur: 'AUS',
-      ext: {
-        paf: {
-          transmission: {version: '12'}
-        }
-      }
+      cur: 'AUS'
     };
 
     context('when there is a response, the common response properties', function () {
@@ -1253,7 +1245,7 @@ describe('OpenxRtbAdapter', function () {
         bidRequest = spec.buildRequests(bidRequestConfigs, {refererInfo: {}})[0];
         bidResponse = deepClone(SAMPLE_BID_RESPONSE);
 
-        bid = spec.interpretResponse({body: bidResponse}, bidRequest)[0];
+        bid = spec.interpretResponse({body: bidResponse}, bidRequest).bids[0];
       });
 
       it('should return a price', function () {
@@ -1308,32 +1300,7 @@ describe('OpenxRtbAdapter', function () {
       it('should return adomain', function () {
         expect(bid.meta.advertiserDomains).to.equal(bidResponse.seatbid[0].bid[0].adomain);
       });
-
-      it('should return paf fields', function () {
-        const paf = {
-          transmission: {version: '12'},
-          content_id: 'paf_content_id'
-        }
-        expect(bid.meta.paf).to.deep.equal(paf);
-      });
     });
-
-    context('when there is more than one response', () => {
-      let bids;
-      beforeEach(function () {
-        bidRequestConfigs = deepClone(SAMPLE_BID_REQUESTS);
-        bidRequest = spec.buildRequests(bidRequestConfigs, {refererInfo: {}})[0];
-        bidResponse = deepClone(SAMPLE_BID_RESPONSE);
-        bidResponse.seatbid[0].bid.push(deepClone(bidResponse.seatbid[0].bid[0]));
-        bidResponse.seatbid[0].bid[1].ext.paf.content_id = 'second_paf'
-
-        bids = spec.interpretResponse({body: bidResponse}, bidRequest);
-      });
-
-      it('should not confuse paf content_id', () => {
-        expect(bids.map(b => b.meta.paf.content_id)).to.eql(['paf_content_id', 'second_paf']);
-      });
-    })
 
     context('when the response is a banner', function() {
       beforeEach(function () {
@@ -1371,7 +1338,7 @@ describe('OpenxRtbAdapter', function () {
           cur: 'AUS'
         };
 
-        bid = spec.interpretResponse({body: bidResponse}, bidRequest)[0];
+        bid = spec.interpretResponse({body: bidResponse}, bidRequest).bids[0];
       });
 
       it('should return the proper mediaType', function () {
@@ -1420,14 +1387,14 @@ describe('OpenxRtbAdapter', function () {
         });
 
         it('should return the proper mediaType', function () {
-          bid = spec.interpretResponse({body: bidResponse}, bidRequest)[0];
+          bid = spec.interpretResponse({body: bidResponse}, bidRequest).bids[0];
           expect(bid.mediaType).to.equal(Object.keys(bidRequestConfigs[0].mediaTypes)[0]);
         });
 
         it('should return the proper mediaType', function () {
           const winUrl = 'https//my.win.url';
           bidResponse.seatbid[0].bid[0].nurl = winUrl
-          bid = spec.interpretResponse({body: bidResponse}, bidRequest)[0];
+          bid = spec.interpretResponse({body: bidResponse}, bidRequest).bids[0];
 
           expect(bid.vastUrl).to.equal(winUrl);
         });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
In building support for the new IAB structure of passing PAAPI auction configs which was added in https://github.com/prebid/Prebid.js/pull/11277 we noticed we are overriding the PAAPI response from the ortbConverter here by only returning response.bids https://github.com/prebid/Prebid.js/blob/22d913e59e75f01ac7a3b35cfd7989db3e1c2136/modules/openxBidAdapter.js#L120 This is a simple fix for that.

Also, cleaned up PAF logic which is no longer used.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->