### PR TITLE
LiveIntent Rtd Provider: initial release

### DIFF
--- a/integrationExamples/gpt/liveIntentRtdProviderExample.html
+++ b/integrationExamples/gpt/liveIntentRtdProviderExample.html
@@ -1,0 +1,164 @@
+<html>
+<head>
+    <link rel="icon" type="image/png" href="/favicon.png">
+    <script async src="//www.googletagservices.com/tag/js/gpt.js"></script>
+    <script async src="../../build/dev/prebid.js"></script>
+    <script>
+        var div_1_sizes = [
+            [300, 250],
+            [300, 600]
+        ];
+        var div_2_sizes = [
+            [728, 90],
+            [970, 250]
+        ];
+        var PREBID_TIMEOUT = 1000;
+        var FAILSAFE_TIMEOUT = 3000;
+        var adUnits = [
+            {
+                code: '/19968336/header-bid-tag-0',
+                mediaTypes: {
+                    banner: {
+                        sizes: div_1_sizes
+                    }
+                },
+                bids: [{
+                    bidder: 'appnexus',
+                    params: {
+                        siteId: 'examplePub123',    // required
+                        productId: 'siab|inview'    // required
+                    }
+                }]
+            },
+            {
+                code: '/19968336/header-bid-tag-1',
+                mediaTypes: {
+                    banner: {
+                        sizes: div_2_sizes
+                    }
+                },
+                bids: [{
+                    bidder: 'appnexus',
+                    params: {
+                        siteId: 'examplePub123',    // required
+                        productId: 'siab|inview'    // required
+                    }
+                }]
+            }
+        ];
+        // ======== DO NOT EDIT BELOW THIS LINE =========== //
+        var googletag = googletag || {};
+        googletag.cmd = googletag.cmd || [];
+        googletag.cmd.push(function() {
+            googletag.pubads().disableInitialLoad();
+        });
+        var pbjs = pbjs || {};
+        pbjs.que = pbjs.que || [];
+        pbjs.que.push(function() {
+            pbjs.setConfig({
+                debug: true,
+                realTimeData: {
+                    dataProviders:[{
+                      name: "liveintent",
+                      waitForIt: true
+                    }]
+                },
+                "consentManagement": {
+                "cmpApi": "static",
+                "consentData": {
+                  "getTCData": {
+                    "tcString": "CO-HDlqO-HDlqAKAXCENBDCsAP_AAH_AACiQHKNd_X_fb39j-_59_9t0eY1f9_7_v20zjgeds-8Nyd_X_L8X42M7vF36pq4KuR4Eu3LBIQFlHOHcTUmw6IkVqTPsak2Mr7NKJ7PEinMbe2dYGHtfn9VTuZKYr97s___z__-__v__75f_r-3_3_vp9V---_fA5QAkw1L4CLMSxwJJo0qhRAhCuJDoAQAUUIwtE1hASuCnZXAR-ggYAIDUBGBECDEFGLIIAAAAAkoiAkAPBAIgCIBAACAFSAhAARoAgsAJAwCAAUA0LACKAIQJCDI4KjlMCAiRaKCeSMASi72MMIQyigBoFH4AAAAA.cAAAAAAAAAAA",
+                    "cmpId": 10,
+                    "cmpVersion": 23,
+                    "tcfPolicyVersion": 2,
+                    "gdprApplies": true,
+                    "cmpStatus": "loaded",
+                    "eventStatus": "tcloaded",
+                    "purpose": {
+                      "consents": {
+                        "1": true,
+                        "2": true
+                      }
+                    },
+                    "vendor": {
+                      "consents": {
+                        // add your GVL ID here and set to true to give consent within pbjs
+                        "148": true,     // liveintent
+                      }
+                    }
+                  }
+                 }
+                },
+                userSync: {
+                    auctionDelay: 1000,
+                    userIds: [
+                        {
+                            "name": "liveIntentId",
+                            "params": {
+                                "liCollectConfig" : {
+                                   "distributorId" : "did-0000"
+                                }
+                            },
+                            "value" : {
+                                "lipbid":
+                                {
+                                    "segments": ["asa_1231", "lalo_4311", "liurl_99123"],
+                                }
+                            }
+                        }
+                   ]
+                }
+            });
+            pbjs.addAdUnits(adUnits);
+            pbjs.requestBids({
+                bidsBackHandler: initAdserver,
+                timeout: PREBID_TIMEOUT
+            });
+        });
+        function initAdserver() {
+            if (pbjs.initAdserverSet) return;
+            pbjs.initAdserverSet = true;
+            googletag.cmd.push(function() {
+                pbjs.que.push(function() {
+                    pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+                });
+            });
+        }
+        // in case PBJS doesn't load
+        setTimeout(function() {
+            initAdserver();
+        }, FAILSAFE_TIMEOUT);
+        googletag.cmd.push(function() {
+            googletag.defineSlot('/19968336/header-bid-tag-0', div_1_sizes, 'div-1').addService(googletag.pubads());
+            googletag.pubads().enableSingleRequest();
+            googletag.enableServices();
+        });
+        googletag.cmd.push(function() {
+            googletag.defineSlot('/19968336/header-bid-tag-1', div_2_sizes, 'div-2').addService(googletag.pubads());
+            googletag.pubads().enableSingleRequest();
+            googletag.enableServices();
+        });
+    </script>
+</head>
+<body>
+<h2>Basic Prebid.js Example</h2>
+<h5>Div-1</h5>
+<div id='div-1'>
+    <script type='text/javascript'>
+        googletag.cmd.push(function() {
+            googletag.display('div-1');
+        });
+    </script>
+</div>
+<br>
+<h5>Div-2</h5>
+<div id='div-2'>
+    <script type='text/javascript'>
+        googletag.cmd.push(function() {
+            googletag.display('div-2');
+        });
+    </script>
+</div>
+</body>
+</html>

