### PR TITLE
HUMAN Security RTD Provider: initial release

### DIFF
--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -80,6 +80,7 @@
       "greenbidsRtdProvider",
       "growthCodeRtdProvider",
       "hadronRtdProvider",
+      "humansecurityRtdProvider",
       "iasRtdProvider",
       "idWardRtdProvider",
       "imRtdProvider",

--- a/modules/humansecurityRtdProvider.js
+++ b/modules/humansecurityRtdProvider.js
@@ -1,0 +1,179 @@
+/**
+ * This module adds humansecurity provider to the real time data module
+ *
+ * The {@link module:modules/realTimeData} module is required
+ * The module will inject the HUMAN Security script into the context where Prebid.js is initialized, enriching bid requests with specific data to provide advanced protection against ad fraud and spoofing.
+ * @module modules/humansecurityRtdProvider
+ * @requires module:modules/realTimeData
+ */
+
+import { submodule } from '../src/hook.js';
+import {
+  prefixLog,
+  mergeDeep,
+  generateUUID,
+  getWindowSelf,
+} from '../src/utils.js';
+import { getRefererInfo } from '../src/refererDetection.js';
+import { getGlobal } from '../src/prebidGlobal.js';
+import { loadExternalScript } from '../src/adloader.js';
+
+/**
+ * @typedef {import('../modules/rtdModule/index.js').RtdSubmodule} RtdSubmodule
+ * @typedef {import('../modules/rtdModule/index.js').SubmoduleConfig} SubmoduleConfig
+ * @typedef {import('../modules/rtdModule/index.js').UserConsentData} UserConsentData
+ */
+
+const SUBMODULE_NAME = 'humansecurity';
+const SCRIPT_URL = 'https://sonar.script.ac/prebid/rtd.js';
+
+const { logInfo, logWarn, logError } = prefixLog(`[${SUBMODULE_NAME}]:`);
+
+/** @type {string} */
+let clientId = '';
+
+/** @type {boolean} */
+let verbose = false;
+
+/** @type {string} */
+let sessionId = '';
+
+/** @type {Object} */
+let hmnsData = { };
+
+/**
+ * Submodule registration
+ */
+function main() {
+  submodule('realTimeData', /** @type {RtdSubmodule} */ ({
+    name: SUBMODULE_NAME,
+
+    //
+    init: (config, userConsent) => {
+      try {
+        load(config);
+        return true;
+      } catch (err) {
+        logError('init', err.message);
+        return false;
+      }
+    },
+
+    getBidRequestData: onGetBidRequestData
+  }));
+}
+
+/**
+ * Injects HUMAN Security script on the page to facilitate pre-bid signal collection.
+ * @param {SubmoduleConfig} config
+ */
+function load(config) {
+  // By default, this submodule loads the generic implementation script
+  // only identified by the referrer information. In the future, if publishers
+  // want to have analytics where their websites are grouped, they can request
+  // Client ID from HUMAN, pass it here, and it will enable advanced reporting
+  clientId = config?.params?.clientId || '';
+  if (clientId && (typeof clientId !== 'string' || !/^\w{3,16}$/.test(clientId))) {
+    throw new Error(`The 'clientId' parameter must be a short alphanumeric string`);
+  }
+
+  // Load/reset the state
+  verbose = !!config?.params?.verbose;
+  sessionId = generateUUID();
+  hmnsData = {};
+
+  // We rely on prebid implementation to get the best domain possible here
+  // In some cases, it still might be null, though
+  const refDomain = getRefererInfo().domain || '';
+
+  // Once loaded, the implementation script will publish an API using
+  // the session ID value it was given in data attributes
+  const scriptAttrs = { 'data-sid': sessionId };
+  const scriptUrl = `${SCRIPT_URL}?r=${refDomain}${clientId ? `&c=${clientId}` : ''}`;
+
+  loadExternalScript(scriptUrl, SUBMODULE_NAME, onImplLoaded, null, scriptAttrs);
+}
+
+/**
+ * The callback to loadExternalScript
+ * Establishes the bridge between this RTD submodule and the loaded implementation
+ */
+function onImplLoaded() {
+  // We then get a hold on this script using the knowledge of this session ID
+  const wnd = getWindowSelf();
+  const impl = wnd[`sonar_${sessionId}`];
+  if (typeof impl !== 'object' || typeof impl.connect !== 'function') {
+    verbose && logWarn('onload', 'Unable to access the implementation script');
+    return;
+  }
+
+  // And set up a bridge between the RTD submodule and the implementation.
+  // The first argument is used to identify the caller.
+  // The callback might be called multiple times to update the signals
+  // once more precise information is available.
+  impl.connect(getGlobal(), onImplMessage);
+}
+
+/**
+ * The bridge function will be called by the implementation script
+ * to update the token information or report errors
+ * @param {Object} msg
+ */
+function onImplMessage(msg) {
+  if (typeof msg !== 'object') {
+    return;
+  }
+
+  switch (msg.type) {
+    case 'hmns': {
+      hmnsData = mergeDeep({}, msg.data || {});
+      break;
+    }
+    case 'error': {
+      logError('impl', msg.data || '');
+      break;
+    }
+    case 'warn': {
+      verbose && logWarn('impl', msg.data || '');
+      break;
+    }
+    case 'info': {
+      verbose && logInfo('impl', msg.data || '');
+      break;
+    }
+  }
+}
+
+/**
+ * onGetBidRequestData is called once per auction.
+ * Update the `ortb2Fragments` object with the data from the injected script.
+ *
+ * @param {Object} reqBidsConfigObj
+ * @param {function} callback
+ * @param {SubmoduleConfig} config
+ * @param {UserConsentData} userConsent
+ */
+function onGetBidRequestData(reqBidsConfigObj, callback, config, userConsent) {
+  // Add device.ext.hmns to the global ORTB data for all vendors to use
+  // At the time of writing this submodule, "hmns" is an object defined
+  // internally by humansecurity, and it currently contains "v1" field
+  // with a token that contains collected signals about this session.
+  mergeDeep(reqBidsConfigObj.ortb2Fragments.global, { device: { ext: { hmns: hmnsData } } });
+  callback();
+}
+
+/**
+ * Exporting local (and otherwise encapsulated to this module) functions
+ * for testing purposes
+ */
+export const __TEST__ = {
+  SUBMODULE_NAME,
+  SCRIPT_URL,
+  main,
+  load,
+  onImplLoaded,
+  onImplMessage,
+  onGetBidRequestData
+};
+
+main();

