### PR TITLE
Appnexus Bid Adapter : fix issue with start delay

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -1094,7 +1094,7 @@ function getContextFromPlacement(ortbPlacement) {
 }
 
 function getContextFromStartDelay(ortbStartDelay) {
-  if (!ortbStartDelay) {
+  if (typeof ortbStartDelay === 'undefined') {
     return;
   }
 

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -431,6 +431,33 @@ describe('AppNexusAdapter', function () {
         expect(payload.tags[0].video_frameworks).to.deep.equal([1, 4])
       });
 
+      it('should include ORTB video values when video params is empty - case 1', function () {
+        let bidRequest = deepClone(bidRequests[0]);
+        bidRequest.mediaTypes = {
+          video: {
+            playerSize: [640, 480],
+            context: 'outstream',
+            mimes: ['video/mp4'],
+            startdelay: 0,
+            skip: 0,
+            minduration: 5,
+            api: [1, 5, 6],
+            playbackmethod: [2, 4]
+          }
+        };
+
+        const request = spec.buildRequests([bidRequest]);
+        const payload = JSON.parse(request.data);
+
+        expect(payload.tags[0].video).to.deep.equal({
+          minduration: 5,
+          playback_method: 2,
+          skippable: false,
+          context: 1
+        });
+        expect(payload.tags[0].video_frameworks).to.deep.equal([1, 4])
+      });
+
       it('should convert and include ORTB2 device data when available', function () {
         const bidRequest = deepClone(bidRequests[0]);
         const bidderRequest = {


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
This PR is a small fix for the startdelay field using the value 0 to represent preroll when placement fields aren't present.