### PR TITLE
Rubicon Bid Adapter : ensure all query parameters follow camelCase convention

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -214,7 +214,7 @@ export const converter = ortbConverter({
     bidRequest.params.position === 'btf' && imp.video && (imp.video.pos = 3);
     delete imp.ext?.prebid?.storedrequest;
 
-    if (bidRequest.params.bidonmultiformat === true && bidRequestType.length > 1) {
+    if (bidRequest.params.bidOnMultiFormat === true && bidRequestType.length > 1) {
       deepSetValue(imp, 'ext.prebid.bidder.rubicon.formats', bidRequestType);
     }
 
@@ -297,7 +297,7 @@ export const spec = {
     filteredRequests = bidRequests.filter(req => {
       const mediaTypes = bidType(req) || [];
       const { length } = mediaTypes;
-      const { bidonmultiformat, video } = req.params || {};
+      const { bidOnMultiFormat, video } = req.params || {};
 
       return (
         // if there's just one mediaType and it's video or native, just send it!
@@ -306,8 +306,8 @@ export const spec = {
         (length === 2 && !mediaTypes.includes(BANNER)) ||
         // if it contains the video param and the Video mediaType, send Video to PBS (not native!)
         (video && mediaTypes.includes(VIDEO)) ||
-        // if bidonmultiformat is on, send everything to PBS
-        (bidonmultiformat && (mediaTypes.includes(VIDEO) || mediaTypes.includes(NATIVE)))
+        // if bidOnMultiFormat is on, send everything to PBS
+        (bidOnMultiFormat && (mediaTypes.includes(VIDEO) || mediaTypes.includes(NATIVE)))
       )
     });
 
@@ -325,18 +325,18 @@ export const spec = {
 
     const bannerBidRequests = bidRequests.filter((req) => {
       const mediaTypes = bidType(req) || [];
-      const {bidonmultiformat, video} = req.params || {};
+      const {bidOnMultiFormat, video} = req.params || {};
       return (
         // Send to fastlane if: it must include BANNER and...
         mediaTypes.includes(BANNER) && (
           // if it's just banner
           (mediaTypes.length === 1) ||
-          // if bidonmultiformat is true
-          bidonmultiformat ||
-          // if bidonmultiformat is false and there's no video parameter
-          (!bidonmultiformat && !video) ||
+          // if bidOnMultiFormat is true
+          bidOnMultiFormat ||
+          // if bidOnMultiFormat is false and there's no video parameter
+          (!bidOnMultiFormat && !video) ||
           // if there's video parameter, but there's no video mediatype
-          (!bidonmultiformat && video && !mediaTypes.includes(VIDEO))
+          (!bidOnMultiFormat && video && !mediaTypes.includes(VIDEO))
         )
       );
     });
@@ -525,7 +525,7 @@ export const spec = {
     }
 
     // Send multiformat data if requested
-    if (params.bidonmultiformat === true && deepAccess(bidRequest, 'mediaTypes') && Object.keys(bidRequest.mediaTypes).length > 1) {
+    if (params.bidOnMultiFormat === true && deepAccess(bidRequest, 'mediaTypes') && Object.keys(bidRequest.mediaTypes).length > 1) {
       data['p_formats'] = Object.keys(bidRequest.mediaTypes).join(',');
     }
 
@@ -1107,7 +1107,7 @@ export function classifiedAsVideo(bidRequest) {
   // based on whether or not there is a video object defined in the params
   // Given this legacy implementation, other code depends on params.video being defined
 
-  // if it's bidonmultiformat, we don't care of the video object
+  // if it's bidOnMultiFormat, we don't care of the video object
   if (isVideo && isBidOnMultiformat) return true;
 
   if (isBanner && isMissingVideoParams) {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -2909,7 +2909,7 @@ describe('the rubicon adapter', function () {
 
       if (FEATURES.NATIVE) {
         describe('when there is a native request', function () {
-          describe('and bidonmultiformat = undefined (false)', () => {
+          describe('and bidOnMultiFormat = undefined (false)', () => {
             it('should send only one native bid to PBS endpoint', function () {
               const bidReq = addNativeToBidRequest(bidderRequest);
               bidReq.bids[0].params = {
@@ -2967,7 +2967,7 @@ describe('the rubicon adapter', function () {
             });
           });
 
-          describe('with bidonmultiformat === true', () => {
+          describe('with bidOnMultiFormat === true', () => {
             it('should send two requests,  to PBS with 2 imps', () => {
               const bidReq = addNativeToBidRequest(bidderRequest);
               // add second mediaType
@@ -2977,7 +2977,7 @@ describe('the rubicon adapter', function () {
                   sizes: [[300, 250]]
                 }
               };
-              bidReq.bids[0].params.bidonmultiformat = true;
+              bidReq.bids[0].params.bidOnMultiFormat = true;
               let [pbsRequest, fastlanteRequest] = spec.buildRequests(bidReq.bids, bidReq);
               expect(pbsRequest.method).to.equal('POST');
               expect(pbsRequest.url).to.equal('https://prebid-server.rubiconproject.com/openrtb2/auction');
@@ -2994,7 +2994,7 @@ describe('the rubicon adapter', function () {
                   sizes: [[300, 250]]
                 }
               };
-              bidReq.bids[0].params.bidonmultiformat = true;
+              bidReq.bids[0].params.bidOnMultiFormat = true;
               let [pbsRequest, fastlanteRequest] = spec.buildRequests(bidReq.bids, bidReq);
               expect(pbsRequest.data.imp[0].ext.prebid.bidder.rubicon.formats).to.deep.equal(['native', 'banner']);
             });
@@ -3008,13 +3008,13 @@ describe('the rubicon adapter', function () {
                   sizes: [[300, 250]]
                 }
               };
-              bidReq.bids[0].params.bidonmultiformat = true;
+              bidReq.bids[0].params.bidOnMultiFormat = true;
               let [pbsRequest, fastlanteRequest] = spec.buildRequests(bidReq.bids, bidReq);
               let formatsIncluded = fastlanteRequest.data.indexOf('formats=native%2Cbanner') !== -1;
               expect(formatsIncluded).to.equal(true);
             });
           });
-          describe('with bidonmultiformat === false', () => {
+          describe('with bidOnMultiFormat === false', () => {
             it('should send only banner request because there\'s no params.video', () => {
               const bidReq = addNativeToBidRequest(bidderRequest);
               // add second mediaType
@@ -3039,7 +3039,7 @@ describe('the rubicon adapter', function () {
                   sizes: [[300, 250]]
                 }
               };
-              // by adding this, when bidonmultiformat is false, the native request will be sent to pbs
+              // by adding this, when bidOnMultiFormat is false, the native request will be sent to pbs
               bidReq.bids[0].params = {
                 video: {}
               }
@@ -4224,7 +4224,7 @@ describe('the rubicon adapter', function () {
           it('should render ad with Magnite renderer without video object', function () {
             const bidderRequest = createVideoBidderRequestOutstream();
             delete bidderRequest.bids[0].params.video;
-            bidderRequest.bids[0].params.bidonmultiformat = true;
+            bidderRequest.bids[0].params.bidOnMultiFormat = true;
             bidderRequest.bids[0].mediaTypes.video.placement = 3;
             bidderRequest.bids[0].mediaTypes.video.playerSize = [640, 480];
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Switching `bidonmultiformat` to `bidOnMultiFormat` to adhere to the camelCase convention.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->

