### PR TITLE
GumGum Bid Adapter: Send content url and additional vid params

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -213,13 +213,21 @@ function _getVidParams(attributes) {
     viw,
     vih,
     skip,
-    api,
-    mimes
   };
-    // Add vplcmt property to the result object if plcmt is available
+
+  // Add vplcmt property to the result object if plcmt is available
   if (plcmt !== undefined && plcmt !== null) {
     result.vplcmt = plcmt;
   }
+  // Add api property to the result object if api is available
+  if (api && api.length) {
+    result.api = api.join(',');
+  }
+  // Add mimes property to the result object if mimes is available
+  if (mimes && mimes.length) {
+    result.mimes = mimes.join(',');
+  }
+
   return result;
 }
 

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -433,7 +433,8 @@ function buildRequests(validBidRequests, bidderRequest) {
     }
     if (bidderRequest && bidderRequest.ortb2 && bidderRequest.ortb2.site) {
       setIrisId(data, bidderRequest.ortb2.site, params);
-      data.curl = bidderRequest.ortb2.site.content && bidderRequest.ortb2.site.content.url;
+      const curl = bidderRequest.ortb2.site.content?.url;
+      if (curl) data.curl = curl;
     }
     if (params.iriscat && typeof params.iriscat === 'string') {
       data.iriscat = params.iriscat;

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -190,7 +190,10 @@ function _getVidParams(attributes) {
     placement: pt,
     plcmt,
     protocols = [],
-    playerSize = []
+    playerSize = [],
+    skip,
+    api,
+    mimes
   } = attributes;
   const sizes = parseSizesInput(playerSize);
   const [viw, vih] = sizes[0] && sizes[0].split('x');
@@ -208,7 +211,10 @@ function _getVidParams(attributes) {
     pt,
     pr,
     viw,
-    vih
+    vih,
+    skip,
+    api,
+    mimes
   };
     // Add vplcmt property to the result object if plcmt is available
   if (plcmt !== undefined && plcmt !== null) {
@@ -416,6 +422,7 @@ function buildRequests(validBidRequests, bidderRequest) {
     }
     if (bidderRequest && bidderRequest.ortb2 && bidderRequest.ortb2.site) {
       setIrisId(data, bidderRequest.ortb2.site, params);
+      data.curl = bidderRequest.ortb2.site.content && bidderRequest.ortb2.site.content.url;
     }
     if (params.iriscat && typeof params.iriscat === 'string') {
       data.iriscat = params.iriscat;

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -194,7 +194,8 @@ function _getVidParams(attributes) {
     skip,
     api,
     mimes,
-    playbackmethod
+    playbackmethod,
+    playbackend: pbe
   } = attributes;
   const sizes = parseSizesInput(playerSize);
   const [viw, vih] = sizes[0] && sizes[0].split('x');
@@ -214,6 +215,7 @@ function _getVidParams(attributes) {
     viw,
     vih,
     skip,
+    pbe
   };
 
   if (plcmt !== undefined && plcmt !== null) {

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -193,7 +193,8 @@ function _getVidParams(attributes) {
     playerSize = [],
     skip,
     api,
-    mimes
+    mimes,
+    playbackmethod
   } = attributes;
   const sizes = parseSizesInput(playerSize);
   const [viw, vih] = sizes[0] && sizes[0].split('x');
@@ -215,17 +216,17 @@ function _getVidParams(attributes) {
     skip,
   };
 
-  // Add vplcmt property to the result object if plcmt is available
   if (plcmt !== undefined && plcmt !== null) {
     result.vplcmt = plcmt;
   }
-  // Add api property to the result object if api is available
   if (api && api.length) {
     result.api = api.join(',');
   }
-  // Add mimes property to the result object if mimes is available
   if (mimes && mimes.length) {
     result.mimes = mimes.join(',');
+  }
+  if (playbackmethod && playbackmethod.length) {
+    result.pbm = playbackmethod.join(',');
   }
 
   return result;

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -525,7 +525,8 @@ describe('gumgumAdapter', function () {
         protocols: [1, 2],
         skip: 1,
         api: [1, 2],
-        mimes: ['video/mp4', 'video/webm']
+        mimes: ['video/mp4', 'video/webm'],
+        playbackmethod: [1, 2]
       };
       const request = Object.assign({}, bidRequests[0]);
       delete request.params;
@@ -550,6 +551,7 @@ describe('gumgumAdapter', function () {
       expect(bidRequest.data.skip).to.eq(videoVals.skip);
       expect(bidRequest.data.api).to.eq(videoVals.api.join(','));
       expect(bidRequest.data.mimes).to.eq(videoVals.mimes.join(','));
+      expect(bidRequest.data.pbm).to.eq(videoVals.playbackmethod.join(','));
     });
     it('should add parameters associated with invideo if invideo request param is found', function () {
       const inVideoVals = {
@@ -564,7 +566,8 @@ describe('gumgumAdapter', function () {
         protocols: [1, 2],
         skip: 1,
         api: [1, 2],
-        mimes: ['video/mp4', 'video/webm']
+        mimes: ['video/mp4', 'video/webm'],
+        playbackmethod: [6]
       };
       const request = Object.assign({}, bidRequests[0]);
       delete request.params;
@@ -589,6 +592,7 @@ describe('gumgumAdapter', function () {
       expect(bidRequest.data.skip).to.eq(inVideoVals.skip);
       expect(bidRequest.data.api).to.eq(inVideoVals.api.join(','));
       expect(bidRequest.data.mimes).to.eq(inVideoVals.mimes.join(','));
+      expect(bidRequest.data.pbm).to.eq(inVideoVals.playbackmethod.join(','));
     });
     it('should not add additional parameters depending on params field', function () {
       const request = spec.buildRequests(bidRequests)[0];

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -526,7 +526,8 @@ describe('gumgumAdapter', function () {
         skip: 1,
         api: [1, 2],
         mimes: ['video/mp4', 'video/webm'],
-        playbackmethod: [1, 2]
+        playbackmethod: [1, 2],
+        playbackend: 2
       };
       const request = Object.assign({}, bidRequests[0]);
       delete request.params;
@@ -552,6 +553,7 @@ describe('gumgumAdapter', function () {
       expect(bidRequest.data.api).to.eq(videoVals.api.join(','));
       expect(bidRequest.data.mimes).to.eq(videoVals.mimes.join(','));
       expect(bidRequest.data.pbm).to.eq(videoVals.playbackmethod.join(','));
+      expect(bidRequest.data.pbe).to.eq(videoVals.playbackend);
     });
     it('should add parameters associated with invideo if invideo request param is found', function () {
       const inVideoVals = {
@@ -567,7 +569,8 @@ describe('gumgumAdapter', function () {
         skip: 1,
         api: [1, 2],
         mimes: ['video/mp4', 'video/webm'],
-        playbackmethod: [6]
+        playbackmethod: [6],
+        playbackend: 1
       };
       const request = Object.assign({}, bidRequests[0]);
       delete request.params;
@@ -593,6 +596,7 @@ describe('gumgumAdapter', function () {
       expect(bidRequest.data.api).to.eq(inVideoVals.api.join(','));
       expect(bidRequest.data.mimes).to.eq(inVideoVals.mimes.join(','));
       expect(bidRequest.data.pbm).to.eq(inVideoVals.playbackmethod.join(','));
+      expect(bidRequest.data.pbe).to.eq(inVideoVals.playbackend);
     });
     it('should not add additional parameters depending on params field', function () {
       const request = spec.buildRequests(bidRequests)[0];

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -287,7 +287,7 @@ describe('gumgumAdapter', function () {
       const bidRequest = spec.buildRequests([request], bidderRequest)[0];
       expect(bidRequest.data).to.have.property('irisid', 'iris_c73g5jq96mwso4d8');
     });
-    it('should set the curl param when found', function() {
+    it('should set the curl param if present', function() {
       const request = { ...bidRequests[0] };
       const bidRequest = spec.buildRequests([request], bidderRequest)[0];
       expect(bidRequest.data).to.have.property('curl', 'http://pub.com/news');

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -110,7 +110,8 @@ describe('gumgumAdapter', function () {
                 segtax: 500,
                 cids: ['iris_c73g5jq96mwso4d8']
               }
-            }]
+            }],
+            url: 'http://pub.com/news',
           },
           page: 'http://pub.com/news',
           ref: 'http://google.com',
@@ -286,7 +287,11 @@ describe('gumgumAdapter', function () {
       const bidRequest = spec.buildRequests([request], bidderRequest)[0];
       expect(bidRequest.data).to.have.property('irisid', 'iris_c73g5jq96mwso4d8');
     });
-
+    it('should set the curl param when found', function() {
+      const request = { ...bidRequests[0] };
+      const bidRequest = spec.buildRequests([request], bidderRequest)[0];
+      expect(bidRequest.data).to.have.property('curl', 'http://pub.com/news');
+    });
     it('should not set the iriscat param when not found', function () {
       const request = { ...bidRequests[0] }
       const bidRequest = spec.buildRequests([request])[0];
@@ -517,7 +522,10 @@ describe('gumgumAdapter', function () {
         startdelay: 1,
         placement: 123456,
         plcmt: 3,
-        protocols: [1, 2]
+        protocols: [1, 2],
+        skip: 1,
+        api: [1, 2],
+        mimes: ['video/mp4', 'video/webm']
       };
       const request = Object.assign({}, bidRequests[0]);
       delete request.params;
@@ -539,6 +547,9 @@ describe('gumgumAdapter', function () {
       expect(bidRequest.data.pr).to.eq(videoVals.protocols.join(','));
       expect(bidRequest.data.viw).to.eq(videoVals.playerSize[0].toString());
       expect(bidRequest.data.vih).to.eq(videoVals.playerSize[1].toString());
+      expect(bidRequest.data.skip).to.eq(videoVals.skip);
+      expect(bidRequest.data.api).to.eq(videoVals.api.join(','));
+      expect(bidRequest.data.mimes).to.eq(videoVals.mimes.join(','));
     });
     it('should add parameters associated with invideo if invideo request param is found', function () {
       const inVideoVals = {
@@ -550,7 +561,10 @@ describe('gumgumAdapter', function () {
         startdelay: 1,
         placement: 123456,
         plcmt: 3,
-        protocols: [1, 2]
+        protocols: [1, 2],
+        skip: 1,
+        api: [1, 2],
+        mimes: ['video/mp4', 'video/webm']
       };
       const request = Object.assign({}, bidRequests[0]);
       delete request.params;
@@ -572,6 +586,9 @@ describe('gumgumAdapter', function () {
       expect(bidRequest.data.pr).to.eq(inVideoVals.protocols.join(','));
       expect(bidRequest.data.viw).to.eq(inVideoVals.playerSize[0].toString());
       expect(bidRequest.data.vih).to.eq(inVideoVals.playerSize[1].toString());
+      expect(bidRequest.data.skip).to.eq(inVideoVals.skip);
+      expect(bidRequest.data.api).to.eq(inVideoVals.api.join(','));
+      expect(bidRequest.data.mimes).to.eq(inVideoVals.mimes.join(','));
     });
     it('should not add additional parameters depending on params field', function () {
       const request = spec.buildRequests(bidRequests)[0];


### PR DESCRIPTION

## Type of change
- [x] Feature
- [x] Updated bidder adapter

## Description of change
Updated data sent to our prebid endpoint to include content url and additional video parameters
