### PR TITLE
Timeout RTD Provider : Module Not Updating bidderTimeout

### DIFF
--- a/modules/rtdModule/index.js
+++ b/modules/rtdModule/index.js
@@ -318,10 +318,8 @@ export const setBidRequestsData = timedAuctionHook('rtd', function setBidRequest
   relevantSubModules.forEach(sm => {
     const fpdGuard = guardOrtb2Fragments(reqBidsConfigObj.ortb2Fragments || {}, activityParams(MODULE_TYPE_RTD, sm.name));
     verifiers.push(fpdGuard.verify);
-    sm.getBidRequestData({
-      ...reqBidsConfigObj,
-      ortb2Fragments: fpdGuard.obj
-    }, onGetBidRequestDataCallback.bind(sm), sm.config, _userConsent)
+    reqBidsConfigObj.ortb2Fragments = fpdGuard.obj;
+    sm.getBidRequestData(reqBidsConfigObj, onGetBidRequestDataCallback.bind(sm), sm.config, _userConsent)
   });
 
   function onGetBidRequestDataCallback() {


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix

## Description of change

This PR resolves the issue where the timeout RTD (Real-Time Data) module was not updating the bidderTimeout value as expected. The module is supposed to modify the bidderTimeout based on predefined rules, but this functionality was not working due to an error in the core RTD module's logic.

The following changes have been made to address the issue:

File Modified: modules/rtdModule/index.js

Fix Description: The argument 'reqBidsConfigObj' passed to the getBidRequestData function has been updated. Previously, the bidderTimeout value was not being updated due to passing the shallow copy of reqBidsConfigObj.

Steps to Reproduce:

Set up the timeout RTD module with rules designed to extend the bidderTimeout.
Observe that the bidderTimeout value does not change as expected.

Existing output :  [Timeout RTD Issue](https://jsfiddle.net/8uxywsLa/) 

We are consoling the bidder Timeout in the above code.
![Issue](https://github.com/user-attachments/assets/1e25753e-2f41-432f-8aa4-f2cc68fd3820)

Expected output :  [Timeout RTD Issue Resolved](https://jsfiddle.net/4jLrdef1/)

We are consoling the bidder Timeout in the above code.
![Fixed](https://github.com/user-attachments/assets/f6eeb762-69d7-4b02-9186-2231188990a4)

Changes:

Corrected the logic in index.js to ensure the bidderTimeout value is updated appropriately when rules are applied.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
