### PR TITLE
IX Bid Adapter: Remove client FT pbjs_allow_all_eids

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -58,19 +58,7 @@ const SOURCE_RTI_MAPPING = {
   'neustar.biz': 'fabrickId',
   'zeotap.com': 'zeotapIdPlus',
   'uidapi.com': 'UID2',
-  'adserver.org': 'TDID',
-  'id5-sync.com': '', // ID5 Universal ID, configured as id5Id
-  'crwdcntrl.net': '', // Lotame Panorama ID, lotamePanoramaId
-  'epsilon.com': '', // Publisher Link, publinkId
-  'audigent.com': '', // Hadron ID from Audigent, hadronId
-  'pubcid.org': '', // SharedID, pubcid
-  'utiq.com': '', // Utiq
-  'criteo.com': '', // Criteo
-  'euid.eu': '', // EUID
-  'intimatemerger.com': '',
-  '33across.com': '',
-  'liveintent.indexexchange.com': '',
-  'google.com': ''
+  'adserver.org': 'TDID'
 };
 const PROVIDERS = [
   'lipbid',
@@ -648,10 +636,9 @@ function getEidInfo(allEids) {
   if (isArray(allEids)) {
     for (const eid of allEids) {
       const isSourceMapped = SOURCE_RTI_MAPPING.hasOwnProperty(eid.source);
-      const allowAllEidsFeatureEnabled = FEATURE_TOGGLES.isFeatureEnabled('pbjs_allow_all_eids');
       const hasUids = deepAccess(eid, 'uids.0');
 
-      if ((isSourceMapped || allowAllEidsFeatureEnabled) && hasUids) {
+      if (hasUids) {
         seenSources[eid.source] = true;
 
         if (isSourceMapped && SOURCE_RTI_MAPPING[eid.source] !== '') {

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -1527,9 +1527,7 @@ describe('IndexexchangeAdapter', function () {
       body: {
         ext: {
           pbjs_allow_all_eids: {
-            test: {
-              activated: false
-            }
+            activated: true
           }
         }
       }
@@ -1544,11 +1542,6 @@ describe('IndexexchangeAdapter', function () {
 
     afterEach(function () {
       delete window.headertag;
-      serverResponse.body.ext.features = {
-        pbjs_allow_all_eids: {
-          activated: false
-        }
-      };
       validIdentityResponse = {}
     });
 
@@ -1562,12 +1555,6 @@ describe('IndexexchangeAdapter', function () {
     });
 
     it('IX adapter filters eids from prebid past the maximum eid limit', function () {
-      serverResponse.body.ext.features = {
-        pbjs_allow_all_eids: {
-          activated: true
-        }
-      };
-      FEATURE_TOGGLES.setFeatureToggles(serverResponse);
       const cloneValidBid = utils.deepClone(DEFAULT_VIDEO_VALID_BID);
       let eid_sent_from_prebid = generateEid(55);
       cloneValidBid[0].userIdAsEids = utils.deepClone(eid_sent_from_prebid);
@@ -1609,12 +1596,6 @@ describe('IndexexchangeAdapter', function () {
           }
         }
       };
-      serverResponse.body.ext.features = {
-        pbjs_allow_all_eids: {
-          activated: true
-        }
-      };
-      FEATURE_TOGGLES.setFeatureToggles(serverResponse);
       const cloneValidBid = utils.deepClone(DEFAULT_VIDEO_VALID_BID);
       let eid_sent_from_prebid = generateEid(49);
       cloneValidBid[0].userIdAsEids = utils.deepClone(eid_sent_from_prebid);
@@ -1635,15 +1616,21 @@ describe('IndexexchangeAdapter', function () {
       expect(payload.ext.ixdiag.eidLength).to.equal(49);
     });
 
-    it('All incoming eids are from unsupported source with feature toggle off', function () {
-      FEATURE_TOGGLES.setFeatureToggles(serverResponse);
+    it('Has incoming eids with no uid', function () {
       const cloneValidBid = utils.deepClone(DEFAULT_VIDEO_VALID_BID);
-      let eid_sent_from_prebid = generateEid(20);
+      let eid_sent_from_prebid = [
+        {
+          source: 'catijah.org'
+        },
+        {
+          source: 'bagel.com'
+        }
+      ];
       cloneValidBid[0].userIdAsEids = utils.deepClone(eid_sent_from_prebid);
       const request = spec.buildRequests(cloneValidBid, DEFAULT_OPTION)[0];
       const payload = extractPayload(request);
       expect(payload.user.eids).to.be.undefined
-      expect(payload.ext.ixdiag.eidLength).to.equal(20);
+      expect(payload.ext.ixdiag.eidLength).to.equal(2);
     });
 
     it('We continue to send in IXL identity info and Prebid takes precedence over IXL', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Remove client side feature toggle that removes dependence on eid allowlist. SOURCE_RTI_MAPPING will no longer operate as an eid allowlist and this has been trimmed to exclude all sources without an RTI mapping.
