### PR TITLE
smartxBidAdapter: add propagation of aderror event

### DIFF
--- a/modules/smartxBidAdapter.js
+++ b/modules/smartxBidAdapter.js
@@ -422,6 +422,12 @@ function createOutstreamConfig(bid) {
 
   var playerListener = function callback(event) {
     switch (event) {
+      case 'AdError':
+        try {
+          window.sc_smartIntxtError();
+        } catch (f) {}
+        break;
+
       case 'AdSlotStarted':
         try {
           window.sc_smartIntxtStart();


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter 
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
adds an error listener to propagate errors to the publisher/integrator.
If an error occurs this will call the function `sc_smartIntxtError` if it is registered to `window` before by the integrator.

## Other information
PR is done by a customer of this bidder, not by the author itself.
A review from the author(s) would be great.
