### PR TITLE
Snigel Bid Adapter: delegate consent-related checks to user sync iframe

### DIFF
--- a/modules/snigelBidAdapter.js
+++ b/modules/snigelBidAdapter.js
@@ -2,7 +2,6 @@ import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER} from '../src/mediaTypes.js';
 import {deepAccess, isArray, isFn, isPlainObject, inIframe, getDNT, generateUUID} from '../src/utils.js';
-import {hasPurpose1Consent} from '../src/utils/gdpr.js';
 import {getStorageManager} from '../src/storageManager.js';
 import { getViewportSize } from '../libraries/viewport/viewport.js';
 
@@ -110,8 +109,8 @@ export const spec = {
 
   getUserSyncs: function (syncOptions, responses, gdprConsent, uspConsent, gppConsent) {
     const syncUrl = getSyncUrl(responses || []);
-    if (syncUrl && syncOptions.iframeEnabled && hasSyncConsent(gdprConsent, uspConsent, gppConsent)) {
-      return [{type: 'iframe', url: getSyncEndpoint(syncUrl, gdprConsent)}];
+    if (syncUrl && syncOptions.iframeEnabled) {
+      return [{type: 'iframe', url: getSyncEndpoint(syncUrl, gdprConsent, uspConsent, gppConsent)}];
     }
   },
 };
@@ -202,21 +201,6 @@ function mapIdToRequestId(id, bidRequest) {
   return bidRequest.bidderRequest.bids.filter((bid) => bid.adUnitCode === id)[0].bidId;
 }
 
-function hasUspConsent(uspConsent) {
-  return typeof uspConsent !== 'string' || !(uspConsent[0] === '1' && uspConsent[2] === 'Y');
-}
-
-function hasGppConsent(gppConsent) {
-  return (
-    !(gppConsent && Array.isArray(gppConsent.applicableSections)) ||
-    gppConsent.applicableSections.every((section) => typeof section === 'number' && section <= 5)
-  );
-}
-
-function hasSyncConsent(gdprConsent, uspConsent, gppConsent) {
-  return hasPurpose1Consent(gdprConsent) && hasUspConsent(uspConsent) && hasGppConsent(gppConsent);
-}
-
 function hasFullGdprConsent(gdprConsent) {
   try {
     const purposeConsents = Object.values(gdprConsent.vendorData.purpose.consents);
@@ -234,10 +218,12 @@ function getSyncUrl(responses) {
   return getConfig(`${BIDDER_CODE}.syncUrl`) || deepAccess(responses[0], 'body.syncUrl');
 }
 
-function getSyncEndpoint(url, gdprConsent) {
+function getSyncEndpoint(url, gdprConsent, uspConsent, gppConsent) {
   return `${url}?gdpr=${gdprConsent?.gdprApplies ? 1 : 0}&gdpr_consent=${encodeURIComponent(
     gdprConsent?.consentString || ''
-  )}`;
+  )}&gpp_sid=${gppConsent?.applicableSections?.join(',') || ''}&gpp=${encodeURIComponent(
+    gppConsent?.gppString || ''
+  )}&us_privacy=${uspConsent || ''}`;
 }
 
 function getSessionId() {

--- a/test/spec/modules/snigelBidAdapter_spec.js
+++ b/test/spec/modules/snigelBidAdapter_spec.js
@@ -36,6 +36,7 @@ const makeBidderRequest = function (overrides) {
 const DUMMY_USP_CONSENT = '1YYN';
 const DUMMY_GDPR_CONSENT_STRING =
   'BOSSotLOSSotLAPABAENBc-AAAAgR7_______9______9uz_Gv_v_f__33e8__9v_l_7_-___u_-33d4-_1vX99yfm1-7ftr3tp_86ues2_XqK_9oIiA';
+const DUMMY_GPP_CONSENT_STRING = 'DBABrw~BAAAAAAAAABA.QA~BAAAAABA.QA';
 
 describe('snigelBidAdapter', function () {
   describe('isBidRequestValid', function () {
@@ -310,31 +311,6 @@ describe('snigelBidAdapter', function () {
       expect(syncs).to.be.undefined;
     });
 
-    it('should not return any user syncs if GDPR applies and the user did not consent to purpose one', function () {
-      const response = {
-        body: {
-          id: BASE_BIDDER_REQUEST.bidderRequestId,
-          cur: 'USD',
-          syncUrl: 'https://somesyncurl',
-          bids: [],
-        },
-      };
-      const syncOptions = {
-        iframeEnabled: true,
-      };
-      const gdprConsent = {
-        gdprApplies: true,
-        vendorData: {
-          purpose: {
-            consents: {1: false},
-          },
-        },
-      };
-
-      const syncs = spec.getUserSyncs(syncOptions, [response], gdprConsent);
-      expect(syncs).to.be.undefined;
-    });
-
     it("should return an iframe specific to the publisher's property if all conditions are met", function () {
       const response = {
         body: {
@@ -357,7 +333,7 @@ describe('snigelBidAdapter', function () {
       expect(sync).to.have.property('type');
       expect(sync.type).to.equal('iframe');
       expect(sync).to.have.property('url');
-      expect(sync.url).to.equal('https://somesyncurl?gdpr=0&gdpr_consent=');
+      expect(sync.url).to.equal('https://somesyncurl?gdpr=0&gdpr_consent=&gpp_sid=&gpp=&us_privacy=');
     });
 
     it('should pass GDPR applicability and consent string as query parameters', function () {
@@ -388,7 +364,37 @@ describe('snigelBidAdapter', function () {
       expect(sync).to.have.property('type');
       expect(sync.type).to.equal('iframe');
       expect(sync).to.have.property('url');
-      expect(sync.url).to.equal(`https://somesyncurl?gdpr=1&gdpr_consent=${DUMMY_GDPR_CONSENT_STRING}`);
+      expect(sync.url).to.equal(
+        `https://somesyncurl?gdpr=1&gdpr_consent=${DUMMY_GDPR_CONSENT_STRING}&gpp_sid=&gpp=&us_privacy=`
+      );
+    });
+
+    it('should pass GPP section IDs and consent string as query parameters', function () {
+      const response = {
+        body: {
+          id: BASE_BIDDER_REQUEST.bidderRequestId,
+          cur: 'USD',
+          syncUrl: 'https://somesyncurl',
+          bids: [],
+        },
+      };
+      const syncOptions = {
+        iframeEnabled: true,
+      };
+      const gppConsent = {
+        applicableSections: [7, 8],
+        gppString: DUMMY_GPP_CONSENT_STRING,
+      };
+
+      const syncs = spec.getUserSyncs(syncOptions, [response], undefined, undefined, gppConsent);
+      expect(syncs).to.be.an('array').and.of.length(1);
+      const sync = syncs[0];
+      expect(sync).to.have.property('type');
+      expect(sync.type).to.equal('iframe');
+      expect(sync).to.have.property('url');
+      expect(sync.url).to.equal(
+        `https://somesyncurl?gdpr=0&gdpr_consent=&gpp_sid=7,8&gpp=${DUMMY_GPP_CONSENT_STRING}&us_privacy=`
+      );
     });
 
     it('should omit session ID if no device access', function () {


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter

## Description of change
Delegate consent-related checks to user sync iframe for easier maintenance on our side.
