### PR TITLE
craft Bid Adapter: fix netRevenue

### DIFF
--- a/modules/craftBidAdapter.js
+++ b/modules/craftBidAdapter.js
@@ -120,7 +120,7 @@ function newBid(serverBid, rtbBid, bidderRequest) {
     ad: rtbBid.rtb.banner.content,
     ttl: TTL,
     creativeId: rtbBid.creative_id,
-    netRevenue: false, // ???
+    netRevenue: true,
     dealId: rtbBid.deal_id,
     meta: null,
     _adUnitCode: bidRequest.adUnitCode,

--- a/test/spec/modules/craftBidAdapter_spec.js
+++ b/test/spec/modules/craftBidAdapter_spec.js
@@ -158,7 +158,7 @@ describe('craftAdapter', function () {
         height: 250,
         mediaType: 'banner',
         meta: null,
-        netRevenue: false,
+        netRevenue: true,
         requestId: '0396fae4eb5f47',
         ttl: 360,
         width: 300,


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
