### PR TITLE
Core: use 'async' hooks for asynchronous hooks

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -492,7 +492,7 @@ export function PrebidServer() {
  * @param onError {function(String, {})} invoked on HTTP failure - with status message and XHR error
  * @param onBid {function({})} invoked once for each bid in the response - with the bid as returned by interpretResponse
  */
-export const processPBSRequest = hook('sync', function (s2sBidRequest, bidRequests, ajax, {onResponse, onError, onBid, onFledge}) {
+export const processPBSRequest = hook('async', function (s2sBidRequest, bidRequests, ajax, {onResponse, onError, onBid, onFledge}) {
   let { gdprConsent } = getConsentData(bidRequests);
   const adUnits = deepClone(s2sBidRequest.ad_units);
 

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -382,7 +382,7 @@ const RESPONSE_PROPS = ['bids', 'paapi']
  * @param onBid {function({})} invoked once for each bid in the response - with the bid as returned by interpretResponse
  * @param onCompletion {function()} invoked once when all bid requests have been processed
  */
-export const processBidderRequests = hook('sync', function (spec, bids, bidderRequest, ajax, wrapCallback, {onRequest, onResponse, onPaapi, onError, onBid, onCompletion}) {
+export const processBidderRequests = hook('async', function (spec, bids, bidderRequest, ajax, wrapCallback, {onRequest, onResponse, onPaapi, onError, onBid, onCompletion}) {
   const metrics = adapterMetrics(bidderRequest);
   onCompletion = metrics.startTiming('total').stopBefore(onCompletion);
   const tidGuard = guardTids(bidderRequest);

--- a/src/auction.js
+++ b/src/auction.js
@@ -83,7 +83,7 @@ import {batchAndStore, storeLocally} from './videoCache.js';
 import {Renderer} from './Renderer.js';
 import {config} from './config.js';
 import {userSync} from './userSync.js';
-import {hook} from './hook.js';
+import {hook, ignoreCallbackArg} from './hook.js';
 import {find, includes} from './polyfill.js';
 import {OUTSTREAM} from './video.js';
 import {VIDEO} from './mediaTypes.js';
@@ -428,13 +428,13 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
  * @param bid
  * @param {function(String): void} reject a function that, when called, rejects `bid` with the given reason.
  */
-export const addBidResponse = hook('sync', function(adUnitCode, bid, reject) {
+export const addBidResponse = ignoreCallbackArg(hook('async', function(adUnitCode, bid, reject) {
   if (!isValidPrice(bid)) {
     reject(REJECTION_REASON.PRICE_TOO_HIGH)
   } else {
     this.dispatch.call(null, adUnitCode, bid);
   }
-}, 'addBidResponse');
+}, 'addBidResponse'));
 
 /**
  * Delay hook for adapter responses.

--- a/test/spec/hook_spec.js
+++ b/test/spec/hook_spec.js
@@ -1,0 +1,15 @@
+import {hook as makeHook, ignoreCallbackArg} from '../../src/hook.js';
+
+describe('hooks', () => {
+  describe('ignoreCallbackArg', () => {
+    it('allows async hooks to treat last argument as a normal argument', () => {
+      let hk = ignoreCallbackArg(makeHook('async', () => null));
+      hk.before((next, arg, fn) => {
+        fn(arg);
+      })
+      hk('arg', (arg) => {
+        expect(arg).to.eql('arg');
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Use 'async' hooks when they may be executed asynchronously - to avoid unexpected behavior from `fun-hooks` (https://github.com/snapwich/fun-hooks/issues/42)

## Other information

Closes https://github.com/prebid/Prebid.js/issues/12916
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
