### PR TITLE
StroeerCore Bid Adapter: add special format parameters to bid request

### DIFF
--- a/modules/stroeerCoreBidAdapter.js
+++ b/modules/stroeerCoreBidAdapter.js
@@ -216,6 +216,7 @@ const mapToPayloadBaseBid = (bidRequest) => ({
   bid: bidRequest.bidId,
   sid: bidRequest.params.sid,
   viz: elementInView(bidRequest.adUnitCode),
+  sfp: bidRequest.params.sfp,
 });
 
 const mapToPayloadBannerBid = (bidRequest) => {

--- a/test/spec/modules/stroeerCoreBidAdapter_spec.js
+++ b/test/spec/modules/stroeerCoreBidAdapter_spec.js
@@ -533,6 +533,7 @@ describe('stroeerCore bid adapter', function () {
                 'siz': [[300, 600], [160, 60]],
                 'fp': undefined
               },
+              'sfp': undefined,
             },
             {
               'sid': 'ABC=',
@@ -541,7 +542,8 @@ describe('stroeerCore bid adapter', function () {
                 'siz': [[100, 200], [300, 500]],
                 'fp': undefined
               },
-              'viz': undefined
+              'viz': undefined,
+              'sfp': undefined,
             }
           ];
 
@@ -555,7 +557,8 @@ describe('stroeerCore bid adapter', function () {
                 'siz': [640, 480],
                 'mim': ['video/mp4', 'video/quicktime'],
                 'fp': undefined
-              }
+              },
+              'sfp': undefined,
             }
           ];
 
@@ -597,7 +600,8 @@ describe('stroeerCore bid adapter', function () {
               'ban': {
                 'siz': [[100, 200], [300, 500]],
                 'fp': undefined
-              }
+              },
+              'sfp': undefined,
             }
           ];
 
@@ -611,14 +615,14 @@ describe('stroeerCore bid adapter', function () {
                 'siz': [640, 480],
                 'mim': ['video/mp4', 'video/quicktime'],
                 'fp': undefined
-              }
+              },
+              'sfp': undefined,
             }
           ];
 
           assert.deepEqual(serverRequestInfo.data.bids, [...expectedBannerBids, ...expectedVideoBids]);
         });
       });
-
       describe('optional fields', () => {
         it('should skip viz field when unable to determine visibility of placement', () => {
           placementElements.length = 0;
@@ -897,6 +901,39 @@ describe('stroeerCore bid adapter', function () {
           const sentOrtb2 = serverRequestInfo.data.ortb2;
 
           assert.deepEqual(sentOrtb2, ortb2);
+        });
+
+        it('should add the special format parameters', () => {
+          const bidReq = buildBidderRequest();
+
+          const sfp0 = {
+            'field1': {
+              'abc': '123',
+            }
+          };
+
+          const sfp1 = {
+            'field3': 'xyz'
+          };
+
+          bidReq.bids[0].params.sfp = utils.deepClone(sfp0);
+          bidReq.bids[1].params.sfp = utils.deepClone(sfp1);
+
+          const serverRequestInfo = spec.buildRequests(bidReq.bids, bidReq);
+
+          assert.deepEqual(serverRequestInfo.data.bids[0].sfp, sfp0);
+          assert.deepEqual(serverRequestInfo.data.bids[1].sfp, sfp1);
+        });
+
+        it('should add the special format parameters even when it is an empty object', () => {
+          const bidReq = buildBidderRequest();
+
+          bidReq.bids[0].params.sfp = {};
+
+          const serverRequestInfo = spec.buildRequests(bidReq.bids, bidReq);
+
+          assert.deepEqual(serverRequestInfo.data.bids[0].sfp, {});
+          assert.isUndefined(serverRequestInfo.data.bids[1].sfp);
         });
       });
     });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 

## Description of change

Add an optional bidder param called `sfp` (special format parameters) to the bid request. These parameters will influence the rendering of special ad formats delivered from the Ströer DSP.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


