### PR TITLE
Fix: Incorrect generation of analytics impression url when bid response is a VAST URL (videoTrackers.js)

### DIFF
--- a/libraries/vastTrackers/vastTrackers.js
+++ b/libraries/vastTrackers/vastTrackers.js
@@ -14,7 +14,7 @@ addBidResponse.before(function (next, adUnitcode, bidResponse, reject) {
       bidResponse.vastXml = insertVastTrackers(vastTrackers, bidResponse.vastXml);
       const impTrackers = vastTrackers.get('impressions');
       if (impTrackers) {
-        bidResponse.vastImpUrl = [].concat(impTrackers).concat(bidResponse.vastImpUrl).filter(t => t);
+        bidResponse.vastImpUrl = [].concat([...impTrackers]).concat(bidResponse.vastImpUrl).filter(t => t);
       }
     }
   }

--- a/libraries/vastTrackers/vastTrackers.js
+++ b/libraries/vastTrackers/vastTrackers.js
@@ -7,7 +7,11 @@ import {activityParams} from '../../src/activities/activityParams.js';
 
 const vastTrackers = [];
 
-addBidResponse.before(function (next, adUnitcode, bidResponse, reject) {
+export function reset() {
+  vastTrackers.length = 0;
+}
+
+export function addTrackersToResponse(next, adUnitcode, bidResponse, reject) {
   if (FEATURES.VIDEO && bidResponse.mediaType === VIDEO) {
     const vastTrackers = getVastTrackers(bidResponse);
     if (vastTrackers) {
@@ -19,7 +23,8 @@ addBidResponse.before(function (next, adUnitcode, bidResponse, reject) {
     }
   }
   next(adUnitcode, bidResponse, reject);
-});
+}
+addBidResponse.before(addTrackersToResponse);
 
 export function registerVastTrackers(moduleType, moduleName, trackerFn) {
   if (typeof trackerFn === 'function') {

--- a/test/spec/libraries/vastTrackers_spec.js
+++ b/test/spec/libraries/vastTrackers_spec.js
@@ -1,17 +1,27 @@
-import {addImpUrlToTrackers, getVastTrackers, insertVastTrackers, registerVastTrackers} from 'libraries/vastTrackers/vastTrackers.js';
+import {
+  addImpUrlToTrackers,
+  addTrackersToResponse,
+  getVastTrackers,
+  insertVastTrackers,
+  registerVastTrackers,
+  reset
+} from 'libraries/vastTrackers/vastTrackers.js';
 import {MODULE_TYPE_ANALYTICS} from '../../../src/activities/modules.js';
 
 describe('vast trackers', () => {
+  beforeEach(() => {
+    registerVastTrackers(MODULE_TYPE_ANALYTICS, 'test', function(bidResponse) {
+      return [
+        {'event': 'impressions', 'url': `https://vasttracking.mydomain.com/vast?cpm=${bidResponse.cpm}`}
+      ];
+    });
+  })
+  afterEach(() => {
+    reset();
+  });
+
   it('insert into tracker list', function() {
-    let trackers = getVastTrackers({'cpm': 1.0});
-    if (!trackers || !trackers.get('impressions')) {
-      registerVastTrackers(MODULE_TYPE_ANALYTICS, 'test', function(bidResponse) {
-        return [
-          {'event': 'impressions', 'url': `https://vasttracking.mydomain.com/vast?cpm=${bidResponse.cpm}`}
-        ];
-      });
-    }
-    trackers = getVastTrackers({'cpm': 1.0});
+    const trackers = getVastTrackers({'cpm': 1.0});
     expect(trackers).to.be.a('map');
     expect(trackers.get('impressions')).to.exists;
     expect(trackers.get('impressions').has('https://vasttracking.mydomain.com/vast?cpm=1')).to.be.true;
@@ -30,4 +40,17 @@ describe('vast trackers', () => {
     expect(trackers.get('impressions')).to.exists;
     expect(trackers.get('impressions').has('imptracker.com')).to.be.true;
   });
+
+  if (FEATURES.VIDEO) {
+    it('should add trackers to bid response', () => {
+      const bidResponse = {
+        mediaType: 'video',
+        cpm: 1
+      }
+      addTrackersToResponse(sinon.stub(), 'au', bidResponse);
+      expect(bidResponse.vastImpUrl).to.eql([
+        'https://vasttracking.mydomain.com/vast?cpm=1'
+      ])
+    });
+  }
 })


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Issue
The issue arises when bid response has `vastUrl` as video response. Impression urls for analytics are registered via [vastTrackers.registerVastTrackers](https://github.com/prebid/Prebid.js/blob/master/libraries/vastTrackers/vastTrackers.js#L24C17-L24C37) function. This module gets impression urls on bidResponse and concatenate to `bidResponse.vastImpUrl` as `Set<Array<string>>`.

![i-2](https://github.com/user-attachments/assets/c65348b9-ffcf-4f45-b749-875ed4325643)

The [videoCache.js](https://github.com/prebid/Prebid.js/blob/master/src/videoCache.js) module then add these impression urls to vast. It requires impression urls as  [string|string[]](https://github.com/prebid/Prebid.js/blob/master/src/videoCache.js#L44C2-L44C104).
The current implementation for generating CDATA blocks in `<Impression>` tags is incorrectly handling impression trackers when the video response is a vastUrl. Instead of embedding the actual URLs, the output is showing `[object Set]`.

**[Code Ref.](https://github.com/prebid/Prebid.js/blob/master/src/videoCache.js#L52)** : 

```javascript
impTrackerURLs ? impTrackerURLs.map(trk => `<Impression><![CDATA[${trk}]]></Impression>`).join('') : '';
```

The code is meant to generate impression URLs by mapping over `impTrackerURLs`, which it assume is `Array<string>`. However, instead of producing URLs as expected, the output inside the <Impression> tags is `[object Set]` when it should be the actual URLs as strings.

![cache](https://github.com/user-attachments/assets/a467dc52-093a-4228-92a0-f3b68db3b4e6)

**This issue will impact video ad tracking, leading to incorrect reporting and analytics.**

### Steps to reproduce

- Register vastTrackers function as mentioned [here](https://github.com/prebid/Prebid.js/blob/master/test/spec/libraries/vastTrackers_spec.js) with any analytics adapter eg., `medianetAnalytics`

- It can be a single url of type `event: impressions` 
```js
    registerVastTrackers(MODULE_TYPE_ANALYTICS, 'test', function(bidResponse) {
      return [
        {'event': 'impressions', 'url': `https://vasttracking.mydomain1.com/vast?cpm=${bidResponse.cpm}`}
      ];
    });
```

- Or can be multiple url's of type `event: impressions` 

```js
    registerVastTrackers(MODULE_TYPE_ANALYTICS, 'test', function(bidResponse) {
      return [
        {'event': 'impressions', 'url': `https://vasttracking.mydomain1.com/vast?cpm=${bidResponse.cpm}`},
        {'event': 'impressions', 'url': `https://vasttracking.mydomain2.com/vast?cpm=${bidResponse.cpm}`}
      ];
    });
```

![issue](https://github.com/user-attachments/assets/01af2d5a-69ba-4d50-9b3d-f08862f1ffe1)

## Solution

Convert the `Set<string>` to an array before concatenating to `bidResponse.vastImpUrl`.

- **`With videoResponse as vastUrl`**
![after fix - vastUrl](https://github.com/user-attachments/assets/6815c554-e47d-4768-bc54-fbdca06256fa)

- **`With videoResponse as vastXml`**
![after fix - vastXml](https://github.com/user-attachments/assets/aac07bef-cf61-4fb3-9102-6a5fbb0d91d9)

