### PR TITLE
Dailymotion bid adapter: Process both ORTB2 sources of category

### DIFF
--- a/modules/dailymotionBidAdapter.js
+++ b/modules/dailymotionBidAdapter.js
@@ -17,10 +17,11 @@ function getVideoMetadata(bidRequest, bidderRequest) {
 
   // As per oRTB 2.5 spec, "A bid request must not contain both an App and a Site object."
   // See section 3.2.14
+  const siteOrAppObj = deepAccess(bidderRequest, 'ortb2.site')
+    ? deepAccess(bidderRequest, 'ortb2.site')
+    : deepAccess(bidderRequest, 'ortb2.app');
   // Content object is either from Object: Site or Object: App
-  const contentObj = deepAccess(bidderRequest, 'ortb2.site')
-    ? deepAccess(bidderRequest, 'ortb2.site.content')
-    : deepAccess(bidderRequest, 'ortb2.app.content');
+  const contentObj = deepAccess(siteOrAppObj, 'content')
 
   const parsedContentData = {
     // Store as object keys to ensure uniqueness
@@ -70,7 +71,8 @@ function getVideoMetadata(bidRequest, bidderRequest) {
       ? videoParams.isCreatedForKids
       : null,
     context: {
-      siteOrAppCat: deepAccess(contentObj, 'cat', []),
+      siteOrAppCat: deepAccess(siteOrAppObj, 'cat', []),
+      siteOrAppContentCat: deepAccess(contentObj, 'cat', []),
       videoViewsInSession: (
         typeof videoParams.videoViewsInSession === 'number' &&
         videoParams.videoViewsInSession >= 0

--- a/test/spec/modules/dailymotionBidAdapter_spec.js
+++ b/test/spec/modules/dailymotionBidAdapter_spec.js
@@ -211,6 +211,7 @@ describe('dailymotionBidAdapterTests', () => {
       isCreatedForKids: bidRequestData[0].params.video.isCreatedForKids,
       context: {
         siteOrAppCat: [],
+        siteOrAppContentCat: [],
         videoViewsInSession: bidRequestData[0].params.video.videoViewsInSession,
         autoplay: bidRequestData[0].params.video.autoplay,
         playerName: bidRequestData[0].params.video.playerName,
@@ -1551,6 +1552,7 @@ describe('dailymotionBidAdapterTests', () => {
       isCreatedForKids: null,
       context: {
         siteOrAppCat: [],
+        siteOrAppContentCat: [],
         videoViewsInSession: null,
         autoplay: null,
         playerName: 'dailymotion',
@@ -1605,6 +1607,7 @@ describe('dailymotionBidAdapterTests', () => {
           coppa: 0,
         },
         site: {
+          cat: ['IAB-1'],
           content: {
             id: '54321',
             language: 'FR',
@@ -1729,7 +1732,8 @@ describe('dailymotionBidAdapterTests', () => {
       livestream: !!bidderRequestData.ortb2.site.content.livestream,
       isCreatedForKids: bidRequestData[0].params.video.isCreatedForKids,
       context: {
-        siteOrAppCat: bidderRequestData.ortb2.site.content.cat,
+        siteOrAppCat: bidderRequestData.ortb2.site.cat,
+        siteOrAppContentCat: bidderRequestData.ortb2.site.content.cat,
         videoViewsInSession: bidRequestData[0].params.video.videoViewsInSession,
         autoplay: bidRequestData[0].params.video.autoplay,
         playerName: bidRequestData[0].params.video.playerName,
@@ -1821,6 +1825,7 @@ describe('dailymotionBidAdapterTests', () => {
       isCreatedForKids: null,
       context: {
         siteOrAppCat: [],
+        siteOrAppContentCat: [],
         videoViewsInSession: null,
         autoplay: null,
         playerName: '',


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter

## Description of change
This fixes a naming issue and correctly reports categories from the main ORTB2 site or app objects along with the one coming from the content object.