### PR TITLE
RTB House Bid Adapter: paapi response interpreter uses additional config params

### DIFF
--- a/test/spec/modules/rtbhouseBidAdapter_spec.js
+++ b/test/spec/modules/rtbhouseBidAdapter_spec.js
@@ -470,7 +470,7 @@ describe('RTBHouseAdapter', () => {
         delete bidRequest[0].params.test;
 
         config.setConfig({ fledgeConfig: false });
-        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: { enabled: true }});
+        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: {enabled: true} });
         const data = JSON.parse(request.data);
         expect(data.ext).to.exist.and.to.be.a('object');
         expect(data.ext.fledge_config).to.exist.and.to.be.a('object');
@@ -490,7 +490,7 @@ describe('RTBHouseAdapter', () => {
             decisionLogicUrl: 'https://sellers.domain/decision.url'
           }
         });
-        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: { enabled: true }});
+        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: {enabled: true} });
         const data = JSON.parse(request.data);
         expect(data.ext).to.exist.and.to.be.a('object');
         expect(data.ext.fledge_config).to.exist.and.to.be.a('object');
@@ -510,7 +510,7 @@ describe('RTBHouseAdapter', () => {
             decisionLogicUrl: 'https://sellers.domain/decision.url'
           }
         });
-        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: { enabled: true }});
+        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: {enabled: true} });
         const data = JSON.parse(request.data);
         expect(data.ext).to.exist.and.to.be.a('object');
         expect(data.ext.fledge_config).to.exist.and.to.be.a('object');
@@ -534,7 +534,7 @@ describe('RTBHouseAdapter', () => {
             decisionLogicUrl: 'https://fledgeconfig.sellers.domain/decision.url'
           }
         });
-        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: { enabled: true }});
+        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: {enabled: true} });
         const data = JSON.parse(request.data);
         expect(data.ext).to.exist.and.to.be.a('object');
         expect(data.ext.fledge_config).to.exist.and.to.be.a('object');
@@ -549,7 +549,7 @@ describe('RTBHouseAdapter', () => {
         bidRequest[0].ortb2Imp = {
           ext: { ae: 2 }
         };
-        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: { enabled: false }});
+        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: {enabled: false} });
         let data = JSON.parse(request.data);
         if (data.imp[0].ext) {
           expect(data.imp[0].ext).to.not.have.property('ae');
@@ -562,7 +562,7 @@ describe('RTBHouseAdapter', () => {
         bidRequest[0].ortb2Imp = {
           ext: { ae: 2 }
         };
-        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: {enabled: true }});
+        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: {enabled: true} });
         let data = JSON.parse(request.data);
         expect(data.imp[0].ext.ae).to.equal(2);
       });
