### PR TITLE
AdagioBidAdapter: add support for instl, rwdd ortb2 signals

### DIFF
--- a/modules/adagioBidAdapter.js
+++ b/modules/adagioBidAdapter.js
@@ -643,6 +643,15 @@ export const spec = {
         bidRequest.gpid = gpid;
       }
 
+      let instl = deepAccess(bidRequest, 'ortb2Imp.instl');
+      if (instl !== undefined) {
+        bidRequest.instl = instl === 1 || instl === '1' ? 1 : undefined;
+      }
+      let rwdd = deepAccess(bidRequest, 'ortb2Imp.rwdd');
+      if (rwdd !== undefined) {
+        bidRequest.rwdd = rwdd === 1 || rwdd === '1' ? 1 : undefined;
+      }
+
       // features are added by the adagioRtdProvider.
       const rawFeatures = {
         ...deepAccess(bidRequest, 'ortb2.site.ext.data.adg_rtd.features', {}),
@@ -668,6 +677,8 @@ export const spec = {
         nativeParams: bidRequest.nativeParams,
         score: bidRequest.score,
         transactionId: bidRequest.transactionId,
+        instl: bidRequest.instl,
+        rwdd: bidRequest.rwdd,
       }
 
       return adUnit;

--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -1076,6 +1076,64 @@ describe('Adagio bid adapter', () => {
         expect(requests[0].data.device).to.deep.equal(expectedData);
       });
     });
+
+    describe('with `rwdd` and `instl` signals', function() {
+      const tests = [
+        {
+          n: 'Should set signals in bidRequest if value is 1',
+          ortb2Imp: {
+            rwdd: 1,
+            instl: '1'
+          },
+          expected: {
+            rwdd: 1,
+            instl: 1
+          }
+        },
+        {
+          n: 'Should not set signals in bidRequest if value is 0',
+          ortb2Imp: {
+            rwdd: 0,
+            instl: '0'
+          },
+          expected: {
+            rwdd: undefined,
+            instl: undefined
+          }
+        },
+        {
+          n: 'Should not set if rwdd and instl are missformated',
+          ortb2Imp: {
+            rwdd: 'a',
+            ext: { instl: 1 }
+          },
+          expected: {
+            rwdd: undefined,
+            instl: undefined
+          }
+        },
+        {
+          n: 'Should not set rwdd and instl in bidRequest if undefined',
+          ortb2Imp: {},
+          expected: {
+            rwdd: undefined,
+            instl: undefined
+          }
+        }
+      ]
+
+      tests.forEach((t) => {
+        it(t.n, function() {
+          const bid01 = new BidRequestBuilder().withParams().build();
+          bid01.ortb2Imp = t.ortb2Imp;
+          const bidderRequest = new BidderRequestBuilder().build();
+          const requests = spec.buildRequests([bid01], bidderRequest);
+          const expected = t.expected;
+          expect(requests[0].data.adUnits[0].rwdd).to.equal(expected.rwdd);
+          expect(requests[0].data.adUnits[0].instl).to.equal(expected.instl);
+        });
+      })
+    })
   });
 
   describe('interpretResponse()', function() {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change

Pass ortb2Imp signals in our bidRequest:

- `rwdd`
- `instl`
