### PR TITLE
Retailspot bidAdapter : Endpoint update

### DIFF
--- a/modules/retailspotBidAdapter.js
+++ b/modules/retailspotBidAdapter.js
@@ -8,14 +8,17 @@ import {BANNER, VIDEO} from '../src/mediaTypes.js';
  */
 
 const BIDDER_CODE = 'retailspot';
-const DEFAULT_SUBDOMAIN = 'ssp';
-const PREPROD_SUBDOMAIN = 'ssp-preprod';
-const HOST = 'retail-spot.io';
-const ENDPOINT = '/prebid';
-const DEV_URL = 'http://localhost:8090/prebid';
+const GVL_ID = 1319;
+
+const DEFAULT_SUBDOMAIN = 'hbapi';
+const PREPROD_SUBDOMAIN = 'hbapi-preprod';
+const HOST = 'retailspotads.com';
+const ENDPOINT = '/';
+const DEV_URL = 'http://localhost:8090/';
 
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVL_ID,
   supportedMediaTypes: [BANNER, VIDEO],
   aliases: ['rs'], // short code
   /**

--- a/modules/retailspotBidAdapter.js
+++ b/modules/retailspotBidAdapter.js
@@ -14,7 +14,7 @@ const DEFAULT_SUBDOMAIN = 'hbapi';
 const PREPROD_SUBDOMAIN = 'hbapi-preprod';
 const HOST = 'retailspotads.com';
 const ENDPOINT = '/';
-const DEV_URL = 'http://localhost:8090/';
+const DEV_URL = 'http://localhost:3030/';
 
 export const spec = {
   code: BIDDER_CODE,

--- a/modules/retailspotBidAdapter.js
+++ b/modules/retailspotBidAdapter.js
@@ -5,6 +5,7 @@ import {BANNER, VIDEO} from '../src/mediaTypes.js';
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
  * @typedef {import('../src/adapters/bidderFactory.js').Bid} Bid
+ * @typedef {import('../src/adapters/bidderFactory.js').BidderRequest} BidderRequest
  */
 
 const BIDDER_CODE = 'retailspot';
