### PR TITLE
Criteo Bid Adapter: Use optional chaining for callbacks

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -284,9 +284,7 @@ export const spec = {
             saveOnAllStorages(BUNDLE_COOKIE_NAME, response.bundle, GUID_RETENTION_TIME_HOUR, refererInfo.domain);
           }
 
-          if (response.callbacks) {
-            response.callbacks.forEach(triggerPixel);
-          }
+          response?.callbacks?.forEach?.(triggerPixel);
         }
       }, true);
 


### PR DESCRIPTION
Avoids errors when callbacks are not iterable.

Closes #12949


## Type of change
- [x] Bugfix

## Description of change
https://github.com/prebid/Prebid.js/issues/12949