### PR TITLE
Yandex Bid Adapter : add support for video ads

### DIFF
--- a/modules/yandexBidAdapter.js
+++ b/modules/yandexBidAdapter.js
@@ -1,6 +1,6 @@
 import { getCurrencyFromBidderRequest } from '../libraries/ortb2Utils/currency.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import { BANNER, NATIVE } from '../src/mediaTypes.js';
+import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import { _each, _map, deepAccess, deepSetValue, formatQS, triggerPixel, logInfo } from '../src/utils.js';
 

--- a/modules/yandexBidAdapter.md
+++ b/modules/yandexBidAdapter.md
@@ -40,8 +40,30 @@ var adUnits = [
       }
     ],
   },
-  { // native
+  { // video
     code: 'banner-2',
+    mediaTypes: {
+      video: {
+        sizes: [[640, 480]],
+        context: 'instream',
+        playerSize: [[640, 480]],
+        mimes: ['video/mp4'],
+        protocols: [1, 2, 3, 4, 5, 6, 7, 8],
+        playbackmethod: [2],
+        skip: 1
+      },
+    },
+    bids: [
+      {
+        bidder: 'yandex',
+        params: {
+          placementId: '346580-1'
+        },
+      }
+    ],
+  },
+  { // native
+    code: 'banner-3',,
     mediaTypes: {
       native: {
         title: {

--- a/test/spec/modules/yandexBidAdapter_spec.js
+++ b/test/spec/modules/yandexBidAdapter_spec.js
@@ -278,6 +278,68 @@ describe('Yandex adapter', function () {
       });
     });
 
+    describe('video', function() {
+      function getVideoBidRequest(extra) {
+        const bannerRequest = getBidRequest(extra);
+        const requests = spec.buildRequests([bannerRequest], bidderRequest);
+
+        return requests[0].data.imp[0].video;
+      }
+
+      it('should map basic video parameters', function() {
+        const bidRequest = getVideoBidRequest({
+          mediaTypes: {
+            video: {
+              context: 'instream',
+              mimes: ['video/mp4'],
+              minduration: 5,
+              maxduration: 30,
+              protocols: [2, 3],
+              playbackmethod: [1],
+              w: 640,
+              h: 480,
+              startdelay: 0,
+              placement: 1,
+              skip: 1,
+              skipafter: 5,
+              minbitrate: 300,
+              maxbitrate: 1500,
+              delivery: [2],
+              api: [2],
+              linearity: 1,
+              battr: [1, 2, 3],
+              sizes: [[640, 480], [800, 600]]
+            }
+          }
+        });
+
+        expect(bidRequest).to.deep.equal({
+          context: 'instream',
+          mimes: ['video/mp4'],
+          minduration: 5,
+          maxduration: 30,
+          protocols: [2, 3],
+          playbackmethod: [1],
+          w: 640,
+          h: 480,
+          startdelay: 0,
+          placement: 1,
+          skip: 1,
+          skipafter: 5,
+          minbitrate: 300,
+          maxbitrate: 1500,
+          delivery: [2],
+          api: [2],
+          linearity: 1,
+          battr: [1, 2, 3],
+          format: [
+            {w: 640, h: 480},
+            {w: 800, h: 600}
+          ]
+        });
+      });
+    });
+
     describe('native', () => {
       function buildRequestAndGetNativeParams(extra) {
         const bannerRequest = getBidRequest(extra);
@@ -483,6 +545,58 @@ describe('Yandex adapter', function () {
       expect(rtbBid.nurl).to.equal('https://example.com/nurl/?price=0.3&cur=USD');
 
       expect(rtbBid.meta.advertiserDomains).to.deep.equal(['example.com']);
+    });
+
+    describe('video', function() {
+      const videoBidRequest = {
+        bidRequest: {
+          mediaType: 'video',
+          bidId: 'videoBid1',
+          adUnitCode: 'videoAdUnit'
+        }
+      };
+
+      const sampleVideoResponse = {
+        body: {
+          seatbid: [{
+            bid: [{
+              impid: 'videoBid1',
+              price: 1.50,
+              adm: '<VAST version="3.0"></VAST>',
+              w: 640,
+              h: 480,
+              adomain: ['advertiser.com'],
+              cid: 'campaign123',
+              crid: 'creative456',
+              nurl: 'https://tracker.example.com/win?price=${AUCTION_PRICE}'
+            }]
+          }],
+          cur: 'USD'
+        }
+      };
+
+      it('should handle valid video response', function() {
+        const result = spec.interpretResponse(sampleVideoResponse, videoBidRequest);
+
+        expect(result).to.have.lengthOf(1);
+        const bid = result[0];
+
+        expect(bid).to.deep.include({
+          requestId: 'videoBid1',
+          cpm: 1.50,
+          width: 640,
+          height: 480,
+          vastXml: '<VAST version="3.0"></VAST>',
+          mediaType: 'video',
+          currency: 'USD',
+          ttl: 180,
+          meta: {
+            advertiserDomains: ['advertiser.com']
+          }
+        });
+
+        expect(bid.nurl).to.equal('https://tracker.example.com/win?price=1.5');
+      });
     });
 
     describe('native', () => {


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter  

## Description of change
Ddd support for video ads for Yandex

## Other information
Recreated PR: https://github.com/prebid/Prebid.js/pull/13014#issuecomment-2839565580