### PR TITLE
OMS Bid Adapter: by default add banner property to imp buildRequests

### DIFF
--- a/modules/omsBidAdapter.js
+++ b/modules/omsBidAdapter.js
@@ -52,6 +52,12 @@ function buildRequests(bidReqs, bidderRequest) {
 
       const imp = {
         id: bid.bidId,
+        banner: {
+          format: processedSizes,
+          ext: {
+            viewability: viewabilityAmountRounded,
+          }
+        },
         ext: {
           ...gpidData
         },
@@ -61,13 +67,6 @@ function buildRequests(bidReqs, bidderRequest) {
       if (bid?.mediaTypes?.video) {
         imp.video = {
           ...bid.mediaTypes.video,
-        }
-      } else {
-        imp.banner = {
-          format: processedSizes,
-          ext: {
-            viewability: viewabilityAmountRounded,
-          }
         }
       }
 


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter 

## Description of change
We want to return default banner property to imp in buildRequests func. We had it [previously](https://github.com/prebid/Prebid.js/pull/12671/files#diff-bffa17ab297d425db95ee937b68adfe03eab8907f771c4cecf81794b5fec951fL55)