### PR TITLE
Previous auction module: added new highestBidCurrency field to payloads

### DIFF
--- a/modules/previousAuctionInfo/index.js
+++ b/modules/previousAuctionInfo/index.js
@@ -92,7 +92,7 @@ export const onAuctionEndHandler = (auctionDetails) => {
               bidderOriginalCpm: receivedBidsMap[bid.bidId]?.originalCpm || null,
               bidderCurrency: receivedBidsMap[bid.bidId]?.currency || null,
               bidderOriginalCurrency: receivedBidsMap[bid.bidId]?.originalCurrency || null,
-              bidderErrorCode: rejectedBidsMap[bid.bidId]?.rejectionReason || null,
+              rejectionReason: rejectedBidsMap[bid.bidId]?.rejectionReason || null,
               timestamp: auctionDetails.timestamp,
               transactionId: bid.transactionId, // this field gets removed before injecting previous auction info into the bid stream
             }


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
- added a new field to previous auction info payloads called "highestBidCurrency".  this new field will capture the currency of the highest submitted bid cpm for a specific adslot during a Prebid auction

## Other information
Prebid Doc's PR: https://github.com/prebid/prebid.github.io/pull/5990
