### PR TITLE
symitriDapRtdProvider - Enable X2 Tokenize endpoint

### DIFF
--- a/modules/symitriDapRtdProvider.js
+++ b/modules/symitriDapRtdProvider.js
@@ -663,6 +663,7 @@ export function createRtdProvider(moduleName, moduleCode, headerPrefix) {
       switch (config.api_version) {
         case 'x1':
         case 'x1-dev':
+        case 'x2':
           method = 'POST';
           path = '/data-activation/' + config.api_version + '/domain/' + config.domain + '/identity/tokenize';
           body = JSON.stringify(apiParams);
@@ -685,6 +686,7 @@ export function createRtdProvider(moduleName, moduleCode, headerPrefix) {
           switch (config.api_version) {
             case 'x1':
             case 'x1-dev':
+            case 'x2':
               token = request.getResponseHeader(headerPrefix + '-DAP-Token');
               break;
           }
@@ -744,8 +746,7 @@ export function createRtdProvider(moduleName, moduleCode, headerPrefix) {
         return;
       }
 
-      let path = '/data-activation/' +
-        config.api_version +
+      let path = '/data-activation/x1' +
         '/token/' + token +
         '/membership';
 
@@ -812,8 +813,7 @@ export function createRtdProvider(moduleName, moduleCode, headerPrefix) {
         error: (error, request) => { onError(request, request.status, error, onDone); }
       };
 
-      let path = '/data-activation/' +
-        config.api_version +
+      let path = '/data-activation/x1' +
         '/token/' + token +
         '/membership/encrypt';
 

--- a/modules/symitriDapRtdProvider.md
+++ b/modules/symitriDapRtdProvider.md
@@ -42,7 +42,7 @@ pbjs.setConfig({
         waitForIt: true,
         params: {
           apiHostname: '<see your Symitri account rep>',
-          apiVersion: "x1",
+          apiVersion: 'x1'|'x2',
           apiAuthToken: '<see your Symitri account rep>',
           domain: 'your-domain.com',
           identityType: 'simpleid'|'compositeid'|'hashedid'|'dap-signature:1.0.0',
@@ -68,7 +68,7 @@ Please reach out to your Symitri account representative(<Prebid@symitri.com>) to
 | name | String | Symitri Dap Rtd module name | 'symitriDap' always|
 | waitForIt | Boolean | Required to ensure that the auction is delayed until prefetch is complete | Optional. Defaults to false |
 | apiHostname | String | Hostname provided by Symitri | Please reach out to your Symitri account representative(<Prebid@symitri.com>) for this value|
-| apiVersion | String | This holds the API version | It should be "x1" always |
+| apiVersion | String | This holds the API version | Please reach out to your Symitri account representative(<Prebid@symitri.com>) for this value |
 | apiAuthToken | String | Symitri API AuthToken | Please reach out to your Symitri account representative(<Prebid@symitri.com>) for this value |
 | domain | String | The domain name of your webpage | |
 | identityType | String | 'simpleid' or 'compositeid' or 'hashedid' or 'dap-signature:1.0.0' | Use 'simpleid' to pass email or other plain text ids and SymitriRTD Module will hash it.

--- a/test/spec/modules/symitriDapRtdProvider_spec.js
+++ b/test/spec/modules/symitriDapRtdProvider_spec.js
@@ -74,6 +74,14 @@ describe('symitriDapRtdProvider', function() {
     'identity': sampleIdentity
   }
 
+  const sampleX2Config = {
+    'api_hostname': 'prebid.dap.akadns.net',
+    'api_version': 'x2',
+    'domain': 'prebid.org',
+    'segtax': 708,
+    'identity': sampleIdentity
+  }
+
   const esampleConfig = {
     'api_hostname': 'prebid.dap.akadns.net',
     'api_version': 'x1',
@@ -248,6 +256,34 @@ describe('symitriDapRtdProvider', function() {
 
     it('dapTokenize success callback', function () {
       let configAsync = JSON.parse(JSON.stringify(sampleConfig));
+      let submoduleCallback = dapUtils.dapTokenize(configAsync, sampleIdentity, onDone,
+        function(token, status, xhr, onDone) {
+        },
+        function(xhr, status, error, onDone) {
+        }
+      );
+      let request = server.requests[0];
+      request.respond(200, responseHeader, JSON.stringify('success'));
+      expect(submoduleCallback).to.equal(undefined);
+    });
+  });
+
+  describe('dapX2Tokenize', function () {
+    it('dapX2Tokenize error callback', function () {
+      let configAsync = JSON.parse(JSON.stringify(sampleX2Config));
+      let submoduleCallback = dapUtils.dapTokenize(configAsync, sampleIdentity, onDone,
+        function(token, status, xhr, onDone) {
+        },
+        function(xhr, status, error, onDone) {
+        }
+      );
+      let request = server.requests[0];
+      request.respond(400, responseHeader, JSON.stringify('error'));
+      expect(submoduleCallback).to.equal(undefined);
+    });
+
+    it('dapX2Tokenize success callback', function () {
+      let configAsync = JSON.parse(JSON.stringify(sampleX2Config));
       let submoduleCallback = dapUtils.dapTokenize(configAsync, sampleIdentity, onDone,
         function(token, status, xhr, onDone) {
         },


### PR DESCRIPTION

## Type of change
- [x] Feature

## Description of change
We are making our new X2 Tokenize endpoint available for clients that so choose to use it. This change allows clients to alter the api_version in their config to use either `x1` or `x2`. The X1 Tokenize endpoint is still available for clients that do not wish to, or need to switch.

Additionally all clients will still use our X1 Membership endpoint regardless of the api_version setting. 

