### PR TITLE
Sparteo Bid Adapter: add adUnitCode

### DIFF
--- a/modules/sparteoBidAdapter.js
+++ b/modules/sparteoBidAdapter.js
@@ -38,6 +38,7 @@ const converter = ortbConverter({
     const imp = buildImp(bidRequest, context);
 
     deepSetValue(imp, 'ext.sparteo.params', bidRequest.params);
+    imp.ext.sparteo.params.adUnitCode = bidRequest.adUnitCode;
 
     return imp;
   },

--- a/test/spec/modules/sparteoBidAdapter_spec.js
+++ b/test/spec/modules/sparteoBidAdapter_spec.js
@@ -71,6 +71,7 @@ const VALID_REQUEST_BANNER = {
         'sparteo': {
           'params': {
             'networkId': '1234567a-eb1b-1fae-1d23-e1fbaef234cf',
+            'adUnitCode': 'id-1234',
             'formats': ['corner']
           }
         }
@@ -112,7 +113,8 @@ const VALID_REQUEST_VIDEO = {
         'pbadslot': 'video',
         'sparteo': {
           'params': {
-            'networkId': '1234567a-eb1b-1fae-1d23-e1fbaef234cf'
+            'networkId': '1234567a-eb1b-1fae-1d23-e1fbaef234cf',
+            'adUnitCode': 'id-5678'
           }
         }
       }
@@ -147,6 +149,7 @@ const VALID_REQUEST = {
         'sparteo': {
           'params': {
             'networkId': '1234567a-eb1b-1fae-1d23-e1fbaef234cf',
+            'adUnitCode': 'id-1234',
             'formats': ['corner']
           }
         }
@@ -170,7 +173,8 @@ const VALID_REQUEST = {
         'pbadslot': 'video',
         'sparteo': {
           'params': {
-            'networkId': '1234567a-eb1b-1fae-1d23-e1fbaef234cf'
+            'networkId': '1234567a-eb1b-1fae-1d23-e1fbaef234cf',
+            'adUnitCode': 'id-5678'
           }
         }
       }


### PR DESCRIPTION
## Type of change

- [X] Updated bidder adapter
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change

Collects adUnitCode and add it to the bid request.

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->

Thank you :-)