### PR TITLE
Various adapters: setting imp secure

### DIFF
--- a/libraries/ortbConverter/processors/default.js
+++ b/libraries/ortbConverter/processors/default.js
@@ -65,7 +65,7 @@ export const DEFAULT_PROCESSORS = {
     secure: {
       // should set imp.secure to 1 unless publisher has set it
       fn(imp, bidRequest) {
-        imp.secure = bidRequest.ortb2Imp?.secure ?? 1;
+        imp.secure = imp.secure ?? 1;
       }
     }
   },

--- a/libraries/ortbConverter/processors/default.js
+++ b/libraries/ortbConverter/processors/default.js
@@ -39,6 +39,7 @@ export const DEFAULT_PROCESSORS = {
       // sets initial imp to bidRequest.ortb2Imp
       priority: 99,
       fn(imp, bidRequest) {
+        imp.secure = imp.secure || 1;
         mergeDeep(imp, bidRequest.ortb2Imp);
       }
     },

--- a/libraries/ortbConverter/processors/default.js
+++ b/libraries/ortbConverter/processors/default.js
@@ -39,7 +39,6 @@ export const DEFAULT_PROCESSORS = {
       // sets initial imp to bidRequest.ortb2Imp
       priority: 99,
       fn(imp, bidRequest) {
-        imp.secure = imp.secure || 1;
         mergeDeep(imp, bidRequest.ortb2Imp);
       }
     },
@@ -61,6 +60,12 @@ export const DEFAULT_PROCESSORS = {
         if (!pbadslot || typeof pbadslot !== 'string') {
           delete imp.ext?.data?.pbadslot;
         }
+      }
+    },
+    secure: {
+      // should set imp.secure to 1 unless publisher has set it
+      fn(imp, bidRequest) {
+        imp.secure = bidRequest.ortb2Imp?.secure ?? 1;
       }
     }
   },

--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -263,7 +263,7 @@ function buildImps(bidRequest, secure) {
     'tagid': bidRequest.adUnitCode
   };
   if (secure) {
-    imp.secure = bidRequest.ortb2Imp?.secure || 1;
+    imp.secure = bidRequest.ortb2Imp?.secure ?? 1;
   }
   var sizes = [];
   let mediaTypes = bidRequest.mediaTypes;

--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -263,7 +263,7 @@ function buildImps(bidRequest, secure) {
     'tagid': bidRequest.adUnitCode
   };
   if (secure) {
-    imp.secure = 1;
+    imp.secure = bidRequest.ortb2Imp?.secure || 1;
   }
   var sizes = [];
   let mediaTypes = bidRequest.mediaTypes;

