### PR TITLE
wurfl Rtd Provider : fix invalid types for pxratio and js in ORTB2 device data

### DIFF
--- a/modules/wurflRtdProvider.js
+++ b/modules/wurflRtdProvider.js
@@ -185,8 +185,8 @@ export const enrichBidderRequest = (reqBidsConfigObj, bidderCode, wurflData) => 
     enrichOrtb2DeviceData('h', wurflData.resolution_height, device, ortb2data);
     enrichOrtb2DeviceData('w', wurflData.resolution_width, device, ortb2data);
     enrichOrtb2DeviceData('ppi', wurflData.pixel_density, device, ortb2data);
-    enrichOrtb2DeviceData('pxratio', wurflData.density_class, device, ortb2data);
-    enrichOrtb2DeviceData('js', wurflData.ajax_support_javascript, device, ortb2data);
+    enrichOrtb2DeviceData('pxratio', toNumber(wurflData.density_class), device, ortb2data);
+    enrichOrtb2DeviceData('js', toNumber(wurflData.ajax_support_javascript), device, ortb2data);
   }
   ortb2data.device.ext['wurfl'] = wurflData
   mergeDeep(reqBidsConfigObj.ortb2Fragments.bidder, { [bidderCode]: ortb2data });
@@ -243,6 +243,20 @@ function enrichOrtb2DeviceData(key, value, device, ortb2data) {
     return;
   }
   ortb2data.device[key] = value;
+}
+
+/**
+ * toNumber converts a given value to a number.
+ * Returns `undefined` if the conversion results in `NaN`.
+ * @param {any} value - The value to convert to a number.
+ * @returns {number|undefined} The converted number, or `undefined` if the conversion fails.
+ */
+export function toNumber(value) {
+  if (value === "" || value === null) {
+    return undefined;
+  }
+  const num = Number(value);
+  return Number.isNaN(num) ? undefined : num;
 }
 
 /**

--- a/modules/wurflRtdProvider.js
+++ b/modules/wurflRtdProvider.js
@@ -252,7 +252,7 @@ function enrichOrtb2DeviceData(key, value, device, ortb2data) {
  * @returns {number|undefined} The converted number, or `undefined` if the conversion fails.
  */
 export function toNumber(value) {
-  if (value === "" || value === null) {
+  if (value === '' || value === null) {
     return undefined;
   }
   const num = Number(value);

--- a/test/spec/modules/wurflRtdProvider_spec.js
+++ b/test/spec/modules/wurflRtdProvider_spec.js
@@ -4,6 +4,7 @@ import {
   lowEntropyData,
   wurflSubmodule,
   makeOrtb2DeviceType,
+  toNumber,
 } from 'modules/wurflRtdProvider';
 import * as ajaxModule from 'src/ajax';
 import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
@@ -116,8 +117,8 @@ describe('wurflRtdProvider', function () {
               h: 1920,
               w: 1080,
               ppi: 443,
-              pxratio: '3.0',
-              js: true,
+              pxratio: 3.0,
+              js: 1,
               ext: {
                 wurfl: {
                   advertised_browser: 'Chrome Mobile',
@@ -166,8 +167,8 @@ describe('wurflRtdProvider', function () {
               h: 1920,
               w: 1080,
               ppi: 443,
-              pxratio: '3.0',
-              js: true,
+              pxratio: 3.0,
+              js: 1,
               ext: {
                 wurfl: {
                   advertised_device_os: 'Android',
@@ -453,6 +454,36 @@ describe('wurflRtdProvider', function () {
       const wurflData = {};
       const result = makeOrtb2DeviceType(wurflData);
       expect(result).to.be.undefined;
+    });
+  });
+
+  describe("toNumber", () => {
+    it("converts valid numbers", () => {
+      expect(toNumber(42)).to.equal(42);
+      expect(toNumber(3.14)).to.equal(3.14);
+      expect(toNumber("100")).to.equal(100);
+      expect(toNumber("3.14")).to.equal(3.14);
+      expect(toNumber("  50  ")).to.equal(50); // Trimmed number
+    });
+
+    it("converts booleans correctly", () => {
+      expect(toNumber(true)).to.equal(1);
+      expect(toNumber(false)).to.equal(0);
+    });
+
+    it("handles special cases", () => {
+      expect(toNumber(null)).to.be.undefined; // Number(null) -> 0 but we want undefined
+      expect(toNumber("")).to.be.undefined;   // Number("") -> 0 but we want undefined
+    });
+
+    it("returns undefined for non-numeric values", () => {
+      expect(toNumber("abc")).to.be.undefined;
+      expect(toNumber(undefined)).to.be.undefined;
+      expect(toNumber(NaN)).to.be.undefined;
+      expect(toNumber({})).to.be.undefined;
+      expect(toNumber([1, 2, 3])).to.be.undefined; // Invalid array conversion
+      // WURFL.js cannot return [] so it is safe to not handle and return undefined instead of 0
+      expect(toNumber([])).to.equal(0);
     });
   });
 });

--- a/test/spec/modules/wurflRtdProvider_spec.js
+++ b/test/spec/modules/wurflRtdProvider_spec.js
@@ -457,32 +457,32 @@ describe('wurflRtdProvider', function () {
     });
   });
 
-  describe("toNumber", () => {
-    it("converts valid numbers", () => {
+  describe('toNumber', function () {
+    it('converts valid numbers', function () {
       expect(toNumber(42)).to.equal(42);
       expect(toNumber(3.14)).to.equal(3.14);
-      expect(toNumber("100")).to.equal(100);
-      expect(toNumber("3.14")).to.equal(3.14);
-      expect(toNumber("  50  ")).to.equal(50); // Trimmed number
+      expect(toNumber('100')).to.equal(100);
+      expect(toNumber('3.14')).to.equal(3.14);
+      expect(toNumber('  50  ')).to.equal(50);
     });
 
-    it("converts booleans correctly", () => {
+    it('converts booleans correctly', function () {
       expect(toNumber(true)).to.equal(1);
       expect(toNumber(false)).to.equal(0);
     });
 
-    it("handles special cases", () => {
-      expect(toNumber(null)).to.be.undefined; // Number(null) -> 0 but we want undefined
-      expect(toNumber("")).to.be.undefined;   // Number("") -> 0 but we want undefined
+    it('handles special cases', function () {
+      expect(toNumber(null)).to.be.undefined;
+      expect(toNumber('')).to.be.undefined;
     });
 
-    it("returns undefined for non-numeric values", () => {
-      expect(toNumber("abc")).to.be.undefined;
+    it('returns undefined for non-numeric values', function () {
+      expect(toNumber('abc')).to.be.undefined;
       expect(toNumber(undefined)).to.be.undefined;
       expect(toNumber(NaN)).to.be.undefined;
       expect(toNumber({})).to.be.undefined;
-      expect(toNumber([1, 2, 3])).to.be.undefined; // Invalid array conversion
-      // WURFL.js cannot return [] so it is safe to not handle and return undefined instead of 0
+      expect(toNumber([1, 2, 3])).to.be.undefined;
+      // WURFL.js cannot return [] so it is safe to not handle and return undefined
       expect(toNumber([])).to.equal(0);
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
This PR corrects the data types for `pixratio` and `js` to match the requirements of the ORTB2 device specification.
