### PR TITLE
hotfix: Send separate requests for native and banner

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -162,12 +162,17 @@ function isBidRequestValid(bidRequest) {
 }
 
 function buildRequests(bids, bidderRequest) {
-  let videoBids = bids.filter(bid => isVideoBid(bid));
-  let bannerAndNativeBids = bids.filter(bid => isBannerBid(bid) || isNativeBid(bid))
-    // In case of multi-format bids remove `video` from mediaTypes as for video a separate bid request is built
-    .map(bid => ({...bid, mediaTypes: {...bid.mediaTypes, video: undefined}}));
+  const videoBids = bids.filter(bid => isVideoBid(bid));
+  const nativeBids = bids.filter(bid => isNativeBid(bid));
+  const bannerBids = bids.filter(bid => isBannerBid(bid));
 
-  let requests = bannerAndNativeBids.length ? [createRequest(bannerAndNativeBids, bidderRequest, null)] : [];
+  const requests = []
+  if (bannerBids.length) {
+    requests.push(createRequest(bannerBids, bidderRequest, BANNER))
+  }
+  if (nativeBids.length) {
+    requests.push(createRequest(nativeBids, bidderRequest, NATIVE));
+  }
   videoBids.forEach(bid => {
     requests.push(createRequest([bid], bidderRequest, VIDEO));
   });

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -435,12 +435,15 @@ describe('OpenxRtbAdapter', function () {
           sizes: [[300, 250], [300, 600]]
         }
         const requests = spec.buildRequests([multiformat], mockBidderRequest);
-        expect(requests).to.have.length(1);
+        expect(requests).to.have.length(FEATURES.NATIVE ? 2 : 1);
         expect(requests[0].data.imp).to.have.length(1);
         expect(requests[0].data.imp[0].banner).to.exist;
+        expect(requests[0].data.imp[0].native).to.not.exist;
         expect(requests[0].data.imp[0].video).to.not.exist;
         if (FEATURES.NATIVE) {
-          expect(requests[0].data.imp[0].native).to.exist;
+          expect(requests[1].data.imp[0].native).to.exist;
+          expect(requests[1].data.imp[0].banner).to.not.exist;
+          expect(requests[1].data.imp[0].video).to.not.exist;
         }
       })
 
@@ -454,18 +457,22 @@ describe('OpenxRtbAdapter', function () {
           sizes: [[300, 250]]
         }
         const requests = spec.buildRequests([multiformat], mockBidderRequest);
-        expect(requests).to.have.length(2);
+        expect(requests).to.have.length(3);
         expect(requests[0].data.imp).to.have.length(1);
         expect(requests[0].data.imp[0].banner).to.exist;
+        expect(requests[0].data.imp[0].native).to.not.exist;
         expect(requests[0].data.imp[0].video).to.not.exist;
         if (FEATURES.NATIVE) {
-          expect(requests[0].data.imp[0].native).to.exist;
+          expect(requests[1].data.imp[0].native).to.exist;
+          expect(requests[1].data.imp[0].banner).to.not.exist;
+          expect(requests[1].data.imp[0].video).to.not.exist;
         }
-        expect(requests[1].data.imp).to.have.length(1);
-        expect(requests[1].data.imp[0].banner).to.not.exist;
-        expect(requests[1].data.imp[0].native).to.not.exist;
+        const videoIndex = FEATURES.NATIVE ? 2 : 1;
+        expect(requests[videoIndex].data.imp).to.have.length(1);
+        expect(requests[videoIndex].data.imp[0].banner).to.not.exist;
+        expect(requests[videoIndex].data.imp[0].native).to.not.exist;
         if (FEATURES.VIDEO) {
-          expect(requests[1].data.imp[0].video).to.exist;
+          expect(requests[videoIndex].data.imp[0].video).to.exist;
         }
       })
 

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -426,6 +426,8 @@ describe('OpenxRtbAdapter', function () {
         expect(requests[1].data.imp[0].native).to.not.exist;
         if (FEATURES.VIDEO) {
           expect(requests[1].data.imp[0].video).to.exist;
+        } else {
+          expect(requests[1].data.imp[0].video).to.not.exist;
         }
       })
 
@@ -435,15 +437,17 @@ describe('OpenxRtbAdapter', function () {
           sizes: [[300, 250], [300, 600]]
         }
         const requests = spec.buildRequests([multiformat], mockBidderRequest);
-        expect(requests).to.have.length(FEATURES.NATIVE ? 2 : 1);
+        expect(requests).to.have.length(2);
         expect(requests[0].data.imp).to.have.length(1);
         expect(requests[0].data.imp[0].banner).to.exist;
         expect(requests[0].data.imp[0].native).to.not.exist;
         expect(requests[0].data.imp[0].video).to.not.exist;
+        expect(requests[1].data.imp[0].banner).to.not.exist;
+        expect(requests[1].data.imp[0].video).to.not.exist;
         if (FEATURES.NATIVE) {
           expect(requests[1].data.imp[0].native).to.exist;
-          expect(requests[1].data.imp[0].banner).to.not.exist;
-          expect(requests[1].data.imp[0].video).to.not.exist;
+        } else {
+          expect(requests[1].data.imp[0].native).to.not.exist;
         }
       })
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
