### PR TITLE
TTD Bid Adapter : add x-integration-type

### DIFF
--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -14,7 +14,7 @@ import { getConnectionType } from '../libraries/connectionInfo/connectionUtils.j
  * @typedef {import('../src/adapters/bidderFactory.js').UserSync} UserSync
  */
 
-const BIDADAPTERVERSION = 'TTD-PREBID-2024.07.27';
+const BIDADAPTERVERSION = 'TTD-PREBID-2024.07.28';
 const BIDDER_CODE = 'ttd';
 const BIDDER_CODE_LONG = 'thetradedesk';
 const BIDDER_ENDPOINT = 'https://direct.adsrvr.org/bid/bidder/';
@@ -441,6 +441,9 @@ export const spec = {
       data: topLevel,
       options: {
         withCredentials: true,
+        customHeaders: {
+          'x-integration-type': 1,
+        },
       }
     };
 

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -291,6 +291,13 @@ describe('ttdBidAdapter', function () {
       expect(requestBody.site.publisher.id).to.equal(baseBannerBidRequests[0].params.publisherId);
     });
 
+    it('sends integration type header', function () {
+      const requestBody = testBuildRequests(baseBannerBidRequests, baseBidderRequest);
+      expect(requestBody.options).to.be.not.null;
+      expect(requestBody.options.customHeaders).to.be.not.null;
+      expect(requestBody.options.customHeaders['x-integration-type']).to.equal(1);
+    });
+
     it('sends placement id in tagid', function () {
       const requestBody = testBuildRequests(baseBannerBidRequests, baseBidderRequest).data;
       expect(requestBody.imp[0].tagid).to.equal(baseBannerBidRequests[0].params.placementId);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Re-adding `x-integration-type` header that signals TTD that this is a PrebidJs integration. This change was previously reverted because if caused CORS issues which have been fixed now.

These changes were now tested and are confirmed to be working with current setup:

```await fetch("https://direct.adsrvr.org/bid/bidder/xxxx", {
  "headers": {
    "accept": "*/*",
    "accept-language": "en-US,en;q=0.9",
    "content-type": "text/plain",
    "sec-ch-ua": "\"Chromium\";v=\"130\", \"Google Chrome\";v=\"130\", \"Not?A_Brand\";v=\"99\"",
    "sec-ch-ua-mobile": "?0",
    "sec-ch-ua-platform": "\"Windows\"",
    "sec-fetch-dest": "empty",
    "sec-fetch-mode": "cors",
    "sec-fetch-site": "cross-site",
     "x-integration-type": 1  <--- NEW HEADER
  },
  "referrer": "xxxx",
  "referrerPolicy": "strict-origin-when-cross-origin",
  "body": "{...}",
  "method": "POST",
  "mode": "cors",
  "credentials": "include"
});
----
Response {type: 'cors', url: 'https://direct.adsrvr.org/bid/bidder/xxxx', redirected: false, status: 200, ok: true, …}
```

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
