### PR TITLE
ttd bid adapter: Parse timeout as tmax and send a minimum of 400

### DIFF
--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -14,7 +14,7 @@ import { getConnectionType } from '../libraries/connectionInfo/connectionUtils.j
  * @typedef {import('../src/adapters/bidderFactory.js').UserSync} UserSync
  */
 
-const BIDADAPTERVERSION = 'TTD-PREBID-2024.07.28';
+const BIDADAPTERVERSION = 'TTD-PREBID-2025.04.25';
 const BIDDER_CODE = 'ttd';
 const BIDDER_CODE_LONG = 'thetradedesk';
 const BIDDER_ENDPOINT = 'https://direct.adsrvr.org/bid/bidder/';
@@ -404,6 +404,7 @@ export const spec = {
       device: getDevice(firstPartyData),
       user: getUser(bidderRequest, firstPartyData),
       at: 1,
+      tmax: Math.max(bidderRequest.timeout || 400, 400),
       cur: ['USD'],
       regs: getRegs(bidderRequest),
       source: getSource(validBidRequests, bidderRequest),

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -262,6 +262,29 @@ describe('ttdBidAdapter', function () {
       expect(request.data).to.be.not.null;
     });
 
+    it('bid request should parse tmax or have a default and minimum', function () {
+      const requestWithoutTimeout = {
+        ...baseBidderRequest,
+        timeout: null
+      };
+      var requestBody = testBuildRequests(baseBannerBidRequests, requestWithoutTimeout).data;
+      expect(requestBody.tmax).to.be.equal(400);
+      
+      const requestWithTimeout = {
+        ...baseBidderRequest,
+        timeout: 600
+      };
+      requestBody = testBuildRequests(baseBannerBidRequests, requestWithTimeout).data;
+      expect(requestBody.tmax).to.be.equal(600);
+
+      const requestWithLowerTimeout = {
+        ...baseBidderRequest,
+        timeout: 300
+      };
+      requestBody = testBuildRequests(baseBannerBidRequests, requestWithLowerTimeout).data;
+      expect(requestBody.tmax).to.be.equal(400);
+    });
+
     it('sets bidrequest.id to bidderRequestId', function () {
       const requestBody = testBuildRequests(baseBannerBidRequests, baseBidderRequest).data;
       expect(requestBody.id).to.equal('18084284054531');


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Parse request tmax/timeout and send a minimum or default of 400 to the The Trade Desk.

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
