### PR TITLE
semantiqRtdProvider: dispatch page impression event on initialization

### DIFF
--- a/modules/semantiqRtdProvider.js
+++ b/modules/semantiqRtdProvider.js
@@ -1,8 +1,8 @@
 import { MODULE_TYPE_RTD } from '../src/activities/modules.js';
-import { ajax } from '../src/ajax.js';
+import { ajax, fetch } from '../src/ajax.js';
 import { submodule } from '../src/hook.js';
 import { getStorageManager } from '../src/storageManager.js';
-import { getWindowLocation, logError, logInfo, logWarn, mergeDeep } from '../src/utils.js';
+import { generateUUID, getWindowLocation, logError, logInfo, logWarn, mergeDeep } from '../src/utils.js';
 
 /**
  * @typedef {import('../modules/rtdModule/index.js').RtdSubmodule} RtdSubmodule
@@ -10,14 +10,13 @@ import { getWindowLocation, logError, logInfo, logWarn, mergeDeep } from '../src
 
 const MODULE_NAME = 'realTimeData';
 const SUBMODULE_NAME = 'semantiq';
-
 const LOG_PREFIX = '[SemantIQ RTD Module]: ';
 const KEYWORDS_URL = 'https://api.adnz.co/api/ws-semantiq/page-keywords';
+const EVENT_COLLECTOR_URL = 'https://api.adnz.co/api/ws-clickstream-collector/submit';
 const STORAGE_KEY = `adnz_${SUBMODULE_NAME}`;
 const AUDIENZZ_COMPANY_ID = 1;
 const FALLBACK_TENANT_IDS = [AUDIENZZ_COMPANY_ID];
 const AUDIENZZ_GLOBAL_VENDOR_ID = 783;
-
 const DEFAULT_TIMEOUT = 1000;
 
 export const storage = getStorageManager({
@@ -53,11 +52,12 @@ const getStorageKeywords = (pageUrl) => {
 const getPageUrl = () => getWindowLocation().href;
 
 /**
- * Gets tenant IDs based on the customer company ID
- * @param {number | number[] | undefined} companyId
+ * Gets tenant IDs based on the module params
+ * @param {Object} params
  * @returns {number[]}
  */
-const getTenantIds = (companyId) => {
+const getTenantIds = (params = {}) => {
+  const { companyId } = params;
   const companyIdArray = Array.isArray(companyId) ? companyId : [companyId];
 
   return companyIdArray.filter(Boolean).length ? companyIdArray : FALLBACK_TENANT_IDS;
@@ -76,8 +76,7 @@ const getKeywords = (params) => new Promise((resolve, reject) => {
     return resolve(storageKeywords);
   }
 
-  const { companyId } = params;
-  const tenantIds = getTenantIds(companyId);
+  const tenantIds = getTenantIds(params);
   const searchParams = new URLSearchParams();
 
   searchParams.append('url', pageUrl);
@@ -143,12 +142,51 @@ export const getOrtbKeywords = (keywords) => Object.entries(keywords).reduce((ac
 }, []).join(',');
 
 /**
+ * Dispatches a page impression event to the SemantIQ service.
+ *
+ * @param {number} companyId
+ * @returns {Promise<void>}
+ */
+const dispatchPageImpressionEvent = (companyId) => {
+  window.audienzz = window.audienzz || {};
+  window.audienzz.collectorPageImpressionId = window.audienzz.collectorPageImpressionId || generateUUID();
+  const pageImpressionId = window.audienzz.collectorPageImpressionId;
+  const pageUrl = getPageUrl();
+
+  const payload = {
+    company_id: companyId,
+    event_id: generateUUID(),
+    event_timestamp: new Date().toISOString(),
+    event_type: 'pageImpression',
+    page_impression_id: pageImpressionId,
+    source: 'semantiqPrebidModule',
+    url: pageUrl,
+  };
+
+  return fetch(EVENT_COLLECTOR_URL, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    keepalive: true,
+  });
+};
+
+/**
  * Module init
  * @param {Object} config
  * @param {Object} userConsent
  * @return {boolean}
  */
-const init = (config, userConsent) => true;
+const init = (config, userConsent) => {
+  const { params = {} } = config;
+  const [mainCompanyId] = getTenantIds(params);
+
+  dispatchPageImpressionEvent(mainCompanyId);
+
+  return true;
+};
 
 /**
  * Receives real-time data from SemantIQ service.

--- a/test/spec/modules/semantiqRtdProvider_spec.js
+++ b/test/spec/modules/semantiqRtdProvider_spec.js
@@ -22,8 +22,49 @@ describe('semantiqRtdProvider', () => {
 
   describe('init', () => {
     it('returns true on initialization', () => {
-      const initResult = semantiqRtdSubmodule.init();
+      const initResult = semantiqRtdSubmodule.init({});
       expect(initResult).to.be.true;
+    });
+  });
+
+  describe('pageImpression event', () => {
+    it('dispatches an event on initialization', () => {
+      getWindowLocationStub.returns(new URL('https://example.com/article'));
+
+      semantiqRtdSubmodule.init({ params: { companyId: 5 } });
+
+      const body = JSON.parse(server.requests[0].requestBody);
+
+      expect(server.requests[0].url).to.be.equal('https://api.adnz.co/api/ws-clickstream-collector/submit');
+      expect(server.requests[0].method).to.be.equal('POST');
+
+      expect(body.company_id).to.be.equal(5);
+      expect(body.event_id).not.to.be.empty;
+      expect(body.event_timestamp).not.to.be.empty;
+      expect(body.event_type).to.be.equal('pageImpression');
+      expect(body.page_impression_id).not.to.be.empty;
+      expect(body.source).to.be.equal('semantiqPrebidModule');
+      expect(body.url).to.be.equal('https://example.com/article');
+    });
+
+    it('uses the correct company ID', () => {
+      semantiqRtdSubmodule.init({ params: { companyId: 555 } });
+      semantiqRtdSubmodule.init({ params: { companyId: [111, 222, 333] } });
+
+      const body1 = JSON.parse(server.requests[0].requestBody);
+      const body2 = JSON.parse(server.requests[1].requestBody);
+
+      expect(body1.company_id).to.be.equal(555);
+      expect(body2.company_id).to.be.equal(111);
+    });
+
+    it('uses cached page impression ID if present', () => {
+      window.audienzz = { collectorPageImpressionId: 'cached-guid' };
+      semantiqRtdSubmodule.init({ params: { companyId: 5 } });
+
+      const body = JSON.parse(server.requests[0].requestBody);
+
+      expect(body.page_impression_id).to.be.equal('cached-guid');
     });
   });
 


### PR DESCRIPTION
## Type of change

- [x] Bugfix

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change

Dispatch a page impression event at initialization, as this is required for the SemantIQ service to function correctly.

