### PR TITLE
Equativ Bid Adapter: add DSP cookie sync

### DIFF
--- a/modules/equativBidAdapter.js
+++ b/modules/equativBidAdapter.js
@@ -17,7 +17,7 @@ const BIDDER_CODE = 'equativ';
 const COOKIE_SYNC_ORIGIN = 'https://apps.smartadserver.com';
 const COOKIE_SYNC_URL = `${COOKIE_SYNC_ORIGIN}/diff/templates/asset/csync.html`;
 const LOG_PREFIX = 'Equativ:';
-const PID_COOKIE_NAME = 'eqt_pid';
+const PID_STORAGE_NAME = 'eqt_pid';
 
 let nwid = 0;
 
@@ -103,9 +103,7 @@ export const spec = {
           }, event.origin);
 
           if (event.data.pid) {
-            const exp = new Date();
-            exp.setTime(Date.now() + 31536000000); // in a year
-            storage.setCookie(PID_COOKIE_NAME, event.data.pid, exp.toUTCString());
+            storage.setDataInLocalStorage(PID_STORAGE_NAME, event.data.pid);
           }
 
           this.removeEventListener('message', handler);
@@ -178,7 +176,7 @@ export const converter = ortbConverter({
       });
     }
 
-    const pid = storage.getCookie(PID_COOKIE_NAME);
+    const pid = storage.getDataFromLocalStorage(PID_STORAGE_NAME);
     if (pid) {
       deepSetValue(req, 'user.buyeruid', pid);
     }

--- a/modules/equativBidAdapter.js
+++ b/modules/equativBidAdapter.js
@@ -111,7 +111,7 @@ export const spec = {
       });
 
       let url = tryAppendQueryString(COOKIE_SYNC_URL + '?', 'nwid', nwid);
-      url = tryAppendQueryString(url, 'gdpr', (gdprConsent.gdprApplies ? 1 : 0));
+      url = tryAppendQueryString(url, 'gdpr', (gdprConsent.gdprApplies ? '1' : '0'));
 
       return [{ type: 'iframe', url }];
     }

--- a/modules/equativBidAdapter.js
+++ b/modules/equativBidAdapter.js
@@ -1,6 +1,7 @@
 
 import { getBidFloor } from '../libraries/equativUtils/equativUtils.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
+import { tryAppendQueryString } from '../libraries/urlUtils/urlUtils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
@@ -17,6 +18,8 @@ const COOKIE_SYNC_ORIGIN = 'https://apps.smartadserver.com';
 const COOKIE_SYNC_URL = `${COOKIE_SYNC_ORIGIN}/diff/templates/asset/csync.html`;
 const LOG_PREFIX = 'Equativ:';
 const PID_COOKIE_NAME = 'eqt_pid';
+
+let nwid = 0;
 
 /**
  * Evaluates impressions for validity.  The entry evaluated is considered valid if NEITHER of these conditions are met:
@@ -89,18 +92,30 @@ export const spec = {
    * @param syncOptions
    * @returns {{type: string, url: string}[]}
    */
