### PR TITLE
Adnuntius Bid Adapter: use advertiserDomains from ad response to populate meta.advertiserDomains

### DIFF
--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -356,10 +356,12 @@ export const spec = {
     }
 
     function buildAdResponse(bidderCode, ad, adUnit, dealCount) {
-      const destinationUrls = ad.destinationUrls || {};
-      const advertiserDomains = [];
-      for (const value of Object.values(destinationUrls)) {
-        advertiserDomains.push(value.split('/')[2])
+      const advertiserDomains = ad.advertiserDomains || [];
+      if (advertiserDomains.length === 0) {
+        const destinationUrls = ad.destinationUrls || {};
+        for (const value of Object.values(destinationUrls)) {
+          advertiserDomains.push(value.split('/')[2])
+        }
       }
       const adResponse = {
         bidderCode: bidderCode,

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -198,6 +198,7 @@ describe('adnuntiusBidAdapter', function () {
       'urlsEsc': {
         'destination': 'https%3A%2F%2Fads.adnuntius.delivery%2Fc%2FyQtMUwYBn5P4v72WJMqLW4z7uJOBFXJTfjoRyz0z_wsAAAAQCtjQz9kbGWD4nuZy3q6HaCYxq6Lckz2kThplNb227EJdQ5032jcIGkf-UrPmXCU2EbXVaQ3Ok6_FNLuIDTONJyx6ZZCB10wGqA3OaSe1EqwQp84u1_5iQZAWDk73UYf7_vcIypn7ev-SICZ3qaevb2jYSRqTVZx6AiBZQQGlzlOOrbZU9AU1F-JwTds-YV3qtJHGlxI2peWFIuxFlOYyeX9Kzg%3Fct%3D673%26r%3Dhttp%253A%252F%252Fadnuntius.com'
       },
+      'advertiserDomains': ['fred.com', 'george.com'],
       'destinationUrls': {
         'destination': 'https://adnuntius.com'
       },
@@ -1255,8 +1256,9 @@ describe('adnuntiusBidAdapter', function () {
       expect(interpretedResponse[0].currency).to.equal(deal.bid.currency);
       expect(interpretedResponse[0].netRevenue).to.equal(false);
       expect(interpretedResponse[0].meta).to.have.property('advertiserDomains');
-      expect(interpretedResponse[0].meta.advertiserDomains).to.have.lengthOf(1);
-      expect(interpretedResponse[0].meta.advertiserDomains[0]).to.equal('adnuntius.com');
+      expect(interpretedResponse[0].meta.advertiserDomains).to.have.lengthOf(2);
+      expect(interpretedResponse[0].meta.advertiserDomains[0]).to.equal('fred.com');
+      expect(interpretedResponse[0].meta.advertiserDomains[1]).to.equal('george.com');
       expect(interpretedResponse[0].ad).to.equal(serverResponse.body.adUnits[0].deals[0].html);
       expect(interpretedResponse[0].ttl).to.equal(360);
       expect(interpretedResponse[0].dealId).to.equal('abc123xyz');


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Uses advertiserDomains from the ad response to populate advertiserDomains in meta.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
