### PR TITLE
33across ID System: Store hashed email when feature is enabled via config 

### DIFF
--- a/modules/33acrossIdSystem.js
+++ b/modules/33acrossIdSystem.js
@@ -60,7 +60,7 @@ function calculateResponseObj(response) {
   };
 }
 
-function calculateQueryStringParams({ pid, hem }, gdprConsentData, enabledStorageTypes) {
+function calculateQueryStringParams({ pid, pubProvidedHem }, gdprConsentData, enabledStorageTypes) {
   const uspString = uspDataHandler.getConsentData();
   const coppaValue = coppaDataHandler.getCoppa();
   const gppConsent = gppDataHandler.getConsentData();
@@ -98,9 +98,9 @@ function calculateQueryStringParams({ pid, hem }, gdprConsentData, enabledStorag
     params.tp = encodeURIComponent(tp);
   }
 
-  const hashedEmail = hem || getStoredValue(STORAGE_HEM_KEY, enabledStorageTypes);
-  if (hashedEmail) {
-    params.sha256 = encodeURIComponent(hashedEmail);
+  const hem = pubProvidedHem || getStoredValue(STORAGE_HEM_KEY, enabledStorageTypes);
+  if (hem) {
+    params.sha256 = encodeURIComponent(hem);
   }
 
   return params;
@@ -239,8 +239,9 @@ export const thirtyThreeAcrossIdSubmodule = {
       storeFpid = DEFAULT_1PID_SUPPORT,
       storeTpid = DEFAULT_TPID_SUPPORT, apiUrl = API_URL,
       pid,
-      hem = window._33across?.hem?.sha256
+      hem
     } = params;
+    const pubProvidedHem = hem || window._33across?.hem?.sha256;
 
     return {
       callback(cb) {
@@ -263,7 +264,7 @@ export const thirtyThreeAcrossIdSubmodule = {
             handleSupplementalIds({
               fp: responseObj.fp,
               tp: responseObj.tp,
-              hem
+              hem: pubProvidedHem
             }, {
               storeFpid,
               storeTpid,
@@ -279,7 +280,7 @@ export const thirtyThreeAcrossIdSubmodule = {
 
             cb();
           }
-        }, calculateQueryStringParams({ pid, hem }, gdprConsentData, enabledStorageTypes), {
+        }, calculateQueryStringParams({ pid, pubProvidedHem }, gdprConsentData, enabledStorageTypes), {
           method: 'GET',
           withCredentials: true
         });

--- a/modules/33acrossIdSystem.js
+++ b/modules/33acrossIdSystem.js
@@ -145,7 +145,7 @@ function getStoredValue(key, enabledStorageTypes) {
   return storedValue;
 }
 
-function filterEnabledSupplementalIds({ tp, fp, hem }, { storeFpid, storeTpid }) {
+function filterEnabledSupplementalIds({ tp, fp, hem }, { storeFpid, storeTpid, privacyConsent }) {
   const ids = [];
 
   if (storeFpid) {
@@ -158,7 +158,7 @@ function filterEnabledSupplementalIds({ tp, fp, hem }, { storeFpid, storeTpid })
        * ]
        */
       [STORAGE_FPID_KEY, fp, true],
-      [STORAGE_HEM_KEY, hem, false]
+      [STORAGE_HEM_KEY, hem, privacyConsent === false] // hashed email should be cleared if there's no privacy consent.
     );
   }
 
@@ -267,6 +267,7 @@ export const thirtyThreeAcrossIdSubmodule = {
             }, {
               storeFpid,
               storeTpid,
+              privacyConsent: !!responseObj.envelope,
               enabledStorageTypes,
               expires: storageConfig.expires
             });

--- a/modules/33acrossIdSystem.js
+++ b/modules/33acrossIdSystem.js
@@ -98,7 +98,7 @@ function calculateQueryStringParams({ pid, hem }, gdprConsentData, enabledStorag
     params.tp = encodeURIComponent(tp);
   }
 
-  const hemParam = hem || getStoredValue(STORAGE_HEM_KEY, enabledStorageTypes);
+  const hemParam = hem || window._33across?.hem?.sha256 || getStoredValue(STORAGE_HEM_KEY, enabledStorageTypes);
   if (hemParam) {
     params.sha256 = encodeURIComponent(hemParam);
   }

--- a/modules/33acrossIdSystem.md
+++ b/modules/33acrossIdSystem.md
@@ -57,4 +57,5 @@ The following settings are available in the `params` property in `userSync.userI
 
 ### HEM Collection
 
-33Across ID System supports user's hashed email, if available in storage.
+33Across ID System supports user's hashed emails (HEMs). HEMs could be collected from 3 different
+sources: publisher configuration, global `_33across.hem.sha256` field or from storage (LS or Cookie).

--- a/modules/33acrossIdSystem.md
+++ b/modules/33acrossIdSystem.md
@@ -57,5 +57,5 @@ The following settings are available in the `params` property in `userSync.userI
 
 ### HEM Collection
 
-33Across ID System supports user's hashed emails (HEMs). HEMs could be collected from 3 different
-sources: `hem` configuration parameter, global `_33across.hem.sha256` field or from storage (cookie or local storage).
+33Across ID System supports user's hashed emails (HEMs). HEMs could be collected from 3 different sources in following
+priority order: `hem` configuration parameter, global `_33across.hem.sha256` field or from storage (cookie or local storage).

--- a/modules/33acrossIdSystem.md
+++ b/modules/33acrossIdSystem.md
@@ -58,4 +58,4 @@ The following settings are available in the `params` property in `userSync.userI
 ### HEM Collection
 
 33Across ID System supports user's hashed emails (HEMs). HEMs could be collected from 3 different
-sources: publisher configuration, global `_33across.hem.sha256` field or from storage (LS or Cookie).
+sources: `hem` configuration parameter, global `_33across.hem.sha256` field or from storage (cookie or local storage).

--- a/test/spec/modules/33acrossIdSystem_spec.js
+++ b/test/spec/modules/33acrossIdSystem_spec.js
@@ -934,6 +934,39 @@ describe('33acrossIdSystem', () => {
     });
 
     context('when a hashed email is NOT provided via configuration options', () => {
+      context('but it\'s provided via global 33across object', () => {
+        it('should call endpoint with the hashed email included', () => {
+          window._33across = {
+            hem: {
+              sha256: 'fake-sha256-hashed-email+'
+            }
+          }
+          const completeCallback = () => {};
+          const { callback } = thirtyThreeAcrossIdSubmodule.getId({
+            params: {
+              pid: '12345'
+              // No hashed email via config option.
+            },
+            enabledStorageTypes: [ 'html5' ],
+            storage: {}
+          });
+
+          // Prioritizes the hashed email given via global object over the one stored in LS.
+          sinon.stub(storage, 'getDataFromLocalStorage')
+            .withArgs('33acrossIdHm')
+            .returns('33acrossIdHmValueLS');
+
+          callback(completeCallback);
+
+          const [request] = server.requests;
+
+          expect(request.url).to.contain('sha256=fake-sha256-hashed-email%2B');
+
+          delete window._33across;
+          storage.getDataFromLocalStorage.restore();
+        });
+      });
+
       context('but it\'s provided via local storage', () => {
         it('should call endpoint with the hashed email included', () => {
           const completeCallback = () => {};

--- a/test/spec/modules/33acrossIdSystem_spec.js
+++ b/test/spec/modules/33acrossIdSystem_spec.js
@@ -21,7 +21,7 @@ describe('33acrossIdSystem', () => {
   });
 
   describe('getId', () => {
-    it('should call endpoint and handle valid response', () => {
+    it('should call endpoint', () => {
       const completeCallback = sinon.spy();
 
       const { callback } = thirtyThreeAcrossIdSubmodule.getId({
@@ -50,7 +50,34 @@ describe('33acrossIdSystem', () => {
       const regExp = new RegExp('https://lexicon.33across.com/v1/envelope\\?pid=12345&gdpr=\\d&src=pbjs&ver=$prebid.version$');
 
       expect(request.url).to.match(regExp);
-      expect(completeCallback.calledOnceWithExactly('foo')).to.be.true;
+    });
+
+    context('when there\'s a successful response containing an ID', () => {
+      it('should execute the callback and pass the ID', () => {
+        const completeCallback = sinon.spy();
+
+        const { callback } = thirtyThreeAcrossIdSubmodule.getId({
+          params: {
+            pid: '12345'
+          }
+        });
+
+        callback(completeCallback);
+
+        const [request] = server.requests;
+
+        request.respond(200, {
+          'Content-Type': 'application/json'
+        }, JSON.stringify({
+          succeeded: true,
+          data: {
+            envelope: 'foo'
+          },
+          expires: 1645667805067
+        }));
+
+        expect(completeCallback.calledOnceWithExactly('foo')).to.be.true;
+      });
     });
 
     const additionalOptions = {


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter
- [ ] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Save the hashed email in browser storage when it's provided via config option or global var. 
Do not remove it if it's no longer provided, unless the absence of the main ID in the endpoint response indicates the opposite.

Documentation Change: https://github.com/prebid/prebid.github.io/pull/5793