### PR TITLE
dfpAdServerVideo: set vconp (continuous playblack on) when playbackmethod contains 7

### DIFF
--- a/modules/dfpAdServerVideo.js
+++ b/modules/dfpAdServerVideo.js
@@ -133,7 +133,7 @@ export function buildDfpVideoUrl(options) {
         return 'preroll';
       }
     },
-    vconp: () => Array.isArray(video?.playbackmethod) && video.playbackmethod.every(m => m === 7) ? '2' : undefined,
+    vconp: () => Array.isArray(video?.playbackmethod) && video.playbackmethod.some(m => m === 7) ? '2' : undefined,
     vpa() {
       // playbackmethod = 3 is play on click; 1, 2, 4, 5, 6 are autoplay
       if (Array.isArray(video?.playbackmethod)) {

--- a/test/spec/modules/dfpAdServerVideo_spec.js
+++ b/test/spec/modules/dfpAdServerVideo_spec.js
@@ -271,7 +271,7 @@ describe('The DFP video support module', function () {
           video: {
             playbackmethod: [7, 1]
           },
-          expected: undefined
+          expected: '2'
         }
       ],
       vpa: [


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Closes https://github.com/prebid/Prebid.js/issues/12562
