### PR TITLE
EClickAds: rename bidder from EClickAds to eClick

### DIFF
--- a/modules/eclickBidAdapter.js
+++ b/modules/eclickBidAdapter.js
@@ -3,7 +3,7 @@ import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { getDevice } from '../libraries/fpdUtils/deviceInfo.js';
 
-// ***** ECLICK ADAPTER *****
+// **** ECLICK ADAPTER ****
 export const BIDDER_CODE = 'eclick';
 const DEFAULT_CURRENCY = ['USD'];
 const DEFAULT_TTL = 1000;

--- a/modules/eclickBidAdapter.js
+++ b/modules/eclickBidAdapter.js
@@ -3,8 +3,8 @@ import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { getDevice } from '../libraries/fpdUtils/deviceInfo.js';
 
-// ***** ECLICKADS ADAPTER *****
-export const BIDDER_CODE = 'eclickads';
+// ***** ECLICK ADAPTER *****
+export const BIDDER_CODE = 'eclick';
 const DEFAULT_CURRENCY = ['USD'];
 const DEFAULT_TTL = 1000;
 export const ENDPOINT = 'https://g.eclick.vn/rtb_hb_request?fosp_uid=';
@@ -70,7 +70,7 @@ export const spec = {
           netRevenue: bid.netRevenue,
           currency: bid.currency || DEFAULT_CURRENCY,
           adserverTargeting: {
-            hb_ad_eclickads: bid.ad,
+            hb_ad_eclick: bid.ad,
           },
         },
       ];

--- a/modules/eclickBidAdapter.md
+++ b/modules/eclickBidAdapter.md
@@ -1,12 +1,12 @@
 # Overview
 
-Module Name: EClickAds Bid Adapter
+Module Name: eClick Bid Adapter
 Type: Bidder Adapter
 Maintainer: vietlv14@fpt.com
 
 # Description
 
-This module connects to EClickAds exchange for bidding NATIVE ADS via prebid.js
+This module connects to eClick exchange for bidding NATIVE ADS via prebid.js
 
 # Test Parameters
 
@@ -36,7 +36,7 @@ var adUnits = [{
         }
     },
     bids: [{
-        bidder: 'eclickads',
+        bidder: 'eclick',
         params: {
 	    	zid:"7096"
         }
@@ -46,10 +46,10 @@ var adUnits = [{
 
 # Notes:
 
-- EClickAdsBidAdapter need serveral params inside bidder config as following
+- eClickBidAdapter need serveral params inside bidder config as following
   - user.myvne_id
   - site.orig_aid
   - site.fosp_aid
   - site.id
   - site.orig_aid
-- EClickAdsBidAdapter will set bid.adserverTargeting.hb_ad_eclickads targeting key while submitting bid to AdServer
+- eClickBidAdapter will set bid.adserverTargeting.hb_ad_eclick targeting key while submitting bid to AdServer

--- a/test/spec/modules/eclickBidAdapter_spec.js
+++ b/test/spec/modules/eclickBidAdapter_spec.js
@@ -3,19 +3,19 @@ import {
   spec,
   ENDPOINT,
   BIDDER_CODE,
-} from '../../../modules/eclickadsBidAdapter.js';
+} from '../../../modules/eclickBidAdapter.js';
 import { NATIVE, BANNER, VIDEO } from '../../../src/mediaTypes.js';
 import { deepClone } from '../../../src/utils.js';
 import { config } from '../../../src/config.js';
 
-describe('eclickadsBidAdapter', () => {
+describe('eclickBidAdapter', () => {
   const bidItem = {
     bidder: BIDDER_CODE,
     params: {
       zid: '7096',
     },
   };
-  const eclickadsBidderConfigData = {
+  const eclickBidderConfigData = {
     orig_aid: 'xqf7zdmg7the65ac.1718271138.des',
     fosp_aid: '1013000403',
     fosp_uid: '7aab24a4663258a2c1d76a08b20f7e6e',
@@ -63,7 +63,7 @@ describe('eclickadsBidAdapter', () => {
         page: 'https://page.example.com/here.html',
         ref: 'https://ref.example.com',
         ext: {
-          data: eclickadsBidderConfigData,
+          data: eclickBidderConfigData,
         },
       },
     },
@@ -99,7 +99,7 @@ describe('eclickadsBidAdapter', () => {
       expect(request.method).to.be.exist;
       expect(request.method).equal('POST');
       expect(request.url).to.be.exist;
-      expect(request.url).equal(ENDPOINT + eclickadsBidderConfigData.fosp_uid);
+      expect(request.url).equal(ENDPOINT + eclickBidderConfigData.fosp_uid);
     });
     it('should return valid data format if bid array is valid', () => {
       expect(_data).to.be.an('object');
@@ -147,7 +147,7 @@ describe('eclickadsBidAdapter', () => {
       expect(_data.imp).to.have.lengthOf(bidList.length);
     });
 
-    it('have to contain required params and correct format for sending to EClickAds', () => {
+    it('have to contain required params and correct format for sending to eClick', () => {
       const item = _data.imp[0];
       expect(item.zid).to.be.an('string');
     });
@@ -167,7 +167,7 @@ describe('eclickadsBidAdapter', () => {
           netRevenue: true,
           currency: ['VND'],
           cpm: 0.1844,
-          ad: 'eclickads_ad_p',
+          ad: 'eclick_ad_p',
         },
       ],
     };
@@ -207,8 +207,8 @@ describe('eclickadsBidAdapter', () => {
       expect(offer.ttl).to.be.an('number');
       expect(offer.cpm).to.be.an('number').greaterThan(0);
       expect(offer.adserverTargeting).to.be.an('object');
-      expect(offer.adserverTargeting['hb_ad_eclickads']).to.be.an('string').that
-        .is.not.empty;
+      expect(offer.adserverTargeting['hb_ad_eclick']).to.be.an('string').that.is
+        .not.empty;
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
This commit does nothing but change the bidder name from `EClickAds` to `eClick` (also `bidderCode` from `eclickads` to `eclick`)

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Docs: https://github.com/prebid/prebid.github.io/pull/5556
