### PR TITLE
adUnits.js: Fix if dots '.' are in adUnitCode

### DIFF
--- a/src/adUnits.js
+++ b/src/adUnits.js
@@ -1,5 +1,3 @@
-import { deepAccess } from './utils.js';
-
 let adUnits = {};
 export function reset() {
   adUnits = {}
@@ -54,7 +52,7 @@ export function incrementBidderWinsCounter(adunit, bidderCode) {
  * @returns {number} current adunit count
  */
 export function getRequestsCounter(adunit) {
-  return deepAccess(adUnits, `${adunit}.requestsCounter`) || 0;
+  return adUnits?.[adunit]?.requestsCounter || 0;
 }
 
 /**
@@ -64,7 +62,7 @@ export function getRequestsCounter(adunit) {
  * @returns {number} current adunit bidder requests count
  */
 export function getBidderRequestsCounter(adunit, bidder) {
-  return deepAccess(adUnits, `${adunit}.bidders.${bidder}.requestsCounter`) || 0;
+  return adUnits?.[adunit]?.bidders?.[bidder]?.requestsCounter || 0;
 }
 
 /**
@@ -74,5 +72,5 @@ export function getBidderRequestsCounter(adunit, bidder) {
  * @returns {number} current adunit bidder requests count
  */
 export function getBidderWinsCounter(adunit, bidder) {
-  return deepAccess(adUnits, `${adunit}.bidders.${bidder}.winsCounter`) || 0;
+  return adUnits?.[adunit]?.bidders?.[bidder]?.winsCounter || 0;
 }

--- a/test/spec/unit/adUnits_spec.js
+++ b/test/spec/unit/adUnits_spec.js
@@ -22,6 +22,11 @@ describe('Adunit Counter', function () {
     adunitCounter.incrementRequestsCounter(ADUNIT_ID_2);
     expect(adunitCounter.getRequestsCounter(ADUNIT_ID_2)).to.be.equal(1);
   });
+  it('increments and checks requests counter if adUnit has a dots in it', function () {
+    const adCode = 'adunit.1'
+    adunitCounter.incrementRequestsCounter(adCode);
+    expect(adunitCounter.getRequestsCounter(adCode)).to.be.equal(1);
+  });
   it('increments and checks requests counter of adunit 1 for bidder 1', function () {
     adunitCounter.incrementBidderRequestsCounter(ADUNIT_ID_1, BIDDER_ID_1);
     expect(adunitCounter.getBidderRequestsCounter(ADUNIT_ID_1, BIDDER_ID_1)).to.be.equal(1);
@@ -34,6 +39,11 @@ describe('Adunit Counter', function () {
     adunitCounter.incrementBidderRequestsCounter(ADUNIT_ID_1, BIDDER_ID_1);
     expect(adunitCounter.getBidderRequestsCounter(ADUNIT_ID_1, BIDDER_ID_1)).to.be.equal(2);
   });
+  it('increments and checks bidder requests counter if adUnit has a dots in it', function () {
+    const adCode = 'adunit.1'
+    adunitCounter.incrementBidderRequestsCounter(adCode, BIDDER_ID_2);
+    expect(adunitCounter.getBidderRequestsCounter(adCode, BIDDER_ID_2)).to.be.equal(1);
+  });
   it('increments and checks wins counter of adunit 1 for bidder 1', function () {
     adunitCounter.incrementBidderWinsCounter(ADUNIT_ID_1, BIDDER_ID_1);
     expect(adunitCounter.getBidderWinsCounter(ADUNIT_ID_1, BIDDER_ID_1)).to.be.equal(1);
@@ -45,5 +55,10 @@ describe('Adunit Counter', function () {
   it('increments and checks wins counter of adunit 1 for bidder 2', function () {
     adunitCounter.incrementBidderWinsCounter(ADUNIT_ID_1, BIDDER_ID_2);
     expect(adunitCounter.getBidderWinsCounter(ADUNIT_ID_1, BIDDER_ID_2)).to.be.equal(1);
+  });
+  it('increments and checks wins counter if adUnit has a dots in it', function () {
+    const adCode = 'adunit.1'
+    adunitCounter.incrementBidderWinsCounter(adCode, BIDDER_ID_2);
+    expect(adunitCounter.getBidderWinsCounter(adCode, BIDDER_ID_2)).to.be.equal(1);
   });
 });


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Fixes #12204 

Some sites have dots `.` in the adUnitCodes which causes some `deepAccess` calls to not do what we expect.

This PR switches those adCode accessors to use optional chaining instead.