### PR TITLE
ixBidAdapter.js: add device fields

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -1174,12 +1174,10 @@ function addFPD(bidderRequest, r, fpd, site, user) {
     if (!isEmpty(sua)) {
       deepSetValue(r, 'device.sua', sua);
     }
-    
     const ip = fpd.device.ip;
     if (ip) {
       deepSetValue(r, 'device.ip', ip);
     }
-
     const ipv6 = fpd.device.ipv6;
     if (ipv6) {
       deepSetValue(r, 'device.ipv6', ipv6);

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -1174,6 +1174,16 @@ function addFPD(bidderRequest, r, fpd, site, user) {
     if (!isEmpty(sua)) {
       deepSetValue(r, 'device.sua', sua);
     }
+    
+    const ip = fpd.device.ip;
+    if (ip) {
+      deepSetValue(r, 'device.ip', ip);
+    }
+
+    const ipv6 = fpd.device.ipv6;
+    if (ipv6) {
+      deepSetValue(r, 'device.ipv6', ipv6);
+    }
   }
 
   // regulations from ortb2

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -2510,6 +2510,19 @@ describe('IndexexchangeAdapter', function () {
         expect(payload.device.sua.mobile).to.equal(0)
       });
 
+      it('should set device ip if available in fpd', function () {
+        const ortb2 = {
+          device: {
+            ip: '1.2.3.4',
+            ipv6: 'somefunkystring'
+          }};
+
+        const request = spec.buildRequests(DEFAULT_BANNER_VALID_BID, { ortb2 })[0];
+        const payload = extractPayload(request);
+        expect(payload.device.ip).to.equal('1.2.3.4')
+        expect(payload.device.ipv6).to.equal('somefunkystring')
+      });
+
       it('should not set device sua if not available in fpd', function () {
         const ortb2 = {
           device: {}};


### PR DESCRIPTION
Ix support tells me device.IP is honored if passed, but the adapter doesn't have it in the payload

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
