### PR TITLE
Gamoshi Bid Adapter : update alias - adding alias of cleanmedianet

### DIFF
--- a/modules/gamoshiBidAdapter.js
+++ b/modules/gamoshiBidAdapter.js
@@ -83,8 +83,8 @@ export const spec = {
     return validBidRequests.map(bidRequest => {
       const {adUnitCode, mediaTypes, params, sizes, bidId} = bidRequest;
 
-      const bidder_code = bidderRequest.bidderCode || 'gamoshi';
-      const baseEndpoint = params['rtbEndpoint'] || ENDPOINTS[bidder_code];
+      const bidderCode = bidderRequest.bidderCode || 'gamoshi';
+      const baseEndpoint = params['rtbEndpoint'] || ENDPOINTS[bidderCode];
       const rtbEndpoint = `${baseEndpoint}/r/${params.supplyPartnerId}/bidr?rformat=open_rtb&reqformat=rtb_json&bidder=prebid` + (params.query ? '&' + params.query : '');
       const rtbBidRequest = {
         id: bidderRequest.bidderRequestId,

--- a/modules/gamoshiBidAdapter.js
+++ b/modules/gamoshiBidAdapter.js
@@ -17,7 +17,8 @@ import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {includes} from '../src/polyfill.js';
 
 const ENDPOINTS = {
-  'gamoshi': 'https://rtb.gamoshi.io'
+  'gamoshi': 'https://rtb.gamoshi.io',
+  'cleanmedianet': 'https://bidder.cleanmediaads.com'
 };
 
 const DEFAULT_TTL = 360;
@@ -66,7 +67,7 @@ export const helper = {
 
 export const spec = {
   code: 'gamoshi',
-  aliases: ['gambid', '9MediaOnline'],
+  aliases: ['gambid', 'cleanmedianet'],
   supportedMediaTypes: ['banner', 'video'],
 
   isBidRequestValid: function (bid) {
@@ -81,7 +82,9 @@ export const spec = {
   buildRequests: function (validBidRequests, bidderRequest) {
     return validBidRequests.map(bidRequest => {
       const {adUnitCode, mediaTypes, params, sizes, bidId} = bidRequest;
-      const baseEndpoint = params['rtbEndpoint'] || ENDPOINTS['gamoshi'];
+
+      const bidder_code = bidderRequest.bidderCode || 'gamoshi';
+      const baseEndpoint = params['rtbEndpoint'] || ENDPOINTS[bidder_code];
       const rtbEndpoint = `${baseEndpoint}/r/${params.supplyPartnerId}/bidr?rformat=open_rtb&reqformat=rtb_json&bidder=prebid` + (params.query ? '&' + params.query : '');
       const rtbBidRequest = {
         id: bidderRequest.bidderRequestId,

--- a/modules/gamoshiBidAdapter.js
+++ b/modules/gamoshiBidAdapter.js
@@ -84,7 +84,7 @@ export const spec = {
       const {adUnitCode, mediaTypes, params, sizes, bidId} = bidRequest;
 
       const bidderCode = bidderRequest.bidderCode || 'gamoshi';
-      const baseEndpoint = params['rtbEndpoint'] || ENDPOINTS[bidderCode];
+      const baseEndpoint = params['rtbEndpoint'] || ENDPOINTS[bidderCode] || 'https://rtb.gamoshi.io';
       const rtbEndpoint = `${baseEndpoint}/r/${params.supplyPartnerId}/bidr?rformat=open_rtb&reqformat=rtb_json&bidder=prebid` + (params.query ? '&' + params.query : '');
       const rtbBidRequest = {
         id: bidderRequest.bidderRequestId,


### PR DESCRIPTION

Following request in issue- 

https://github.com/prebid/Prebid.js/issues/12001

_"one of either gamoshi and cleanmedia needs removing"_

## Type of change
-  [x] Bugfix
-  [x] Refactoring (no functional changes, no api changes)

## Description of change
Adding an alias **cleanmedianet**  with specific endpoint.

_Please advise if you need anything else from us to facilitate clean delete / merge._

Question - To  my understanding the **cleanmedianet** adaptor will still be available to download  (in version 10) from 
https://docs.prebid.org/download.html
Is this correct ? 
 


