### PR TITLE
LiveIntent User ID Module And Analytics Adapter: Built-in Treatment/Holdout Mechanism And Auction Events Collection Improvements

### DIFF
--- a/libraries/liveIntentId/externalIdSystem.js
+++ b/libraries/liveIntentId/externalIdSystem.js
@@ -1,7 +1,7 @@
 import { logError } from '../../src/utils.js';
 import { gdprDataHandler, uspDataHandler, gppDataHandler } from '../../src/adapterManager.js';
 import { submodule } from '../../src/hook.js';
-import { DEFAULT_AJAX_TIMEOUT, MODULE_NAME, parseRequestedAttributes, composeIdObject, eids, GVLID, PRIMARY_IDS, makeSourceEventToSend } from './shared.js'
+import { DEFAULT_AJAX_TIMEOUT, MODULE_NAME, parseRequestedAttributes, composeResult, eids, GVLID, PRIMARY_IDS, makeSourceEventToSend, setUpTreatment } from './shared.js'
 
 // Reference to the client for the liQHub.
 let cachedClientRef
@@ -149,11 +149,12 @@ export const liveIntentExternalIdSubmodule = {
    */
   decode(value, config) {
     const configParams = config?.params ?? {};
+    setUpTreatment(configParams);
 
     // Ensure client is initialized and we fired at least one collect request.
     initializeClient(configParams)
 
-    return composeIdObject(value);
+    return composeResult(value, configParams)
   },
 
   /**
@@ -162,6 +163,7 @@ export const liveIntentExternalIdSubmodule = {
    */
   getId(config) {
     const configParams = config?.params ?? {};
+    setUpTreatment(configParams);
 
     const clientRef = initializeClient(configParams)
 

--- a/libraries/liveIntentId/idSystem.js
+++ b/libraries/liveIntentId/idSystem.js
@@ -11,7 +11,7 @@ import { submodule } from '../../src/hook.js';
 import { LiveConnect } from 'live-connect-js'; // eslint-disable-line prebid/validate-imports
 import { getStorageManager } from '../../src/storageManager.js';
 import { MODULE_TYPE_UID } from '../../src/activities/modules.js';
-import { DEFAULT_AJAX_TIMEOUT, MODULE_NAME, composeIdObject, eids, GVLID, DEFAULT_DELAY, PRIMARY_IDS, parseRequestedAttributes, makeSourceEventToSend } from './shared.js'
+import { DEFAULT_AJAX_TIMEOUT, MODULE_NAME, composeResult, eids, GVLID, DEFAULT_DELAY, PRIMARY_IDS, parseRequestedAttributes, makeSourceEventToSend, setUpTreatment } from './shared.js'
 
 /**
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
@@ -191,13 +191,14 @@ export const liveIntentIdSubmodule = {
    */
   decode(value, config) {
     const configParams = (config && config.params) || {};
+    setUpTreatment(configParams);
 
     if (!liveConnect) {
       initializeLiveConnect(configParams);
     }
     tryFireEvent();
 
-    return composeIdObject(value);
+    return composeResult(value, configParams);
   },
 
   /**
@@ -208,6 +209,8 @@ export const liveIntentIdSubmodule = {
    */
   getId(config) {
     const configParams = (config && config.params) || {};
+    setUpTreatment(configParams);
+
     const liveConnect = initializeLiveConnect(configParams);
     if (!liveConnect) {
       return;

--- a/libraries/liveIntentId/shared.js
+++ b/libraries/liveIntentId/shared.js
@@ -2,6 +2,7 @@ import {UID1_EIDS} from '../uid1Eids/uid1Eids.js';
 import {UID2_EIDS} from '../uid2Eids/uid2Eids.js';
 import { getRefererInfo } from '../../src/refererDetection.js';
 import { coppaDataHandler } from '../../src/adapterManager.js';
+import { isNumber } from '../../src/utils.js'
 
 export const PRIMARY_IDS = ['libp'];
 export const GVLID = 148;
@@ -10,6 +11,7 @@ export const DEFAULT_DELAY = 500;
 export const MODULE_NAME = 'liveIntentId';
 export const LI_PROVIDER_DOMAIN = 'liveintent.com';
 export const DEFAULT_REQUESTED_ATTRIBUTES = { 'nonId': true };
+export const DEFAULT_TREATMENT_RATE = 0.95;
 
 export function parseRequestedAttributes(overrides) {
   function renameAttribute(attribute) {
@@ -54,7 +56,19 @@ export function makeSourceEventToSend(configParams) {
   }
 }
 
-export function composeIdObject(value) {
+export function composeResult(value, config) {
+  if (config.activatePartialTreatment) {
+    if (window.liModuleEnabled) {
+      return composeIdObject(value);
+    } else {
+      return {};
+    }
+  } else {
+    return composeIdObject(value);
+  }
+}
+
+function composeIdObject(value) {
   const result = {};
 
   // old versions stored lipbid in unifiedId. Ensure that we can still read the data.
@@ -128,6 +142,16 @@ export function composeIdObject(value) {
   }
 
   return result
+}
+
+export function setUpTreatment(config) {
+  // If the treatment decision has not been made yet
+  // and Prebid is configured to make this decision.
+  if (window.liModuleEnabled === undefined && config.activatePartialTreatment) {
+    const treatmentRate = isNumber(window.liTreatmentRate) ? window.liTreatmentRate : DEFAULT_TREATMENT_RATE;
+    window.liModuleEnabled = Math.random() < treatmentRate;
+    window.liTreatmentRate = treatmentRate;
+  };
 }
 
 export const eids = {

--- a/modules/liveIntentAnalyticsAdapter.js
+++ b/modules/liveIntentAnalyticsAdapter.js
@@ -1,134 +1,121 @@
-import {ajax} from '../src/ajax.js';
-import { generateUUID, logInfo, logWarn } from '../src/utils.js';
+import { ajax } from '../src/ajax.js';
+import { generateUUID, isNumber } from '../src/utils.js';
 import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
 import { EVENTS } from '../src/constants.js';
 import adapterManager from '../src/adapterManager.js';
-import { auctionManager } from '../src/auctionManager.js';
 import { getRefererInfo } from '../src/refererDetection.js';
+import { config as prebidConfig } from '../src/config.js';
+import { auctionManager } from '../src/auctionManager.js';
 
 const ANALYTICS_TYPE = 'endpoint';
 const URL = 'https://wba.liadm.com/analytic-events';
 const GVL_ID = 148;
 const ADAPTER_CODE = 'liveintent';
-const DEFAULT_BID_WON_TIMEOUT = 2000;
-const { AUCTION_END } = EVENTS;
-let bidWonTimeout;
+const { AUCTION_INIT, BID_WON } = EVENTS;
+const INTEGRATION_ID = '$$PREBID_GLOBAL$$';
 
-function handleAuctionEnd(args) {
-  setTimeout(() => {
-    const auction = auctionManager.index.getAuction({auctionId: args.auctionId});
-    const winningBids = (auction) ? auction.getWinningBids() : [];
-    const data = createAnalyticsEvent(args, winningBids);
-    sendAnalyticsEvent(data);
-  }, bidWonTimeout);
-}
-
-function getAnalyticsEventBids(bidsReceived) {
-  return bidsReceived.map(bid => {
-    return {
-      adUnitCode: bid.adUnitCode,
-      timeToRespond: bid.timeToRespond,
-      cpm: bid.cpm,
-      currency: bid.currency,
-      ttl: bid.ttl,
-      bidder: bid.bidder
-    };
-  });
-}
-
-function getBannerSizes(banner) {
-  if (banner && banner.sizes) {
-    return banner.sizes.map(size => {
-      const [width, height] = size;
-      return {w: width, h: height};
-    });
-  } else return [];
-}
-
-function getUniqueBy(arr, key) {
-  return [...new Map(arr.map(item => [item[key], item])).values()]
-}
-
-function createAnalyticsEvent(args, winningBids) {
-  let payload = {
-    instanceId: generateUUID(),
-    url: getRefererInfo().page,
-    bidsReceived: getAnalyticsEventBids(args.bidsReceived),
-    auctionStart: args.timestamp,
-    auctionEnd: args.auctionEnd,
-    adUnits: [],
-    userIds: [],
-    bidders: []
-  }
-  let allUserIds = [];
-
-  if (args.adUnits) {
-    args.adUnits.forEach(unit => {
-      if (unit.mediaTypes && unit.mediaTypes.banner) {
-        payload['adUnits'].push({
-          code: unit.code,
-          mediaType: 'banner',
-          sizes: getBannerSizes(unit.mediaTypes.banner),
-          ortb2Imp: unit.ortb2Imp
-        });
-      }
-      if (unit.bids) {
-        let userIds = unit.bids.flatMap(getAnalyticsEventUserIds);
-        allUserIds.push(...userIds);
-        let bidders = unit.bids.map(({bidder, params}) => {
-          return { bidder, params }
-        });
-
-        payload['bidders'].push(...bidders);
-      }
-    })
-    let uniqueUserIds = getUniqueBy(allUserIds, 'source');
-    payload['userIds'] = uniqueUserIds;
-  }
-  payload['winningBids'] = getAnalyticsEventBids(winningBids);
-  payload['auctionId'] = args.auctionId;
-  return payload;
-}
-
-function getAnalyticsEventUserIds(bid) {
-  if (bid && bid.userIdAsEids) {
-    return bid.userIdAsEids.map(({source, uids, ext}) => {
-      let analyticsEventUserId = {source, uids, ext};
-      return ignoreUndefined(analyticsEventUserId)
-    });
-  } else { return []; }
-}
-
-function sendAnalyticsEvent(data) {
-  ajax(URL, {
-    success: function () {
-      logInfo('LiveIntent Prebid Analytics: send data success');
-    },
-    error: function (e) {
-      logWarn('LiveIntent Prebid Analytics: send data error' + e);
-    }
-  }, JSON.stringify(data), {
-    contentType: 'application/json',
-    method: 'POST'
-  })
-}
-
-function ignoreUndefined(data) {
-  const filteredData = Object.entries(data).filter(([key, value]) => value)
-  return Object.fromEntries(filteredData)
-}
+let partnerIdFromUserIdConfig;
+let sendAuctionInitEvents;
 
 let liAnalytics = Object.assign(adapter({URL, ANALYTICS_TYPE}), {
   track({ eventType, args }) {
-    if (eventType == AUCTION_END && args) { handleAuctionEnd(args); }
+    switch (eventType) {
+      case AUCTION_INIT:
+        if (sendAuctionInitEvents) {
+          handleAuctionInitEvent(args);
+        }
+        break;
+      case BID_WON:
+        handleBidWonEvent(args);
+        break;
+    }
   }
 });
+
+function handleAuctionInitEvent(auctionInitEvent) {
+  const liveIntentIdsPresent = checkLiveIntentIdsPresent(auctionInitEvent.bidderRequests)
+
+  // This is for old integration that enable or disable the user id module
+  // dependeing on the result of rolling the dice outside of Prebid.
+  const partnerIdFromAnalyticsLabels = auctionInitEvent.analyticsLabels?.partnerId;
+
+  const data = {
+    id: generateUUID(),
+    aid: auctionInitEvent.auctionId,
+    u: getRefererInfo().page,
+    ats: auctionInitEvent.timestamp,
+    pid: partnerIdFromUserIdConfig || partnerIdFromAnalyticsLabels,
+    iid: INTEGRATION_ID,
+    tr: window.liTreatmentRate,
+    me: encodeBoolean(window.liModuleEnabled),
+    liip: encodeBoolean(liveIntentIdsPresent),
+    aun: auctionInitEvent?.adUnits?.length || 0
+  };
+  const filteredData = ignoreUndefined(data);
+  sendData('auction-init', filteredData);
+}
+
+function handleBidWonEvent(bidWonEvent) {
+  const auction = auctionManager.index.getAuction({auctionId: bidWonEvent.auctionId});
+  const liveIntentIdsPresent = checkLiveIntentIdsPresent(auction?.getBidRequests())
+
+  // This is for old integration that enable or disable the user id module
+  // depending on the result of rolling the dice outside of Prebid.
+  const partnerIdFromAnalyticsLabels = bidWonEvent.analyticsLabels?.partnerId;
+
+  const data = {
+    id: generateUUID(),
+    aid: bidWonEvent.auctionId,
+    u: getRefererInfo().page,
+    ats: auction?.getAuctionStart(),
+    auc: bidWonEvent.adUnitCode,
+    auid: bidWonEvent.adUnitId,
+    cpm: bidWonEvent.cpm,
+    c: bidWonEvent.currency,
+    b: bidWonEvent.bidder,
+    bc: bidWonEvent.bidderCode,
+    pid: partnerIdFromUserIdConfig || partnerIdFromAnalyticsLabels,
+    iid: INTEGRATION_ID,
+    sts: bidWonEvent.requestTimestamp,
+    rts: bidWonEvent.responseTimestamp,
+    tr: window.liTreatmentRate,
+    me: encodeBoolean(window.liModuleEnabled),
+    liip: encodeBoolean(liveIntentIdsPresent)
+  };
+
+  const filteredData = ignoreUndefined(data);
+  sendData('bid-won', filteredData);
+}
+
+function encodeBoolean(value) {
+  return value === undefined ? undefined : value ? 'y' : 'n'
+}
+
+function checkLiveIntentIdsPresent(bidRequests) {
+  const eids = bidRequests?.flatMap(r => r?.bids).flatMap(b => b?.userIdAsEids);
+  return !!eids.find(eid => eid?.source === 'liveintent.com') || !!eids.flatMap(e => e?.uids).find(u => u?.ext?.provider === 'liveintent.com')
+}
+
+function sendData(path, data) {
+  const fields = Object.entries(data);
+  if (fields.length > 0) {
+    const params = fields.map(([key, value]) => key + '=' + encodeURIComponent(value)).join('&');
+    ajax(URL + '/' + path + '?' + params, undefined, null, { method: 'GET' });
+  }
+}
+
+function ignoreUndefined(data) {
+  const filteredData = Object.entries(data).filter(([key, value]) => isNumber(value) || value);
+  return Object.fromEntries(filteredData);
+}
 
 // save the base class function
 liAnalytics.originEnableAnalytics = liAnalytics.enableAnalytics;
 // override enableAnalytics so we can get access to the config passed in from the page
 liAnalytics.enableAnalytics = function (config) {
-  bidWonTimeout = config?.options?.bidWonTimeout ?? DEFAULT_BID_WON_TIMEOUT;
+  const userIdModuleConfig = prebidConfig.getConfig('userSync.userIds').filter(m => m.name == 'liveIntentId')?.at(0)?.params
+  partnerIdFromUserIdConfig = userIdModuleConfig?.liCollectConfig?.appId || userIdModuleConfig?.distributorId;
+  sendAuctionInitEvents = config?.options.sendAuctionInitEvents;
   liAnalytics.originEnableAnalytics(config); // call the base class function
 };
 

--- a/test/fixtures/liveIntentAuctionEvents.js
+++ b/test/fixtures/liveIntentAuctionEvents.js
@@ -1,0 +1,2347 @@
+export const AUCTION_INIT_EVENT = {
+  'auctionId': '87b4a93d-19ae-432a-96f0-8c2d4cc1c539',
+  'timestamp': 1739969798557,
+  'auctionStatus': 'inProgress',
+  'adUnits': [
+    {
+      'code': 'test-div',
+      'mediaTypes': {
+        'banner': {
+          'sizes': [
+            [
+              300,
+              250
+            ]
+          ]
+        }
+      },
+      'bids': [
+        {
+          'bidder': 'appnexus',
+          'params': {
+            'placementId': 13144370
+          },
+          'userId': {
+            'lipb': {
+              'nonId': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+              'sovrn': 'testSovrn',
+              'medianet': 'testMadianet',
+              'bidswitch': 'testBidswitch',
+              'magnite': 'testMagnite',
+              'lipbid': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg=='
+            },
+            'bidswitch': {
+              'id': 'testBidswitch',
+              'ext': {
+                'provider': 'liveintent.com'
+              }
+            },
+            'medianet': {
+              'id': 'testMadianet',
+              'ext': {
+                'provider': 'liveintent.com'
+              }
+            },
+            'magnite': {
+              'id': 'testMagnite',
+              'ext': {
+                'provider': 'liveintent.com'
+              }
+            },
+            'sovrn': {
+              'id': 'testSovrn',
+              'ext': {
+                'provider': 'liveintent.com'
+              }
+            }
+          },
+          'userIdAsEids': [
+            {
+              'source': 'liveintent.com',
+              'uids': [
+                {
+                  'id': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+                  'atype': 3
+                }
+              ]
+            },
+            {
+              'source': 'bidswitch.net',
+              'uids': [
+                {
+                  'id': 'testBidswitch',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'liveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'media.net',
+              'uids': [
+                {
+                  'id': 'testMadianet',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'liveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'rubiconproject.com',
+              'uids': [
+                {
+                  'id': 'testMagnite',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'liveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'liveintent.sovrn.com',
+              'uids': [
+                {
+                  'id': 'testSovrn',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'liveintent.com'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      'sizes': [
+        [
+          300,
+          250
+        ]
+      ],
+      'adUnitId': 'dfeffb52-99fc-4b81-b29c-2c275cd856f5',
+      'transactionId': '2a3815e5-5285-415f-8d16-efdbe7eb9be5',
+      'ortb2Imp': {
+        'ext': {
+          'tid': '2a3815e5-5285-415f-8d16-efdbe7eb9be5'
+        }
+      }
+    },
+    {
+      'code': 'test-div2',
+      'mediaTypes': {
+        'banner': {
+          'sizes': [
+            [
+              728,
+              90
+            ]
+          ]
+        }
+      },
+      'bids': [
+        {
+          'bidder': 'appnexus',
+          'params': {
+            'placementId': 13144370
+          },
+          'userId': {
+            'lipb': {
+              'nonId': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+              'sovrn': 'testSovrn',
+              'medianet': 'testMadianet',
+              'bidswitch': 'testBidswitch',
+              'magnite': 'testMagnite',
+              'lipbid': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg=='
+            },
+            'bidswitch': {
+              'id': 'testBidswitch',
+              'ext': {
+                'provider': 'liveintent.com'
+              }
+            },
+            'medianet': {
+              'id': 'testMadianet',
+              'ext': {
+                'provider': 'liveintent.com'
+              }
+            },
+            'magnite': {
+              'id': 'testMagnite',
+              'ext': {
+                'provider': 'liveintent.com'
+              }
+            },
+            'sovrn': {
+              'id': 'testSovrn',
+              'ext': {
+                'provider': 'liveintent.com'
+              }
+            }
+          },
+          'userIdAsEids': [
+            {
+              'source': 'liveintent.com',
+              'uids': [
+                {
+                  'id': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+                  'atype': 3
+                }
+              ]
+            },
+            {
+              'source': 'bidswitch.net',
+              'uids': [
+                {
+                  'id': 'testBidswitch',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'liveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'media.net',
+              'uids': [
+                {
+                  'id': 'testMadianet',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'liveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'rubiconproject.com',
+              'uids': [
+                {
+                  'id': 'testMagnite',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'liveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'liveintent.sovrn.com',
+              'uids': [
+                {
+                  'id': 'testSovrn',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'liveintent.com'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      'sizes': [
+        [
+          728,
+          90
+        ]
+      ],
+      'adUnitId': '64ed0035-8f8b-49a9-956c-4d21be034175',
+      'transactionId': '744fa14d-62a6-45a2-a880-c0a2a5aa6c01',
+      'ortb2Imp': {
+        'ext': {
+          'tid': '744fa14d-62a6-45a2-a880-c0a2a5aa6c01'
+        }
+      }
+    }
+  ],
+  'adUnitCodes': [
+    'test-div',
+    'test-div2'
+  ],
+  'bidderRequests': [
+    {
+      'bidderCode': 'appnexus',
+      'auctionId': '87b4a93d-19ae-432a-96f0-8c2d4cc1c539',
+      'bidderRequestId': '16ed05f7946bed',
+      'bids': [
+        {
+          'bidder': 'appnexus',
+          'params': {
+            'placement_id': 13144370
+          },
+          'userId': {
+            'lipb': {
+              'nonId': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+              'sovrn': 'testSovrn',
+              'medianet': 'testMadianet',
+              'bidswitch': 'testBidswitch',
+              'magnite': 'testMagnite',
+              'lipbid': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg=='
+            },
+            'bidswitch': {
+              'id': 'testBidswitch',
+              'ext': {
+                'provider': 'liveintent.com'
+              }
+            },
+            'medianet': {
+              'id': 'testMadianet',
+              'ext': {
+                'provider': 'liveintent.com'
+              }
+            },
+            'magnite': {
+              'id': 'testMagnite',
+              'ext': {
+                'provider': 'liveintent.com'
+              }
+            },
+            'sovrn': {
+              'id': 'testSovrn',
+              'ext': {
+                'provider': 'liveintent.com'
+              }
+            }
+          },
+          'userIdAsEids': [
+            {
+              'source': 'liveintent.com',
+              'uids': [
+                {
+                  'id': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+                  'atype': 3
+                }
+              ]
+            },
+            {
+              'source': 'bidswitch.net',
+              'uids': [
+                {
+                  'id': 'testBidswitch',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'liveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'media.net',
+              'uids': [
+                {
+                  'id': 'testMadianet',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'liveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'rubiconproject.com',
+              'uids': [
+                {
+                  'id': 'testMagnite',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'liveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'liveintent.sovrn.com',
+              'uids': [
+                {
+                  'id': 'testSovrn',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'liveintent.com'
+                  }
+                }
+              ]
+            }
+          ],
+          'ortb2Imp': {
+            'ext': {}
+          },
+          'mediaTypes': {
+            'banner': {
+              'sizes': [
+                [
+                  300,
+                  250
+                ]
+              ]
+            }
+          },
+          'adUnitCode': 'test-div',
+          'transactionId': '2a3815e5-5285-415f-8d16-efdbe7eb9be5',
+          'adUnitId': 'dfeffb52-99fc-4b81-b29c-2c275cd856f5',
+          'sizes': [
+            [
+              300,
+              250
+            ]
+          ],
+          'bidId': '2635cc051f8d47',
+          'bidderRequestId': '16ed05f7946bed',
+          'auctionId': '87b4a93d-19ae-432a-96f0-8c2d4cc1c539',
+          'src': 'client',
+          'metrics': {
+            'userId.init.consent': [
+              0
+            ],
+            'userId.mod.init': [
+              2.0999999940395355
+            ],
+            'userId.mods.liveIntentId.init': [
+              2.0999999940395355
+            ],
+            'userId.init.modules': [
+              2.2999999821186066
+            ],
+            'userId.callbacks.pending': [
+              0
+            ],
+            'userId.mod.callback': [
+              626.0999999940395
+            ],
+            'userId.mods.liveIntentId.callback': [
+              626.0999999940395
+            ],
+            'userId.callbacks.total': [
+              626.3000000119209
+            ],
+            'userId.total': [
+              629.5999999940395
+            ],
+            'requestBids.userId': 623.7999999821186,
+            'requestBids.validate': 0.20000001788139343,
+            'requestBids.makeRequests': 1,
+            'adapter.client.validate': 0.10000002384185791,
+            'adapters.client.appnexus.validate': 0.10000002384185791,
+            'adapter.client.buildRequests': 1.0999999940395355,
+            'adapters.client.appnexus.buildRequests': 1.0999999940395355
+          },
+          'auctionsCount': 1,
+          'bidRequestsCount': 1,
+          'bidderRequestsCount': 1,
+          'bidderWinsCount': 0,
+          'deferBilling': false,
+          'ortb2': {
+            'source': {},
+            'site': {
+              'domain': 'vdreiling-lab-test.s3.us-east-1.amazonaws.com',
+              'publisher': {
+                'domain': 'vdreiling-lab-test.s3.us-east-1.amazonaws.com'
+              },
+              'page': 'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html'
+            },
+            'device': {
+              'w': 3840,
+              'h': 2160,
+              'dnt': 1,
+              'ua': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
+              'language': 'en',
+              'ext': {
+                'vpw': 150,
+                'vph': 1573
+              },
+              'sua': {
+                'source': 1,
+                'platform': {
+                  'brand': 'macOS'
+                },
+                'browsers': [
+                  {
+                    'brand': 'Not(A:Brand',
+                    'version': [
+                      '99'
+                    ]
+                  },
+                  {
+                    'brand': 'Google Chrome',
+                    'version': [
+                      '133'
+                    ]
+                  },
+                  {
+                    'brand': 'Chromium',
+                    'version': [
+                      '133'
+                    ]
+                  }
+                ],
+                'mobile': 0
+              }
+            },
+            'user': {
+              'ext': {
+                'eids': [
+                  {
+                    'source': 'liveintent.com',
+                    'uids': [
+                      {
+                        'id': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+                        'atype': 3
+                      }
+                    ]
+                  },
+                  {
+                    'source': 'bidswitch.net',
+                    'uids': [
+                      {
+                        'id': 'testBidswitch',
+                        'atype': 3,
+                        'ext': {
+                          'provider': 'liveintent.com'
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    'source': 'media.net',
+                    'uids': [
+                      {
+                        'id': 'testMadianet',
+                        'atype': 3,
+                        'ext': {
+                          'provider': 'liveintent.com'
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    'source': 'rubiconproject.com',
+                    'uids': [
+                      {
+                        'id': 'testMagnite',
+                        'atype': 3,
+                        'ext': {
+                          'provider': 'liveintent.com'
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    'source': 'liveintent.sovrn.com',
+                    'uids': [
+                      {
+                        'id': 'testSovrn',
+                        'atype': 3,
+                        'ext': {
+                          'provider': 'liveintent.com'
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          'bidder': 'appnexus',
+          'params': {
+            'placement_id': 13144370
+          },
+          'userId': {
+            'lipb': {
+              'nonId': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+              'sovrn': 'testSovrn',
+              'medianet': 'testMadianet',
+              'bidswitch': 'testBidswitch',
+              'magnite': 'testMagnite',
+              'lipbid': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg=='
+            },
+            'bidswitch': {
+              'id': 'testBidswitch',
+              'ext': {
+                'provider': 'liveintent.com'
+              }
+            },
+            'medianet': {
+              'id': 'testMadianet',
+              'ext': {
+                'provider': 'liveintent.com'
+              }
+            },
+            'magnite': {
+              'id': 'testMagnite',
+              'ext': {
+                'provider': 'liveintent.com'
+              }
+            },
+            'sovrn': {
+              'id': 'testSovrn',
+              'ext': {
+                'provider': 'liveintent.com'
+              }
+            }
+          },
+          'userIdAsEids': [
+            {
+              'source': 'liveintent.com',
+              'uids': [
+                {
+                  'id': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+                  'atype': 3
+                }
+              ]
+            },
+            {
+              'source': 'bidswitch.net',
+              'uids': [
+                {
+                  'id': 'testBidswitch',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'liveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'media.net',
+              'uids': [
+                {
+                  'id': 'testMadianet',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'liveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'rubiconproject.com',
+              'uids': [
+                {
+                  'id': 'testMagnite',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'liveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'liveintent.sovrn.com',
+              'uids': [
+                {
+                  'id': 'testSovrn',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'liveintent.com'
+                  }
+                }
+              ]
+            }
+          ],
+          'ortb2Imp': {
+            'ext': {}
+          },
+          'mediaTypes': {
+            'banner': {
+              'sizes': [
+                [
+                  728,
+                  90
+                ]
+              ]
+            }
+          },
+          'adUnitCode': 'test-div2',
+          'transactionId': '744fa14d-62a6-45a2-a880-c0a2a5aa6c01',
+          'adUnitId': '64ed0035-8f8b-49a9-956c-4d21be034175',
+          'sizes': [
+            [
+              728,
+              90
+            ]
+          ],
+          'bidId': '39ca9c9224aa1a',
+          'bidderRequestId': '16ed05f7946bed',
+          'auctionId': '87b4a93d-19ae-432a-96f0-8c2d4cc1c539',
+          'src': 'client',
+          'metrics': {
+            'userId.init.consent': [
+              0
+            ],
+            'userId.mod.init': [
+              2.0999999940395355
+            ],
+            'userId.mods.liveIntentId.init': [
+              2.0999999940395355
+            ],
+            'userId.init.modules': [
+              2.2999999821186066
+            ],
+            'userId.callbacks.pending': [
+              0
+            ],
+            'userId.mod.callback': [
+              626.0999999940395
+            ],
+            'userId.mods.liveIntentId.callback': [
+              626.0999999940395
+            ],
+            'userId.callbacks.total': [
+              626.3000000119209
+            ],
+            'userId.total': [
+              629.5999999940395
+            ],
+            'requestBids.userId': 623.7999999821186,
+            'requestBids.validate': 0.20000001788139343,
+            'requestBids.makeRequests': 1,
+            'adapter.client.validate': 0.10000002384185791,
+            'adapters.client.appnexus.validate': 0.10000002384185791,
+            'adapter.client.buildRequests': 1.0999999940395355,
+            'adapters.client.appnexus.buildRequests': 1.0999999940395355
+          },
+          'auctionsCount': 1,
+          'bidRequestsCount': 1,
+          'bidderRequestsCount': 1,
+          'bidderWinsCount': 0,
+          'deferBilling': false,
+          'ortb2': {
+            'source': {},
+            'site': {
+              'domain': 'vdreiling-lab-test.s3.us-east-1.amazonaws.com',
+              'publisher': {
+                'domain': 'vdreiling-lab-test.s3.us-east-1.amazonaws.com'
+              },
+              'page': 'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html'
+            },
+            'device': {
+              'w': 3840,
+              'h': 2160,
+              'dnt': 1,
+              'ua': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
+              'language': 'en',
+              'ext': {
+                'vpw': 150,
+                'vph': 1573
+              },
+              'sua': {
+                'source': 1,
+                'platform': {
+                  'brand': 'macOS'
+                },
+                'browsers': [
+                  {
+                    'brand': 'Not(A:Brand',
+                    'version': [
+                      '99'
+                    ]
+                  },
+                  {
+                    'brand': 'Google Chrome',
+                    'version': [
+                      '133'
+                    ]
+                  },
+                  {
+                    'brand': 'Chromium',
+                    'version': [
+                      '133'
+                    ]
+                  }
+                ],
+                'mobile': 0
+              }
+            },
+            'user': {
+              'ext': {
+                'eids': [
+                  {
+                    'source': 'liveintent.com',
+                    'uids': [
+                      {
+                        'id': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+                        'atype': 3
+                      }
+                    ]
+                  },
+                  {
+                    'source': 'bidswitch.net',
+                    'uids': [
+                      {
+                        'id': 'testBidswitch',
+                        'atype': 3,
+                        'ext': {
+                          'provider': 'liveintent.com'
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    'source': 'media.net',
+                    'uids': [
+                      {
+                        'id': 'testMadianet',
+                        'atype': 3,
+                        'ext': {
+                          'provider': 'liveintent.com'
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    'source': 'rubiconproject.com',
+                    'uids': [
+                      {
+                        'id': 'testMagnite',
+                        'atype': 3,
+                        'ext': {
+                          'provider': 'liveintent.com'
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    'source': 'liveintent.sovrn.com',
+                    'uids': [
+                      {
+                        'id': 'testSovrn',
+                        'atype': 3,
+                        'ext': {
+                          'provider': 'liveintent.com'
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      'auctionStart': 1739969798557,
+      'timeout': 2000,
+      'refererInfo': {
+        'reachedTop': true,
+        'isAmp': false,
+        'numIframes': 0,
+        'stack': [
+          'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html'
+        ],
+        'topmostLocation': 'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html',
+        'location': 'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html',
+        'canonicalUrl': null,
+        'page': 'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html',
+        'domain': 'vdreiling-lab-test.s3.us-east-1.amazonaws.com',
+        'ref': null,
+        'legacy': {
+          'reachedTop': true,
+          'isAmp': false,
+          'numIframes': 0,
+          'stack': [
+            'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html'
+          ],
+          'referer': 'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html',
+          'canonicalUrl': null
+        }
+      },
+      'metrics': {
+        'userId.init.consent': [
+          0
+        ],
+        'userId.mod.init': [
+          2.0999999940395355
+        ],
+        'userId.mods.liveIntentId.init': [
+          2.0999999940395355
+        ],
+        'userId.init.modules': [
+          2.2999999821186066
+        ],
+        'userId.callbacks.pending': [
+          0
+        ],
+        'userId.mod.callback': [
+          626.0999999940395
+        ],
+        'userId.mods.liveIntentId.callback': [
+          626.0999999940395
+        ],
+        'userId.callbacks.total': [
+          626.3000000119209
+        ],
+        'userId.total': [
+          629.5999999940395
+        ],
+        'requestBids.userId': 623.7999999821186,
+        'requestBids.validate': 0.20000001788139343,
+        'requestBids.makeRequests': 1,
+        'adapter.client.validate': 0.10000002384185791,
+        'adapters.client.appnexus.validate': 0.10000002384185791,
+        'adapter.client.buildRequests': 1.0999999940395355,
+        'adapters.client.appnexus.buildRequests': 1.0999999940395355
+      },
+      'ortb2': {
+        'source': {},
+        'site': {
+          'domain': 'vdreiling-lab-test.s3.us-east-1.amazonaws.com',
+          'publisher': {
+            'domain': 'vdreiling-lab-test.s3.us-east-1.amazonaws.com'
+          },
+          'page': 'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html'
+        },
+        'device': {
+          'w': 3840,
+          'h': 2160,
+          'dnt': 1,
+          'ua': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
+          'language': 'en',
+          'ext': {
+            'vpw': 150,
+            'vph': 1573
+          },
+          'sua': {
+            'source': 1,
+            'platform': {
+              'brand': 'macOS'
+            },
+            'browsers': [
+              {
+                'brand': 'Not(A:Brand',
+                'version': [
+                  '99'
+                ]
+              },
+              {
+                'brand': 'Google Chrome',
+                'version': [
+                  '133'
+                ]
+              },
+              {
+                'brand': 'Chromium',
+                'version': [
+                  '133'
+                ]
+              }
+            ],
+            'mobile': 0
+          }
+        },
+        'user': {
+          'ext': {
+            'eids': [
+              {
+                'source': 'liveintent.com',
+                'uids': [
+                  {
+                    'id': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+                    'atype': 3
+                  }
+                ]
+              },
+              {
+                'source': 'bidswitch.net',
+                'uids': [
+                  {
+                    'id': 'testBidswitch',
+                    'atype': 3,
+                    'ext': {
+                      'provider': 'liveintent.com'
+                    }
+                  }
+                ]
+              },
+              {
+                'source': 'media.net',
+                'uids': [
+                  {
+                    'id': 'testMadianet',
+                    'atype': 3,
+                    'ext': {
+                      'provider': 'liveintent.com'
+                    }
+                  }
+                ]
+              },
+              {
+                'source': 'rubiconproject.com',
+                'uids': [
+                  {
+                    'id': 'testMagnite',
+                    'atype': 3,
+                    'ext': {
+                      'provider': 'liveintent.com'
+                    }
+                  }
+                ]
+              },
+              {
+                'source': 'liveintent.sovrn.com',
+                'uids': [
+                  {
+                    'id': 'testSovrn',
+                    'atype': 3,
+                    'ext': {
+                      'provider': 'liveintent.com'
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      'start': 1739969798558
+    }
+  ],
+  'noBids': [],
+  'bidsReceived': [],
+  'bidsRejected': [],
+  'winningBids': [],
+  'timeout': 2000,
+  'metrics': {
+    'userId.init.consent': [
+      0
+    ],
+    'userId.mod.init': [
+      2.0999999940395355
+    ],
+    'userId.mods.liveIntentId.init': [
+      2.0999999940395355
+    ],
+    'userId.init.modules': [
+      2.2999999821186066
+    ],
+    'userId.callbacks.pending': [
+      0
+    ],
+    'userId.mod.callback': [
+      626.0999999940395
+    ],
+    'userId.mods.liveIntentId.callback': [
+      626.0999999940395
+    ],
+    'userId.callbacks.total': [
+      626.3000000119209
+    ],
+    'userId.total': [
+      629.5999999940395
+    ],
+    'adapter.client.validate': [
+      0.10000002384185791
+    ],
+    'adapters.client.appnexus.validate': [
+      0.10000002384185791
+    ],
+    'adapter.client.buildRequests': [
+      1.0999999940395355
+    ],
+    'adapters.client.appnexus.buildRequests': [
+      1.0999999940395355
+    ],
+    'requestBids.userId': 623.7999999821186,
+    'requestBids.validate': 0.20000001788139343,
+    'requestBids.makeRequests': 1
+  },
+  'seatNonBids': []
+}
+
+export const AUCTION_INIT_EVENT_NOT_LI = {
+  'auctionId': '87b4a93d-19ae-432a-96f0-8c2d4cc1c539',
+  'timestamp': 1739969798557,
+  'auctionStatus': 'inProgress',
+  'adUnits': [
+    {
+      'code': 'test-div',
+      'mediaTypes': {
+        'banner': {
+          'sizes': [
+            [
+              300,
+              250
+            ]
+          ]
+        }
+      },
+      'bids': [
+        {
+          'bidder': 'appnexus',
+          'params': {
+            'placementId': 13144370
+          },
+          'userId': {
+            'lipb': {
+              'nonId': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+              'sovrn': 'testSovrn',
+              'medianet': 'testMadianet',
+              'bidswitch': 'testBidswitch',
+              'magnite': 'testMagnite',
+              'lipbid': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg=='
+            },
+            'bidswitch': {
+              'id': 'testBidswitch',
+              'ext': {
+                'provider': 'NOTNOTliveintent.com'
+              }
+            },
+            'medianet': {
+              'id': 'testMadianet',
+              'ext': {
+                'provider': 'NOTliveintent.com'
+              }
+            },
+            'magnite': {
+              'id': 'testMagnite',
+              'ext': {
+                'provider': 'NOTliveintent.com'
+              }
+            },
+            'sovrn': {
+              'id': 'testSovrn',
+              'ext': {
+                'provider': 'NOTliveintent.com'
+              }
+            }
+          },
+          'userIdAsEids': [
+            {
+              'source': 'NOTliveintent.com',
+              'uids': [
+                {
+                  'id': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+                  'atype': 3
+                }
+              ]
+            },
+            {
+              'source': 'bidswitch.net',
+              'uids': [
+                {
+                  'id': 'testBidswitch',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'NOTliveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'media.net',
+              'uids': [
+                {
+                  'id': 'testMadianet',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'NOTliveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'rubiconproject.com',
+              'uids': [
+                {
+                  'id': 'testMagnite',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'NOTliveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'liveintent.sovrn.com',
+              'uids': [
+                {
+                  'id': 'testSovrn',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'NOTliveintent.com'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      'sizes': [
+        [
+          300,
+          250
+        ]
+      ],
+      'adUnitId': 'dfeffb52-99fc-4b81-b29c-2c275cd856f5',
+      'transactionId': '2a3815e5-5285-415f-8d16-efdbe7eb9be5',
+      'ortb2Imp': {
+        'ext': {
+          'tid': '2a3815e5-5285-415f-8d16-efdbe7eb9be5'
+        }
+      }
+    },
+    {
+      'code': 'test-div2',
+      'mediaTypes': {
+        'banner': {
+          'sizes': [
+            [
+              728,
+              90
+            ]
+          ]
+        }
+      },
+      'bids': [
+        {
+          'bidder': 'appnexus',
+          'params': {
+            'placementId': 13144370
+          },
+          'userId': {
+            'lipb': {
+              'nonId': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+              'sovrn': 'testSovrn',
+              'medianet': 'testMadianet',
+              'bidswitch': 'testBidswitch',
+              'magnite': 'testMagnite',
+              'lipbid': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg=='
+            },
+            'bidswitch': {
+              'id': 'testBidswitch',
+              'ext': {
+                'provider': 'NOTliveintent.com'
+              }
+            },
+            'medianet': {
+              'id': 'testMadianet',
+              'ext': {
+                'provider': 'NOTliveintent.com'
+              }
+            },
+            'magnite': {
+              'id': 'testMagnite',
+              'ext': {
+                'provider': 'NOTliveintent.com'
+              }
+            },
+            'sovrn': {
+              'id': 'testSovrn',
+              'ext': {
+                'provider': 'NOTliveintent.com'
+              }
+            }
+          },
+          'userIdAsEids': [
+            {
+              'source': 'NOTliveintent.com',
+              'uids': [
+                {
+                  'id': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+                  'atype': 3
+                }
+              ]
+            },
+            {
+              'source': 'bidswitch.net',
+              'uids': [
+                {
+                  'id': 'testBidswitch',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'NOTliveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'media.net',
+              'uids': [
+                {
+                  'id': 'testMadianet',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'NOTliveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'rubiconproject.com',
+              'uids': [
+                {
+                  'id': 'testMagnite',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'NOTliveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'liveintent.sovrn.com',
+              'uids': [
+                {
+                  'id': 'testSovrn',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'NOTliveintent.com'
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      'sizes': [
+        [
+          728,
+          90
+        ]
+      ],
+      'adUnitId': '64ed0035-8f8b-49a9-956c-4d21be034175',
+      'transactionId': '744fa14d-62a6-45a2-a880-c0a2a5aa6c01',
+      'ortb2Imp': {
+        'ext': {
+          'tid': '744fa14d-62a6-45a2-a880-c0a2a5aa6c01'
+        }
+      }
+    }
+  ],
+  'adUnitCodes': [
+    'test-div',
+    'test-div2'
+  ],
+  'bidderRequests': [
+    {
+      'bidderCode': 'appnexus',
+      'auctionId': '87b4a93d-19ae-432a-96f0-8c2d4cc1c539',
+      'bidderRequestId': '16ed05f7946bed',
+      'bids': [
+        {
+          'bidder': 'appnexus',
+          'params': {
+            'placement_id': 13144370
+          },
+          'userId': {
+            'lipb': {
+              'nonId': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+              'sovrn': 'testSovrn',
+              'medianet': 'testMadianet',
+              'bidswitch': 'testBidswitch',
+              'magnite': 'testMagnite',
+              'lipbid': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg=='
+            },
+            'bidswitch': {
+              'id': 'testBidswitch',
+              'ext': {
+                'provider': 'NOTliveintent.com'
+              }
+            },
+            'medianet': {
+              'id': 'testMadianet',
+              'ext': {
+                'provider': 'NOTliveintent.com'
+              }
+            },
+            'magnite': {
+              'id': 'testMagnite',
+              'ext': {
+                'provider': 'NOTliveintent.com'
+              }
+            },
+            'sovrn': {
+              'id': 'testSovrn',
+              'ext': {
+                'provider': 'NOTliveintent.com'
+              }
+            }
+          },
+          'userIdAsEids': [
+            {
+              'source': 'NOTliveintent.com',
+              'uids': [
+                {
+                  'id': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+                  'atype': 3
+                }
+              ]
+            },
+            {
+              'source': 'bidswitch.net',
+              'uids': [
+                {
+                  'id': 'testBidswitch',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'NOTliveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'media.net',
+              'uids': [
+                {
+                  'id': 'testMadianet',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'NOTliveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'rubiconproject.com',
+              'uids': [
+                {
+                  'id': 'testMagnite',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'NOTliveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'liveintent.sovrn.com',
+              'uids': [
+                {
+                  'id': 'testSovrn',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'NOTliveintent.com'
+                  }
+                }
+              ]
+            }
+          ],
+          'ortb2Imp': {
+            'ext': {}
+          },
+          'mediaTypes': {
+            'banner': {
+              'sizes': [
+                [
+                  300,
+                  250
+                ]
+              ]
+            }
+          },
+          'adUnitCode': 'test-div',
+          'transactionId': '2a3815e5-5285-415f-8d16-efdbe7eb9be5',
+          'adUnitId': 'dfeffb52-99fc-4b81-b29c-2c275cd856f5',
+          'sizes': [
+            [
+              300,
+              250
+            ]
+          ],
+          'bidId': '2635cc051f8d47',
+          'bidderRequestId': '16ed05f7946bed',
+          'auctionId': '87b4a93d-19ae-432a-96f0-8c2d4cc1c539',
+          'src': 'client',
+          'metrics': {
+            'userId.init.consent': [
+              0
+            ],
+            'userId.mod.init': [
+              2.0999999940395355
+            ],
+            'userId.mods.liveIntentId.init': [
+              2.0999999940395355
+            ],
+            'userId.init.modules': [
+              2.2999999821186066
+            ],
+            'userId.callbacks.pending': [
+              0
+            ],
+            'userId.mod.callback': [
+              626.0999999940395
+            ],
+            'userId.mods.liveIntentId.callback': [
+              626.0999999940395
+            ],
+            'userId.callbacks.total': [
+              626.3000000119209
+            ],
+            'userId.total': [
+              629.5999999940395
+            ],
+            'requestBids.userId': 623.7999999821186,
+            'requestBids.validate': 0.20000001788139343,
+            'requestBids.makeRequests': 1,
+            'adapter.client.validate': 0.10000002384185791,
+            'adapters.client.appnexus.validate': 0.10000002384185791,
+            'adapter.client.buildRequests': 1.0999999940395355,
+            'adapters.client.appnexus.buildRequests': 1.0999999940395355
+          },
+          'auctionsCount': 1,
+          'bidRequestsCount': 1,
+          'bidderRequestsCount': 1,
+          'bidderWinsCount': 0,
+          'deferBilling': false,
+          'ortb2': {
+            'source': {},
+            'site': {
+              'domain': 'vdreiling-lab-test.s3.us-east-1.amazonaws.com',
+              'publisher': {
+                'domain': 'vdreiling-lab-test.s3.us-east-1.amazonaws.com'
+              },
+              'page': 'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html'
+            },
+            'device': {
+              'w': 3840,
+              'h': 2160,
+              'dnt': 1,
+              'ua': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
+              'language': 'en',
+              'ext': {
+                'vpw': 150,
+                'vph': 1573
+              },
+              'sua': {
+                'source': 1,
+                'platform': {
+                  'brand': 'macOS'
+                },
+                'browsers': [
+                  {
+                    'brand': 'Not(A:Brand',
+                    'version': [
+                      '99'
+                    ]
+                  },
+                  {
+                    'brand': 'Google Chrome',
+                    'version': [
+                      '133'
+                    ]
+                  },
+                  {
+                    'brand': 'Chromium',
+                    'version': [
+                      '133'
+                    ]
+                  }
+                ],
+                'mobile': 0
+              }
+            },
+            'user': {
+              'ext': {
+                'eids': [
+                  {
+                    'source': 'NOTliveintent.com',
+                    'uids': [
+                      {
+                        'id': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+                        'atype': 3
+                      }
+                    ]
+                  },
+                  {
+                    'source': 'bidswitch.net',
+                    'uids': [
+                      {
+                        'id': 'testBidswitch',
+                        'atype': 3,
+                        'ext': {
+                          'provider': 'NOTliveintent.com'
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    'source': 'media.net',
+                    'uids': [
+                      {
+                        'id': 'testMadianet',
+                        'atype': 3,
+                        'ext': {
+                          'provider': 'NOTliveintent.com'
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    'source': 'rubiconproject.com',
+                    'uids': [
+                      {
+                        'id': 'testMagnite',
+                        'atype': 3,
+                        'ext': {
+                          'provider': 'NOTliveintent.com'
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    'source': 'liveintent.sovrn.com',
+                    'uids': [
+                      {
+                        'id': 'testSovrn',
+                        'atype': 3,
+                        'ext': {
+                          'provider': 'NOTliveintent.com'
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          'bidder': 'appnexus',
+          'params': {
+            'placement_id': 13144370
+          },
+          'userId': {
+            'lipb': {
+              'nonId': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+              'sovrn': 'testSovrn',
+              'medianet': 'testMadianet',
+              'bidswitch': 'testBidswitch',
+              'magnite': 'testMagnite',
+              'lipbid': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg=='
+            },
+            'bidswitch': {
+              'id': 'testBidswitch',
+              'ext': {
+                'provider': 'NOTliveintent.com'
+              }
+            },
+            'medianet': {
+              'id': 'testMadianet',
+              'ext': {
+                'provider': 'NOTliveintent.com'
+              }
+            },
+            'magnite': {
+              'id': 'testMagnite',
+              'ext': {
+                'provider': 'NOTliveintent.com'
+              }
+            },
+            'sovrn': {
+              'id': 'testSovrn',
+              'ext': {
+                'provider': 'NOTliveintent.com'
+              }
+            }
+          },
+          'userIdAsEids': [
+            {
+              'source': 'NOTliveintent.com',
+              'uids': [
+                {
+                  'id': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+                  'atype': 3
+                }
+              ]
+            },
+            {
+              'source': 'bidswitch.net',
+              'uids': [
+                {
+                  'id': 'testBidswitch',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'NOTliveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'media.net',
+              'uids': [
+                {
+                  'id': 'testMadianet',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'NOTliveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'rubiconproject.com',
+              'uids': [
+                {
+                  'id': 'testMagnite',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'NOTliveintent.com'
+                  }
+                }
+              ]
+            },
+            {
+              'source': 'liveintent.sovrn.com',
+              'uids': [
+                {
+                  'id': 'testSovrn',
+                  'atype': 3,
+                  'ext': {
+                    'provider': 'NOTliveintent.com'
+                  }
+                }
+              ]
+            }
+          ],
+          'ortb2Imp': {
+            'ext': {}
+          },
+          'mediaTypes': {
+            'banner': {
+              'sizes': [
+                [
+                  728,
+                  90
+                ]
+              ]
+            }
+          },
+          'adUnitCode': 'test-div2',
+          'transactionId': '744fa14d-62a6-45a2-a880-c0a2a5aa6c01',
+          'adUnitId': '64ed0035-8f8b-49a9-956c-4d21be034175',
+          'sizes': [
+            [
+              728,
+              90
+            ]
+          ],
+          'bidId': '39ca9c9224aa1a',
+          'bidderRequestId': '16ed05f7946bed',
+          'auctionId': '87b4a93d-19ae-432a-96f0-8c2d4cc1c539',
+          'src': 'client',
+          'metrics': {
+            'userId.init.consent': [
+              0
+            ],
+            'userId.mod.init': [
+              2.0999999940395355
+            ],
+            'userId.mods.liveIntentId.init': [
+              2.0999999940395355
+            ],
+            'userId.init.modules': [
+              2.2999999821186066
+            ],
+            'userId.callbacks.pending': [
+              0
+            ],
+            'userId.mod.callback': [
+              626.0999999940395
+            ],
+            'userId.mods.liveIntentId.callback': [
+              626.0999999940395
+            ],
+            'userId.callbacks.total': [
+              626.3000000119209
+            ],
+            'userId.total': [
+              629.5999999940395
+            ],
+            'requestBids.userId': 623.7999999821186,
+            'requestBids.validate': 0.20000001788139343,
+            'requestBids.makeRequests': 1,
+            'adapter.client.validate': 0.10000002384185791,
+            'adapters.client.appnexus.validate': 0.10000002384185791,
+            'adapter.client.buildRequests': 1.0999999940395355,
+            'adapters.client.appnexus.buildRequests': 1.0999999940395355
+          },
+          'auctionsCount': 1,
+          'bidRequestsCount': 1,
+          'bidderRequestsCount': 1,
+          'bidderWinsCount': 0,
+          'deferBilling': false,
+          'ortb2': {
+            'source': {},
+            'site': {
+              'domain': 'vdreiling-lab-test.s3.us-east-1.amazonaws.com',
+              'publisher': {
+                'domain': 'vdreiling-lab-test.s3.us-east-1.amazonaws.com'
+              },
+              'page': 'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html'
+            },
+            'device': {
+              'w': 3840,
+              'h': 2160,
+              'dnt': 1,
+              'ua': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
+              'language': 'en',
+              'ext': {
+                'vpw': 150,
+                'vph': 1573
+              },
+              'sua': {
+                'source': 1,
+                'platform': {
+                  'brand': 'macOS'
+                },
+                'browsers': [
+                  {
+                    'brand': 'Not(A:Brand',
+                    'version': [
+                      '99'
+                    ]
+                  },
+                  {
+                    'brand': 'Google Chrome',
+                    'version': [
+                      '133'
+                    ]
+                  },
+                  {
+                    'brand': 'Chromium',
+                    'version': [
+                      '133'
+                    ]
+                  }
+                ],
+                'mobile': 0
+              }
+            },
+            'user': {
+              'ext': {
+                'eids': [
+                  {
+                    'source': 'NOTliveintent.com',
+                    'uids': [
+                      {
+                        'id': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+                        'atype': 3
+                      }
+                    ]
+                  },
+                  {
+                    'source': 'bidswitch.net',
+                    'uids': [
+                      {
+                        'id': 'testBidswitch',
+                        'atype': 3,
+                        'ext': {
+                          'provider': 'NOTliveintent.com'
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    'source': 'media.net',
+                    'uids': [
+                      {
+                        'id': 'testMadianet',
+                        'atype': 3,
+                        'ext': {
+                          'provider': 'NOTliveintent.com'
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    'source': 'rubiconproject.com',
+                    'uids': [
+                      {
+                        'id': 'testMagnite',
+                        'atype': 3,
+                        'ext': {
+                          'provider': 'NOTliveintent.com'
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    'source': 'liveintent.sovrn.com',
+                    'uids': [
+                      {
+                        'id': 'testSovrn',
+                        'atype': 3,
+                        'ext': {
+                          'provider': 'NOTliveintent.com'
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ],
+      'auctionStart': 1739969798557,
+      'timeout': 2000,
+      'refererInfo': {
+        'reachedTop': true,
+        'isAmp': false,
+        'numIframes': 0,
+        'stack': [
+          'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html'
+        ],
+        'topmostLocation': 'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html',
+        'location': 'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html',
+        'canonicalUrl': null,
+        'page': 'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html',
+        'domain': 'vdreiling-lab-test.s3.us-east-1.amazonaws.com',
+        'ref': null,
+        'legacy': {
+          'reachedTop': true,
+          'isAmp': false,
+          'numIframes': 0,
+          'stack': [
+            'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html'
+          ],
+          'referer': 'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html',
+          'canonicalUrl': null
+        }
+      },
+      'metrics': {
+        'userId.init.consent': [
+          0
+        ],
+        'userId.mod.init': [
+          2.0999999940395355
+        ],
+        'userId.mods.liveIntentId.init': [
+          2.0999999940395355
+        ],
+        'userId.init.modules': [
+          2.2999999821186066
+        ],
+        'userId.callbacks.pending': [
+          0
+        ],
+        'userId.mod.callback': [
+          626.0999999940395
+        ],
+        'userId.mods.liveIntentId.callback': [
+          626.0999999940395
+        ],
+        'userId.callbacks.total': [
+          626.3000000119209
+        ],
+        'userId.total': [
+          629.5999999940395
+        ],
+        'requestBids.userId': 623.7999999821186,
+        'requestBids.validate': 0.20000001788139343,
+        'requestBids.makeRequests': 1,
+        'adapter.client.validate': 0.10000002384185791,
+        'adapters.client.appnexus.validate': 0.10000002384185791,
+        'adapter.client.buildRequests': 1.0999999940395355,
+        'adapters.client.appnexus.buildRequests': 1.0999999940395355
+      },
+      'ortb2': {
+        'source': {},
+        'site': {
+          'domain': 'vdreiling-lab-test.s3.us-east-1.amazonaws.com',
+          'publisher': {
+            'domain': 'vdreiling-lab-test.s3.us-east-1.amazonaws.com'
+          },
+          'page': 'https://vdreiling-lab-test.s3.us-east-1.amazonaws.com/prebid-presentation/pageWith2.html'
+        },
+        'device': {
+          'w': 3840,
+          'h': 2160,
+          'dnt': 1,
+          'ua': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36',
+          'language': 'en',
+          'ext': {
+            'vpw': 150,
+            'vph': 1573
+          },
+          'sua': {
+            'source': 1,
+            'platform': {
+              'brand': 'macOS'
+            },
+            'browsers': [
+              {
+                'brand': 'Not(A:Brand',
+                'version': [
+                  '99'
+                ]
+              },
+              {
+                'brand': 'Google Chrome',
+                'version': [
+                  '133'
+                ]
+              },
+              {
+                'brand': 'Chromium',
+                'version': [
+                  '133'
+                ]
+              }
+            ],
+            'mobile': 0
+          }
+        },
+        'user': {
+          'ext': {
+            'eids': [
+              {
+                'source': 'NOTliveintent.com',
+                'uids': [
+                  {
+                    'id': '12-hMaZCgZ9Q99h3cGDam21dEfxTawgIafx1J1zxvXTHwnrXUHWudCwcgIjkbTbZpRd2DV9ivSyz2L9t27VTNWXYAvYmk82zmrmciW71dSFq00zHg==',
+                    'atype': 3
+                  }
+                ]
+              },
+              {
+                'source': 'bidswitch.net',
+                'uids': [
+                  {
+                    'id': 'testBidswitch',
+                    'atype': 3,
+                    'ext': {
+                      'provider': 'NOTliveintent.com'
+                    }
+                  }
+                ]
+              },
+              {
+                'source': 'media.net',
+                'uids': [
+                  {
+                    'id': 'testMadianet',
+                    'atype': 3,
+                    'ext': {
+                      'provider': 'NOTliveintent.com'
+                    }
+                  }
+                ]
+              },
+              {
+                'source': 'rubiconproject.com',
+                'uids': [
+                  {
+                    'id': 'testMagnite',
+                    'atype': 3,
+                    'ext': {
+                      'provider': 'NOTliveintent.com'
+                    }
+                  }
+                ]
+              },
+              {
+                'source': 'liveintent.sovrn.com',
+                'uids': [
+                  {
+                    'id': 'testSovrn',
+                    'atype': 3,
+                    'ext': {
+                      'provider': 'NOTliveintent.com'
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      'start': 1739969798558
+    }
+  ],
+  'noBids': [],
+  'bidsReceived': [],
+  'bidsRejected': [],
+  'winningBids': [],
+  'timeout': 2000,
+  'metrics': {
+    'userId.init.consent': [
+      0
+    ],
+    'userId.mod.init': [
+      2.0999999940395355
+    ],
+    'userId.mods.liveIntentId.init': [
+      2.0999999940395355
+    ],
+    'userId.init.modules': [
+      2.2999999821186066
+    ],
+    'userId.callbacks.pending': [
+      0
+    ],
+    'userId.mod.callback': [
+      626.0999999940395
+    ],
+    'userId.mods.liveIntentId.callback': [
+      626.0999999940395
+    ],
+    'userId.callbacks.total': [
+      626.3000000119209
+    ],
+    'userId.total': [
+      629.5999999940395
+    ],
+    'adapter.client.validate': [
+      0.10000002384185791
+    ],
+    'adapters.client.appnexus.validate': [
+      0.10000002384185791
+    ],
+    'adapter.client.buildRequests': [
+      1.0999999940395355
+    ],
+    'adapters.client.appnexus.buildRequests': [
+      1.0999999940395355
+    ],
+    'requestBids.userId': 623.7999999821186,
+    'requestBids.validate': 0.20000001788139343,
+    'requestBids.makeRequests': 1
+  },
+  'seatNonBids': []
+}
+
+export const BID_WON_EVENT = {
+  'bidderCode': 'appnexus',
+  'width': 728,
+  'height': 90,
+  'statusMessage': 'Bid available',
+  'adId': '4e02072b881823',
+  'requestId': '3fae2718fd70f',
+  'transactionId': '6daa1dac-9eea-47ce-82ce-ce9681df1ec5',
+  'adUnitId': 'afc6bc6a-3082-4940-b37f-d22e1b026e48',
+  'auctionId': '87b4a93d-19ae-432a-96f0-8c2d4cc1c539',
+  'mediaType': 'banner',
+  'source': 'client',
+  'cpm': 1.5,
+  'creativeId': 98493734,
+  'currency': 'USD',
+  'netRevenue': true,
+  'ttl': 300,
+  'adUnitCode': 'test-div2',
+  'appnexus': {
+    'buyerMemberId': 9325
+  },
+  'meta': {
+    'advertiserId': 2529885,
+    'dchain': {
+      'ver': '1.0',
+      'complete': 0,
+      'nodes': [
+        {
+          'bsid': '9325'
+        }
+      ]
+    },
+    'brandId': 555545
+  },
+  'ad': "<!-- Creative 98493734 served by Member 9325 via AppNexus --><a href=\"https://fra1-ib.adnxs.com/click2?e=wqT_3QKfAfBtnwAAAAMAxBkFAQjLtNe9BhCkr-mSn9zTvwsYh6Pop7Cy0rQSILKiogYo7Ugw7Ug4AkCmyvsuSJzxW1AAWgNVU0RiA1VTRGjYBXBaeLXPeYABstgFiAEBkAEBmAEDoAECqQEAAAAAAAD4P7EBAAABDDD4P7kBAAAAwPUo-D_BAQoAAAEeAMkVCjDYAQDgAQDwAfUv-AEA/s=6676f8c324bf37b4366612bef92c11edbe7356f1/bcr=AAAAAAAA8D8=/cnd=%21uBDL_QjKvJodEKbK-y4YnPFbIAQoADEAAAAAAAD4PzoJRlJBMTo1Njg5QMtISQAAAAAAAPA_UQAAAAAAAAAAWQAAAAAAAAAAYQAAAAAAAAAAaQAAAAAAAAAAcQAAAAAAAAAAeACJAQAAAAAAAAAA/cca=OTMyNSNGUkExOjU2ODk=/bn=93234/clickenc=https%3A%2F%2Fdocs.prebid.org%2Fdev-docs%2Fgetting-started.html\" target=\"_blank\"><img width=\"728\" height=\"90\" style=\"border-style: none\" src=\"https://vcdn.adnxs.com/p/creative-image/f6/11/33/19/f6113319-e789-4408-b69d-b178d60c5a6e.png\" /></a><iframe src=\"https://acdn.adnxs.com/dmp/async_usersync.html?gdpr=0&seller_id=9325&pub_id=1193043\" width=\"1\" height=\"1\" frameborder=\"0\" scrolling=\"no\" marginheight=\"0\" marginwidth=\"0\" topmargin=\"0\" leftmargin=\"0\" style=\"position:absolute;overflow:hidden;clip:rect(0 0 0 0);height:1px;width:1px;margin:-1px;padding:0;border:0;\"></iframe><script>try {!function(){function e(e,t){return\"function\"==typeof __an_obj_extend_thunk?__an_obj_extend_thunk(e,t):e}function t(e,t){\"function\"==typeof __an_err_thunk&&__an_err_thunk(e,t)}function n(e,t){if(\"function\"==typeof __an_redirect_thunk)__an_redirect_thunk(e);else{var n=navigator.connection;navigator.__an_connection&&(n=navigator.__an_connection),window==window.top&&n&&n.downlinkMax<=.115&&\"function\"==typeof HTMLIFrameElement&&HTMLIFrameElement.prototype.hasOwnProperty(\"srcdoc\")?(window.__an_resize=function(e,t,n){var r=e.frameElement;r&&\"__an_if\"==r.getAttribute(\"name\")&&(t&&(r.style.width=t+\"px\"),n&&(r.style.height=n+\"px\"))},document.write('<iframe name=\"__an_if\" style=\"width:0;height:0\" srcdoc=\"<script type=\\'text/javascript\\' src=\\''+e+\"&\"+t.bdfif+\"=1'></sc\"),document.write('ript>\" frameborder=\"0\" scrolling=\"no\" marginheight=0 marginwidth=0 topmargin=\"0\" leftmargin=\"0\" allowtransparency=\"true\"></iframe>')):document.write('<script language=\"javascript\" src=\"'+e+'\"></scr'+'ipt>')}};var r=function(e){this.rdParams=e};r.prototype={constructor:r,walkAncestors:function(e){try{if(!window.location.ancestorOrigins)return;for(var t=0,n=window.location.ancestorOrigins.length;n>t;t++)e.call(null,window.location.ancestorOrigins[t],t)}catch(r){\"undefined\"!=typeof console}return[]},walkUpWindows:function(e){var t,n=[];do try{t=t?t.parent:window,e.call(null,t,n)}catch(r){return\"undefined\"!=typeof console,n.push({referrer:null,location:null,isTop:!1}),n}while(t!=window.top);return n},getPubUrlStack:function(e){var n,r=[],o=null,i=null,a=null,c=null,d=null,s=null,u=null;for(n=e.length-1;n>=0;n--){try{a=e[n].location}catch(l){\"undefined\"!=typeof console,t(l,\"AnRDModule::getPubUrlStack:: location\")}if(a)i=encodeURIComponent(a),r.push(i),u||(u=i);else if(0!==n){c=e[n-1];try{d=c.referrer,s=c.ancestor}catch(l){\"undefined\"!=typeof console,t(l,\"AnRDModule::getPubUrlStack:: prevFrame\")}d?(i=encodeURIComponent(d),r.push(i),u||(u=i)):s?(i=encodeURIComponent(s),r.push(i),u||(u=i)):r.push(o)}else r.push(o)}return{stack:r,detectUrl:u}},getLevels:function(){var e=this.walkUpWindows(function(e,n){try{n.push({referrer:e.document.referrer||null,location:e.location.href||null,isTop:e==window.top})}catch(r){n.push({referrer:null,location:null,isTop:e==window.top}),\"undefined\"!=typeof console,t(r,\"AnRDModule::getLevels\")}});return this.walkAncestors(function(t,n){e[n].ancestor=t}),e},getRefererInfo:function(){var e=\"\";try{var n=this.getLevels(),r=n.length-1,o=null!==n[r].location||r>0&&null!==n[r-1].referrer,i=this.getPubUrlStack(n);e=this.rdParams.rdRef+\"=\"+i.detectUrl+\"&\"+this.rdParams.rdTop+\"=\"+o+\"&\"+this.rdParams.rdIfs+\"=\"+r+\"&\"+this.rdParams.rdStk+\"=\"+i.stack+\"&\"+decodeURI(this.rdParams.rdQs)}catch(a){e=\"\",\"undefined\"!=typeof console,t(a,\"AnRDModule::getRefererInfo\")}return e}};var o=function(n){var o=\"\";try{n=e(n,0);var i=e(new r(n),1);return i.getRefererInfo()}catch(a){o=\"\",\"undefined\"!=typeof console,t(a,\"AnRDModule::executeRD\")}return o};;var c=\"https://fra1-ib.adnxs.com/rd_log?an_audit=0&referrer=https%3A%2F%2Fvdreiling-lab-test.s3.us-east-1.amazonaws.com%2Fprebid-presentation%2FpageWith2.html&e=wqT_3QL4DqB4BwAAAwDWAAUBCMu0170GEKSv6ZKf3NO_CxiHo-insLLStBIqNgkAAAECCPg_EQEHNAAA-D8ZAAAAwPUo-D8hERIAKREJADERG6gwsqKiBjjtSEDtSEgCUKbK-y5YnPFbYABotc95eLLYBYABAYoBA1VTRJIBAQbgmAHYBaABWqgBAbABALgBAcABA8gBAtABANgBAOABAPABAIoCKXVmKCdhJywgMjUyOTg4NSwgMCk7ARQwcicsIDk4NDkzNzM0LAEV8P2SArkEIWdHWkdOQWpLdkpvZEVLYksteTRZQUNDYzhWc3dBRGdBUUFSSTdVaFFzcUtpQmxnQVlPOEJhQUJ3SG5nZWdBRXVpQUVla0FFQm1BRUJvQUVCcUFFRHNBRUF1UUctMEV6RkFBRDRQOEVCdnRCTXhRQUEtRF9KQVh2RGw4S1c5LWtfMlFFQUFBQUFBQUR3UC1BQkFQVUJBQUFBQUpnQ0FLQUNBTFVDQUFBQUFMMENBQUFBQU1BQ0FNZ0NBTkFDQU5nQ0FPQUNBT2dDQVBnQ0FJQURBWmdEQWJvRENVWlNRVEU2TlRZNE9lQUR5MGlJQkFDUUJBQ1lCQUhCQgVNCQEIeVFRCQkBARROZ0VBUEURlSxBQUFDSUJia3NxUVUBDQmoCDdFRgEKCQEIREJCHT8AeRUoDEFBQU4yKAAAWi4oAPBlNEFYd2t3bnFCU1lJQkJJaUFBQUVHaXVpMDIwUjBQTVFldUxka0Rha19yMmI3VWFsX3MtZUlTM3FFRmx3bV9BRjdmemFBdmdGM2JTYUFZSUdBMVZUUklnR0FKQUdBWmdHQUtFR0FBAYU0QUEtRC1vQmdHeUJpUUoJEgUBAFIFBgkBAFoJBwUBAGgFBgUBGEM0QmdxQkMFDAkBSGlBZ0FrQWdBmgKVASF1QkRMX1E2PQIkblBGYklBUW9BRDFEWEQ0UHpvSlJsSkJNVG8xTmpnNVFNdElTMTUMUEFfVREMDEFBQVcdDABZHQwAYR0MAGMdDBBlQUNKQR0QeMICNWh0dHBzOi8vZG9jcy5wcmViaWQub3JnL2Rldi0BFIgvZ2V0dGluZy1zdGFydGVkLmh0bWzYAvfpA-ACrZhI6gJYaA1CFHZkcmVpbAErkGxhYi10ZXN0LnMzLnVzLWVhc3QtMS5hbWF6b25hd3MuY29tL3AFa1gtcHJlc2VudGF0aW9uL3BhZ2VXaXRoMgVlMPICEQoGQURWX0lEEgdtoQUUCENQRwUUFDU2ODQ4NAUUCAVDUAETNAg2MTI1MTE0NvICDgoIATxoRlJFURICMjPyAg0KCFJFTV9VU0VSEgEw8gIMCSEUQ09ERRIABQ8BWBEPEAsKB0NQFQ4QCQoFSU8BYQQA8gEaBElPFRo4EwoPQ1VTVE9NX01PREVMDSQIGgoWMhYAHExFQUZfTkFNBWoIHgoaNh0ACEFTVAE-EElGSUVEAWIcDQoIU1BMSVQBTdABMIADAIgDAZADAJgDF6ADAaoDAMAD2ATIAwDYA76sAuADAOgDAPgDAYAEAJIEDS91dC92My1d8H2YBACiBAw5MS45Ni42OC4xNzioBOfJB7IEEwgEEAQY2AUgWigBKAIwADgCQgC4BADABIDauCLIBADSBA45MzI1I0ZSQTE6NTY4OdoEAggB4AQB8ASmyvsuiAUBmAUAoAX___________8BwAUAyQUAAAAAAADwP9IFCQkAAAClwHDYBQHgBQHwBZn0IfoFBAgAEACQBgCYBgC4BgDBBgUiLADwP9AG9S_aBhYKEAkRGQFwEAAYAOAGAfIGAggAgAcBiAcAoAcByAey2AXSBw8VZAEmECAA2gcGAV_w9hgA4AcA6gcCCADwB_maAYoIwgEKvQEAAAGVHly0-At_TuHyWlekBSbXDsn7MA9kiN8zpQ3JU8nyaO8zDdp7eXakZns5iCya3WWSR84RbuXAFW3-XwQJeVDN6TyG7YPNRXX4XdmMcWX9_1-QRFJpDfa-JbkkC7fYcZAqd8ZtVFwqslqguelw0STCq4BqBFk4FzPd-AeWHANk_mkOfwp6MpZue28Vux_gDUVUgG02dxjB3K6zennqYPc7saGU_2WRWY3DmLT5qRojJ63yZx_ce2dwxwsQAZUIAACAP5gIAcAIANIIBggAEAAYANoIBAgAIADgCADoCAA.&s=85d0e398f1a637f01e83f3a42d8ad7d3bf45b8ac\";c+=\"&\"+o({rdRef:\"bdref\",rdTop:\"bdtop\",rdIfs:\"bdifs\",rdStk:\"bstk\",rdQs:\"\"}),n(c,{bdfif:\"bdfif\"})}();} catch (e) { }</script><div name=\"anxv\" lnttag=\"v;tv=view7-1hs;st=0;d=728x90;vc=iab;vid_ccr=1;tag_id=13144370;cb=https%3A%2F%2Ffra1-ib.adnxs.com%2Fvevent%3Fan_audit%3D0%26referrer%3Dhttps%253A%252F%252Fvdreiling-lab-test.s3.us-east-1.amazonaws.com%252Fprebid-presentation%252FpageWith2.html%26e%3DwqT_3QL5DKB5BgAAAwDWAAUBCMu0170GEKSv6ZKf3NO_CxiHo-insLLStBIqNgkAAAECCPg_EQEHNAAA-D8ZAAAAwPUo-D8hERIAKREJADERG6gwsqKiBjjtSEDtSEgCUKbK-y5YnPFbYABotc95eLLYBYABAYoBA1VTRJIBAQbgmAHYBaABWqgBAbABALgBAcABA8gBAtABANgBAOABAPABAIoCKXVmKCdhJywgMjUyOTg4NSwgMCk7ARQwcicsIDk4NDkzNzM0LAEV8P2SArkEIWdHWkdOQWpLdkpvZEVLYksteTRZQUNDYzhWc3dBRGdBUUFSSTdVaFFzcUtpQmxnQVlPOEJhQUJ3SG5nZWdBRXVpQUVla0FFQm1BRUJvQUVCcUFFRHNBRUF1UUctMEV6RkFBRDRQOEVCdnRCTXhRQUEtRF9KQVh2RGw4S1c5LWtfMlFFQUFBQUFBQUR3UC1BQkFQVUJBQUFBQUpnQ0FLQUNBTFVDQUFBQUFMMENBQUFBQU1BQ0FNZ0NBTkFDQU5nQ0FPQUNBT2dDQVBnQ0FJQURBWmdEQWJvRENVWlNRVEU2TlRZNE9lQUR5MGlJQkFDUUJBQ1lCQUhCQgVNCQEIeVFRCQkBARROZ0VBUEURlSxBQUFDSUJia3NxUVUBDQmoCDdFRgEKCQEIREJCHT8AeRUoDEFBQU4yKAAAWi4oAPBlNEFYd2t3bnFCU1lJQkJJaUFBQUVHaXVpMDIwUjBQTVFldUxka0Rha19yMmI3VWFsX3MtZUlTM3FFRmx3bV9BRjdmemFBdmdGM2JTYUFZSUdBMVZUUklnR0FKQUdBWmdHQUtFR0FBAYU0QUEtRC1vQmdHeUJpUUoJEgUBAFIFBgkBAFoJBwUBAGgFBgUBGEM0QmdxQkMFDAkBSGlBZ0FrQWdBmgKVASF1QkRMX1E2PQIkblBGYklBUW9BRDFEWEQ0UHpvSlJsSkJNVG8xTmpnNVFNdElTMTUMUEFfVREMDEFBQVcdDABZHQwAYR0MAGMdDBBlQUNKQR0QeMICNWh0dHBzOi8vZG9jcy5wcmViaWQub3JnL2Rldi0BFIgvZ2V0dGluZy1zdGFydGVkLmh0bWzYAvfpA-ACrZhI6gJYaA1CFHZkcmVpbAErkGxhYi10ZXN0LnMzLnVzLWVhc3QtMS5hbWF6b25hd3MuY29tL3AFa1gtcHJlc2VudGF0aW9uL3BhZ2VXaXRoMgVlyIADAIgDAZADAJgDF6ADAaoDAMAD2ATIAwDYA76sAuADAOgDAPgDAYAEAJIEDS91dC92Mw1W8H2YBACiBAw5MS45Ni42OC4xNzioBOfJB7IEEwgEEAQY2AUgWigBKAIwADgCQgC4BADABIDauCLIBADSBA45MzI1I0ZSQTE6NTY4OdoEAggB4AQB8ASmyvsuiAUBmAUAoAX___________8BwAUAyQUAAAAAAADwP9IFCQkAAACFuXDYBQHgBQHwBZn0IfoFBAgAEACQBgCYBgC4BgDBBgUiLADwP9AG9S_aBhYKEAkRGQFwEAAYAOAGAfIGAggAgAcBiAcAoAcByAey2AXSBw8VZAEmECAA2gcGAV_w_hgA4AcA6gcCCADwB_maAYoIwgEKvQEAAAGVHly0-At_TuHyWlekBSbXDsn7MA9kiN8zpQ3JU8nyaO8zDdp7eXakZns5iCya3WWSR84RbuXAFW3-XwQJeVDN6TyG7YPNRXX4XdmMcWX9_1-QRFJpDfa-JbkkC7fYcZAqd8ZtVFwqslqguelw0STCq4BqBFk4FzPd-AeWHANk_mkOfwp6MpZue28Vux_gDUVUgG02dxjB3K6zennqYPc7saGU_2WRWY3DmLT5qRojJ63yZx_ce2dwxwsQAZUIAACAP5gIAcAIANIIDgiBgoSIkKDAgAEQABgA2ggECAAgAOAIAOgIAA..%26s%3D9e2f1bc1368ef251ec44c5d79310bc41bba2ca52;ts=1739971147;cet=0;cecb=\" width=\"0\" height=\"0\" style=\"display: block; margin: 0; padding: 0; height: 0; width: 0;\"><script type=\"text/javascript\" async=\"true\" src=\"https://cdn.adnxs.com/v/s/249/trk.js\"></script></div><div style=\"position:absolute;left:0px;top:0px;visibility:hidden;\"><img src=\"https://fra1-ib.adnxs.com/it?an_audit=0&referrer=https%253A%252F%252Fvdreiling-lab-test.s3.us-east-1.amazonaws.com%252Fprebid-presentation%252FpageWith2.html&e=wqT_3QL5DKB5BgAAAwDWAAUBCMu0170GEKSv6ZKf3NO_CxiHo-insLLStBIqNgkAAAECCPg_EQEHNAAA-D8ZAAAAwPUo-D8hERIAKREJADERG6gwsqKiBjjtSEDtSEgCUKbK-y5YnPFbYABotc95eLLYBYABAYoBA1VTRJIBAQbgmAHYBaABWqgBAbABALgBAcABBMgBAtABANgBAOABAPABAIoCKXVmKCdhJywgMjUyOTg4NSwgMCk7ARQwcicsIDk4NDkzNzM0LAEV8P2SArkEIWdHWkdOQWpLdkpvZEVLYksteTRZQUNDYzhWc3dBRGdBUUFSSTdVaFFzcUtpQmxnQVlPOEJhQUJ3SG5nZWdBRXVpQUVla0FFQm1BRUJvQUVCcUFFRHNBRUF1UUctMEV6RkFBRDRQOEVCdnRCTXhRQUEtRF9KQVh2RGw4S1c5LWtfMlFFQUFBQUFBQUR3UC1BQkFQVUJBQUFBQUpnQ0FLQUNBTFVDQUFBQUFMMENBQUFBQU1BQ0FNZ0NBTkFDQU5nQ0FPQUNBT2dDQVBnQ0FJQURBWmdEQWJvRENVWlNRVEU2TlRZNE9lQUR5MGlJQkFDUUJBQ1lCQUhCQgVNCQEIeVFRCQkBARROZ0VBUEURlSxBQUFDSUJia3NxUVUBDQmoCDdFRgEKCQEIREJCHT8AeRUoDEFBQU4yKAAAWi4oAPBlNEFYd2t3bnFCU1lJQkJJaUFBQUVHaXVpMDIwUjBQTVFldUxka0Rha19yMmI3VWFsX3MtZUlTM3FFRmx3bV9BRjdmemFBdmdGM2JTYUFZSUdBMVZUUklnR0FKQUdBWmdHQUtFR0FBAYU0QUEtRC1vQmdHeUJpUUoJEgUBAFIFBgkBAFoJBwUBAGgFBgUBGEM0QmdxQkMFDAkBSGlBZ0FrQWdBmgKVASF1QkRMX1E2PQIkblBGYklBUW9BRDFEWEQ0UHpvSlJsSkJNVG8xTmpnNVFNdElTMTUMUEFfVREMDEFBQVcdDABZHQwAYR0MAGMdDBBlQUNKQR0QeMICNWh0dHBzOi8vZG9jcy5wcmViaWQub3JnL2Rldi0BFIgvZ2V0dGluZy1zdGFydGVkLmh0bWzYAvfpA-ACrZhI6gJYaA1CFHZkcmVpbAErkGxhYi10ZXN0LnMzLnVzLWVhc3QtMS5hbWF6b25hd3MuY29tL3AFa1gtcHJlc2VudGF0aW9uL3BhZ2VXaXRoMgVlyIADAIgDAZADAJgDF6ADAaoDAMAD2ATIAwDYA76sAuADAOgDAPgDAYAEAJIEDS91dC92Mw1W8H2YBACiBAw5MS45Ni42OC4xNzioBOfJB7IEEwgEEAQY2AUgWigBKAIwADgCQgC4BADABIDauCLIBADSBA45MzI1I0ZSQTE6NTY4OdoEAggB4AQB8ASmyvsuiAUBmAUAoAX___________8BwAUAyQUAAAAAAADwP9IFCQkAAACFuXDYBQHgBQHwBZn0IfoFBAgAEACQBgCYBgC4BgDBBgUiLADwP9AG9S_aBhYKEAkRGQFwEAAYAOAGAfIGAggAgAcBiAcAoAcByAey2AXSBw8VZAEmECAA2gcGAV_w_hgA4AcA6gcCCADwB_maAYoIwgEKvQEAAAGVHly0-At_TuHyWlekBSbXDsn7MA9kiN8zpQ3JU8nyaO8zDdp7eXakZns5iCya3WWSR84RbuXAFW3-XwQJeVDN6TyG7YPNRXX4XdmMcWX9_1-QRFJpDfa-JbkkC7fYcZAqd8ZtVFwqslqguelw0STCq4BqBFk4FzPd-AeWHANk_mkOfwp6MpZue28Vux_gDUVUgG02dxjB3K6zennqYPc7saGU_2WRWY3DmLT5qRojJ63yZx_ce2dwxwsQAZUIAACAP5gIAcAIANIIDgiBgoSIkKDAgAEQABgA2ggECAAgAOAIAOgIAA..&s=c6fcf3b118918dba361b8ec2960485117d3805ae\"></div>",
+  'metrics': {
+    'userId.init.consent': [
+      0.09999999403953552
+    ],
+    'userId.mod.init': [
+      1.7999999821186066
+    ],
+    'userId.mods.liveIntentId.init': [
+      1.7999999821186066
+    ],
+    'userId.init.modules': [
+      1.9000000059604645
+    ],
+    'userId.callbacks.pending': [
+      0
+    ],
+    'userId.mod.callback': [
+      149.69999998807907
+    ],
+    'userId.mods.liveIntentId.callback': [
+      149.69999998807907
+    ],
+    'userId.callbacks.total': [
+      149.80000001192093
+    ],
+    'userId.total': [
+      152.90000000596046
+    ],
+    'requestBids.userId': 147.2999999821186,
+    'requestBids.validate': 0.30000001192092896,
+    'requestBids.makeRequests': 0.699999988079071,
+    'requestBids.total': 215.7999999821186,
+    'requestBids.callBids': 65,
+    'adapter.client.validate': 0,
+    'adapters.client.appnexus.validate': 0,
+    'adapter.client.buildRequests': 1.199999988079071,
+    'adapters.client.appnexus.buildRequests': 1.199999988079071,
+    'adapter.client.total': 62.69999998807907,
+    'adapters.client.appnexus.total': 62.69999998807907,
+    'adapter.client.net': 59.5,
+    'adapters.client.appnexus.net': 59.5,
+    'adapter.client.interpretResponse': 0.5,
+    'adapters.client.appnexus.interpretResponse': 0.5,
+    'addBidResponse.validate': 0.09999999403953552,
+    'addBidResponse.total': 0.9000000059604645,
+    'render.deferred': null,
+    'render.pending': 130.60000002384186,
+    'render.e2e': 346.40000000596046,
+    'adserver.pending': 130.80000001192093,
+    'adserver.e2e': 346.59999999403954
+  },
+  'adapterCode': 'appnexus',
+  'originalCpm': 1.5,
+  'originalCurrency': 'USD',
+  'deferBilling': false,
+  'deferRendering': false,
+  'responseTimestamp': 1739971147806,
+  'requestTimestamp': 1739971147744,
+  'bidder': 'appnexus',
+  'timeToRespond': 62,
+  'pbLg': '1.50',
+  'pbMg': '1.50',
+  'pbHg': '1.50',
+  'pbAg': '1.50',
+  'pbDg': '1.50',
+  'pbCg': '',
+  'size': '728x90',
+  'adserverTargeting': {
+    'hb_bidder': 'appnexus',
+    'hb_adid': '4e02072b881823',
+    'hb_pb': '1.50',
+    'hb_size': '728x90',
+    'hb_source': 'client',
+    'hb_format': 'banner',
+    'hb_adomain': '',
+    'hb_crid': 98493734
+  },
+  'latestTargetedAuctionId': 'a8ac8297-9f6f-4e35-bb42-8405ea908e92',
+  'status': 'rendered',
+  'params': [
+    {
+      'placementId': 13144370
+    }
+  ]
+}
+
+export const BID_WON_EVENT_UNDEFINED = {
+  'bidderCode': undefined,
+  'width': 728,
+  'height': 90,
+  'statusMessage': 'Bid available',
+  'adId': '4e02072b881823',
+  'requestId': '3fae2718fd70f',
+  'transactionId': '6daa1dac-9eea-47ce-82ce-ce9681df1ec5',
+  'adUnitId': undefined,
+  'auctionId': '87b4a93d-19ae-432a-96f0-8c2d4cc1c539',
+  'mediaType': 'banner',
+  'source': 'client',
+  'cpm': undefined,
+  'creativeId': 98493734,
+  'currency': undefined,
+  'netRevenue': true,
+  'ttl': 300,
+  'adUnitCode': undefined,
+  'appnexus': {
+    'buyerMemberId': 9325
+  },
+  'meta': {
+    'advertiserId': 2529885,
+    'dchain': {
+      'ver': '1.0',
+      'complete': 0,
+      'nodes': [
+        {
+          'bsid': '9325'
+        }
+      ]
+    },
+    'brandId': 555545
+  },
+  'ad': "<!-- Creative 98493734 served by Member 9325 via AppNexus --><a href=\"https://fra1-ib.adnxs.com/click2?e=wqT_3QKfAfBtnwAAAAMAxBkFAQjLtNe9BhCkr-mSn9zTvwsYh6Pop7Cy0rQSILKiogYo7Ugw7Ug4AkCmyvsuSJzxW1AAWgNVU0RiA1VTRGjYBXBaeLXPeYABstgFiAEBkAEBmAEDoAECqQEAAAAAAAD4P7EBAAABDDD4P7kBAAAAwPUo-D_BAQoAAAEeAMkVCjDYAQDgAQDwAfUv-AEA/s=6676f8c324bf37b4366612bef92c11edbe7356f1/bcr=AAAAAAAA8D8=/cnd=%21uBDL_QjKvJodEKbK-y4YnPFbIAQoADEAAAAAAAD4PzoJRlJBMTo1Njg5QMtISQAAAAAAAPA_UQAAAAAAAAAAWQAAAAAAAAAAYQAAAAAAAAAAaQAAAAAAAAAAcQAAAAAAAAAAeACJAQAAAAAAAAAA/cca=OTMyNSNGUkExOjU2ODk=/bn=93234/clickenc=https%3A%2F%2Fdocs.prebid.org%2Fdev-docs%2Fgetting-started.html\" target=\"_blank\"><img width=\"728\" height=\"90\" style=\"border-style: none\" src=\"https://vcdn.adnxs.com/p/creative-image/f6/11/33/19/f6113319-e789-4408-b69d-b178d60c5a6e.png\" /></a><iframe src=\"https://acdn.adnxs.com/dmp/async_usersync.html?gdpr=0&seller_id=9325&pub_id=1193043\" width=\"1\" height=\"1\" frameborder=\"0\" scrolling=\"no\" marginheight=\"0\" marginwidth=\"0\" topmargin=\"0\" leftmargin=\"0\" style=\"position:absolute;overflow:hidden;clip:rect(0 0 0 0);height:1px;width:1px;margin:-1px;padding:0;border:0;\"></iframe><script>try {!function(){function e(e,t){return\"function\"==typeof __an_obj_extend_thunk?__an_obj_extend_thunk(e,t):e}function t(e,t){\"function\"==typeof __an_err_thunk&&__an_err_thunk(e,t)}function n(e,t){if(\"function\"==typeof __an_redirect_thunk)__an_redirect_thunk(e);else{var n=navigator.connection;navigator.__an_connection&&(n=navigator.__an_connection),window==window.top&&n&&n.downlinkMax<=.115&&\"function\"==typeof HTMLIFrameElement&&HTMLIFrameElement.prototype.hasOwnProperty(\"srcdoc\")?(window.__an_resize=function(e,t,n){var r=e.frameElement;r&&\"__an_if\"==r.getAttribute(\"name\")&&(t&&(r.style.width=t+\"px\"),n&&(r.style.height=n+\"px\"))},document.write('<iframe name=\"__an_if\" style=\"width:0;height:0\" srcdoc=\"<script type=\\'text/javascript\\' src=\\''+e+\"&\"+t.bdfif+\"=1'></sc\"),document.write('ript>\" frameborder=\"0\" scrolling=\"no\" marginheight=0 marginwidth=0 topmargin=\"0\" leftmargin=\"0\" allowtransparency=\"true\"></iframe>')):document.write('<script language=\"javascript\" src=\"'+e+'\"></scr'+'ipt>')}};var r=function(e){this.rdParams=e};r.prototype={constructor:r,walkAncestors:function(e){try{if(!window.location.ancestorOrigins)return;for(var t=0,n=window.location.ancestorOrigins.length;n>t;t++)e.call(null,window.location.ancestorOrigins[t],t)}catch(r){\"undefined\"!=typeof console}return[]},walkUpWindows:function(e){var t,n=[];do try{t=t?t.parent:window,e.call(null,t,n)}catch(r){return\"undefined\"!=typeof console,n.push({referrer:null,location:null,isTop:!1}),n}while(t!=window.top);return n},getPubUrlStack:function(e){var n,r=[],o=null,i=null,a=null,c=null,d=null,s=null,u=null;for(n=e.length-1;n>=0;n--){try{a=e[n].location}catch(l){\"undefined\"!=typeof console,t(l,\"AnRDModule::getPubUrlStack:: location\")}if(a)i=encodeURIComponent(a),r.push(i),u||(u=i);else if(0!==n){c=e[n-1];try{d=c.referrer,s=c.ancestor}catch(l){\"undefined\"!=typeof console,t(l,\"AnRDModule::getPubUrlStack:: prevFrame\")}d?(i=encodeURIComponent(d),r.push(i),u||(u=i)):s?(i=encodeURIComponent(s),r.push(i),u||(u=i)):r.push(o)}else r.push(o)}return{stack:r,detectUrl:u}},getLevels:function(){var e=this.walkUpWindows(function(e,n){try{n.push({referrer:e.document.referrer||null,location:e.location.href||null,isTop:e==window.top})}catch(r){n.push({referrer:null,location:null,isTop:e==window.top}),\"undefined\"!=typeof console,t(r,\"AnRDModule::getLevels\")}});return this.walkAncestors(function(t,n){e[n].ancestor=t}),e},getRefererInfo:function(){var e=\"\";try{var n=this.getLevels(),r=n.length-1,o=null!==n[r].location||r>0&&null!==n[r-1].referrer,i=this.getPubUrlStack(n);e=this.rdParams.rdRef+\"=\"+i.detectUrl+\"&\"+this.rdParams.rdTop+\"=\"+o+\"&\"+this.rdParams.rdIfs+\"=\"+r+\"&\"+this.rdParams.rdStk+\"=\"+i.stack+\"&\"+decodeURI(this.rdParams.rdQs)}catch(a){e=\"\",\"undefined\"!=typeof console,t(a,\"AnRDModule::getRefererInfo\")}return e}};var o=function(n){var o=\"\";try{n=e(n,0);var i=e(new r(n),1);return i.getRefererInfo()}catch(a){o=\"\",\"undefined\"!=typeof console,t(a,\"AnRDModule::executeRD\")}return o};;var c=\"https://fra1-ib.adnxs.com/rd_log?an_audit=0&referrer=https%3A%2F%2Fvdreiling-lab-test.s3.us-east-1.amazonaws.com%2Fprebid-presentation%2FpageWith2.html&e=wqT_3QL4DqB4BwAAAwDWAAUBCMu0170GEKSv6ZKf3NO_CxiHo-insLLStBIqNgkAAAECCPg_EQEHNAAA-D8ZAAAAwPUo-D8hERIAKREJADERG6gwsqKiBjjtSEDtSEgCUKbK-y5YnPFbYABotc95eLLYBYABAYoBA1VTRJIBAQbgmAHYBaABWqgBAbABALgBAcABA8gBAtABANgBAOABAPABAIoCKXVmKCdhJywgMjUyOTg4NSwgMCk7ARQwcicsIDk4NDkzNzM0LAEV8P2SArkEIWdHWkdOQWpLdkpvZEVLYksteTRZQUNDYzhWc3dBRGdBUUFSSTdVaFFzcUtpQmxnQVlPOEJhQUJ3SG5nZWdBRXVpQUVla0FFQm1BRUJvQUVCcUFFRHNBRUF1UUctMEV6RkFBRDRQOEVCdnRCTXhRQUEtRF9KQVh2RGw4S1c5LWtfMlFFQUFBQUFBQUR3UC1BQkFQVUJBQUFBQUpnQ0FLQUNBTFVDQUFBQUFMMENBQUFBQU1BQ0FNZ0NBTkFDQU5nQ0FPQUNBT2dDQVBnQ0FJQURBWmdEQWJvRENVWlNRVEU2TlRZNE9lQUR5MGlJQkFDUUJBQ1lCQUhCQgVNCQEIeVFRCQkBARROZ0VBUEURlSxBQUFDSUJia3NxUVUBDQmoCDdFRgEKCQEIREJCHT8AeRUoDEFBQU4yKAAAWi4oAPBlNEFYd2t3bnFCU1lJQkJJaUFBQUVHaXVpMDIwUjBQTVFldUxka0Rha19yMmI3VWFsX3MtZUlTM3FFRmx3bV9BRjdmemFBdmdGM2JTYUFZSUdBMVZUUklnR0FKQUdBWmdHQUtFR0FBAYU0QUEtRC1vQmdHeUJpUUoJEgUBAFIFBgkBAFoJBwUBAGgFBgUBGEM0QmdxQkMFDAkBSGlBZ0FrQWdBmgKVASF1QkRMX1E2PQIkblBGYklBUW9BRDFEWEQ0UHpvSlJsSkJNVG8xTmpnNVFNdElTMTUMUEFfVREMDEFBQVcdDABZHQwAYR0MAGMdDBBlQUNKQR0QeMICNWh0dHBzOi8vZG9jcy5wcmViaWQub3JnL2Rldi0BFIgvZ2V0dGluZy1zdGFydGVkLmh0bWzYAvfpA-ACrZhI6gJYaA1CFHZkcmVpbAErkGxhYi10ZXN0LnMzLnVzLWVhc3QtMS5hbWF6b25hd3MuY29tL3AFa1gtcHJlc2VudGF0aW9uL3BhZ2VXaXRoMgVlMPICEQoGQURWX0lEEgdtoQUUCENQRwUUFDU2ODQ4NAUUCAVDUAETNAg2MTI1MTE0NvICDgoIATxoRlJFURICMjPyAg0KCFJFTV9VU0VSEgEw8gIMCSEUQ09ERRIABQ8BWBEPEAsKB0NQFQ4QCQoFSU8BYQQA8gEaBElPFRo4EwoPQ1VTVE9NX01PREVMDSQIGgoWMhYAHExFQUZfTkFNBWoIHgoaNh0ACEFTVAE-EElGSUVEAWIcDQoIU1BMSVQBTdABMIADAIgDAZADAJgDF6ADAaoDAMAD2ATIAwDYA76sAuADAOgDAPgDAYAEAJIEDS91dC92My1d8H2YBACiBAw5MS45Ni42OC4xNzioBOfJB7IEEwgEEAQY2AUgWigBKAIwADgCQgC4BADABIDauCLIBADSBA45MzI1I0ZSQTE6NTY4OdoEAggB4AQB8ASmyvsuiAUBmAUAoAX___________8BwAUAyQUAAAAAAADwP9IFCQkAAAClwHDYBQHgBQHwBZn0IfoFBAgAEACQBgCYBgC4BgDBBgUiLADwP9AG9S_aBhYKEAkRGQFwEAAYAOAGAfIGAggAgAcBiAcAoAcByAey2AXSBw8VZAEmECAA2gcGAV_w9hgA4AcA6gcCCADwB_maAYoIwgEKvQEAAAGVHly0-At_TuHyWlekBSbXDsn7MA9kiN8zpQ3JU8nyaO8zDdp7eXakZns5iCya3WWSR84RbuXAFW3-XwQJeVDN6TyG7YPNRXX4XdmMcWX9_1-QRFJpDfa-JbkkC7fYcZAqd8ZtVFwqslqguelw0STCq4BqBFk4FzPd-AeWHANk_mkOfwp6MpZue28Vux_gDUVUgG02dxjB3K6zennqYPc7saGU_2WRWY3DmLT5qRojJ63yZx_ce2dwxwsQAZUIAACAP5gIAcAIANIIBggAEAAYANoIBAgAIADgCADoCAA.&s=85d0e398f1a637f01e83f3a42d8ad7d3bf45b8ac\";c+=\"&\"+o({rdRef:\"bdref\",rdTop:\"bdtop\",rdIfs:\"bdifs\",rdStk:\"bstk\",rdQs:\"\"}),n(c,{bdfif:\"bdfif\"})}();} catch (e) { }</script><div name=\"anxv\" lnttag=\"v;tv=view7-1hs;st=0;d=728x90;vc=iab;vid_ccr=1;tag_id=13144370;cb=https%3A%2F%2Ffra1-ib.adnxs.com%2Fvevent%3Fan_audit%3D0%26referrer%3Dhttps%253A%252F%252Fvdreiling-lab-test.s3.us-east-1.amazonaws.com%252Fprebid-presentation%252FpageWith2.html%26e%3DwqT_3QL5DKB5BgAAAwDWAAUBCMu0170GEKSv6ZKf3NO_CxiHo-insLLStBIqNgkAAAECCPg_EQEHNAAA-D8ZAAAAwPUo-D8hERIAKREJADERG6gwsqKiBjjtSEDtSEgCUKbK-y5YnPFbYABotc95eLLYBYABAYoBA1VTRJIBAQbgmAHYBaABWqgBAbABALgBAcABA8gBAtABANgBAOABAPABAIoCKXVmKCdhJywgMjUyOTg4NSwgMCk7ARQwcicsIDk4NDkzNzM0LAEV8P2SArkEIWdHWkdOQWpLdkpvZEVLYksteTRZQUNDYzhWc3dBRGdBUUFSSTdVaFFzcUtpQmxnQVlPOEJhQUJ3SG5nZWdBRXVpQUVla0FFQm1BRUJvQUVCcUFFRHNBRUF1UUctMEV6RkFBRDRQOEVCdnRCTXhRQUEtRF9KQVh2RGw4S1c5LWtfMlFFQUFBQUFBQUR3UC1BQkFQVUJBQUFBQUpnQ0FLQUNBTFVDQUFBQUFMMENBQUFBQU1BQ0FNZ0NBTkFDQU5nQ0FPQUNBT2dDQVBnQ0FJQURBWmdEQWJvRENVWlNRVEU2TlRZNE9lQUR5MGlJQkFDUUJBQ1lCQUhCQgVNCQEIeVFRCQkBARROZ0VBUEURlSxBQUFDSUJia3NxUVUBDQmoCDdFRgEKCQEIREJCHT8AeRUoDEFBQU4yKAAAWi4oAPBlNEFYd2t3bnFCU1lJQkJJaUFBQUVHaXVpMDIwUjBQTVFldUxka0Rha19yMmI3VWFsX3MtZUlTM3FFRmx3bV9BRjdmemFBdmdGM2JTYUFZSUdBMVZUUklnR0FKQUdBWmdHQUtFR0FBAYU0QUEtRC1vQmdHeUJpUUoJEgUBAFIFBgkBAFoJBwUBAGgFBgUBGEM0QmdxQkMFDAkBSGlBZ0FrQWdBmgKVASF1QkRMX1E2PQIkblBGYklBUW9BRDFEWEQ0UHpvSlJsSkJNVG8xTmpnNVFNdElTMTUMUEFfVREMDEFBQVcdDABZHQwAYR0MAGMdDBBlQUNKQR0QeMICNWh0dHBzOi8vZG9jcy5wcmViaWQub3JnL2Rldi0BFIgvZ2V0dGluZy1zdGFydGVkLmh0bWzYAvfpA-ACrZhI6gJYaA1CFHZkcmVpbAErkGxhYi10ZXN0LnMzLnVzLWVhc3QtMS5hbWF6b25hd3MuY29tL3AFa1gtcHJlc2VudGF0aW9uL3BhZ2VXaXRoMgVlyIADAIgDAZADAJgDF6ADAaoDAMAD2ATIAwDYA76sAuADAOgDAPgDAYAEAJIEDS91dC92Mw1W8H2YBACiBAw5MS45Ni42OC4xNzioBOfJB7IEEwgEEAQY2AUgWigBKAIwADgCQgC4BADABIDauCLIBADSBA45MzI1I0ZSQTE6NTY4OdoEAggB4AQB8ASmyvsuiAUBmAUAoAX___________8BwAUAyQUAAAAAAADwP9IFCQkAAACFuXDYBQHgBQHwBZn0IfoFBAgAEACQBgCYBgC4BgDBBgUiLADwP9AG9S_aBhYKEAkRGQFwEAAYAOAGAfIGAggAgAcBiAcAoAcByAey2AXSBw8VZAEmECAA2gcGAV_w_hgA4AcA6gcCCADwB_maAYoIwgEKvQEAAAGVHly0-At_TuHyWlekBSbXDsn7MA9kiN8zpQ3JU8nyaO8zDdp7eXakZns5iCya3WWSR84RbuXAFW3-XwQJeVDN6TyG7YPNRXX4XdmMcWX9_1-QRFJpDfa-JbkkC7fYcZAqd8ZtVFwqslqguelw0STCq4BqBFk4FzPd-AeWHANk_mkOfwp6MpZue28Vux_gDUVUgG02dxjB3K6zennqYPc7saGU_2WRWY3DmLT5qRojJ63yZx_ce2dwxwsQAZUIAACAP5gIAcAIANIIDgiBgoSIkKDAgAEQABgA2ggECAAgAOAIAOgIAA..%26s%3D9e2f1bc1368ef251ec44c5d79310bc41bba2ca52;ts=1739971147;cet=0;cecb=\" width=\"0\" height=\"0\" style=\"display: block; margin: 0; padding: 0; height: 0; width: 0;\"><script type=\"text/javascript\" async=\"true\" src=\"https://cdn.adnxs.com/v/s/249/trk.js\"></script></div><div style=\"position:absolute;left:0px;top:0px;visibility:hidden;\"><img src=\"https://fra1-ib.adnxs.com/it?an_audit=0&referrer=https%253A%252F%252Fvdreiling-lab-test.s3.us-east-1.amazonaws.com%252Fprebid-presentation%252FpageWith2.html&e=wqT_3QL5DKB5BgAAAwDWAAUBCMu0170GEKSv6ZKf3NO_CxiHo-insLLStBIqNgkAAAECCPg_EQEHNAAA-D8ZAAAAwPUo-D8hERIAKREJADERG6gwsqKiBjjtSEDtSEgCUKbK-y5YnPFbYABotc95eLLYBYABAYoBA1VTRJIBAQbgmAHYBaABWqgBAbABALgBAcABBMgBAtABANgBAOABAPABAIoCKXVmKCdhJywgMjUyOTg4NSwgMCk7ARQwcicsIDk4NDkzNzM0LAEV8P2SArkEIWdHWkdOQWpLdkpvZEVLYksteTRZQUNDYzhWc3dBRGdBUUFSSTdVaFFzcUtpQmxnQVlPOEJhQUJ3SG5nZWdBRXVpQUVla0FFQm1BRUJvQUVCcUFFRHNBRUF1UUctMEV6RkFBRDRQOEVCdnRCTXhRQUEtRF9KQVh2RGw4S1c5LWtfMlFFQUFBQUFBQUR3UC1BQkFQVUJBQUFBQUpnQ0FLQUNBTFVDQUFBQUFMMENBQUFBQU1BQ0FNZ0NBTkFDQU5nQ0FPQUNBT2dDQVBnQ0FJQURBWmdEQWJvRENVWlNRVEU2TlRZNE9lQUR5MGlJQkFDUUJBQ1lCQUhCQgVNCQEIeVFRCQkBARROZ0VBUEURlSxBQUFDSUJia3NxUVUBDQmoCDdFRgEKCQEIREJCHT8AeRUoDEFBQU4yKAAAWi4oAPBlNEFYd2t3bnFCU1lJQkJJaUFBQUVHaXVpMDIwUjBQTVFldUxka0Rha19yMmI3VWFsX3MtZUlTM3FFRmx3bV9BRjdmemFBdmdGM2JTYUFZSUdBMVZUUklnR0FKQUdBWmdHQUtFR0FBAYU0QUEtRC1vQmdHeUJpUUoJEgUBAFIFBgkBAFoJBwUBAGgFBgUBGEM0QmdxQkMFDAkBSGlBZ0FrQWdBmgKVASF1QkRMX1E2PQIkblBGYklBUW9BRDFEWEQ0UHpvSlJsSkJNVG8xTmpnNVFNdElTMTUMUEFfVREMDEFBQVcdDABZHQwAYR0MAGMdDBBlQUNKQR0QeMICNWh0dHBzOi8vZG9jcy5wcmViaWQub3JnL2Rldi0BFIgvZ2V0dGluZy1zdGFydGVkLmh0bWzYAvfpA-ACrZhI6gJYaA1CFHZkcmVpbAErkGxhYi10ZXN0LnMzLnVzLWVhc3QtMS5hbWF6b25hd3MuY29tL3AFa1gtcHJlc2VudGF0aW9uL3BhZ2VXaXRoMgVlyIADAIgDAZADAJgDF6ADAaoDAMAD2ATIAwDYA76sAuADAOgDAPgDAYAEAJIEDS91dC92Mw1W8H2YBACiBAw5MS45Ni42OC4xNzioBOfJB7IEEwgEEAQY2AUgWigBKAIwADgCQgC4BADABIDauCLIBADSBA45MzI1I0ZSQTE6NTY4OdoEAggB4AQB8ASmyvsuiAUBmAUAoAX___________8BwAUAyQUAAAAAAADwP9IFCQkAAACFuXDYBQHgBQHwBZn0IfoFBAgAEACQBgCYBgC4BgDBBgUiLADwP9AG9S_aBhYKEAkRGQFwEAAYAOAGAfIGAggAgAcBiAcAoAcByAey2AXSBw8VZAEmECAA2gcGAV_w_hgA4AcA6gcCCADwB_maAYoIwgEKvQEAAAGVHly0-At_TuHyWlekBSbXDsn7MA9kiN8zpQ3JU8nyaO8zDdp7eXakZns5iCya3WWSR84RbuXAFW3-XwQJeVDN6TyG7YPNRXX4XdmMcWX9_1-QRFJpDfa-JbkkC7fYcZAqd8ZtVFwqslqguelw0STCq4BqBFk4FzPd-AeWHANk_mkOfwp6MpZue28Vux_gDUVUgG02dxjB3K6zennqYPc7saGU_2WRWY3DmLT5qRojJ63yZx_ce2dwxwsQAZUIAACAP5gIAcAIANIIDgiBgoSIkKDAgAEQABgA2ggECAAgAOAIAOgIAA..&s=c6fcf3b118918dba361b8ec2960485117d3805ae\"></div>",
+  'metrics': {
+    'userId.init.consent': [
+      0.09999999403953552
+    ],
+    'userId.mod.init': [
+      1.7999999821186066
+    ],
+    'userId.mods.liveIntentId.init': [
+      1.7999999821186066
+    ],
+    'userId.init.modules': [
+      1.9000000059604645
+    ],
+    'userId.callbacks.pending': [
+      0
+    ],
+    'userId.mod.callback': [
+      149.69999998807907
+    ],
+    'userId.mods.liveIntentId.callback': [
+      149.69999998807907
+    ],
+    'userId.callbacks.total': [
+      149.80000001192093
+    ],
+    'userId.total': [
+      152.90000000596046
+    ],
+    'requestBids.userId': 147.2999999821186,
+    'requestBids.validate': 0.30000001192092896,
+    'requestBids.makeRequests': 0.699999988079071,
+    'requestBids.total': 215.7999999821186,
+    'requestBids.callBids': 65,
+    'adapter.client.validate': 0,
+    'adapters.client.appnexus.validate': 0,
+    'adapter.client.buildRequests': 1.199999988079071,
+    'adapters.client.appnexus.buildRequests': 1.199999988079071,
+    'adapter.client.total': 62.69999998807907,
+    'adapters.client.appnexus.total': 62.69999998807907,
+    'adapter.client.net': 59.5,
+    'adapters.client.appnexus.net': 59.5,
+    'adapter.client.interpretResponse': 0.5,
+    'adapters.client.appnexus.interpretResponse': 0.5,
+    'addBidResponse.validate': 0.09999999403953552,
+    'addBidResponse.total': 0.9000000059604645,
+    'render.deferred': null,
+    'render.pending': 130.60000002384186,
+    'render.e2e': 346.40000000596046,
+    'adserver.pending': 130.80000001192093,
+    'adserver.e2e': 346.59999999403954
+  },
+  'adapterCode': 'appnexus',
+  'originalCpm': 1.5,
+  'originalCurrency': 'USD',
+  'deferBilling': false,
+  'deferRendering': false,
+  'responseTimestamp': undefined,
+  'requestTimestamp': undefined,
+  'bidder': undefined,
+  'timeToRespond': 62,
+  'pbLg': '1.50',
+  'pbMg': '1.50',
+  'pbHg': '1.50',
+  'pbAg': '1.50',
+  'pbDg': '1.50',
+  'pbCg': '',
+  'size': '728x90',
+  'adserverTargeting': {
+    'hb_bidder': 'appnexus',
+    'hb_adid': '4e02072b881823',
+    'hb_pb': '1.50',
+    'hb_size': '728x90',
+    'hb_source': 'client',
+    'hb_format': 'banner',
+    'hb_adomain': '',
+    'hb_crid': 98493734
+  },
+  'latestTargetedAuctionId': 'a8ac8297-9f6f-4e35-bb42-8405ea908e92',
+  'status': 'rendered',
+  'params': [
+    {
+      'placementId': 13144370
+    }
+  ]
+}

--- a/test/spec/modules/liveIntentAnalyticsAdapter_spec.js
+++ b/test/spec/modules/liveIntentAnalyticsAdapter_spec.js
@@ -2,8 +2,9 @@ import liAnalytics from 'modules/liveIntentAnalyticsAdapter';
 import { expect } from 'chai';
 import { server } from 'test/mocks/xhr.js';
 import { auctionManager } from 'src/auctionManager.js';
-import {expectEvents} from '../../helpers/analytics.js';
 import { EVENTS } from 'src/constants.js';
+import { config } from 'src/config.js';
+import { BID_WON_EVENT, AUCTION_INIT_EVENT, BID_WON_EVENT_UNDEFINED, AUCTION_INIT_EVENT_NOT_LI } from '../../fixtures/liveIntentAuctionEvents';
 
 let utils = require('src/utils');
 let refererDetection = require('src/refererDetection');
@@ -14,13 +15,24 @@ let clock;
 let now = new Date();
 
 let events = require('src/events');
-let auctionId = '99abbc81-c1f1-41cd-8f25-f7149244c897'
+
+const USERID_CONFIG = [
+  {
+    'name': 'liveIntentId',
+    'params': {
+      'liCollectConfig': {
+        'appId': 'a123'
+      }
+    }
+  }
+];
 
 const configWithSamplingAll = {
   provider: 'liveintent',
   options: {
     bidWonTimeout: 2000,
-    sampling: 1
+    sampling: 1,
+    sendAuctionInitEvents: true
   }
 }
 
@@ -28,291 +40,123 @@ const configWithSamplingNone = {
   provider: 'liveintent',
   options: {
     bidWonTimeout: 2000,
-    sampling: 0
+    sampling: 0,
+    sendAuctionInitEvents: true
   }
 }
 
-let args = {
-  auctionId: auctionId,
-  timestamp: 1660915379703,
-  auctionEnd: 1660915381635,
-  adUnits: [
-    {
-      code: 'ID_Bot100AdJ1',
-      mediaTypes: {
-        banner: {
-          sizes: [
-            [
-              300,
-              250
-            ],
-            [
-              320,
-              50
-            ]
-          ]
-        }
-      },
-      ortb2Imp: {
-        gpid: '/777/test/home/ID_Bot100AdJ1',
-        ext: {
-          data: {
-            aupName: '/777/test/home/ID_Bot100AdJ1',
-            adserver: {
-              name: 'gam',
-              adslot: '/777/test/home/ID_Bot100AdJ1'
-            },
-            pbadslot: '/777/test/home/ID_Bot100AdJ1'
-          },
-          gpid: '/777/test/home/ID_Bot100AdJ1'
-        }
-      },
-      bids: [
-        {
-          bidder: 'testBidder',
-          params: {
-            siteId: 321218,
-            zoneId: 1732558,
-            position: 'bug',
-            accountId: 10777
-          },
-          userIdAsEids: [
-            {
-              source: 'source1.com',
-              uids: [
-                {
-                  id: 'ID5*yO-L9xRugTx4mkIJ9z99eYva6CZQhz8B70QOkLLSEEQWowsxvVQqMaZOt4qpBTYAFqR3y6ZtZ8qLJJBAsRqnRRalTfy8iZszQavAAkZcAjkWpxp6DnOSkF3R5LafC10OFqhwcxH699dDc_fI6RVEGBasN6zrJwgqCGelgfQLtQwWrikWRyi0l3ICFj9JUiVGFrCF8SAFaqJD9A0_I07a8xa0-jADtEj1T8w30oX--sMWvTK_I5_3zA5f3z0OMoxbFsCMFdhfGRDuw5GrpI475g',
-                  atype: 1,
-                  ext: {
-                    linkType: 2
-                  }
-                }
-              ]
-            },
-            {
-              source: 'source2.com',
-              uids: [
-                {
-                  id: 'ID5*yO-L9xRugTx4mkIJ9z99eYva6CZQhz8B70QOkLLSEEQWowsxvVQqMaZOt4qpBTYAFqR3y6ZtZ8qLJJBAsRqnRRalTfy8iZszQavAAkZcAjkWpxp6DnOSkF3R5LafC10OFqhwcxH699dDc_fI6RVEGBasN6zrJwgqCGelgfQLtQwWrikWRyi0l3ICFj9JUiVGFrCF8SAFaqJD9A0_I07a8xa0-jADtEj1T8w30oX--sMWvTK_I5_3zA5f3z0OMoxbFsCMFdhfGRDuw5GrpI475g',
-                  atype: 1,
-                  ext: {
-                    linkType: 2
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          bidder: 'testBidder2',
-          params: {
-            adSlot: '2926251',
-            publisherId: '159423'
-          },
-          userIdAsEids: [
-            {
-              source: 'source1.com',
-              uids: [
-                {
-                  id: 'ID5*yO-L9xRugTx4mkIJ9z99eYva6CZQhz8B70QOkLLSEEQWowsxvVQqMaZOt4qpBTYAFqR3y6ZtZ8qLJJBAsRqnRRalTfy8iZszQavAAkZcAjkWpxp6DnOSkF3R5LafC10OFqhwcxH699dDc_fI6RVEGBasN6zrJwgqCGelgfQLtQwWrikWRyi0l3ICFj9JUiVGFrCF8SAFaqJD9A0_I07a8xa0-jADtEj1T8w30oX--sMWvTK_I5_3zA5f3z0OMoxbFsCMFdhfGRDuw5GrpI475g',
-                  atype: 1,
-                  ext: {
-                    linkType: 2
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ],
-  bidderRequests: [
-    {
-      bidderCode: 'tripl_ss1',
-      auctionId: '8e5a5eda-a7dc-49a3-bc7f-654fc',
-      bidderRequestId: '953fe1ee8a1645',
-      uniquePbsTid: '0da1f980-8351-415d-860d-ebbdb4274179',
-      auctionStart: 1660915379703
-    },
-    {
-      bidderCode: 'tripl_ss2',
-      auctionId: '8e5a5eda-a7dc-49a3-bc7f-6ca682ae893c',
-      bidderRequestId: '953fe1ee8a164e',
-      uniquePbsTid: '0da1f980-8351-415d-860d-ebbdb4274180',
-      auctionStart: 1660915379703
-    }
-  ],
-  bidsReceived: [
-    {
-      adUnitCode: 'ID_Bot100AdJ1',
-      timeToRespond: 824,
-      cpm: 0.447,
-      currency: 'USD',
-      ttl: 300,
-      bidder: 'testBidder'
-    }
-  ],
-  winningBids: []
-}
-
-let winningBids = [
-  {
-    adUnitCode: 'ID_Bot100AdJ1',
-    timeToRespond: 824,
-    cpm: 0.447,
-    currency: 'USD',
-    ttl: 300,
-    bidder: 'testBidder'
+const configWithNoAuctionInit = {
+  provider: 'liveintent',
+  options: {
+    bidWonTimeout: 2000,
+    sampling: 1,
+    sendAuctionInitEvents: false
   }
-];
-
-let expectedEvent = {
-  instanceId: instanceId,
-  url: url,
-  bidsReceived: [
-    {
-      adUnitCode: 'ID_Bot100AdJ1',
-      timeToRespond: 824,
-      cpm: 0.447,
-      currency: 'USD',
-      ttl: 300,
-      bidder: 'testBidder'
-    }
-  ],
-  auctionStart: 1660915379703,
-  auctionEnd: 1660915381635,
-  adUnits: [
-    {
-      code: 'ID_Bot100AdJ1',
-      mediaType: 'banner',
-      sizes: [
-        {
-          w: 300,
-          h: 250
-        },
-        {
-          w: 320,
-          h: 50
-        }
-      ],
-      ortb2Imp: {
-        gpid: '/777/test/home/ID_Bot100AdJ1',
-        ext: {
-          data: {
-            aupName: '/777/test/home/ID_Bot100AdJ1',
-            adserver: {
-              name: 'gam',
-              adslot: '/777/test/home/ID_Bot100AdJ1'
-            },
-            pbadslot: '/777/test/home/ID_Bot100AdJ1'
-          },
-          gpid: '/777/test/home/ID_Bot100AdJ1'
-        }
-      }
-    }
-  ],
-  winningBids: [
-    {
-      adUnitCode: 'ID_Bot100AdJ1',
-      timeToRespond: 824,
-      cpm: 0.447,
-      currency: 'USD',
-      ttl: 300,
-      bidder: 'testBidder'
-    }
-  ],
-  auctionId: auctionId,
-  userIds: [
-    {
-      source: 'source1.com',
-      uids: [
-        {
-          id: 'ID5*yO-L9xRugTx4mkIJ9z99eYva6CZQhz8B70QOkLLSEEQWowsxvVQqMaZOt4qpBTYAFqR3y6ZtZ8qLJJBAsRqnRRalTfy8iZszQavAAkZcAjkWpxp6DnOSkF3R5LafC10OFqhwcxH699dDc_fI6RVEGBasN6zrJwgqCGelgfQLtQwWrikWRyi0l3ICFj9JUiVGFrCF8SAFaqJD9A0_I07a8xa0-jADtEj1T8w30oX--sMWvTK_I5_3zA5f3z0OMoxbFsCMFdhfGRDuw5GrpI475g',
-          atype: 1,
-          ext: {
-            linkType: 2
-          }
-        }
-      ]
-    },
-    {
-      source: 'source2.com',
-      uids: [
-        {
-          id: 'ID5*yO-L9xRugTx4mkIJ9z99eYva6CZQhz8B70QOkLLSEEQWowsxvVQqMaZOt4qpBTYAFqR3y6ZtZ8qLJJBAsRqnRRalTfy8iZszQavAAkZcAjkWpxp6DnOSkF3R5LafC10OFqhwcxH699dDc_fI6RVEGBasN6zrJwgqCGelgfQLtQwWrikWRyi0l3ICFj9JUiVGFrCF8SAFaqJD9A0_I07a8xa0-jADtEj1T8w30oX--sMWvTK_I5_3zA5f3z0OMoxbFsCMFdhfGRDuw5GrpI475g',
-          atype: 1,
-          ext: {
-            linkType: 2
-          }
-        }
-      ]
-    }
-  ],
-  bidders: [
-    {
-      bidder: 'testBidder',
-      params: {
-        siteId: 321218,
-        zoneId: 1732558,
-        position: 'bug',
-        accountId: 10777
-      }
-    },
-    {
-      bidder: 'testBidder2',
-      params: {
-        adSlot: '2926251',
-        publisherId: '159423'
-      }
-    }
-  ]
-};
+}
 
 describe('LiveIntent Analytics Adapter ', () => {
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
     sandbox.stub(events, 'getEvents').returns([]);
+    sandbox.stub(config, 'getConfig').withArgs('userSync.userIds').returns(USERID_CONFIG);
+    sandbox.stub(utils, 'generateUUID').returns(instanceId);
+    sandbox.stub(refererDetection, 'getRefererInfo').returns({page: url});
+    sandbox.stub(auctionManager.index, 'getAuction').withArgs({auctionId: AUCTION_INIT_EVENT.auctionId}).returns({
+      getBidRequests: () => AUCTION_INIT_EVENT.bidderRequests,
+      getAuctionStart: () => AUCTION_INIT_EVENT.timestamp
+    });
     clock = sandbox.useFakeTimers(now.getTime());
   });
   afterEach(function () {
     liAnalytics.disableAnalytics();
     sandbox.restore();
     clock.restore();
+    window.liTreatmentRate = undefined
+    window.liModuleEnabled = undefined
   });
 
   it('request is computed and sent correctly when sampling is 1', () => {
     liAnalytics.enableAnalytics(configWithSamplingAll);
-    sandbox.stub(utils, 'generateUUID').returns(instanceId);
-    sandbox.stub(refererDetection, 'getRefererInfo').returns({page: url});
-    sandbox.stub(auctionManager.index, 'getAuction').withArgs({auctionId}).returns({ getWinningBids: () => winningBids });
-    events.emit(EVENTS.AUCTION_END, args);
-    clock.tick(2000);
-    expect(server.requests.length).to.equal(1);
 
-    let requestBody = JSON.parse(server.requests[0].requestBody);
-    expect(requestBody).to.deep.equal(expectedEvent);
+    events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT);
+    expect(server.requests.length).to.equal(1);
+    expect(server.requests[0].url).to.equal('https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=pbjs&liip=y&aun=2')
+
+    events.emit(EVENTS.BID_WON, BID_WON_EVENT);
+    expect(server.requests.length).to.equal(2);
+    expect(server.requests[1].url).to.equal('https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=pbjs&sts=1739971147744&rts=1739971147806&liip=y');
   });
 
-  it('track is called', () => {
-    sandbox.stub(liAnalytics, 'track');
+  it('request is computed and sent correctly when sampling is 1 and liModule is enabled', () => {
+    window.liModuleEnabled = true
     liAnalytics.enableAnalytics(configWithSamplingAll);
-    expectEvents().to.beTrackedBy(liAnalytics.track);
-  })
 
-  it('no request is computed when sampling is 0', () => {
-    liAnalytics.enableAnalytics(configWithSamplingNone);
-    sandbox.stub(utils, 'generateUUID').returns(instanceId);
-    sandbox.stub(refererDetection, 'getRefererInfo').returns({page: url});
-    sandbox.stub(auctionManager.index, 'getAuction').withArgs({auctionId}).returns({ getWinningBids: () => winningBids });
-    events.emit(EVENTS.AUCTION_END, args);
-    clock.tick(2000);
+    events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT);
+    expect(server.requests.length).to.equal(1);
+    expect(server.requests[0].url).to.equal('https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=pbjs&me=y&liip=y&aun=2')
+
+    events.emit(EVENTS.BID_WON, BID_WON_EVENT);
+    expect(server.requests.length).to.equal(2);
+    expect(server.requests[1].url).to.equal('https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=pbjs&sts=1739971147744&rts=1739971147806&me=y&liip=y');
+  });
+
+  it('request is computed and sent correctly when sampling is 1 and liModule is disabled', () => {
+    window.liModuleEnabled = false
+    liAnalytics.enableAnalytics(configWithSamplingAll);
+
+    events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT);
+    expect(server.requests.length).to.equal(1);
+    expect(server.requests[0].url).to.equal('https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=pbjs&me=n&liip=y&aun=2')
+
+    events.emit(EVENTS.BID_WON, BID_WON_EVENT);
+    expect(server.requests.length).to.equal(2);
+    expect(server.requests[1].url).to.equal('https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=pbjs&sts=1739971147744&rts=1739971147806&me=n&liip=y');
+  });
+
+  it('request is computed and sent correctly when sampling is 1 and should forward the correct liTreatmentRate', () => {
+    window.liTreatmentRate = 0.95
+    liAnalytics.enableAnalytics(configWithSamplingAll);
+
+    events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT);
+    expect(server.requests.length).to.equal(1);
+    expect(server.requests[0].url).to.equal('https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=pbjs&tr=0.95&liip=y&aun=2')
+
+    events.emit(EVENTS.BID_WON, BID_WON_EVENT);
+    expect(server.requests.length).to.equal(2);
+    expect(server.requests[1].url).to.equal('https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=pbjs&sts=1739971147744&rts=1739971147806&tr=0.95&liip=y');
+  });
+
+  it('not send any events on auction init if disabled in settings', () => {
+    liAnalytics.enableAnalytics(configWithNoAuctionInit);
+
+    events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT);
     expect(server.requests.length).to.equal(0);
   });
 
-  it('track is not called', () => {
-    sandbox.stub(liAnalytics, 'track');
+  it('not send fields that are undefined', () => {
+    liAnalytics.enableAnalytics(configWithSamplingAll);
+
+    events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT);
+    events.emit(EVENTS.BID_WON, BID_WON_EVENT_UNDEFINED);
+
+    expect(server.requests.length).to.equal(2);
+    expect(server.requests[1].url).to.equal('https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=pbjs&liip=y');
+  });
+
+  it('liip should be n if there is no source or provider in userIdAsEids have the value liveintent.com', () => {
+    liAnalytics.enableAnalytics(configWithSamplingAll);
+
+    events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT_NOT_LI);
+    expect(server.requests.length).to.equal(1);
+    expect(server.requests[0].url).to.equal('https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=pbjs&liip=n&aun=2');
+  });
+
+  it('no request is computed when sampling is 0', () => {
     liAnalytics.enableAnalytics(configWithSamplingNone);
-    sinon.assert.callCount(liAnalytics.track, 0);
-  })
+
+    events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT);
+    events.emit(EVENTS.BID_WON, BID_WON_EVENT);
+
+    expect(server.requests.length).to.equal(0);
+  });
 });

--- a/test/spec/modules/liveIntentExternalIdSystem_spec.js
+++ b/test/spec/modules/liveIntentExternalIdSystem_spec.js
@@ -1,4 +1,5 @@
 import { liveIntentExternalIdSubmodule, resetSubmodule } from 'libraries/liveIntentId/externalIdSystem.js';
+import { DEFAULT_TREATMENT_RATE } from 'libraries/liveIntentId/shared.js';
 import { gdprDataHandler, uspDataHandler, gppDataHandler, coppaDataHandler } from '../../../src/adapterManager.js';
 import * as refererDetection from '../../../src/refererDetection.js';
 const DEFAULT_AJAX_TIMEOUT = 5000
@@ -11,6 +12,7 @@ describe('LiveIntentExternalId', function() {
   let gppConsentDataStub;
   let coppaConsentDataStub;
   let refererInfoStub;
+  let randomStub;
 
   beforeEach(function() {
     uspConsentDataStub = sinon.stub(uspDataHandler, 'getConsentData');
@@ -18,6 +20,7 @@ describe('LiveIntentExternalId', function() {
     gppConsentDataStub = sinon.stub(gppDataHandler, 'getConsentData');
     coppaConsentDataStub = sinon.stub(coppaDataHandler, 'getCoppa');
     refererInfoStub = sinon.stub(refererDetection, 'getRefererInfo');
+    randomStub = sinon.stub(Math, 'random').returns(0.6);
   });
 
   afterEach(function() {
@@ -26,7 +29,10 @@ describe('LiveIntentExternalId', function() {
     gppConsentDataStub.restore();
     coppaConsentDataStub.restore();
     refererInfoStub.restore();
+    randomStub.restore();
     window.liQHub = []; // reset
+    window.liModuleEnabled = undefined; // reset
+    window.liTreatmentRate = undefined; // reset
     resetSubmodule();
   });
 
@@ -312,7 +318,7 @@ describe('LiveIntentExternalId', function() {
   });
 
   it('should decode values with the segments but no nonId', function() {
-    const result = liveIntentExternalIdSubmodule.decode({segments: ['tak']}, { params: defaultConfigParams });
+    const result = liveIntentExternalIdSubmodule.decode({segments: ['tak']}, defaultConfigParams);
     expect(result).to.eql({'lipb': {'segments': ['tak']}});
   });
 
@@ -467,7 +473,185 @@ describe('LiveIntentExternalId', function() {
   });
 
   it('should decode the segments as part of lipb', function() {
-    const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', 'segments': ['bar'] }, { params: defaultConfigParams });
+    const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', 'segments': ['bar'] }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'segments': ['bar']}});
+  });
+
+  it('getId does not set the global variables when liModuleEnabled, liTreatmentRate and activatePartialTreatment are undefined', function() {
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = undefined;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: undefined } };
+
+    liveIntentExternalIdSubmodule.getId(configWithPartialTreatment).callback(() => {});
+    expect(window.liModuleEnabled).to.be.undefined
+    expect(window.liTreatmentRate).to.be.undefined
+  });
+
+  it('getId does not set the global variables when liModuleEnabled is undefined, liTreatmentRate is 0.7 and activatePartialTreatment is undefined', function() {
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: undefined } };
+
+    liveIntentExternalIdSubmodule.getId(configWithPartialTreatment).callback(() => {});
+    expect(window.liModuleEnabled).to.be.undefined
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('getId does not set the global variables when liModuleEnabled is undefined, liTreatmentRate is 0.7 and activatePartialTreatment is false', function() {
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: false } };
+
+    liveIntentExternalIdSubmodule.getId(configWithPartialTreatment).callback(() => {});
+    expect(window.liModuleEnabled).to.be.undefined
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('getId does not change the global variables when liModuleEnabled is true, liTreatmentRate is 0.7 and activatePartialTreatment is true', function() {
+    randomStub.returns(1.0) // 1.0 < 0.7 = false, but should be ignored by the module
+    window.liModuleEnabled = true;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    liveIntentExternalIdSubmodule.getId(configWithPartialTreatment).callback(() => {});
+    expect(window.liModuleEnabled).to.eq(true)
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('getId does not change the global variables when liModuleEnabled is false, liTreatmentRate is 0.7 and activatePartialTreatment is true', function() {
+    randomStub.returns(0.5) // 0.5 < 0.7 = true, but should be ignored by the module
+    window.liModuleEnabled = false;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    liveIntentExternalIdSubmodule.getId(configWithPartialTreatment).callback(() => {});
+    expect(window.liModuleEnabled).to.eq(false)
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('getId sets the global variables correctly when liModuleEnabled is undefined, liTreatmentRate is 0.7 and activatePartialTreatment is true, and experiment returns false', function() {
+    randomStub.returns(1) // 1 < 0.7 = false
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    liveIntentExternalIdSubmodule.getId(configWithPartialTreatment).callback(() => {});
+    expect(window.liModuleEnabled).to.eq(false)
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('getId sets the global variables correctly when liModuleEnabled is undefined, liTreatmentRate is undefined and activatePartialTreatment is true, and experiment returns true', function() {
+    randomStub.returns(0.0) // 0.0 < DEFAULT_TREATMENT_RATE (0.97) = true
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = undefined;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    liveIntentExternalIdSubmodule.getId(configWithPartialTreatment).callback(() => {});
+    expect(window.liModuleEnabled).to.eq(true)
+    expect(window.liTreatmentRate).to.eq(DEFAULT_TREATMENT_RATE)
+  });
+
+  it('should decode IDs when liModuleEnabled, liTreatmentRate and activatePartialTreatment are undefined', function() {
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = undefined;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: undefined } };
+
+    const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar', 'segments': ['tak']}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+    expect(window.liModuleEnabled).to.be.undefined
+    expect(window.liTreatmentRate).to.be.undefined
+  });
+
+  it('should decode IDs when liModuleEnabled is undefined, liTreatmentRate is 0.7 and activatePartialTreatment is undefined', function() {
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: undefined } };
+
+    const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar', 'segments': ['tak']}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+    expect(window.liModuleEnabled).to.be.undefined
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('should decode IDs when liModuleEnabled is undefined, liTreatmentRate is 0.7 and activatePartialTreatment is false', function() {
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: false } };
+
+    const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar', 'segments': ['tak']}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+    expect(window.liModuleEnabled).to.be.undefined
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('should decode IDs when liModuleEnabled is true, liTreatmentRate is 0.7 and activatePartialTreatment is true', function() {
+    randomStub.returns(1.0) // 1 < 0.7 = false, but should be ignored by the module as liModuleEnabled is already defined
+    window.liModuleEnabled = true;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar', 'segments': ['tak']}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+    expect(window.liModuleEnabled).to.eq(true)
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('should not decode IDs when liModuleEnabled is false, liTreatmentRate is 0.7 and activatePartialTreatment is true', function() {
+    randomStub.returns(0.5) // 0.5 < 0.7 = true, but should be ignored by the module as liModuleEnabled is already defined
+    window.liModuleEnabled = false;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({});
+    expect(window.liModuleEnabled).to.eq(false)
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('should not decode IDs when liModuleEnabled is false, liTreatmentRate is 0.7 and activatePartialTreatment is true', function() {
+    window.liModuleEnabled = false;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({});
+    expect(window.liModuleEnabled).to.eq(false)
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('should not decode IDs when liModuleEnabled is undefined, liTreatmentRate is 0.7 and activatePartialTreatment is true, and experiment returns false', function() {
+    randomStub.returns(1.0) // 1.0 < 0.7 = false
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({});
+    expect(window.liModuleEnabled).to.eq(false)
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('should not decode IDs when liModuleEnabled is undefined, liTreatmentRate is undefined and activatePartialTreatment is true, and experiment returns false', function() {
+    randomStub.returns(1.0) // 1.0 < DEFAULT_TREATMENT_RATE (0.97) = false
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = undefined;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({});
+    expect(window.liModuleEnabled).to.eq(false)
+    expect(window.liTreatmentRate).to.eq(DEFAULT_TREATMENT_RATE)
+  });
+
+  it('should decode IDs when liModuleEnabled is undefined, liTreatmentRate is undefined and activatePartialTreatment is true, and experiment returns true', function() {
+    randomStub.returns(0.0) // 0.0 < DEFAULT_TREATMENT_RATE (0.97) = true
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = undefined;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar', 'segments': ['tak']}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+    expect(window.liModuleEnabled).to.eq(true)
+    expect(window.liTreatmentRate).to.eq(DEFAULT_TREATMENT_RATE)
   });
 });

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -1,5 +1,6 @@
 import { liveIntentIdSubmodule, reset as resetLiveIntentIdSubmodule, storage } from 'libraries/liveIntentId/idSystem.js';
 import * as utils from 'src/utils.js';
+import { DEFAULT_TREATMENT_RATE } from 'libraries/liveIntentId/shared.js';
 import { gdprDataHandler, uspDataHandler, gppDataHandler, coppaDataHandler } from '../../../src/adapterManager.js';
 import { server } from 'test/mocks/xhr.js';
 import * as refererDetection from '../../../src/refererDetection.js';
@@ -9,7 +10,7 @@ import {createEidsArray} from '../../../modules/userId/eids.js';
 resetLiveIntentIdSubmodule();
 liveIntentIdSubmodule.setModuleMode('standard')
 const PUBLISHER_ID = '89899';
-const defaultConfigParams = {publisherId: PUBLISHER_ID, fireEventDelay: 1};
+const defaultConfigParams = { params: { publisherId: PUBLISHER_ID, fireEventDelay: 1 } };
 const responseHeader = {'Content-Type': 'application/json'}
 
 function requests(...urlRegExps) {
@@ -34,6 +35,7 @@ describe('LiveIntentId', function() {
   let imgStub;
   let coppaConsentDataStub;
   let refererInfoStub;
+  let randomStub;
 
   beforeEach(function() {
     liveIntentIdSubmodule.setModuleMode('standard');
@@ -46,6 +48,7 @@ describe('LiveIntentId', function() {
     gppConsentDataStub = sinon.stub(gppDataHandler, 'getConsentData');
     coppaConsentDataStub = sinon.stub(coppaDataHandler, 'getCoppa');
     refererInfoStub = sinon.stub(refererDetection, 'getRefererInfo');
+    randomStub = sinon.stub(Math, 'random').returns(0.6);
   });
 
   afterEach(function() {
@@ -58,6 +61,9 @@ describe('LiveIntentId', function() {
     gppConsentDataStub.restore();
     coppaConsentDataStub.restore();
     refererInfoStub.restore();
+    randomStub.restore();
+    window.liModuleEnabled = undefined; // reset
+    window.liTreatmentRate = undefined; // reset
     resetLiveIntentIdSubmodule();
   });
 
@@ -72,7 +78,7 @@ describe('LiveIntentId', function() {
       applicableSections: [1, 2]
     })
     let callBackSpy = sinon.spy();
-    let submoduleCallback = liveIntentIdSubmodule.getId({ params: defaultConfigParams }).callback;
+    let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
     setTimeout(() => {
       let requests = idxRequests().concat(rpRequests());
@@ -92,7 +98,7 @@ describe('LiveIntentId', function() {
       gppString: 'gppConsentDataString',
       applicableSections: [1]
     })
-    liveIntentIdSubmodule.getId({ params: defaultConfigParams });
+    liveIntentIdSubmodule.getId(defaultConfigParams);
     setTimeout(() => {
       let request = rpRequests()[0];
       expect(request.url).to.match(/https:\/\/rp.liadm.com\/j\?.*&us_privacy=1YNY.*&wpn=prebid.*&gdpr=0.*&gdpr_consent=consentDataString.*&gpp_s=gppConsentDataString.*&gpp_as=1.*/);
@@ -102,7 +108,7 @@ describe('LiveIntentId', function() {
 
   it('should fire an event when getId and a hash is provided', function(done) {
     liveIntentIdSubmodule.getId({ params: {
-      ...defaultConfigParams,
+      ...defaultConfigParams.params,
       emailHash: '58131bc547fb87af94cebdaf3102321f'
     }});
     setTimeout(() => {
@@ -113,7 +119,7 @@ describe('LiveIntentId', function() {
   });
 
   it('should initialize LiveConnect and forward the prebid version when decode and emit an event', function(done) {
-    liveIntentIdSubmodule.decode({}, { params: defaultConfigParams });
+    liveIntentIdSubmodule.decode({}, defaultConfigParams);
     setTimeout(() => {
       let request = rpRequests()[0];
       expect(request.url).to.contain('tv=$prebid.version$')
@@ -123,7 +129,7 @@ describe('LiveIntentId', function() {
 
   it('should initialize LiveConnect with the config params when decode and emit an event', function (done) {
     liveIntentIdSubmodule.decode({}, { params: {
-      ...defaultConfigParams,
+      ...defaultConfigParams.params,
       ...{
         url: 'https://dummy.liveintent.com',
         liCollectConfig: {
@@ -168,7 +174,7 @@ describe('LiveIntentId', function() {
       gppString: 'gppConsentDataString',
       applicableSections: [1]
     })
-    liveIntentIdSubmodule.decode({}, { params: defaultConfigParams });
+    liveIntentIdSubmodule.decode({}, defaultConfigParams);
     setTimeout(() => {
       let request = rpRequests()[0];
       expect(request.url).to.match(/.*us_privacy=1YNY.*&gdpr=0&gdpr_consent=consentDataString.*&gpp_s=gppConsentDataString&gpp_as=1.*/);
@@ -178,7 +184,7 @@ describe('LiveIntentId', function() {
 
   it('should fire an event when decode and a hash is provided', function(done) {
     liveIntentIdSubmodule.decode({}, { params: {
-      ...defaultConfigParams,
+      ...defaultConfigParams.params,
       emailHash: '58131bc547fb87af94cebdaf3102321f'
     }});
     setTimeout(() => {
@@ -189,7 +195,7 @@ describe('LiveIntentId', function() {
   });
 
   it('should fire an event when decode', function(done) {
-    liveIntentIdSubmodule.decode({}, { params: defaultConfigParams });
+    liveIntentIdSubmodule.decode({}, defaultConfigParams);
     setTimeout(() => {
       expect(rpRequests().length).to.be.eq(1);
       done();
@@ -197,10 +203,10 @@ describe('LiveIntentId', function() {
   });
 
   it('should initialize LiveConnect and send data only once', function(done) {
-    liveIntentIdSubmodule.getId({ params: defaultConfigParams });
-    liveIntentIdSubmodule.decode({}, { params: defaultConfigParams });
-    liveIntentIdSubmodule.getId({ params: defaultConfigParams });
-    liveIntentIdSubmodule.decode({}, { params: defaultConfigParams });
+    liveIntentIdSubmodule.getId(defaultConfigParams);
+    liveIntentIdSubmodule.decode({}, defaultConfigParams);
+    liveIntentIdSubmodule.getId(defaultConfigParams);
+    liveIntentIdSubmodule.decode({}, defaultConfigParams);
     setTimeout(() => {
       expect(rpRequests().length).to.be.eq(1);
       done();
@@ -210,7 +216,7 @@ describe('LiveIntentId', function() {
   it('should call the custom URL of the LiveIntent Identity Exchange endpoint', function() {
     getCookieStub.returns(null);
     let callBackSpy = sinon.spy();
-    let submoduleCallback = liveIntentIdSubmodule.getId({ params: {...defaultConfigParams, ...{'url': 'https://dummy.liveintent.com/idex'}} }).callback;
+    let submoduleCallback = liveIntentIdSubmodule.getId({ params: {...defaultConfigParams.params, ...{'url': 'https://dummy.liveintent.com/idex'}} }).callback;
     submoduleCallback(callBackSpy);
     let request = requests(/https:\/\/dummy.liveintent.com\/idex\/.*/)[0];
     expect(request.url).to.match(/https:\/\/dummy.liveintent.com\/idex\/prebid\/89899\?.*cd=.localhost.*&resolve=nonId.*/);
@@ -253,7 +259,7 @@ describe('LiveIntentId', function() {
     getCookieStub.returns(null);
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId({ params: {
-      ...defaultConfigParams,
+      ...defaultConfigParams.params,
       ...{
         'url': 'https://dummy.liveintent.com/idex',
         'partner': 'rubicon'
@@ -273,7 +279,7 @@ describe('LiveIntentId', function() {
   it('should call the LiveIntent Identity Exchange endpoint, with no additional query params', function() {
     getCookieStub.returns(null);
     let callBackSpy = sinon.spy();
-    let submoduleCallback = liveIntentIdSubmodule.getId({ params: defaultConfigParams }).callback;
+    let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = idxRequests()[0];
     expect(request.url).to.match(/https:\/\/idx.liadm.com\/idex\/prebid\/89899\?.*cd=.localhost.*&resolve=nonId.*/);
@@ -288,7 +294,7 @@ describe('LiveIntentId', function() {
   it('should log an error and continue to callback if ajax request errors', function() {
     getCookieStub.returns(null);
     let callBackSpy = sinon.spy();
-    let submoduleCallback = liveIntentIdSubmodule.getId({ params: defaultConfigParams }).callback;
+    let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = idxRequests()[0];
     expect(request.url).to.match(/https:\/\/idx.liadm.com\/idex\/prebid\/89899\?.*cd=.localhost.*&resolve=nonId.*/);
@@ -305,7 +311,7 @@ describe('LiveIntentId', function() {
     const oldCookie = 'a-xxxx--123e4567-e89b-12d3-a456-426655440000'
     getCookieStub.withArgs('_lc2_fpi').returns(oldCookie)
     let callBackSpy = sinon.spy();
-    let submoduleCallback = liveIntentIdSubmodule.getId({ params: defaultConfigParams }).callback;
+    let submoduleCallback = liveIntentIdSubmodule.getId(defaultConfigParams).callback;
     submoduleCallback(callBackSpy);
     let request = idxRequests()[0];
     const expected = new RegExp('https:\/\/idx.liadm.com\/idex\/prebid\/89899\?.*duid=' + oldCookie + '.*&cd=.localhost.*&resolve=nonId.*');
@@ -323,7 +329,7 @@ describe('LiveIntentId', function() {
     getCookieStub.withArgs('_lc2_fpi').returns(oldCookie);
     getDataFromLocalStorageStub.withArgs('_thirdPC').returns('third-pc');
     const configParams = { params: {
-      ...defaultConfigParams,
+      ...defaultConfigParams.params,
       ...{
         'identifiersToResolve': ['_thirdPC']
       }
@@ -346,7 +352,7 @@ describe('LiveIntentId', function() {
     getCookieStub.returns(null);
     getDataFromLocalStorageStub.withArgs('_thirdPC').returns({'key': 'value'});
     const configParams = { params: {
-      ...defaultConfigParams,
+      ...defaultConfigParams.params,
       ...{
         'identifiersToResolve': ['_thirdPC']
       }
@@ -366,7 +372,7 @@ describe('LiveIntentId', function() {
 
   it('should include ip4,ip6,userAgent if it\'s present', function(done) {
     liveIntentIdSubmodule.getId({ params: {
-      ...defaultConfigParams,
+      ...defaultConfigParams.params,
       ipv4: 'foov4',
       ipv6: 'foov6',
       userAgent: 'boo'
@@ -381,24 +387,24 @@ describe('LiveIntentId', function() {
 
   it('should send an error when the cookie jar throws an unexpected error', function() {
     getCookieStub.throws('CookieError', 'A message');
-    liveIntentIdSubmodule.getId({ params: defaultConfigParams });
+    liveIntentIdSubmodule.getId(defaultConfigParams);
     expect(imgStub.getCall(0).args[0]).to.match(/.*ae=.+/);
   });
 
   it('should decode a unifiedId to lipbId and remove it', function() {
-    const result = liveIntentIdSubmodule.decode({ unifiedId: 'data' }, { params: defaultConfigParams });
+    const result = liveIntentIdSubmodule.decode({ unifiedId: 'data' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'data'}});
   });
 
   it('should decode a nonId to lipbId', function() {
-    const result = liveIntentIdSubmodule.decode({ nonId: 'data' }, { params: defaultConfigParams });
+    const result = liveIntentIdSubmodule.decode({ nonId: 'data' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'data', 'nonId': 'data'}});
   });
 
   it('should resolve extra attributes', function() {
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId({ params: {
-      ...defaultConfigParams,
+      ...defaultConfigParams.params,
       ...{ requestedAttributesOverrides: { 'foo': true, 'bar': false } }
     } }).callback;
     submoduleCallback(callBackSpy);
@@ -413,71 +419,71 @@ describe('LiveIntentId', function() {
   });
 
   it('should decode a uid2 to a separate object when present', function() {
-    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', uid2: 'bar' }, { params: defaultConfigParams });
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', uid2: 'bar' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'uid2': 'bar'}, 'uid2': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
   it('should decode values with the segments but no nonId', function() {
-    const result = liveIntentIdSubmodule.decode({segments: ['tak']}, { params: defaultConfigParams });
+    const result = liveIntentIdSubmodule.decode({segments: ['tak']}, defaultConfigParams);
     expect(result).to.eql({'lipb': {'segments': ['tak']}});
   });
 
   it('should decode values with uid2 but no nonId', function() {
-    const result = liveIntentIdSubmodule.decode({ uid2: 'bar' }, { params: defaultConfigParams });
+    const result = liveIntentIdSubmodule.decode({ uid2: 'bar' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'uid2': 'bar'}, 'uid2': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
   it('should decode a bidswitch id to a separate object when present', function() {
-    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', bidswitch: 'bar' }, { params: defaultConfigParams });
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', bidswitch: 'bar' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'bidswitch': 'bar'}, 'bidswitch': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
   it('should decode a medianet id to a separate object when present', function() {
-    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', medianet: 'bar' }, { params: defaultConfigParams });
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', medianet: 'bar' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'medianet': 'bar'}, 'medianet': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
   it('should decode a sovrn id to a separate object when present', function() {
-    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', sovrn: 'bar' }, { params: defaultConfigParams });
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', sovrn: 'bar' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'sovrn': 'bar'}, 'sovrn': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
   it('should decode a magnite id to a separate object when present', function() {
-    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', magnite: 'bar' }, { params: defaultConfigParams });
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', magnite: 'bar' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'magnite': 'bar'}, 'magnite': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
   it('should decode an index id to a separate object when present', function() {
-    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', index: 'bar' }, { params: defaultConfigParams });
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', index: 'bar' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'index': 'bar'}, 'index': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
   it('should decode an openx id to a separate object when present', function () {
-    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', openx: 'bar' }, { params: defaultConfigParams });
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', openx: 'bar' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'openx': 'bar'}, 'openx': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
   it('should decode an pubmatic id to a separate object when present', function() {
-    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', pubmatic: 'bar' }, { params: defaultConfigParams });
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', pubmatic: 'bar' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'pubmatic': 'bar'}, 'pubmatic': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
   it('should decode a thetradedesk id to a separate object when present', function() {
     const provider = 'liveintent.com'
     refererInfoStub.returns({domain: provider})
-    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', thetradedesk: 'bar' }, { params: defaultConfigParams });
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', thetradedesk: 'bar' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'tdid': 'bar'}, 'tdid': {'id': 'bar', 'ext': {'rtiPartner': 'TDID', 'provider': provider}}});
   });
 
   it('should decode the segments as part of lipb', function() {
-    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', 'segments': ['bar'] }, { params: defaultConfigParams });
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', 'segments': ['bar'] }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'segments': ['bar']}});
   });
 
   it('should allow disabling nonId resolution', function() {
     let callBackSpy = sinon.spy();
     let submoduleCallback = liveIntentIdSubmodule.getId({ params: {
-      ...defaultConfigParams,
+      ...defaultConfigParams.params,
       ...{ requestedAttributesOverrides: { 'nonId': false, 'uid2': true } }
     } }).callback;
     submoduleCallback(callBackSpy);
@@ -493,13 +499,13 @@ describe('LiveIntentId', function() {
 
   it('should decode a idCookie as fpid if it exists and coppa is false', function() {
     coppaConsentDataStub.returns(false)
-    const result = liveIntentIdSubmodule.decode({nonId: 'foo', idCookie: 'bar'}, { params: defaultConfigParams })
+    const result = liveIntentIdSubmodule.decode({nonId: 'foo', idCookie: 'bar'}, defaultConfigParams)
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'fpid': 'bar'}, 'fpid': {'id': 'bar'}})
   });
 
   it('should not decode a idCookie as fpid if it exists and coppa is true', function() {
     coppaConsentDataStub.returns(true)
-    const result = liveIntentIdSubmodule.decode({nonId: 'foo', idCookie: 'bar'}, { params: defaultConfigParams })
+    const result = liveIntentIdSubmodule.decode({nonId: 'foo', idCookie: 'bar'}, defaultConfigParams)
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo'}})
   });
 
@@ -508,7 +514,7 @@ describe('LiveIntentId', function() {
     const cookieName = 'testcookie'
     getCookieStub.withArgs(cookieName).returns(expectedValue)
     const config = { params: {
-      ...defaultConfigParams,
+      ...defaultConfigParams.params,
       fpid: { 'strategy': 'cookie', 'name': cookieName },
       requestedAttributesOverrides: { 'fpid': true } }
     }
@@ -532,12 +538,12 @@ describe('LiveIntentId', function() {
   });
 
   it('should decode a sharethrough id to a separate object when present', function() {
-    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', sharethrough: 'bar' }, { params: defaultConfigParams });
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', sharethrough: 'bar' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'sharethrough': 'bar'}, 'sharethrough': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
   it('should decode a sonobi id to a separate object when present', function() {
-    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', sonobi: 'bar' }, { params: defaultConfigParams });
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', sonobi: 'bar' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'sonobi': 'bar'}, 'sonobi': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
@@ -547,8 +553,186 @@ describe('LiveIntentId', function() {
   });
 
   it('should decode a vidazoo id to a separate object when present', function() {
-    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar' }, { params: defaultConfigParams });
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar' }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar'}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
+  it('getId does not set the global variables when liModuleEnabled, liTreatmentRate and activatePartialTreatment are undefined', function() {
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = undefined;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: undefined } };
+
+    liveIntentIdSubmodule.getId(configWithPartialTreatment).callback(() => {});
+    expect(window.liModuleEnabled).to.be.undefined
+    expect(window.liTreatmentRate).to.be.undefined
+  });
+
+  it('getId does not set the global variables when liModuleEnabled is undefined, liTreatmentRate is 0.7 and activatePartialTreatment is undefined', function() {
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: undefined } };
+
+    liveIntentIdSubmodule.getId(configWithPartialTreatment).callback(() => {});
+    expect(window.liModuleEnabled).to.be.undefined
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('getId does not set the global variables when liModuleEnabled is undefined, liTreatmentRate is 0.7 and activatePartialTreatment is false', function() {
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: false } };
+
+    liveIntentIdSubmodule.getId(configWithPartialTreatment).callback(() => {});
+    expect(window.liModuleEnabled).to.be.undefined
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('getId does not change the global variables when liModuleEnabled is true, liTreatmentRate is 0.7 and activatePartialTreatment is true', function() {
+    randomStub.returns(1.0) // 1.0 < 0.7 = false, but should be ignored by the module
+    window.liModuleEnabled = true;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    liveIntentIdSubmodule.getId(configWithPartialTreatment).callback(() => {});
+    expect(window.liModuleEnabled).to.eq(true)
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('getId does not change the global variables when liModuleEnabled is false, liTreatmentRate is 0.7 and activatePartialTreatment is true', function() {
+    randomStub.returns(0.5) // 0.5 < 0.7 = true, but should be ignored by the module
+    window.liModuleEnabled = false;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    liveIntentIdSubmodule.getId(configWithPartialTreatment).callback(() => {});
+    expect(window.liModuleEnabled).to.eq(false)
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('getId sets the global variables correctly when liModuleEnabled is undefined, liTreatmentRate is 0.7 and activatePartialTreatment is true, and experiment returns false', function() {
+    randomStub.returns(1) // 1 < 0.7 = false
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    liveIntentIdSubmodule.getId(configWithPartialTreatment).callback(() => {});
+    expect(window.liModuleEnabled).to.eq(false)
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('getId sets the global variables correctly when liModuleEnabled is undefined, liTreatmentRate is undefined and activatePartialTreatment is true, and experiment returns true', function() {
+    randomStub.returns(0.0) // 0.0 < DEFAULT_TREATMENT_RATE (0.97) = true
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = undefined;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    liveIntentIdSubmodule.getId(configWithPartialTreatment).callback(() => {});
+    expect(window.liModuleEnabled).to.eq(true)
+    expect(window.liTreatmentRate).to.eq(DEFAULT_TREATMENT_RATE)
+  });
+
+  it('should decode IDs when liModuleEnabled, liTreatmentRate and activatePartialTreatment are undefined', function() {
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = undefined;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: undefined } };
+
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar', 'segments': ['tak']}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+    expect(window.liModuleEnabled).to.be.undefined
+    expect(window.liTreatmentRate).to.be.undefined
+  });
+
+  it('should decode IDs when liModuleEnabled is undefined, liTreatmentRate is 0.7 and activatePartialTreatment is undefined', function() {
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: undefined } };
+
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar', 'segments': ['tak']}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+    expect(window.liModuleEnabled).to.be.undefined
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('should decode IDs when liModuleEnabled is undefined, liTreatmentRate is 0.7 and activatePartialTreatment is false', function() {
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: false } };
+
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar', 'segments': ['tak']}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+    expect(window.liModuleEnabled).to.be.undefined
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('should decode IDs when liModuleEnabled is true, liTreatmentRate is 0.7 and activatePartialTreatment is true', function() {
+    randomStub.returns(1.0) // 1 < 0.7 = false, but should be ignored by the module as liModuleEnabled is already defined
+    window.liModuleEnabled = true;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar', 'segments': ['tak']}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+    expect(window.liModuleEnabled).to.eq(true)
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('should not decode IDs when liModuleEnabled is false, liTreatmentRate is 0.7 and activatePartialTreatment is true', function() {
+    randomStub.returns(0.5) // 0.5 < 0.7 = true, but should be ignored by the module as liModuleEnabled is already defined
+    window.liModuleEnabled = false;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({});
+    expect(window.liModuleEnabled).to.eq(false)
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('should not decode IDs when liModuleEnabled is false, liTreatmentRate is 0.7 and activatePartialTreatment is true', function() {
+    window.liModuleEnabled = false;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({});
+    expect(window.liModuleEnabled).to.eq(false)
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('should not decode IDs when liModuleEnabled is undefined, liTreatmentRate is 0.7 and activatePartialTreatment is true, and experiment returns false', function() {
+    randomStub.returns(1.0) // 1.0 < 0.7 = false
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = 0.7;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({});
+    expect(window.liModuleEnabled).to.eq(false)
+    expect(window.liTreatmentRate).to.eq(0.7)
+  });
+
+  it('should not decode IDs when liModuleEnabled is undefined, liTreatmentRate is undefined and activatePartialTreatment is true, and experiment returns false', function() {
+    randomStub.returns(1.0) // 1.0 < DEFAULT_TREATMENT_RATE (0.97) = false
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = undefined;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({});
+    expect(window.liModuleEnabled).to.eq(false)
+    expect(window.liTreatmentRate).to.eq(DEFAULT_TREATMENT_RATE)
+  });
+
+  it('should decode IDs when liModuleEnabled is undefined, liTreatmentRate is undefined and activatePartialTreatment is true, and experiment returns true', function() {
+    randomStub.returns(0.0) // 0.0 < DEFAULT_TREATMENT_RATE (0.97) = true
+    window.liModuleEnabled = undefined;
+    window.liTreatmentRate = undefined;
+    const configWithPartialTreatment = { params: { ...defaultConfigParams.params, activatePartialTreatment: true } };
+
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', vidazoo: 'bar', segments: ['tak'] }, configWithPartialTreatment);
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar', 'segments': ['tak']}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+    expect(window.liModuleEnabled).to.eq(true)
+    expect(window.liTreatmentRate).to.eq(DEFAULT_TREATMENT_RATE)
   });
 
   describe('eid', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->

- [x] Feature

## Description of change

The goal of this PR is to adjust LiveIntent's Prebid User ID module and the LiveIntent Analytics Adapter such that they allow revenue lift computation for our customers. 

The feature toggle `activatePartialTreatment` ensures that all existing customers do not experience any changes in user ID resolution. The toggle as well as new configuration parameters for the Analytics Adapter are not documented for now as we want to have a beta test with a group of customers before we make this feature GA. 

## Other information

