### PR TITLE
WURFL RTD Module: enrich the ortb2.device object with WURFL data

### DIFF
--- a/modules/wurflRtdProvider.js
+++ b/modules/wurflRtdProvider.js
@@ -101,13 +101,12 @@ function enrichBidderRequests(reqBidsConfigObj, bidders, wjsResponse) {
       // inject WURFL data
       enrichedBidders.add(bidderCode);
       const data = bidderData(wjsResponse.WURFL, caps, authBidders[bidderCode]);
-      logger.logMessage(`injecting data for ${bidderCode}: `, data);
+      data['enrich_device'] = true;
       enrichBidderRequest(reqBidsConfigObj, bidderCode, data);
       return;
     }
     // inject WURFL low entropy data
     const data = lowEntropyData(wjsResponse.WURFL, wjsResponse.wurfl_pbjs?.low_entropy_caps);
-    logger.logMessage(`injecting low entropy data for ${bidderCode}: `, data);
     enrichBidderRequest(reqBidsConfigObj, bidderCode, data);
   });
 }
@@ -147,9 +146,14 @@ export const lowEntropyData = (wurflData, lowEntropyCaps) => {
     }
     data[cap] = value;
   });
+  if ('model_name' in wurflData) {
+    data['model_name'] = wurflData.model_name.replace(/(iP(hone|ad|od)).*/, 'iP$2');
+  }
+  if ('brand_name' in wurflData) {
+    data['brand_name'] = wurflData.brand_name;
+  }
   return data;
 }
