### PR TITLE
Kobler bid adapter: added page view ID

### DIFF
--- a/modules/koblerBidAdapter.js
+++ b/modules/koblerBidAdapter.js
@@ -1,5 +1,6 @@
 import {
   deepAccess,
+  generateUUID,
   getWindowSelf,
   isArray,
   isStr,
@@ -13,6 +14,8 @@ import {getRefererInfo} from '../src/refererDetection.js';
 import { getCurrencyFromBidderRequest } from '../libraries/ortb2Utils/currency.js';
 
 const additionalData = new WeakMap();
+
+export const pageViewId = generateUUID();
 
 export function setAdditionalData(obj, key, value) {
   const prevValue = additionalData.get(obj) || {};
@@ -169,7 +172,8 @@ function buildOpenRtbBidRequestPayload(validBidRequests, bidderRequest) {
     ext: {
       kobler: {
         tcf_purpose_2_given: purpose2Given,
-        tcf_purpose_3_given: purpose3Given
+        tcf_purpose_3_given: purpose3Given,
+        page_view_id: pageViewId
       }
     }
   };

--- a/test/spec/modules/koblerBidAdapter_spec.js
+++ b/test/spec/modules/koblerBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {spec} from 'modules/koblerBidAdapter.js';
+import {pageViewId, spec} from 'modules/koblerBidAdapter.js';
 import {newBidder} from 'src/adapters/bidderFactory.js';
 import {config} from 'src/config.js';
 import * as utils from 'src/utils.js';
@@ -245,6 +245,21 @@ describe('KoblerAdapter', function () {
       expect(openRtbRequest.tmax).to.be.equal(timeout);
       expect(openRtbRequest.id).to.exist;
       expect(openRtbRequest.site.page).to.be.equal(testUrl);
+    });
+
+    it('should reuse the same page view ID on subsequent calls', function () {
+      const testUrl = 'kobler.no';
+      const auctionId1 = '8319af54-9795-4642-ba3a-6f57d6ff9100';
+      const auctionId2 = 'e19f2d0c-602d-4969-96a1-69a22d483f47';
+      const timeout = 5000;
+      const validBidRequests = [createValidBidRequest()];
+      const bidderRequest1 = createBidderRequest(auctionId1, timeout, testUrl);
+      const bidderRequest2 = createBidderRequest(auctionId2, timeout, testUrl);
+
+      const openRtbRequest1 = JSON.parse(spec.buildRequests(validBidRequests, bidderRequest1).data);
+      expect(openRtbRequest1.ext.kobler.page_view_id).to.be.equal(pageViewId);
+      const openRtbRequest2 = JSON.parse(spec.buildRequests(validBidRequests, bidderRequest2).data);
+      expect(openRtbRequest2.ext.kobler.page_view_id).to.be.equal(pageViewId);
     });
 
     it('should read data from valid bid requests', function () {
@@ -538,7 +553,8 @@ describe('KoblerAdapter', function () {
         ext: {
           kobler: {
             tcf_purpose_2_given: true,
-            tcf_purpose_3_given: false
+            tcf_purpose_3_given: false,
+            page_view_id: pageViewId
           }
         }
       };


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [X] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
A page view ID was added, which is a unique identifier (UUID) generated when the adapter first loads. Thus, it is unique per "page view".