### PR TITLE
Adnuntius Bid Adapter: support native ad requests

### DIFF
--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -1,5 +1,5 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import {BANNER, VIDEO} from '../src/mediaTypes.js';
+import {BANNER, VIDEO, NATIVE} from '../src/mediaTypes.js';
 import {isStr, isEmpty, deepAccess, getUnixTimestampFromNow, convertObjectToArray, getWindowTop} from '../src/utils.js';
 import { config } from '../src/config.js';
 import { getStorageManager } from '../src/storageManager.js';
@@ -12,7 +12,7 @@ const BIDDER_CODE_DEAL_ALIASES = [1, 2, 3, 4, 5].map(num => {
 const ENDPOINT_URL = 'https://ads.adnuntius.delivery/i';
 const ENDPOINT_URL_EUROPE = 'https://europe.delivery.adnuntius.com/i';
 const GVLID = 855;
-const SUPPORTED_MEDIA_TYPES = [BANNER, VIDEO];
+const SUPPORTED_MEDIA_TYPES = [BANNER, VIDEO, NATIVE];
 const MAXIMUM_DEALS_LIMIT = 5;
 const VALID_BID_TYPES = ['netBid', 'grossBid'];
 const METADATA_KEY = 'adn.metaData';
@@ -319,6 +319,9 @@ export const spec = {
         const adUnit = {...bidTargeting, auId: bid.params.auId, targetId: targetId};
         if (mediaType === VIDEO) {
           adUnit.adType = 'VAST';
+        } else if (mediaType === NATIVE) {
+          adUnit.adType = 'NATIVE';
+          adUnit.nativeRequest = mediaTypeData.ortb;
         }
         const maxDeals = Math.max(0, Math.min(bid.params.maxDeals || 0, MAXIMUM_DEALS_LIMIT));
         if (maxDeals > 0) {
@@ -391,10 +394,13 @@ export const spec = {
       const isDeal = dealCount > 0;
       const renderSource = isDeal ? ad : adUnit;
       if (renderSource.vastXml) {
-        adResponse.vastXml = renderSource.vastXml
-        adResponse.mediaType = VIDEO
+        adResponse.vastXml = renderSource.vastXml;
+        adResponse.mediaType = VIDEO;
+      } else if (renderSource.nativeJson) {
+        adResponse.mediaType = NATIVE;
+        adResponse.native = renderSource.nativeJson;
       } else {
-        adResponse.ad = renderSource.html
+        adResponse.ad = renderSource.html;
       }
       return adResponse;
     }

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -106,7 +106,33 @@ describe('adnuntiusBidAdapter', function () {
     }
   ];
 
-  const multiBidderInResponse = {
+  const nativeBidderRequest = {bid: [
+    {
+      bidId: 'adn-0000000000000551',
+      bidder: 'adnuntius',
+      params: {
+        auId: '0000000000000551',
+        network: 'adnuntius',
+      },
+      mediaTypes: {
+        native: {
+          ortb: {
+            assets: [{
+              id: 1,
+              required: 1,
+              img: {
+                type: 3,
+                w: 250,
+                h: 250,
+              }
+            }]
+          }
+        }
+      },
+    }
+  ]};
+
+  const multiBidAndFormatRequest = {
     bid: [{
       bidder: 'adnuntius',
       bidId: '3a602680158a85',
@@ -127,6 +153,7 @@ describe('adnuntiusBidAdapter', function () {
     },
     {
       bidder: 'adnuntius',
+      bidId: 'fewwef',
       params: {
         auId: '381535',
         network: '1287',
@@ -140,6 +167,51 @@ describe('adnuntiusBidAdapter', function () {
         video: {
           playerSize: [200, 200],
           context: 'instream'
+        },
+        native: {
+          ortb: {
+            assets: [{
+              id: 1,
+              required: 1,
+              img: {
+                type: 3,
+                w: 150,
+                h: 50,
+              }
+            }]
+          }
+        }
+      }
+    },
+    {
+      bidder: 'adnuntius',
+      bidId: 'pol',
+      params: {
+        auId: '381535',
+        network: '1287',
+        bidType: 'netBid',
+        targetId: 'alt',
+      },
+      mediaTypes: {
+        banner: {
+          sizes: [[200, 200]]
+        },
+        video: {
+          playerSize: [200, 200],
+          context: 'instream'
+        },
+        native: {
+          ortb: {
+            assets: [{
+              id: 1,
+              required: 1,
+              img: {
+                type: 3,
+                w: 150,
+                h: 50,
+              }
+            }]
+          }
         }
       }
     }]
@@ -172,7 +244,7 @@ describe('adnuntiusBidAdapter', function () {
         bidId: 'adn-0000000000000551',
       }
     ]
-  }
+  };
 
   const videoBidRequest = {
     bid: videoBidderRequest,
@@ -180,7 +252,7 @@ describe('adnuntiusBidAdapter', function () {
     params: {
       bidType: 'justsomestuff-error-handling'
     }
-  }
+  };
 
   const deals = [
     {
@@ -246,6 +318,72 @@ describe('adnuntiusBidAdapter', function () {
     }
   ];
 
+  const nativeResponseBody = [
+    {
+      'auId': '0000000000000551',
+      'targetId': 'adn-0000000000000551',
+      'nativeJson': {
+        'assets': [
+          {
+            'id': 1,
+            'required': 1,
+            'img': {
+              'url': 'http://something.com/something.png'
+            }
+          },
+          {
+            'url': 'http://whatever.com'
+          }]
+      },
+      'matchedAdCount': 1,
+      'responseId': '',
+      'ads': [
+        {
+          'advertiserDomains': ['adnuntius.com'],
+          'creativeWidth': 640,
+          'creativeHeight': 640,
+          'cpm': {
+            'amount': 2000,
+            'currency': 'NOK'
+          },
+          'bid': {
+            'amount': 2,
+            'currency': 'NOK'
+          },
+          'grossBid': {
+            'amount': 2,
+            'currency': 'NOK'
+          },
+          'netBid': {
+            'amount': 2,
+            'currency': 'NOK'
+          },
+          'cost': {
+            'amount': 2,
+            'currency': 'NOK'
+          },
+          'assets': {
+            'img': {
+              'cdnId': 'http://localhost:8079/cdn/9urJusYWpjFDLcpOwfejrkWlLP1heM3vWIJjuHk48BQ.mp4',
+              'width': '1920',
+              'height': '1080'
+            }
+          },
+        }
+      ]
+    }
+  ];
+
+  const nativeResponse = {
+    body: {
+      'adUnits': nativeResponseBody
+    }
+  };
+
+  const nativeMultiFormatResponseBody = JSON.parse(JSON.stringify(nativeResponseBody[0]));
+  nativeMultiFormatResponseBody.auId = '0000000000381535';
+  nativeMultiFormatResponseBody.targetId = 'alt-native';
+
   const multiFormatServerResponse = {
     body: {
       'adUnits': [
@@ -258,23 +396,23 @@ describe('adnuntiusBidAdapter', function () {
           'ads': [
             {
               'cpm': {
-                'amount': 1500.0,
+                'amount': 12500.0,
                 'currency': 'NOK'
               },
               'bid': {
-                'amount': 1.5,
+                'amount': 5,
                 'currency': 'NOK'
               },
               'grossBid': {
-                'amount': 1.5,
+                'amount': 5,
                 'currency': 'NOK'
               },
               'netBid': {
-                'amount': 1.5,
+                'amount': 5,
                 'currency': 'NOK'
               },
               'cost': {
-                'amount': 1.5,
+                'amount': 5,
                 'currency': 'NOK'
               },
               creativeWidth: 200,
@@ -321,6 +459,7 @@ describe('adnuntiusBidAdapter', function () {
             }
           ]
         },
+        nativeMultiFormatResponseBody,
         {
           'auId': '0000000000381535',
           'targetId': '3a602680158a85',
@@ -341,6 +480,42 @@ describe('adnuntiusBidAdapter', function () {
               'destinationUrlEsc': '',
               'cpm': {
                 'amount': 1250.0,
+                'currency': 'NOK'
+              },
+              creativeWidth: 200,
+              creativeHeight: 240,
+              'bid': {
+                'amount': 1.75,
+                'currency': 'NOK'
+              },
+              'grossBid': {
+                'amount': 1.75,
+                'currency': 'NOK'
+              },
+              'netBid': {
+                'amount': 1.75,
+                'currency': 'NOK'
+              },
+              'cost': {
+                'amount': 1.75,
+                'currency': 'NOK'
+              },
+              'html': '\u003Ca \'\u003E\u003C/script\u003E',
+            }
+          ]
+        },
+        {
+          'auId': '0000000000381535',
+          'renderOption': 'DIV',
+          'targetId': 'alt',
+          'html': '\u003C!DOCTYPE html\u003E\n\u003C\u003E\n\u003C/html\u003E',
+          'matchedAdCount': 1,
+          'responseId': 'adn-rsp-1620340740',
+          'ads': [
+            {
+              'destinationUrlEsc': '',
+              'cpm': {
+                'amount': 1000.0,
                 'currency': 'NOK'
               },
               creativeWidth: 200,
@@ -1322,8 +1497,8 @@ describe('adnuntiusBidAdapter', function () {
         }
       });
 
-      const interpretedResponse = config.runWithBidder('adnuntius', () => spec.interpretResponse(multiFormatServerResponse, multiBidderInResponse));
-      expect(interpretedResponse).to.have.lengthOf(2);
+      const interpretedResponse = config.runWithBidder('adnuntius', () => spec.interpretResponse(multiFormatServerResponse, multiBidAndFormatRequest));
+      expect(interpretedResponse).to.have.lengthOf(3);
 
       let ad = multiFormatServerResponse.body.adUnits[0].ads[0];
       expect(interpretedResponse[0].bidderCode).to.equal('adnuntius');
@@ -1336,7 +1511,7 @@ describe('adnuntiusBidAdapter', function () {
       expect(interpretedResponse[0].ad).to.equal(multiFormatServerResponse.body.adUnits[0].html);
       expect(interpretedResponse[0].ttl).to.equal(360);
 
-      ad = multiFormatServerResponse.body.adUnits[3].ads[0];
+      ad = multiFormatServerResponse.body.adUnits[4].ads[0];
       expect(interpretedResponse[1].bidderCode).to.equal('adnuntius');
       expect(interpretedResponse[1].cpm).to.equal(ad.netBid.amount * 1000);
       expect(interpretedResponse[1].width).to.equal(Number(ad.creativeWidth));
@@ -1344,8 +1519,19 @@ describe('adnuntiusBidAdapter', function () {
       expect(interpretedResponse[1].creativeId).to.equal(ad.creativeId);
       expect(interpretedResponse[1].currency).to.equal(ad.bid.currency);
       expect(interpretedResponse[1].netRevenue).to.equal(false);
-      expect(interpretedResponse[1].ad).to.equal(multiFormatServerResponse.body.adUnits[3].html);
+      expect(interpretedResponse[1].ad).to.equal(multiFormatServerResponse.body.adUnits[4].html);
       expect(interpretedResponse[1].ttl).to.equal(360);
+
+      ad = multiFormatServerResponse.body.adUnits[2].ads[0];
+      expect(interpretedResponse[2].native).to.not.be.undefined;
+      expect(interpretedResponse[2].bidderCode).to.equal('adnuntius');
+      expect(interpretedResponse[2].cpm).to.equal(ad.netBid.amount * 1000);
+      expect(interpretedResponse[2].width).to.equal(Number(ad.creativeWidth));
+      expect(interpretedResponse[2].height).to.equal(Number(ad.creativeHeight));
+      expect(interpretedResponse[2].creativeId).to.equal(ad.creativeId);
+      expect(interpretedResponse[2].currency).to.equal(ad.bid.currency);
+      expect(interpretedResponse[2].netRevenue).to.equal(false);
+      expect(interpretedResponse[2].ttl).to.equal(360);
     });
 
     it('should not process valid response when passed alt bidder that is an adndeal', function () {
@@ -1437,6 +1623,26 @@ describe('adnuntiusBidAdapter', function () {
       expect(interpretedResponse[1].vastXml).to.equal(serverVideoResponse.body.adUnits[0].vastXml);
       expect(interpretedResponse[1].dealId).to.equal('not-in-deal-array');
       expect(interpretedResponse[1].dealCount).to.equal(0);
+    });
+  });
+
+  describe('interpretNativeResponse', function () {
+    it('should return valid response when passed valid server response', function () {
+      const interpretedResponse = spec.interpretResponse(nativeResponse, nativeBidderRequest);
+      const ad = nativeResponse.body.adUnits[0].ads[0]
+      expect(interpretedResponse).to.have.lengthOf(1);
+
+      expect(interpretedResponse[0].bidderCode).to.equal('adnuntius');
+      expect(interpretedResponse[0].cpm).to.equal(ad.bid.amount * 1000);
+      expect(interpretedResponse[0].width).to.equal(Number(ad.creativeWidth));
+      expect(interpretedResponse[0].height).to.equal(Number(ad.creativeHeight));
+      expect(interpretedResponse[0].creativeId).to.equal(ad.creativeId);
+      expect(interpretedResponse[0].currency).to.equal(ad.bid.currency);
+      expect(interpretedResponse[0].netRevenue).to.equal(false);
+      expect(interpretedResponse[0].meta).to.have.property('advertiserDomains');
+      expect(interpretedResponse[0].meta.advertiserDomains).to.have.lengthOf(1);
+      expect(interpretedResponse[0].meta.advertiserDomains[0]).to.equal('adnuntius.com');
+      expect(interpretedResponse[0].vastXml).to.equal(ad.vastXml);
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Sends through newly-supported native ad requests to Adnuntius ad server and manages the response.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
