### PR TITLE
Adtelligent Bid Adapter : deprecate old copper6 alias

### DIFF
--- a/modules/adtelligentBidAdapter.js
+++ b/modules/adtelligentBidAdapter.js
@@ -25,7 +25,6 @@ const HOST_GETTERS = {
   janet: () => 'ghb.bidder.jmgads.com',
   ocm: () => 'ghb.cenarius.orangeclickmedia.com',
   '9dotsmedia': () => 'ghb.platform.audiodots.com',
-  copper6: () => 'ghb.app.copper6.com',
   indicue: () => 'ghb.console.indicue.com',
 }
 const getUri = function (bidderCode) {
@@ -48,7 +47,6 @@ export const spec = {
     { code: 'selectmedia', gvlid: 775 },
     { code: 'ocm', gvlid: 1148 },
     '9dotsmedia',
-    'copper6',
     'indicue',
   ],
   supportedMediaTypes: [VIDEO, BANNER],

--- a/test/spec/modules/adtelligentBidAdapter_spec.js
+++ b/test/spec/modules/adtelligentBidAdapter_spec.js
@@ -16,7 +16,6 @@ const aliasEP = {
   'janet': 'https://ghb.bidder.jmgads.com/v2/auction/',
   'ocm': 'https://ghb.cenarius.orangeclickmedia.com/v2/auction/',
   '9dotsmedia': 'https://ghb.platform.audiodots.com/v2/auction/',
-  'copper6': 'https://ghb.app.copper6.com/v2/auction/',
   'indicue': 'https://ghb.console.indicue.com/v2/auction/',
 };
 


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 


## Description of change
Deprecating copper6 in favor of copper6sspBidAdapter

## Other information
DocPR: https://github.com/prebid/prebid.github.io/pull/5542