### PR TITLE
Core & PBS Adapter: support `eventtrackers`, and normalize `burl` / `ext.prebid.events.win` into it

### DIFF
--- a/libraries/ortbConverter/processors/default.js
+++ b/libraries/ortbConverter/processors/default.js
@@ -113,6 +113,9 @@ export const DEFAULT_PROCESSORS = {
         if (bid.attr) {
           bidResponse.meta.attr = bid.attr;
         }
+        if (bid.ext?.eventtrackers) {
+          bidResponse.eventtrackers = (bidResponse.eventtrackers ?? []).concat(bid.ext.eventtrackers);
+        }
       }
     }
   }

--- a/libraries/pbsExtensions/processors/eventTrackers.js
+++ b/libraries/pbsExtensions/processors/eventTrackers.js
@@ -1,0 +1,18 @@
+import {EVENT_TYPE_IMPRESSION, EVENT_TYPE_WIN, TRACKER_METHOD_IMG} from '../../../src/eventTrackers.js';
+
+export function addWinTrackers(bidResponse, bid) {
+  bidResponse.eventtrackers = bidResponse.eventtrackers || [];
+  [
+    [bid.burl, EVENT_TYPE_IMPRESSION], // core used to fire burl directly, but only for bids coming from PBS
+    [bid?.ext?.prebid?.events?.win, EVENT_TYPE_WIN]
+  ].filter(([winUrl, type]) => winUrl && bidResponse.eventtrackers.find(
+    ({method, event, url}) => event === type && method === TRACKER_METHOD_IMG && url === winUrl
+  ) == null)
+    .forEach(([url, event]) => {
+      bidResponse.eventtrackers.push({
+        method: TRACKER_METHOD_IMG,
+        event,
+        url
+      })
+    })
+}

--- a/libraries/pbsExtensions/processors/eventTrackers.js
+++ b/libraries/pbsExtensions/processors/eventTrackers.js
@@ -1,6 +1,6 @@
 import {EVENT_TYPE_IMPRESSION, EVENT_TYPE_WIN, TRACKER_METHOD_IMG} from '../../../src/eventTrackers.js';
 
