### PR TITLE
Bugfix: Update adRendering.js styling for iframe in case of insterstitial ads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -514,21 +514,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/parser": {
       "version": "7.26.10",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
@@ -29210,18 +29195,6 @@
       "requires": {
         "@babel/template": "^7.26.9",
         "@babel/types": "^7.26.10"
-      }
-    },
-    "@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
       }
     },
     "@babel/parser": {

--- a/src/adRendering.js
+++ b/src/adRendering.js
@@ -257,8 +257,17 @@ export function renderAdDirect(doc, adId, options) {
   }
   function resizeFn(width, height) {
     if (doc.defaultView && doc.defaultView.frameElement) {
-      width && (doc.defaultView.frameElement.width = width);
-      height && (doc.defaultView.frameElement.height = height);
+      let frame = doc.defaultView.frameElement;
+      if (frame.id === "ad_iframe") {
+        frame.width = width;
+        frame.height = height;
+        frame.style.width = `${width}px`;
+        frame.style.height = `${height}px`;
+        frame.style.display = "block";
+      } else {
+        width && (doc.defaultView.frameElement.width = width);
+        height && (doc.defaultView.frameElement.height = height);
+      }
     }
   }
   const messageHandler = creativeMessageHandler({resizeFn});
@@ -269,30 +278,42 @@ export function renderAdDirect(doc, adId, options) {
       emitAdRenderSucceeded({doc, bid, id: bid.adId});
     } else {
       getCreativeRenderer(bid)
-        .then(render => render(adData, {
-          sendMessage: (type, data) => messageHandler(type, data, bid),
-          mkFrame: createIframe,
-        }, doc.defaultView))
+        .then((render) => render(adData,
+            {
+              sendMessage: (type, data) => messageHandler(type, data, bid),
+              mkFrame: createIframe,
+            },
+            doc.defaultView
+          )
+        )
         .then(
           () => emitAdRenderSucceeded({doc, bid, id: bid.adId}),
           (e) => {
-            fail(e?.reason || AD_RENDER_FAILED_REASON.EXCEPTION, e?.message)
+            fail(e?.reason || AD_RENDER_FAILED_REASON.EXCEPTION, e?.message);
             e?.stack && logError(e);
           }
         );
     }
-    // TODO: this is almost certainly the wrong way to do this
-    const creativeComment = document.createComment(`Creative ${bid.creativeId} served by ${bid.bidder} Prebid.js Header Bidding`);
-    insertElement(creativeComment, doc, 'html');
+    const creativeComment = document.createComment(
+      `Creative ${bid.creativeId} served by ${bid.bidder} Prebid.js Header Bidding`
+    );
+    insertElement(creativeComment, doc, "html");
   }
   try {
     if (!adId || !doc) {
       fail(AD_RENDER_FAILED_REASON.MISSING_DOC_OR_ADID, `missing ${adId ? 'doc' : 'adId'}`);
     } else {
+      if (doc === document && !inIframe()) {
+        fail(
+          AD_RENDER_FAILED_REASON.PREVENT_WRITING_ON_MAIN_DOCUMENT,
+          "renderAd was prevented from writing to the main document."
+        );
+      } else {
       getBidToRender(adId).then(bidResponse => {
         bid = bidResponse;
         handleRender({renderFn, resizeFn, adId, options: {clickUrl: options?.clickThrough}, bidResponse, doc});
       });
+      }
     }
   } catch (e) {
     fail(EXCEPTION, e.message);


### PR DESCRIPTION
Type of change
- [ ] Bugfix

## Description of change
It assures that styling is added to the iframe even in case of the interstitial ads, as it was working fine for on page units but overriding 1px in styling

Other information
Closes #12914 
