### PR TITLE
Adnuntius Bid Adapter: make ad server address configurable

### DIFF
--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -9,14 +9,48 @@ const BIDDER_CODE_DEAL_ALIAS_BASE = 'adndeal';
 const BIDDER_CODE_DEAL_ALIASES = [1, 2, 3, 4, 5].map(num => {
   return BIDDER_CODE_DEAL_ALIAS_BASE + num;
 });
-const ENDPOINT_URL = 'https://ads.adnuntius.delivery/i';
-const ENDPOINT_URL_EUROPE = 'https://europe.delivery.adnuntius.com/i';
 const GVLID = 855;
 const SUPPORTED_MEDIA_TYPES = [BANNER, VIDEO, NATIVE];
 const MAXIMUM_DEALS_LIMIT = 5;
 const VALID_BID_TYPES = ['netBid', 'grossBid'];
 const METADATA_KEY = 'adn.metaData';
 const METADATA_KEY_SEPARATOR = '@@@';
+
+const ENVS = {
+  localhost: {
+    id: 'localhost',
+    as: 'localhost:8078'
+  },
+  lcl: {
+    id: 'lcl',
+    as: 'adserver.dev.lcl.test'
+  },
+  andemu: {
+    id: 'andemu',
+    as: '10.0.2.2:8078'
+  },
+  dev: {
+    id: 'dev',
+    as: 'adserver.dev.adnuntius.com'
+  },
+  staging: {
+    id: 'staging',
+    as: 'adserver.staging.adnuntius.com'
+  },
+  production: {
+    id: 'production',
+    as: 'ads.adnuntius.delivery',
+    asEu: 'europe.delivery.adnuntius.com'
+  },
+  cloudflare: {
+    id: 'cloudflare',
+    as: 'ads.adnuntius.delivery'
+  },
+  limited: {
+    id: 'limited',
+    as: 'limited.delivery.adnuntius.com'
+  }
+};
 
 export const misc = {
   findHighestPrice: function(arr, bidType) {
@@ -344,7 +378,11 @@ export const spec = {
     const networkKeys = Object.keys(networks);
     for (let j = 0; j < networkKeys.length; j++) {
       const network = networkKeys[j];
-      const requestURL = gdprApplies ? ENDPOINT_URL_EUROPE : ENDPOINT_URL
+      let requestURL = gdprApplies ? ENVS.production.asEu : ENVS.production.as;
+      if (bidderConfig.env && ENVS[bidderConfig.env]) {
+        requestURL = ENVS[bidderConfig.env][bidderConfig.endPointType || 'as'];
+      }
+      requestURL = (bidderConfig.protocol || 'https') + '://' + requestURL + '/i';
       requests.push({
         method: 'POST',
         url: requestURL + '?' + queryParamsAndValues.join('&'),

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -2,7 +2,7 @@
 import { expect } from 'chai'; // may prefer 'assert' in place of 'expect'
 import { misc, spec } from 'modules/adnuntiusBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
-import { config } from 'src/config.js';
+import {config, newConfig} from 'src/config.js';
 import * as utils from 'src/utils.js';
 import { getStorageManager } from 'src/storageManager.js';
 import { getGlobal } from '../../../src/prebidGlobal';
@@ -53,6 +53,7 @@ describe('adnuntiusBidAdapter', function () {
   const viewport = win.innerWidth + 'x' + win.innerHeight;
   const ENDPOINT_URL_BASE = `${URL}${tzo}&format=prebid&screen=${screen}&viewport=${viewport}`;
   const ENDPOINT_URL = `${ENDPOINT_URL_BASE}&userId=${usi}`;
+  const LOCALHOST_URL = `http://localhost:8078/i?tzo=${tzo}&format=prebid&screen=${screen}&viewport=${viewport}&userId=${usi}`;
   const ENDPOINT_URL_NOCOOKIE = `${ENDPOINT_URL_BASE}&userId=${usi}&noCookies=true`;
   const ENDPOINT_URL_SEGMENTS = `${ENDPOINT_URL_BASE}&segments=segment1,segment2,segment3&userId=${usi}`;
   const ENDPOINT_URL_CONSENT = `${EURO_URL}${tzo}&format=prebid&consentString=consentString&gdpr=1&screen=${screen}&viewport=${viewport}&userId=${usi}`;
@@ -851,6 +852,17 @@ describe('adnuntiusBidAdapter', function () {
       expect(request[0].url).to.equal(ENDPOINT_URL.replace('&userId', '&so=overridden-value&userId'));
       expect(request[0]).to.have.property('data');
       expect(request[0].data).to.equal('{"adUnits":[{"auId":"000000000008b6bc","targetId":"123","maxDeals":1,"dimensions":[[640,480],[600,400]]},{"auId":"0000000000000551","targetId":"adn-0000000000000551","dimensions":[[1640,1480],[1600,1400]]}],"context":"https://canonical.com/something-else.html","canonical":"https://canonical.com/page.html"}');
+    });
+
+    it('should pass for different end points in config', function () {
+      config.setConfig({
+        env: 'localhost',
+        protocol: 'http'
+      })
+      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(bidderRequests, { }));
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(LOCALHOST_URL);
     });
 
     it('Test requests with no local storage', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Makes adserver address configurable to aid in debugging in different environments.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
