### PR TITLE
51Degrees RTD submodule: optimise ORTB2 enrichment speed

### DIFF
--- a/integrationExamples/gpt/51DegreesRtdProvider_example.html
+++ b/integrationExamples/gpt/51DegreesRtdProvider_example.html
@@ -92,7 +92,7 @@
                             name: '51Degrees',
                             waitForIt: true,
                             params: {
-                                // Get your resource key from https://configure.51degrees.com/tWrhNfY6
+                                // Get your resource key from https://configure.51degrees.com/HNZ75HT1
                                 resourceKey: '<YOUR_RESOURCE_KEY>',
                                 // alternatively, you can use the on-premise version of the 51Degrees service and connect to your chosen end point
                                 // onPremiseJSUrl: 'https://localhost/51Degrees.core.js'
@@ -181,12 +181,11 @@
         <h3>Testing/Debugging Guidance</h3>
         <ol>
             <li>Make sure you have <code>debug: true</code> under <code>pbjs.setConfig</code> in this example code (be sure to remove it for production!)
-            <li>Make sure you have replaced <code>&lt;YOUR RESOURCE KEY&gt;</code> in this example code with the one you have obtained 
-            from the <a href="https://configure.51degrees.com/tWrhNfY6" target="blank;">51Degrees Configurator Tool</a></li>
+            <li>Make sure you have replaced <code>&lt;YOUR RESOURCE KEY&gt;</code> in this example code with the one you have obtained
+            from the <a href="https://configure.51degrees.com/HNZ75HT1" target="blank;">51Degrees Configurator Tool</a></li>
             <li>Open DevTools Console in your browser and refresh the page</li>
             <li>Observe the enriched ortb device data shown below and also in the console as part of the <code>[51Degrees RTD Submodule]: reqBidsConfigObj:</code> message (under <code>reqBidsConfigObj.global.device</code>)</li>
         </ol>
-        
     </div>
     <div id="enriched-51" style="display: none">
         <h3>Enriched ORTB2 device data</h3>

--- a/modules/51DegreesRtdProvider.js
+++ b/modules/51DegreesRtdProvider.js
@@ -4,6 +4,7 @@ import {submodule} from '../src/hook.js';
 import {
   deepAccess,
   deepSetValue,
+  formatQS,
   mergeDeep,
   prefixLog,
 } from '../src/utils.js';
@@ -107,14 +108,41 @@ export const extractConfig = (moduleConfig, reqBidsConfigObj) => {
  * @param {Object} pathData API path data
  * @param {string} [pathData.resourceKey] Resource key
  * @param {string} [pathData.onPremiseJSUrl] On-premise JS URL
+ * @param {Object<string, any>} [pathData.hev] High entropy values
+ * @param {Window} [win] Window object (mainly for testing)
  * @returns {string} 51Degrees JS URL
  */
-export const get51DegreesJSURL = (pathData) => {
-  if (pathData.onPremiseJSUrl) {
-    return pathData.onPremiseJSUrl;
-  }
-  return `https://cloud.51degrees.com/api/v4/${pathData.resourceKey}.js`;
+export const get51DegreesJSURL = (pathData, win) => {
+  const _window = win || window;
+  const baseURL = pathData.onPremiseJSUrl || `https://cloud.51degrees.com/api/v4/${pathData.resourceKey}.js`;
+
+  const queryPrefix = baseURL.includes('?') ? '&' : '?';
+  const qs = {};
+
+  deepSetNotEmptyValue(
+    qs,
+    '51D_GetHighEntropyValues',
+    pathData.hev && Object.keys(pathData.hev).length ? btoa(JSON.stringify(pathData.hev)) : null,
+  );
+  deepSetNotEmptyValue(qs, '51D_ScreenPixelsHeight', _window?.screen?.height);
+  deepSetNotEmptyValue(qs, '51D_ScreenPixelsWidth', _window?.screen?.width);
+  deepSetNotEmptyValue(qs, '51D_PixelRatio', _window?.devicePixelRatio);
+
+  const _qs = formatQS(qs);
+  const _qsString = _qs ? `${queryPrefix}${_qs}` : '';
+
+  return `${baseURL}${_qsString}`;
 }
+
+/**
+ * Retrieves high entropy values from `navigator.userAgentData` if available
+ *
+ * @param {Array<string>} hints - An array of hints indicating which high entropy values to retrieve
+ * @returns {Promise<undefined | Object<string, any>>} A promise that resolves to an object containing high entropy values if supported, or `undefined` if not
+ */
+export const getHighEntropyValues = async (hints) => {
+  return navigator?.userAgentData?.getHighEntropyValues?.(hints);
+};
 
 /**
  * Check if meta[http-equiv="Delegate-CH"] tag is present in the document head and points to 51Degrees cloud
@@ -251,10 +279,6 @@ export const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, user
     logMessage('Resource key: ', resourceKey);
     logMessage('On-premise JS URL: ', onPremiseJSUrl);
 
-    // Get 51Degrees JS URL, which is either cloud or on-premise
-    const scriptURL = get51DegreesJSURL(resourceKey ? {resourceKey} : {onPremiseJSUrl});
-    logMessage('URL of the script to be injected: ', scriptURL);
-
     // Check if 51Degrees meta is present (cloud only)
     if (resourceKey) {
       logMessage('Checking if 51Degrees meta is present in the document head');
@@ -263,21 +287,27 @@ export const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, user
       }
     }
 
-    // Inject 51Degrees script, get device data and merge it into the ORTB2 object
-    loadExternalScript(scriptURL, MODULE_TYPE_RTD, MODULE_NAME, () => {
-      logMessage('Successfully injected 51Degrees script');
-      const fod = /** @type {Object} */ (window.fod);
-      // Convert and merge device data in the callback
-      fod.complete((data) => {
-        logMessage('51Degrees raw data: ', data);
-        mergeDeep(
-          reqBidsConfigObj.ortb2Fragments.global,
-          convert51DegreesDataToOrtb2(data),
-        );
-        logMessage('reqBidsConfigObj: ', reqBidsConfigObj);
-        callback();
-      });
-    }, document, {crossOrigin: 'anonymous'});
+    getHighEntropyValues(['model', 'platform', 'platformVersion', 'fullVersionList']).then((hev) => {
+      // Get 51Degrees JS URL, which is either cloud or on-premise
+      const scriptURL = get51DegreesJSURL({resourceKey, onPremiseJSUrl, hev});
+      logMessage('URL of the script to be injected: ', scriptURL);
+
+      // Inject 51Degrees script, get device data and merge it into the ORTB2 object
+      loadExternalScript(scriptURL, MODULE_TYPE_RTD, MODULE_NAME, () => {
+        logMessage('Successfully injected 51Degrees script');
+        const fod = /** @type {Object} */ (window.fod);
+        // Convert and merge device data in the callback
+        fod.complete((data) => {
+          logMessage('51Degrees raw data: ', data);
+          mergeDeep(
+            reqBidsConfigObj.ortb2Fragments.global,
+            convert51DegreesDataToOrtb2(data),
+          );
+          logMessage('reqBidsConfigObj: ', reqBidsConfigObj);
+          callback();
+        });
+      }, document, {crossOrigin: 'anonymous'});
+    });
   } catch (error) {
     // In case of an error, log it and continue
     logError(error);


### PR DESCRIPTION
## Type of change
- [x] Updated RTD submodule

## Description of change
This pull request optimises the ORTB2 enrichment speed for the 51Degrees RTD submodule by eliminating a redundant API call. The changes allow for some device details to be sent directly in the first request, instead of making a second call to the 51Degrees API HTTP endpoint.

- Refactored the `get51DegreesJSURL` function to include device details such as screen height, width, HEV, and pixel ratio directly in the JS request query string.
- Introduced a new function to retrieve high entropy values from navigator.userAgentData, if supported.
- Updated relevant tests to ensure the new functionality works as intended and to validate the inclusion of device details in the API request.