### PR TITLE
Prebid Core: targeting keys issue when enableSendAllBids and alwaysIncludeDeals is true

### DIFF
--- a/src/targeting.js
+++ b/src/targeting.js
@@ -207,9 +207,7 @@ export function newTargeting(auctionManager) {
     });
   };
 
-  function addBidToTargeting(bids, bidderLevelTargetingEnabled = false, deals = false) {
-    if (!bidderLevelTargetingEnabled) return [];
-
+  function addBidToTargeting(bids, enableSendAllBids = false, deals = false) {
     const standardKeys = FEATURES.NATIVE ? TARGETING_KEYS_ARR.concat(NATIVE_TARGETING_KEYS) : TARGETING_KEYS_ARR.slice();
     const allowSendAllBidsTargetingKeys = config.getConfig('targetingControls.allowSendAllBidsTargetingKeys');
 
@@ -218,7 +216,7 @@ export function newTargeting(auctionManager) {
       : standardKeys;
 
     return bids.reduce((result, bid) => {
-      if ((!deals || bid.dealId)) {
+      if (enableSendAllBids || (deals && bid.dealId)) {
         const targetingValue = getTargetingMap(bid, standardKeys.filter(
           key => typeof bid.adserverTargeting[key] !== 'undefined' &&
           (deals || allowedSendAllBidTargeting.indexOf(key) !== -1)));
@@ -233,8 +231,8 @@ export function newTargeting(auctionManager) {
 
   function getBidderTargeting(bids) {
     const alwaysIncludeDeals = config.getConfig('targetingControls.alwaysIncludeDeals');
-    const bidderLevelTargetingEnabled = config.getConfig('enableSendAllBids') || alwaysIncludeDeals;
-    return addBidToTargeting(bids, bidderLevelTargetingEnabled, alwaysIncludeDeals);
+    const enableSendAllBids = config.getConfig('enableSendAllBids');
+    return addBidToTargeting(bids, enableSendAllBids, alwaysIncludeDeals);
   }
 
   /**

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -861,6 +861,51 @@ describe('targeting tests', function () {
       });
     });
 
+    describe('targetingControls.alwaysIncludeDeals with enableSendAllBids', function () {
+      beforeEach(function() {
+        enableSendAllBids = true;
+      });
+
+      it('includes bids w/o deal when enableSendAllBids and alwaysIncludeDeals set to true', function () {
+        config.setConfig({
+          enableSendAllBids: true,
+          targetingControls: {
+            alwaysIncludeDeals: true
+          }
+        });
+
+        let bid5 = utils.deepClone(bid1);
+        bid5.adserverTargeting = {
+          hb_pb: '3.0',
+          hb_adid: '111111',
+          hb_bidder: 'pubmatic',
+          foobar: '300x250'
+        };
+        bid5.bidder = bid5.bidderCode = 'pubmatic';
+        bid5.cpm = 3.0; // winning bid!
+        delete bid5.dealId; // no deal with winner
+        bidsReceived.push(bid5);
+
+        const targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);
+
+        // Pubmatic wins but no deal. But enableSendAllBids is true.
+        // So Pubmatic is passed through
+        expect(targeting['/123456/header-bid-tag-0']).to.deep.equal({
+          'hb_bidder': 'pubmatic',
+          'hb_adid': '111111',
+          'hb_pb': '3.0',
+          'foobar': '300x250',
+          'hb_pb_pubmatic': '3.0',
+          'hb_adid_pubmatic': '111111',
+          'hb_bidder_pubmatic': 'pubmatic',
+          'hb_deal_rubicon': '1234',
+          'hb_pb_rubicon': '0.53',
+          'hb_adid_rubicon': '148018fe5e',
+          'hb_bidder_rubicon': 'rubicon'
+        });
+      });
+    });
+
     it('selects the top bid when enableSendAllBids true', function () {
       enableSendAllBids = true;
       let targeting = targetingInstance.getAllTargeting(['/123456/header-bid-tag-0']);


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
When both the **enableSendAllBids** and **alwaysIncludeDeals** flags are set to **true**, targeting keys for bids without deals have not been passed to the ad server since version 9.16.0.
We suspect that this issue may have been caused by the changes introduced in [PR #12273](https://github.com/prebid/Prebid.js/pull/12273).
Specifically, before checking the value of the alwaysIncludeDeals flag and dealId, we are not checking the value of the enableSendAllBids flag.

## Other information
When below config is set, if there is a bid without deal, targeting keys for that bid were being skipped in adserver call.
```
        enableSendAllBids: true,
        targetingControls: {
          alwaysIncludeDeals: true
        }
```
