### PR TITLE
legacy: backport WURFL Rtd Module to 8.52.x

### DIFF
--- a/integrationExamples/gpt/wurflRtdProvider_example.html
+++ b/integrationExamples/gpt/wurflRtdProvider_example.html
@@ -1,0 +1,106 @@
+<html>
+
+<head>
+    <meta http-equiv="delegate-ch" content="sec-ch-ua https://prebid.wurflcloud.com; sec-ch-ua-bitness https://prebid.wurflcloud.com; sec-ch-ua-arch https://prebid.wurflcloud.com; sec-ch-ua-model https://prebid.wurflcloud.com; sec-ch-ua-platform https://prebid.wurflcloud.com; sec-ch-ua-platform-version https://prebid.wurflcloud.com; sec-ch-ua-full-version https://prebid.wurflcloud.com; sec-ch-ua-full-version-list https://prebid.wurflcloud.com; sec-ch-ua-mobile https://prebid.wurflcloud.com">
+    <script async src="../../build/dev/prebid.js"></script>
+    <script async src="https://www.googletagservices.com/tag/js/gpt.js"></script>
+    <script>
+        var FAILSAFE_TIMEOUT = 3300;
+        var PREBID_TIMEOUT = 2000;
+
+        var adUnits = [
+        {
+            code: 'div-gpt-ad-1460505748561-0',
+            mediaTypes: {
+                banner: {
+                    sizes: [[300, 250]],
+                }
+            },
+            sizes: [
+                [300, 250],
+                [728, 90]
+            ],  
+            bids: [
+                {
+                    bidder: 'appnexus',
+                    params: {
+                      placementId: 13144370
+                    }
+                },
+            ]
+
+        }];
+
+        var pbjs = pbjs || {};
+        pbjs.que = pbjs.que || [];
+    </script>
+
+    <script>
+        var googletag = googletag || {};
+        googletag.cmd = googletag.cmd || [];
+        googletag.cmd.push(function () {
+            googletag.pubads().disableInitialLoad();
+        });
+
+        pbjs.que.push(function () {
+            // configure the WURFL RTD module
+            pbjs.setConfig({
+                debug: true, // enabled for testing purposes
+                realTimeData: {
+                    auctionDelay: 2000, 
+                    dataProviders: [
+                        // WURFL RTD module configuration
+                        {
+                            name: 'wurfl',
+                            waitForIt: true
+                        },
+                    ]
+                }
+            });
+
+            pbjs.addAdUnits(adUnits);
+
+            pbjs.requestBids({
+                bidsBackHandler: sendAdserverRequest,
+                timeout: PREBID_TIMEOUT
+            });
+        });
+
+        function sendAdserverRequest() {
+            if (pbjs.adserverRequestSent) return;
+            pbjs.adserverRequestSent = true;
+            googletag.cmd.push(function () {
+                pbjs.que.push(function () {
+                    pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+                });
+            });
+        }
+
+        setTimeout(function () {
+            sendAdserverRequest();
+        }, FAILSAFE_TIMEOUT);
+
+    </script>
+
+    <script>
+        googletag.cmd.push(function () {
+            googletag.defineSlot('/19968336/header-bid-tag-0', [[300, 250], [300, 600]], 'div-gpt-ad-1460505748561-0').addService(googletag.pubads());
+            
+            googletag.pubads().enableSingleRequest();
+            googletag.enableServices();
+        });
+    </script>
+</head>
+
+<body>
+    <h2>Prebid.js Test</h2>
+    <h5>Div-1</h5>
+    <div id='div-gpt-ad-1460505748561-0'>
+        <script type='text/javascript'>
+            googletag.cmd.push(function () { googletag.display('div-gpt-ad-1460505748561-0'); });
+        </script>
+    </div>
+</body>
+
+</html>

--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -99,7 +99,8 @@
       "relevadRtdProvider",
       "sirdataRtdProvider",
       "timeoutRtdProvider",
