### PR TITLE
impactifyBidAdapter: fix exception related to USP

### DIFF
--- a/modules/impactifyBidAdapter.js
+++ b/modules/impactifyBidAdapter.js
@@ -170,7 +170,6 @@ function createOpenRtbRequest(validBidRequests, bidderRequest) {
 
   if (bidderRequest.uspConsent) {
     deepSetValue(request, 'regs.ext.us_privacy', bidderRequest.uspConsent);
-    this.syncStore.uspConsent = bidderRequest.uspConsent;
   }
 
   if (GET_CONFIG('coppa') == true) deepSetValue(request, 'regs.coppa', 1);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fixes https://github.com/prebid/Prebid.js/issues/12377

I do not understand the intent behind the offending line, but since `syncStore` is not referenced anywhere else, I believe it's safe to remove.
