### PR TITLE
Prebid Core: Added TTL validation for suppressing expired ads

### DIFF
--- a/src/adRendering.js
+++ b/src/adRendering.js
@@ -20,7 +20,7 @@ import {fireNativeTrackers} from './native.js';
 import {GreedyPromise} from './utils/promise.js';
 import adapterManager from './adapterManager.js';
 import {useMetrics} from './utils/perfMetrics.js';
-import {filters} from '../../../Prebid.js/src/targeting.js';
+import {filters} from './targeting.js';
 
 const { AD_RENDER_FAILED, AD_RENDER_SUCCEEDED, STALE_RENDER, BID_WON, EXPIRED_RENDER } = EVENTS;
 const { EXCEPTION } = AD_RENDER_FAILED_REASON;

--- a/src/adRendering.js
+++ b/src/adRendering.js
@@ -20,8 +20,9 @@ import {fireNativeTrackers} from './native.js';
 import {GreedyPromise} from './utils/promise.js';
 import adapterManager from './adapterManager.js';
 import {useMetrics} from './utils/perfMetrics.js';
+import {filters} from '../../../Prebid.js/src/targeting.js';
 
-const { AD_RENDER_FAILED, AD_RENDER_SUCCEEDED, STALE_RENDER, BID_WON } = EVENTS;
+const { AD_RENDER_FAILED, AD_RENDER_SUCCEEDED, STALE_RENDER, BID_WON, EXPIRED_RENDER } = EVENTS;
 const { EXCEPTION } = AD_RENDER_FAILED_REASON;
 
 export const getBidToRender = hook('sync', function (adId, forRender = true, override = GreedyPromise.resolve()) {
@@ -185,6 +186,14 @@ export function handleRender({renderFn, resizeFn, adId, options, bidResponse, do
         return;
       }
     }
+    if (!filters.isBidNotExpired(bidResponse)) {
+      logWarn(`Ad id ${adId} has been expired`);
+      events.emit(EXPIRED_RENDER, bidResponse);
+      if (deepAccess(config.getConfig('auctionOptions'), 'suppressExpiredRender')) {
+        return;
+      }
+    }
+
     try {
       doRender({renderFn, resizeFn, bidResponse, options, doc});
     } catch (e) {

--- a/src/config.js
+++ b/src/config.js
@@ -179,7 +179,7 @@ function attachProperties(config, useDefaultValues = true) {
     }
 
     for (let k of Object.keys(val)) {
-      if (k !== 'secondaryBidders' && k !== 'suppressStaleRender') {
+      if (k !== 'secondaryBidders' && k !== 'suppressStaleRender' && k !== 'suppressExpiredRender') {
         logWarn(`Auction Options given an incorrect param: ${k}`)
         return false
       }
@@ -191,7 +191,7 @@ function attachProperties(config, useDefaultValues = true) {
           logWarn(`Auction Options ${k} must be only string`);
           return false
         }
-      } else if (k === 'suppressStaleRender') {
+      } else if (k === 'suppressStaleRender' || k === 'suppressExpiredRender') {
         if (!isBoolean(val[k])) {
           logWarn(`Auction Options ${k} must be of type boolean`);
           return false;

--- a/src/constants.js
+++ b/src/constants.js
@@ -40,6 +40,7 @@ export const EVENTS = {
   AUCTION_DEBUG: 'auctionDebug',
   BID_VIEWABLE: 'bidViewable',
   STALE_RENDER: 'staleRender',
+  EXPIRED_RENDER: 'expiredRender',
   BILLABLE_EVENT: 'billableEvent',
   BID_ACCEPTED: 'bidAccepted',
   RUN_PAAPI_AUCTION: 'paapiRunAuction',

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -386,7 +386,7 @@ describe('config API', function () {
     const warning = 'Auction Options suppressExpiredRender must be of type boolean';
     assert.ok(logWarnSpy.calledWith(warning), 'expected warning was logged');
   });
-  
+
   it('should log warning for invalid properties to auctionOptions', function () {
     setConfig({ auctionOptions: {
       'testing': true

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -345,6 +345,14 @@ describe('config API', function () {
     expect(getConfig('auctionOptions')).to.eql(auctionOptionsConfig);
   });
 
+  it('sets auctionOptions suppressExpiredRender', function () {
+    const auctionOptionsConfig = {
+      'suppressExpiredRender': true
+    }
+    setConfig({ auctionOptions: auctionOptionsConfig });
+    expect(getConfig('auctionOptions')).to.eql(auctionOptionsConfig);
+  });
+
   it('should log warning for the wrong value passed to auctionOptions', function () {
     setConfig({ auctionOptions: '' });
     expect(logWarnSpy.calledOnce).to.equal(true);
@@ -370,6 +378,15 @@ describe('config API', function () {
     assert.ok(logWarnSpy.calledWith(warning), 'expected warning was logged');
   });
 
+  it('should log warning for invalid auctionOptions suppress expired render', function () {
+    setConfig({ auctionOptions: {
+      'suppressExpiredRender': 'test',
+    }});
+    expect(logWarnSpy.calledOnce).to.equal(true);
+    const warning = 'Auction Options suppressExpiredRender must be of type boolean';
+    assert.ok(logWarnSpy.calledWith(warning), 'expected warning was logged');
+  });
+  
   it('should log warning for invalid properties to auctionOptions', function () {
     setConfig({ auctionOptions: {
       'testing': true

--- a/test/spec/unit/adRendering_spec.js
+++ b/test/spec/unit/adRendering_spec.js
@@ -16,6 +16,7 @@ import {config} from 'src/config.js';
 import {VIDEO} from '../../../src/mediaTypes.js';
 import {auctionManager} from '../../../src/auctionManager.js';
 import adapterManager from '../../../src/adapterManager.js';
+import {filters} from 'src/targeting.js';
 
 describe('adRendering', () => {
   let sandbox;
@@ -305,6 +306,26 @@ describe('adRendering', () => {
         });
         it('should skip rendering if suppressStaleRender', () => {
           config.setConfig({auctionOptions: {suppressStaleRender: true}});
+          handleRender({adId, bidResponse});
+          sinon.assert.notCalled(doRenderStub);
+        })
+      });
+
+      describe('when bid has already expired', () => {
+        let isBidNotExpiredStub = sinon.stub(filters,'isBidNotExpired');
+        beforeEach(() => {
+          isBidNotExpiredStub.returns(false);
+        });
+        afterEach(() => {
+          isBidNotExpiredStub.restore();
+        })
+        it('should emit EXPIRED_RENDER', () => {
+          handleRender({adId, bidResponse});
+          sinon.assert.calledWith(events.emit, EVENTS.EXPIRED_RENDER, bidResponse);
+          sinon.assert.called(doRenderStub);
+        });
+        it('should skip rendering if suppressExpiredRender', () => {
+          config.setConfig({auctionOptions: {suppressExpiredRender: true}});
           handleRender({adId, bidResponse});
           sinon.assert.notCalled(doRenderStub);
         })

--- a/test/spec/unit/adRendering_spec.js
+++ b/test/spec/unit/adRendering_spec.js
@@ -312,7 +312,7 @@ describe('adRendering', () => {
       });
 
       describe('when bid has already expired', () => {
-        let isBidNotExpiredStub = sinon.stub(filters,'isBidNotExpired');
+        let isBidNotExpiredStub = sinon.stub(filters, 'isBidNotExpired');
         beforeEach(() => {
           isBidNotExpiredStub.returns(false);
         });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->

We are validating the ttl property before rendering an ad. If the ad has exceeded its ttl value and the `suppressExpiredRender` property is enabled, the system will suppress the rendering of the expired ad.

We are emitting an event EXPIRED_RENDER similar to STALE_RENDER that publishers can listen to and either render a different ad, call for a new auction, or call the ad server again

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Closes https://github.com/prebid/Prebid.js/issues/12521