### PR TITLE
Sparteo Bid Adapter : adapt error messages following param deprecation

### DIFF
--- a/modules/sparteoBidAdapter.js
+++ b/modules/sparteoBidAdapter.js
@@ -76,7 +76,8 @@ export const spec = {
     }
 
     if (!bid.params.networkId && !bid.params.publisherId) {
-      logError('The networkId or publisherId is required');
+      // publisherId is deprecated but is still accepted for now for retrocompatibility purpose.
+      logError('The networkId is required');
       return false;
     }
 


### PR DESCRIPTION
## Type of change
- [X] Updated bidder adapter

## Description of change

Updating error message as "publisherId" is now deprecated. Old parameter is still supported until further notice.
There is another "sparteo bid adaptor" PR request but I made them separated to preserve atomicity.

## Other information

* Documentation PR which reflects this change: https://github.com/prebid/prebid.github.io/pull/5644
* There is another "sparteo bid adaptor" PR request. Code is unrelated. I made them separate to preserve atomicity: https://github.com/prebid/Prebid.js/pull/12305#pullrequestreview-2357298681


Thank you :-)