### PR TITLE
LiveIntent ID Module: Bump live-connect dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "fun-hooks": "^0.9.9",
         "gulp-wrap": "^0.15.0",
         "klona": "^2.0.6",
-        "live-connect-js": "^7.1.0"
+        "live-connect-js": "^7.2.0"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.16.5",
@@ -18209,9 +18209,10 @@
       }
     },
     "node_modules/live-connect-js": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-7.1.0.tgz",
-      "integrity": "sha512-fFxvQjOsHkCjulWsbirjxb6Y8xuAoWdgYqZvBLoSVKry48IyvVnLfvWgJg66qENjxig+8RH9bvlE16I6hJ7J7Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-7.2.0.tgz",
+      "integrity": "sha512-oZY4KqwrG1C+CDKApcsdDdMG4j2d44lhmvbNy4ZE6sPFr+W8R3m0+V+JxXB8p6tgSePJ8X/uhzAGos0lDg/MAg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "live-connect-common": "^v4.1.0",
         "tiny-hashes": "1.0.1"
@@ -41730,9 +41731,9 @@
       "integrity": "sha512-sRklgbe13377aR+G0qCBiZPayQw5oZZozkuxKEoyipxscLbVzwe9gtA7CPpbmo6UcOdQxdCE6A7J1tI0wTSmqw=="
     },
     "live-connect-js": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-7.1.0.tgz",
-      "integrity": "sha512-fFxvQjOsHkCjulWsbirjxb6Y8xuAoWdgYqZvBLoSVKry48IyvVnLfvWgJg66qENjxig+8RH9bvlE16I6hJ7J7Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/live-connect-js/-/live-connect-js-7.2.0.tgz",
+      "integrity": "sha512-oZY4KqwrG1C+CDKApcsdDdMG4j2d44lhmvbNy4ZE6sPFr+W8R3m0+V+JxXB8p6tgSePJ8X/uhzAGos0lDg/MAg==",
       "requires": {
         "live-connect-common": "^v4.1.0",
         "tiny-hashes": "1.0.1"

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "fun-hooks": "^0.9.9",
     "gulp-wrap": "^0.15.0",
     "klona": "^2.0.6",
-    "live-connect-js": "^7.1.0"
+    "live-connect-js": "^7.2.0"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
The user ID module can be provided with an information about the user agent. The provided user agent string is sent to the backend as a header. 

This PR fixes a bug that leads to sending an additional `OPTIONS` call to the backend even when no user agent is provided. 

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
