### PR TITLE
UserID: allow any contents in EIDs

### DIFF
--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -1,4 +1,4 @@
-import {deepClone, isFn, isStr} from '../../src/utils.js';
+import {logError, deepClone, isFn, isStr} from '../../src/utils.js';
 
 /**
  * @typedef {import('./index.js').SubmodulePriorityMap} SubmodulePriorityMap
@@ -38,7 +38,10 @@ function createEidObject(userIdData, subModuleKey, eidConf) {
 export function createEidsArray(bidRequestUserId, eidConfigs = EID_CONFIG) {
   const allEids = {};
   function collect(eid) {
-    const key = JSON.stringify([eid.source?.toLowerCase(), eid.ext]);
+    const key = JSON.stringify([
+      eid.source?.toLowerCase(),
+      ...Object.keys(eid).filter(k => !['uids', 'source'].includes(k)).sort().map(k => eid[k])
+    ]);
     if (allEids.hasOwnProperty(key)) {
       allEids[key].uids.push(...eid.uids);
     } else {
@@ -48,8 +51,25 @@ export function createEidsArray(bidRequestUserId, eidConfigs = EID_CONFIG) {
 
   Object.entries(bidRequestUserId).forEach(([name, values]) => {
     values = Array.isArray(values) ? values : [values];
-    const eids = name === 'pubProvidedId' ? deepClone(values) : values.map(value => createEidObject(value, name, eidConfigs.get(name)));
-    eids.filter(eid => eid != null).forEach(collect);
+    const eidConf = eidConfigs.get(name);
+    let eids;
+    if (name === 'pubProvidedId') {
+      eids = deepClone(values);
+    } else if (typeof eidConf === 'function') {
+      try {
+        eids = eidConf(values);
+        if (!Array.isArray(eids)) {
+          eids = [eids];
+        }
+      } catch (e) {
+        logError(`Could not generate EID for "${name}"`, e);
+      }
+    } else {
+      eids = values.map(value => createEidObject(value, name, eidConf));
+    }
+    if (Array.isArray(eids)) {
+      eids.filter(eid => eid != null).forEach(collect);
+    }
   })
   return Object.values(allEids);
 }
@@ -64,7 +84,12 @@ export function getEids(priorityMap) {
     const submodule = submodules.find(mod => mod.idObj?.[key] != null);
     if (submodule) {
       idValues[key] = submodule.idObj[key];
-      eidConfigs.set(key, submodule.submodule.eids?.[key])
+      let eidConf = submodule.submodule.eids?.[key];
+      if (typeof eidConf === 'function') {
+        // if eid config is given as a function, append the active module configuration to its args
+        eidConf = ((orig) => (...args) => orig(...args, submodule.config))(eidConf);
+      }
+      eidConfigs.set(key, eidConf);
     }
   })
   return createEidsArray(idValues, eidConfigs);


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change

This allows ID modules to provide a single EID generation function instead of current mix (`getValue`, `getUidExt`, etc), which in turn also enables them to fill in some currently unsupported fields (`inserter`, `matcher` and `mm`).

The function is passed two arguments `(values, config)` and should return one or more EID objects. `values` is an array with IDs as returned by the submodule's `decode`, and `config` is the module's configuration.

For example, a definition like https://github.com/prebid/Prebid.js/blob/ea87c0e78eedb6d87f0dd50d9688e9b22add0118/libraries/liveIntentId/shared.js#L135-L148

could be translated like so:

```javascript
    libp(values) {
        return values.map(data => {
            const eid = {
                source: 'liveintent.com',
                uids: [{
                    id: data.libpid,
                    atype: 3
                }]
            }
            if (Array.isArray(data.segments) && data.segments.length) {
                eid.ext = {
                    segments: data.segments
                }
            }
            return eid;
        })
    }
```

## Other information

Related to https://github.com/prebid/Prebid.js/issues/12641
