### PR TITLE
Dailymotion bid adapter: add publisher restrictions in consent enforcement

### DIFF
--- a/modules/dailymotionBidAdapter.js
+++ b/modules/dailymotionBidAdapter.js
@@ -4,6 +4,8 @@ import { deepAccess } from '../src/utils.js';
 import { config } from '../src/config.js';
 import { userSync } from '../src/userSync.js';
 
+const DAILYMOTION_VENDOR_ID = 573;
+
 /**
  * Get video metadata from bid request
  *
@@ -110,7 +112,7 @@ function isUserSyncEnabled() {
 
 export const spec = {
   code: 'dailymotion',
-  gvlid: 573,
+  gvlid: DAILYMOTION_VENDOR_ID,
   supportedMediaTypes: [VIDEO],
 
   /**
@@ -157,13 +159,21 @@ export const spec = {
       deepAccess(bidderRequest, 'gdprConsent.vendorData.hasGlobalConsent') === true ||
       (
         // Vendor consent
-        deepAccess(bidderRequest, 'gdprConsent.vendorData.vendor.consents.573') === true &&
-        // Purposes
-        [1, 3, 4].every(v => deepAccess(bidderRequest, `gdprConsent.vendorData.purpose.consents.${v}`) === true) &&
-        // Flexible purposes
+        deepAccess(bidderRequest, `gdprConsent.vendorData.vendor.consents.${DAILYMOTION_VENDOR_ID}`) === true &&
+
+        // Purposes with legal basis "consent". These are not flexible, so if publisher requires legitimate interest (2) it cancels them
+        [1, 3, 4].every(v =>
+          deepAccess(bidderRequest, `gdprConsent.vendorData.publisher.restrictions.${v}.${DAILYMOTION_VENDOR_ID}`) !== 0 &&
+          deepAccess(bidderRequest, `gdprConsent.vendorData.publisher.restrictions.${v}.${DAILYMOTION_VENDOR_ID}`) !== 2 &&
+          deepAccess(bidderRequest, `gdprConsent.vendorData.purpose.consents.${v}`) === true
+        ) &&
+
+        // Purposes with legal basis "legitimate interest" (default) or "consent" (when specified as such by publisher)
         [2, 7, 9, 10].every(v =>
-          deepAccess(bidderRequest, `gdprConsent.vendorData.purpose.consents.${v}`) === true ||
-          deepAccess(bidderRequest, `gdprConsent.vendorData.purpose.legitimateInterests.${v}`) === true
+          deepAccess(bidderRequest, `gdprConsent.vendorData.publisher.restrictions.${v}.${DAILYMOTION_VENDOR_ID}`) !== 0 &&
+          (deepAccess(bidderRequest, `gdprConsent.vendorData.publisher.restrictions.${v}.${DAILYMOTION_VENDOR_ID}`) === 1
+            ? deepAccess(bidderRequest, `gdprConsent.vendorData.purpose.consents.${v}`) === true
+            : deepAccess(bidderRequest, `gdprConsent.vendorData.purpose.legitimateInterests.${v}`) === true)
         )
       );
 

--- a/test/spec/modules/dailymotionBidAdapter_spec.js
+++ b/test/spec/modules/dailymotionBidAdapter_spec.js
@@ -394,7 +394,7 @@ describe('dailymotionBidAdapterTests', () => {
     expect(request.options.withCredentials).to.eql(true);
   });
 
-  it('validates buildRequests with detailed consent, no legitimate interest', () => {
+  it('validates buildRequests with detailed consent without legitimate interest', () => {
     const bidRequestData = [{
       auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
       bidId: 123456,
@@ -497,7 +497,7 @@ describe('dailymotionBidAdapterTests', () => {
       () => spec.buildRequests(bidRequestData, bidderRequestData),
     );
 
-    expect(request.options.withCredentials).to.eql(true);
+    expect(request.options.withCredentials).to.eql(false);
   });
 
   it('validates buildRequests with detailed consent, with legitimate interest', () => {
@@ -558,6 +558,694 @@ describe('dailymotionBidAdapterTests', () => {
         gdprApplies: true,
         vendorData: {
           hasGlobalConsent: false,
+          purpose: {
+            consents: {
+              1: true,
+              3: true,
+              4: true,
+            },
+            legitimateInterests: {
+              2: true,
+              7: true,
+              9: true,
+              10: true,
+            },
+          },
+          vendor: {
+            consents: {
+              573: true
+            }
+          },
+        },
+      },
+      gppConsent: {
+        gppString: 'xxx',
+        applicableSections: [5],
+      },
+      ortb2: {
+        regs: {
+          coppa: 1,
+        },
+        site: {
+          content: {
+            data: [
+              {
+                name: 'dataprovider.com',
+                ext: { segtax: 5 },
+                segment: [{ id: '200' }],
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const [request] = config.runWithBidder(
+      'dailymotion',
+      () => spec.buildRequests(bidRequestData, bidderRequestData),
+    );
+
+    expect(request.options.withCredentials).to.eql(true);
+  });
+
+  it('validates buildRequests with detailed consent and legitimate interest but publisher forces consent', () => {
+    const bidRequestData = [{
+      auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+      bidId: 123456,
+      adUnitCode: 'preroll',
+      mediaTypes: {
+        video: {
+          api: [2, 7],
+          mimes: ['video/mp4'],
+          minduration: 5,
+          maxduration: 30,
+          playbackmethod: [3],
+          plcmt: 1,
+          protocols: [1, 2, 3, 4, 5, 6, 7, 8],
+          skip: 1,
+          skipafter: 5,
+          skipmin: 10,
+          startdelay: 0,
+          w: 1280,
+          h: 720,
+        },
+      },
+      sizes: [[1920, 1080]],
+      params: {
+        apiKey: 'test_api_key',
+        video: {
+          description: 'this is a test video',
+          duration: 556,
+          iabcat1: ['IAB-1'],
+          iabcat2: ['6', '17'],
+          id: '54321',
+          lang: 'FR',
+          private: false,
+          tags: 'tag_1,tag_2,tag_3',
+          title: 'test video',
+          url: 'https://test.com/test',
+          topics: 'topic_1, topic_2',
+          livestream: 1,
+          isCreatedForKids: true,
+          videoViewsInSession: 2,
+          autoplay: true,
+          playerName: 'dailymotion',
+          playerVolume: 8,
+        },
+      },
+    }];
+
+    const bidderRequestData = {
+      refererInfo: {
+        page: 'https://publisher.com',
+      },
+      uspConsent: '1YN-',
+      gdprConsent: {
+        apiVersion: 2,
+        consentString: 'xxx',
+        gdprApplies: true,
+        vendorData: {
+          hasGlobalConsent: false,
+          publisher: {
+            restrictions: {
+              2: { 573: 1 },
+              7: { 573: 1 },
+              9: { 573: 1 },
+              10: { 573: 1 },
+            },
+          },
+          purpose: {
+            consents: {
+              1: true,
+              3: true,
+              4: true,
+            },
+            legitimateInterests: {
+              2: true,
+              7: true,
+              9: true,
+              10: true,
+            },
+          },
+          vendor: {
+            consents: {
+              573: true
+            }
+          },
+        },
+      },
+      gppConsent: {
+        gppString: 'xxx',
+        applicableSections: [5],
+      },
+      ortb2: {
+        regs: {
+          coppa: 1,
+        },
+        site: {
+          content: {
+            data: [
+              {
+                name: 'dataprovider.com',
+                ext: { segtax: 5 },
+                segment: [{ id: '200' }],
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const [request] = config.runWithBidder(
+      'dailymotion',
+      () => spec.buildRequests(bidRequestData, bidderRequestData),
+    );
+
+    expect(request.options.withCredentials).to.eql(false);
+  });
+
+  it('validates buildRequests with detailed consent, no legitimate interest and publisher forces consent', () => {
+    const bidRequestData = [{
+      auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+      bidId: 123456,
+      adUnitCode: 'preroll',
+      mediaTypes: {
+        video: {
+          api: [2, 7],
+          mimes: ['video/mp4'],
+          minduration: 5,
+          maxduration: 30,
+          playbackmethod: [3],
+          plcmt: 1,
+          protocols: [1, 2, 3, 4, 5, 6, 7, 8],
+          skip: 1,
+          skipafter: 5,
+          skipmin: 10,
+          startdelay: 0,
+          w: 1280,
+          h: 720,
+        },
+      },
+      sizes: [[1920, 1080]],
+      params: {
+        apiKey: 'test_api_key',
+        video: {
+          description: 'this is a test video',
+          duration: 556,
+          iabcat1: ['IAB-1'],
+          iabcat2: ['6', '17'],
+          id: '54321',
+          lang: 'FR',
+          private: false,
+          tags: 'tag_1,tag_2,tag_3',
+          title: 'test video',
+          url: 'https://test.com/test',
+          topics: 'topic_1, topic_2',
+          livestream: 1,
+          isCreatedForKids: true,
+          videoViewsInSession: 2,
+          autoplay: true,
+          playerName: 'dailymotion',
+          playerVolume: 8,
+        },
+      },
+    }];
+
+    const bidderRequestData = {
+      refererInfo: {
+        page: 'https://publisher.com',
+      },
+      uspConsent: '1YN-',
+      gdprConsent: {
+        apiVersion: 2,
+        consentString: 'xxx',
+        gdprApplies: true,
+        vendorData: {
+          hasGlobalConsent: false,
+          publisher: {
+            restrictions: {
+              2: { 573: 1 },
+              7: { 573: 1 },
+              9: { 573: 1 },
+              10: { 573: 1 },
+            },
+          },
+          purpose: {
+            consents: {
+              1: true,
+              2: true,
+              3: true,
+              4: true,
+              7: true,
+              9: true,
+              10: true,
+            },
+          },
+          vendor: {
+            consents: {
+              573: true
+            }
+          },
+        },
+      },
+      gppConsent: {
+        gppString: 'xxx',
+        applicableSections: [5],
+      },
+      ortb2: {
+        regs: {
+          coppa: 1,
+        },
+        site: {
+          content: {
+            data: [
+              {
+                name: 'dataprovider.com',
+                ext: { segtax: 5 },
+                segment: [{ id: '200' }],
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const [request] = config.runWithBidder(
+      'dailymotion',
+      () => spec.buildRequests(bidRequestData, bidderRequestData),
+    );
+
+    expect(request.options.withCredentials).to.eql(true);
+  });
+
+  it('validates buildRequests with detailed consent but publisher full restriction on purpose 1', () => {
+    const bidRequestData = [{
+      auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+      bidId: 123456,
+      adUnitCode: 'preroll',
+      mediaTypes: {
+        video: {
+          api: [2, 7],
+          mimes: ['video/mp4'],
+          minduration: 5,
+          maxduration: 30,
+          playbackmethod: [3],
+          plcmt: 1,
+          protocols: [1, 2, 3, 4, 5, 6, 7, 8],
+          skip: 1,
+          skipafter: 5,
+          skipmin: 10,
+          startdelay: 0,
+          w: 1280,
+          h: 720,
+        },
+      },
+      sizes: [[1920, 1080]],
+      params: {
+        apiKey: 'test_api_key',
+        video: {
+          description: 'this is a test video',
+          duration: 556,
+          iabcat1: ['IAB-1'],
+          iabcat2: ['6', '17'],
+          id: '54321',
+          lang: 'FR',
+          private: false,
+          tags: 'tag_1,tag_2,tag_3',
+          title: 'test video',
+          url: 'https://test.com/test',
+          topics: 'topic_1, topic_2',
+          xid: 'x123456',
+          livestream: 1,
+          isCreatedForKids: true,
+          videoViewsInSession: 2,
+          autoplay: true,
+          playerVolume: 8,
+        },
+      },
+    }];
+
+    const bidderRequestData = {
+      refererInfo: {
+        page: 'https://publisher.com',
+      },
+      uspConsent: '1YN-',
+      gdprConsent: {
+        apiVersion: 2,
+        consentString: 'xxx',
+        gdprApplies: true,
+        vendorData: {
+          hasGlobalConsent: false,
+          publisher: {
+            restrictions: {
+              1: {
+                573: 0,
+              },
+            },
+          },
+          purpose: {
+            consents: {
+              1: true,
+              2: true,
+              3: true,
+              4: true,
+              7: true,
+              9: true,
+              10: true,
+            },
+          },
+          vendor: {
+            consents: {
+              573: true
+            }
+          },
+        },
+      },
+      gppConsent: {
+        gppString: 'xxx',
+        applicableSections: [5],
+      },
+      ortb2: {
+        regs: {
+          coppa: 1,
+        },
+        site: {
+          content: {
+            data: [
+              {
+                name: 'dataprovider.com',
+                ext: { segtax: 5 },
+                segment: [{ id: '200' }],
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const [request] = config.runWithBidder(
+      'dailymotion',
+      () => spec.buildRequests(bidRequestData, bidderRequestData),
+    );
+
+    expect(request.options.withCredentials).to.eql(false);
+  });
+
+  it('validates buildRequests with detailed consent but publisher restriction 2 on consent purpose 1', () => {
+    const bidRequestData = [{
+      auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+      bidId: 123456,
+      adUnitCode: 'preroll',
+      mediaTypes: {
+        video: {
+          api: [2, 7],
+          mimes: ['video/mp4'],
+          minduration: 5,
+          maxduration: 30,
+          playbackmethod: [3],
+          plcmt: 1,
+          protocols: [1, 2, 3, 4, 5, 6, 7, 8],
+          skip: 1,
+          skipafter: 5,
+          skipmin: 10,
+          startdelay: 0,
+          w: 1280,
+          h: 720,
+        },
+      },
+      sizes: [[1920, 1080]],
+      params: {
+        apiKey: 'test_api_key',
+        video: {
+          description: 'this is a test video',
+          duration: 556,
+          iabcat1: ['IAB-1'],
+          iabcat2: ['6', '17'],
+          id: '54321',
+          lang: 'FR',
+          private: false,
+          tags: 'tag_1,tag_2,tag_3',
+          title: 'test video',
+          url: 'https://test.com/test',
+          topics: 'topic_1, topic_2',
+          xid: 'x123456',
+          livestream: 1,
+          isCreatedForKids: true,
+          videoViewsInSession: 2,
+          autoplay: true,
+          playerVolume: 8,
+        },
+      },
+    }];
+
+    const bidderRequestData = {
+      refererInfo: {
+        page: 'https://publisher.com',
+      },
+      uspConsent: '1YN-',
+      gdprConsent: {
+        apiVersion: 2,
+        consentString: 'xxx',
+        gdprApplies: true,
+        vendorData: {
+          hasGlobalConsent: false,
+          publisher: {
+            restrictions: {
+              1: {
+                573: 2,
+              },
+            },
+          },
+          purpose: {
+            consents: {
+              1: true,
+              3: true,
+              4: true,
+            },
+            legitimateInterests: {
+              2: true,
+              7: true,
+              9: true,
+              10: true,
+            },
+          },
+          vendor: {
+            consents: {
+              573: true
+            }
+          },
+        },
+      },
+      gppConsent: {
+        gppString: 'xxx',
+        applicableSections: [5],
+      },
+      ortb2: {
+        regs: {
+          coppa: 1,
+        },
+        site: {
+          content: {
+            data: [
+              {
+                name: 'dataprovider.com',
+                ext: { segtax: 5 },
+                segment: [{ id: '200' }],
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const [request] = config.runWithBidder(
+      'dailymotion',
+      () => spec.buildRequests(bidRequestData, bidderRequestData),
+    );
+
+    expect(request.options.withCredentials).to.eql(false);
+  });
+
+  it('validates buildRequests with detailed consent, legitimate interest and publisher restriction on purpose 1', () => {
+    const bidRequestData = [{
+      auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+      bidId: 123456,
+      adUnitCode: 'preroll',
+      mediaTypes: {
+        video: {
+          api: [2, 7],
+          mimes: ['video/mp4'],
+          minduration: 5,
+          maxduration: 30,
+          playbackmethod: [3],
+          plcmt: 1,
+          protocols: [1, 2, 3, 4, 5, 6, 7, 8],
+          skip: 1,
+          skipafter: 5,
+          skipmin: 10,
+          startdelay: 0,
+          w: 1280,
+          h: 720,
+        },
+      },
+      sizes: [[1920, 1080]],
+      params: {
+        apiKey: 'test_api_key',
+        video: {
+          description: 'this is a test video',
+          duration: 556,
+          iabcat1: ['IAB-1'],
+          iabcat2: ['6', '17'],
+          id: '54321',
+          lang: 'FR',
+          private: false,
+          tags: 'tag_1,tag_2,tag_3',
+          title: 'test video',
+          url: 'https://test.com/test',
+          topics: 'topic_1, topic_2',
+          xid: 'x123456',
+          livestream: 1,
+          isCreatedForKids: true,
+          videoViewsInSession: 2,
+          autoplay: true,
+          playerVolume: 8,
+        },
+      },
+    }];
+
+    const bidderRequestData = {
+      refererInfo: {
+        page: 'https://publisher.com',
+      },
+      uspConsent: '1YN-',
+      gdprConsent: {
+        apiVersion: 2,
+        consentString: 'xxx',
+        gdprApplies: true,
+        vendorData: {
+          hasGlobalConsent: false,
+          publisher: {
+            restrictions: {
+              1: {
+                573: 1,
+              },
+            },
+          },
+          purpose: {
+            consents: {
+              1: true,
+              3: true,
+              4: true,
+            },
+            legitimateInterests: {
+              2: true,
+              7: true,
+              9: true,
+              10: true,
+            },
+          },
+          vendor: {
+            consents: {
+              573: true
+            }
+          },
+        },
+      },
+      gppConsent: {
+        gppString: 'xxx',
+        applicableSections: [5],
+      },
+      ortb2: {
+        regs: {
+          coppa: 1,
+        },
+        site: {
+          content: {
+            data: [
+              {
+                name: 'dataprovider.com',
+                ext: { segtax: 5 },
+                segment: [{ id: '200' }],
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const [request] = config.runWithBidder(
+      'dailymotion',
+      () => spec.buildRequests(bidRequestData, bidderRequestData),
+    );
+
+    expect(request.options.withCredentials).to.eql(true);
+  });
+
+  it('validates buildRequests with detailed consent and legitimate interest but publisher restriction on legitimate interest 2', () => {
+    const bidRequestData = [{
+      auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+      bidId: 123456,
+      adUnitCode: 'preroll',
+      mediaTypes: {
+        video: {
+          api: [2, 7],
+          mimes: ['video/mp4'],
+          minduration: 5,
+          maxduration: 30,
+          playbackmethod: [3],
+          plcmt: 1,
+          protocols: [1, 2, 3, 4, 5, 6, 7, 8],
+          skip: 1,
+          skipafter: 5,
+          skipmin: 10,
+          startdelay: 0,
+          w: 1280,
+          h: 720,
+        },
+      },
+      sizes: [[1920, 1080]],
+      params: {
+        apiKey: 'test_api_key',
+        video: {
+          description: 'this is a test video',
+          duration: 556,
+          iabcat1: ['IAB-1'],
+          iabcat2: ['6', '17'],
+          id: '54321',
+          lang: 'FR',
+          private: false,
+          tags: 'tag_1,tag_2,tag_3',
+          title: 'test video',
+          url: 'https://test.com/test',
+          topics: 'topic_1, topic_2',
+          xid: 'x123456',
+          livestream: 1,
+          isCreatedForKids: true,
+          videoViewsInSession: 2,
+          autoplay: true,
+          playerVolume: 8,
+        },
+      },
+    }];
+
+    const bidderRequestData = {
+      refererInfo: {
+        page: 'https://publisher.com',
+      },
+      uspConsent: '1YN-',
+      gdprConsent: {
+        apiVersion: 2,
+        consentString: 'xxx',
+        gdprApplies: true,
+        vendorData: {
+          hasGlobalConsent: false,
+          publisher: {
+            restrictions: {
+              2: {
+                573: 2,
+              },
+            },
+          },
           purpose: {
             consents: {
               1: true,


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter

## Description of change
The previous version of the consent enforcement was only looking at the consent given by the user.

This change now also looks at the publisher restrictions to disable cookie sending when the user gave consent but the publisher disallows some consents.