### PR TITLE
Prebid Core : Remove duplicate event call for actionDebug event

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -194,7 +194,6 @@ function validateAdUnitPos(adUnit, mediaType) {
     let warning = `Value of property 'pos' on ad unit ${adUnit.code} should be of type: Number`;
 
     logWarn(warning);
-    events.emit(EVENTS.AUCTION_DEBUG, { type: 'WARNING', arguments: warning });
     delete adUnit.mediaTypes[mediaType].pos;
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
 
This PR removes the redundant auction debug logging that was present in the code. The debug log statement was found to be a duplicate of the implementation already handled by the logWarn function. The logWarn function is already invoked within the validateAdUnitPos function, ensuring that the necessary logging occurs without repetition.

By removing this duplicate logging, we streamline the code, reduce unnecessary verbosity in the logs, and improve overall maintainability. This change does not affect the existing functionality, as the necessary logging is still being performed through the logWarn function.

<img width="1128" alt="Screenshot 2024-08-30 at 4 19 38 PM" src="https://github.com/user-attachments/assets/c1583526-0e59-44c0-8392-dbaa6355248b">
       

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
