### PR TITLE
Core: support adAuctionHeaders

### DIFF
--- a/src/ajax.js
+++ b/src/ajax.js
@@ -47,10 +47,14 @@ export function toFetchRequest(url, data, options = {}) {
   if (options.withCredentials) {
     rqOpts.credentials = 'include';
   }
-  if (options.browsingTopics && isSecureContext) {
-    // the Request constructor will throw an exception if the browser supports topics
-    // but we're not in a secure context
-    rqOpts.browsingTopics = true;
+  if (isSecureContext) {
+    ['browsingTopics', 'adAuctionHeaders'].forEach(opt => {
+      // the Request constructor will throw an exception if the browser supports topics/fledge
+      // but we're not in a secure context
+      if (options[opt]) {
+        rqOpts[opt] = true;
+      }
+    })
   }
   if (options.keepalive) {
     rqOpts.keepalive = true;

--- a/test/spec/unit/core/ajax_spec.js
+++ b/test/spec/unit/core/ajax_spec.js
@@ -185,28 +185,30 @@ describe('toFetchRequest', () => {
     });
   });
 
-  describe('browsingTopics', () => {
-    Object.entries({
-      'browsingTopics = true': [{browsingTopics: true}, true],
-      'browsingTopics = false': [{browsingTopics: false}, false],
-      'browsingTopics is undef': [{}, false]
-    }).forEach(([t, [opts, shouldBeSet]]) => {
-      describe(`when options has ${t}`, () => {
-        const sandbox = sinon.createSandbox();
-        afterEach(() => {
-          sandbox.restore();
-        });
+  describe('chrome options', () => {
+    ['browsingTopics', 'adAuctionHeaders'].forEach(option => {
+      Object.entries({
+        [`${option} = true`]: [{[option]: true}, true],
+        [`${option} = false`]: [{[option]: false}, false],
+        [`${option} undef`]: [{}, false]
+      }).forEach(([t, [opts, shouldBeSet]]) => {
+        describe(`when options has ${t}`, () => {
+          const sandbox = sinon.createSandbox();
+          afterEach(() => {
+            sandbox.restore();
+          });
 
-        it(`should ${!shouldBeSet ? 'not ' : ''}be set when in a secure context`, () => {
-          sandbox.stub(window, 'isSecureContext').get(() => true);
-          toFetchRequest(EXAMPLE_URL, null, opts);
-          sinon.assert.calledWithMatch(dep.makeRequest, sinon.match.any, {browsingTopics: shouldBeSet ? true : undefined});
-        });
-        it(`should not be set when not in a secure context`, () => {
-          sandbox.stub(window, 'isSecureContext').get(() => false);
-          toFetchRequest(EXAMPLE_URL, null, opts);
-          sinon.assert.calledWithMatch(dep.makeRequest, sinon.match.any, {browsingTopics: undefined});
-        });
+          it(`should ${!shouldBeSet ? 'not ' : ''}be set when in a secure context`, () => {
+            sandbox.stub(window, 'isSecureContext').get(() => true);
+            toFetchRequest(EXAMPLE_URL, null, opts);
+            sinon.assert.calledWithMatch(dep.makeRequest, sinon.match.any, {[option]: shouldBeSet ? true : undefined});
+          });
+          it(`should not be set when not in a secure context`, () => {
+            sandbox.stub(window, 'isSecureContext').get(() => false);
+            toFetchRequest(EXAMPLE_URL, null, opts);
+            sinon.assert.calledWithMatch(dep.makeRequest, sinon.match.any, {[option]: undefined});
+          });
+        })
       })
     })
   })


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

Add support for the `adAuctionHeaders` fetch option. Adapters can set `options.adAuctionHeaders` to true in the return value from `buildRequests`, and the same flag will passed to `fetch`.

## Other information

Related to https://github.com/prebid/Prebid.js/issues/12456 and https://github.com/prebid/Prebid.js/issues/10740