--- a/libraries/liveIntentId/shared.js
+++ b/libraries/liveIntentId/shared.js
@@ -59,11 +59,8 @@ export function composeIdObject(value) {
 
   // old versions stored lipbid in unifiedId. Ensure that we can still read the data.
   const lipbid = value.nonId || value.unifiedId
-  if (lipbid) {
-    const lipb = { ...value, lipbid };
-    delete lipb.unifiedId;
-    result.lipb = lipb;
-  }
+  result.lipb = lipbid ? { ...value, lipbid } : value
+  delete result.lipb?.unifiedId
 
   // Lift usage of uid2 by exposing uid2 if we were asked to resolve it.
   // As adapters are applied in lexicographical order, we will always

--- a/modules/liveIntentRtdProvider.js
+++ b/modules/liveIntentRtdProvider.js
@@ -4,6 +4,12 @@
 import { submodule } from '../src/hook.js';
 import {deepAccess, deepSetValue} from '../src/utils.js'
 
+/**
+ * @typedef {import('../modules/rtdModule/index.js').RtdSubmodule} RtdSubmodule
+ * @typedef {import('../modules/rtdModule/index.js').SubmoduleConfig} SubmoduleConfig
+ * @typedef {import('../modules/rtdModule/index.js').UserConsentData} UserConsentData
+ */
+
 const SUBMODULE_NAME = 'liveintent';
 const GVLID = 148;
 

--- a/modules/liveIntentRtdProvider.js
+++ b/modules/liveIntentRtdProvider.js
@@ -1,0 +1,46 @@
+/**
+ * This module adds the LiveIntent provider to the Real Time Data module (rtdModule).
+ */
+import { submodule } from '../src/hook.js';
+import {deepAccess, deepSetValue} from '../src/utils.js'
+
+const SUBMODULE_NAME = 'liveintent';
+const GVLID = 148;
+
+/**
+ * Init
+ * @param {Object} config Module configuration
+ * @param {UserConsentData} userConsent User consent
+ * @returns true
+ */
+const init = (config, userConsent) => {
+  return true;
+}
+
+/**
+ * onBidRequest is called for each bidder during an auction and contains the bids for that bidder.
+ *
+ * @param {Object} bidRequest
+ * @param {SubmoduleConfig} config
+ * @param {UserConsentData} userConsent
+ */
+
+function onBidRequest(bidRequest, config, userConsent) {
+  bidRequest.bids.forEach(bid => {
+    const providedSegmentsFromUserId = deepAccess(bid, 'userId.lipb.segments', [])
+    if (providedSegmentsFromUserId.length > 0) {
+      const providedSegments = { name: 'liveintent.com', segment: providedSegmentsFromUserId.map(id => ({ id })) }
+      const existingData = deepAccess(bid, 'ortb2.user.data', [])
+      deepSetValue(bid, 'ortb2.user.data', existingData.concat(providedSegments))
+    }
+  })
+}
+
+export const liveIntentRtdSubmodule = {
+  name: SUBMODULE_NAME,
+  gvlid: GVLID,
+  init: init,
+  onBidRequestEvent: onBidRequest
+};
+
+submodule('realTimeData', liveIntentRtdSubmodule);

--- a/modules/liveIntentRtdProvider.md
+++ b/modules/liveIntentRtdProvider.md
@@ -1,0 +1,45 @@
+# Overview
+
+Module Name: LiveIntent Provider
+Module Type: Rtd Provider
+Maintainer: product@liveIntent.com
+
+# Description
+
+This module extracts segments from `bidRequest.userId.lipb.segments` enriched by the userID module and
+injects them in `ortb2.user.data` array entry.
+
+Please visit [LiveIntent](https://www.liveIntent.com/) for more information.
+
+# Testing
+
+To run the example and test the Rtd provider:
+
+```sh
+gulp serve --modules=appnexusBidAdapter,rtdModule,liveIntentRtdProvider,userId,liveIntentIdSystem
+```
+
+Open chrome with this URL:
+`http://localhost:9999/integrationExamples/gpt/liveIntentRtdProviderExample.html`
+
+To run the unit test:
+```sh
+gulp test --file "test/spec/modules/liveIntentRtdProvider_spec.js"
+```
+
+# Integration
+
+```bash
+gulp build --modules=userId,liveIntentIdSystem,rtdModule,liveIntentRtdProvider
+```
+
+```javascript
+pbjs.setConfig({
+  realTimeData: {
+    dataProviders:[{
+      name: 'liveintent',
+      waitForIt: true
+    }]
+  }
+});
+```

--- a/test/spec/modules/liveIntentExternalIdSystem_spec.js
+++ b/test/spec/modules/liveIntentExternalIdSystem_spec.js
@@ -269,11 +269,6 @@ describe('LiveIntentExternalId', function() {
     expect(window.liQHub).to.have.length(1) // instead of 2
   });
 
-  it('should not return a decoded identifier when the unifiedId is not present in the value', function() {
-    const result = liveIntentExternalIdSubmodule.decode({ fireEventDelay: 1, additionalData: 'data' });
-    expect(result).to.be.eql({});
-  });
-
   it('should decode a unifiedId to lipbId and remove it', function() {
     const result = liveIntentExternalIdSubmodule.decode({ unifiedId: 'data' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'data'}});
@@ -316,6 +311,11 @@ describe('LiveIntentExternalId', function() {
     })
   });
 
+  it('should decode values with the segments but no nonId', function() {
+    const result = liveIntentExternalIdSubmodule.decode({segments: ['tak']}, { params: defaultConfigParams });
+    expect(result).to.eql({'lipb': {'segments': ['tak']}});
+  });
+
   it('should decode a uid2 to a separate object when present', function() {
     const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', uid2: 'bar' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'uid2': 'bar'}, 'uid2': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
@@ -323,7 +323,7 @@ describe('LiveIntentExternalId', function() {
 
   it('should decode values with uid2 but no nonId', function() {
     const result = liveIntentExternalIdSubmodule.decode({ uid2: 'bar' }, defaultConfigParams);
-    expect(result).to.eql({'uid2': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+    expect(result).to.eql({'lipb': {'uid2': 'bar'}, 'uid2': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
   it('should decode a bidswitch id to a separate object when present', function() {
@@ -459,5 +459,10 @@ describe('LiveIntentExternalId', function() {
   it('should decode a vidazoo id to a separate object when present', function() {
     const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar'}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
+  it('should decode the segments as part of lipb', function() {
+    const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', 'segments': ['bar'] }, { params: defaultConfigParams });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'segments': ['bar']}});
   });
 });

--- a/test/spec/modules/liveIntentIdMinimalSystem_spec.js
+++ b/test/spec/modules/liveIntentIdMinimalSystem_spec.js
@@ -49,11 +49,6 @@ describe('LiveIntentMinimalId', function() {
     expect(server.requests[0]).to.eql(undefined)
   });
 
-  it('should not return a decoded identifier when the unifiedId is not present in the value', function() {
-    const result = liveIntentIdSubmodule.decode({ additionalData: 'data' });
-    expect(result).to.be.eql({});
-  });
-
   it('should initialize LiveConnect and send no data', function() {
     liveIntentIdSubmodule.getId(defaultConfigParams);
     liveIntentIdSubmodule.decode({}, defaultConfigParams);
@@ -245,6 +240,11 @@ describe('LiveIntentMinimalId', function() {
     expect(callBackSpy.calledOnce).to.be.true;
   });
 
+  it('should decode values with the segments but no nonId', function() {
+    const result = liveIntentIdSubmodule.decode({segments: ['tak']}, { params: defaultConfigParams });
+    expect(result).to.eql({'lipb': {'segments': ['tak']}});
+  });
+
   it('should decode a uid2 to a separate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', uid2: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'uid2': 'bar'}, 'uid2': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
@@ -252,7 +252,7 @@ describe('LiveIntentMinimalId', function() {
 
   it('should decode values with uid2 but no nonId', function() {
     const result = liveIntentIdSubmodule.decode({ uid2: 'bar' });
-    expect(result).to.eql({'uid2': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+    expect(result).to.eql({'lipb': {'uid2': 'bar'}, 'uid2': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
   it('should decode a bidswitch id to a separate object when present', function() {
@@ -327,5 +327,10 @@ describe('LiveIntentMinimalId', function() {
   it('should decode a vidazoo id to a separate object when present', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar' });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar'}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
+  it('should decode the segments as part of lipb', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', 'segments': ['bar'] }, { params: defaultConfigParams });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'segments': ['bar']}});
   });
 });

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -188,11 +188,6 @@ describe('LiveIntentId', function() {
     }, 300);
   });
 
-  it('should not return a decoded identifier when the unifiedId is not present in the value', function() {
-    const result = liveIntentIdSubmodule.decode({ params: { fireEventDelay: 1, additionalData: 'data' } });
-    expect(result).to.be.eql({});
-  });
-
   it('should fire an event when decode', function(done) {
     liveIntentIdSubmodule.decode({}, { params: defaultConfigParams });
     setTimeout(() => {
@@ -422,9 +417,14 @@ describe('LiveIntentId', function() {
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'uid2': 'bar'}, 'uid2': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
+  it('should decode values with the segments but no nonId', function() {
+    const result = liveIntentIdSubmodule.decode({segments: ['tak']}, { params: defaultConfigParams });
+    expect(result).to.eql({'lipb': {'segments': ['tak']}});
+  });
+
   it('should decode values with uid2 but no nonId', function() {
     const result = liveIntentIdSubmodule.decode({ uid2: 'bar' }, { params: defaultConfigParams });
-    expect(result).to.eql({'uid2': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+    expect(result).to.eql({'lipb': {'uid2': 'bar'}, 'uid2': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
   it('should decode a bidswitch id to a separate object when present', function() {
@@ -467,6 +467,13 @@ describe('LiveIntentId', function() {
     refererInfoStub.returns({domain: provider})
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', thetradedesk: 'bar' }, { params: defaultConfigParams });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'tdid': 'bar'}, 'tdid': {'id': 'bar', 'ext': {'rtiPartner': 'TDID', 'provider': provider}}});
+  });
+
+  it('should decode the segments as part of lipb', function() {
+    const provider = 'liveintent.com'
+    refererInfoStub.returns({domain: provider})
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', 'segments': ['bar'] }, { params: defaultConfigParams });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'segments': ['bar']}});
   });
 
   it('should allow disabling nonId resolution', function() {

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -470,8 +470,6 @@ describe('LiveIntentId', function() {
   });
 
   it('should decode the segments as part of lipb', function() {
-    const provider = 'liveintent.com'
-    refererInfoStub.returns({domain: provider})
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', 'segments': ['bar'] }, { params: defaultConfigParams });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'segments': ['bar']}});
   });

--- a/test/spec/modules/liveIntentRtdProvider_spec.js
+++ b/test/spec/modules/liveIntentRtdProvider_spec.js
@@ -1,0 +1,116 @@
+import {liveIntentRtdSubmodule} from 'modules/liveIntentRtdProvider.js';
+import * as utils from 'src/utils.js';
+import { expect } from 'chai';
+
+describe('LiveIntent Rtd Provider', function () {
+  const SUBMODULE_NAME = 'liveintent';
+
+  describe('submodule `init`', function () {
+    const config = {
+      name: SUBMODULE_NAME,
+    };
+    it('init returns true when the subModuleName is defined', function () {
+      const value = liveIntentRtdSubmodule.init(config);
+      expect(value).to.equal(true);
+    });
+  })
+
+  describe('submodule `onBidRequestEvent`', function () {
+    const bidRequestExample = {
+      bidderCode: 'appnexus',
+      auctionId: '8dbd7cb1-7f6d-4f84-946c-d0df4837234a',
+      bidderRequestId: '2a038c6820142b',
+      bids: [
+        {
+        	bidder: 'appnexus',
+        	userId: {
+        		lipb: {
+        			segments: [
+        				'asa_1231',
+        				'lalo_4311',
+        				'liurl_99123'
+        			]
+        		}
+        	}
+        }
+      ]
+    }
+
+    it('exists', function () {
+      expect(liveIntentRtdSubmodule.onBidRequestEvent).to.be.a('function');
+    });
+
+    it('undefined segments field does not change the ortb2', function() {
+      const bidRequest = {
+        bidderCode: 'appnexus',
+        auctionId: '8dbd7cb1-7f6d-4f84-946c-d0df4837234a',
+        bidderRequestId: '2a038c6820142b',
+        bids: [
+          {
+            	bidder: 'appnexus',
+            	ortb2: {}
+          }
+        ]
+      }
+
+      liveIntentRtdSubmodule.onBidRequestEvent(bidRequest);
+      const ortb2 = bidRequest.bids[0].ortb2;
+      expect(ortb2).to.deep.equal({});
+    });
+
+    it('extracts segments and move them to the bidRequest.ortb2.user.data when the ortb2 is undefined', function() {
+      const bidRequest = utils.deepClone(bidRequestExample);
+
+      liveIntentRtdSubmodule.onBidRequestEvent(bidRequest);
+      const ortb2 = bidRequest.bids[0].ortb2;
+      const expectedOrtb2 = {user: {data: [{name: 'liveintent.com', segment: [{id: 'asa_1231'}, {id: 'lalo_4311'}, {id: 'liurl_99123'}]}]}}
+      expect(ortb2).to.deep.equal(expectedOrtb2);
+    });
+
+    it('extracts segments and move them to the bidRequest.ortb2.user.data when user is undefined', function() {
+      bidRequestExample.bids[0].ortb2 = { source: {} }
+      const bidRequest = utils.deepClone(bidRequestExample);
+
+      liveIntentRtdSubmodule.onBidRequestEvent(bidRequest);
+      const ortb2 = bidRequest.bids[0].ortb2;
+      const expectedOrtb2 = {source: {}, user: {data: [{name: 'liveintent.com', segment: [{id: 'asa_1231'}, {id: 'lalo_4311'}, {id: 'liurl_99123'}]}]}}
+      expect(ortb2).to.deep.equal(expectedOrtb2);
+    });
+
+    it('extracts segments and move them to the bidRequest.ortb2.user.data when data is undefined', function() {
+      bidRequestExample.bids[0].ortb2 = {
+        source: {},
+        user: {}
+      }
+      const bidRequest = utils.deepClone(bidRequestExample);
+
+      liveIntentRtdSubmodule.onBidRequestEvent(bidRequest);
+      const ortb2 = bidRequest.bids[0].ortb2;
+      const expectedOrtb2 = {source: {}, user: {data: [{name: 'liveintent.com', segment: [{id: 'asa_1231'}, {id: 'lalo_4311'}, {id: 'liurl_99123'}]}]}}
+      expect(ortb2).to.deep.equal(expectedOrtb2);
+    });
+
+    it('extracts segments and move them to the bidRequest.ortb2.user.data with the existing data', function() {
+      bidRequestExample.bids[0].ortb2 = {
+        source: {},
+        user: {
+          data: [
+            {
+              name: 'example.com',
+              segment: [
+                { id: 'a_1231' },
+                { id: 'b_4311' }
+              ]
+            }
+          ]
+        }
+      }
+      const bidRequest = utils.deepClone(bidRequestExample);
+
+      liveIntentRtdSubmodule.onBidRequestEvent(bidRequest);
+      const ortb2 = bidRequest.bids[0].ortb2;
+      const expectedOrtb2 = {source: {}, user: {data: [{name: 'example.com', segment: [{id: 'a_1231'}, {id: 'b_4311'}]}, {name: 'liveintent.com', segment: [{id: 'asa_1231'}, {id: 'lalo_4311'}, {id: 'liurl_99123'}]}]}}
+      expect(ortb2).to.deep.equal(expectedOrtb2);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
New Rtd Provider for LiveIntent. 
This module extracts segments from `bidRequest.userId.lipb.segments` enriched by the userID module and
injects them in `ortb2.user.data` array entry.

* Documentation PR: https://github.com/prebid/prebid.github.io/pull/5795
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
There is an additional change in this PR in the liveIntentIdSystem, we collect the identifiers in lipb even if the `nonId` is undefined.