### PR TITLE
Add sourceSchain OpenRTB processor for schain handling

### DIFF
--- a/modules/schain.js
+++ b/modules/schain.js
@@ -204,4 +204,14 @@ export function setOrtbSourceExtSchain(ortbRequest, bidderRequest, context) {
   }
 }
 
+export function setOrtbSourceSchain(ortbRequest, bidderRequest, context) {
+  if (!deepAccess(ortbRequest, 'source.schain')) {
+    const schain = deepAccess(context, 'bidRequests.0.schain');
+    if (schain) {
+      deepSetValue(ortbRequest, 'source.schain', schain);
+    }
+  }
+}
+
 registerOrtbProcessor({type: REQUEST, name: 'sourceExtSchain', fn: setOrtbSourceExtSchain});
+registerOrtbProcessor({type: REQUEST, name: 'sourceSchain', fn: setOrtbSourceSchain});


### PR DESCRIPTION
Type of change


- [x] Feature


Description of change

The Supply Chain Object module currently adds the supply chain object to source.ext.schain as per OpenRTB 2.5 specification. This PR adds support for OpenRTB 2.6 by also including the supply chain object in source.schain which is now the standard location according to the OpenRTB 2.6 specification.

This change ensures compatibility with both OpenRTB 2.5 and 2.6 implementations, maintaining backward compatibility while supporting the latest standard.

Changes made:


Modified the Supply Chain module to add the schain object to both locations:

source.ext.schain (OpenRTB 2.5)
source.schain (OpenRTB 2.6)

Other information

This change ensures Prebid.js remains compatible with SSPs and exchanges that have upgraded to OpenRTB 2.6 while maintaining backward compatibility with those still using OpenRTB 2.5.

Reference to OpenRTB 2.6 source object specification: https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md#objectsource