### PR TITLE
vastTrackers: make request and auction info available to VAST trackers

### DIFF
--- a/libraries/vastTrackers/vastTrackers.js
+++ b/libraries/vastTrackers/vastTrackers.js
@@ -4,27 +4,47 @@ import {logError} from '../../src/utils.js';
 import {isActivityAllowed} from '../../src/activities/rules.js';
 import {ACTIVITY_REPORT_ANALYTICS} from '../../src/activities/activities.js';
 import {activityParams} from '../../src/activities/activityParams.js';
+import {auctionManager} from '../../src/auctionManager.js';
 
 const vastTrackers = [];
+let enabled = false;
 
 export function reset() {
   vastTrackers.length = 0;
 }
 
-export function addTrackersToResponse(next, adUnitcode, bidResponse, reject) {
-  if (FEATURES.VIDEO && bidResponse.mediaType === VIDEO) {
-    const vastTrackers = getVastTrackers(bidResponse);
-    if (vastTrackers) {
-      bidResponse.vastXml = insertVastTrackers(vastTrackers, bidResponse.vastXml);
-      const impTrackers = vastTrackers.get('impressions');
-      if (impTrackers) {
-        bidResponse.vastImpUrl = [].concat([...impTrackers]).concat(bidResponse.vastImpUrl).filter(t => t);
+export function enable() {
+  if (!enabled) {
+    addBidResponse.before(addTrackersToResponse);
+    enabled = true;
+  }
+}
+
+export function disable() {
+  if (enabled) {
+    addBidResponse.getHooks({hook: addTrackersToResponse}).remove();
+    enabled = false;
+  }
+}
+
+export function responseHook({index = auctionManager.index} = {}) {
+  return function addTrackersToResponse(next, adUnitcode, bidResponse, reject) {
+    if (FEATURES.VIDEO && bidResponse.mediaType === VIDEO) {
+      const vastTrackers = getVastTrackers(bidResponse, {index});
+      if (vastTrackers) {
+        bidResponse.vastXml = insertVastTrackers(vastTrackers, bidResponse.vastXml);
+        const impTrackers = vastTrackers.get('impressions');
+        if (impTrackers) {
+          bidResponse.vastImpUrl = [].concat([...impTrackers]).concat(bidResponse.vastImpUrl).filter(t => t);
+        }
       }
     }
+    next(adUnitcode, bidResponse, reject);
   }
-  next(adUnitcode, bidResponse, reject);
 }
-addBidResponse.before(addTrackersToResponse);
+
+const addTrackersToResponse = responseHook();
+enable();
 
 export function registerVastTrackers(moduleType, moduleName, trackerFn) {
   if (typeof trackerFn === 'function') {
@@ -54,7 +74,7 @@ export function insertVastTrackers(trackers, vastXml) {
   return vastXml;
 }
 
-export function getVastTrackers(bid) {
+export function getVastTrackers(bid, {index = auctionManager.index}) {
   let trackers = [];
   vastTrackers.filter(
     ({
@@ -63,7 +83,9 @@ export function getVastTrackers(bid) {
       trackerFn
     }) => isActivityAllowed(ACTIVITY_REPORT_ANALYTICS, activityParams(moduleType, moduleName))
   ).forEach(({trackerFn}) => {
-    let trackersToAdd = trackerFn(bid);
+    const auction = index.getAuction(bid).getProperties();
+    const bidRequest = index.getBidRequest(bid);
+    let trackersToAdd = trackerFn(bid, {auction, bidRequest});
     trackersToAdd.forEach(trackerToAdd => {
       if (isValidVastTracker(trackers, trackerToAdd)) {
         trackers.push(trackerToAdd);

--- a/test/spec/libraries/vastTrackers_spec.js
+++ b/test/spec/libraries/vastTrackers_spec.js
@@ -4,38 +4,74 @@ import {
   getVastTrackers,
   insertVastTrackers,
   registerVastTrackers,
-  reset
+  reset, responseHook,
+  disable
 } from 'libraries/vastTrackers/vastTrackers.js';
 import {MODULE_TYPE_ANALYTICS} from '../../../src/activities/modules.js';
+import {AuctionIndex} from '../../../src/auctionIndex.js';
 
 describe('vast trackers', () => {
+  let sandbox, tracker, auction, bid, bidRequest, index;
   beforeEach(() => {
-    registerVastTrackers(MODULE_TYPE_ANALYTICS, 'test', function(bidResponse) {
+    bid = {
+      requestId: 'bid',
+      cpm: 1.0,
+      auctionId: 'aid',
+      mediaType: 'video',
+    }
+    bidRequest = {
+      auctionId: 'aid',
+      bidId: 'bid',
+    }
+    auction = {
+      getAuctionId() {
+        return 'aid';
+      },
+      getProperties() {
+        return {auction: 'props'};
+      },
+      getBidRequests() {
+        return [{bids: [bidRequest]}]
+      }
+    };
+    sandbox = sinon.sandbox.create();
+    index = new AuctionIndex(() => [auction]);
+    tracker = sinon.stub().callsFake(function (bidResponse) {
       return [
         {'event': 'impressions', 'url': `https://vasttracking.mydomain.com/vast?cpm=${bidResponse.cpm}`}
       ];
     });
+    registerVastTrackers(MODULE_TYPE_ANALYTICS, 'test', tracker);
   })
   afterEach(() => {
     reset();
+    sandbox.restore();
   });
 
-  it('insert into tracker list', function() {
-    const trackers = getVastTrackers({'cpm': 1.0});
+  after(disable);
+
+  it('insert into tracker list', function () {
+    const trackers = getVastTrackers(bid, {index});
     expect(trackers).to.be.a('map');
     expect(trackers.get('impressions')).to.exists;
     expect(trackers.get('impressions').has('https://vasttracking.mydomain.com/vast?cpm=1')).to.be.true;
   });
 
-  it('insert trackers in vastXml', function() {
-    const trackers = getVastTrackers({'cpm': 1.0});
+  it('insert trackers in vastXml', function () {
+    const trackers = getVastTrackers(bid, {index});
     let vastXml = '<VAST><Ad><Wrapper></Wrapper></Ad></VAST>';
     vastXml = insertVastTrackers(trackers, vastXml);
     expect(vastXml).to.equal('<VAST><Ad><Wrapper><Impression><![CDATA[https://vasttracking.mydomain.com/vast?cpm=1]]></Impression></Wrapper></Ad></VAST>');
   });
 
-  it('test addImpUrlToTrackers', function() {
-    const trackers = addImpUrlToTrackers({'vastImpUrl': 'imptracker.com'}, getVastTrackers({'cpm': 1.0}));
+  it('should pass request and auction properties to trackerFn', () => {
+    const bid = {requestId: 'bid', auctionId: 'aid'};
+    getVastTrackers(bid, {index});
+    sinon.assert.calledWith(tracker, bid, sinon.match({auction: auction.getProperties(), bidRequest}))
+  })
+
+  it('test addImpUrlToTrackers', function () {
+    const trackers = addImpUrlToTrackers({'vastImpUrl': 'imptracker.com'}, getVastTrackers(bid, {index}));
     expect(trackers).to.be.a('map');
     expect(trackers.get('impressions')).to.exists;
     expect(trackers.get('impressions').has('imptracker.com')).to.be.true;
@@ -43,12 +79,8 @@ describe('vast trackers', () => {
 
   if (FEATURES.VIDEO) {
     it('should add trackers to bid response', () => {
-      const bidResponse = {
-        mediaType: 'video',
-        cpm: 1
-      }
-      addTrackersToResponse(sinon.stub(), 'au', bidResponse);
-      expect(bidResponse.vastImpUrl).to.eql([
+      responseHook({index})(sinon.stub(), 'au', bid);
+      expect(bid.vastImpUrl).to.eql([
         'https://vasttracking.mydomain.com/vast?cpm=1'
       ])
     });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

Make bid request and auction information available to VAST tracker functions (introduced by https://github.com/prebid/Prebid.js/pull/10191)

## Other information

Closes https://github.com/prebid/Prebid.js/issues/12375