@@ -833,14 +833,14 @@ describe('RTBHouseAdapter', () => {
 
     context('when the response contains FLEDGE auction config and bid request has additional signals in paapiConfig', function () {
       let bidderRequest;
-      config.setConfig({ 
+      config.setConfig({
         paapiConfig: {
           interestGroupBuyers: ['https://buyer1.com'],
           perBuyerSignals: {
             'https://buyer1.com': { signal: 1 }
           },
           customSignal: 1
-        } 
+        }
       });
       let response = spec.interpretResponse({body: fledgeResponse}, {bidderRequest});
 

--- a/test/spec/modules/rtbhouseBidAdapter_spec.js
+++ b/test/spec/modules/rtbhouseBidAdapter_spec.js
@@ -460,7 +460,7 @@ describe('RTBHouseAdapter', () => {
         let bidRequest = Object.assign([], bidRequests);
         delete bidRequest[0].params.test;
         config.setConfig({ fledgeConfig: true });
-        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: {enabled: true} });
+        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: { enabled: true } });
         expect(request.url).to.equal('https://prebid-eu.creativecdn.com/bidder/prebidfledge/bids');
         expect(request.method).to.equal('POST');
       });
@@ -470,7 +470,7 @@ describe('RTBHouseAdapter', () => {
         delete bidRequest[0].params.test;
 
         config.setConfig({ fledgeConfig: false });
-        const request = spec.buildRequests(bidRequest, {...bidderRequest, paapi: {enabled: true}});
+        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: { enabled: true }});
         const data = JSON.parse(request.data);
         expect(data.ext).to.exist.and.to.be.a('object');
         expect(data.ext.fledge_config).to.exist.and.to.be.a('object');
@@ -480,7 +480,7 @@ describe('RTBHouseAdapter', () => {
         expect(data.ext.fledge_config.sellerTimeout).to.equal(500);
       });
 
-      it('sets a fledgeConfig object values when available from config', function () {
+      it('sets request.ext.fledge_config object values when available from fledgeConfig', function () {
         let bidRequest = Object.assign([], bidRequests);
         delete bidRequest[0].params.test;
 
@@ -490,7 +490,7 @@ describe('RTBHouseAdapter', () => {
             decisionLogicUrl: 'https://sellers.domain/decision.url'
           }
         });
-        const request = spec.buildRequests(bidRequest, {...bidderRequest, paapi: {enabled: true}});
+        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: { enabled: true }});
         const data = JSON.parse(request.data);
         expect(data.ext).to.exist.and.to.be.a('object');
         expect(data.ext.fledge_config).to.exist.and.to.be.a('object');
@@ -500,13 +500,56 @@ describe('RTBHouseAdapter', () => {
         expect(data.ext.fledge_config.sellerTimeout).to.not.exist;
       });
 
+      it('sets request.ext.fledge_config object values when available from paapiConfig', function () {
+        let bidRequest = Object.assign([], bidRequests);
+        delete bidRequest[0].params.test;
+
+        config.setConfig({
+          paapiConfig: {
+            seller: 'https://sellers.domain',
+            decisionLogicUrl: 'https://sellers.domain/decision.url'
+          }
+        });
+        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: { enabled: true }});
+        const data = JSON.parse(request.data);
+        expect(data.ext).to.exist.and.to.be.a('object');
+        expect(data.ext.fledge_config).to.exist.and.to.be.a('object');
+        expect(data.ext.fledge_config).to.contain.keys('seller', 'decisionLogicUrl');
+        expect(data.ext.fledge_config.seller).to.equal('https://sellers.domain');
+        expect(data.ext.fledge_config.decisionLogicUrl).to.equal('https://sellers.domain/decision.url');
+        expect(data.ext.fledge_config.sellerTimeout).to.not.exist;
+      });
+
+      it('sets request.ext.fledge_config object values when available from paapiConfig rather than from fledgeConfig if both exist', function () {
+        let bidRequest = Object.assign([], bidRequests);
+        delete bidRequest[0].params.test;
+
+        config.setConfig({
+          paapiConfig: {
+            seller: 'https://paapiconfig.sellers.domain',
+            decisionLogicUrl: 'https://paapiconfig.sellers.domain/decision.url'
+          },
+          fledgeConfig: {
+            seller: 'https://fledgeconfig.sellers.domain',
+            decisionLogicUrl: 'https://fledgeconfig.sellers.domain/decision.url'
+          }
+        });
+        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: { enabled: true }});
+        const data = JSON.parse(request.data);
+        expect(data.ext).to.exist.and.to.be.a('object');
+        expect(data.ext.fledge_config).to.exist.and.to.be.a('object');
+        expect(data.ext.fledge_config).to.contain.keys('seller', 'decisionLogicUrl');
+        expect(data.ext.fledge_config.seller).to.equal('https://paapiconfig.sellers.domain');
+        expect(data.ext.fledge_config.decisionLogicUrl).to.equal('https://paapiconfig.sellers.domain/decision.url');
+      });
+
       it('when FLEDGE is disabled, should not send imp.ext.ae', function () {
         let bidRequest = Object.assign([], bidRequests);
         delete bidRequest[0].params.test;
         bidRequest[0].ortb2Imp = {
           ext: { ae: 2 }
         };
-        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: {enabled: false} });
+        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: { enabled: false }});
         let data = JSON.parse(request.data);
         if (data.imp[0].ext) {
           expect(data.imp[0].ext).to.not.have.property('ae');
@@ -519,7 +562,7 @@ describe('RTBHouseAdapter', () => {
         bidRequest[0].ortb2Imp = {
           ext: { ae: 2 }
         };
-        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: {enabled: true} });
+        const request = spec.buildRequests(bidRequest, { ...bidderRequest, paapi: {enabled: true }});
         let data = JSON.parse(request.data);
         expect(data.imp[0].ext.ae).to.equal(2);
       });
@@ -785,6 +828,36 @@ describe('RTBHouseAdapter', () => {
         expect(response).to.have.property('paapi');
         expect(response.paapi.length).to.equal(1);
         expect(response.paapi[0].bidId).to.equal('test-bid-id');
+      });
+    });
+
+    context('when the response contains FLEDGE auction config and bid request has additional signals in paapiConfig', function () {
+      let bidderRequest;
+      config.setConfig({ 
+        paapiConfig: {
+          interestGroupBuyers: ['https://buyer1.com'],
+          perBuyerSignals: {
+            'https://buyer1.com': { signal: 1 }
+          },
+          customSignal: 1
+        } 
+      });
+      let response = spec.interpretResponse({body: fledgeResponse}, {bidderRequest});
+
+      it('should have 2 buyers in interestGroupBuyers', function () {
+        expect(response.paapi[0].config.interestGroupBuyers.length).to.equal(2);
+        expect(response.paapi[0].config.interestGroupBuyers).to.have.members(['https://buyer1.com', 'https://buyer-domain.com']);
+      });
+
+      it('should have 2 perBuyerSignals with proper values', function () {
+        expect(response.paapi[0].config.perBuyerSignals).to.contain.keys('https://buyer1.com', 'https://buyer-domain.com');
+        expect(response.paapi[0].config.perBuyerSignals['https://buyer1.com']).to.deep.equal({ signal: 1 });
+        expect(response.paapi[0].config.perBuyerSignals['https://buyer-domain.com']).to.deep.equal({});
+      });
+
+      it('should contain any custom signal passed via paapiConfig', function () {
+        expect(response.paapi[0].config).to.contain.keys('customSignal');
+        expect(response.paapi[0].config.customSignal).to.equal(1);
       });
     });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
This PR changes PAAPI request/response handling to work a more flexible way. Now you can pass bidder-specific paapiConfig object (instead of deprecated but still supported "fledgeConfig") with additional features: specify additional buyers list with signals specific to them and any component auction settings defined in PAAPI specs such as sellerSignals or auctionSignals.

## Other information
Please reach us at [inventory_support@rtbhouse.com](mailto:inventory_support@rtbhouse.com) with [piotr.jaworski@rtbhouse.com](mailto:piotr.jaworski@rtbhouse.com) and cc [leandro.otani@rtbhouse.com](mailto:leandro.otani@rtbhouse.com).
