### PR TITLE
UserID: improve handling of IDs coming from multiple alternate sources but having conflicting bidder restrictions

### DIFF
--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -82,8 +82,8 @@ export function createEidsArray(bidRequestUserId, eidConfigs = EID_CONFIG) {
 export function getEids(priorityMap) {
   const eidConfigs = new Map();
   const idValues = {};
-  Object.entries(priorityMap).forEach(([key, submodules]) => {
-    const submodule = submodules.find(mod => mod.idObj?.[key] != null);
+  Object.entries(priorityMap).forEach(([key, getActiveModule]) => {
+    const submodule = getActiveModule();
     if (submodule) {
       idValues[key] = submodule.idObj[key];
       let eidConf = submodule.submodule.eids?.[key];


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Since https://github.com/prebid/Prebid.js/pull/12110 user IDs are treated as first party data. There are some configurations whose desired output is not expressible as first party data; namely if an id can be provided by multiple modules, but the preferred (highest `idPriority`) module is restricted to only some bidders, it's not possible to use a lower priority module for the other bidders as FPD cannot be specified for "all bidders except these".

To address this we exclude IDs that have conflicting bidder filters, which is unnecessarily aggressive - this updates the logic to only exclude in the scenario above, and only for "every bidder except these". 

## Other information

Closes https://github.com/prebid/Prebid.js/issues/12844
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
