### PR TITLE
GumGum Bid Adapter: bug fix to handle site.content.data.name undefined values

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -495,8 +495,8 @@ function buildRequests(validBidRequests, bidderRequest) {
 export function getCids(site) {
   if (site.content && Array.isArray(site.content.data)) {
     for (const dataItem of site.content.data) {
-      if (dataItem.name.includes('iris.com') || dataItem.name.includes('iris.tv')) {
-        return dataItem.ext.cids.join(',');
+      if (typeof dataItem?.name === 'string' && (dataItem.name.includes('iris.com') || dataItem.name.includes('iris.tv'))) {
+        return Array.isArray(dataItem.ext?.cids) ? dataItem.ext.cids.join(',') : '';
       }
     }
   }


### PR DESCRIPTION


- [ x] Bugfix



## Description of change
We encountered an issue where site.content.data.name in ORTB2 was undefined, causing the .includes() function to throw an error.
Added a typeof check to ensure name is a string before calling .includes().
Prevents potential TypeError when name is null or undefined.
Used optional chaining (?.) for additional safety.


