### PR TITLE
PAAPI: parallel contextual and IG auctions

### DIFF
--- a/integrationExamples/top-level-paapi/gam-contextual.html
+++ b/integrationExamples/top-level-paapi/gam-contextual.html
@@ -52,6 +52,7 @@
                 debug: true,
                 paapi: {
                     enabled: true,
+                    parallel: true,
                     gpt: {
                         autoconfig: false
                     },

--- a/integrationExamples/top-level-paapi/no_adserver.html
+++ b/integrationExamples/top-level-paapi/no_adserver.html
@@ -43,6 +43,7 @@
                 debug: true,
                 paapi: {
                     enabled: true,
+                    parallel: true,
                     gpt: {
                         autoconfig: false
                     },

--- a/modules/optableBidAdapter.js
+++ b/modules/optableBidAdapter.js
@@ -17,16 +17,41 @@ const BIDDER_CODE = 'optable';
 const DEFAULT_REGION = 'ca'
 const DEFAULT_ORIGIN = 'https://ads.optable.co'
 
+function getOrigin() {
+  return config.getConfig('optable.origin') ?? DEFAULT_ORIGIN;
+}
+
+function getBaseUrl() {
+  const region = config.getConfig('optable.region') ?? DEFAULT_REGION;
+  return `${getOrigin()}/${region}`
+}
+
 export const spec = {
   code: BIDDER_CODE,
   isBidRequestValid: function(bid) { return !!bid.params?.site },
   buildRequests: function(bidRequests, bidderRequest) {
-    const region = config.getConfig('optable.region') ?? DEFAULT_REGION
-    const origin = config.getConfig('optable.origin') ?? DEFAULT_ORIGIN
-    const requestURL = `${origin}/${region}/ortb2/v1/ssp/bid`
+    const requestURL = `${getBaseUrl()}/ortb2/v1/ssp/bid`
     const data = converter.toORTB({ bidRequests, bidderRequest, context: { mediaType: BANNER } });
-
     return { method: 'POST', url: requestURL, data }
+  },
+  buildPAAPIConfigs: function(bidRequests) {
+    const origin = getOrigin();
+    return bidRequests
+      .filter(req => req.ortb2Imp?.ext?.ae)
+      .map(bid => ({
+        bidId: bid.bidId,
+        config: {
+          seller: origin,
+          decisionLogicURL: `${getBaseUrl()}/paapi/v1/ssp/decision-logic.js?origin=${bid.params.site}`,
+          interestGroupBuyers: [origin],
+          perBuyerMultiBidLimits: {
+            [origin]: 100
+          },
+          perBuyerCurrencies: {
+            [origin]: 'USD'
+          }
+        }
+      }))
   },
   interpretResponse: function(response, request) {
     const bids = converter.fromORTB({ response: response.body, request: request.data }).bids

--- a/modules/optableBidAdapter.js
+++ b/modules/optableBidAdapter.js
@@ -3,7 +3,6 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
 import { BANNER } from '../src/mediaTypes.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js'
-import {deepClone} from "../src/utils.js";
 const converter = ortbConverter({
   context: { netRevenue: true, ttl: 300 },
   imp(buildImp, bidRequest, context) {
@@ -31,17 +30,9 @@ export const spec = {
   },
   interpretResponse: function(response, request) {
     const bids = converter.fromORTB({ response: response.body, request: request.data }).bids
-    const auctionConfigs = (response.body.ext?.optable?.fledge?.auctionconfigs ?? []).flatMap((cfg) => {
+    const auctionConfigs = (response.body.ext?.optable?.fledge?.auctionconfigs ?? []).map((cfg) => {
       const { impid, ...config } = cfg;
-      const asnc = ['auctionSignals', 'sellerSignals', 'perBuyerSignals', 'perBuyerTimeouts', 'deprecatedRenderURLReplacements', 'directFromSellerSignals']
-      const config2 = deepClone(config);
-      Object.keys(config)
-        .filter(key => asnc.includes(key))
-        .forEach(key => {
-          config[key] = ((val) => new Promise((resolve) => setTimeout(() => resolve(val), 2000)))(config[key]);
-          config2[key] = ((val) => new Promise((resolve, reject) => setTimeout(() => resolve({}), 2000)))(config[key]);
-        });
-      return [{ bidId: impid, config }, {bidId: impid, config: config2}]
+      return { bidId: impid, config }
     })
 
     return { bids, paapi: auctionConfigs }

--- a/modules/paapi.js
+++ b/modules/paapi.js
@@ -11,8 +11,7 @@ import {
   logInfo,
   logWarn,
   mergeDeep,
-  sizesToSizeTuples,
-  deepClone
+  sizesToSizeTuples
 } from '../src/utils.js';
 import {IMP, PBS, registerOrtbProcessor, RESPONSE} from '../src/pbjsORTB.js';
 import * as events from '../src/events.js';

--- a/modules/paapi.js
+++ b/modules/paapi.js
@@ -577,8 +577,7 @@ export function parallelPaapiProcessing(next, spec, bids, bidderRequest, ...args
         latestAuctionForAdUnit[adUnitCode] = auctionId;
         const deferredConfigs = deferredConfigsForAuction(auctionId);
 
-        // eslint-disable-next-line no-inner-declarations
-        function getDeferredConfig() {
+        const getDeferredConfig = () => {
           if (!deferredConfigs.hasOwnProperty(adUnitCode)) {
             const [deferrals, promises] = makeDeferrals();
             auctionConfigs[adUnitCode] = {

--- a/modules/paapi.js
+++ b/modules/paapi.js
@@ -83,8 +83,8 @@ function attachHandlers() {
   getHook('addPaapiConfig').before(addPaapiConfigHook);
   getHook('makeBidRequests').before(addPaapiData);
   getHook('makeBidRequests').after(markForFledge);
-//getHook('processBidderRequests').before(parallelPaapiProcessing);
-//events.on(EVENTS.AUCTION_INIT, onAuctionInit);
+  getHook('processBidderRequests').before(parallelPaapiProcessing);
+  events.on(EVENTS.AUCTION_INIT, onAuctionInit);
   events.on(EVENTS.AUCTION_END, onAuctionEnd);
 }
 
@@ -92,9 +92,9 @@ function detachHandlers() {
   getHook('addPaapiConfig').getHooks({hook: addPaapiConfigHook}).remove();
   getHook('makeBidRequests').getHooks({hook: addPaapiData}).remove();
   getHook('makeBidRequests').getHooks({hook: markForFledge}).remove();
-  //getHook('processBidderRequests').before({hook: parallelPaapiProcessing}).remove();
+  getHook('processBidderRequests').getHooks({hook: parallelPaapiProcessing}).remove();
+  events.off(EVENTS.AUCTION_INIT, onAuctionInit);
   events.off(EVENTS.AUCTION_END, onAuctionEnd);
-  //events.off(EVENTS.AUCTION_INIT, onAuctionInit);
 }
 
 function getStaticSignals(adUnit = {}) {

--- a/modules/paapi.js
+++ b/modules/paapi.js
@@ -492,7 +492,7 @@ export function markForFledge(next, bidderRequests) {
   next(bidderRequests);
 }
 
-export const ASYNC_SIGNALS = ['auctionSignals', 'sellerSignals', 'perBuyerSignals', 'perBuyerTimeouts', 'deprecatedRenderURLReplacements', 'directFromSellerSignals'];
+export const ASYNC_SIGNALS = ['auctionSignals', 'sellerSignals', 'perBuyerSignals', 'perBuyerTimeouts', 'directFromSellerSignals'];
 
 const validatePartialConfig = (() => {
   const REQUIRED_SYNC_SIGNALS = [

--- a/modules/paapi.js
+++ b/modules/paapi.js
@@ -515,25 +515,25 @@ const validatePartialConfig = (() => {
   }
 })()
 
-/*
+/**
  * Adapters can provide a `spec.buildPAAPIConfigs(validBidRequests, bidderRequest)` to be included in PAAPI auctions
- * that can be started in parallel to contextual auctions.
+ * that can be started in parallel with contextual auctions.
  *
- * If PAAPI is enabled, and an adapter provides `buildPAAPIConfigs`, it is invoked just before `buildRequests`, and takes
- * the same arguments. It should return an array of PAAPI configuration objects withe same format as in `interpretResponse`,
- * {bidId, config?, igb?}.
+ * If PAAPI is enabled, and an adapter provides `buildPAAPIConfigs`, it is invoked just before `buildRequests`,
+ * and takes the same arguments. It should return an array of PAAPI configuration objects with the same format
+ * as in `interpretResponse` (`{bidId, config?, igb?}`).
  *
- * Everything returned by `buildPAAPIConfigs` is treated in the same way as if it was returned by `interpetResponse` -
- * except for signals that can be provided asynchronously (cfr. `ASYNC_SIGNALS`), which are tentatively replaced by promises.
- *
+ * Everything returned by `buildPAAPIConfigs` is treated in the same way as if it was returned by `interpretResponse` -
+ * except for signals that can be provided asynchronously (cfr. `ASYNC_SIGNALS`), which are replaced by promises.
  * When the (contextual) auction ends, the promises are resolved.
- * If during the auction the adapter's `interpretResponse` returned matching configurations (same `bidId`, and a `config` with the same `seller`,
- * or an `igb` with the same `origin`), the promises resolve to their contents. Otherwise, they resolve to the values
- * provided by `buildPAAPIConfigs`, or an empty object if no value was provided.
  *
- * Promisified auction configs are available from `getPAAPIConfig` immediately after a contextual auction is started.
- * If the `paapi.parallel` config flag is set, PAAPI submodules are also triggered at the same time (instead of
- * when the auction ends).
+ * If during the auction the adapter's `interpretResponse` returned matching configurations (same `bidId`,
+ * and a `config` with the same `seller`, or an `igb` with the same `origin`), the promises resolve to their contents.
+ * Otherwise, they resolve to the values provided by `buildPAAPIConfigs`, or an empty object if no value was provided.
+ *
+ * Promisified auction configs are available from `getPAAPIConfig` immediately after `requestBids`.
+ * If the `paapi.parallel` config flag is set, PAAPI submodules are also triggered at the same time
+ * (instead of when the auction ends).
  */
 export function parallelPaapiProcessing(next, spec, bids, bidderRequest, ...args) {
   function makeDeferrals(defaults = {}) {
@@ -558,10 +558,10 @@ export function parallelPaapiProcessing(next, spec, bids, bidderRequest, ...args
 
   if (enabled && spec.buildPAAPIConfigs) {
     const metrics = adapterMetrics(bidderRequest);
+    const tidGuard = guardTids(bidderRequest);
     let partialConfigs;
     metrics.measureTime('buildPAAPIConfigs', () => {
       try {
-        const tidGuard = guardTids(bidderRequest);
         partialConfigs = spec.buildPAAPIConfigs(bids.map(tidGuard.bidRequest), tidGuard.bidderRequest(bidderRequest))
       } catch (e) {
         logError(`Error invoking "buildPAAPIConfigs":`, e);

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -609,6 +609,6 @@ export function isValid(adUnitCode, bid, {index = auctionManager.index} = {}) {
   return true;
 }
 
-function adapterMetrics(bidderRequest) {
+export function adapterMetrics(bidderRequest) {
   return useMetrics(bidderRequest.metrics).renameWith(n => [`adapter.client.${n}`, `adapters.client.${bidderRequest.bidderCode}.${n}`])
 }

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -190,7 +190,7 @@ export function registerBidder(spec) {
   }
 }
 
-export function guardTids(bidderCode) {
+export const guardTids = memoize(({bidderCode}) => {
   if (isActivityAllowed(ACTIVITY_TRANSMIT_TID, activityParams(MODULE_TYPE_BIDDER, bidderCode))) {
     return {
       bidRequest: (br) => br,
@@ -228,7 +228,7 @@ export function guardTids(bidderCode) {
       }
     })
   }
-}
+});
 
 /**
  * Make a new bidder from the given spec. This is exported mainly for testing.
@@ -246,7 +246,7 @@ export function newBidder(spec) {
       if (!Array.isArray(bidderRequest.bids)) {
         return;
       }
-      const tidGuard = guardTids(bidderRequest.bidderCode);
+      const tidGuard = guardTids(bidderRequest);
 
       const adUnitCodesHandled = {};
       function addBidWithCode(adUnitCode, bid) {
@@ -287,7 +287,7 @@ export function newBidder(spec) {
         }
       });
 
-      processBidderRequests(spec, validBidRequests.map(tidGuard.bidRequest), tidGuard.bidderRequest(bidderRequest), ajax, configEnabledCallback, {
+      processBidderRequests(spec, validBidRequests, bidderRequest, ajax, configEnabledCallback, {
         onRequest: requestObject => events.emit(EVENTS.BEFORE_BIDDER_HTTP, bidderRequest, requestObject),
         onResponse: (resp) => {
           onTimelyResponse(spec.code);
@@ -381,8 +381,8 @@ const RESPONSE_PROPS = ['bids', 'paapi']
 export const processBidderRequests = hook('sync', function (spec, bids, bidderRequest, ajax, wrapCallback, {onRequest, onResponse, onPaapi, onError, onBid, onCompletion}) {
   const metrics = adapterMetrics(bidderRequest);
   onCompletion = metrics.startTiming('total').stopBefore(onCompletion);
-
-  let requests = metrics.measureTime('buildRequests', () => spec.buildRequests(bids, bidderRequest));
+  const tidGuard = guardTids(bidderRequest);
+  let requests = metrics.measureTime('buildRequests', () => spec.buildRequests(bids.map(tidGuard.bidRequest), tidGuard.bidderRequest(bidderRequest)));
 
   if (!requests || requests.length === 0) {
     onCompletion();

--- a/src/auction.js
+++ b/src/auction.js
@@ -150,6 +150,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
   const _timeout = cbTimeout;
   const _timelyRequests = new Set();
   const done = defer();
+  const requestsDone = defer();
   let _bidsRejected = [];
   let _callback = callback;
   let _bidderRequests = [];
@@ -320,6 +321,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
             }
           }
         }, _timeout, onTimelyResponse, ortb2Fragments);
+        requestsDone.resolve();
       }
     };
 
@@ -408,7 +410,8 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
     getNonBids: () => _nonBids,
     getFPD: () => ortb2Fragments,
     getMetrics: () => metrics,
-    end: done.promise
+    end: done.promise,
+    requestsDone: requestsDone.promise
   };
 }
 

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -841,6 +841,13 @@ describe('auctionmanager.js', function () {
       expect(auction.getNonBids()[0]).to.equal('test');
     });
 
+    it('resolves .requestsDone', async () => {
+      const auction = auctionManager.createAuction({adUnits});
+      stubCallAdapters.reset();
+      auction.callBids();
+      await auction.requestsDone;
+    })
+
     describe('stale auctions', () => {
       let clock, auction;
       beforeEach(() => {

--- a/test/spec/modules/optableBidAdapter_spec.js
+++ b/test/spec/modules/optableBidAdapter_spec.js
@@ -47,6 +47,33 @@ describe('optableBidAdapter', function() {
     });
   });
 
+  describe('buildPAAPIConfigs', () => {
+    function makeRequest({bidId, site = 'mockSite', ae = 1}) {
+      return {
+        bidId,
+        params: {
+          site
+        },
+        ortb2Imp: {
+          ext: {ae}
+        }
+      }
+    }
+    it('should generate auction configs for ae requests', () => {
+      const configs = spec.buildPAAPIConfigs([
+        makeRequest({bidId: 'bid1', ae: 1}),
+        makeRequest({bidId: 'bid2', ae: 0}),
+        makeRequest({bidId: 'bid3', ae: 1}),
+      ]);
+      expect(configs.map(cfg => cfg.bidId)).to.eql(['bid1', 'bid3']);
+      configs.forEach(cfg => sinon.assert.match(cfg.config, {
+        seller: 'https://ads.optable.co',
+        decisionLogicURL: `https://ads.optable.co/ca/paapi/v1/ssp/decision-logic.js?origin=mockSite`,
+        interestGroupBuyers: ['https://ads.optable.co']
+      }))
+    })
+  })
+
   describe('interpretResponse', function() {
     const validBid = {
       bidder: 'optable',

--- a/test/spec/modules/paapi_spec.js
+++ b/test/spec/modules/paapi_spec.js
@@ -1562,7 +1562,6 @@ describe('paapi module', () => {
             startParallel();
           }
 
-
           describe('when using separateAuctions=false', () => {
             beforeEach(() => {
               config.mergeConfig({
@@ -1603,7 +1602,6 @@ describe('paapi module', () => {
               })
             })
           })
-
         })
       })
     });

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -1751,7 +1751,7 @@ describe('the price floors module', function () {
         const req = utils.deepClone(bidRequest);
         _floorDataForAuction[req.auctionId] = utils.deepClone(basicFloorConfig);
 
-        expect(guardTids('mock-bidder').bidRequest(req).getFloor({})).to.deep.equal({
+        expect(guardTids({bidderCode: 'mock-bidder'}).bidRequest(req).getFloor({})).to.deep.equal({
           currency: 'USD',
           floor: 1.0
         });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

Adapters can provide a `spec.buildPAAPIConfigs(validBidRequests, bidderRequest)` to be included in PAAPI auctions that can be started in parallel to contextual auctions.

If PAAPI is enabled, and an adapter provides `buildPAAPIConfigs`, it is invoked just before `buildRequests`, and takes the same arguments. It should return an array of PAAPI configuration objects with the same format as in `interpretResponse` (`{bidId, config?, igb?}`).

Everything returned by `buildPAAPIConfigs` is treated in the same way as if it was returned by `interpretResponse` - except for signals that can be provided asynchronously (cfr. `ASYNC_SIGNALS`), which are replaced by promises. When the (contextual) auction ends, the promises are resolved.

If during the auction the adapter's `interpretResponse` returned matching configurations (same `bidId`, and a `config` with the same `seller`, or an `igb` with the same `origin`), the promises resolve to their contents. Otherwise, they resolve to the values provided by `buildPAAPIConfigs`, or an empty object if no value was provided.

Promisified auction configs are available from `getPAAPIConfig` immediately after `requestBids`. If the `paapi.parallel` config flag is set, PAAPI submodules are also triggered at the same time (instead of when the auction ends). Currently this is only relevant with `topLevelPAAPI`, where it has the effect of starting PAAPI auctions at the time of `requestBids`. The same could be done for GAM/`paapiForGpt` as soon as we have a method to trigger its PAAPI auctions separately from targeting/slot refreshes.

## Other information

Closes https://github.com/prebid/Prebid.js/issues/11730
