### PR TITLE
Criteo Bid Adapter: conditionally stop sending push_sync requests

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -9,6 +9,8 @@ import {OUTSTREAM} from '../src/video.js';
 import {ajax} from '../src/ajax.js';
 import {ortbConverter} from '../libraries/ortbConverter/converter.js';
 import {ortb25Translator} from '../libraries/ortb2.5Translator/translator.js';
+import {browserTypes, osTypes} from "../libraries/userAgentUtils/userAgentTypes.enums";
+import {getBrowser, getOS} from "../libraries/userAgentUtils";
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -219,6 +221,11 @@ export const spec = {
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 
   getUserSyncs: function (syncOptions, _, gdprConsent, uspConsent, gppConsent = {}) {
+    // Stop sending push_sync requests in case of Safari browser OR iOS device
+    if (getBrowser() === browserTypes.SAFARI || getOS() === osTypes.IOS) {
+      return []
+    }
+
     let { gppString = '', applicableSections = [] } = gppConsent;
 
     const refererInfo = getRefererInfo();


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Conditionally stop sending push_sync requests for Safari and iOS users

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->

