### PR TITLE
Core: always signal rendererVersion to PUC

### DIFF
--- a/modules/nativeRendering.js
+++ b/modules/nativeRendering.js
@@ -7,8 +7,7 @@ import {getCreativeRendererSource} from '../src/creativeRenderers.js';
 function getRenderingDataHook(next, bidResponse, options) {
   if (isNativeResponse(bidResponse)) {
     next.bail({
-      native: getNativeRenderingData(bidResponse, auctionManager.index.getAdUnit(bidResponse)),
-      rendererVersion: 2 // 9.28 fixed a rendering bug; this signals to PUC that the native renderer is safe to use
+      native: getNativeRenderingData(bidResponse, auctionManager.index.getAdUnit(bidResponse))
     })
   } else {
     next(bidResponse, options)

--- a/src/creativeRenderers.js
+++ b/src/creativeRenderers.js
@@ -3,6 +3,9 @@ import {createInvisibleIframe} from './utils.js';
 import {RENDERER} from '../libraries/creative-renderer-display/renderer.js';
 import {hook} from './hook.js';
 
+// the minimum rendererVersion that will be used by PUC
+export const PUC_MIN_VERSION = 3;
+
 export const getCreativeRendererSource = hook('sync', function (bidResponse) {
   return RENDERER;
 })

--- a/src/native.js
+++ b/src/native.js
@@ -15,7 +15,7 @@ import {auctionManager} from './auctionManager.js';
 import {NATIVE_ASSET_TYPES, NATIVE_IMAGE_TYPES, PREBID_NATIVE_DATA_KEYS_TO_ORTB, NATIVE_KEYS_THAT_ARE_NOT_ASSETS, NATIVE_KEYS} from './constants.js';
 import {NATIVE} from './mediaTypes.js';
 import {getRenderingData} from './adRendering.js';
-import {getCreativeRendererSource} from './creativeRenderers.js';
+import {getCreativeRendererSource, PUC_MIN_VERSION} from './creativeRenderers.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -436,16 +436,14 @@ function assetsMessage(data, adObject, keys, {index = auctionManager.index} = {}
     message: 'assetResponse',
     adId: data.adId,
   };
-  let {native: renderData, rendererVersion} = getRenderingData(adObject);
+  let renderData = getRenderingData(adObject).native;
   if (renderData) {
     // if we have native rendering data (set up by the nativeRendering module)
     // include it in full ("all assets") together with the renderer.
     // this is to allow PUC to use dynamic renderers without requiring changes in creative setup
-    Object.assign(msg, {
-      native: Object.assign({}, renderData),
-      renderer: getCreativeRendererSource(adObject),
-      rendererVersion,
-    })
+    msg.native = Object.assign({}, renderData);
+    msg.renderer = getCreativeRendererSource(adObject);
+    msg.rendererVersion = PUC_MIN_VERSION;
     if (keys != null) {
       renderData.assets = renderData.assets.filter(({key}) => keys.includes(key))
     }

--- a/src/secureCreatives.js
+++ b/src/secureCreatives.js
@@ -15,7 +15,7 @@ import {
   handleRender,
   markWinner
 } from './adRendering.js';
-import {getCreativeRendererSource} from './creativeRenderers.js';
+import {getCreativeRendererSource, PUC_MIN_VERSION} from './creativeRenderers.js';
 
 const { REQUEST, RESPONSE, NATIVE, EVENT } = MESSAGES;
 
@@ -89,7 +89,8 @@ function handleRenderRequest(reply, message, bidResponse) {
     renderFn(adData) {
       reply(Object.assign({
         message: RESPONSE,
-        renderer: getCreativeRendererSource(bidResponse)
+        renderer: getCreativeRendererSource(bidResponse),
+        rendererVersion: PUC_MIN_VERSION
       }, adData));
     },
     resizeFn: getResizer(message.adId, bidResponse),

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -21,7 +21,7 @@ import { stubAuctionIndex } from '../helpers/indexStub.js';
 import { convertOrtbRequestToProprietaryNative, fromOrtbNativeRequest } from '../../src/native.js';
 import {auctionManager} from '../../src/auctionManager.js';
 import {getRenderingData} from '../../src/adRendering.js';
-import {getCreativeRendererSource} from '../../src/creativeRenderers.js';
+import {getCreativeRendererSource, PUC_MIN_VERSION} from '../../src/creativeRenderers.js';
 import {deepSetValue} from '../../src/utils.js';
 const utils = require('src/utils');
 
@@ -434,7 +434,7 @@ describe('native.js', function () {
         function checkRenderer(message) {
           if (withRenderer) {
             expect(message.renderer).to.eql('mock-native-renderer')
-            expect(message.rendererVersion).to.eql('native-render-version');
+            expect(message.rendererVersion).to.eql(PUC_MIN_VERSION);
             Object.entries(message).forEach(([key, val]) => {
               if (!['native', 'adId', 'message', 'assets', 'renderer', 'rendererVersion'].includes(key)) {
                 expect(message.native[key]).to.eql(val);

--- a/test/spec/unit/secureCreatives_spec.js
+++ b/test/spec/unit/secureCreatives_spec.js
@@ -15,6 +15,7 @@ import {expect} from 'chai';
 
 import {AD_RENDER_FAILED_REASON, BID_STATUS, EVENTS} from 'src/constants.js';
 import {getBidToRender} from '../../../src/adRendering.js';
+import {PUC_MIN_VERSION} from 'src/creativeRenderers.js';
 
 describe('secureCreatives', () => {
   let sandbox;
@@ -298,7 +299,10 @@ describe('secureCreatives', () => {
           data: JSON.stringify({adId: bidId, message: 'Prebid Request'})
         });
         return receive(ev).then(() => {
-          sinon.assert.calledWith(ev.source.postMessage, sinon.match(ob => JSON.parse(ob).renderer === 'mock-renderer'));
+          sinon.assert.calledWith(ev.source.postMessage, sinon.match(ob => {
+            const {renderer, rendererVersion} = JSON.parse(ob);
+            return renderer === 'mock-renderer' && rendererVersion === PUC_MIN_VERSION;
+          }));
         });
       });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

This updates creative messages to signal `rendererVersion: 3`, to enable the use of dynamic renderers in PUC (https://github.com/prebid/prebid-universal-creative/pull/252).

This is the same idea as in https://github.com/prebid/Prebid.js/pull/12655, where `rendererVersion` was used so that PUC could disregard some versions that had known bugs - but extended to all versions before this is released.

The intent is to reduce the impact of releasing https://github.com/prebid/prebid-universal-creative/pull/229, and allowing publishers to potentially roll back Prebid if they find problems with the new logic.

