### PR TITLE
Adnuntius Bid Adapter: pass on native ad request sizes to ad server.

### DIFF
--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -333,7 +333,7 @@ export const spec = {
         if (maxDeals > 0) {
           adUnit.maxDeals = maxDeals;
         }
-        if (mediaType === BANNER && mediaTypeData && mediaTypeData.sizes) {
+        if (mediaType !== VIDEO && mediaTypeData && mediaTypeData.sizes) {
           adUnit.dimensions = mediaTypeData.sizes;
         }
         networks[network].adUnits.push(adUnit);

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -116,6 +116,7 @@ describe('adnuntiusBidAdapter', function () {
       },
       mediaTypes: {
         native: {
+          sizes: [[200, 200], [300, 300]],
           ortb: {
             assets: [{
               id: 1,
@@ -1636,7 +1637,15 @@ describe('adnuntiusBidAdapter', function () {
     });
   });
 
-  describe('interpretNativeResponse', function () {
+  describe('Native ads handling', function () {
+    it('should pass requests on correctly', function () {
+      const request = spec.buildRequests(nativeBidderRequest.bid, {});
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('bid');
+      expect(request[0]).to.have.property('data');
+      expect(request[0].data).to.equal('{"adUnits":[{"auId":"0000000000000551","targetId":"adn-0000000000000551","adType":"NATIVE","nativeRequest":{"assets":[{"id":1,"required":1,"img":{"type":3,"w":250,"h":250}}]},"dimensions":[[200,200],[300,300]]}]}');
+    });
+
     it('should return valid response when passed valid server response', function () {
       const interpretedResponse = spec.interpretResponse(nativeResponse, nativeBidderRequest);
       const ad = nativeResponse.body.adUnits[0].ads[0]


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
When ad request sizes are specified on native ad requests, pass them onto the ad server. This fixes the bug where this wasn't happening.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
