### PR TITLE
Adkernel Bid Adapter: add spinx alias

### DIFF
--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -99,7 +99,8 @@ export const spec = {
     {code: 'voisetech'},
     {code: 'global_sun'},
     {code: 'rxnetwork'},
-    {code: 'revbid'}
+    {code: 'revbid'},
+    {code: 'spinx', gvlid: 1308}
   ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter

## Description of change
Added alias for spinx.biz partner network

## Other information

https://github.com/prebid/prebid.github.io/pull/5716