### PR TITLE
Update adloader.js: remove showheroes after refactor

### DIFF
--- a/src/adloader.js
+++ b/src/adloader.js
@@ -10,8 +10,6 @@ const _approvedLoadExternalJSList = [
   // Prebid maintained modules:
   'debugging',
   'outstream',
-  // Bid Modules - only exception is on rendering edge cases, to clean up in Prebid 10:
-  'showheroes-bs',
   // RTD modules:
   'aaxBlockmeter',
   'adagio',


### PR DESCRIPTION
fixes #11656 , no longer needed after #12283 