### PR TITLE
PubMatic Bid Adapter: Passing POS value from mediaType

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -61,7 +61,8 @@ const VIDEO_CUSTOM_PARAMS = {
   'plcmt': DATA_TYPES.NUMBER,
   'minbitrate': DATA_TYPES.NUMBER,
   'maxbitrate': DATA_TYPES.NUMBER,
-  'skip': DATA_TYPES.NUMBER
+  'skip': DATA_TYPES.NUMBER,
+  'pos': DATA_TYPES.NUMBER
 }
 
 const NATIVE_ASSET_IMAGE_TYPE = {
@@ -70,7 +71,8 @@ const NATIVE_ASSET_IMAGE_TYPE = {
 }
 
 const BANNER_CUSTOM_PARAMS = {
-  'battr': DATA_TYPES.ARRAY
+  'battr': DATA_TYPES.ARRAY,
+  'pos': DATA_TYPES.NUMBER,
 }
 
 const NET_REVENUE = true;

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -356,13 +356,20 @@ describe('PubMatic adapter', function () {
     bannerAndVideoBidRequests = [
       {
         code: 'div-banner-video',
+        ortb2Imp: {
+          banner: {
+            pos: 1
+          }
+        },
         mediaTypes: {
           video: {
             playerSize: [640, 480],
-            context: 'instream'
+            context: 'instream',
+            pos: 2
           },
           banner: {
-            sizes: [[300, 250], [300, 600]]
+            sizes: [[300, 250], [300, 600]],
+            pos: 1
           }
         },
         bidder: 'pubmatic',
@@ -2556,9 +2563,9 @@ describe('PubMatic adapter', function () {
           expect(data.user.yob).to.equal(parseInt(multipleMediaRequests[0].params.yob)); // YOB
           expect(data.user.gender).to.equal(multipleMediaRequests[0].params.gender); // Gender
           expect(data.device.geo.lat).to.equal('36.5189'); // Latitude
-  		  expect(data.device.geo.lon).to.equal('-76.4063'); // Lognitude
-  		  expect(data.user.geo.lat).to.equal('26.8915'); // Latitude
-  		  expect(data.user.geo.lon).to.equal('-56.6340'); // Lognitude
+  		    expect(data.device.geo.lon).to.equal('-76.4063'); // Lognitude
+  		    expect(data.user.geo.lat).to.equal('26.8915'); // Latitude
+  		    expect(data.user.geo.lon).to.equal('-56.6340'); // Lognitude
           expect(data.ext.wrapper.wv).to.equal($$REPO_AND_VERSION$$); // Wrapper Version
           expect(data.ext.wrapper.transactionId).to.equal(multipleMediaRequests[0].transactionId); // Prebid TransactionId
           expect(data.ext.wrapper.wiid).to.equal(multipleMediaRequests[0].params.wiid); // OpenWrap: Wrapper Impression ID
@@ -2621,6 +2628,7 @@ describe('PubMatic adapter', function () {
           expect(data.banner.h).to.equal(250);
           expect(data.banner.format).to.exist;
           expect(data.banner.format.length).to.equal(bannerAndVideoBidRequests[0].mediaTypes.banner.sizes.length);
+          expect(data.banner.pos).to.equal(1);
 
           // Case: when size is not present in adslo
           bannerAndVideoBidRequests[0].params.adSlot = '/15671365/DMDemo';
@@ -2638,6 +2646,7 @@ describe('PubMatic adapter', function () {
           expect(data.video).to.exist;
           expect(data.video.w).to.equal(bannerAndVideoBidRequests[0].mediaTypes.video.playerSize[0]);
           expect(data.video.h).to.equal(bannerAndVideoBidRequests[0].mediaTypes.video.playerSize[1]);
+          expect(data.video.pos).to.equal(2);
         });
 
         it('Request params - should handle banner, video and native format in single adunit', function() {
@@ -2659,6 +2668,7 @@ describe('PubMatic adapter', function () {
 
           expect(data.native).to.exist;
           expect(data.native.request).to.exist;
+          expect(data.banner.pos).to.equal(0);
         });
 
         it('Request params - should handle video and native format in single adunit', function() {


### PR DESCRIPTION
1st draft Changes

change in pos logic

Update pubmaticBidAdapter.js

updated test case for pos

Update pubmaticAnalyticsAdapter.js

changes sending pos in translator and test cases fix

Update pubmaticBidAdapter.js

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Earlier in PubMatic Bid Adapter the value of imp.banner.pos was hard coded as 0, now we are accepting the values set in bid.mediaType and passing it to our adapter.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
