### PR TITLE
Richaudience Bid Adapter : add gvlid to alias

### DIFF
--- a/modules/richaudienceBidAdapter.js
+++ b/modules/richaudienceBidAdapter.js
@@ -11,7 +11,7 @@ let REFERER = '';
 export const spec = {
   code: BIDDER_CODE,
   gvlid: 108,
-  aliases: ['ra'],
+  aliases: [{code: 'ra', gvlid: 108}],
   supportedMediaTypes: [BANNER, VIDEO],
 
   /***

--- a/test/spec/modules/richaudienceBidAdapter_spec.js
+++ b/test/spec/modules/richaudienceBidAdapter_spec.js
@@ -796,7 +796,7 @@ describe('Richaudience adapter tests', function () {
 
   it('Verifies bidder aliases', function () {
     expect(spec.aliases).to.have.lengthOf(1);
-    expect(spec.aliases[0]).to.equal({code: 'ra', gvlid: 108});
+    expect(spec.aliases[0]).to.deep.equal({code: 'ra', gvlid: 108});
   });
 
   it('Verifies bidder gvlid', function () {

--- a/test/spec/modules/richaudienceBidAdapter_spec.js
+++ b/test/spec/modules/richaudienceBidAdapter_spec.js
@@ -796,7 +796,7 @@ describe('Richaudience adapter tests', function () {
 
   it('Verifies bidder aliases', function () {
     expect(spec.aliases).to.have.lengthOf(1);
-    expect(spec.aliases[0]).to.equal('ra');
+    expect(spec.aliases[0]).to.equal({code: 'ra', gvlid: 108});
   });
 
   it('Verifies bidder gvlid', function () {


### PR DESCRIPTION

## Type of change

- [x] Bugfix

## Description of change

Prebid.js doesn't use the `spec.gvlid` as a fallback for `aliases`. This change makes the rich audience adapter work out-of-the-box if the `ra` aliases is used.

Without this change a `gvlMapping` definition ( https://docs.prebid.org/dev-docs/modules/tcfControl.html#page-integration ) would be required.

## Other information

