### PR TITLE
Adkernel Bid Adapter: add UrekaMedia alias

### DIFF
--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -102,7 +102,8 @@ export const spec = {
     {code: 'revbid'},
     {code: 'spinx', gvlid: 1308},
     {code: 'oppamedia'},
-    {code: 'pixelpluses', gvlid: 1209}
+    {code: 'pixelpluses', gvlid: 1209},
+    {code: 'urekamedia'}
   ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter 

## Description of change

Added alias for UrekaMedia partner network



## Other information
https://github.com/prebid/prebid.github.io/pull/5790