### PR TITLE
Mobian RTD module: add ap values to mobian RTD provider

### DIFF
--- a/modules/mobianRtdProvider.js
+++ b/modules/mobianRtdProvider.js
@@ -61,14 +61,14 @@ function getBidRequestData(bidReqConfig, callback, config) {
           apValues: apValues,
         };
 
-        deepSetValue(ortb2Site.ext, 'data.mobianRisk', mobianRisk);
-        deepSetValue(ortb2Site.ext, 'data.mobianContentCategories', contentCategories);
-        deepSetValue(ortb2Site.ext, 'data.mobianSentiment', sentiment);
-        deepSetValue(ortb2Site.ext, 'data.mobianEmotions', emotions);
-        deepSetValue(ortb2Site.ext, 'data.mobianThemes', themes);
-        deepSetValue(ortb2Site.ext, 'data.mobianTones', tones);
-        deepSetValue(ortb2Site.ext, 'data.mobianGenres', genres);
-        deepSetValue(ortb2Site.ext, 'data.apValues', apValues);
+        deepSetValue(ortb2Site, 'ext.data.mobianRisk', mobianRisk);
+        deepSetValue(ortb2Site, 'ext.data.mobianContentCategories', contentCategories);
+        deepSetValue(ortb2Site, 'ext.data.mobianSentiment', sentiment);
+        deepSetValue(ortb2Site, 'ext.data.mobianEmotions', emotions);
+        deepSetValue(ortb2Site, 'ext.data.mobianThemes', themes);
+        deepSetValue(ortb2Site, 'ext.data.mobianTones', tones);
+        deepSetValue(ortb2Site, 'ext.data.mobianGenres', genres);
+        deepSetValue(ortb2Site, 'ext.data.apValues', apValues);
 
         resolve(risk);
         callback();

--- a/modules/mobianRtdProvider.js
+++ b/modules/mobianRtdProvider.js
@@ -48,6 +48,7 @@ function getBidRequestData(bidReqConfig, callback, config) {
         const themes = results.mobianThemes || [];
         const tones = results.mobianTones || [];
         const genres = results.mobianGenres || [];
+        const apValues = results.ap || {};
 
         const risk = {
           risk: mobianRisk,
@@ -57,6 +58,7 @@ function getBidRequestData(bidReqConfig, callback, config) {
           themes: themes,
           tones: tones,
           genres: genres,
+          apValues: apValues,
         };
 
         deepSetValue(ortb2Site.ext, 'data.mobianRisk', mobianRisk);
@@ -66,6 +68,7 @@ function getBidRequestData(bidReqConfig, callback, config) {
         deepSetValue(ortb2Site.ext, 'data.mobianThemes', themes);
         deepSetValue(ortb2Site.ext, 'data.mobianTones', tones);
         deepSetValue(ortb2Site.ext, 'data.mobianGenres', genres);
+        deepSetValue(ortb2Site.ext, 'data.apValues', apValues);
 
         resolve(risk);
         callback();

--- a/test/spec/modules/mobianRtdProvider_spec.js
+++ b/test/spec/modules/mobianRtdProvider_spec.js
@@ -228,4 +228,47 @@ describe('Mobian RTD Submodule', function () {
       });
     });
   });
+
+  it('should set key-value pairs when ext object is missing', function () {
+    bidReqConfig = {
+      ortb2Fragments: {
+        global: {
+          site: {}
+        }
+      }
+    };
+
+    ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
+      callbacks.success(JSON.stringify({
+        meta: {
+          url: 'https://example.com',
+          has_results: true
+        },
+        results: {
+          mobianRisk: 'low',
+          mobianSentiment: 'positive',
+          mobianContentCategories: [],
+          mobianEmotions: ['joy'],
+          mobianThemes: [],
+          mobianTones: [],
+          mobianGenres: [],
+          ap: { a0: [], a1: [2313, 12], p0: [1231231, 212], p1: [231, 419] }
+        }
+      }));
+    });
+
+    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, () => {}, {}).then(() => {
+      expect(bidReqConfig.ortb2Fragments.global.site.ext).to.exist;
+      expect(bidReqConfig.ortb2Fragments.global.site.ext.data).to.deep.include({
+        mobianRisk: 'low',
+        mobianContentCategories: [],
+        mobianSentiment: 'positive',
+        mobianEmotions: ['joy'],
+        mobianThemes: [],
+        mobianTones: [],
+        mobianGenres: [],
+        apValues: { a0: [], a1: [2313, 12], p0: [1231231, 212], p1: [231, 419] }
+      });
+    });
+  });
 });

--- a/test/spec/modules/mobianRtdProvider_spec.js
+++ b/test/spec/modules/mobianRtdProvider_spec.js
@@ -39,7 +39,8 @@ describe('Mobian RTD Submodule', function () {
           mobianEmotions: ['joy'],
           mobianThemes: [],
           mobianTones: [],
-          mobianGenres: []
+          mobianGenres: [],
+          ap: { a0: [], a1: [2313, 12], p0: [1231231, 212], p1: [231, 419] }
         }
       }));
     });
