### PR TITLE
symitriDapRtdProvider - set content-type header in correct spot

### DIFF
--- a/modules/symitriDapRtdProvider.js
+++ b/modules/symitriDapRtdProvider.js
@@ -673,7 +673,7 @@ export function createRtdProvider(moduleName, moduleCode, headerPrefix) {
           return;
       }
 
-      let customHeaders = { 'Content-Type': 'application/json' };
+      let customHeaders = {};
       let dapSSID = JSON.parse(storage.getDataFromLocalStorage(DAP_SS_ID));
       if (dapSSID) {
         customHeaders[headerPrefix + '-DAP-SS-ID'] = dapSSID;
@@ -699,7 +699,8 @@ export function createRtdProvider(moduleName, moduleCode, headerPrefix) {
 
       ajax(url, cb, body, {
         method: method,
-        customHeaders: customHeaders
+        customHeaders: customHeaders,
+        contentType: 'application/json'
       });
     },
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
The Content-Type for the Tokenize call was set in the wrong spot, causing the AJAX request 
to use the default `text/plain` content-type.
