### PR TITLE
Rediads bid adapter

### DIFF
--- a/modules/rediadsBidAdapter.js
+++ b/modules/rediadsBidAdapter.js
@@ -59,7 +59,7 @@ export const spec = {
     let data = {};
     let FINAL_ENDPOINT_URL = params.endpoint || ENDPOINT_URL
     try {
-      const data = converter.toORTB({ bidRequests, bidderRequest });
+      data = converter.toORTB({ bidRequests, bidderRequest });
       const testBidsRequested = location.hash.includes('rediads-test-bids');
       const stagingEnvRequested = location.hash.includes('rediads-staging');
 

--- a/modules/rediadsBidAdapter.js
+++ b/modules/rediadsBidAdapter.js
@@ -1,0 +1,75 @@
+import { ortbConverter } from '../libraries/ortbConverter/converter.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { deepSetValue } from '../src/utils.js';
+import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
+import { config } from '../src/config.js';
+
+const BIDDER_CODE = 'rediads';
+const ENDPOINT_URL = 'https://stagingbidding.rediads.com/openrtb2/auction';
+const DEFAULT_CURRENCY = 'USD';
+
+const MEDIA_TYPES = {
+  [BANNER]: 1,
+  [VIDEO]: 2,
+  [NATIVE]: 4,
+};
+
+const converter = ortbConverter({
+  context: {
+    netRevenue: true,
+    ttl: 300,
+    currency: DEFAULT_CURRENCY,
+  },
+  bidResponse(buildBidResponse, bid, context) {
+    let mediaType;
+    if (bid.video) {
+      mediaType = 'video'; // Video-specific response handling
+    } else if (bid.native) {
+      mediaType = 'native'; // Native-specific response handling
+    } else {
+      mediaType = 'banner'; // Default to banner
+    }
+    bid.mediaType = mediaType;
+    bid.mtype = MEDIA_TYPES[mediaType];
+
+    if (bid.mediaType === BANNER) {
+      bid.ad = bid.adm;
+    }
+    return buildBidResponse(bid, context);
+  },
+});
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [NATIVE, BANNER, VIDEO],
+  isBidRequestValid: function (bid) {
+    return !!(bid.params && bid.params.accountID);
+  },
+  buildRequests(bidRequests, bidderRequest) {
+    const accountID = bidRequests[0]?.params?.accountID;
+    const data = converter.toORTB({ bidRequests, bidderRequest });
+    // deepSetValue(data.imp[0], 'ext.prebid.bidder', {
+    //   amx: { tagId: 'dnV1a2xlLmNvbQ' },
+    // });
+
+    deepSetValue(data, 'test', 1);
+    deepSetValue(data, 'ext.rediads.account_id', accountID?.toString());
+    deepSetValue(data, 'site.content', config.getConfig('content'));
+    return [
+      {
+        method: 'POST',
+        url: ENDPOINT_URL,
+        data,
+      },
+    ];
+  },
+  interpretResponse(response, request) {
+    const bids = converter.fromORTB({
+      response: response.body,
+      request: request.data,
+    }).bids;
+    return bids;
+  },
+};
+
+registerBidder(spec);

--- a/modules/rediadsBidAdapter.md
+++ b/modules/rediadsBidAdapter.md
@@ -27,7 +27,9 @@ Please reach out to support@rediads.com for more information.
                 {
                     bidder: "rediads",
                     params: {
-                        accountID: 123
+                        account_id: '123',
+                        site: 'rediads.com',
+                        slot: '321'
                     }
                 }
             ]

--- a/modules/rediadsBidAdapter.md
+++ b/modules/rediadsBidAdapter.md
@@ -1,0 +1,36 @@
+# Overview
+
+```
+Module Name:  RediAds Bid Adapter
+Module Type:  Bidder Adapter
+Maintainer:   support@rediads.com
+```
+
+# Description
+
+Connect to RediAds exchange for bids.
+
+The RediAds adapter requires setup and approval.
+Please reach out to support@rediads.com for more information.
+
+# Test Parameters
+```
+    var adUnits = [
+        {
+            code: 'test-div',
+            mediaTypes: {
+                banner: {
+                    sizes: [[300, 250]]
+                }
+            },
+            bids: [
+                {
+                    bidder: "rediads",
+                    params: {
+                        accountID: 123
+                    }
+                }
+            ]
+        }
+    ];
+```

