### PR TITLE
Missena Bid Adapter : refactor getUserSyncs, send screen size

### DIFF
--- a/modules/missenaBidAdapter.js
+++ b/modules/missenaBidAdapter.js
@@ -86,6 +86,7 @@ function toPayload(bidRequest, bidderRequest) {
   payload.schain = bidRequest.schain;
   payload.coppa = bidderRequest?.ortb2?.regs?.coppa ? 1 : 0;
   payload.autoplay = isAutoplayEnabled() === true ? 1 : 0;
+  payload.screen = { height: screen.height, width: screen.width };
 
   return {
     method: 'POST',

--- a/modules/missenaBidAdapter.js
+++ b/modules/missenaBidAdapter.js
@@ -130,6 +130,8 @@ export const spec = {
       return [];
     }
 
+    this.msnaApiKey = validBidRequests[0]?.params.apiKey;
+
     return validBidRequests.map((bidRequest) =>
       toPayload(bidRequest, bidderRequest),
     );
@@ -154,26 +156,25 @@ export const spec = {
   getUserSyncs: function (
     syncOptions,
     serverResponses,
-    gdprConsent,
+    gdprConsent = {},
     uspConsent,
   ) {
-    if (!syncOptions.iframeEnabled) {
+    if (!syncOptions.iframeEnabled || !this.msnaApiKey) {
       return [];
     }
 
-    let gdprParams = '';
-    if (
-      gdprConsent &&
-      'gdprApplies' in gdprConsent &&
-      typeof gdprConsent.gdprApplies === 'boolean'
-    ) {
-      gdprParams = `?gdpr=${Number(gdprConsent.gdprApplies)}&gdpr_consent=${
-        gdprConsent.consentString
-      }`;
+    const url = new URL('https://sync.missena.io/iframe');
+    url.searchParams.append('t', this.msnaApiKey);
+
+    if (typeof gdprConsent.gdprApplies === 'boolean') {
+      url.searchParams.append('gdpr', Number(gdprConsent.gdprApplies));
+      url.searchParams.append('gdpr_consent', gdprConsent.consentString);
     }
-    return [
-      { type: 'iframe', url: 'https://sync.missena.io/iframe' + gdprParams },
-    ];
+    if (uspConsent) {
+      url.searchParams.append('us_privacy', uspConsent);
+    }
+
+    return [{ type: 'iframe', url: url.href }];
   },
   /**
    * Register bidder specific code, which will execute if bidder timed out after an auction

--- a/test/spec/modules/missenaBidAdapter_spec.js
+++ b/test/spec/modules/missenaBidAdapter_spec.js
@@ -173,6 +173,11 @@ describe('Missena Adapter', function () {
       expect(payload.ik).to.equal(window.msna_ik);
     });
 
+    it('should send screen', function () {
+      expect(payload.screen.width).to.equal(screen.width);
+      expect(payload.screen.height).to.equal(screen.height);
+    });
+
     getDataFromLocalStorageStub.restore();
     getDataFromLocalStorageStub = sinon.stub(
       storage,

--- a/test/spec/modules/missenaBidAdapter_spec.js
+++ b/test/spec/modules/missenaBidAdapter_spec.js
@@ -7,6 +7,7 @@ import * as autoplay from 'libraries/autoplayDetection/autoplay.js';
 const REFERRER = 'https://referer';
 const REFERRER2 = 'https://referer2';
 const COOKIE_DEPRECATION_LABEL = 'test';
+const API_KEY = 'PA-XXXXXX';
 
 describe('Missena Adapter', function () {
   $$PREBID_GLOBAL$$.bidderSettings = {
@@ -30,7 +31,7 @@ describe('Missena Adapter', function () {
       },
     },
     params: {
-      apiKey: 'PA-34745704',
+      apiKey: API_KEY,
       placement: 'sticky',
       formats: ['sticky-banner'],
     },
@@ -57,7 +58,7 @@ describe('Missena Adapter', function () {
     sizes: [[1, 1]],
     mediaTypes: { banner: { sizes: [[1, 1]] } },
     params: {
-      apiKey: 'PA-34745704',
+      apiKey: API_KEY,
       placement: 'sticky',
       formats: ['sticky-banner'],
     },
@@ -299,7 +300,7 @@ describe('Missena Adapter', function () {
 
       expect(userSync.length).to.be.equal(1);
       expect(userSync[0].type).to.be.equal('iframe');
-      expect(userSync[0].url).to.be.equal(syncFrameUrl);
+      expect(userSync[0].url).to.be.equal(`${syncFrameUrl}?t=${API_KEY}`);
     });
 
     it('should return empty array when iframeEnabled is false', function () {
@@ -312,7 +313,7 @@ describe('Missena Adapter', function () {
         gdprApplies: true,
         consentString,
       });
-      const expectedUrl = `${syncFrameUrl}?gdpr=1&gdpr_consent=${consentString}`;
+      const expectedUrl = `${syncFrameUrl}?t=${API_KEY}&gdpr=1&gdpr_consent=${consentString}`;
       expect(userSync.length).to.be.equal(1);
       expect(userSync[0].type).to.be.equal('iframe');
       expect(userSync[0].url).to.be.equal(expectedUrl);
@@ -322,7 +323,7 @@ describe('Missena Adapter', function () {
         gdprApplies: false,
         consentString,
       });
-      const expectedUrl = `${syncFrameUrl}?gdpr=0&gdpr_consent=${consentString}`;
+      const expectedUrl = `${syncFrameUrl}?t=${API_KEY}&gdpr=0&gdpr_consent=${consentString}`;
       expect(userSync.length).to.be.equal(1);
       expect(userSync[0].type).to.be.equal('iframe');
       expect(userSync[0].url).to.be.equal(expectedUrl);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Refactoring (no functional changes, no api changes)

## Description of change

We need to personalize the sync iframe with the `apiKey` of the publisher. 
I also took this opportunity to send the screen size to our servers. 