### PR TITLE
null check config.rate and config.defaultRate in currency module

### DIFF
--- a/modules/currency.js
+++ b/modules/currency.js
@@ -62,13 +62,13 @@ export let responseReady = defer();
 export function setConfig(config) {
   ratesURL = DEFAULT_CURRENCY_RATE_URL;
 
-  if (typeof config.rates === 'object') {
+  if (config.rates !== null && typeof config.rates === 'object') {
     currencyRates.conversions = config.rates;
     currencyRatesLoaded = true;
     needToCallForCurrencyFile = false; // don't call if rates are already specified
   }
 
-  if (typeof config.defaultRates === 'object') {
+  if (config.defaultRates !== null && typeof config.defaultRates === 'object') {
     defaultRates = config.defaultRates;
 
     // set up the default rates to be used if the rate file doesn't get loaded in time


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
in cases you call with a null value for `rates` or `defaultRates` the currency module accepts these values, causing later the `getCurrencyConversion` to throw an error as it tries to de-reference the null value. 
eg.
`pbjs.setConfig({
 currency:{
  defaultRates:null
}
})`