### PR TITLE
ResetDigital Bid Adapter: keywords params validation

### DIFF
--- a/modules/resetdigitalBidAdapter.js
+++ b/modules/resetdigitalBidAdapter.js
@@ -101,10 +101,11 @@ export const spec = {
         }
       }
 
-      // get param kewords (if it exists)
-      let paramsKeywords = req.params.keywords
-        ? req.params.keywords.split(',')
-        : [];
+      // get param keywords (if it exists)
+      let paramsKeywords =
+        typeof req.params.keywords === 'string'
+          ? req.params.keywords.split(",")
+          : [];
       // merge all keywords
       let keywords = ortb2KeywordsList
         .concat(paramsKeywords)

--- a/modules/resetdigitalBidAdapter.js
+++ b/modules/resetdigitalBidAdapter.js
@@ -102,10 +102,15 @@ export const spec = {
       }
 
       // get param keywords (if it exists)
-      let paramsKeywords =
-        typeof req.params.keywords === 'string'
-          ? req.params.keywords.split(",")
-          : [];
+      let paramsKeywords = req.params.keywords
+
+      if (typeof req.params.keywords === 'string') {
+        paramsKeywords = req.params.keywords.split(',');
+      } else if (Array.isArray(req.params.keywords)) {
+        paramsKeywords = req.params.keywords;
+      } else {
+        paramsKeywords = [];
+      }
       // merge all keywords
       let keywords = ortb2KeywordsList
         .concat(paramsKeywords)


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
## Description of change
We encountered an issue where req.params.keywords in buildRequests was undefined, causing the .split() function to throw an error.
Added a typeof check to ensure keywrods is a string before calling .split().
Prevents potential TypeError when keywords is null or undefined.