### PR TITLE
Showheroes Bid Adapter : full rework of the adapter

### DIFF
--- a/modules/showheroes-bsBidAdapter.js
+++ b/modules/showheroes-bsBidAdapter.js
@@ -49,14 +49,6 @@ const converter = ortbConverter({
     }
     return imp;
   },
-  request(buildRequest, imps, bidderRequest, context) {
-    const req = buildRequest(imps, bidderRequest, context);
-    // delete user agent from oRTB, we'll get it from the header
-    (req?.device?.ua) && delete req.device['ua'];
-    // 'sua' is 2.6 standard, we operate with 2.5
-    (req?.device?.sua) && delete req.device['sua'];
-    return req;
-  },
 
   bidResponse(buildBidResponse, bid, context) {
     const bidResponse = buildBidResponse(bid, context);
@@ -132,7 +124,7 @@ export const spec = {
         });
       });
     }
-    logInfo(`found urls to sync:`, syncs);
+
     return syncs;
   },
 

--- a/modules/showheroes-bsBidAdapter.js
+++ b/modules/showheroes-bsBidAdapter.js
@@ -35,6 +35,12 @@ const converter = ortbConverter({
     deepSetValue(imp, 'ext.mediaType', mediaTypeContenxt);
     imp.ext.params = bidRequest.params;
     imp.ext.adUnitCode = bidRequest.adUnitCode;
+
+    if (!imp.displaymanager) {
+      imp.displaymanager = 'Prebid.js';
+      imp.displaymanagerver = '$prebid.version$'; // prebid version
+    }
+
     if (!isFn(bidRequest.getFloor)) {
       return imp
     }

--- a/modules/showheroes-bsBidAdapter.js
+++ b/modules/showheroes-bsBidAdapter.js
@@ -172,7 +172,7 @@ function createBids(bidRes, reqData) {
     bidUnit.adUnitCode = bid.adUnitCode;
     bidUnit.currency = bid.currency;
     bidUnit.mediaType = bid.mediaType || VIDEO;
-    bidUnit.ttl = TTL;
+    bidUnit.ttl = bid.exp || TTL;
     bidUnit.creativeId = 'c_' + requestId;
     bidUnit.netRevenue = true;
     bidUnit.width = size.width;

--- a/modules/showheroes-bsBidAdapter.js
+++ b/modules/showheroes-bsBidAdapter.js
@@ -151,10 +151,10 @@ function outstreamRender(response, renderConfig) {
     if (!isFn(func)) {
       return;
     }
-    const renderPayload = { ...response, ...renderConfig.renderOptions };
-    if (renderPayload.vastXml) {
+    const renderPayload = { ...renderConfig.renderOptions };
+    if (response.vastXml) {
       renderPayload.adResponse = {
-        content: renderPayload.vastXml,
+        content: response.vastXml,
       };
     }
     func(renderPayload);

--- a/modules/showheroes-bsBidAdapter.js
+++ b/modules/showheroes-bsBidAdapter.js
@@ -3,7 +3,8 @@ import {
   deepSetValue,
   triggerPixel,
   isFn,
-  logInfo} from '../src/utils.js';
+  logInfo
+} from '../src/utils.js';
 import { Renderer } from '../src/Renderer.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
@@ -188,8 +189,7 @@ function createBids(bidRes, reqData) {
     }
     if (bid.mediaType === BANNER) {
       bidUnit.ad = getBannerHtml(bid, reqData);
-    }
-    else if (bid.context === 'outstream') {
+    } else if (bid.context === 'outstream') {
       const renderConfig = {
         rendererUrl: bid.rendererConfig?.rendererUrl,
         renderFunc: bid.rendererConfig?.renderFunc,
@@ -211,7 +211,7 @@ function outstreamRender(response, renderConfig) {
     if (!isFn(func)) {
       return;
     }
-    const renderPayload = {...response, ...renderConfig.renderOptions};
+    const renderPayload = { ...response, ...renderConfig.renderOptions };
     func(renderPayload);
   });
 }

--- a/modules/showheroes-bsBidAdapter.js
+++ b/modules/showheroes-bsBidAdapter.js
@@ -23,8 +23,9 @@ const converter = ortbConverter({
   },
   imp(buildImp, bidRequest, context) {
     const imp = buildImp(bidRequest, context);
-    const mediaTypeContext = deepAccess(bidRequest, 'mediaTypes.video.context');
-    deepSetValue(imp, 'ext.mediaType', mediaTypeContext);
+    const videoContext = deepAccess(bidRequest, 'mediaTypes.video.context');
+    deepSetValue(imp, 'video.ext.context', videoContext);
+    imp.ext = imp.ext || {};
     imp.ext.params = bidRequest.params;
     imp.ext.adUnitCode = bidRequest.adUnitCode;
 
@@ -60,7 +61,7 @@ const converter = ortbConverter({
   bidResponse(buildBidResponse, bid, context) {
     const bidResponse = buildBidResponse(bid, context);
 
-    if (context.imp?.ext?.mediaType === 'outstream') {
+    if (context.imp?.video?.ext?.context === 'outstream') {
       const renderConfig = {
         rendererUrl: bid.ext?.rendererConfig?.rendererUrl,
         renderFunc: bid.ext?.rendererConfig?.renderFunc,

--- a/modules/showheroes-bsBidAdapter.js
+++ b/modules/showheroes-bsBidAdapter.js
@@ -71,7 +71,7 @@ const converter = ortbConverter({
         bidResponse.renderer = createRenderer(bidResponse, renderConfig);
       }
     }
-    bidResponse.callbacks = bid.ext.callbacks;
+    bidResponse.callbacks = bid.ext?.callbacks;
     bidResponse.extra = bid.ext?.extra;
     return bidResponse;
   },

--- a/modules/showheroes-bsBidAdapter.js
+++ b/modules/showheroes-bsBidAdapter.js
@@ -118,15 +118,7 @@ export const spec = {
           type: 'iframe',
           url
         });
-        (userSync.pixels || []).forEach(url => {
-          syncs.push({
-            type: 'iframe',
-            url
-          });
-        });
       });
-      logInfo(`found ${syncs.length} iframe urls to sync`);
-      return syncs;
     }
 
     if (syncOptions.pixelEnabled) {
@@ -136,9 +128,8 @@ export const spec = {
           url
         });
       });
-
-      logInfo(`found ${syncs.length} pixel urls to sync`);
     }
+    logInfo(`found urls to sync:`, syncs);
     return syncs;
   },
 

--- a/modules/showheroes-bsBidAdapter.js
+++ b/modules/showheroes-bsBidAdapter.js
@@ -10,7 +10,7 @@ import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { VIDEO } from '../src/mediaTypes.js';
 
-const ENDPOINT = 'https://ads.viralize.tv/openrtb2/auction';
+const ENDPOINT = 'https://ads.viralize.tv/openrtb2/auction/';
 const BIDDER_CODE = 'showheroes-bs';
 const TTL = 300;
 

--- a/modules/showheroes-bsBidAdapter.js
+++ b/modules/showheroes-bsBidAdapter.js
@@ -172,7 +172,7 @@ function createBids(bidRes, reqData) {
     bidUnit.mediaType = bid.mediaType || VIDEO;
     bidUnit.ttl = bid.exp || TTL;
     bidUnit.creativeId = 'c_' + requestId;
-    bidUnit.netRevenue = true;
+    bidUnit.netRevenue = bid.netRevenue ?? true;
     bidUnit.width = size.width;
     bidUnit.height = size.height;
     bidUnit.meta = {
@@ -189,6 +189,9 @@ function createBids(bidRes, reqData) {
     }
     if (bid.mediaType === BANNER) {
       bidUnit.ad = getBannerHtml(bid, reqData);
+    }
+    if (bid.extra) {
+      bidUnit.extra = bid.extra;
     }
     bids.push(bidUnit);
   });

--- a/modules/showheroes-bsBidAdapter.js
+++ b/modules/showheroes-bsBidAdapter.js
@@ -16,8 +16,6 @@ const STAGE_VL = 'https://video-library.stage.showheroes.com';
 const BIDDER_CODE = 'showheroes-bs';
 const TTL = 300;
 
-export const SYNC_URL = 'https://sync.dev.showheroes.com/cookie_sync'
-
 const converter = ortbConverter({
   context: {
     netRevenue: true,

--- a/modules/showheroes-bsBidAdapter.md
+++ b/modules/showheroes-bsBidAdapter.md
@@ -1,16 +1,14 @@
 # Overview
 
+```
 Module Name: ShowHeroes Bidder Adapter
-
 Module Type: Bidder Adapter
-
 Alias: showheroesBs
-
 Maintainer: tech@showheroes.com
-
+```
 # Description
 
-Module that connects to ShowHeroes demand source to fetch bids.
+A module that connects to ShowHeroes demand source to fetch bids.
 
 # Test Parameters
 ```
@@ -27,122 +25,7 @@ Module that connects to ShowHeroes demand source to fetch bids.
                    {
                        bidder: "showheroes-bs",
                        params: {
-                           playerId: '0151f985-fb1a-4f37-bb26-cfc62e43ec05',
-                           vpaidMode: true // by default is 'false'
-                       }
-                   }
-               ]
-           },
-           {
-               // if you have adSlot renderer or oustream should be returned as banner
-               code: 'video',
-               mediaTypes: {
-                   video: {
-                       playerSize: [640, 480],
-                       context: 'outstream',
-                   }
-               },
-               bids: [
-                   {
-                       bidder: "showheroes-bs",
-                       params: {
-                           playerId: '0151f985-fb1a-4f37-bb26-cfc62e43ec05',
-                       }
-                   }
-               ]
-           },
-           {
-               code: 'video',
-               mediaTypes: {
-                   video: {
-                       playerSize: [640, 480],
-                       context: 'outstream',
-                   }
-               },
-               bids: [
-                   {
-                       bidder: "showheroes-bs",
-                       params: {
-                           playerId: '0151f985-fb1a-4f37-bb26-cfc62e43ec05',
-
-                           outstreamOptions: {
-                               // Required for the outstream renderer to exact node, one of
-                               iframe: 'iframe_id',
-                               // or
-                               slot: 'slot_id'
-                           }
-                       }
-                   }
-               ]
-           },
-           {
-               code: 'video',
-               mediaTypes: {
-                   video: {
-                       playerSize: [640, 480],
-                       context: 'outstream',
-                   }
-               },
-               bids: [
-                   {
-                       bidder: "showheroes-bs",
-                       params: {
-                           playerId: '0151f985-fb1a-4f37-bb26-cfc62e43ec05',
-
-                           outstreamOptions: {
-                               // Custom outstream rendering function
-                               customRender: function(bid, embedCode) {
-                                   // Example with embedCode
-                                   someContainer.appendChild(embedCode);
-
-                                   // bid config data
-                                   var vastUrl = bid.renderer.config.vastUrl;
-                                   var vastXML = bid.renderer.config.vastXML;
-                                   var videoWidth = bid.renderer.config.width;
-                                   var videoHeight = bid.renderer.config.height;
-                                   var playerId = bid.renderer.config.playerId;
-                               },
-                           }
-                       }
-                   }
-               ]
-           },
-           {
-               code: 'banner',
-               mediaTypes: {
-                   banner: {
-                       sizes: [[640, 480]],
-                   }
-               },
-               bids: [
-                   {
-                       bidder: "showheroes-bs",
-                       params: {
-                           playerId: '0151f985-fb1a-4f37-bb26-cfc62e43ec05',
-                       }
-                   }
-               ]
-           }
-       ];
-```
-
-# Test Parameters (V2)
-```
-    var adUnits = [
-           {
-               code: 'video',
-               mediaTypes: {
-                   video: {
-                       playerSize: [640, 480],
-                       context: 'instream',
-                   }
-               },
-               bids: [
-                   {
-                       bidder: "showheroes-bs",
-                       params: {
                            unitId: 'AACBWAcof-611K4U',
-                           vpaidMode: true // by default is 'false'
                        }
                    }
                ]
@@ -160,17 +43,9 @@ Module that connects to ShowHeroes demand source to fetch bids.
                        bidder: "showheroes-bs",
                        params: {
                            unitId: 'AACBTwsZVANd9NlB',
-
-                           outstreamOptions: {
-                               // Required for the outstream renderer to exact node, one of
-                               iframe: 'iframe_id',
-                               // or
-                               slot: 'slot_id'
-                           }
                        }
                    }
                ]
            }
        ];
 ```
-

--- a/modules/showheroes-bsBidAdapter.md
+++ b/modules/showheroes-bsBidAdapter.md
@@ -25,7 +25,7 @@ A module that connects to ShowHeroes demand source to fetch bids.
                    {
                        bidder: "showheroes-bs",
                        params: {
-                           unitId: 'AACBWAcof-611K4U',
+                           unitId: '1234abcd-5678efgh',
                        }
                    }
                ]
@@ -42,7 +42,7 @@ A module that connects to ShowHeroes demand source to fetch bids.
                    {
                        bidder: "showheroes-bs",
                        params: {
-                           unitId: 'AACBTwsZVANd9NlB',
+                           unitId: '1234abcd-5678efgh',
                        }
                    }
                ]

--- a/test/spec/modules/showheroes-bsBidAdapter_spec.js
+++ b/test/spec/modules/showheroes-bsBidAdapter_spec.js
@@ -133,6 +133,7 @@ describe('shBidAdapter', () => {
     expect(payload.test).to.eql(0);
     expect(payload.imp[0].bidfloor).eql(3);
     expect(payload.imp[0].bidfloorcur).eql('EUR');
+    expect(payload.imp[0].displaymanager).eql('Prebid.js');
     expect(payload.site.page).to.eql('https://example.com/home');
     expect(payload.device.ua).to.undefined;
     expect(payload.device.sua).to.undefined;

--- a/test/spec/modules/showheroes-bsBidAdapter_spec.js
+++ b/test/spec/modules/showheroes-bsBidAdapter_spec.js
@@ -116,8 +116,6 @@ describe('shBidAdapter', () => {
     expect(payload.imp[0].bidfloorcur).eql('EUR');
     expect(payload.imp[0].displaymanager).eql('Prebid.js');
     expect(payload.site.page).to.eql('https://example.com/home');
-    expect(payload.device.ua).to.undefined;
-    expect(payload.device.sua).to.undefined;
   });
 
   describe('interpretResponse', function () {

--- a/test/spec/modules/showheroes-bsBidAdapter_spec.js
+++ b/test/spec/modules/showheroes-bsBidAdapter_spec.js
@@ -121,11 +121,6 @@ describe('shBidAdapter', () => {
   });
 
   describe('interpretResponse', function () {
-    it('handles nobid responses', function () {
-      expect(spec.interpretResponse({ body: {} }, { data: { meta: {} } }).length).to.equal(0)
-      expect(spec.interpretResponse({ body: [] }, { data: { meta: {} } }).length).to.equal(0)
-    })
-
     const vastXml = '<?xml version="1.0" encoding="utf-8"?><VAST version="3.0"><Error><![CDATA[https://static.showheroes.com/shim.gif]]></Error></VAST>'
 
     const callback_won = 'https://test.com/track/?ver=15&session_id=01ecd03ce381505ccdeb88e555b05001&category=request_session&type=event&request_session_id=01ecd03ce381505ccdeb88e555b05001&label=prebid_won&reason=ok'
@@ -139,12 +134,12 @@ describe('shBidAdapter', () => {
           adm: vastXml,
           impid: '38b373e1e31c18',
           crid: 'c_38b373e1e31c18',
-          extra: 'test',
           adomain: adomain,
           ext: {
             callbacks: {
               won: [callback_won],
             },
+            extra: 'test',
           },
         }],
         seat: 'showheroes',
@@ -158,10 +153,12 @@ describe('shBidAdapter', () => {
         {
           cpm: 1,
           creativeId: 'c_38b373e1e31c18',
-          adUnitCode: 'adunit-code-1',
+          creative_id: 'c_38b373e1e31c18',
           currency: 'EUR',
           width: 640,
           height: 480,
+          playerHeight: 480,
+          playerWidth: 640,
           mediaType: 'video',
           netRevenue: true,
           requestId: '38b373e1e31c18',
@@ -170,9 +167,6 @@ describe('shBidAdapter', () => {
             advertiserDomains: adomain
           },
           vastXml: vastXml,
-          adResponse: {
-            content: vastXml,
-          },
           callbacks: {
             won: [callback_won],
           },

--- a/test/spec/modules/showheroes-bsBidAdapter_spec.js
+++ b/test/spec/modules/showheroes-bsBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { spec, SYNC_URL, resetUserSync } from 'modules/showheroes-bsBidAdapter.js'
+import { spec } from 'modules/showheroes-bsBidAdapter.js'
 import { syncAddFPDToBidderRequest } from '../../helpers/fpd.js';
 import 'modules/priceFloors.js';
 import 'modules/consentManagementTcf.js';

--- a/test/spec/modules/showheroes-bsBidAdapter_spec.js
+++ b/test/spec/modules/showheroes-bsBidAdapter_spec.js
@@ -311,46 +311,38 @@ describe('shBidAdapter', () => {
     })
   });
 
-  describe('user sync', () => {
-    beforeEach(() => {
-      resetUserSync();
+  describe('getUserSyncs', function () {
+    const response = [{
+      body: {
+        userSync: {
+          iframes: ['https://sync.showheroes.com/iframe'],
+          pixels: ['https://sync.showheroes.com/pixel']
+        }
+      }
+    }]
+
+    it('empty', function () {
+      let result = spec.getUserSyncs({}, []);
+
+      expect(result).to.deep.equal([]);
     });
 
-    it('should register the ShowHeroes iframe', () => {
-      const syncs = spec.getUserSyncs({
+    it('iframe', function () {
+      let result = spec.getUserSyncs({
         iframeEnabled: true
-      });
+      }, response);
 
-      expect(syncs).to.deep.equal({ type: 'iframe', url: SYNC_URL });
-      const secondSync = spec.getUserSyncs({
-        iframeEnabled: true
-      });
-
-      expect(secondSync).to.be.undefined;
+      expect(result[0].type).to.equal('iframe');
+      expect(result[0].url).to.equal('https://sync.showheroes.com/iframe');
     });
 
-    it('should skip sync without iframe', () => {
-      const sync = spec.getUserSyncs({
-        iframeEnabled: false
-      });
+    it('pixel', function () {
+      let result = spec.getUserSyncs({
+        pixelEnabled: true
+      }, response);
 
-      expect(sync).to.be.undefined;
-    });
-
-    it('should include privacy parameters', () => {
-      const syncs = spec.getUserSyncs({
-        iframeEnabled: true
-      }, undefined, {
-        gdprApplies: true,
-        consentString: 'test_consent',
-      },
-      '1---', {
-        gppString: 'test_gpp',
-        applicableSections: ['1', '2'],
-      });
-
-      const expectedURL = `${SYNC_URL}?gdpr=1&gdpr_consent=test_consent&usp=1---&gpp=test_gpp&gpp_sid=1,2`;
-      expect(syncs).to.deep.equal({ type: 'iframe', url: expectedURL });
+      expect(result[0].type).to.equal('image');
+      expect(result[0].url).to.equal('https://sync.showheroes.com/pixel');
     });
   });
 });

--- a/test/spec/modules/showheroes-bsBidAdapter_spec.js
+++ b/test/spec/modules/showheroes-bsBidAdapter_spec.js
@@ -1,98 +1,67 @@
-import {expect} from 'chai'
-import {spec} from 'modules/showheroes-bsBidAdapter.js'
-import {newBidder} from 'src/adapters/bidderFactory.js'
-import {VIDEO, BANNER} from 'src/mediaTypes.js'
+import { expect } from 'chai'
+import { spec, SYNC_URL, resetUserSync } from 'modules/showheroes-bsBidAdapter.js'
+import { syncAddFPDToBidderRequest } from '../../helpers/fpd.js';
+import 'modules/priceFloors.js';
+import 'modules/consentManagementTcf.js';
+import 'modules/consentManagementUsp.js';
+import 'modules/schain.js';
+import { VIDEO, BANNER } from 'src/mediaTypes.js'
 
 const bidderRequest = {
   refererInfo: {
-    canonicalUrl: 'https://example.com'
+    page: 'https://example.com/home',
+    ref: 'https://referrer'
   }
 }
 
 const adomain = ['showheroes.com'];
 
 const gdpr = {
-  'gdprConsent': {
-    'apiVersion': 2,
-    'consentString': 'BOEFEAyOEFEAyAHABDENAI4AAAB9vABAASA',
-    'gdprApplies': true
+  gdprConsent: {
+    apiVersion: 2,
+    consentString: 'CONSENT',
+    vendorData: { purpose: { consents: { 1: true } } },
+    gdprApplies: true,
   }
 }
 
 const uspConsent = '1---';
 
 const schain = {
-  'schain': {
-    'validation': 'strict',
-    'config': {
-      'ver': '1.0',
-      'complete': 1,
-      'nodes': [
+  schain: {
+    validation: 'strict',
+    config: {
+      ver: '1.0',
+      complete: 1,
+      nodes: [
         {
-          'asi': 'some.com',
-          'sid': '00001',
-          'hp': 1
+          asi: 'some.com',
+          sid: '00001',
+          hp: 1
         }
       ]
     }
   }
 }
 
-const bidRequestCommonParams = {
-  'bidder': 'showheroes-bs',
-  'params': {
-    'playerId': '47427aa0-f11a-4d24-abca-1295a46a46cd',
-  },
-  'adUnitCode': 'adunit-code-1',
-  'sizes': [[640, 480]],
-  'bidId': '38b373e1e31c18',
-  'bidderRequestId': '12e3ade2543ba6',
-  'auctionId': '43aa080090a47f',
-}
-
 const bidRequestCommonParamsV2 = {
-  'bidder': 'showheroes-bs',
-  'params': {
-    'unitId': 'AACBWAcof-611K4U',
+  bidder: 'showheroes-bs',
+  params: {
+    unitId: 'AACBWAcof-611K4U',
   },
-  'adUnitCode': 'adunit-code-1',
-  'sizes': [[640, 480]],
-  'bidId': '38b373e1e31c18',
-  'bidderRequestId': '12e3ade2543ba6',
-  'auctionId': '43aa080090a47f',
-}
-
-const bidRequestVideo = {
-  ...bidRequestCommonParams,
-  ...{
-    'mediaTypes': {
-      'video': {
-        'playerSize': [640, 480],
-        'context': 'instream',
-      }
-    }
-  }
-}
-
-const bidRequestOutstream = {
-  ...bidRequestCommonParams,
-  ...{
-    'mediaTypes': {
-      'video': {
-        'playerSize': [640, 480],
-        'context': 'outstream',
-      }
-    }
-  }
+  adUnitCode: 'adunit-code-1',
+  bidId: '38b373e1e31c18',
+  bidderRequestId: '12e3ade2543ba6',
+  auctionId: '43aa080090a47f',
 }
 
 const bidRequestVideoV2 = {
   ...bidRequestCommonParamsV2,
   ...{
-    'mediaTypes': {
-      'video': {
-        'playerSize': [640, 480],
-        'context': 'instream',
+    mediaTypes: {
+      video: {
+        playerSize: [640, 480],
+        context: 'instream',
       }
     }
   }
@@ -101,322 +70,133 @@ const bidRequestVideoV2 = {
 const bidRequestOutstreamV2 = {
   ...bidRequestCommonParamsV2,
   ...{
-    'mediaTypes': {
-      'video': {
-        'playerSize': [640, 480],
-        'context': 'outstream'
-      }
-    }
-  }
-}
-
-const bidRequestVideoVpaid = {
-  ...bidRequestCommonParams,
-  ...{
-    'params': {
-      'playerId': '47427aa0-f11a-4d24-abca-1295a46a46cd',
-      'vpaidMode': true,
-    },
-    'mediaTypes': {
-      'video': {
-        'playerSize': [640, 480],
-        'context': 'instream',
-      }
+    mediaTypes: {
+      video: {
+        playerSize: [640, 480],
+        context: 'outstream'
+      },
     }
   }
 }
 
 const bidRequestBanner = {
-  ...bidRequestCommonParams,
+  ...bidRequestCommonParamsV2,
   ...{
-    'mediaTypes': {
-      'banner': {
-        'sizes': [[640, 360]]
-      }
-    }
-  }
-}
-
-const bidRequestBannerMultiSizes = {
-  ...bidRequestCommonParams,
-  ...{
-    'mediaTypes': {
-      'banner': {
-        'sizes': [[640, 360], [480, 320]]
+    mediaTypes: {
+      banner: {
+        sizes: [[640, 360]]
       }
     }
   }
 }
 
 const bidRequestVideoAndBanner = {
-  ...bidRequestCommonParams,
-  'mediaTypes': {
+  ...bidRequestCommonParamsV2,
+  mediaTypes: {
     ...bidRequestBanner.mediaTypes,
-    ...bidRequestVideo.mediaTypes
+    ...bidRequestVideoV2.mediaTypes
   }
 }
 
-describe('shBidAdapter', function () {
-  const adapter = newBidder(spec)
+describe('shBidAdapter', () => {
+  it('validates request', () => {
+    const bid = {
+      params: {
+        testKey: 'testValue',
+      },
+    };
+    expect(spec.isBidRequestValid(bid)).to.eql(false);
+    bid.params = {
+      unitId: 'test_unit',
+    };
+    expect(spec.isBidRequestValid(bid)).to.eql(true);
+  });
 
-  describe('inherited functions', function () {
-    it('exists and is a function', function () {
-      expect(adapter.callBids).to.exist.and.to.be.a('function')
-    })
-  })
+  it('passes gdpr, usp, schain, floor in ortb request', () => {
+    const bidRequest = Object.assign({}, bidRequestVideoV2)
+    const fullRequest = {
+      bids: [bidRequestVideoV2],
+      ...bidderRequest,
+      ...gdpr,
+      ...schain,
+      ...{ uspConsent: uspConsent },
+    };
+    bidRequest.schain = schain.schain.config;
+    const getFloorResponse = { currency: 'EUR', floor: 3 };
+    bidRequest.getFloor = () => getFloorResponse;
+    const request = spec.buildRequests([bidRequest], syncAddFPDToBidderRequest(fullRequest));
+    const payload = request.data;
+    expect(payload.regs.ext.gdpr).to.eql(Number(gdpr.gdprConsent.gdprApplies));
+    expect(payload.regs.ext.us_privacy).to.eql(uspConsent);
+    expect(payload.user.ext.consent).to.eql(gdpr.gdprConsent.consentString);
+    expect(payload.source.ext.schain).to.eql(bidRequest.schain);
+    expect(payload.test).to.eql(0);
+    expect(payload.imp[0].bidfloor).eql(3);
+    expect(payload.imp[0].bidfloorcur).eql('EUR');
+    expect(payload.site.page).to.eql('https://example.com/home');
+    expect(payload.device.ua).to.undefined;
+    expect(payload.device.sua).to.undefined;
+  });
 
-  describe('isBidRequestValid', function () {
-    it('should return true when required params found', function () {
-      const requestV1 = {
-        'params': {
-          'playerId': '47427aa0-f11a-4d24-abca-1295a46a46cd',
-        }
-      }
-      expect(spec.isBidRequestValid(requestV1)).to.equal(true)
+  it('override QA params', () => {
+    const bidRequest = Object.assign({}, bidRequestVideoV2)
+    const fullRequest = {
+      bids: [bidRequestVideoV2],
+    };
+    const bidEndpoint = 'https://bidder.com/endpoint';
+    const fakePageURL = 'https://testing.page.com/'
+    bidRequest.params.qa = {
+      endpoint: bidEndpoint,
+      pageURL: fakePageURL,
+    };
+    const request = spec.buildRequests([bidRequest], syncAddFPDToBidderRequest(fullRequest));
+    expect(request.url).to.eql(bidEndpoint);
+    expect(request.data.site.page).to.eql(fakePageURL)
+    expect(request.data.site.domain).to.eql('testing.page.com');
+    expect(request.data.test).to.eql(1);
+  });
 
-      const requestV2 = {
-        'params': {
-          'unitId': 'AACBTwsZVANd9NlB',
-        }
-      }
-      expect(spec.isBidRequestValid(requestV2)).to.equal(true)
-    })
+  // it('handle banner and video', () => {
+  //   const bidRequest = Object.assign({}, bidRequestVideoAndBanner)
+  //   const fullRequest = {
+  //     bids: [bidRequest],
+  //   };
+  //   const request = spec.buildRequests([bidRequest], syncAddFPDToBidderRequest(fullRequest));
+  //   const payload = request.data;
 
-    it('should return false when required params are not passed', function () {
-      const request = {
-        'params': {}
-      }
-      expect(spec.isBidRequestValid(request)).to.equal(false)
-    })
-  })
+  //   expect(payload.imp[0].video).to.be.a('object');
+  //   expect(payload.imp[0].ext.mediaType).eql('instream')
+  //   expect(payload.imp[0].banner).to.be.undefined;
+  //   const requestBanner = Object.assign({}, bidRequestBanner)
+  //   const fullRequestBanner = {
+  //     bids: [requestBanner],
+  //   };
+  //   const bannerORTB = spec.buildRequests([requestBanner], syncAddFPDToBidderRequest(fullRequestBanner));
+  //   const payloadBanner = bannerORTB.data;
 
-  describe('buildRequests', function () {
-    it('sends bid request to ENDPOINT via POST', function () {
-      const request = spec.buildRequests([bidRequestVideo], bidderRequest)
-      expect(request.method).to.equal('POST')
-
-      const requestV2 = spec.buildRequests([bidRequestVideoV2], bidderRequest)
-      expect(requestV2.method).to.equal('POST')
-    })
-
-    it('check sizes formats', function () {
-      const request = spec.buildRequests([{
-        'params': {},
-        'mediaTypes': {
-          'banner': {
-            'sizes': [[320, 240]]
-          }
-        },
-      }], bidderRequest)
-      const payload = request.data.requests[0];
-      expect(payload).to.be.an('object');
-      expect(payload.size).to.have.property('width', 320);
-      expect(payload.size).to.have.property('height', 240);
-
-      const request2 = spec.buildRequests([{
-        'params': {},
-        'mediaTypes': {
-          'video': {
-            'playerSize': [640, 360]
-          }
-        },
-      }], bidderRequest)
-      const payload2 = request2.data.requests[0];
-      expect(payload).to.be.an('object');
-      expect(payload2.size).to.have.property('width', 640);
-      expect(payload2.size).to.have.property('height', 360);
-    })
-
-    it('should get size from mediaTypes when sizes property is empty', function () {
-      const request = spec.buildRequests([{
-        'params': {},
-        'mediaTypes': {
-          'video': {
-            'playerSize': [640, 480]
-          }
-        },
-        'sizes': [],
-      }], bidderRequest)
-      const payload = request.data.requests[0];
-      expect(payload).to.be.an('object');
-      expect(payload.size).to.have.property('width', 640);
-      expect(payload.size).to.have.property('height', 480);
-
-      const request2 = spec.buildRequests([{
-        'params': {},
-        'mediaTypes': {
-          'banner': {
-            'sizes': [[320, 240]]
-          }
-        },
-        'sizes': [],
-      }], bidderRequest)
-      const payload2 = request2.data.requests[0];
-      expect(payload).to.be.an('object');
-      expect(payload2.size).to.have.property('width', 320);
-      expect(payload2.size).to.have.property('height', 240);
-    })
-
-    it('should attach valid params to the payload when type is video', function () {
-      const request = spec.buildRequests([bidRequestVideo], bidderRequest)
-      const payload = request.data.requests[0];
-      expect(payload).to.be.an('object');
-      expect(payload).to.have.property('playerId', '47427aa0-f11a-4d24-abca-1295a46a46cd');
-      expect(payload).to.have.property('mediaType', VIDEO);
-      expect(payload).to.have.property('type', 2);
-    })
-
-    it('should attach valid params to the payload when type is video & vpaid mode on', function () {
-      const request = spec.buildRequests([bidRequestVideoVpaid], bidderRequest)
-      const payload = request.data.requests[0];
-      expect(payload).to.be.an('object');
-      expect(payload).to.have.property('playerId', '47427aa0-f11a-4d24-abca-1295a46a46cd');
-      expect(payload).to.have.property('mediaType', VIDEO);
-      expect(payload).to.have.property('type', 1);
-    })
-
-    it('should attach valid params to the payload when type is banner', function () {
-      const request = spec.buildRequests([bidRequestBanner], bidderRequest)
-      const payload = request.data.requests[0];
-      expect(payload).to.be.an('object');
-      expect(payload).to.have.property('playerId', '47427aa0-f11a-4d24-abca-1295a46a46cd');
-      expect(payload).to.have.property('mediaType', BANNER);
-      expect(payload).to.have.property('type', 5);
-    })
-
-    it('should attach valid params to the payload when type is banner (multi sizes)', function () {
-      const request = spec.buildRequests([bidRequestBannerMultiSizes], bidderRequest)
-      const payload = request.data.requests[0];
-      expect(payload).to.be.an('object');
-      expect(payload).to.have.property('playerId', '47427aa0-f11a-4d24-abca-1295a46a46cd');
-      expect(payload).to.have.property('mediaType', BANNER);
-      expect(payload).to.have.property('type', 5);
-      expect(payload).to.have.nested.property('size.width', 640);
-      expect(payload).to.have.nested.property('size.height', 360);
-      const payload2 = request.data.requests[1];
-      expect(payload2).to.be.an('object');
-      expect(payload2).to.have.property('playerId', '47427aa0-f11a-4d24-abca-1295a46a46cd');
-      expect(payload2).to.have.property('mediaType', BANNER);
-      expect(payload2).to.have.property('type', 5);
-      expect(payload2).to.have.nested.property('size.width', 480);
-      expect(payload2).to.have.nested.property('size.height', 320);
-    })
-
-    it('should attach valid params to the payload when type is banner and video', function () {
-      const request = spec.buildRequests([bidRequestVideoAndBanner], bidderRequest)
-      const payload = request.data.requests[0];
-      expect(payload).to.be.an('object');
-      expect(payload).to.have.property('playerId', '47427aa0-f11a-4d24-abca-1295a46a46cd');
-      expect(payload).to.have.property('mediaType', VIDEO);
-      expect(payload).to.have.property('type', 2);
-      const payload2 = request.data.requests[1];
-      expect(payload2).to.be.an('object');
-      expect(payload2).to.have.property('playerId', '47427aa0-f11a-4d24-abca-1295a46a46cd');
-      expect(payload2).to.have.property('mediaType', BANNER);
-      expect(payload2).to.have.property('type', 5);
-    })
-
-    it('should attach valid params to the payload when type is video (instream V2)', function () {
-      const request = spec.buildRequests([bidRequestVideoV2], bidderRequest)
-      const payload = request.data.bidRequests[0];
-      expect(payload).to.be.an('object');
-      expect(payload).to.have.property('unitId', 'AACBWAcof-611K4U');
-      expect(payload.mediaTypes).to.eql({
-        [VIDEO]: {
-          'context': 'instream'
-        }
-      });
-    })
-
-    it('should attach valid params to the payload when type is video (outstream V2)', function () {
-      const request = spec.buildRequests([bidRequestOutstreamV2], bidderRequest)
-      const payload = request.data.bidRequests[0];
-      expect(payload).to.be.an('object');
-      expect(payload).to.have.property('unitId', 'AACBWAcof-611K4U');
-      expect(payload.mediaTypes).to.eql({
-        [VIDEO]: {
-          'context': 'outstream'
-        }
-      });
-    })
-
-    it('passes gdpr & uspConsent if present', function () {
-      const request = spec.buildRequests([bidRequestVideo], {
-        ...bidderRequest,
-        ...gdpr,
-        uspConsent,
-      })
-      const payload = request.data.requests[0];
-      expect(payload).to.be.an('object');
-      expect(payload.gdprConsent).to.eql(gdpr.gdprConsent)
-      expect(payload.uspConsent).to.eql(uspConsent)
-    })
-
-    it('passes gdpr & usp if present (V2)', function () {
-      const request = spec.buildRequests([bidRequestVideoV2], {
-        ...bidderRequest,
-        ...gdpr,
-        uspConsent,
-      })
-      const context = request.data.context;
-      expect(context).to.be.an('object');
-      expect(context.gdprConsent).to.eql(gdpr.gdprConsent)
-      expect(context.uspConsent).to.eql(uspConsent)
-    })
-
-    it('passes schain object if present', function() {
-      const request = spec.buildRequests([{
-        ...bidRequestVideo,
-        ...schain
-      }], bidderRequest)
-      const payload = request.data.requests[0];
-      expect(payload).to.be.an('object');
-      expect(payload.schain).to.eql(schain.schain);
-    })
-
-    it('passes schain object if present (V2)', function() {
-      const request = spec.buildRequests([{
-        ...bidRequestVideoV2,
-        ...schain
-      }], bidderRequest)
-      const context = request.data.context;
-      expect(context).to.be.an('object');
-      expect(context.schain).to.eql(schain.schain);
-    })
-  })
+  //   expect(payloadBanner.imp[0].banner).to.be.a('object');
+  //   expect(payloadBanner.imp[0].ext.mediaType).eql('banner')
+  //   expect(payloadBanner.imp[0].video).to.be.undefined;
+  // });
 
   describe('interpretResponse', function () {
     it('handles nobid responses', function () {
-      expect(spec.interpretResponse({body: {}}, {data: {meta: {}}}).length).to.equal(0)
-      expect(spec.interpretResponse({body: []}, {data: {meta: {}}}).length).to.equal(0)
+      expect(spec.interpretResponse({ body: {} }, { data: { meta: {} } }).length).to.equal(0)
+      expect(spec.interpretResponse({ body: [] }, { data: { meta: {} } }).length).to.equal(0)
     })
 
-    const vastTag = 'https://test.com/commercial/wrapper?player_id=47427aa0-f11a-4d24-abca-1295a46a46cd&ad_bidder=showheroes-bs&master_shadt=1&description_url=https%3A%2F%2Fbid-service.stage.showheroes.com%2Fvast%2Fad%2Fcache%2F4840b920-40e1-4e09-9231-60bbf088c8d6'
     const vastXml = '<?xml version="1.0" encoding="utf-8"?><VAST version="3.0"><Error><![CDATA[https://static.showheroes.com/shim.gif]]></Error></VAST>'
 
     const basicResponse = {
-      'cpm': 5,
-      'currency': 'EUR',
-      'mediaType': VIDEO,
-      'context': 'instream',
-      'bidId': '38b373e1e31c18',
-      'size': {'width': 640, 'height': 480},
-      'vastTag': 'https:\/\/test.com\/commercial\/wrapper?player_id=47427aa0-f11a-4d24-abca-1295a46a46cd&ad_bidder=showheroes-bs&master_shadt=1&description_url=https%3A%2F%2Fbid-service.stage.showheroes.com%2Fvast%2Fad%2Fcache%2F4840b920-40e1-4e09-9231-60bbf088c8d6',
-      'vastXml': vastXml,
-      'adomain': adomain,
-    };
-
-    const responseVideo = {
-      'bids': [{
-        ...basicResponse,
-      }],
-    };
-
-    const responseVideoOutstream = {
-      'bids': [{
-        ...basicResponse,
-        'context': 'outstream',
-      }],
+      cpm: 5,
+      currency: 'EUR',
+      mediaType: VIDEO,
+      context: 'instream',
+      bidId: '38b373e1e31c18',
+      size: { 'width': 640, 'height': 480 },
+      vastTag: 'https:\/\/test.com\/commercial\/wrapper?player_id=47427aa0-f11a-4d24-abca-1295a46a46cd&ad_bidder=showheroes-bs&master_shadt=1&description_url=https%3A%2F%2Fbid-service.stage.showheroes.com%2Fvast%2Fad%2Fcache%2F4840b920-40e1-4e09-9231-60bbf088c8d6',
+      vastXml: vastXml,
+      adomain: adomain,
     };
 
     const responseBanner = {
@@ -427,126 +207,76 @@ describe('shBidAdapter', function () {
     };
 
     const basicResponseV2 = {
-      'requestId': '38b373e1e31c18',
-      'adUnitCode': 'adunit-code-1',
-      'cpm': 1,
-      'currency': 'EUR',
-      'width': 640,
-      'height': 480,
-      'advertiserDomain': [],
-      'callbacks': {
-        'won': ['https://test.com/track/?ver=15&session_id=01ecd03ce381505ccdeb88e555b05001&category=request_session&type=event&request_session_id=01ecd03ce381505ccdeb88e555b05001&label=prebid_won&reason=ok']
+      requestId: '38b373e1e31c18',
+      adUnitCode: 'adunit-code-1',
+      cpm: 1,
+      currency: 'EUR',
+      width: 640,
+      height: 480,
+      advertiserDomain: [],
+      callbacks: {
+        won: ['https://test.com/track/?ver=15&session_id=01ecd03ce381505ccdeb88e555b05001&category=request_session&type=event&request_session_id=01ecd03ce381505ccdeb88e555b05001&label=prebid_won&reason=ok']
       },
-      'mediaType': 'video',
-      'adomain': adomain,
+      vastXml: vastXml,
+      mediaType: 'video',
+      adomain: adomain,
     };
 
     const vastUrl = 'https://test.com/vast/?zid=AACBWAcof-611K4U&u=https://example.org/?foo=bar&gdpr=0&cs=XXXXXXXXXXXXXXXXXXXX&sid=01ecd03ce381505ccdeb88e555b05001&width=300&height=200&prebidmode=1'
 
     const responseVideoV2 = {
-      'bidResponses': [{
+      bidResponses: [{
         ...basicResponseV2,
-        'context': 'instream',
-        'vastUrl': vastUrl,
+        context: 'instream',
+        vastUrl: vastUrl,
       }],
     };
 
     const responseVideoOutstreamV2 = {
-      'bidResponses': [{
+      bidResponses: [{
         ...basicResponseV2,
-        'context': 'outstream',
-        'ad': '<script id="testScript" data-wid="auto" type="text/javascript" src="https://test.tv/display/?zid=AACBTwsZVANd9NlB&u=https%3A%2F%2Fexample.org%2F%3Ffoo%3Dbar&gdpr=0&cs=XXXXXXXXXXXXXXXXXXXX&sid=01ececb3b4c19270d6a77ccf75433001&width=300&height=200&prebidmode=1"></script>',
+        context: 'outstream',
+        ad: '<script id="testScript" data-wid="auto" type="text/javascript" src="https://test.tv/display/?zid=AACBTwsZVANd9NlB&u=https%3A%2F%2Fexample.org%2F%3Ffoo%3Dbar&gdpr=0&cs=XXXXXXXXXXXXXXXXXXXX&sid=01ececb3b4c19270d6a77ccf75433001&width=300&height=200&prebidmode=1"></script>',
+        vastUrl: vastUrl,
       }],
     };
-
-    it('should get correct bid response when type is video', function () {
-      const request = spec.buildRequests([bidRequestVideo], bidderRequest)
-      const expectedResponse = [
-        {
-          'cpm': 5,
-          'creativeId': 'c_38b373e1e31c18',
-          'adUnitCode': 'adunit-code-1',
-          'currency': 'EUR',
-          'width': 640,
-          'height': 480,
-          'mediaType': 'video',
-          'netRevenue': true,
-          'vastUrl': vastTag,
-          'vastXml': vastXml,
-          'requestId': '38b373e1e31c18',
-          'ttl': 300,
-          'adResponse': {
-            'content': vastXml
-          },
-          'meta': {
-            'advertiserDomains': adomain
-          }
-        }
-      ]
-
-      const result = spec.interpretResponse({'body': responseVideo}, request)
-      expect(result).to.deep.equal(expectedResponse)
-    })
 
     it('should get correct bid response when type is video (V2)', function () {
       const request = spec.buildRequests([bidRequestVideoV2], bidderRequest)
       const expectedResponse = [
         {
-          'cpm': 1,
-          'creativeId': 'c_38b373e1e31c18',
-          'adUnitCode': 'adunit-code-1',
-          'currency': 'EUR',
-          'width': 640,
-          'height': 480,
-          'mediaType': 'video',
-          'netRevenue': true,
-          'vastUrl': vastUrl,
-          'requestId': '38b373e1e31c18',
-          'ttl': 300,
-          'meta': {
-            'advertiserDomains': adomain
-          }
+          cpm: 1,
+          creativeId: 'c_38b373e1e31c18',
+          adUnitCode: 'adunit-code-1',
+          currency: 'EUR',
+          width: 640,
+          height: 480,
+          mediaType: 'video',
+          netRevenue: true,
+          vastUrl: vastUrl,
+          requestId: '38b373e1e31c18',
+          ttl: 300,
+          meta: {
+            advertiserDomains: adomain
+          },
+          vastXml: vastXml,
+          adResponse: {
+            content: vastXml,
+          },
         }
       ]
 
-      const result = spec.interpretResponse({'body': responseVideoV2}, request)
+      const result = spec.interpretResponse({ 'body': responseVideoV2 }, request)
       expect(result).to.deep.equal(expectedResponse)
     })
 
     it('should get correct bid response when type is banner', function () {
       const request = spec.buildRequests([bidRequestBanner], bidderRequest)
 
-      const result = spec.interpretResponse({'body': responseBanner}, request)
+      const result = spec.interpretResponse({ 'body': responseBanner }, request)
       expect(result[0]).to.have.property('mediaType', BANNER);
       expect(result[0].ad).to.include('<script async src="https://static.showheroes.com/publishertag.js')
       expect(result[0].ad).to.include('<div class="showheroes-spot"')
-    })
-
-    it('should get correct bid response when type is outstream (slot)', function () {
-      const bidRequest = JSON.parse(JSON.stringify(bidRequestOutstream));
-      const slotId = 'testSlot'
-      bidRequest.params.outstreamOptions = {
-        slot: slotId
-      }
-
-      const container = document.createElement('div')
-      container.setAttribute('id', slotId)
-      document.body.appendChild(container)
-
-      const request = spec.buildRequests([bidRequest], bidderRequest)
-
-      const result = spec.interpretResponse({'body': responseVideoOutstream}, request)
-      const bid = result[0]
-      expect(bid).to.have.property('mediaType', VIDEO);
-
-      const renderer = bid.renderer
-      expect(renderer).to.be.an('object')
-      expect(renderer.id).to.equal(bidRequest.bidId)
-      expect(renderer.config.vastUrl).to.equal(vastTag)
-      renderer.render(bid)
-
-      const spots = document.querySelectorAll('.showheroes-spot')
-      expect(spots.length).to.equal(1)
     })
 
     it('should get correct bid response when type is outstream (slot V2)', function () {
@@ -562,106 +292,65 @@ describe('shBidAdapter', function () {
 
       const request = spec.buildRequests([bidRequestV2], bidderRequest)
 
-      const result = spec.interpretResponse({'body': responseVideoOutstreamV2}, request)
+      const result = spec.interpretResponse({ 'body': responseVideoOutstreamV2 }, request)
       const bid = result[0]
       expect(bid).to.have.property('mediaType', VIDEO);
-
-      const renderer = bid.renderer
-      expect(renderer).to.be.an('object')
-      expect(renderer.id).to.equal(bidRequestV2.bidId)
-      renderer.render(bid)
-
-      const scripts = container.querySelectorAll('#testScript')
-      expect(scripts.length).to.equal(1)
     })
 
-    it('should get correct bid response when type is outstream (iframe)', function () {
-      const bidRequest = JSON.parse(JSON.stringify(bidRequestOutstream));
-      const slotId = 'testIframe'
-      bidRequest.params.outstreamOptions = {
-        iframe: slotId
-      }
-
-      const iframe = document.createElement('iframe')
-      iframe.setAttribute('id', slotId)
-      document.body.appendChild(iframe)
+    it('should get correct bid response when type is outstream (customRender)', function () {
+      const bidRequest = JSON.parse(JSON.stringify(bidRequestOutstreamV2));
 
       const request = spec.buildRequests([bidRequest], bidderRequest)
 
-      const result = spec.interpretResponse({'body': responseVideoOutstream}, request)
-      const bid = result[0]
+      const result = spec.interpretResponse({ 'body': responseVideoOutstreamV2 }, request)
+      const bid = result[0];
       expect(bid).to.have.property('mediaType', VIDEO);
 
-      const renderer = bid.renderer
-      expect(renderer).to.be.an('object')
-      expect(renderer.id).to.equal(bidRequest.bidId)
-      renderer.render(bid)
-
-      const iframeDocument = iframe.contentDocument || (iframe.contentWindow && iframe.contentWindow.document)
-      const spots = iframeDocument.querySelectorAll('.showheroes-spot')
-      expect(spots.length).to.equal(1)
+      expect(bid.vastXml).to.eql(vastXml);
+      expect(bid.vastUrl).to.equal(vastUrl);
     })
+  });
 
-    it('should get correct bid response when type is outstream (customRender)', function (done) {
-      const bidRequest = JSON.parse(JSON.stringify(bidRequestOutstream));
-      bidRequest.params.outstreamOptions = {
-        customRender: function (bid, embedCode) {
-          const container = document.createElement('div')
-          container.appendChild(embedCode)
-          const spots = container.querySelectorAll('.showheroes-spot')
-          expect(spots.length).to.equal(1)
-
-          expect(bid.renderer.config.vastUrl).to.equal(vastTag)
-          expect(bid.renderer.config.vastXml).to.equal(vastXml)
-          done()
-        }
-      }
-
-      const request = spec.buildRequests([bidRequest], bidderRequest)
-
-      const result = spec.interpretResponse({'body': responseVideoOutstream}, request)
-      const bid = result[0]
-      expect(bid).to.have.property('mediaType', VIDEO);
-
-      const renderer = bid.renderer
-      expect(renderer).to.be.an('object')
-      expect(renderer.id).to.equal(bidRequest.bidId)
-      renderer.render(bid)
-    })
-  })
-
-  describe('getUserSyncs', function () {
-    const response = [{
-      body: {
-        userSync: {
-          iframes: ['https://sync.showheroes.com/iframe'],
-          pixels: ['https://sync.showheroes.com/pixel']
-        }
-      }
-    }]
-
-    it('empty', function () {
-      let result = spec.getUserSyncs({}, []);
-
-      expect(result).to.deep.equal([]);
+  describe('user sync', () => {
+    beforeEach(() => {
+      resetUserSync();
     });
 
-    it('iframe', function () {
-      let result = spec.getUserSyncs({
+    it('should register the ShowHeroes iframe', () => {
+      const syncs = spec.getUserSyncs({
         iframeEnabled: true
-      }, response);
+      });
 
-      expect(result[0].type).to.equal('iframe');
-      expect(result[0].url).to.equal('https://sync.showheroes.com/iframe');
+      expect(syncs).to.deep.equal({ type: 'iframe', url: SYNC_URL });
+      const secondSync = spec.getUserSyncs({
+        iframeEnabled: true
+      });
+
+      expect(secondSync).to.be.undefined;
     });
 
-    it('pixel', function () {
-      let result = spec.getUserSyncs({
-        pixelEnabled: true
-      }, response);
+    it('should skip sync without iframe', () => {
+      const sync = spec.getUserSyncs({
+        iframeEnabled: false
+      });
 
-      expect(result[0].type).to.equal('image');
-      expect(result[0].url).to.equal('https://sync.showheroes.com/pixel');
+      expect(sync).to.be.undefined;
+    });
+
+    it('should include privacy parameters', () => {
+      const syncs = spec.getUserSyncs({
+        iframeEnabled: true
+      }, undefined, {
+        gdprApplies: true,
+        consentString: 'test_consent',
+      },
+      '1---', {
+        gppString: 'test_gpp',
+        applicableSections: ['1', '2'],
+      });
+
+      const expectedURL = `${SYNC_URL}?gdpr=1&gdpr_consent=test_consent&usp=1---&gpp=test_gpp&gpp_sid=1,2`;
+      expect(syncs).to.deep.equal({ type: 'iframe', url: expectedURL });
     });
   });
-})
+});

--- a/test/spec/modules/showheroes-bsBidAdapter_spec.js
+++ b/test/spec/modules/showheroes-bsBidAdapter_spec.js
@@ -157,28 +157,28 @@ describe('shBidAdapter', () => {
     expect(request.data.test).to.eql(1);
   });
 
-  // it('handle banner and video', () => {
-  //   const bidRequest = Object.assign({}, bidRequestVideoAndBanner)
-  //   const fullRequest = {
-  //     bids: [bidRequest],
-  //   };
-  //   const request = spec.buildRequests([bidRequest], syncAddFPDToBidderRequest(fullRequest));
-  //   const payload = request.data;
+  it('handle banner and video', () => {
+    const bidRequest = Object.assign({}, bidRequestVideoAndBanner)
+    const fullRequest = {
+      bids: [bidRequest],
+    };
+    const request = spec.buildRequests([bidRequest], syncAddFPDToBidderRequest(fullRequest));
+    const payload = request.data;
 
-  //   expect(payload.imp[0].video).to.be.a('object');
-  //   expect(payload.imp[0].ext.mediaType).eql('instream')
-  //   expect(payload.imp[0].banner).to.be.undefined;
-  //   const requestBanner = Object.assign({}, bidRequestBanner)
-  //   const fullRequestBanner = {
-  //     bids: [requestBanner],
-  //   };
-  //   const bannerORTB = spec.buildRequests([requestBanner], syncAddFPDToBidderRequest(fullRequestBanner));
-  //   const payloadBanner = bannerORTB.data;
+    expect(payload.imp[0].video).to.be.a('object');
+    expect(payload.imp[0].ext.mediaType).eql('instream')
+    expect(payload.imp[0].banner).to.be.undefined;
+    const requestBanner = Object.assign({}, bidRequestBanner)
+    const fullRequestBanner = {
+      bids: [requestBanner],
+    };
+    const bannerORTB = spec.buildRequests([requestBanner], syncAddFPDToBidderRequest(fullRequestBanner));
+    const payloadBanner = bannerORTB.data;
 
-  //   expect(payloadBanner.imp[0].banner).to.be.a('object');
-  //   expect(payloadBanner.imp[0].ext.mediaType).eql('banner')
-  //   expect(payloadBanner.imp[0].video).to.be.undefined;
-  // });
+    expect(payloadBanner.imp[0].banner).to.be.a('object');
+    expect(payloadBanner.imp[0].ext.mediaType).eql('banner')
+    expect(payloadBanner.imp[0].video).to.be.undefined;
+  });
 
   describe('interpretResponse', function () {
     it('handles nobid responses', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Updated bidder adapter

## Description of change
<!-- Describe the change proposed in this pull request -->

Update the `showheroes-bs` bidder adapter.

PR has the following updates:
- remove legacy code that is not supported anymore
- replace the old endpoint with `prebid-sh` with the new `openrtb2/auction`
- use `ortbConverter` to construct a bid request
- in case of outstream ads, provide the renderer-related parameters in the response (the old static renderer is not working anymore)
- by using openRTB, automatically add support for: `fpd`, `floor` module, `eids`, etc.

To test the upgrade just set the openRTB request as a test request:
```javascript
pbjs.setConfig({ortb2: {test: 1}})
```

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