-  getUserSyncs: (syncOptions) => {
+  getUserSyncs: (syncOptions, serverResponses, gdprConsent) => {
     if (syncOptions.iframeEnabled) {
       window.addEventListener('message', function handler(event) {
-        if (event.origin === COOKIE_SYNC_ORIGIN && event.data.pid) {
-          const exp = new Date();
-          exp.setTime(Date.now() + 31536000000); // in a year
-          storage.setCookie(PID_COOKIE_NAME, event.data.pid, exp.toUTCString());
+        if (event.origin === COOKIE_SYNC_ORIGIN && event.data.action === 'getConsent') {
+          event.source.postMessage({
+            action: 'consentResponse',
+            id: event.data.id,
+            consents: gdprConsent.vendorData.vendor.consents
+          }, event.origin);
+
+          if (event.data.pid) {
+            const exp = new Date();
+            exp.setTime(Date.now() + 31536000000); // in a year
+            storage.setCookie(PID_COOKIE_NAME, event.data.pid, exp.toUTCString());
+          }
+
           this.removeEventListener('message', handler);
         }
       });
 
-      return [{ type: 'iframe', url: COOKIE_SYNC_URL }];
+      let url = tryAppendQueryString(COOKIE_SYNC_URL + '?', 'nwid', nwid);
+      url = tryAppendQueryString(url, 'gdpr', (gdprConsent.gdprApplies ? 1 : 0));
+
+      return [{ type: 'iframe', url }];
     }
 
     return [];
@@ -141,7 +156,8 @@ export const converter = ortbConverter({
     const req = buildRequest(imps, bidderRequest, context);
 
     let env = ['ortb2.site.publisher', 'ortb2.app.publisher', 'ortb2.dooh.publisher'].find(propPath => deepAccess(bid, propPath)) || 'ortb2.site.publisher';
-    deepSetValue(req, env.replace('ortb2.', '') + '.id', deepAccess(bid, env + '.id') || bid.params.networkId);
+    nwid = deepAccess(bid, env + '.id') || bid.params.networkId;
+    deepSetValue(req, env.replace('ortb2.', '') + '.id', nwid);
 
     if (deepAccess(bid, 'mediaTypes.video')) {
       ['mimes', 'placement'].forEach(prop => {

--- a/test/spec/modules/equativBidAdapter_spec.js
+++ b/test/spec/modules/equativBidAdapter_spec.js
@@ -125,7 +125,7 @@ describe('Equativ bid adapter tests', () => {
       nativeOrtbRequest,
       bidder: 'equativ',
       params: {
-        networkId: 777,
+        networkId: 111,
       },
       requestId: 'equativ_native_reqid_42',
       ortb2Imp: {
@@ -807,7 +807,7 @@ describe('Equativ bid adapter tests', () => {
       expect(syncs).to.have.lengthOf(1);
       expect(syncs[0]).to.deep.equal({
         type: 'iframe',
-        url: 'https://apps.smartadserver.com/diff/templates/asset/csync.html?nwid=777&gdpr=1&'
+        url: 'https://apps.smartadserver.com/diff/templates/asset/csync.html?nwid=111&gdpr=1&'
       });
     });
 
@@ -820,7 +820,7 @@ describe('Equativ bid adapter tests', () => {
       expect(syncs).to.have.lengthOf(1);
       expect(syncs[0]).to.deep.equal({
         type: 'iframe',
-        url: 'https://apps.smartadserver.com/diff/templates/asset/csync.html?nwid=777&gdpr=0&'
+        url: 'https://apps.smartadserver.com/diff/templates/asset/csync.html?nwid=111&gdpr=0&'
       });
     });
   });

--- a/test/spec/modules/equativBidAdapter_spec.js
+++ b/test/spec/modules/equativBidAdapter_spec.js
@@ -372,25 +372,25 @@ describe('Equativ bid adapter tests', () => {
     });
 
     it('should read and send pid as buyeruid', () => {
-      const cookieData = {
+      const localStorageData = {
         'eqt_pid': '7789746781'
       };
-      const getCookieStub = sinon.stub(storage, 'getCookie');
-      getCookieStub.callsFake(cookieName => cookieData[cookieName]);
+      const getDataFromLocalStorage = sinon.stub(storage, 'getDataFromLocalStorage');
+      getDataFromLocalStorage.callsFake(name => localStorageData[name]);
 
       const request = spec.buildRequests(
         DEFAULT_BANNER_BID_REQUESTS,
         DEFAULT_BANNER_BIDDER_REQUEST
       )[0];
 
-      expect(request.data.user).to.have.property('buyeruid').that.eq(cookieData['eqt_pid']);
+      expect(request.data.user).to.have.property('buyeruid').that.eq(localStorageData['eqt_pid']);
 
-      getCookieStub.restore();
+      getDataFromLocalStorage.restore();
     });
 
     it('should not send buyeruid', () => {
-      const getCookieStub = sinon.stub(storage, 'getCookie');
-      getCookieStub.callsFake(() => null);
+      const getDataFromLocalStorage = sinon.stub(storage, 'getDataFromLocalStorage');
+      getDataFromLocalStorage.callsFake(() => null);
 
       const request = spec.buildRequests(
         DEFAULT_BANNER_BID_REQUESTS,
@@ -399,12 +399,12 @@ describe('Equativ bid adapter tests', () => {
 
       expect(request.data).to.not.have.property('user');
 
-      getCookieStub.restore();
+      getDataFromLocalStorage.restore();
     });
 
     it('should pass buyeruid defined in config', () => {
-      const getCookieStub = sinon.stub(storage, 'getCookie');
-      getCookieStub.callsFake(() => undefined);
+      const getDataFromLocalStorageStub = sinon.stub(storage, 'getDataFromLocalStorage');
+      getDataFromLocalStorageStub.callsFake(() => undefined);
 
       const bidRequest = {
         ...DEFAULT_BANNER_BIDDER_REQUEST,
@@ -418,7 +418,7 @@ describe('Equativ bid adapter tests', () => {
 
       expect(request.data.user.buyeruid).to.deep.eq(bidRequest.ortb2.user.buyeruid);
 
-      getCookieStub.restore();
+      getDataFromLocalStorageStub.restore();
     });
 
     it('should build a video request properly under normal circumstances', () => {
@@ -720,11 +720,11 @@ describe('Equativ bid adapter tests', () => {
   });
 
   describe('getUserSyncs', () => {
-    let setCookieStub;
+    let setDataInLocalStorageStub;
 
-    beforeEach(() => setCookieStub = sinon.stub(storage, 'setCookie'));
+    beforeEach(() => setDataInLocalStorageStub = sinon.stub(storage, 'setDataInLocalStorage'));
 
-    afterEach(() => setCookieStub.restore());
+    afterEach(() => setDataInLocalStorageStub.restore());
 
     it('should return empty array if iframe sync not enabled', () => {
       const syncs = spec.getUserSyncs({}, SAMPLE_RESPONSE);
@@ -732,75 +732,95 @@ describe('Equativ bid adapter tests', () => {
     });
 
     it('should retrieve and save user pid', (done) => {
-      const userSyncs = spec.getUserSyncs(
+      spec.getUserSyncs(
         { iframeEnabled: true },
-        SAMPLE_RESPONSE
+        SAMPLE_RESPONSE,
+        { gdprApplies: true, vendorData: { vendor: { consents: {} } } }
       );
 
       window.dispatchEvent(new MessageEvent('message', {
         data: {
+          action: 'getConsent',
           pid: '7767825890726'
         },
-        origin: 'https://apps.smartadserver.com'
+        origin: 'https://apps.smartadserver.com',
+        source: window
       }));
 
-      const exp = new Date();
-      exp.setTime(Date.now() + 31536000000);
-
       setTimeout(() => {
-        expect(setCookieStub.calledOnce).to.be.true;
-        expect(setCookieStub.calledWith('eqt_pid', '7767825890726', exp.toUTCString())).to.be.true;
+        expect(setDataInLocalStorageStub.calledOnce).to.be.true;
+        expect(setDataInLocalStorageStub.calledWith('eqt_pid', '7767825890726')).to.be.true;
         done();
       });
     });
 
-    it('should not save user pid coming from not origin', (done) => {
-      const userSyncs = spec.getUserSyncs(
+    it('should not save user pid coming from incorrect origin', (done) => {
+      spec.getUserSyncs(
         { iframeEnabled: true },
-        SAMPLE_RESPONSE
+        SAMPLE_RESPONSE,
+        { gdprApplies: true, vendorData: { vendor: { consents: {} } } }
       );
 
       window.dispatchEvent(new MessageEvent('message', {
         data: {
+          action: 'getConsent',
           pid: '7767825890726'
         },
-        origin: 'https://another-origin.com'
+        origin: 'https://another-origin.com',
+        source: window
       }));
 
       setTimeout(() => {
-        expect(setCookieStub.notCalled).to.be.true;
+        expect(setDataInLocalStorageStub.notCalled).to.be.true;
         done();
       });
     });
 
     it('should not save empty pid', (done) => {
-      const userSyncs = spec.getUserSyncs(
+      spec.getUserSyncs(
         { iframeEnabled: true },
-        SAMPLE_RESPONSE
+        SAMPLE_RESPONSE,
+        { gdprApplies: true, vendorData: { vendor: { consents: {} } } }
       );
 
       window.dispatchEvent(new MessageEvent('message', {
         data: {
+          action: 'getConsent',
           pid: ''
         },
-        origin: 'https://apps.smartadserver.com'
+        origin: 'https://apps.smartadserver.com',
+        source: window
       }));
 
       setTimeout(() => {
-        expect(setCookieStub.notCalled).to.be.true;
+        expect(setDataInLocalStorageStub.notCalled).to.be.true;
         done();
       });
     });
 
-    it('should return array including iframe cookie sync object', () => {
+    it('should return array including iframe cookie sync object (gdprApplies=true)', () => {
       const syncs = spec.getUserSyncs(
         { iframeEnabled: true },
-        SAMPLE_RESPONSE
+        SAMPLE_RESPONSE,
+        { gdprApplies: true }
       );
       expect(syncs).to.have.lengthOf(1);
       expect(syncs[0]).to.deep.equal({
         type: 'iframe',
-        url: 'https://apps.smartadserver.com/diff/templates/asset/csync.html'
+        url: 'https://apps.smartadserver.com/diff/templates/asset/csync.html?nwid=777&gdpr=1&'
+      });
+    });
+
+    it('should return array including iframe cookie sync object (gdprApplies=false)', () => {
+      const syncs = spec.getUserSyncs(
+        { iframeEnabled: true },
+        SAMPLE_RESPONSE,
+        { gdprApplies: false }
+      );
+      expect(syncs).to.have.lengthOf(1);
+      expect(syncs[0]).to.deep.equal({
+        type: 'iframe',
+        url: 'https://apps.smartadserver.com/diff/templates/asset/csync.html?nwid=777&gdpr=0&'
       });
     });
   });


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Adds a DSP cookie sync mechanism to Equativ Bid Adapter, utilizing an iframe.
