### PR TITLE
Symitri Analytics Adapter: initial release

### DIFF
--- a/modules/symitriAnalyticsAdapter.js
+++ b/modules/symitriAnalyticsAdapter.js
@@ -1,0 +1,61 @@
+import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
+import adapterManager from '../src/adapterManager.js';
+import { EVENTS } from '../src/constants.js';
+import { logMessage } from '../src/utils.js';
+import {ajax} from '../src/ajax.js';
+
+const analyticsType = 'endpoint';
+const url = 'https://ProdSymPrebidEventhub1.servicebus.windows.net/prebid-said-1/messages';
+
+const { BID_WON } = EVENTS;
+
+let initOptions;
+
+let symitriAnalytics = Object.assign(adapter({url, analyticsType}), {
+  track({ eventType, args }) {
+    switch (eventType) {
+      case BID_WON:
+        logMessage('##### symitriAnalytics :: Event Triggered : ' + eventType);
+        sendEvent(args);
+        break;
+      default:
+        logMessage('##### symitriAnalytics :: Event Triggered : ' + eventType);
+        break;
+    }
+  }
+});
+
+function sendEvent(payload) {
+  try {
+    if (initOptions.apiAuthToken) {
+      const body = JSON.stringify(payload);
+      logMessage('##### symitriAnalytics :: sendEvent ', payload);
+      let cb = {
+        success: () => {
+          logMessage('##### symitriAnalytics :: Bid Reported Successfully');
+        },
+        error: (request, error) => {
+          logMessage('##### symitriAnalytics :: Bid Report Failed' + error);
+        }
+      };
+
+      ajax(url, cb, body, {
+        method: 'POST',
+        customHeaders: {'Content-Type': 'application/atom+xml;type=entry;charset=utf-8', 'Authorization': initOptions.apiAuthToken}
+      });
+    }
+  } catch (err) { logMessage('##### symitriAnalytics :: error' + err) }
+}
+
+symitriAnalytics.originEnableAnalytics = symitriAnalytics.enableAnalytics;
+symitriAnalytics.enableAnalytics = function (config) {
+  initOptions = config.options;
+  symitriAnalytics.originEnableAnalytics(config);
+};
+
+adapterManager.registerAnalyticsAdapter({
+  adapter: symitriAnalytics,
+  code: 'symitri'
+});
+
+export default symitriAnalytics;

--- a/modules/symitriAnalyticsAdapter.md
+++ b/modules/symitriAnalyticsAdapter.md
@@ -1,0 +1,35 @@
+### Overview
+
+ Symitri Analytics Adapter.
+
+### Integration
+
+ 1) Build the symitriAnalyticsAdapter module into the Prebid.js package with:
+
+ ```
+ gulp build --modules=symitriAnalyticsAdapter,...
+ ```
+
+ 2) Use `enableAnalytics` to instruct Prebid.js to initilaize the symitriAnalyticsAdapter module, as specified below.
+
+### Configuration
+
+```
+  pbjs.enableAnalytics({
+				provider: 'symitri',
+				options: {
+					'apiAuthToken': '<see your Symitri account rep>'
+				}
+			});
+ ```
+
+Please reach out to your Symitri account representative(Prebid@symitri.com) to get provisioned on the DAP platform.
+
+
+### Testing
+To view an example of available segments returned by dap:
+```
+‘gulp serve --modules=rtdModule,symitriDapRtdProvider,symitriAnalyticsAdapter,appnexusBidAdapter,sovrnBidAdapter’
+```
+and then point your browser at:
+"http://localhost:9999/integrationExamples/gpt/symitridap_segments_example.html"

--- a/test/spec/modules/symitriAnalyticsAdapter_spec.js
+++ b/test/spec/modules/symitriAnalyticsAdapter_spec.js
@@ -1,0 +1,90 @@
+import symitriAnalyticsAdapter from 'modules/symitriAnalyticsAdapter.js';
+import { expect } from 'chai';
+import adapterManager from 'src/adapterManager.js';
+import { server } from 'test/mocks/xhr.js';
+import { EVENTS } from 'src/constants.js';
+
+let events = require('src/events');
+
+describe('symitri analytics adapter', function () {
+  beforeEach(function () {
+    sinon.stub(events, 'getEvents').returns([]);
+  });
+
+  afterEach(function () {
+    events.getEvents.restore();
+  });
+
+  describe('track', function () {
+    let initOptionsValid = {
+      apiAuthToken: 'TOKEN1234'
+    };
+    let initOptionsInValid = {
+    };
+
+    let bidWon = {
+      'bidderCode': 'appnexus',
+      'width': 300,
+      'height': 250,
+      'statusMessage': 'Bid available',
+      'adId': '393976d8770041',
+      'requestId': '263efc09896d0c',
+      'mediaType': 'banner',
+      'source': 'client',
+      'cpm': 0.5,
+      'creativeId': 96846035,
+      'currency': 'USD',
+      'netRevenue': true,
+      'ttl': 300,
+      'adUnitCode': 'div-gpt-ad-1460505748561-0',
+      'originalCpm': 0.5,
+      'originalCurrency': 'USD',
+      'auctionId': 'db377024-d866-4a24-98ac-5e430f881313',
+      'responseTimestamp': 1576823894050,
+      'requestTimestamp': 1576823893838,
+      'bidder': 'appnexus',
+      'timeToRespond': 212,
+      'status': 'rendered'
+    };
+
+    adapterManager.registerAnalyticsAdapter({
+      code: 'symitri',
+      adapter: symitriAnalyticsAdapter
+    });
+
+    afterEach(function () {
+      symitriAnalyticsAdapter.disableAnalytics();
+    });
+
+    it('Test with valid apiAuthToken', function () {
+      adapterManager.enableAnalytics({
+        provider: 'symitri',
+        options: initOptionsValid
+      });
+      events.emit(EVENTS.BID_WON, bidWon);
+      expect(server.requests.length).to.equal(1);
+    });
+
+    it('Test with missing apiAuthToken', function () {
+      adapterManager.enableAnalytics({
+        provider: 'symitri',
+        options: initOptionsInValid
+      });
+      events.emit(EVENTS.BID_WON, bidWon);
+      expect(server.requests.length).to.equal(0);
+    });
+
+    it('Test correct winning bid is sent to server', function () {
+      adapterManager.enableAnalytics({
+        provider: 'symitri',
+        options: initOptionsValid
+      });
+      events.emit(EVENTS.BID_WON, bidWon);
+      expect(server.requests.length).to.equal(1);
+      let winEventData = JSON.parse(server.requests[0].requestBody);
+      expect(winEventData).to.deep.equal(bidWon);
+      let authToken = server.requests[0].requestHeaders['Authorization'];
+      expect(authToken).to.equal(initOptionsValid.apiAuthToken);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
This is a new Analytics Adapter.
It listens to all the "Bid Won" events and sends winning bid data to backend.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
