### PR TITLE
Core: allow for splitting bid requests on pbsHost

### DIFF
--- a/modules/prebidServerBidAdapter/index.js
+++ b/modules/prebidServerBidAdapter/index.js
@@ -199,7 +199,7 @@ export function validateConfig(options) {
  */
 function setS2sConfig(options) {
   options = validateConfig(options);
-  if (options.length) {
+  if (options?.length) {
     _s2sConfigs = options;
   }
 }
@@ -403,9 +403,10 @@ export function PrebidServer() {
     let { gdprConsent, uspConsent, gppConsent } = getConsentData(bidRequests);
 
     if (Array.isArray(_s2sConfigs)) {
-      if (s2sBidRequest.s2sConfig && s2sBidRequest.s2sConfig.syncEndpoint && getMatchingConsentUrl(s2sBidRequest.s2sConfig.syncEndpoint, gdprConsent)) {
-        const s2sAliases = (s2sBidRequest.s2sConfig.extPrebid && s2sBidRequest.s2sConfig.extPrebid.aliases) ?? {};
-        let syncBidders = s2sBidRequest.s2sConfig.bidders
+      const s2sConfig = s2sBidRequest.s2sConfig;
+      if (s2sConfig?.syncEndpoint && getMatchingConsentUrl(s2sConfig.syncEndpoint, gdprConsent)) {
+        const s2sAliases = (s2sConfig.extPrebid?.aliases) ?? {};
+        let syncBidders = (s2sConfig.syncBidders ?? s2sConfig.bidders)
           .map(bidder => adapterManager.aliasRegistry[bidder] || s2sAliases[bidder] || bidder)
           .filter((bidder, index, array) => (array.indexOf(bidder) === index));
 

--- a/modules/prebidServerBidAdapter/ortbConverter.js
+++ b/modules/prebidServerBidAdapter/ortbConverter.js
@@ -194,9 +194,11 @@ const PBS_CONVERTER = ortbConverter({
         context.getRedactor().ortb2(ortbRequest);
 
         const fpdConfigs = Object.entries(context.s2sBidRequest.ortb2Fragments?.bidder || {}).filter(([bidder]) => {
-          const bidders = context.s2sBidRequest.s2sConfig.bidders;
-          const allowUnknownBidderCodes = context.s2sBidRequest.s2sConfig.allowUnknownBidderCodes;
-          return allowUnknownBidderCodes || (bidders && bidders.includes(bidder));
+          const s2sConfig = context.s2sBidRequest.s2sConfig;
+          const bidders = s2sConfig.bidders;
+          const syncBidders = s2sConfig.syncBidders;
+          const allowUnknownBidderCodes = s2sConfig.allowUnknownBidderCodes;
+          return allowUnknownBidderCodes || (bidders?.includes(bidder)) || (syncBidders?.includes(bidder));
         }).map(([bidder, ortb2]) => ({
           // ... but for bidder specific FPD we can use the actual bidder
           bidders: [bidder],

--- a/modules/s2sTesting.js
+++ b/modules/s2sTesting.js
@@ -110,7 +110,7 @@ partitionBidders.before(function (next, adUnits, s2sConfigs) {
     }
   });
 
-  next.bail(getBidderCodes(adUnits).reduce((memo, bidder) => {
+  next.bail(getBidderCodes(adUnits).reduce((memo, {bidder}) => {
     if (serverBidders.has(bidder)) {
       memo[SERVER].push(bidder);
     }

--- a/src/adapterManager.js
+++ b/src/adapterManager.js
@@ -164,7 +164,7 @@ export function _filterBidsForAdUnit(bids, s2sConfig, {getS2SBidders = getS2SBid
     return bids;
   } else {
     const serverBidders = getS2SBidders(s2sConfig);
-    return bids.filter((bid) => serverBidders.has(bid.bidder))
+    return bids.filter((bid) => serverBidders.has(bid.pbsHost ?? bid.bidder))
   }
 }
 export const filterBidsForAdUnit = hook('sync', _filterBidsForAdUnit, 'filterBidsForAdUnit');
@@ -246,8 +246,8 @@ export function getS2SBidderSet(s2sConfigs) {
  */
 export function _partitionBidders (adUnits, s2sConfigs, {getS2SBidders = getS2SBidderSet} = {}) {
   const serverBidders = getS2SBidders(s2sConfigs);
-  return getBidderCodes(adUnits).reduce((memo, bidder) => {
-    const partition = serverBidders.has(bidder) ? PARTITIONS.SERVER : PARTITIONS.CLIENT;
+  return getBidderCodes(adUnits).reduce((memo, {bidder, pbsHost}) => {
+    const partition = serverBidders.has(pbsHost || bidder) ? PARTITIONS.SERVER : PARTITIONS.CLIENT;
     memo[partition].push(bidder);
     return memo;
   }, {[PARTITIONS.CLIENT]: [], [PARTITIONS.SERVER]: []})
@@ -319,13 +319,16 @@ adapterManager.makeBidRequests = hook('sync', function (adUnits, auctionStart, a
       (serverBidders.length === 0 && hasModuleBids ? [null] : serverBidders).forEach(bidderCode => {
         const bidderRequestId = getUniqueIdentifierStr();
         const metrics = auctionMetrics.fork();
+        const bids = hookedGetBids({ bidderCode, auctionId, bidderRequestId, 'adUnits': deepClone(adUnitsS2SCopy), src: S2S.SRC, metrics });
+        const pbsHost = bids?.find(bid => bid.pbsHost)?.pbsHost;
         const bidderRequest = addOrtb2({
           bidderCode,
           auctionId,
           bidderRequestId,
           uniquePbsTid,
-          bids: hookedGetBids({ bidderCode, auctionId, bidderRequestId, 'adUnits': deepClone(adUnitsS2SCopy), src: S2S.SRC, metrics }),
+          bids,
           auctionStart: auctionStart,
+          pbsHost,
           timeout: s2sConfig.timeout,
           src: S2S.SRC,
           refererInfo,
@@ -420,7 +423,9 @@ adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, request
   let counter = 0;
 
   _s2sConfigs.forEach((s2sConfig) => {
-    if (s2sConfig && uniqueServerBidRequests[counter] && getS2SBidderSet(s2sConfig).has(uniqueServerBidRequests[counter].bidderCode)) {
+    const uniqueServerBid = uniqueServerBidRequests[counter];
+
+    if (s2sConfig && uniqueServerBid && getS2SBidderSet(s2sConfig).has(uniqueServerBid.pbsHost || uniqueServerBid.bidderCode)) {
       // s2s should get the same client side timeout as other client side requests.
       const s2sAjax = ajaxBuilder(requestBidsTimeout, requestCallbacks ? {
         request: requestCallbacks.request.bind(null, 's2s'),
@@ -428,8 +433,8 @@ adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, request
       } : undefined);
       let adaptersServerSide = s2sConfig.bidders;
       const s2sAdapter = _bidderRegistry[s2sConfig.adapter];
-      let uniquePbsTid = uniqueServerBidRequests[counter].uniquePbsTid;
-      let adUnitsS2SCopy = uniqueServerBidRequests[counter].adUnitsS2SCopy;
+      let uniquePbsTid = uniqueServerBid.uniquePbsTid;
+      let adUnitsS2SCopy = uniqueServerBid.adUnitsS2SCopy;
 
       let uniqueServerRequests = serverBidderRequests.filter(serverBidRequest => serverBidRequest.uniquePbsTid === uniquePbsTid);
 
@@ -446,7 +451,7 @@ adapterManager.callBids = (adUnits, bidRequests, addBidResponse, doneCb, request
             }
           });
 
-          const bidders = getBidderCodes(s2sBidRequest.ad_units).filter((bidder) => adaptersServerSide.includes(bidder));
+          const bidders = getBidderCodes(s2sBidRequest.ad_units).filter(({bidder, pbsHost}) => adaptersServerSide.includes(pbsHost) || adaptersServerSide.includes(bidder));
           logMessage(`CALLING S2S HEADER BIDDERS ==== ${bidders.length > 0 ? bidders.join(', ') : 'No bidder specified, using "ortb2Imp" definition(s) only'}`);
 
           // fire BID_REQUESTED event for each s2s bidRequest

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -648,7 +648,7 @@ export const startAuction = hook('async', function ({ bidsBackHandler, timeout: 
     const adUnitMediaTypes = Object.keys(adUnit.mediaTypes || { 'banner': 'banner' });
 
     // get the bidder's mediaTypes
-    const allBidders = adUnit.bids.map(bid => bid.bidder);
+    const allBidders = adUnit.bids.map(bid => bid.pbsHost || bid.bidder);
     const bidderRegistry = adapterManager.bidderRegistry;
 
     const bidders = allBidders.filter(bidder => !s2sBidders.has(bidder));

--- a/src/utils.js
+++ b/src/utils.js
@@ -644,8 +644,20 @@ export function getValue(obj, key) {
 
 export function getBidderCodes(adUnits = pbjsInstance.adUnits) {
   // this could memoize adUnits
-  return adUnits.map(unit => unit.bids.map(bid => bid.bidder)
-    .reduce(flatten, [])).reduce(flatten, []).filter((bidder) => typeof bidder !== 'undefined').filter(uniques);
+  const seen = new Set();
+  return adUnits.reduce((acc, unit) => {
+    unit.bids.forEach(bid => {
+      const { bidder, pbsHost } = bid;
+      if (typeof bidder !== 'undefined') {
+        const key = `${bidder}-${pbsHost || ''}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          acc.push({ bidder, pbsHost });
+        }
+      }
+    });
+    return acc;
+  }, []);
 }
 
 export function isGptPubadsDefined() {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2839,6 +2839,107 @@ describe('S2S Adapter', function () {
       expect(parsedRequestBody.bcat).to.deep.equal(bcat);
     });
 
+    it('passes first party data in request for pbsHost/syncBidders', async () => {
+      const cfg = {...CONFIG, allowUnknownBidderCodes: false};
+      cfg.bidders = ['appnexus-alt'];
+      cfg.syncBidders = ['appnexus'];
+      config.setConfig({s2sConfig: cfg});
+
+      const clonedReq = {...REQUEST, s2sConfig: cfg}
+      const s2sBidRequest = utils.deepClone(clonedReq);
+      const bidRequests = utils.deepClone(BID_REQUESTS).map(request => {
+        request.bids.forEach(bid => bid.pbsHost = `${bid.bidder}-alt`);
+        return request;
+      });
+
+      const commonSite = {
+        keywords: ['power tools'],
+        search: 'drill'
+      };
+      const commonUser = {
+        keywords: ['a', 'b'],
+        gender: 'M'
+      };
+
+      const site = {
+        content: {userrating: 4},
+        ext: {
+          data: {
+            pageType: 'article',
+            category: 'tools'
+          }
+        }
+      };
+      const user = {
+        yob: '1984',
+        geo: {country: 'ca'},
+        ext: {
+          data: {
+            registered: true,
+            interests: ['cars']
+          }
+        }
+      };
+      const bcat = ['IAB25', 'IAB7-39'];
+      const badv = ['blockedAdv-1.com', 'blockedAdv-2.com'];
+      const allowedBidders = ['appnexus'];
+
+      const expected = allowedBidders.map(bidder => ({
+        bidders: [bidder],
+        config: {
+          ortb2: {
+            site: {
+              content: {userrating: 4},
+              ext: {
+                data: {
+                  pageType: 'article',
+                  category: 'tools'
+                }
+              }
+            },
+            user: {
+              yob: '1984',
+              geo: {country: 'ca'},
+              ext: {
+                data: {
+                  registered: true,
+                  interests: ['cars']
+                }
+              }
+            },
+            bcat: ['IAB25', 'IAB7-39'],
+            badv: ['blockedAdv-1.com', 'blockedAdv-2.com']
+          }
+        }
+      }));
+      const commonContextExpected = utils.mergeDeep({
+        'page': 'http://mytestpage.com',
+        'domain': 'mytestpage.com',
+        'publisher': {
+          'id': '1',
+          'domain': 'mytestpage.com'
+        }
+      }, commonSite);
+
+      const ortb2Fragments = {
+        global: {site: commonSite, user: commonUser, badv, bcat},
+        bidder: Object.fromEntries(allowedBidders.map(bidder => [bidder, {site, user, bcat, badv}]))
+      };
+
+      // adapter.callBids({ ...REQUEST, s2sConfig: cfg }, BID_REQUESTS, addBidResponse, done, ajax);
+
+      adapter.callBids(await addFpdEnrichmentsToS2SRequest({
+        ...s2sBidRequest,
+        ortb2Fragments
+      }, bidRequests, cfg), bidRequests, addBidResponse, done, ajax);
+      const parsedRequestBody = JSON.parse(server.requests[0].requestBody);
+      expect(parsedRequestBody.ext.prebid.bidderconfig).to.deep.equal(expected);
+      expect(parsedRequestBody.site).to.deep.equal(commonContextExpected);
+      expect(parsedRequestBody.user).to.deep.equal(commonUser);
+      expect(parsedRequestBody.badv).to.deep.equal(badv);
+      expect(parsedRequestBody.bcat).to.deep.equal(bcat);
+    });
+
     describe('pbAdSlot config', function () {
       it('should not send \"imp.ext.data.pbadslot\" if \"ortb2Imp.ext\" is undefined', function () {
         const consentConfig = { s2sConfig: CONFIG };

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1824,6 +1824,22 @@ describe('adapterManager tests', function () {
       })
     })
 
+    it('should set pbsHost is exists on bid', function () {
+      const previousState = config.getConfig('s2sConfig');
+      config.setConfig({s2sConfig: { enabled: true, bidders: ['appnexus'] }});
+      hook.ready();
+      adUnits = [utils.deepClone(getAdUnits()[0])];
+      adUnits[0].bids.splice(1);
+      adUnits[0].bids[0].bidder = 'appnexus';
+      adUnits[0].bids[0].pbsHost = 'adnx';
+
+      let bidRequests = makeBidRequests([adUnits[0]]);
+      expect(bidRequests[0].bidderCode).to.equal('appnexus');
+      expect(bidRequests[0].pbsHost).to.equal('adnx');
+
+      config.setConfig({s2sConfig: previousState});
+    });
+
     it('should set and increment bidRequestsCounter', () => {
       const [au1, au2] = adUnits;
       makeBidRequests([au1, au2]).flatMap(br => br.bids).forEach(bid => {
@@ -2887,11 +2903,28 @@ describe('adapterManager tests', function () {
           sinon.assert.calledWith(getS2SBidders, sinon.match.same(s2sConfig));
         });
       });
+
+      it('should partition to server if pbsHost is in server bidders', () => {
+        const adUnits = [{
+          bids: [{
+            bidder: 'A',
+          }, {
+            bidder: 'B',
+            pbsHost: 'B-2'
+          }]
+        }];
+        s2sBidders = new Set(['B-2']);
+        const s2sConfig = {};
+        expect(partition(adUnits, s2sConfig)).to.eql({
+          [PARTITIONS.CLIENT]: ['A'],
+          [PARTITIONS.SERVER]: ['B']
+        });
+      });
     });
 
     describe('filterBidsForAdUnit', () => {
-      function filterBids(bids, s2sConfig) {
-        return _filterBidsForAdUnit(bids, s2sConfig, {getS2SBidders});
+      function filterBids(bids, s2sConfig, getBidders) {
+        return _filterBidsForAdUnit(bids, s2sConfig, {getS2SBidders: getBidders ?? getS2SBidders});
       }
       it('should not filter any bids when s2sConfig == null', () => {
         const bids = ['untouched', 'data'];
@@ -2903,6 +2936,13 @@ describe('adapterManager tests', function () {
         const s2sConfig = {};
         expect(filterBids(['A', 'C', 'D'].map((code) => ({bidder: code})), s2sConfig)).to.eql([{bidder: 'A'}]);
         sinon.assert.calledWith(getS2SBidders, sinon.match.same(s2sConfig));
+      })
+
+      it('should not filter bidders that match a bids pbsHost but not bidder code', () => {
+        const s2sConfig = {};
+        const bids = ['A', 'C', 'D'].map((code) => ({bidder: code, pbsHost: `${code}Z`}));
+        const getBidders = () => new Set(['AZ', 'B']);
+        expect(filterBids(bids, s2sConfig, getBidders)).to.eql([{bidder: 'A', pbsHost: 'AZ'}]);
       })
     });
   });

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -1824,7 +1824,7 @@ describe('adapterManager tests', function () {
       })
     })
 
-    it('should set pbsHost is exists on bid', function () {
+    it('should set pbsHost if it exists on bid', function () {
       const previousState = config.getConfig('s2sConfig');
       config.setConfig({s2sConfig: { enabled: true, bidders: ['appnexus'] }});
       hook.ready();


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
**Routing for Multiple PBS instances**

This PR allows multiple PBS instances to utilize the same bidder codes and route bids via pbsHost property. Example below:

Bids:
```
[{
    bidder: 'foobar',
    params: {...},
},
{
    bidder: 'foobar',
    params: {...},
    pbsHost: 'foobar-2'
}]
```

s2sConfig:
```
[{
    accountId: 1234,
    bidders: ['foobar'],
    enabled: true,
    endpoint: {
        noP1Consent : 'https://pbs.auction/openrtb2/auction',
        p1Consent : 'https://pbs.auction/openrtb2/auction'
    }
},
{
     accountId: 5678,
     bidders: ['foobar-2'],
     syncBidders: ['foobar'],
     enabled: true,
     endpoint: {
        noP1Consent : 'https://pbs.alt.auction/openrtb2/auction',
        p1Consent : 'https://pbs.alt.auction/openrtb2/auction'
     }
}]
```

The above would distribute `bid[0]` to s2s endpoint `https://pbs.auction/openrtb2/auction`, whereas `bid[1]` will be distributed to `https://pbs.alt.auction/openrtb2/auction`. The syncBidders is used to both sync with the original biddercode to ensure user syncs are still working as expected as well as applying bidder specific FPD for pbs calls via bidderconfig.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
