### PR TITLE
Adkernel Bid Adapter: add revbid alias

### DIFF
--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -99,7 +99,8 @@ export const spec = {
     {code: 'hyperbrainz'},
     {code: 'voisetech'},
     {code: 'global_sun'},
-    {code: 'rxnetwork'}
+    {code: 'rxnetwork'},
+    {code: 'revbid'}
   ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 


## Description of change
Added alias for revbid.net partner network

## Other information

https://github.com/prebid/prebid.github.io/pull/5704