### PR TITLE
IdentityLinkIdSystem: fix identity link throwing unhandled promises

### DIFF
--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -132,6 +132,8 @@ function getEnvelope(url, callback, configParams) {
     utils.logInfo('identityLink: A 3P retrieval is attempted!');
     setEnvelopeSource(false);
     ajax(url, callbacks, undefined, { method: 'GET', withCredentials: true });
+  } else {
+    callback()
   }
 }
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
[This pull request references the issue that was opened here](https://github.com/prebid/Prebid.js/issues/12243)

Essentially [this callback here](https://github.com/prebid/Prebid.js/blob/1f3b6848b78f8bdfc4b9f63465a5d37aaafaa6b6/modules/userId/index.js#L382) never gets executed when either of one of those 2 conditions [inside this if](https://github.com/prebid/Prebid.js/blob/1f3b6848b78f8bdfc4b9f63465a5d37aaafaa6b6/modules/identityLinkIdSystem.js#L130) is false. 
In this case probably the identity link will return an empty value and we should see a message like this:
<img width="1492" alt="Screenshot 2024-09-17 at 10 06 28" src="https://github.com/user-attachments/assets/711257b6-141c-4c4a-8381-c74f05bdcda4">

But instead we are seeing something like this:

<img width="1501" alt="Screenshot 2024-09-15 at 21 16 25" src="https://github.com/user-attachments/assets/e94fd028-3690-44c8-9a92-3464be9bd6ce">

While this [pull request here](https://github.com/prebid/Prebid.js/pull/12246) is addressing the error of unhandling the promise, it won't address the fact that we should see in this case a message from prebid saying that it did return with an empty value, and that's what this PR is addressing.


## Other information