### PR TITLE
Previous Auction Info: Module release

### DIFF
--- a/modules/previousAuctionInfo/index.js
+++ b/modules/previousAuctionInfo/index.js
@@ -86,7 +86,7 @@ export const onAuctionEndHandler = (auctionDetails) => {
               rendered: 0,
               source: 'pbjs',
               adUnitCode: bid.adUnitCode,
-              highestBidCpm: highestBidsByAdUnitCode[bid.adUnitCode]?.cpm || 0,
+              highestBidCpm: highestBidsByAdUnitCode[bid.adUnitCode]?.cpm || null,
               bidderCpm: receivedBidsMap[bid.bidId]?.cpm || null,
               bidderOriginalCpm: receivedBidsMap[bid.bidId]?.originalCpm || null,
               bidderCurrency: receivedBidsMap[bid.bidId]?.currency || null,

--- a/modules/previousAuctionInfo/index.js
+++ b/modules/previousAuctionInfo/index.js
@@ -2,9 +2,6 @@ import {on as onEvent, off as offEvent} from '../../src/events.js';
 import { EVENTS } from '../../src/constants.js';
 import { config } from '../../src/config.js';
 
-// eslint-disable-next-line no-console
-console.log('previousAuctionInfo module loaded');
-
 export let previousAuctionInfoEnabled = false;
 let enabledBidders = [];
 let maxQueueLength = 10;
@@ -19,8 +16,6 @@ export const resetPreviousAuctionInfo = (cb = deinitHandlers) => {
 };
 
 export const initPreviousAuctionInfo = (cb = initHandlers) => {
-  // eslint-disable-next-line no-console
-  console.log('initPreviousAuctionInfo');
   config.getConfig('previousAuctionInfo', (conf) => {
     if (!conf.previousAuctionInfo || !conf.previousAuctionInfo.enabled) {
       if (previousAuctionInfoEnabled) { resetPreviousAuctionInfo(); }
@@ -31,15 +26,11 @@ export const initPreviousAuctionInfo = (cb = initHandlers) => {
     if (conf.previousAuctionInfo.maxQueueLength) { maxQueueLength = conf.previousAuctionInfo.maxQueueLength; }
 
     previousAuctionInfoEnabled = true;
-    // eslint-disable-next-line no-console
-    console.log('initPreviousAuctionInfo: enabled');
     cb();
   });
 };
 
 export const initHandlers = () => {
-  // eslint-disable-next-line no-console
-  console.log('initHandlers');
   onEvent(EVENTS.AUCTION_END, onAuctionEndHandler);
   onEvent(EVENTS.BID_WON, onBidWonHandler);
   onEvent(EVENTS.BID_REQUESTED, onBidRequestedHandler);
@@ -52,8 +43,6 @@ const deinitHandlers = () => {
 }
 
 export const onAuctionEndHandler = (auctionDetails) => {
-  // eslint-disable-next-line no-console
-  console.log('onAuctionEndHandler', auctionDetails);
   try {
     const receivedBidsMap = {};
     const rejectedBidsMap = {};
@@ -113,8 +102,6 @@ export const onAuctionEndHandler = (auctionDetails) => {
 }
 
 export const onBidWonHandler = (winningBid) => {
-  // eslint-disable-next-line no-console
-  console.log('onBidWonHandler', winningBid);
   const winningTid = winningBid.transactionId;
 
   Object.values(auctionState).flat().forEach(prevAuctPayload => {
@@ -125,8 +112,6 @@ export const onBidWonHandler = (winningBid) => {
 };
 
 export const onBidRequestedHandler = (bidRequest) => {
-  // eslint-disable-next-line no-console
-  console.log('onBidRequestedHandler', bidRequest);
   try {
     const enabledBidder = enabledBidders.length === 0 || enabledBidders.find(bidderCode => bidderCode === bidRequest.bidderCode);
     if (enabledBidder && auctionState[bidRequest.bidderCode]) {
@@ -139,8 +124,6 @@ export const onBidRequestedHandler = (bidRequest) => {
       bidRequest.ortb2.ext.prebid = Object.assign({}, bidRequest.ortb2.ext.prebid);
 
       bidRequest.ortb2.ext.prebid.previousauctioninfo = auctionState[bidRequest.bidderCode];
-      // eslint-disable-next-line no-console
-      console.log('previousAuctionInfo injected into bidRequest');
       delete auctionState[bidRequest.bidderCode];
     }
   } catch (error) {}

--- a/modules/previousAuctionInfo/index.js
+++ b/modules/previousAuctionInfo/index.js
@@ -91,7 +91,7 @@ export const onAuctionEndHandler = (auctionDetails) => {
               bidderOriginalCpm: receivedBidsMap[bid.bidId]?.originalCpm || null,
               bidderCurrency: receivedBidsMap[bid.bidId]?.currency || null,
               bidderOriginalCurrency: receivedBidsMap[bid.bidId]?.originalCurrency || null,
-              bidderErrorCode: rejectedBidsMap[bid.bidId] ? rejectedBidsMap[bid.bidId].rejectionReason : -1,
+              bidderErrorCode: rejectedBidsMap[bid.bidId]?.rejectionReason || null,
               timestamp: auctionDetails.timestamp,
               transactionId: bid.transactionId, // this field gets removed before injecting previous auction info into the bid stream
             }

--- a/modules/previousAuctionInfo/index.js
+++ b/modules/previousAuctionInfo/index.js
@@ -86,8 +86,6 @@ export const onAuctionEndHandler = (auctionDetails) => {
               rendered: 0,
               source: 'pbjs',
               adUnitCode: bid.adUnitCode,
-              highestTargetedBidCpm: highestBidsByAdUnitCode[bid.adUnitCode]?.adserverTargeting?.hb_pb || null,
-              targetedBidCpm: receivedBidsMap[bid.bidId]?.adserverTargeting?.hb_pb || null,
               highestBidCpm: highestBidsByAdUnitCode[bid.adUnitCode]?.cpm || 0,
               bidderCpm: receivedBidsMap[bid.bidId]?.cpm || null,
               bidderOriginalCpm: receivedBidsMap[bid.bidId]?.originalCpm || null,

--- a/test/spec/modules/previousAuctionInfo_spec.js
+++ b/test/spec/modules/previousAuctionInfo_spec.js
@@ -1,4 +1,4 @@
-import * as previousAuctionInfo from 'libraries/previousAuctionInfo/previousAuctionInfo.js';
+import * as previousAuctionInfo from '../../../modules/previousAuctionInfo';
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { config } from 'src/config.js';
@@ -57,7 +57,8 @@ describe('previous auction info', () => {
   describe('config', () => {
     it('should initialize the module if publisher enabled', () => {
       previousAuctionInfo.initPreviousAuctionInfo(initHandlersStub);
-      config.setConfig({ previousAuctionInfo: true });
+      config.setConfig({ previousAuctionInfo: { enabled: true, bidders: ['testBidder1', 'testBidder2'] } });
+      expect(previousAuctionInfo.previousAuctionInfoEnabled).to.be.true;
       sandbox.assert.calledOnce(initHandlersStub);
     });
 
@@ -71,8 +72,8 @@ describe('previous auction info', () => {
 
   describe('onAuctionEndHandler', () => {
     it('should store auction data for enabled bidders in auctionState', () => {
-      const config = { bidderCode: 'testBidder2' };
-      previousAuctionInfo.enablePreviousAuctionInfo(config);
+      config.setConfig({ previousAuctionInfo: { enabled: true, bidders: ['testBidder2'] } });
+      previousAuctionInfo.initPreviousAuctionInfo();
       previousAuctionInfo.onAuctionEndHandler(auctionDetails);
 
       expect(previousAuctionInfo.auctionState).to.have.property('testBidder2');
@@ -97,10 +98,8 @@ describe('previous auction info', () => {
     });
 
     it('should store auction data for multiple bidders correctly', () => {
-      const config1 = { bidderCode: 'testBidder1' };
-      const config2 = { bidderCode: 'testBidder3' };
-      previousAuctionInfo.enablePreviousAuctionInfo(config1);
-      previousAuctionInfo.enablePreviousAuctionInfo(config2);
+      config.setConfig({ previousAuctionInfo: { enabled: true, bidders: ['testBidder1', 'testBidder3'] } });
+      previousAuctionInfo.initPreviousAuctionInfo();
       previousAuctionInfo.onAuctionEndHandler(auctionDetails);
 
       expect(previousAuctionInfo.auctionState).to.have.property('testBidder1');
@@ -124,15 +123,19 @@ describe('previous auction info', () => {
     });
 
     it('should not store auction data for disabled bidders', () => {
+      config.setConfig({ previousAuctionInfo: { enabled: true, bidders: ['testBidder1'] } });
+      previousAuctionInfo.initPreviousAuctionInfo();
       previousAuctionInfo.onAuctionEndHandler(auctionDetails);
+
+      expect(previousAuctionInfo.auctionState).to.have.property('testBidder1');
       expect(previousAuctionInfo.auctionState).to.not.have.property('testBidder2');
     });
   });
 
   describe('onBidWonHandler', () => {
     it('should update the rendered field in auctionState when a pbjs bid wins', () => {
-      const config = { bidderCode: 'testBidder3' };
-      previousAuctionInfo.enablePreviousAuctionInfo(config);
+      config.setConfig({ previousAuctionInfo: { enabled: true, bidders: ['testBidder3'] } });
+      previousAuctionInfo.initPreviousAuctionInfo();
 
       previousAuctionInfo.auctionState['testBidder3'] = [
         { transactionId: 'trans789', rendered: 0 }
@@ -148,8 +151,8 @@ describe('previous auction info', () => {
     });
 
     it('should not update the rendered field if no matching transactionId is found', () => {
-      const config = { bidderCode: 'testBidder3' };
-      previousAuctionInfo.enablePreviousAuctionInfo(config);
+      config.setConfig({ previousAuctionInfo: { enabled: true, bidders: ['testBidder3'] } });
+      previousAuctionInfo.initPreviousAuctionInfo();
 
       previousAuctionInfo.auctionState['testBidder3'] = [
         { transactionId: 'someOtherTid', rendered: 0 }

--- a/test/spec/modules/previousAuctionInfo_spec.js
+++ b/test/spec/modules/previousAuctionInfo_spec.js
@@ -2,10 +2,11 @@ import * as previousAuctionInfo from '../../../modules/previousAuctionInfo';
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { config } from 'src/config.js';
+import * as events from 'src/events.js';
+import {CONFIG_NS, resetPreviousAuctionInfo, startAuctionHook} from '../../../modules/previousAuctionInfo';
 
 describe('previous auction info', () => {
   let sandbox;
-  let initHandlersStub;
 
   const auctionDetails = {
     auctionId: 'auction123',
@@ -44,36 +45,37 @@ describe('previous auction info', () => {
     timestamp: Date.now(),
   };
 
+  before(() => {
+    config.resetConfig();
+  })
+
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    previousAuctionInfo.resetPreviousAuctionInfo();
-    initHandlersStub = sandbox.stub();
   });
 
   afterEach(() => {
+    config.resetConfig();
+    resetPreviousAuctionInfo();
     sandbox.restore();
   });
 
   describe('config', () => {
     it('should initialize the module if publisher enabled', () => {
-      previousAuctionInfo.initPreviousAuctionInfo(initHandlersStub);
-      config.setConfig({ previousAuctionInfo: { enabled: true, bidders: ['testBidder1', 'testBidder2'] } });
+      sandbox.spy(events, 'on');
+      config.setConfig({ [CONFIG_NS]: { enabled: true, bidders: ['testBidder1', 'testBidder2'] } });
       expect(previousAuctionInfo.previousAuctionInfoEnabled).to.be.true;
-      sandbox.assert.calledOnce(initHandlersStub);
+      sinon.assert.called(events.on);
     });
 
     it('should not enable previous auction info if config.previousAuctionInfo is not set', () => {
-      sandbox.restore();
-      previousAuctionInfo.initPreviousAuctionInfo(initHandlersStub);
-      config.setConfig({ previousAuctionInfo: false });
+      config.setConfig({});
       expect(previousAuctionInfo.previousAuctionInfoEnabled).to.be.false;
     });
   });
 
   describe('onAuctionEndHandler', () => {
     it('should store auction data for enabled bidders in auctionState', () => {
-      config.setConfig({ previousAuctionInfo: { enabled: true, bidders: ['testBidder2'] } });
-      previousAuctionInfo.initPreviousAuctionInfo();
+      config.setConfig({ [CONFIG_NS]: { enabled: true, bidders: ['testBidder2'] } });
       previousAuctionInfo.onAuctionEndHandler(auctionDetails);
 
       expect(previousAuctionInfo.auctionState).to.have.property('testBidder2');
@@ -98,8 +100,7 @@ describe('previous auction info', () => {
     });
 
     it('should store auction data for multiple bidders correctly', () => {
-      config.setConfig({ previousAuctionInfo: { enabled: true, bidders: ['testBidder1', 'testBidder3'] } });
-      previousAuctionInfo.initPreviousAuctionInfo();
+      config.setConfig({ [CONFIG_NS]: { enabled: true, bidders: ['testBidder1', 'testBidder3'] } });
       previousAuctionInfo.onAuctionEndHandler(auctionDetails);
 
       expect(previousAuctionInfo.auctionState).to.have.property('testBidder1');
@@ -123,8 +124,7 @@ describe('previous auction info', () => {
     });
 
     it('should not store auction data for disabled bidders', () => {
-      config.setConfig({ previousAuctionInfo: { enabled: true, bidders: ['testBidder1'] } });
-      previousAuctionInfo.initPreviousAuctionInfo();
+      config.setConfig({ [CONFIG_NS]: { enabled: true, bidders: ['testBidder1'] } });
       previousAuctionInfo.onAuctionEndHandler(auctionDetails);
 
       expect(previousAuctionInfo.auctionState).to.have.property('testBidder1');
@@ -132,10 +132,62 @@ describe('previous auction info', () => {
     });
   });
 
+  describe('startAuctionHook', () => {
+    let global, bidder, next;
+    beforeEach(() => {
+      global = {};
+      bidder = {};
+      next = sinon.spy();
+    });
+    function runHook() {
+      startAuctionHook(next, {ortb2Fragments: {global, bidder}});
+    }
+    it('should not add info when none is available', () => {
+      runHook();
+      expect(global).to.eql({});
+      expect(bidder).to.eql({});
+    })
+    it('should call next', () => {
+      runHook();
+      sinon.assert.called(next);
+    })
+    describe('when info is available', () => {
+      beforeEach(() => {
+        Object.assign(previousAuctionInfo.auctionState, {
+          bidder1: [{transactionId: 'tid1', auction: '1'}],
+          bidder2: [{transactionId: 'tid2', auction: '2'}]
+        })
+      })
+
+      function extractInfo() {
+        return Object.fromEntries(
+          Object.entries(bidder)
+            .map(([bidder, ortb2]) => [bidder, ortb2.ext?.prebid?.previousauctioninfo])
+        )
+      }
+
+      it('should set info for enabled bidders, when only some are enabled', () => {
+        config.setConfig({[CONFIG_NS]: {enabled: true, bidders: ['bidder1']}});
+        runHook();
+        expect(extractInfo()).to.eql({
+          bidder1: [{auction: '1'}]
+        })
+      });
+
+      it('should set info for all bidders, when none is specified', () => {
+        config.setConfig({[CONFIG_NS]: {enabled: true}});
+        runHook();
+        expect(extractInfo()).to.eql({
+          bidder1: [{auction: '1'}],
+          bidder2: [{auction: '2'}]
+        })
+      })
+    })
+  })
+
   describe('onBidWonHandler', () => {
     it('should update the rendered field in auctionState when a pbjs bid wins', () => {
       config.setConfig({ previousAuctionInfo: { enabled: true, bidders: ['testBidder3'] } });
-      previousAuctionInfo.initPreviousAuctionInfo();
 
       previousAuctionInfo.auctionState['testBidder3'] = [
         { transactionId: 'trans789', rendered: 0 }
@@ -152,7 +204,6 @@ describe('previous auction info', () => {
 
     it('should not update the rendered field if no matching transactionId is found', () => {
       config.setConfig({ previousAuctionInfo: { enabled: true, bidders: ['testBidder3'] } });
-      previousAuctionInfo.initPreviousAuctionInfo();
 
       previousAuctionInfo.auctionState['testBidder3'] = [
         { transactionId: 'someOtherTid', rendered: 0 }

--- a/test/spec/modules/previousAuctionInfo_spec.js
+++ b/test/spec/modules/previousAuctionInfo_spec.js
@@ -94,7 +94,7 @@ describe('previous auction info', () => {
         bidderOriginalCpm: 2.1,
         bidderCurrency: 'EUR',
         bidderOriginalCurrency: 'EUR',
-        bidderErrorCode: -1,
+        bidderErrorCode: null,
         timestamp: auctionDetails.timestamp
       });
     });


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
- changed the module to be an actual module (no longer requiring a bid adapter to registers itself with it)
- updated publisher configuration to be setConfig({prevAuctionInfo: {enabled: true, bidders: []}})
- by default, all bidders are enabled.
- updated logic to make info available to prebid server as well
- updated null values to null instead of various special strings (what they were prior)

## Other information
GitHub Issue: https://github.com/prebid/Prebid.js/issues/12822