--- a/modules/humansecurityRtdProvider.md
+++ b/modules/humansecurityRtdProvider.md
@@ -1,0 +1,223 @@
+# Overview
+
+```
+Module Name: HUMAN Security Rtd provider
+Module Type: Rtd Provider
+Maintainer: alexey@humansecurity.com
+```
+
+## What is it?
+
+The HUMAN Security RTD submodule offers publishers a mechanism to integrate pre-bid signal collection
+for the purpose of providing real-time protection against all sorts of invalid traffic,
+such as bot-generated ad interactions or sophisticated ad fraud schemes.
+
+## How does it work?
+
+HUMAN Security RTD submodule generates a HUMAN Security token, which then can be consumed by adapters,
+sent within bid requests, and used for bot detection on the backend.
+
+## Key Facts about the HUMAN Security RTD Submodule
+
+* Enriches bid requests with IVT signal, historically done post-bid
+* No incremental signals collected beyond existing HUMAN post-bid solution
+* Offsets negative impact from loss of granularity in IP and User Agent at bid time
+* Does not expose collected IVT signal to any party who doesn’t otherwise already have access to the same signal collected post-bid
+* Does not introduce meaningful latency, as demonstrated in the Latency section
+* Comes at no additional cost to collect IVT signal and make it available at bid time
+* Leveraged to differentiate the invalid bid requests at device level, and cannot be used to identify a user or a device, thus preserving privacy.
+
+# Build
+
+First, make sure to add the HUMAN Security submodule to your Prebid.js package with:
+
+```bash
+gulp build --modules="rtdModule,humansecurityRtdProvider,..."
+```
+
+> `rtdModule` is a required module to use HUMAN Security RTD module.
+
+# Configuration
+
+This module is configured as part of the `realTimeData.dataProviders` object.
+Please refer to [Prebid Documentation](https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#setConfig-realTimeData)
+on RTD module configuration for details on required and optional parameters of `realTimeData`.
+
+By default, using this submodule *does not require any prior communication with HUMAN, nor any special configuration*,
+besides just indicating that it should be loaded:
+
+```javascript
+pbjs.setConfig({
+    realTimeData: {
+        dataProviders: [{
+            name: 'humansecurity'
+        }]
+    }
+});
+```
+
+It can be optionally parameterized, for example, to include client ID obtained from HUMAN,
+should any advanced reporting be needed, or to have verbose output for troubleshooting:
+
+```javascript
+pbjs.setConfig({
+    realTimeData: {
+        dataProviders: [{
+            name: 'humansecurity',
+            params: {
+                clientId: 'ABC123',
+                verbose: true
+            }
+        }]
+    }
+});
+```
+
+## Supported parameters
+
+| Name             |Type           | Description                                                         | Required |
+| :--------------- | :------------ | :------------------------------------------------------------------ |:---------|
+| `clientId`  | String | Should you need advanced reporting, contact [prebid@humansecurity.com](prebid@humansecurity.com) to receive client ID. | No |
+| `verbose`   | Boolean | Only set to `true` if troubleshooting issues. | No |
+
+## Logging, latency and troubleshooting
+
+The optional `verbose` parameter can be especially helpful to troubleshoot any issues and/or monitor latency.
+
+By default, the submodule may, in case of unexpected issues, invoke `logError`, emitting `auctionDebug` events
+of type `ERROR`. With `verbose` parameter set to `true`, it may additionally:
+
+* Call `logWarning`, resulting in `auctionDebug` events of type `WARNING`,
+* Call `logInfo` with latency information.
+  * To observe these messages in console, Prebid.js must be run in
+    [debug mode](https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#debugging) -
+    either by adding `?pbjs_debug=true` to your page's URL, or by configuring with `pbjs.setConfig({ debug: true });`
+
+Example output of the latency information:
+
+```
+INFO: [humansecurity]: impl JS time to init (ms): 6.
+INFO: [humansecurity]: impl JS time to collect (ms): 13.
+```
+
+Here, the two reported metrics are how much time the signal collection script spent blocking on initialization,
+and the total time required to obtain the signals, respectively. Note that "time to collect" metric accounts
+for all the time spent since the script has started initializing until the signals were made available to the bidders,
+therefore it includes "time to init", and typically some non-blocking time spent waiting for signals. Only “time to init” is blocking.
+
+# How can I contribute?
+
+Prebid has launched a Measurement Taskforce to address signal deprecation and measurement in the current environment,
+which has become a publisher-level issue. Without a solution, granularity of measurement disappears.
+If you would like to participate to help identify and develop solutions to these problems such as the one tackled
+by this submodule, please consider joining the [Measurement Taskforce](https://prebid.org/project-management-committees/).
+
+# Notes
+
+## Operation model
+
+Following is the expected data flow:
+
+* Prebid.js gets initialized, including the HUMAN RTD submodule.
+* The submodule loads the signal collection implementation script from a high-performance, low latency endpoint.
+* This script starts collecting the signals, and makes them available to the RTD submodule as soon as possible.
+* The RTD submodule places the collected signals into the ORTB structure for bid adapters to pick up.
+* Bid adapters are expected to retrieve the `ortb2.device.ext.hmns` object and incorporate it into their bid requests.
+* Bid requests having the `ortb2.device.ext.hmns` data allow their backend to make more informative requests to HUMAN Ad Fraud Defense.
+  * Should bid requests be passed to other platforms during the bidding process, adapter developers are
+    encouraged to keep `ortb2.device.ext.hmns` so that, for example, a downstream DSP can also have this data passed to HUMAN.
+
+## Remarks on the collected signals
+
+There are a few points that are worth being mentioned separately, to avoid confusion and unnecessary suspicion:
+
+* The nature of the collected signals is exactly the same as those already collected in analytics scripts
+  that arrive in the ads via existing post-bid processes.
+* The signals themselves are even less verbose than those HUMAN normally collects post-bid, because of timing / performance requirements.
+* No signals attempt to identify users. Their only purpose is to classify traffic into valid / invalid.
+* The signal collection script is external to Prebid.js. This ensures that it can be constantly kept up to date with
+  the ever-evolving nature of the threat landscape without the publishers having to rebuild their Prebid.js frequently.
+  * The signal collection script is also obfuscated, as a defense-in-depth measure in order to complicate tampering by
+    bad actors, as are all similar scripts in the industry, which is something that cannot be accommodated by Prebid.js itself.
+
+## Why is this approach an innovation?
+
+Historically, IVT protection is achieved via dropping analytics scripts and/or pixels in the ads, which enriches impression data with collected signals.
+Those signals, when analyzed by IVT protection vendors, allow distinguishing valid from invalid traffic, but only retroactively -
+after the impression was served, and all the participant infrastructures have already participated in serving the request.
+
+This not only leads to unnecessary infrastructure costs, but to uncomfortable and often difficult processes of reconciliation
+and reimbursement, or claw-back. When handled only at the post-bid stage, the true bad actors have already achieved their objectives,
+and legitimate advertisers, platforms, and publishers are left holding the bag.
+
+HUMAN’s Ad Fraud Defense solves this problem by making predictions at the pre-bid stage about whether the traffic is fraudulent,
+allowing the platforms to knowingly not participate in the IVT-generated auctions.
+
+However, the challenge in making those predictions is that even these prebid predictions rely primarily on historical data,
+which not only introduces lag, but typically might be less accurate than direct decision making (were it possible) using
+the high-quality signals obtained from the pixels and/or JS analytics scripts delivered in the ads.
+
+The HUMAN Security RTD submodule bridges the gap by introducing a new innovation: it **facilitates the very same signal
+collection that is typically performed post-bid, but at the pre-bid stage, and makes the signals available during bidding.**
+This not only permits for accurate invalid traffic detection at the earliest stages of the auction process, but diminishes
+the impacts of signal deprecation such as the loss of IP and User Agent on effective fraud mitigation.
+
+## Why is this good for publishers?
+
+In the process of Invalid Traffic reconciliation, publishers are often the last to know, as they are informed by their downstream
+partners that the inventory they had provided in good faith has been detected as invalid traffic. This is most painful when it
+happens via post-bid detection when publishers are often the last party in the chain from whom the others can collect clawbacks,
+and the publishers themselves are left with little recourse. And when invalid traffic is blocked by platforms prebid, it is after
+the fact of publishers having sent out bid requests, thus harming fill rates, revenue opportunities, and overall auction and bidding
+efficiencies. And of course, invalid traffic whether detected post-bid or pre-bid is damaging to the publisher’s reputation
+with its demand partners.
+
+The HUMAN Security RTD submodule creates a more efficient integration for the process of invalid traffic mitigation.
+Invalid traffic detection and filtration is being done already with or without the participation of publishers, and measurement
+will be done on the ad inventory because advertisers need it to manage their own ad spend. The HUMAN Security RTD submodule gives
+publishers a direct seat, and in fact the first seat, in the invalid traffic detection process, allowing it to be done effectively,
+directly, and in a way that provides the publisher with more direct insight.
+
+Existing models of signal deprecation suggest that IP protection is going to be 100 times or more less granular.
+This would normally be expected to significantly reduce the ability to do prebid publisher-side predictions. This in turn would prevent
+the ability to see if specific impressions are bad and instead potentially result in the whole publisher being identified as being
+invalid traffic by a buyer. It is important to note that the purpose of data collection by the HUMAN Security RTD submodule is
+specifically for invalid traffic detection and filtration. It will not be used for unrelated and unauthorized purposes
+like targeting audiences, etc.
+
+The HUMAN Security RTD submodule makes sure to have the best integration possible to avoid revenue loss.
+It will help publishers avoid painful clawbacks. Currently, clawbacks are based on opaque measurement processes downstream from
+publishers where the information is controlled and withheld. The HUMAN Security RTD submodule will make publishers a more direct
+party to the measurement and verification process and help make sure the origin and the recipient match.
+
+Importantly, the effective use of the HUMAN Security RTD submodule signifies to SSPs and buyers that the publisher
+is a joint partner in ensuring quality ad delivery, and demonstrates that the publisher is a premium supply source.
+
+Finally, the HUMAN Security RTD submodule sets the ecosystem up for a future where publisher level reporting is facilitated.
+This will allow for increased transparency about what is happening with publisher inventory, further enhancing and
+ensuring the value of the inventory.
+
+## FAQ
+
+### Is latency an issue?
+
+The HUMAN Security RTD submodule is designed to minimize any latency in the auction within normal SLAs.
+
+### Do publishers get any insight into how the measurement is judged?
+
+Having the The HUMAN Security RTD submodule be part of the prebid process will allow the publisher to have insight
+into the invalid traffic metrics as they are determined and provide confidence that they are delivering quality
+inventory to the buyer.
+
+### How are privacy concerns addressed?
+
+The HUMAN Security RTD submodule seeks to reduce the impacts from signal deprecation that are inevitable without
+compromising privacy by avoiding re-identification. Each bid request is enriched with just enough signal
+to identify if the traffic is invalid or not.
+
+By having the The HUMAN Security RTD submodule operate at the Prebid level, data can be controlled
+and not as freely passed through the bidstream where it may be accessible to various unknown parties.
+
+Note: anti-fraud use cases typically have carve outs in laws and regulations to permit data collection
+essential for effective fraud mitigation, but this does not constitute legal advice and you should
+consult your attorney when making data access decisions.

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -20,6 +20,7 @@ const _approvedLoadExternalJSList = [
   'browsi',
   'brandmetrics',
   'clean.io',
+  'humansecurity',
   'confiant',
   'contxtful',
   'hadron',

--- a/test/spec/modules/humansecurityRtdProvider_spec.js
+++ b/test/spec/modules/humansecurityRtdProvider_spec.js
@@ -1,0 +1,210 @@
+import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
+
+import * as utils from '../../../src/utils.js';
+import * as hook from '../../../src/hook.js';
+import * as refererDetection from '../../../src/refererDetection.js';
+
+import { __TEST__ } from '../../../modules/humansecurityRtdProvider.js';
+
+const {
+  SUBMODULE_NAME,
+  SCRIPT_URL,
+  main,
+  load,
+  onImplLoaded,
+  onImplMessage,
+  onGetBidRequestData
+} = __TEST__;
+
+describe('humansecurity RTD module', function () {
+  let sandbox;
+
+  const stubUuid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+  const sonarStubId = `sonar_${stubUuid}`;
+  const stubWindow = { [sonarStubId]: undefined };
+
+  beforeEach(function() {
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(utils, 'getWindowSelf').returns(stubWindow);
+    sandbox.stub(utils, 'generateUUID').returns(stubUuid);
+    sandbox.stub(refererDetection, 'getRefererInfo').returns({ domain: 'example.com' });
+  });
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  describe('Initialization step', function () {
+    let sandbox2;
+    let connectSpy;
+    beforeEach(function() {
+      sandbox2 = sinon.sandbox.create();
+      connectSpy = sandbox.spy();
+      // Once the impl script is loaded, it registers the API using session ID
+      sandbox2.stub(stubWindow, sonarStubId).value({ connect: connectSpy });
+    });
+    afterEach(function () {
+      sandbox2.restore();
+    });
+
+    it('should accept valid configurations', function () {
+      // Default configuration - empty
+      expect(() => load({})).to.not.throw();
+      expect(() => load({ params: {} })).to.not.throw();
+      // Configuration with clientId
+      expect(() => load({ params: { clientId: 'customer123' } })).to.not.throw();
+    });
+
+    it('should throw an Error on invalid configuration', function () {
+      expect(() => load({ params: { clientId: 123 } })).to.throw();
+      expect(() => load({ params: { clientId: 'abc.def' } })).to.throw();
+      expect(() => load({ params: { clientId: '1' } })).to.throw();
+      expect(() => load({ params: { clientId: '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ' } })).to.throw();
+    });
+
+    it('should insert implementation script', () => {
+      load({ });
+
+      expect(loadExternalScriptStub.calledOnce).to.be.true;
+
+      const args = loadExternalScriptStub.getCall(0).args;
+      expect(args[0]).to.be.equal(`${SCRIPT_URL}?r=example.com`);
+      expect(args[1]).to.be.equal(SUBMODULE_NAME);
+      expect(args[2]).to.be.equal(onImplLoaded);
+      expect(args[3]).to.be.equal(null);
+      expect(args[4]).to.be.deep.equal({ 'data-sid': 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' });
+    });
+
+    it('should insert external script element with "customerId" info from config', () => {
+      load({ params: { clientId: 'customer123' } });
+
+      expect(loadExternalScriptStub.calledOnce).to.be.true;
+
+      const args = loadExternalScriptStub.getCall(0).args;
+      expect(args[0]).to.be.equal(`${SCRIPT_URL}?r=example.com&c=customer123`);
+    });
+
+    it('should connect to the implementation script once it loads', function () {
+      load({ });
+
+      expect(loadExternalScriptStub.calledOnce).to.be.true;
+      expect(connectSpy.calledOnce).to.be.true;
+
+      const args = connectSpy.getCall(0).args;
+      expect(args[0]).to.haveOwnProperty('cmd'); // pbjs global
+      expect(args[0]).to.haveOwnProperty('que');
+      expect(args[1]).to.be.equal(onImplMessage);
+    });
+  });
+
+  describe('Bid enrichment step', function () {
+    const hmnsData = { 'v1': 'sometoken' };
+
+    let sandbox2;
+    let callbackSpy;
+    let reqBidsConfig;
+    beforeEach(function() {
+      sandbox2 = sinon.sandbox.create();
+      callbackSpy = sandbox2.spy();
+      reqBidsConfig = { ortb2Fragments: { bidder: {}, global: {} } };
+    });
+    afterEach(function () {
+      sandbox2.restore();
+    });
+
+    it('should add empty device.ext.hmns to global ortb2 when data is yet to be received from the impl script', () => {
+      load({ });
+
+      onGetBidRequestData(reqBidsConfig, callbackSpy, { params: {} }, {});
+
+      expect(callbackSpy.calledOnce).to.be.true;
+      expect(reqBidsConfig.ortb2Fragments.global).to.have.own.property('device');
+      expect(reqBidsConfig.ortb2Fragments.global.device).to.have.own.property('ext');
+      expect(reqBidsConfig.ortb2Fragments.global.device.ext).to.have.own.property('hmns').which.is.an('object').that.deep.equals({});
+    });
+
+    it('should add the default device.ext.hmns to global ortb2 when no "hmns" data was yet received', () => {
+      load({ });
+
+      onImplMessage({ type: 'info', data: 'not a hmns message' });
+      onGetBidRequestData(reqBidsConfig, callbackSpy, { params: {} }, {});
+
+      expect(callbackSpy.calledOnce).to.be.true;
+      expect(reqBidsConfig.ortb2Fragments.global).to.have.own.property('device');
+      expect(reqBidsConfig.ortb2Fragments.global.device).to.have.own.property('ext');
+      expect(reqBidsConfig.ortb2Fragments.global.device.ext).to.have.own.property('hmns').which.is.an('object').that.deep.equals({});
+    });
+
+    it('should add device.ext.hmns with received tokens to global ortb2 when the data was received', () => {
+      load({ });
+
+      onImplMessage({ type: 'hmns', data: hmnsData });
+      onGetBidRequestData(reqBidsConfig, callbackSpy, { params: {} }, {});
+
+      expect(callbackSpy.calledOnce).to.be.true;
+      expect(reqBidsConfig.ortb2Fragments.global).to.have.own.property('device');
+      expect(reqBidsConfig.ortb2Fragments.global.device).to.have.own.property('ext');
+      expect(reqBidsConfig.ortb2Fragments.global.device.ext).to.have.own.property('hmns').which.is.an('object').that.deep.equals(hmnsData);
+    });
+
+    it('should update device.ext.hmns with new data', () => {
+      load({ });
+
+      onImplMessage({ type: 'hmns', data: { 'v1': 'should be overwritten' } });
+      onImplMessage({ type: 'hmns', data: hmnsData });
+      onGetBidRequestData(reqBidsConfig, callbackSpy, { params: {} }, {});
+
+      expect(callbackSpy.calledOnce).to.be.true;
+      expect(reqBidsConfig.ortb2Fragments.global).to.have.own.property('device');
+      expect(reqBidsConfig.ortb2Fragments.global.device).to.have.own.property('ext');
+      expect(reqBidsConfig.ortb2Fragments.global.device.ext).to.have.own.property('hmns').which.is.an('object').that.deep.equals(hmnsData);
+    });
+  });
+
+  describe('Sumbodule execution', function() {
+    let sandbox2;
+    let submoduleStub;
+    beforeEach(function() {
+      sandbox2 = sinon.sandbox.create();
+      submoduleStub = sandbox2.stub(hook, 'submodule');
+    });
+    afterEach(function () {
+      sandbox2.restore();
+    });
+
+    function getModule() {
+      main();
+
+      expect(submoduleStub.calledOnceWith('realTimeData')).to.equal(true);
+
+      const submoduleDef = submoduleStub.getCall(0).args[1];
+      expect(submoduleDef).to.be.an('object');
+      expect(submoduleDef).to.have.own.property('name', SUBMODULE_NAME);
+      expect(submoduleDef).to.have.own.property('init').that.is.a('function');
+      expect(submoduleDef).to.have.own.property('getBidRequestData').that.is.a('function');
+
+      return submoduleDef;
+    }
+
+    it('should register humansecurity RTD submodule provider', function () {
+      getModule();
+    });
+
+    it('should refuse initialization on invalid customer id configuration', function () {
+      const { init } = getModule();
+      expect(init({ params: { clientId: 123 } })).to.equal(false);
+      expect(loadExternalScriptStub.notCalled).to.be.true;
+    });
+
+    it('should commence initialization on valid initialization', function () {
+      const { init } = getModule();
+      expect(init({ params: { clientId: 'customer123' } })).to.equal(true);
+      expect(loadExternalScriptStub.calledOnce).to.be.true;
+    });
+
+    it('should commence initialization on default initialization', function () {
+      const { init } = getModule();
+      expect(init({ })).to.equal(true);
+      expect(loadExternalScriptStub.calledOnce).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [x] New RTD provider

## Description of change

* We're submitting the HUMAN RTD Submodule for review;
* It enriches bid requests with additional bid-level signal, as described in the documentation (link)
It uses `device.ext.hmns` as the IVT signal collected is not considered "user data" and cannot be used to identify a user or a device; we request feedback on whether this is the right placement, and whether any other controls should be present to govern this location or data collected
* The Human Security RTD submodule offers pre-bid signal collection, aimed to improve real-time protection against all sorts of invalid traffic, such as bot-generated ad interactions or sophisticated ad fraud schemes. It generates Human Security token, which then can be consumed by vendors, sent within bid requests, and used for bot detection on the backend.

## Other information

Contact email of the maintainer: [alexey@humansecurity.com](mailto:alexey@humansecurity.com)

Documentation PR: https://github.com/prebid/prebid.github.io/pull/5577