--- a/modules/adtrgtmeBidAdapter.js
+++ b/modules/adtrgtmeBidAdapter.js
@@ -55,7 +55,7 @@ function extractUserSyncUrls(syncOptions, pixels) {
 }
 
 function isSecure(bid) {
-  return deepAccess(bid, 'params.bidOverride.imp.secure') || deepAccess(bid, 'ortb2Imp.secure') || 1;
+  return deepAccess(bid, 'params.bidOverride.imp.secure') ?? deepAccess(bid, 'ortb2Imp.secure') ?? 1;
 };
 
 function getMediaType(bid) {

--- a/modules/adtrgtmeBidAdapter.js
+++ b/modules/adtrgtmeBidAdapter.js
@@ -55,7 +55,7 @@ function extractUserSyncUrls(syncOptions, pixels) {
 }
 
 function isSecure(bid) {
-  return deepAccess(bid, 'params.bidOverride.imp.secure') || (document.location.protocol === 'https:') ? 1 : 0;
+  return deepAccess(bid, 'params.bidOverride.imp.secure') || deepAccess(bid, 'ortb2Imp.secure') || 1;
 };
 
 function getMediaType(bid) {

--- a/modules/adxcgBidAdapter.js
+++ b/modules/adxcgBidAdapter.js
@@ -122,7 +122,7 @@ const converter = ortbConverter({
       };
     }
 
-    imp.secure = bidRequest.ortb2Imp?.secure || 1;
+    imp.secure = bidRequest.ortb2Imp?.secure ?? 1;
 
     if (!imp.bidfloor && bidRequest.params.bidFloor) {
       imp.bidfloor = bidRequest.params.bidFloor;

--- a/modules/adxcgBidAdapter.js
+++ b/modules/adxcgBidAdapter.js
@@ -122,7 +122,7 @@ const converter = ortbConverter({
       };
     }
 
-    imp.secure = Number(window.location.protocol === 'https:');
+    imp.secure = bidRequest.ortb2Imp?.secure || 1;
 
     if (!imp.bidfloor && bidRequest.params.bidFloor) {
       imp.bidfloor = bidRequest.params.bidFloor;

--- a/modules/asoBidAdapter.js
+++ b/modules/asoBidAdapter.js
@@ -106,7 +106,7 @@ const converter = ortbConverter({
     const imp = buildImp(bidRequest, context);
 
     imp.tagid = bidRequest.adUnitCode;
-    imp.secure = bidRequest.ortb2Imp?.secure || 1;
+    imp.secure = bidRequest.ortb2Imp?.secure ?? 1;
     return imp;
   },
 

--- a/modules/asoBidAdapter.js
+++ b/modules/asoBidAdapter.js
@@ -106,7 +106,7 @@ const converter = ortbConverter({
     const imp = buildImp(bidRequest, context);
 
     imp.tagid = bidRequest.adUnitCode;
-    imp.secure = Number(window.location.protocol === 'https:');
+    imp.secure = bidRequest.ortb2Imp?.secure || 1;
     return imp;
   },
 

--- a/modules/equativBidAdapter.js
+++ b/modules/equativBidAdapter.js
@@ -94,7 +94,7 @@ export const converter = ortbConverter({
     delete imp.dt;
 
     imp.bidfloor = imp.bidfloor || getBidFloor(bidRequest);
-    imp.secure = bidRequest.ortb2Imp?.secure || 1;
+    imp.secure = bidRequest.ortb2Imp?.secure ?? 1;
     imp.tagid = bidRequest.adUnitCode;
 
     if (siteId || pageId || formatId) {

--- a/modules/equativBidAdapter.js
+++ b/modules/equativBidAdapter.js
@@ -94,7 +94,7 @@ export const converter = ortbConverter({
     delete imp.dt;
 
     imp.bidfloor = imp.bidfloor || getBidFloor(bidRequest);
-    imp.secure = 1;
+    imp.secure = bidRequest.ortb2Imp?.secure || 1;
     imp.tagid = bidRequest.adUnitCode;
 
     if (siteId || pageId || formatId) {

--- a/modules/eskimiBidAdapter.js
+++ b/modules/eskimiBidAdapter.js
@@ -80,7 +80,7 @@ const CONVERTER = ortbConverter({
   },
   imp(buildImp, bidRequest, context) {
     let imp = buildImp(bidRequest, context);
-    imp.secure = bidRequest.ortb2Imp?.secure || 1;
+    imp.secure = bidRequest.ortb2Imp?.secure ?? 1;
     if (!imp.bidfloor && bidRequest.params.bidFloor) {
       imp.bidfloor = bidRequest.params.bidFloor;
       imp.bidfloorcur = getBidIdParameter('bidFloorCur', bidRequest.params).toUpperCase() || 'USD'

--- a/modules/eskimiBidAdapter.js
+++ b/modules/eskimiBidAdapter.js
@@ -80,7 +80,7 @@ const CONVERTER = ortbConverter({
   },
   imp(buildImp, bidRequest, context) {
     let imp = buildImp(bidRequest, context);
-    imp.secure = Number(window.location.protocol === 'https:');
+    imp.secure = bidRequest.ortb2Imp?.secure || 1;
     if (!imp.bidfloor && bidRequest.params.bidFloor) {
       imp.bidfloor = bidRequest.params.bidFloor;
       imp.bidfloorcur = getBidIdParameter('bidFloorCur', bidRequest.params).toUpperCase() || 'USD'

--- a/modules/improvedigitalBidAdapter.js
+++ b/modules/improvedigitalBidAdapter.js
@@ -153,7 +153,7 @@ export const CONVERTER = ortbConverter({
   },
   imp(buildImp, bidRequest, context) {
     const imp = buildImp(bidRequest, context);
-    imp.secure = bidRequest.ortb2Imp?.secure || 1;
+    imp.secure = bidRequest.ortb2Imp?.secure ?? 1;
     if (!imp.bidfloor && bidRequest.params.bidFloor) {
       imp.bidfloor = bidRequest.params.bidFloor;
       imp.bidfloorcur = getBidIdParameter('bidFloorCur', bidRequest.params).toUpperCase() || DEFAULT_CURRENCY;

--- a/modules/improvedigitalBidAdapter.js
+++ b/modules/improvedigitalBidAdapter.js
@@ -153,7 +153,7 @@ export const CONVERTER = ortbConverter({
   },
   imp(buildImp, bidRequest, context) {
     const imp = buildImp(bidRequest, context);
-    imp.secure = Number(window.location.protocol === 'https:');
+    imp.secure = bidRequest.ortb2Imp?.secure || 1;
     if (!imp.bidfloor && bidRequest.params.bidFloor) {
       imp.bidfloor = bidRequest.params.bidFloor;
       imp.bidfloorcur = getBidIdParameter('bidFloorCur', bidRequest.params).toUpperCase() || DEFAULT_CURRENCY;

--- a/modules/interactiveOffersBidAdapter.js
+++ b/modules/interactiveOffersBidAdapter.js
@@ -79,7 +79,6 @@ function parseRequestPrebidjsToOpenRTB(prebidRequest, bidderRequest) {
   // TODO: these should probably look at refererInfo
   let pageURL = window.location.href;
   let domain = window.location.hostname;
-  let secure = (window.location.protocol == 'https:' ? 1 : 0);
   let openRTBRequest = deepClone(DEFAULT['OpenRTBBidRequest']);
   openRTBRequest.id = bidderRequest.bidderRequestId;
   openRTBRequest.ext = {
@@ -120,7 +119,7 @@ function parseRequestPrebidjsToOpenRTB(prebidRequest, bidderRequest) {
     }
     let imp = deepClone(DEFAULT['OpenRTBBidRequestImp']);
     imp.id = bid.bidId;
-    imp.secure = secure;
+    imp.secure = bid.ortb2Imp?.secure || 1;
     imp.tagid = bid.adUnitCode;
     imp.ext = {
       rawdata: bid

--- a/modules/interactiveOffersBidAdapter.js
+++ b/modules/interactiveOffersBidAdapter.js
@@ -119,7 +119,7 @@ function parseRequestPrebidjsToOpenRTB(prebidRequest, bidderRequest) {
     }
     let imp = deepClone(DEFAULT['OpenRTBBidRequestImp']);
     imp.id = bid.bidId;
-    imp.secure = bid.ortb2Imp?.secure || 1;
+    imp.secure = bid.ortb2Imp?.secure ?? 1;
     imp.tagid = bid.adUnitCode;
     imp.ext = {
       rawdata: bid

--- a/modules/prebidServerBidAdapter/ortbConverter.js
+++ b/modules/prebidServerBidAdapter/ortbConverter.js
@@ -37,7 +37,7 @@ const PBS_CONVERTER = ortbConverter({
       }
     });
     if (Object.values(SUPPORTED_MEDIA_TYPES).some(mtype => imp[mtype])) {
-      imp.secure = proxyBidRequest.ortb2Imp?.secure || 1;
+      imp.secure = proxyBidRequest.ortb2Imp?.secure ?? 1;
       return imp;
     }
   },

--- a/modules/prebidServerBidAdapter/ortbConverter.js
+++ b/modules/prebidServerBidAdapter/ortbConverter.js
@@ -37,7 +37,7 @@ const PBS_CONVERTER = ortbConverter({
       }
     });
     if (Object.values(SUPPORTED_MEDIA_TYPES).some(mtype => imp[mtype])) {
-      imp.secure = context.s2sBidRequest.s2sConfig.secure;
+      imp.secure = proxyBidRequest.ortb2Imp?.secure || 1;
       return imp;
     }
   },

--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -369,7 +369,7 @@ function buildOneRequest(validBidRequests, bidderRequest) {
 
   imp.id = validBidRequests.bidId;
   imp.tagid = tagid;
-  imp.secure = validBidRequests.ortb2Imp?.secure || 1;
+  imp.secure = validBidRequests.ortb2Imp?.secure ?? 1;
 
   imp.bidfloor = deepAccess(validBidRequests, 'params.bidfloor');
   if (isFn(validBidRequests.getFloor)) {

--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -369,7 +369,7 @@ function buildOneRequest(validBidRequests, bidderRequest) {
 
   imp.id = validBidRequests.bidId;
   imp.tagid = tagid;
-  imp.secure = 1;
+  imp.secure = validBidRequests.ortb2Imp?.secure || 1;
 
   imp.bidfloor = deepAccess(validBidRequests, 'params.bidfloor');
   if (isFn(validBidRequests.getFloor)) {

--- a/modules/yahooAdsBidAdapter.js
+++ b/modules/yahooAdsBidAdapter.js
@@ -150,7 +150,7 @@ function getSupportedEids(bid) {
 }
 
 function isSecure(bid) {
-  return deepAccess(bid, 'params.bidOverride.imp.secure') || bid.ortb2Imp?.secure || 1;
+  return deepAccess(bid, 'params.bidOverride.imp.secure') ?? bid.ortb2Imp?.secure ?? 1;
 };
 
 function getPubIdMode(bid) {

--- a/modules/yahooAdsBidAdapter.js
+++ b/modules/yahooAdsBidAdapter.js
@@ -150,7 +150,7 @@ function getSupportedEids(bid) {
 }
 
 function isSecure(bid) {
-  return deepAccess(bid, 'params.bidOverride.imp.secure') || (document.location.protocol === 'https:') ? 1 : 0;
+  return deepAccess(bid, 'params.bidOverride.imp.secure') || bid.ortb2Imp?.secure || 1;
 };
 
 function getPubIdMode(bid) {

--- a/test/spec/modules/a1MediaBidAdapter_spec.js
+++ b/test/spec/modules/a1MediaBidAdapter_spec.js
@@ -75,7 +75,8 @@ const getConvertedBidReq = () => {
         },
         bidfloor: 0,
         bidfloorcur: 'JPY',
-        id: '2e9f38ea93bb9e'
+        id: '2e9f38ea93bb9e',
+        secure: 1
       }
     ],
     test: 0,

--- a/test/spec/modules/aidemBidAdapter_spec.js
+++ b/test/spec/modules/aidemBidAdapter_spec.js
@@ -455,7 +455,7 @@ describe('Aidem adapter', () => {
       expect(data.imp).to.be.a('array').that.has.lengthOf(DEFAULT_VALID_BANNER_REQUESTS.length)
 
       expect(data.imp[0]).to.be.a('object').that.has.all.keys(
-        'banner', 'id', 'tagId'
+        'banner', 'id', 'tagId', 'secure'
       )
       expect(data.imp[0].banner).to.be.a('object').that.has.all.keys(
         'format', 'topframe'
@@ -471,7 +471,7 @@ describe('Aidem adapter', () => {
         expect(data.imp).to.be.a('array').that.has.lengthOf(DEFAULT_VALID_VIDEO_REQUESTS.length)
 
         expect(data.imp[0]).to.be.a('object').that.has.all.keys(
-          'video', 'id', 'tagId'
+          'video', 'id', 'tagId', 'secure'
         )
         expect(data.imp[0].video).to.be.a('object').that.has.all.keys(
           'mimes', 'minduration', 'maxduration', 'protocols', 'w', 'h'

--- a/test/spec/modules/bidmaticBidAdapter_spec.js
+++ b/test/spec/modules/bidmaticBidAdapter_spec.js
@@ -3,6 +3,7 @@ import { END_POINT, spec } from 'modules/bidmaticBidAdapter.js';
 import { deepClone, deepSetValue, mergeDeep } from '../../../src/utils';
 
 const expectedImp = {
+  'secure': 1,
   'id': '2eb89f0f062afe',
   'banner': {
     'topframe': 0,

--- a/test/spec/modules/dsp_genieeBidAdapter_spec.js
+++ b/test/spec/modules/dsp_genieeBidAdapter_spec.js
@@ -38,7 +38,8 @@ describe('Geniee adapter tests', () => {
               ext: {
                 test: 1
               },
-              id: 'bid-id'
+              id: 'bid-id',
+              secure: 1
             }
           ],
           test: 1

--- a/test/spec/modules/improvedigitalBidAdapter_spec.js
+++ b/test/spec/modules/improvedigitalBidAdapter_spec.js
@@ -238,7 +238,7 @@ describe('Improve Digital Adapter Tests', function () {
       sinon.assert.match(payload.imp, [
         sinon.match({
           id: '33e9500b21129f',
-          secure: 0,
+          secure: 1,
           ext: {
             bidder: {
               placementId: 1053688,
@@ -265,7 +265,7 @@ describe('Improve Digital Adapter Tests', function () {
       sinon.assert.match(payload.imp, [
         sinon.match({
           id: '33e9500b21129f',
-          secure: 0,
+          secure: 1,
           ext: {
             bidder: {
               placementId: 1053688,

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1489,7 +1489,8 @@ describe('OpenxRtbAdapter', function () {
               },
               ext: {
                 divid: 'adunit-code',
-              }
+              },
+              secure: 1
             }
           }
         });

--- a/test/spec/modules/smaatoBidAdapter_spec.js
+++ b/test/spec/modules/smaatoBidAdapter_spec.js
@@ -174,6 +174,7 @@ describe('smaatoBidAdapterTest', () => {
             id: 'bidId',
             banner: BANNER_OPENRTB_IMP,
             tagid: 'adspaceId',
+            secure: 1
           }
         ]);
       });

--- a/test/spec/modules/sparteoBidAdapter_spec.js
+++ b/test/spec/modules/sparteoBidAdapter_spec.js
@@ -59,6 +59,7 @@ const VALID_REQUEST_BANNER = {
   url: REQUEST_URL,
   data: {
     'imp': [{
+      'secure': 1,
       'id': '1a2b3c4d',
       'banner': {
         'format': [{
@@ -95,6 +96,7 @@ const VALID_REQUEST_VIDEO = {
   url: REQUEST_URL,
   data: {
     'imp': [{
+      'secure': 1,
       'id': '5e6f7g8h',
       'video': {
         'w': 640,
@@ -137,6 +139,7 @@ const VALID_REQUEST = {
   url: REQUEST_URL,
   data: {
     'imp': [{
+      'secure': 1,
       'id': '1a2b3c4d',
       'banner': {
         'format': [{
@@ -155,6 +158,7 @@ const VALID_REQUEST = {
         }
       }
     }, {
+      'secure': 1,
       'id': '5e6f7g8h',
       'video': {
         'w': 640,

--- a/test/spec/modules/taboolaBidAdapter_spec.js
+++ b/test/spec/modules/taboolaBidAdapter_spec.js
@@ -180,6 +180,7 @@ describe('Taboola Adapter', function () {
       const res = spec.buildRequests([defaultBidRequest], commonBidderRequest);
       const expectedData = {
         'imp': [{
+          'secure': 1,
           'id': res.data.imp[0].id,
           'banner': {
             format: [{

--- a/test/spec/modules/taboolaBidAdapter_spec.js
+++ b/test/spec/modules/taboolaBidAdapter_spec.js
@@ -180,8 +180,8 @@ describe('Taboola Adapter', function () {
       const res = spec.buildRequests([defaultBidRequest], commonBidderRequest);
       const expectedData = {
         'imp': [{
-          'secure': 1,
           'id': res.data.imp[0].id,
+          'secure': 1,
           'banner': {
             format: [{
               w: displayBidRequestParams.sizes[0][0],

--- a/test/spec/ortbConverter/common_spec.js
+++ b/test/spec/ortbConverter/common_spec.js
@@ -1,5 +1,5 @@
 import {DEFAULT_PROCESSORS} from '../../../libraries/ortbConverter/processors/default.js';
-import {BID_RESPONSE} from '../../../src/pbjsORTB.js';
+import {BID_RESPONSE, IMP} from '../../../src/pbjsORTB.js';
 
 describe('common processors', () => {
   describe('bid response properties', () => {
@@ -25,5 +25,22 @@ describe('common processors', () => {
         expect(resp.meta.dsa).to.eql(MOCK_DSA);
       })
     })
+  })
+  describe('bid imp fpd', () => {
+    const impFpd = DEFAULT_PROCESSORS[IMP].secure.fn;
+
+    it('should set secure as 1 if publisher did not set it', () => {
+      const imp = {secure: 1};
+      const bidRequest = {adUnitCode: 'ad-code-1', ortb2Imp: {}};
+      impFpd(imp, bidRequest);
+      expect(imp.secure).to.eql(1);
+    });
+
+    it('should not overwrite secure if set by publisher', () => {
+      const imp = {secure: 1};
+      const bidRequest = {adUnitCode: 'ad-code-1', ortb2Imp: {secure: 0}};
+      impFpd(imp, bidRequest);
+      expect(imp.secure).to.eql(0);
+    });
   })
 })

--- a/test/spec/ortbConverter/common_spec.js
+++ b/test/spec/ortbConverter/common_spec.js
@@ -30,16 +30,14 @@ describe('common processors', () => {
     const impFpd = DEFAULT_PROCESSORS[IMP].secure.fn;
 
     it('should set secure as 1 if publisher did not set it', () => {
-      const imp = {secure: 1};
-      const bidRequest = {adUnitCode: 'ad-code-1', ortb2Imp: {}};
-      impFpd(imp, bidRequest);
+      const imp = {};
+      impFpd(imp);
       expect(imp.secure).to.eql(1);
     });
 
     it('should not overwrite secure if set by publisher', () => {
-      const imp = {secure: 1};
-      const bidRequest = {adUnitCode: 'ad-code-1', ortb2Imp: {secure: 0}};
-      impFpd(imp, bidRequest);
+      const imp = {secure: 0};
+      impFpd(imp);
       expect(imp.secure).to.eql(0);
     });
   })


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
#12366 