### PR TITLE
beopBidAdapter - First Party Cookie read and set

### DIFF
--- a/modules/beopBidAdapter.js
+++ b/modules/beopBidAdapter.js
@@ -1,6 +1,6 @@
 import {
   buildUrl,
-  deepAccess, getBidIdParameter,
+  deepAccess, generateUUID, getBidIdParameter,
   getValue,
   isArray,
   logInfo,
@@ -9,6 +9,7 @@ import {
 } from '../src/utils.js';
 import {getRefererInfo} from '../src/refererDetection.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
+import { getStorageManager } from '../src/storageManager.js';
 import {config} from '../src/config.js';
 import {getAllOrtbKeywords} from '../libraries/keywords/keywords.js';
 
@@ -20,9 +21,11 @@ import {getAllOrtbKeywords} from '../libraries/keywords/keywords.js';
 
 const BIDDER_CODE = 'beop';
 const ENDPOINT_URL = 'https://hb.beop.io/bid';
+const COOKIE_NAME = 'beopid';
 const TCF_VENDOR_ID = 666;
 
 const validIdRegExp = /^[0-9a-fA-F]{24}$/
+const storage = getStorageManager({bidderCode: BIDDER_CODE});
 
 export const spec = {
   code: BIDDER_CODE,
@@ -63,6 +66,19 @@ export const spec = {
     const kwdsFromRequest = firstSlot.kwds;
     let keywords = getAllOrtbKeywords(bidderRequest.ortb2, kwdsFromRequest);
 
+    let beopid = '';
+    if (storage.cookiesAreEnabled) {
+      beopid = storage.getCookie(COOKIE_NAME, undefined);
+      if (!beopid) {
+        beopid = generateUUID();
+        let expirationDate = new Date();
+        expirationDate.setTime(expirationDate.getTime() + 86400 * 183 * 1000);
+        storage.setCookie(COOKIE_NAME, beopid, expirationDate.toUTCString());
+      }
+    } else {
+      storage.setCookie(COOKIE_NAME, '', 0);
+    }
+
     const payloadObject = {
       at: new Date().toString(),
       nid: firstSlot.nid,
@@ -73,6 +89,7 @@ export const spec = {
       lang: (window.navigator.language || window.navigator.languages[0]),
       kwds: keywords,
       dbg: false,
+      fg: beopid,
       slts: slots,
       is_amp: deepAccess(bidderRequest, 'referrerInfo.isAmp'),
       gdpr_applies: gdpr ? gdpr.gdprApplies : false,

--- a/test/spec/modules/beopBidAdapter_spec.js
+++ b/test/spec/modules/beopBidAdapter_spec.js
@@ -327,4 +327,16 @@ describe('BeOp Bid Adapter tests', () => {
       expect(payload.eids[0].source).to.equal('provider.com');
     });
   })
+
+  describe('Ensure first party cookie is well managed', function () {
+    let bidRequests = [];
+
+    it(`should generate a new uuid`, function () {
+      let bid = Object.assign({}, validBid);
+      bidRequests.push(bid);
+      const request = spec.buildRequests(bidRequests, {});
+      const payload = JSON.parse(request.data);
+      expect(payload.fg).to.exist;
+    })
+  })
 });


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Our native SDK is already reading and setting our first party cookie for better user experience and capping features. We need to propagate it on Prebid too