### PR TITLE
Core: Remove createBid API and update getHighestUnusedBidResponseForAdUnitCode function 

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -31,7 +31,6 @@ import {isBidUsable, targeting} from './targeting.js';
 import {hook, wrapHook} from './hook.js';
 import {loadSession} from './debugging.js';
 import {includes} from './polyfill.js';
-import {createBid} from './bidfactory.js';
 import {storageCallbacks} from './storageManager.js';
 import {default as adapterManager, getS2SBidderSet} from './adapterManager.js';
 import { BID_STATUS, EVENTS, NATIVE_KEYS } from './constants.js';
@@ -826,17 +825,6 @@ pbjsInstance.registerAnalyticsAdapter = function (options) {
   } catch (e) {
     logError('Error registering analytics adapter : ' + e.message);
   }
-};
-
-/**
- * Wrapper to bidfactory.createBid()
- * @param  {string} statusCode [description]
- * @alias module:pbjs.createBid
- * @return {Object} bidResponse [description]
- */
-pbjsInstance.createBid = function (statusCode) {
-  logInfo('Invoking $$PREBID_GLOBAL$$.createBid', arguments);
-  return createBid(statusCode);
 };
 
 /**

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -383,14 +383,14 @@ pbjsInstance.getAdserverTargetingForAdUnitCodeStr = function (adunitCode) {
  * This function returns the query string targeting parameters available at this moment for a given ad unit. Note that some bidder's response may not have been received if you call this function too quickly after the requests are sent.
  * @param adunitCode {string} adUnitCode to get the bid responses for
  * @alias module:pbjs.getHighestUnusedBidResponseForAdUnitCode
- * @returns {Object}  returnObj return bid
+ * @returns {Object|null}  returnObj return bid or null if no suitable bid exists
  */
 pbjsInstance.getHighestUnusedBidResponseForAdUnitCode = function (adunitCode) {
   if (adunitCode) {
     const bid = auctionManager.getAllBidsForAdUnitCode(adunitCode)
       .filter(isBidUsable)
 
-    return bid.length ? bid.reduce(getHighestCpm) : {}
+    return bid.length ? bid.reduce(getHighestCpm) : null
   } else {
     logMessage('Need to call getHighestUnusedBidResponseForAdUnitCode with adunitCode');
   }

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -3371,19 +3371,6 @@ describe('Unit: Prebid Module', function () {
     });
   });
 
-  describe('createBid', function () {
-    it('should return a bid object', function () {
-      const statusCode = 1;
-      const bid = $$PREBID_GLOBAL$$.createBid(statusCode);
-      assert.isObject(bid, 'bid is an object');
-      assert.equal(bid.getStatusCode(), statusCode, 'bid has correct status');
-
-      const defaultStatusBid = $$PREBID_GLOBAL$$.createBid();
-      assert.isObject(defaultStatusBid, 'bid is an object');
-      assert.equal(defaultStatusBid.getStatusCode(), 0, 'bid has correct status');
-    });
-  });
-
   describe('aliasBidder', function () {
     it('should call adapterManager.aliasBidder', function () {
       const aliasBidAdapterSpy = sinon.spy(adapterManager, 'aliasBidAdapter');

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -3625,9 +3625,9 @@ describe('Unit: Prebid Module', function () {
       resetAuction();
     })
 
-    it('returns an empty object if there is no bid for the given adUnitCode', () => {
+    it('returns null if there is no bid for the given adUnitCode', () => {
       const highestBid = $$PREBID_GLOBAL$$.getHighestUnusedBidResponseForAdUnitCode('stallone');
-      expect(highestBid).to.deep.equal({});
+      expect(highestBid).to.equal(null);
     })
 
     it('returns undefined if adUnitCode is provided', () => {


### PR DESCRIPTION
## Type of change

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
For the [12895](https://github.com/prebid/Prebid.js/issues/12895) breaking changes / API cleanup, covered below points: 

1. Change null value for getHighestUnusedBidResponseForAdUnitCode
2. remove pbjs.createBid()

## Other information
https://github.com/prebid/Prebid.js/issues/12895
