### PR TITLE
Missena Bid Adapter : send viewport and add getViewportSize to viewport library

### DIFF
--- a/libraries/viewport/viewport.js
+++ b/libraries/viewport/viewport.js
@@ -11,3 +11,15 @@ export function getViewportCoordinates() {
     return {};
   }
 }
+
+export function getViewportSize() {
+  try {
+    const win = getWindowTop();
+    let { innerHeight, innerWidth } = win;
+    innerHeight = innerHeight || win.document.documentElement.clientWidth || win.document.body.clientWidth;
+    innerWidth = innerWidth || win.document.documentElement.clientHeight || win.document.body.clientHeight
+    return { width: innerWidth, height: innerHeight };
+  } catch (e) {
+    return {};
+  }
+}

--- a/modules/missenaBidAdapter.js
+++ b/modules/missenaBidAdapter.js
@@ -13,6 +13,7 @@ import { getStorageManager } from '../src/storageManager.js';
 import { getCurrencyFromBidderRequest } from '../libraries/ortb2Utils/currency.js';
 import { isAutoplayEnabled } from '../libraries/autoplayDetection/autoplay.js';
 import { normalizeBannerSizes } from '../libraries/sizeUtils/sizeUtils.js';
+import { getViewportSize } from '../libraries/viewport/viewport.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -88,6 +89,7 @@ function toPayload(bidRequest, bidderRequest) {
   payload.coppa = bidderRequest?.ortb2?.regs?.coppa ? 1 : 0;
   payload.autoplay = isAutoplayEnabled() === true ? 1 : 0;
   payload.screen = { height: screen.height, width: screen.width };
+  payload.viewport = getViewportSize();
   payload.sizes = normalizeBannerSizes(bidRequest.mediaTypes.banner.sizes);
 
   return {

--- a/test/spec/modules/missenaBidAdapter_spec.js
+++ b/test/spec/modules/missenaBidAdapter_spec.js
@@ -18,6 +18,7 @@ describe('Missena Adapter', function () {
   let sandbox = sinon.sandbox.create();
   sandbox.stub(config, 'getConfig').withArgs('coppa').returns(true);
   sandbox.stub(autoplay, 'isAutoplayEnabled').returns(false);
+  const viewport = { width: window.top.innerWidth, height: window.top.innerHeight };
 
   const bidId = 'abc';
   const bid = {
@@ -153,6 +154,11 @@ describe('Missena Adapter', function () {
     it('should send referer information to the request', function () {
       expect(payload.referer).to.equal(REFERRER);
       expect(payload.referer_canonical).to.equal('https://canonical');
+    });
+
+    it('should send viewport', function () {
+      expect(payload.viewport.width).to.equal(viewport.width);
+      expect(payload.viewport.height).to.equal(viewport.height);
     });
 
     it('should send gdpr consent information to the request', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Updated bidder adapter 

## Description of change
We need the actual client size in order to optimize some of our ads on desktop. 
I have added the `getViewportSize` to the libraries in case it might be useful to others. 

 