### PR TITLE
Adagio Rtd Provider: fix apntag event callback

### DIFF
--- a/modules/adagioRtdProvider.js
+++ b/modules/adagioRtdProvider.js
@@ -683,7 +683,7 @@ function registerEventsForAdServers(config) {
   register('apntag', 'anq', ws, 'ast', () => {
     ws.apntag.anq.push(() => {
       AST_EVENTS.forEach(eventName => {
-        ws.apntag.onEvent(eventName, () => {
+        ws.apntag.onEvent(eventName, function () {
           _internal.getAdagioNs().queue.push({
             action: 'ast-event',
             data: { eventName, args: arguments, _window: ws },


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Change the `apntag.onEvent` callback to use a regular function instead of an arrow function in order to be able to rely on the arguments object.

