### PR TITLE
Agma Analytics : allow config of ortb2 data for anayltics adapter during runtime

### DIFF
--- a/modules/agmaAnalyticsAdapter.js
+++ b/modules/agmaAnalyticsAdapter.js
@@ -3,6 +3,8 @@ import {
   generateUUID,
   logInfo,
   logError,
+  getWindowSelf,
+  getWindowTop,
   getPerformanceNow,
   isEmpty,
   isEmptyStr,
@@ -17,19 +19,19 @@ import { config } from '../src/config.js';
 const GVLID = 1122;
 const ModuleCode = 'agma';
 const analyticsType = 'endpoint';
-const scriptVersion = '1.8.0';
+const scriptVersion = '1.9.0';
 const batchDelayInMs = 1000;
 const agmaURL = 'https://pbc.agma-analytics.de/v1';
 const pageViewId = generateUUID();
 
 // Helper functions
 const getScreen = () => {
-  const w = window;
+  const win = getWindowTop();
   const d = document;
   const e = d.documentElement;
   const g = d.getElementsByTagName('body')[0];
-  const x = w.innerWidth || e.clientWidth || g.clientWidth;
-  const y = w.innerHeight || e.clientHeight || g.clientHeight;
+  const x = win.innerWidth || e.clientWidth || g.clientWidth;
+  const y = win.innerHeight || e.clientHeight || g.clientHeight;
   return { x, y };
 };
 
@@ -40,32 +42,13 @@ const getUserIDs = () => {
   return [];
 };
 
-export const getOrtb2Data = (options) => {
-  let site = null;
-  let user = null;
-
-  // check if data is provided via config
-  if (options.ortb2) {
-    if (options.ortb2.user) {
-      user = options.ortb2.user;
-    }
-    if (options.ortb2.site) {
-      site = options.ortb2.site;
-    }
-    if (site && user) {
-      return { site, user };
-    }
+export const getOrtb2Data = (options = {}) => {
+  const configData = config.getConfig();
+  const win = getWindowSelf();
+  return {
+    site: win.agma?.ortb2?.site ?? options.ortb2?.site ?? configData.ortb2?.site,
+    user: win.agma?.ortb2?.user ?? options.ortb2?.user ?? configData.ortb2?.user,
   }
-  try {
-    const configData = config.getConfig();
-    // try to fallback to global config
-    if (configData.ortb2) {
-      site = site || configData.ortb2.site;
-      user = user || configData.ortb2.user;
-    }
-  } catch (e) {}
-
-  return { site, user };
 };
 
 export const getTiming = () => {

--- a/test/spec/modules/agmaAnalyticsAdapter_spec.js
+++ b/test/spec/modules/agmaAnalyticsAdapter_spec.js
@@ -8,7 +8,7 @@ import { gdprDataHandler } from '../../../src/adapterManager.js';
 import { expect } from 'chai';
 import * as events from '../../../src/events.js';
 import { EVENTS } from '../../../src/constants.js';
-import { generateUUID } from '../../../src/utils.js';
+import * as utils from 'src/utils.js';
 import { server } from '../../mocks/xhr.js';
 import { config } from 'src/config.js';
 
@@ -80,7 +80,7 @@ describe('AGMA Analytics Adapter', () => {
   describe('getPayload', () => {
     it('should use non extended payload with no consent info', () => {
       sandbox.stub(gdprDataHandler, 'getConsentData').callsFake(() => null)
-      const payload = getPayload([generateUUID()], {
+      const payload = getPayload([utils.generateUUID()], {
         code: 'test',
       });
 
@@ -97,7 +97,7 @@ describe('AGMA Analytics Adapter', () => {
           },
         },
       }));
-      const payload = getPayload([generateUUID()], {
+      const payload = getPayload([utils.generateUUID()], {
         code: 'test',
       });
       expect(payload).to.have.all.keys([...nonExtendedKey, 'debug']);
@@ -113,7 +113,7 @@ describe('AGMA Analytics Adapter', () => {
           },
         },
       }));
-      const payload = getPayload([generateUUID()], {
+      const payload = getPayload([utils.generateUUID()], {
         code: 'test',
       });
       expect(payload).to.have.all.keys([...extendedKey, 'debug']);
@@ -242,6 +242,35 @@ describe('AGMA Analytics Adapter', () => {
     });
   });
 
+  it('can be overwritten with a global agma variable', () => {
+    sandbox.stub(utils, 'getWindowSelf').returns({
+      agma: {
+        ortb2: {
+          site: {
+            domain: 'overwritten.com',
+          },
+        },
+      },
+    });
+
+    const ortb2 = {
+      site: {
+        domain: 'inital.com'
+      }
+    };
+
+    const result = getOrtb2Data({
+      ortb2,
+    });
+
+    expect(result).to.deep.equal({
+      user: undefined,
+      site: {
+        domain: 'overwritten.com',
+      }
+    });
+  });
+
   describe('Event Payload', () => {
     beforeEach(() => {
       agmaAnalyticsAdapter.enableAnalytics({
@@ -278,26 +307,26 @@ describe('AGMA Analytics Adapter', () => {
         },
       }));
       const auction = {
-        auctionId: generateUUID(),
+        auctionId: utils.generateUUID(),
       };
 
       events.emit(EVENTS.AUCTION_INIT, {
-        auctionId: generateUUID('1'),
+        auctionId: utils.generateUUID('1'),
         auction,
       });
 
       clock.tick(200);
 
       events.emit(EVENTS.AUCTION_INIT, {
-        auctionId: generateUUID('2'),
+        auctionId: utils.generateUUID('2'),
         auction,
       });
       events.emit(EVENTS.AUCTION_INIT, {
-        auctionId: generateUUID('3'),
+        auctionId: utils.generateUUID('3'),
         auction,
       });
       events.emit(EVENTS.AUCTION_INIT, {
-        auctionId: generateUUID('4'),
+        auctionId: utils.generateUUID('4'),
         auction,
       });
 
@@ -324,7 +353,7 @@ describe('AGMA Analytics Adapter', () => {
         },
       }));
       const auction = {
-        auctionId: generateUUID(),
+        auctionId: utils.generateUUID(),
       };
 
       events.emit(EVENTS.AUCTION_INIT, auction);
@@ -348,7 +377,7 @@ describe('AGMA Analytics Adapter', () => {
       }));
 
       const auction = {
-        auctionId: generateUUID(),
+        auctionId: utils.generateUUID(),
       };
 
       events.emit(EVENTS.AUCTION_INIT, auction);
@@ -373,7 +402,7 @@ describe('AGMA Analytics Adapter', () => {
         },
       });
       const auction = {
-        auctionId: generateUUID(),
+        auctionId: utils.generateUUID(),
       };
 
       events.emit(EVENTS.AUCTION_INIT, auction);


### PR DESCRIPTION
## Type of change
- [x] Feature for agma analytics adapter

## Description of change
This is a follow up on https://github.com/prebid/Prebid.js/issues/12633. Our users need to pass in additional data at runtime. Since we did not find a way to pass data into a specific analytics adapter after initialization, we chose to look into a global variable on the self window.