### PR TITLE
Adkernel Bid Adapter: Remove FelixAds

### DIFF
--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -84,7 +84,6 @@ export const spec = {
     {code: 'unibots'},
     {code: 'ergadx'},
     {code: 'turktelekom'},
-    {code: 'felixads'},
     {code: 'motionspots'},
     {code: 'sonic_twist'},
     {code: 'displayioads'},


### PR DESCRIPTION
NOTE I am NOT the maintainer for AdKernel nor a representative of FelixAds, just noticed a potential duplicated alias while analyzing the codebase. Requires approval from @felixads @SmartHubSolutions @ckbo3hrk 

## Type of change
- [X] Bugfix
- [X] Updated bidder adapter  

## Description of change
Remove possibly incorrect alias (currently felixads is aliased to both adkernel and smarthub). 

What is the expected behavior of two bid adapters listing the same code as an alias? Is it considered a bug, or should both bid adapters send requests?

## Other information
Reason I believe this alias may no longer be valid is since #12072, and docs for FelixAds were updated to smarthub bid params from adkernel's in https://github.com/prebid/prebid.github.io/pull/5521
