### PR TITLE
bidCPMAdjustment: Convert currency code along with CPM adjustment

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -908,10 +908,11 @@ function setKeys(keyValues, bidderSettings, custBidObj, bidReq) {
 }
 
 export function adjustBids(bid) {
-  let bidPriceAdjusted = adjustCpm(bid.cpm, bid);
+  let bidPriceAdjusted = adjustCpm(bid, bid);
 
-  if (bidPriceAdjusted >= 0) {
-    bid.cpm = bidPriceAdjusted;
+  if (bidPriceAdjusted.cpm >= 0) {
+    bid.cpm = bidPriceAdjusted.cpm;
+    bid.currency = bidPriceAdjusted.currency
   }
 }
 


### PR DESCRIPTION
However, this change updates the behavior to allow passing the entire bid object. With this enhancement, not only will the bid.cpm be adjusted, but the bid's currency code will also be updated, as demonstrated in the Prebid Professor extension.

Previously, bidCPMAdjustment only adjusted the CPM value but did not account for changes to the currency code. This enhancement addresses that limitation. 

Although currency module solves this problem, but teams who still prefer bidcpmadjustment for various reasons should get this change