### PR TITLE
Goldbach Bid Adapter: switching to ortb endpoint, added uid when consent is granted

### DIFF
--- a/modules/goldbachBidAdapter.js
+++ b/modules/goldbachBidAdapter.js
@@ -1,17 +1,19 @@
 import { ajax } from '../src/ajax.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { Renderer } from '../src/Renderer.js';
 
 /* General config */
-const IS_LOCAL_MODE = false;
+const IS_LOCAL_MODE = true;
 const BIDDER_CODE = 'goldbach';
 const GVLID = 580;
-const URL = 'https://goldlayer-api.prod.gbads.net/bid/pbjs';
-const URL_LOCAL = 'http://localhost:3000/bid/pbjs';
+const URL_LOGGING = 'https://l.da-services.ch/pb';
+const URL = 'https://goldlayer-api.prod.gbads.net/openrtb/2.5/auction';
+const URL_LOCAL = 'http://localhost:3000/openrtb/2.5/auction';
+const METHOD = 'POST';
 const LOGGING_PERCENTAGE_REGULAR = 0.0001;
 const LOGGING_PERCENTAGE_ERROR = 0.001;
-const LOGGING_URL = 'https://l.da-services.ch/pb';
 
 /* Renderer settings */
 const RENDERER_OPTIONS = {
@@ -29,17 +31,6 @@ const EVENTS = {
   RENDER: 'creative_render',
   TIMEOUT: 'timeout',
   ERROR: 'error'
-};
-
-/* Targeting mapping */
-const TARGETING_KEYS = {
-  // request level
-  GEO_LAT: 'lat',
-  GEO_LON: 'long',
-  GEO_ZIP: 'zip',
-  CONNECTION_TYPE: 'connection',
-  // slot level
-  VIDEO_DURATION: 'duration',
 };
 
 /* Native mapping */
@@ -60,185 +51,25 @@ export const OPENRTB = {
   }
 };
 
