### PR TITLE
Missena Bid Adapter : send schain & uspConsent

### DIFF
--- a/test/spec/modules/missenaBidAdapter_spec.js
+++ b/test/spec/modules/missenaBidAdapter_spec.js
@@ -29,6 +29,12 @@ describe('Missena Adapter', function () {
       placement: 'sticky',
       formats: ['sticky-banner'],
     },
+    schain: {
+      validation: 'strict',
+      config: {
+        ver: '1.0',
+      },
+    },
     getFloor: (inputParams) => {
       if (inputParams.mediaType === BANNER) {
         return {
@@ -58,6 +64,7 @@ describe('Missena Adapter', function () {
       consentString: consentString,
       gdprApplies: true,
     },
+    uspConsent: 'IDO',
     refererInfo: {
       topmostLocation: REFERRER,
       canonicalUrl: 'https://canonical',
@@ -99,6 +106,14 @@ describe('Missena Adapter', function () {
     const request = requests[0];
     const payload = JSON.parse(request.data);
     const payloadNoFloor = JSON.parse(requests[1].data);
+
+    it('should contain uspConsent', function () {
+      expect(payload.us_privacy).to.equal('IDO');
+    });
+
+    it('should contain schain', function () {
+      expect(payload.schain.config.ver).to.equal('1.0');
+    });
 
     it('should return as many server requests as bidder requests', function () {
       expect(requests.length).to.equal(2);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Updated bidder adapter  
 
## Description of change
The update sends the `schain` and the `upsConsent` to our servers. 

The section of code that builds the payload that our servers expect has been refactored (extracted) to an helper function. 

There are also some updates to the documentation of the function` @params` required to get rid of the `jdoc` warnings that the adapter was throwing. 
 