### PR TITLE
Setupad Bid Adapter : fix gdprConsent undefined error

### DIFF
--- a/modules/setupadBidAdapter.js
+++ b/modules/setupadBidAdapter.js
@@ -117,8 +117,8 @@ export const spec = {
       const queryParams = [];
 
       queryParams.push(`bidders=${bidders}`);
-      queryParams.push('gdpr=' + +gdprConsent.gdprApplies);
-      queryParams.push('gdpr_consent=' + gdprConsent.consentString);
+      queryParams.push('gdpr=' + +gdprConsent?.gdprApplies);
+      queryParams.push('gdpr_consent=' + gdprConsent?.consentString);
       queryParams.push('usp_consent=' + (uspConsent || ''));
 
       const strQueryParams = queryParams.join('&');


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
if gdprConsent object is undefined trying to access its properties during user sync throws an error.
