### PR TITLE
SharedIdSystem: add configurable inserter

### DIFF
--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -183,9 +183,15 @@ export const sharedIdSystemSubmodule = {
 
   domainOverride: domainOverrideToRootDomain(storage, 'sharedId'),
   eids: {
-    'pubcid': {
-      source: 'pubcid.org',
-      atype: 1
+    'pubcid'(values, config) {
+      const eid = {
+        source: 'pubcid.org',
+        uids: values.map(id => ({id, atype: 1}))
+      }
+      if (config?.params?.inserter != null) {
+        eid.inserter = config.params.inserter;
+      }
+      return eid;
     },
   }
 };

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -61,6 +61,8 @@ export function createEidsArray(bidRequestUserId, eidConfigs = EID_CONFIG) {
         if (!Array.isArray(eids)) {
           eids = [eids];
         }
+        eids.forEach(eid => eid.uids = eid.uids.filter(({id}) => isStr(id)))
+        eids = eids.filter(({uids}) => uids?.length > 0);
       } catch (e) {
         logError(`Could not generate EID for "${name}"`, e);
       }

--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -1,10 +1,12 @@
 import {sharedIdSystemSubmodule, storage} from 'modules/sharedIdSystem.js';
 import {coppaDataHandler} from 'src/adapterManager';
+import {config} from 'src/config.js';
 
 import sinon from 'sinon';
 import * as utils from 'src/utils.js';
 import {createEidsArray} from '../../../modules/userId/eids.js';
-import {attachIdSystem} from '../../../modules/userId/index.js';
+import {attachIdSystem, init} from '../../../modules/userId/index.js';
+import {getGlobal} from '../../../src/prebidGlobal.js';
 
 let expect = require('chai').expect;
 
@@ -97,6 +99,9 @@ describe('SharedId System', function () {
     before(() => {
       attachIdSystem(sharedIdSystemSubmodule);
     });
+    afterEach(() => {
+      config.resetConfig();
+    });
     it('pubCommonId', function() {
       const userId = {
         pubcid: 'some-random-id-value'
@@ -108,5 +113,24 @@ describe('SharedId System', function () {
         uids: [{id: 'some-random-id-value', atype: 1}]
       });
     });
+
+    it('should set inserter, if provided in config', async () => {
+      config.setConfig({
+        userSync: {
+          userIds: [{
+            name: 'sharedId',
+            params: {
+              inserter: 'mock-inserter'
+            },
+            value: {pubcid: 'mock-id'}
+          }]
+        }
+      });
+      const eids = getGlobal().getUserIdsAsEids();
+      sinon.assert.match(eids[0], {
+        source: 'pubcid.org',
+        inserter: 'mock-inserter'
+      })
+    })
   })
 });

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -479,6 +479,25 @@ describe('User ID', function () {
         ]);
       });
 
+      it('should filter out non-string uid returned by generator functions', () => {
+        const eids = createEidsArray({
+          mockId2v3: [null, 'id1', 123],
+        });
+        expect(eids[0].uids).to.eql([
+          {
+            atype: 2,
+            id: 'id1'
+          }
+        ]);
+      });
+
+      it('should filter out entire EID if none of the uids are strings', () => {
+        const eids = createEidsArray({
+          mockId2v3: [null],
+        });
+        expect(eids).to.eql([]);
+      })
+
       it('should group UIDs by everything except uid', () => {
         const eids = createEidsArray({
           mockId1: ['mock-1-1', 'mock-1-2'],


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

This adds the option to set `inserter` in the EIDs generated by sharedId, taking it from `params.inserter`, e.g.

```javascript
pbjs.setConfig({
  userSync: {
    userIds: [{
      name: 'sharedId',
      params: {
        inserter: 'publisher.com'
      },
    }]
  }
});
```

## Other information

Closes https://github.com/prebid/Prebid.js/issues/12641
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
