### PR TITLE
AppNexus Bid Adapter: Add support for 'video' in custom Native fields

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -710,6 +710,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
 
     // Custom fields
     bid[NATIVE].ext = {
+      video: nativeAd.video,
       customImage1: nativeAd.image1 && {
         url: nativeAd.image1.url,
         height: nativeAd.image1.height,

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -2085,6 +2085,8 @@ describe('AppNexusAdapter', function () {
         expect(result[0].native.body2).to.equal('Additional body text');
         expect(result[0].native.cta).to.equal('Do it');
         expect(result[0].native.image.url).to.equal('https://cdn.adnxs.com/img.png');
+        // Video is technically not a base Prebid native field, so it should be included as part of the ext
+        // But it's also included here for backwards compatibility if people read the bid directly
         expect(result[0].native.video.content).to.equal('<?xml version=\"1.0\"></xml>');
       });
 
@@ -2093,6 +2095,7 @@ describe('AppNexusAdapter', function () {
         response1.tags[0].ads[0].ad_type = 'native';
         response1.tags[0].ads[0].rtb.native = {
           ...BASE_NATIVE,
+          // 'video' is included in base native
           'title1': 'Custom Title 1',
           'title2': 'Custom Title 2',
           'title3': 'Custom Title 3',
@@ -2204,6 +2207,9 @@ describe('AppNexusAdapter', function () {
 
         let result = spec.interpretResponse({ body: response1 }, { bidderRequest });
         expect(result[0].native.ext).to.deep.equal({
+          'video': {
+            'content': '<?xml version=\"1.0\"></xml>'
+          },
           'customTitle1': 'Custom Title 1',
           'customTitle2': 'Custom Title 2',
           'customTitle3': 'Custom Title 3',


### PR DESCRIPTION
## Type of change
- Updated bidder adapter

## Description of change
Copy 'video' over to custom native fields so it can be used in native creatives directly.
It already exists in the base native object, but that's not accessible as asset as it's not a [default field](https://github.com/prebid/Prebid.js/blob/f1b4705c3bad512944b9fccdadb9a999461002be/src/constants.js#L101) in Prebid.

I've also kept the 'video' field in the base object for backwards compatibility, in case people are reading it from the bid directly already.

## Other information
This PR will also be forwarded to the Xandr teams for their approval.
