### PR TITLE
Bug fix: Export getProperties method

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -417,7 +417,8 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
     getFPD: () => ortb2Fragments,
     getMetrics: () => metrics,
     end: done.promise,
-    requestsDone: requestsDone.promise
+    requestsDone: requestsDone.promise,
+    getProperties
   };
 }
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change

The `getProperties`method from `auction.js` was used in `vastTracker.js`, but since it was not exported, it caused console errors.


###  Code reference 
- [error in vastracker.js](https://github.com/prebid/Prebid.js/blob/e2a4631ae256c8d99cead8da46f21156d56dae7e/libraries/vastTrackers/vastTrackers.js#L86) 


### Error
![Screenshot from 2024-12-13 13-09-50](https://github.com/user-attachments/assets/445506c1-3fbb-44bd-9c5d-aa31f6a4d0b0)

