### PR TITLE
JW Player Video Adapter: Determine Size before player is rendered

### DIFF
--- a/integrationExamples/videoModule/jwplayer/bidMarkedAsUsed.html
+++ b/integrationExamples/videoModule/jwplayer/bidMarkedAsUsed.html
@@ -48,7 +48,9 @@
                 params: {
                   vendorConfig: {
                     file: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4',
-                    advertising: { client: 'vast' }
+                    advertising: { client: 'vast' },
+                    width: 640,
+                    height: 480
                   }
                 }
               },

--- a/integrationExamples/videoModule/jwplayer/bidRequestScheduling.html
+++ b/integrationExamples/videoModule/jwplayer/bidRequestScheduling.html
@@ -24,6 +24,8 @@
                 params: {
                   vendorConfig: {
                     file: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4',
+                    width: 640,
+                    height: 480,
                     advertising: {
                       client: "googima",
                       schedule: {

--- a/integrationExamples/videoModule/jwplayer/bidsBackHandlerOverride.html
+++ b/integrationExamples/videoModule/jwplayer/bidsBackHandlerOverride.html
@@ -47,6 +47,8 @@
                 params: {
                   vendorConfig: {
                     file: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4',
+                    width: 640,
+                    height: 480,
                     advertising: { client: 'vast' }
                   }
                 }

--- a/integrationExamples/videoModule/jwplayer/eventListeners.html
+++ b/integrationExamples/videoModule/jwplayer/eventListeners.html
@@ -49,6 +49,8 @@
                   vendorConfig: {
                     file: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4',
                     mediaid: 'd9J2zcaA',
+                    width: 640,
+                    height: 480,
                     advertising: { client: 'vast' }
                   }
                 }

--- a/integrationExamples/videoModule/jwplayer/eventsUI.html
+++ b/integrationExamples/videoModule/jwplayer/eventsUI.html
@@ -53,6 +53,8 @@
                       file: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4',
                       title: "Subaru Outback on Street and Dirt",
                     }],
+                    width: 640,
+                    height: 480,
                     advertising: { client: 'vast' }
                   }
                 }

--- a/integrationExamples/videoModule/jwplayer/gamAdServerMediation.html
+++ b/integrationExamples/videoModule/jwplayer/gamAdServerMediation.html
@@ -47,6 +47,8 @@
                 params: {
                   vendorConfig: {
                     file: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4',
+                    width: 640,
+                    height: 480,
                     advertising: { client: 'googima' }
                   }
                 }

--- a/integrationExamples/videoModule/jwplayer/mediaMetadata.html
+++ b/integrationExamples/videoModule/jwplayer/mediaMetadata.html
@@ -51,7 +51,9 @@
                     file: 'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4',
                     title: 'Subaru Outback On Street And Dirt',
                     description: 'Smoking Tire takes the all-new Subaru Outback to the highest point we can find in hopes our customer-appreciation Balloon Launch will get some free T-shirts into the hands of our viewers.',
-                    advertising: { client: 'googima' }
+                    advertising: { client: 'googima' },
+                    width: 640,
+                    height: 480
                   }
                 }
               }

--- a/integrationExamples/videoModule/jwplayer/playlist.html
+++ b/integrationExamples/videoModule/jwplayer/playlist.html
@@ -63,7 +63,9 @@
                     title : "Sintel",
                     description: "Sintel is an independently produced short film, initiated by the Blender Foundation as a means to further improve and validate the free/open source 3D creation suite Blender. With initial funding provided by 1000s of donations via the internet community, it has again proven to be a viable development model for both open 3D technology as for independent animation film.\nThis 15 minute film has been realized in the studio of the Amsterdam Blender Institute, by an international team of artists and developers. In addition to that, several crucial technical and creative targets have been realized online, by developers and artists and teams all over the world.\nwww.sintel.org",
                   }],
-                  advertising: { client: 'vast' }
+                  advertising: { client: 'vast' },
+                  width: 640,
+                  height: 480
                 }
               }
             }

