### PR TITLE
Module: appnexusBidAdapter. handle the case when userId is set, but userIdAsEids not

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -354,18 +354,23 @@ export const spec = {
 
     if (bidRequests[0].userId) {
       let eids = [];
-      bidRequests[0].userIdAsEids.forEach(eid => {
-        if (!eid || !eid.uids || eid.uids.length < 1) { return; }
-        eid.uids.forEach(uid => {
-          let tmp = {'source': eid.source, 'id': uid.id};
-          if (eid.source == 'adserver.org') {
-            tmp.rti_partner = 'TDID';
-          } else if (eid.source == 'uidapi.com') {
-            tmp.rti_partner = 'UID2';
-          }
-          eids.push(tmp);
+      const processEids = (uids) => {
+        uids?.forEach(eid => {
+          if (!eid || !eid.uids || eid.uids.length < 1) { return; }
+          eid.uids.forEach(uid => {
+            let tmp = {'source': eid.source, 'id': uid.id};
+            if (eid.source == 'adserver.org') {
+              tmp.rti_partner = 'TDID';
+            } else if (eid.source == 'uidapi.com') {
+              tmp.rti_partner = 'UID2';
+            }
+            eids.push(tmp);
+          });
         });
-      });
+      }
+      if(bidRequests[0].userIdAsEids){
+        processEids(bidRequests[0].userIdAsEids);
+      }
       if (eids.length) {
         payload.eids = eids;
       }

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -368,7 +368,7 @@ export const spec = {
           });
         });
       }
-      if(bidRequests[0].userIdAsEids){
+      if (bidRequests[0].userIdAsEids) {
         processEids(bidRequests[0].userIdAsEids);
       }
       if (eids.length) {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -355,7 +355,7 @@ export const spec = {
     if (bidRequests[0].userId) {
       let eids = [];
       const processEids = (uids) => {
-        uids?.forEach(eid => {
+        uids.forEach(eid => {
           if (!eid || !eid.uids || eid.uids.length < 1) { return; }
           eid.uids.forEach(uid => {
             let tmp = {'source': eid.source, 'id': uid.id};


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
it appears that when appnexus tries to populate the eids, a scenario can exists where the `bidRequests[0].userId` is set, but the `bidRequests[0].userIdAsEids` not in which case the adapter produces an error; 
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/fd0038b7-11a2-4784-84a1-9031346fa22d" />