-export function addWinTrackers(bidResponse, bid) {
+export function addEventTrackers(bidResponse, bid) {
   bidResponse.eventtrackers = bidResponse.eventtrackers || [];
   [
     [bid.burl, EVENT_TYPE_IMPRESSION], // core used to fire burl directly, but only for bids coming from PBS

--- a/libraries/pbsExtensions/processors/pbs.js
+++ b/libraries/pbsExtensions/processors/pbs.js
@@ -6,6 +6,7 @@ import {setImpBidParams} from './params.js';
 import {setImpAdUnitCode} from './adUnitCode.js';
 import {setRequestExtPrebid, setRequestExtPrebidChannel} from './requestExtPrebid.js';
 import {setBidResponseVideoCache} from './video.js';
+import {addWinTrackers} from "./eventTrackers.js";
 
 export const PBS_PROCESSORS = {
   [REQUEST]: {
@@ -74,14 +75,9 @@ export const PBS_PROCESSORS = {
         bidResponse.meta = mergeDeep({}, deepAccess(bid, 'ext.prebid.meta'), bidResponse.meta);
       }
     },
-    pbsWurl: {
-      // sets bidResponse.pbsWurl from ext.prebid.events.win
-      fn(bidResponse, bid) {
-        const wurl = deepAccess(bid, 'ext.prebid.events.win');
-        if (isStr(wurl)) {
-          bidResponse.pbsWurl = wurl;
-        }
-      }
+    pbsWinTrackers: {
+      // converts "legacy" burl and ext.prebid.events.win into eventtrackers
+      fn: addWinTrackers
     },
   },
   [RESPONSE]: {

--- a/libraries/pbsExtensions/processors/pbs.js
+++ b/libraries/pbsExtensions/processors/pbs.js
@@ -6,7 +6,7 @@ import {setImpBidParams} from './params.js';
 import {setImpAdUnitCode} from './adUnitCode.js';
 import {setRequestExtPrebid, setRequestExtPrebidChannel} from './requestExtPrebid.js';
 import {setBidResponseVideoCache} from './video.js';
-import {addWinTrackers} from "./eventTrackers.js";
+import {addEventTrackers} from "./eventTrackers.js";
 
 export const PBS_PROCESSORS = {
   [REQUEST]: {
@@ -77,7 +77,7 @@ export const PBS_PROCESSORS = {
     },
     pbsWinTrackers: {
       // converts "legacy" burl and ext.prebid.events.win into eventtrackers
-      fn: addWinTrackers
+      fn: addEventTrackers
     },
   },
   [RESPONSE]: {

--- a/libraries/pbsExtensions/processors/pbs.js
+++ b/libraries/pbsExtensions/processors/pbs.js
@@ -6,7 +6,7 @@ import {setImpBidParams} from './params.js';
 import {setImpAdUnitCode} from './adUnitCode.js';
 import {setRequestExtPrebid, setRequestExtPrebidChannel} from './requestExtPrebid.js';
 import {setBidResponseVideoCache} from './video.js';
-import {addEventTrackers} from "./eventTrackers.js";
+import {addEventTrackers} from './eventTrackers.js';
 
 export const PBS_PROCESSORS = {
   [REQUEST]: {

--- a/src/adRendering.js
+++ b/src/adRendering.js
@@ -5,7 +5,7 @@ import {
   insertElement,
   logError,
   logWarn,
-  replaceMacros
+  replaceMacros, triggerPixel
 } from './utils.js';
 import * as events from './events.js';
 import {AD_RENDER_FAILED_REASON, BID_STATUS, EVENTS, MESSAGES, PB_LOCATOR} from './constants.js';
@@ -20,6 +20,7 @@ import {GreedyPromise} from './utils/promise.js';
 import adapterManager from './adapterManager.js';
 import {useMetrics} from './utils/perfMetrics.js';
 import {filters} from './targeting.js';
+import {EVENT_TYPE_WIN, parseEventTrackers, TRACKER_METHOD_IMG} from './eventTrackers.js';
 
 const { AD_RENDER_FAILED, AD_RENDER_SUCCEEDED, STALE_RENDER, BID_WON, EXPIRED_RENDER } = EVENTS;
 const { EXCEPTION } = AD_RENDER_FAILED_REASON;
@@ -31,6 +32,8 @@ export const getBidToRender = hook('sync', function (adId, forRender = true, ove
 })
 
 export const markWinningBid = hook('sync', function (bid) {
+  (parseEventTrackers(bid.eventtrackers)[EVENT_TYPE_WIN]?.[TRACKER_METHOD_IMG] || [])
+    .forEach(url => triggerPixel(url));
   events.emit(BID_WON, bid);
   auctionManager.addWinningBid(bid);
 })

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -49,6 +49,7 @@ import {isActivityAllowed} from './activities/rules.js';
 import {ACTIVITY_FETCH_BIDS, ACTIVITY_REPORT_ANALYTICS} from './activities/activities.js';
 import {ACTIVITY_PARAM_ANL_CONFIG, ACTIVITY_PARAM_S2S_NAME, activityParamsBuilder} from './activities/params.js';
 import {redactor} from './activities/redactor.js';
+import {EVENT_TYPE_IMPRESSION, parseEventTrackers, TRACKER_METHOD_IMG} from './eventTrackers.js';
 
 export {gdprDataHandler, gppDataHandler, uspDataHandler, coppaDataHandler} from './consentHandler.js';
 
@@ -689,9 +690,8 @@ adapterManager.triggerBilling = (() => {
   return (bid) => {
     if (!BILLED.has(bid)) {
       BILLED.add(bid);
-      if (bid.source === S2S.SRC && bid.burl) {
-        internal.triggerPixel(bid.burl);
-      }
+      (parseEventTrackers(bid.eventtrackers)[EVENT_TYPE_IMPRESSION]?.[TRACKER_METHOD_IMG] || [])
+        .forEach((url) => internal.triggerPixel(url));
       tryCallBidderMethod(bid.bidder, 'onBidBillable', bid);
     }
   }

--- a/src/eventTrackers.js
+++ b/src/eventTrackers.js
@@ -1,0 +1,22 @@
+export const TRACKER_METHOD_IMG = 1;
+export const TRACKER_METHOD_JS = 2;
+export const EVENT_TYPE_IMPRESSION = 1;
+export const EVENT_TYPE_WIN = 500;
+
+/**
+ * Returns a map from event type (EVENT_TYPE_*)
+ * to a map from tracker method (TRACKER_METHOD_*)
+ * to an array of tracking URLs
+ *
+ * @param {{}[]} eventTrackers an array of "Event Tracker Response Object" as defined
+ *  in the ORTB native 1.2 spec (https://www.iab.com/wp-content/uploads/2018/03/OpenRTB-Native-Ads-Specification-Final-1.2.pdf, section 5.8)
+ * @returns {{[type]: {[method]: string[]}}}
+ */
+export function parseEventTrackers(eventTrackers) {
+  return (eventTrackers ?? []).reduce((tally, {event, method, url}) => {
+    const trackersForType = tally[event] = tally[event] ?? {};
+    const trackersForMethod = trackersForType[method] = trackersForType[method] ?? [];
+    trackersForMethod.push(url);
+    return tally;
+  }, {})
+}

--- a/src/eventTrackers.js
+++ b/src/eventTrackers.js
@@ -10,7 +10,7 @@ export const EVENT_TYPE_WIN = 500;
  *
  * @param {{}[]} eventTrackers an array of "Event Tracker Response Object" as defined
  *  in the ORTB native 1.2 spec (https://www.iab.com/wp-content/uploads/2018/03/OpenRTB-Native-Ads-Specification-Final-1.2.pdf, section 5.8)
- * @returns {{[type]: {[method]: string[]}}}
+ * @returns {{[type: string]: {[method: string]: string[]}}}
  */
 export function parseEventTrackers(eventTrackers) {
   return (eventTrackers ?? []).reduce((tally, {event, method, url}) => {

--- a/src/native.js
+++ b/src/native.js
@@ -16,7 +16,7 @@ import {NATIVE_ASSET_TYPES, NATIVE_IMAGE_TYPES, PREBID_NATIVE_DATA_KEYS_TO_ORTB,
 import {NATIVE} from './mediaTypes.js';
 import {getRenderingData} from './adRendering.js';
 import {getCreativeRendererSource} from './creativeRenderers.js';
-import {EVENT_TYPE_IMPRESSION, parseEventTrackers, TRACKER_METHOD_IMG, TRACKER_METHOD_JS} from "./eventTrackers.js";
+import {EVENT_TYPE_IMPRESSION, parseEventTrackers, TRACKER_METHOD_IMG, TRACKER_METHOD_JS} from './eventTrackers.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest

--- a/src/native.js
+++ b/src/native.js
@@ -16,6 +16,7 @@ import {NATIVE_ASSET_TYPES, NATIVE_IMAGE_TYPES, PREBID_NATIVE_DATA_KEYS_TO_ORTB,
 import {NATIVE} from './mediaTypes.js';
 import {getRenderingData} from './adRendering.js';
 import {getCreativeRendererSource} from './creativeRenderers.js';
+import {EVENT_TYPE_IMPRESSION, parseEventTrackers, TRACKER_METHOD_IMG, TRACKER_METHOD_JS} from "./eventTrackers.js";
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -88,20 +89,6 @@ const SUPPORTED_TYPES = {
 // inverse native maps useful for converting to legacy
 const PREBID_NATIVE_DATA_KEYS_TO_ORTB_INVERSE = inverse(PREBID_NATIVE_DATA_KEYS_TO_ORTB);
 const NATIVE_ASSET_TYPES_INVERSE = inverse(NATIVE_ASSET_TYPES);
-
-const TRACKER_METHODS = {
-  img: 1,
-  js: 2,
-  1: 'img',
-  2: 'js'
-}
-
-const TRACKER_EVENTS = {
-  impression: 1,
-  'viewable-mrc50': 2,
-  'viewable-mrc100': 3,
-  'viewable-video50': 4,
-}
 
 export function isNativeResponse(bidResponse) {
   // check for native data and not mediaType; it's possible
@@ -289,15 +276,9 @@ export function fireNativeTrackers(message, bidResponse) {
 }
 
 export function fireImpressionTrackers(nativeResponse, {runMarkup = (mkup) => insertHtmlIntoIframe(mkup), fetchURL = triggerPixel} = {}) {
-  const impTrackers = (nativeResponse.eventtrackers || [])
-    .filter(tracker => tracker.event === TRACKER_EVENTS.impression);
-
-  let {img, js} = impTrackers.reduce((tally, tracker) => {
-    if (TRACKER_METHODS.hasOwnProperty(tracker.method)) {
-      tally[TRACKER_METHODS[tracker.method]].push(tracker.url)
-    }
-    return tally;
-  }, {img: [], js: []});
+  let {[TRACKER_METHOD_IMG]: img = [], [TRACKER_METHOD_JS]: js = []} = parseEventTrackers(
+    nativeResponse.eventtrackers || []
+  )[EVENT_TYPE_IMPRESSION] || {};
 
   if (nativeResponse.imptrackers) {
     img = img.concat(nativeResponse.imptrackers);
@@ -726,8 +707,8 @@ export function legacyPropertiesToOrtbNative(legacyNative) {
       case 'impressionTrackers':
         (Array.isArray(value) ? value : [value]).forEach(url => {
           response.eventtrackers.push({
-            event: TRACKER_EVENTS.impression,
-            method: TRACKER_METHODS.img,
+            event: EVENT_TYPE_IMPRESSION,
+            method: TRACKER_METHOD_IMG,
             url
           });
         });
@@ -830,10 +811,10 @@ export function toLegacyResponse(ortbResponse, ortbRequest) {
     legacyResponse.impressionTrackers.push(...ortbResponse.imptrackers);
   }
   for (const eventTracker of ortbResponse?.eventtrackers || []) {
-    if (eventTracker.event === TRACKER_EVENTS.impression && eventTracker.method === TRACKER_METHODS.img) {
+    if (eventTracker.event === EVENT_TYPE_IMPRESSION && eventTracker.method === TRACKER_METHOD_IMG) {
       legacyResponse.impressionTrackers.push(eventTracker.url);
     }
-    if (eventTracker.event === TRACKER_EVENTS.impression && eventTracker.method === TRACKER_METHODS.js) {
+    if (eventTracker.event === EVENT_TYPE_IMPRESSION && eventTracker.method === TRACKER_METHOD_JS) {
       jsTrackers.push(eventTracker.url);
     }
   }

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -929,10 +929,12 @@ if (FEATURES.VIDEO) {
    * @typedef {Object} MarkBidRequest
    * @property {string} adUnitCode The ad unit code
    * @property {string} adId The id representing the ad we want to mark
+   * @property {boolean} events If true, fires tracking pixels and BID_WON handlers
+   * @property {boolean} analytics alias of `events` (for backwards compat)
    *
    * @alias module:pbjs.markWinningBidAsUsed
    */
-  pbjsInstance.markWinningBidAsUsed = function ({adId, adUnitCode, analytics = false}) {
+  pbjsInstance.markWinningBidAsUsed = function ({adId, adUnitCode, analytics = false, events = false}) {
     let bids;
     if (adUnitCode && adId == null) {
       bids = targeting.getWinningBids(adUnitCode);
@@ -942,7 +944,7 @@ if (FEATURES.VIDEO) {
       logWarn('Improper use of markWinningBidAsUsed. It needs an adUnitCode or an adId to function.');
     }
     if (bids.length > 0) {
-      if (analytics) {
+      if (analytics || events) {
         markWinningBid(bids[0]);
       } else {
         auctionManager.addWinningBid(bids[0]);

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -3806,6 +3806,27 @@ describe('S2S Adapter', function () {
       triggerPixelStub.restore();
     });
 
+    it('should translate wurl and burl into eventtrackers', () => {
+      const burlEvent = {event: 1, method: 1, url: 'burl'};
+      const winEvent = {event: 500, method: 1, url: 'events.win'};
+      const trackerEvent = {event: 500, method: 1, url: 'eventtracker'};
+
+      const resp = utils.deepClone(RESPONSE_OPENRTB);
+      resp.seatbid[0].bid[0].ext.eventtrackers = [
+        trackerEvent,
+        burlEvent
+      ]
+      resp.seatbid[0].bid[0].ext.prebid.events = {
+        win: winEvent.url
+      };
+      resp.seatbid[0].bid[0].burl = burlEvent.url;
+      adapter.callBids(REQUEST, BID_REQUESTS, addBidResponse, done, ajax);
+      server.requests[0].respond(200, {}, JSON.stringify(resp));
+      expect(addBidResponse.getCall(0).args[1].eventtrackers).to.have.deep.members([
+        burlEvent, trackerEvent, winEvent
+      ]);
+    })
+
     it('should call triggerPixel if wurl is defined', function () {
       const clonedResponse = utils.deepClone(RESPONSE_OPENRTB);
       clonedResponse.seatbid[0].bid[0].ext.prebid.events = {

--- a/test/spec/ortbConverter/pbsExtensions/trackers_spec.js
+++ b/test/spec/ortbConverter/pbsExtensions/trackers_spec.js
@@ -1,5 +1,5 @@
 import {EVENT_TYPE_IMPRESSION, EVENT_TYPE_WIN, TRACKER_METHOD_IMG} from '../../../../src/eventTrackers.js';
-import {addWinTrackers} from '../../../../libraries/pbsExtensions/processors/eventTrackers.js';
+import {addEventTrackers} from '../../../../libraries/pbsExtensions/processors/eventTrackers.js';
 
 describe('PBS event trackers', () => {
   let bidResponse;
@@ -32,18 +32,18 @@ describe('PBS event trackers', () => {
     }
 
     it(`should add ${t}`, () => {
-      addWinTrackers(bidResponse, bid);
+      addEventTrackers(bidResponse, bid);
       expect(getTracker()).to.exist;
     });
     it(`should append ${t}`, () => {
       bidResponse.eventtrackers = [{method: 123, event: 321, url: 'other-tracker'}];
-      addWinTrackers(bidResponse, bid);
+      addEventTrackers(bidResponse, bid);
       expect(getTracker()).to.exist;
       expect(bidResponse.eventtrackers.length).to.eql(2);
     });
     it('should NOT add a duplicate tracker', () => {
       bidResponse.eventtrackers = [{method: TRACKER_METHOD_IMG, event: type, url: 'tracker'}];
-      addWinTrackers(bidResponse, bid);
+      addEventTrackers(bidResponse, bid);
       expect(getTracker()).to.exist;
       expect(bidResponse.eventtrackers.length).to.eql(1);
     })

--- a/test/spec/ortbConverter/pbsExtensions/trackers_spec.js
+++ b/test/spec/ortbConverter/pbsExtensions/trackers_spec.js
@@ -1,0 +1,51 @@
+import {EVENT_TYPE_IMPRESSION, EVENT_TYPE_WIN, TRACKER_METHOD_IMG} from '../../../../src/eventTrackers.js';
+import {addWinTrackers} from '../../../../libraries/pbsExtensions/processors/eventTrackers.js';
+
+describe('PBS event trackers', () => {
+  let bidResponse;
+  beforeEach(() => {
+    bidResponse = {};
+  });
+
+  Object.entries({
+    'burl': {
+      bid: {
+        burl: 'tracker'
+      },
+      type: EVENT_TYPE_IMPRESSION
+    },
+    'ext.prebid.events.win': {
+      bid: {
+        ext: {
+          prebid: {
+            events: {
+              win: 'tracker'
+            }
+          }
+        }
+      },
+      type: EVENT_TYPE_WIN
+    }
+  }).forEach(([t, {type, bid}]) => {
+    function getTracker() {
+      return bidResponse.eventtrackers?.find(({event, method, url}) => url === 'tracker' && method === TRACKER_METHOD_IMG && event === type)
+    }
+
+    it(`should add ${t}`, () => {
+      addWinTrackers(bidResponse, bid);
+      expect(getTracker()).to.exist;
+    });
+    it(`should append ${t}`, () => {
+      bidResponse.eventtrackers = [{method: 123, event: 321, url: 'other-tracker'}];
+      addWinTrackers(bidResponse, bid);
+      expect(getTracker()).to.exist;
+      expect(bidResponse.eventtrackers.length).to.eql(2);
+    });
+    it('should NOT add a duplicate tracker', () => {
+      bidResponse.eventtrackers = [{method: TRACKER_METHOD_IMG, event: type, url: 'tracker'}];
+      addWinTrackers(bidResponse, bid);
+      expect(getTracker()).to.exist;
+      expect(bidResponse.eventtrackers.length).to.eql(1);
+    })
+  })
+})

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -27,6 +27,12 @@ import {MODULE_TYPE_ANALYTICS, MODULE_TYPE_BIDDER} from '../../../../src/activit
 import {ACTIVITY_FETCH_BIDS, ACTIVITY_REPORT_ANALYTICS} from '../../../../src/activities/activities.js';
 import {reset as resetAdUnitCounters} from '../../../../src/adUnits.js';
 import {deepClone} from 'src/utils.js';
+import {
+  EVENT_TYPE_IMPRESSION,
+  EVENT_TYPE_WIN,
+  TRACKER_METHOD_IMG,
+  TRACKER_METHOD_JS
+} from "../../../../src/eventTrackers.js";
 var events = require('../../../../src/events');
 
 const CONFIG = {
@@ -409,11 +415,26 @@ describe('adapterManager tests', function () {
         criteoSpec.onBidBillable = sinon.spy();
         sandbox.stub(utils.internal, 'triggerPixel');
       });
+      it('should fire impression pixels from eventtrackers', () => {
+        bids[0].eventtrackers = [
+          {event: EVENT_TYPE_IMPRESSION, method: TRACKER_METHOD_IMG, url: 'tracker'},
+        ]
+        adapterManager.triggerBilling(bids[0]);
+        sinon.assert.calledWith(utils.internal.triggerPixel, 'tracker');
+      });
+
+      it('should NOT fire non-impression or non-pixel trackers', () => {
+        bids[0].eventtrackers = [
+          {event: EVENT_TYPE_WIN, method: TRACKER_METHOD_IMG, url: 'ignored'},
+          {event: EVENT_TYPE_IMPRESSION, method: TRACKER_METHOD_JS, url: 'ignored'},
+        ]
+        adapterManager.triggerBilling(bids[0]);
+        sinon.assert.notCalled(utils.internal.triggerPixel);
+      })
       describe('on client bids', () => {
-        it('should call bidder\'s onBidBillable, and ignore burl', () => {
+        it('should call bidder\'s onBidBillable', () => {
           adapterManager.triggerBilling(bids[0]);
           sinon.assert.called(criteoSpec.onBidBillable);
-          sinon.assert.notCalled(utils.internal.triggerPixel)
         });
         it('should not call again on second trigger', () => {
           adapterManager.triggerBilling(bids[0]);
@@ -425,21 +446,10 @@ describe('adapterManager tests', function () {
         beforeEach(() => {
           bids[0].source = S2S.SRC;
         });
-        it('should call burl and not onBidBillable', () => {
+        it('should not call onBidBillable', () => {
           bids[0].burl = 'burl';
           adapterManager.triggerBilling(bids[0]);
           sinon.assert.notCalled(criteoSpec.onBidBillable);
-          sinon.assert.calledWith(utils.internal.triggerPixel, 'burl');
-        });
-        it('should not call burl if not present', () => {
-          adapterManager.triggerBilling(bids[0]);
-          sinon.assert.notCalled(utils.internal.triggerPixel);
-        });
-        it('should not call burl again on second triggerBilling', () => {
-          bids[0].burl = 'burl';
-          adapterManager.triggerBilling(bids[0]);
-          adapterManager.triggerBilling(bids[0]);
-          sinon.assert.calledOnce(utils.internal.triggerPixel)
         });
       });
     })

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -32,7 +32,7 @@ import {
   EVENT_TYPE_WIN,
   TRACKER_METHOD_IMG,
   TRACKER_METHOD_JS
-} from "../../../../src/eventTrackers.js";
+} from '../../../../src/eventTrackers.js';
 var events = require('../../../../src/events');
 
 const CONFIG = {

--- a/test/spec/unit/core/eventTrackers_spec.js
+++ b/test/spec/unit/core/eventTrackers_spec.js
@@ -1,0 +1,61 @@
+import {
+  EVENT_TYPE_IMPRESSION, EVENT_TYPE_WIN,
+  parseEventTrackers,
+  TRACKER_METHOD_IMG,
+  TRACKER_METHOD_JS
+} from '../../../../src/eventTrackers.js';
+
+describe('event trackers', () => {
+  describe('parseEventTrackers', () => {
+    Object.entries({
+      'null': {
+        eventtrackers: null,
+        expected: {}
+      },
+      'undef': {
+        expected: {}
+      },
+      'empty array': {
+        eventtrackers: [],
+        expected: {}
+      },
+      'unsupported methods and events': {
+        eventtrackers: [
+          {event: EVENT_TYPE_IMPRESSION, method: TRACKER_METHOD_IMG, url: 'u1'},
+          {event: 999, method: TRACKER_METHOD_IMG, url: 'u2'},
+          {event: EVENT_TYPE_IMPRESSION, method: 999, url: 'u3'},
+        ],
+        expected: {
+          [EVENT_TYPE_IMPRESSION]: {
+            [TRACKER_METHOD_IMG]: ['u1'],
+            999: ['u3']
+          },
+          999: {
+            [TRACKER_METHOD_IMG]: ['u2']
+          }
+        }
+      },
+      'mixed methods and events': {
+        eventtrackers: [
+          {event: EVENT_TYPE_IMPRESSION, method: TRACKER_METHOD_JS, url: 'u1'},
+          {event: EVENT_TYPE_IMPRESSION, method: TRACKER_METHOD_JS, url: 'u2'},
+          {event: EVENT_TYPE_IMPRESSION, method: TRACKER_METHOD_IMG, url: 'u3'},
+          {event: EVENT_TYPE_WIN, method: TRACKER_METHOD_IMG, url: 'u4'}
+        ],
+        expected: {
+          [EVENT_TYPE_IMPRESSION]: {
+            [TRACKER_METHOD_JS]: ['u1', 'u2'],
+            [TRACKER_METHOD_IMG]: ['u3'],
+          },
+          [EVENT_TYPE_WIN]: {
+            [TRACKER_METHOD_IMG]: ['u4']
+          }
+        }
+      },
+    }).forEach(([t, {eventtrackers, expected}]) => {
+      it(`can parse ${t}`, () => {
+        expect(parseEventTrackers(eventtrackers)).to.eql(expected);
+      })
+    })
+  })
+})

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -3601,15 +3601,15 @@ describe('Unit: Prebid Module', function () {
       }
 
       Object.entries({
-        'analytics=true': {
+        'events=true': {
           mark(options = {}) {
-            $$PREBID_GLOBAL$$.markWinningBidAsUsed(Object.assign({analytics: true}, options))
+            $$PREBID_GLOBAL$$.markWinningBidAsUsed(Object.assign({events: true}, options))
           },
           checkBidWon() {
             sinon.assert.calledWith(events.emit, EVENTS.BID_WON, markedBid);
           }
         },
-        'analytics=false': {
+        'events=false': {
           mark(options = {}) {
             $$PREBID_GLOBAL$$.markWinningBidAsUsed(options)
           },

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1381,17 +1381,19 @@ describe('Unit: Prebid Module', function () {
       });
     });
 
-    it('fires billing url if present on s2s bid', function () {
-      const burl = 'http://www.example.com/burl';
+    it('fires impression trackers if present', function () {
+      const url = 'http://www.example.com/burl';
       pushBidResponseToAuction({
         ad: '<div>ad</div>',
         source: 's2s',
-        burl
+        eventtrackers: [
+          {event: 1, method: 1, url}
+        ]
       });
 
       return renderAd(doc, bidId).then(() => {
         sinon.assert.calledOnce(triggerPixelStub);
-        sinon.assert.calledWith(triggerPixelStub, burl);
+        sinon.assert.calledWith(triggerPixelStub, url);
       });
     });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

The PBS Adapter had special handling for two tracking URLs:

 - `bid.burl`, which was fired when a bid is deemed billable;
 - `bid.ext.prebid.events.win`, fired when a bid is rendered.

This allows bid responses (from any adapter) to provide an `eventtrackers` array as described in https://github.com/prebid/Prebid.js/issues/12216:

 - `ortbConverter` now moves `imp.ext.eventtrackers` into `bidResponse.eventtrackers`;
 - the PBS extensions for `ortbConverter` translate `burl` into an impression pixel and `events.win` into a "win" pixel (custom event 500), appending them to `eventtrackers`;
 - core fires win pixels on render, and impression pixels on billing;
 - `markWinningBidAsUsed`'s `analytics` flag is renamed to `events`, and triggers both when appropriate.

## Other information

Closes https://github.com/prebid/Prebid.js/issues/12698#top
Closes https://github.com/prebid/Prebid.js/issues/12216
