### PR TITLE
NodalAiRtdModule:  stricter consent checks

### DIFF
--- a/modules/nodalsAiRtdProvider.js
+++ b/modules/nodalsAiRtdProvider.js
@@ -246,11 +246,11 @@ class NodalsAiRtdProvider {
    */
 
   #hasRequiredUserConsent(userConsent) {
-    if (userConsent?.gdpr?.gdprApplies !== true) {
+    if (userConsent?.gdpr?.gdprApplies === false) {
       return true;
     }
     if (
-      userConsent?.gdpr?.vendorData?.vendor?.consents?.[this.gvlid] === false
+      [false, undefined].includes(userConsent?.gdpr?.vendorData?.vendor?.consents?.[this.gvlid])
     ) {
       return false;
     } else if (userConsent?.gdpr?.vendorData?.purpose?.consents[1] === false) {

--- a/modules/nodalsAiRtdProvider.js
+++ b/modules/nodalsAiRtdProvider.js
@@ -246,14 +246,16 @@ class NodalsAiRtdProvider {
    */
 
   #hasRequiredUserConsent(userConsent) {
-    if (userConsent?.gdpr?.gdprApplies === false) {
+    if (userConsent.gdpr === undefined || userConsent.gdpr?.gdprApplies === false) {
       return true;
     }
     if (
-      [false, undefined].includes(userConsent?.gdpr?.vendorData?.vendor?.consents?.[this.gvlid])
+      [false, undefined].includes(userConsent.gdpr.vendorData?.vendor?.consents?.[this.gvlid])
     ) {
       return false;
-    } else if (userConsent?.gdpr?.vendorData?.purpose?.consents[1] === false) {
+    } else if (userConsent.gdpr.vendorData?.purpose?.consents[1] === false ||
+      userConsent.gdpr.vendorData?.purpose?.consents[7] === false
+    ) {
       return false;
     }
     return true;

--- a/test/spec/modules/nodalsAiRtdProvider_spec.js
+++ b/test/spec/modules/nodalsAiRtdProvider_spec.js
@@ -71,6 +71,7 @@ const generateGdprConsent = (consent = {}) => {
   const defaults = {
     gdprApplies: true,
     purpose1Consent: true,
+    purpose7Consent: true,
     nodalsConsent: true,
   };
   const mergedConsent = { ...defaults, ...consent };
@@ -82,11 +83,15 @@ const generateGdprConsent = (consent = {}) => {
         purpose: {
           consents: {
             1: mergedConsent.purpose1Consent,
+            2: true,
             3: true,
             4: true,
             5: true,
             6: true,
+            7: mergedConsent.purpose7Consent,
+            8: true,
             9: true,
+            10: true,
           },
         },
         specialFeatureOptins: {
@@ -141,6 +146,7 @@ describe('NodalsAI RTD Provider', () => {
   const permissiveUserConsent = generateGdprConsent();
   const vendorRestrictiveUserConsent = generateGdprConsent({ nodalsConsent: false });
   const noPurpose1UserConsent = generateGdprConsent({ purpose1Consent: false });
+  const noPurpose7UserConsent = generateGdprConsent({ purpose7Consent: false });
   const outsideGdprUserConsent = generateGdprConsent({ gdprApplies: false });
 
   beforeEach(() => {
@@ -182,15 +188,15 @@ describe('NodalsAI RTD Provider', () => {
 
   describe('init()', () => {
     describe('when initialised with empty consent data', () => {
-      it('should return false when initialized with valid config and empty user consent', function () {
+      it('should return true when initialised with valid config and empty user consent', function () {
         const result = nodalsAiRtdSubmodule.init(validConfig, {});
         server.respond();
 
-        expect(result).to.be.false;
-        expect(server.requests.length).to.equal(0);
+        expect(result).to.be.true;
+        expect(server.requests.length).to.equal(1);
       });
 
-      it('should return false when initialized with invalid config', () => {
+      it('should return false when initialised with invalid config', () => {
         const config = { params: { invalid: true } };
         const result = nodalsAiRtdSubmodule.init(config, {});
         server.respond();
@@ -203,6 +209,14 @@ describe('NodalsAI RTD Provider', () => {
     describe('when initialised with valid config data', () => {
       it('should return false when user is under GDPR jurisdiction and purpose1 has not been granted', () => {
         const result = nodalsAiRtdSubmodule.init(validConfig, noPurpose1UserConsent);
+        server.respond();
+
+        expect(result).to.be.false;
+        expect(server.requests.length).to.equal(0);
+      });
+
+      it('should return false when user is under GDPR jurisdiction and purpose7 has not been granted', () => {
+        const result = nodalsAiRtdSubmodule.init(validConfig, noPurpose7UserConsent);
         server.respond();
 
         expect(result).to.be.false;


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
Consent data from CMPs that are yet to update to the latest vendor list, results in our vendor ID not being present under the `gdpr.vendorConsents.vendor` object - which the module simply saw as having consent granted. Naughty, naughty.

Actual module change is tiny. Bulk of these changes is refactored tests.

