### PR TITLE
Adagio Analytics Adapter: add beacon data bdrs_timeout, adsrv, adsrv_empty

### DIFF
--- a/libraries/gptUtils/gptUtils.js
+++ b/libraries/gptUtils/gptUtils.js
@@ -57,3 +57,67 @@ export function getSegments(fpd, sections, segtax) {
     .filter(ob => ob)
     .filter(uniques)
 }
+
+/**
+ * Add an event listener on the given GAM event.
+ * If GPT Pubads isn't defined, window.googletag is set to a new object.
+ * @param {String} event
+ * @param {Function} callback
+ */
+export function subscribeToGamEvent(event, callback) {
+  const register = () => window.googletag.pubads().addEventListener(event, callback);
+  if (isGptPubadsDefined()) {
+    register();
+    return;
+  }
+  window.googletag = window.googletag || {};
+  window.googletag.cmd = window.googletag.cmd || [];
+  window.googletag.cmd.push(register);
+}
+
+/**
+ * @typedef {Object} Slot
+ * @property {function(String): (String|null)} get
+ * @property {function(): String} getAdUnitPath
+ * @property {function(): String[]} getAttributeKeys
+ * @property {function(): String[]} getCategoryExclusions
+ * @property {function(String): String} getSlotElementId
+ * @property {function(): String[]} getTargeting
+ * @property {function(): String[]} getTargetingKeys
+ * @see {@link https://developers.google.com/publisher-tag/reference#googletag.Slot GPT official docs}
+ */
+
+/**
+ * @typedef {Object} SlotRenderEndedEvent
+ * @property {(String|null)} advertiserId
+ * @property {(String|null)} campaignId
+ * @property {(String[]|null)} companyIds
+ * @property {(Number|null)} creativeId
+ * @property {(Number|null)} creativeTemplateId
+ * @property {(Boolean)} isBackfill
+ * @property {(Boolean)} isEmpty
+ * @property {(Number[]|null)} labelIds
+ * @property {(Number|null)} lineItemId
+ * @property {(String)} serviceName
+ * @property {(string|Number[]|null)} size
+ * @property {(Slot)} slot
+ * @property {(Boolean)} slotContentChanged
+ * @property {(Number|null)} sourceAgnosticCreativeId
+ * @property {(Number|null)} sourceAgnosticLineItemId
+ * @property {(Number[]|null)} yieldGroupIds
+ * @see {@link https://developers.google.com/publisher-tag/reference#googletag.events.SlotRenderEndedEvent GPT official docs}
+ */
+
+/**
+ * @callback SlotRenderEndedEventCallback
+ * @param {SlotRenderEndedEvent} event
+ * @returns {void}
+ */
+
+/**
+ * Add an event listener on the GAM event 'slotRenderEnded'.
+ * @param {SlotRenderEndedEventCallback} callback
+ */
+export function subscribeToGamSlotRenderEndedEvent(callback) {
+  subscribeToGamEvent('slotRenderEnded', callback)
+}

--- a/modules/adagioAnalyticsAdapter.js
+++ b/modules/adagioAnalyticsAdapter.js
@@ -10,6 +10,7 @@ import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
 import adapterManager from '../src/adapterManager.js';
 import { ajax } from '../src/ajax.js';
 import { getGlobal } from '../src/prebidGlobal.js';
+import { subscribeToGamSlotRenderEndedEvent, SlotRenderEndedEvent } from '../libraries/gptUtils/gptUtils.js';
 
 const emptyUrl = '';
 const analyticsType = 'endpoint';
@@ -24,7 +25,8 @@ const ADAGIO_CODE = 'adagio';
 export const _internal = {
   getAdagioNs: function() {
     return _ADAGIO;
-  }
+  },
+  gamSlotCallback
 };
 
 const cache = {
@@ -52,6 +54,18 @@ const cache = {
   },
   getAdagioAuctionId(auctionId) {
     return this.auctionIdReferences[auctionId];
+  },
+
+  // Map adunitcode with prebid auction ID
+  auctionByAdunit: {},
+  getAuctionIdByAdunit(adUnitPath, adSlotElementId) {
+    if (cache.auctionByAdunit[adUnitPath]) {
+      return { auctionId: cache.auctionByAdunit[adUnitPath], adUnitCode: adUnitPath }
+    }
+    if (cache.auctionByAdunit[adSlotElementId]) {
+      return { auctionId: cache.auctionByAdunit[adSlotElementId], adUnitCode: adSlotElementId }
+    }
+    return { auctionId: null, adUnitCode: null }
   }
 };
 const enc = window.encodeURIComponent;
