### PR TITLE
LiveIntent UserId Module : add support for sharethrough, sonobi, vidazoo IDs

### DIFF
--- a/libraries/liveIntentId/shared.js
+++ b/libraries/liveIntentId/shared.js
@@ -89,6 +89,18 @@ export function composeIdObject(value) {
     delete result.lipb.thetradedesk
   }
 
+  if (value.sharethrough) {
+    result.sharethrough = { 'id': value.sharethrough, ext: { provider: LI_PROVIDER_DOMAIN } }
+  }
+
+  if (value.sonobi) {
+    result.sonobi = { 'id': value.sonobi, ext: { provider: LI_PROVIDER_DOMAIN } }
+  }
+
+  if (value.vidazoo) {
+    result.vidazoo = { 'id': value.vidazoo, ext: { provider: LI_PROVIDER_DOMAIN } }
+  }
+
   return result
 }
 
@@ -195,6 +207,27 @@ export const eids = {
   },
   'fpid': {
     source: 'fpid.liveintent.com',
+    atype: 1,
+    getValue: function(data) {
+      return data.id;
+    }
+  },
+  'sharethrough': {
+    source: 'sharethrough.com',
+    atype: 1,
+    getValue: function(data) {
+      return data.id;
+    }
+  },
+  'sonobi': {
+    source: 'liveintent.sonobi.com',
+    atype: 1,
+    getValue: function(data) {
+      return data.id;
+    }
+  },
+  'vidazoo': {
+    source: 'liveintent.vidazoo.com',
     atype: 1,
     getValue: function(data) {
       return data.id;

--- a/libraries/liveIntentId/shared.js
+++ b/libraries/liveIntentId/shared.js
@@ -217,6 +217,11 @@ export const eids = {
     atype: 3,
     getValue: function(data) {
       return data.id;
+    },
+    getUidExt: function(data) {
+      if (data.ext) {
+        return data.ext;
+      }
     }
   },
   'sonobi': {
@@ -224,6 +229,11 @@ export const eids = {
     atype: 3,
     getValue: function(data) {
       return data.id;
+    },
+    getUidExt: function(data) {
+      if (data.ext) {
+        return data.ext;
+      }
     }
   },
   'vidazoo': {
@@ -231,6 +241,11 @@ export const eids = {
     atype: 3,
     getValue: function(data) {
       return data.id;
+    },
+    getUidExt: function(data) {
+      if (data.ext) {
+        return data.ext;
+      }
     }
   }
 }

--- a/libraries/liveIntentId/shared.js
+++ b/libraries/liveIntentId/shared.js
@@ -214,21 +214,21 @@ export const eids = {
   },
   'sharethrough': {
     source: 'sharethrough.com',
-    atype: 1,
+    atype: 3,
     getValue: function(data) {
       return data.id;
     }
   },
   'sonobi': {
     source: 'liveintent.sonobi.com',
-    atype: 1,
+    atype: 3,
     getValue: function(data) {
       return data.id;
     }
   },
   'vidazoo': {
     source: 'liveintent.vidazoo.com',
-    atype: 1,
+    atype: 3,
     getValue: function(data) {
       return data.id;
     }

--- a/test/spec/modules/liveIntentExternalIdSystem_spec.js
+++ b/test/spec/modules/liveIntentExternalIdSystem_spec.js
@@ -416,4 +416,19 @@ describe('LiveIntentExternalId', function() {
       type: 'resolve'
     })
   });
+
+  it('should decode a sharethrough id to a separate object when present', function() {
+    const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', sharethrough: 'bar' }, defaultConfigParams);
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'sharethrough': 'bar'}, 'sharethrough': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
+  it('should decode a sonobi id to a separate object when present', function() {
+    const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', sonobi: 'bar' }, defaultConfigParams);
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'sonobi': 'bar'}, 'sonobi': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
+  it('should decode a vidazoo id to a separate object when present', function() {
+    const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar' }, defaultConfigParams);
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar'}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
 });

--- a/test/spec/modules/liveIntentIdMinimalSystem_spec.js
+++ b/test/spec/modules/liveIntentIdMinimalSystem_spec.js
@@ -313,4 +313,19 @@ describe('LiveIntentMinimalId', function() {
     );
     expect(callBackSpy.calledOnce).to.be.true;
   });
+
+  it('should decode a sharethrough id to a separate object when present', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', sharethrough: 'bar' });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'sharethrough': 'bar'}, 'sharethrough': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
+  it('should decode a sonobi id to a separate object when present', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', sonobi: 'bar' });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'sonobi': 'bar'}, 'sonobi': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
+  it('should decode a vidazoo id to a separate object when present', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar' });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar'}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
 });

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -511,6 +511,21 @@ describe('LiveIntentId', function() {
     });
   });
 
+  it('should decode a sharethrough id to a separate object when present', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', sharethrough: 'bar' }, { params: defaultConfigParams });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'sharethrough': 'bar'}, 'sharethrough': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
+  it('should decode a sonobi id to a separate object when present', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', sonobi: 'bar' }, { params: defaultConfigParams });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'sonobi': 'bar'}, 'sonobi': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
+  it('should decode a vidazoo id to a separate object when present', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar' }, { params: defaultConfigParams });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar'}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
   describe('eid', () => {
     before(() => {
       attachIdSystem(liveIntentIdSubmodule);
@@ -783,6 +798,105 @@ describe('LiveIntentId', function() {
       expect(newEids[0]).to.deep.equal({
         source: 'liveintent.com',
         uids: [{id: 'some-random-id-value', atype: 3}]
+      });
+    });
+
+    it('sharethrough', function () {
+      const userId = {
+        sharethrough: { 'id': 'sample_id' }
+      };
+      const newEids = createEidsArray(userId);
+      expect(newEids.length).to.equal(1);
+      expect(newEids[0]).to.deep.equal({
+        source: 'sharethrough.com',
+        uids: [{
+          id: 'sample_id',
+          atype: 3
+        }]
+      });
+    });
+
+    it('sharethrough with ext', function () {
+      const userId = {
+        sharethrough: { 'id': 'sample_id', 'ext': { 'provider': 'some.provider.com' } }
+      };
+      const newEids = createEidsArray(userId);
+      expect(newEids.length).to.equal(1);
+      expect(newEids[0]).to.deep.equal({
+        source: 'sharethrough.com',
+        uids: [{
+          id: 'sample_id',
+          atype: 3,
+          ext: {
+            provider: 'some.provider.com'
+          }
+        }]
+      });
+    });
+
+    it('sonobi', function () {
+      const userId = {
+        sonobi: { 'id': 'sample_id' }
+      };
+      const newEids = createEidsArray(userId);
+      expect(newEids.length).to.equal(1);
+      expect(newEids[0]).to.deep.equal({
+        source: 'liveintent.sonobi.com',
+        uids: [{
+          id: 'sample_id',
+          atype: 3
+        }]
+      });
+    });
+
+    it('sonobi with ext', function () {
+      const userId = {
+        sonobi: { 'id': 'sample_id', 'ext': { 'provider': 'some.provider.com' } }
+      };
+      const newEids = createEidsArray(userId);
+      expect(newEids.length).to.equal(1);
+      expect(newEids[0]).to.deep.equal({
+        source: 'liveintent.sonobi.com',
+        uids: [{
+          id: 'sample_id',
+          atype: 3,
+          ext: {
+            provider: 'some.provider.com'
+          }
+        }]
+      });
+    });
+
+    it('vidazoo', function () {
+      const userId = {
+        vidazoo: { 'id': 'sample_id' }
+      };
+      const newEids = createEidsArray(userId);
+      expect(newEids.length).to.equal(1);
+      expect(newEids[0]).to.deep.equal({
+        source: 'liveintent.vidazoo.com',
+        uids: [{
+          id: 'sample_id',
+          atype: 3
+        }]
+      });
+    });
+
+    it('vidazoo with ext', function () {
+      const userId = {
+        vidazoo: { 'id': 'sample_id', 'ext': { 'provider': 'some.provider.com' } }
+      };
+      const newEids = createEidsArray(userId);
+      expect(newEids.length).to.equal(1);
+      expect(newEids[0]).to.deep.equal({
+        source: 'liveintent.vidazoo.com',
+        uids: [{
+          id: 'sample_id',
+          atype: 3,
+          ext: {
+            provider: 'some.provider.com'
+          }
+        }]
       });
     });
   })


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
This pull request adds an EID mapping for sharethrough, sonobi abd vidazoo IDs that now can be resolved via the LiveIntent UserId module.

## Other information
- docs PR: https://github.com/prebid/prebid.github.io/pull/5674
