### PR TITLE
priceFloors & PBS adapter: support mediaType and size specific floors

### DIFF
--- a/modules/prebidServerBidAdapter/ortbConverter.js
+++ b/modules/prebidServerBidAdapter/ortbConverter.js
@@ -1,5 +1,5 @@
 import {ortbConverter} from '../../libraries/ortbConverter/converter.js';
-import {deepSetValue, getBidRequest, logError, logWarn, mergeDeep, timestamp} from '../../src/utils.js';
+import {deepClone, deepSetValue, getBidRequest, logError, logWarn, mergeDeep, timestamp} from '../../src/utils.js';
 import {config} from '../../src/config.js';
 import {S2S, STATUS} from '../../src/constants.js';
 import {createBid} from '../../src/bidfactory.js';
@@ -17,11 +17,25 @@ import {currencyCompare} from '../../libraries/currencyUtils/currency.js';
 import {minimum} from '../../src/utils/reducers.js';
 import {s2sDefaultConfig} from './index.js';
 import {premergeFpd} from './bidderConfig.js';
+import {ORTB_MTYPES} from '../../libraries/ortbConverter/processors/mediaType.js';
+import {BANNER} from '../../src/mediaTypes.js';
 
 const DEFAULT_S2S_TTL = 60;
 const DEFAULT_S2S_CURRENCY = 'USD';
 const DEFAULT_S2S_NETREVENUE = true;
 const BIDDER_SPECIFIC_REQUEST_PROPS = new Set(['bidderCode', 'bidderRequestId', 'uniquePbsTid', 'bids', 'timeout']);