@@ -36,7 +37,8 @@ export const spec = {
   /**
    * Make a server request from the list of BidRequests.
    *
-   * @param {BidRequests} - bidRequests.bids[] is an array of AdUnits and bids
+   * @param {BidRequest} bidRequests is an array of AdUnits and bids
+   * @param {BidderRequest} bidderRequest
    * @return ServerRequest Info describing the request to the server.
    */
   buildRequests: function (bidRequests, bidderRequest) {
@@ -99,11 +101,10 @@ export const spec = {
   }
 }
 
-
 /* Get parsed size from request size */
 function getSize(bid) {
   let inputSize = bid.sizes || [];
-  
+
   if (bid.mediaTypes?.banner) {
     inputSize = bid.mediaTypes.banner.sizes || [];
   }
@@ -119,7 +120,7 @@ function getSize(bid) {
   const sizesArray = parseSizesInput(inputSize);
   const parsed = {};
 
-  // Use the first size as the main requested one 
+  // Use the first size as the main requested one
   const size = sizesArray[0];
 
   // size is ready
@@ -128,7 +129,7 @@ function getSize(bid) {
   }
 
   // size is given as string "wwwxhhh" or "www*hhh"
-  const parsedSize = size.includes('*') ? size.split('*') :  size.toUpperCase().split('X');
+  const parsedSize = size.includes('*') ? size.split('*') : size.toUpperCase().split('X');
   const width = parseInt(parsedSize[0], 10);
   if (width) {
     parsed.width = width;

--- a/modules/retailspotBidAdapter.js
+++ b/modules/retailspotBidAdapter.js
@@ -28,7 +28,7 @@ export const spec = {
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: function (bid) {
-    const sizes = getSize(getSizeArray(bid));
+    const sizes = getSize(bid);
     const sizeValid = sizes.width > 0 && sizes.height > 0;
 
     return deepAccess(bid, 'params.placement') && sizeValid;
@@ -99,40 +99,40 @@ export const spec = {
   }
 }
 
-function getSizeArray(bid) {
-  let inputSize = bid.sizes || [];
 
-  if (bid.mediaTypes && bid.mediaTypes.banner) {
+/* Get parsed size from request size */
+function getSize(bid) {
+  let inputSize = bid.sizes || [];
+  
+  if (bid.mediaTypes?.banner) {
     inputSize = bid.mediaTypes.banner.sizes || [];
   }
 
-  // handle size in bid.params in formats: [w, h] and [[w,h]].
-  if (bid.params && Array.isArray(bid.params.size)) {
+  // Size can be [w, h] or array of sizes : [[w,h]].
+  if (Array.isArray(bid.params?.size)) {
     inputSize = bid.params.size;
     if (!Array.isArray(inputSize[0])) {
       inputSize = [inputSize]
     }
   }
 
-  return parseSizesInput(inputSize);
-}
-
-/* Get parsed size from request size */
-function getSize(sizesArray) {
+  const sizesArray = parseSizesInput(inputSize);
   const parsed = {};
-  // the main requested size is the first one
+
+  // Use the first size as the main requested one 
   const size = sizesArray[0];
 
+  // size is ready
   if (typeof size !== 'string') {
     return parsed;
   }
 
-  const parsedSize = size.toUpperCase().split('X');
+  // size is given as string "wwwxhhh" or "www*hhh"
+  const parsedSize = size.includes('*') ? size.split('*') :  size.toUpperCase().split('X');
   const width = parseInt(parsedSize[0], 10);
   if (width) {
     parsed.width = width;
   }
-
   const height = parseInt(parsedSize[1], 10);
   if (height) {
     parsed.height = height;

--- a/modules/retailspotBidAdapter.md
+++ b/modules/retailspotBidAdapter.md
@@ -25,7 +25,7 @@ Banner and Video ad formats are supported.
     bids: [{
       bidder: "retailspot",
       params: {
-        placement: "test-12345"
+        placement: "eq-609785-1856964-125234"
       }
     }]
   };

--- a/test/spec/modules/retailspotBidAdapter_spec.js
+++ b/test/spec/modules/retailspotBidAdapter_spec.js
@@ -246,7 +246,7 @@ describe('RetailSpot Adapter', function () {
   ];
   const adapter = newBidder(spec);
 
-  const DEV_URL = 'http://localhost:8090/';
+  const DEV_URL = 'http://localhost:3030/';
 
   describe('inherited functions', function () {
     it('exists and is a function', function () {
@@ -333,7 +333,7 @@ describe('RetailSpot Adapter', function () {
       const request = spec.buildRequests(bidRequestWithSinglePlacement, bidderRequest);
       const payload = JSON.parse(request.data);
 
-      expect(request.url).to.contain('https://ssp.retail-spot.io/prebid');
+      expect(request.url).to.contain('https://hbapi.retailspotads.com/');
       expect(request.method).to.equal('POST');
 
       expect(payload).to.deep.equal(bidderRequest);
@@ -344,7 +344,7 @@ describe('RetailSpot Adapter', function () {
       const request = spec.buildRequests(bidRequestWithSinglePlacement, bidderRequest);
       const payload = JSON.parse(request.data);
 
-      expect(request.url).to.contain('https://ssp.retail-spot.io/prebid');
+      expect(request.url).to.contain('https://hbapi.retailspotads.com/');
       expect(request.method).to.equal('POST');
 
       expect(payload).to.deep.equal(bidderRequest);
@@ -355,7 +355,7 @@ describe('RetailSpot Adapter', function () {
       const request = spec.buildRequests(bidRequestMultiPlacements, bidderRequest);
       const payload = JSON.parse(request.data);
 
-      expect(request.url).to.contain('https://ssp.retail-spot.io/prebid');
+      expect(request.url).to.contain('https://hbapi.retailspotads.com/');
       expect(request.method).to.equal('POST');
 
       expect(payload).to.deep.equal(bidderRequest);


### PR DESCRIPTION
## Type of change
- [*] Updated bidder adapter 

Does this change affect user-facing APIs or examples documented on http://prebid.org?
No

## Description of change
Our endpoint for incoming header bidding trafic has been changed. Update the bidder adapter accordingly.
Test parameters and unit tests have been updated too.

## Other information
This is an official bid adapter release from [RetailSpot](https://retail-spot.io).
See our format  on this [demo page](https://retailspot.github.io/RSPlayer-Demo/testPages/prebid/simple.html).
