### PR TITLE
EXCO Bid Adapter: Support of new `publisherId`, `accountId` and `tagId` parameters.

### DIFF
--- a/modules/asoBidAdapter.js
+++ b/modules/asoBidAdapter.js
@@ -18,7 +18,8 @@ export const spec = {
   aliases: [
     {code: 'bcmint'},
     {code: 'bidgency'},
-    {code: 'kuantyx'}
+    {code: 'kuantyx'},
+    {code: 'cordless'}
   ],
 
   isBidRequestValid: bid => {

--- a/modules/excoBidAdapter.js
+++ b/modules/excoBidAdapter.js
@@ -213,9 +213,16 @@ export const spec = {
   isBidRequestValid: function (bid) {
     const props = ['accountId', 'publisherId', 'tagId'];
     const missing = props.filter(prop => !bid.params[prop]);
+    const existingLegacy = ['cId', 'pId'].filter(prop => bid.params[prop]);
     const nonStr = props.filter(prop => !isStr(bid.params[prop]));
     const message = `Bid will not be sent for ad unit '${bid.adUnitCode}'`;
     const suggestion = 'wrap it in quotes in your config';
+
+    if (existingLegacy.length) {
+      existingLegacy.forEach(prop => {
+        helpers.log('warn', `Warn: '${prop}' was deprecated.`);
+      });
+    }
 
     if (missing.length) {
       missing.forEach(prop => {

--- a/modules/excoBidAdapter.js
+++ b/modules/excoBidAdapter.js
@@ -87,25 +87,6 @@ export class AdapterHelpers {
     return deepAccess(bid, 'mediaTypes.banner') || !this.isVideoBid(bid);
   }
 
-  isBannerRatioValid([width, height]) {
-    const r = parseInt(width, 10) / parseInt(height, 10);
-    return 0.7 < r && r < 1.7;
-  };
-
-  isBannerSizeValid(bannerSize) {
-    if (isArray(bannerSize) && bannerSize.length) {
-      if (isArray(bannerSize[0])) {
-        return bannerSize.every((sizes) => {
-          return this.isBannerRatioValid(sizes);
-        });
-      }
-
-      return this.isBannerRatioValid(bannerSize);
-    }
-
-    return false;
-  }
-
   adoptVideoImp(imp, bidRequest) {
     imp.id = bidRequest.adUnitCode;
 
@@ -252,10 +233,6 @@ export const spec = {
         helpers.log('warn', `Error: '${prop}' must be a string (${suggestion}). ${message}`);
       });
 
-      return false;
-    }
-
-    if (helpers.isBannerBid(bid) && helpers.isBannerSizeValid(bid.sizes) === false) {
       return false;
     }
 

--- a/modules/excoBidAdapter.js
+++ b/modules/excoBidAdapter.js
@@ -213,8 +213,8 @@ export const spec = {
   isBidRequestValid: function (bid) {
     const props = ['accountId', 'publisherId', 'tagId'];
     const missing = props.filter(prop => !bid.params[prop]);
-    const existingLegacy = ['cId', 'pId'].filter(prop => bid.params[prop]);
     const nonStr = props.filter(prop => !isStr(bid.params[prop]));
+    const existingLegacy = ['cId', 'pId'].filter(prop => bid.params[prop]);
     const message = `Bid will not be sent for ad unit '${bid.adUnitCode}'`;
     const suggestion = 'wrap it in quotes in your config';
 

--- a/modules/excoBidAdapter.js
+++ b/modules/excoBidAdapter.js
@@ -203,6 +203,7 @@ export const converter = ortbConverter({
 export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: [VIDEO, BANNER],
+
   /**
    * Determines whether or not the given bid request is valid.
    *
@@ -234,6 +235,7 @@ export const spec = {
 
     return true;
   },
+
   /**
    * Make a server request from the list of BidRequests.
    *
@@ -259,6 +261,7 @@ export const spec = {
 
     return requests;
   },
+
   /**
    * Unpack the response from the server into a list of bids.
    *

--- a/modules/excoBidAdapter.js
+++ b/modules/excoBidAdapter.js
@@ -1,37 +1,299 @@
-import {registerBidder} from '../src/adapters/bidderFactory.js';
-import {BANNER, VIDEO} from '../src/mediaTypes.js';
-import {getStorageManager} from '../src/storageManager.js';
-import {
-  isBidRequestValid, createUserSyncGetter, createInterpretResponseFn, createBuildRequestsFn
-} from '../libraries/vidazooUtils/bidderUtils.js';
+import { config } from 'src/config';
+import { _each, mergeDeep, deepAccess, logInfo, logWarn, insertUserSyncIframe, logError, isStr, generateUUID } from '../src/utils.js';
+import { registerBidder } from 'src/adapters/bidderFactory';
+import { VIDEO, BANNER } from 'src/mediaTypes.js';
+import { ortbConverter } from '../libraries/ortbConverter/converter';
+import { pbsExtensions } from '../libraries/pbsExtensions/pbsExtensions';
 
-const DEFAULT_SUB_DOMAIN = 'rtb';
-const BIDDER_CODE = 'exco';
-const BIDDER_VERSION = '1.0.0';
-const GVLID = 444;
-export const storage = getStorageManager({bidderCode: BIDDER_CODE});
+const SID = window.excoPid || window.pbPageIdentifier || generateUUID();
+const BIDDER_CODE = 'exco-ssp';
+const VERSION = '0.0.1';
 
-export function createDomain(subDomain = DEFAULT_SUB_DOMAIN) {
-  return `https://${subDomain}.exco-pb.com`;
+const ENDPOINT = '//v.ex.co/se/openrtb/hb/pbjs';
+const SYNC_URL = '//cdn.ex.co/sync/0.0.1-488ee93/cookie_sync.html';
+const CURRENCY = 'USD';
+
+const SYNC = {
+  done: false,
+};
+
+export class AdapterHelpers {
+  doSync(gdprConsent = { consentString: '', gdprApplies: false }, network) {
+    insertUserSyncIframe(
+      this.createSyncUrl(gdprConsent, network)
+    );
+  }
+
+  createSyncUrl({ consentString, gppString, applicableSections, gdprApplies }, network) {
+    try {
+      const url = new URL(window.location.protocol + SYNC_URL);
+      const networks = [ '368531133' ];
+
+      if (network) {
+        networks.push(network);
+      }
+
+      url.searchParams.set('network', networks.join(','));
+      url.searchParams.set('gdpr', encodeURIComponent((Number(gdprApplies) || 0).toString()));
+      url.searchParams.set('gdpr_consent', encodeURIComponent(consentString || ''));
+
+      if (gppString && applicableSections?.length) {
+        url.searchParams.set('gpp', encodeURIComponent(gppString));
+        url.searchParams.set('gpp_sid', encodeURIComponent(applicableSections.join(',')));
+      }
+
+      return url.toString();
+    } catch (error) {/* Do nothing */ }
+
+    return null;
+  }
+
+  addOrtbFirstPartyData(data, bidRequests) {
+    const params = bidRequests[0].params || {};
+    const key = data.app ? 'app' : 'site';
+
+    if (data[key] && data[key].publisher && params.publisherId) {
+      mergeDeep(data[key].publisher, {
+        id: bidRequests[0].params.publisherId
+      });
+    }
+  }
+
+  getExtData(bidRequests, bidderRequest) {
+    return {
+      version: VERSION,
+      pbversion: '$prebid.version$',
+      sid: SID,
+      aid: bidRequests[0]?.auctionId || bidderRequest.bidderRequestId,
+      rc: bidRequests[0]?.bidRequestsCount,
+      brc: bidRequests[0]?.bidderRequestsCount,
+    }
+  }
+
+  createRequest(converter, bidRequests, bidderRequest, mediaType) {
+    const data = converter.toORTB({ bidRequests, bidderRequest, context: { mediaType } });
+
+    data.ext[BIDDER_CODE] = this.getExtData(bidRequests, bidderRequest);
+
+    return { method: 'POST', url: ENDPOINT, data };
+  }
+
+  isVideoBid(bid) {
+    return deepAccess(bid, 'mediaTypes.video');
+  }
+
+  isBannerBid(bid) {
+    return deepAccess(bid, 'mediaTypes.banner') || !this.isVideoBid(bid);
+  }
+
+  adoptVideoImp(imp, bidRequest) {
+    imp.id = bidRequest.adUnitCode;
+
+    if (bidRequest.params) {
+      imp.tagId = bidRequest.params.tagId;
+    }
+  }
+
+  adoptBannerImp(imp, bidRequest) {
+    if (bidRequest.params) {
+      imp.tagId = bidRequest.params.tagId;
+    }
+  }
+
+  adoptBidResponse(bidResponse, bid, context) {
+    bidResponse.bidderCode = BIDDER_CODE;
+
+    bidResponse.vastXml = bidResponse.ad || bid.adm;
+
+    bidResponse.ad = bid.ad;
+    bidResponse.adUrl = bid.adUrl;
+
+    bidResponse.mediaType = bid.mediaType || VIDEO;
+    bidResponse.meta.mediaType = bid.mediaType || VIDEO;
+    bidResponse.meta.advertiserDomains = bidResponse.meta.advertiserDomains || [];
+
+    bidResponse.creativeId = bidResponse.creativeId || `creative-${Date.now()}`;
+    bidResponse.netRevenue = bid.netRevenue || true;
+    bidResponse.currency = CURRENCY;
+
+    bidResponse.cpm = bid.cpm;
+
+    const { bidRequest } = context;
+
+    bidResponse.width = bid.w || deepAccess(bidRequest, 'mediaTypes.video.w') || deepAccess(bidRequest, 'params.video.playerWidth');
+    bidResponse.height = bid.h || deepAccess(bidRequest, 'mediaTypes.video.h') || deepAccess(bidRequest, 'params.video.playerHeight');
+
+    if (deepAccess(bid, 'ext.bidder.rp.advid')) {
+      deepSetValue(bidResponse, 'meta.advertiserId', bid.ext.bidder.rp.advid);
+    }
+
+    return bidResponse;
+  }
+
+  log(severity, message) {
+    const msg = `${BIDDER_CODE.toUpperCase()}: ${message}`;
+
+    if (severity === 'warn') {
+      logWarn(msg);
+    }
+    if (severity === 'error') {
+      logError(msg);
+    }
+    if (severity === 'info') {
+      logInfo(msg);
+    }
+  }
+
+  dropMessage(eventName, eventData) {
+    try {
+      const message = { type: 'exco-ssp', eventName, eventData };
+      window.parent.postMessage(message, '*');
+
+      for (let i = 0; i < window.parent.frames.length; i++) {
+        window.parent.frames[i].postMessage(message, '*');
+      }
+    } catch (error) {
+      /* Do nothing */
+    }
+  }
 }
 
-const buildRequests = createBuildRequestsFn(createDomain, null, storage, BIDDER_CODE, BIDDER_VERSION, false);
+const helpers = new AdapterHelpers();
 
-const interpretResponse = createInterpretResponseFn(BIDDER_CODE, false);
+/**
+ * @doc https://github.com/prebid/Prebid.js/blob/master/libraries/ortbConverter/README.md
+ */
+export const converter = ortbConverter({
+  request(buildRequest, imps, bidderRequest, context) {
+    const data = buildRequest(imps, bidderRequest, context);
 
-const getUserSyncs = createUserSyncGetter({
-  iframeSyncUrl: 'https://cs.exco-pb.com/api/sync/iframe', imageSyncUrl: 'https://cs.exco-pb.com/api/sync/image'
+    if (data.cur && !data.cur.includes('USD')) {
+      helpers.log('warn', 'Warning - EX.CO adapter is supporting USD only. processing with USD');
+    }
+
+    data.cur = [CURRENCY];
+    data.test = config.getConfig('debug') ? 1 : 0;
+
+    helpers.addOrtbFirstPartyData(data, context.bidRequests || []);
+
+    return data;
+  },
+  imp(buildImp, bidRequest, context) {
+    const imp = buildImp(bidRequest, context);
+
+    imp.secure = window.location.protocol === 'http:' ? 0 : 1;
+
+    if (imp.video) {
+      helpers.adoptVideoImp(imp, bidRequest)
+    }
+
+    if (imp.banner) {
+      helpers.adoptBannerImp(imp, bidRequest);
+    }
+
+    return imp;
+  },
+  bidResponse(buildBidResponse, bid, context) {
+    const bidResponse = buildBidResponse(bid, context);
+    return helpers.adoptBidResponse(bidResponse, bid, context);
+  },
+  context: {
+    ttl: 3000,
+  },
+  processors: pbsExtensions
 });
 
 export const spec = {
   code: BIDDER_CODE,
-  version: BIDDER_VERSION,
-  supportedMediaTypes: [BANNER, VIDEO],
-  gvlid: GVLID,
-  isBidRequestValid,
-  buildRequests,
-  interpretResponse,
-  getUserSyncs
+  supportedMediaTypes: [VIDEO, BANNER],
+  /**
+   * Determines whether or not the given bid request is valid.
+   *
+   * @param {BidRequest} bid The bid params to validate.
+   * @return boolean True if this is a valid bid, and false otherwise.
+   */
+  isBidRequestValid: function (bid) {
+    const props = ['publisherId', 'tagId'];
+    const missing = props.filter(prop => !bid.params[prop]);
+    const nonStr = props.filter(prop => !isStr(bid.params[prop]));
+    const message = `Bid will not be sent for ad unit '${bid.adUnitCode}'`;
+    const suggestion = 'wrap it in quotes in your config';
+
+    if (missing.length) {
+      missing.forEach(prop => {
+        helpers.log('warn', `Error: '${prop}' is missing. ${message}`);
+      });
+
+      return false;
+    }
+
+    if (nonStr.length) {
+      nonStr.forEach(prop => {
+        helpers.log('warn', `Error: '${prop}' must be a string (${suggestion}). ${message}`);
+      });
+
+      return false;
+    }
+
+    return true;
+  },
+  /**
+   * Make a server request from the list of BidRequests.
+   *
+   * @param {validBidRequests[]} - an array of bids
+   * @return ServerRequest Info describing the request to the server.
+   */
+  buildRequests: function (bids, bidderRequest) {
+    const videoBids = bids.filter(bid => helpers.isVideoBid(bid));
+    const bannerBids = bids.filter(bid => helpers.isBannerBid(bid));
+    const requests = [];
+
+    if (bannerBids.length) {
+      requests.push(
+        helpers.createRequest(converter, bannerBids, bidderRequest, BANNER)
+      );
+    }
+
+    if (videoBids.length) {
+      requests.push(
+        helpers.createRequest(converter, videoBids, bidderRequest, VIDEO)
+      );
+    }
+
+    return requests;
+  },
+  /**
+   * Unpack the response from the server into a list of bids.
+   *
+   * @param {ServerResponse} response A successful response from the server.
+   * @return {Bid[]} An array of bids which were nested inside the server.
+   */
+  interpretResponse: function (response, request) {
+    const body = response.body.Result || response.body || {};
+    helpers.dropMessage('exco-ssp-adapter-done', body.ext);
+    return converter.fromORTB({response: body, request: request.data}).bids || [];
+  },
+
+  /**
+   * Register the user sync pixels which should be dropped after the auction.
+   *
+   * @param {SyncOptions} syncOptions Which user syncs are allowed?
+   * @param {ServerResponse[]} serverResponses List of server's responses.
+   * @return {UserSync[]} The user syncs which should be dropped.
+   */
+  getUserSyncs: function (
+    syncOptions,
+    serverResponses,
+    gdprConsent,
+    uspConsent
+  ) {
+    if (syncOptions.iframeEnabled && !SYNC.done) {
+      helpers.doSync(gdprConsent);
+      SYNC.done = true;
+    }
+
+    return [];
+  },
 };
 
 registerBidder(spec);

--- a/modules/excoBidAdapter.js
+++ b/modules/excoBidAdapter.js
@@ -158,7 +158,7 @@ export class AdapterHelpers {
 const helpers = new AdapterHelpers();
 
 /**
- * @doc https://github.com/prebid/Prebid.js/blob/master/libraries/ortbConverter/README.md
+ * @description https://github.com/prebid/Prebid.js/blob/master/libraries/ortbConverter/README.md
  */
 export const converter = ortbConverter({
   request(buildRequest, imps, bidderRequest, context) {
@@ -207,7 +207,7 @@ export const spec = {
   /**
    * Determines whether or not the given bid request is valid.
    *
-   * @param {BidRequest} bid The bid params to validate.
+   * @param {import('../src/auction.js').BidRequest} bid The bid params to validate.
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: function (bid) {
@@ -239,7 +239,8 @@ export const spec = {
   /**
    * Make a server request from the list of BidRequests.
    *
-   * @param {validBidRequests[]} - an array of bids
+   * @param {import('../src/auction.js').Bid[]} bids - an array of bids
+   * @param {import('../src/auction.js').BidderRequest} bidderRequest - bidder request object
    * @return ServerRequest Info describing the request to the server.
    */
   buildRequests: function (bids, bidderRequest) {
@@ -265,8 +266,8 @@ export const spec = {
   /**
    * Unpack the response from the server into a list of bids.
    *
-   * @param {ServerResponse} response A successful response from the server.
-   * @return {Bid[]} An array of bids which were nested inside the server.
+   * @param {object} response A successful response from the server.
+   * @return {import('../src/auction.js').Bid[]} An array of bids which were nested inside the server.
    */
   interpretResponse: function (response, request) {
     const body = response.body.Result || response.body || {};
@@ -276,9 +277,9 @@ export const spec = {
   /**
    * Register the user sync pixels which should be dropped after the auction.
    *
-   * @param {SyncOptions} syncOptions Which user syncs are allowed?
-   * @param {ServerResponse[]} serverResponses List of server's responses.
-   * @return {UserSync[]} The user syncs which should be dropped.
+   * @param {import('../src/adapters/bidderFactory.js').SyncOptions} syncOptions Which user syncs are allowed?
+   * @param {object[]} serverResponses List of server's responses.
+   * @return {import('../src/adapters/bidderFactory.js').UserSync[]} The user syncs which should be dropped.
    */
   getUserSyncs: function (
     syncOptions,

--- a/modules/excoBidAdapter.js
+++ b/modules/excoBidAdapter.js
@@ -16,11 +16,11 @@ import {
   generateUUID,
 } from '../src/utils.js';
 
-const SID = window.excoPid || generateUUID();
-const BIDDER_CODE = 'exco';
-const VERSION = '0.0.1';
-const ENDPOINT = '//v.ex.co/se/openrtb/hb/pbjs';
+export const SID = window.excoPid || generateUUID();
+export const ENDPOINT = '//v.ex.co/se/openrtb/hb/pbjs';
 const SYNC_URL = '//cdn.ex.co/sync/e15e216-l/cookie_sync.html';
+export const BIDDER_CODE = 'exco';
+const VERSION = '0.0.1';
 const CURRENCY = 'USD';
 
 const SYNC = {
@@ -270,8 +270,8 @@ export const spec = {
    * @return {import('../src/auction.js').Bid[]} An array of bids which were nested inside the server.
    */
   interpretResponse: function (response, request) {
-    const body = response.body.Result || response.body || {};
-    return converter.fromORTB({response: body, request: request.data}).bids || [];
+    const body = response?.body?.Result || response?.body || {};
+    return converter.fromORTB({response: body, request: request?.data}).bids || [];
   },
 
   /**

--- a/modules/excoBidAdapter.js
+++ b/modules/excoBidAdapter.js
@@ -1,3 +1,4 @@
+
 import { config } from 'src/config';
 import { _each, mergeDeep, deepAccess, logInfo, logWarn, insertUserSyncIframe, logError, isStr, generateUUID } from '../src/utils.js';
 import { registerBidder } from 'src/adapters/bidderFactory';
@@ -84,6 +85,25 @@ export class AdapterHelpers {
 
   isBannerBid(bid) {
     return deepAccess(bid, 'mediaTypes.banner') || !this.isVideoBid(bid);
+  }
+
+  isBannerRatioValid([width, height]) {
+    const r = parseInt(width, 10) / parseInt(height, 10);
+    return 0.7 < r && r < 1.7;
+  };
+
+  isBannerSizeValid(bannerSize) {
+    if (isArray(bannerSize) && bannerSize.length) {
+      if (isArray(bannerSize[0])) {
+        return bannerSize.every((sizes) => {
+          return this.isBannerRatioValid(sizes);
+        });
+      }
+
+      return this.isBannerRatioValid(bannerSize);
+    }
+
+    return false;
   }
 
   adoptVideoImp(imp, bidRequest) {
@@ -232,6 +252,10 @@ export const spec = {
         helpers.log('warn', `Error: '${prop}' must be a string (${suggestion}). ${message}`);
       });
 
+      return false;
+    }
+
+    if (helpers.isBannerBid(bid) && helpers.isBannerSizeValid(bid.sizes) === false) {
       return false;
     }
 

--- a/modules/excoBidAdapter.md
+++ b/modules/excoBidAdapter.md
@@ -20,13 +20,9 @@ var adUnits = [
       {
         bidder: 'exco',
         params: {
-          cId: '562524b21b1c1f08117fc7f9',
-          pId: '59ac17c192832d0011283fe3',
-          bidFloor: 0.0001,
-          ext: {
-            param1: 'loremipsum',
-            param2: 'dolorsitamet'
-          }
+          accountId: 'accountId',
+          publisherId: 'publisherId',
+          tagId: 'tagId',
         }
       }
     ]

--- a/test/spec/modules/excoBidAdapter_spec.js
+++ b/test/spec/modules/excoBidAdapter_spec.js
@@ -1,211 +1,103 @@
-import {expect} from 'chai';
-import {
-  spec as adapter,
-  createDomain,
-  storage
-} from 'modules/excoBidAdapter';
-import * as utils from 'src/utils.js';
-import {version} from 'package.json';
-import {useFakeTimers} from 'sinon';
-import {BANNER, VIDEO} from '../../../src/mediaTypes';
-import {config} from '../../../src/config';
-import {
-  hashCode,
-  extractPID,
-  extractCID,
-  extractSubDomain,
-  getStorageItem,
-  setStorageItem,
-  tryParseJSON,
-  getUniqueDealId,
-} from '../../../libraries/vidazooUtils/bidderUtils.js';
-
-export const TEST_ID_SYSTEMS = ['criteoId', 'id5id', 'idl_env', 'lipb', 'netId', 'pubcid', 'tdid', 'pubProvidedId'];
-
-const SUB_DOMAIN = 'rtb';
+import { expect } from 'chai';
+import { spec as adapter } from 'modules/excoBidAdapter';
+import { version } from 'package.json';
+import { BANNER, VIDEO } from '../../../src/mediaTypes';
+import { config } from '../../../src/config';
 
 const BID = {
-  'bidId': '2d52001cabd527',
-  'adUnitCode': 'div-gpt-ad-12345-0',
-  'params': {
-    'subDomain': SUB_DOMAIN,
-    'cId': '59db6b3b4ffaa70004f45cdc',
-    'pId': '59ac17c192832d0011283fe3',
-    'bidFloor': 0.1,
-    'ext': {
-      'param1': 'loremipsum',
-      'param2': 'dolorsitamet'
-    }
+  bidId: '1731e91fa1236fd',
+  adUnitCode: '300x250',
+  params: {
+    accountId: 'accountId',
+    publisherId: 'publisherId',
+    tagId: 'tagId',
   },
-  'placementCode': 'div-gpt-ad-1460505748561-0',
-  'sizes': [[300, 250], [300, 600]],
-  'bidderRequestId': '1fdb5ff1b6eaa7',
-  'bidRequestsCount': 4,
-  'bidderRequestsCount': 3,
-  'bidderWinsCount': 1,
-  'requestId': 'b0777d85-d061-450e-9bc7-260dd54bbb7a',
-  'schain': 'a0819c69-005b-41ed-af06-1be1e0aefefc',
-  'mediaTypes': [BANNER],
-  'ortb2Imp': {
-    'ext': {
-      'gpid': '0123456789',
-      'tid': '56e184c6-bde9-497b-b9b9-cf47a61381ee'
-    }
-  }
+  maxBidderCalls: -1,
+  ortb2Imp: { ext: {} },
+  mediaTypes: {
+    banner: {
+      sizes: [[300, 250]],
+    },
+  },
+  transactionId: null,
+  sizes: [[300, 250]],
+  bidderRequestId: '1677eaa35e64f46',
+  auctionId: null,
+  bidRequestsCount: 1,
+  bidderRequestsCount: 1,
+  bidderWinsCount: 0,
 };
 
-const VIDEO_BID = {
-  'bidId': '2d52001cabd527',
-  'adUnitCode': '63550ad1ff6642d368cba59dh5884270560',
-  'bidderRequestId': '12a8ae9ada9c13',
-  'bidRequestsCount': 4,
-  'bidderRequestsCount': 3,
-  'bidderWinsCount': 1,
-  'schain': 'a0819c69-005b-41ed-af06-1be1e0aefefc',
-  'params': {
-    'subDomain': SUB_DOMAIN,
-    'cId': '635509f7ff6642d368cb9837',
-    'pId': '59ac17c192832d0011283fe3',
-    'bidFloor': 0.1
-  },
-  'sizes': [[545, 307]],
-  'mediaTypes': {
-    'video': {
-      'playerSize': [[545, 307]],
-      'context': 'instream',
-      'mimes': [
-        'video/mp4',
-        'application/javascript'
-      ],
-      'protocols': [2, 3, 5, 6],
-      'maxduration': 60,
-      'minduration': 0,
-      'startdelay': 0,
-      'linearity': 1,
-      'api': [2],
-      'placement': 1
-    }
-  },
-  'ortb2Imp': {
-    'ext': {
-      'gpid': '0123456789',
-      'tid': '56e184c6-bde9-497b-b9b9-cf47a61381ee'
-    }
-  }
-}
-
 const ORTB2_DEVICE = {
-  sua: {
-    'source': 2,
-    'platform': {
-      'brand': 'Android',
-      'version': ['8', '0', '0']
-    },
-    'browsers': [
-      {'brand': 'Not_A Brand', 'version': ['99', '0', '0', '0']},
-      {'brand': 'Google Chrome', 'version': ['109', '0', '5414', '119']},
-      {'brand': 'Chromium', 'version': ['109', '0', '5414', '119']}
-    ],
-    'mobile': 1,
-    'model': 'SM-G955U',
-    'bitness': '64',
-    'architecture': ''
-  },
-  w: 980,
-  h: 1720,
+  w: 1309,
+  h: 1305,
   dnt: 0,
-  ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.80 Mobile/15E148 Safari/604.1',
+  ua: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
   language: 'en',
-  devicetype: 1,
-  make: 'Apple',
-  model: 'iPhone 12 Pro Max',
-  os: 'iOS',
-  osv: '17.4',
-  ext: {fiftyonedegrees_deviceId: '17595-133085-133468-18092'},
+  sua: {
+    source: 1,
+    platform: { brand: 'Windows' },
+    browsers: [
+      { brand: 'Not(A:Brand', version: ['99'] },
+      { brand: 'Google Chrome', version: ['133'] },
+      { brand: 'Chromium', version: ['133'] },
+    ],
+    mobile: 0,
+  },
 };
 
 const BIDDER_REQUEST = {
-  'gdprConsent': {
-    'consentString': 'consent_string',
-    'gdprApplies': true
+  gdprConsent: {
+    consentString: 'consent_string',
+    gdprApplies: true,
   },
-  'gppString': 'gpp_string',
-  'gppSid': [7],
-  'uspConsent': 'consent_string',
-  'refererInfo': {
-    'page': 'https://www.greatsite.com',
-    'ref': 'https://www.somereferrer.com'
+  gppString: 'gpp_string',
+  gppSid: [7],
+  uspConsent: 'consent_string',
+  refererInfo: {
+    page: 'https://www.greatsite.com',
+    ref: 'https://www.somereferrer.com',
   },
-  'ortb2': {
-    'site': {
-      'content': {
-        'language': 'en'
-      }
+  ortb2: {
+    site: {
+      content: {
+        language: 'en',
+      },
     },
-    'regs': {
-      'gpp': 'gpp_string',
-      'gpp_sid': [7],
-      'coppa': 0
-    },
-    'device': ORTB2_DEVICE,
-  }
+    device: ORTB2_DEVICE,
+  },
 };
 
 const SERVER_RESPONSE = {
   body: {
     cid: 'testcid123',
-    results: [{
-      'ad': '<iframe>console.log("hello world")</iframe>',
-      'price': 0.8,
-      'creativeId': '12610997325162499419',
-      'exp': 30,
-      'width': 300,
-      'height': 250,
-      'advertiserDomains': ['securepubads.g.doubleclick.net'],
-      'cookies': [{
-        'src': 'https://sync.com',
-        'type': 'iframe'
-      }, {
-        'src': 'https://sync.com',
-        'type': 'img'
-      }]
-    }]
-  }
-};
-
-const VIDEO_SERVER_RESPONSE = {
-  body: {
-    'cid': '635509f7ff6642d368cb9837',
-    'results': [{
-      'ad': '<VAST version=\"3.0\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"></VAST>',
-      'advertiserDomains': ['exco.com'],
-      'exp': 60,
-      'width': 545,
-      'height': 307,
-      'mediaType': 'video',
-      'creativeId': '12610997325162499419',
-      'price': 2,
-      'cookies': []
-    }]
-  }
+    results: [
+      {
+        ad: '<iframe>console.log("hello world")</iframe>',
+        price: 0.8,
+        creativeId: '12610997325162499419',
+        exp: 30,
+        width: 300,
+        height: 250,
+        advertiserDomains: ['securepubads.g.doubleclick.net'],
+        cookies: [
+          {
+            src: 'https://sync.com',
+            type: 'iframe',
+          },
+        ],
+      },
+    ],
+  },
 };
 
 const REQUEST = {
   data: {
     width: 300,
     height: 250,
-    bidId: '2d52001cabd527'
-  }
+    bidId: BID.bidId,
+  },
 };
-
-function getTopWindowQueryParams() {
-  try {
-    const parsedUrl = utils.parseUrl(window.top.document.URL, {decodeSearchAsString: true});
-    return parsedUrl.search;
-  } catch (e) {
-    return '';
-  }
-}
 
 describe('ExcoBidAdapter', function () {
   describe('validtae spec', function () {
@@ -230,26 +122,43 @@ describe('ExcoBidAdapter', function () {
     });
 
     it('exists and contains media types', function () {
-      expect(adapter.supportedMediaTypes).to.exist.and.to.be.an('array').with.length(2);
+      expect(adapter.supportedMediaTypes)
+        .to.exist.and.to.be.an('array')
+        .with.length(2);
       expect(adapter.supportedMediaTypes).to.contain.members([BANNER, VIDEO]);
     });
   });
 
   describe('validate bid requests', function () {
-    it('should require cId', function () {
+    it('should require accountId', function () {
       const isValid = adapter.isBidRequestValid({
         params: {
-          pId: 'pid'
-        }
+          publisherId: 'publisherId',
+          // accountId: 'accountId',
+          tagId: 'tagId',
+        },
       });
       expect(isValid).to.be.false;
     });
 
-    it('should require pId', function () {
+    it('should require publisherId', function () {
       const isValid = adapter.isBidRequestValid({
         params: {
-          cId: 'cid'
-        }
+          // publisherId: 'publisherId',
+          accountId: 'accountId',
+          tagId: 'tagId',
+        },
+      });
+      expect(isValid).to.be.false;
+    });
+
+    it('should require tagId', function () {
+      const isValid = adapter.isBidRequestValid({
+        params: {
+          publisherId: 'publisherId',
+          accountId: 'accountId',
+          // tagId: 'tagId',
+        },
       });
       expect(isValid).to.be.false;
     });
@@ -257,9 +166,10 @@ describe('ExcoBidAdapter', function () {
     it('should validate correctly', function () {
       const isValid = adapter.isBidRequestValid({
         params: {
-          cId: 'cid',
-          pId: 'pid'
-        }
+          publisherId: 'publisherId',
+          accountId: 'accountId',
+          tagId: 'tagId',
+        },
       });
       expect(isValid).to.be.true;
     });
@@ -270,162 +180,112 @@ describe('ExcoBidAdapter', function () {
     before(function () {
       $$PREBID_GLOBAL$$.bidderSettings = {
         exco: {
-          storageAllowed: true
-        }
+          storageAllowed: true,
+        },
       };
       sandbox = sinon.sandbox.create();
       sandbox.stub(Date, 'now').returns(1000);
     });
 
-    it('should build video request', function () {
-      const hashUrl = hashCode(BIDDER_REQUEST.refererInfo.page);
-      config.setConfig({
-        bidderTimeout: 3000,
-        enableTIDs: true
-      });
-      const requests = adapter.buildRequests([VIDEO_BID], BIDDER_REQUEST);
-      expect(requests).to.have.length(1);
-      expect(requests[0]).to.deep.equal({
-        method: 'POST',
-        url: `${createDomain(SUB_DOMAIN)}/prebid/multi/635509f7ff6642d368cb9837`,
-        data: {
-          adUnitCode: '63550ad1ff6642d368cba59dh5884270560',
-          bidFloor: 0.1,
-          bidId: '2d52001cabd527',
-          bidderVersion: adapter.version,
-          bidderRequestId: '12a8ae9ada9c13',
-          cb: 1000,
-          gdpr: 1,
-          gdprConsent: 'consent_string',
-          usPrivacy: 'consent_string',
-          gppString: 'gpp_string',
-          gppSid: [7],
-          transactionId: '56e184c6-bde9-497b-b9b9-cf47a61381ee',
-          prebidVersion: version,
-          bidRequestsCount: 4,
-          bidderRequestsCount: 3,
-          bidderWinsCount: 1,
-          bidderTimeout: 3000,
-          publisherId: '59ac17c192832d0011283fe3',
-          url: 'https%3A%2F%2Fwww.greatsite.com',
-          referrer: 'https://www.somereferrer.com',
-          res: `${window.top.screen.width}x${window.top.screen.height}`,
-          schain: VIDEO_BID.schain,
-          sizes: ['545x307'],
-          sua: {
-            'source': 2,
-            'platform': {
-              'brand': 'Android',
-              'version': ['8', '0', '0']
-            },
-            'browsers': [
-              {'brand': 'Not_A Brand', 'version': ['99', '0', '0', '0']},
-              {'brand': 'Google Chrome', 'version': ['109', '0', '5414', '119']},
-              {'brand': 'Chromium', 'version': ['109', '0', '5414', '119']}
-            ],
-            'mobile': 1,
-            'model': 'SM-G955U',
-            'bitness': '64',
-            'architecture': ''
-          },
-          device: ORTB2_DEVICE,
-          uniqueDealId: `${hashUrl}_${Date.now().toString()}`,
-          uqs: getTopWindowQueryParams(),
-          mediaTypes: {
-            video: {
-              api: [2],
-              context: 'instream',
-              linearity: 1,
-              maxduration: 60,
-              mimes: [
-                'video/mp4',
-                'application/javascript'
-              ],
-              minduration: 0,
-              placement: 1,
-              playerSize: [[545, 307]],
-              protocols: [2, 3, 5, 6],
-              startdelay: 0
-            }
-          },
-          gpid: '0123456789',
-          cat: [],
-          contentData: [],
-          contentLang: 'en',
-          isStorageAllowed: true,
-          pagecat: [],
-          userData: [],
-          coppa: 0
-        }
-      });
-    });
-
     it('should build banner request for each size', function () {
-      const hashUrl = hashCode(BIDDER_REQUEST.refererInfo.page);
       config.setConfig({
         bidderTimeout: 3000,
-        enableTIDs: true
+        enableTIDs: true,
       });
       const requests = adapter.buildRequests([BID], BIDDER_REQUEST);
       expect(requests).to.have.length(1);
       expect(requests[0]).to.deep.equal({
         method: 'POST',
-        url: `${createDomain(SUB_DOMAIN)}/prebid/multi/59db6b3b4ffaa70004f45cdc`,
+        url: '//v.ex.co/se/openrtb/hb/pbjs',
         data: {
-          gdprConsent: 'consent_string',
-          gdpr: 1,
-          gppString: 'gpp_string',
-          gppSid: [7],
-          usPrivacy: 'consent_string',
-          bidRequestsCount: 4,
-          bidderRequestsCount: 3,
-          bidderWinsCount: 1,
-          bidderTimeout: 3000,
-          bidderRequestId: '1fdb5ff1b6eaa7',
-          transactionId: '56e184c6-bde9-497b-b9b9-cf47a61381ee',
-          sizes: ['300x250', '300x600'],
-          sua: {
-            'source': 2,
-            'platform': {
-              'brand': 'Android',
-              'version': ['8', '0', '0']
+          imp: [
+            {
+              ext: {
+                prebid: {
+                  bidder: {
+                    exco: {
+                      accountId: 'accountId',
+                      publisherId: 'publisherId',
+                      tagId: 'tagId',
+                    },
+                  },
+                  adunitcode: '300x250',
+                },
+              },
+              id: BID.bidId,
+              banner: {
+                topframe: 1,
+                format: [
+                  {
+                    w: 300,
+                    h: 250,
+                  },
+                ],
+              },
+              secure: 1,
+              tagId: 'tagId',
             },
-            'browsers': [
-              {'brand': 'Not_A Brand', 'version': ['99', '0', '0', '0']},
-              {'brand': 'Google Chrome', 'version': ['109', '0', '5414', '119']},
-              {'brand': 'Chromium', 'version': ['109', '0', '5414', '119']}
-            ],
-            'mobile': 1,
-            'model': 'SM-G955U',
-            'bitness': '64',
-            'architecture': ''
+          ],
+          source: {},
+          site: {
+            content: {
+              language: 'en',
+            },
           },
-          device: ORTB2_DEVICE,
-          url: 'https%3A%2F%2Fwww.greatsite.com',
-          referrer: 'https://www.somereferrer.com',
-          cb: 1000,
-          bidFloor: 0.1,
-          bidId: '2d52001cabd527',
-          adUnitCode: 'div-gpt-ad-12345-0',
-          publisherId: '59ac17c192832d0011283fe3',
-          uniqueDealId: `${hashUrl}_${Date.now().toString()}`,
-          bidderVersion: adapter.version,
-          prebidVersion: version,
-          schain: BID.schain,
-          res: `${window.top.screen.width}x${window.top.screen.height}`,
-          mediaTypes: [BANNER],
-          gpid: '0123456789',
-          uqs: getTopWindowQueryParams(),
-          'ext.param1': 'loremipsum',
-          'ext.param2': 'dolorsitamet',
-          cat: [],
-          contentData: [],
-          contentLang: 'en',
-          isStorageAllowed: true,
-          pagecat: [],
-          userData: [],
-          coppa: 0
-        }
+          device: {
+            w: 1309,
+            h: 1305,
+            dnt: 0,
+            ua: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
+            language: 'en',
+            sua: {
+              source: 1,
+              platform: {
+                brand: 'Windows',
+              },
+              browsers: [
+                {
+                  brand: 'Not(A:Brand',
+                  version: ['99'],
+                },
+                {
+                  brand: 'Google Chrome',
+                  version: ['133'],
+                },
+                {
+                  brand: 'Chromium',
+                  version: ['133'],
+                },
+              ],
+              mobile: 0,
+            },
+          },
+          id: '2761790c-1ee0-4aea-8cba-e201d5474920',
+          test: 0,
+          tmax: 3000,
+          ext: {
+            prebid: {
+              auctiontimestamp: 1739870889391,
+              targeting: {
+                includewinners: true,
+                includebidderkeys: false,
+              },
+              channel: {
+                name: 'pbjs',
+                version: `v${version}`,
+              },
+            },
+            exco: {
+              version: '0.0.1',
+              pbversion: version,
+              sid: '234a2e26-d55e-4de3-b49f-ab0f3729f03b',
+              aid: '1677eaa35e64f46',
+              rc: 1,
+              brc: 1,
+            },
+          },
+          cur: ['USD'],
+        },
       });
     });
 
@@ -433,33 +293,6 @@ describe('ExcoBidAdapter', function () {
       $$PREBID_GLOBAL$$.bidderSettings = {};
       sandbox.restore();
     });
-  });
-  describe('getUserSyncs', function () {
-    it('should have valid user sync with iframeEnabled', function () {
-      const result = adapter.getUserSyncs({iframeEnabled: true}, [SERVER_RESPONSE]);
-
-      expect(result).to.deep.equal([{
-        type: 'iframe',
-        url: 'https://cs.exco-pb.com/api/sync/iframe/?cid=testcid123&gdpr=0&gdpr_consent=&us_privacy='
-      }]);
-    });
-
-    it('should have valid user sync with cid on response', function () {
-      const result = adapter.getUserSyncs({iframeEnabled: true}, [SERVER_RESPONSE]);
-      expect(result).to.deep.equal([{
-        type: 'iframe',
-        url: 'https://cs.exco-pb.com/api/sync/iframe/?cid=testcid123&gdpr=0&gdpr_consent=&us_privacy='
-      }]);
-    });
-
-    it('should have valid user sync with pixelEnabled', function () {
-      const result = adapter.getUserSyncs({pixelEnabled: true}, [SERVER_RESPONSE]);
-
-      expect(result).to.deep.equal([{
-        'url': 'https://cs.exco-pb.com/api/sync/image/?cid=testcid123&gdpr=0&gdpr_consent=&us_privacy=',
-        'type': 'image'
-      }]);
-    })
   });
 
   describe('interpret response', function () {
@@ -469,12 +302,15 @@ describe('ExcoBidAdapter', function () {
     });
 
     it('should return empty array when there is no ad', function () {
-      const responses = adapter.interpretResponse({price: 1, ad: ''});
+      const responses = adapter.interpretResponse({ price: 1, ad: '' });
       expect(responses).to.be.empty;
     });
 
     it('should return empty array when there is no price', function () {
-      const responses = adapter.interpretResponse({price: null, ad: 'great ad'});
+      const responses = adapter.interpretResponse({
+        price: null,
+        ad: 'great ad',
+      });
       expect(responses).to.be.empty;
     });
 
@@ -482,189 +318,27 @@ describe('ExcoBidAdapter', function () {
       const responses = adapter.interpretResponse(SERVER_RESPONSE, REQUEST);
       expect(responses).to.have.length(1);
       expect(responses[0]).to.deep.equal({
-        requestId: '2d52001cabd527',
-        cpm: 0.8,
-        width: 300,
-        height: 250,
-        creativeId: '12610997325162499419',
-        currency: 'USD',
-        netRevenue: true,
-        ttl: 30,
-        ad: '<iframe>console.log("hello world")</iframe>',
-        meta: {
-          advertiserDomains: ['securepubads.g.doubleclick.net']
-        }
+        'mediaType': 'banner',
+        'requestId': BID.bidId,
+        'seatBidId': '7f79235c-9f04-4241-b55f-62bc8b23740c',
+        'cpm': 16.38,
+        'width': 450,
+        'height': 350,
+        'creative_id': 'h6bvt3rl',
+        'creativeId': 'h6bvt3rl',
+        'ttl': 3000,
+        'meta': {
+          'advertiserDomains': [
+            'crest.com'
+          ],
+          'mediaType': 'banner'
+        },
+        'bidderCode': 'exco',
+        'adapterCode': 'exco',
+        'ad': '<iframe>console.log("hello world")</iframe>',
+        'netRevenue': true,
+        'currency': 'USD'
       });
-    });
-
-    it('should get meta from response metaData', function () {
-      const serverResponse = utils.deepClone(SERVER_RESPONSE);
-      serverResponse.body.results[0].metaData = {
-        advertiserDomains: ['exco.com'],
-        agencyName: 'Agency Name',
-      };
-      const responses = adapter.interpretResponse(serverResponse, REQUEST);
-      expect(responses[0].meta).to.deep.equal({
-        advertiserDomains: ['exco.com'],
-        agencyName: 'Agency Name'
-      });
-    });
-
-    it('should return an array of interpreted video responses', function () {
-      const responses = adapter.interpretResponse(VIDEO_SERVER_RESPONSE, REQUEST);
-      expect(responses).to.have.length(1);
-      expect(responses[0]).to.deep.equal({
-        requestId: '2d52001cabd527',
-        cpm: 2,
-        width: 545,
-        height: 307,
-        mediaType: 'video',
-        creativeId: '12610997325162499419',
-        currency: 'USD',
-        netRevenue: true,
-        ttl: 60,
-        vastXml: '<VAST version=\"3.0\" xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"></VAST>',
-        meta: {
-          advertiserDomains: ['exco.com']
-        }
-      });
-    });
-
-    it('should take default TTL', function () {
-      const serverResponse = utils.deepClone(SERVER_RESPONSE);
-      delete serverResponse.body.results[0].exp;
-      const responses = adapter.interpretResponse(serverResponse, REQUEST);
-      expect(responses).to.have.length(1);
-      expect(responses[0].ttl).to.equal(300);
-    });
-  });
-
-  describe('user id system', function () {
-    TEST_ID_SYSTEMS.forEach((idSystemProvider) => {
-      const id = Date.now().toString();
-      const bid = utils.deepClone(BID);
-
-      const userId = (function () {
-        switch (idSystemProvider) {
-          case 'lipb':
-            return {lipbid: id};
-          case 'id5id':
-            return {uid: id};
-          default:
-            return id;
-        }
-      })();
-
-      bid.userId = {
-        [idSystemProvider]: userId
-      };
-
-      it(`should include 'uid.${idSystemProvider}' in request params`, function () {
-        const requests = adapter.buildRequests([bid], BIDDER_REQUEST);
-        expect(requests[0].data[`uid.${idSystemProvider}`]).to.equal(id);
-      });
-    });
-  });
-
-  describe('alternate param names extractors', function () {
-    it('should return undefined when param not supported', function () {
-      const cid = extractCID({'c_id': '1'});
-      const pid = extractPID({'p_id': '1'});
-      const subDomain = extractSubDomain({'sub_domain': 'prebid'});
-      expect(cid).to.be.undefined;
-      expect(pid).to.be.undefined;
-      expect(subDomain).to.be.undefined;
-    });
-
-    it('should return value when param supported', function () {
-      const cid = extractCID({'cId': '1'});
-      const pid = extractPID({'pId': '2'});
-      const subDomain = extractSubDomain({'subDomain': 'prebid'});
-      expect(cid).to.be.equal('1');
-      expect(pid).to.be.equal('2');
-      expect(subDomain).to.be.equal('prebid');
-    });
-  });
-
-  describe('unique deal id', function () {
-    before(function () {
-      $$PREBID_GLOBAL$$.bidderSettings = {
-        exco: {
-          storageAllowed: true
-        }
-      };
-    });
-    after(function () {
-      $$PREBID_GLOBAL$$.bidderSettings = {};
-    });
-    const key = 'myKey';
-    let uniqueDealId;
-    beforeEach(() => {
-      uniqueDealId = getUniqueDealId(storage, key, 0);
-    })
-
-    it('should get current unique deal id', function (done) {
-      // waiting some time so `now` will become past
-      setTimeout(() => {
-        const current = getUniqueDealId(storage, key);
-        expect(current).to.be.equal(uniqueDealId);
-        done();
-      }, 200);
-    });
-
-    it('should get new unique deal id on expiration', function (done) {
-      setTimeout(() => {
-        const current = getUniqueDealId(storage, key, 100);
-        expect(current).to.not.be.equal(uniqueDealId);
-        done();
-      }, 200)
-    });
-  });
-
-  describe('storage utils', function () {
-    before(function () {
-      $$PREBID_GLOBAL$$.bidderSettings = {
-        exco: {
-          storageAllowed: true
-        }
-      };
-    });
-    after(function () {
-      $$PREBID_GLOBAL$$.bidderSettings = {};
-    });
-    it('should get value from storage with create param', function () {
-      const now = Date.now();
-      const clock = useFakeTimers({
-        shouldAdvanceTime: true,
-        now
-      });
-      setStorageItem(storage, 'myKey', 2020);
-      const {value, created} = getStorageItem(storage, 'myKey');
-      expect(created).to.be.equal(now);
-      expect(value).to.be.equal(2020);
-      expect(typeof value).to.be.equal('number');
-      expect(typeof created).to.be.equal('number');
-      clock.restore();
-    });
-
-    it('should get external stored value', function () {
-      const value = 'superman'
-      window.localStorage.setItem('myExternalKey', value);
-      const item = getStorageItem(storage, 'myExternalKey');
-      expect(item).to.be.equal(value);
-    });
-
-    it('should parse JSON value', function () {
-      const data = JSON.stringify({event: 'send'});
-      const {event} = tryParseJSON(data);
-      expect(event).to.be.equal('send');
-    });
-
-    it('should get original value on parse fail', function () {
-      const value = 21;
-      const parsed = tryParseJSON(value);
-      expect(typeof parsed).to.be.equal('number');
-      expect(parsed).to.be.equal(value);
     });
   });
 });

--- a/test/spec/modules/excoBidAdapter_spec.js
+++ b/test/spec/modules/excoBidAdapter_spec.js
@@ -1,344 +1,213 @@
 import { expect } from 'chai';
-import { spec as adapter } from 'modules/excoBidAdapter';
-import { version } from 'package.json';
-import { BANNER, VIDEO } from '../../../src/mediaTypes';
+import { spec as adapter, SID, ENDPOINT, BIDDER_CODE } from 'modules/excoBidAdapter';
+import { BANNER } from '../../../src/mediaTypes';
 import { config } from '../../../src/config';
-
-const BID = {
-  bidId: '1731e91fa1236fd',
-  adUnitCode: '300x250',
-  params: {
-    accountId: 'accountId',
-    publisherId: 'publisherId',
-    tagId: 'tagId',
-  },
-  maxBidderCalls: -1,
-  ortb2Imp: { ext: {} },
-  mediaTypes: {
-    banner: {
-      sizes: [[300, 250]],
-    },
-  },
-  transactionId: null,
-  sizes: [[300, 250]],
-  bidderRequestId: '1677eaa35e64f46',
-  auctionId: null,
-  bidRequestsCount: 1,
-  bidderRequestsCount: 1,
-  bidderWinsCount: 0,
-};
-
-const ORTB2_DEVICE = {
-  w: 1309,
-  h: 1305,
-  dnt: 0,
-  ua: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
-  language: 'en',
-  sua: {
-    source: 1,
-    platform: { brand: 'Windows' },
-    browsers: [
-      { brand: 'Not(A:Brand', version: ['99'] },
-      { brand: 'Google Chrome', version: ['133'] },
-      { brand: 'Chromium', version: ['133'] },
-    ],
-    mobile: 0,
-  },
-};
-
-const BIDDER_REQUEST = {
-  gdprConsent: {
-    consentString: 'consent_string',
-    gdprApplies: true,
-  },
-  gppString: 'gpp_string',
-  gppSid: [7],
-  uspConsent: 'consent_string',
-  refererInfo: {
-    page: 'https://www.greatsite.com',
-    ref: 'https://www.somereferrer.com',
-  },
-  ortb2: {
-    site: {
-      content: {
-        language: 'en',
-      },
-    },
-    device: ORTB2_DEVICE,
-  },
-};
-
-const SERVER_RESPONSE = {
-  body: {
-    cid: 'testcid123',
-    results: [
-      {
-        ad: '<iframe>console.log("hello world")</iframe>',
-        price: 0.8,
-        creativeId: '12610997325162499419',
-        exp: 30,
-        width: 300,
-        height: 250,
-        advertiserDomains: ['securepubads.g.doubleclick.net'],
-        cookies: [
-          {
-            src: 'https://sync.com',
-            type: 'iframe',
-          },
-        ],
-      },
-    ],
-  },
-};
-
-const REQUEST = {
-  data: {
-    width: 300,
-    height: 250,
-    bidId: BID.bidId,
-  },
-};
+import sinon from 'sinon';
 
 describe('ExcoBidAdapter', function () {
-  describe('validtae spec', function () {
-    it('exists and is a function', function () {
-      expect(adapter.isBidRequestValid).to.exist.and.to.be.a('function');
+  const BID = {
+    bidId: '1731e91fa1236fd',
+    adUnitCode: '300x250',
+    bidder: BIDDER_CODE,
+    params: {
+      accountId: 'accountId',
+      publisherId: 'publisherId',
+      tagId: 'tagId',
+    },
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]],
+      },
+    },
+    transactionId: 'transactionId',
+    sizes: [[300, 250]],
+    bidderRequestId: '1677eaa35e64f46',
+    auctionId: 'auctionId',
+    bidRequestsCount: 1,
+    bidderRequestsCount: 1,
+    bidderWinsCount: 0,
+  };
+
+  const BIDDER_REQUEST = {
+    bidderCode: BIDDER_CODE,
+    auctionId: 'auctionId',
+    bidderRequestId: '1677eaa35e64f46',
+    bids: [BID],
+    gdprConsent: {
+      consentString: 'consent_string',
+      gdprApplies: true,
+    },
+    gppString: 'gpp_string',
+    gppSid: [7],
+    uspConsent: 'consent_string',
+    refererInfo: {
+      page: 'https://www.greatsite.com',
+      ref: 'https://www.somereferrer.com',
+    },
+    ortb2: {
+      site: {
+        content: {
+          language: 'en',
+        },
+      },
+      device: {
+        w: 1309,
+        h: 1305,
+        dnt: 0,
+        ua: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
+        language: 'en',
+        sua: {
+          source: 1,
+          platform: { brand: 'Windows' },
+          browsers: [
+            { brand: 'Not(A:Brand', version: ['99'] },
+            { brand: 'Google Chrome', version: ['133'] },
+            { brand: 'Chromium', version: ['133'] },
+          ],
+          mobile: 0,
+        },
+      }
+    },
+  };
+
+  let BUILT_REQ = null;
+
+  describe('isBidRequestValid', function () {
+    it('should return false if accountId is missing', function () {
+      const bid = { ...BID, params: { publisherId: 'publisherId', tagId: 'tagId' } };
+      expect(adapter.isBidRequestValid(bid)).to.be.false;
     });
 
-    it('exists and is a function', function () {
-      expect(adapter.buildRequests).to.exist.and.to.be.a('function');
+    it('should return false if publisherId is missing', function () {
+      const bid = { ...BID, params: { accountId: 'accountId', tagId: 'tagId' } };
+      expect(adapter.isBidRequestValid(bid)).to.be.false;
     });
 
-    it('exists and is a function', function () {
-      expect(adapter.interpretResponse).to.exist.and.to.be.a('function');
+    it('should return false if tagId is missing', function () {
+      const bid = { ...BID, params: { accountId: 'accountId', publisherId: 'publisherId' } };
+      expect(adapter.isBidRequestValid(bid)).to.be.false;
     });
 
-    it('exists and is a function', function () {
-      expect(adapter.getUserSyncs).to.exist.and.to.be.a('function');
-    });
-
-    it('exists and is a string', function () {
-      expect(adapter.code).to.exist.and.to.be.a('string');
-    });
-
-    it('exists and contains media types', function () {
-      expect(adapter.supportedMediaTypes)
-        .to.exist.and.to.be.an('array')
-        .with.length(2);
-      expect(adapter.supportedMediaTypes).to.contain.members([BANNER, VIDEO]);
+    it('should return true if all required params are present', function () {
+      expect(adapter.isBidRequestValid(BID)).to.be.true;
     });
   });
 
-  describe('validate bid requests', function () {
-    it('should require accountId', function () {
-      const isValid = adapter.isBidRequestValid({
-        params: {
-          publisherId: 'publisherId',
-          // accountId: 'accountId',
-          tagId: 'tagId',
-        },
-      });
-      expect(isValid).to.be.false;
-    });
-
-    it('should require publisherId', function () {
-      const isValid = adapter.isBidRequestValid({
-        params: {
-          // publisherId: 'publisherId',
-          accountId: 'accountId',
-          tagId: 'tagId',
-        },
-      });
-      expect(isValid).to.be.false;
-    });
-
-    it('should require tagId', function () {
-      const isValid = adapter.isBidRequestValid({
-        params: {
-          publisherId: 'publisherId',
-          accountId: 'accountId',
-          // tagId: 'tagId',
-        },
-      });
-      expect(isValid).to.be.false;
-    });
-
-    it('should validate correctly', function () {
-      const isValid = adapter.isBidRequestValid({
-        params: {
-          publisherId: 'publisherId',
-          accountId: 'accountId',
-          tagId: 'tagId',
-        },
-      });
-      expect(isValid).to.be.true;
-    });
-  });
-
-  describe('build requests', function () {
+  describe('buildRequests', function () {
     let sandbox;
     before(function () {
-      $$PREBID_GLOBAL$$.bidderSettings = {
-        exco: {
-          storageAllowed: true,
-        },
-      };
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       sandbox.stub(Date, 'now').returns(1000);
     });
 
-    it('should build banner request for each size', function () {
+    it('should build request', function () {
       config.setConfig({
         bidderTimeout: 3000,
         enableTIDs: true,
       });
+
       const requests = adapter.buildRequests([BID], BIDDER_REQUEST);
       expect(requests).to.have.length(1);
-      expect(requests[0]).to.deep.equal({
-        method: 'POST',
-        url: '//v.ex.co/se/openrtb/hb/pbjs',
-        data: {
-          imp: [
-            {
-              ext: {
-                prebid: {
-                  bidder: {
-                    exco: {
-                      accountId: 'accountId',
-                      publisherId: 'publisherId',
-                      tagId: 'tagId',
-                    },
-                  },
-                  adunitcode: '300x250',
-                },
-              },
-              id: BID.bidId,
-              banner: {
-                topframe: 1,
-                format: [
-                  {
-                    w: 300,
-                    h: 250,
-                  },
-                ],
-              },
-              secure: 1,
-              tagId: 'tagId',
-            },
-          ],
-          source: {},
-          site: {
-            content: {
-              language: 'en',
-            },
-          },
-          device: {
-            w: 1309,
-            h: 1305,
-            dnt: 0,
-            ua: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
-            language: 'en',
-            sua: {
-              source: 1,
-              platform: {
-                brand: 'Windows',
-              },
-              browsers: [
-                {
-                  brand: 'Not(A:Brand',
-                  version: ['99'],
-                },
-                {
-                  brand: 'Google Chrome',
-                  version: ['133'],
-                },
-                {
-                  brand: 'Chromium',
-                  version: ['133'],
-                },
-              ],
-              mobile: 0,
-            },
-          },
-          id: '2761790c-1ee0-4aea-8cba-e201d5474920',
-          test: 0,
-          tmax: 3000,
-          ext: {
-            prebid: {
-              auctiontimestamp: 1739870889391,
-              targeting: {
-                includewinners: true,
-                includebidderkeys: false,
-              },
-              channel: {
-                name: 'pbjs',
-                version: `v${version}`,
-              },
-            },
-            exco: {
-              version: '0.0.1',
-              pbversion: version,
-              sid: '234a2e26-d55e-4de3-b49f-ab0f3729f03b',
-              aid: '1677eaa35e64f46',
-              rc: 1,
-              brc: 1,
-            },
-          },
-          cur: ['USD'],
-        },
-      });
+
+      const req = requests[0];
+      expect(req.method).to.equal('POST');
+      expect(req.url).to.equal(ENDPOINT);
+
+      const ext = req.data.ext[BIDDER_CODE] || {};
+      expect(ext.pbversion).to.equal('$prebid.version$');
+      expect(ext.sid).to.equal(SID);
+
+      BUILT_REQ = req;
     });
 
     after(function () {
-      $$PREBID_GLOBAL$$.bidderSettings = {};
       sandbox.restore();
     });
   });
 
-  describe('interpret response', function () {
+  describe('interpretResponse', function () {
+    const SERVER_RESPONSE = {
+      body: {
+        id: 'b1ec10d0-a1af-44e5-8a85-cb7b1652fe81',
+        seatbid: [
+          {
+            bid: [
+              {
+                id: 'b7b6eddb-9924-425e-aa52-5eba56689abe',
+                impid: BID.bidId,
+                cpm: 10.56,
+                ad: '<iframe>console.log("hello world")</iframe>',
+                lurl: 'https://ads-ssp-stg.hit.buzz/loss?loss=${AUCTION_LOSS}&min_to_win=${AUCTION_MIN_TO_WIN}',
+                adomain: ['crest.com'],
+                iurl: 'https://thetradedesk-t-general.s3.amazonaws.com/AdvertiserLogos/qrr9d3g.png',
+                crid: 'h6bvt3rl',
+                w: 300,
+                h: 250,
+                mtype: 2,
+                creativeId: 'h6bvt3rl',
+                netRevenue: true,
+                mediaType: BANNER,
+                ext: {
+                  advid: 37981,
+                  bidtype: 1,
+                  dspid: 377,
+                  origbidcpm: 0,
+                  origbidcur: 'USD',
+                  wDSPByrId: '3000',
+                },
+                currency: 'USD',
+              },
+            ],
+          },
+        ],
+      }
+    };
+
+    it('should return an array of interpreted banner responses', function () {
+      const responses = adapter.interpretResponse(SERVER_RESPONSE, BUILT_REQ);
+      expect(responses).to.have.length(1);
+      expect(responses[0]).to.deep.equal({
+        seatBidId: 'b7b6eddb-9924-425e-aa52-5eba56689abe',
+        mediaType: BANNER,
+        requestId: BID.bidId,
+        cpm: 10.56,
+        width: 300,
+        height: 250,
+        adapterCode: BIDDER_CODE,
+        bidderCode: BIDDER_CODE,
+        creativeId: 'h6bvt3rl',
+        creative_id: 'h6bvt3rl',
+        ttl: 3000,
+        meta: {
+          advertiserDomains: [
+            'crest.com'
+          ],
+          mediaType: BANNER
+        },
+        ad: '<iframe>console.log("hello world")</iframe>',
+        netRevenue: true,
+        currency: 'USD',
+        vastXml: undefined,
+        adUrl: undefined,
+      });
+    });
+
     it('should return empty array when there is no response', function () {
-      const responses = adapter.interpretResponse(null);
-      expect(responses).to.be.empty;
+      const responses = adapter.interpretResponse(null, BUILT_REQ);
+      expect(responses).to.have.length(0);
     });
 
     it('should return empty array when there is no ad', function () {
-      const responses = adapter.interpretResponse({ price: 1, ad: '' });
-      expect(responses).to.be.empty;
+      const responses = adapter.interpretResponse({ price: 1, ad: '' }, BUILT_REQ);
+      expect(responses).to.have.length(0);
     });
 
     it('should return empty array when there is no price', function () {
       const responses = adapter.interpretResponse({
         price: null,
         ad: 'great ad',
-      });
-      expect(responses).to.be.empty;
-    });
-
-    it('should return an array of interpreted banner responses', function () {
-      const responses = adapter.interpretResponse(SERVER_RESPONSE, REQUEST);
-      expect(responses).to.have.length(1);
-      expect(responses[0]).to.deep.equal({
-        'mediaType': 'banner',
-        'requestId': BID.bidId,
-        'seatBidId': '7f79235c-9f04-4241-b55f-62bc8b23740c',
-        'cpm': 16.38,
-        'width': 450,
-        'height': 350,
-        'creative_id': 'h6bvt3rl',
-        'creativeId': 'h6bvt3rl',
-        'ttl': 3000,
-        'meta': {
-          'advertiserDomains': [
-            'crest.com'
-          ],
-          'mediaType': 'banner'
-        },
-        'bidderCode': 'exco',
-        'adapterCode': 'exco',
-        'ad': '<iframe>console.log("hello world")</iframe>',
-        'netRevenue': true,
-        'currency': 'USD'
-      });
+      }, BUILT_REQ);
+      expect(responses).to.have.length(0);
     });
   });
 });


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 

## Description of change
```javascript
{
  bidder: 'exco',
  params: {
    cId: 'cId',                         // Legacy parameter
    pId: 'pId',                         // Legacy parameter
    accountId: 'EXCO Account ID',       // New EXCO parameter
    publisherId: 'EXCO Publisher ID',   // New EXCO parameter
    tagId: 'EXCO Tag ID',               // New EXCO parameter
    bidFloor: 0.0001,
    ext: {
      param1: 'loremipsum',
      param2: 'dolorsitamet'
    }
  }
}
```