### PR TITLE
Aniview Bid Adapter : pass replacements and s2s winning ad source in bid meta

### DIFF
--- a/test/spec/modules/aniviewBidAdapter_spec.js
+++ b/test/spec/modules/aniviewBidAdapter_spec.js
@@ -37,6 +37,8 @@ const BANNER_SIZE = { width: 250, height: 250 };
 const CUSTOM_RENDERER_URL = `https://${CUSTOM_DOMAIN}/script/6.1/prebidRenderer.js`;
 const DEFAULT_RENDERER_URL = `https://player.aniview.com/script/6.1/prebidRenderer.js`;
 
+const REPLACEMENT_1 = '12345';
+
 const MOCK = {
   bidRequest: () => ({
     bidderCode: 'aniview',
@@ -67,6 +69,9 @@ const MOCK = {
           AV_PUBLISHERID: PUBLISHER_ID_2,
           AV_CHANNELID: CHANNEL_ID_2,
           playerDomain: CUSTOM_DOMAIN,
+          replacements: {
+            AV_CDIM1: REPLACEMENT_1,
+          },
         },
         mediaTypes: {
           video: {
@@ -198,6 +203,13 @@ describe('Aniview Bid Adapter', function () {
 
       expect(imp.bidfloor).equal(FLOOR_PRICE);
       expect(imp.bidfloorcur).equal(CURRENCY);
+    });
+
+    it('should have replacements in request', function () {
+      const bidRequest = spec.buildRequests(videoBidRequest.bids, videoBidRequest);
+      const { replacements } = bidRequest[1].data.ext.aniview;
+
+      expect(replacements.AV_CDIM1).equal(REPLACEMENT_1);
     });
 
     it('should not have floor data in imp if getFloor returns empty object', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
- Pass replacements with request (params.replacements -> ext.aniview.replacements);
- Provide s2s winning ad source in Prebid bid meta.