### PR TITLE
RubiconBidAdapter: update AdUnit selector for Outstream Renderer

### DIFF
--- a/integrationExamples/gpt/rewardedInterestIdSystem_example.html
+++ b/integrationExamples/gpt/rewardedInterestIdSystem_example.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>Rewarded Interest ID Example</title>
+    <script>
+        const FAILSAFE_TIMEOUT = 2000;
+        const adUnits = [
+            {
+                code: 'test-div',
+                mediaTypes: {
+                    banner: {
+                        sizes: [[300, 250], [300, 600], [728, 90]]
+                    },
+                },
+                bids: [
+                    {
+                        bidder: 'rubicon',
+                        params: {
+                            accountId: '1001',
+                            siteId: '113932',
+                            zoneId: '535510'
+                        }
+                    }
+                ]
+            }
+        ];
+        var pbjs = pbjs || {};
+        pbjs.que = pbjs.que || [];
+    </script>
+    <script src="../../build/dev/prebid.js" async></script>
+
+    <script>
+        var googletag = googletag || {};
+        googletag.cmd = googletag.cmd || [];
+        googletag.cmd.push(function () {
+            googletag.pubads().disableInitialLoad();
+        });
+
+        pbjs.que.push(function () {
+            pbjs.setConfig({
+                debug: true,
+                userSync: {
+                    userIds: [
+                        {
+                            name: 'rewardedInterestId',
+                        },
+                    ],
+                    syncDelay: 5000,
+                    auctionDelay: 1000,
+                }
+            });
+            pbjs.addAdUnits(adUnits);
+            pbjs.requestBids({
+                bidsBackHandler: sendAdserverRequest
+            });
+        });
+
+        function sendAdserverRequest() {
+            if (pbjs.adserverRequestSent) return;
+            pbjs.adserverRequestSent = true;
+            googletag.cmd.push(function () {
+                pbjs.que.push(function () {
+                    pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+                });
+            });
+        }
+
+        setTimeout(function () {
+            sendAdserverRequest();
+        }, FAILSAFE_TIMEOUT);
+    </script>
+
+    <script>
+        (function () {
+            var gads = document.createElement('script');
+            gads.async = true;
+            gads.type = 'text/javascript';
+            gads.src = 'https://securepubads.g.doubleclick.net/tag/js/gpt.js';
+            var node = document.getElementsByTagName('script')[0];
+            node.parentNode.insertBefore(gads, node);
+        })();
+    </script>
+
+    <script>
+        googletag.cmd.push(function () {
+            googletag.defineSlot('/112115922/FL_PB_MedRect', [[300, 250], [300, 600], [728, 90]], 'test-div').addService(googletag.pubads());
+            googletag.pubads().enableSingleRequest();
+            googletag.enableServices();
+        });
+    </script>
+</head>
+
+<body>
+<script>
+    pbjs.que.push(function () {
+        pbjs.getUserIdsAsync().then(ids => {
+            document.getElementById('ids-div').innerHTML = JSON.stringify(ids, null, ' ');
+            document.getElementById('eids-div').innerHTML = JSON.stringify(pbjs.getUserIdsAsEids(), null, ' ');
+        });
+    });
+</script>
+
+<h2>Rewarded Interest ID Example</h2>
+
+<h4>Generated IDs:</h4>
+<pre id="ids-div" style="border:1px solid #333; padding:5px; overflow: auto"></pre>
+
+<h4>Generated EIDs</h4>
+<pre id="eids-div" style="border:1px solid #333; padding:5px; overflow: auto"></pre>
+</body>
+
+</html>

--- a/libraries/braveUtils/buildAndInterpret.js
+++ b/libraries/braveUtils/buildAndInterpret.js
@@ -1,0 +1,78 @@
+import { isEmpty, parseUrl } from '../../src/utils.js';
+import {config} from '../../src/config.js';
+import { createNativeRequest, createBannerRequest, createVideoRequest } from './index.js';
+import { convertOrtbRequestToProprietaryNative } from '../../src/native.js';
+
+export const buildRequests = (validBidRequests, bidderRequest, endpointURL, defaultCur) => {
+  validBidRequests = convertOrtbRequestToProprietaryNative(validBidRequests);
+  if (!validBidRequests.length || !bidderRequest) return [];
+
+  const endpoint = endpointURL.replace('hash', validBidRequests[0].params.placementId);
+  const imp = validBidRequests.map((br) => {
+    const impObject = { id: br.bidId, secure: 1 };
+    if (br.mediaTypes.banner) impObject.banner = createBannerRequest(br);
+    else if (br.mediaTypes.video) impObject.video = createVideoRequest(br);
+    else if (br.mediaTypes.native) impObject.native = { id: br.transactionId, ver: '1.2', request: createNativeRequest(br) };
+    return impObject;
+  });
+
+  const page = bidderRequest.refererInfo.page || bidderRequest.refererInfo.topmostLocation;
+  const data = {
+    id: bidderRequest.bidderRequestId,
+    cur: [defaultCur],
+    device: { w: screen.width, h: screen.height, language: navigator.language?.split('-')[0], ua: navigator.userAgent },
+    site: { domain: parseUrl(page).hostname, page: page },
+    tmax: bidderRequest.timeout,
+    imp,
+  };
+
+  if (bidderRequest.refererInfo.ref) data.site.ref = bidderRequest.refererInfo.ref;
+  if (bidderRequest.gdprConsent) {
+    data.regs = { ext: { gdpr: bidderRequest.gdprConsent.gdprApplies ? 1 : 0 } };
+    data.user = { ext: { consent: bidderRequest.gdprConsent.consentString || '' } };
+  }
+  if (bidderRequest.uspConsent) data.regs.ext.us_privacy = bidderRequest.uspConsent;
+  if (config.getConfig('coppa')) data.regs.coppa = 1;
+  if (validBidRequests[0].schain) data.source = { ext: { schain: validBidRequests[0].schain } };
+
+  return { method: 'POST', url: endpoint, data };
+};
+
+export const interpretResponse = (serverResponse, defaultCur, parseNative) => {
+  if (!serverResponse || isEmpty(serverResponse.body)) return [];
+
+  let bids = [];
+  serverResponse.body.seatbid.forEach(response => {
+    response.bid.forEach(bid => {
+      const mediaType = bid.ext?.mediaType || 'banner';
+
+      const bidObj = {
+        requestId: bid.impid,
+        cpm: bid.price,
+        width: bid.w,
+        height: bid.h,
+        ttl: 1200,
+        currency: defaultCur,
+        netRevenue: true,
+        creativeId: bid.crid,
+        dealId: bid.dealid || null,
+        mediaType,
+      };
+
+      switch (mediaType) {
+        case 'video':
+          bidObj.vastUrl = bid.adm;
+          break;
+        case 'native':
+          bidObj.native = parseNative(bid.adm);
+          break;
+        default:
+          bidObj.ad = bid.adm;
+      }
+
+      bids.push(bidObj);
+    });
+  });
+
+  return bids;
+};

--- a/libraries/braveUtils/index.js
+++ b/libraries/braveUtils/index.js
@@ -1,0 +1,95 @@
+import { NATIVE_ASSETS, NATIVE_ASSETS_IDS } from './nativeAssets.js';
+
+/**
+ * Builds a native request object based on the bid request
+ * @param {object} br - The bid request
+ * @returns {object} The native request object
+ */
+export function createNativeRequest(br) {
+  let impObject = {
+    ver: '1.2',
+    assets: []
+  };
+
+  Object.keys(br.mediaTypes.native).forEach((key) => {
+    const props = NATIVE_ASSETS[key];
+    if (props) {
+      const asset = {
+        required: br.mediaTypes.native[key].required ? 1 : 0,
+        id: props.id,
+        [props.name]: {}
+      };
+
+      if (props.type) asset[props.name]['type'] = props.type;
+      if (br.mediaTypes.native[key].len) asset[props.name]['len'] = br.mediaTypes.native[key].len;
+      if (br.mediaTypes.native[key].sizes && br.mediaTypes.native[key].sizes[0]) {
+        asset[props.name]['w'] = br.mediaTypes.native[key].sizes[0];
+        asset[props.name]['h'] = br.mediaTypes.native[key].sizes[1];
+      }
+
+      impObject.assets.push(asset);
+    }
+  });
+
+  return impObject;
+}
+
+/**
+ * Builds a banner request object based on the bid request
+ * @param {object} br - The bid request
+ * @returns {object} The banner request object
+ */
+export function createBannerRequest(br) {
+  let size = br.mediaTypes.banner.sizes?.[0] || [300, 250];
+  return { id: br.transactionId, w: size[0], h: size[1] };
+}
+
+/**
+ * Builds a video request object based on the bid request
+ * @param {object} br - The bid request
+ * @returns {object} The video request object
+ */
+export function createVideoRequest(br) {
+  let videoObj = { id: br.transactionId };
+  const supportedParams = ['mimes', 'minduration', 'maxduration', 'protocols', 'startdelay', 'skip', 'minbitrate', 'maxbitrate', 'api', 'linearity'];
+
+  supportedParams.forEach((param) => {
+    if (br.mediaTypes.video[param] !== undefined) {
+      videoObj[param] = br.mediaTypes.video[param];
+    }
+  });
+
+  const playerSize = br.mediaTypes.video.playerSize;
+  if (playerSize) {
+    videoObj.w = Array.isArray(playerSize[0]) ? playerSize[0][0] : playerSize[0];
+    videoObj.h = Array.isArray(playerSize[0]) ? playerSize[0][1] : playerSize[1];
+  } else {
+    videoObj.w = 640;
+    videoObj.h = 480;
+  }
+
+  return videoObj;
+}
+
+/**
+ * Parses the native ad response
+ * @param {object} adm - The native ad response
+ * @returns {object} Parsed native ad object
+ */
+export function parseNative(adm) {
+  let bid = {
+    clickUrl: adm.native.link?.url,
+    impressionTrackers: adm.native.imptrackers || [],
+    clickTrackers: adm.native.link?.clicktrackers || [],
+    jstracker: adm.native.jstracker || []
+  };
+  adm.native.assets.forEach((asset) => {
+    const kind = NATIVE_ASSETS_IDS[asset.id];
+    const content = kind && asset[NATIVE_ASSETS[kind].name];
+    if (content) {
+      bid[kind] = content.text || content.value || { url: content.url, width: content.w, height: content.h };
+    }
+  });
+
+  return bid;
+}

--- a/libraries/braveUtils/nativeAssets.js
+++ b/libraries/braveUtils/nativeAssets.js
@@ -1,0 +1,23 @@
+/**
+ * IDs and asset types for native ad assets.
+ */
+export const NATIVE_ASSETS_IDS = {
+  1: 'title',
+  2: 'icon',
+  3: 'image',
+  4: 'body',
+  5: 'sponsoredBy',
+  6: 'cta'
+};
+
+/**
+ * Native assets definition for mapping purposes.
+ */
+export const NATIVE_ASSETS = {
+  title: { id: 1, name: 'title' },
+  icon: { id: 2, type: 1, name: 'img' },
+  image: { id: 3, type: 3, name: 'img' },
+  body: { id: 4, type: 2, name: 'data' },
+  sponsoredBy: { id: 5, type: 1, name: 'data' },
+  cta: { id: 6, type: 12, name: 'data' }
+};

