### PR TITLE
PAAPIForGPT: fix for submodule registration

### DIFF
--- a/modules/paapiForGpt.js
+++ b/modules/paapiForGpt.js
@@ -157,7 +157,7 @@ getGlobal().setPAAPIConfigForGPT = setPAAPIConfigFactory();
 const setTargetingHook = setTargetingHookFactory();
 
 submodule('paapi', {
-  name: 'gpt',
+  name: MODULE,
   init(params) {
     getPAAPIConfig = params.getPAAPIConfig;
     getHook('getPAAPISize').before(getPAAPISizeHook);


### PR DESCRIPTION
I noticed when running PAAPI with only the `paapiForGpt` module included, it produced errors.
According to [this](https://docs.prebid.org/dev-docs/modules/paapiForGpt.html), it should automatically include the `paapi` module as well.

## Type of change
- [x] Bugfix

## Description of change
This just changes the hardcoded `gpt` to the defined `MODULE` name.