+
+const getMinimumFloor = (() => {
+  const getMin = minimum(currencyCompare(floor => [floor.bidfloor, floor.bidfloorcur]));
+  return function(candidates) {
+    let min;
+    for (const candidate of candidates) {
+      if (candidate?.bidfloorcur == null || candidate?.bidfloor == null) return null;
+      min = min == null ? candidate : getMin(min, candidate);
+    }
+    return min;
+  }
+})();
 
 const PBS_CONVERTER = ortbConverter({
   processors: pbsExtensions,
@@ -126,24 +140,39 @@ const PBS_CONVERTER = ortbConverter({
           }
         }
       },
+      // for bid floors, we pass each bidRequest associated with this imp through normal bidfloor/extBidfloor processing,
+      // and aggregate all of them into a single, minimum floor to put in the request
       bidfloor(orig, imp, proxyBidRequest, context) {
-        // for bid floors, we pass each bidRequest associated with this imp through normal bidfloor processing,
-        // and aggregate all of them into a single, minimum floor to put in the request
-        const getMin = minimum(currencyCompare(floor => [floor.bidfloor, floor.bidfloorcur]));
-        let min;
-        for (const req of context.actualBidRequests.values()) {
-          const floor = {};
-          orig(floor, req, context);
-          // if any bid does not have a valid floor, do not attempt to send any to PBS
-          if (floor.bidfloorcur == null || floor.bidfloor == null) {
-            min = null;
-            break;
+        const min = getMinimumFloor((function * () {
+          for (const req of context.actualBidRequests.values()) {
+            const floor = {};
+            orig(floor, req, context);
+            yield floor;
           }
-          min = min == null ? floor : getMin(min, floor);
-        }
+        })())
         if (min != null) {
           Object.assign(imp, min);
         }
+      },
+      extBidfloor(orig, imp, proxyBidRequest, context) {
+        function setExtFloor(target, minFloor) {
+          if (minFloor != null) {
+            deepSetValue(target, 'ext.bidfloor', minFloor.bidfloor);
+            deepSetValue(target, 'ext.bidfloorcur', minFloor.bidfloorcur);
+          }
+        }
+        const imps = Array.from(context.actualBidRequests.values())
+          .map(request => {
+            const requestImp = deepClone(imp);
+            orig(requestImp, request, context);
+            return requestImp;
+          });
+        Object.values(ORTB_MTYPES).forEach(mediaType => {
+          setExtFloor(imp[mediaType], getMinimumFloor(imps.map(imp => imp[mediaType]?.ext)))
+        });
+        (imp[BANNER]?.format || []).forEach((format, i) => {
+          setExtFloor(format, getMinimumFloor(imps.map(imp => imp[BANNER].format[i]?.ext)))
+        })
       }
     },
     [REQUEST]: {

--- a/modules/prebidServerBidAdapter/ortbConverter.js
+++ b/modules/prebidServerBidAdapter/ortbConverter.js
@@ -17,8 +17,7 @@ import {currencyCompare} from '../../libraries/currencyUtils/currency.js';
 import {minimum} from '../../src/utils/reducers.js';
 import {s2sDefaultConfig} from './index.js';
 import {premergeFpd} from './bidderConfig.js';
-import {ORTB_MTYPES} from '../../libraries/ortbConverter/processors/mediaType.js';
-import {BANNER} from '../../src/mediaTypes.js';
+import {ALL_MEDIATYPES, BANNER} from '../../src/mediaTypes.js';
 
 const DEFAULT_S2S_TTL = 60;
 const DEFAULT_S2S_CURRENCY = 'USD';
@@ -167,7 +166,7 @@ const PBS_CONVERTER = ortbConverter({
             orig(requestImp, request, context);
             return requestImp;
           });
-        Object.values(ORTB_MTYPES).forEach(mediaType => {
+        Object.values(ALL_MEDIATYPES).forEach(mediaType => {
           setExtFloor(imp[mediaType], getMinimumFloor(imps.map(imp => imp[mediaType]?.ext)))
         });
         (imp[BANNER]?.format || []).forEach((format, i) => {

--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -31,8 +31,7 @@ import {adjustCpm} from '../src/utils/cpm.js';
 import {getGptSlotInfoForAdUnitCode} from '../libraries/gptUtils/gptUtils.js';
 import {convertCurrency} from '../libraries/currencyUtils/currency.js';
 import { timeoutQueue } from '../libraries/timeoutQueue/timeoutQueue.js';
-import {ORTB_MTYPES} from '../libraries/ortbConverter/processors/mediaType.js';
-import {BANNER} from '../src/mediaTypes.js';
+import {ALL_MEDIATYPES, BANNER} from '../src/mediaTypes.js';
 
 export const FLOOR_SKIPPED_REASON = {
   NOT_FOUND: 'not_found',
@@ -853,7 +852,7 @@ export function setGranularBidfloors(imp, bidRequest, context) {
     }
   }
 
-  Object.values(ORTB_MTYPES)
+  Object.values(ALL_MEDIATYPES)
     .filter(mediaType => imp[mediaType] != null)
     .forEach(mediaType => {
       tryGetFloor(bidRequest, {

--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -264,7 +264,10 @@ export function getFloor(requestParams = {currency: 'USD', mediaType: '*', size:
     // pub provided inverse function takes precedence, otherwise do old adjustment stuff
     const inverseFunction = bidderSettings.get(bidRequest.bidder, 'inverseBidAdjustment');
     if (inverseFunction) {
-      floorInfo.matchingFloor = inverseFunction(floorInfo.matchingFloor, bidRequest);
+      const definedParams = Object.fromEntries(
+        Object.entries(requestParams).filter(([key, val]) => val !== '*' && ['mediaType', 'size'].includes(key))
+      );
+      floorInfo.matchingFloor = inverseFunction(floorInfo.matchingFloor, bidRequest, definedParams);
     } else {
       let cpmAdjustment = getBiddersCpmAdjustment(floorInfo.matchingFloor, null, bidRequest);
       floorInfo.matchingFloor = cpmAdjustment ? calculateAdjustedFloor(floorInfo.matchingFloor, cpmAdjustment) : floorInfo.matchingFloor;

--- a/modules/priceFloors.js
+++ b/modules/priceFloors.js
@@ -31,8 +31,8 @@ import {adjustCpm} from '../src/utils/cpm.js';
 import {getGptSlotInfoForAdUnitCode} from '../libraries/gptUtils/gptUtils.js';
 import {convertCurrency} from '../libraries/currencyUtils/currency.js';
 import { timeoutQueue } from '../libraries/timeoutQueue/timeoutQueue.js';
-import {ORTB_MTYPES} from "../libraries/ortbConverter/processors/mediaType.js";
-import {BANNER} from "../src/mediaTypes.js";
+import {ORTB_MTYPES} from '../libraries/ortbConverter/processors/mediaType.js';
+import {BANNER} from '../src/mediaTypes.js';
 
 export const FLOOR_SKIPPED_REASON = {
   NOT_FOUND: 'not_found',
@@ -913,6 +913,6 @@ export function setOrtbExtPrebidFloors(ortbRequest, bidderRequest, context) {
 
 registerOrtbProcessor({type: IMP, name: 'bidfloor', fn: setOrtbImpBidFloor});
 // granular floors should be set after both "normal" bidfloors and mediaypes
-registerOrtbProcessor({type: IMP, name: 'granularBidfloors', fn: setGranularBidfloors, priority: -10})
+registerOrtbProcessor({type: IMP, name: 'extBidfloor', fn: setGranularBidfloors, priority: -10})
 registerOrtbProcessor({type: IMP, name: 'extPrebidFloors', fn: setImpExtPrebidFloors, dialects: [PBS], priority: -1});
 registerOrtbProcessor({type: REQUEST, name: 'extPrebidFloors', fn: setOrtbExtPrebidFloors, dialects: [PBS]});

--- a/src/mediaTypes.js
+++ b/src/mediaTypes.js
@@ -18,3 +18,5 @@ export const VIDEO = 'video';
 export const BANNER = 'banner';
 /** @type {VideoContext} */
 export const ADPOD = 'adpod';
+
+export const ALL_MEDIATYPES = [NATIVE, VIDEO, BANNER];

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1380,7 +1380,6 @@ describe('S2S Adapter', function () {
         })
 
         Object.entries({
-          /*
           'imp level floors': {
             target: 'imp.0'
           },
@@ -1388,7 +1387,6 @@ describe('S2S Adapter', function () {
             target: 'imp.0.banner.ext',
             floorFilter: ({mediaType, size}) => size === '*' && mediaType !== '*'
           },
-           */
           'format level floors': {
             target: 'imp.0.banner.format.0.ext',
             floorFilter: ({size}) => size !== '*'

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -1865,159 +1865,194 @@ describe('the price floors module', function () {
         });
       });
 
-      it('should use inverseFloorAdjustment function before bidder cpm adjustment', function () {
-        let functionUsed;
-        getGlobal().bidderSettings = {
-          rubicon: {
-            bidCpmAdjustment: function (bidCpm, bidResponse) {
-              functionUsed = 'Rubicon Adjustment';
-              bidCpm *= 0.5;
-              if (bidResponse.mediaType === 'video') bidCpm -= 0.18;
-              return bidCpm;
+      describe('inverse adjustment', () => {
+        beforeEach(() => {
+          _floorDataForAuction[bidRequest.auctionId] = utils.deepClone(basicFloorConfig);
+          _floorDataForAuction[bidRequest.auctionId].data.values = { '*': 1.0 };
+        });
+
+        it('should use inverseFloorAdjustment function before bidder cpm adjustment', function () {
+          let functionUsed;
+          getGlobal().bidderSettings = {
+            rubicon: {
+              bidCpmAdjustment: function (bidCpm, bidResponse) {
+                functionUsed = 'Rubicon Adjustment';
+                bidCpm *= 0.5;
+                if (bidResponse.mediaType === 'video') bidCpm -= 0.18;
+                return bidCpm;
+              },
+              inverseBidAdjustment: function (bidCpm, bidRequest) {
+                functionUsed = 'Rubicon Inverse';
+                // if video is the only mediaType on Bid Request => add 0.18
+                if (bidRequest.mediaTypes.video && Object.keys(bidRequest.mediaTypes).length === 1) bidCpm += 0.18;
+                return bidCpm / 0.5;
+              },
             },
-            inverseBidAdjustment: function (bidCpm, bidRequest) {
-              functionUsed = 'Rubicon Inverse';
-              // if video is the only mediaType on Bid Request => add 0.18
-              if (bidRequest.mediaTypes.video && Object.keys(bidRequest.mediaTypes).length === 1) bidCpm += 0.18;
-              return bidCpm / 0.5;
-            },
+            appnexus: {
+              bidCpmAdjustment: function (bidCpm, bidResponse) {
+                functionUsed = 'Appnexus Adjustment';
+                bidCpm *= 0.75;
+                if (bidResponse.mediaType === 'video') bidCpm -= 0.18;
+                return bidCpm;
+              },
+              inverseBidAdjustment: function (bidCpm, bidRequest) {
+                functionUsed = 'Appnexus Inverse';
+                // if video is the only mediaType on Bid Request => add 0.18
+                if (bidRequest.mediaTypes.video && Object.keys(bidRequest.mediaTypes).length === 1) bidCpm += 0.18;
+                return bidCpm / 0.75;
+              },
+            }
+          };
+
+          // start with banner as only mediaType
+          bidRequest.mediaTypes = { banner: { sizes: [[300, 250]] } };
+          let appnexusBid = {
+            ...bidRequest,
+            bidder: 'appnexus',
+          };
+
+          // should be same as the adjusted calculated inverses above test (banner)
+          expect(bidRequest.getFloor()).to.deep.equal({
+            currency: 'USD',
+            floor: 2.0
+          });
+
+          // should use rubicon inverse
+          expect(functionUsed).to.equal('Rubicon Inverse');
+
+          // appnexus just using banner should be same
+          expect(appnexusBid.getFloor()).to.deep.equal({
+            currency: 'USD',
+            floor: 1.3334
+          });
+
+          expect(functionUsed).to.equal('Appnexus Inverse');
+
+          // now since asking for 'video' only mediaType inverse function should include the .18
+          bidRequest.mediaTypes = { video: { context: 'instream' } };
+          expect(bidRequest.getFloor({ mediaType: 'video' })).to.deep.equal({
+            currency: 'USD',
+            floor: 2.36
+          });
+
+          expect(functionUsed).to.equal('Rubicon Inverse');
+
+          // now since asking for 'video' inverse function should include the .18
+          appnexusBid.mediaTypes = { video: { context: 'instream' } };
+          expect(appnexusBid.getFloor({ mediaType: 'video' })).to.deep.equal({
+            currency: 'USD',
+            floor: 1.5734
+          });
+
+          expect(functionUsed).to.equal('Appnexus Inverse');
+        });
+
+        it('should pass inverseFloorAdjustment the bidRequest object so it can be used', function () {
+          // Adjustment factors based on Bid Media Type
+          const mediaTypeFactors = {
+            banner: 0.5,
+            native: 0.7,
+            video: 0.9
+          }
+          getGlobal().bidderSettings = {
+            rubicon: {
+              bidCpmAdjustment: function (bidCpm, bidResponse) {
+                return bidCpm * mediaTypeFactors[bidResponse.mediaType];
+              },
+              inverseBidAdjustment: function (bidCpm, bidRequest) {
+                // For the inverse we add up each mediaType in the request and divide by number of Mt's to get the inverse number
+                let factor = Object.keys(bidRequest.mediaTypes).reduce((sum, mediaType) => sum += mediaTypeFactors[mediaType], 0);
+                factor = factor / Object.keys(bidRequest.mediaTypes).length;
+                return bidCpm / factor;
+              },
+            }
+          };
+
+          // banner only should be 2
+          bidRequest.mediaTypes = { banner: {} };
+          expect(bidRequest.getFloor()).to.deep.equal({
+            currency: 'USD',
+            floor: 2.0
+          });
+
+          // native only should be 1.4286
+          bidRequest.mediaTypes = { native: {} };
+          expect(bidRequest.getFloor()).to.deep.equal({
+            currency: 'USD',
+            floor: 1.4286
+          });
+
+          // video only should be 1.1112
+          bidRequest.mediaTypes = { video: {} };
+          expect(bidRequest.getFloor()).to.deep.equal({
+            currency: 'USD',
+            floor: 1.1112
+          });
+
+          // video and banner should even out to 0.7 factor so 1.4286
+          bidRequest.mediaTypes = { video: {}, banner: {} };
+          expect(bidRequest.getFloor()).to.deep.equal({
+            currency: 'USD',
+            floor: 1.4286
+          });
+
+          // video and native should even out to 0.8 factor so -- 1.25
+          bidRequest.mediaTypes = { video: {}, native: {} };
+          expect(bidRequest.getFloor()).to.deep.equal({
+            currency: 'USD',
+            floor: 1.25
+          });
+
+          // banner and native should even out to 0.6 factor so -- 1.6667
+          bidRequest.mediaTypes = { banner: {}, native: {} };
+          expect(bidRequest.getFloor()).to.deep.equal({
+            currency: 'USD',
+            floor: 1.6667
+          });
+
+          // all 3 banner video and native should even out to 0.7 factor so -- 1.4286
+          bidRequest.mediaTypes = { banner: {}, native: {}, video: {} };
+          expect(bidRequest.getFloor()).to.deep.equal({
+            currency: 'USD',
+            floor: 1.4286
+          });
+        });
+
+        Object.entries({
+          'both unspecified': {
+            getFloorParams: undefined,
+            inverseParams: {}
           },
-          appnexus: {
-            bidCpmAdjustment: function (bidCpm, bidResponse) {
-              functionUsed = 'Appnexus Adjustment';
-              bidCpm *= 0.75;
-              if (bidResponse.mediaType === 'video') bidCpm -= 0.18;
-              return bidCpm;
-            },
-            inverseBidAdjustment: function (bidCpm, bidRequest) {
-              functionUsed = 'Appnexus Inverse';
-              // if video is the only mediaType on Bid Request => add 0.18
-              if (bidRequest.mediaTypes.video && Object.keys(bidRequest.mediaTypes).length === 1) bidCpm += 0.18;
-              return bidCpm / 0.75;
-            },
+          'only mediaType': {
+            getFloorParams: {mediaType: 'video'},
+            inverseParams: {mediaType: 'video'}
+          },
+          'only size': {
+            getFloorParams: {mediaType: '*', size: [1, 2]},
+            inverseParams: {size: [1, 2]}
+          },
+          'both': {
+            getFloorParams: {mediaType: 'banner', size: [1, 2]},
+            inverseParams: {mediaType: 'banner', size: [1, 2]}
           }
-        };
-
-        _floorDataForAuction[bidRequest.auctionId] = utils.deepClone(basicFloorConfig);
-
-        _floorDataForAuction[bidRequest.auctionId].data.values = { '*': 1.0 };
-
-        // start with banner as only mediaType
-        bidRequest.mediaTypes = { banner: { sizes: [[300, 250]] } };
-        let appnexusBid = {
-          ...bidRequest,
-          bidder: 'appnexus',
-        };
-
-        // should be same as the adjusted calculated inverses above test (banner)
-        expect(bidRequest.getFloor()).to.deep.equal({
-          currency: 'USD',
-          floor: 2.0
-        });
-
-        // should use rubicon inverse
-        expect(functionUsed).to.equal('Rubicon Inverse');
-
-        // appnexus just using banner should be same
-        expect(appnexusBid.getFloor()).to.deep.equal({
-          currency: 'USD',
-          floor: 1.3334
-        });
-
-        expect(functionUsed).to.equal('Appnexus Inverse');
-
-        // now since asking for 'video' only mediaType inverse function should include the .18
-        bidRequest.mediaTypes = { video: { context: 'instream' } };
-        expect(bidRequest.getFloor({ mediaType: 'video' })).to.deep.equal({
-          currency: 'USD',
-          floor: 2.36
-        });
-
-        expect(functionUsed).to.equal('Rubicon Inverse');
-
-        // now since asking for 'video' inverse function should include the .18
-        appnexusBid.mediaTypes = { video: { context: 'instream' } };
-        expect(appnexusBid.getFloor({ mediaType: 'video' })).to.deep.equal({
-          currency: 'USD',
-          floor: 1.5734
-        });
-
-        expect(functionUsed).to.equal('Appnexus Inverse');
-      });
-
-      it('should pass inverseFloorAdjustment the bidRequest object so it can be used', function () {
-        // Adjustment factors based on Bid Media Type
-        const mediaTypeFactors = {
-          banner: 0.5,
-          native: 0.7,
-          video: 0.9
-        }
-        getGlobal().bidderSettings = {
-          rubicon: {
-            bidCpmAdjustment: function (bidCpm, bidResponse) {
-              return bidCpm * mediaTypeFactors[bidResponse.mediaType];
-            },
-            inverseBidAdjustment: function (bidCpm, bidRequest) {
-              // For the inverse we add up each mediaType in the request and divide by number of Mt's to get the inverse number
-              let factor = Object.keys(bidRequest.mediaTypes).reduce((sum, mediaType) => sum += mediaTypeFactors[mediaType], 0);
-              factor = factor / Object.keys(bidRequest.mediaTypes).length;
-              return bidCpm / factor;
-            },
-          }
-        };
-
-        _floorDataForAuction[bidRequest.auctionId] = utils.deepClone(basicFloorConfig);
-
-        _floorDataForAuction[bidRequest.auctionId].data.values = { '*': 1.0 };
-
-        // banner only should be 2
-        bidRequest.mediaTypes = { banner: {} };
-        expect(bidRequest.getFloor()).to.deep.equal({
-          currency: 'USD',
-          floor: 2.0
-        });
-
-        // native only should be 1.4286
-        bidRequest.mediaTypes = { native: {} };
-        expect(bidRequest.getFloor()).to.deep.equal({
-          currency: 'USD',
-          floor: 1.4286
-        });
-
-        // video only should be 1.1112
-        bidRequest.mediaTypes = { video: {} };
-        expect(bidRequest.getFloor()).to.deep.equal({
-          currency: 'USD',
-          floor: 1.1112
-        });
-
-        // video and banner should even out to 0.7 factor so 1.4286
-        bidRequest.mediaTypes = { video: {}, banner: {} };
-        expect(bidRequest.getFloor()).to.deep.equal({
-          currency: 'USD',
-          floor: 1.4286
-        });
-
-        // video and native should even out to 0.8 factor so -- 1.25
-        bidRequest.mediaTypes = { video: {}, native: {} };
-        expect(bidRequest.getFloor()).to.deep.equal({
-          currency: 'USD',
-          floor: 1.25
-        });
-
-        // banner and native should even out to 0.6 factor so -- 1.6667
-        bidRequest.mediaTypes = { banner: {}, native: {} };
-        expect(bidRequest.getFloor()).to.deep.equal({
-          currency: 'USD',
-          floor: 1.6667
-        });
-
-        // all 3 banner video and native should even out to 0.7 factor so -- 1.4286
-        bidRequest.mediaTypes = { banner: {}, native: {}, video: {} };
-        expect(bidRequest.getFloor()).to.deep.equal({
-          currency: 'USD',
-          floor: 1.4286
-        });
+        }).forEach(([t, {getFloorParams, inverseParams}]) => {
+          it(`should pass inverseFloorAdjustment mediatype and size (${t})`, () => {
+            getGlobal().bidderSettings = {
+              standard: {
+                inverseBidAdjustment: sinon.stub()
+              }
+            }
+            bidRequest.mediaTypes = {
+              video: {},
+              native: {},
+              banner: {
+                sizes: [[100, 200], [200, 300]]
+              }
+            }
+            bidRequest.getFloor(getFloorParams);
+            sinon.assert.calledWith(getGlobal().bidderSettings.standard.inverseBidAdjustment, 1, bidRequest, inverseParams);
+          });
+        })
       });
 
       it('should use standard cpmAdjustment if no bidder cpmAdjustment', function () {

--- a/test/spec/ortbConverter/priceFloors_spec.js
+++ b/test/spec/ortbConverter/priceFloors_spec.js
@@ -1,7 +1,7 @@
 import {config} from 'src/config.js';
 import {setOrtbExtPrebidFloors, setOrtbImpBidFloor, setGranularBidfloors} from '../../../modules/priceFloors.js';
 import 'src/prebid.js';
-import {ORTB_MTYPES} from "../../../libraries/ortbConverter/processors/mediaType.js";
+import {ORTB_MTYPES} from '../../../libraries/ortbConverter/processors/mediaType.js';
 
 describe('pbjs - ortb imp floor params', () => {
   before(() => {

--- a/test/spec/ortbConverter/priceFloors_spec.js
+++ b/test/spec/ortbConverter/priceFloors_spec.js
@@ -1,6 +1,7 @@
 import {config} from 'src/config.js';
-import {setOrtbExtPrebidFloors, setOrtbImpBidFloor} from '../../../modules/priceFloors.js';
+import {setOrtbExtPrebidFloors, setOrtbImpBidFloor, setGranularBidfloors} from '../../../modules/priceFloors.js';
 import 'src/prebid.js';
+import {ORTB_MTYPES} from "../../../libraries/ortbConverter/processors/mediaType.js";
 
 describe('pbjs - ortb imp floor params', () => {
   before(() => {
@@ -112,6 +113,87 @@ describe('pbjs - ortb imp floor params', () => {
     expect(reqMediaType).to.eql('banner');
   })
 });
+
+describe('setOrtbImpExtBidFloor', () => {
+  let bidRequest, floor, currency, imp;
+  beforeEach(() => {
+    bidRequest = {
+      getFloor: sinon.stub().callsFake(() => ({floor, currency}))
+    }
+    imp = {
+      bidfloor: 1.23,
+      bidfloorcur: 'EUR'
+    };
+  });
+
+  Object.values(ORTB_MTYPES).forEach(mediaType => {
+    describe(`${mediaType}.ext.bidfloor`, () => {
+      it(`should NOT be set if imp has no ${mediaType}`, () => {
+        setGranularBidfloors(imp, bidRequest);
+        expect(imp[mediaType]).to.not.exist;
+      });
+      it('should NOT be set if floor is same as imp.bidfloor', () => {
+        floor = 1.23
+        currency = 'EUR'
+        imp[mediaType] = {};
+        setGranularBidfloors(imp, bidRequest);
+        expect(imp[mediaType].ext).to.not.exist;
+        sinon.assert.calledWith(bidRequest.getFloor, sinon.match({mediaType}))
+      });
+      it('should be set otherwise', () => {
+        floor = 3.21;
+        currency = 'JPY';
+        imp[mediaType] = {};
+        setGranularBidfloors(imp, bidRequest);
+        expect(imp[mediaType].ext).to.eql({
+          bidfloor: 3.21,
+          bidfloorcur: 'JPY'
+        });
+        sinon.assert.calledWith(bidRequest.getFloor, sinon.match({mediaType}))
+      });
+    });
+  });
+  describe('per-format floors', () => {
+    beforeEach(() => {
+      imp = {
+        banner: {
+          format: [
+            {w: 1, h: 2},
+            {w: 3, h: 4}
+          ]
+        }
+      }
+    });
+
+    it('should NOT be set if same as imp.bidfloor', () => {
+      floor = 1.23
+      currency = 'EUR';
+      setGranularBidfloors(imp, bidRequest);
+      expect(imp.banner.format.filter(fmt => fmt.bidfloor)).to.eql([]);
+      [[1, 2], [3, 4]].forEach(size => {
+        sinon.assert.calledWith(bidRequest.getFloor, sinon.match({size}));
+      });
+    });
+
+    it('should be set otherwise', () => {
+      floor = 3.21;
+      currency = 'JPY';
+      setGranularBidfloors(imp, bidRequest);
+      imp.banner.format.forEach((fmt) => {
+        expect(fmt.ext).to.eql({bidfloor: 3.21, bidfloorcur: 'JPY'});
+        sinon.assert.calledWith(bidRequest.getFloor, sinon.match({mediaType: 'banner', size: [fmt.w, fmt.h]}));
+      })
+    });
+
+    it('should not be set if format is missing w/h', () => {
+      floor = 3.21;
+      currency = 'JPY';
+      delete imp.banner.format[0].w;
+      setGranularBidfloors(imp, bidRequest);
+      expect(imp.banner.format[0].ext).to.not.exist;
+    })
+  })
+})
 
 describe('setOrtbExtPrebidFloors', () => {
   before(() => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

 - Updated priceFloors to pass a 3rd argument `{size, mediaType}` to `inverseCpmAdjustment`
 - Updated ORTB converter to ask for specific floors for each mediatype and banner size. If these are different from `imp.bidfloor`, they're set to `ext.bidfloor` & `ext.bidfloorcur` under `native`/`video`/`banner` and each format in `banner.format`.
 - Updated the PBS adapter to aggregate granular floors in a similar way to `imp.bidfloor` (in case floors are different across bidders).

## Other information

Closes https://github.com/prebid/Prebid.js/issues/12308