--- a/libraries/mspa/activityControls.js
+++ b/libraries/mspa/activityControls.js
@@ -105,7 +105,7 @@ export function mspaRule(sids, getConsent, denies, applicableSids = () => gppDat
 }
 
 function flatSection(subsections) {
-  if (subsections == null) return subsections;
+  if (!Array.isArray(subsections)) return subsections;
   return subsections.reduceRight((subsection, consent) => {
     return Object.assign(consent, subsection);
   }, {});

--- a/libraries/targetVideoUtils/constants.js
+++ b/libraries/targetVideoUtils/constants.js
@@ -6,6 +6,7 @@ const BIDDER_CODE = 'targetVideo';
 const TIME_TO_LIVE = 300;
 const BANNER_ENDPOINT_URL = 'https://ib.adnxs.com/ut/v3/prebid';
 const VIDEO_ENDPOINT_URL = 'https://pbs.prebrid.tv/openrtb2/auction';
+const SYNC_URL = 'https://bppb.link/static/';
 const VIDEO_PARAMS = [
   'api', 'linearity', 'maxduration', 'mimes', 'minduration',
   'plcmt', 'playbackmethod', 'protocols', 'startdelay'
@@ -16,6 +17,7 @@ export {
   GVLID,
   MARGIN,
   BIDDER_CODE,
+  SYNC_URL,
   TIME_TO_LIVE,
   BANNER_ENDPOINT_URL,
   VIDEO_ENDPOINT_URL,

--- a/libraries/viewport/viewport.js
+++ b/libraries/viewport/viewport.js
@@ -1,0 +1,13 @@
+import {getWindowTop} from '../../src/utils.js';
+
+export function getViewportCoordinates() {
+  try {
+    const win = getWindowTop();
+    let { scrollY: top, scrollX: left, innerHeight, innerWidth } = win;
+    innerHeight = innerHeight || win.document.documentElement.clientWidth || win.document.body.clientWidth;
+    innerWidth = innerWidth || win.document.documentElement.clientHeight || win.document.body.clientHeight
+    return { top, right: left + innerWidth, bottom: top + innerHeight, left };
+  } catch (e) {
+    return {};
+  }
+}

--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -40,6 +40,7 @@
       "pubProvidedIdSystem",
       "publinkIdSystem",
       "quantcastIdSystem",
+      "rewardedInterestIdSystem",
       "sharedIdSystem",
       "tapadIdSystem",
       "teadsIdSystem",

--- a/modules/adagioRtdProvider.js
+++ b/modules/adagioRtdProvider.js
@@ -73,13 +73,14 @@ const _SESSION = (function() {
 
       storage.getDataFromLocalStorage('adagio', (storageValue) => {
         // session can be an empty object
-        const { rnd, new: isNew = false, vwSmplg, vwSmplgNxt, lastActivityTime, id, testName, testVersion, initiator } = _internal.getSessionFromLocalStorage(storageValue);
+        const { rnd, new: isNew = false, vwSmplg, vwSmplgNxt, lastActivityTime, id, testName, testVersion, initiator, pages } = _internal.getSessionFromLocalStorage(storageValue);
 
         // isNew can be `true` if the session has been initialized by the A/B test snippet (external)
         const isNewSess = (initiator === 'snippet') ? isNew : isNewSession(lastActivityTime);
 
         data.session = {
           rnd,
+          pages: pages || 1,
           new: isNewSess, // legacy: `new` was used but the choosen name is not good.
           // Don't use values if they are not defined.
           ...(vwSmplg !== undefined && { vwSmplg }),
@@ -685,6 +686,7 @@ function registerEventsForAdServers(config) {
  * @property {number} vwSmplg - View sampling rate.
  * @property {number} vwSmplgNxt - Next view sampling rate.
  * @property {number} lastActivityTime - Last activity time.
+ * @property {number} pages - current number of pages seen.
  */
 
 /**

--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -84,7 +84,6 @@ export const spec = {
     {code: 'unibots'},
     {code: 'ergadx'},
     {code: 'turktelekom'},
-    {code: 'felixads'},
     {code: 'motionspots'},
     {code: 'sonic_twist'},
     {code: 'displayioads'},

--- a/modules/admaticBidAdapter.js
+++ b/modules/admaticBidAdapter.js
@@ -23,7 +23,8 @@ export const spec = {
     {code: 'admaticde', gvlid: 1281},
     {code: 'pixad', gvlid: 1281},
     {code: 'monetixads', gvlid: 1281},
-    {code: 'netaddiction', gvlid: 1281}
+    {code: 'netaddiction', gvlid: 1281},
+    {code: 'adt', gvlid: 779}
   ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
   /**
@@ -54,7 +55,7 @@ export const spec = {
     const bids = validBidRequests.map(buildRequestObject);
     const ortb = bidderRequest.ortb2;
     const networkId = getValue(validBidRequests[0].params, 'networkId');
-    const host = getValue(validBidRequests[0].params, 'host');
+    let host = getValue(validBidRequests[0].params, 'host');
     const bidderName = validBidRequests[0].bidder;
 
     const payload = {
@@ -137,11 +138,15 @@ export const spec = {
         case 'admaticde':
           SYNC_URL = 'https://static.cdn.admatic.de/admaticde/sync.html';
           break;
+        case 'adt':
+          SYNC_URL = 'https://static.cdn.adtarget.org/adt/sync.html';
+          break;
         default:
           SYNC_URL = 'https://static.cdn.admatic.com.tr/sync.html';
           break;
       }
 
+      host = host?.replace('https://', '')?.replace('http://', '')?.replace('/', '');
       return { method: 'POST', url: `https://${host}/pb`, data: payload, options: { contentType: 'application/json' } };
     }
   },
@@ -150,7 +155,7 @@ export const spec = {
     if (!hasSynced && syncOptions.iframeEnabled) {
       // data is only assigned if params are available to pass to syncEndpoint
       let params = getUserSyncParams(gdprConsent, uspConsent, gppConsent);
-      params = Object.keys(params).length ? `?${formatQS(params)}` : '';
+      params = Object.keys(params).length ? `&${formatQS(params)}` : '';
 
       hasSynced = true;
       return {

--- a/modules/adotBidAdapter.js
+++ b/modules/adotBidAdapter.js
@@ -6,6 +6,7 @@ import {find} from '../src/polyfill.js';
 import {config} from '../src/config.js';
 import {OUTSTREAM} from '../src/video.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
+import { NATIVE_ASSETS_IDS as NATIVE_ID_MAPPING, NATIVE_ASSETS as NATIVE_PLACEMENTS } from '../libraries/braveUtils/nativeAssets.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -24,6 +25,37 @@ import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
  * @typedef {import('../src/adapters/bidderFactory.js').Imp} Imp
  */
 
+/**
+ * @typedef {Object} OpenRtbRequest
+ * @property {string} id - Unique request ID
+ * @property {Array<Imp>} imp - List of impression objects
+ * @property {Site} site - Site information
+ * @property {Device} device - Device information
+ * @property {User} user - User information
+ * @property {object} regs - Regulatory data, including GDPR and COPPA
+ * @property {object} ext - Additional extensions, such as custom data for the bid request
+ * @property {number} at - Auction type, typically first-price or second-price
+ */
+
+/**
+ * @typedef {Object} OpenRtbBid
+ * @property {string} impid - ID of the impression this bid relates to
+ * @property {number} price - Bid price for the impression
+ * @property {string} adid - Ad ID for the bid
+ * @property {number} [crid] - Creative ID, if available
+ * @property {string} [dealid] - Deal ID if the bid is part of a private marketplace deal
+ * @property {object} [ext] - Additional bid-specific extensions, such as media type
+ * @property {string} [adm] - Ad markup if it’s directly included in the bid response
+ * @property {string} [nurl] - Notification URL to be called when the bid wins
+ */
+
+/**
+ * @typedef {Object} OpenRtbBidResponse
+ * @property {string} id - ID of the bid response
+ * @property {Array<{bid: Array<OpenRTBBid>}>} seatbid - Array of seat bids, each containing a list of bids
+ * @property {string} cur - Currency in which bid amounts are expressed
+ */
+
 const BIDDER_CODE = 'adot';
 const ADAPTER_VERSION = 'v2.0.0';
 const GVLID = 272;
@@ -32,15 +64,6 @@ const BIDDER_URL = 'https://dsp.adotmob.com/headerbidding{PUBLISHER_PATH}/bidreq
 const REQUIRED_VIDEO_PARAMS = ['mimes', 'protocols'];
 const FIRST_PRICE = 1;
 const IMP_BUILDER = { banner: buildBanner, video: buildVideo, native: buildNative };
-const NATIVE_PLACEMENTS = {
-  title: { id: 1, name: 'title' },
-  icon: { id: 2, type: 1, name: 'img' },
-  image: { id: 3, type: 3, name: 'img' },
-  sponsoredBy: { id: 4, name: 'data', type: 1 },
-  body: { id: 5, name: 'data', type: 2 },
-  cta: { id: 6, type: 12, name: 'data' }
-};
-const NATIVE_ID_MAPPING = { 1: 'title', 2: 'icon', 3: 'image', 4: 'sponsoredBy', 5: 'body', 6: 'cta' };
 const OUTSTREAM_VIDEO_PLAYER_URL = 'https://adserver.adotmob.com/video/player.min.js';
 const BID_RESPONSE_NET_REVENUE = true;
 const BID_RESPONSE_TTL = 10;

--- a/modules/adverxoBidAdapter.js
+++ b/modules/adverxoBidAdapter.js
@@ -1,0 +1,356 @@
+import * as utils from '../src/utils.js';
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+import {BANNER, VIDEO, NATIVE} from '../src/mediaTypes.js';
+import {ortbConverter as OrtbConverter} from '../libraries/ortbConverter/converter.js';
+import {Renderer} from '../src/Renderer.js';
+import {deepAccess, deepSetValue} from '../src/utils.js';
+import {config} from '../src/config.js';
+
+/**
+ * @typedef {import('../src/adapters/bidderFactory.js').Bid} Bid
+ * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
+ * @typedef {import('../src/adapters/bidderFactory.js').ServerRequest} ServerRequest
+ * @typedef {import('../src/adapters/bidderFactory.js').ServerResponse} ServerResponse
+ * @typedef {import('../src/auction.js').BidderRequest} BidderRequest
+ * @typedef {import('../src/adapters/bidderFactory.js').SyncOptions} SyncOptions
+ * @typedef {import('../src/adapters/bidderFactory.js').UserSync} UserSync
+ */
+
+const BIDDER_CODE = 'adverxo';
+
+const ALIASES = [
+  {code: 'adport', skipPbsAliasing: true},
+  {code: 'bidsmind', skipPbsAliasing: true},
+  {code: 'mobupps', skipPbsAliasing: true}
+];
+
+const AUCTION_URLS = {
+  adverxo: 'js.pbsadverxo.com',
+  adport: 'diclotrans.com',
+  bidsmind: 'egrevirda.com',
+  mobupps: 'traffhb.com'
+};
+
+const ENDPOINT_URL_AD_UNIT_PLACEHOLDER = '{AD_UNIT}';
+const ENDPOINT_URL_AUTH_PLACEHOLDER = '{AUTH}';
+const ENDPOINT_URL_HOST_PLACEHOLDER = '{HOST}';
+
+const ENDPOINT_URL = `https://${ENDPOINT_URL_HOST_PLACEHOLDER}/pickpbs?id=${ENDPOINT_URL_AD_UNIT_PLACEHOLDER}&auth=${ENDPOINT_URL_AUTH_PLACEHOLDER}`;
+
+const ORTB_MTYPES = {
+  1: BANNER,
+  2: VIDEO,
+  4: NATIVE
+};
+
+const USYNC_TYPES = {
+  IFRAME: 'iframe',
+  REDIRECT: 'image'
+};
+
+const DEFAULT_CURRENCY = 'USD';
+
+const ortbConverter = OrtbConverter({
+  context: {
+    netRevenue: true,
+    ttl: 60,
+  },
+  request: function request(buildRequest, imps, bidderRequest, context) {
+    const request = buildRequest(imps, bidderRequest, context);
+
+    utils.deepSetValue(request, 'device.ip', 'caller');
+    utils.deepSetValue(request, 'ext.avx_add_vast_url', 1);
+
+    const eids = deepAccess(bidderRequest, 'bids.0.userIdAsEids');
+
+    if (eids && eids.length) {
+      deepSetValue(request, 'user.ext.eids', eids);
+    }
+
+    return request;
+  },
+  imp(buildImp, bidRequest, context) {
+    const imp = buildImp(bidRequest, context);
+    const floor = adverxoUtils.getBidFloor(bidRequest);
+
+    if (floor) {
+      imp.bidfloor = floor;
+      imp.bidfloorcur = DEFAULT_CURRENCY;
+    }
+
+    return imp;
+  },
+  bidResponse: function (buildBidResponse, bid, context) {
+    bid.adm = bid.adm.replaceAll(`\${AUCTION_PRICE}`, bid.price);
+
+    if (FEATURES.NATIVE && ORTB_MTYPES[bid.mtype] === NATIVE) {
+      if (typeof bid?.adm === 'string') {
+        bid.adm = JSON.parse(bid.adm);
+      }
+
+      if (bid?.adm?.native) {
+        bid.adm = bid.adm.native;
+      }
+    }
+
+    const result = buildBidResponse(bid, context);
+
+    if (FEATURES.VIDEO) {
+      if (bid?.ext?.avx_vast_url) {
+        result.vastUrl = bid.ext.avx_vast_url;
+      }
+
+      if (bid?.ext?.avx_video_renderer_url) {
+        result.avxVideoRendererUrl = bid.ext.avx_video_renderer_url;
+      }
+    }
+
+    return result;
+  }
+});
+
+const userSyncUtils = {
+  buildUsyncParams: function (gdprConsent, uspConsent, gppConsent) {
+    const params = [];
+
+    if (gdprConsent) {
+      params.push('gdpr=' + (gdprConsent.gdprApplies ? 1 : 0));
+      params.push('gdpr_consent=' + encodeURIComponent(gdprConsent.consentString || ''));
+    }
+
+    if (config.getConfig('coppa') === true) {
+      params.push('coppa=1');
+    }
+
+    if (uspConsent) {
+      params.push('us_privacy=' + encodeURIComponent(uspConsent));
+    }
+
+    if (gppConsent?.gppString && gppConsent?.applicableSections?.length) {
+      params.push('gpp=' + encodeURIComponent(gppConsent.gppString));
+      params.push('gpp_sid=' + encodeURIComponent(gppConsent?.applicableSections?.join(',')));
+    }
+
+    return params.length ? params.join('&') : '';
+  }
+};
+
+const videoUtils = {
+  createOutstreamVideoRenderer: function (bid) {
+    const renderer = Renderer.install({
+      id: bid.bidId,
+      url: bid.avxVideoRendererUrl,
+      loaded: false,
+      adUnitCode: bid.adUnitCode
+    });
+
+    try {
+      renderer.setRender(this.outstreamRender.bind(this));
+    } catch (err) {
+      utils.logWarn('Prebid Error calling setRender on renderer', err);
+    }
+
+    return renderer;
+  },
+
+  outstreamRender: function (bid, doc) {
+    bid.renderer.push(() => {
+      const win = (doc) ? doc.defaultView : window;
+
+      win.adxVideoRenderer.renderAd({
+        targetId: bid.adUnitCode,
+        adResponse: {content: bid.vastXml}
+      });
+    });
+  }
+};
+
+const adverxoUtils = {
+  buildAuctionUrl: function (bidderCode, host, adUnitId, adUnitAuth) {
+    const auctionUrl = host || AUCTION_URLS[bidderCode];
+
+    return ENDPOINT_URL
+      .replace(ENDPOINT_URL_HOST_PLACEHOLDER, auctionUrl)
+      .replace(ENDPOINT_URL_AD_UNIT_PLACEHOLDER, adUnitId)
+      .replace(ENDPOINT_URL_AUTH_PLACEHOLDER, adUnitAuth);
+  },
+
+  groupBidRequestsByAdUnit: function (bidRequests) {
+    const groupedBidRequests = new Map();
+
+    bidRequests.forEach(bidRequest => {
+      const adUnit = {
+        host: bidRequest.params.host,
+        id: bidRequest.params.adUnitId,
+        auth: bidRequest.params.auth,
+      };
+
+      if (!groupedBidRequests.get(adUnit)) {
+        groupedBidRequests.set(adUnit, []);
+      }
+
+      groupedBidRequests.get(adUnit).push(bidRequest);
+    });
+
+    return groupedBidRequests;
+  },
+
+  getBidFloor: function (bid) {
+    if (utils.isFn(bid.getFloor)) {
+      const floor = bid.getFloor({
+        currency: DEFAULT_CURRENCY,
+        mediaType: '*',
+        size: '*',
+      });
+
+      if (utils.isPlainObject(floor) && !isNaN(floor.floor) && floor.currency === DEFAULT_CURRENCY) {
+        return floor.floor;
+      }
+    }
+
+    return null;
+  }
+};
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [BANNER, NATIVE, VIDEO],
+  aliases: ALIASES,
+
+  /**
+   * Determines whether the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return {boolean} True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: function (bid) {
+    if (!utils.isPlainObject(bid.params) || !Object.keys(bid.params).length) {
+      utils.logWarn('Adverxo Bid Adapter: bid params must be provided.');
+      return false;
+    }
+
+    if (!bid.params.adUnitId || typeof bid.params.adUnitId !== 'number') {
+      utils.logWarn('Adverxo Bid Adapter: adUnitId bid param is required and must be a number');
+      return false;
+    }
+
+    if (!bid.params.auth || typeof bid.params.auth !== 'string') {
+      utils.logWarn('Adverxo Bid Adapter: auth bid param is required and must be a string');
+      return false;
+    }
+
+    return true;
+  },
+
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {BidRequest[]} validBidRequests an array of bids
+   * @param {BidderRequest} bidderRequest an array of bids
+   * @return {ServerRequest} Info describing the request to the server.
+   */
+  buildRequests: function (validBidRequests, bidderRequest) {
+    const result = [];
+
+    const bidRequestsByAdUnit = adverxoUtils.groupBidRequestsByAdUnit(validBidRequests);
+
+    bidRequestsByAdUnit.forEach((adUnitBidRequests, adUnit) => {
+      const ortbRequest = ortbConverter.toORTB({
+        bidRequests: adUnitBidRequests,
+        bidderRequest
+      });
+
+      result.push({
+        method: 'POST',
+        url: adverxoUtils.buildAuctionUrl(bidderRequest.bidderCode, adUnit.host, adUnit.id, adUnit.auth),
+        data: ortbRequest,
+        bids: adUnitBidRequests
+      });
+    });
+
+    return result;
+  },
+
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} serverResponse A successful response from the server.
+   * @param {BidRequest} bidRequest Adverxo bidRequest
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: function (serverResponse, bidRequest) {
+    if (!serverResponse || !bidRequest) {
+      return [];
+    }
+
+    const bids = ortbConverter.fromORTB({
+      response: serverResponse.body,
+      request: bidRequest.data,
+    }).bids;
+
+    return bids.map((bid) => {
+      const thisRequest = utils.getBidRequest(bid.requestId, [bidRequest]);
+      const context = utils.deepAccess(thisRequest, 'mediaTypes.video.context');
+
+      if (FEATURES.VIDEO && bid.mediaType === 'video' && context === 'outstream') {
+        bid.renderer = videoUtils.createOutstreamVideoRenderer(bid);
+      }
+
+      return bid;
+    });
+  },
+
+  /**
+   * Register the user sync pixels which should be dropped after the auction.
+   *
+   * @param {SyncOptions} syncOptions Which user syncs are allowed?
+   * @param {ServerResponse[]} responses List of server's responses.
+   * @param {*} gdprConsent
+   * @param {*} uspConsent
+   * @param {*} gppConsent
+   * @return {UserSync[]} The user syncs which should be dropped.
+   */
+  getUserSyncs: (syncOptions, responses, gdprConsent, uspConsent, gppConsent) => {
+    if (!responses || responses.length === 0 || (!syncOptions.pixelEnabled && !syncOptions.iframeEnabled)) {
+      return [];
+    }
+
+    const privacyParams = userSyncUtils.buildUsyncParams(gdprConsent, uspConsent, gppConsent);
+    const syncType = syncOptions.iframeEnabled ? USYNC_TYPES.IFRAME : USYNC_TYPES.REDIRECT;
+
+    const result = [];
+
+    for (const response of responses) {
+      const syncUrls = response.body?.ext?.avx_usync;
+
+      if (!syncUrls || syncUrls.length === 0) {
+        continue;
+      }
+
+      for (const url of syncUrls) {
+        let finalUrl = url;
+
+        if (!finalUrl.includes('?')) {
+          finalUrl += '?';
+        } else {
+          finalUrl += '&';
+        }
+
+        finalUrl += 'type=' + syncType;
+
+        if (privacyParams.length !== 0) {
+          finalUrl += `&${privacyParams}`;
+        }
+
+        result.push({
+          type: syncType,
+          url: finalUrl
+        });
+      }
+    }
+
+    return result;
+  }
+}
+
+registerBidder(spec);

--- a/modules/adverxoBidAdapter.md
+++ b/modules/adverxoBidAdapter.md
@@ -1,0 +1,101 @@
+# Overview
+
+```
+Module Name: Adverxo Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: developer@adverxo.com
+```
+
+# Description
+
+Module that connects to Adverxo to fetch bids.
+Banner, native and video formats are supported.
+
+# Bid Parameters
+
+| Name       | Required? | Description                                                       | Example                                      | Type      |
+|------------|-----------|-------------------------------------------------------------------|----------------------------------------------|-----------|
+| `host`     | No        | Ad network host.                                                  | `prebidTest.adverxo.com`                     | `String`  |
+| `adUnitId` | Yes       | Unique identifier for the ad unit in Adverxo platform.            | `413`                                        | `Integer` |
+| `auth`     | Yes       | Authentication token provided by Adverxo platform for the AdUnit. | `'61336d75e414c77c367ce5c47c2599ce80a8x32b'` | `String`  |
+
+# Test Parameters
+
+```javascript
+var adUnits = [
+    {
+        code: 'banner-ad-div',
+        mediaTypes: {
+            banner: {
+                sizes: [
+                    [400, 300],
+                    [320, 50]
+                ]
+            }
+        },
+        bids: [{
+            bidder: 'adverxo',
+            params: {
+                host: 'example.com',
+                adUnitId: 1,
+                auth: '61336e753414c77c367deac47c2595ce80a8032b'
+            }
+        }]
+    },
+    {
+        code: 'native-ad-div',
+        mediaTypes: {
+            native: {
+                image: {
+                    required: true,
+                    sizes: [400, 300]
+                },
+                title: {
+                    required: true,
+                    len: 75
+                },
+                body: {
+                    required: false,
+                    len: 200
+                },
+                cta: {
+                    required: false,
+                    len: 75
+                },
+                sponsoredBy: {
+                    required: false
+                }
+            }
+        },
+        bids: [{
+            bidder: 'adverxo',
+            params: {
+                host: 'example.com',
+                adUnitId: 2,
+                auth: '9a640dfccc3381e71fxc29ffd4a72wabd29g9d86'
+            }
+        }]
+    },
+    {
+        code: 'video-div',
+        mediaTypes: {
+            video: {
+                playerSize: [640, 480],
+                context: 'outstream',
+                mimes: ['video/mp4'],
+                maxduration: 30,
+                skip: 1
+            }
+        },
+        bids: [{
+            bidder: 'adverxo',
+            params: {
+                host: 'example.com',
+                adUnitId: 3,
+                auth: '1ax23d9621f21da28a2eab6f79bd5fbcf4d037c1'
+            }
+        }]
+    }
+];
+
+```

--- a/modules/braveBidAdapter.js
+++ b/modules/braveBidAdapter.js
@@ -1,8 +1,8 @@
-import {isEmpty, isStr, parseUrl, triggerPixel} from '../src/utils.js';
-import {registerBidder} from '../src/adapters/bidderFactory.js';
-import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
-import {config} from '../src/config.js';
-import {convertOrtbRequestToProprietaryNative} from '../src/native.js';
+import { isStr, triggerPixel } from '../src/utils.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
+import { parseNative } from '../libraries/braveUtils/index.js';
+import { buildRequests, interpretResponse } from '../libraries/braveUtils/buildAndInterpret.js'
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -13,160 +13,15 @@ const BIDDER_CODE = 'brave';
 const DEFAULT_CUR = 'USD';
 const ENDPOINT_URL = `https://point.bravegroup.tv/?t=2&partner=hash`;
 
-const NATIVE_ASSETS_IDS = { 1: 'title', 2: 'icon', 3: 'image', 4: 'body', 5: 'sponsoredBy', 6: 'cta' };
-const NATIVE_ASSETS = {
-  title: { id: 1, name: 'title' },
-  icon: { id: 2, type: 1, name: 'img' },
-  image: { id: 3, type: 3, name: 'img' },
-  body: { id: 4, type: 2, name: 'data' },
-  sponsoredBy: { id: 5, type: 1, name: 'data' },
-  cta: { id: 6, type: 12, name: 'data' }
-};
-
 export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 
-  /**
-   * Determines whether or not the given bid request is valid.
-   *
-   * @param {object} bid The bid to validate.
-   * @return boolean True if this is a valid bid, and false otherwise.
-   */
-  isBidRequestValid: (bid) => {
-    return !!(bid.params.placementId && bid.params.placementId.toString().length === 32);
-  },
+  isBidRequestValid: (bid) => !!(bid.params.placementId && bid.params.placementId.toString().length === 32),
 
-  /**
-   * Make a server request from the list of BidRequests.
-   *
-   * @param {BidRequest[]} validBidRequests A non-empty list of valid bid requests that should be sent to the Server.
-   * @return ServerRequest Info describing the request to the server.
-   */
-  buildRequests: (validBidRequests, bidderRequest) => {
-    // convert Native ORTB definition to old-style prebid native definition
-    validBidRequests = convertOrtbRequestToProprietaryNative(validBidRequests);
+  buildRequests: (validBidRequests, bidderRequest) => buildRequests(validBidRequests, bidderRequest, ENDPOINT_URL, DEFAULT_CUR),
 
-    if (validBidRequests.length === 0 || !bidderRequest) return [];
-
-    const endpointURL = ENDPOINT_URL.replace('hash', validBidRequests[0].params.placementId);
-
-    let imp = validBidRequests.map(br => {
-      let impObject = {
-        id: br.bidId,
-        secure: 1
-      };
-
-      if (br.mediaTypes.banner) {
-        impObject.banner = createBannerRequest(br);
-      } else if (br.mediaTypes.video) {
-        impObject.video = createVideoRequest(br);
-      } else if (br.mediaTypes.native) {
-        impObject.native = {
-          // TODO: `id` is not part of the ORTB native spec, is this intentional?
-          id: br.bidId,
-          ver: '1.2',
-          request: createNativeRequest(br)
-        };
-      }
-      return impObject;
-    });
-
-    // TODO: do these values make sense?
-    let page = bidderRequest.refererInfo.page || bidderRequest.refererInfo.topmostLocation;
-    let r = bidderRequest.refererInfo.ref;
-
-    let data = {
-      id: bidderRequest.bidderRequestId,
-      cur: [ DEFAULT_CUR ],
-      device: {
-        w: screen.width,
-        h: screen.height,
-        language: (navigator && navigator.language) ? navigator.language.indexOf('-') != -1 ? navigator.language.split('-')[0] : navigator.language : '',
-        ua: navigator.userAgent,
-      },
-      site: {
-        domain: parseUrl(page).hostname,
-        page: page,
-      },
-      tmax: bidderRequest.timeout,
-      imp
-    };
-
-    if (r) {
-      data.site.ref = r;
-    }
-
-    if (bidderRequest.gdprConsent) {
-      data['regs'] = {'ext': {'gdpr': bidderRequest.gdprConsent.gdprApplies ? 1 : 0}};
-      data['user'] = {'ext': {'consent': bidderRequest.gdprConsent.consentString ? bidderRequest.gdprConsent.consentString : ''}};
-    }
-
-    if (bidderRequest.uspConsent !== undefined) {
-      if (!data['regs'])data['regs'] = {'ext': {}};
-      data['regs']['ext']['us_privacy'] = bidderRequest.uspConsent;
-    }
-
-    if (config.getConfig('coppa') === true) {
-      if (!data['regs'])data['regs'] = {'coppa': 1};
-      else data['regs']['coppa'] = 1;
-    }
-
-    if (validBidRequests[0].schain) {
-      data['source'] = {'ext': {'schain': validBidRequests[0].schain}};
-    }
-
-    return {
-      method: 'POST',
-      url: endpointURL,
-      data: data
-    };
-  },
-
-  /**
-   * Unpack the response from the server into a list of bids.
-   *
-   * @param {*} serverResponse A successful response from the server.
-   * @return {Bid[]} An array of bids which were nested inside the server.
-   */
-  interpretResponse: (serverResponse) => {
-    if (!serverResponse || isEmpty(serverResponse.body)) return [];
-
-    let bids = [];
-    serverResponse.body.seatbid.forEach(response => {
-      response.bid.forEach(bid => {
-        let mediaType = bid.ext && bid.ext.mediaType ? bid.ext.mediaType : 'banner';
-
-        let bidObj = {
-          requestId: bid.impid,
-          cpm: bid.price,
-          width: bid.w,
-          height: bid.h,
-          ttl: 1200,
-          currency: DEFAULT_CUR,
-          netRevenue: true,
-          creativeId: bid.crid,
-          dealId: bid.dealid || null,
-          mediaType: mediaType
-        };
-
-        switch (mediaType) {
-          case 'video':
-            bidObj.vastUrl = bid.adm;
-            break;
-          case 'native':
-            bidObj.native = parseNative(bid.adm);
-            break;
-          default:
-            bidObj.ad = bid.adm;
-        }
-
-        bids.push(bidObj);
-      });
-    });
-
-    return bids;
-  },
+  interpretResponse: (serverResponse) => interpretResponse(serverResponse, DEFAULT_CUR, parseNative),
 
   onBidWon: (bid) => {
     if (isStr(bid.nurl) && bid.nurl !== '') {
@@ -174,91 +29,5 @@ export const spec = {
     }
   }
 };
-
-const parseNative = adm => {
-  let bid = {
-    clickUrl: adm.native.link && adm.native.link.url,
-    impressionTrackers: adm.native.imptrackers || [],
-    clickTrackers: (adm.native.link && adm.native.link.clicktrackers) || [],
-    jstracker: adm.native.jstracker || []
-  };
-  adm.native.assets.forEach(asset => {
-    let kind = NATIVE_ASSETS_IDS[asset.id];
-    let content = kind && asset[NATIVE_ASSETS[kind].name];
-    if (content) {
-      bid[kind] = content.text || content.value || { url: content.url, width: content.w, height: content.h };
-    }
-  });
-
-  return bid;
-}
-
-const createNativeRequest = br => {
-  let impObject = {
-    ver: '1.2',
-    assets: []
-  };
-
-  let keys = Object.keys(br.mediaTypes.native);
-
-  for (let key of keys) {
-    const props = NATIVE_ASSETS[key];
-    if (props) {
-      const asset = {
-        required: br.mediaTypes.native[key].required ? 1 : 0,
-        id: props.id,
-        [props.name]: {}
-      };
-
-      if (props.type) asset[props.name]['type'] = props.type;
-      if (br.mediaTypes.native[key].len) asset[props.name]['len'] = br.mediaTypes.native[key].len;
-      if (br.mediaTypes.native[key].sizes && br.mediaTypes.native[key].sizes[0]) {
-        asset[props.name]['w'] = br.mediaTypes.native[key].sizes[0];
-        asset[props.name]['h'] = br.mediaTypes.native[key].sizes[1];
-      }
-
-      impObject.assets.push(asset);
-    }
-  }
-
-  return impObject;
-}
-
-const createBannerRequest = br => {
-  let size = [];
-
-  if (br.mediaTypes.banner.sizes && Array.isArray(br.mediaTypes.banner.sizes)) {
-    if (Array.isArray(br.mediaTypes.banner.sizes[0])) { size = br.mediaTypes.banner.sizes[0]; } else { size = br.mediaTypes.banner.sizes; }
-  } else size = [300, 250];
-
-  return { id: br.transactionId, w: size[0], h: size[1] };
-};
-
-const createVideoRequest = br => {
-  // TODO: `id` is not part of imp.video in ORTB; is this intentional?
-  let videoObj = {id: br.bidId};
-  let supportParamsList = ['mimes', 'minduration', 'maxduration', 'protocols', 'startdelay', 'skip', 'minbitrate', 'maxbitrate', 'api', 'linearity'];
-
-  for (let param of supportParamsList) {
-    if (br.mediaTypes.video[param] !== undefined) {
-      videoObj[param] = br.mediaTypes.video[param];
-    }
-  }
-
-  if (br.mediaTypes.video.playerSize && Array.isArray(br.mediaTypes.video.playerSize)) {
-    if (Array.isArray(br.mediaTypes.video.playerSize[0])) {
-      videoObj.w = br.mediaTypes.video.playerSize[0][0];
-      videoObj.h = br.mediaTypes.video.playerSize[0][1];
-    } else {
-      videoObj.w = br.mediaTypes.video.playerSize[0];
-      videoObj.h = br.mediaTypes.video.playerSize[1];
-    }
-  } else {
-    videoObj.w = 640;
-    videoObj.h = 480;
-  }
-
-  return videoObj;
-}
 
 registerBidder(spec);

--- a/modules/medianetBidAdapter.js
+++ b/modules/medianetBidAdapter.js
@@ -21,6 +21,7 @@ import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import {getGlobal} from '../src/prebidGlobal.js';
 import {getGptSlotInfoForAdUnitCode} from '../libraries/gptUtils/gptUtils.js';
 import {ajax} from '../src/ajax.js';
+import {getViewportCoordinates} from '../libraries/viewport/viewport.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -180,6 +181,7 @@ function extParams(bidRequest, bidderRequests) {
   const gdprApplies = !!(gdpr && gdpr.gdprApplies);
   const uspApplies = !!(uspConsent);
   const coppaApplies = !!(config.getConfig('coppa'));
+  const {top = -1, right = -1, bottom = -1, left = -1} = getViewportCoordinates();
   return Object.assign({},
     { customer_id: params.cid },
     { prebid_version: 'v' + '$prebid.version$' },
@@ -191,7 +193,13 @@ function extParams(bidRequest, bidderRequests) {
     windowSize.w !== -1 && windowSize.h !== -1 && { screen: windowSize },
     userId && { user_id: userId },
     getGlobal().medianetGlobals.analyticsEnabled && { analytics: true },
-    !isEmpty(sChain) && {schain: sChain}
+    !isEmpty(sChain) && {schain: sChain},
+    {
+      vcoords: {
+        top_left: { x: left, y: top },
+        bottom_right: { x: right, y: bottom }
+      }
+    }
   );
 }
 
@@ -317,14 +325,15 @@ function getOverlapArea(topLeft1, bottomRight1, topLeft2, bottomRight2) {
 }
 
 function normalizeCoordinates(coordinates) {
+  const {scrollX, scrollY} = window;
   return {
     top_left: {
-      x: coordinates.top_left.x + window.pageXOffset,
-      y: coordinates.top_left.y + window.pageYOffset,
+      x: coordinates.top_left.x + scrollX,
+      y: coordinates.top_left.y + scrollY,
     },
     bottom_right: {
-      x: coordinates.bottom_right.x + window.pageXOffset,
-      y: coordinates.bottom_right.y + window.pageYOffset,
+      x: coordinates.bottom_right.x + scrollX,
+      y: coordinates.bottom_right.y + scrollY,
     }
   }
 }

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -859,6 +859,14 @@ function _handleEids(payload, validBidRequests) {
   }
 }
 
+// Setting IBV field into the bid response
+export function setIBVField(bid, newBid) {
+  if (bid?.ext?.ibv) {
+    newBid.ext = newBid.ext || {};
+    newBid.ext['ibv'] = bid.ext.ibv;
+  }
+}
+
 function _checkMediaType(bid, newBid) {
   // Create a regex here to check the strings
   if (bid.ext && bid.ext['bidtype'] != undefined) {
@@ -1401,6 +1409,7 @@ export const spec = {
                   }
                 });
               }
+              setIBVField(bid, newBid);
               if (bid.ext && bid.ext.deal_channel) {
                 newBid['dealChannel'] = dealChannelValues[bid.ext.deal_channel] || null;
               }

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -859,14 +859,6 @@ function _handleEids(payload, validBidRequests) {
   }
 }
 
-// Setting IBV field into the bid response
-export function setIBVField(bid, newBid) {
-  if (bid?.ext?.ibv) {
-    newBid.ext = newBid.ext || {};
-    newBid.ext['ibv'] = bid.ext.ibv;
-  }
-}
-
 function _checkMediaType(bid, newBid) {
   // Create a regex here to check the strings
   if (bid.ext && bid.ext['bidtype'] != undefined) {
@@ -1409,7 +1401,6 @@ export const spec = {
                   }
                 });
               }
-              setIBVField(bid, newBid);
               if (bid.ext && bid.ext.deal_channel) {
                 newBid['dealChannel'] = dealChannelValues[bid.ext.deal_channel] || null;
               }

--- a/modules/rewardedInterestIdSystem.js
+++ b/modules/rewardedInterestIdSystem.js
@@ -1,0 +1,142 @@
+/**
+ * This module adds rewarded interest ID to the User ID module
+ * The {@link module:modules/userId} module is required
+ * @module modules/rewardedInterestIdSystem
+ * @requires module:modules/userId
+ */
+
+/**
+ * @typedef {import('../modules/userId/index.js').Submodule} Submodule
+ * @typedef {import('../modules/userId/index.js').IdResponse} IdResponse
+ */
+
+/**
+ * @typedef RewardedInterestApi
+ * @property {getApiVersion} getApiVersion
+ * @property {getIdentityToken} getIdentityToken
+ */
+
+/**
+ * Retrieves the Rewarded Interest API version.
+ * @callback getApiVersion
+ * @return {string}
+ */
+
+/**
+ * Retrieves the current identity token.
+ * @callback getIdentityToken
+ * @return {Promise<string>}
+ */
+
+import {submodule} from '../src/hook.js';
+import {logError} from '../src/utils.js';
+
+export const MODULE_NAME = 'rewardedInterestId';
+export const SOURCE = 'rewardedinterest.com';
+
+/**
+ * Get rewarded interest API
+ * @function
+ * @returns {RewardedInterestApi|undefined}
+ */
+export function getRewardedInterestApi() {
+  if (window.__riApi && window.__riApi.getIdentityToken) {
+    return window.__riApi;
+  }
+}
+
+/**
+ * Wait while rewarded interest API to be set and execute the callback function
+ * @param {function} callback
+ */
+export function watchRewardedInterestApi(callback) {
+  Object.defineProperties(window, {
+    __rewardedInterestApi: {
+      value: undefined,
+      writable: true
+    },
+    __riApi: {
+      get: () => {
+        return window.__rewardedInterestApi;
+      },
+      set: value => {
+        window.__rewardedInterestApi = value;
+        callback(value);
+      },
+      configurable: true,
+    }
+  });
+}
+
+/**
+ * Get rewarded interest ID from API and pass it to the callback function
+ * @param {RewardedInterestApi} rewardedInterestApi
+ * @param {function} callback User ID callbackCompleted
+ */
+export function getRewardedInterestId(rewardedInterestApi, callback) {
+  rewardedInterestApi.getIdentityToken().then(callback).catch(error => {
+    callback();
+    logError(`${MODULE_NAME} module: ID fetch encountered an error`, error);
+  });
+}
+
+/**
+ * @param {function} callback User ID callbackCompleted
+ */
+export function apiNotAvailable(callback) {
+  callback();
+  logError(`${MODULE_NAME} module: Rewarded Interest API not found`);
+}
+
+/** @type {Submodule} */
+export const rewardedInterestIdSubmodule = {
+  /**
+   * Used to link submodule with config
+   * @type {string}
+   */
+  name: MODULE_NAME,
+
+  /**
+   * Decode the stored id value for passing to bid requests
+   * @function
+   * @param {string} value
+   * @returns {{rewardedInterestId: string}|undefined}
+   */
+  decode(value) {
+    return value ? {[MODULE_NAME]: value} : undefined;
+  },
+
+  /**
+   * Performs action to obtain id and return a value in the callback's response argument
+   * @function
+   * @returns {IdResponse|undefined}
+   */
+  getId() {
+    return {
+      callback: cb => {
+        const api = getRewardedInterestApi();
+        if (api) {
+          getRewardedInterestId(api, cb);
+        } else if (document.readyState === 'complete') {
+          apiNotAvailable(cb);
+        } else {
+          watchRewardedInterestApi(api => getRewardedInterestId(api, cb));
+          // Ensure that cb is called when API is not available
+          window.addEventListener('load', () => {
+            if (!getRewardedInterestApi()) {
+              apiNotAvailable(cb);
+            }
+          })
+        }
+      },
+    };
+  },
+  eids: {
+    [MODULE_NAME]: {
+      source: SOURCE,
+      atype: 3,
+    },
+  },
+};
+
+submodule('userId', rewardedInterestIdSubmodule);

--- a/modules/rewardedInterestIdSystem.md
+++ b/modules/rewardedInterestIdSystem.md
@@ -1,0 +1,23 @@
+## Rewarded Interest User ID Submodule
+
+This module adds rewarded interest advertising token to the user ID module
+
+*Note: The storage config should be omitted
+
+### Prebid Params
+
+```javascript
+pbjs.setConfig({
+    userSync: {
+        userIds: [{
+            name: 'rewardedInterestId',
+        }]
+    }
+});
+```
+
+## Parameter Descriptions for the `usersync` Configuration Section
+
+| Param under usersync.userIds[] | Scope    | Type   | Description              | Example                |
+|--------------------------------|----------|--------|--------------------------|------------------------|
+| name                           | Required | String | The name of this module. | `"rewardedInterestId"` |

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -840,7 +840,7 @@ function renderBid(bid) {
       height: bid.height,
       vastUrl: bid.vastUrl,
       placement: {
-        attachTo: adUnitElement,
+        attachTo: `#${bid.adUnitCode}`,
         align: config.align,
         position: config.position
       },

--- a/modules/vdoaiBidAdapter.js
+++ b/modules/vdoaiBidAdapter.js
@@ -1,6 +1,8 @@
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {getAdUnitSizes} from '../libraries/sizeUtils/sizeUtils.js';
+import { deepClone, logError, deepAccess } from '../src/utils.js';
+import { config } from '../src/config.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -9,7 +11,86 @@ import {getAdUnitSizes} from '../libraries/sizeUtils/sizeUtils.js';
  */
 
 const BIDDER_CODE = 'vdoai';
-const ENDPOINT_URL = 'https://prebid.vdo.ai/auction';
+const ENDPOINT_URL = 'https://prebid-v2.vdo.ai/auction';
+
+function getFrameNesting() {
+  let topmostFrame = window;
+  let parent = window.parent;
+  try {
+    while (topmostFrame !== topmostFrame.parent) {
+      parent = topmostFrame.parent;
+      // eslint-disable-next-line no-unused-expressions
+      parent.location.href;
+      topmostFrame = topmostFrame.parent;
+    }
+  } catch (e) { }
+  return topmostFrame;
+}
+
+/**
+ * Returns information about the page needed by the server in an object to be converted in JSON
+ *
+ * @returns {{location: *, referrer: (*|string), stack: (*|Array.<String>), numIframes: (*|Number), wWidth: (*|Number), wHeight: (*|Number), sWidth, sHeight, date: string, timeOffset: number}}
+ */
+function getPageInfo(bidderRequest) {
+  const topmostFrame = getFrameNesting();
+  return {
+    referrer: deepAccess(bidderRequest, 'refererInfo.ref', null),
+    stack: deepAccess(bidderRequest, 'refererInfo.stack', []),
+    numIframes: deepAccess(bidderRequest, 'refererInfo.numIframes', 0),
+    wWidth: topmostFrame.innerWidth,
+    location: deepAccess(bidderRequest, 'refererInfo.page', null),
+    wHeight: topmostFrame.innerHeight,
+    aWidth: topmostFrame.screen.availWidth,
+    aHeight: topmostFrame.screen.availHeight,
+    oWidth: topmostFrame.outerWidth,
+    oHeight: topmostFrame.outerHeight,
+    sWidth: topmostFrame.screen.width,
+    sHeight: topmostFrame.screen.height,
+    sLeft: 'screenLeft' in topmostFrame ? topmostFrame.screenLeft : topmostFrame.screenX,
+    sTop: 'screenTop' in topmostFrame ? topmostFrame.screenTop : topmostFrame.screenY,
+    xOffset: topmostFrame.pageXOffset,
+    docHeight: topmostFrame.document.body ? topmostFrame.document.body.scrollHeight : null,
+    hLength: history.length,
+    yOffset: topmostFrame.pageYOffset,
+    version: {
+      prebid_version: '$prebid.version$',
+      adapter_version: '1.0.0',
+      vendor: '$$PREBID_GLOBAL$$',
+    }
+  };
+}
+
+export function isSchainValid(schain) {
+  let isValid = false;
+  const requiredFields = ['asi', 'sid', 'hp'];
+  if (!schain || !schain.nodes) return isValid;
+  isValid = schain.nodes.reduce((status, node) => {
+    if (!status) return status;
+    return requiredFields.every(field => node.hasOwnProperty(field));
+  }, true);
+  if (!isValid) {
+    logError('VDO.AI: required schain params missing');
+  }
+  return isValid;
+}
+
+function parseVideoSize(bid) {
+  const playerSize = bid.mediaTypes.video.playerSize;
+  if (typeof playerSize !== 'undefined' && Array.isArray(playerSize) && playerSize.length > 0) {
+    return getSizes(playerSize)
+  }
+  return [];
+}
+
+function getSizes(sizes) {
+  const ret = [];
+  for (let i = 0; i < sizes.length; i++) {
+    const size = sizes[i];
+    ret.push({ width: size[0], height: size[1] })
+  }
+  return ret;
+}
 
 export const spec = {
   code: BIDDER_CODE,
@@ -21,7 +102,7 @@ export const spec = {
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: function (bid) {
-    return !!(bid.params.placementId);
+    return !!(bid.params.placementId) && typeof bid.params.placementId === 'string';
   },
 
   /**
@@ -31,23 +112,82 @@ export const spec = {
    * @param validBidRequests
    * @param bidderRequest
    */
+
   buildRequests: function (validBidRequests, bidderRequest) {
     if (validBidRequests.length === 0) {
       return [];
     }
-
     return validBidRequests.map(bidRequest => {
       const sizes = getAdUnitSizes(bidRequest);
-      const payload = {
+      let payload = {
         placementId: bidRequest.params.placementId,
         sizes: sizes,
         bidId: bidRequest.bidId,
-        // TODO: is 'page' the right value here?
-        referer: bidderRequest.refererInfo.page,
-        // TODO: fix auctionId leak: https://github.com/prebid/Prebid.js/issues/9781
-        id: bidRequest.auctionId,
-        mediaType: bidRequest.mediaTypes.video ? 'video' : 'banner'
+        mediaType: bidRequest.mediaTypes.video ? 'video' : 'banner',
+        domain: bidderRequest.ortb2.site.domain,
+        publisherDomain: bidderRequest.ortb2.site.publisher.domain,
+        adUnitCode: bidRequest.adUnitCode,
+        bidder: bidRequest.bidder,
+        tmax: bidderRequest.timeout
       };
+
+      payload.bidderRequestId = bidRequest.bidderRequestId;
+      payload.auctionId = deepAccess(bidRequest, 'ortb2.source.tid');
+      payload.transactionId = deepAccess(bidRequest, 'ortb2Imp.ext.tid');
+      payload.gpid = deepAccess(bidRequest, 'ortb2Imp.ext.gpid') || deepAccess(bidRequest, 'ortb2Imp.ext.data.pbadslot');
+      payload.ortb2Imp = deepAccess(bidRequest, 'ortb2Imp');
+
+      if (payload.mediaType === 'video') {
+        payload.context = bidRequest.mediaTypes.video.context;
+        payload.playerSize = parseVideoSize(bidRequest);
+        payload.mediaTypeInfo = deepClone(bidRequest.mediaTypes.video);
+      }
+
+      if (typeof bidRequest.getFloor === 'function') {
+        let floor = bidRequest.getFloor({
+          currency: 'USD',
+          mediaType: '*',
+          size: '*'
+        });
+        if (floor && floor.floor && floor.currency === 'USD') {
+          payload.bidFloor = floor.floor;
+        }
+      } else if (bidRequest.params.bidFloor) {
+        payload.bidFloor = bidRequest.params.bidFloor;
+      }
+
+      payload.pageInfo = getPageInfo(bidderRequest);
+
+      if (bidderRequest && bidderRequest.gdprConsent) {
+        payload.gdprConsent = {
+          consentRequired: bidderRequest.gdprConsent.gdprApplies,
+          consentString: bidderRequest.gdprConsent.consentString,
+          addtlConsent: bidderRequest.gdprConsent.addtlConsent
+        };
+      }
+      if (bidderRequest && bidderRequest.gppConsent) {
+        payload.gppConsent = {
+          applicableSections: bidderRequest.gppConsent.applicableSections,
+          consentString: bidderRequest.gppConsent.gppString,
+        }
+      }
+      if (bidderRequest && bidderRequest.ortb2) {
+        payload.ortb2 = bidderRequest.ortb2;
+      }
+      if (bidderRequest && bidderRequest.uspConsent) {
+        payload.usPrivacy = bidderRequest.uspConsent;
+      }
+      if (validBidRequests && validBidRequests.length !== 0 && validBidRequests[0].schain && isSchainValid(validBidRequests[0].schain)) {
+        payload.schain = validBidRequests[0].schain;
+      }
+      if (validBidRequests && validBidRequests.length !== 0 && validBidRequests[0].userIdAsEids) {
+        payload.userId = validBidRequests[0].userIdAsEids;
+      }
+      let coppaOrtb2 = !!deepAccess(bidderRequest, 'ortb2.regs.coppa');
+      let coppaConfig = config.getConfig('coppa');
+      if (coppaOrtb2 === true || coppaConfig === true) {
+        payload.coppa = true;
+      }
       return {
         method: 'POST',
         url: ENDPOINT_URL,
@@ -67,35 +207,24 @@ export const spec = {
     const bidResponses = [];
     const response = serverResponse.body;
     const creativeId = response.adid || 0;
-    // const width = response.w || 0;
-    const width = response.width;
-    // const height = response.h || 0;
-    const height = response.height;
+    const width = response.w;
+    const height = response.h;
     const cpm = response.price || 0;
-
-    response.rWidth = width;
-    response.rHeight = height;
 
     const adCreative = response.vdoCreative;
 
     if (width !== 0 && height !== 0 && cpm !== 0 && creativeId !== 0) {
-      // const dealId = response.dealid || '';
       const currency = response.cur || 'USD';
       const netRevenue = true;
-      // const referrer = bidRequest.data.referer;
       const bidResponse = {
         requestId: response.bidId,
         cpm: cpm,
         width: width,
         height: height,
         creativeId: creativeId,
-        // dealId: dealId,
         currency: currency,
         netRevenue: netRevenue,
         ttl: 60,
-        // referrer: referrer,
-        // ad: response.adm
-        // ad: adCreative,
         mediaType: response.mediaType
       };
 
@@ -104,9 +233,9 @@ export const spec = {
       } else {
         bidResponse.ad = adCreative;
       }
-      if (response.adDomain) {
+      if (response.adomain) {
         bidResponse.meta = {
-          advertiserDomains: response.adDomain
+          advertiserDomains: response.adomain
         };
       }
       bidResponses.push(bidResponse);
@@ -130,7 +259,7 @@ export const spec = {
     return [];
   },
 
-  onTImeout: function(data) {},
+  onTimeout: function(data) {},
   onBidWon: function(bid) {},
   onSetTargeting: function(bid) {}
 };

--- a/modules/videoheroesBidAdapter.js
+++ b/modules/videoheroesBidAdapter.js
@@ -1,8 +1,8 @@
-import { isEmpty, parseUrl, isStr, triggerPixel } from '../src/utils.js';
+import { triggerPixel, isStr } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
-import { config } from '../src/config.js';
-import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
+import { parseNative } from '../libraries/braveUtils/index.js';
+import { buildRequests, interpretResponse } from '../libraries/braveUtils/buildAndInterpret.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -13,158 +13,15 @@ const BIDDER_CODE = 'videoheroes';
 const DEFAULT_CUR = 'USD';
 const ENDPOINT_URL = `https://point.contextualadv.com/?t=2&partner=hash`;
 
-const NATIVE_ASSETS_IDS = { 1: 'title', 2: 'icon', 3: 'image', 4: 'body', 5: 'sponsoredBy', 6: 'cta' };
-const NATIVE_ASSETS = {
-  title: { id: 1, name: 'title' },
-  icon: { id: 2, type: 1, name: 'img' },
-  image: { id: 3, type: 3, name: 'img' },
-  body: { id: 4, type: 2, name: 'data' },
-  sponsoredBy: { id: 5, type: 1, name: 'data' },
-  cta: { id: 6, type: 12, name: 'data' }
-};
-
 export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 
-  /**
-   * Determines whether or not the given bid request is valid.
-   *
-   * @param {object} bid The bid to validate.
-   * @return boolean True if this is a valid bid, and false otherwise.
-   */
-  isBidRequestValid: (bid) => {
-    return !!(bid.params.placementId && bid.params.placementId.toString().length === 32);
-  },
+  isBidRequestValid: (bid) => !!(bid.params.placementId && bid.params.placementId.toString().length === 32),
 
-  /**
-   * Make a server request from the list of BidRequests.
-   *
-   * @param {BidRequest[]} validBidRequests A non-empty list of valid bid requests that should be sent to the Server.
-   * @return ServerRequest Info describing the request to the server.
-   */
-  buildRequests: (validBidRequests, bidderRequest) => {
-    // convert Native ORTB definition to old-style prebid native definition
-    validBidRequests = convertOrtbRequestToProprietaryNative(validBidRequests);
-    if (validBidRequests.length === 0 || !bidderRequest) return [];
+  buildRequests: (validBidRequests, bidderRequest) => buildRequests(validBidRequests, bidderRequest, ENDPOINT_URL, DEFAULT_CUR),
 
-    const endpointURL = ENDPOINT_URL.replace('hash', validBidRequests[0].params.placementId);
-
-    let imp = validBidRequests.map(br => {
-      let impObject = {
-        id: br.bidId,
-        secure: 1
-      };
-
-      if (br.mediaTypes.banner) {
-        impObject.banner = createBannerRequest(br);
-      } else if (br.mediaTypes.video) {
-        impObject.video = createVideoRequest(br);
-      } else if (br.mediaTypes.native) {
-        impObject.native = {
-          // TODO: fix transactionId leak: https://github.com/prebid/Prebid.js/issues/9781
-          // Also, `id` is not in the ORTB native spec
-          id: br.transactionId,
-          ver: '1.2',
-          request: createNativeRequest(br)
-        };
-      }
-      return impObject;
-    });
-
-    let page = bidderRequest.refererInfo.page || bidderRequest.refererInfo.topmostLocation;
-
-    let data = {
-      id: bidderRequest.bidderRequestId,
-      cur: [ DEFAULT_CUR ],
-      device: {
-        w: screen.width,
-        h: screen.height,
-        language: (navigator && navigator.language) ? navigator.language.indexOf('-') != -1 ? navigator.language.split('-')[0] : navigator.language : '',
-        ua: navigator.userAgent,
-      },
-      site: {
-        domain: parseUrl(page).hostname,
-        page: page,
-      },
-      tmax: bidderRequest.timeout,
-      imp
-    };
-
-    if (bidderRequest.refererInfo.ref) {
-      data.site.ref = bidderRequest.refererInfo.ref;
-    }
-
-    if (bidderRequest.gdprConsent) {
-      data['regs'] = {'ext': {'gdpr': bidderRequest.gdprConsent.gdprApplies ? 1 : 0}};
-      data['user'] = {'ext': {'consent': bidderRequest.gdprConsent.consentString ? bidderRequest.gdprConsent.consentString : ''}};
-    }
-
-    if (bidderRequest.uspConsent !== undefined) {
-      if (!data['regs'])data['regs'] = {'ext': {}};
-      data['regs']['ext']['us_privacy'] = bidderRequest.uspConsent;
-    }
-
-    if (config.getConfig('coppa') === true) {
-      if (!data['regs'])data['regs'] = {'coppa': 1};
-      else data['regs']['coppa'] = 1;
-    }
-
-    if (validBidRequests[0].schain) {
-      data['source'] = {'ext': {'schain': validBidRequests[0].schain}};
-    }
-
-    return {
-      method: 'POST',
-      url: endpointURL,
-      data: data
-    };
-  },
-
-  /**
-   * Unpack the response from the server into a list of bids.
-   *
-   * @param {*} serverResponse A successful response from the server.
-   * @return {Bid[]} An array of bids which were nested inside the server.
-   */
-  interpretResponse: (serverResponse) => {
-    if (!serverResponse || isEmpty(serverResponse.body)) return [];
-
-    let bids = [];
-    serverResponse.body.seatbid.forEach(response => {
-      response.bid.forEach(bid => {
-        let mediaType = bid.ext && bid.ext.mediaType ? bid.ext.mediaType : 'banner';
-
-        let bidObj = {
-          requestId: bid.impid,
-          cpm: bid.price,
-          width: bid.w,
-          height: bid.h,
-          ttl: 1200,
-          currency: DEFAULT_CUR,
-          netRevenue: true,
-          creativeId: bid.crid,
-          dealId: bid.dealid || null,
-          mediaType: mediaType
-        };
-
-        switch (mediaType) {
-          case 'video':
-            bidObj.vastUrl = bid.adm;
-            break;
-          case 'native':
-            bidObj.native = parseNative(bid.adm);
-            break;
-          default:
-            bidObj.ad = bid.adm;
-        }
-
-        bids.push(bidObj);
-      });
-    });
-
-    return bids;
-  },
+  interpretResponse: (serverResponse) => interpretResponse(serverResponse, DEFAULT_CUR, parseNative),
 
   onBidWon: (bid) => {
     if (isStr(bid.nurl) && bid.nurl !== '') {
@@ -172,90 +29,5 @@ export const spec = {
     }
   }
 };
-
-const parseNative = adm => {
-  let bid = {
-    clickUrl: adm.native.link && adm.native.link.url,
-    impressionTrackers: adm.native.imptrackers || [],
-    clickTrackers: (adm.native.link && adm.native.link.clicktrackers) || [],
-    jstracker: adm.native.jstracker || []
-  };
-  adm.native.assets.forEach(asset => {
-    let kind = NATIVE_ASSETS_IDS[asset.id];
-    let content = kind && asset[NATIVE_ASSETS[kind].name];
-    if (content) {
-      bid[kind] = content.text || content.value || { url: content.url, width: content.w, height: content.h };
-    }
-  });
-
-  return bid;
-}
-
-const createNativeRequest = br => {
-  let impObject = {
-    ver: '1.2',
-    assets: []
-  };
-
-  let keys = Object.keys(br.mediaTypes.native);
-
-  for (let key of keys) {
-    const props = NATIVE_ASSETS[key];
-    if (props) {
-      const asset = {
-        required: br.mediaTypes.native[key].required ? 1 : 0,
-        id: props.id,
-        [props.name]: {}
-      };
-
-      if (props.type) asset[props.name]['type'] = props.type;
-      if (br.mediaTypes.native[key].len) asset[props.name]['len'] = br.mediaTypes.native[key].len;
-      if (br.mediaTypes.native[key].sizes && br.mediaTypes.native[key].sizes[0]) {
-        asset[props.name]['w'] = br.mediaTypes.native[key].sizes[0];
-        asset[props.name]['h'] = br.mediaTypes.native[key].sizes[1];
-      }
-
-      impObject.assets.push(asset);
-    }
-  }
-
-  return impObject;
-}
-
-const createBannerRequest = br => {
-  let size = [];
-
-  if (br.mediaTypes.banner.sizes && Array.isArray(br.mediaTypes.banner.sizes)) {
-    if (Array.isArray(br.mediaTypes.banner.sizes[0])) { size = br.mediaTypes.banner.sizes[0]; } else { size = br.mediaTypes.banner.sizes; }
-  } else size = [300, 250];
-
-  return { id: br.transactionId, w: size[0], h: size[1] };
-};
-
-const createVideoRequest = br => {
-  let videoObj = {id: br.transactionId};
-  let supportParamsList = ['mimes', 'minduration', 'maxduration', 'protocols', 'startdelay', 'skip', 'minbitrate', 'maxbitrate', 'api', 'linearity'];
-
-  for (let param of supportParamsList) {
-    if (br.mediaTypes.video[param] !== undefined) {
-      videoObj[param] = br.mediaTypes.video[param];
-    }
-  }
-
-  if (br.mediaTypes.video.playerSize && Array.isArray(br.mediaTypes.video.playerSize)) {
-    if (Array.isArray(br.mediaTypes.video.playerSize[0])) {
-      videoObj.w = br.mediaTypes.video.playerSize[0][0];
-      videoObj.h = br.mediaTypes.video.playerSize[0][1];
-    } else {
-      videoObj.w = br.mediaTypes.video.playerSize[0];
-      videoObj.h = br.mediaTypes.video.playerSize[1];
-    }
-  } else {
-    videoObj.w = 640;
-    videoObj.h = 480;
-  }
-
-  return videoObj;
-}
 
 registerBidder(spec);

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -39,7 +39,13 @@ import {newMetrics, useMetrics} from './utils/perfMetrics.js';
 import {defer, GreedyPromise} from './utils/promise.js';
 import {enrichFPD} from './fpd/enrichment.js';
 import {allConsent} from './consentHandler.js';
-import {insertLocatorFrame, markBidAsRendered, renderAdDirect, renderIfDeferred} from './adRendering.js';
+import {
+  insertLocatorFrame,
+  markBidAsRendered,
+  markWinningBid,
+  renderAdDirect,
+  renderIfDeferred
+} from './adRendering.js';
 import {getHighestCpm} from './utils/reducers.js';
 import {fillVideoDefaults, validateOrtbVideoFields} from './video.js';
 
@@ -905,7 +911,7 @@ if (FEATURES.VIDEO) {
    *
    * @alias module:pbjs.markWinningBidAsUsed
    */
-  pbjsInstance.markWinningBidAsUsed = function ({adId, adUnitCode}) {
+  pbjsInstance.markWinningBidAsUsed = function ({adId, adUnitCode, analytics = false}) {
     let bids;
     if (adUnitCode && adId == null) {
       bids = targeting.getWinningBids(adUnitCode);
@@ -915,7 +921,11 @@ if (FEATURES.VIDEO) {
       logWarn('Improper use of markWinningBidAsUsed. It needs an adUnitCode or an adId to function.');
     }
     if (bids.length > 0) {
-      auctionManager.addWinningBid(bids[0]);
+      if (analytics) {
+        markWinningBid(bids[0]);
+      } else {
+        auctionManager.addWinningBid(bids[0]);
+      }
       markBidAsRendered(bids[0])
     }
   }

--- a/test/spec/libraries/mspa/activityControls_spec.js
+++ b/test/spec/libraries/mspa/activityControls_spec.js
@@ -229,6 +229,13 @@ describe('setupRules', () => {
     sinon.assert.calledWith(rules.mockActivity, {mock: 'consent'})
   });
 
+  it('should accept already flattened section data', () => {
+    consent.parsedSections.mockApi = {flat: 'consent'};
+    runSetup('mockApi', [1]);
+    isAllowed('mockActivity', {});
+    sinon.assert.calledWith(rules.mockActivity, {flat: 'consent'})
+  })
+
   it('should not choke when no consent data is available', () => {
     consent = null;
     runSetup('mockApi', [1]);

--- a/test/spec/modules/adagioRtdProvider_spec.js
+++ b/test/spec/modules/adagioRtdProvider_spec.js
@@ -121,7 +121,8 @@ describe('Adagio Rtd Provider', function () {
         id: 'uid-1234',
         rnd: 0.5697,
         vwSmplg: 0.1,
-        vwSmplgNxt: 0.1
+        vwSmplgNxt: 0.1,
+        pages: 1
       };
 
       it('store new session data for further usage', function () {
@@ -139,7 +140,8 @@ describe('Adagio Rtd Provider', function () {
           session: {
             new: true,
             id: utils.generateUUID(),
-            rnd: Math.random()
+            rnd: Math.random(),
+            pages: 1,
           }
         }
 
@@ -211,7 +213,8 @@ describe('Adagio Rtd Provider', function () {
         vwSmplgNxt: 0.1,
         testName: 'adg-test',
         testVersion: 'srv',
-        initiator: 'snippet'
+        initiator: 'snippet',
+        pages: 1
       };
 
       it('store new session data instancied by the AB Test snippet for further usage', function () {
@@ -591,7 +594,8 @@ describe('Adagio Rtd Provider', function () {
                       'new': true,
                       'rnd': 0.020644826280300954,
                       'vwSmplg': 0.1,
-                      'vwSmplgNxt': 0.1
+                      'vwSmplgNxt': 0.1,
+                      'pages': 1
                     }
                   }
                 }
@@ -617,7 +621,8 @@ describe('Adagio Rtd Provider', function () {
                   'new': true,
                   'rnd': 0.020644826280300954,
                   'vwSmplg': 0.1,
-                  'vwSmplgNxt': 0.1
+                  'vwSmplgNxt': 0.1,
+                  'pages': 1
                 }
               }
             }

--- a/test/spec/modules/adverxoBidAdapter_spec.js
+++ b/test/spec/modules/adverxoBidAdapter_spec.js
@@ -1,0 +1,724 @@
+import {expect} from 'chai';
+import {spec} from 'modules/adverxoBidAdapter.js';
+import {config} from 'src/config';
+
+describe('Adverxo Bid Adapter', () => {
+  function makeBidRequestWithParams(params) {
+    return {
+      bidId: '2e9f38ea93bb9e',
+      bidder: 'adverxo',
+      adUnitCode: 'adunit-code',
+      mediaTypes: {banner: {sizes: [[300, 250]]}},
+      params: params,
+      bidderRequestId: 'test-bidder-request-id'
+    };
+  }
+
+  const bannerBidRequests = [
+    {
+      bidId: 'bid-banner',
+      bidder: 'adverxo',
+      adUnitCode: 'adunit-code',
+      userIdAsEids: [{
+        'source': 'pubcid.org',
+        'uids': [{
+          'atype': 1,
+          'id': '01EAJWWNEPN3CYMM5N8M5VXY22'
+        }]
+      }],
+      mediaTypes: {banner: {sizes: [[300, 250]]}},
+      params: {
+        host: 'bid.example.com',
+        adUnitId: 1,
+        auth: 'authExample',
+      },
+      bidderRequestId: 'test-bidder-request-id',
+    },
+  ];
+
+  const bannerBidderRequest = {
+    bidderCode: 'adverxo',
+    bidderRequestId: 'test-bidder-request-id',
+    bids: bannerBidRequests,
+    auctionId: 'new-auction-id'
+  };
+
+  const nativeOrtbRequest = {
+    assets: [
+      {
+        id: 1,
+        required: 1,
+        img: {type: 3, w: 150, h: 50}
+      },
+      {
+        id: 2,
+        required: 1,
+        title: {len: 80}
+      },
+      {
+        id: 3,
+        required: 0,
+        data: {type: 1}
+      }
+    ]
+  };
+
+  const nativeBidRequests = [
+    {
+      bidId: 'bid-native',
+      mediaTypes: {
+        native: {
+          ortb: nativeOrtbRequest
+        }
+      },
+      nativeOrtbRequest,
+      params: {
+        host: 'bid.example.com',
+        adUnitId: 1,
+        auth: 'authExample'
+      }
+    },
+  ];
+
+  const nativeBidderRequest = {
+    bidderCode: 'adverxo',
+    bidderRequestId: 'test-bidder-request-id',
+    bids: nativeBidRequests,
+    auctionId: 'new-auction-id'
+  };
+
+  const videoInstreamBidRequests = [
+    {
+      bidId: 'bid-video',
+      mediaTypes: {
+        video: {
+          context: 'instream',
+          playerSize: [400, 300],
+          w: 400,
+          h: 300,
+          minduration: 5,
+          maxduration: 10,
+          startdelay: 0,
+          skip: 1,
+          minbitrate: 200,
+          protocols: [1, 2, 4]
+        }
+      },
+      params: {
+        host: 'bid.example.com',
+        adUnitId: 1,
+        auth: 'authExample'
+      }
+    }
+  ];
+
+  const videoInstreamBidderRequest = {
+    bidderCode: 'adverxo',
+    bidderRequestId: 'test-bidder-request-id',
+    bids: videoInstreamBidRequests,
+    auctionId: 'new-auction-id'
+  };
+
+  const videoOutstreamBidRequests = [
+    {
+      bidId: 'bid-video',
+      mediaTypes: {
+        video: {
+          context: 'outstream',
+          playerSize: [400, 300],
+          w: 400,
+          h: 300,
+          minduration: 5,
+          maxduration: 10,
+          startdelay: 0,
+          skip: 1,
+          minbitrate: 200,
+          protocols: [1, 2, 4]
+        }
+      },
+      params: {
+        host: 'bid.example.com',
+        adUnitId: 1,
+        auth: 'authExample'
+      }
+    }
+  ];
+
+  const videoOutstreamBidderRequest = {
+    bidderCode: 'adverxo',
+    bidderRequestId: 'test-bidder-request-id',
+    bids: videoOutstreamBidRequests,
+    auctionId: 'new-auction-id'
+  };
+
+  afterEach(function () {
+    config.resetConfig();
+  });
+
+  describe('isBidRequestValid', function () {
+    it('should validate bid request with valid params', () => {
+      const validBid = makeBidRequestWithParams({
+        adUnitId: 1,
+        auth: 'authExample',
+        host: 'www.bidExample.com'
+      });
+
+      const isValid = spec.isBidRequestValid(validBid);
+
+      expect(isValid).to.be.true;
+    });
+
+    it('should not validate bid request with empty params', () => {
+      const invalidBid = makeBidRequestWithParams({});
+
+      const isValid = spec.isBidRequestValid(invalidBid);
+
+      expect(isValid).to.be.false;
+    });
+
+    it('should not validate bid request with missing param(adUnitId)', () => {
+      const invalidBid = makeBidRequestWithParams({
+        auth: 'authExample',
+        host: 'www.bidExample.com'
+      });
+
+      const isValid = spec.isBidRequestValid(invalidBid);
+
+      expect(isValid).to.be.false;
+    });
+
+    it('should not validate bid request with missing param(auth)', () => {
+      const invalidBid = makeBidRequestWithParams({
+        adUnitId: 1,
+        host: 'www.bidExample.com'
+      });
+
+      const isValid = spec.isBidRequestValid(invalidBid);
+
+      expect(isValid).to.be.false;
+    });
+
+    it('should validate bid request with missing param(host)', () => {
+      const invalidBid = makeBidRequestWithParams({
+        adUnitId: 1,
+        auth: 'authExample',
+      });
+
+      const isValid = spec.isBidRequestValid(invalidBid);
+
+      expect(isValid).to.be.true;
+    });
+  });
+
+  describe('buildRequests', () => {
+    it('should add eids information to the request', function () {
+      const request = spec.buildRequests(bannerBidRequests, bannerBidderRequest)[0];
+
+      expect(request.data.user.ext.eids).to.exist;
+      expect(request.data.user.ext.eids).to.deep.equal(bannerBidRequests[0].userIdAsEids);
+    });
+
+    it('should use correct bidUrl for an alias', () => {
+      const bidRequests = [
+        {
+          bidder: 'bidsmind',
+          mediaTypes: {banner: {sizes: [[300, 250]]}},
+          params: {
+            adUnitId: 1,
+            auth: 'authExample',
+          }
+        },
+      ];
+
+      const bidderRequest = {
+        bidderCode: 'bidsmind',
+        bids: bidRequests,
+      };
+
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+
+      expect(request.method).to.equal('POST');
+      expect(request.url).to.equal('https://egrevirda.com/pickpbs?id=1&auth=authExample');
+    });
+
+    it('should use correct default bidUrl', () => {
+      const bidRequests = [
+        {
+          bidder: 'adverxo',
+          mediaTypes: {banner: {sizes: [[300, 250]]}},
+          params: {
+            adUnitId: 1,
+            auth: 'authExample',
+          }
+        },
+      ];
+
+      const bidderRequest = {
+        bidderCode: 'adverxo',
+        bids: bidRequests
+      };
+
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+
+      expect(request.method).to.equal('POST');
+      expect(request.url).to.equal('https://js.pbsadverxo.com/pickpbs?id=1&auth=authExample');
+    });
+
+    it('should build post request for banner', () => {
+      const request = spec.buildRequests(bannerBidRequests, bannerBidderRequest)[0];
+
+      expect(request.method).to.equal('POST');
+      expect(request.url).to.equal('https://bid.example.com/pickpbs?id=1&auth=authExample');
+      expect(request.data.device.ip).to.equal('caller');
+      expect(request.data.ext.avx_add_vast_url).to.equal(1);
+    });
+
+    if (FEATURES.NATIVE) {
+      it('should build post request for native', () => {
+        const request = spec.buildRequests(nativeBidRequests, nativeBidderRequest)[0];
+
+        expect(request.method).to.equal('POST');
+        expect(request.url).to.equal('https://bid.example.com/pickpbs?id=1&auth=authExample');
+
+        const nativeRequest = JSON.parse(request.data.imp[0]['native'].request);
+
+        expect(nativeRequest.assets).to.have.lengthOf(3);
+
+        expect(nativeRequest.assets[0]).to.deep.equal({
+          id: 1,
+          required: 1,
+          img: {w: 150, h: 50, type: 3}
+        });
+
+        expect(nativeRequest.assets[1]).to.deep.equal({
+          id: 2,
+          required: 1,
+          title: {len: 80}
+        });
+
+        expect(nativeRequest.assets[2]).to.deep.equal({
+          id: 3,
+          required: 0,
+          data: {type: 1}
+        });
+      });
+    }
+
+    if (FEATURES.VIDEO) {
+      it('should build post request for video', function () {
+        const request = spec.buildRequests(videoInstreamBidRequests, videoInstreamBidderRequest)[0];
+
+        expect(request.method).to.equal('POST');
+        expect(request.url).to.equal('https://bid.example.com/pickpbs?id=1&auth=authExample');
+
+        const ortbRequest = request.data;
+
+        expect(ortbRequest.imp).to.have.lengthOf(1);
+
+        expect(ortbRequest.imp[0]).to.deep.equal({
+          id: 'bid-video',
+          video: {
+            w: 400,
+            h: 300,
+            minduration: 5,
+            maxduration: 10,
+            startdelay: 0,
+            skip: 1,
+            minbitrate: 200,
+            protocols: [1, 2, 4]
+          }
+        });
+      });
+    }
+
+    it('should add bid floor to request', function () {
+      const bannerBidRequestWithFloor = {
+        ...bannerBidRequests[0],
+        getFloor: () => ({currency: 'USD', floor: 3})
+      };
+
+      const request = spec.buildRequests([bannerBidRequestWithFloor], {})[0].data;
+
+      expect(request.imp[0].bidfloor).to.equal(3);
+      expect(request.imp[0].bidfloorcur).to.equal('USD');
+    });
+  });
+
+  describe('interpretResponse', () => {
+    it('should return empty array if serverResponse is not defined', () => {
+      const bidRequest = spec.buildRequests(bannerBidRequests, bannerBidderRequest);
+      const bids = spec.interpretResponse(undefined, bidRequest);
+
+      expect(bids.length).to.equal(0);
+    });
+
+    it('should interpret banner response', () => {
+      const bidResponse = {
+        body: {
+          id: 'bid-response',
+          cur: 'USD',
+          seatbid: [
+            {
+              bid: [
+                {
+                  impid: 'bid-banner',
+                  crid: 'creative-id',
+                  cur: 'USD',
+                  price: 2,
+                  w: 300,
+                  h: 250,
+                  mtype: 1,
+                  adomain: ['test.com'],
+                  adm: '<div></div>'
+                },
+              ],
+              seat: 'test-seat',
+            },
+          ],
+        },
+      };
+
+      const expectedBids = [
+        {
+          cpm: 2,
+          creativeId: 'creative-id',
+          creative_id: 'creative-id',
+          currency: 'USD',
+          height: 250,
+          mediaType: 'banner',
+          meta: {
+            advertiserDomains: ['test.com'],
+          },
+          netRevenue: true,
+          requestId: 'bid-banner',
+          ttl: 60,
+          width: 300,
+          ad: '<div></div>'
+        },
+      ];
+
+      const request = spec.buildRequests(bannerBidRequests, bannerBidderRequest)[0];
+      const bids = spec.interpretResponse(bidResponse, request);
+
+      expect(bids).to.deep.equal(expectedBids);
+    });
+
+    it('should replace openrtb auction price macro', () => {
+      const bidResponse = {
+        body: {
+          id: 'bid-response',
+          cur: 'USD',
+          seatbid: [
+            {
+              bid: [
+                {
+                  impid: 'bid-banner',
+                  crid: 'creative-id',
+                  cur: 'USD',
+                  price: 2,
+                  w: 300,
+                  h: 250,
+                  mtype: 1,
+                  adomain: ['test.com'],
+                  adm: '<a href="https://www.example.com/imp?prc=${AUCTION_PRICE}" target="_blank"><img src="https://www.example.com/click?prc=${AUCTION_PRICE}"</a>'
+                },
+              ],
+              seat: 'test-seat',
+            },
+          ],
+        },
+      };
+
+      const request = spec.buildRequests(bannerBidRequests, bannerBidderRequest)[0];
+      const bids = spec.interpretResponse(bidResponse, request);
+
+      expect(bids[0].ad).to.equal('<a href="https://www.example.com/imp?prc=2" target="_blank"><img src="https://www.example.com/click?prc=2"</a>');
+    });
+
+    if (FEATURES.NATIVE) {
+      it('should interpret native response', () => {
+        const bidResponse = {
+          body: {
+            id: 'native-response',
+            cur: 'USD',
+            seatbid: [
+              {
+                bid: [
+                  {
+                    impid: 'bid-native',
+                    crid: 'creative-id',
+                    cur: 'USD',
+                    price: 2,
+                    w: 300,
+                    h: 250,
+                    mtype: 4,
+                    adomain: ['test.com'],
+                    adm: '{"native":{"assets":[{"id":2,"title":{"text":"Title"}},{"id":3,"data":{"value":"Description"}},{"id":1,"img":{"url":"http://example.com?img","w":150,"h":50}}],"link":{"url":"http://example.com?link"}}}'
+                  },
+                ],
+                seat: 'test-seat',
+              },
+            ],
+          },
+        };
+
+        const expectedBids = [
+          {
+            cpm: 2,
+            creativeId: 'creative-id',
+            creative_id: 'creative-id',
+            currency: 'USD',
+            height: 250,
+            mediaType: 'native',
+            meta: {
+              advertiserDomains: ['test.com'],
+            },
+            netRevenue: true,
+            requestId: 'bid-native',
+            ttl: 60,
+            width: 300,
+            native: {
+              ortb: {
+                assets: [
+                  {id: 2, title: {text: 'Title'}},
+                  {id: 3, data: {value: 'Description'}},
+                  {id: 1, img: {url: 'http://example.com?img', w: 150, h: 50}}
+                ],
+                link: {url: 'http://example.com?link'}
+              }
+            }
+          }
+        ];
+
+        const request = spec.buildRequests(nativeBidRequests, nativeBidderRequest)[0];
+        const bids = spec.interpretResponse(bidResponse, request);
+
+        expect(bids).to.deep.equal(expectedBids);
+      });
+    }
+
+    if (FEATURES.VIDEO) {
+      it('should interpret video instream response', () => {
+        const bidResponse = {
+          body: {
+            id: 'video-response',
+            cur: 'USD',
+            seatbid: [
+              {
+                bid: [
+                  {
+                    impid: 'bid-video',
+                    crid: 'creative-id',
+                    cur: 'USD',
+                    price: 2,
+                    w: 300,
+                    h: 250,
+                    mtype: 2,
+                    adomain: ['test.com'],
+                    adm: 'vastXml',
+                    ext: {
+                      avx_vast_url: 'vastUrl'
+                    }
+                  },
+                ],
+                seat: 'test-seat',
+              },
+            ],
+          },
+        };
+
+        const expectedBids = [
+          {
+            cpm: 2,
+            creativeId: 'creative-id',
+            creative_id: 'creative-id',
+            currency: 'USD',
+            height: 250,
+            mediaType: 'video',
+            meta: {
+              advertiserDomains: ['test.com'],
+            },
+            netRevenue: true,
+            playerHeight: 300,
+            playerWidth: 400,
+            requestId: 'bid-video',
+            ttl: 60,
+            vastUrl: 'vastUrl',
+            vastXml: 'vastXml',
+            width: 300
+          }
+        ];
+
+        const request = spec.buildRequests(videoInstreamBidRequests, videoInstreamBidderRequest)[0];
+        const bids = spec.interpretResponse(bidResponse, request);
+
+        expect(bids).to.deep.equal(expectedBids);
+      });
+
+      it('should interpret video outstream response', () => {
+        const bidResponse = {
+          body: {
+            id: 'video-response',
+            cur: 'USD',
+            seatbid: [
+              {
+                bid: [
+                  {
+                    impid: 'bid-video',
+                    crid: 'creative-id',
+                    cur: 'USD',
+                    price: 2,
+                    w: 300,
+                    h: 250,
+                    mtype: 2,
+                    adomain: ['test.com'],
+                    adm: 'vastXml',
+                    ext: {
+                      avx_vast_url: 'vastUrl',
+                      avx_video_renderer_url: 'videoRendererUrl',
+                    }
+                  },
+                ],
+                seat: 'test-seat',
+              },
+            ],
+          },
+        };
+
+        const expectedBids = [
+          {
+            avxVideoRendererUrl: 'videoRendererUrl',
+            cpm: 2,
+            creativeId: 'creative-id',
+            creative_id: 'creative-id',
+            currency: 'USD',
+            height: 250,
+            mediaType: 'video',
+            meta: {
+              advertiserDomains: ['test.com'],
+            },
+            netRevenue: true,
+            playerHeight: 300,
+            playerWidth: 400,
+            requestId: 'bid-video',
+            ttl: 60,
+            vastUrl: 'vastUrl',
+            vastXml: 'vastXml',
+            width: 300
+          }
+        ];
+
+        const request = spec.buildRequests(videoOutstreamBidRequests, videoOutstreamBidderRequest)[0];
+        const bids = spec.interpretResponse(bidResponse, request);
+
+        expect(bids[0].renderer.url).to.equal('videoRendererUrl');
+
+        delete (bids[0].renderer);
+        expect(bids).to.deep.equal(expectedBids);
+      });
+    }
+  });
+
+  describe('getUserSyncs', () => {
+    const exampleUrl = 'https://example.com/usync?id=5';
+    const iframeConfig = {iframeEnabled: true};
+
+    const responses = [{
+      body: {ext: {avx_usync: [exampleUrl]}}
+    }];
+
+    const responseWithoutQueryString = [{
+      body: {ext: {avx_usync: ['https://example.com/usync/sf/5']}}
+    }];
+
+    it('should not return empty list if not allowed', function () {
+      expect(spec.getUserSyncs({
+        iframeEnabled: false,
+        pixelEnabled: false
+      }, responses, undefined, undefined, undefined)).to.be.empty;
+    });
+
+    it('should not return iframe if not allowed', function () {
+      expect(spec.getUserSyncs({
+        iframeEnabled: false,
+        pixelEnabled: true
+      }, responses, undefined, undefined, undefined)).to.deep.equal([{
+        type: 'image', url: `${exampleUrl}&type=image`
+      }]);
+    });
+
+    it('should add query string to url when missing', function () {
+      expect(spec.getUserSyncs(iframeConfig, responseWithoutQueryString, undefined, undefined, undefined)).to.deep.equal([{
+        type: 'iframe', url: `https://example.com/usync/sf/5?type=iframe`
+      }]);
+    });
+
+    it('should not add parameters if not provided', function () {
+      expect(spec.getUserSyncs(iframeConfig, responses, undefined, undefined, undefined)).to.deep.equal([{
+        type: 'iframe', url: `${exampleUrl}&type=iframe`
+      }]);
+    });
+
+    it('should add GDPR parameters if provided', function () {
+      expect(spec.getUserSyncs(iframeConfig, responses, {gdprApplies: true}, undefined, undefined)).to.deep.equal([{
+        type: 'iframe', url: `${exampleUrl}&type=iframe&gdpr=1&gdpr_consent=`
+      }]);
+
+      expect(spec.getUserSyncs(iframeConfig, responses,
+        {gdprApplies: true, consentString: 'foo?'}, undefined, undefined)).to.deep.equal([{
+        type: 'iframe', url: `${exampleUrl}&type=iframe&gdpr=1&gdpr_consent=foo%3F`
+      }]);
+
+      expect(spec.getUserSyncs(iframeConfig, responses,
+        {gdprApplies: false, consentString: 'bar'}, undefined, undefined)).to.deep.equal([{
+        type: 'iframe', url: `${exampleUrl}&type=iframe&gdpr=0&gdpr_consent=bar`
+      }]);
+    });
+
+    it('should add CCPA parameters if provided', function () {
+      expect(spec.getUserSyncs(iframeConfig, responses, undefined, 'foo?', undefined)).to.deep.equal([{
+        type: 'iframe', url: `${exampleUrl}&type=iframe&us_privacy=foo%3F`
+      }]);
+    });
+
+    it('should not apply if not gppConsent.gppString', function () {
+      const gppConsent = {gppString: '', applicableSections: [123]};
+      const result = spec.getUserSyncs(iframeConfig, responses, undefined, undefined, gppConsent);
+      expect(result).to.deep.equal([{
+        type: 'iframe', url: `${exampleUrl}&type=iframe`
+      }]);
+    });
+
+    it('should not apply if not gppConsent.applicableSections', function () {
+      const gppConsent = {gppString: '', applicableSections: undefined};
+      const result = spec.getUserSyncs(iframeConfig, responses, undefined, undefined, gppConsent);
+      expect(result).to.deep.equal([{
+        type: 'iframe', url: `${exampleUrl}&type=iframe`
+      }]);
+    });
+
+    it('should not apply if empty gppConsent.applicableSections', function () {
+      const gppConsent = {gppString: '', applicableSections: []};
+      const result = spec.getUserSyncs(iframeConfig, responses, undefined, undefined, gppConsent);
+      expect(result).to.deep.equal([{
+        type: 'iframe', url: `${exampleUrl}&type=iframe`
+      }]);
+    });
+
+    it('should apply if all above are available', function () {
+      const gppConsent = {gppString: 'foo?', applicableSections: [123]};
+      const result = spec.getUserSyncs(iframeConfig, responses, undefined, undefined, gppConsent);
+      expect(result).to.deep.equal([{
+        type: 'iframe', url: `${exampleUrl}&type=iframe&gpp=foo%3F&gpp_sid=123`
+      }]);
+    });
+
+    it('should support multiple sections', function () {
+      const gppConsent = {gppString: 'foo', applicableSections: [123, 456]};
+      const result = spec.getUserSyncs(iframeConfig, responses, undefined, undefined, gppConsent);
+      expect(result).to.deep.equal([{
+        type: 'iframe', url: `${exampleUrl}&type=iframe&gpp=foo&gpp_sid=123%2C456`
+      }]);
+    });
+  });
+});

--- a/test/spec/modules/bridBidAdapter_spec.js
+++ b/test/spec/modules/bridBidAdapter_spec.js
@@ -1,4 +1,5 @@
 import { spec } from '../../../modules/bridBidAdapter.js'
+import { SYNC_URL } from '../../../libraries/targetVideoUtils/constants.js';
 
 describe('Brid Bid Adapter', function() {
   const videoRequest = [{
@@ -125,5 +126,24 @@ describe('Brid Bid Adapter', function() {
 
     expect(payload.regs.ext.gdpr).to.be.undefined;
     expect(payload.regs.ext.us_privacy).to.equal(uspConsentString);
+  });
+
+  it('Test userSync have only one object and it should have a property type=iframe', function () {
+    let userSync = spec.getUserSyncs({ iframeEnabled: true });
+    expect(userSync).to.be.an('array');
+    expect(userSync.length).to.be.equal(1);
+    expect(userSync[0]).to.have.property('type');
+    expect(userSync[0].type).to.be.equal('iframe');
+  });
+
+  it('Test userSync valid sync url for iframe', function () {
+    let [userSync] = spec.getUserSyncs({ iframeEnabled: true }, {}, {consentString: 'anyString'});
+    expect(userSync.url).to.contain(SYNC_URL + 'load-cookie.html?endpoint=brid&gdpr=0&gdpr_consent=anyString');
+    expect(userSync.type).to.be.equal('iframe');
+  });
+
+  it('Test userSyncs iframeEnabled=false', function () {
+    let userSyncs = spec.getUserSyncs({iframeEnabled: false});
+    expect(userSyncs).to.have.lengthOf(0);
   });
 });

--- a/test/spec/modules/medianetBidAdapter_spec.js
+++ b/test/spec/modules/medianetBidAdapter_spec.js
@@ -531,6 +531,16 @@ let VALID_BID_REQUEST = [{
       'screen': {
         'w': 1000,
         'h': 1000
+      },
+      'vcoords': {
+        'top_left': {
+          'x': 50,
+          'y': 100
+        },
+        'bottom_right': {
+          'x': 490,
+          'y': 880
+        }
       }
     },
     'id': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
@@ -622,6 +632,16 @@ let VALID_BID_REQUEST = [{
       'screen': {
         'w': 1000,
         'h': 1000
+      },
+      'vcoords': {
+        'top_left': {
+          'x': 50,
+          'y': 100
+        },
+        'bottom_right': {
+          'x': 490,
+          'y': 880
+        }
       }
     },
     'id': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
@@ -714,6 +734,16 @@ let VALID_BID_REQUEST = [{
       'screen': {
         'w': 1000,
         'h': 1000
+      },
+      'vcoords': {
+        'top_left': {
+          'x': 50,
+          'y': 100
+        },
+        'bottom_right': {
+          'x': 490,
+          'y': 880
+        }
       }
     },
     'id': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
@@ -807,6 +837,16 @@ let VALID_BID_REQUEST = [{
       'screen': {
         'w': 1000,
         'h': 1000
+      },
+      'vcoords': {
+        'top_left': {
+          'x': 50,
+          'y': 100
+        },
+        'bottom_right': {
+          'x': 490,
+          'y': 880
+        }
       }
     },
     'id': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
@@ -901,6 +941,16 @@ let VALID_BID_REQUEST = [{
       'screen': {
         'w': 1000,
         'h': 1000
+      },
+      'vcoords': {
+        'top_left': {
+          'x': 50,
+          'y': 100
+        },
+        'bottom_right': {
+          'x': 490,
+          'y': 880
+        }
       }
     },
     'id': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
@@ -1008,6 +1058,16 @@ let VALID_BID_REQUEST = [{
       'screen': {
         'w': 1000,
         'h': 1000
+      },
+      'vcoords': {
+        'top_left': {
+          'x': 50,
+          'y': 100
+        },
+        'bottom_right': {
+          'x': 490,
+          'y': 880
+        }
       }
     },
     'id': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
@@ -1104,6 +1164,16 @@ let VALID_BID_REQUEST = [{
         'w': 1000,
         'h': 1000
       },
+      'vcoords': {
+        'top_left': {
+          'x': 50,
+          'y': 100
+        },
+        'bottom_right': {
+          'x': 490,
+          'y': 880
+        }
+      }
     },
     'id': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
     'imp': [
@@ -1640,6 +1710,16 @@ let VALID_BID_REQUEST = [{
       'screen': {
         'w': 1000,
         'h': 1000
+      },
+      'vcoords': {
+        'top_left': {
+          'x': 50,
+          'y': 100
+        },
+        'bottom_right': {
+          'x': 490,
+          'y': 880
+        }
       }
     },
     'id': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
@@ -1747,6 +1827,16 @@ let VALID_BID_REQUEST = [{
       'screen': {
         'w': 1000,
         'h': 1000
+      },
+      'vcoords': {
+        'top_left': {
+          'x': 50,
+          'y': 100
+        },
+        'bottom_right': {
+          'x': 490,
+          'y': 880
+        }
       }
     },
     'id': 'aafabfd0-28c0-4ac0-aa09-99689e88b81d',
@@ -1829,6 +1919,10 @@ describe('Media.net bid adapter', function () {
   let sandbox;
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
+    sandbox.stub(window.top, 'innerHeight').value(780)
+    sandbox.stub(window.top, 'innerWidth').value(440)
+    sandbox.stub(window.top, 'scrollY').value(100)
+    sandbox.stub(window.top, 'scrollX').value(50)
   });
 
   afterEach(function () {

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { spec, checkVideoPlacement, _getDomainFromURL, assignDealTier, prepareMetaObject, getDeviceConnectionType, setIBVField } from 'modules/pubmaticBidAdapter.js';
+import { spec, checkVideoPlacement, _getDomainFromURL, assignDealTier, prepareMetaObject, getDeviceConnectionType } from 'modules/pubmaticBidAdapter.js';
 import * as utils from 'src/utils.js';
 import { config } from 'src/config.js';
 import { createEidsArray } from 'modules/userId/eids.js';
@@ -3579,30 +3579,6 @@ describe('PubMatic adapter', function () {
         expect(response[0].renderer).to.not.exist;
       });
 
-      it('should set ibv field in bid.ext when bid.ext.ibv exists', function() {
-        let request = spec.buildRequests(bidRequests, {
-          auctionId: 'new-auction-id'
-        });
-
-        let copyOfBidResponse = utils.deepClone(bannerBidResponse);
-        let bidExt = utils.deepClone(copyOfBidResponse.body.seatbid[0].bid[0].ext);
-        copyOfBidResponse.body.seatbid[0].bid[0].ext = Object.assign(bidExt, {
-          ibv: true
-        });
-
-        let response = spec.interpretResponse(copyOfBidResponse, request);
-        expect(response[0].ext.ibv).to.equal(true);
-      });
-
-      it('should not set ibv field when bid.ext does not exist ', function() {
-        let request = spec.buildRequests(bidRequests, {
-          auctionId: 'new-auction-id'
-        });
-
-        let response = spec.interpretResponse(bannerBidResponse, request);
-        expect(response[0].ext).to.not.exist;
-      });
-
       if (FEATURES.VIDEO) {
         it('should check for valid video mediaType in case of multiformat request', function() {
           let request = spec.buildRequests(videoBidRequests, {
@@ -4198,52 +4174,6 @@ describe('PubMatic adapter', function () {
         });
         let data = JSON.parse(req.data);
         expect(data.imp[0]['banner']['battr']).to.equal(undefined);
-      });
-    });
-
-    describe('setIBVField', function() {
-      it('should set ibv field in newBid.ext when bid.ext.ibv exists', function() {
-        const bid = {
-          ext: {
-            ibv: true
-          }
-        };
-        const newBid = {};
-        setIBVField(bid, newBid);
-        expect(newBid.ext).to.exist;
-        expect(newBid.ext.ibv).to.equal(true);
-      });
-
-      it('should not set ibv field when bid.ext.ibv does not exist', function() {
-        const bid = {
-          ext: {}
-        };
-        const newBid = {};
-        setIBVField(bid, newBid);
-        expect(newBid.ext).to.not.exist;
-      });
-
-      it('should not set ibv field when bid.ext does not exist', function() {
-        const bid = {};
-        const newBid = {};
-        setIBVField(bid, newBid);
-        expect(newBid.ext).to.not.exist;
-      });
-
-      it('should preserve existing newBid.ext properties', function() {
-        const bid = {
-          ext: {
-            ibv: true
-          }
-        };
-        const newBid = {
-          ext: {
-            existingProp: 'should remain'
-          }
-        };
-        setIBVField(bid, newBid);
-        expect(newBid.ext.existingProp).to.equal('should remain');
-        expect(newBid.ext.ibv).to.equal(true);
       });
     });
   });

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { spec, checkVideoPlacement, _getDomainFromURL, assignDealTier, prepareMetaObject, getDeviceConnectionType } from 'modules/pubmaticBidAdapter.js';
+import { spec, checkVideoPlacement, _getDomainFromURL, assignDealTier, prepareMetaObject, getDeviceConnectionType, setIBVField } from 'modules/pubmaticBidAdapter.js';
 import * as utils from 'src/utils.js';
 import { config } from 'src/config.js';
 import { createEidsArray } from 'modules/userId/eids.js';
@@ -3579,6 +3579,30 @@ describe('PubMatic adapter', function () {
         expect(response[0].renderer).to.not.exist;
       });
 
+      it('should set ibv field in bid.ext when bid.ext.ibv exists', function() {
+        let request = spec.buildRequests(bidRequests, {
+          auctionId: 'new-auction-id'
+        });
+
+        let copyOfBidResponse = utils.deepClone(bannerBidResponse);
+        let bidExt = utils.deepClone(copyOfBidResponse.body.seatbid[0].bid[0].ext);
+        copyOfBidResponse.body.seatbid[0].bid[0].ext = Object.assign(bidExt, {
+          ibv: true
+        });
+
+        let response = spec.interpretResponse(copyOfBidResponse, request);
+        expect(response[0].ext.ibv).to.equal(true);
+      });
+
+      it('should not set ibv field when bid.ext does not exist ', function() {
+        let request = spec.buildRequests(bidRequests, {
+          auctionId: 'new-auction-id'
+        });
+
+        let response = spec.interpretResponse(bannerBidResponse, request);
+        expect(response[0].ext).to.not.exist;
+      });
+
       if (FEATURES.VIDEO) {
         it('should check for valid video mediaType in case of multiformat request', function() {
           let request = spec.buildRequests(videoBidRequests, {
@@ -4174,6 +4198,52 @@ describe('PubMatic adapter', function () {
         });
         let data = JSON.parse(req.data);
         expect(data.imp[0]['banner']['battr']).to.equal(undefined);
+      });
+    });
+
+    describe('setIBVField', function() {
+      it('should set ibv field in newBid.ext when bid.ext.ibv exists', function() {
+        const bid = {
+          ext: {
+            ibv: true
+          }
+        };
+        const newBid = {};
+        setIBVField(bid, newBid);
+        expect(newBid.ext).to.exist;
+        expect(newBid.ext.ibv).to.equal(true);
+      });
+
+      it('should not set ibv field when bid.ext.ibv does not exist', function() {
+        const bid = {
+          ext: {}
+        };
+        const newBid = {};
+        setIBVField(bid, newBid);
+        expect(newBid.ext).to.not.exist;
+      });
+
+      it('should not set ibv field when bid.ext does not exist', function() {
+        const bid = {};
+        const newBid = {};
+        setIBVField(bid, newBid);
+        expect(newBid.ext).to.not.exist;
+      });
+
+      it('should preserve existing newBid.ext properties', function() {
+        const bid = {
+          ext: {
+            ibv: true
+          }
+        };
+        const newBid = {
+          ext: {
+            existingProp: 'should remain'
+          }
+        };
+        setIBVField(bid, newBid);
+        expect(newBid.ext.existingProp).to.equal('should remain');
+        expect(newBid.ext.ibv).to.equal(true);
       });
     });
   });

--- a/test/spec/modules/rewardedInterestIdSystem_spec.js
+++ b/test/spec/modules/rewardedInterestIdSystem_spec.js
@@ -1,0 +1,190 @@
+import sinon from 'sinon';
+import {expect} from 'chai';
+import * as utils from 'src/utils.js';
+import {attachIdSystem} from 'modules/userId';
+import {createEidsArray} from 'modules/userId/eids';
+import {
+  MODULE_NAME,
+  SOURCE,
+  getRewardedInterestApi,
+  watchRewardedInterestApi,
+  getRewardedInterestId,
+  apiNotAvailable,
+  rewardedInterestIdSubmodule
+} from 'modules/rewardedInterestIdSystem.js';
+
+describe('rewardedInterestIdSystem', () => {
+  const mockUserId = 'rewarded_interest_id';
+  const mockApi = {
+    getApiVersion: () => '1.0',
+    getIdentityToken: () => Promise.resolve(mockUserId)
+  };
+  const errorApiNotFound = `${MODULE_NAME} module: Rewarded Interest API not found`;
+  const errorIdFetch = `${MODULE_NAME} module: ID fetch encountered an error`;
+  let mockReadySate = 'complete';
+  let logErrorSpy;
+  let callbackSpy;
+
+  before(() => {
+    Object.defineProperty(document, 'readyState', {
+      get() {
+        return mockReadySate;
+      },
+    });
+  });
+
+  beforeEach(() => {
+    logErrorSpy = sinon.spy(utils, 'logError');
+    callbackSpy = sinon.spy();
+  });
+
+  afterEach(() => {
+    mockReadySate = 'complete';
+    delete window.__riApi;
+    logErrorSpy.restore();
+  });
+
+  describe('getRewardedInterestApi', () => {
+    it('should return Rewarded Interest Api if exists', () => {
+      expect(getRewardedInterestApi()).to.be.undefined;
+      window.__riApi = {};
+      expect(getRewardedInterestApi()).to.be.undefined;
+      window.__riApi.getIdentityToken = mockApi.getIdentityToken;
+      expect(getRewardedInterestApi()).to.deep.equal(window.__riApi);
+    });
+  });
+
+  describe('watchRewardedInterestApi', () => {
+    it('should execute callback when __riApi is set', () => {
+      watchRewardedInterestApi(callbackSpy);
+      expect(window.__riApi).to.be.undefined;
+      window.__riApi = mockApi;
+      expect(callbackSpy.calledOnceWithExactly(mockApi)).to.be.true;
+      expect(getRewardedInterestApi()).to.deep.equal(mockApi);
+    });
+  });
+
+  describe('getRewardedInterestId', () => {
+    it('should get id from API and pass it to callback', async () => {
+      await getRewardedInterestId(mockApi, callbackSpy);
+      expect(callbackSpy.calledOnceWithExactly(mockUserId)).to.be.true;
+    });
+  });
+
+  describe('apiNotAvailable', () => {
+    it('should call callback without ID and log error', () => {
+      apiNotAvailable(callbackSpy);
+      expect(callbackSpy.calledOnceWithExactly()).to.be.true;
+      expect(logErrorSpy.calledOnceWithExactly(errorApiNotFound)).to.be.true;
+    });
+  });
+
+  describe('rewardedInterestIdSubmodule.name', () => {
+    it('should expose the name of the submodule', () => {
+      expect(rewardedInterestIdSubmodule).to.be.an.instanceof(Object);
+      expect(rewardedInterestIdSubmodule.name).to.equal(MODULE_NAME);
+    });
+  });
+
+  describe('rewardedInterestIdSubmodule.decode', () => {
+    it('should wrap the given value inside an object literal', () => {
+      expect(rewardedInterestIdSubmodule.decode(mockUserId)).to.deep.equal({ [MODULE_NAME]: mockUserId });
+      expect(rewardedInterestIdSubmodule.decode('')).to.be.undefined;
+      expect(rewardedInterestIdSubmodule.decode(null)).to.be.undefined;
+    });
+  });
+
+  describe('rewardedInterestIdSubmodule.getId', () => {
+    it('should return object with callback property', () => {
+      const idResponse = rewardedInterestIdSubmodule.getId();
+      expect(idResponse).to.be.an.instanceof(Object);
+      expect(idResponse).to.have.property('callback');
+      expect(idResponse.callback).to.be.a('function');
+    });
+
+    it('API not found, window loaded', async () => {
+      const idResponse = rewardedInterestIdSubmodule.getId();
+      idResponse.callback(callbackSpy);
+      await Promise.resolve();
+      expect(callbackSpy.calledOnceWithExactly()).to.be.true;
+      expect(logErrorSpy.calledOnceWithExactly(errorApiNotFound)).to.be.true;
+    });
+
+    it('API not found, window not loaded', async () => {
+      mockReadySate = 'loading';
+      const idResponse = rewardedInterestIdSubmodule.getId();
+      idResponse.callback(callbackSpy);
+      window.dispatchEvent(new Event('load'));
+      expect(callbackSpy.calledOnceWithExactly()).to.be.true;
+      expect(logErrorSpy.calledOnceWithExactly(errorApiNotFound)).to.be.true;
+    });
+
+    it('API is set before getId, getIdentityToken return error', async () => {
+      const error = Error();
+      window.__riApi = {getIdentityToken: () => Promise.reject(error)};
+      const idResponse = rewardedInterestIdSubmodule.getId();
+      idResponse.callback(callbackSpy);
+      await window.__riApi.getIdentityToken().catch(() => {});
+      expect(callbackSpy.calledOnceWithExactly()).to.be.true;
+      expect(logErrorSpy.calledOnceWithExactly(errorIdFetch, error)).to.be.true;
+    });
+
+    it('API is set after getId, getIdentityToken return error', async () => {
+      const error = Error();
+      mockReadySate = 'loading';
+      const idResponse = rewardedInterestIdSubmodule.getId();
+      idResponse.callback(callbackSpy);
+      window.__riApi = {getIdentityToken: () => Promise.reject(error)};
+      await window.__riApi.getIdentityToken().catch(() => {});
+      expect(callbackSpy.calledOnceWithExactly()).to.be.true;
+      expect(logErrorSpy.calledOnceWithExactly(errorIdFetch, error)).to.be.true;
+    });
+
+    it('API is set before getId, getIdentityToken return user ID', async () => {
+      window.__riApi = mockApi;
+      const idResponse = rewardedInterestIdSubmodule.getId();
+      idResponse.callback(callbackSpy);
+      await mockApi.getIdentityToken();
+      expect(callbackSpy.calledOnceWithExactly(mockUserId)).to.be.true;
+    });
+
+    it('API is set after getId, getIdentityToken return user ID', async () => {
+      mockReadySate = 'loading';
+      const idResponse = rewardedInterestIdSubmodule.getId();
+      idResponse.callback(callbackSpy);
+      window.__riApi = mockApi;
+      window.dispatchEvent(new Event('load'));
+      await window.__riApi.getIdentityToken().catch(() => {});
+      expect(callbackSpy.calledOnceWithExactly(mockUserId)).to.be.true;
+    });
+  });
+
+  describe('rewardedInterestIdSubmodule.eids', () => {
+    it('should expose the eids of the submodule', () => {
+      expect(rewardedInterestIdSubmodule).to.have.property('eids');
+      expect(rewardedInterestIdSubmodule.eids).to.be.a('object');
+      expect(rewardedInterestIdSubmodule.eids).to.deep.equal({
+        [MODULE_NAME]: {
+          source: SOURCE,
+          atype: 3,
+        },
+      });
+    });
+
+    it('createEidsArray', () => {
+      attachIdSystem(rewardedInterestIdSubmodule);
+      const eids = createEidsArray({
+        [MODULE_NAME]: mockUserId
+      });
+      expect(eids).to.be.a('array');
+      expect(eids.length).to.equal(1);
+      expect(eids[0]).to.deep.equal({
+        source: SOURCE,
+        uids: [{
+          id: mockUserId,
+          atype: 3,
+        }]
+      });
+    });
+  });
+});

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -4210,6 +4210,7 @@ describe('the rubicon adapter', function () {
             const bid = bids[0];
             bid.adUnitCode = 'outstream_video1_placement';
             const adUnit = document.createElement('div');
+            const adUnitSelector = `#${bid.adUnitCode}`
             adUnit.id = bid.adUnitCode;
             document.body.appendChild(adUnit);
 
@@ -4223,7 +4224,7 @@ describe('the rubicon adapter', function () {
               label: undefined,
               placement: {
                 align: 'left',
-                attachTo: adUnit,
+                attachTo: adUnitSelector,
                 position: 'append',
               },
               vastUrl: 'https://test.com/vast.xml',
@@ -4279,6 +4280,7 @@ describe('the rubicon adapter', function () {
             const bid = bids[0];
             bid.adUnitCode = 'outstream_video1_placement';
             const adUnit = document.createElement('div');
+            const adUnitSelector = `#${bid.adUnitCode}`
             adUnit.id = bid.adUnitCode;
             document.body.appendChild(adUnit);
 
@@ -4292,7 +4294,7 @@ describe('the rubicon adapter', function () {
               label: undefined,
               placement: {
                 align: 'left',
-                attachTo: adUnit,
+                attachTo: adUnitSelector,
                 position: 'append',
               },
               vastUrl: 'https://test.com/vast.xml',

--- a/test/spec/modules/vdoaiBidAdapter_spec.js
+++ b/test/spec/modules/vdoaiBidAdapter_spec.js
@@ -1,11 +1,19 @@
 import {assert, expect} from 'chai';
 import {spec} from 'modules/vdoaiBidAdapter.js';
 import {newBidder} from 'src/adapters/bidderFactory.js';
+import { config } from 'src/config.js';
 
-const ENDPOINT_URL = 'https://prebid.vdo.ai/auction';
+const ENDPOINT_URL = 'https://prebid-v2.vdo.ai/auction';
 
 describe('vdoaiBidAdapter', function () {
   const adapter = newBidder(spec);
+  const sandbox = sinon.sandbox.create();
+  beforeEach(function() {
+    sandbox.stub(config, 'getConfig').withArgs('coppa').returns(true);
+  });
+  afterEach(function() {
+    sandbox.restore();
+  });
   describe('isBidRequestValid', function () {
     let bid = {
       'bidder': 'vdoai',
@@ -20,8 +28,24 @@ describe('vdoaiBidAdapter', function () {
       'bidderRequestId': '1234asdf1234asdf',
       'auctionId': '61466567-d482-4a16-96f0-fe5f25ffbdf120'
     };
+    let invalidParams = {
+      'bidder': 'vdoai',
+      'params': {
+        placementId: false
+      },
+      'adUnitCode': 'adunit-code',
+      'sizes': [
+        [300, 250]
+      ],
+      'bidId': '1234asdf1234',
+      'bidderRequestId': '1234asdf1234asdf',
+      'auctionId': '61466567-d482-4a16-96f0-fe5f25ffbdf120'
+    };
     it('should return true where required params found', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+    it('should return false where required params not found', function () {
+      expect(spec.isBidRequestValid(invalidParams)).to.equal(false);
     });
   });
   describe('buildRequests', function () {
@@ -29,7 +53,8 @@ describe('vdoaiBidAdapter', function () {
       {
         'bidder': 'vdoai',
         'params': {
-          placementId: 'testPlacementId'
+          placementId: 'testPlacementId',
+          bidFloor: 0.1
         },
         'sizes': [
           [300, 250]
@@ -37,16 +62,84 @@ describe('vdoaiBidAdapter', function () {
         'bidId': '23beaa6af6cdde',
         'bidderRequestId': '19c0c1efdf37e7',
         'auctionId': '61466567-d482-4a16-96f0-fe5f25ffbdf1',
-        'mediaTypes': 'banner'
+        'mediaType': 'banner',
+        'adUnitCode': '1234',
+        'mediaTypes': {
+          banner: {
+            sizes: [300, 250]
+          }
+        }
+      },
+      {
+        'bidder': 'vdoai',
+        'params': {
+          placementId: 'testPlacementId',
+          bidFloor: 0.1
+        },
+        'width': '300',
+        'height': '200',
+        'bidId': 'bidId123',
+        'referer': 'www.example.com',
+        'mediaType': 'video',
+        'mediaTypes': {
+          video: {
+            context: 'instream',
+            playerSize: [[640, 360]]
+          }
+        }
       }
     ];
 
     let bidderRequests = {
+      timeout: 3000,
       'refererInfo': {
         'numIframes': 0,
         'reachedTop': true,
         'referer': 'https://example.com',
-        'stack': ['https://example.com']
+        'stack': ['https://example.com'],
+        'page': 'example.com',
+        'ref': 'example2.com'
+      },
+      'ortb2': {
+        source: {
+          tid: 123456789
+        },
+        'site': {
+          'domain': 'abc.com',
+          'publisher': {
+            'domain': 'abc.com'
+          }
+        }
+      },
+      'ortb2Imp': {
+        ext: {
+          tid: '12345',
+          gpid: '1234'
+        }
+      },
+      gdprConsent: {
+        consentString: 'abc',
+        gdprApplies: true,
+        addtlConsent: 'xyz'
+      },
+      gppConsent: {
+        gppString: 'abcd',
+        applicableSections: ''
+      },
+      uspConsent: {
+        uspConsent: '12345'
+      },
+      userIdAsEids: {},
+      schain: {
+        'ver': '1.0',
+        'complete': 1,
+        'nodes': [
+          {
+            'asi': 'vdo.ai',
+            'sid': '4359',
+            'hp': 1
+          }
+        ]
       }
     };
 
@@ -56,6 +149,44 @@ describe('vdoaiBidAdapter', function () {
     });
     it('attaches source and version to endpoint URL as query params', function () {
       expect(request[0].url).to.equal(ENDPOINT_URL);
+    });
+    it('should contain all keys', function() {
+      expect(request[0].data.pageInfo).to.include.all.keys('location', 'referrer', 'stack', 'numIframes', 'sHeight', 'sWidth', 'docHeight', 'wHeight', 'wWidth', 'oHeight', 'oWidth', 'aWidth', 'aHeight', 'sLeft', 'sTop', 'hLength', 'xOffset', 'yOffset', 'version');
+    })
+    it('should return empty array if no valid bid was passed', function () {
+      expect(spec.buildRequests([], bidderRequests)).to.be.empty;
+    });
+    it('should not send invalid schain', function () {
+      delete bidderRequests.schain.nodes[0].asi;
+      let result = spec.buildRequests(bidRequests, bidderRequests);
+      expect(result[0].data.schain).to.be.undefined;
+    });
+    it('should not send invalid schain', function () {
+      delete bidderRequests.schain;
+      let result = spec.buildRequests(bidRequests, bidderRequests);
+      expect(result[0].data.schain).to.be.undefined;
+    });
+    it('should check for correct sizes', function () {
+      delete bidRequests[1].mediaTypes.video.playerSize;
+      let result = spec.buildRequests(bidRequests, bidderRequests);
+      expect(result[1].data.playerSize).to.be.empty;
+    });
+    it('should not pass undefined in GDPR string', function () {
+      delete bidderRequests.gdprConsent;
+      let result = spec.buildRequests(bidRequests, bidderRequests);
+      expect(result[0].data.gdprConsent).to.be.undefined;
+    });
+
+    it('should not pass undefined in gppConsent', function () {
+      delete bidderRequests.gppConsent;
+      let result = spec.buildRequests(bidRequests, bidderRequests);
+      expect(result[0].data.gppConsent).to.be.undefined;
+    });
+
+    it('should not pass undefined in uspConsent', function () {
+      delete bidderRequests.uspConsent;
+      let result = spec.buildRequests(bidRequests, bidderRequests);
+      expect(result[0].data.uspConsent).to.be.undefined;
     });
   });
 
@@ -75,29 +206,31 @@ describe('vdoaiBidAdapter', function () {
       }
     ];
     let serverResponse = {
-      body: {
-        'vdoCreative': '<html><h3>I am an ad</h3></html> ',
-        'price': 4.2,
-        'adid': '12345asdfg',
-        'currency': 'EUR',
-        'statusMessage': 'Bid available',
-        'requestId': 'bidId123',
-        'width': 300,
-        'height': 250,
-        'netRevenue': true,
-        'adDomain': ['text.abc']
+      body:
+      {
+        'price': 2,
+        'adid': 'test-ad',
+        'adomain': [
+          'text.abc'
+        ],
+        'w': 300,
+        'h': 250,
+        'vdoCreative': '<html><h3>I am an ad</h3></html>',
+        'bidId': '31d1375caab87a',
+        'mediaType': 'banner'
       }
     };
+
     it('should get the correct bid response', function () {
       let expectedResponse = [{
-        'requestId': 'bidId123',
-        'cpm': 4.2,
+        'requestId': '31d1375caab87a',
+        'cpm': 2,
         'width': 300,
         'height': 250,
-        'creativeId': '12345asdfg',
-        'currency': 'EUR',
+        'creativeId': 'test-ad',
+        'currency': 'USD',
         'netRevenue': true,
-        'ttl': 3000,
+        'ttl': 60,
         'ad': '<html><h3>I am an ad</h3></html>',
         'meta': {
           'advertiserDomains': ['text.abc']
@@ -112,9 +245,9 @@ describe('vdoaiBidAdapter', function () {
       let serverResponse = {
         body: {
           'vdoCreative': '<!-- VAST Creative -->',
-          'price': 4.2,
+          'price': 2,
           'adid': '12345asdfg',
-          'currency': 'EUR',
+          'currency': 'USD',
           'statusMessage': 'Bid available',
           'requestId': 'bidId123',
           'width': 300,
@@ -133,7 +266,13 @@ describe('vdoaiBidAdapter', function () {
             'height': '200',
             'bidId': 'bidId123',
             'referer': 'www.example.com',
-            'mediaType': 'video'
+            'mediaType': 'video',
+            'mediaTypes': {
+              video: {
+                context: 'instream',
+                playerSize: [[640, 360]]
+              }
+            }
           }
         }
       ];
@@ -141,6 +280,132 @@ describe('vdoaiBidAdapter', function () {
       let result = spec.interpretResponse(serverResponse, bidRequest[0]);
       expect(result[0]).to.have.property('vastXml');
       expect(result[0]).to.have.property('mediaType', 'video');
+    });
+    it('should not return invalid responses', function() {
+      serverResponse.body.w = 0;
+      let result = spec.interpretResponse(serverResponse, bidRequest[0]);
+      expect(result).to.be.empty;
+    });
+    it('should not return invalid responses with invalid height', function() {
+      serverResponse.body.w = 300;
+      serverResponse.body.h = 0;
+      let result = spec.interpretResponse(serverResponse, bidRequest[0]);
+      expect(result).to.be.empty;
+    });
+    it('should not return invalid responses with invalid cpm', function() {
+      serverResponse.body.h = 250;
+      serverResponse.body.price = 0;
+      let result = spec.interpretResponse(serverResponse, bidRequest[0]);
+      expect(result).to.be.empty;
+    });
+    it('should not return invalid responses with invalid creative ID', function() {
+      serverResponse.body.price = 2;
+      serverResponse.body.adid = undefined;
+      let result = spec.interpretResponse(serverResponse, bidRequest[0]);
+      expect(result).to.be.empty;
+    });
+  });
+  describe('getUserSyncs', function() {
+    it('should return correct sync urls', function() {
+      let serverResponse = [{
+        body: {
+          'vdoCreative': '<!-- VAST Creative -->',
+          'price': 2,
+          'adid': '12345asdfg',
+          'currency': 'USD',
+          'statusMessage': 'Bid available',
+          'requestId': 'bidId123',
+          'width': 300,
+          'height': 250,
+          'netRevenue': true,
+          'mediaType': 'video',
+          'cookiesync': {
+            'status': 'no_cookie',
+            'bidder_status': [
+              {
+                'bidder': 'vdoai',
+                'no_cookie': true,
+                'usersync': {
+                  'url': 'https://rtb.vdo.ai/setuid/',
+                  'type': 'iframe'
+                }
+              }
+            ]
+          }
+        }
+      }];
+
+      let syncUrls = spec.getUserSyncs({
+        iframeEnabled: true
+      }, serverResponse);
+      expect(syncUrls[0].url).to.be.equal(serverResponse[0].body.cookiesync.bidder_status[0].usersync.url);
+
+      syncUrls = spec.getUserSyncs({
+        iframeEnabled: false
+      }, serverResponse);
+      expect(syncUrls[0]).to.be.undefined;
+    });
+    it('should not return invalid sync urls', function() {
+      let serverResponse = [{
+        body: {
+          'vdoCreative': '<!-- VAST Creative -->',
+          'price': 2,
+          'adid': '12345asdfg',
+          'currency': 'USD',
+          'statusMessage': 'Bid available',
+          'requestId': 'bidId123',
+          'width': 300,
+          'height': 250,
+          'netRevenue': true,
+          'mediaType': 'video',
+          'cookiesync': {
+            'status': 'no_cookie',
+            'bidder_status': [
+            ]
+          }
+        }
+      }];
+
+      var syncUrls = spec.getUserSyncs({
+        iframeEnabled: true
+      }, serverResponse);
+      expect(syncUrls[0]).to.be.undefined;
+
+      delete serverResponse[0].body.cookiesync.bidder_status;
+      syncUrls = spec.getUserSyncs({
+        iframeEnabled: true
+      }, serverResponse);
+      expect(syncUrls[0]).to.be.undefined;
+
+      delete serverResponse[0].body.cookiesync;
+      syncUrls = spec.getUserSyncs({
+        iframeEnabled: true
+      }, serverResponse);
+      expect(syncUrls[0]).to.be.undefined;
+
+      delete serverResponse[0].body;
+      syncUrls = spec.getUserSyncs({
+        iframeEnabled: true
+      }, serverResponse);
+      expect(syncUrls[0]).to.be.undefined;
+    });
+  });
+
+  describe('onTimeout', function() {
+    it('should run without errors', function() {
+      spec.onTimeout();
+    });
+  });
+
+  describe('onBidWon', function() {
+    it('should run without errors', function() {
+      spec.onBidWon();
+    });
+  });
+
+  describe('onSetTargeting', function() {
+    it('should run without errors', function() {
+      spec.onSetTargeting();
     });
   });
 });


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change

Instead of passing the whole adUnitElement to the Apex Renderer, it passes a CSS query selector of the id of the element. 

This solves an issue where the Apex Renderer was erroring from stringifying the JS object as it contained circular references. 

This issue only happened in React, as the DOM elements created by React contained circular references. 
