### PR TITLE
33across: bugfix in isBidRequestValid() to allow aliasing

### DIFF
--- a/modules/33acrossBidAdapter.js
+++ b/modules/33acrossBidAdapter.js
@@ -73,9 +73,7 @@ function isBidRequestValid(bid) {
 }
 
 function _validateBasic(bid) {
-  const invalidBidderName = bid.bidder !== BIDDER_CODE && !BIDDER_ALIASES.includes(bid.bidder);
-
-  if (invalidBidderName || !bid.params) {
+  if (!bid.params) {
     return false;
   }
 

--- a/test/spec/modules/33acrossBidAdapter_spec.js
+++ b/test/spec/modules/33acrossBidAdapter_spec.js
@@ -527,27 +527,6 @@ describe('33acrossBidAdapter:', function () {
         });
       });
 
-      it('returns false for invalid bidder name values', function() {
-        const invalidBidderName = [
-          undefined,
-          '33',
-          '33x',
-          'thirtythree',
-          ''
-        ];
-
-        invalidBidderName.forEach((bidderName) => {
-          const bid = {
-            bidder: bidderName,
-            params: {
-              siteId: 'sample33xGUID123456789'
-            }
-          };
-
-          expect(spec.isBidRequestValid(bid)).to.be.false;
-        });
-      });
-
       it('returns true for valid guid values', function() {
         // NOTE: We ignore whitespace at the start and end since
         // in our experience these are common typos


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Updating logic in isBidRequestValid() to _**not**_ manually check bidder code, which will now properly allow custom aliases as expected

## Other information
fix for #12135
