### PR TITLE
Debugging module: make mock creatives respect requested sizes

### DIFF
--- a/integrationExamples/testBidder/testBidderVideoExample.html
+++ b/integrationExamples/testBidder/testBidderVideoExample.html
@@ -70,6 +70,6 @@
     <body>
         <h2>Prebid Test Bidder Example</h2>
         <h5>Video ad</h5>
-        <div id="player"></div>
+        <div id="adUnit-0000"></div>
     </body>
 </html>

--- a/modules/debugging/pbsInterceptor.js
+++ b/modules/debugging/pbsInterceptor.js
@@ -17,7 +17,7 @@ export function makePbsInterceptor({createBid}) {
     function addBid(bid, bidRequest) {
       onBid({
         adUnit: bidRequest.adUnitCode,
-        bid: Object.assign(createBid(STATUS.GOOD, bidRequest), bid)
+        bid: Object.assign(createBid(STATUS.GOOD, bidRequest), {requestBidder: bidRequest.bidder}, bid)
       })
     }
     bidRequests = bidRequests

--- a/modules/debugging/responses.js
+++ b/modules/debugging/responses.js
@@ -7,7 +7,8 @@ const ORTB_NATIVE_ASSET_TYPES = ['img', 'video', 'link', 'data', 'title'];
 export default {
   [BANNER]: (bid, bidResponse) => {
     if (!bidResponse.hasOwnProperty('ad') && !bidResponse.hasOwnProperty('adUrl')) {
-      bidResponse.ad = `<html><head><style>#ad {width: ${bidResponse.width}px;height: ${bidResponse.height}px;background-color: #f6f6ae;color: #85144b;padding: 5px;text-align: center;display: flex;flex-direction: column;align-items: center;justify-content: center;}#bidder {font-family: monospace;font-weight: normal;}#title {font-size: x-large;font-weight: bold;margin-bottom: 5px;}#body {font-size: large;margin-top: 5px;}</style></head><body><div id="ad"><div id="title">Mock ad: <span id="bidder">${bid.bidder}</span></div><div id="body">${bidResponse.width}x${bidResponse.height}</div></div></body></html>`;
+      const [size, repeat] = bidResponse.width < bidResponse.height ? [bidResponse.width, 'repeat-y'] : [bidResponse.height, 'repeat-x'];
+      bidResponse.ad = `<html><body><div style="display: inline-block; height: ${bidResponse.height}px; width: ${bidResponse.width}px; background-image: url(https://vcdn.adnxs.com/p/creative-image/27/c0/52/67/27c05267-5a6d-4874-834e-18e218493c32.png); background-size: ${size}px; background-repeat: ${repeat}"></div></body></html>`;
     }
   },
   [VIDEO]: (bid, bidResponse) => {

--- a/modules/debugging/responses.js
+++ b/modules/debugging/responses.js
@@ -1,18 +1,56 @@
-import { BANNER, NATIVE, VIDEO } from '../../src/mediaTypes.js';
+import {BANNER, NATIVE, VIDEO} from '../../src/mediaTypes.js';
+import {Renderer} from '../../src/Renderer.js';
+import {getGptSlotInfoForAdUnitCode} from '../../libraries/gptUtils/gptUtils.js';
 
 const ORTB_NATIVE_ASSET_TYPES = ['img', 'video', 'link', 'data', 'title'];
 
 export default {
-  [BANNER]: () => `<html><head><body><img src="https://vcdn.adnxs.com/p/creative-image/27/c0/52/67/27c05267-5a6d-4874-834e-18e218493c32.png"/></body></html>`,
-  [VIDEO]: () => '<?xml version=\"1.0\" encoding=\"UTF-8\"?><VAST version=\"3.0\"><Ad><InLine><AdSystem>GDFP</AdSystem><AdTitle>Demo</AdTitle><Description><![CDATA[Demo]]></Description><Creatives><Creative><Linear ><Duration>00:00:11</Duration><VideoClicks><ClickThrough><![CDATA[https://prebid.org/]]></ClickThrough></VideoClicks><MediaFiles><MediaFile delivery=\"progressive\" width=\"640\" height=\"360\" type=\"video/mp4\" scalable=\"true\" maintainAspectRatio=\"true\"><![CDATA[https://s3.amazonaws.com/files.prebid.org/creatives/PrebidLogo.mp4]]></MediaFile></MediaFiles></Linear></Creative></Creatives></InLine></Ad></VAST>',
-  [NATIVE]: (bid) => {
-    return {
-      ortb: {
-        link: {
-          url: 'https://www.link.example',
-          clicktrackers: ['https://impression.example']
-        },
-        assets: bid.nativeOrtbRequest.assets.map(mapDefaultNativeOrtbAsset)
+  [BANNER]: (bid, bidResponse) => {
+    if (!bidResponse.hasOwnProperty('ad') && !bidResponse.hasOwnProperty('adUrl')) {
+      bidResponse.ad = `<html><head><style>#ad {width: ${bidResponse.width}px;height: ${bidResponse.height}px;background-color: #f6f6ae;color: #85144b;padding: 5px;text-align: center;display: flex;flex-direction: column;align-items: center;justify-content: center;}#bidder {font-family: monospace;font-weight: normal;}#title {font-size: x-large;font-weight: bold;margin-bottom: 5px;}#body {font-size: large;margin-top: 5px;}</style></head><body><div id="ad"><div id="title">Mock ad: <span id="bidder">${bid.bidder}</span></div><div id="body">${bidResponse.width}x${bidResponse.height}</div></div></body></html>`;
+    }
+  },
+  [VIDEO]: (bid, bidResponse) => {
+    if (!bidResponse.hasOwnProperty('vastXml') && !bidResponse.hasOwnProperty('vastUrl')) {
+      bidResponse.vastXml = '<?xml version="1.0" encoding="UTF-8"?><VAST version="3.0"><Ad><InLine><AdSystem>GDFP</AdSystem><AdTitle>Demo</AdTitle><Description><![CDATA[Demo]]></Description><Creatives><Creative><Linear ><Duration>00:00:11</Duration><VideoClicks><ClickThrough><![CDATA[https://prebid.org/]]></ClickThrough></VideoClicks><MediaFiles><MediaFile delivery="progressive" width="640" height="360" type="video/mp4" scalable="true" maintainAspectRatio="true"><![CDATA[https://s3.amazonaws.com/files.prebid.org/creatives/PrebidLogo.mp4]]></MediaFile></MediaFiles></Linear></Creative></Creatives></InLine></Ad></VAST>';
+      bidResponse.renderer = Renderer.install({
+        url: 'https://cdn.jwplayer.com/libraries/l5MchIxB.js',
+      });
+      bidResponse.renderer.setRender(function (bid, doc) {
+        const parentId = getGptSlotInfoForAdUnitCode(bid.adUnitCode).divId ?? bid.adUnitCode;
+        const div = doc.createElement('div');
+        div.id = `${parentId}-video-player`;
+        doc.getElementById(parentId).appendChild(div);
+        const player = window.jwplayer(div.id).setup({
+          debug: true,
+          width: bidResponse.width,
+          height: bidResponse.height,
+          advertising: {
+            client: 'vast',
+            outstream: true,
+            endstate: 'close'
+          },
+        });
+        player.on('ready', async function () {
+          if (bid.vastUrl) {
+            player.loadAdTag(bid.vastUrl);
+          } else {
+            player.loadAdXml(bid.vastXml);
+          }
+        });
+      })
+    }
+  },
+  [NATIVE]: (bid, bidResponse) => {
+    if (!bidResponse.hasOwnProperty('native')) {
+      bidResponse.native = {
+        ortb: {
+          link: {
+            url: 'https://www.link.example',
+            clicktrackers: ['https://impression.example']
+          },
+          assets: bid.nativeOrtbRequest.assets.map(mapDefaultNativeOrtbAsset)
+        }
       }
     }
   }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

When mocking a banner ad with the debugging module, restore the old creatives from before https://github.com/prebid/Prebid.js/pull/12720  (fixes https://github.com/prebid/Prebid.js/issues/12796)

While the new image is nicer, it isn't if we try to fit it to a different aspect ratio IMO - open to reconsider.

