### PR TITLE
Autoplay detection update: ignore NotSupportedError exceptions

### DIFF
--- a/libraries/autoplayDetection/autoplay.js
+++ b/libraries/autoplayDetection/autoplay.js
@@ -41,8 +41,12 @@ function startDetection() {
       // if the video is played on a WebView with playsinline = false, this stops the video, to prevent it from being displayed fullscreen
       videoElement.src = '';
     })
-    .catch(() => {
-      autoplayEnabled = false;
+    .catch((error) => {
+      if (error instanceof DOMException && error.name === 'NotSupportedError') {
+        // ignore this error caused by a Content Security Policy that disables data: scheme for media URLs
+      } else {
+        autoplayEnabled = false;
+      }
     });
 }
 

--- a/libraries/autoplayDetection/autoplay.js
+++ b/libraries/autoplayDetection/autoplay.js
@@ -1,7 +1,6 @@
 let autoplayEnabled = null;
 
 /**
- * DEVELOPER WARNING: IMPORTING THIS LIBRARY MAY MAKE YOUR ADAPTER NO LONGER COMPATIBLE WITH APP PUBLISHERS USING WKWEBVIEW
  * Note: this function returns true if detection is not done yet. This is by design: if autoplay is not allowed,
  * the call to video.play() will fail immediately, otherwise it may not terminate.
  * @returns true if autoplay is not forbidden


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
This PR:
  - fixes a edge case in the autoplay detection feature that would disable autoplay entirely if the website had a Content Security Policy disabling the `data:` scheme in Media URLs because of NotSupportedError exceptions. This PR ignores these exceptions, which is the same as disabling autoplay detection in this case.
  - removes a comment that @patmmccann had made regarding the use of the adapter in Webkit Webviews, since this issue was fixed subsequently in #11822, but I had forgotten to remove the comment.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
