### PR TITLE
Seedtag Bid Adapter: sends ortb2 site cat, cattax and pagecat signals in payload

### DIFF
--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -285,7 +285,8 @@ export const spec = {
       auctionStart: bidderRequest.auctionStart || Date.now(),
       ttfb: ttfb(),
       bidRequests: _map(validBidRequests, buildBidRequest),
-      user: { topics: [], eids: [] }
+      user: { topics: [], eids: [] },
+      site: {}
     };
 
     if (payload.cmp) {
@@ -335,6 +336,18 @@ export const spec = {
 
     if (bidderRequest.ortb2?.device?.sua) {
       payload.sua = bidderRequest.ortb2.device.sua
+    }
+
+    if (bidderRequest.ortb2?.site?.cat) {
+      payload.site.cat = bidderRequest.ortb2.site.cat
+    }
+
+    if (bidderRequest.ortb2?.site?.cattax) {
+      payload.site.cattax = bidderRequest.ortb2.site.cattax
+    }
+
+    if (bidderRequest.ortb2?.site?.pagecat) {
+      payload.site.pagecat = bidderRequest.ortb2.site.pagecat
     }
 
     const payloadString = JSON.stringify(payload);

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -629,6 +629,61 @@ describe('Seedtag Adapter', function () {
       });
     });
 
+    describe('Site params', function () {
+      it('should add cat param to payload when bidderRequest has ortb2 site cat info', function () {
+        const siteCategories = ['1217', 'bsr004', '692']
+        var ortb2 = {
+          site: {
+            cat: siteCategories
+          }
+        }
+        bidderRequest['ortb2'] = ortb2
+
+        const request = spec.buildRequests(validBidRequests, bidderRequest);
+        const data = JSON.parse(request.data);
+        expect(data.site.cat).to.deep.equal(siteCategories);
+      });
+
+      it('should add pagecat param to payload when bidderRequest has ortb2 site pagecat info', function () {
+        const pageCategories = ['1217', 'bsr004', '692']
+        var ortb2 = {
+          site: {
+            pagecat: pageCategories
+          }
+        }
+        bidderRequest['ortb2'] = ortb2
+
+        const request = spec.buildRequests(validBidRequests, bidderRequest);
+        const data = JSON.parse(request.data);
+        expect(data.site.pagecat).to.deep.equal(pageCategories);
+      });
+
+      it('should add cattac param to payload when bidderRequest has ortb2 site cattax info', function () {
+        const taxonomy = 6
+        var ortb2 = {
+          site: {
+            cattax: taxonomy
+          }
+        }
+        bidderRequest['ortb2'] = ortb2
+
+        const request = spec.buildRequests(validBidRequests, bidderRequest);
+        const data = JSON.parse(request.data);
+        expect(data.site.cattax).to.equal(taxonomy);
+      });
+
+      it('should not add site params to payload when bidderRequest does not have ortb2 site info', function () {
+        var ortb2 = {}
+        bidderRequest['ortb2'] = ortb2
+
+        const request = spec.buildRequests(validBidRequests, bidderRequest);
+        const data = JSON.parse(request.data);
+        expect(data.site.cattax).to.be.undefined;
+        expect(data.site.cat).to.be.undefined;
+        expect(data.site.pagecat).to.be.undefined;
+      });
+    });
+
     describe('device.sua param', function () {
       it('should add device.sua param to payload when bidderRequest has ortb2 device.sua info', function () {
         const sua = 1


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Sends ortb2 site cat, cattax and pagecat into payload if available

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
