### PR TITLE
51Degrees RTD submodule: add `crossorigin` attribute to `script` tag

### DIFF
--- a/modules/51DegreesRtdProvider.js
+++ b/modules/51DegreesRtdProvider.js
@@ -277,7 +277,7 @@ export const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, user
         logMessage('reqBidsConfigObj: ', reqBidsConfigObj);
         callback();
       });
-    });
+    }, document, {crossOrigin: 'anonymous'});
   } catch (error) {
     // In case of an error, log it and continue
     logError(error);


### PR DESCRIPTION
## Type of change
- [x] Updated RTD submodule

## Description of change

- Added `crossorigin="anonymous"` attribute to address an issue with Chromium making two separate connections on different sockets due to CORS restrictions.

This is happening because Chromium assigns different privacy modes (`pm=disabled` for the script and `pm=enabled` for the API call). When the privacy mode is `enabled` for one request and `disabled` for another, Chromium opens separate connections on different sockets.

By adding the `crossorigin="anonymous"` attribute, the script request is forced into [`pm=enabled`](https://github.com/chromium/chromium/blob/b94803ac9209dda25dad3db059ef14efbd7c5daf/net/socket/client_socket_pool.cc#L85-L86) mode, ensuring that both the script and subsequent API calls reuse the same socket. Using the same socket reduces the elapsed time to complete processing.

A big thanks to @BohdanVV for working on this.