### PR TITLE
OpenX Bid Adapter: mtype cleanup

### DIFF
--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -174,9 +174,9 @@ function isBidRequestValid(bidRequest) {
   return !!(bidRequest.params.unit && hasDelDomainOrPlatform);
 }
 
-function buildRequests(bids, bidderRequest) {
-  let videoBids = bids.filter(bid => isVideoBid(bid));
-  let bannerAndNativeBids = bids.filter(bid => isBannerBid(bid) || isNativeBid(bid))
+function buildRequests(bidRequests, bidderRequest) {
+  let videoBids = bidRequests.filter(bidRequest => isVideoBidRequest(bidRequest));
+  let bannerAndNativeBids = bidRequests.filter(bidRequest => isBannerBidRequest(bidRequest) || isNativeBidRequest(bidRequest))
     // In case of multi-format bids remove `video` from mediaTypes as for video a separate bid request is built
     .map(bid => ({...bid, mediaTypes: {...bid.mediaTypes, video: undefined}}));
 
@@ -195,17 +195,17 @@ function createRequest(bidRequests, bidderRequest, mediaType) {
   }
 }
 
-function isVideoBid(bid) {
-  return utils.deepAccess(bid, 'mediaTypes.video');
+function isVideoBidRequest(bidRequest) {
+  return utils.deepAccess(bidRequest, 'mediaTypes.video');
 }
 
-function isNativeBid(bid) {
-  return utils.deepAccess(bid, 'mediaTypes.native');
+function isNativeBidRequest(bidRequest) {
+  return utils.deepAccess(bidRequest, 'mediaTypes.native');
 }
 
-function isBannerBid(bid) {
-  const isNotVideoOrNativeBid = !isVideoBid(bid) && !isNativeBid(bid)
-  return utils.deepAccess(bid, 'mediaTypes.banner') || isNotVideoOrNativeBid;
+function isBannerBidRequest(bidRequest) {
+  const isNotVideoOrNativeBid = !isVideoBidRequest(bidRequest) && !isNativeBidRequest(bidRequest)
+  return utils.deepAccess(bidRequest, 'mediaTypes.banner') || isNotVideoOrNativeBid;
 }
 
 function interpretResponse(resp, req) {

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -4,7 +4,6 @@ import * as utils from '../src/utils.js';
 import {mergeDeep} from '../src/utils.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
 import {ortbConverter} from '../libraries/ortbConverter/converter.js';
-import {ORTB_MTYPES} from '../libraries/ortbConverter/processors/mediaType.js';
 
 const bidderConfig = 'hb_pb_ortb';
 const bidderVersion = '2.0';
@@ -80,18 +79,6 @@ const converter = ortbConverter({
     return req;
   },
   bidResponse(buildBidResponse, bid, context) {
-    if (!context.mediaType && !bid.mtype) {
-      let mediaType = BANNER; // default media type
-      const vastKeywords = ['VAST ', 'vast ', 'videoad', 'VAST_VERSION', 'dc_vast', 'video '];
-      if (bid.adm && bid.adm.startsWith('{') && bid.adm.includes('"assets"')) {
-        mediaType = NATIVE;
-      } else if (bid.vastXml || bid.vastUrl || (bid.adm && vastKeywords.some(v => bid.adm.includes(v)))) {
-        mediaType = VIDEO;
-      }
-      bid.mediaType = mediaType;
-      bid.mtype = Object.keys(ORTB_MTYPES).find(key => ORTB_MTYPES[key] === mediaType);
-    }
-
     const bidResponse = buildBidResponse(bid, context);
     if (bid.ext) {
       bidResponse.meta.networkId = bid.ext.dsp_id;

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -175,13 +175,13 @@ function isBidRequestValid(bidRequest) {
 }
 
 function buildRequests(bidRequests, bidderRequest) {
-  let videoBids = bidRequests.filter(bidRequest => isVideoBidRequest(bidRequest));
-  let bannerAndNativeBids = bidRequests.filter(bidRequest => isBannerBidRequest(bidRequest) || isNativeBidRequest(bidRequest))
+  let videoRequests = bidRequests.filter(bidRequest => isVideoBidRequest(bidRequest));
+  let bannerAndNativeRequests = bidRequests.filter(bidRequest => isBannerBidRequest(bidRequest) || isNativeBidRequest(bidRequest))
     // In case of multi-format bids remove `video` from mediaTypes as for video a separate bid request is built
     .map(bid => ({...bid, mediaTypes: {...bid.mediaTypes, video: undefined}}));
 
-  let requests = bannerAndNativeBids.length ? [createRequest(bannerAndNativeBids, bidderRequest, null)] : [];
-  videoBids.forEach(bid => {
+  let requests = bannerAndNativeRequests.length ? [createRequest(bannerAndNativeRequests, bidderRequest, null)] : [];
+  videoRequests.forEach(bid => {
     requests.push(createRequest([bid], bidderRequest, VIDEO));
   });
   return requests;

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1497,7 +1497,6 @@ describe('OpenxRtbAdapter', function () {
       });
 
       it('should return the proper mediaType', function () {
-        expect(bid).not.to.equal(undefined);
         expect(bid.mediaType).to.equal(Object.keys(bidRequestConfigs[0].mediaTypes)[0]);
       });
     });

--- a/test/spec/modules/openxBidAdapter_spec.js
+++ b/test/spec/modules/openxBidAdapter_spec.js
@@ -1381,6 +1381,7 @@ describe('OpenxRtbAdapter', function () {
           crid: 'test-creative-id',
           dealid: 'test-deal-id',
           adm: 'test-ad-markup',
+          mtype: 1,
           adomain: ['brand.com'],
           ext: {
             dsp_id: '123',
@@ -1485,7 +1486,8 @@ describe('OpenxRtbAdapter', function () {
               h: 250,
               crid: 'test-creative-id',
               dealid: 'test-deal-id',
-              adm: 'test-ad-markup'
+              adm: 'test-ad-markup',
+              mtype: 1,
             }]
           }],
           cur: 'AUS'
@@ -1495,6 +1497,7 @@ describe('OpenxRtbAdapter', function () {
       });
 
       it('should return the proper mediaType', function () {
+        expect(bid).not.to.equal(undefined);
         expect(bid.mediaType).to.equal(Object.keys(bidRequestConfigs[0].mediaTypes)[0]);
       });
     });
@@ -1581,6 +1584,7 @@ describe('OpenxRtbAdapter', function () {
                 impid: 'test-bid-id',
                 price: 5,
                 adm: '<VAST version="4.0"><Ad></Ad></VAST>',
+                mtype: 2
               }]
             }],
             cur: 'USD'
@@ -1636,6 +1640,7 @@ describe('OpenxRtbAdapter', function () {
                 impid: 'test-bid-id-2',
                 price: 2,
                 adm: '<iframe src="https://test.url"></iframe>',
+                mtype: 1
               }]
             }],
             cur: 'USD'
@@ -1688,6 +1693,7 @@ describe('OpenxRtbAdapter', function () {
                 impid: 'test-bid-id',
                 price: 2,
                 adm: '{"ver": "1.2", "assets": [{"id": 1, "required": 1,"title": {"text": "OpenX (Title)"}}], "link": {"url": "https://www.openx.com/"}, "eventtrackers":[{"event":1,"method":1,"url":"http://example.com/impression"}]}',
+                mtype: 4
               }]
             }],
             cur: 'AUS'
@@ -1760,6 +1766,7 @@ describe('OpenxRtbAdapter', function () {
                 impid: 'test-bid-id',
                 price: 2,
                 adm: '<iframe src="https://test.url"></iframe>',
+                mtype: 1
               }]
             }],
             cur: 'AUS'
@@ -1826,6 +1833,7 @@ describe('OpenxRtbAdapter', function () {
                 impid: 'test-bid-id-1',
                 price: 2,
                 adm: '{"ver": "1.2", "assets": [{"id": 1, "required": 1,"title": {"text": "OpenX (Title)"}}], "link": {"url": "https://www.openx.com/"}, "eventtrackers":[{"event":1,"method":1,"url":"http://example.com/impression"}]}',
+                mtype: 4
               }]
             }],
             cur: 'USD'


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
OpenX Exchange started to return `mtype` field, which now can be used to resolve `bid.mediaType` out of the box. Therefore, the `mtype` guessing by adm is now redundant, so can be removed to avoid confusion.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
