### PR TITLE
Adkernel Bid Adapter: add OppaMedia alias

### DIFF
--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -100,7 +100,8 @@ export const spec = {
     {code: 'global_sun'},
     {code: 'rxnetwork'},
     {code: 'revbid'},
-    {code: 'spinx', gvlid: 1308}
+    {code: 'spinx', gvlid: 1308},
+    {code: 'oppamedia'}
   ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter 

## Description of change

Added alias for OppaMedia partner network



## Other information
https://github.com/prebid/prebid.github.io/pull/5730