### PR TITLE
Rubicon Bid Adapter: Fix client Hints full ver

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -1028,7 +1028,10 @@ function applyFPD(bidRequest, mediaType, data) {
           // reduce down into ua and full version list attributes
           const [ua, fullVer] = browsers.reduce((accum, browserData) => {
             accum[0].push(`"${browserData?.brand}"|v="${browserData?.version?.[0]}"`);
-            accum[1].push(`"${browserData?.brand}"|v="${browserData?.version?.join?.('.')}"`);
+            // only set fullVer if long enough
+            if (browserData.version.length > 1) {
+              accum[1].push(`"${browserData?.brand}"|v="${browserData?.version?.join?.('.')}"`);
+            }
             return accum;
           }, [[], []]);
           data.m_ch_ua = ua?.join?.(',');

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1971,7 +1971,7 @@ describe('the rubicon adapter', function () {
               architecture: 'x86'
             }
           });
-          it('should send m_ch_* params if ortb2.device.sua object is there', function () {
+          it('should send m_ch_* params if ortb2.device.sua object is there with igh entropy', function () {
             let bidRequestSua = utils.deepClone(bidderRequest);
             bidRequestSua.bids[0].ortb2 = { device: { sua: standardSuaObject } };
 


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Even when low entropy hints were set only, it still sent the high entropy full version browser list `m_ch_full_ver`

This value was still low entropy so no issue, but not needed to send