@@ -52,7 +53,8 @@ describe('Mobian RTD Submodule', function () {
         emotions: ['joy'],
         themes: [],
         tones: [],
-        genres: []
+        genres: [],
+        apValues: { a0: [], a1: [2313, 12], p0: [1231231, 212], p1: [231, 419] }
       });
       expect(bidReqConfig.ortb2Fragments.global.site.ext.data).to.deep.include({
         mobianRisk: 'low',
@@ -61,12 +63,13 @@ describe('Mobian RTD Submodule', function () {
         mobianEmotions: ['joy'],
         mobianThemes: [],
         mobianTones: [],
-        mobianGenres: []
+        mobianGenres: [],
+        apValues: { a0: [], a1: [2313, 12], p0: [1231231, 212], p1: [231, 419] }
       });
     });
   });
 
-  it('should handle response with content categories and multiple emotions', function () {
+  it('should handle response with content categories, multiple emotions, and ap values', function () {
     ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
       callbacks.success(JSON.stringify({
         meta: {
@@ -80,7 +83,8 @@ describe('Mobian RTD Submodule', function () {
           mobianEmotions: ['anger', 'fear'],
           mobianThemes: ['conflict', 'international relations'],
           mobianTones: ['factual', 'serious'],
-          mobianGenres: ['news', 'political_analysis']
+          mobianGenres: ['news', 'political_analysis'],
+          ap: { a0: [100], a1: [200, 300], p0: [400, 500], p1: [600] }
         }
       }));
     });
@@ -93,7 +97,8 @@ describe('Mobian RTD Submodule', function () {
         emotions: ['anger', 'fear'],
         themes: ['conflict', 'international relations'],
         tones: ['factual', 'serious'],
-        genres: ['news', 'political_analysis']
+        genres: ['news', 'political_analysis'],
+        apValues: { a0: [100], a1: [200, 300], p0: [400, 500], p1: [600] }
       });
       expect(bidReqConfig.ortb2Fragments.global.site.ext.data).to.deep.include({
         mobianRisk: 'medium',
@@ -102,7 +107,8 @@ describe('Mobian RTD Submodule', function () {
         mobianEmotions: ['anger', 'fear'],
         mobianThemes: ['conflict', 'international relations'],
         mobianTones: ['factual', 'serious'],
-        mobianGenres: ['news', 'political_analysis']
+        mobianGenres: ['news', 'political_analysis'],
+        apValues: { a0: [100], a1: [200, 300], p0: [400, 500], p1: [600] }
       });
     });
   });
@@ -121,7 +127,7 @@ describe('Mobian RTD Submodule', function () {
     return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((result) => {
       expect(result).to.deep.equal({});
       expect(bidReqConfig.ortb2Fragments.global.site.ext.data).to.not.have.any.keys(
-        'mobianRisk', 'mobianContentCategories', 'mobianSentiment', 'mobianEmotions', 'mobianThemes', 'mobianTones', 'mobianGenres'
+        'mobianRisk', 'mobianContentCategories', 'mobianSentiment', 'mobianEmotions', 'mobianThemes', 'mobianTones', 'mobianGenres', 'apValues'
       );
     });
   });
@@ -171,6 +177,7 @@ describe('Mobian RTD Submodule', function () {
         themes: [],
         tones: [],
         genres: [],
+        apValues: {}
       });
       expect(bidReqConfig.ortb2Fragments.global.site.ext.data).to.deep.include({
         mobianRisk: 'high',
@@ -179,7 +186,45 @@ describe('Mobian RTD Submodule', function () {
         mobianEmotions: [],
         mobianThemes: [],
         mobianTones: [],
-        mobianGenres: []
+        mobianGenres: [],
+        apValues: {}
+      });
+    });
+  });
+
+  it('should handle response with only ap values', function () {
+    ajaxStub = sinon.stub(ajax, 'ajaxBuilder').returns(function(url, callbacks) {
+      callbacks.success(JSON.stringify({
+        meta: {
+          url: 'https://example.com',
+          has_results: true
+        },
+        results: {
+          ap: { a0: [1, 2], a1: [3, 4], p0: [5, 6], p1: [7, 8] }
+        }
+      }));
+    });
+
+    return mobianBrandSafetySubmodule.getBidRequestData(bidReqConfig, {}, {}).then((result) => {
+      expect(result).to.deep.equal({
+        risk: 'unknown',
+        contentCategories: [],
+        sentiment: 'unknown',
+        emotions: [],
+        themes: [],
+        tones: [],
+        genres: [],
+        apValues: { a0: [1, 2], a1: [3, 4], p0: [5, 6], p1: [7, 8] }
+      });
+      expect(bidReqConfig.ortb2Fragments.global.site.ext.data).to.deep.include({
+        mobianRisk: 'unknown',
+        mobianContentCategories: [],
+        mobianSentiment: 'unknown',
+        mobianEmotions: [],
+        mobianThemes: [],
+        mobianTones: [],
+        mobianGenres: [],
+        apValues: { a0: [1, 2], a1: [3, 4], p0: [5, 6], p1: [7, 8] }
       });
     });
   });


### PR DESCRIPTION
## Type of change

- [x] Feature

## Description of change
The Mobian API will soon contain a new "AP" data object which various downstream publisher partners can read. The "AP" (advertiser-persona) data is a pure function of the page URL and can be used by publishers who partner with Mobian to make more specific decisions about our contextual offering.