### PR TITLE
TTD Bid Adapter : revert integration type header due to CORS error

### DIFF
--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -441,9 +441,6 @@ export const spec = {
       data: topLevel,
       options: {
         withCredentials: true,
-        customHeaders: {
-          'x-integration-type': 1,
-        },
       }
     };
 

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -291,13 +291,6 @@ describe('ttdBidAdapter', function () {
       expect(requestBody.site.publisher.id).to.equal(baseBannerBidRequests[0].params.publisherId);
     });
 
-    it('sends integration type header', function () {
-      const requestBody = testBuildRequests(baseBannerBidRequests, baseBidderRequest);
-      expect(requestBody.options).to.be.not.null;
-      expect(requestBody.options.customHeaders).to.be.not.null;
-      expect(requestBody.options.customHeaders['x-integration-type']).to.equal(1);
-    });
-
     it('sends placement id in tagid', function () {
       const requestBody = testBuildRequests(baseBannerBidRequests, baseBidderRequest).data;
       expect(requestBody.imp[0].tagid).to.equal(baseBannerBidRequests[0].params.placementId);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Reverting these changes because of the following error:
```
Access to fetch at 'https://direct.adsrvr.org/bid/bidder/ezoic' from origin 'https://play2048.co' has been blocked by CORS policy: Request header field x-integration-type is not allowed by Access-Control-Allow-Headers in preflight response.

Prebid also gave a "Server call for ttd failed, continuing without bids" error, most likely due to the failed request.
```
I need to investigate why this is happening but to avoid other problems I'm reverting this for now while we check what is going on.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
