### PR TITLE
semantiq Rtd Provider : avoid adding default company ID if parameter is present

### DIFF
--- a/modules/semantiqRtdProvider.js
+++ b/modules/semantiqRtdProvider.js
@@ -15,7 +15,7 @@ const LOG_PREFIX = '[SemantIQ RTD Module]: ';
 const KEYWORDS_URL = 'https://api.adnz.co/api/ws-semantiq/page-keywords';
 const STORAGE_KEY = `adnz_${SUBMODULE_NAME}`;
 const AUDIENZZ_COMPANY_ID = 1;
-const REQUIRED_TENANT_IDS = [AUDIENZZ_COMPANY_ID];
+const FALLBACK_TENANT_IDS = [AUDIENZZ_COMPANY_ID];
 const AUDIENZZ_GLOBAL_VENDOR_ID = 783;
 
 const DEFAULT_TIMEOUT = 1000;
@@ -58,13 +58,9 @@ const getPageUrl = () => getWindowLocation().href;
  * @returns {number[]}
  */
 const getTenantIds = (companyId) => {
-  if (!companyId) {
-    return REQUIRED_TENANT_IDS;
-  }
-
   const companyIdArray = Array.isArray(companyId) ? companyId : [companyId];
 
-  return [...REQUIRED_TENANT_IDS, ...companyIdArray];
+  return companyIdArray.filter(Boolean).length ? companyIdArray : FALLBACK_TENANT_IDS;
 };
 
 /**

--- a/test/spec/modules/semantiqRtdProvider_spec.js
+++ b/test/spec/modules/semantiqRtdProvider_spec.js
@@ -106,7 +106,7 @@ describe('semantiqRtdProvider', () => {
 
       const requestUrl = new URL(server.requests[0].url);
 
-      expect(requestUrl.searchParams.get('tenantIds')).to.be.equal('1,13');
+      expect(requestUrl.searchParams.get('tenantIds')).to.be.equal('13');
     });
 
     it('allows to specify multiple company IDs as a parameter', async () => {
@@ -136,7 +136,7 @@ describe('semantiqRtdProvider', () => {
 
       const requestUrl = new URL(server.requests[0].url);
 
-      expect(requestUrl.searchParams.get('tenantIds')).to.be.equal('1,13,23');
+      expect(requestUrl.searchParams.get('tenantIds')).to.be.equal('13,23');
     });
 
     it('gets keywords from the cache if the data is present in the storage', async () => {


### PR DESCRIPTION
## Type of change

- [x] Bugfix

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Avoid adding the default company ID if the `companyId` parameter is present.
