### PR TITLE
gppControl: accept flat section data

### DIFF
--- a/libraries/mspa/activityControls.js
+++ b/libraries/mspa/activityControls.js
@@ -105,7 +105,7 @@ export function mspaRule(sids, getConsent, denies, applicableSids = () => gppDat
 }
 
 function flatSection(subsections) {
-  if (subsections == null) return subsections;
+  if (!Array.isArray(subsections)) return subsections;
   return subsections.reduceRight((subsection, consent) => {
     return Object.assign(consent, subsection);
   }, {});

--- a/test/spec/libraries/mspa/activityControls_spec.js
+++ b/test/spec/libraries/mspa/activityControls_spec.js
@@ -229,6 +229,13 @@ describe('setupRules', () => {
     sinon.assert.calledWith(rules.mockActivity, {mock: 'consent'})
   });
 
+  it('should accept already flattened section data', () => {
+    consent.parsedSections.mockApi = {flat: 'consent'};
+    runSetup('mockApi', [1]);
+    isAllowed('mockActivity', {});
+    sinon.assert.calledWith(rules.mockActivity, {flat: 'consent'})
+  })
+
   it('should not choke when no consent data is available', () => {
     consent = null;
     runSetup('mockApi', [1]);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

Some CMPs do not split parsed section data into subsections; this updates the MSPA controls to accommodate them.

## Other information

Closes https://github.com/prebid/Prebid.js/issues/12441
