### PR TITLE
TimeoutRtdProvider: auction timeout as the primary timeout value

### DIFF
--- a/modules/timeoutRtdProvider.js
+++ b/modules/timeoutRtdProvider.js
@@ -163,7 +163,7 @@ function getBidRequestData(reqBidsConfigObj, callback, config, userConsent) {
 function handleTimeoutIncrement(reqBidsConfigObj, rules) {
   const adUnits = reqBidsConfigObj.adUnits || getGlobal().adUnits;
   const timeoutModifier = timeoutRtdFunctions.calculateTimeoutModifier(adUnits, rules);
-  const bidderTimeout = getGlobal().getConfig('bidderTimeout');
+  const bidderTimeout = reqBidsConfigObj.timeout || getGlobal().getConfig('bidderTimeout');
   reqBidsConfigObj.timeout = bidderTimeout + timeoutModifier;
 }
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

The auction timeout takes precedence over the bidderTimeout, we should consider it as the primary timeout value.