### PR TITLE
linter.yml: also install dependencies for PR branch

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Check out PR
         run: git checkout ${{ github.event.pull_request.head.sha }}
 
+      - name: Install dependencies
+        run: npm ci
+
       - name: Run linter on PR
         run: npx eslint --no-inline-config --format json $(cat __changed_files.txt | xargs stat --printf '%n\n' 2> /dev/null) > __pr.json || true
 


### PR DESCRIPTION
## Type of change
- [X] CI related changes

## Description of change
Because the PR branch does not install module before getting the diff, the test will fail if dependencies change.
To avoid this this PR will add `npm ci` for the PR branch after pull.

## Other information
Needs to be merged before [#12260](https://github.com/prebid/Prebid.js/pull/12260) to get the checks working.
