### PR TITLE
PAAPI: automatically enable adAuctionHeaders when PAAPI is enabled

### DIFF
--- a/modules/paapi.js
+++ b/modules/paapi.js
@@ -84,6 +84,7 @@ function attachHandlers() {
   getHook('makeBidRequests').before(addPaapiData);
   getHook('makeBidRequests').after(markForFledge);
   getHook('processBidderRequests').before(parallelPaapiProcessing);
+  getHook('processBidderRequests').before(adAuctionHeadersHook);
   events.on(EVENTS.AUCTION_INIT, onAuctionInit);
   events.on(EVENTS.AUCTION_END, onAuctionEnd);
 }
@@ -93,8 +94,22 @@ function detachHandlers() {
   getHook('makeBidRequests').getHooks({hook: addPaapiData}).remove();
   getHook('makeBidRequests').getHooks({hook: markForFledge}).remove();
   getHook('processBidderRequests').getHooks({hook: parallelPaapiProcessing}).remove();
+  getHook('processBidderRequests').getHooks({hook: adAuctionHeadersHook}).remove();
   events.off(EVENTS.AUCTION_INIT, onAuctionInit);
   events.off(EVENTS.AUCTION_END, onAuctionEnd);
+}
+
+export function adAuctionHeadersHook(next, spec, bids, bidderRequest, ajax, ...args) {
+  if (bidderRequest.paapi?.enabled) {
+    ajax = ((orig) => {
+      return function (url, callback, data, options) {
+        options = options ?? {};
+        options.adAuctionHeaders = options.adAuctionHeaders ?? true;
+        return orig.call(this, url, callback, data, options);
+      }
+    })(ajax);
+  }
+  return next.call(this, spec, bids, bidderRequest, ajax, ...args);
 }
 
 function getStaticSignals(adUnit = {}) {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

When PAAPI is enabled for a bidder, automatically set the `adAuctionHeaders` fetch flag for that bidder's requests.

## Other information

Closes https://github.com/prebid/Prebid.js/issues/12574
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
