### PR TITLE
Rubicon Bid Adapter: Added support for IAB segtax 7 in Rubicon bid adapter; 

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -922,7 +922,7 @@ function applyFPD(bidRequest, mediaType, data) {
 
   const gpid = deepAccess(bidRequest, 'ortb2Imp.ext.gpid');
   const dsa = deepAccess(fpd, 'regs.ext.dsa');
-  const SEGTAX = {user: [4], site: [1, 2, 5, 6]};
+  const SEGTAX = {user: [4], site: [1, 2, 5, 6, 7]};
   const MAP = {user: 'tg_v.', site: 'tg_i.', adserver: 'tg_i.dfp_ad_unit_code', pbadslot: 'tg_i.pbadslot', keywords: 'kw'};
   const validate = function(prop, key, parentName) {
     if (key === 'data' && Array.isArray(prop)) {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -2916,6 +2916,29 @@ describe('the rubicon adapter', function () {
           expect(slotParams['tg_v.tax404']).is.equal(undefined);
         });
 
+        it('should support IAB segtax 7 in site segments', () => {
+          const localBidderRequest = Object.assign({}, bidderRequest);
+          localBidderRequest.refererInfo = {domain: 'bob'};
+          config.setConfig({
+            rubicon: {
+              sendUserSegtax: [4],
+              sendSiteSegtax: [1, 2, 5, 6, 7]
+            }
+          });
+          localBidderRequest.ortb2.site = {
+            content: {
+              data: [{
+                ext: {
+                  segtax: '7'
+                },
+                segment: [{id: 8}, {id: 9}]
+              }]
+            }
+          };
+          const slotParams = spec.createSlotParams(bidderRequest.bids[0], localBidderRequest);
+          expect(slotParams['tg_i.tax7']).to.equal('8,9');
+        });
+
         it('should add p_site.mobile if mobile is a number in ortb2.site', function () {
           // Set up a bidRequest with mobile property as a number
           const localBidderRequest = Object.assign({}, bidderRequest);


### PR DESCRIPTION
## Type of change
- [X] Feature
- [X] Updated bidder adapter 

## Description of change

- Added support for IAB segtax 7 in the Rubicon bid adapter.

- Added unit test to verify the correct functionality of segtax 7.


## Other information
- No API changes; the update enhances existing segment handling.