### PR TITLE
Adnuntius Bid Adapter: send eids to adserver

### DIFF
--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -1,6 +1,6 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO, NATIVE} from '../src/mediaTypes.js';
-import {isStr, isEmpty, deepAccess, getUnixTimestampFromNow, convertObjectToArray, getWindowTop, deepClone, getWinDimensions} from '../src/utils.js';
+import {isStr, isEmpty, deepAccess, isArray, getUnixTimestampFromNow, convertObjectToArray, getWindowTop, deepClone, getWinDimensions} from '../src/utils.js';
 import { config } from '../src/config.js';
 import { getStorageManager } from '../src/storageManager.js';
 import {toLegacyResponse, toOrtbNativeRequest} from '../src/native.js';
@@ -154,28 +154,35 @@ const storageTool = (function () {
     storage.setDataInLocalStorage(METADATA_KEY, JSON.stringify(metaDataForSaving));
   };
 
-  const getUsi = function (meta, ortb2, bidParams) {
-    // Fetch user id from parameters.
-    for (let i = 0; i < bidParams.length; i++) {
-      const bidParam = bidParams[i];
-      if (bidParam.userId) {
-        return bidParam.userId;
-      }
-    }
-    if (ortb2 && ortb2.user && ortb2.user.id) {
-      return ortb2.user.id
-    }
-    return (meta && meta.usi) ? meta.usi : false
-  }
+  const getFirstValidValueFromArray = function(arr, param) {
+    const example = (arr || []).find((b) => {
+      return deepAccess(b, param);
+    });
+    return example ? deepAccess(example, param) : undefined;
+  };
 
   return {
-    refreshStorage: function (bidderRequest) {
-      const ortb2 = bidderRequest.ortb2 || {};
+    refreshStorage: function (validBidRequests, bidderRequest) {
       const bidParams = (bidderRequest.bids || []).map((b) => {
         return b.params ? b.params : {};
       });
       metaInternal = getMetaDataFromLocalStorage(bidParams).reduce((a, entry) => ({ ...a, [entry.key]: entry.value }), {});
-      metaInternal.usi = getUsi(metaInternal, ortb2, bidParams);
+      const bidParamUserId = getFirstValidValueFromArray(bidParams, 'userId');
+      const ortb2 = bidderRequest.ortb2 || {};
+
+      if (isStr(bidParamUserId)) {
+        metaInternal.usi = bidParamUserId;
+      } else if (isStr(ortb2?.user?.id)) {
+        metaInternal.usi = ortb2.user.id;
+      } else {
+        const unvettedOrtb2Eids = deepAccess(ortb2, 'user.ext.eids');
+        const vettedOrtb2Eids = isArray(unvettedOrtb2Eids) && unvettedOrtb2Eids.length > 0 ? unvettedOrtb2Eids : false;
+
+        if (vettedOrtb2Eids) {
+          metaInternal.eids = vettedOrtb2Eids;
+        }
+      }
+
       if (!metaInternal.usi) {
         delete metaInternal.usi;
       }
@@ -190,8 +197,8 @@ const storageTool = (function () {
     },
     getUrlRelatedData: function () {
       // getting the URL information is theoretically not network-specific
-      const { usi, voidAuIdsArray } = metaInternal;
-      return { usi, voidAuIdsArray };
+      const { usi, voidAuIdsArray, eids } = metaInternal;
+      return { usi, voidAuIdsArray, eids };
     },
     getPayloadRelatedData: function (network) {
       // getting the payload data should be network-specific
@@ -301,12 +308,13 @@ export const spec = {
       queryParamsAndValues.push('so=' + searchParams.get('script-override'));
     }
 
-    storageTool.refreshStorage(bidderRequest);
+    storageTool.refreshStorage(validBidRequests, bidderRequest);
 
     const urlRelatedMetaData = storageTool.getUrlRelatedData();
     targetingTool.addSegmentsToUrlData(validBidRequests, bidderRequest, urlRelatedMetaData);
     if (urlRelatedMetaData.segments.length > 0) queryParamsAndValues.push('segments=' + urlRelatedMetaData.segments.join(','));
     if (urlRelatedMetaData.usi) queryParamsAndValues.push('userId=' + urlRelatedMetaData.usi);
+    if (isArray(urlRelatedMetaData.eids) && urlRelatedMetaData.eids.length > 0) queryParamsAndValues.push('eids=' + encodeURIComponent(JSON.stringify(urlRelatedMetaData.eids)));
 
     const bidderConfig = config.getConfig();
     if (bidderConfig.useCookie === false) queryParamsAndValues.push('noCookies=true');
@@ -323,7 +331,7 @@ export const spec = {
         continue;
       }
 
-      let network = bid.params.network || 'network';
+      const network = bid.params.network || 'network';
       bidRequests[network] = bidRequests[network] || [];
       bidRequests[network].push(bid);
 

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -1252,18 +1252,36 @@ describe('adnuntiusBidAdapter', function () {
       config.setBidderConfig({
         bidders: ['adnuntius'],
       });
+
       const req = [
         {
           bidId: 'adn-000000000008b6bc',
           bidder: 'adnuntius',
           params: {
             auId: '000000000008b6bc',
-            network: 'adnuntius',
-            userId: 'different_user_id'
+            network: 'adnuntius'
           }
         }
-      ]
-      const request = config.runWithBidder('adnuntius', () => spec.buildRequests(req, { bids: req }));
+      ];
+      let request = config.runWithBidder('adnuntius', () => spec.buildRequests(req, { bids: req }));
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(`${ENDPOINT_URL_BASE}&userId=${usi}`);
+
+      const ortb2 = {user: {ext: {eids: [{source: 'a', uids: [{id: '123', atype: 1}]}, {source: 'b', uids: [{id: '456', atype: 3, ext: {some: '1'}}]}]}}};
+      request = config.runWithBidder('adnuntius', () => spec.buildRequests(req, { bids: req, ortb2: ortb2 }));
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(`${ENDPOINT_URL_BASE}&userId=${usi}&eids=%5B%7B%22source%22%3A%22a%22%2C%22uids%22%3A%5B%7B%22id%22%3A%22123%22%2C%22atype%22%3A1%7D%5D%7D%2C%7B%22source%22%3A%22b%22%2C%22uids%22%3A%5B%7B%22id%22%3A%22456%22%2C%22atype%22%3A3%2C%22ext%22%3A%7B%22some%22%3A%221%22%7D%7D%5D%7D%5D`);
+
+      ortb2.user.id = "ortb2userid"
+      request = config.runWithBidder('adnuntius', () => spec.buildRequests(req, { bids: req, ortb2: ortb2 }));
+      expect(request.length).to.equal(1);
+      expect(request[0]).to.have.property('url')
+      expect(request[0].url).to.equal(`${ENDPOINT_URL_BASE}&userId=ortb2userid`);
+
+      req[0].params.userId = 'different_user_id';
+      request = config.runWithBidder('adnuntius', () => spec.buildRequests(req, { bids: req }));
       expect(request.length).to.equal(1);
       expect(request[0]).to.have.property('url')
       expect(request[0].url).to.equal(`${ENDPOINT_URL_BASE}&userId=different_user_id`);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Previously, we only sent a singular userId if it is specified in the bid params or ortb2.user.id.

Now, we do that as well as looking for eids specified in any of: ortb2.user.ext.eids, userIdAsEids or userId

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
