### PR TITLE
Adagio Rtd Provider : always set session.expiry

### DIFF
--- a/test/spec/modules/adagioRtdProvider_spec.js
+++ b/test/spec/modules/adagioRtdProvider_spec.js
@@ -127,7 +127,7 @@ describe('Adagio Rtd Provider', function () {
       };
 
       it('store new session data for further usage', function () {
-        const storageValue = null;
+        const storageValue = JSON.stringify({abTest: {}});
         sandbox.stub(storage, 'getDataFromLocalStorage').callsArgWith(1, storageValue);
         sandbox.stub(Date, 'now').returns(1714116520710);
         sandbox.stub(Math, 'random').returns(0.8);
@@ -155,7 +155,7 @@ describe('Adagio Rtd Provider', function () {
       });
 
       it('store existing session data for further usage', function () {
-        const storageValue = JSON.stringify({session: session});
+        const storageValue = JSON.stringify({session: session, abTest: {}});
         sandbox.stub(storage, 'getDataFromLocalStorage').callsArgWith(1, storageValue);
         sandbox.stub(Date, 'now').returns(1714116520710);
         sandbox.stub(Math, 'random').returns(0.8);
@@ -179,7 +179,7 @@ describe('Adagio Rtd Provider', function () {
       });
 
       it('store new session if old session has expired data for further usage', function () {
-        const storageValue = JSON.stringify({session: session});
+        const storageValue = JSON.stringify({session: session, abTest: {}});
         sandbox.stub(Date, 'now').returns(1715679344351);
         sandbox.stub(storage, 'getDataFromLocalStorage').callsArgWith(1, storageValue);
         sandbox.stub(Math, 'random').returns(0.8);
@@ -195,6 +195,122 @@ describe('Adagio Rtd Provider', function () {
             new: true,
             id: utils.generateUUID(),
             rnd: Math.random(),
+          }
+        }
+        expect(spy.withArgs({
+          action: 'session',
+          ts: Date.now(),
+          data: expected,
+        }).calledOnce).to.be.true;
+      });
+    });
+
+    describe('store session data in localStorage for old snippet', function () {
+      it('store new session data for further usage', function () {
+        const storageValue = null;
+        sandbox.stub(storage, 'getDataFromLocalStorage').callsArgWith(1, storageValue);
+        sandbox.stub(Date, 'now').returns(1714116520710);
+        sandbox.stub(Math, 'random').returns(0.8);
+        sandbox.stub(utils, 'generateUUID').returns('uid-1234');
+
+        const spy = sandbox.spy(_internal.getAdagioNs().queue, 'push')
+
+        adagioRtdSubmodule.init(config);
+
+        const expected = {
+          session: {
+            new: true,
+            id: utils.generateUUID(),
+            rnd: Math.random(),
+            pages: 1
+          }
+        }
+
+        expect(spy.withArgs({
+          action: 'session',
+          ts: Date.now(),
+          data: expected,
+        }).calledOnce).to.be.true;
+      });
+
+      it('update session data for further usage', function () {
+        const storageValue = JSON.stringify({
+          session: {
+            new: true,
+            id: 'uid-1234',
+            rnd: 0.8,
+            pages: 1,
+            expiry: 1714116520710,
+            testName: 't',
+            testVersion: 'clt'
+          }
+        });
+        sandbox.stub(storage, 'getDataFromLocalStorage').callsArgWith(1, storageValue);
+        sandbox.stub(Date, 'now').returns(1714116520710);
+        sandbox.stub(Math, 'random').returns(0.8);
+        sandbox.stub(utils, 'generateUUID').returns('uid-1234');
+
+        const spy = sandbox.spy(_internal.getAdagioNs().queue, 'push')
+
+        adagioRtdSubmodule.init(config);
+
+        const expected = {
+          session: {
+            new: false,
+            expiry: 1714116520710,
+            id: utils.generateUUID(),
+            rnd: Math.random(),
+            pages: 1,
+            testName: 't',
+            testVersion: 'clt'
+          }
+        }
+
+        expect(spy.withArgs({
+          action: 'session',
+          ts: Date.now(),
+          data: expected,
+        }).calledOnce).to.be.true;
+      });
+    });
+
+    describe('update session data in localStorage from old snippet to new version', function () {
+      it('update session data for new snippet', function () {
+        const storageValue = JSON.stringify({
+          session: {
+            new: false,
+            id: 'uid-1234',
+            rnd: 0.8,
+            pages: 1,
+            expiry: 1714116520710,
+            testName: 't',
+            testVersion: 'clt'
+          },
+          abTest: {
+            expiry: 1714116520810,
+            testName: 't',
+            testVersion: 'srv'
+          }
+        });
+        sandbox.stub(storage, 'getDataFromLocalStorage').callsArgWith(1, storageValue);
+        sandbox.stub(Date, 'now').returns(1714116520710);
+        sandbox.stub(Math, 'random').returns(0.8);
+        sandbox.stub(utils, 'generateUUID').returns('uid-1234');
+
+        const spy = sandbox.spy(_internal.getAdagioNs().queue, 'push')
+
+        adagioRtdSubmodule.init(config);
+
+        const expected = {
+          session: {
+            new: false,
+            expiry: 1714116520710,
+            id: utils.generateUUID(),
+            rnd: Math.random(),
+            pages: 1,
+            testName: 't',
+            testVersion: 'srv',
+            v: 2
           }
         }
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->

PR https://github.com/prebid/Prebid.js/pull/11935 introduced the adg_rtd.session signal for AB testing.
It was further modified in https://github.com/prebid/Prebid.js/pull/12563
This logic works with a snippet (external to prebid.js) and this PR fixes a backward compatibility issue with said snippet.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->
