### PR TITLE
Michao Bid Adapter: Initial release

### DIFF
--- a/modules/michaoBidAdapter.js
+++ b/modules/michaoBidAdapter.js
@@ -19,7 +19,7 @@ const ENV = {
   NET_REVENUE: true,
   DEFAULT_CURRENCY: 'USD',
   OUTSTREAM_RENDERER_URL:
-    'https://cdn.jsdelivr.net/npm/in-renderer-js@1.0.6/dist/in-video-renderer.umd.min.js',
+    'https://cdn.jsdelivr.net/npm/in-renderer-js@1/dist/in-video-renderer.umd.min.js',
 };
 
 export const spec = {

--- a/modules/michaoBidAdapter.js
+++ b/modules/michaoBidAdapter.js
@@ -260,7 +260,7 @@ const converter = ortbConverter({
         id: bidRequest.bidId,
         adUnitCode: bidRequest.adUnitCode,
       });
-      renderer.render(() => {
+      renderer.setRender((bid) => {
         bid.renderer.push(() => {
           const inRenderer = new window.InVideoRenderer();
           inRenderer.render(bid.adUnitCode, bid);

--- a/modules/michaoBidAdapter.js
+++ b/modules/michaoBidAdapter.js
@@ -196,7 +196,7 @@ const converter = ortbConverter({
 
     deepSetValue(
       openRTBBidRequest,
-      'site.id',
+      'site.ext.michao.site',
       bidRequest.params.site.toString()
     );
     if (bidRequest?.schain) {
@@ -206,7 +206,7 @@ const converter = ortbConverter({
     if (bidRequest.params?.partner) {
       deepSetValue(
         openRTBBidRequest,
-        'site.publisher.ext.partner',
+        'site.publisher.ext.michao.partner',
         bidRequest.params.partner.toString()
       );
     }
@@ -216,7 +216,7 @@ const converter = ortbConverter({
 
   imp(buildImp, bidRequest, context) {
     const imp = buildImp(bidRequest, context);
-    deepSetValue(imp, 'ext.placement', bidRequest.params.placement.toString());
+    deepSetValue(imp, 'ext.michao.placement', bidRequest.params.placement.toString());
 
     if (!bidRequest.mediaTypes?.native) {
       delete imp.native;

--- a/modules/michaoBidAdapter.js
+++ b/modules/michaoBidAdapter.js
@@ -20,7 +20,7 @@ const ENV = {
   ENDPOINT: 'https://rtb.michao-ssp.com/openrtb/prebid',
   NET_REVENUE: true,
   DEFAULT_CURRENCY: 'USD',
-  RENDERER_URL:
+  OUTSTREAM_RENDERER_URL:
     'https://cdn.jsdelivr.net/npm/in-renderer-js@latest/dist/in-video-renderer.umd.min.js',
 };
 
@@ -326,7 +326,7 @@ const converter = ortbConverter({
     ) {
       bidResponse.vastXml = bid.adm;
       const renderer = Renderer.install({
-        url: ENV.RENDERER_URL,
+        url: ENV.OUTSTREAM_RENDERER_URL,
         id: bidRequest.bidId,
         adUnitCode: bidRequest.adUnitCode,
       });

--- a/modules/michaoBidAdapter.js
+++ b/modules/michaoBidAdapter.js
@@ -1,7 +1,7 @@
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
-import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { Renderer } from '../src/Renderer.js';
 import {
   deepSetValue,
@@ -13,7 +13,7 @@ import {
 
 const ENV = {
   BIDDER_CODE: 'michao',
-  SUPPORTED_MEDIA_TYPES: [BANNER, VIDEO],
+  SUPPORTED_MEDIA_TYPES: [BANNER, VIDEO, NATIVE],
   ENDPOINT: 'https://rtb.michao-ssp.com/openrtb/prebid',
   NET_REVENUE: true,
   DEFAULT_CURRENCY: 'USD',
@@ -42,19 +42,19 @@ export const spec = {
     const bidRequests = [];
 
     validBidRequests.forEach((validBidRequest) => {
-      if (
-        hasVideoMediaType(validBidRequest) &&
-        hasBannerMediaType(validBidRequest)
-      ) {
+      if (hasVideoMediaType(validBidRequest)) {
+        bidRequests.push(buildRequest(validBidRequest, bidderRequest, 'video'));
+      }
+
+      if (hasBannerMediaType(validBidRequest)) {
         bidRequests.push(
           buildRequest(validBidRequest, bidderRequest, 'banner')
         );
-        bidRequests.push(buildRequest(validBidRequest, bidderRequest, 'video'));
-      } else if (hasVideoMediaType(validBidRequest)) {
-        bidRequests.push(buildRequest(validBidRequest, bidderRequest, 'video'));
-      } else if (hasBannerMediaType(validBidRequest)) {
+      }
+
+      if (hasNativeMediaType(validBidRequest)) {
         bidRequests.push(
-          buildRequest(validBidRequest, bidderRequest, 'banner')
+          buildRequest(validBidRequest, bidderRequest, 'native')
         );
       }
     });
@@ -184,7 +184,7 @@ const converter = ortbConverter({
   imp(buildImp, bidRequest, context) {
     const imp = buildImp(bidRequest, context);
     deepSetValue(imp, 'ext.placement', bidRequest.params.placement.toString());
-    deepSetValue(imp, 'rwdd', bidRequest.params?.reward ? 1 : false);
+    deepSetValue(imp, 'rwdd', bidRequest.params?.reward ? 1 : 0);
 
     return imp;
   },
@@ -221,6 +221,10 @@ function hasBannerMediaType(bid) {
 
 function hasVideoMediaType(bid) {
   return hasMediaType(bid, 'video');
+}
+
+function hasNativeMediaType(bid) {
+  return hasMediaType(bid, 'native');
 }
 
 function hasMediaType(bid, mediaType) {

--- a/modules/michaoBidAdapter.js
+++ b/modules/michaoBidAdapter.js
@@ -190,6 +190,7 @@ const converter = ortbConverter({
     const imp = buildImp(bidRequest, context);
     deepSetValue(imp, 'ext.placement', bidRequest.params.placement.toString());
     deepSetValue(imp, 'rwdd', bidRequest.params?.reward ? 1 : 0);
+    deepSetValue(imp, 'bidfloor', isNumber(bidRequest.params?.bidFloor) ? bidRequest.params?.bidFloor : 0);
 
     return imp;
   },

--- a/modules/michaoBidAdapter.js
+++ b/modules/michaoBidAdapter.js
@@ -21,7 +21,7 @@ const ENV = {
   NET_REVENUE: true,
   DEFAULT_CURRENCY: 'USD',
   OUTSTREAM_RENDERER_URL:
-    'https://cdn.jsdelivr.net/npm/in-renderer-js@latest/dist/in-video-renderer.umd.min.js',
+    'https://cdn.jsdelivr.net/npm/in-renderer-js@1.0.6/dist/in-video-renderer.umd.min.js',
 };
 
 export const spec = {

--- a/modules/michaoBidAdapter.js
+++ b/modules/michaoBidAdapter.js
@@ -183,6 +183,10 @@ const converter = ortbConverter({
       deepSetValue(openRTBBidRequest, 'source.schain', bidRequest.schain);
     }
 
+    if (bidRequest.params.partner) {
+      deepSetValue(openRTBBidRequest, 'site.publisher.ext.partner', bidRequest.params.partner.toString())
+    }
+
     return openRTBBidRequest;
   },
 

--- a/modules/michaoBidAdapter.js
+++ b/modules/michaoBidAdapter.js
@@ -86,7 +86,7 @@ export const spec = {
 
 export const domainLogger = {
   bidRequestValidationError() {
-    logError('Michao: wrong format of site or placement.');
+    logError('Michao Bid Adapter: wrong format of site or placement.');
   },
 };
 

--- a/modules/michaoBidAdapter.js
+++ b/modules/michaoBidAdapter.js
@@ -120,20 +120,20 @@ export const spec = {
         });
       }
 
-      if (validBidRequest.mediaTypes?.video) {
-        bidRequestEachFormat.push({
-          ...validBidRequest,
-          mediaTypes: {
-            video: validBidRequest.mediaTypes.video,
-          },
-        });
-      }
-
       if (validBidRequest.mediaTypes?.native) {
         bidRequestEachFormat.push({
           ...validBidRequest,
           mediaTypes: {
             native: validBidRequest.mediaTypes.native,
+          },
+        });
+      }
+
+      if (validBidRequest.mediaTypes?.video) {
+        bidRequestEachFormat.push({
+          ...validBidRequest,
+          mediaTypes: {
+            video: validBidRequest.mediaTypes.video,
           },
         });
       }

--- a/modules/michaoBidAdapter.js
+++ b/modules/michaoBidAdapter.js
@@ -169,6 +169,8 @@ const converter = ortbConverter({
     const openRTBBidRequest = buildRequest(imps, bidderRequest, context);
     openRTBBidRequest.cur = [ENV.DEFAULT_CURRENCY];
     openRTBBidRequest.test = config.getConfig('debug') ? 1 : 0;
+    openRTBBidRequest.bcat = bidRequest.params?.bcat || [];
+    openRTBBidRequest.badv = bidRequest.params?.badv || [];
     deepSetValue(
       openRTBBidRequest,
       'site.id',

--- a/modules/michaoBidAdapter.js
+++ b/modules/michaoBidAdapter.js
@@ -1,0 +1,222 @@
+import { ortbConverter } from '../libraries/ortbConverter/converter.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { config } from '../src/config.js';
+import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import { Renderer } from '../src/Renderer.js';
+import {
+  deepSetValue,
+  isStr,
+  logError,
+  replaceAuctionPrice,
+  triggerPixel,
+} from '../src/utils.js';
+
+const ENV = {
+  BIDDER_CODE: 'michao',
+  SUPPORTED_MEDIA_TYPES: [BANNER, VIDEO],
+  ENDPOINT: 'https://rtb.michao-ssp.com/openrtb/prebid',
+  NET_REVENUE: true,
+  DEFAULT_CURRENCY: 'USD',
+  RENDERER_URL:
+    'https://cdn.jsdelivr.net/npm/in-renderer-js@latest/dist/in-renderer.umd.min.js',
+};
+
+export const spec = {
+  code: ENV.BIDDER_CODE,
+  supportedMediaTypes: ENV.SUPPORTED_MEDIA_TYPES,
+
+  isBidRequestValid: function (bid) {
+    if (!hasParamsObject(bid)) {
+      return false;
+    }
+
+    if (!validateMichaoParams(bid.params)) {
+      domainLogger.bidRequestValidationError();
+      return false;
+    }
+
+    return true;
+  },
+
+  buildRequests: function (validBidRequests, bidderRequest) {
+    const bidRequests = [];
+
+    validBidRequests.forEach((validBidRequest) => {
+      if (
+        hasVideoMediaType(validBidRequest) &&
+        hasBannerMediaType(validBidRequest)
+      ) {
+        bidRequests.push(
+          buildRequest(validBidRequest, bidderRequest, 'banner')
+        );
+        bidRequests.push(buildRequest(validBidRequest, bidderRequest, 'video'));
+      } else if (hasVideoMediaType(validBidRequest)) {
+        bidRequests.push(buildRequest(validBidRequest, bidderRequest, 'video'));
+      } else if (hasBannerMediaType(validBidRequest)) {
+        bidRequests.push(
+          buildRequest(validBidRequest, bidderRequest, 'banner')
+        );
+      }
+    });
+
+    return bidRequests;
+  },
+
+  interpretResponse: function (serverResponse, request) {
+    return interpretResponse(serverResponse, request);
+  },
+
+  getUserSyncs: function (
+    syncOptions,
+    serverResponses,
+    gdprConsent,
+    uspConsent
+  ) {
+    if (syncOptions.iframeEnabled) {
+      return [syncUser(gdprConsent)];
+    }
+  },
+
+  onBidBillable: function (bid) {
+    if (bid.burl && isStr(bid.burl)) {
+      billBid(bid);
+    }
+  },
+};
+
+export const domainLogger = {
+  bidRequestValidationError() {
+    logError('Michao: wrong format of site or placement.');
+  },
+};
+
+export function buildRequest(bidRequest, bidderRequest, mediaType) {
+  const openRTBBidRequest = converter.toORTB({
+    bidRequests: [bidRequest],
+    bidderRequest,
+    context: {
+      mediaType: mediaType,
+    },
+  });
+
+  return {
+    method: 'POST',
+    url: ENV.ENDPOINT,
+    data: openRTBBidRequest,
+    options: { contentType: 'application/json', withCredentials: true },
+  };
+}
+
+export function interpretResponse(response, request) {
+  const bids = converter.fromORTB({
+    response: response.body,
+    request: request.data,
+  }).bids;
+
+  return bids;
+}
+
+export function syncUser(gdprConsent) {
+  let gdprParams = '';
+
+  if (typeof gdprConsent === 'object') {
+    if (typeof gdprConsent.gdprApplies === 'boolean') {
+      gdprParams = `gdpr=${Number(gdprConsent.gdprApplies)}&gdpr_consent=${
+        gdprConsent.consentString
+      }`;
+    } else {
+      gdprParams = `gdpr_consent=${gdprConsent.consentString}`;
+    }
+  }
+
+  return {
+    type: 'iframe',
+    url: 'https://sync.michao-ssp.com/cookie-syncs?' + gdprParams,
+  };
+}
+
+export function addRenderer(bid) {
+  bid.renderer.push(() => {
+    const inRenderer = new window.InRenderer();
+    inRenderer.render(bid.adUnitCode, bid);
+  });
+}
+
+export function hasParamsObject(bid) {
+  return typeof bid.params === 'object';
+}
+
+export function validateMichaoParams(params) {
+  const michaoParams = ['site', 'placement'];
+  return michaoParams.every((michaoParam) =>
+    Number.isFinite(params[michaoParam])
+  );
+}
+
+export function billBid(bid) {
+  bid.burl = replaceAuctionPrice(bid.burl, bid.originalCpm || bid.cpm);
+  triggerPixel(bid.burl);
+}
+
+const converter = ortbConverter({
+  request(buildRequest, imps, bidderRequest, context) {
+    const bidRequest = context.bidRequests[0];
+    const openRTBBidRequest = buildRequest(imps, bidderRequest, context);
+    openRTBBidRequest.cur = [ENV.DEFAULT_CURRENCY];
+    openRTBBidRequest.test = config.getConfig('debug') ? 1 : 0;
+    deepSetValue(
+      openRTBBidRequest,
+      'site.id',
+      bidRequest.params.site.toString()
+    );
+    if (bidRequest?.schain) {
+      deepSetValue(openRTBBidRequest, 'source.schain', bidRequest.schain);
+    }
+
+    return openRTBBidRequest;
+  },
+
+  imp(buildImp, bidRequest, context) {
+    const imp = buildImp(bidRequest, context);
+    // imp.id = bidRequest.adUnitCode;
+    deepSetValue(imp, 'ext.placement', bidRequest.params.placement.toString());
+
+    return imp;
+  },
+
+  bidResponse(buildBidResponse, bid, context) {
+    const { bidRequest } = context;
+    let bidResponse = buildBidResponse(bid, context);
+    if (bidRequest.mediaTypes.video?.context === 'outstream') {
+      const renderer = Renderer.install({
+        id: bid.bidId,
+        url: ENV.RENDERER_URL,
+        adUnitCode: bid.adUnitCode,
+      });
+      renderer.setRender(addRenderer);
+      bidResponse.renderer = renderer;
+    }
+
+    return bidResponse;
+  },
+
+  context: {
+    netRevenue: ENV.NET_REVENUE,
+    currency: ENV.DEFAULT_CURRENCY,
+    ttl: 360,
+  },
+});
+
+function hasBannerMediaType(bid) {
+  return hasMediaType(bid, 'banner');
+}
+
+function hasVideoMediaType(bid) {
+  return hasMediaType(bid, 'video');
+}
+
+function hasMediaType(bid, mediaType) {
+  return bid.mediaTypes.hasOwnProperty(mediaType);
+}
+
+registerBidder(spec);

--- a/modules/michaoBidAdapter.js
+++ b/modules/michaoBidAdapter.js
@@ -310,6 +310,10 @@ const converter = ortbConverter({
       isNumber(bidRequest.params?.bidFloor) ? bidRequest.params?.bidFloor : 0
     );
 
+    if (!bidRequest.mediaTypes?.native) {
+      delete imp.native;
+    }
+
     return imp;
   },
 

--- a/modules/michaoBidAdapter.js
+++ b/modules/michaoBidAdapter.js
@@ -5,6 +5,7 @@ import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { Renderer } from '../src/Renderer.js';
 import {
   deepSetValue,
+  isNumber,
   isStr,
   logError,
   replaceAuctionPrice,
@@ -149,11 +150,13 @@ export function hasParamsObject(bid) {
 export function validateMichaoParams(params) {
   let valid = true;
 
-  const michaoAdUnitInfoParams = ['site', 'placement'];
+  if (!isNumber(params?.site)) {
+    valid = false;
+  }
 
-  valid = michaoAdUnitInfoParams.every((michaoParam) =>
-    Number.isFinite(params[michaoParam])
-  );
+  if (!isStr(params?.placement)) {
+    valid = false;
+  }
 
   return valid
 }

--- a/modules/michaoBidAdapter.js
+++ b/modules/michaoBidAdapter.js
@@ -18,7 +18,7 @@ const ENV = {
   NET_REVENUE: true,
   DEFAULT_CURRENCY: 'USD',
   RENDERER_URL:
-    'https://cdn.jsdelivr.net/npm/in-renderer-js@latest/dist/in-renderer.umd.min.js',
+    'https://cdn.jsdelivr.net/npm/in-renderer-js@latest/dist/in-video-renderer.umd.min.js',
 };
 
 export const spec = {
@@ -137,7 +137,7 @@ export function syncUser(gdprConsent) {
 
 export function addRenderer(bid) {
   bid.renderer.push(() => {
-    const inRenderer = new window.InRenderer();
+    const inRenderer = new window.InVideoRenderer();
     inRenderer.render(bid.adUnitCode, bid);
   });
 }

--- a/modules/michaoBidAdapter.js
+++ b/modules/michaoBidAdapter.js
@@ -147,10 +147,15 @@ export function hasParamsObject(bid) {
 }
 
 export function validateMichaoParams(params) {
-  const michaoParams = ['site', 'placement'];
-  return michaoParams.every((michaoParam) =>
+  let valid = true;
+
+  const michaoAdUnitInfoParams = ['site', 'placement'];
+
+  valid = michaoAdUnitInfoParams.every((michaoParam) =>
     Number.isFinite(params[michaoParam])
   );
+
+  return valid
 }
 
 export function billBid(bid) {
@@ -178,8 +183,8 @@ const converter = ortbConverter({
 
   imp(buildImp, bidRequest, context) {
     const imp = buildImp(bidRequest, context);
-    // imp.id = bidRequest.adUnitCode;
     deepSetValue(imp, 'ext.placement', bidRequest.params.placement.toString());
+    deepSetValue(imp, 'rwdd', bidRequest.params?.reward ? 1 : false);
 
     return imp;
   },

--- a/modules/michaoBidAdapter.js
+++ b/modules/michaoBidAdapter.js
@@ -187,14 +187,17 @@ const converter = ortbConverter({
   bidResponse(buildBidResponse, bid, context) {
     const { bidRequest } = context;
     let bidResponse = buildBidResponse(bid, context);
-    if (bidRequest.mediaTypes.video?.context === 'outstream') {
-      const renderer = Renderer.install({
-        id: bid.bidId,
-        url: ENV.RENDERER_URL,
-        adUnitCode: bid.adUnitCode,
-      });
-      renderer.setRender(addRenderer);
-      bidResponse.renderer = renderer;
+    if (hasVideoMediaType(bidRequest)) {
+      bidResponse.vastXml = bid.adm;
+      if (bidRequest.mediaTypes.video?.context === 'outstream') {
+        const renderer = Renderer.install({
+          id: bid.bidId,
+          url: ENV.RENDERER_URL,
+          adUnitCode: bid.adUnitCode,
+        });
+        renderer.setRender(addRenderer);
+        bidResponse.renderer = renderer;
+      }
     }
 
     return bidResponse;

--- a/modules/michaoBidAdapter.md
+++ b/modules/michaoBidAdapter.md
@@ -13,6 +13,7 @@ Module that connects to Michao’s demand sources
 Supported Ad format:
 * Banner
 * Video (instream and outstream)
+* Native
 
 # Test Parameters
 ```
@@ -29,7 +30,7 @@ var adUnits = [
             bidder: 'michao',
             params: {
                 site: 1,
-                placement: 1,
+                placement: '1',
             }
         }]
     },
@@ -50,7 +51,35 @@ var adUnits = [
             bidder: 'michao',
             params: {
                 site: 1,
-                placement: 1,
+                placement: '1',
+            }
+        }]
+    },
+    // Native AdUnit
+    {
+        code: 'native-div',
+        mediaTypes: {
+            native: {
+                ortb: {
+                    assets: [
+                        {
+                            id: 1,
+                            required: 1,
+                            img: {
+                                type: 3,
+                                w: 989,
+                                h: 742,
+                            },
+                        },
+                    ]
+                }
+            }
+        },
+        bids: [{
+            bidder: 'michao',
+            params: {
+                site: 1,
+                placement: '1',
             }
         }]
     }

--- a/modules/michaoBidAdapter.md
+++ b/modules/michaoBidAdapter.md
@@ -1,0 +1,58 @@
+# Overview
+
+```markdown
+Module Name: Michao Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: miyamoto.kai@lookverin.com
+```
+
+# Description
+
+Module that connects to Michao’s demand sources
+
+Supported Ad format:
+* Banner
+* Video (instream and outstream)
+
+# Test Parameters
+```
+var adUnits = [
+    // Banner adUnit
+    {
+        code: 'banner-div',
+        mediaTypes: {
+            banner: {
+                sizes: [[300, 250]],
+            }
+        },
+        bids: [{
+            bidder: 'michao',
+            params: {
+                site: 1,
+                placement: 1,
+            }
+        }]
+    },
+    // Video adUnit
+    {
+        code: 'video-div',
+        mediaTypes: {
+            video: {
+                context: 'outstream',
+                playerSize: [640, 480],
+                minduration: 0,
+                maxduration: 120,
+                mimes: ['video/mp4'],
+                protocols: [7]
+            }
+        },
+        bids: [{
+            bidder: 'michao',
+            params: {
+                site: 1,
+                placement: 1,
+            }
+        }]
+    }
+];
+```

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -486,7 +486,7 @@ describe('Michao Bid Adapter', () => {
       expect(triggerPixelSpy.calledOnce).to.be.false;
     });
 
-    it('generates billing when billing URL is a string', () => {
+    it('calls billing url when billing URL is a string', () => {
       const bid = {
         burl: 'https://example.com/burl',
         cpm: 1,
@@ -497,7 +497,18 @@ describe('Michao Bid Adapter', () => {
       expect(triggerPixelSpy.calledOnce).to.be.true;
     });
 
-    it('does not generate billing when billing URL is not a string', () => {
+    it('calls bidder billing url when billing URL includes bidder burl', () => {
+      const bid = {
+        burl: 'https://example.com/burl?burl=https://bidder.example.com/burl',
+        cpm: 1,
+      };
+
+      spec.onBidBillable(bid);
+
+      expect(triggerPixelSpy.calledTwice).to.be.true;
+    });
+
+    it('does not calls billing url when billing URL is not a string', () => {
       const bid = {
         burl: 123,
       };

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -488,7 +488,7 @@ describe('Michao Bid Adapter', () => {
 
     it('calls billing url when billing URL is a string', () => {
       const bid = {
-        burl: 'https://example.com/burl',
+        burl: 'https://example.com/burls',
         cpm: 1,
       };
 

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -382,7 +382,7 @@ describe('Michao Bid Adapter', () => {
       const result = spec.interpretResponse(videoServerResponse, request[0]);
 
       expect(result[0].renderer.url).to.equal(
-        'https://cdn.jsdelivr.net/npm/in-renderer-js@1.0.6/dist/in-video-renderer.umd.min.js'
+        'https://cdn.jsdelivr.net/npm/in-renderer-js@1/dist/in-video-renderer.umd.min.js'
       );
     });
 

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -308,7 +308,7 @@ describe('Michao Bid Adapter', () => {
 
         const result = spec.buildRequests([bannerBidRequest], bidderRequest);
 
-        expect(result[0].data.site.id).to.equal('456');
+        expect(result[0].data.site.ext.michao.site).to.equal('456');
       });
 
       it('sets placementId in impression object', () => {
@@ -324,7 +324,7 @@ describe('Michao Bid Adapter', () => {
 
         const result = spec.buildRequests([bannerBidRequest], bidderRequest);
 
-        expect(result[0].data.imp[0].ext.placement).to.equal('123');
+        expect(result[0].data.imp[0].ext.michao.placement).to.equal('123');
       });
     });
 
@@ -343,7 +343,7 @@ describe('Michao Bid Adapter', () => {
 
         const result = spec.buildRequests([bannerBidRequest], bidderRequest);
 
-        expect(result[0].data.site.publisher.ext.partner).to.equal('123');
+        expect(result[0].data.site.publisher.ext.michao.partner).to.equal('123');
       });
 
       it('sets test in publisher when specified', () => {

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -126,6 +126,58 @@ describe('the michao bidder adapter', () => {
         });
       });
 
+      it('Native bid requests are converted to video server request objects', () => {
+        const nativeBidRequest = {
+          adUnitCode: 'test-div',
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          bidId: '22c4871113f461',
+          bidder: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bidRequestsCount: 1,
+          bidderRequestsCount: 1,
+          bidderWinsCount: 0,
+          mediaTypes: {
+            native: {
+              ortb: {
+                assets: [
+                  {
+                    id: 2,
+                    required: 1,
+                    title: {
+                      len: 80
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          params: {
+            site: 123,
+            placement: 456,
+          },
+        };
+        const bidderRequest = {
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          auctionStart: 1579746300522,
+          bidderCode: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bids: [nativeBidRequest],
+        };
+
+        const result = buildRequest(nativeBidRequest, bidderRequest, 'native');
+
+        expect(result).to.nested.include({
+          url: 'https://rtb.michao-ssp.com/openrtb/prebid',
+          'options.contentType': 'application/json',
+          'options.withCredentials': true,
+          method: 'POST',
+          'data.cur[0]': 'USD',
+          'data.imp[0].ext.placement': '456',
+          'data.site.id': '123',
+          'data.test': 0,
+        });
+      });
+
       it('Converted to server request object for testing in debug mode', () => {
         const bidRequest = {
           adUnitCode: 'test-div',
@@ -467,8 +519,36 @@ describe('the michao bidder adapter', () => {
           bidder: 'michao',
           bidderRequestId: 'bidder-request-2',
           mediaTypes: {
-            banner: {
-              sizes: [[300, 250]],
+            video: {
+              context: 'outstream',
+              playerSize: [640, 480],
+              mimes: ['video/mp4'],
+            },
+          },
+          params: {
+            site: 12,
+            placement: 12,
+          },
+        },
+        {
+          adUnitCode: 'test-div',
+          auctionId: 'auction-2',
+          bidId: 'bid-2',
+          bidder: 'michao',
+          bidderRequestId: 'bidder-request-2',
+          mediaTypes: {
+            native: {
+              ortb: {
+                assets: [
+                  {
+                    id: 2,
+                    required: 1,
+                    title: {
+                      len: 80
+                    }
+                  }
+                ]
+              }
             },
           },
           params: {
@@ -486,7 +566,7 @@ describe('the michao bidder adapter', () => {
 
       const result = spec.buildRequests(validBidRequests, bidderRequest);
 
-      expect(result.length).to.equal(2);
+      expect(result.length).to.equal(3);
     });
 
     it('`interpretResponse`', () => {

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -142,7 +142,7 @@ describe('Michao Bid Adapter', () => {
       it('detects invalid input when test is not a boolean', () => {
         bannerBidRequest.params = {
           ...bannerBidRequest.params,
-          test: 'truee',
+          test: 'trueee',
         };
 
         const result = spec.isBidRequestValid(bannerBidRequest);

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -352,6 +352,41 @@ describe('the michao bidder adapter', () => {
           'data.imp[0].bidfloor': 1,
         });
       });
+
+      it('Partner ID is set from Partner ID parameter', () => {
+        const bidRequest = {
+          adUnitCode: 'test-div',
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          bidId: '22c4871113f461',
+          bidder: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bidRequestsCount: 1,
+          bidderRequestsCount: 1,
+          bidderWinsCount: 0,
+          mediaTypes: { banner: [[300, 250]] },
+          params: {
+            site: 123,
+            placement: '456',
+            partner: 11,
+          },
+        };
+        const bidderRequest = {
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          auctionStart: 1579746300522,
+          bidderCode: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bids: [bidRequest],
+        };
+        config.setConfig({
+          debug: true,
+        });
+
+        const result = buildRequest(bidRequest, bidderRequest, 'banner');
+
+        expect(result).to.nested.include({
+          'data.site.publisher.ext.partner': '11',
+        });
+      });
     });
 
     describe('interpret response', () => {

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -159,6 +159,41 @@ describe('the michao bidder adapter', () => {
           'data.test': 1,
         });
       });
+
+      it('Specifying a reward builds a bid request for the reward.', () => {
+        const bidRequest = {
+          adUnitCode: 'test-div',
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          bidId: '22c4871113f461',
+          bidder: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bidRequestsCount: 1,
+          bidderRequestsCount: 1,
+          bidderWinsCount: 0,
+          mediaTypes: { banner: [[300, 250]] },
+          params: {
+            site: 123,
+            placement: 456,
+            reward: true,
+          },
+        };
+        const bidderRequest = {
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          auctionStart: 1579746300522,
+          bidderCode: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bids: [bidRequest],
+        };
+        config.setConfig({
+          debug: true,
+        });
+
+        const result = buildRequest(bidRequest, bidderRequest, 'banner');
+
+        expect(result).to.nested.include({
+          'data.imp[0].rwdd': 1,
+        });
+      });
     });
 
     describe('interpret response', () => {
@@ -427,17 +462,13 @@ describe('the michao bidder adapter', () => {
         },
         {
           adUnitCode: 'test-div',
-          auctionId: 'auction-1',
+          auctionId: 'auction-2',
           bidId: 'bid-2',
           bidder: 'michao',
-          bidderRequestId: 'bidder-request-1',
+          bidderRequestId: 'bidder-request-2',
           mediaTypes: {
-            video: {
-              context: 'outstream',
-              playerSize: [640, 480],
-              mimes: ['video/mp4'],
-              minduration: 0,
-              maxduration: 30,
+            banner: {
+              sizes: [[300, 250]],
             },
           },
           params: {

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -497,9 +497,6 @@ describe('Michao Bid Adapter', () => {
         expect(result[0].data.imp[0]).to.have.property(
           'banner'
         );
-        expect(result[0].data.imp[1]).to.have.property(
-          'video'
-        );
       });
     });
 

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -467,7 +467,7 @@ describe('the michao bidder adapter', () => {
                   id: 'bidId1',
                   impid: 'bidId1',
                   price: 0.18,
-                  adm: '<VAST version="2.0"></VAST>',
+                  adm: '<div>ad</div>',
                   adid: '144762342',
                   adomain: ['https://dummydomain.com'],
                   iurl: 'iurl',
@@ -495,11 +495,8 @@ describe('the michao bidder adapter', () => {
         bidderRequestsCount: 1,
         bidderWinsCount: 0,
         mediaTypes: {
-          video: {
-            context: 'outstream',
-            mimes: ['video/mp4'],
-            minduration: 0,
-            maxduration: 120,
+          banner: {
+            sizes: [[300, 250]]
           },
         },
         params: {
@@ -524,7 +521,7 @@ describe('the michao bidder adapter', () => {
       expect(result[0]).to.have.property('cpm', 0.18);
       expect(result[0]).to.have.property('width', 640);
       expect(result[0]).to.have.property('height', 480);
-      expect(result[0]).to.have.property('ad', '<VAST version="2.0"></VAST>');
+      expect(result[0]).to.have.property('ad', '<div>ad</div>');
       expect(result[0]).to.have.property('creativeId', 'creativeId');
       expect(result[0]).to.have.property('netRevenue', true);
     });

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -142,7 +142,7 @@ describe('Michao Bid Adapter', () => {
       it('detects invalid input when test is not a boolean', () => {
         bannerBidRequest.params = {
           ...bannerBidRequest.params,
-          test: 'true',
+          test: 'truee',
         };
 
         const result = spec.isBidRequestValid(bannerBidRequest);

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -388,7 +388,6 @@ describe('Michao Bid Adapter', () => {
 
         expect(result.length).to.equal(1);
         expect(result[0].data.imp.length).to.equal(1);
-        expect(result[0].data.imp[0]).to.have.property('video');
       });
 
       it('creates native-specific bid request from bid request containing one native format', () => {
@@ -427,9 +426,6 @@ describe('Michao Bid Adapter', () => {
         expect(result[0].data.imp.length).to.equal(2);
         expect(result[0].data.imp[0]).to.have.property(
           'banner'
-        );
-        expect(result[0].data.imp[1]).to.have.property(
-          'video'
         );
       });
 
@@ -476,7 +472,6 @@ describe('Michao Bid Adapter', () => {
 
         expect(result.length).to.equal(1);
         expect(result[0].data.imp.length).to.equal(2);
-        expect(result[0].data.imp[0]).to.have.property('video');
       });
 
       it('creates banner, video and native bid request with three impressions from bid request containing all three formats', () => {

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -34,7 +34,7 @@ describe('the michao bidder adapter', () => {
       it('If the site ID and placement ID are correct, the verification succeeds.', () => {
         const params = {
           site: 123,
-          placement: 234,
+          placement: 'placement'
         };
 
         const result = validateMichaoParams(params);
@@ -57,7 +57,7 @@ describe('the michao bidder adapter', () => {
           mediaTypes: { banner: [[300, 250]] },
           params: {
             site: 123,
-            placement: 456,
+            placement: '456',
           },
         };
         const bidderRequest = {
@@ -101,7 +101,7 @@ describe('the michao bidder adapter', () => {
           },
           params: {
             site: 123,
-            placement: 456,
+            placement: '456',
           },
         };
         const bidderRequest = {
@@ -153,7 +153,7 @@ describe('the michao bidder adapter', () => {
           },
           params: {
             site: 123,
-            placement: 456,
+            placement: '456',
           },
         };
         const bidderRequest = {
@@ -191,7 +191,7 @@ describe('the michao bidder adapter', () => {
           mediaTypes: { banner: [[300, 250]] },
           params: {
             site: 123,
-            placement: 456,
+            placement: '456',
           },
         };
         const bidderRequest = {
@@ -225,7 +225,7 @@ describe('the michao bidder adapter', () => {
           mediaTypes: { banner: [[300, 250]] },
           params: {
             site: 123,
-            placement: 456,
+            placement: '456',
             reward: true,
           },
         };
@@ -260,7 +260,7 @@ describe('the michao bidder adapter', () => {
           mediaTypes: { banner: [[300, 250]] },
           params: {
             site: 123,
-            placement: 456,
+            placement: '456',
             bcat: ['IAB2']
           },
         };
@@ -295,7 +295,7 @@ describe('the michao bidder adapter', () => {
           mediaTypes: { banner: [[300, 250]] },
           params: {
             site: 123,
-            placement: 456,
+            placement: '456',
             badv: ['adomain.com']
           },
         };
@@ -361,7 +361,7 @@ describe('the michao bidder adapter', () => {
           mediaTypes: { banner: [[300, 250]] },
           params: {
             site: 123,
-            placement: 456,
+            placement: '456',
           },
         };
         const bidderRequest = {
@@ -400,7 +400,7 @@ describe('the michao bidder adapter', () => {
           mediaTypes: { banner: [[300, 250]] },
           params: {
             site: 123,
-            placement: 456,
+            placement: '456',
           },
         };
         const bidderRequest = {
@@ -468,7 +468,7 @@ describe('the michao bidder adapter', () => {
           },
           params: {
             site: 123,
-            placement: 456,
+            placement: '456',
           },
         };
         const bidderRequest = {
@@ -526,7 +526,7 @@ describe('the michao bidder adapter', () => {
         mediaTypes: { banner: [[300, 250]] },
         params: {
           site: 123,
-          placement: 456,
+          placement: '456',
         },
         burl: 'https://example.com/burl',
       };
@@ -554,8 +554,8 @@ describe('the michao bidder adapter', () => {
     it('`isBidRequestValid`', () => {
       const validBidRequest = {
         params: {
-          placement: 124,
-          site: 456,
+          placement: '124',
+          site: 234,
         },
       };
 
@@ -579,7 +579,7 @@ describe('the michao bidder adapter', () => {
           },
           params: {
             site: 12,
-            placement: 12,
+            placement: '12',
           },
         },
         {
@@ -597,7 +597,7 @@ describe('the michao bidder adapter', () => {
           },
           params: {
             site: 12,
-            placement: 12,
+            placement: '12',
           },
         },
         {
@@ -623,7 +623,7 @@ describe('the michao bidder adapter', () => {
           },
           params: {
             site: 12,
-            placement: 12,
+            placement: '12',
           },
         },
       ];
@@ -685,7 +685,7 @@ describe('the michao bidder adapter', () => {
         },
         params: {
           site: 123,
-          placement: 456,
+          placement: '456',
         },
       };
       const bidderRequest = {
@@ -744,7 +744,7 @@ describe('the michao bidder adapter', () => {
         mediaTypes: { banner: [[300, 250]] },
         params: {
           site: 123,
-          placement: 456,
+          placement: '456',
         },
         burl: 'https://example.com/burl',
       };

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -1,0 +1,577 @@
+import { expect } from 'chai';
+import {
+  addRenderer,
+  billBid,
+  buildRequest,
+  interpretResponse,
+  spec,
+  syncUser,
+  validateMichaoParams,
+} from '../../../modules/michaoBidAdapter';
+import * as utils from 'src/utils.js';
+import { config } from '../../../src/config';
+
+describe('the michao bidder adapter', () => {
+  beforeEach(() => {
+    config.resetConfig();
+  });
+
+  describe('unit', () => {
+    describe('validate bid request', () => {
+      const invalidBidParams = [
+        { site: '123', placement: 'super-placement' },
+        { site: '123', placement: 456 },
+        { site: Infinity, placement: 456 },
+      ];
+      invalidBidParams.forEach((params) => {
+        it('Detecting incorrect parameters', () => {
+          const result = validateMichaoParams(params);
+
+          expect(result).to.be.false;
+        });
+      });
+
+      it('If the site ID and placement ID are correct, the verification succeeds.', () => {
+        const params = {
+          site: 123,
+          placement: 234,
+        };
+
+        const result = validateMichaoParams(params);
+
+        expect(result).to.be.true;
+      });
+    });
+
+    describe('build bid request', () => {
+      it('Banner bid requests are converted to banner server request objects', () => {
+        const bannerBidRequest = {
+          adUnitCode: 'test-div',
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          bidId: '22c4871113f461',
+          bidder: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bidRequestsCount: 1,
+          bidderRequestsCount: 1,
+          bidderWinsCount: 0,
+          mediaTypes: { banner: [[300, 250]] },
+          params: {
+            site: 123,
+            placement: 456,
+          },
+        };
+        const bidderRequest = {
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          auctionStart: 1579746300522,
+          bidderCode: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bids: [bannerBidRequest],
+        };
+
+        const result = buildRequest(bannerBidRequest, bidderRequest, 'banner');
+
+        expect(result).to.nested.include({
+          url: 'https://rtb.michao-ssp.com/openrtb/prebid',
+          'options.contentType': 'application/json',
+          'options.withCredentials': true,
+          method: 'POST',
+          'data.cur[0]': 'USD',
+          'data.imp[0].ext.placement': '456',
+          'data.site.id': '123',
+          'data.test': 0,
+        });
+      });
+
+      it('Video bid requests are converted to video server request objects', () => {
+        const videoBidRequest = {
+          adUnitCode: 'test-div',
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          bidId: '22c4871113f461',
+          bidder: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bidRequestsCount: 1,
+          bidderRequestsCount: 1,
+          bidderWinsCount: 0,
+          mediaTypes: {
+            video: {
+              context: 'outstream',
+              playerSize: [640, 480],
+              mimes: ['video/mp4'],
+            },
+          },
+          params: {
+            site: 123,
+            placement: 456,
+          },
+        };
+        const bidderRequest = {
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          auctionStart: 1579746300522,
+          bidderCode: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bids: [videoBidRequest],
+        };
+
+        const result = buildRequest(videoBidRequest, bidderRequest, 'banner');
+
+        expect(result).to.nested.include({
+          url: 'https://rtb.michao-ssp.com/openrtb/prebid',
+          'options.contentType': 'application/json',
+          'options.withCredentials': true,
+          method: 'POST',
+          'data.cur[0]': 'USD',
+          'data.imp[0].ext.placement': '456',
+          'data.site.id': '123',
+          'data.test': 0,
+        });
+      });
+
+      it('Converted to server request object for testing in debug mode', () => {
+        const bidRequest = {
+          adUnitCode: 'test-div',
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          bidId: '22c4871113f461',
+          bidder: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bidRequestsCount: 1,
+          bidderRequestsCount: 1,
+          bidderWinsCount: 0,
+          mediaTypes: { banner: [[300, 250]] },
+          params: {
+            site: 123,
+            placement: 456,
+          },
+        };
+        const bidderRequest = {
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          auctionStart: 1579746300522,
+          bidderCode: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bids: [bidRequest],
+        };
+        config.setConfig({
+          debug: true,
+        });
+
+        const result = buildRequest(bidRequest, bidderRequest, 'banner');
+
+        expect(result).to.nested.include({
+          'data.test': 1,
+        });
+      });
+    });
+
+    describe('interpret response', () => {
+      it('Server response is interpreted as a bid.', () => {
+        const response = {
+          headers: null,
+          body: {
+            id: 'requestId',
+            seatbid: [
+              {
+                bid: [
+                  {
+                    id: 'bidId1',
+                    impid: 'bidId1',
+                    price: 0.18,
+                    adm: '<script>adm</script>',
+                    adid: '144762342',
+                    adomain: ['https://dummydomain.com'],
+                    iurl: 'iurl',
+                    cid: '109',
+                    crid: 'creativeId',
+                    cat: [],
+                    w: 300,
+                    h: 250,
+                    mtype: 1,
+                  },
+                ],
+                seat: 'seat',
+              },
+            ],
+            cur: 'USD',
+          },
+        };
+        const bannerBidRequest = {
+          adUnitCode: 'test-div',
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          bidId: 'bidId1',
+          bidder: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bidRequestsCount: 1,
+          bidderRequestsCount: 1,
+          bidderWinsCount: 0,
+          mediaTypes: { banner: [[300, 250]] },
+          params: {
+            site: 123,
+            placement: 456,
+          },
+        };
+        const bidderRequest = {
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          auctionStart: 1579746300522,
+          bidderCode: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bids: [bannerBidRequest],
+        };
+        const request = buildRequest(bannerBidRequest, bidderRequest, 'banner');
+
+        const result = interpretResponse(response, request);
+
+        expect(result).to.be.an('array');
+        expect(result[0]).to.have.property('currency', 'USD');
+        expect(result[0]).to.have.property('requestId', 'bidId1');
+        expect(result[0]).to.have.property('cpm', 0.18);
+        expect(result[0]).to.have.property('width', 300);
+        expect(result[0]).to.have.property('height', 250);
+        expect(result[0]).to.have.property('ad', '<script>adm</script>');
+        expect(result[0]).to.have.property('creativeId', 'creativeId');
+        expect(result[0]).to.have.property('netRevenue', true);
+      });
+
+      it('Empty server responses are interpreted as empty bids', () => {
+        const response = { body: {} };
+        const bannerBidRequest = {
+          adUnitCode: 'test-div',
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          bidId: '22c4871113f461',
+          bidder: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bidRequestsCount: 1,
+          bidderRequestsCount: 1,
+          bidderWinsCount: 0,
+          mediaTypes: { banner: [[300, 250]] },
+          params: {
+            site: 123,
+            placement: 456,
+          },
+        };
+        const bidderRequest = {
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          auctionStart: 1579746300522,
+          bidderCode: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bids: [bannerBidRequest],
+        };
+        const request = buildRequest(bannerBidRequest, bidderRequest, 'banner');
+
+        const result = interpretResponse(response, request);
+
+        expect(result).to.be.an('array');
+        expect(result.length).to.equal(0);
+      });
+
+      it('Set renderer with outstream video ads', () => {
+        const response = {
+          headers: null,
+          body: {
+            id: 'requestId',
+            seatbid: [
+              {
+                bid: [
+                  {
+                    id: 'bidId1',
+                    impid: 'bidId1',
+                    price: 0.18,
+                    adm: '<VAST></VAST>',
+                    adid: '144762342',
+                    adomain: ['https://dummydomain.com'],
+                    iurl: 'iurl',
+                    cid: '109',
+                    crid: 'creativeId',
+                    cat: [],
+                    w: 300,
+                    h: 250,
+                    mtype: 1,
+                  },
+                ],
+                seat: 'seat',
+              },
+            ],
+            cur: 'USD',
+          },
+        };
+        const videoBidRequest = {
+          adUnitCode: 'test-div',
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          bidId: 'bidId1',
+          bidder: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bidRequestsCount: 1,
+          bidderRequestsCount: 1,
+          bidderWinsCount: 0,
+          mediaTypes: {
+            video: {
+              context: 'outstream',
+              playerSize: [640, 480],
+            },
+          },
+          params: {
+            site: 123,
+            placement: 456,
+          },
+        };
+        const bidderRequest = {
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          auctionStart: 1579746300522,
+          bidderCode: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bids: [videoBidRequest],
+        };
+        const request = buildRequest(videoBidRequest, bidderRequest, 'video');
+
+        const result = interpretResponse(response, request);
+
+        expect(result).to.be.an('array');
+        expect(result[0]).to.have.property('currency', 'USD');
+        expect(result[0]).to.have.property('requestId', 'bidId1');
+        expect(result[0]).to.have.property('cpm', 0.18);
+        expect(result[0]).to.have.property('width', 300);
+        expect(result[0]).to.have.property('height', 250);
+        expect(result[0]).to.have.property('vastXml', '<VAST></VAST>');
+        expect(result[0]).to.have.property('creativeId', 'creativeId');
+        expect(result[0]).to.have.property('netRevenue', true);
+        expect(result[0]).to.have.property('mediaType', 'video');
+        expect(result[0]).to.have.property('renderer');
+      });
+    });
+
+    describe('user syncs', () => {
+      it('Sync Users', () => {
+        const gdprConsent = {
+          gdprApplies: false,
+          consentString: '',
+        };
+
+        const result = syncUser(gdprConsent);
+
+        expect(result).to.deep.equal({
+          type: 'iframe',
+          url: 'https://sync.michao-ssp.com/cookie-syncs?gdpr=0&gdpr_consent=',
+        });
+      });
+    });
+
+    describe('bill a bid', () => {
+      const triggerPixelSpy = sinon.spy(utils, 'triggerPixel');
+      const bid = {
+        adUnitCode: 'test-div',
+        auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+        bidId: '22c4871113f461',
+        bidder: 'michao',
+        bidderRequestId: '15246a574e859f',
+        bidRequestsCount: 1,
+        bidderRequestsCount: 1,
+        bidderWinsCount: 0,
+        mediaTypes: { banner: [[300, 250]] },
+        params: {
+          site: 123,
+          placement: 456,
+        },
+        burl: 'https://example.com/burl',
+      };
+
+      billBid(bid);
+
+      expect(triggerPixelSpy.calledWith('https://example.com/burl')).to.true;
+      triggerPixelSpy.restore();
+    });
+
+    describe('renderer', () => {
+      it('Set outstream renderer', () => {
+        const bid = {
+          renderer: [],
+        };
+
+        addRenderer(bid);
+
+        expect(bid.renderer[0]).that.is.a('function');
+      });
+    });
+  });
+
+  describe('integration', () => {
+    it('`isBidRequestValid`', () => {
+      const validBidRequest = {
+        params: {
+          placement: 124,
+          site: 456,
+        },
+      };
+
+      const result = spec.isBidRequestValid(validBidRequest);
+
+      expect(result).to.true;
+    });
+
+    it('`buildRequests`', () => {
+      const validBidRequests = [
+        {
+          adUnitCode: 'test-div',
+          auctionId: 'auction-1',
+          bidId: 'bid-1',
+          bidder: 'michao',
+          bidderRequestId: 'bidder-request-1',
+          mediaTypes: {
+            banner: {
+              sizes: [[300, 250]],
+            },
+          },
+          params: {
+            site: 12,
+            placement: 12,
+          },
+        },
+        {
+          adUnitCode: 'test-div',
+          auctionId: 'auction-1',
+          bidId: 'bid-2',
+          bidder: 'michao',
+          bidderRequestId: 'bidder-request-1',
+          mediaTypes: {
+            video: {
+              context: 'outstream',
+              playerSize: [640, 480],
+              mimes: ['video/mp4'],
+              minduration: 0,
+              maxduration: 30,
+            },
+          },
+          params: {
+            site: 12,
+            placement: 12,
+          },
+        },
+      ];
+      const bidderRequest = {
+        auctionId: 'auction-1',
+        auctionStart: 1579746300522,
+        bidderCode: 'michao',
+        bidderRequestId: 'bidder-request-1',
+      };
+
+      const result = spec.buildRequests(validBidRequests, bidderRequest);
+
+      expect(result.length).to.equal(2);
+    });
+
+    it('`interpretResponse`', () => {
+      const response = {
+        headers: null,
+        body: {
+          id: 'requestId',
+          seatbid: [
+            {
+              bid: [
+                {
+                  id: 'bidId1',
+                  impid: 'bidId1',
+                  price: 0.18,
+                  adm: '<VAST version="2.0"></VAST>',
+                  adid: '144762342',
+                  adomain: ['https://dummydomain.com'],
+                  iurl: 'iurl',
+                  cid: '109',
+                  crid: 'creativeId',
+                  cat: [],
+                  w: 640,
+                  h: 480,
+                  mtype: 1,
+                },
+              ],
+              seat: 'seat',
+            },
+          ],
+          cur: 'USD',
+        },
+      };
+      const bannerBidRequest = {
+        adUnitCode: 'test-div',
+        auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+        bidId: 'bidId1',
+        bidder: 'michao',
+        bidderRequestId: '15246a574e859f',
+        bidRequestsCount: 1,
+        bidderRequestsCount: 1,
+        bidderWinsCount: 0,
+        mediaTypes: {
+          video: {
+            context: 'outstream',
+            mimes: ['video/mp4'],
+            minduration: 0,
+            maxduration: 120,
+          },
+        },
+        params: {
+          site: 123,
+          placement: 456,
+        },
+      };
+      const bidderRequest = {
+        auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+        auctionStart: 1579746300522,
+        bidderCode: 'michao',
+        bidderRequestId: '15246a574e859f',
+        bids: [bannerBidRequest],
+      };
+      const request = buildRequest(bannerBidRequest, bidderRequest, 'banner');
+
+      const result = interpretResponse(response, request);
+
+      expect(result).to.be.an('array');
+      expect(result[0]).to.have.property('currency', 'USD');
+      expect(result[0]).to.have.property('requestId', 'bidId1');
+      expect(result[0]).to.have.property('cpm', 0.18);
+      expect(result[0]).to.have.property('width', 640);
+      expect(result[0]).to.have.property('height', 480);
+      expect(result[0]).to.have.property('ad', '<VAST version="2.0"></VAST>');
+      expect(result[0]).to.have.property('creativeId', 'creativeId');
+      expect(result[0]).to.have.property('netRevenue', true);
+    });
+
+    it('`getUserSyncs`', () => {
+      const syncOptions = {
+        iframeEnabled: true,
+      };
+      const gdprConsent = {
+        gdprApplies: true,
+        consentString:
+          'CQIhBPbQIhBPbEkAAAENCZCAAAAAAAAAAAAAAAAAAAAA.II7Nd_X__bX9n-_7_6ft0eY1f9_r37uQzDhfNs-8F3L_W_LwX32E7NF36tq4KmR4ku1bBIQNtHMnUDUmxaolVrzHsak2cpyNKJ_JkknsZe2dYGF9Pn9lD-YKZ7_5_9_f52T_9_9_-39z3_9f___dv_-__-vjf_599n_v9fV_78_Kf9______-____________8A',
+      };
+
+      const result = spec.getUserSyncs(syncOptions, {}, gdprConsent);
+
+      expect(result).to.deep.equal([
+        {
+          type: 'iframe',
+          url: 'https://sync.michao-ssp.com/cookie-syncs?gdpr=1&gdpr_consent=CQIhBPbQIhBPbEkAAAENCZCAAAAAAAAAAAAAAAAAAAAA.II7Nd_X__bX9n-_7_6ft0eY1f9_r37uQzDhfNs-8F3L_W_LwX32E7NF36tq4KmR4ku1bBIQNtHMnUDUmxaolVrzHsak2cpyNKJ_JkknsZe2dYGF9Pn9lD-YKZ7_5_9_f52T_9_9_-39z3_9f___dv_-__-vjf_599n_v9fV_78_Kf9______-____________8A',
+        },
+      ]);
+    });
+
+    it('`onBidBillable`', () => {
+      const triggerPixelSpy = sinon.spy(utils, 'triggerPixel');
+      const bid = {
+        adUnitCode: 'test-div',
+        auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+        bidId: '22c4871113f461',
+        bidder: 'michao',
+        bidderRequestId: '15246a574e859f',
+        bidRequestsCount: 1,
+        bidderRequestsCount: 1,
+        bidderWinsCount: 0,
+        mediaTypes: { banner: [[300, 250]] },
+        params: {
+          site: 123,
+          placement: 456,
+        },
+        burl: 'https://example.com/burl',
+      };
+
+      spec.onBidBillable(bid);
+
+      expect(triggerPixelSpy.calledWith('https://example.com/burl')).to.true;
+      triggerPixelSpy.restore();
+    });
+  });
+});

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -3,6 +3,7 @@ import {
   addRenderer,
   billBid,
   buildRequest,
+  domainLogger,
   interpretResponse,
   spec,
   syncUser,
@@ -586,17 +587,35 @@ describe('the michao bidder adapter', () => {
   });
 
   describe('integration', () => {
-    it('`isBidRequestValid`', () => {
-      const validBidRequest = {
-        params: {
-          placement: '124',
-          site: 234,
-        },
-      };
+    describe('`isBidRequestValid`', () => {
+      it('Happy path', () => {
+        const validBidRequest = {
+          params: {
+            placement: '124',
+            site: 234,
+          },
+        };
 
-      const result = spec.isBidRequestValid(validBidRequest);
+        const result = spec.isBidRequestValid(validBidRequest);
 
-      expect(result).to.true;
+        expect(result).to.true;
+      });
+
+      it('If the parameter is invalid, it will be logged', () => {
+        const validationErrorLog = sinon.spy(domainLogger, 'bidRequestValidationError');
+        const validBidRequest = {
+          params: {
+            placement: '124',
+            site: '234',
+          },
+        };
+
+        const result = spec.isBidRequestValid(validBidRequest);
+
+        expect(result).to.false;
+        expect(validationErrorLog.calledOnce).to.true;
+        validationErrorLog.restore();
+      });
     });
 
     it('`buildRequests`', () => {

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -78,140 +78,6 @@ describe('Michao Bid Adapter', () => {
       });
     });
 
-    describe('mediaTypes behavior', () => {
-      it('passes when video context is instream', () => {
-        videoBidRequest.mediaTypes.video = {
-          ...videoBidRequest.mediaTypes.video,
-          context: 'instream',
-        };
-
-        const result = spec.isBidRequestValid(videoBidRequest);
-
-        expect(result).to.be.true;
-        expect(domainLoggerMock.invalidVideoContext.calledOnce).to.be.false;
-      });
-
-      it('passes when video playerSize is valid array', () => {
-        videoBidRequest.mediaTypes.video = {
-          ...videoBidRequest.mediaTypes.video,
-          playerSize: [[640, 480]],
-        };
-
-        const result = spec.isBidRequestValid(videoBidRequest);
-
-        expect(result).to.be.true;
-        expect(domainLoggerMock.invalidVideoPlayerSize.calledOnce).to.be.false;
-      });
-
-      it('passes when valid video minDuration is set', () => {
-        videoBidRequest.mediaTypes.video = {
-          ...videoBidRequest.mediaTypes.video,
-          minduration: 5,
-        };
-
-        const result = spec.isBidRequestValid(videoBidRequest);
-
-        expect(result).to.be.true;
-        expect(domainLoggerMock.invalidVideoMinDuration.calledOnce).to.be.false;
-      });
-
-      it('passes when valid video maxDuration is set', () => {
-        videoBidRequest.mediaTypes.video = {
-          ...videoBidRequest.mediaTypes.video,
-          maxduration: 30,
-        };
-
-        const result = spec.isBidRequestValid(videoBidRequest);
-
-        expect(result).to.be.true;
-        expect(domainLoggerMock.invalidVideoMaxDuration.calledOnce).to.be.false;
-      });
-
-      it('passes when valid video mimes are set', () => {
-        videoBidRequest.mediaTypes.video = {
-          ...videoBidRequest.mediaTypes.video,
-          mimes: ['video/mp4'],
-        };
-
-        const result = spec.isBidRequestValid(videoBidRequest);
-
-        expect(result).to.be.true;
-        expect(domainLoggerMock.invalidVideoMimes.calledOnce).to.be.false;
-      });
-
-      it('detects invalid input when video context is not set', () => {
-        videoBidRequest.mediaTypes.video = {
-          ...videoBidRequest.mediaTypes.video,
-          context: undefined,
-        };
-
-        const result = spec.isBidRequestValid(videoBidRequest);
-
-        expect(result).to.be.false;
-        expect(domainLoggerMock.invalidVideoContext.calledOnce).to.be.true;
-      });
-
-      it('detects invalid input when video playerSize is not set', () => {
-        videoBidRequest.mediaTypes.video = {
-          ...videoBidRequest.mediaTypes.video,
-          playerSize: undefined,
-        };
-
-        const result = spec.isBidRequestValid(videoBidRequest);
-
-        expect(result).to.be.false;
-        expect(domainLoggerMock.invalidVideoPlayerSize.calledOnce).to.be.true;
-      });
-
-      it('detects invalid input when video minDuration is not set', () => {
-        videoBidRequest.mediaTypes.video = {
-          ...videoBidRequest.mediaTypes.video,
-          minduration: undefined,
-        };
-
-        const result = spec.isBidRequestValid(videoBidRequest);
-
-        expect(result).to.be.false;
-        expect(domainLoggerMock.invalidVideoMinDuration.calledOnce).to.be.true;
-      });
-
-      it('detects invalid input when video maxDuration is not set', () => {
-        videoBidRequest.mediaTypes.video = {
-          ...videoBidRequest.mediaTypes.video,
-          maxduration: undefined,
-        };
-
-        const result = spec.isBidRequestValid(videoBidRequest);
-
-        expect(result).to.be.false;
-        expect(domainLoggerMock.invalidVideoMaxDuration.calledOnce).to.be.true;
-      });
-
-      it('detects invalid input when video mimes is not set', () => {
-        videoBidRequest.mediaTypes.video = {
-          ...videoBidRequest.mediaTypes.video,
-          mimes: undefined,
-        };
-
-        const result = spec.isBidRequestValid(videoBidRequest);
-
-        expect(result).to.be.false;
-        expect(domainLoggerMock.invalidVideoMimes.calledOnce).to.be.true;
-      });
-
-      it('detects invalid input when video protocols is not set', () => {
-        videoBidRequest.mediaTypes.video = {
-          ...videoBidRequest.mediaTypes.video,
-          protocols: undefined,
-        };
-
-        const result = spec.isBidRequestValid(videoBidRequest);
-
-        expect(result).to.be.false;
-        expect(domainLoggerMock.invalidVideoProtocols.calledOnce).to.be.true;
-      });
-    });
-
     describe('Optional parameter behavior', () => {
       it('passes when partnerId is not specified', () => {
         bannerBidRequest.params = {
@@ -249,112 +115,40 @@ describe('Michao Bid Adapter', () => {
         expect(domainLoggerMock.invalidPartnerError.calledOnce).to.be.true;
       });
 
-      it('passes when blockCategories is not specified', () => {
+      it('passes when test is not specified', () => {
         bannerBidRequest.params = {
           ...bannerBidRequest.params,
-          bcat: undefined,
+          test: undefined,
         };
 
         const result = spec.isBidRequestValid(bannerBidRequest);
 
         expect(result).to.be.true;
-        expect(domainLoggerMock.invalidBcatError.calledOnce).to.be.false;
+        expect(domainLoggerMock.invalidTestParamError.calledOnce).to.be.false;
       });
 
-      it('passes when blockCategories is an array', () => {
+      it('passes when test is a boolean', () => {
         bannerBidRequest.params = {
           ...bannerBidRequest.params,
-          bcat: ['IAB2'],
+          test: false,
         };
 
         const result = spec.isBidRequestValid(bannerBidRequest);
 
         expect(result).to.be.true;
-        expect(domainLoggerMock.invalidBcatError.calledOnce).to.be.false;
+        expect(domainLoggerMock.invalidTestParamError.calledOnce).to.be.false;
       });
 
-      it('detects invalid input when blockCategories is not an array', () => {
+      it('detects invalid input when test is not a boolean', () => {
         bannerBidRequest.params = {
           ...bannerBidRequest.params,
-          bcat: 'IAB2',
+          test: 'true',
         };
 
         const result = spec.isBidRequestValid(bannerBidRequest);
 
         expect(result).to.be.false;
-        expect(domainLoggerMock.invalidBcatError.calledOnce).to.be.true;
-      });
-
-      it('passes when blockAdvertisers is not specified', () => {
-        bannerBidRequest.params = {
-          ...bannerBidRequest.params,
-          badv: undefined,
-        };
-
-        const result = spec.isBidRequestValid(bannerBidRequest);
-
-        expect(result).to.be.true;
-        expect(domainLoggerMock.invalidBadvError.calledOnce).to.be.false;
-      });
-
-      it('passes when blockAdvertisers is an array', () => {
-        bannerBidRequest.params = {
-          ...bannerBidRequest.params,
-          badv: ['adomain.com'],
-        };
-
-        const result = spec.isBidRequestValid(bannerBidRequest);
-
-        expect(result).to.be.true;
-        expect(domainLoggerMock.invalidBadvError.calledOnce).to.be.false;
-      });
-
-      it('detects invalid input when blockAdvertisers is not an array', () => {
-        bannerBidRequest.params = {
-          ...bannerBidRequest.params,
-          badv: 'adomain.com',
-        };
-
-        const result = spec.isBidRequestValid(bannerBidRequest);
-
-        expect(result).to.be.false;
-        expect(domainLoggerMock.invalidBadvError.calledOnce).to.be.true;
-      });
-
-      it('passes when reward is not specified', () => {
-        bannerBidRequest.params = {
-          ...bannerBidRequest.params,
-          reward: undefined,
-        };
-
-        const result = spec.isBidRequestValid(bannerBidRequest);
-
-        expect(result).to.be.true;
-        expect(domainLoggerMock.invalidRewardError.calledOnce).to.be.false;
-      });
-
-      it('passes when reward is a boolean', () => {
-        bannerBidRequest.params = {
-          ...bannerBidRequest.params,
-          reward: true,
-        };
-
-        const result = spec.isBidRequestValid(bannerBidRequest);
-
-        expect(result).to.be.true;
-        expect(domainLoggerMock.invalidRewardError.calledOnce).to.be.false;
-      });
-
-      it('detects invalid input when reward is not a boolean', () => {
-        bannerBidRequest.params = {
-          ...bannerBidRequest.params,
-          reward: 'true',
-        };
-
-        const result = spec.isBidRequestValid(bannerBidRequest);
-
-        expect(result).to.be.false;
-        expect(domainLoggerMock.invalidRewardError.calledOnce).to.be.true;
+        expect(domainLoggerMock.invalidTestParamError.calledOnce).to.be.true;
       });
     });
   });
@@ -552,10 +346,11 @@ describe('Michao Bid Adapter', () => {
         expect(result[0].data.site.publisher.ext.partner).to.equal('123');
       });
 
-      it('does not set publisher when partnerId is not specified', () => {
+      it('sets test in publisher when specified', () => {
         bannerBidRequest.params = {
           site: 456,
           placement: '123',
+          test: true,
         };
         const bidderRequest = {
           bids: [bannerBidRequest],
@@ -565,107 +360,7 @@ describe('Michao Bid Adapter', () => {
 
         const result = spec.buildRequests([bannerBidRequest], bidderRequest);
 
-        expect(result[0].data.site.publisher).to.be.undefined;
-      });
-
-      it('sets reward enabled parameter in impression object when reward is specified', () => {
-        bannerBidRequest.params = {
-          site: 456,
-          placement: '123',
-          reward: true,
-        };
-        const bidderRequest = {
-          bids: [bannerBidRequest],
-          auctionId: bannerBidRequest.auctionId,
-          bidderRequestId: bannerBidRequest.bidderRequestId,
-        };
-
-        const result = spec.buildRequests([bannerBidRequest], bidderRequest);
-
-        expect(result[0].data.imp[0].rwdd).to.equal(1);
-      });
-
-      it('sets reward disabled parameter in impression object when reward is not specified', () => {
-        bannerBidRequest.params = {
-          site: 456,
-          placement: '123',
-        };
-        const bidderRequest = {
-          bids: [bannerBidRequest],
-          auctionId: bannerBidRequest.auctionId,
-          bidderRequestId: bannerBidRequest.bidderRequestId,
-        };
-
-        const result = spec.buildRequests([bannerBidRequest], bidderRequest);
-
-        expect(result[0].data.imp[0].rwdd).to.equal(0);
-      });
-
-      it('sets bid floor in impression object when specified', () => {
-        bannerBidRequest.params = {
-          site: 456,
-          placement: '123',
-          bidFloor: 0.2,
-        };
-        const bidderRequest = {
-          bids: [bannerBidRequest],
-          auctionId: bannerBidRequest.auctionId,
-          bidderRequestId: bannerBidRequest.bidderRequestId,
-        };
-
-        const result = spec.buildRequests([bannerBidRequest], bidderRequest);
-
-        expect(result[0].data.imp[0].bidfloor).to.equal(0.2);
-      });
-
-      it('sets bid floor to 0 in impression object when not specified', () => {
-        bannerBidRequest.params = {
-          site: 456,
-          placement: '123',
-        };
-        const bidderRequest = {
-          bids: [bannerBidRequest],
-          auctionId: bannerBidRequest.auctionId,
-          bidderRequestId: bannerBidRequest.bidderRequestId,
-        };
-
-        const result = spec.buildRequests([bannerBidRequest], bidderRequest);
-
-        expect(result[0].data.imp[0].bidfloor).to.equal(0);
-      });
-
-      it('sets block categories in bid request when specified', () => {
-        bannerBidRequest.params = {
-          site: 456,
-          placement: '123',
-          bcat: ['IAB2'],
-        };
-        const bidderRequest = {
-          bids: [bannerBidRequest],
-          auctionId: bannerBidRequest.auctionId,
-          bidderRequestId: bannerBidRequest.bidderRequestId,
-        };
-
-        const result = spec.buildRequests([bannerBidRequest], bidderRequest);
-
-        expect(result[0].data.bcat).to.deep.equal(['IAB2']);
-      });
-
-      it('sets block advertisers in bid request when specified', () => {
-        bannerBidRequest.params = {
-          site: 456,
-          placement: '123',
-          badv: ['adomain.com'],
-        };
-        const bidderRequest = {
-          bids: [bannerBidRequest],
-          auctionId: bannerBidRequest.auctionId,
-          bidderRequestId: bannerBidRequest.bidderRequestId,
-        };
-
-        const result = spec.buildRequests([bannerBidRequest], bidderRequest);
-
-        expect(result[0].data.badv).to.deep.equal(['adomain.com']);
+        expect(result[0].data.test).to.equal(1);
       });
     });
   });

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -372,7 +372,7 @@ describe('Michao Bid Adapter', () => {
 
         expect(result.length).to.equal(1);
         expect(result[0].data.imp.length).to.equal(1);
-        expect(result[0].data.imp[0]).to.have.haveOwnPropertyDescriptor(
+        expect(result[0].data.imp[0]).to.have.property(
           'banner'
         );
       });
@@ -388,9 +388,7 @@ describe('Michao Bid Adapter', () => {
 
         expect(result.length).to.equal(1);
         expect(result[0].data.imp.length).to.equal(1);
-        expect(result[0].data.imp[0]).to.have.haveOwnPropertyDescriptor(
-          'video'
-        );
+        expect(result[0].data.imp[0]).to.have.property('video');
       });
 
       it('creates native-specific bid request from bid request containing one native format', () => {
@@ -427,10 +425,10 @@ describe('Michao Bid Adapter', () => {
 
         expect(result.length).to.equal(1);
         expect(result[0].data.imp.length).to.equal(2);
-        expect(result[0].data.imp[0]).to.have.haveOwnPropertyDescriptor(
+        expect(result[0].data.imp[0]).to.have.property(
           'banner'
         );
-        expect(result[0].data.imp[1]).to.have.haveOwnPropertyDescriptor(
+        expect(result[0].data.imp[1]).to.have.property(
           'video'
         );
       });
@@ -454,7 +452,7 @@ describe('Michao Bid Adapter', () => {
 
         expect(result.length).to.equal(1);
         expect(result[0].data.imp.length).to.equal(2);
-        expect(result[0].data.imp[0]).to.have.haveOwnPropertyDescriptor(
+        expect(result[0].data.imp[0]).to.have.property(
           'banner'
         );
       });
@@ -478,9 +476,7 @@ describe('Michao Bid Adapter', () => {
 
         expect(result.length).to.equal(1);
         expect(result[0].data.imp.length).to.equal(2);
-        expect(result[0].data.imp[0]).to.have.haveOwnPropertyDescriptor(
-          'video'
-        );
+        expect(result[0].data.imp[0]).to.have.property('video');
       });
 
       it('creates banner, video and native bid request with three impressions from bid request containing all three formats', () => {
@@ -503,10 +499,10 @@ describe('Michao Bid Adapter', () => {
 
         expect(result.length).to.equal(1);
         expect(result[0].data.imp.length).to.equal(3);
-        expect(result[0].data.imp[0]).to.have.haveOwnPropertyDescriptor(
+        expect(result[0].data.imp[0]).to.have.property(
           'banner'
         );
-        expect(result[0].data.imp[1]).to.have.haveOwnPropertyDescriptor(
+        expect(result[0].data.imp[1]).to.have.property(
           'video'
         );
       });

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -304,6 +304,9 @@ describe('the michao bidder adapter', () => {
             video: {
               context: 'outstream',
               playerSize: [640, 480],
+              minduration: 0,
+              maxduration: 30,
+              protocols: [7]
             },
           },
           params: {

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -316,6 +316,41 @@ describe('the michao bidder adapter', () => {
           'data.badv[0]': 'adomain.com',
         });
       });
+
+      it('The lowest bid will be set', () => {
+        const bidRequest = {
+          adUnitCode: 'test-div',
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          bidId: '22c4871113f461',
+          bidder: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bidRequestsCount: 1,
+          bidderRequestsCount: 1,
+          bidderWinsCount: 0,
+          mediaTypes: { banner: [[300, 250]] },
+          params: {
+            site: 123,
+            placement: '456',
+            bidFloor: 1,
+          },
+        };
+        const bidderRequest = {
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          auctionStart: 1579746300522,
+          bidderCode: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bids: [bidRequest],
+        };
+        config.setConfig({
+          debug: true,
+        });
+
+        const result = buildRequest(bidRequest, bidderRequest, 'banner');
+
+        expect(result).to.nested.include({
+          'data.imp[0].bidfloor': 1,
+        });
+      });
     });
 
     describe('interpret response', () => {

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -212,7 +212,7 @@ describe('the michao bidder adapter', () => {
         });
       });
 
-      it('Specifying a reward builds a bid request for the reward.', () => {
+      it('Specifying a reward builds a bid request for the reward', () => {
         const bidRequest = {
           adUnitCode: 'test-div',
           auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
@@ -244,6 +244,76 @@ describe('the michao bidder adapter', () => {
 
         expect(result).to.nested.include({
           'data.imp[0].rwdd': 1,
+        });
+      });
+
+      it('Block categories are set in the bid request through parameters', () => {
+        const bidRequest = {
+          adUnitCode: 'test-div',
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          bidId: '22c4871113f461',
+          bidder: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bidRequestsCount: 1,
+          bidderRequestsCount: 1,
+          bidderWinsCount: 0,
+          mediaTypes: { banner: [[300, 250]] },
+          params: {
+            site: 123,
+            placement: 456,
+            bcat: ['IAB2']
+          },
+        };
+        const bidderRequest = {
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          auctionStart: 1579746300522,
+          bidderCode: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bids: [bidRequest],
+        };
+        config.setConfig({
+          debug: true,
+        });
+
+        const result = buildRequest(bidRequest, bidderRequest, 'banner');
+
+        expect(result).to.nested.include({
+          'data.bcat[0]': 'IAB2',
+        });
+      });
+
+      it('Block advertisers set in bid request through parameters', () => {
+        const bidRequest = {
+          adUnitCode: 'test-div',
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          bidId: '22c4871113f461',
+          bidder: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bidRequestsCount: 1,
+          bidderRequestsCount: 1,
+          bidderWinsCount: 0,
+          mediaTypes: { banner: [[300, 250]] },
+          params: {
+            site: 123,
+            placement: 456,
+            badv: ['adomain.com']
+          },
+        };
+        const bidderRequest = {
+          auctionId: 'b06c5141-fe8f-4cdf-9d7d-54415490a917',
+          auctionStart: 1579746300522,
+          bidderCode: 'michao',
+          bidderRequestId: '15246a574e859f',
+          bids: [bidRequest],
+        };
+        config.setConfig({
+          debug: true,
+        });
+
+        const result = buildRequest(bidRequest, bidderRequest, 'banner');
+
+        expect(result).to.nested.include({
+          'data.badv[0]': 'adomain.com',
         });
       });
     });

--- a/test/spec/modules/michaoBidAdapter_spec.js
+++ b/test/spec/modules/michaoBidAdapter_spec.js
@@ -687,7 +687,7 @@ describe('Michao Bid Adapter', () => {
       const result = spec.interpretResponse(videoServerResponse, request[0]);
 
       expect(result[0].renderer.url).to.equal(
-        'https://cdn.jsdelivr.net/npm/in-renderer-js@latest/dist/in-video-renderer.umd.min.js'
+        'https://cdn.jsdelivr.net/npm/in-renderer-js@1.0.6/dist/in-video-renderer.umd.min.js'
       );
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
- contact email of the adapter’s maintainer: kaihogehoge@gmail.com
- test parameters for validating bids: 
```
{
  bidder: 'michao',
  params: {
    placement: 1,
    site: 1
  }
}
```

(Turn on debug mode)

<!-- Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Nice to meet you!
Thanks for the great solution.
We have developed a new adapter and noticed that the outstream video ad (in renderer) is not well maintained around it.
Prebid-outstream is not working in its current version and the examples on Prebid.org are not well maintained.
- https://docs.prebid.org/examples/video/outstream/pb-ve-outstream-no-server.html
- https://docs.prebid.org/examples/video/outstream/pb-ve-outstream-dfp.htm

So we thought it would be useful to have a library dedicated to in-renderer integration without the need for hosting, so we developed one. (https://github.com/hogekai/in-renderer-js)

The UI has been adjusted for outstream video ads, and we plan to develop the README and other related documentation in the future.
(If you want to check how it works, you can check the test ads by using the debug mode and test parameters, as they are included in this adapter.)

If you would like, please let us know what you think and what steps you would like to take to get the in-renderer integration area in place.

(Perhaps this is not the right place to ask. If I'm wrong, please let me know where I should ask. I would appreciate it if you would consider that I am not as familiar with Prebid.js as the maintainer).