### PR TITLE
PAAPI: fix bug where auctions break if adunits have only placeholder sizes

### DIFF
--- a/modules/paapi.js
+++ b/modules/paapi.js
@@ -314,9 +314,11 @@ function getFledgeConfig(bidder) {
  * Given an array of size tuples, return the one that should be used for PAAPI.
  */
 export const getPAAPISize = hook('sync', function (sizes) {
+  sizes = sizes
+    ?.filter(([w, h]) => !(w === h && w <= 5));
+
   if (sizes?.length) {
     return sizes
-      .filter(([w, h]) => !(w === h && w <= 5))
       .reduce(maximum(keyCompare(([w, h]) => w * h)));
   }
 }, 'getPAAPISize');

--- a/test/spec/modules/paapi_spec.js
+++ b/test/spec/modules/paapi_spec.js
@@ -1122,6 +1122,10 @@ describe('paapi module', () => {
       'can handle no input': {
         in: undefined,
         out: undefined
+      },
+      'can handle placeholder sizes': {
+        in: [[1, 1]],
+        out: undefined
       }
     }).forEach(([t, {in: input, out}]) => {
       it(t, () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fixes https://github.com/prebid/Prebid.js/issues/12218
