### PR TITLE
IX Bid Adapter: fix request options field [PB-3461]

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -753,6 +753,7 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
         data: deepClone(r),
         options: {
           contentType: 'text/plain',
+          withCredentials: true
         },
         validBidRequests
       });

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -751,7 +751,7 @@ function buildRequest(validBidRequests, bidderRequest, impressions, version) {
         method: 'POST',
         url: exchangeUrl,
         data: deepClone(r),
-        option: {
+        options: {
           contentType: 'text/plain',
         },
         validBidRequests

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -2088,7 +2088,6 @@ describe('IndexexchangeAdapter', function () {
     it('request should be made to IX endpoint with POST method and siteId in query param', function () {
       expect(requestMethod).to.equal('POST');
       expect(requestUrl).to.equal(IX_SECURE_ENDPOINT + '?s=' + DEFAULT_BANNER_VALID_BID[0].params.siteId);
-
     });
 
     it('request made to IX endpoint with POST method should have correct options fields set', function () {

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -2088,7 +2088,7 @@ describe('IndexexchangeAdapter', function () {
     it('request should be made to IX endpoint with POST method and siteId in query param', function () {
       expect(requestMethod).to.equal('POST');
       expect(requestUrl).to.equal(IX_SECURE_ENDPOINT + '?s=' + DEFAULT_BANNER_VALID_BID[0].params.siteId);
-      expect(request.option.contentType).to.equal('text/plain')
+      expect(request.options.contentType).to.equal('text/plain')
     });
 
     it('auction type should be set correctly', function () {

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -5429,6 +5429,5 @@ describe('IndexexchangeAdapter', function () {
       expect(fetchOptions.headers['Content-Type']).to.equal('text/plain');
     });
   });
-
 });
 

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -5430,4 +5430,3 @@ describe('IndexexchangeAdapter', function () {
     });
   });
 });
-

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -2088,7 +2088,12 @@ describe('IndexexchangeAdapter', function () {
     it('request should be made to IX endpoint with POST method and siteId in query param', function () {
       expect(requestMethod).to.equal('POST');
       expect(requestUrl).to.equal(IX_SECURE_ENDPOINT + '?s=' + DEFAULT_BANNER_VALID_BID[0].params.siteId);
+
+    });
+
+    it('request made to IX endpoint with POST method should have correct options fields set', function () {
       expect(request.options.contentType).to.equal('text/plain')
+      expect(request.options.withCredentials).to.equal(true)
     });
 
     it('auction type should be set correctly', function () {

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -5007,6 +5007,7 @@ describe('IndexexchangeAdapter', function () {
       expect(result['b8c6b5d5-76a1-4a90-b635-0c7eae1bfaa7'].ixImps.length).to.equal(1);
     });
   });
+
   describe('apply floors test', function () {
     it('video test', function() {
       const bid = utils.deepClone(DEFAULT_VIDEO_VALID_BID[0]);
@@ -5371,6 +5372,7 @@ describe('IndexexchangeAdapter', function () {
       expect(removeSiteIDs(request)).to.deep.equal(expected);
     });
   });
+
   describe('addDeviceInfo', () => {
     it('should add device to request when device already exists', () => {
       let r = {
@@ -5389,4 +5391,44 @@ describe('IndexexchangeAdapter', function () {
       expect(r.device.h).to.exist;
     });
   });
+
+  describe('fetch requests', function () {
+    let fetchStub;
+
+    beforeEach(() => {
+      fetchStub = sinon.stub(window, 'fetch');
+    });
+
+    afterEach(() => {
+      fetchStub.restore();
+    });
+
+    it('should send the correct headers in the actual fetch call', async function () {
+      const requests = spec.buildRequests(DEFAULT_BANNER_VALID_BID, DEFAULT_OPTION);
+
+      requests.forEach((request) => {
+        fetch(request.url, {
+          method: request.method,
+          headers: {
+            'Content-Type': request.options.contentType,
+          },
+          credentials: request.options.withCredentials ? 'include' : 'omit',
+          body: JSON.stringify(request.data),
+        });
+      });
+
+      sinon.assert.called(fetchStub);
+
+      const fetchArgs = fetchStub.getCall(0).args;
+      const fetchUrl = fetchArgs[0];
+      const fetchOptions = fetchArgs[1];
+
+      expect(fetchUrl).to.equal(requests[0].url);
+      expect(fetchOptions.method).to.equal('POST');
+      expect(fetchOptions.credentials).to.equal('include');
+      expect(fetchOptions.headers['Content-Type']).to.equal('text/plain');
+    });
+  });
+
 });
+

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -5412,7 +5412,7 @@ describe('IndexexchangeAdapter', function () {
           headers: {
             'Content-Type': request.options.contentType,
           },
-          credentials: request.options.withCredentials ? 'include' : 'omit',
+          credentials: request.options.withCredentials,
           body: JSON.stringify(request.data),
         });
       });
@@ -5425,7 +5425,7 @@ describe('IndexexchangeAdapter', function () {
 
       expect(fetchUrl).to.equal(requests[0].url);
       expect(fetchOptions.method).to.equal('POST');
-      expect(fetchOptions.credentials).to.equal('include');
+      expect(fetchOptions.credentials).to.equal(true);
       expect(fetchOptions.headers['Content-Type']).to.equal('text/plain');
     });
   });

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -5412,7 +5412,7 @@ describe('IndexexchangeAdapter', function () {
           headers: {
             'Content-Type': request.options.contentType,
           },
-          credentials: request.options.withCredentials,
+          credentials: request.options.withCredentials ? 'include' : 'omit',
           body: JSON.stringify(request.data),
         });
       });
@@ -5425,7 +5425,7 @@ describe('IndexexchangeAdapter', function () {
 
       expect(fetchUrl).to.equal(requests[0].url);
       expect(fetchOptions.method).to.equal('POST');
-      expect(fetchOptions.credentials).to.equal(true);
+      expect(fetchOptions.credentials).to.equal('include');
       expect(fetchOptions.headers['Content-Type']).to.equal('text/plain');
     });
   });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
- Fixes requests options field.
- Does not affect users

## Other information
For more information please contact shahin.rahbariasl@indexexchange.com
