### PR TITLE
gppControl: check for usnat consent version

### DIFF
--- a/libraries/mspa/activityControls.js
+++ b/libraries/mspa/activityControls.js
@@ -97,6 +97,9 @@ export function mspaRule(sids, getConsent, denies, applicableSids = () => gppDat
       if (consent == null) {
         return {allow: false, reason: 'consent data not available'};
       }
+      if (consent.Version !== 1) {
+        return {allow: false, reason: `unsupported consent specification version "${consent.Version}"`}
+      }
       if (denies(consent)) {
         return {allow: false};
       }

--- a/test/spec/libraries/mspa/activityControls_spec.js
+++ b/test/spec/libraries/mspa/activityControls_spec.js
@@ -181,13 +181,18 @@ describe('mspaRule', () => {
       expect(mkRule()().allow).to.equal(false);
     });
 
+    it('should deny when consent is using version != 1', () => {
+      consent = {Version: 2};
+      expect(mkRule()().allow).to.equal(false);
+    })
+
     Object.entries({
       'denies': true,
       'allows': false
     }).forEach(([t, denied]) => {
       it(`should check if deny fn ${t}`, () => {
         denies.returns(denied);
-        consent = {mock: 'value'};
+        consent = {mock: 'value', Version: 1};
         const result = mkRule()();
         sinon.assert.calledWith(denies, consent);
         if (denied) {
@@ -212,6 +217,7 @@ describe('setupRules', () => {
       parsedSections: {
         mockApi: [
           {
+            Version: 1,
             mock: 'consent'
           }
         ]
@@ -226,14 +232,14 @@ describe('setupRules', () => {
   it('should use flatten section data for the given api', () => {
     runSetup('mockApi', [1]);
     expect(isAllowed('mockActivity', {})).to.equal(false);
-    sinon.assert.calledWith(rules.mockActivity, {mock: 'consent'})
+    sinon.assert.calledWith(rules.mockActivity, consent.parsedSections.mockApi[0])
   });
 
   it('should accept already flattened section data', () => {
-    consent.parsedSections.mockApi = {flat: 'consent'};
+    consent.parsedSections.mockApi = {flat: 'consent', Version: 1};
     runSetup('mockApi', [1]);
     isAllowed('mockActivity', {});
-    sinon.assert.calledWith(rules.mockActivity, {flat: 'consent'})
+    sinon.assert.calledWith(rules.mockActivity, consent.parsedSections.mockApi)
   })
 
   it('should not choke when no consent data is available', () => {
@@ -248,11 +254,11 @@ describe('setupRules', () => {
   });
 
   it('should pass flattened consent through normalizeConsent', () => {
-    const normalize = sinon.stub().returns({normalized: 'consent'})
+    const normalize = sinon.stub().returns({normalized: 'consent', Version: 1})
     runSetup('mockApi', [1], normalize);
     expect(isAllowed('mockActivity', {})).to.equal(false);
-    sinon.assert.calledWith(normalize, {mock: 'consent'});
-    sinon.assert.calledWith(rules.mockActivity, {normalized: 'consent'});
+    sinon.assert.calledWith(normalize, {mock: 'consent', Version: 1});
+    sinon.assert.calledWith(rules.mockActivity, {normalized: 'consent', Version: 1});
   });
 
   it('should return a function that unregisters activity controls', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

If usnat or us state sections are applicable, but consent version is not `1`, treat it as if consent was denied.

## Other information

Closes https://github.com/prebid/Prebid.js/issues/12467
