### PR TITLE
Adnuntius Bid Adapter: fix bugs on legacy native bid requests and converting ortb adserver responses to legacy responses

### DIFF
--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -364,9 +364,20 @@ export const spec = {
           adUnit.adType = 'NATIVE';
           if (!mediaTypeData.ortb) {
             // assume it's using old format if ortb not specified
-            const oldStyleNativeRequest = deepClone(mediaTypeData);
-            delete oldStyleNativeRequest.sizes;
-            adUnit.nativeRequest = {ortb: toOrtbNativeRequest(oldStyleNativeRequest)}
+            const legacyStyleNativeRequest = deepClone(mediaTypeData);
+            const nativeOrtb = toOrtbNativeRequest(legacyStyleNativeRequest);
+            // add explicit event tracker requests for impressions and viewable impressions, which do not exist in legacy format
+            nativeOrtb.eventtrackers = [
+              {
+                'event': 1,
+                'methods': [1]
+              },
+              {
+                'event': 2,
+                'methods': [1]
+              }
+            ];
+            adUnit.nativeRequest = {ortb: nativeOrtb}
           } else {
             adUnit.nativeRequest = {ortb: mediaTypeData.ortb};
           }
@@ -450,8 +461,8 @@ export const spec = {
         adResponse.mediaType = VIDEO;
       } else if (renderSource.nativeJson) {
         adResponse.mediaType = NATIVE;
-        if (!bidOnRequest.mediaTypes?.native?.ortb) {
-          adResponse.native = toLegacyResponse(renderSource.nativeJson);
+        if (bidOnRequest.mediaTypes?.native && !bidOnRequest.mediaTypes?.native?.ortb) {
+          adResponse.native = toLegacyResponse(renderSource.nativeJson.ortb, toOrtbNativeRequest(bidOnRequest.mediaTypes.native));
         } else {
           adResponse.native = renderSource.nativeJson;
         }

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -344,10 +344,11 @@ describe('adnuntiusBidAdapter', function () {
       'auId': '0000000000000551',
       'targetId': 'adn-0000000000000551',
       'nativeJson': {
-        'link': {
-          'url': 'https://whatever.com'
-        },
-        'assets': [
+        'ortb': {
+          'link': {
+            'url': 'https://whatever.com'
+          },
+          'assets': [
           {
             'id': 1,
             'required': 1,
@@ -355,6 +356,7 @@ describe('adnuntiusBidAdapter', function () {
               'url': 'http://something.com/something.png'
             }
           }]
+        }
       },
       'matchedAdCount': 1,
       'responseId': '',
@@ -1693,7 +1695,7 @@ describe('adnuntiusBidAdapter', function () {
       expect(interpretedResponse[0].meta.advertiserDomains).to.have.lengthOf(1);
       expect(interpretedResponse[0].meta.advertiserDomains[0]).to.equal('adnuntius.com');
       expect(interpretedResponse[0].vastXml).to.equal(ad.vastXml);
-      expect(JSON.stringify(interpretedResponse[0].native)).to.equal('{"link":{"url":"https://whatever.com"},"assets":[{"id":1,"required":1,"img":{"url":"http://something.com/something.png"}}]}');
+      expect(JSON.stringify(interpretedResponse[0].native.ortb)).to.equal('{"link":{"url":"https://whatever.com"},"assets":[{"id":1,"required":1,"img":{"url":"http://something.com/something.png"}}]}');
     });
 
     it('should pass legacy requests on correctly', function () {
@@ -1701,7 +1703,7 @@ describe('adnuntiusBidAdapter', function () {
       expect(request.length).to.equal(1);
       expect(request[0]).to.have.property('bid');
       expect(request[0]).to.have.property('data');
-      expect(request[0].data).to.equal('{"adUnits":[{"auId":"0000000000000551","targetId":"adn-0000000000000551","adType":"NATIVE","nativeRequest":{"ortb":{"ver":"1.2","assets":[{"id":0,"required":1,"img":{"type":3,"w":250,"h":250}}]}},"dimensions":[[200,200],[300,300]]}]}');
+      expect(request[0].data).to.equal('{"adUnits":[{"auId":"0000000000000551","targetId":"adn-0000000000000551","adType":"NATIVE","nativeRequest":{"ortb":{"ver":"1.2","assets":[{"id":0,"required":1,"img":{"type":3,"w":250,"h":250}}],"eventtrackers":[{"event":1,"methods":[1]},{"event":2,"methods":[1]}]}},"dimensions":[[200,200],[300,300]]}]}');
     });
 
     it('should return valid legacy response when passed valid server response', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
There were bugs in handling legacy native bid requests and converting ortb adserver responses to legacy responses.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