@@ -269,6 +283,7 @@ function handlerAuctionInit(event) {
     }
 
     cache.auctions[prebidAuctionId][adUnitCode] = qp;
+    cache.auctionByAdunit[adUnitCode] = prebidAuctionId;
     sendNewBeacon(prebidAuctionId, adUnitCode);
   });
 };
@@ -316,6 +331,10 @@ function handlerAuctionEnd(event) {
 
     const perfNavigation = performance.getEntriesByType('navigation')[0];
 
+    const auction = cache.getAuction(auctionId, adUnitCode);
+    const bdrs = auction.bdrs.split(',');
+    const bdrsTimeout = auction.bdrs_timeout || [];
+
     cache.updateAuction(auctionId, adUnitCode, {
       bdrs_bid: cache.getBiddersFromAuction(auctionId, adUnitCode).map(bidResponseMapper).join(','),
       bdrs_cpm: cache.getBiddersFromAuction(auctionId, adUnitCode).map(bidCpmMapper).join(','),
@@ -323,6 +342,7 @@ function handlerAuctionEnd(event) {
       dom_i: Math.round(perfNavigation['domInteractive']) || null,
       dom_c: Math.round(perfNavigation['domComplete']) || null,
       loa_e: Math.round(perfNavigation['loadEventEnd']) || null,
+      bdrs_timeout: bdrs.map(b => bdrsTimeout.includes(b) ? '1' : '0').join(','),
     });
 
     sendNewBeacon(auctionId, adUnitCode);
@@ -378,6 +398,23 @@ function handlerAdRender(event, isSuccess) {
   sendNewBeacon(auctionId, adUnitCode);
 };
 
+function handlerBidTimeout(args) {
+  args.forEach(event => {
+    const auction = cache.getAuction(event.auctionId, event.adUnitCode);
+    if (!auction) {
+      logWarn(`bid timeout on auction ${event.auctionId}, with adunitCode ${event.adUnitCode}: could not retrieve auction from cache`);
+      return;
+    }
+
+    // an array of bidder names is first created
+    // in AUCTION_END handler, this array is sorted
+    // and transformed in a comma-separated list.
+    const bdrsTimeout = auction.bdrs_timeout || [];
+    bdrsTimeout.push(event.bidder);
+    auction.bdrs_timeout = bdrsTimeout;
+  });
+};
+
 /**
  * handlerPbsAnalytics add to the cache data coming from Adagio PBS AdResponse.
  * The data is retrieved from an AnalyticsTag (set by a custom PBS module named `adg-pba`),
@@ -409,10 +446,36 @@ function handlerPbsAnalytics(event) {
  * END HANDLERS
  */
 
+/**
+ * @param {SlotRenderEndedEvent} event
+ * @returns {void}
+ */
+function gamSlotCallback(event) {
+  const { auctionId, adUnitCode } = cache.getAuctionIdByAdunit(event.slot.getAdUnitPath(), event.slot.getSlotElementId());
+  if (!auctionId) {
+    const slotName = `${event.slot.getAdUnitPath()} - ${event.slot.getSlotElementId()}`;
+    logWarn('Could not find configured ad unit matching GAM render of slot: ' + slotName);
+    return;
+  }
+
+  cache.updateAuction(auctionId, adUnitCode, {
+    adsrv: 'gam',
+    adsrv_empty: event.isEmpty
+  });
+
+  // This event can be triggered after AUCTION_END
+  // To make sure the data is sent, we must send a new beacon version.
+  const auction = cache.getAuction(auctionId, adUnitCode)
+  if (auction?.loa_e !== undefined) {
+    // loa_e = loadEventEnd
+    // It means the AUCTION_END has already been sent.
+    sendNewBeacon(auctionId, adUnitCode);
+  }
+}
+
 let adagioAdapter = Object.assign(adapter({ emptyUrl, analyticsType }), {
   track: function(event) {
     const { eventType, args } = event;
-
     try {
       switch (eventType) {
         case EVENTS.AUCTION_INIT:
@@ -434,6 +497,9 @@ let adagioAdapter = Object.assign(adapter({ emptyUrl, analyticsType }), {
           break;
         case EVENTS.PBS_ANALYTICS:
           handlerPbsAnalytics(args);
+          break;
+        case EVENTS.BID_TIMEOUT:
+          handlerBidTimeout(args);
           break;
       }
     } catch (error) {
@@ -478,6 +544,8 @@ adagioAdapter.enableAnalytics = config => {
     adagioAdapter.options.site = undefined;
   }
   adagioAdapter.originEnableAnalytics(config);
+
+  subscribeToGamSlotRenderEndedEvent(gamSlotCallback)
 }
 
 adapterManager.registerAnalyticsAdapter({

--- a/test/spec/modules/adagioAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adagioAnalyticsAdapter_spec.js
@@ -641,6 +641,20 @@ const MOCK = {
     adagio: BID_ADAGIO,
     another: BID_ANOTHER
   },
+  BID_TIMEOUT: {
+    another: [
+      {
+        auctionId: AUCTION_ID,
+        adUnitCode: '/19968336/header-bid-tag-1',
+        bidder: 'another',
+      },
+      {
+        auctionId: AUCTION_ID,
+        adUnitCode: '/19968336/footer-bid-tag-1',
+        bidder: 'another',
+      },
+    ]
+  },
   AUCTION_END: {
     another: AUCTION_END_ANOTHER,
     another_nobid: AUCTION_END_ANOTHER_NOBID
@@ -758,6 +772,7 @@ describe('adagio analytics adapter', () => {
         expect(search.ban_szs).to.equal('640x100,640x480');
         expect(search.bdrs).to.equal('adagio,another,anotherWithAlias,nobid');
         expect(search.bdrs_code).to.equal('adagio,another,another,nobid');
+        expect(search.bdrs_timeout).to.not.exist;
         expect(search.adg_mts).to.equal('ban');
       }
 
@@ -780,6 +795,7 @@ describe('adagio analytics adapter', () => {
         expect(search.e_pba_test).to.equal('true');
         expect(search.bdrs_bid).to.equal('1,1,0,0');
         expect(search.bdrs_cpm).to.equal('1.42,2.052,,');
+        expect(search.bdrs_timeout).to.equal('0,0,0,0');
       }
 
       {
@@ -790,6 +806,7 @@ describe('adagio analytics adapter', () => {
         expect(search.v).to.equal('2');
         expect(search.auct_id).to.equal(RTD_AUCTION_ID);
         expect(search.adu_code).to.equal('/19968336/footer-bid-tag-1');
+        expect(search.bdrs_timeout).to.equal('0');
       }
 
       {
@@ -805,6 +822,7 @@ describe('adagio analytics adapter', () => {
         expect(search.win_ban_sz).to.equal('728x90');
         expect(search.win_net_cpm).to.equal('2.052');
         expect(search.win_og_cpm).to.equal('2.592');
+        expect(search.bdrs_timeout).to.equal('0,0,0,0');
       }
     });
 
@@ -839,6 +857,7 @@ describe('adagio analytics adapter', () => {
         expect(search.ban_szs).to.equal('640x100,640x480');
         expect(search.bdrs).to.equal('adagio,another');
         expect(search.bdrs_code).to.equal('adagio,another');
+        expect(search.bdrs_timeout).to.not.exist;
         expect(search.adg_mts).to.equal('ban');
         expect(search.t_n).to.equal('test');
         expect(search.t_v).to.equal('version');
@@ -863,6 +882,7 @@ describe('adagio analytics adapter', () => {
         expect(search.ban_szs).to.equal('640x480');
         expect(search.bdrs).to.equal('another');
         expect(search.bdrs_code).to.equal('another');
+        expect(search.bdrs_timeout).to.not.exist;
         expect(search.adg_mts).to.not.exist;
       }
 
@@ -885,6 +905,7 @@ describe('adagio analytics adapter', () => {
         expect(search.ban_szs).to.equal('640x100,640x480');
         expect(search.bdrs).to.equal('adagio,another,anotherWithAlias,nobid');
         expect(search.bdrs_code).to.equal('adagio,another,another,nobid');
+        expect(search.bdrs_timeout).to.not.exist;
         expect(search.adg_mts).to.equal('ban');
       }
 
@@ -897,6 +918,7 @@ describe('adagio analytics adapter', () => {
         expect(search.auct_id).to.equal(RTD_AUCTION_ID);
         expect(search.adu_code).to.equal('/19968336/footer-bid-tag-1');
         expect(search.pv_id).to.equal('a68e6d70-213b-496c-be0a-c468ff387106');
+        expect(search.bdrs_timeout).to.not.exist;
       }
 
       {
@@ -911,6 +933,7 @@ describe('adagio analytics adapter', () => {
         expect(search.e_pba_test).to.equal('true');
         expect(search.bdrs_bid).to.equal('0,0,0,0');
         expect(search.bdrs_cpm).to.equal(',,,');
+        expect(search.bdrs_timeout).to.equal('0,0,0,0');
       }
 
       {
@@ -922,6 +945,7 @@ describe('adagio analytics adapter', () => {
         expect(search.auct_id).to.equal(RTD_AUCTION_ID);
         expect(search.adu_code).to.equal('/19968336/footer-bid-tag-1');
         expect(search.rndr).to.not.exist;
+        expect(search.bdrs_timeout).to.equal('0');
       }
 
       {
@@ -939,6 +963,7 @@ describe('adagio analytics adapter', () => {
         expect(search.win_net_cpm).to.equal('1.42');
         expect(search.win_og_cpm).to.equal('1.42');
         expect(search.rndr).to.not.exist;
+        expect(search.bdrs_timeout).to.equal('0,0,0,0');
       }
 
       {
@@ -956,6 +981,7 @@ describe('adagio analytics adapter', () => {
         expect(search.win_net_cpm).to.equal('1.42');
         expect(search.win_og_cpm).to.equal('1.42');
         expect(search.rndr).to.equal('0');
+        expect(search.bdrs_timeout).to.equal('0,0,0,0');
       }
     });
 
@@ -1040,6 +1066,139 @@ describe('adagio analytics adapter', () => {
 
         expect(search.e_st_id).to.be.undefined;
         expect(search.e_splt_cs_id).to.be.undefined;
+      }
+    });
+
+    it('builds and sends auction data with a bid timeout', () => {
+      events.emit(EVENTS.AUCTION_INIT, MOCK.AUCTION_INIT.another);
+      events.emit(EVENTS.BID_RESPONSE, MOCK.BID_RESPONSE.adagio);
+      events.emit(EVENTS.BID_TIMEOUT, MOCK.BID_TIMEOUT.another);
+      events.emit(EVENTS.AUCTION_END, MOCK.AUCTION_END.another);
+
+      expect(server.requests.length).to.equal(4, 'requests count');
+      {
+        const { protocol, hostname, pathname, search } = utils.parseUrl(server.requests[0].url);
+        expect(protocol).to.equal('https');
+        expect(hostname).to.equal('c.4dex.io');
+        expect(pathname).to.equal('/pba.gif');
+        expect(search.v).to.equal('1');
+        expect(search.bdrs_timeout).to.not.exist;
+      }
+      {
+        const { protocol, hostname, pathname, search } = utils.parseUrl(server.requests[1].url);
+        expect(protocol).to.equal('https');
+        expect(hostname).to.equal('c.4dex.io');
+        expect(pathname).to.equal('/pba.gif');
+        expect(search.v).to.equal('1');
+        expect(search.bdrs_timeout).to.not.exist;
+      }
+      {
+        const { protocol, hostname, pathname, search } = utils.parseUrl(server.requests[2].url);
+        expect(protocol).to.equal('https');
+        expect(hostname).to.equal('c.4dex.io');
+        expect(pathname).to.equal('/pba.gif');
+        expect(search.v).to.equal('2');
+        expect(search.bdrs).to.equal('adagio,another,anotherWithAlias,nobid');
+        expect(search.bdrs_timeout).to.equal('0,1,0,0');
+      }
+      {
+        const { protocol, hostname, pathname, search } = utils.parseUrl(server.requests[3].url);
+        expect(protocol).to.equal('https');
+        expect(hostname).to.equal('c.4dex.io');
+        expect(pathname).to.equal('/pba.gif');
+        expect(search.v).to.equal('2');
+        expect(search.bdrs).to.equal('another');
+        expect(search.bdrs_timeout).to.equal('1');
+      }
+    });
+
+    it('builds and sends auction data with GAM slot callback', () => {
+      events.emit(EVENTS.AUCTION_INIT, MOCK.AUCTION_INIT.another);
+      events.emit(EVENTS.BID_RESPONSE, MOCK.BID_RESPONSE.another);
+      _internal.gamSlotCallback({
+        slot: {
+          getAdUnitPath() {
+            return '/19968336/header-bid-tag-1'
+          },
+          getSlotElementId() {
+            return '/19968336/header-bid-tag-1'
+          }
+        },
+        isEmpty: true,
+      });
+      events.emit(EVENTS.AUCTION_END, MOCK.AUCTION_END.another);
+
+      expect(server.requests.length).to.equal(4, 'requests count');
+      {
+        const { search } = utils.parseUrl(server.requests[0].url);
+        expect(search.adsrv).to.not.exist;
+        expect(search.adsrv_empty).to.not.exist;
+      }
+      {
+        const { search } = utils.parseUrl(server.requests[1].url);
+        expect(search.v).to.equal('1');
+        expect(search.adsrv).to.not.exist;
+        expect(search.adsrv_empty).to.not.exist;
+      }
+      {
+        const { search } = utils.parseUrl(server.requests[2].url);
+        expect(search.v).to.equal('2');
+        expect(search.adsrv).to.equal('gam');
+        expect(search.adsrv_empty).to.equal('true');
+      }
+      {
+        const { search } = utils.parseUrl(server.requests[3].url);
+        expect(search.v).to.equal('2');
+        expect(search.adsrv).to.not.exist;
+        expect(search.adsrv_empty).to.not.exist;
+      }
+    });
+
+    it('builds and sends auction data with GAM slot callback after auction ended', () => {
+      events.emit(EVENTS.AUCTION_INIT, MOCK.AUCTION_INIT.another);
+      events.emit(EVENTS.BID_RESPONSE, MOCK.BID_RESPONSE.another);
+      events.emit(EVENTS.AUCTION_END, MOCK.AUCTION_END.another);
+      _internal.gamSlotCallback({
+        slot: {
+          getAdUnitPath() {
+            return '/19968336/header-bid-tag-1'
+          },
+          getSlotElementId() {
+            return '/19968336/header-bid-tag-1'
+          }
+        },
+        isEmpty: true,
+      });
+
+      expect(server.requests.length).to.equal(5, 'requests count');
+      {
+        const { search } = utils.parseUrl(server.requests[0].url);
+        expect(search.adsrv).to.not.exist;
+        expect(search.adsrv_empty).to.not.exist;
+      }
+      {
+        const { search } = utils.parseUrl(server.requests[1].url);
+        expect(search.v).to.equal('1');
+        expect(search.adsrv).to.not.exist;
+        expect(search.adsrv_empty).to.not.exist;
+      }
+      {
+        const { search } = utils.parseUrl(server.requests[2].url);
+        expect(search.v).to.equal('2');
+        expect(search.adsrv).to.not.exist;
+        expect(search.adsrv_empty).to.not.exist;
+      }
+      {
+        const { search } = utils.parseUrl(server.requests[3].url);
+        expect(search.v).to.equal('2');
+        expect(search.adsrv).to.not.exist;
+        expect(search.adsrv_empty).to.not.exist;
+      }
+      {
+        const { search } = utils.parseUrl(server.requests[4].url);
+        expect(search.v).to.equal('3');
+        expect(search.adsrv).to.equal('gam');
+        expect(search.adsrv_empty).to.equal('true');
       }
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 

## Description of change
<!-- Describe the change proposed in this pull request -->
- Added three new beacon data in the Adagio analytics adapter (`bdrs_timeout`, `adsrv` and `adsrv_empty`)
- Added new utility functions in `gptUtils.js`: `subscribeToGamEvent` and `subscribeToGamSlotRenderEndedEvent` and documented them.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
@osazos 
