### PR TITLE
geoedge rtd module: support site override

### DIFF
--- a/modules/geoedgeRtdProvider.js
+++ b/modules/geoedgeRtdProvider.js
@@ -53,6 +53,10 @@ export let wrapper
 let wrapperReady;
 /** @type {boolean} */;
 let preloaded;
+/** @type {object} */;
+let refererInfo = getRefererInfo();
+/** @type {object} */;
+let overrides = window.grumi?.overrides;
 
 /**
  * fetches the creative wrapper
@@ -75,9 +79,8 @@ export function setWrapper(responseText) {
 }
 
 export function getInitialParams(key) {
-  let refererInfo = getRefererInfo();
   let params = {
-    wver: 'pbjs',
+    wver: '1.1.1',
     wtype: 'pbjs-module',
     key,
     meta: {
@@ -141,7 +144,7 @@ export function getMacros(bid, key) {
     '%_hbcid!': bid.creativeId || '',
     '%_hbadomains': bid.meta && bid.meta.advertiserDomains,
     '%%PATTERN:hb_pb%%': bid.pbHg,
-    '%%SITE%%': location.hostname,
+    '%%SITE%%': overrides?.site || refererInfo.domain,
     '%_pimp%': PV_ID,
     '%_hbCpm!': bid.cpm,
     '%_hbCurrency!': bid.currency

--- a/test/spec/modules/geoedgeRtdProvider_spec.js
+++ b/test/spec/modules/geoedgeRtdProvider_spec.js
@@ -143,6 +143,14 @@ describe('Geoedge RTD module', function () {
         const hasCurrency = dict['%_hbCurrency!'] === bid.currency;
         expect(hasCpm && hasCurrency);
       });
+      it('return a dictionary of macros replaced with values from overrides object if provided', function () {
+        const bid = mockBid('testBidder');
+        window.grumi.overrides = { site: 'test-overrides' };
+        const overrides = window.grumi.overrides;
+        const dict = getMacros(bid, key);
+        const siteOveridden = dict['%%SITE%%'] === overrides.site;
+        expect(siteOveridden);
+      });
     });
     describe('onBidResponseEvent', function () {
       const bidFromA = mockBid('bidderA');


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Maintenance 
- [x] Feature

## Description of change
Add the ability to override the "site" parameter from Prebid provided domain to publisher provided value.

## Other information
[GeoEdge module](https://docs.prebid.org/dev-docs/modules/geoedgeRtdProvider.html)
https://github.com/prebid/Prebid.js/pull/5869
https://github.com/prebid/Prebid.js/pull/9267
https://github.com/prebid/Prebid.js/pull/10291
https://github.com/prebid/Prebid.js/pull/10765
https://github.com/prebid/Prebid.js/pull/10911