### PR TITLE
SymitriDap RTD Module : segment taxonomy values changed to Symitri registered values

### DIFF
--- a/modules/symitriDapRtdProvider.js
+++ b/modules/symitriDapRtdProvider.js
@@ -114,7 +114,7 @@ export function createRtdProvider(moduleName, moduleCode, headerPrefix) {
     dapRetryTokenize = 0;
     var jsonData = null;
     if (rtdConfig && isPlainObject(rtdConfig.params)) {
-      if (rtdConfig.params.segtax == 504) {
+      if (rtdConfig.params.segtax == 710) {
         let encMembership = dapUtils.dapGetEncryptedMembershipFromLocalStorage();
         if (encMembership) {
           jsonData = dapUtils.dapGetEncryptedRtdObj(encMembership, rtdConfig.params.segtax)
@@ -191,7 +191,7 @@ export function createRtdProvider(moduleName, moduleCode, headerPrefix) {
         const ortb2 = bidConfig.ortb2Fragments.global;
         logMessage('token is: ', token);
         if (token !== null) { // If token is not null then check the membership in storage and add the RTD object
-          if (config.segtax == 504) { // Follow the encrypted membership path
+          if (config.segtax == 710) { // Follow the encrypted membership path
             dapUtils.dapRefreshEncryptedMembership(ortb2, config, token, onDone) // Get the encrypted membership from server
             refreshMembership = false;
           } else {
@@ -248,7 +248,7 @@ export function createRtdProvider(moduleName, moduleCode, headerPrefix) {
             dapUtils.dapLog('Successfully stored DAP 100 Device ID: ' + deviceId100);
           }
           if (refreshMembership) {
-            if (config.segtax == 504) {
+            if (config.segtax == 710) {
               dapUtils.dapRefreshEncryptedMembership(ortb2, config, token, onDone);
             } else {
               dapUtils.dapRefreshMembership(ortb2, config, token, onDone);
@@ -449,7 +449,7 @@ export function createRtdProvider(moduleName, moduleCode, headerPrefix) {
 
     checkAndAddRealtimeData: function(ortb2, data, segtax) {
       if (data.rtd) {
-        if (segtax == 504 && dapUtils.checkIfSegmentsAlreadyExist(ortb2, data.rtd, 504)) {
+        if (segtax == 710 && dapUtils.checkIfSegmentsAlreadyExist(ortb2, data.rtd, 710)) {
           logMessage('DEBUG(handleInit): rtb Object already added');
         } else {
           addRealTimeData(ortb2, data.rtd);

--- a/modules/symitriDapRtdProvider.md
+++ b/modules/symitriDapRtdProvider.md
@@ -47,7 +47,7 @@ pbjs.setConfig({
           domain: 'your-domain.com',
           identityType: 'simpleid'|'compositeid'|'hashedid'|'dap-signature:1.0.0',
           identityValue: '<user hid>',
-          segtax: 501,
+          segtax: 708,
           dapEntropyUrl: 'https://sym-dist.symitri.net/dapentropy.js',
           dapEntropyTimeout: 1500,
           pixelUrl: '<see your Symitri account rep>',
@@ -80,7 +80,7 @@ Use 'hashedid' to pass in single already hashed id. Use 'compositeid' to pass in
 }
 |
 | identityValue | String | This is optional field to pass user hid. Will be used only if identityType is hid | |
-| segtax | Integer | The taxonomy for Symitri | The value should be 501 |
+| segtax | Integer | The taxonomy for Symitri | The value should be 708 |
 | dapEntropyUrl | String | URL to dap entropy script | Optional if the script is directly included on the webpage. Contact your Symitri account rep for more details |
 | dapEntropyTimeout | Integer | Maximum time allotted for the entropy calculation to happen | |
 | pixelUrl | String | Pixel URL provided by Symitri which will be triggered when bid matching with Symitri dealid wins and creative gets rendered | |

--- a/test/spec/modules/akamaiDapRtdProvider_spec.js
+++ b/test/spec/modules/akamaiDapRtdProvider_spec.js
@@ -44,7 +44,7 @@ describe('akamaiDapRtdProvider', function() {
       'apiVersion': 'x1',
       'domain': 'prebid.org',
       'identityType': 'dap-signature:1.0.0',
-      'segtax': 503
+      'segtax': 708
     }
   }
 
@@ -56,7 +56,7 @@ describe('akamaiDapRtdProvider', function() {
       'apiVersion': 'x1',
       'domain': 'prebid.org',
       'identityType': 'dap-signature:1.0.0',
-      'segtax': 504
+      'segtax': 710
     }
   }
 
@@ -64,7 +64,7 @@ describe('akamaiDapRtdProvider', function() {
     'api_hostname': 'prebid.dap.akadns.net',
     'api_version': 'x1',
     'domain': 'prebid.org',
-    'segtax': 503,
+    'segtax': 708,
     'identity': sampleIdentity
   }
 
@@ -72,7 +72,7 @@ describe('akamaiDapRtdProvider', function() {
     'api_hostname': 'prebid.dap.akadns.net',
     'api_version': 'x1',
     'domain': 'prebid.org',
-    'segtax': 504,
+    'segtax': 710,
     'identity': sampleIdentity
   }
   let cacheExpiry = Math.round(Date.now() / 1000.0) + 300; // in seconds
@@ -97,7 +97,7 @@ describe('akamaiDapRtdProvider', function() {
   const encRtdUserObj = {
     name: 'www.dataprovider3.com',
     ext: {
-      segtax: 504,
+      segtax: 710,
       taxonomyname: 'iab_audience_taxonomy'
     },
     segment: []
@@ -262,13 +262,13 @@ describe('akamaiDapRtdProvider', function() {
         'api_hostname': 'prebid.dap.akadns.net',
         'api_version': 1,
         'domain': '',
-        'segtax': 503
+        'segtax': 708
       };
       const encConfig = {
         'api_hostname': 'prebid.dap.akadns.net',
         'api_version': 1,
         'domain': '',
-        'segtax': 504
+        'segtax': 710
       };
       let identity = {
         type: 'dap-signature:1.0.0'
@@ -396,7 +396,7 @@ describe('akamaiDapRtdProvider', function() {
         apiHostname: 'prebid.dap.akadns.net',
         apiVersion: 'x1',
         domain: 'prebid.org',
-        segtax: 503
+        segtax: 708
       };
       expect(dapUtils.dapRefreshMembership(ortb2, config, 'token', onDone)).to.equal(undefined)
       const membership = {cohorts: ['1', '5', '7']}
@@ -405,11 +405,11 @@ describe('akamaiDapRtdProvider', function() {
   });
 
   describe('checkAndAddRealtimeData test', function () {
-    it('add realtime data for segtax 503 and 504', function () {
-      dapUtils.checkAndAddRealtimeData(ortb2, cachedEncRtd, 504);
-      dapUtils.checkAndAddRealtimeData(ortb2, cachedEncRtd, 504);
+    it('add realtime data for segtax 708 and 710', function () {
+      dapUtils.checkAndAddRealtimeData(ortb2, cachedEncRtd, 710);
+      dapUtils.checkAndAddRealtimeData(ortb2, cachedEncRtd, 710);
       expect(ortb2.user.data).to.deep.include.members([encRtdUserObj]);
-      dapUtils.checkAndAddRealtimeData(ortb2, cachedRtd, 503);
+      dapUtils.checkAndAddRealtimeData(ortb2, cachedRtd, 708);
       expect(ortb2.user.data).to.deep.include.members([rtdUserObj]);
     });
   });
@@ -466,7 +466,7 @@ describe('akamaiDapRtdProvider', function() {
       let request = server.requests[0];
       responseHeader['Akamai-DAP-Token'] = encMembership;
       request.respond(200, responseHeader, encMembership);
-      let rtdObj = dapUtils.dapGetEncryptedRtdObj({'encryptedSegments': encMembership}, 504)
+      let rtdObj = dapUtils.dapGetEncryptedRtdObj({'encryptedSegments': encMembership}, 710)
       expect(ortb2.user.data).to.deep.include.members(rtdObj.rtd.ortb2.user.data);
       expect(JSON.parse(storage.getDataFromLocalStorage(DAP_ENCRYPTED_MEMBERSHIP)).expires_at).to.equal(expiry);
     });
@@ -477,7 +477,7 @@ describe('akamaiDapRtdProvider', function() {
       let request = server.requests[0];
       responseHeader['Akamai-DAP-Token'] = encMembership;
       request.respond(200, responseHeader, encMembership);
-      let rtdObj = dapUtils.dapGetEncryptedRtdObj({'encryptedSegments': encMembership}, 504)
+      let rtdObj = dapUtils.dapGetEncryptedRtdObj({'encryptedSegments': encMembership}, 710)
       expect(ortb2.user.data).to.deep.include.members(rtdObj.rtd.ortb2.user.data);
       expect(JSON.parse(storage.getDataFromLocalStorage(DAP_ENCRYPTED_MEMBERSHIP)).expires_at).to.equal(1643830630);
     });
@@ -508,7 +508,7 @@ describe('akamaiDapRtdProvider', function() {
       dapUtils.dapRefreshMembership(ortb2, sampleConfig, sampleCachedToken.token, onDone);
       let request = server.requests[0];
       request.respond(200, responseHeader, JSON.stringify(membership));
-      let rtdObj = dapUtils.dapGetRtdObj(membership, 503);
+      let rtdObj = dapUtils.dapGetRtdObj(membership, 708);
       expect(ortb2.user.data).to.deep.include.members(rtdObj.rtd.ortb2.user.data);
     });
 
@@ -517,7 +517,7 @@ describe('akamaiDapRtdProvider', function() {
       dapUtils.dapRefreshMembership(ortb2, sampleConfig, sampleCachedToken.token, onDone);
       let request = server.requests[0];
       request.respond(200, responseHeader, JSON.stringify(membership));
-      let rtdObj = dapUtils.dapGetRtdObj(membership, 503)
+      let rtdObj = dapUtils.dapGetRtdObj(membership, 708)
       expect(ortb2.user.data).to.deep.include.members(rtdObj.rtd.ortb2.user.data);
       expect(JSON.parse(storage.getDataFromLocalStorage(DAP_MEMBERSHIP)).expires_at).to.be.equal(1647971548);
     });

--- a/test/spec/modules/symitriDapRtdProvider_spec.js
+++ b/test/spec/modules/symitriDapRtdProvider_spec.js
@@ -49,7 +49,7 @@ describe('symitriDapRtdProvider', function() {
       'apiAuthToken': 'Token 1234',
       'domain': 'prebid.org',
       'identityType': 'dap-signature:1.0.0',
-      'segtax': 503
+      'segtax': 708
     }
   }
 
@@ -61,7 +61,7 @@ describe('symitriDapRtdProvider', function() {
       'apiVersion': 'x1',
       'domain': 'prebid.org',
       'identityType': 'dap-signature:1.0.0',
-      'segtax': 504,
+      'segtax': 710,
       'pixelUrl': 'https://www.test.com/pixel'
     }
   }
@@ -70,7 +70,7 @@ describe('symitriDapRtdProvider', function() {
     'api_hostname': 'prebid.dap.akadns.net',
     'api_version': 'x1',
     'domain': 'prebid.org',
-    'segtax': 503,
+    'segtax': 708,
     'identity': sampleIdentity
   }
 
@@ -78,7 +78,7 @@ describe('symitriDapRtdProvider', function() {
     'api_hostname': 'prebid.dap.akadns.net',
     'api_version': 'x1',
     'domain': 'prebid.org',
-    'segtax': 504,
+    'segtax': 710,
     'identity': sampleIdentity
   }
   let cacheExpiry = Math.round(Date.now() / 1000.0) + 300; // in seconds
@@ -104,7 +104,7 @@ describe('symitriDapRtdProvider', function() {
   const encRtdUserObj = {
     name: 'www.dataprovider3.com',
     ext: {
-      segtax: 504,
+      segtax: 710,
       taxonomyname: 'iab_audience_taxonomy'
     },
     segment: []
@@ -269,13 +269,13 @@ describe('symitriDapRtdProvider', function() {
         'api_hostname': 'prebid.dap.akadns.net',
         'api_version': 1,
         'domain': '',
-        'segtax': 503
+        'segtax': 708
       };
       const encConfig = {
         'api_hostname': 'prebid.dap.akadns.net',
         'api_version': 1,
         'domain': '',
-        'segtax': 504
+        'segtax': 710
       };
       let identity = {
         type: 'dap-signature:1.0.0'
@@ -403,7 +403,7 @@ describe('symitriDapRtdProvider', function() {
         apiHostname: 'prebid.dap.akadns.net',
         apiVersion: 'x1',
         domain: 'prebid.org',
-        segtax: 503
+        segtax: 708
       };
       expect(dapUtils.dapRefreshMembership(ortb2, config, 'token', onDone)).to.equal(undefined)
       const membership = {cohorts: ['1', '5', '7']}
@@ -412,11 +412,11 @@ describe('symitriDapRtdProvider', function() {
   });
 
   describe('checkAndAddRealtimeData test', function () {
-    it('add realtime data for segtax 503 and 504', function () {
-      dapUtils.checkAndAddRealtimeData(ortb2, cachedEncRtd, 504);
-      dapUtils.checkAndAddRealtimeData(ortb2, cachedEncRtd, 504);
+    it('add realtime data for segtax 708 and 710', function () {
+      dapUtils.checkAndAddRealtimeData(ortb2, cachedEncRtd, 710);
+      dapUtils.checkAndAddRealtimeData(ortb2, cachedEncRtd, 710);
       expect(ortb2.user.data).to.deep.include.members([encRtdUserObj]);
-      dapUtils.checkAndAddRealtimeData(ortb2, cachedRtd, 503);
+      dapUtils.checkAndAddRealtimeData(ortb2, cachedRtd, 708);
       expect(ortb2.user.data).to.deep.include.members([rtdUserObj]);
     });
   });
@@ -473,7 +473,7 @@ describe('symitriDapRtdProvider', function() {
       let request = server.requests[0];
       responseHeader['Symitri-DAP-Token'] = encMembership;
       request.respond(200, responseHeader, encMembership);
-      let rtdObj = dapUtils.dapGetEncryptedRtdObj({'encryptedSegments': encMembership}, 504)
+      let rtdObj = dapUtils.dapGetEncryptedRtdObj({'encryptedSegments': encMembership}, 710)
       expect(ortb2.user.data).to.deep.include.members(rtdObj.rtd.ortb2.user.data);
       expect(JSON.parse(storage.getDataFromLocalStorage(DAP_ENCRYPTED_MEMBERSHIP)).expires_at).to.equal(expiry);
     });
@@ -484,7 +484,7 @@ describe('symitriDapRtdProvider', function() {
       let request = server.requests[0];
       responseHeader['Symitri-DAP-Token'] = encMembership;
       request.respond(200, responseHeader, encMembership);
-      let rtdObj = dapUtils.dapGetEncryptedRtdObj({'encryptedSegments': encMembership}, 504)
+      let rtdObj = dapUtils.dapGetEncryptedRtdObj({'encryptedSegments': encMembership}, 710)
       expect(ortb2.user.data).to.deep.include.members(rtdObj.rtd.ortb2.user.data);
       expect(JSON.parse(storage.getDataFromLocalStorage(DAP_ENCRYPTED_MEMBERSHIP)).expires_at).to.equal(1643830630);
     });
@@ -515,7 +515,7 @@ describe('symitriDapRtdProvider', function() {
       dapUtils.dapRefreshMembership(ortb2, sampleConfig, sampleCachedToken.token, onDone);
       let request = server.requests[0];
       request.respond(200, responseHeader, JSON.stringify(membership));
-      let rtdObj = dapUtils.dapGetRtdObj(membership, 503);
+      let rtdObj = dapUtils.dapGetRtdObj(membership, 708);
       expect(ortb2.user.data).to.deep.include.members(rtdObj.rtd.ortb2.user.data);
     });
 
@@ -524,7 +524,7 @@ describe('symitriDapRtdProvider', function() {
       dapUtils.dapRefreshMembership(ortb2, sampleConfig, sampleCachedToken.token, onDone);
       let request = server.requests[0];
       request.respond(200, responseHeader, JSON.stringify(membership));
-      let rtdObj = dapUtils.dapGetRtdObj(membership, 503)
+      let rtdObj = dapUtils.dapGetRtdObj(membership, 708)
       expect(ortb2.user.data).to.deep.include.members(rtdObj.rtd.ortb2.user.data);
       expect(JSON.parse(storage.getDataFromLocalStorage(DAP_MEMBERSHIP)).expires_at).to.be.equal(1647971548);
     });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix

documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [X] Refactoring (no functional changes, no api changes)
- [X] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->
Segment Taxonomy Values changed to use correct Symitri registered values.
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Site Documentation change PR:
https://github.com/prebid/prebid.github.io/pull/5648
