### PR TITLE
stop sending push_sync requests in YieldOne adapter in case of Safari…

### DIFF
--- a/modules/yieldoneBidAdapter.js
+++ b/modules/yieldoneBidAdapter.js
@@ -2,6 +2,8 @@ import {deepAccess, isEmpty, isStr, logWarn, parseSizesInput} from '../src/utils
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {Renderer} from '../src/Renderer.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
+import {getBrowser, getOS} from "../libraries/userAgentUtils";
+import {browserTypes, osTypes} from "../libraries/userAgentUtils/userAgentTypes.enums";
 
 /**
  * @typedef {import('../src/adapters/bidderFactory').Bid} Bid
@@ -222,7 +224,7 @@ export const spec = {
    * @returns {UserSync[]} The user syncs which should be dropped.
    */
   getUserSyncs: function(syncOptions) {
-    if (syncOptions.iframeEnabled) {
+    if (syncOptions.iframeEnabled && !restrictedUserAgentConfiguration()) {
       return [{
         type: 'iframe',
         url: USER_SYNC_URL
@@ -391,6 +393,14 @@ function cmerRender(bid) {
   bid.renderer.push(() => {
     window.CMERYONEPREBID.renderPrebid(bid);
   });
+}
+
+/**
+ * Stop sending push_sync requests in case of Safari browser OR iOS device
+ * Data extracted from navigator's userAgent
+ */
+function restrictedUserAgentConfiguration() {
+  return getBrowser() === browserTypes.SAFARI || getOS() === osTypes.IOS
 }
 
 registerBidder(spec);

--- a/modules/yieldoneBidAdapter.js
+++ b/modules/yieldoneBidAdapter.js
@@ -2,8 +2,8 @@ import {deepAccess, isEmpty, isStr, logWarn, parseSizesInput} from '../src/utils
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {Renderer} from '../src/Renderer.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
-import {getBrowser, getOS} from "../libraries/userAgentUtils";
-import {browserTypes, osTypes} from "../libraries/userAgentUtils/userAgentTypes.enums";
+import {getBrowser, getOS} from '../libraries/userAgentUtils/index.js';
+import {browserTypes, osTypes} from '../libraries/userAgentUtils/userAgentTypes.enums.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory').Bid} Bid

--- a/test/spec/modules/yieldoneBidAdapter_spec.js
+++ b/test/spec/modules/yieldoneBidAdapter_spec.js
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import { spec } from 'modules/yieldoneBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
+import { getBrowser, getOS } from '../../../libraries/userAgentUtils/index.js';
+import { browserTypes, osTypes } from '../../../libraries/userAgentUtils/userAgentTypes.enums.js';
 
 const ENDPOINT = 'https://y.one.impact-ad.jp/h_bid';
 const USER_SYNC_URL = 'https://y.one.impact-ad.jp/push_sync';
@@ -8,7 +10,7 @@ const VIDEO_PLAYER_URL = 'https://img.ak.impact-ad.jp/ic/pone/ivt/firstview/js/d
 
 const DEFAULT_VIDEO_SIZE = {w: 640, h: 360};
 
-describe('yieldoneBidAdapter', function() {
+describe('yieldoneBidAdapter', function () {
   const adapter = newBidder(spec);
 
   describe('isBidRequestValid', function () {
@@ -638,12 +640,18 @@ describe('yieldoneBidAdapter', function() {
       expect(spec.getUserSyncs({})).to.be.undefined;
     });
 
-    it('should return a sync url if iframe syncs are enabled', function () {
-      expect(spec.getUserSyncs({
+    it('should return a sync url if iframe syncs are enabled and UserAgent is not Safari or iOS', function () {
+      const result = spec.getUserSyncs({
         'iframeEnabled': true
-      })).to.deep.equal([{
-        type: 'iframe', url: USER_SYNC_URL
-      }]);
+      });
+
+      if (getBrowser() === browserTypes.SAFARI || getOS() === osTypes.IOS) {
+        expect(result).to.be.undefined;
+      } else {
+        expect(result).to.deep.equal([{
+          type: 'iframe', url: USER_SYNC_URL
+        }]);
+      }
     });
   });
 });

--- a/test/spec/modules/yieldoneBidAdapter_spec.js
+++ b/test/spec/modules/yieldoneBidAdapter_spec.js
@@ -653,5 +653,12 @@ describe('yieldoneBidAdapter', function () {
         }]);
       }
     });
+
+    it('should skip sync request in case GDPR applies', function () {
+      expect(spec.getUserSyncs({'iframeEnabled': true}, [], {
+        consentString: 'GDPR_CONSENT_STRING',
+        gdprApplies: true,
+      })).to.be.undefined;
+    });
   });
 });


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Conditionally stop sending push_sync requests in YieldOne adapter in case of Safari browser OR iOS device
