### PR TITLE
Adloox Analytics Module: apply 'js' param constraint

### DIFF
--- a/modules/adlooxAnalyticsAdapter.js
+++ b/modules/adlooxAnalyticsAdapter.js
@@ -81,8 +81,6 @@ const PARAMS_DEFAULT = {
   'id11': '$ADLOOX_WEBSITE'
 };
 
-const NOOP = function() {};
-
 let analyticsAdapter = Object.assign(adapter({ analyticsType: 'endpoint' }), {
   track({ eventType, args }) {
     if (!analyticsAdapter[`handle_${eventType}`]) return;
@@ -225,20 +223,24 @@ analyticsAdapter.url = function(url, args, bid) {
   return url + a2qs(args);
 }
 
+const preloaded = {};
 analyticsAdapter[`handle_${EVENTS.AUCTION_END}`] = function(auctionDetails) {
   if (!(auctionDetails.auctionStatus == AUCTION_COMPLETED && auctionDetails.bidsReceived.length > 0)) return;
-  analyticsAdapter[`handle_${EVENTS.AUCTION_END}`] = NOOP;
+
+  const uri = parseUrl(analyticsAdapter.url(`${analyticsAdapter.context.js}#`));
+  const href = `${uri.protocol}://${uri.host}${uri.pathname}`;
+  if (preloaded[href]) return;
 
   logMessage(MODULE, 'preloading verification JS');
 
-  const uri = parseUrl(analyticsAdapter.url(`${analyticsAdapter.context.js}#`));
-
   const link = document.createElement('link');
-  link.setAttribute('href', `${uri.protocol}://${uri.host}${uri.pathname}`);
+  link.setAttribute('href', href);
   link.setAttribute('rel', 'preload');
   link.setAttribute('as', 'script');
   // TODO fix rules violation
   insertElement(link);
+
+  preloaded[href] = true;
 }
 
 analyticsAdapter[`handle_${EVENTS.BID_WON}`] = function(bid) {

--- a/modules/adlooxAnalyticsAdapter.js
+++ b/modules/adlooxAnalyticsAdapter.js
@@ -109,6 +109,10 @@ analyticsAdapter.enableAnalytics = function(config) {
     logError(MODULE, 'invalid js options value');
     return;
   }
+  if (isStr(config.options.js) && !/\.adlooxtracking\.(com|ru)$/.test(parseUrl(config.options.js, { 'noDecodeWholeURL': true }).host)) {
+    logError(MODULE, "invalid js options value, must be a sub-domain of 'adlooxtracking.com'");
+    return;
+  }
   if (!(config.options.toselector === undefined || isFn(config.options.toselector))) {
     logError(MODULE, 'invalid toselector options value');
     return;

--- a/test/spec/modules/adlooxAdServerVideo_spec.js
+++ b/test/spec/modules/adlooxAdServerVideo_spec.js
@@ -34,7 +34,6 @@ describe('Adloox Ad Server Video', function () {
   };
 
   const analyticsOptions = {
-    js: 'https://j.adlooxtracking.com/ads/js/tfav_adl_%%clientid%%.js',
     client: 'adlooxtest',
     clientid: 127,
     platformid: 0,

--- a/test/spec/modules/adlooxAnalyticsAdapter_spec.js
+++ b/test/spec/modules/adlooxAnalyticsAdapter_spec.js
@@ -45,6 +45,11 @@ describe('Adloox Analytics Adapter', function () {
     adapter: analyticsAdapter
   });
   describe('enableAnalytics', function () {
+    afterEach(function () {
+      analyticsAdapter.disableAnalytics();
+      expect(analyticsAdapter.context).is.null;
+    });
+
     describe('invalid options', function () {
       it('should require options', function (done) {
         adapterManager.enableAnalytics({
@@ -58,6 +63,32 @@ describe('Adloox Analytics Adapter', function () {
       it('should reject non-string options.js', function (done) {
         const analyticsOptionsLocal = utils.deepClone(analyticsOptions);
         analyticsOptionsLocal.js = function () { };
+
+        adapterManager.enableAnalytics({
+          provider: analyticsAdapterName,
+          options: analyticsOptionsLocal
+        });
+        expect(analyticsAdapter.context).is.null;
+
+        done();
+      });
+
+      it('should accept subdomains of adlooxtracking.com for options.js', function (done) {
+        const analyticsOptionsLocal = utils.deepClone(analyticsOptions);
+        analyticsOptionsLocal.js = 'https://test.adlooxtracking.com/test.js';
+
+        adapterManager.enableAnalytics({
+          provider: analyticsAdapterName,
+          options: analyticsOptionsLocal
+        });
+        expect(analyticsAdapter.context).is.not.null;
+
+        done();
+      });
+
+      it('should reject non-subdomains of adlooxtracking.com for options.js', function (done) {
+        const analyticsOptionsLocal = utils.deepClone(analyticsOptions);
+        analyticsOptionsLocal.js = 'https://example.com/test.js';
 
         adapterManager.enableAnalytics({
           provider: analyticsAdapterName,


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
- [ ] Feature
- [ ] Other

## Description of change
The publisher is allowed to provide an override URL for the Adloox Analytics Module which us use as the location to load the verification JS by way of `loadExternalScript`.

Anything is allowed, whilst in practice only sub-domains of `adlooxtracking.{com,ru}` are meaningful.

This PR changes the module to only accept sub-domains of `adlooxtracking.{com,ru}` for the value of the option `js`.

## Other information
The trigger for this change is a client had a setup where a bad actor could provide a URL for their own script instead before the module initialised.

At a glance (51Degrees, aaxBlockmeterRtd, browsiRtd, ...) I suspect there are other modules with a similar problem.

Maybe it worth amending `loadExternalScript` to include an enforcer that which validates against a list of module provided (sub)domains to make review/vetting easier? When not supplied, the debug version can state something like "pants may explode" or prompt a code reviewer to require better justification for arbitrary URL external script loading.