### PR TITLE
Analytics adapters: attach arbitrary labels to analytics events

### DIFF
--- a/test/spec/modules/genericAnalyticsAdapter_spec.js
+++ b/test/spec/modules/genericAnalyticsAdapter_spec.js
@@ -120,7 +120,7 @@ describe('Generic analytics', () => {
           recv = arg;
         });
         events.emit(BID_RESPONSE, {i: 1});
-        expect(recv).to.eql([{eventType: BID_RESPONSE, args: {i: 1}}]);
+        sinon.assert.match(recv, [sinon.match({eventType: BID_RESPONSE, args: {i: 1}})])
       });
 
       it('should not cause infinite recursion, if handler triggers more events', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

This allows attaching arbitrary labels to all analytics events, to facilitate distinguishing between experiment groups. For example, setting

```javascript
pbjs.setConfig({
   analyticsLabels: {
      "some_experiment": "some_group"
   }
})
```

will cause all event payloads seen by analytics adapters to contain 

```
 {
   // ...
   analyticsLabels: {
     "some_experiment": "some_group"
   }
 }
```

Additionally, adapters that extend the base AnalyticsAdapter's `track` method will see the same label data come in as a new `labels` parameter, e.g. `track({eventType, args, labels})`. (Unfortunately the nicer name `labels` is already taken in event payloads, where it sometimes refers to sizeMapping labels).


## Other information

Closes https://github.com/prebid/Prebid.js/issues/10705
