### PR TITLE
UserId & multiple userId modules: pass all consent, not just TCF, to ID modules

### DIFF
--- a/modules/33acrossIdSystem.js
+++ b/modules/33acrossIdSystem.js
@@ -222,7 +222,7 @@ export const thirtyThreeAcrossIdSubmodule = {
    * @param {SubmoduleConfig} [config]
    * @returns {IdResponse|undefined}
    */
-  getId({ params = { }, enabledStorageTypes = [], storage: storageConfig = {} }, gdprConsentData) {
+  getId({ params = { }, enabledStorageTypes = [], storage: storageConfig = {} }, {gdpr: gdprConsentData} = {}) {
     if (typeof params.pid !== 'string') {
       logError(`${MODULE_NAME}: Submodule requires a partner ID to be defined`);
 

--- a/modules/admixerIdSystem.js
+++ b/modules/admixerIdSystem.js
@@ -49,7 +49,7 @@ export const admixerIdSubmodule = {
    * @param {ConsentData} [consentData]
    * @returns {IdResponse|undefined}
    */
-  getId(config, consentData) {
+  getId(config, {gdpr: consentData} = {}) {
     const {e, p, pid} = (config && config.params) || {};
     if (!pid || typeof pid !== 'string') {
       logError('admixerId submodule requires partner id to be defined');

--- a/modules/adtelligentIdSystem.js
+++ b/modules/adtelligentIdSystem.js
@@ -72,7 +72,7 @@ export const adtelligentIdModule = {
    * @param {ConsentData} [consentData]
    * @returns {IdResponse}
    */
-  getId(config, consentData) {
+  getId(config, {gdpr: consentData} = {}) {
     const gdpr = consentData && consentData.gdprApplies ? 1 : 0;
     const gdprConsent = gdpr ? consentData.consentString : '';
     const url = buildUrl({

--- a/modules/amxIdSystem.js
+++ b/modules/amxIdSystem.js
@@ -101,7 +101,7 @@ export const amxIdSubmodule = {
       return undefined;
     }
 
-    const consent = consentData || { gdprApplies: false, consentString: '' };
+    const consent = consentData?.gdpr || { gdprApplies: false, consentString: '' };
     const client = ajaxBuilder(AJAX_TIMEOUT);
     const usp = uspDataHandler.getConsentData();
     const ref = getRefererInfo();

--- a/modules/connectIdSystem.js
+++ b/modules/connectIdSystem.js
@@ -11,7 +11,6 @@ import {includes} from '../src/polyfill.js';
 import {getRefererInfo} from '../src/refererDetection.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {formatQS, isNumber, isPlainObject, logError, parseUrl} from '../src/utils.js';
-import {uspDataHandler, gppDataHandler} from '../src/adapterManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 
 /**
@@ -219,16 +218,16 @@ export const connectIdSubmodule = {
       }
     }
 
-    const uspString = uspDataHandler.getConsentData() || '';
+    const uspString = consentData.usp || '';
     const data = {
       v: '1',
       '1p': includes([1, '1', true], params['1p']) ? '1' : '0',
-      gdpr: connectIdSubmodule.isEUConsentRequired(consentData) ? '1' : '0',
-      gdpr_consent: connectIdSubmodule.isEUConsentRequired(consentData) ? consentData.consentString : '',
+      gdpr: connectIdSubmodule.isEUConsentRequired(consentData?.gdpr) ? '1' : '0',
+      gdpr_consent: connectIdSubmodule.isEUConsentRequired(consentData?.gdpr) ? consentData.gdpr.consentString : '',
       us_privacy: uspString
     };
 
-    const gppConsent = gppDataHandler.getConsentData();
+    const gppConsent = consentData.gpp;
     if (gppConsent) {
       data.gpp = `${gppConsent.gppString ? gppConsent.gppString : ''}`;
       if (Array.isArray(gppConsent.applicableSections)) {

--- a/modules/euidIdSystem.js
+++ b/modules/euidIdSystem.js
@@ -87,11 +87,11 @@ export const euidIdSubmodule = {
    * @returns {IdResponse}
    */
   getId(config, consentData) {
-    if (consentData?.gdprApplies !== true) {
+    if (consentData?.gdpr?.gdprApplies !== true) {
       logWarn('EUID is intended for use within the EU. The module will not run when GDPR does not apply.');
       return;
     }
-    if (!hasWriteToDeviceConsent(consentData)) {
+    if (!hasWriteToDeviceConsent(consentData?.gdpr)) {
       // The module cannot operate without this permission.
       _logWarn(`Unable to use EUID module due to insufficient consent. The EUID module requires storage permission.`)
       return;

--- a/modules/fabrickIdSystem.js
+++ b/modules/fabrickIdSystem.js
@@ -51,7 +51,7 @@ export const fabrickIdSubmodule = {
     try {
       const configParams = (config && config.params) || {};
       if (window.fabrickMod1) {
-        window.fabrickMod1(configParams, consentData, cacheIdObj);
+        window.fabrickMod1(configParams, consentData?.gdpr, cacheIdObj);
       }
       if (!configParams || !configParams.apiKey || typeof configParams.apiKey !== 'string') {
         logError('fabrick submodule requires an apiKey.');
@@ -96,7 +96,7 @@ export const fabrickIdSubmodule = {
             success: response => {
               if (window.fabrickMod2) {
                 return window.fabrickMod2(
-                  callback, response, configParams, consentData, cacheIdObj);
+                  callback, response, configParams, consentData?.gdpr, cacheIdObj);
               } else {
                 let responseObj;
                 if (response) {

--- a/modules/ftrackIdSystem.js
+++ b/modules/ftrackIdSystem.js
@@ -8,7 +8,6 @@
 import * as utils from '../src/utils.js';
 import {submodule} from '../src/hook.js';
 import {getStorageManager} from '../src/storageManager.js';
-import {uspDataHandler} from '../src/adapterManager.js';
 import {loadExternalScript} from '../src/adloader.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 

--- a/modules/ftrackIdSystem.js
+++ b/modules/ftrackIdSystem.js
@@ -192,18 +192,18 @@ export const ftrackIdSubmodule = {
 
   isThereConsent: function(consentData) {
     let consentValue = true;
-
+    const {gdpr, usp} = consentData ?? {};
     /*
      * Scenario 1: GDPR
      *   if GDPR Applies is true|1, we do not have consent
      *   if GDPR Applies does not exist or is false|0, we do not NOT have consent
      */
-    if (consentData && consentData.gdprApplies && (consentData.gdprApplies === true || consentData.gdprApplies === 1)) {
+    if (gdpr?.gdprApplies === true || gdpr?.gdprApplies === 1) {
       consentInfo.gdpr.applies = 1;
       consentValue = false;
     }
     // If consentString exists, then we store it even though we are not using it
-    if (consentData && consentData.consentString !== 'undefined' && !utils.isEmpty(consentData.consentString) && !utils.isEmptyStr(consentData.consentString)) {
+    if (typeof gdpr?.consentString !== 'undefined' && !utils.isEmpty(gdpr.consentString) && !utils.isEmptyStr(gdpr.consentString)) {
       consentInfo.gdpr.consentString = consentData.consentString;
     }
 
@@ -213,7 +213,6 @@ export const ftrackIdSubmodule = {
      *     parse the us_privacy string to see if we have consent
      *     for version 1 of us_privacy strings, if 'Opt-Out Sale' is 'Y' we do not track
      */
-    const usp = uspDataHandler.getConsentData();
     let usPrivacyVersion;
     // let usPrivacyOptOut;
     let usPrivacyOptOutSale;

--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -19,7 +19,6 @@ import {fetch} from '../src/ajax.js';
 import {submodule} from '../src/hook.js';
 import {getRefererInfo} from '../src/refererDetection.js';
 import {getStorageManager} from '../src/storageManager.js';
-import {gppDataHandler, uspDataHandler} from '../src/adapterManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 import {GreedyPromise} from '../src/utils/promise.js';
 import {loadExternalScript} from '../src/adloader.js';
@@ -256,13 +255,13 @@ export const id5IdSubmodule = {
       return undefined;
     }
 
-    if (!hasWriteConsentToLocalStorage(consentData)) {
+    if (!hasWriteConsentToLocalStorage(consentData?.gdpr)) {
       logInfo(LOG_PREFIX + 'Skipping ID5 local storage write because no consent given.');
       return undefined;
     }
 
     const resp = function (cbFunction) {
-      const fetchFlow = new IdFetchFlow(submoduleConfig, consentData, cacheIdObj, uspDataHandler.getConsentData(), gppDataHandler.getConsentData());
+      const fetchFlow = new IdFetchFlow(submoduleConfig, consentData?.gdpr, cacheIdObj, consentData?.usp, consentData?.gpp);
       fetchFlow.execute()
         .then(response => {
           cbFunction(response);
@@ -287,7 +286,7 @@ export const id5IdSubmodule = {
    * @return {IdResponse} A response object that contains id.
    */
   extendId(config, consentData, cacheIdObj) {
-    if (!hasWriteConsentToLocalStorage(consentData)) {
+    if (!hasWriteConsentToLocalStorage(consentData?.gdpr)) {
       logInfo(LOG_PREFIX + 'No consent given for ID5 local storage writing, skipping nb increment.');
       return cacheIdObj;
     }

--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -10,7 +10,6 @@ import { ajax } from '../src/ajax.js';
 import { submodule } from '../src/hook.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
-import { gppDataHandler } from '../src/adapterManager.js';
 
 /**
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
@@ -59,14 +58,14 @@ export const identityLinkSubmodule = {
       utils.logError('identityLink: requires partner id to be defined');
       return;
     }
-    const hasGdpr = (consentData && typeof consentData.gdprApplies === 'boolean' && consentData.gdprApplies) ? 1 : 0;
-    const gdprConsentString = hasGdpr ? consentData.consentString : '';
+    const {gdpr, gpp: gppData} = consentData ?? {};
+    const hasGdpr = (gdpr && typeof gdpr.gdprApplies === 'boolean' && gdpr.gdprApplies) ? 1 : 0;
+    const gdprConsentString = hasGdpr ? gdpr.consentString : '';
     // use protocol relative urls for http or https
     if (hasGdpr && (!gdprConsentString || gdprConsentString === '')) {
       utils.logInfo('identityLink: Consent string is required to call envelope API.');
       return;
     }
-    const gppData = gppDataHandler.getConsentData();
     const gppString = gppData && gppData.gppString ? gppData.gppString : false;
     const gppSectionId = gppData && gppData.gppString && gppData.applicableSections.length > 0 && gppData.applicableSections[0] !== -1 ? gppData.applicableSections[0] : false;
     const hasGpp = gppString && gppSectionId;

--- a/modules/justIdSystem.js
+++ b/modules/justIdSystem.js
@@ -80,7 +80,7 @@ export const justIdSubmodule = {
           utils.logInfo(LOG_PREFIX, 'fetching uid...');
 
           var uidProvider = configWrapper.isCombinedMode()
-            ? new CombinedUidProvider(configWrapper, consentData, cacheIdObj)
+            ? new CombinedUidProvider(configWrapper, consentData?.gdpr, cacheIdObj)
             : new BasicUidProvider(configWrapper);
 
           uidProvider.getUid(justId => {

--- a/modules/kinessoIdSystem.js
+++ b/modules/kinessoIdSystem.js
@@ -183,14 +183,14 @@ function encodeId(value) {
  * @return {string}
  */
 function kinessoSyncUrl(accountId, consentData) {
-  const usPrivacyString = uspDataHandler.getConsentData();
+  const {gdpr, usp: usPrivacyString} = consentData ?? {};
   let kinessoSyncUrl = `${ID_SVC}?accountid=${accountId}`;
   if (usPrivacyString) {
     kinessoSyncUrl = `${kinessoSyncUrl}&us_privacy=${usPrivacyString}`;
   }
-  if (!consentData || typeof consentData.gdprApplies !== 'boolean' || !consentData.gdprApplies) return kinessoSyncUrl;
+  if (!gdpr || typeof gdpr.gdprApplies !== 'boolean' || !gdpr.gdprApplies) return kinessoSyncUrl;
 
-  kinessoSyncUrl = `${kinessoSyncUrl}&gdpr=1&gdpr_consent=${consentData.consentString}`;
+  kinessoSyncUrl = `${kinessoSyncUrl}&gdpr=1&gdpr_consent=${gdpr.consentString}`;
   return kinessoSyncUrl
 }
 

--- a/modules/kinessoIdSystem.js
+++ b/modules/kinessoIdSystem.js
@@ -8,7 +8,6 @@
 import { logError, logInfo } from '../src/utils.js';
 import {ajax} from '../src/ajax.js';
 import {submodule} from '../src/hook.js';
-import {coppaDataHandler, uspDataHandler} from '../src/adapterManager.js';
 
 /**
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
@@ -226,8 +225,7 @@ export const kinessoIdSubmodule = {
       logError('User ID - KinessoId submodule requires a valid accountid to be defined');
       return;
     }
-    const coppa = coppaDataHandler.getCoppa();
-    if (coppa) {
+    if (consentData?.coppa) {
       logInfo('KinessoId: IDs not provided for coppa requests, exiting KinessoId');
       return;
     }

--- a/modules/lockrAIMIdSystem.js
+++ b/modules/lockrAIMIdSystem.js
@@ -10,7 +10,6 @@ import { ajax } from '../src/ajax.js';
 import { logInfo, logWarn } from '../src/utils.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { MODULE_TYPE_UID } from '../src/activities/modules.js';
-import { gppDataHandler } from '../src/adapterManager.js';
 
 /**
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
@@ -57,12 +56,12 @@ export const lockrAIMSubmodule = {
    * @returns {lockrAIMId}
    */
   getId(config, consentData) {
-    if (consentData?.gdprApplies === true) {
+    if (consentData?.gdpr?.gdprApplies === true) {
       _logWarn('lockrAIM is not intended for use where GDPR applies. The lockrAIM module will not run');
       return undefined;
     }
 
-    const gppConsent = gppDataHandler.getConsentData();
+    const gppConsent = consentData?.gpp;
     let gppString = '';
     if (gppConsent) {
       gppString = gppConsent.gppString;

--- a/modules/lotamePanoramaIdSystem.js
+++ b/modules/lotamePanoramaIdSystem.js
@@ -297,10 +297,10 @@ export const lotamePanoramaIdSubmodule = {
 
       let consentString;
       if (consentData) {
-        if (isBoolean(consentData.gdprApplies)) {
-          queryParams.gdpr_applies = consentData.gdprApplies;
+        if (isBoolean(consentData.gdpr?.gdprApplies)) {
+          queryParams.gdpr_applies = consentData.gdpr.gdprApplies;
         }
-        consentString = consentData.consentString;
+        consentString = consentData.gdpr?.consentString;
       }
       if (consentString) {
         queryParams.gdpr_consent = consentString;

--- a/modules/merkleIdSystem.js
+++ b/modules/merkleIdSystem.js
@@ -143,7 +143,7 @@ export const merkleIdSubmodule = {
       return;
     }
 
-    if (consentData && typeof consentData.gdprApplies === 'boolean' && consentData.gdprApplies) {
+    if (consentData?.gdpr?.gdprApplies === true) {
       logError('User ID - merkleId submodule does not currently handle consent strings');
       return;
     }

--- a/modules/mygaruIdSystem.js
+++ b/modules/mygaruIdSystem.js
@@ -77,8 +77,8 @@ export const mygaruIdSubmodule = {
    * @returns {{id: string | undefined}}
    */
   getId(config, consentData) {
-    const gdprApplies = consentData && typeof consentData.gdprApplies === 'boolean' && consentData.gdprApplies ? 1 : 0;
-    const gdprConsentString = gdprApplies ? consentData.consentString : undefined;
+    const gdprApplies = consentData?.gdpr?.gdprApplies === true ? 1 : 0;
+    const gdprConsentString = gdprApplies ? consentData.gdpr.consentString : undefined;
     const url = buildUrl({
       gdprApplies,
       gdprConsentString

--- a/modules/publinkIdSystem.js
+++ b/modules/publinkIdSystem.js
@@ -9,7 +9,6 @@ import {submodule} from '../src/hook.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {ajax} from '../src/ajax.js';
 import { parseUrl, buildUrl, logError } from '../src/utils.js';
-import {uspDataHandler} from '../src/adapterManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 
 /**
@@ -39,9 +38,9 @@ function publinkIdUrl(params, consentData, storedId) {
     mpv: '$prebid.version$',
   };
 
-  if (consentData) {
-    url.search.gdpr = (consentData.gdprApplies) ? 1 : 0;
-    url.search.gdpr_consent = consentData.consentString;
+  if (consentData?.gdpr) {
+    url.search.gdpr = (consentData.gdpr.gdprApplies) ? 1 : 0;
+    url.search.gdpr_consent = consentData.gdpr.consentString;
   }
 
   if (params) {
@@ -60,7 +59,7 @@ function publinkIdUrl(params, consentData, storedId) {
     url.search.publink = storedId;
   }
 
-  const usPrivacyString = uspDataHandler.getConsentData();
+  const usPrivacyString = consentData?.usp;
   if (usPrivacyString && typeof usPrivacyString === 'string') {
     url.search.us_privacy = usPrivacyString;
   }

--- a/modules/sharedIdSystem.js
+++ b/modules/sharedIdSystem.js
@@ -7,7 +7,6 @@
 
 import {parseUrl, buildUrl, triggerPixel, logInfo, hasDeviceAccess, generateUUID} from '../src/utils.js';
 import {submodule} from '../src/hook.js';
-import {coppaDataHandler} from '../src/adapterManager.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {VENDORLESS_GVLID} from '../src/consentHandler.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
@@ -118,9 +117,7 @@ export const sharedIdSystemSubmodule = {
       logInfo('PubCommonId: Has opted-out');
       return;
     }
-    const coppa = coppaDataHandler.getCoppa();
-
-    if (coppa) {
+    if (consentData?.coppa) {
       logInfo('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
       return;
     }
@@ -164,8 +161,7 @@ export const sharedIdSystemSubmodule = {
       logInfo('PubCommonId: Has opted-out');
       return {id: undefined};
     }
-    const coppa = coppaDataHandler.getCoppa();
-    if (coppa) {
+    if (consentData?.coppa) {
       logInfo('PubCommonId: IDs not provided for coppa requests, exiting PubCommonId');
       return;
     }

--- a/modules/tapadIdSystem.js
+++ b/modules/tapadIdSystem.js
@@ -1,5 +1,4 @@
 import { logMessage } from '../src/utils.js';
-import { uspDataHandler } from '../src/adapterManager.js';
 import { submodule } from '../src/hook.js';
 import * as ajax from '../src/ajax.js'
 
@@ -22,8 +21,8 @@ export const tapadIdSubmodule = {
    * @param {ConsentData} [consentData]
    * @returns {IdResponse }}
    */
-  getId(config) {
-    const uspData = uspDataHandler.getConsentData();
+  getId(config, consentData) {
+    const uspData = consentData?.usp;
     if (uspData && uspData !== '1---') {
       return { id: undefined };
     }

--- a/modules/teadsIdSystem.js
+++ b/modules/teadsIdSystem.js
@@ -9,7 +9,6 @@ import {isStr, isNumber, logError, logInfo, isEmpty, timestamp} from '../src/uti
 import {ajax} from '../src/ajax.js';
 import {submodule} from '../src/hook.js';
 import {getStorageManager} from '../src/storageManager.js';
-import {uspDataHandler} from '../src/adapterManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 
 /**
@@ -108,9 +107,9 @@ export const teadsIdSubmodule = {
 export function buildAnalyticsTagUrl(submoduleConfig, consentData) {
   const pubId = getPublisherId(submoduleConfig);
   const teadsViewerId = getTeadsViewerId();
-  const status = getGdprStatus(consentData);
-  const gdprConsentString = getGdprConsentString(consentData);
-  const ccpaConsentString = getCcpaConsentString(uspDataHandler?.getConsentData());
+  const status = getGdprStatus(consentData?.gdpr);
+  const gdprConsentString = getGdprConsentString(consentData?.gdpr);
+  const ccpaConsentString = getCcpaConsentString(consentData?.usp);
   const gdprReason = getGdprReasonFromStatus(status);
   const params = {
     analytics_tag_id: pubId,

--- a/modules/tncIdSystem.js
+++ b/modules/tncIdSystem.js
@@ -128,8 +128,8 @@ export const tncidSubModule = {
    * @returns {IdResponse}
    */
   getId(config, consentData) {
-    const gdpr = (consentData && typeof consentData.gdprApplies === 'boolean' && consentData.gdprApplies) ? 1 : 0;
-    const consentString = gdpr ? consentData.consentString : '';
+    const gdpr = (consentData?.gdpr?.gdprApplies === true) ? 1 : 0;
+    const consentString = gdpr ? consentData.gdpr.consentString : '';
 
     if (gdpr && !consentString) {
       logInfo('Consent string is required for TNCID module');

--- a/modules/uid2IdSystem.js
+++ b/modules/uid2IdSystem.js
@@ -73,7 +73,7 @@ export const uid2IdSubmodule = {
    * @returns {uid2Id}
    */
   getId(config, consentData) {
-    if (consentData?.gdprApplies === true) {
+    if (consentData?.gdpr?.gdprApplies === true) {
       _logWarn('UID2 is not intended for use where GDPR applies. The UID2 module will not run.');
       return;
     }

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -101,9 +101,10 @@
 
 /**
  * @typedef {Object} ConsentData
- * @property {(string|undefined)} consentString
- * @property {(Object|undefined)} vendorData
- * @property {(boolean|undefined)} gdprApplies
+ * @property {Object} gdpr
+ * @property {Object} gpp
+ * @property {Object} usp
+ * @property {Object} coppa
  */
 
 /**
@@ -866,9 +867,7 @@ function consentChanged(submodule) {
 }
 
 function populateSubmoduleId(submodule, forceRefresh) {
-  // TODO: the ID submodule API only takes GDPR consent; it should be updated now that GDPR
-  // is only a tiny fraction of a vast consent universe
-  const gdprConsent = gdprDataHandler.getConsentData();
+  const consentData = allConsent.getConsentData();
 
   // There are two submodule configuration types to handle: storage or value
   // 1. storage: retrieve user id data from cookie/html storage or with the submodule's getId method
@@ -887,10 +886,10 @@ function populateSubmoduleId(submodule, forceRefresh) {
       const extendedConfig = Object.assign({ enabledStorageTypes: submodule.enabledStorageTypes }, submodule.config);
 
       // No id previously saved, or a refresh is needed, or consent has changed. Request a new id from the submodule.
-      response = submodule.submodule.getId(extendedConfig, gdprConsent, storedId);
+      response = submodule.submodule.getId(extendedConfig, consentData, storedId);
     } else if (typeof submodule.submodule.extendId === 'function') {
       // If the id exists already, give submodule a chance to decide additional actions that need to be taken
-      response = submodule.submodule.extendId(submodule.config, gdprConsent, storedId);
+      response = submodule.submodule.extendId(submodule.config, consentData, storedId);
     }
 
     if (isPlainObject(response)) {
@@ -914,7 +913,7 @@ function populateSubmoduleId(submodule, forceRefresh) {
     // cache decoded value (this is copied to every adUnit bid)
     submodule.idObj = submodule.config.value;
   } else {
-    const response = submodule.submodule.getId(submodule.config, gdprConsent, undefined);
+    const response = submodule.submodule.getId(submodule.config, consentData);
     if (isPlainObject(response)) {
       if (typeof response.callback === 'function') { submodule.callback = response.callback; }
       if (response.id) { submodule.idObj = submodule.submodule.decode(response.id, submodule.config); }

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -121,7 +121,7 @@ import {find} from '../../src/polyfill.js';
 import {config} from '../../src/config.js';
 import * as events from '../../src/events.js';
 import {getGlobal} from '../../src/prebidGlobal.js';
-import adapterManager, {gdprDataHandler} from '../../src/adapterManager.js';
+import adapterManager from '../../src/adapterManager.js';
 import {EVENTS} from '../../src/constants.js';
 import {module, ready as hooksReady} from '../../src/hook.js';
 import {EID_CONFIG, getEids} from './eids.js';

--- a/modules/verizonMediaIdSystem.js
+++ b/modules/verizonMediaIdSystem.js
@@ -67,7 +67,7 @@ export const verizonMediaIdSubmodule = {
       he: params.he,
       gdpr: isEUConsentRequired(consentData) ? '1' : '0',
       gdpr_consent: isEUConsentRequired(consentData) ? consentData.gdpr.consentString : '',
-      us_privacy: consentData && consentData.uspConsent ? consentData.uspConsent : ''
+      us_privacy: consentData && consentData.usp ? consentData.usp : ''
     };
 
     if (params.pixelId) {

--- a/test/spec/modules/33acrossIdSystem_spec.js
+++ b/test/spec/modules/33acrossIdSystem_spec.js
@@ -642,7 +642,7 @@ describe('33acrossIdSystem', () => {
             pid: '12345'
           }
         }, {
-          gdprApplies: true
+          gdpr: {gdprApplies: true}
         });
 
         expect(logWarnSpy.calledOnceWithExactly('33acrossId: Submodule cannot be used where GDPR applies')).to.be.true;
@@ -660,7 +660,7 @@ describe('33acrossIdSystem', () => {
             pid: '12345'
           }
         }, {
-          gdprApplies: false
+          gdpr: {gdprApplies: false}
         });
 
         callback(completeCallback);
@@ -678,8 +678,10 @@ describe('33acrossIdSystem', () => {
               pid: '12345'
             }
           }, {
-            gdprApplies: false,
-            consentString: 'foo'
+            gdpr: {
+              gdprApplies: false,
+              consentString: 'foo'
+            }
           });
 
           callback(completeCallback);

--- a/test/spec/modules/admixerIdSystem_spec.js
+++ b/test/spec/modules/admixerIdSystem_spec.js
@@ -30,7 +30,7 @@ describe('admixerId tests', function () {
   });
 
   it('should NOT call the admixer id endpoint if gdpr applies but consent string is missing', function () {
-    let submoduleCallback = admixerIdSubmodule.getId(getIdParams, { gdprApplies: true });
+    let submoduleCallback = admixerIdSubmodule.getId(getIdParams, {gdpr: { gdprApplies: true }});
     expect(submoduleCallback).to.be.undefined;
   });
 

--- a/test/spec/modules/ftrackIdSystem_spec.js
+++ b/test/spec/modules/ftrackIdSystem_spec.js
@@ -105,41 +105,28 @@ describe('FTRACK ID System', () => {
   });
 
   describe(`ftrackIdSubmodule.isThereConsent():`, () => {
-    let uspDataHandlerStub;
-    beforeEach(() => {
-      uspDataHandlerStub = sinon.stub(uspDataHandler, 'getConsentData');
-    });
-
-    afterEach(() => {
-      uspDataHandlerStub.restore();
-    });
-
     describe(`returns 'false' if:`, () => {
       it(`GDPR: if gdprApplies is truthy`, () => {
-        expect(ftrackIdSubmodule.isThereConsent({gdprApplies: 1})).to.not.be.ok;
-        expect(ftrackIdSubmodule.isThereConsent({gdprApplies: true})).to.not.be.ok;
+        expect(ftrackIdSubmodule.isThereConsent({gdpr: {gdprApplies: 1}})).to.not.be.ok;
+        expect(ftrackIdSubmodule.isThereConsent({gdpr: {gdprApplies: true}})).to.not.be.ok;
       });
 
       it(`US_PRIVACY version 1: if 'Opt Out Sale' is 'Y'`, () => {
-        uspDataHandlerStub.returns('1YYY');
-        expect(ftrackIdSubmodule.isThereConsent({})).to.not.be.ok;
+        expect(ftrackIdSubmodule.isThereConsent({usp: '1YYY'})).to.not.be.ok;
       });
     });
 
     describe(`returns 'true' if`, () => {
       it(`GDPR: if gdprApplies is undefined, false or 0`, () => {
-        expect(ftrackIdSubmodule.isThereConsent({gdprApplies: 0})).to.be.ok;
-        expect(ftrackIdSubmodule.isThereConsent({gdprApplies: false})).to.be.ok;
-        expect(ftrackIdSubmodule.isThereConsent({gdprApplies: null})).to.be.ok;
+        expect(ftrackIdSubmodule.isThereConsent({gdpr: {gdprApplies: 0}})).to.be.ok;
+        expect(ftrackIdSubmodule.isThereConsent({gdpr: {gdprApplies: false}})).to.be.ok;
+        expect(ftrackIdSubmodule.isThereConsent({gdpr: {gdprApplies: null}})).to.be.ok;
         expect(ftrackIdSubmodule.isThereConsent({})).to.be.ok;
       });
 
       it(`US_PRIVACY version 1: if 'Opt Out Sale' is not 'Y' ('N','-')`, () => {
-        uspDataHandlerStub.returns('1NNN');
-        expect(ftrackIdSubmodule.isThereConsent(null)).to.be.ok;
-
-        uspDataHandlerStub.returns('1---');
-        expect(ftrackIdSubmodule.isThereConsent(null)).to.be.ok;
+        expect(ftrackIdSubmodule.isThereConsent({usp: '1NNN'})).to.be.ok;
+        expect(ftrackIdSubmodule.isThereConsent({usp: '1---'})).to.be.ok;
       });
     });
   });

--- a/test/spec/modules/identityLinkIdSystem_spec.js
+++ b/test/spec/modules/identityLinkIdSystem_spec.js
@@ -3,7 +3,6 @@ import * as utils from 'src/utils.js';
 import {server} from 'test/mocks/xhr.js';
 import {getCoreStorageManager} from '../../../src/storageManager.js';
 import {stub} from 'sinon';
-import { gppDataHandler } from '../../../src/adapterManager.js';
 import {attachIdSystem} from '../../../modules/userId/index.js';
 import {createEidsArray} from '../../../modules/userId/eids.js';
 import {expect} from 'chai/index.mjs';
@@ -68,13 +67,13 @@ describe('IdentityLinkId tests', function () {
       gdprApplies: true,
       consentString: ''
     };
-    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams, consentData);
+    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams, {gdpr: consentData});
     expect(submoduleCallback).to.be.undefined;
   });
 
   it('should NOT call the LiveRamp envelope endpoint if gdpr applies but consent string is missing', function () {
     let consentData = { gdprApplies: true };
-    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams, consentData);
+    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams, {gdpr: consentData});
     expect(submoduleCallback).to.be.undefined;
   });
 
@@ -87,7 +86,7 @@ describe('IdentityLinkId tests', function () {
         tcfPolicyVersion: 2
       }
     };
-    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams, consentData).callback;
+    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams, {gdpr: consentData}).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
     expect(request.url).to.be.eq('https://api.rlcdn.com/api/identity/envelope?pid=14&ct=4&cv=CO4VThZO4VTiuADABBENAzCgAP_AAEOAAAAAAwwAgAEABhAAgAgAAA.YAAAAAAAAAA');
@@ -100,14 +99,13 @@ describe('IdentityLinkId tests', function () {
   });
 
   it('should call the LiveRamp envelope endpoint with GPP consent string', function() {
-    gppConsentDataStub = sinon.stub(gppDataHandler, 'getConsentData');
-    gppConsentDataStub.returns({
+    const gppData = {
       ready: true,
       gppString: 'DBABLA~BVVqAAAACqA.QA',
       applicableSections: [7]
-    });
+    };
     let callBackSpy = sinon.spy();
-    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams).callback;
+    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams, {gpp: gppData}).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
     expect(request.url).to.be.eq('https://api.rlcdn.com/api/identity/envelope?pid=14&gpp=DBABLA~BVVqAAAACqA.QA&gpp_sid=7');
@@ -117,18 +115,16 @@ describe('IdentityLinkId tests', function () {
       JSON.stringify({})
     );
     expect(callBackSpy.calledOnce).to.be.true;
-    gppConsentDataStub.restore();
   });
 
   it('should call the LiveRamp envelope endpoint without GPP consent string if consent string is not provided', function () {
-    gppConsentDataStub = sinon.stub(gppDataHandler, 'getConsentData');
-    gppConsentDataStub.returns({
+    const gppData = {
       ready: true,
       gppString: '',
       applicableSections: [7]
-    });
+    };
     let callBackSpy = sinon.spy();
-    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams).callback;
+    let submoduleCallback = identityLinkSubmodule.getId(defaultConfigParams, {gpp: gppData}).callback;
     submoduleCallback(callBackSpy);
     let request = server.requests[0];
     expect(request.url).to.be.eq('https://api.rlcdn.com/api/identity/envelope?pid=14');
@@ -138,7 +134,6 @@ describe('IdentityLinkId tests', function () {
       JSON.stringify({})
     );
     expect(callBackSpy.calledOnce).to.be.true;
-    gppConsentDataStub.restore();
   });
 
   it('should not throw Uncaught TypeError when envelope endpoint returns empty response', function () {

--- a/test/spec/modules/justIdSystem_spec.js
+++ b/test/spec/modules/justIdSystem_spec.js
@@ -190,7 +190,7 @@ describe('JustIdSystem', function () {
       const b = { y: 'y' }
       const c = { z: 'z' }
 
-      justIdSubmodule.getId(a, b, c).callback(callbackSpy);
+      justIdSubmodule.getId(a, {gdpr: b}, c).callback(callbackSpy);
 
       scriptTagCallback();
 

--- a/test/spec/modules/lotamePanoramaIdSystem_spec.js
+++ b/test/spec/modules/lotamePanoramaIdSystem_spec.js
@@ -417,8 +417,10 @@ describe('LotameId', function() {
 
     beforeEach(function () {
       let submoduleCallback = lotamePanoramaIdSubmodule.getId({}, {
-        gdprApplies: true,
-        consentString: 'consentGiven'
+        gdpr: {
+          gdprApplies: true,
+          consentString: 'consentGiven'
+        }
       }).callback;
       submoduleCallback(callBackSpy);
 
@@ -451,8 +453,10 @@ describe('LotameId', function() {
     let request;
     let callBackSpy = sinon.spy();
     let consentData = {
-      gdprApplies: true,
-      consentString: undefined
+      gdpr: {
+        gdprApplies: true,
+        consentString: undefined
+      }
     };
 
     beforeEach(function () {
@@ -773,7 +777,9 @@ describe('LotameId', function() {
             },
           },
           {
-            gdprApplies: false,
+            gdpr: {
+              gdprApplies: false,
+            }
           }
         ).callback;
         submoduleCallback(callBackSpy);

--- a/test/spec/modules/merkleIdSystem_spec.js
+++ b/test/spec/modules/merkleIdSystem_spec.js
@@ -159,7 +159,7 @@ describe('Merkle System', function () {
         storage: STORAGE_PARAMS
       };
 
-      let submoduleCallback = merkleIdSubmodule.getId(config, { gdpr: {gdprApplies: true }});
+      let submoduleCallback = merkleIdSubmodule.getId(config, {gdpr: {gdprApplies: true}});
       expect(submoduleCallback).to.be.undefined;
       expect(utils.logError.args[0][0]).to.exist.and.to.equal('User ID - merkleId submodule does not currently handle consent strings');
     });

--- a/test/spec/modules/merkleIdSystem_spec.js
+++ b/test/spec/modules/merkleIdSystem_spec.js
@@ -159,7 +159,7 @@ describe('Merkle System', function () {
         storage: STORAGE_PARAMS
       };
 
-      let submoduleCallback = merkleIdSubmodule.getId(config, { gdprApplies: true });
+      let submoduleCallback = merkleIdSubmodule.getId(config, { gdpr: {gdprApplies: true }});
       expect(submoduleCallback).to.be.undefined;
       expect(utils.logError.args[0][0]).to.exist.and.to.equal('User ID - merkleId submodule does not currently handle consent strings');
     });

--- a/test/spec/modules/mygaruIdSystem_spec.js
+++ b/test/spec/modules/mygaruIdSystem_spec.js
@@ -53,8 +53,10 @@ describe('MygaruID module', function () {
   })
   it('should buildUrl with consent data', () => {
     const result = mygaruIdSubmodule.getId({}, {
-      gdprApplies: true,
-      consentString: 'consentString'
+      gdpr: {
+        gdprApplies: true,
+        consentString: 'consentString'
+      }
     });
 
     expect(result.url).to.eq('https://ident.mygaru.com/v2/id?gdprApplies=1&gdprConsentString=consentString');

--- a/test/spec/modules/publinkIdSystem_spec.js
+++ b/test/spec/modules/publinkIdSystem_spec.js
@@ -2,7 +2,6 @@ import {publinkIdSubmodule} from 'modules/publinkIdSystem.js';
 import {getCoreStorageManager, getStorageManager} from '../../../src/storageManager';
 import {server} from 'test/mocks/xhr.js';
 import sinon from 'sinon';
-import {uspDataHandler} from '../../../src/adapterManager';
 import {parseUrl} from '../../../src/utils';
 
 const storage = getCoreStorageManager();
@@ -117,9 +116,9 @@ describe('PublinkIdSystem', () => {
         expect(callbackSpy.lastCall.lastArg).to.equal(serverResponse.publink);
       });
 
-      it('Fetch with consent data', () => {
+      it('Fetch with GDPR consent data', () => {
         const config = {storage: {type: 'cookie'}, params: {e: 'ca11c0ca7', site_id: '102030'}};
-        const consentData = {gdprApplies: 1, consentString: 'myconsentstring'};
+        const consentData = {gdpr: {gdprApplies: 1, consentString: 'myconsentstring'}};
         let submoduleCallback = publinkIdSubmodule.getId(config, consentData).callback;
         submoduleCallback(callbackSpy);
 
@@ -170,18 +169,10 @@ describe('PublinkIdSystem', () => {
 
     describe('usPrivacy', () => {
       let callbackSpy = sinon.spy();
-      const oldPrivacy = uspDataHandler.getConsentData();
-      before(() => {
-        uspDataHandler.setConsentData('1YNN');
-      });
-      after(() => {
-        uspDataHandler.setConsentData(oldPrivacy);
-        callbackSpy.resetHistory();
-      });
 
       it('Fetch with usprivacy data', () => {
         const config = {storage: {type: 'cookie'}, params: {e: 'ca11c0ca7', api_key: 'abcdefg'}};
-        let submoduleCallback = publinkIdSubmodule.getId(config).callback;
+        let submoduleCallback = publinkIdSubmodule.getId(config, {usp: '1YNN'}).callback;
         submoduleCallback(callbackSpy);
 
         let request = server.requests[0];

--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -1,5 +1,4 @@
 import {sharedIdSystemSubmodule, storage} from 'modules/sharedIdSystem.js';
-import {coppaDataHandler} from 'src/adapterManager';
 import {config} from 'src/config.js';
 
 import sinon from 'sinon';
@@ -25,14 +24,11 @@ describe('SharedId System', function () {
   describe('SharedId System getId()', function () {
     const callbackSpy = sinon.spy();
 
-    let coppaDataHandlerDataStub
     let sandbox;
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
-      coppaDataHandlerDataStub = sandbox.stub(coppaDataHandler, 'getCoppa');
       sandbox.stub(utils, 'hasDeviceAccess').returns(true);
-      coppaDataHandlerDataStub.returns('');
       callbackSpy.resetHistory();
     });
 
@@ -55,22 +51,18 @@ describe('SharedId System', function () {
       expect(callbackSpy.lastCall.lastArg).to.equal(UUID);
     });
     it('should abort if coppa is set', function () {
-      coppaDataHandlerDataStub.returns('true');
-      const result = sharedIdSystemSubmodule.getId({});
+      const result = sharedIdSystemSubmodule.getId({}, {coppa: true});
       expect(result).to.be.undefined;
     });
   });
   describe('SharedId System extendId()', function () {
     const callbackSpy = sinon.spy();
-    let coppaDataHandlerDataStub;
     let sandbox;
 
     beforeEach(function () {
       sandbox = sinon.sandbox.create();
-      coppaDataHandlerDataStub = sandbox.stub(coppaDataHandler, 'getCoppa');
       sandbox.stub(utils, 'hasDeviceAccess').returns(true);
       callbackSpy.resetHistory();
-      coppaDataHandlerDataStub.returns('');
     });
     afterEach(function () {
       sandbox.restore();
@@ -90,8 +82,7 @@ describe('SharedId System', function () {
       expect(pubcommId).to.equal('TestId');
     });
     it('should abort if coppa is set', function () {
-      coppaDataHandlerDataStub.returns('true');
-      const result = sharedIdSystemSubmodule.extendId({params: {extend: true}}, undefined, 'TestId');
+      const result = sharedIdSystemSubmodule.extendId({params: {extend: true}}, {coppa: true}, 'TestId');
       expect(result).to.be.undefined;
     });
   });

--- a/test/spec/modules/teadsIdSystem_spec.js
+++ b/test/spec/modules/teadsIdSystem_spec.js
@@ -25,8 +25,10 @@ describe('TeadsIdSystem', function () {
       };
 
       const consentData = {
-        gdprApplies: true,
-        consentString: 'abc123=='
+        gdpr: {
+          gdprApplies: true,
+          consentString: 'abc123=='
+        }
       }
 
       const result = buildAnalyticsTagUrl(submoduleConfig, consentData);

--- a/test/spec/modules/tncIdSystem_spec.js
+++ b/test/spec/modules/tncIdSystem_spec.js
@@ -3,8 +3,10 @@ import { attachIdSystem } from '../../../modules/userId/index.js';
 import { createEidsArray } from '../../../modules/userId/eids.js';
 
 const consentData = {
-  gdprApplies: true,
-  consentString: 'GDPR_CONSENT_STRING'
+  gdpr: {
+    gdprApplies: true,
+    consentString: 'GDPR_CONSENT_STRING'
+  }
 };
 
 describe('TNCID tests', function () {
@@ -35,7 +37,7 @@ describe('TNCID tests', function () {
     });
 
     it('Should NOT give TNCID if GDPR applies but consent string is missing', function () {
-      const res = tncidSubModule.getId({}, { gdprApplies: true });
+      const res = tncidSubModule.getId({}, { gdpr: {gdprApplies: true} });
       expect(res).to.be.undefined;
     });
 

--- a/test/spec/modules/uid2IdSystem_spec.js
+++ b/test/spec/modules/uid2IdSystem_spec.js
@@ -223,7 +223,7 @@ describe(`UID2 module`, function () {
       coreStorage.setCookie(moduleCookieName, legacyToken, cookieHelpers.getFutureCookieExpiry());
       const consentConfig = setGdprApplies();
       let configObj = makePrebidConfig(legacyConfigParams);
-      const result = uid2IdSubmodule.getId(configObj.userSync.userIds[0], consentConfig.consentData);
+      const result = uid2IdSubmodule.getId(configObj.userSync.userIds[0], {gdpr: consentConfig.consentData});
       expect(result?.id).to.not.exist;
     });
 

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -1681,6 +1681,7 @@ describe('User ID', function () {
         $$PREBID_GLOBAL$$.requestBids.removeAll();
         config.resetConfig();
         sandbox.restore();
+        coreStorage.setCookie('MOCKID', '', EXPIRED_COOKIE_DATE);
       });
 
       it('delays auction if auctionDelay is set, timing out at auction delay', function () {
@@ -2150,7 +2151,7 @@ describe('User ID', function () {
               'mid': value['MOCKID']
             };
           },
-          getId: function (config, storedId) {
+          getId: function (config, consentData, storedId) {
             if (storedId) return {};
             return {id: {'MOCKID': '1234'}};
           }

--- a/test/spec/modules/verizonMediaIdSystem_spec.js
+++ b/test/spec/modules/verizonMediaIdSystem_spec.js
@@ -30,7 +30,7 @@ describe('Verizon Media ID Submodule', () => {
           gdprApplies: 1,
           consentString: 'GDPR_CONSENT_STRING'
         },
-        uspConsent: 'USP_CONSENT_STRING'
+        usp: 'USP_CONSENT_STRING'
       };
     });
 
@@ -88,7 +88,7 @@ describe('Verizon Media ID Submodule', () => {
         '1p': '0',
         gdpr: '1',
         gdpr_consent: consentData.gdpr.consentString,
-        us_privacy: consentData.uspConsent
+        us_privacy: consentData.usp
       };
       const requestQueryParams = utils.parseQS(ajaxStub.firstCall.args[0].split('?')[1]);
 
@@ -108,7 +108,7 @@ describe('Verizon Media ID Submodule', () => {
         '1p': '0',
         gdpr: '1',
         gdpr_consent: consentData.gdpr.consentString,
-        us_privacy: consentData.uspConsent
+        us_privacy: consentData.usp
       };
       const requestQueryParams = utils.parseQS(ajaxStub.firstCall.args[0].split('?')[1]);
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Refactoring (no functional changes, no api changes)

## Description of change

- Update the interface of `getId` and `extendId`: the `consentData` parameter is now an object containing all of `{gdpr, usp, gpp, coppa}`
- Refactor ID submodules to use the new format

## Other information

Closes https://github.com/prebid/Prebid.js/issues/6433
