### PR TITLE
Debugging module: fix bug where mocked bidders always time out with auctions

### DIFF
--- a/modules/debugging/debugging.js
+++ b/modules/debugging/debugging.js
@@ -105,11 +105,13 @@ export function bidderBidInterceptor(next, interceptBids, spec, bids, bidRequest
   ({bids, bidRequest} = interceptBids({
     bids,
     bidRequest,
-    addBid: cbs.onBid,
-    addPaapiConfig: (config, bidRequest) => cbs.onPaapi({bidId: bidRequest.bidId, ...config}),
+    addBid: wrapCallback(cbs.onBid),
+    addPaapiConfig: wrapCallback((config, bidRequest) => cbs.onPaapi({bidId: bidRequest.bidId, ...config})),
     done
   }));
   if (bids.length === 0) {
+    // eslint-disable-next-line no-unused-expressions
+    cbs.onResponse?.({}); // trigger onResponse so that the bidder may be marked as "timely" if necessary
     done();
   } else {
     next(spec, bids, bidRequest, ajax, wrapCallback, {...cbs, onCompletion: done});


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

This fixes two bugs in the debugging module:

 - if an auction times out, bidders that were mocked through the debugging will sometimes be considered timed out, regardless of when their bids were mocked;
 - mocked bids were not setting up `config.currentBidder` which breaks some functionality (esp. with mocked PAAPI auction configs).

## Other information

Related to https://github.com/prebid/Prebid.js/issues/12176
