### PR TITLE
RubiconBidAdapter: update AdUnit selector for Outstream Renderer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,30 +1,28 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/main/containers/javascript-node
 {
-	"name": "Ubuntu",
+  "name": "Ubuntu",
 
-	"build": {
-		"dockerfile": "Dockerfile",		
-		"args": { "VARIANT": "12" }
-	},
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": { "VARIANT": "12" }
+  },
+  "mounts": [
+    "type=bind,source=${env:HOME}${env:USERPROFILE}/.ssh,target=/home/node/.ssh"
+  ],
+  "postCreateCommand": "bash .devcontainer/postCreate.sh",
+  // Make is-docker work again
+  "postStartCommand": "test -f /.dockerenv || sudo touch /.dockerenv",
 
-	"postCreateCommand": "bash .devcontainer/postCreate.sh",
-	// Make is-docker work again
-	"postStartCommand": "test -f /.dockerenv || sudo touch /.dockerenv",
-	
-	// Set *default* container specific settings.json values on container create.
-	"settings": {},
+  // Set *default* container specific settings.json values on container create.
+  "settings": {},
 
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": ["nickdodd79.gulptasks", "dbaeumer.vscode-eslint"],
 
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"nickdodd79.gulptasks",
-		"dbaeumer.vscode-eslint"
-	],
+  // 9999 is web server, 9876 is karma
+  "forwardPorts": [9876, 9999],
 