-      "weboramaRtdProvider"
+      "weboramaRtdProvider",
+      "wurflRtdProvider"
     ],
     "fpdModule": [
       "validationFpdModule",

--- a/modules/wurflRtdProvider.js
+++ b/modules/wurflRtdProvider.js
@@ -68,7 +68,7 @@ const getBidRequestData = (reqBidsConfigObj, callback, config, userConsent) => {
   url.searchParams.set('wurfl_id', 'true')
 
   try {
-    loadExternalScript(url.toString(), MODULE_TYPE_RTD, MODULE_NAME, () => {
+    loadExternalScript(url.toString(), MODULE_NAME, () => {
       logger.logMessage('script injected');
       window.WURFLPromises.complete.then((res) => {
         logger.logMessage('received data', res);

--- a/modules/wurflRtdProvider.js
+++ b/modules/wurflRtdProvider.js
@@ -1,0 +1,292 @@
+import { submodule } from '../src/hook.js';
+import { fetch, sendBeacon } from '../src/ajax.js';
+import { loadExternalScript } from '../src/adloader.js';
+import {
+  mergeDeep,
+  prefixLog,
+} from '../src/utils.js';
+import { MODULE_TYPE_RTD } from '../src/activities/modules.js';
+
+// Constants
+const REAL_TIME_MODULE = 'realTimeData';
+const MODULE_NAME = 'wurfl';
+
+// WURFL_JS_HOST is the host for the WURFL service endpoints
+const WURFL_JS_HOST = 'https://prebid.wurflcloud.com';
+// WURFL_JS_ENDPOINT_PATH is the path for the WURFL.js endpoint used to load WURFL data
+const WURFL_JS_ENDPOINT_PATH = '/wurfl.js';
+// STATS_ENDPOINT_PATH is the path for the stats endpoint used to send analytics data
+const STATS_ENDPOINT_PATH = '/v1/prebid/stats';
+
+const logger = prefixLog('[WURFL RTD Submodule]');
+
+// enrichedBidders holds a list of prebid bidder names, of bidders which have been
+// injected with WURFL data
+const enrichedBidders = new Set();
+
+/**
+ * init initializes the WURFL RTD submodule
+ * @param {Object} config Configuration for WURFL RTD submodule
+ * @param {Object} userConsent User consent data
+ */
+const init = (config, userConsent) => {
+  logger.logMessage('initialized');
+  return true;
+}
+
+/**
+ * getBidRequestData enriches the OpenRTB 2.0 device data with WURFL data
+ * @param {Object} reqBidsConfigObj Bid request configuration object
+ * @param {Function} callback Called on completion
+ * @param {Object} config Configuration for WURFL RTD submodule
+ * @param {Object} userConsent User consent data
+ */
+const getBidRequestData = (reqBidsConfigObj, callback, config, userConsent) => {
+  const altHost = config.params?.altHost ?? null;
+  const isDebug = config.params?.debug ?? false;
+
+  const bidders = new Set();
+  reqBidsConfigObj.adUnits.forEach(adUnit => {
+    adUnit.bids.forEach(bid => {
+      bidders.add(bid.bidder);
+    });
+  });
+
+  let host = WURFL_JS_HOST;
+  if (altHost) {
+    host = altHost;
+  }
+
+  const url = new URL(host);
+  url.pathname = WURFL_JS_ENDPOINT_PATH;
+
+  if (isDebug) {
+    url.searchParams.set('debug', 'true')
+  }
+
+  url.searchParams.set('mode', 'prebid')
+  url.searchParams.set('wurfl_id', 'true')
+
+  try {
+    loadExternalScript(url.toString(), MODULE_TYPE_RTD, MODULE_NAME, () => {
+      logger.logMessage('script injected');
+      window.WURFLPromises.complete.then((res) => {
+        logger.logMessage('received data', res);
+        if (!res.wurfl_pbjs) {
+          logger.logError('invalid WURFL.js for Prebid response');
+        } else {
+          enrichBidderRequests(reqBidsConfigObj, bidders, res);
+        }
+        callback();
+      });
+    });
+  } catch (err) {
+    logger.logError(err);
+    callback();
+  }
+}
+
+/**
+ * enrichBidderRequests enriches the OpenRTB 2.0 device data with WURFL data for Business Edition
+ * @param {Object} reqBidsConfigObj Bid request configuration object
+ * @param {Array} bidders List of bidders
+ * @param {Object} wjsResponse WURFL.js response
+ */
+function enrichBidderRequests(reqBidsConfigObj, bidders, wjsResponse) {
+  const authBidders = wjsResponse.wurfl_pbjs?.authorized_bidders ?? {};
+  const caps = wjsResponse.wurfl_pbjs?.caps ?? [];
+
+  bidders.forEach((bidderCode) => {
+    if (bidderCode in authBidders) {
+      // inject WURFL data
+      enrichedBidders.add(bidderCode);
+      const data = bidderData(wjsResponse.WURFL, caps, authBidders[bidderCode]);
+      data['enrich_device'] = true;
+      enrichBidderRequest(reqBidsConfigObj, bidderCode, data);
+      return;
+    }
+    // inject WURFL low entropy data
+    const data = lowEntropyData(wjsResponse.WURFL, wjsResponse.wurfl_pbjs?.low_entropy_caps);
+    enrichBidderRequest(reqBidsConfigObj, bidderCode, data);
+  });
+}
+
+/**
+ * bidderData returns the WURFL data for a bidder
+ * @param {Object} wurflData WURFL data
+ * @param {Array} caps Capability list
+ * @param {Array} filter Filter list
+ * @returns {Object} Bidder data
+ */
+export const bidderData = (wurflData, caps, filter) => {
+  const data = {};
+  if ('wurfl_id' in wurflData) {
+    data['wurfl_id'] = wurflData.wurfl_id;
+  }
+  caps.forEach((cap, index) => {
+    if (!filter.includes(index)) {
+      return;
+    }
+    if (cap in wurflData) {
+      data[cap] = wurflData[cap];
+    }
+  });
+  return data;
+}
+
+/**
+ * lowEntropyData returns the WURFL low entropy data
+ * @param {Object} wurflData WURFL data
+ * @param {Array} lowEntropyCaps Low entropy capability list
+ * @returns {Object} Bidder data
+ */
+export const lowEntropyData = (wurflData, lowEntropyCaps) => {
+  const data = {};
+  lowEntropyCaps.forEach((cap, _) => {
+    let value = wurflData[cap];
+    if (cap == 'complete_device_name') {
+      value = value.replace(/Apple (iP(hone|ad|od)).*/, 'Apple iP$2');
+    }
+    data[cap] = value;
+  });
+  if ('model_name' in wurflData) {
+    data['model_name'] = wurflData.model_name.replace(/(iP(hone|ad|od)).*/, 'iP$2');
+  }
+  if ('brand_name' in wurflData) {
+    data['brand_name'] = wurflData.brand_name;
+  }
+  if ('wurfl_id' in wurflData) {
+    data['wurfl_id'] = wurflData.wurfl_id;
+  }
+  return data;
+}
+/**
+ * enrichBidderRequest enriches the bidder request with WURFL data
+ * @param {Object} reqBidsConfigObj Bid request configuration object
+ * @param {String} bidderCode Bidder code
+ * @param {Object} wurflData WURFL data
+ */
+export const enrichBidderRequest = (reqBidsConfigObj, bidderCode, wurflData) => {
+  const ortb2data = {
+    'device': {
+      'ext': {},
+    },
+  };
+
+  const device = reqBidsConfigObj.ortb2Fragments.global.device;
+  enrichOrtb2DeviceData('make', wurflData.brand_name, device, ortb2data);
+  enrichOrtb2DeviceData('model', wurflData.model_name, device, ortb2data);
+  if (wurflData.enrich_device) {
+    delete wurflData.enrich_device;
+    enrichOrtb2DeviceData('devicetype', makeOrtb2DeviceType(wurflData), device, ortb2data);
+    enrichOrtb2DeviceData('os', wurflData.advertised_device_os, device, ortb2data);
+    enrichOrtb2DeviceData('osv', wurflData.advertised_device_os_version, device, ortb2data);
+    enrichOrtb2DeviceData('hwv', wurflData.model_name, device, ortb2data);
+    enrichOrtb2DeviceData('h', wurflData.resolution_height, device, ortb2data);
+    enrichOrtb2DeviceData('w', wurflData.resolution_width, device, ortb2data);
+    enrichOrtb2DeviceData('ppi', wurflData.pixel_density, device, ortb2data);
+    enrichOrtb2DeviceData('pxratio', wurflData.density_class, device, ortb2data);
+    enrichOrtb2DeviceData('js', wurflData.ajax_support_javascript, device, ortb2data);
+  }
+  ortb2data.device.ext['wurfl'] = wurflData
+  mergeDeep(reqBidsConfigObj.ortb2Fragments.bidder, { [bidderCode]: ortb2data });
+}
+
+/**
+ * makeOrtb2DeviceType returns the ortb2 device type based on WURFL data
+ * @param {Object} wurflData WURFL data
+ * @returns {Number} ortb2 device type
+ * @see https://www.scientiamobile.com/how-to-populate-iab-openrtb-device-object/
+ */
+export function makeOrtb2DeviceType(wurflData) {
+  if (wurflData.is_mobile) {
+    if (!('is_phone' in wurflData) || !('is_tablet' in wurflData)) {
+      return undefined;
+    }
+    if (wurflData.is_phone || wurflData.is_tablet) {
+      return 1;
+    }
+    return 6;
+  }
+  if (wurflData.is_full_desktop) {
+    return 2;
+  }
+  if (wurflData.is_connected_tv) {
+    return 3;
+  }
+  if (wurflData.is_phone) {
+    return 4;
+  }
+  if (wurflData.is_tablet) {
+    return 5;
+  }
+  if (wurflData.is_ott) {
+    return 7;
+  }
+  return undefined;
+}
+
+/**
+ * enrichOrtb2DeviceData enriches the ortb2data device data with WURFL data.
+ * Note: it does not overrides properties set by Prebid.js
+ * @param {String} key the device property key
+ * @param {any} value the value of the device property
+ * @param {Object} device the ortb2 device object from Prebid.js
+ * @param {Object} ortb2data the ortb2 device data enrchiced with WURFL data
+ */
+function enrichOrtb2DeviceData(key, value, device, ortb2data) {
+  if (device?.[key] !== undefined) {
+    // value already defined by Prebid.js, do not overrides
+    return;
+  }
+  if (value === undefined) {
+    return;
+  }
+  ortb2data.device[key] = value;
+}
+
+/**
+ * onAuctionEndEvent is called when the auction ends
+ * @param {Object} auctionDetails Auction details
+ * @param {Object} config Configuration for WURFL RTD submodule
+ * @param {Object} userConsent User consent data
+ */
+function onAuctionEndEvent(auctionDetails, config, userConsent) {
+  const altHost = config.params?.altHost ?? null;
+
+  let host = WURFL_JS_HOST;
+  if (altHost) {
+    host = altHost;
+  }
+
+  const url = new URL(host);
+  url.pathname = STATS_ENDPOINT_PATH;
+
+  if (enrichedBidders.size === 0) {
+    return;
+  }
+
+  var payload = JSON.stringify({ bidders: [...enrichedBidders] });
+  const sentBeacon = sendBeacon(url.toString(), payload);
+  if (sentBeacon) {
+    return;
+  }
+
+  fetch(url.toString(), {
+    method: 'POST',
+    body: payload,
+    mode: 'no-cors',
+    keepalive: true
+  });
+}
+
+// The WURFL submodule
+export const wurflSubmodule = {
+  name: MODULE_NAME,
+  init,
+  getBidRequestData,
+  onAuctionEndEvent,
+}
+
+// Register the WURFL submodule as submodule of realTimeData
+submodule(REAL_TIME_MODULE, wurflSubmodule);

--- a/modules/wurflRtdProvider.js
+++ b/modules/wurflRtdProvider.js
@@ -5,7 +5,6 @@ import {
   mergeDeep,
   prefixLog,
 } from '../src/utils.js';
-import { MODULE_TYPE_RTD } from '../src/activities/modules.js';
 
 // Constants
 const REAL_TIME_MODULE = 'realTimeData';

--- a/modules/wurflRtdProvider.md
+++ b/modules/wurflRtdProvider.md
@@ -1,0 +1,67 @@
+# WURFL Real-time Data Submodule
+
+## Overview
+
+    Module Name: WURFL Rtd Provider
+    Module Type: Rtd Provider
+    Maintainer: prebid@scientiamobile.com
+
+## Description
+
+The WURFL RTD module enriches the OpenRTB 2.0 device data with [WURFL data](https://www.scientiamobile.com/wurfl-js-business-edition-at-the-intersection-of-javascript-and-enterprise/).
+The module sets the WURFL data in `device.ext.wurfl` and all the bidder adapters will always receive the low entry capabilities like `is_mobile`, `complete_device_name` and `form_factor`, and the `wurfl_id`.
+
+For a more detailed analysis bidders can subscribe to detect iPhone and iPad models and receive additional [WURFL device capabilities](https://www.scientiamobile.com/capabilities/?products%5B%5D=wurfl-js).
+
+## User-Agent Client Hints
+
+WURFL.js is fully compatible with Chromium's User-Agent Client Hints (UA-CH) initiative. If User-Agent Client Hints are absent in the HTTP headers that WURFL.js receives, the service will automatically fall back to using the User-Agent Client Hints' JS API to fetch [high entropy client hint values](https://wicg.github.io/ua-client-hints/#getHighEntropyValues) from the client device. However, we recommend that you explicitly opt-in/advertise support for User-Agent Client Hints on your website and delegate them to the WURFL.js service for the fastest detection experience. Our documentation regarding implementing User-Agent Client Hint support [is available here](https://docs.scientiamobile.com/guides/implementing-useragent-clienthints). 
+
+## Usage
+
+### Build
+```
+gulp build --modules="wurflRtdProvider,appnexusBidAdapter,..."  
+```
+
+### Configuration
+
+Use `setConfig` to instruct Prebid.js to initilize the WURFL RTD module, as specified below. 
+
+This module is configured as part of the `realTimeData.dataProviders`
+
+```javascript
+var TIMEOUT = 1000;
+pbjs.setConfig({
+    realTimeData: {
+        auctionDelay: TIMEOUT,
+        dataProviders: [{
+            name: 'wurfl',
+            waitForIt: true,
+            params: {
+                debug: false
+            }
+        }]
+    }
+});
+```
+
+### Parameters 
+
+| Name                      | Type          | Description                                                      | Default           |
+| :------------------------ | :------------ | :--------------------------------------------------------------- |:----------------- |
+| name                      | String        | Real time data module name                                       | Always 'wurfl'    |
+| waitForIt                 | Boolean       | Should be `true` if there's an `auctionDelay` defined (optional) | `false`           |
+| params                    | Object        |                                                                  |                   |
+| params.altHost            | String        | Alternate host to connect to WURFL.js                            |                   |
+| params.debug              | Boolean       | Enable debug                                                     | `false`           |
+
+## Testing 
+
+To view an example of how the WURFL RTD module works :
+
+`gulp serve --modules=wurflRtdProvider,appnexusBidAdapter`
+
+and then point your browser at:
+
+`http://localhost:9999/integrationExamples/gpt/wurflRtdProvider_example.html`

--- a/src/adloader.js
+++ b/src/adloader.js
@@ -1,4 +1,4 @@
-import {includes} from './polyfill.js';
+import { includes } from './polyfill.js';
 import { logError, logWarn, insertElement, setScriptAttributes } from './utils.js';
 
 const _requestCache = new WeakMap();
@@ -34,6 +34,7 @@ const _approvedLoadExternalJSList = [
   'contxtful',
   'id5',
   '51Degrees',
+  'wurfl',
 ];
 
 /**

--- a/src/ajax.js
+++ b/src/ajax.js
@@ -147,5 +147,19 @@ export function ajaxBuilder(timeout = 3000, {request, done} = {}) {
   };
 }
 
+/**
+ * simple wrapper around sendBeacon such that invocations of navigator.sendBeacon can be centrally maintained.
+ * verifies that the navigator and sendBeacon are defined for maximum compatibility
+ * @param {string} url The URL that will receive the data. Can be relative or absolute.
+ * @param {*} data An ArrayBuffer, a TypedArray, a DataView, a Blob, a string literal or object, a FormData or a URLSearchParams object containing the data to send.
+ * @returns {boolean} true if the user agent successfully queued the data for transfer. Otherwise, it returns false.
+ */
+export function sendBeacon(url, data) {
+  if (!window.navigator || !window.navigator.sendBeacon) {
+    return false;
+  }
+  return window.navigator.sendBeacon(url, data);
+}
+
 export const ajax = ajaxBuilder();
 export const fetch = fetcherFactory();

--- a/test/spec/modules/wurflRtdProvider_spec.js
+++ b/test/spec/modules/wurflRtdProvider_spec.js
@@ -229,7 +229,7 @@ describe('wurflRtdProvider', function () {
       expect(loadExternalScriptStub.calledOnce).to.be.true;
       const loadExternalScriptCall = loadExternalScriptStub.getCall(0);
       expect(loadExternalScriptCall.args[0]).to.equal(expectedURL.toString());
-      expect(loadExternalScriptCall.args[2]).to.equal('wurfl');
+      expect(loadExternalScriptCall.args[1]).to.equal('wurfl');
     });
 
     it('onAuctionEndEvent: should send analytics data using navigator.sendBeacon, if available', () => {

--- a/test/spec/modules/wurflRtdProvider_spec.js
+++ b/test/spec/modules/wurflRtdProvider_spec.js
@@ -1,0 +1,458 @@
+import {
+  bidderData,
+  enrichBidderRequest,
+  lowEntropyData,
+  wurflSubmodule,
+  makeOrtb2DeviceType,
+} from 'modules/wurflRtdProvider';
+import * as ajaxModule from 'src/ajax';
+import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
+
+describe('wurflRtdProvider', function () {
+  describe('wurflSubmodule', function () {
+    const altHost = 'http://example.local/wurfl.js';
+
+    const wurfl_pbjs = {
+      low_entropy_caps: ['is_mobile', 'complete_device_name', 'form_factor'],
+      caps: ['advertised_browser', 'advertised_browser_version', 'advertised_device_os', 'advertised_device_os_version', 'ajax_support_javascript', 'brand_name', 'complete_device_name', 'density_class', 'form_factor', 'is_android', 'is_app_webview', 'is_connected_tv', 'is_full_desktop', 'is_ios', 'is_mobile', 'is_ott', 'is_phone', 'is_robot', 'is_smartphone', 'is_smarttv', 'is_tablet', 'manufacturer_name', 'marketing_name', 'max_image_height', 'max_image_width', 'model_name', 'physical_screen_height', 'physical_screen_width', 'pixel_density', 'pointing_method', 'resolution_height', 'resolution_width'],
+      authorized_bidders: {
+        bidder1: [0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31],
+        bidder2: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 21, 25, 28, 30, 31]
+      }
+    }
+    const WURFL = {
+      advertised_browser: 'Chrome Mobile',
+      advertised_browser_version: '130.0.0.0',
+      advertised_device_os: 'Android',
+      advertised_device_os_version: '6.0',
+      ajax_support_javascript: !0,
+      brand_name: 'Google',
+      complete_device_name: 'Google Nexus 5',
+      density_class: '3.0',
+      form_factor: 'Feature Phone',
+      is_android: !0,
+      is_app_webview: !1,
+      is_connected_tv: !1,
+      is_full_desktop: !1,
+      is_ios: !1,
+      is_mobile: !0,
+      is_ott: !1,
+      is_phone: !0,
+      is_robot: !1,
+      is_smartphone: !1,
+      is_smarttv: !1,
+      is_tablet: !1,
+      manufacturer_name: 'LG',
+      marketing_name: '',
+      max_image_height: 640,
+      max_image_width: 360,
+      model_name: 'Nexus 5',
+      physical_screen_height: 110,
+      physical_screen_width: 62,
+      pixel_density: 443,
+      pointing_method: 'touchscreen',
+      resolution_height: 1920,
+      resolution_width: 1080,
+      wurfl_id: 'lg_nexus5_ver1',
+    };
+
+    // expected analytics values
+    const expectedStatsURL = 'https://prebid.wurflcloud.com/v1/prebid/stats';
+    const expectedData = JSON.stringify({ bidders: ['bidder1', 'bidder2'] });
+
+    let sandbox;
+
+    beforeEach(function () {
+      sandbox = sinon.createSandbox();
+      window.WURFLPromises = {
+        init: new Promise(function (resolve, reject) { resolve({ WURFL, wurfl_pbjs }) }),
+        complete: new Promise(function (resolve, reject) { resolve({ WURFL, wurfl_pbjs }) }),
+      };
+    });
+
+    afterEach(() => {
+      // Restore the original functions
+      sandbox.restore();
+      window.WURFLPromises = undefined;
+    });
+
+    // Bid request config
+    const reqBidsConfigObj = {
+      adUnits: [{
+        bids: [
+          { bidder: 'bidder1' },
+          { bidder: 'bidder2' },
+          { bidder: 'bidder3' },
+        ]
+      }],
+      ortb2Fragments: {
+        global: {
+          device: {},
+        },
+        bidder: {},
+      }
+    };
+
+    it('initialises the WURFL RTD provider', function () {
+      expect(wurflSubmodule.init()).to.be.true;
+    });
+
+    it('should enrich the bid request data', (done) => {
+      const expectedURL = new URL(altHost);
+      expectedURL.searchParams.set('debug', true);
+      expectedURL.searchParams.set('mode', 'prebid');
+      expectedURL.searchParams.set('wurfl_id', true);
+
+      const callback = () => {
+        const v = {
+          bidder1: {
+            device: {
+              make: 'Google',
+              model: 'Nexus 5',
+              devicetype: 1,
+              os: 'Android',
+              osv: '6.0',
+              hwv: 'Nexus 5',
+              h: 1920,
+              w: 1080,
+              ppi: 443,
+              pxratio: '3.0',
+              js: true,
+              ext: {
+                wurfl: {
+                  advertised_browser: 'Chrome Mobile',
+                  advertised_browser_version: '130.0.0.0',
+                  advertised_device_os: 'Android',
+                  advertised_device_os_version: '6.0',
+                  ajax_support_javascript: !0,
+                  brand_name: 'Google',
+                  complete_device_name: 'Google Nexus 5',
+                  density_class: '3.0',
+                  form_factor: 'Feature Phone',
+                  is_app_webview: !1,
+                  is_connected_tv: !1,
+                  is_full_desktop: !1,
+                  is_mobile: !0,
+                  is_ott: !1,
+                  is_phone: !0,
+                  is_robot: !1,
+                  is_smartphone: !1,
+                  is_smarttv: !1,
+                  is_tablet: !1,
+                  manufacturer_name: 'LG',
+                  marketing_name: '',
+                  max_image_height: 640,
+                  max_image_width: 360,
+                  model_name: 'Nexus 5',
+                  physical_screen_height: 110,
+                  physical_screen_width: 62,
+                  pixel_density: 443,
+                  pointing_method: 'touchscreen',
+                  resolution_height: 1920,
+                  resolution_width: 1080,
+                  wurfl_id: 'lg_nexus5_ver1',
+                },
+              },
+            },
+          },
+          bidder2: {
+            device: {
+              make: 'Google',
+              model: 'Nexus 5',
+              devicetype: 1,
+              os: 'Android',
+              osv: '6.0',
+              hwv: 'Nexus 5',
+              h: 1920,
+              w: 1080,
+              ppi: 443,
+              pxratio: '3.0',
+              js: true,
+              ext: {
+                wurfl: {
+                  advertised_device_os: 'Android',
+                  advertised_device_os_version: '6.0',
+                  ajax_support_javascript: !0,
+                  brand_name: 'Google',
+                  complete_device_name: 'Google Nexus 5',
+                  density_class: '3.0',
+                  form_factor: 'Feature Phone',
+                  is_android: !0,
+                  is_app_webview: !1,
+                  is_connected_tv: !1,
+                  is_full_desktop: !1,
+                  is_ios: !1,
+                  is_mobile: !0,
+                  is_ott: !1,
+                  is_phone: !0,
+                  is_tablet: !1,
+                  manufacturer_name: 'LG',
+                  model_name: 'Nexus 5',
+                  pixel_density: 443,
+                  resolution_height: 1920,
+                  resolution_width: 1080,
+                  wurfl_id: 'lg_nexus5_ver1',
+                },
+              },
+            },
+          },
+          bidder3: {
+            device: {
+              make: 'Google',
+              model: 'Nexus 5',
+              ext: {
+                wurfl: {
+                  complete_device_name: 'Google Nexus 5',
+                  form_factor: 'Feature Phone',
+                  is_mobile: !0,
+                  model_name: 'Nexus 5',
+                  brand_name: 'Google',
+                  wurfl_id: 'lg_nexus5_ver1',
+                },
+              },
+            },
+          },
+        };
+        expect(reqBidsConfigObj.ortb2Fragments.bidder).to.deep.equal(v);
+        done();
+      };
+
+      const config = {
+        params: {
+          altHost: altHost,
+          debug: true,
+        }
+      };
+      const userConsent = {};
+
+      wurflSubmodule.getBidRequestData(reqBidsConfigObj, callback, config, userConsent);
+      expect(loadExternalScriptStub.calledOnce).to.be.true;
+      const loadExternalScriptCall = loadExternalScriptStub.getCall(0);
+      expect(loadExternalScriptCall.args[0]).to.equal(expectedURL.toString());
+      expect(loadExternalScriptCall.args[2]).to.equal('wurfl');
+    });
+
+    it('onAuctionEndEvent: should send analytics data using navigator.sendBeacon, if available', () => {
+      const auctionDetails = {};
+      const config = {};
+      const userConsent = {};
+
+      const sendBeaconStub = sandbox.stub(navigator, 'sendBeacon');
+
+      // Call the function
+      wurflSubmodule.onAuctionEndEvent(auctionDetails, config, userConsent);
+
+      // Assertions
+      expect(sendBeaconStub.calledOnce).to.be.true;
+      expect(sendBeaconStub.calledWithExactly(expectedStatsURL, expectedData)).to.be.true;
+    });
+
+    it('onAuctionEndEvent: should send analytics data using fetch as fallback, if navigator.sendBeacon is not available', () => {
+      const auctionDetails = {};
+      const config = {};
+      const userConsent = {};
+
+      const sendBeaconStub = sandbox.stub(navigator, 'sendBeacon').value(undefined);
+      const windowFetchStub = sandbox.stub(window, 'fetch');
+      const fetchAjaxStub = sandbox.stub(ajaxModule, 'fetch');
+
+      // Call the function
+      wurflSubmodule.onAuctionEndEvent(auctionDetails, config, userConsent);
+
+      // Assertions
+      expect(sendBeaconStub.called).to.be.false;
+
+      expect(fetchAjaxStub.calledOnce).to.be.true;
+      const fetchAjaxCall = fetchAjaxStub.getCall(0);
+      expect(fetchAjaxCall.args[0]).to.equal(expectedStatsURL);
+      expect(fetchAjaxCall.args[1].method).to.equal('POST');
+      expect(fetchAjaxCall.args[1].body).to.equal(expectedData);
+      expect(fetchAjaxCall.args[1].mode).to.equal('no-cors');
+    });
+  });
+
+  describe('bidderData', () => {
+    it('should return the WURFL data for a bidder', () => {
+      const wjsData = {
+        capability1: 'value1',
+        capability2: 'value2',
+        capability3: 'value3',
+      };
+      const caps = ['capability1', 'capability2', 'capability3'];
+      const filter = [0, 2];
+
+      const result = bidderData(wjsData, caps, filter);
+
+      expect(result).to.deep.equal({
+        capability1: 'value1',
+        capability3: 'value3',
+      });
+    });
+
+    it('should return an empty object if the filter is empty', () => {
+      const wjsData = {
+        capability1: 'value1',
+        capability2: 'value2',
+        capability3: 'value3',
+      };
+      const caps = ['capability1', 'capability3'];
+      const filter = [];
+
+      const result = bidderData(wjsData, caps, filter);
+
+      expect(result).to.deep.equal({});
+    });
+  });
+
+  describe('lowEntropyData', () => {
+    it('should return the correct low entropy data for Apple devices', () => {
+      const wjsData = {
+        complete_device_name: 'Apple iPhone X',
+        form_factor: 'Smartphone',
+        is_mobile: !0,
+        brand_name: 'Apple',
+        model_name: 'iPhone X',
+      };
+      const lowEntropyCaps = ['complete_device_name', 'form_factor', 'is_mobile'];
+      const expectedData = {
+        complete_device_name: 'Apple iPhone',
+        form_factor: 'Smartphone',
+        is_mobile: !0,
+        brand_name: 'Apple',
+        model_name: 'iPhone',
+      };
+      const result = lowEntropyData(wjsData, lowEntropyCaps);
+      expect(result).to.deep.equal(expectedData);
+    });
+
+    it('should return the correct low entropy data for Android devices', () => {
+      const wjsData = {
+        complete_device_name: 'Samsung SM-G981B (Galaxy S20 5G)',
+        form_factor: 'Smartphone',
+        is_mobile: !0,
+      };
+      const lowEntropyCaps = ['complete_device_name', 'form_factor', 'is_mobile'];
+      const expectedData = {
+        complete_device_name: 'Samsung SM-G981B (Galaxy S20 5G)',
+        form_factor: 'Smartphone',
+        is_mobile: !0,
+      };
+      const result = lowEntropyData(wjsData, lowEntropyCaps);
+      expect(result).to.deep.equal(expectedData);
+    });
+
+    it('should return an empty object if the lowEntropyCaps array is empty', () => {
+      const wjsData = {
+        complete_device_name: 'Samsung SM-G981B (Galaxy S20 5G)',
+        form_factor: 'Smartphone',
+        is_mobile: !0,
+      };
+      const lowEntropyCaps = [];
+      const expectedData = {};
+      const result = lowEntropyData(wjsData, lowEntropyCaps);
+      expect(result).to.deep.equal(expectedData);
+    });
+  });
+
+  describe('enrichBidderRequest', () => {
+    it('should enrich the bidder request with WURFL data', () => {
+      const reqBidsConfigObj = {
+        ortb2Fragments: {
+          global: {
+            device: {},
+          },
+          bidder: {
+            exampleBidder: {
+              device: {
+                ua: 'user-agent',
+              }
+            }
+          }
+        }
+      };
+      const bidderCode = 'exampleBidder';
+      const wjsData = {
+        capability1: 'value1',
+        capability2: 'value2'
+      };
+
+      enrichBidderRequest(reqBidsConfigObj, bidderCode, wjsData);
+
+      expect(reqBidsConfigObj.ortb2Fragments.bidder).to.deep.equal({
+        exampleBidder: {
+          device: {
+            ua: 'user-agent',
+            ext: {
+              wurfl: {
+                capability1: 'value1',
+                capability2: 'value2'
+              }
+            }
+          }
+        }
+      });
+    });
+  });
+
+  describe('makeOrtb2DeviceType', function () {
+    it('should return 1 when wurflData is_mobile and is_phone is true', function () {
+      const wurflData = { is_mobile: true, is_phone: true, is_tablet: false };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.equal(1);
+    });
+
+    it('should return 1 when wurflData is_mobile and is_tablet is true', function () {
+      const wurflData = { is_mobile: true, is_phone: false, is_tablet: true };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.equal(1);
+    });
+
+    it('should return 6 when wurflData is_mobile but is_phone and is_tablet are false', function () {
+      const wurflData = { is_mobile: true, is_phone: false, is_tablet: false };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.equal(6);
+    });
+
+    it('should return 2 when wurflData is_full_desktop is true', function () {
+      const wurflData = { is_full_desktop: true };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.equal(2);
+    });
+
+    it('should return 3 when wurflData is_connected_tv is true', function () {
+      const wurflData = { is_connected_tv: true };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.equal(3);
+    });
+
+    it('should return 4 when wurflData is_phone is true and is_mobile is false or undefined', function () {
+      const wurflData = { is_phone: true };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.equal(4);
+    });
+
+    it('should return 5 when wurflData is_tablet is true and is_mobile is false or undefined', function () {
+      const wurflData = { is_tablet: true };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.equal(5);
+    });
+
+    it('should return 7 when wurflData is_ott is true', function () {
+      const wurflData = { is_ott: true };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.equal(7);
+    });
+
+    it('should return undefined when wurflData is_mobile is true but is_phone and is_tablet are missing', function () {
+      const wurflData = { is_mobile: true };
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.be.undefined;
+    });
+
+    it('should return undefined when no conditions are met', function () {
+      const wurflData = {};
+      const result = makeOrtb2DeviceType(wurflData);
+      expect(result).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This PR backports the WURFL Rtd module to v8.52.x

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->