### PR TITLE
PBS Adapter: only include known bidders in eidpermissions

### DIFF
--- a/modules/prebidServerBidAdapter/bidderConfig.js
+++ b/modules/prebidServerBidAdapter/bidderConfig.js
@@ -121,7 +121,7 @@ export function consolidateEids({eids, conflicts = new Set()}) {
   }
 }
 
-function replaceEids({global, bidder}) {
+function replaceEids({global, bidder}, requestedBidders) {
   const consolidated = consolidateEids(extractEids({global, bidder}));
   global = deepClone(global);
   bidder = deepClone(bidder);
@@ -134,6 +134,9 @@ function replaceEids({global, bidder}) {
   if (consolidated.global.length) {
     deepSetValue(global, 'user.ext.eids', consolidated.global);
   }
+  if (requestedBidders?.length) {
+    consolidated.permissions.forEach((permission) => permission.bidders = permission.bidders.filter(bidder => requestedBidders.includes(bidder)));
+  }
   if (consolidated.permissions.length) {
     deepSetValue(global, 'ext.prebid.data.eidpermissions', consolidated.permissions);
   }
@@ -145,11 +148,11 @@ function replaceEids({global, bidder}) {
   return {global, bidder}
 }
 
-export function premergeFpd(ortb2Fragments) {
+export function premergeFpd(ortb2Fragments, requestedBidders) {
   if (ortb2Fragments == null || Object.keys(ortb2Fragments.bidder || {}).length === 0) {
     return ortb2Fragments;
   } else {
-    ortb2Fragments = replaceEids(ortb2Fragments);
+    ortb2Fragments = replaceEids(ortb2Fragments, requestedBidders);
     return {
       ...ortb2Fragments,
       bidder: getPBSBidderConfig(ortb2Fragments)

--- a/modules/prebidServerBidAdapter/ortbConverter.js
+++ b/modules/prebidServerBidAdapter/ortbConverter.js
@@ -299,7 +299,7 @@ export function buildPBSRequest(s2sBidRequest, bidderRequests, adUnits, requeste
       requestTimestamp,
       s2sBidRequest: {
         ...s2sBidRequest,
-        ortb2Fragments: premergeFpd(s2sBidRequest.ortb2Fragments)
+        ortb2Fragments: premergeFpd(s2sBidRequest.ortb2Fragments, requestedBidders)
       },
       requestedBidders,
       actualBidderRequests: bidderRequests,

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2115,6 +2115,23 @@ describe('S2S Adapter', function () {
         }]);
       });
 
+      it('should not set eidpermissions for unrequested bidders', () => {
+        req.ortb2Fragments.bidder.unknown = {
+          user: {
+            eids: [{source: 'idC', id: 3}, {source: 'idD', id: 4}]
+          }
+        }
+        adapter.callBids(req, BID_REQUESTS, addBidResponse, done, ajax);
+        const payload = JSON.parse(server.requests[0].requestBody);
+        expect(payload.ext.prebid.data.eidpermissions).to.eql([{
+          bidders: ['appnexus'],
+          source: 'idC'
+        }, {
+          bidders: [],
+          source: 'idD'
+        }]);
+      })
+
       it('should repeat global EIDs when bidder-specific EIDs conflict', () => {
         BID_REQUESTS.push({
           ...BID_REQUESTS[0],
@@ -4710,8 +4727,8 @@ describe('S2S Adapter', function () {
           bidder: {
             bidderA: [mkEid('idA', 'idA2')]
           }
-        })
-      })
+        });
+      });
     })
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

PBS rejects reuests if `eidpermissions` refers to bidders it does not recognize (such as client side bidders).


## Other information
Related to https://github.com/prebid/Prebid.js/pull/12571
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