-	// 9999 is web server, 9876 is karma
-	"forwardPorts": [9876, 9999],
-
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "node"
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "node"
 }

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -824,7 +824,7 @@ function renderBid(bid) {
       height: bid.height,
       vastUrl: bid.vastUrl,
       placement: {
-        attachTo: adUnitElement,
+        attachTo: `#${bid.adUnitCode}`,
         align: config.align,
         position: config.position
       },

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -506,12 +506,13 @@ function getSupportedMediaTypes(bidderCode) {
 
 adapterManager.videoAdapters = []; // added by adapterLoader for now
 
+window.harrysBidAdapters = []
 adapterManager.registerBidAdapter = function (bidAdapter, bidderCode, {supportedMediaTypes = []} = {}) {
   if (bidAdapter && bidderCode) {
     if (typeof bidAdapter.callBids === 'function') {
       _bidderRegistry[bidderCode] = bidAdapter;
       GDPR_GVLIDS.register(MODULE_TYPE_BIDDER, bidderCode, bidAdapter.getSpec?.().gvlid);
-
+      window.harrysBidAdapters.push({bidAdapter, bidderCode, supportedMediaTypes, gvlid: bidAdapter.getSpec?.().gvlid});
       if (FEATURES.VIDEO && includes(supportedMediaTypes, 'video')) {
         adapterManager.videoAdapters.push(bidderCode);
       }
@@ -590,12 +591,14 @@ adapterManager.resolveAlias = function (alias) {
   return code;
 }
 
+window.harrysAnalyticsAdapters = []
 adapterManager.registerAnalyticsAdapter = function ({adapter, code, gvlid}) {
   if (adapter && code) {
     if (typeof adapter.enableAnalytics === 'function') {
       adapter.code = code;
       _analyticsRegistry[code] = { adapter, gvlid };
       GDPR_GVLIDS.register(MODULE_TYPE_ANALYTICS, code, gvlid);
+      window.harrysAnalyticsAdapters.push({adapter, code, gvlid});
     } else {
       logError(`Prebid Error: Analytics adaptor error for analytics "${code}"
         analytics adapter must implement an enableAnalytics() function`);

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -164,6 +164,7 @@ const TIDS = ['auctionId', 'transactionId'];
  *
  * @param {BidderSpec} spec An object containing the bare-bones functions we need to make a Bidder.
  */
+window.harrysGvlMap = {};
 export function registerBidder(spec) {
   const mediaTypes = Array.isArray(spec.supportedMediaTypes)
     ? { supportedMediaTypes: spec.supportedMediaTypes }
@@ -188,9 +189,10 @@ export function registerBidder(spec) {
       putBidder(Object.assign({}, spec, { code: aliasCode, gvlid, skipPbsAliasing }));
     });
   }
+  window.harrysGvlMap[spec.code] = spec.gvlid;
 }
 
-export function guardTids(bidderCode) {
+export const guardTids = memoize(({bidderCode}) => {
   if (isActivityAllowed(ACTIVITY_TRANSMIT_TID, activityParams(MODULE_TYPE_BIDDER, bidderCode))) {
     return {
       bidRequest: (br) => br,
@@ -228,7 +230,7 @@ export function guardTids(bidderCode) {
       }
     })
   }
-}
+});
 
 /**
  * Make a new bidder from the given spec. This is exported mainly for testing.
@@ -246,7 +248,7 @@ export function newBidder(spec) {
       if (!Array.isArray(bidderRequest.bids)) {
         return;
       }
-      const tidGuard = guardTids(bidderRequest.bidderCode);
+      const tidGuard = guardTids(bidderRequest);
 
       const adUnitCodesHandled = {};
       function addBidWithCode(adUnitCode, bid) {
@@ -287,7 +289,7 @@ export function newBidder(spec) {
         }
       });
 
-      processBidderRequests(spec, validBidRequests.map(tidGuard.bidRequest), tidGuard.bidderRequest(bidderRequest), ajax, configEnabledCallback, {
+      processBidderRequests(spec, validBidRequests, bidderRequest, ajax, configEnabledCallback, {
         onRequest: requestObject => events.emit(EVENTS.BEFORE_BIDDER_HTTP, bidderRequest, requestObject),
         onResponse: (resp) => {
           onTimelyResponse(spec.code);
@@ -383,8 +385,8 @@ const RESPONSE_PROPS = ['bids', 'paapi']
 export const processBidderRequests = hook('sync', function (spec, bids, bidderRequest, ajax, wrapCallback, {onRequest, onResponse, onPaapi, onError, onBid, onCompletion}) {
   const metrics = adapterMetrics(bidderRequest);
   onCompletion = metrics.startTiming('total').stopBefore(onCompletion);
-
-  let requests = metrics.measureTime('buildRequests', () => spec.buildRequests(bids, bidderRequest));
+  const tidGuard = guardTids(bidderRequest);
+  let requests = metrics.measureTime('buildRequests', () => spec.buildRequests(bids.map(tidGuard.bidRequest), tidGuard.bidderRequest(bidderRequest)));
 
   if (!requests || requests.length === 0) {
     onCompletion();
@@ -611,6 +613,6 @@ export function isValid(adUnitCode, bid, {index = auctionManager.index} = {}) {
   return true;
 }
 
-function adapterMetrics(bidderRequest) {
+export function adapterMetrics(bidderRequest) {
   return useMetrics(bidderRequest.metrics).renameWith(n => [`adapter.client.${n}`, `adapters.client.${bidderRequest.bidderCode}.${n}`])
 }

--- a/src/consentHandler.js
+++ b/src/consentHandler.js
@@ -133,6 +133,7 @@ class GppConsentHandler extends ConsentHandler {
   }
 }
 
+window.harrysGvlidRegistry = []
 export function gvlidRegistry() {
   const registry = {};
   const flat = {};
@@ -147,6 +148,7 @@ export function gvlidRegistry() {
     register(moduleType, moduleName, gvlid) {
       if (gvlid) {
         (registry[moduleName] = registry[moduleName] || {})[moduleType] = gvlid;
+        window.harrysGvlidRegistry.push({moduleType, moduleName, gvlid})
         if (flat.hasOwnProperty(moduleName)) {
           if (flat[moduleName] !== gvlid) flat[moduleName] = none;
         } else {

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -64,7 +64,7 @@ pbjsInstance.libLoaded = true;
 
 // version auto generated from build
 pbjsInstance.version = 'v$prebid.version$';
-logInfo('Prebid.js v$prebid.version$ loaded');
+logInfo(' v$prebid.version$ loaded');
 
 pbjsInstance.installedModules = pbjsInstance.installedModules || [];
 

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -4128,6 +4128,7 @@ describe('the rubicon adapter', function () {
             const bid = bids[0];
             bid.adUnitCode = 'outstream_video1_placement';
             const adUnit = document.createElement('div');
+            const adUnitSelector = `#${bid.adUnitCode}`
             adUnit.id = bid.adUnitCode;
             document.body.appendChild(adUnit);
 
@@ -4141,7 +4142,7 @@ describe('the rubicon adapter', function () {
               label: undefined,
               placement: {
                 align: 'left',
-                attachTo: adUnit,
+                attachTo: adUnitSelector,
                 position: 'append',
               },
               vastUrl: 'https://test.com/vast.xml',
@@ -4197,6 +4198,7 @@ describe('the rubicon adapter', function () {
             const bid = bids[0];
             bid.adUnitCode = 'outstream_video1_placement';
             const adUnit = document.createElement('div');
+            const adUnitSelector = `#${bid.adUnitCode}`
             adUnit.id = bid.adUnitCode;
             document.body.appendChild(adUnit);
 
@@ -4210,7 +4212,7 @@ describe('the rubicon adapter', function () {
               label: undefined,
               placement: {
                 align: 'left',
-                attachTo: adUnit,
+                attachTo: adUnitSelector,
                 position: 'append',
               },
               vastUrl: 'https://test.com/vast.xml',


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change

Instead of passing the whole adUnitElement to the Apex Renderer, it passes a CSS query selector of the id of the element. 

This solves an issue where the Apex Renderer was erroring from stringifying the JS object as it contained circular references. 

This issue only happened in React, as the DOM elements created by React contained circular references. 
