### PR TITLE
Aniview: Removed setting the AV_WIDTH/AV_HEIGHT, bidWidth/bidHeight to `imp.ext` for video.

### DIFF
--- a/modules/aniviewBidAdapter.js
+++ b/modules/aniviewBidAdapter.js
@@ -31,7 +31,6 @@ const converter = ortbConverter({
   imp(buildImp, bidRequest, context) {
     const { mediaType } = context;
     const imp = buildImp(bidRequest, context);
-    const isVideo = mediaType === VIDEO;
     const isBanner = mediaType === BANNER;
     const { width, height } = getSize(context, bidRequest);
     const floor = getFloor(bidRequest, { width, height }, mediaType);
@@ -43,14 +42,7 @@ const converter = ortbConverter({
       imp.bidfloorcur = DEFAULT_CURRENCY;
     }
 
-    if (isVideo) {
-      deepSetValue(imp, `ext.${BIDDER_CODE}`, {
-        AV_WIDTH: width,
-        AV_HEIGHT: height,
-        bidWidth: width,
-        bidHeight: height,
-      });
-    } else if (isBanner) {
+    if (isBanner) {
       // TODO: remove once serving will be fixed
       deepSetValue(imp, 'banner', { w: width, h: height });
     }

--- a/test/spec/modules/aniviewBidAdapter_spec.js
+++ b/test/spec/modules/aniviewBidAdapter_spec.js
@@ -188,7 +188,6 @@ describe('Aniview Bid Adapter', function () {
       expect(url).equal('https://rtb.aniview.com/sspRTB2');
       expect(method).equal('POST');
       expect(imp[0].tagid).equal(CHANNEL_ID_1);
-      expect(imp[0].ext.aniview.AV_HEIGHT).equal(VIDEO_SIZE.height);
       expect(imp[0].id).equal(videoBidRequest.bids[0].bidId);
       expect(ext.aniview.pbjs).equal(1);
     });


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter

## Description of change
Removed unnecessary `ext` for video imp. This change also fixes ability to use `ortb2imp`.