-/* Mapping */
-const convertToCustomTargeting = (bidderRequest) => {
-  const customTargeting = {};
-
-  // geo - lat/long
-  if (bidderRequest?.ortb2?.device?.geo) {
-    if (bidderRequest?.ortb2?.device?.geo?.lon) {
-      customTargeting[TARGETING_KEYS.GEO_LON] = bidderRequest.ortb2.device.geo.lon;
-    }
-    if (bidderRequest?.ortb2?.device?.geo?.lat) {
-      customTargeting[TARGETING_KEYS.GEO_LAT] = bidderRequest.ortb2.device.geo.lat;
-    }
-  }
-
-  // connection
-  if (bidderRequest?.ortb2?.device?.connectiontype) {
-    switch (bidderRequest.ortb2.device.connectiontype) {
-      case 1:
-        customTargeting[TARGETING_KEYS.CONNECTION_TYPE] = 'ethernet';
-        break;
-      case 2:
-        customTargeting[TARGETING_KEYS.CONNECTION_TYPE] = 'wifi';
-        break;
-      case 4:
-        customTargeting[TARGETING_KEYS.CONNECTION_TYPE] = '2G';
-        break;
-      case 5:
-        customTargeting[TARGETING_KEYS.CONNECTION_TYPE] = '3G';
-        break;
-      case 6:
-        customTargeting[TARGETING_KEYS.CONNECTION_TYPE] = '4G';
-        break;
-      case 0:
-      case 3:
-      default:
-        break;
-    }
-  }
-
-  // zip
-  if (bidderRequest?.ortb2?.device?.geo?.zip) {
-    customTargeting[TARGETING_KEYS.GEO_ZIP] = bidderRequest.ortb2.device.geo.zip;
-  }
-
-  return customTargeting;
-}
-
-const convertToCustomSlotTargeting = (validBidRequest) => {
-  const customTargeting = {};
-
-  // Video duration
-  if (validBidRequest.mediaTypes?.[VIDEO]) {
-    if (validBidRequest.params?.video?.maxduration) {
-      const duration = validBidRequest.params?.video?.maxduration;
-      if (duration <= 15) customTargeting[TARGETING_KEYS.VIDEO_DURATION] = 'M';
-      if (duration > 15 && duration <= 30) customTargeting[TARGETING_KEYS.VIDEO_DURATION] = 'XL';
-      if (duration > 30) customTargeting[TARGETING_KEYS.VIDEO_DURATION] = 'XXL';
-    }
-  }
-
-  return customTargeting
-}
-
-const convertToProprietaryData = (validBidRequests, bidderRequest) => {
-  const requestData = {
-    mock: false,
-    debug: false,
-    timestampStart: undefined,
-    timestampEnd: undefined,
-    config: {
-      publisher: {
-        id: undefined,
-      }
-    },
-    gdpr: {
-      consent: undefined,
-      consentString: undefined,
-    },
-    contextInfo: {
-      contentUrl: undefined,
-      bidderResources: undefined,
-    },
-    appInfo: {
-      id: undefined,
-    },
-    userInfo: {
-      ip: undefined,
-      ua: undefined,
-      ifa: undefined,
-      ppid: [],
-    },
-    slots: [],
-    targetings: {},
-  };
-
-  // Set timestamps
-  requestData.timestampStart = Date.now();
-  requestData.timestampEnd = Date.now() + (!isNaN(bidderRequest.timeout) ? Number(bidderRequest.timeout) : 0);
-
-  // Set config
-  if (validBidRequests[0]?.params?.publisherId) {
-    requestData.config.publisher.id = validBidRequests[0].params.publisherId;
-  }
-
-  // Set GDPR
-  if (bidderRequest?.gdprConsent) {
-    requestData.gdpr.consent = bidderRequest.gdprConsent.gdprApplies;
-    requestData.gdpr.consentString = bidderRequest.gdprConsent.consentString;
-  }
-
-  // Set contextInfo
-  requestData.contextInfo.contentUrl = bidderRequest.refererInfo?.canonicalUrl || bidderRequest.refererInfo?.topmostLocation || bidderRequest?.ortb2?.site?.page;
-
-  // Set appInfo
-  requestData.appInfo.id = bidderRequest?.ortb2?.site?.domain || bidderRequest.refererInfo?.page;
-
-  // Set userInfo
-  requestData.userInfo.ip = bidderRequest?.ortb2?.device?.ip || navigator.ip;
-  requestData.userInfo.ua = bidderRequest?.ortb2?.device?.ua || navigator.userAgent;
-
-  // Set userInfo.ppid
-  requestData.userInfo.ppid = (validBidRequests || []).reduce((ppids, validBidRequest) => {
-    const extractedPpids = [];
-    (validBidRequest.userIdAsEids || []).forEach((eid) => {
-      (eid?.uids || []).forEach(uid => {
-        if (uid?.ext?.stype === 'ppuid') {
-          const isExistingInExtracted = !!extractedPpids.find(id => id.source === eid.source);
-          const isExistingInPpids = !!ppids.find(id => id.source === eid.source);
-          if (!isExistingInExtracted && !isExistingInPpids) extractedPpids.push({source: eid.source, id: uid.id});
-        }
-      });
-    })
-    return [...ppids, ...extractedPpids];
-  }, []);
-
-  // Set userInfo.ifa
-  if (bidderRequest.ortb2?.device?.ifa) {
-    requestData.userInfo.ifa = bidderRequest.ortb2.device.ifa;
-  } else {
-    requestData.userInfo.ifa = validBidRequests.find(validBidRequest => {
-      return !!validBidRequest.ortb2?.device?.ifa;
-    });
-  }
-
-  // Set slots
-  requestData.slots = validBidRequests.map((validBidRequest) => {
-    const slot = {
-      id: validBidRequest.params?.slotId,
-      sizes: [
-        ...(validBidRequest.sizes || []),
-        ...(validBidRequest.mediaTypes?.[VIDEO]?.sizes ? validBidRequest.mediaTypes[VIDEO].sizes : [])
-      ],
-      targetings: {
-        ...validBidRequest?.params?.customTargeting,
-        ...convertToCustomSlotTargeting(validBidRequest)
-      }
-    };
-    return slot;
-  });
-
-  // Set targetings
-  requestData.targetings = convertToCustomTargeting(bidderRequest);
-
-  return requestData;
-}
-
-const getRendererForBid = (bidRequest, creative) => {
-  if (!bidRequest.renderer && creative.contextType === 'video_outstream') {
-    if (!creative.vastUrl && !creative.vastXml) return undefined;
-
+/* Custom extensions */
+const getRendererForBid = (bidRequest, bidResponse) => {
+  if (!bidRequest.renderer) {
+    const vastUrl = bidResponse.adm?.startsWith('http') ? bidResponse.adm : undefined;
+    const vastXml = (bidResponse.adm?.startsWith('<?xml') || bidResponse.adm?.startsWith('<VAST')) ? bidResponse.adm : undefined;
     const config = { documentResolver: (_, sourceDocument, renderDocument) => renderDocument ?? sourceDocument };
-    const renderer = Renderer.install({id: bidRequest.bidId, url: RENDERER_OPTIONS.OUTSTREAM_GP.URL, adUnitCode: bidRequest.adUnitCode, config});
+    const renderer = Renderer.install({
+      id: bidRequest.bidId,
+      url: RENDERER_OPTIONS.OUTSTREAM_GP.URL,
+      adUnitCode: bidRequest.adUnitCode,
+      config
+    });
 
     renderer.setRender((bid, doc) => {
       bid.renderer.push(() => {
         if (doc.defaultView?.GoldPlayer) {
           const options = {
-            vastUrl: creative.vastUrl,
-            vastXML: creative.vastXml,
+            vastUrl: vastUrl,
+            vastXML: vastXml,
             autoplay: false,
             muted: false,
             controls: true,
@@ -252,98 +83,32 @@ const getRendererForBid = (bidRequest, creative) => {
         }
       });
     });
-
     return renderer;
   }
   return undefined;
-}
+};
 
-const getNativeAssetsForBid = (bidRequest, creative) => {
-  if (creative.contextType === 'native' && creative.ad) {
-    const nativeAssets = JSON.parse(creative.ad);
-    const result = {
-      clickUrl: encodeURI(nativeAssets?.link?.url),
-      impressionTrackers: nativeAssets?.imptrackers,
-      clickTrackers: nativeAssets?.clicktrackers,
-      javascriptTrackers: nativeAssets?.jstracker && [nativeAssets.jstracker],
-    };
-    (nativeAssets?.assets || []).forEach(asset => {
-      switch (asset.id) {
-        case OPENRTB.NATIVE.ASSET_ID.TITLE:
-          result.title = asset.title?.text;
-          break;
-        case OPENRTB.NATIVE.ASSET_ID.IMAGE:
-          result.image = {
-            url: encodeURI(asset.img?.url),
-            width: asset.img?.w,
-            height: asset.img?.h
-          };
-          break;
-        case OPENRTB.NATIVE.ASSET_ID.ICON:
-          result.icon = {
-            url: encodeURI(asset.img.url),
-            width: asset.img?.w,
-            height: asset.img?.h
-          };
-          break;
-        case OPENRTB.NATIVE.ASSET_ID.BODY:
-          result.body = asset.data?.value;
-          break;
-        case OPENRTB.NATIVE.ASSET_ID.SPONSORED:
-          result.sponsoredBy = asset.data?.value;
-          break;
-        case OPENRTB.NATIVE.ASSET_ID.CTA:
-          result.cta = asset.data?.value;
-          break;
-      }
-    });
-    return result;
+/* Converter config, applying custom extensions */
+const converter = ortbConverter({
+  context: { netRevenue: true },
+  bidResponse(buildBidResponse, bid, context) {
+    const bidResponse = buildBidResponse(bid, context);
+    const {bidRequest} = context;
+    // Outstream video renderer
+    if (bidResponse.mediaType === VIDEO && bidRequest.mediaTypes.video.context === 'outstream') {
+      bidResponse.renderer = getRendererForBid(bidRequest, bidResponse);
+    }
+    return bidResponse;
   }
-  return undefined;
-}
-
-const convertProprietaryResponseToBidResponses = (serverResponse, bidRequest) => {
-  const bidRequests = bidRequest?.bidderRequest?.bids || [];
-  const creativeGroups = serverResponse?.body?.creatives || {};
-
-  return bidRequests.reduce((bidResponses, bidRequest) => {
-    const matchingCreativeGroup = (creativeGroups[bidRequest.params?.slotId] || []).filter((creative) => {
-      if (bidRequest.mediaTypes?.[BANNER] && creative.mediaType === BANNER) return true;
-      if (bidRequest.mediaTypes?.[VIDEO] && creative.mediaType === VIDEO) return true;
-      if (bidRequest.mediaTypes?.[NATIVE] && creative.mediaType === NATIVE) return true;
-      return false;
-    });
-    const matchingBidResponses = matchingCreativeGroup.map((creative) => {
-      return {
-        requestId: bidRequest.bidId,
-        cpm: creative.cpm,
-        currency: creative.currency,
-        width: creative.width,
-        height: creative.height,
-        creativeId: creative.creativeId,
-        dealId: creative.dealId,
-        netRevenue: creative.netRevenue,
-        ttl: creative.ttl,
-        ad: creative.ad,
-        vastUrl: creative.vastUrl,
-        vastXml: creative.vastXml,
-        mediaType: creative.mediaType,
-        meta: creative.meta,
-        native: getNativeAssetsForBid(bidRequest, creative),
-        renderer: getRendererForBid(bidRequest, creative),
-      };
-    });
-    return [...bidResponses, ...matchingBidResponses];
-  }, []);
-}
+});
 
 /* Logging */
 const sendLog = (data, percentage = 0.0001) => {
   if (Math.random() > percentage) return;
   const encodedData = `data=${window.btoa(JSON.stringify({...data, source: 'goldbach_pbjs', projectedAmount: (1 / percentage)}))}`;
-  ajax(LOGGING_URL, null, encodedData, {
+  ajax(URL_LOGGING, null, encodedData, {
     withCredentials: false,
-    method: 'POST',
+    method: METHOD,
     crossOrigin: true,
     contentType: 'application/x-www-form-urlencoded',
   });
@@ -356,11 +121,11 @@ export const spec = {
   isBidRequestValid: function (bid) {
     return typeof bid.params.publisherId === 'string' && Array.isArray(bid.sizes);
   },
-  buildRequests: function (validBidRequests, bidderRequest) {
+  buildRequests: function (pbjsBidRequests, bidderRequest) {
     const url = IS_LOCAL_MODE ? URL_LOCAL : URL;
-    const data = convertToProprietaryData(validBidRequests, bidderRequest);
+    const data = converter.toORTB({pbjsBidRequests, bidderRequest})
     return [{
-      method: 'POST',
+      method: METHOD,
       url: url,
       data: data,
       bidderRequest: bidderRequest,
@@ -370,8 +135,9 @@ export const spec = {
       }
     }];
   },
-  interpretResponse: function (serverResponse, request) {
-    return convertProprietaryResponseToBidResponses(serverResponse, request);
+  interpretResponse: function (ortbResponse, request) {
+    const bids = converter.fromORTB({response: ortbResponse.body, request: request.data}).bids;
+    return bids
   },
   onTimeout: function(timeoutData) {
     const payload = {

--- a/modules/goldbachBidAdapter.js
+++ b/modules/goldbachBidAdapter.js
@@ -96,6 +96,7 @@ const converter = ortbConverter({
   request(buildRequest, imps, bidderRequest, context) {
     const ortbRequest = buildRequest(imps, bidderRequest, context);
     const { bidRequests = [] } = context;
+    const firstBidRequest = bidRequests?.[0];
 
     // Apply custom extensions to each impression
     bidRequests.forEach((bidRequest, index) => {
@@ -108,13 +109,24 @@ const converter = ortbConverter({
 
     // Apply custom extensions to the request
     if (bidRequests.length > 0) {
-      const firstBidRequest = bidRequests?.[0];
       ortbRequest.ext = ortbRequest.ext || {};
       ortbRequest.ext[BIDDER_CODE] = ortbRequest.ext[BIDDER_CODE] || {};
       ortbRequest.ext[BIDDER_CODE].targetings = firstBidRequest?.params?.customTargeting || {};
       ortbRequest.ext[BIDDER_CODE].publisherId = firstBidRequest?.params?.publisherId;
       ortbRequest.ext[BIDDER_CODE].mockResponse = firstBidRequest?.params?.mockResponse || false;
     }
+
+    // Apply gdpr consent data
+    if (bidderRequest?.gdprConsent) {
+      console.log("consent", bidderRequest.gdprConsent);
+      ortbRequest.regs = ortbRequest.regs || {};
+      ortbRequest.regs.ext = ortbRequest.regs.ext || {};
+      ortbRequest.regs.ext.gdpr = bidderRequest.gdprConsent.gdprApplies ? 1 : 0;
+      ortbRequest.user = ortbRequest.user || {};
+      ortbRequest.user.ext = ortbRequest.user.ext || {};
+      ortbRequest.user.ext.consent = bidderRequest.gdprConsent.consentString;
+    }
+
     return ortbRequest;
   },
   bidResponse(buildBidResponse, bid, context) {

--- a/modules/goldbachBidAdapter.js
+++ b/modules/goldbachBidAdapter.js
@@ -118,7 +118,6 @@ const converter = ortbConverter({
 
     // Apply gdpr consent data
     if (bidderRequest?.gdprConsent) {
-      console.log("consent", bidderRequest.gdprConsent);
       ortbRequest.regs = ortbRequest.regs || {};
       ortbRequest.regs.ext = ortbRequest.regs.ext || {};
       ortbRequest.regs.ext.gdpr = bidderRequest.gdprConsent.gdprApplies ? 1 : 0;

--- a/test/spec/modules/goldbachBidAdapter_spec.js
+++ b/test/spec/modules/goldbachBidAdapter_spec.js
@@ -4,11 +4,12 @@ import { spec } from 'modules/goldbachBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
 import { auctionManager } from 'src/auctionManager.js';
 import { deepClone } from 'src/utils.js';
-import { VIDEO } from 'src/mediaTypes.js';
+import { BANNER, VIDEO } from 'src/mediaTypes.js';
 import * as ajaxLib from 'src/ajax.js';
 
 const BIDDER_NAME = 'goldbach'
-const ENDPOINT = 'https://goldlayer-api.prod.gbads.net/bid/pbjs';
+const ENDPOINT = 'https://goldlayer-api.prod.gbads.net/openrtb/2.5/auction';
+const ENDPOINT_COOKIESYNC = 'https://goldlayer-api.prod.gbads.net/cookiesync';
 
 /* Eids */
 let eids = [
@@ -44,7 +45,7 @@ let eids = [
   }
 ];
 
-const validNativeAd = {
+const validNativeObject = {
   link: {
     url: 'https://example.com/cta',
   },
@@ -78,19 +79,19 @@ const validNativeAd = {
     {
       id: 4,
       data: {
-        value: 'This is the description of the product. Its so good youll love it!',
+        value: 'This is the description of the product or service being advertised.',
       },
     },
     {
       id: 5,
       data: {
-        value: 'Sponsored by ExampleBrand',
+        value: 'Sponsored by some brand',
       },
     },
     {
       id: 6,
       data: {
-        value: 'Shop Now',
+        value: 'Buy Now',
       },
     },
   ],
@@ -98,6 +99,9 @@ const validNativeAd = {
 
 /* Ortb2 bid information */
 let ortb2 = {
+  source: {
+    tid: 'tid000'
+  },
   device: {
     ip: '133.713.371.337',
     connectiontype: 6,
@@ -105,9 +109,11 @@ let ortb2 = {
     h: 982,
     ifa: '23575619-ef35-4908-b468-ffc4000cdf07',
     ua: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36',
-    geo: {lat: 47.318054, lon: 8.582883, zip: '8700'}
+    geo: {lat: 47.318054, lon: 8.582883, zip: '8700'},
+    dnt: 0,
   },
   site: {
+    mobile: 0,
     domain: 'publisher-page.ch',
     page: 'https://publisher-page.ch/home',
     publisher: { domain: 'publisher-page.ch' },
@@ -117,7 +123,7 @@ let ortb2 = {
     ext: {
       eids: eids
     }
-  }
+  },
 };
 
 /* Minimal bidderRequest */
@@ -154,9 +160,7 @@ let validBidRequests = [
     params: {
       publisherId: 'de-publisher.ch-ios',
       slotId: '/46753895/publisher.ch/inside-full-content-pos1/pbjs-test',
-      customTargeting: {
-        language: 'de'
-      }
+      customTargeting: { language: 'de' }
     }
   },
   {
@@ -170,16 +174,14 @@ let validBidRequests = [
     ortb2: ortb2,
     mediaTypes: {
       video: {
-        sizes: [[640, 480]]
+        sizes: [[640, 480]],
+        context: 'outstream'
       }
     },
     sizes: [[640, 480]],
     params: {
       publisherId: 'de-publisher.ch-ios',
       slotId: '/46753895/publisher.ch/inside-full-content-pos1/pbjs-test/video',
-      video: {
-        maxduration: 30,
-      },
       customTargeting: {
         language: 'de'
       }
@@ -232,179 +234,71 @@ let validBidRequests = [
   }
 ];
 
-/* Creative request send to server */
-let validCreativeRequest = {
-  mock: false,
-  debug: false,
-  timestampStart: 1731680672811,
-  timestampEnd: 1731680675811,
-  config: {
-    publisher: {
-      id: 'de-20minuten.ch',
-    },
-  },
-  gdpr: {},
-  contextInfo: {
-    contentUrl: 'http://127.0.0.1:5500/sample-request.html',
-  },
-  appInfo: {
-    id: '127.0.0.1:5500',
-  },
-  userInfo: {
-    ua: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36',
-    ifa: '23575619-ef35-4908-b468-ffc4000cdf07',
-    ppid: [
-      {
-        source: 'oneid.live',
-        id: '0d862e87-14e9-47a4-9e9b-886b7d7a9d1b',
-      },
-      {
-        source: 'goldbach.com',
-        id: 'aa07ead5044f47bb28894ffa0346ed2c',
-      },
-    ],
-  },
-  slots: [
+/* OpenRTB response from auction endpoint */
+let validOrtbBidResponse = {
+  id: '3d52a1909b972a',
+  seatbid: [
     {
-      id: '/46753895/publisher.ch/inside-full-content-pos1/pbjs-test',
-      sizes: [
-        [300, 50],
-        [300, 250],
-        [300, 600],
-        [320, 50],
-        [320, 480],
-        [320, 64],
-        [320, 160],
-        [320, 416],
-        [336, 280],
-      ],
-      targetings: {
-        gpsenabled: 'false',
-        fr: 'false',
-        pagetype: 'story',
-        darkmode: 'false',
-        userloggedin: 'false',
-        iosbuild: '24110',
-        language: 'de',
-        storyId: '103211763',
-        connection: 'wifi',
-      },
-    },
-    {
-      id: '/46753895/publisher.ch/inside-full-content-pos1/pbjs-test/video',
-      sizes: [[640, 480]],
-      targetings: {
-        gpsenabled: 'false',
-        fr: 'false',
-        pagetype: 'story',
-        darkmode: 'false',
-        userloggedin: 'false',
-        iosbuild: '24110',
-        language: 'de',
-        storyId: '103211763',
-        connection: 'wifi',
-        duration: 'XL',
-      },
-    },
+      bid: [
+        {
+          id: '3d52a1909b972a',
+          impid: '3d52a1909b972a',
+          price: 0.5,
+          adm: '<div>creative</div>',
+          crid: 'creative-id',
+          w: 300,
+          h: 250,
+          ext: {
+            origbidcur: 'USD',
+            prebid: {
+              type: 'banner'
+            }
+          }
+        },
+        {
+          id: '3d52a1909b972b',
+          impid: '3d52a1909b972b',
+          price: 0.5,
+          adm: '<div>creative</div>',
+          crid: 'creative-id',
+          w: 640,
+          h: 480,
+          ext: {
+            origbidcur: 'USD',
+            prebid: {
+              type: 'video'
+            }
+          }
+        },
+        {
+          id: '3d52a1909b972c',
+          impid: '3d52a1909b972c',
+          price: 0.5,
+          adm: validNativeObject,
+          crid: 'creative-id',
+          ext: {
+            origbidcur: 'USD',
+            prebid: {
+              type: 'native'
+            }
+          }
+        }
+      ]
+    }
   ],
-  targetings: {
-    long: 8.582883,
-    lat: 47.318054,
-    connection: '4G',
-    zip: '8700',
-  },
-};
-
-/* Creative response received from server */
-let validCreativeResponse = {
-  creatives: {
-    '/46753895/publisher.ch/inside-full-content-pos1/pbjs-test': [
-      {
-        cpm: 32.2,
-        currency: 'USD',
-        width: 1,
-        height: 1,
-        creativeId: '1',
-        ttl: 3600,
-        mediaType: 'native',
-        netRevenue: true,
-        contextType: 'native',
-        ad: JSON.stringify(validNativeAd),
-        meta: {
-          advertiserDomains: ['example.com'],
-          mediaType: 'native'
-        }
-      },
-      {
-        cpm: 21.9,
-        currency: 'USD',
-        width: 300,
-        height: 50,
-        creativeId: '2',
-        ttl: 3600,
-        mediaType: 'banner',
-        netRevenue: true,
-        contextType: 'banner',
-        ad: 'banner-ad',
-        meta: {
-          advertiserDomains: ['example.com'],
-          mediaType: 'banner'
-        }
+  cur: 'USD',
+  ext: {
+    prebid: {
+      targeting: {
+        hb_bidder: 'appnexus',
+        hb_pb: '0.50',
+        hb_adid: '3d52a1909b972a',
+        hb_deal: 'deal-id',
+        hb_size: '300x250'
       }
-    ],
-    '/46753895/publisher.ch/inside-full-content-pos1/pbjs-test/video': [
-      {
-        cpm: 44.2,
-        currency: 'USD',
-        width: 1,
-        height: 1,
-        creativeId: '3',
-        ttl: 3600,
-        mediaType: 'video',
-        netRevenue: true,
-        contextType: 'video_preroll',
-        ad: 'video-ad',
-        meta: {
-          advertiserDomains: ['example.com'],
-          mediaType: 'video'
-        }
-      }
-    ],
-    '/46753895/publisher.ch/inside-full-content-pos1/pbjs-test/native': [
-      {
-        cpm: 10.2,
-        currency: 'USD',
-        width: 1,
-        height: 1,
-        creativeId: '4',
-        ttl: 3600,
-        mediaType: 'native',
-        netRevenue: true,
-        contextType: 'native',
-        ad: JSON.stringify(validNativeAd),
-        meta: {
-          advertiserDomains: ['example.com'],
-          mediaType: 'native'
-        }
-      }
-    ],
+    }
   }
 };
-
-/* composed request */
-let validRequest = {
-  url: ENDPOINT,
-  method: 'POST',
-  data: validCreativeRequest,
-  options: {
-    contentType: 'application/json',
-    withCredentials: false
-  },
-  bidderRequest: {
-    ...validBidderRequest,
-    bids: validBidRequests
-  }
-}
 
 describe('GoldbachBidAdapter', function () {
   const adapter = newBidder(spec);
@@ -431,6 +325,8 @@ describe('GoldbachBidAdapter', function () {
       bidder: BIDDER_NAME,
       params: {
         publisherId: 'de-publisher.ch-ios',
+        slotId: '/46753895/publisher.ch/inside-full-content-pos1/pbjs-test',
+        customTargeting: { language: 'de' }
       },
       adUnitCode: '/46753895/publisher.ch/inside-full-content-pos1/pbjs-test',
       sizes: [[300, 250], [300, 600]]
@@ -472,271 +368,76 @@ describe('GoldbachBidAdapter', function () {
       expect(requests[0].url).to.equal(ENDPOINT);
     })
 
-    it('should parse all bids to valid slots', function () {
+    it('should parse all bids to a valid openRRB request', function () {
       let bidRequests = deepClone(validBidRequests);
       let bidderRequest = deepClone(validBidderRequest);
-
       const requests = spec.buildRequests(bidRequests, bidderRequest);
       const payload = requests[0].data;
 
-      expect(payload.slots).to.exist;
-      expect(Array.isArray(payload.slots)).to.be.true;
-      expect(payload.slots.length).to.equal(3);
-      expect(payload.slots[0].id).to.equal(bidRequests[0].params.slotId);
-      expect(Array.isArray(payload.slots[0].sizes)).to.be.true;
-      expect(payload.slots[0].sizes.length).to.equal(bidRequests[0].sizes.length);
-      expect(payload.slots[1].id).to.equal(bidRequests[1].params.slotId);
-      expect(Array.isArray(payload.slots[1].sizes)).to.be.true;
+      expect(payload.imp).to.exist;
+      expect(Array.isArray(payload.imp)).to.be.true;
+      expect(payload.imp.length).to.equal(3);
+      expect(payload.imp[0].ext.goldbach.slotId).to.equal(bidRequests[0].params.slotId);
+      expect(Array.isArray(payload.imp[0][BANNER].format)).to.be.true;
+      expect(payload.imp[0][BANNER].format.length).to.equal(bidRequests[0].sizes.length);
+      expect(payload.imp[1].ext.goldbach.slotId).to.equal(bidRequests[1].params.slotId);
     });
 
-    it('should parse all video bids to valid video slots (use video sizes)', function () {
+    it('should parse all video bids to valid video imps (use video player size)', function () {
       let bidRequests = validBidRequests.map(request => Object.assign({}, []));
       let bidderRequest = deepClone(validBidderRequest);
-
       const requests = spec.buildRequests([{
         ...bidRequests[1],
-        sizes: [],
+        sizes: [[642, 482]],
         mediaTypes: {
           [VIDEO]: {
-            sizes: [[640, 480]]
+            sizes: [[641, 481]],
+            playerSize: [640, 480]
           }
         }
       }], bidderRequest);
       const payload = requests[0].data;
 
-      expect(payload.slots.length).to.equal(1);
-      expect(payload.slots[0].sizes.length).to.equal(1);
-      expect(payload.slots[0].sizes[0][0]).to.equal(640);
-      expect(payload.slots[0].sizes[0][1]).to.equal(480);
+      expect(payload.imp.length).to.equal(1);
+      expect(payload.imp[0][VIDEO].w).to.equal(640);
+      expect(payload.imp[0][VIDEO].h).to.equal(480);
     });
 
-    it('should set timestamps on request', function () {
+    it('should set custom config on request', function () {
       let bidRequests = deepClone(validBidRequests);
       let bidderRequest = deepClone(validBidderRequest);
-
       const requests = spec.buildRequests(bidRequests, bidderRequest);
       const payload = requests[0].data;
 
-      expect(payload.timestampStart).to.exist;
-      expect(payload.timestampStart).to.be.greaterThan(1)
-      expect(payload.timestampEnd).to.exist;
-      expect(payload.timestampEnd).to.be.greaterThan(1)
-    });
-
-    it('should set config on request', function () {
-      let bidRequests = deepClone(validBidRequests);
-      let bidderRequest = deepClone(validBidderRequest);
-
-      const requests = spec.buildRequests(bidRequests, bidderRequest);
-      const payload = requests[0].data;
-
-      expect(payload.config.publisher.id).to.equal(bidRequests[0].params.publisherId);
-    });
-
-    it('should set config on request', function () {
-      let bidRequests = deepClone(validBidRequests);
-      let bidderRequest = deepClone(validBidderRequest);
-
-      const requests = spec.buildRequests(bidRequests, bidderRequest);
-      const payload = requests[0].data;
-
-      expect(payload.config.publisher.id).to.equal(bidRequests[0].params.publisherId);
+      expect(payload.ext.goldbach.publisherId).to.equal(bidRequests[0].params.publisherId);
     });
 
     it('should set gdpr on request', function () {
       let bidRequests = deepClone(validBidRequests);
       let bidderRequest = deepClone(validBidderRequest);
-
       const requests = spec.buildRequests(bidRequests, bidderRequest);
       const payload = requests[0].data;
 
-      expect(payload.gdpr).to.exist;
-      expect(payload.gdpr.consent).to.equal(bidderRequest.gdprConsent.gdprApplies);
-      expect(payload.gdpr.consentString).to.equal(bidderRequest.gdprConsent.consentString);
+      expect(!!payload.regs.ext.gdpr).to.equal(bidderRequest.gdprConsent.gdprApplies);
+      expect(payload.user.ext.consent).to.equal(bidderRequest.gdprConsent.consentString);
     });
 
-    it('should set contextInfo on request', function () {
+    it('should set custom targeting on request', function () {
       let bidRequests = deepClone(validBidRequests);
       let bidderRequest = deepClone(validBidderRequest);
-
       const requests = spec.buildRequests(bidRequests, bidderRequest);
       const payload = requests[0].data;
 
-      expect(payload.contextInfo.contentUrl).to.exist;
-      expect(payload.contextInfo.contentUrl).to.equal(bidderRequest.ortb2.site.page);
-    });
-
-    it('should set appInfo on request', function () {
-      let bidRequests = deepClone(validBidRequests);
-      let bidderRequest = deepClone(validBidderRequest);
-
-      const requests = spec.buildRequests(bidRequests, bidderRequest);
-      const payload = requests[0].data;
-
-      expect(payload.appInfo.id).to.exist;
-      expect(payload.appInfo.id).to.equal(bidderRequest.ortb2.site.domain);
-    });
-
-    it('should set userInfo on request', function () {
-      let bidRequests = deepClone(validBidRequests);
-      let bidderRequest = deepClone(validBidderRequest);
-
-      const requests = spec.buildRequests(bidRequests, bidderRequest);
-      const payload = requests[0].data;
-
-      expect(payload.userInfo).to.exist;
-      expect(payload.userInfo.ua).to.equal(bidderRequest.ortb2.device.ua);
-      expect(payload.userInfo.ip).to.equal(bidderRequest.ortb2.device.ip);
-      expect(payload.userInfo.ifa).to.equal(bidderRequest.ortb2.device.ifa);
-      expect(Array.isArray(payload.userInfo.ppid)).to.be.true;
-      expect(payload.userInfo.ppid.length).to.equal(2);
-    });
-
-    it('should set mapped general targetings on request', function () {
-      let bidRequests = deepClone(validBidRequests);
-      let bidderRequest = deepClone(validBidderRequest);
-
-      const requests = spec.buildRequests(bidRequests, bidderRequest);
-      const payload = requests[0].data;
-
-      expect(payload.slots[0].targetings['duration']).to.not.exist;
-      expect(payload.slots[1].targetings['duration']).to.exist;
-      expect(payload.targetings['duration']).to.not.exist;
-      expect(payload.targetings['lat']).to.exist;
-      expect(payload.targetings['long']).to.exist;
-      expect(payload.targetings['zip']).to.exist;
-      expect(payload.targetings['connection']).to.exist;
-    });
-
-    it('should set mapped video duration targetings on request', function () {
-      let bidRequests = deepClone(validBidRequests);
-      let videoRequest = deepClone(validBidRequests[1]);
-      let bidderRequest = deepClone(validBidderRequest);
-
-      bidRequests.push({
-        ...videoRequest,
-        params: {
-          ...videoRequest.params,
-          video: {
-            maxduration: 10
-          }
-        }
-      })
-
-      bidRequests.push({
-        ...videoRequest,
-        params: {
-          ...videoRequest.params,
-          video: {
-            maxduration: 35
-          }
-        }
-      })
-
-      const requests = spec.buildRequests(bidRequests, bidderRequest);
-      const payload = requests[0].data;
-
-      expect(payload.slots[0].targetings['duration']).to.not.exist;
-      expect(payload.slots[1].targetings['duration']).to.exist;
-      expect(payload.slots[1].targetings['duration']).to.equal('XL');
-      expect(payload.slots[3].targetings['duration']).to.equal('M');
-      expect(payload.slots[4].targetings['duration']).to.equal('XXL');
-    });
-
-    it('should set mapped connection targetings on request', function () {
-      let bidRequests = deepClone(validBidRequests);
-      let bidderRequest = deepClone(validBidderRequest);
-
-      const bidderRequestEthernet = deepClone(bidderRequest);
-      bidderRequestEthernet.ortb2.device.connectiontype = 1;
-      const payloadEthernet = spec.buildRequests(bidRequests, bidderRequestEthernet)[0].data;
-
-      const bidderRequestWifi = deepClone(bidderRequest);
-      bidderRequestWifi.ortb2.device.connectiontype = 2;
-      const payloadWifi = spec.buildRequests(bidRequests, bidderRequestWifi)[0].data;
-
-      const bidderRequest2G = deepClone(bidderRequest);
-      bidderRequest2G.ortb2.device.connectiontype = 4;
-      const payload2G = spec.buildRequests(bidRequests, bidderRequest2G)[0].data;
-
-      const bidderRequest3G = deepClone(bidderRequest);
-      bidderRequest3G.ortb2.device.connectiontype = 5;
-      const payload3G = spec.buildRequests(bidRequests, bidderRequest3G)[0].data;
-
-      const bidderRequest4G = deepClone(bidderRequest);
-      bidderRequest4G.ortb2.device.connectiontype = 6;
-      const payload4G = spec.buildRequests(bidRequests, bidderRequest4G)[0].data;
-
-      const bidderRequestNoConnection = deepClone(bidderRequest);
-      bidderRequestNoConnection.ortb2.device.connectiontype = undefined;
-      const payloadNoConnection = spec.buildRequests(bidRequests, bidderRequestNoConnection)[0].data;
-
-      expect(payloadEthernet.targetings['connection']).to.equal('ethernet');
-      expect(payloadWifi.targetings['connection']).to.equal('wifi');
-      expect(payload2G.targetings['connection']).to.equal('2G');
-      expect(payload3G.targetings['connection']).to.equal('3G');
-      expect(payload4G.targetings['connection']).to.equal('4G');
-      expect(payloadNoConnection.targetings['connection']).to.equal(undefined);
-    });
-
-    it('should create a request with minimal information', function () {
-      let bidderRequest = Object.assign({}, validBidderRequest);
-      let bidRequests = validBidRequests.map(request => Object.assign({}, request));
-
-      // Removing usable bidderRequest values
-      bidderRequest.gdprConsent = undefined;
-      bidderRequest.ortb2.device.connectiontype = undefined;
-      bidderRequest.ortb2.device.geo = undefined;
-      bidderRequest.ortb2.device.ip = undefined;
-      bidderRequest.ortb2.device.ifa = undefined;
-      bidderRequest.ortb2.device.ua = undefined;
-
-      // Removing usable bidRequests values
-      bidRequests = bidRequests.map(request => {
-        request.ortb2.device.connectiontype = undefined;
-        request.ortb2.device.geo = undefined;
-        request.ortb2.device.ip = undefined;
-        request.ortb2.device.ifa = undefined;
-        request.ortb2.device.ua = undefined;
-        request.userIdAsEids = undefined;
-        request.params = {
-          publisherId: 'de-publisher.ch-ios'
-        };
-        return request;
-      });
-
-      const requests = spec.buildRequests(bidRequests, bidderRequest);
-      const payload = requests[0].data;
-
-      // bidderRequest mappings
-      expect(payload.gdpr).to.exist;
-      expect(payload.gdpr.consent).to.not.exist;
-      expect(payload.gdpr.consentString).to.not.exist;
-      expect(payload.userInfo).to.exist;
-      expect(payload.userInfo.ua).to.exist;
-      expect(payload.userInfo.ip).to.not.exist;
-      expect(payload.userInfo.ifa).to.not.exist;
-      expect(payload.userInfo.ppid.length).to.equal(0);
-      expect(payload.targetings).to.exist;
-      expect(payload.targetings['connection']).to.not.exist;
-      expect(payload.targetings['lat']).to.not.exist;
-      expect(payload.targetings['long']).to.not.exist;
-      expect(payload.targetings['zip']).to.not.exist;
-
-      // bidRequests mapping
-      expect(payload.slots).to.exist;
-      expect(payload.slots.length).to.equal(3);
-      expect(payload.slots[0].targetings).to.exist
-      expect(payload.slots[1].targetings).to.exist
+      expect(payload.imp[0].ext.goldbach.targetings).to.exist;
+      expect(payload.imp[0].ext.goldbach.targetings).to.deep.equal(bidRequests[0].params.customTargeting);
     });
   });
 
   describe('interpretResponse', function () {
     it('should map response to valid bids (amount)', function () {
-      let request = deepClone(validRequest);
-      let bidResponse = deepClone({body: validCreativeResponse});
-
-      const response = spec.interpretResponse(bidResponse, request);
+      let bidRequest = spec.buildRequests(validBidRequests, validBidderRequest)[0];
+      let bidResponse = deepClone({body: validOrtbBidResponse});
+      const response = spec.interpretResponse(bidResponse, bidRequest);
 
       expect(response).to.exist;
       expect(response.length).to.equal(3);
@@ -745,29 +446,71 @@ describe('GoldbachBidAdapter', function () {
     });
 
     it('should attach a custom video renderer ', function () {
-      let request = deepClone(validRequest);
-      let bidResponse = deepClone({body: validCreativeResponse});
-      bidResponse.body.creatives[validBidRequests[1].params.slotId][0].mediaType = 'video';
-      bidResponse.body.creatives[validBidRequests[1].params.slotId][0].vastXml = '<VAST></VAST>';
-      bidResponse.body.creatives[validBidRequests[1].params.slotId][0].contextType = 'video_outstream';
-
-      const response = spec.interpretResponse(bidResponse, request);
+      let bidRequest = spec.buildRequests(validBidRequests, validBidderRequest)[0];
+      let bidResponse = deepClone({body: validOrtbBidResponse});
+      bidResponse.body.seatbid[0].bid[1].adm = '<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><VAST version=\"4.0\"></VAST>';
+      bidResponse.body.seatbid[0].bid[1].ext = { prebid: { type: 'video', meta: { type: 'video_outstream' } } };
+      const response = spec.interpretResponse(bidResponse, bidRequest);
 
       expect(response).to.exist;
       expect(response.filter(bid => !!bid.renderer).length).to.equal(1);
     });
 
     it('should not attach a custom video renderer when VAST url/xml is missing', function () {
-      let request = deepClone(validRequest);
-      let bidResponse = deepClone({body: validCreativeResponse});
-      bidResponse.body.creatives[validBidRequests[1].params.slotId][0].mediaType = 'video';
-      bidResponse.body.creatives[validBidRequests[1].params.slotId][0].contextType = 'video_outstream';
-
-      const response = spec.interpretResponse(bidResponse, request);
+      let bidRequest = spec.buildRequests(validBidRequests, validBidderRequest)[0];
+      let bidResponse = deepClone({body: validOrtbBidResponse});
+      bidResponse.body.seatbid[0].bid[1].adm = undefined;
+      bidResponse.body.seatbid[0].bid[1].ext = { prebid: { type: 'video', meta: { type: 'video_outstream' } } };
+      const response = spec.interpretResponse(bidResponse, bidRequest);
 
       expect(response).to.exist;
       expect(response.filter(bid => !!bid.renderer).length).to.equal(0);
     });
+
+    it('should set the player accordingly to config', function () {
+      let bidRequest = spec.buildRequests(validBidRequests, validBidderRequest)[0];
+      let bidResponse = deepClone({body: validOrtbBidResponse});
+      bidResponse.body.seatbid[0].bid[1].adm = '<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><VAST version=\"4.0\"></VAST>';
+      bidResponse.body.seatbid[0].bid[1].ext = { prebid: { type: 'video', meta: { type: 'video_outstream' } } };
+      validBidRequests[1].mediaTypes.video.playbackmethod = 1;
+      const response = spec.interpretResponse(bidResponse, bidRequest);
+      const renderer = response.find(bid => !!bid.renderer);
+      renderer?.renderer?.render();
+
+      expect(response).to.exist;
+      expect(response.filter(bid => !!bid.renderer).length).to.equal(1);
+      expect(renderer.renderer.config.documentResolver).to.exist;
+    });
+  });
+
+  describe('getUserSyncs', function () {
+    it('user-syncs with enabled pixel option', function () {
+      let gdprConsent = {
+        vendorData: {
+          purpose: {
+            consents: 1
+          }
+        }};
+      let synOptions = {pixelEnabled: true, iframeEnabled: true};
+      const userSyncs = spec.getUserSyncs(synOptions, {}, gdprConsent, {});
+
+      expect(userSyncs[0].type).to.equal('image');
+      expect(userSyncs[0].url).to.equal(`https://ib.adnxs.com/getuid?${ENDPOINT_COOKIESYNC}?xandrId=$UID`);
+    })
+
+    it('user-syncs with enabled iframe option', function () {
+      let gdprConsent = {
+        vendorData: {
+          purpose: {
+            consents: 1
+          }
+        }};
+      let synOptions = {iframeEnabled: true};
+      const userSyncs = spec.getUserSyncs(synOptions, {}, gdprConsent, {});
+
+      expect(userSyncs[0].type).to.equal('iframe');
+      expect(userSyncs[0].url).to.equal(`https://ib.adnxs.com/getuid?${ENDPOINT_COOKIESYNC}?xandrId=$UID`);
+    })
   });
 
   describe('sendLogs', function () {


### PR DESCRIPTION
Updated Goldbach Bidder Adapter
- connecting to ortb endpoint
- using uid when enabled by publisher (storage)

## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter
- [x] Updated bidder adapter 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## Description of change
This change connects a new, updated endpoint to the Goldbach Adapter. All requests now use the ortb standard, utilizing prebid.js standard converting functions and further utils. Also a uid is stored and forwarded, if storage is enabled for this particular bidder.