### PR TITLE
Yieldlab Bid Adapter : fix meta.advertiserDomains

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -201,7 +201,7 @@ export const spec = {
           referrer: '',
           ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/?ts=${timestamp}${extId}${gdprApplies}${gdprConsent}${pvId}${iabContent}"></script>`,
           meta: {
-            advertiserDomains: (matchedBid.advertiser) ? matchedBid.advertiser : 'n/a',
+            advertiserDomains: [(matchedBid.advertiser) ? matchedBid.advertiser : 'n/a'],
           },
         };
 

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -682,7 +682,7 @@ describe('yieldlabBidAdapter', () => {
       expect(result[0].netRevenue).to.equal(false);
       expect(result[0].ttl).to.equal(300);
       expect(result[0].referrer).to.equal('');
-      expect(result[0].meta.advertiserDomains).to.equal('yieldlab');
+      expect(result[0].meta.advertiserDomains).to.deep.equal(['yieldlab']);
       expect(result[0].ad).to.include('<script src="https://ad.yieldlab.net/d/1111/2222/?ts=');
       expect(result[0].ad).to.include('&id=abc');
     });
@@ -719,7 +719,7 @@ describe('yieldlabBidAdapter', () => {
       expect(result[0].netRevenue).to.equal(false);
       expect(result[0].ttl).to.equal(300);
       expect(result[0].referrer).to.equal('');
-      expect(result[0].meta.advertiserDomains).to.equal('yieldlab');
+      expect(result[0].meta.advertiserDomains).to.deep.equal(['yieldlab']);
       expect(result[0].ad).to.include('<script src="https://ad.yieldlab.net/d/1111/2222/?ts=');
       expect(result[0].ad).to.include('&id=abc');
     });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x ] Bugfix

## Description of change
meta.advertiserDomains should've been an array all this time. Specs: https://docs.prebid.org/dev-docs/bidder-adaptor.html