### PR TITLE
bidResponseFilter Module : do not run if not configured

### DIFF
--- a/modules/bidResponseFilter/index.js
+++ b/modules/bidResponseFilter/index.js
@@ -10,17 +10,21 @@ export const BID_ATTR_REJECTION_REASON = 'Attr is not allowed';
 let moduleConfig;
 let enabled = false;
 
-function init(addBidResponse = getHook('addBidResponse')) {
+function init() {
   config.getConfig(MODULE_NAME, (cfg) => {
     moduleConfig = cfg[MODULE_NAME];
     if (enabled && !moduleConfig) {
-      enabled = false;
-      addBidResponse.getHooks({hook: addBidResponseHook}).remove();
+      reset();
     } else if (!enabled && moduleConfig) {
       enabled = true;
-      addBidResponse.before(addBidResponseHook);
+      getHook('addBidResponse').before(addBidResponseHook);
     }
   })
+}
+
+export function reset() {
+  enabled = false;
+  getHook('addBidResponse').getHooks({hook: addBidResponseHook}).remove();
 }
 
 export function addBidResponseHook(next, adUnitCode, bid, reject, index = auctionManager.index) {

--- a/modules/bidResponseFilter/index.js
+++ b/modules/bidResponseFilter/index.js
@@ -7,14 +7,25 @@ export const BID_CATEGORY_REJECTION_REASON = 'Category is not allowed';
 export const BID_ADV_DOMAINS_REJECTION_REASON = 'Adv domain is not allowed';
 export const BID_ATTR_REJECTION_REASON = 'Attr is not allowed';
 
-function init() {
-  getHook('addBidResponse').before(addBidResponseHook);
-};
+let moduleConfig;
+let enabled = false;
+
+function init(addBidResponse = getHook('addBidResponse')) {
+  config.getConfig(MODULE_NAME, (cfg) => {
+    moduleConfig = cfg[MODULE_NAME];
+    if (enabled && !moduleConfig) {
+      enabled = false;
+      addBidResponse.getHooks({hook: addBidResponseHook}).remove();
+    } else if (!enabled && moduleConfig) {
+      enabled = true;
+      addBidResponse.before(addBidResponseHook);
+    }
+  })
+}
 
 export function addBidResponseHook(next, adUnitCode, bid, reject, index = auctionManager.index) {
   const {bcat = [], badv = []} = index.getOrtb2(bid) || {};
   const battr = index.getBidRequest(bid)?.ortb2Imp[bid.mediaType]?.battr || index.getAdUnit(bid)?.ortb2Imp[bid.mediaType]?.battr || [];
-  const moduleConfig = config.getConfig(MODULE_NAME);
 
   const catConfig = {enforce: true, blockUnknown: true, ...(moduleConfig?.cat || {})};
   const advConfig = {enforce: true, blockUnknown: true, ...(moduleConfig?.adv || {})};

--- a/test/spec/modules/bidResponseFilter_spec.js
+++ b/test/spec/modules/bidResponseFilter_spec.js
@@ -1,14 +1,53 @@
-import { BID_ADV_DOMAINS_REJECTION_REASON, BID_ATTR_REJECTION_REASON, BID_CATEGORY_REJECTION_REASON, MODULE_NAME, PUBLISHER_FILTER_REJECTION_REASON, addBidResponseHook } from '../../../modules/bidResponseFilter';
-import { config } from '../../../src/config';
+import {
+  addBidResponseHook,
+  BID_ADV_DOMAINS_REJECTION_REASON,
+  BID_ATTR_REJECTION_REASON,
+  BID_CATEGORY_REJECTION_REASON,
+  init,
+  MODULE_NAME
+} from '../../../modules/bidResponseFilter';
+import {config} from '../../../src/config';
+import {addBidResponse} from "../../../src/auction.js";
 
 describe('bidResponseFilter', () => {
   let mockAuctionIndex
   beforeEach(() => {
-    config.resetConfig();
     mockAuctionIndex = {
-      getBidRequest: () => {},
-      getAdUnit: () => {}
+      getBidRequest: () => {
+      },
+      getAdUnit: () => {
+      }
     };
+  });
+  afterEach(() => {
+    config.resetConfig();
+  })
+
+  describe('enable/disable', () => {
+    let reject, dispatch;
+
+    beforeEach(() => {
+      reject = sinon.stub();
+      dispatch = sinon.stub();
+    });
+
+    it('should not run if not configured', () => {
+      config.setConfig({
+        bidResponseFilter: null
+      })
+      addBidResponse.call({dispatch}, 'au', {}, reject);
+      sinon.assert.notCalled(reject);
+      sinon.assert.called(dispatch);
+    });
+
+    it('should run if configured', () => {
+      config.setConfig({
+        bidResponseFilter: {}
+      });
+      addBidResponse.call({dispatch}, 'au', {}, reject);
+      sinon.assert.called(reject);
+      sinon.assert.notCalled(dispatch);
+    })
   });
 
   it('should pass the bid after successful ortb2 rules validation', () => {
@@ -26,7 +65,8 @@ describe('bidResponseFilter', () => {
       }
     };
 
-    addBidResponseHook(call, 'adcode', bid, () => {}, mockAuctionIndex);
+    addBidResponseHook(call, 'adcode', bid, () => {
+    }, mockAuctionIndex);
     sinon.assert.calledOnce(call);
   });
 
@@ -109,7 +149,8 @@ describe('bidResponseFilter', () => {
 
     config.setConfig({[MODULE_NAME]: {cat: {enforce: false}}});
 
-    addBidResponseHook(call, 'adcode', bid, () => {}, mockAuctionIndex);
+    addBidResponseHook(call, 'adcode', bid, () => {
+    }, mockAuctionIndex);
     sinon.assert.calledOnce(call);
   });
 
@@ -129,7 +170,8 @@ describe('bidResponseFilter', () => {
 
     config.setConfig({[MODULE_NAME]: {cat: {blockUnknown: false}}});
 
-    addBidResponseHook(call, 'adcode', bid, () => {});
+    addBidResponseHook(call, 'adcode', bid, () => {
+    });
     sinon.assert.calledOnce(call);
   });
 })

--- a/test/spec/modules/bidResponseFilter_spec.js
+++ b/test/spec/modules/bidResponseFilter_spec.js
@@ -5,7 +5,7 @@ import {
   BID_CATEGORY_REJECTION_REASON,
   init,
   MODULE_NAME
-} from '../../../modules/bidResponseFilter';
+  , reset} from '../../../modules/bidResponseFilter';
 import {config} from '../../../src/config';
 import {addBidResponse} from '../../../src/auction.js';
 
@@ -21,6 +21,7 @@ describe('bidResponseFilter', () => {
   });
   afterEach(() => {
     config.resetConfig();
+    reset();
   })
 
   describe('enable/disable', () => {
@@ -32,9 +33,7 @@ describe('bidResponseFilter', () => {
     });
 
     it('should not run if not configured', () => {
-      config.setConfig({
-        bidResponseFilter: null
-      })
+      reset();
       addBidResponse.call({dispatch}, 'au', {}, reject);
       sinon.assert.notCalled(reject);
       sinon.assert.called(dispatch);

--- a/test/spec/modules/bidResponseFilter_spec.js
+++ b/test/spec/modules/bidResponseFilter_spec.js
@@ -7,7 +7,7 @@ import {
   MODULE_NAME
 } from '../../../modules/bidResponseFilter';
 import {config} from '../../../src/config';
-import {addBidResponse} from "../../../src/auction.js";
+import {addBidResponse} from '../../../src/auction.js';
 
 describe('bidResponseFilter', () => {
   let mockAuctionIndex


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix (?)

## Description of change

The bid response filter does not require any configuration, and by default will reject any bid that does not specify a category. This has the effect of breaking most of our integration examples, since they automatically include every module.

This updates the module to require at least an empty config object (`setConfig({bidResponseFilter: {})`) to activate.

