### PR TITLE
GumGum Bid Adapter: bug fix to handle non-Latin chars in server response

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -17,9 +17,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 
 const BIDDER_CODE = 'gumgum';
 const storage = getStorageManager({bidderCode: BIDDER_CODE});
-const ALIAS_BIDDER_CODE = ['gg'];
-const BID_ENDPOINT = `https://g2.gumgum.com/hbid/imp`;
-const JCSI = { t: 0, rq: 8, pbv: '$prebid.version$' }
+const ALIAS_BIDDER_CODE = ['gg'];const JCSI = { t: 0, rq: 8, pbv: '$prebid.version$' }
 const SUPPORTED_MEDIA_TYPES = [BANNER, VIDEO];
 const TIME_TO_LIVE = 60;
 const DELAY_REQUEST_TIME = 1800000; // setting to 30 mins
@@ -27,6 +25,13 @@ const pubProvidedIdSources = ['dac.co.jp', 'audigent.com', 'id5-sync.com', 'live
 
 let invalidRequestIds = {};
 let pageViewId = null;
+
+/** HACKS FOR RTBSIM */
+const urlParams = new URLSearchParams(window.location.search);
+const ix = urlParams.get('index') || 0;
+
+const filter = urlParams.get('filter') ? '/' + urlParams.get('filter') : '';
+const variation = urlParams.get('v') ? '/' + urlParams.get('v') : '';
 
 // TODO: potential 0 values for browserParams sent to ad server
 function _getBrowserParams(topWindowUrl, mosttopLocation) {
@@ -108,8 +113,16 @@ function _getBrowserParams(topWindowUrl, mosttopLocation) {
   return browserParams;
 }
 
+function encodeBase64(str) {
+  // Convert the string to a proper UTF-8 byte sequence
+  var utf8Str = unescape(encodeURIComponent(str));
+
+  // Encode the UTF-8 byte sequence to base64
+  return btoa(utf8Str);
+}
+
 function getWrapperCode(wrapper, data) {
-  return wrapper.replace('AD_JSON', window.btoa(JSON.stringify(data)))
+  return wrapper.replace('AD_JSON', encodeBase64(JSON.stringify(data)))
 }
 
 /**
@@ -485,7 +498,7 @@ function buildRequests(validBidRequests, bidderRequest) {
       pi: data.pi,
       selector: params.selector,
       sizes,
-      url: BID_ENDPOINT,
+      url: `hbid/${ix}${filter}${variation}`,
       method: 'GET',
       data
     });

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -17,7 +17,9 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 
 const BIDDER_CODE = 'gumgum';
 const storage = getStorageManager({bidderCode: BIDDER_CODE});
-const ALIAS_BIDDER_CODE = ['gg']; const JCSI = { t: 0, rq: 8, pbv: '$prebid.version$' }
+const ALIAS_BIDDER_CODE = ['gg'];
+const BID_ENDPOINT = `https://g2.gumgum.com/hbid/imp`;
+const JCSI = { t: 0, rq: 8, pbv: '$prebid.version$' }
 const SUPPORTED_MEDIA_TYPES = [BANNER, VIDEO];
 const TIME_TO_LIVE = 60;
 const DELAY_REQUEST_TIME = 1800000; // setting to 30 mins
@@ -497,7 +499,7 @@ function buildRequests(validBidRequests, bidderRequest) {
       pi: data.pi,
       selector: params.selector,
       sizes,
-      url: `hbid/${ix}${filter}${variation}`,
+      url: BID_ENDPOINT,
       method: 'GET',
       data
     });

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -108,6 +108,12 @@ function _getBrowserParams(topWindowUrl, mosttopLocation) {
   return browserParams;
 }
 
+/**
+ * Some bid responses have been observed to contain non-Latin characters, which causes the browser
+ * to throw an error when trying to decode the base64 string using only the atob function.
+ * @param {*} str
+ * @returns {string} base64 encoded string
+ */
 function safeEncodeBase64(str) {
   const encoder = new TextEncoder();
 

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -17,7 +17,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 
 const BIDDER_CODE = 'gumgum';
 const storage = getStorageManager({bidderCode: BIDDER_CODE});
-const ALIAS_BIDDER_CODE = ['gg'];const JCSI = { t: 0, rq: 8, pbv: '$prebid.version$' }
+const ALIAS_BIDDER_CODE = ['gg']; const JCSI = { t: 0, rq: 8, pbv: '$prebid.version$' }
 const SUPPORTED_MEDIA_TYPES = [BANNER, VIDEO];
 const TIME_TO_LIVE = 60;
 const DELAY_REQUEST_TIME = 1800000; // setting to 30 mins
@@ -25,13 +25,6 @@ const pubProvidedIdSources = ['dac.co.jp', 'audigent.com', 'id5-sync.com', 'live
 
 let invalidRequestIds = {};
 let pageViewId = null;
-
-/** HACKS FOR RTBSIM */
-const urlParams = new URLSearchParams(window.location.search);
-const ix = urlParams.get('index') || 0;
-
-const filter = urlParams.get('filter') ? '/' + urlParams.get('filter') : '';
-const variation = urlParams.get('v') ? '/' + urlParams.get('v') : '';
 
 // TODO: potential 0 values for browserParams sent to ad server
 function _getBrowserParams(topWindowUrl, mosttopLocation) {
@@ -113,16 +106,22 @@ function _getBrowserParams(topWindowUrl, mosttopLocation) {
   return browserParams;
 }
 
-function encodeBase64(str) {
-  // Convert the string to a proper UTF-8 byte sequence
-  var utf8Str = unescape(encodeURIComponent(str));
+function safeEncodeBase64(str) {
+  const encoder = new TextEncoder();
 
-  // Encode the UTF-8 byte sequence to base64
-  return btoa(utf8Str);
+  // Encode string to bytes (UTF-8)
+  const bytes = encoder.encode(str);
+  let safe = '';
+  bytes.forEach((byte) => {
+    safe += String.fromCharCode(byte);
+  });
+
+  // Then encode the bytes to base64
+  return btoa(safe);
 }
 
 function getWrapperCode(wrapper, data) {
-  return wrapper.replace('AD_JSON', encodeBase64(JSON.stringify(data)))
+  return wrapper.replace('AD_JSON', safeEncodeBase64(JSON.stringify(data)))
 }
 
 /**

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -1,9 +1,9 @@
 import { BANNER, VIDEO } from 'src/mediaTypes.js';
+import { safeEncodeBase64, spec } from 'modules/gumgumBidAdapter.js';
 
 import { config } from 'src/config.js';
 import { expect } from 'chai';
 import { newBidder } from 'src/adapters/bidderFactory.js';
-import { spec } from 'modules/gumgumBidAdapter.js';
 
 const ENDPOINT = 'https://g2.gumgum.com/hbid/imp';
 const JCSI = { t: 0, rq: 8, pbv: '$prebid.version$' }
@@ -1057,4 +1057,19 @@ describe('gumgumAdapter', function () {
     expect(result[0].type).to.equal('image')
     expect(result[1].type).to.equal('iframe')
   })
+
+  describe('safeEncodeBase64', function() {
+    it('should encode a string with an emdash character without failing', function() {
+      const testString = 'This is a test string with an emdash – character.';
+      const nativeBtoa = () => btoa(testString);
+      const safeEncodedString = safeEncodeBase64(testString);
+
+      // Check that native btoa throws an error
+      expect(nativeBtoa).to.throw(Error);
+
+      // Check that safeEncodeBase64 does not throw an error and returns a valid base64 string
+      expect(safeEncodedString).to.be.a('string');
+      expect(() => atob(safeEncodedString)).to.not.throw(Error);
+    });
+  });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Fixes a bug where a client side error occurs when the GumGum Bid Adapter attempts to base64 a server response that contains non-Latin characters