--- a/modules/jwplayerVideoProvider.js
+++ b/modules/jwplayerVideoProvider.js
@@ -50,6 +50,8 @@ export function JWPlayerProvider(config, jwplayer_, adState_, timeState_, callba
     VIDEO_MIME_TYPE.AAC,
     VIDEO_MIME_TYPE.HLS
   ];
+  let height = null;
+  let width = null;
 
   function init() {
     if (!jwplayer) {
@@ -92,6 +94,20 @@ export function JWPlayerProvider(config, jwplayer_, adState_, timeState_, callba
     const adConfig = config.advertising || {};
     supportedMediaTypes = supportedMediaTypes || utils.getSupportedMediaTypes(MEDIA_TYPES);
 
+    if (height === null) {
+      height = utils.getPlayerHeight(player, config);
+    }
+
+    if (width === null) {
+      width = utils.getPlayerWidth(player, config);
+    }
+
+    if (config.aspectratio && !height && !width) {
+      const size = utils.getPlayerSizeFromAspectRatio(config, divId);
+      height = size.height;
+      width = size.width;
+    }
+
     const video = {
       mimes: supportedMediaTypes,
       protocols: [
@@ -102,8 +118,8 @@ export function JWPlayerProvider(config, jwplayer_, adState_, timeState_, callba
         PROTOCOLS.VAST_3_0_WRAPPER,
         PROTOCOLS.VAST_4_0_WRAPPER
       ],
-      h: player.getHeight(), // TODO does player call need optimization ?
-      w: player.getWidth(), // TODO does player call need optimization ?
+      h: height,
+      w: width,
       startdelay: utils.getStartDelay(),
       placement: utils.getPlacement(adConfig, player),
       // linearity is omitted because both forms are supported.
@@ -414,10 +430,14 @@ export function JWPlayerProvider(config, jwplayer_, adState_, timeState_, callba
         break;
 
       case PLAYER_RESIZE:
-        getEventPayload = e => ({
-          height: e.height,
-          width: e.width,
-        });
+        getEventPayload = e => {
+          height = e.height;
+          width = e.width;
+          return {
+            height,
+            width
+          };
+        };
         break;
 
       case VIEWABLE:
@@ -583,6 +603,74 @@ export const utils = {
 
     jwConfig.advertising = advertising;
     return jwConfig;
+  },
+
+  getPlayerHeight: function(player, config) {
+    let height;
+
+    if (player.getHeight) {
+      height = player.getHeight();
+    }
+
+    // Height is undefined when player has not yet rendered
+    if (height !== undefined) {
+      return height;
+    }
+
+    return config.height;
+  },
+
+  getPlayerWidth: function(player, config) {
+    let width;
+
+    if (player.getWidth) {
+      width = player.getWidth();
+    }
+
+    // Width is undefined when player has not yet rendered
+    if (width !== undefined) {
+      return width;
+    }
+
+    // Width can be a string when aspectratio is set
+    if (typeof config.width === 'number') {
+      return config.width;
+    }
+  },
+
+  getPlayerSizeFromAspectRatio: function(player, config) {
+    const aspectRatio = config.aspectratio;
+    let percentageWidth = config.width;
+
+    if (typeof aspectRatio !== 'string' && typeof percentageWidth !== 'string') {
+      return {};
+    }
+
+    const ratios = aspectRatio.split(':');
+
+    if (ratios.length !== 2) {
+      return {};
+    }
+
+    const containerElement = player.getContainer();
+    if (!containerElement) {
+      return {};
+    }
+
+    const containerWidth = containerElement.clientWidth;
+    const containerHeight = containerElement.clientHeight;
+
+    const xRatio = parseInt(ratios[0], 10);
+    const yRatio = parseInt(ratios[1], 10);
+    const numericWidthPercentage = parseInt(percentageWidth, 10);
+
+    const desiredWidth = containerWidth * numericWidthPercentage / 100;
+    const desiredHeight = Math.min(desiredWidth * yRatio / xRatio, containerHeight);
+
+    return {
+      height: desiredHeight,
+      width: desiredWidth
+    };
   },
 
   getJwEvent: function(eventName) {

--- a/modules/jwplayerVideoProvider.js
+++ b/modules/jwplayerVideoProvider.js
@@ -103,7 +103,7 @@ export function JWPlayerProvider(config, jwplayer_, adState_, timeState_, callba
     }
 
     if (config.aspectratio && !height && !width) {
-      const size = utils.getPlayerSizeFromAspectRatio(config, divId);
+      const size = utils.getPlayerSizeFromAspectRatio(player, config);
       height = size.height;
       width = size.width;
     }

--- a/modules/jwplayerVideoProvider.js
+++ b/modules/jwplayerVideoProvider.js
@@ -642,7 +642,7 @@ export const utils = {
     const aspectRatio = config.aspectratio;
     let percentageWidth = config.width;
 
-    if (typeof aspectRatio !== 'string' && typeof percentageWidth !== 'string') {
+    if (typeof aspectRatio !== 'string' || typeof percentageWidth !== 'string') {
       return {};
     }
 
@@ -662,6 +662,11 @@ export const utils = {
 
     const xRatio = parseInt(ratios[0], 10);
     const yRatio = parseInt(ratios[1], 10);
+
+    if (isNaN(xRatio) || isNaN(yRatio)) {
+      return {};
+    }
+
     const numericWidthPercentage = parseInt(percentageWidth, 10);
 
     const desiredWidth = containerWidth * numericWidthPercentage / 100;

--- a/modules/jwplayerVideoProvider.js
+++ b/modules/jwplayerVideoProvider.js
@@ -652,7 +652,7 @@ export const utils = {
       return {};
     }
 
-    const containerElement = player.getContainer();
+    const containerElement = player.getContainer && player.getContainer();
     if (!containerElement) {
       return {};
     }

--- a/test/spec/modules/videoModule/submodules/jwplayerVideoProvider_spec.js
+++ b/test/spec/modules/videoModule/submodules/jwplayerVideoProvider_spec.js
@@ -690,6 +690,53 @@ describe('utils', function () {
       expect(jwConfig.advertising).to.have.property('client', 'vast');
     });
   });
+
+  describe('getPlayerHeight', function () {
+    it('should return height from API when defined', function () {
+
+    });
+
+    it('should return height from config when API returns undefined', function () {
+
+    });
+  });
+
+  describe('getPlayerWidth', function () {
+    it('should return width from API when defined', function () {
+
+    });
+
+    it('should return width from config when API returns undefined', function () {
+
+    });
+
+    it('should return undefined when width is string', function () {
+
+    });
+  });
+
+  describe('getPlayerSizeFromAspectRatio', function () {
+    it('should return an empty object when width and aspectratio are not strings', function () {
+
+    });
+
+    it('should return an empty object when aspectratio is malformed', function () {
+
+    });
+
+    it('should return an empty object when player container cannot be obtained', function () {
+
+    });
+
+    it('should calculate the size give the width percentage and aspect ratio', function () {
+
+    });
+
+    it('should return the container height when smaller than the calculated height', function () {
+
+    });
+  });
+
   describe('getSkipParams', function () {
     const getSkipParams = utils.getSkipParams;
 

--- a/test/spec/modules/videoModule/submodules/jwplayerVideoProvider_spec.js
+++ b/test/spec/modules/videoModule/submodules/jwplayerVideoProvider_spec.js
@@ -698,48 +698,75 @@ describe('utils', function () {
   });
 
   describe('getPlayerHeight', function () {
-    it('should return height from API when defined', function () {
+    const getPlayerHeight = utils.getPlayerHeight;
 
+    it('should return height from API when defined', function () {
+      const expectedHeight = 500;
+      const playerMock = { getHeight: () => expectedHeight };
+      expect(getPlayerHeight(playerMock, {})).to.equal(expectedHeight);
     });
 
     it('should return height from config when API returns undefined', function () {
-
+      const expectedHeight = 500;
+      const playerMock = { getHeight: () => undefined };
+      expect(getPlayerHeight(playerMock, { height: 500 })).to.equal(expectedHeight);
     });
   });
 
   describe('getPlayerWidth', function () {
-    it('should return width from API when defined', function () {
+    const getPlayerWidth = utils.getPlayerWidth;
 
+    it('should return width from API when defined', function () {
+      const expectedWidth = 1000;
+      const playerMock = { getWidth: () => expectedWidth };
+      expect(getPlayerWidth(playerMock, {})).to.equal(expectedWidth);
     });
 
     it('should return width from config when API returns undefined', function () {
-
+      const expectedWidth = 1000;
+      const playerMock = { getWidth: () => undefined };
+      expect(getPlayerWidth(playerMock, { width: expectedWidth })).to.equal(expectedWidth);
     });
 
     it('should return undefined when width is string', function () {
-
+      const playerMock = { getWidth: () => undefined };
+      expect(getPlayerWidth(playerMock, { width: '50%' })).to.be.undefined;
     });
   });
 
   describe('getPlayerSizeFromAspectRatio', function () {
-    it('should return an empty object when width and aspectratio are not strings', function () {
+    const getPlayerSizeFromAspectRatio = utils.getPlayerSizeFromAspectRatio;
+    const testContainer = document.createElement('div');
+    testContainer.style.width = '640px';
+    testContainer.style.height = '480px';
 
+    it('should return an empty object when width and aspectratio are not strings', function () {
+      expect(getPlayerSizeFromAspectRatio({ getContainer: () => testContainer }, {})).to.deep.equal({});
+      expect(getPlayerSizeFromAspectRatio({ getContainer: () => testContainer }, {width: 100})).to.deep.equal({});
+      expect(getPlayerSizeFromAspectRatio({ getContainer: () => testContainer }, {aspectratio: '1:2', width: 100})).to.deep.equal({});
     });
 
     it('should return an empty object when aspectratio is malformed', function () {
-
+      expect(getPlayerSizeFromAspectRatio({ getContainer: () => testContainer }, {aspectratio: '0.5', width: '100%'})).to.deep.equal({});
+      expect(getPlayerSizeFromAspectRatio({ getContainer: () => testContainer }, {aspectratio: '1-2', width: '100%'})).to.deep.equal({});
+      expect(getPlayerSizeFromAspectRatio({ getContainer: () => testContainer }, {aspectratio: '1:', width: '100%'})).to.deep.equal({});
+      expect(getPlayerSizeFromAspectRatio({ getContainer: () => testContainer }, {aspectratio: ':2', width: '100%'})).to.deep.equal({});
+      expect(getPlayerSizeFromAspectRatio({ getContainer: () => testContainer }, {aspectratio: ':', width: '100%'})).to.deep.equal({});
+      expect(getPlayerSizeFromAspectRatio({ getContainer: () => testContainer }, {aspectratio: '1:2:3', width: '100%'})).to.deep.equal({});
     });
 
     it('should return an empty object when player container cannot be obtained', function () {
-
+      expect(getPlayerSizeFromAspectRatio({}, {aspectratio: '1:2', width: '100%'})).to.deep.equal({});
+      expect(getPlayerSizeFromAspectRatio({ getContainer: () => undefined }, {aspectratio: '1:2', width: '100%'})).to.deep.equal({});
     });
 
-    it('should calculate the size give the width percentage and aspect ratio', function () {
-
+    it('should calculate the size given the width percentage and aspect ratio', function () {
+      expect(getPlayerSizeFromAspectRatio({ getContainer: () => testContainer }, {aspectratio: '1:2', width: '100%'})).to.deep.equal({ height: 370, width: 640 });
+      expect(getPlayerSizeFromAspectRatio({ getContainer: () => testContainer }, {aspectratio: '1:4', width: '70%'})).to.deep.equal({ height: 112, width: 448 });
     });
 
     it('should return the container height when smaller than the calculated height', function () {
-
+      expect(getPlayerSizeFromAspectRatio({ getContainer: () => testContainer }, {aspectratio: '1:1', width: '100%'})).to.deep.equal({ height: 480, width: 640 });
     });
   });
 

--- a/test/spec/modules/videoModule/submodules/jwplayerVideoProvider_spec.js
+++ b/test/spec/modules/videoModule/submodules/jwplayerVideoProvider_spec.js
@@ -26,6 +26,7 @@ function getPlayerMock() {
     getVolume: function () {},
     getConfig: function () {},
     getHeight: function () {},
+    getContainer: function () {},
     getWidth: function () {},
     getFullscreen: function () {},
     getPlaylistItem: function () {},
@@ -51,6 +52,9 @@ function makePlayerFactoryMock(playerMock_) {
 function getUtilsMock() {
   return {
     getJwConfig: function () {},
+    getPlayerHeight: function () {},
+    getPlayerWidth: function () {},
+    getPlayerSizeFromAspectRatio: function () {},
     getSupportedMediaTypes: function () {},
     getStartDelay: function () {},
     getPlacement: function () {},
@@ -212,6 +216,8 @@ describe('JWPlayerProvider', function () {
       player.getWidth = () => test_width;
       player.getFullscreen = () => true; //
 
+      utils.getPlayerHeight = () => 100;
+      utils.getPlayerWidth = () => 200;
       utils.getSupportedMediaTypes = () => [test_media_type];
       utils.getStartDelay = () => test_start_delay;
       utils.getPlacement = () => test_placement;

--- a/test/spec/modules/videoModule/submodules/jwplayerVideoProvider_spec.js
+++ b/test/spec/modules/videoModule/submodules/jwplayerVideoProvider_spec.js
@@ -736,9 +736,10 @@ describe('utils', function () {
 
   describe('getPlayerSizeFromAspectRatio', function () {
     const getPlayerSizeFromAspectRatio = utils.getPlayerSizeFromAspectRatio;
-    const testContainer = document.createElement('div');
-    testContainer.style.width = '640px';
-    testContainer.style.height = '480px';
+    const testContainer = {
+      clientWidth: 640,
+      clientHeight: 480
+    };
 
     it('should return an empty object when width and aspectratio are not strings', function () {
       expect(getPlayerSizeFromAspectRatio({ getContainer: () => testContainer }, {})).to.deep.equal({});
@@ -761,8 +762,8 @@ describe('utils', function () {
     });
 
     it('should calculate the size given the width percentage and aspect ratio', function () {
-      expect(getPlayerSizeFromAspectRatio({ getContainer: () => testContainer }, {aspectratio: '1:2', width: '100%'})).to.deep.equal({ height: 370, width: 640 });
-      expect(getPlayerSizeFromAspectRatio({ getContainer: () => testContainer }, {aspectratio: '1:4', width: '70%'})).to.deep.equal({ height: 112, width: 448 });
+      expect(getPlayerSizeFromAspectRatio({ getContainer: () => testContainer }, {aspectratio: '2:1', width: '100%'})).to.deep.equal({ height: 320, width: 640 });
+      expect(getPlayerSizeFromAspectRatio({ getContainer: () => testContainer }, {aspectratio: '4:1', width: '70%'})).to.deep.equal({ height: 112, width: 448 });
     });
 
     it('should return the container height when smaller than the calculated height', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature


## Description of change
The JW Player Video Submodule is the source of truth for indicating the size of the player. This PR adds logic to determine the size of the player before it is even rendered. This is accomplished by reading the values in the player's config. When the player is configured to render relative to the container element, it factors in the container's size as well. 

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
