### PR TITLE
WURFL Rtd Provider: add wurfl_id to device.ext.wurfl

### DIFF
--- a/modules/wurflRtdProvider.js
+++ b/modules/wurflRtdProvider.js
@@ -65,7 +65,7 @@ const getBidRequestData = (reqBidsConfigObj, callback, config, userConsent) => {
   }
 
   url.searchParams.set('mode', 'prebid')
-  logger.logMessage('url', url.toString());
+  url.searchParams.set('wurfl_id', 'true')
 
   try {
     loadExternalScript(url.toString(), MODULE_TYPE_RTD, MODULE_NAME, () => {
@@ -120,6 +120,9 @@ function enrichBidderRequests(reqBidsConfigObj, bidders, wjsResponse) {
  */
 export const bidderData = (wurflData, caps, filter) => {
   const data = {};
+  if ('wurfl_id' in wurflData) {
+    data['wurfl_id'] = wurflData.wurfl_id;
+  }
   caps.forEach((cap, index) => {
     if (!filter.includes(index)) {
       return;
@@ -151,6 +154,9 @@ export const lowEntropyData = (wurflData, lowEntropyCaps) => {
   }
   if ('brand_name' in wurflData) {
     data['brand_name'] = wurflData.brand_name;
+  }
+  if ('wurfl_id' in wurflData) {
+    data['wurfl_id'] = wurflData.wurfl_id;
   }
   return data;
 }

--- a/modules/wurflRtdProvider.md
+++ b/modules/wurflRtdProvider.md
@@ -9,7 +9,7 @@
 ## Description
 
 The WURFL RTD module enriches the OpenRTB 2.0 device data with [WURFL data](https://www.scientiamobile.com/wurfl-js-business-edition-at-the-intersection-of-javascript-and-enterprise/).
-The module sets the WURFL data in `device.ext.wurfl` and all the bidder adapters will always receive the low entry capabilites like `is_mobile`, `complete_device_name` and `form_factor`. 
+The module sets the WURFL data in `device.ext.wurfl` and all the bidder adapters will always receive the low entry capabilities like `is_mobile`, `complete_device_name` and `form_factor`, and the `wurfl_id`.
 
 For a more detailed analysis bidders can subscribe to detect iPhone and iPad models and receive additional [WURFL device capabilities](https://www.scientiamobile.com/capabilities/?products%5B%5D=wurfl-js).
 

--- a/test/spec/modules/wurflRtdProvider_spec.js
+++ b/test/spec/modules/wurflRtdProvider_spec.js
@@ -52,7 +52,8 @@ describe('wurflRtdProvider', function () {
       pixel_density: 443,
       pointing_method: 'touchscreen',
       resolution_height: 1920,
-      resolution_width: 1080
+      resolution_width: 1080,
+      wurfl_id: 'lg_nexus5_ver1',
     };
 
     // expected analytics values
@@ -100,6 +101,7 @@ describe('wurflRtdProvider', function () {
       const expectedURL = new URL(altHost);
       expectedURL.searchParams.set('debug', true);
       expectedURL.searchParams.set('mode', 'prebid');
+      expectedURL.searchParams.set('wurfl_id', true);
 
       const callback = () => {
         const v = {
@@ -147,7 +149,8 @@ describe('wurflRtdProvider', function () {
                   pixel_density: 443,
                   pointing_method: 'touchscreen',
                   resolution_height: 1920,
-                  resolution_width: 1080
+                  resolution_width: 1080,
+                  wurfl_id: 'lg_nexus5_ver1',
                 },
               },
             },
@@ -187,7 +190,8 @@ describe('wurflRtdProvider', function () {
                   model_name: 'Nexus 5',
                   pixel_density: 443,
                   resolution_height: 1920,
-                  resolution_width: 1080
+                  resolution_width: 1080,
+                  wurfl_id: 'lg_nexus5_ver1',
                 },
               },
             },
@@ -203,6 +207,7 @@ describe('wurflRtdProvider', function () {
                   is_mobile: !0,
                   model_name: 'Nexus 5',
                   brand_name: 'Google',
+                  wurfl_id: 'lg_nexus5_ver1',
                 },
               },
             },


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->

This PR updates the WURFL Rtd Provider adding the `wurfl_id` to the `device.ext.wurfl` field

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
