### PR TITLE
Medianet Analytics Adapter : add video placement logic

### DIFF
--- a/modules/medianetAnalyticsAdapter.js
+++ b/modules/medianetAnalyticsAdapter.js
@@ -20,6 +20,8 @@ import {AUCTION_COMPLETED, AUCTION_IN_PROGRESS, getPriceGranularity} from '../sr
 import {includes} from '../src/polyfill.js';
 import {getGlobal} from '../src/prebidGlobal.js';
 import {convertCurrency} from '../libraries/currencyUtils/currency.js';
+import {INSTREAM, OUTSTREAM} from '../src/video.js';
+import {ADPOD} from '../src/mediaTypes.js';
 
 const analyticsType = 'endpoint';
 const ENDPOINT = 'https://pb-logs.media.net/log?logid=kfk&evtid=prebid_analytics_events_client';
@@ -266,10 +268,22 @@ class AdSlot {
       tmax: this.tmax,
       targ: JSON.stringify(this.targeting),
       ismn: this.medianetPresent,
-      vplcmtt: this.context,
+      vplcmtt: this.getVideoPlacement(),
     },
     this.adext && {'adext': JSON.stringify(this.adext)},
     );
+  }
+  getVideoPlacement() {
+    switch (this.context) {
+      case INSTREAM:
+        return 1
+      case OUTSTREAM:
+        return 6
+      case ADPOD:
+        return 7
+      default:
+        return 0
+    }
   }
 }
 

--- a/test/spec/modules/medianetAnalyticsAdapter_spec.js
+++ b/test/spec/modules/medianetAnalyticsAdapter_spec.js
@@ -200,7 +200,7 @@ describe('Media.net Analytics Adapter', function() {
       medianetAnalytics.clearlogsQueue();
       expect(noBidLog.mtype).to.have.ordered.members([encodeURIComponent('banner|native|video'), encodeURIComponent('banner|video|native')]);
       expect(noBidLog.szs).to.have.ordered.members([encodeURIComponent('300x250|1x1|640x480'), encodeURIComponent('300x250|1x1|640x480')]);
-      expect(noBidLog.vplcmtt).to.equal('instream');
+      expect(noBidLog.vplcmtt).to.equal('1');
     });
 
     it('twin ad units should have correct sizes', function() {


### PR DESCRIPTION
## Type of change
- [x] Updated analytics adapter

## Description of change
The `vplcmtt` (video placement) field logic has been updated. Instead of logging `instream`, `outstream` or `adpod`, we will now log integer values.

| Context   	| Video placement  	|
|-----------	|------------------	|
| instream  	| 1                	|
| outstream 	| 6                	|
| adpod     	| 7                	|
| default   	| 0                	|