### PR TITLE
OpenX Bid Adapter : fix to determine bid mediaType based on ad markup

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -82,7 +82,7 @@ const converter = ortbConverter({
   bidResponse(buildBidResponse, bid, context) {
     if (!context.mediaType && !bid.mtype) {
       let mediaType = BANNER; // default media type
-      const vastKeywords = ['VAST ', 'vast ', 'videoad', 'dur', 'VAST_VERSION', 'dc_vast', 'video '];
+      const vastKeywords = ['VAST ', 'vast ', 'videoad', 'VAST_VERSION', 'dc_vast', 'video '];
       if (bid.adm && bid.adm.startsWith('{') && bid.adm.includes('"assets"')) {
         mediaType = NATIVE;
       } else if (bid.vastXml || bid.vastUrl || (bid.adm && vastKeywords.some(v => bid.adm.includes(v)))) {

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -80,13 +80,16 @@ const converter = ortbConverter({
     return req;
   },
   bidResponse(buildBidResponse, bid, context) {
-    let mediaType = BANNER; // default media type
-    if (bid.vastXml || bid.vastUrl || (bid.adm && bid.adm.startsWith('<VAST'))) {
-      mediaType = VIDEO;
-    } else if (bid.adm && bid.adm.startsWith('{') && bid.adm.includes('"assets"')) {
-      mediaType = NATIVE;
+    if (!context.mediaType) {
+      let mediaType = BANNER; // default media type
+      if (bid.vastXml || bid.vastUrl || (bid.adm && bid.adm.startsWith('<VAST'))) {
+        mediaType = VIDEO;
+      } else if (bid.adm && bid.adm.startsWith('{') && bid.adm.includes('"assets"')) {
+        mediaType = NATIVE;
+      }
+      bid.mediaType = mediaType;
+      bid.mtype = Object.keys(ORTB_MTYPES).find(key => ORTB_MTYPES[key] === mediaType);
     }
-    bid.mtype = Object.keys(ORTB_MTYPES).find(key => ORTB_MTYPES[key] === mediaType);
 
     const bidResponse = buildBidResponse(bid, context);
     if (bid.ext) {

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -82,7 +82,7 @@ const converter = ortbConverter({
   bidResponse(buildBidResponse, bid, context) {
     if (!context.mediaType && !bid.mtype) {
       let mediaType = BANNER; // default media type
-      const vastKeywords = ['VAST ', 'vast ', 'videoad', 'dur', 'VAST_VERSION', 'dc_vast', 'video ']
+      const vastKeywords = ['VAST ', 'vast ', 'videoad', 'dur', 'VAST_VERSION', 'dc_vast', 'video '];
       if (bid.adm && bid.adm.startsWith('{') && bid.adm.includes('"assets"')) {
         mediaType = NATIVE;
       } else if (bid.vastXml || bid.vastUrl || (bid.adm && vastKeywords.some(v => bid.adm.includes(v)))) {

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -82,10 +82,11 @@ const converter = ortbConverter({
   bidResponse(buildBidResponse, bid, context) {
     if (!context.mediaType && !bid.mtype) {
       let mediaType = BANNER; // default media type
-      if (bid.vastXml || bid.vastUrl || (bid.adm && bid.adm.startsWith('<VAST'))) {
-        mediaType = VIDEO;
-      } else if (bid.adm && bid.adm.startsWith('{') && bid.adm.includes('"assets"')) {
+      const vastKeywords = ['VAST ', 'vast ', 'videoad', 'dur', 'VAST_VERSION', 'dc_vast', 'video ']
+      if (bid.adm && bid.adm.startsWith('{') && bid.adm.includes('"assets"')) {
         mediaType = NATIVE;
+      } else if (bid.vastXml || bid.vastUrl || (bid.adm && vastKeywords.some(v => bid.adm.includes(v)))) {
+        mediaType = VIDEO;
       }
       bid.mediaType = mediaType;
       bid.mtype = Object.keys(ORTB_MTYPES).find(key => ORTB_MTYPES[key] === mediaType);

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -4,6 +4,7 @@ import * as utils from '../src/utils.js';
 import {mergeDeep} from '../src/utils.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
 import {ortbConverter} from '../libraries/ortbConverter/converter.js';
+import {ORTB_MTYPES} from '../libraries/ortbConverter/processors/mediaType.js';
 
 const bidderConfig = 'hb_pb_ortb';
 const bidderVersion = '2.0';
@@ -79,6 +80,14 @@ const converter = ortbConverter({
     return req;
   },
   bidResponse(buildBidResponse, bid, context) {
+    let mediaType = BANNER; // default media type
+    if (bid.vastXml || bid.vastUrl || (bid.adm && bid.adm.startsWith('<VAST'))) {
+      mediaType = VIDEO;
+    } else if (bid.adm && bid.adm.startsWith('{') && bid.adm.includes('"assets"')) {
+      mediaType = NATIVE;
+    }
+    bid.mtype = Object.keys(ORTB_MTYPES).find(key => ORTB_MTYPES[key] === mediaType);
+
     const bidResponse = buildBidResponse(bid, context);
     if (bid.ext) {
       bidResponse.meta.networkId = bid.ext.dsp_id;

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -80,7 +80,7 @@ const converter = ortbConverter({
     return req;
   },
   bidResponse(buildBidResponse, bid, context) {
-    if (!context.mediaType) {
+    if (!context.mediaType && !bid.mtype) {
       let mediaType = BANNER; // default media type
       if (bid.vastXml || bid.vastUrl || (bid.adm && bid.adm.startsWith('<VAST'))) {
         mediaType = VIDEO;

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1381,7 +1381,6 @@ describe('OpenxRtbAdapter', function () {
           crid: 'test-creative-id',
           dealid: 'test-deal-id',
           adm: 'test-ad-markup',
-          mtype: 1,
           adomain: ['brand.com'],
           ext: {
             dsp_id: '123',
@@ -1593,7 +1592,6 @@ describe('OpenxRtbAdapter', function () {
               bid: [{
                 impid: 'test-bid-id',
                 price: 2,
-                mtype: 4,
                 adm: '{"ver": "1.2", "assets": [{"id": 1, "required": 1,"title": {"text": "OpenX (Title)"}}], "link": {"url": "https://www.openx.com/"}, "eventtrackers":[{"event":1,"method":1,"url":"http://example.com/impression"}]}',
               }]
             }],

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1530,7 +1530,7 @@ describe('OpenxRtbAdapter', function () {
                 h: 480,
                 crid: 'test-creative-id',
                 dealid: 'test-deal-id',
-                adm: 'test-ad-markup',
+                adm: '<VAST version="4.0"><Ad></Ad></VAST>',
               }]
             }],
             cur: 'AUS'
@@ -1619,6 +1619,59 @@ describe('OpenxRtbAdapter', function () {
               url: 'http://example.com/impression'
             }]
           });
+        });
+      });
+
+      context('when banner + native request and the response is a banner', function() {
+        beforeEach(function () {
+          const nativeOrtbRequest = {
+            ver: '1.2',
+            assets: [{
+              id: 1,
+              required: 1,
+              title: {
+                len: 80
+              }
+            }]
+          };
+          bidRequestConfigs = [{
+            bidder: 'openx',
+            params: {
+              unit: '12345678',
+              delDomain: 'test-del-domain'
+            },
+            adUnitCode: 'adunit-code',
+            mediaTypes: {
+              banner: {
+                sizes: [[300, 250], [300, 600]]
+              },
+              native: {
+                ...nativeOrtbRequest
+              },
+            },
+            nativeOrtbRequest,
+            bidId: 'test-bid-id',
+            bidderRequestId: 'test-bidder-request-id',
+            auctionId: 'test-auction-id'
+          }];
+
+          bidRequest = spec.buildRequests(bidRequestConfigs, {refererInfo: {}})[0];
+
+          bidResponse = {
+            seatbid: [{
+              bid: [{
+                impid: 'test-bid-id',
+                price: 2,
+                adm: '<iframe src="https://test.url"></iframe>',
+              }]
+            }],
+            cur: 'AUS'
+          };
+        });
+
+        it('should return banner mediaType', function () {
+          bid = spec.interpretResponse({body: bidResponse}, bidRequest).bids[0];
+          expect(bid.mediaType).to.equal(BANNER);
         });
       });
     }

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1495,9 +1495,7 @@ describe('OpenxRtbAdapter', function () {
       });
 
       it('should return the proper mediaType', function () {
-        it('should return a creativeId', function () {
-          expect(bid.mediaType).to.equal(Object.keys(bidRequestConfigs[0].mediaTypes)[0]);
-        });
+        expect(bid.mediaType).to.equal(Object.keys(bidRequestConfigs[0].mediaTypes)[0]);
       });
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
These changes are connected with the bug introduced in this commit: [743f100](https://github.com/prebid/Prebid.js/commit/743f100fcfc2551b79cc1e677170a4e1796ebd51#diff-1b7b8529cd571697ee8f92b2d0214da8e41c7ab8a4cb1e87be5db4083dc03ab5R166%7Chttps://github.com/prebid/Prebid.js/commit/743f100fcfc2551b79cc1e677170a4e1796ebd51%23diff-1b7b8529cd571697ee8f92b2d0214da8e41c7ab8a4cb1e87be5db4083dc03ab5R166%7Csmart-link).
This implementation assumed that the `bid.mtype` will be always returned in the response. It is not, that's why I added the code which determine bid mediaType based on ad markup.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
