### PR TITLE
criteo Bid Adapter: allow to specify tagid in params

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -59,7 +59,7 @@ function imp(buildImp, bidRequest, context) {
   let imp = buildImp(bidRequest, context);
   const params = bidRequest.params;
 
-  imp.tagid = params?.tagid || bidRequest.adUnitCode;
+  imp.tagid = deepAccess(bidRequest, 'ortb2Imp.tagid') || bidRequest.adUnitCode;
   deepSetValue(imp, 'ext', {
     ...bidRequest.params.ext,
     ...imp.ext,

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -59,7 +59,7 @@ function imp(buildImp, bidRequest, context) {
   let imp = buildImp(bidRequest, context);
   const params = bidRequest.params;
 
-  imp.tagid = bidRequest.adUnitCode;
+  imp.tagid = params?.tagid || bidRequest.adUnitCode;
   deepSetValue(imp, 'ext', {
     ...bidRequest.params.ext,
     ...imp.ext,


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
We use the networkId and not zoneId's. But there are still cases where we are constrained by the requirement to have a fully matching adUnitCode to get the tagid set.

All other adapters support to explicit set placement, id, ect I think its extremely useful to be able to continue to use the network id approach but still specify the adUnitCode or tagid which is the internal name for the same mapping