-
 /**
  * enrichBidderRequest enriches the bidder request with WURFL data
  * @param {Object} reqBidsConfigObj Bid request configuration object
@@ -159,12 +163,80 @@ export const lowEntropyData = (wurflData, lowEntropyCaps) => {
 export const enrichBidderRequest = (reqBidsConfigObj, bidderCode, wurflData) => {
   const ortb2data = {
     'device': {
-      'ext': {
-        'wurfl': wurflData,
-      }
+      'ext': {},
     },
   };
+
+  const device = reqBidsConfigObj.ortb2Fragments.global.device;
+  enrichOrtb2DeviceData('make', wurflData.brand_name, device, ortb2data);
+  enrichOrtb2DeviceData('model', wurflData.model_name, device, ortb2data);
+  if (wurflData.enrich_device) {
+    delete wurflData.enrich_device;
+    enrichOrtb2DeviceData('devicetype', makeOrtb2DeviceType(wurflData), device, ortb2data);
+    enrichOrtb2DeviceData('os', wurflData.advertised_device_os, device, ortb2data);
+    enrichOrtb2DeviceData('osv', wurflData.advertised_device_os_version, device, ortb2data);
+    enrichOrtb2DeviceData('hwv', wurflData.model_name, device, ortb2data);
+    enrichOrtb2DeviceData('h', wurflData.resolution_height, device, ortb2data);
+    enrichOrtb2DeviceData('w', wurflData.resolution_width, device, ortb2data);
+    enrichOrtb2DeviceData('ppi', wurflData.pixel_density, device, ortb2data);
+    enrichOrtb2DeviceData('pxratio', wurflData.density_class, device, ortb2data);
+    enrichOrtb2DeviceData('js', wurflData.ajax_support_javascript, device, ortb2data);
+  }
+  ortb2data.device.ext['wurfl'] = wurflData
   mergeDeep(reqBidsConfigObj.ortb2Fragments.bidder, { [bidderCode]: ortb2data });
+}
+
+/**
+ * makeOrtb2DeviceType returns the ortb2 device type based on WURFL data
+ * @param {Object} wurflData WURFL data
+ * @returns {Number} ortb2 device type
+ * @see https://www.scientiamobile.com/how-to-populate-iab-openrtb-device-object/
+ */
+export function makeOrtb2DeviceType(wurflData) {
+  if (wurflData.is_mobile) {
+    if (!('is_phone' in wurflData) || !('is_tablet' in wurflData)) {
+      return undefined;
+    }
+    if (wurflData.is_phone || wurflData.is_tablet) {
+      return 1;
+    }
+    return 6;
+  }
+  if (wurflData.is_full_desktop) {
+    return 2;
+  }
+  if (wurflData.is_connected_tv) {
+    return 3;
+  }
+  if (wurflData.is_phone) {
+    return 4;
+  }
+  if (wurflData.is_tablet) {
+    return 5;
+  }
+  if (wurflData.is_ott) {
+    return 7;
+  }
+  return undefined;
+}
+
+/**
+ * enrichOrtb2DeviceData enriches the ortb2data device data with WURFL data.
+ * Note: it does not overrides properties set by Prebid.js
+ * @param {String} key the device property key
+ * @param {any} value the value of the device property
+ * @param {Object} device the ortb2 device object from Prebid.js
+ * @param {Object} ortb2data the ortb2 device data enrchiced with WURFL data
+ */
+function enrichOrtb2DeviceData(key, value, device, ortb2data) {
+  if (device?.[key] !== undefined) {
+    // value already defined by Prebid.js, do not overrides
+    return;
+  }
+  if (value === undefined) {
+    return;
+  }
+  ortb2data.device[key] = value;
 }
 
 /**

--- a/test/spec/modules/wurflRtdProvider_spec.js
+++ b/test/spec/modules/wurflRtdProvider_spec.js
@@ -3,6 +3,7 @@ import {
   enrichBidderRequest,
   lowEntropyData,
   wurflSubmodule,
+  makeOrtb2DeviceType,
 } from 'modules/wurflRtdProvider';
 import * as ajaxModule from 'src/ajax';
 import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
@@ -10,50 +11,49 @@ import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
 describe('wurflRtdProvider', function () {
   describe('wurflSubmodule', function () {
     const altHost = 'http://example.local/wurfl.js';
+
     const wurfl_pbjs = {
-      low_entropy_caps: ['complete_device_name', 'form_factor', 'is_mobile'],
-      caps: [
-        'advertised_browser',
-        'advertised_browser_version',
-        'advertised_device_os',
-        'advertised_device_os_version',
-        'brand_name',
-        'complete_device_name',
-        'form_factor',
-        'is_app_webview',
-        'is_full_desktop',
-        'is_mobile',
-        'is_robot',
-        'is_smartphone',
-        'is_smarttv',
-        'is_tablet',
-        'manufacturer_name',
-        'marketing_name'
-      ],
+      low_entropy_caps: ['is_mobile', 'complete_device_name', 'form_factor'],
+      caps: ['advertised_browser', 'advertised_browser_version', 'advertised_device_os', 'advertised_device_os_version', 'ajax_support_javascript', 'brand_name', 'complete_device_name', 'density_class', 'form_factor', 'is_android', 'is_app_webview', 'is_connected_tv', 'is_full_desktop', 'is_ios', 'is_mobile', 'is_ott', 'is_phone', 'is_robot', 'is_smartphone', 'is_smarttv', 'is_tablet', 'manufacturer_name', 'marketing_name', 'max_image_height', 'max_image_width', 'model_name', 'physical_screen_height', 'physical_screen_width', 'pixel_density', 'pointing_method', 'resolution_height', 'resolution_width'],
       authorized_bidders: {
-        'bidder1': [0, 1, 2, 3, 4, 5, 6, 7, 10, 13, 15],
-        'bidder2': [5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+        bidder1: [0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31],
+        bidder2: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 21, 25, 28, 30, 31]
       }
     }
-
     const WURFL = {
-      advertised_browser: 'Chrome',
-      advertised_browser_version: '125.0.6422.76',
-      advertised_device_os: 'Linux',
-      advertised_device_os_version: '6.5.0',
+      advertised_browser: 'Chrome Mobile',
+      advertised_browser_version: '130.0.0.0',
+      advertised_device_os: 'Android',
+      advertised_device_os_version: '6.0',
+      ajax_support_javascript: !0,
       brand_name: 'Google',
-      complete_device_name: 'Google Chrome',
-      form_factor: 'Desktop',
+      complete_device_name: 'Google Nexus 5',
+      density_class: '3.0',
+      form_factor: 'Feature Phone',
+      is_android: !0,
       is_app_webview: !1,
-      is_full_desktop: !0,
-      is_mobile: !1,
+      is_connected_tv: !1,
+      is_full_desktop: !1,
+      is_ios: !1,
+      is_mobile: !0,
+      is_ott: !1,
+      is_phone: !0,
       is_robot: !1,
       is_smartphone: !1,
       is_smarttv: !1,
       is_tablet: !1,
-      manufacturer_name: '',
+      manufacturer_name: 'LG',
       marketing_name: '',
-    }
+      max_image_height: 640,
+      max_image_width: 360,
+      model_name: 'Nexus 5',
+      physical_screen_height: 110,
+      physical_screen_width: 62,
+      pixel_density: 443,
+      pointing_method: 'touchscreen',
+      resolution_height: 1920,
+      resolution_width: 1080
+    };
 
     // expected analytics values
     const expectedStatsURL = 'https://prebid.wurflcloud.com/v1/prebid/stats';
@@ -61,11 +61,11 @@ describe('wurflRtdProvider', function () {
 
     let sandbox;
 
-    beforeEach(function() {
+    beforeEach(function () {
       sandbox = sinon.createSandbox();
       window.WURFLPromises = {
-        init: new Promise(function(resolve, reject) { resolve({ WURFL, wurfl_pbjs }) }),
-        complete: new Promise(function(resolve, reject) { resolve({ WURFL, wurfl_pbjs }) }),
+        init: new Promise(function (resolve, reject) { resolve({ WURFL, wurfl_pbjs }) }),
+        complete: new Promise(function (resolve, reject) { resolve({ WURFL, wurfl_pbjs }) }),
       };
     });
 
@@ -85,6 +85,9 @@ describe('wurflRtdProvider', function () {
         ]
       }],
       ortb2Fragments: {
+        global: {
+          device: {},
+        },
         bidder: {},
       }
     };
@@ -99,56 +102,113 @@ describe('wurflRtdProvider', function () {
       expectedURL.searchParams.set('mode', 'prebid');
 
       const callback = () => {
-        expect(reqBidsConfigObj.ortb2Fragments.bidder).to.deep.equal({
+        const v = {
           bidder1: {
             device: {
+              make: 'Google',
+              model: 'Nexus 5',
+              devicetype: 1,
+              os: 'Android',
+              osv: '6.0',
+              hwv: 'Nexus 5',
+              h: 1920,
+              w: 1080,
+              ppi: 443,
+              pxratio: '3.0',
+              js: true,
               ext: {
                 wurfl: {
-                  advertised_browser: 'Chrome',
-                  advertised_browser_version: '125.0.6422.76',
-                  advertised_device_os: 'Linux',
-                  advertised_device_os_version: '6.5.0',
+                  advertised_browser: 'Chrome Mobile',
+                  advertised_browser_version: '130.0.0.0',
+                  advertised_device_os: 'Android',
+                  advertised_device_os_version: '6.0',
+                  ajax_support_javascript: !0,
                   brand_name: 'Google',
-                  complete_device_name: 'Google Chrome',
-                  form_factor: 'Desktop',
+                  complete_device_name: 'Google Nexus 5',
+                  density_class: '3.0',
+                  form_factor: 'Feature Phone',
                   is_app_webview: !1,
+                  is_connected_tv: !1,
+                  is_full_desktop: !1,
+                  is_mobile: !0,
+                  is_ott: !1,
+                  is_phone: !0,
                   is_robot: !1,
+                  is_smartphone: !1,
+                  is_smarttv: !1,
                   is_tablet: !1,
+                  manufacturer_name: 'LG',
                   marketing_name: '',
+                  max_image_height: 640,
+                  max_image_width: 360,
+                  model_name: 'Nexus 5',
+                  physical_screen_height: 110,
+                  physical_screen_width: 62,
+                  pixel_density: 443,
+                  pointing_method: 'touchscreen',
+                  resolution_height: 1920,
+                  resolution_width: 1080
                 },
               },
             },
           },
           bidder2: {
             device: {
+              make: 'Google',
+              model: 'Nexus 5',
+              devicetype: 1,
+              os: 'Android',
+              osv: '6.0',
+              hwv: 'Nexus 5',
+              h: 1920,
+              w: 1080,
+              ppi: 443,
+              pxratio: '3.0',
+              js: true,
               ext: {
                 wurfl: {
-                  complete_device_name: 'Google Chrome',
-                  form_factor: 'Desktop',
+                  advertised_device_os: 'Android',
+                  advertised_device_os_version: '6.0',
+                  ajax_support_javascript: !0,
+                  brand_name: 'Google',
+                  complete_device_name: 'Google Nexus 5',
+                  density_class: '3.0',
+                  form_factor: 'Feature Phone',
+                  is_android: !0,
                   is_app_webview: !1,
-                  is_full_desktop: !0,
-                  is_mobile: !1,
-                  is_robot: !1,
-                  is_smartphone: !1,
-                  is_smarttv: !1,
+                  is_connected_tv: !1,
+                  is_full_desktop: !1,
+                  is_ios: !1,
+                  is_mobile: !0,
+                  is_ott: !1,
+                  is_phone: !0,
                   is_tablet: !1,
-                  manufacturer_name: '',
+                  manufacturer_name: 'LG',
+                  model_name: 'Nexus 5',
+                  pixel_density: 443,
+                  resolution_height: 1920,
+                  resolution_width: 1080
                 },
               },
             },
           },
           bidder3: {
             device: {
+              make: 'Google',
+              model: 'Nexus 5',
               ext: {
                 wurfl: {
-                  complete_device_name: 'Google Chrome',
-                  form_factor: 'Desktop',
-                  is_mobile: !1,
+                  complete_device_name: 'Google Nexus 5',
+                  form_factor: 'Feature Phone',
+                  is_mobile: !0,
+                  model_name: 'Nexus 5',
+                  brand_name: 'Google',
                 },
               },
             },
           },
-        });
+        };
+        expect(reqBidsConfigObj.ortb2Fragments.bidder).to.deep.equal(v);
         done();
       };
 
@@ -245,12 +305,16 @@ describe('wurflRtdProvider', function () {
         complete_device_name: 'Apple iPhone X',
         form_factor: 'Smartphone',
         is_mobile: !0,
+        brand_name: 'Apple',
+        model_name: 'iPhone X',
       };
       const lowEntropyCaps = ['complete_device_name', 'form_factor', 'is_mobile'];
       const expectedData = {
         complete_device_name: 'Apple iPhone',
         form_factor: 'Smartphone',
         is_mobile: !0,
+        brand_name: 'Apple',
+        model_name: 'iPhone',
       };
       const result = lowEntropyData(wjsData, lowEntropyCaps);
       expect(result).to.deep.equal(expectedData);
@@ -289,6 +353,9 @@ describe('wurflRtdProvider', function () {
     it('should enrich the bidder request with WURFL data', () => {
       const reqBidsConfigObj = {
         ortb2Fragments: {
+          global: {
+            device: {},
+          },
           bidder: {
             exampleBidder: {
               device: {
@@ -319,6 +386,68 @@ describe('wurflRtdProvider', function () {
           }
         }
       });
+    });
+  });
+
+  describe('makeOrtb2DeviceType', function () {
+    it('should return 1 when wurflData is_mobile and is_phone is true', function () {
+      const wurflData = { is_mobile: true, is_phone: true, is_tablet: false };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.equal(1);
+    });
+
+    it('should return 1 when wurflData is_mobile and is_tablet is true', function () {
+      const wurflData = { is_mobile: true, is_phone: false, is_tablet: true };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.equal(1);
+    });
+
+    it('should return 6 when wurflData is_mobile but is_phone and is_tablet are false', function () {
+      const wurflData = { is_mobile: true, is_phone: false, is_tablet: false };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.equal(6);
+    });
+
+    it('should return 2 when wurflData is_full_desktop is true', function () {
+      const wurflData = { is_full_desktop: true };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.equal(2);
+    });
+
+    it('should return 3 when wurflData is_connected_tv is true', function () {
+      const wurflData = { is_connected_tv: true };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.equal(3);
+    });
+
+    it('should return 4 when wurflData is_phone is true and is_mobile is false or undefined', function () {
+      const wurflData = { is_phone: true };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.equal(4);
+    });
+
+    it('should return 5 when wurflData is_tablet is true and is_mobile is false or undefined', function () {
+      const wurflData = { is_tablet: true };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.equal(5);
+    });
+
+    it('should return 7 when wurflData is_ott is true', function () {
+      const wurflData = { is_ott: true };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.equal(7);
+    });
+
+    it('should return undefined when wurflData is_mobile is true but is_phone and is_tablet are missing', function () {
+      const wurflData = { is_mobile: true };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.be.undefined;
+    });
+
+    it('should return undefined when no conditions are met', function () {
+      const wurflData = {};
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.be.undefined;
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->

This PR updates the WURFL RTD Module to enrich the ortb2.device object with WURFL data.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
