### PR TITLE
Core: remove individual bids from cache when minBidCacheTTL is set

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -98,6 +98,8 @@ import {defer, GreedyPromise} from './utils/promise.js';
 import {useMetrics} from './utils/perfMetrics.js';
 import {adjustCpm} from './utils/cpm.js';
 import {getGlobal} from './prebidGlobal.js';
+import {ttlCollection} from './utils/ttlCollection.js';
+import {getMinBidCacheTTL, onMinBidCacheTTLChange} from './bidTTL.js';
 
 const { syncUsers } = userSync;
 
@@ -153,7 +155,10 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
   let _bidsRejected = [];
   let _callback = callback;
   let _bidderRequests = [];
-  let _bidsReceived = [];
+  let _bidsReceived = ttlCollection({
+    startTime: (bid) => bid.responseTimestamp,
+    ttl: (bid) => getMinBidCacheTTL() == null ? null : Math.max(getMinBidCacheTTL(), bid.ttl) * 1000
+  });
   let _noBids = [];
   let _winningBids = [];
   let _auctionStart;
@@ -162,8 +167,10 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
   let _auctionStatus;
   let _nonBids = [];
 
+  onMinBidCacheTTLChange(() => _bidsReceived.refresh());
+
   function addBidRequests(bidderRequests) { _bidderRequests = _bidderRequests.concat(bidderRequests); }
-  function addBidReceived(bidsReceived) { _bidsReceived = _bidsReceived.concat(bidsReceived); }
+  function addBidReceived(bid) { _bidsReceived.add(bid); }
   function addBidRejected(bidsRejected) { _bidsRejected = _bidsRejected.concat(bidsRejected); }
   function addNoBid(noBid) { _noBids = _noBids.concat(noBid); }
   function addNonBids(seatnonbids) { _nonBids = _nonBids.concat(seatnonbids); }
@@ -179,7 +186,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
       labels: _labels,
       bidderRequests: _bidderRequests,
       noBids: _noBids,
-      bidsReceived: _bidsReceived,
+      bidsReceived: _bidsReceived.toArray(),
       bidsRejected: _bidsRejected,
       winningBids: _winningBids,
       timeout: _timeout,
@@ -219,7 +226,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
       bidsBackCallback(_adUnits, function () {
         try {
           if (_callback != null) {
-            const bids = _bidsReceived
+            const bids = _bidsReceived.toArray()
               .filter(bid => _adUnitCodes.includes(bid.adUnitCode))
               .reduce(groupByPlacement, {});
             _callback.apply(pbjsInstance, [bids, timedOut, _auctionId]);
@@ -246,7 +253,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
   function auctionDone() {
     config.resetBidder();
     // when all bidders have called done callback atleast once it means auction is complete
-    logInfo(`Bids Received for Auction with id: ${_auctionId}`, _bidsReceived);
+    logInfo(`Bids Received for Auction with id: ${_auctionId}`, _bidsReceived.toArray());
     _auctionStatus = AUCTION_COMPLETED;
     executeCallback(false);
   }
@@ -404,7 +411,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
     getAdUnits: () => _adUnits,
     getAdUnitCodes: () => _adUnitCodes,
     getBidRequests: () => _bidderRequests,
-    getBidsReceived: () => _bidsReceived,
+    getBidsReceived: () => _bidsReceived.toArray(),
     getNoBids: () => _noBids,
     getNonBids: () => _nonBids,
     getFPD: () => ortb2Fragments,

--- a/src/bidTTL.js
+++ b/src/bidTTL.js
@@ -1,25 +1,35 @@
 import {config} from './config.js';
 import {logError} from './utils.js';
+const CACHE_TTL_SETTING = 'minBidCacheTTL';
 let TTL_BUFFER = 1;
-
+let minCacheTTL = null;
 const listeners = [];
 
 config.getConfig('ttlBuffer', (cfg) => {
   if (typeof cfg.ttlBuffer === 'number') {
-    const prev = TTL_BUFFER;
     TTL_BUFFER = cfg.ttlBuffer;
-    if (prev !== TTL_BUFFER) {
-      listeners.forEach(l => l(TTL_BUFFER))
-    }
   } else {
     logError('Invalid value for ttlBuffer', cfg.ttlBuffer);
   }
 })
 
-export function getTTL(bid) {
+export function getBufferedTTL(bid) {
   return bid.ttl - (bid.hasOwnProperty('ttlBuffer') ? bid.ttlBuffer : TTL_BUFFER);
 }
 
-export function onTTLBufferChange(listener) {
+export function getMinBidCacheTTL() {
+  return minCacheTTL;
+}
+
+config.getConfig(CACHE_TTL_SETTING, (cfg) => {
+  const prev = minCacheTTL;
+  minCacheTTL = cfg?.[CACHE_TTL_SETTING];
+  minCacheTTL = typeof minCacheTTL === 'number' ? minCacheTTL : null;
+  if (prev !== minCacheTTL) {
+    listeners.forEach(l => l(minCacheTTL))
+  }
+})
+
+export function onMinBidCacheTTLChange(listener) {
   listeners.push(listener);
 }

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -1,5 +1,5 @@
 import { auctionManager } from './auctionManager.js';
-import { getTTL } from './bidTTL.js';
+import { getBufferedTTL } from './bidTTL.js';
 import { bidderSettings } from './bidderSettings.js';
 import { config } from './config.js';
 import {
@@ -48,7 +48,7 @@ export const TARGETING_KEYS_ARR = Object.keys(TARGETING_KEYS).map(
 );
 
 // return unexpired bids
-const isBidNotExpired = (bid) => (bid.responseTimestamp + getTTL(bid) * 1000) > timestamp();
+const isBidNotExpired = (bid) => (bid.responseTimestamp + getBufferedTTL(bid) * 1000) > timestamp();
 
 // return bids whose status is not set. Winning bids can only have a status of `rendered`.
 const isUnusedBid = (bid) => bid && ((bid.status && !includes([BID_STATUS.RENDERED], bid.status)) || !bid.status);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

`minBidCacheTTL` currently acts on discrete auctions, and bids are removed from cache only when all the bids in their auction have become stale. This updates it so that it acts on individual bids.

## Other information

Closes https://github.com/prebid/Prebid.js/issues/11310
Related to https://github.com/prebid/Prebid.js/pull/11776#top

