### PR TITLE
PBS Adapter: handle edge case with duplicated EID permissions

### DIFF
--- a/modules/prebidServerBidAdapter/bidderConfig.js
+++ b/modules/prebidServerBidAdapter/bidderConfig.js
@@ -52,7 +52,7 @@ export function extractEids({global, bidder}) {
   function getEntry(eid) {
     let entry = entries.find((candidate) => deepEqual(candidate.eid, eid));
     if (entry == null) {
-      entry = {eid, bidders: []}
+      entry = {eid, bidders: new Set()}
       entries.push(entry);
     }
     if (bySource[eid.source] == null) {
@@ -74,12 +74,12 @@ export function extractEids({global, bidder}) {
       (deepAccess(bidderConfig, path) || []).forEach(eid => {
         const entry = getEntry(eid);
         if (entry.bidders !== false) {
-          entry.bidders.push(bidderCode);
+          entry.bidders.add(bidderCode);
         }
       })
     })
   })
-  return {eids: entries, conflicts};
+  return {eids: entries.map(({eid, bidders}) => ({eid, bidders: bidders && Array.from(bidders)})), conflicts};
 }
 
 /**

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -4650,7 +4650,7 @@ describe('S2S Adapter', function () {
           },
           expected: {
             eids: [
-              eidEntry('id', 'id',['bidderA'])
+              eidEntry('id', 'id', ['bidderA'])
             ]
           }
         }

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2130,7 +2130,7 @@ describe('S2S Adapter', function () {
           bidders: [],
           source: 'idD'
         }]);
-      })
+      });
 
       it('should repeat global EIDs when bidder-specific EIDs conflict', () => {
         BID_REQUESTS.push({
@@ -4637,6 +4637,21 @@ describe('S2S Adapter', function () {
               eidEntry('idD', 'idD', ['bidderA', 'bidderB'])
             ],
             conflicts: ['idA', 'idB']
+          }
+        },
+        {
+          t: 'duplicated bidder-specific eids',
+          bidder: {
+            bidderA: {
+              user: {
+                eids: [mkEid('id'), mkEid('id')]
+              }
+            }
+          },
+          expected: {
+            eids: [
+              eidEntry('id', 'id',['bidderA'])
+            ]
           }
         }
       ].forEach(({t, global = {}, bidder = {}, expected}) => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

This fixes a bug where duplicate bidder-specific EIDs will cause `eidpermissions[].bidder` to contain duplicates.

## Other information

Related to https://github.com/prebid/Prebid.js/pull/12571