--- a/test/spec/modules/rediadsBidAdapter_spec.js
+++ b/test/spec/modules/rediadsBidAdapter_spec.js
@@ -1,0 +1,140 @@
+import { spec } from 'modules/rediadsBidAdapter';
+import { deepSetValue } from 'src/utils.js';
+import { config } from 'src/config.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+// Test for isBidRequestValid
+describe('isBidRequestValid', function() {
+  it('should return true if accountID is present', function() {
+    const bidRequest = {
+      params: {
+        accountID: '12345',
+      },
+    };
+    const result = spec.isBidRequestValid(bidRequest);
+    expect(result).to.be.true;
+  });
+
+  it('should return false if accountID is missing', function() {
+    const bidRequest = {
+      params: {},
+    };
+    const result = spec.isBidRequestValid(bidRequest);
+    expect(result).to.be.false;
+  });
+});
+
+// Test for buildRequests
+describe('buildRequests', function() {
+  it('should build a valid request with account_id and test flag', function() {
+    const bidRequests = [{
+      params: {
+        accountID: '12345',
+      },
+    }];
+    const bidderRequest = {}; // Mock bidderRequest if needed
+
+    // Mock config.getConfig('content') to return a valid value
+    sinon.stub(config, 'getConfig').returns('content_value');
+
+    const requests = spec.buildRequests(bidRequests, bidderRequest);
+
+    const data = requests[0].data;
+    expect(data).to.have.property('test', 1);
+    expect(data).to.have.property('ext');
+    expect(data.ext).to.have.property('rediads.account_id', '12345');
+    expect(data.site).to.have.property('content', 'content_value');
+    expect(requests[0].url).to.equal('https://stagingbidding.rediads.com/openrtb2/auction');
+
+    // Restore the stub after the test
+    sinon.restore();
+  });
+});
+
+// Test for interpretResponse
+describe('interpretResponse', function() {
+  it('should correctly interpret the OpenRTB response and return bids', function() {
+    const mockResponse = {
+      body: {
+        bids: [
+          {
+            requestId: '123',
+            cpm: 1.5,
+            ad: '<html></html>',
+            mediaType: 'banner',
+            currency: 'USD',
+            ttl: 300,
+          },
+        ],
+      },
+    };
+
+    const request = {
+      data: {
+        test: 1,
+        ext: {
+          rediads: {
+            account_id: '12345',
+          },
+        },
+      },
+    };
+
+    const bids = spec.interpretResponse(mockResponse, request);
+
+    expect(bids).to.have.lengthOf(1);
+    expect(bids[0]).to.have.property('requestId', '123');
+    expect(bids[0]).to.have.property('cpm', 1.5);
+    expect(bids[0]).to.have.property('ad', '<html></html>');
+    expect(bids[0]).to.have.property('mediaType', 'banner');
+  });
+});
+
+// Test for Default Values (Currency, Net Revenue)
+describe('Default Values', function() {
+  it('should set the default currency as USD', function() {
+    const bidRequest = {
+      params: {
+        accountID: '12345',
+      },
+    };
+    const request = spec.buildRequests([bidRequest], {});
+    expect(request[0].data.ext.rediads.account_id).to.equal('12345');
+    expect(request[0].data.ext.rediads.currency).to.equal('USD');
+  });
+
+  it('should set netRevenue to true', function() {
+    const bidRequest = {
+      params: {
+        accountID: '12345',
+      },
+    };
+    const request = spec.buildRequests([bidRequest], {});
+    expect(request[0].data.ext.rediads.netRevenue).to.be.true;
+  });
+});
+
+// Test for Media Type Handling
+describe('Media Type Handling', function() {
+  it('should assign "banner" as mediaType by default', function() {
+    const bid = { adm: '<html></html>', mediaType: 'banner' };
+    const result = spec.converter.bidResponse(() => {}, bid, {});
+    expect(result.mediaType).to.equal('banner');
+    expect(result.mtype).to.equal(1); // BANNER = 1
+  });
+
+  it('should assign "video" when video object exists', function() {
+    const bid = { video: {}, mediaType: 'video' };
+    const result = spec.converter.bidResponse(() => {}, bid, {});
+    expect(result.mediaType).to.equal('video');
+    expect(result.mtype).to.equal(2); // VIDEO = 2
+  });
+
+  it('should assign "native" when native object exists', function() {
+    const bid = { native: {}, mediaType: 'native' };
+    const result = spec.converter.bidResponse(() => {}, bid, {});
+    expect(result.mediaType).to.equal('native');
+    expect(result.mtype).to.equal(4); // NATIVE = 4
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [x] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Pull request to add rediads bidder adapter into prebid.js

- contact email of the adapter’s maintainer : support@rediads.com
- test parameters for validating bids:
```
{
  bidder: 'rediads',
  params: {
     account_id: '123',
     site: 'rediads.com',
     slot: '321'
  }
}
```
Note - Please add 'rediads-test-bid' to the page URL's hash to enable test bids

## Other information
Related dev docs PR - https://github.com/prebid/prebid.github.io/pull/5743
