### PR TITLE
Core: Adding useBaseGvlid to aliasBidAdapter

### DIFF
--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -553,11 +553,13 @@ adapterManager.aliasBidAdapter = function (bidderCode, alias, options) {
           newAdapter = new bidAdapter.constructor();
           newAdapter.setBidderCode(alias);
         } else {
+          const { useBaseGvlid = false } = options || {};
           let spec = bidAdapter.getSpec();
-          let gvlid = options && options.gvlid;
-          if (spec.gvlid != null && gvlid == null) {
+          const gvlid = useBaseGvlid ? spec.gvlid : options?.gvlid;
+          if (!useBaseGvlid && spec.gvlid != null && options?.gvlid == null) {
             logWarn(`Alias '${alias}' will NOT re-use the GVL ID of the original adapter ('${spec.code}', gvlid: ${spec.gvlid}). Functionality that requires TCF consent may not work as expected.`)
           }
+
           let skipPbsAliasing = options && options.skipPbsAliasing;
           newAdapter = newBidder(Object.assign({}, spec, { code: alias, gvlid, skipPbsAliasing }));
           _aliasRegistry[alias] = bidderCode;

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -556,7 +556,7 @@ adapterManager.aliasBidAdapter = function (bidderCode, alias, options) {
           const { useBaseGvlid = false } = options || {};
           let spec = bidAdapter.getSpec();
           const gvlid = useBaseGvlid ? spec.gvlid : options?.gvlid;
-          if (!useBaseGvlid && spec.gvlid != null && options?.gvlid == null) {
+          if (gvlid == null && spec.gvlid != null) {
             logWarn(`Alias '${alias}' will NOT re-use the GVL ID of the original adapter ('${spec.code}', gvlid: ${spec.gvlid}). Functionality that requires TCF consent may not work as expected.`)
           }
 

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1632,9 +1632,8 @@ describe('adapterManager tests', function () {
       });
 
       it('should use gvlid of original adapter when option set', () => {
-        const mediaType = FEATURES.VIDEO ? 'video' : 'banner'
         const gvlid = 'origvlid';
-        let thisSpec = Object.assign(spec, { supportedMediaTypes: [mediaType], gvlid });
+        let thisSpec = Object.assign(spec, { gvlid });
         registerBidder(thisSpec);
         const alias = 'bidderWithGvlid';
         adapterManager.aliasBidAdapter(CODE, alias, {useBaseGvlid: true});

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1630,6 +1630,16 @@ describe('adapterManager tests', function () {
           expect(adapterManager.videoAdapters).to.include(alias);
         }
       });
+
+      it('should use gvlid of original adapter when option set', () => {
+        const mediaType = FEATURES.VIDEO ? 'video' : 'banner'
+        const gvlid = 'origvlid';
+        let thisSpec = Object.assign(spec, { supportedMediaTypes: [mediaType], gvlid });
+        registerBidder(thisSpec);
+        const alias = 'bidderWithGvlid';
+        adapterManager.aliasBidAdapter(CODE, alias, {useBaseGvlid: true});
+        expect(adapterManager.bidderRegistry[alias].getSpec()?.gvlid).to.deep.eql(gvlid);
+      })
     });
 
     describe('special case for s2s-only bidders', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
#10759 