### PR TITLE
Aniview Bid Adapter: Filter bids without `adm` or `nurl`; Use only `vastXml` OR `vastUrl`

### DIFF
--- a/modules/aniviewBidAdapter.js
+++ b/modules/aniviewBidAdapter.js
@@ -157,31 +157,40 @@ export const spec = {
       return [];
     }
 
-    return converter.fromORTB({ response: body, request: bidderRequest.data }).bids.map((prebidBid, index) => {
-      const bid = bids[index];
-      const replacements = {
-        auctionPrice: prebidBid.cpm,
-        auctionId: prebidBid.requestId,
-        auctionBidId: bid.bidid,
-        auctionImpId: bid.impid,
-        auctionSeatId: prebidBid.seatBidId,
-        auctionAdId: bid.adid,
-      };
+    return converter.fromORTB({ response: body, request: bidderRequest.data }).bids
+      .filter((prebidBid, index) => !!bids[index].adm || !!bids[index].nurl)
+      .map((prebidBid, index) => {
+        const bid = bids[index];
+        const replacements = {
+          auctionPrice: prebidBid.cpm,
+          auctionId: prebidBid.requestId,
+          auctionBidId: bid.bidid,
+          auctionImpId: bid.impid,
+          auctionSeatId: prebidBid.seatBidId,
+          auctionAdId: bid.adid,
+        };
 
-      const bidAdmWithReplacedMacros = replaceMacros(bid.adm, replacements);
+        const bidAdmWithReplacedMacros = replaceMacros(bid.adm, replacements);
 
-      if (isVideoType(prebidBid.mediaType)) {
-        prebidBid.vastXml = bidAdmWithReplacedMacros;
+        if (isVideoType(prebidBid.mediaType)) {
+          if (bidAdmWithReplacedMacros) {
+            prebidBid.vastXml = bidAdmWithReplacedMacros;
+          }
 
-        if (bid?.nurl) {
-          prebidBid.vastUrl = replaceMacros(bid.nurl, replacements);
+          if (bid.nurl) {
+            if (!prebidBid.vastXml) {
+              prebidBid.vastUrl = replaceMacros(bid.nurl, replacements);
+            } else {
+              // We do not want to use the vastUrl if we have the vastXml
+              delete prebidBid.vastUrl
+            }
+          }
+        } else {
+          prebidBid.ad = bidAdmWithReplacedMacros;
         }
-      } else {
-        prebidBid.ad = bidAdmWithReplacedMacros;
-      }
 
-      return prebidBid;
-    });
+        return prebidBid;
+      });
   },
 
   getUserSyncs(syncOptions, serverResponses) {

--- a/test/spec/modules/aniviewBidAdapter_spec.js
+++ b/test/spec/modules/aniviewBidAdapter_spec.js
@@ -222,6 +222,20 @@ describe('Aniview Bid Adapter', function () {
       expect(imp.bidfloorcur).not.exist;
     });
 
+    it('should have vastUrl if adm is not provided but nurl is', function () {
+      const bidRequests = spec.buildRequests(videoBidRequest.bids, videoBidRequest);
+      const bidderResponse = MOCK.bidderResponse();
+
+      delete bidderResponse.body.seatbid[0].bid[0].adm
+
+      const bids = spec.interpretResponse(bidderResponse, bidRequests[0]);
+      const bid = bids[0];
+
+      expect(bid.vastXml).to.not.exist;
+      expect(bid.vastUrl).to.exist.and.to.not.have.string('${AUCTION_PRICE}');
+      expect(bid.vastUrl).to.have.string('cpm=' + PRICE);
+    });
+
     it('should use dev environment', function () {
       const DEV_ENDPOINT = 'https://dev.aniview.com/sspRTB2';
       videoBidRequest.bids[0].params.dev = { endpoint: DEV_ENDPOINT };
@@ -257,8 +271,7 @@ describe('Aniview Bid Adapter', function () {
         expect(bids.length).to.greaterThan(0);
         expect(bid.vastXml).to.exist.and.to.not.have.string('${AUCTION_PRICE}');
         expect(bid.vastXml).to.have.string('cpm=' + PRICE);
-        expect(bid.vastUrl).to.exist.and.to.not.have.string('${AUCTION_PRICE}');
-        expect(bid.vastUrl).to.have.string('cpm=' + PRICE);
+        expect(bid.vastUrl).to.not.exist;
         expect(bid.requestId).to.equal(bidRequests[0].data.imp[0].id);
         expect(bid.cpm).to.equal(PRICE);
         expect(bid.ttl).to.equal(TTL);


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
- Filter bids that do not have `adm` or `nurl`
- Use only `vastXml` if we have `adm` or `adm` + `nurl`
- Use only `vastUrl` if we have `nurl` only