### PR TITLE
Yandex Bid Adapter : add support for eventtrackers in native ads

### DIFF
--- a/modules/yandexBidAdapter.js
+++ b/modules/yandexBidAdapter.js
@@ -55,7 +55,19 @@ const DEFAULT_CURRENCY = 'EUR';
  */
 const SUPPORTED_MEDIA_TYPES = [BANNER, NATIVE];
 const SSP_ID = 10500;
-const ADAPTER_VERSION = '2.0.0';
+const ADAPTER_VERSION = '2.1.0';
+
+const TRACKER_METHODS = {
+  img: 1,
+  js: 2,
+};
+
+const TRACKER_EVENTS = {
+  impression: 1,
+  'viewable-mrc50': 2,
+  'viewable-mrc100': 3,
+  'viewable-video50': 4,
+};
 
 const IMAGE_ASSET_TYPES = {
   ICON: 1,
@@ -322,10 +334,13 @@ function mapNative(bidRequest) {
     });
 
     return {
-      ver: 1.1,
+      ver: 1.2,
       request: JSON.stringify({
-        ver: 1.1,
-        assets
+        ver: 1.2,
+        assets,
+        eventtrackers: [
+          { event: TRACKER_EVENTS.impression, methods: [TRACKER_METHODS.img] },
+        ],
       }),
     };
   }
@@ -457,9 +472,22 @@ function interpretNativeAd(bidReceived, price, currency) {
       }
     });
 
-    result.impressionTrackers = _map(native.imptrackers, (tracker) =>
+    const impressionTrackers = _map(native.imptrackers || [], (tracker) =>
       replaceAuctionPrice(tracker, price, currency)
     );
+
+    _each(native.eventtrackers || [], (eventtracker) => {
+      if (
+        eventtracker.event === TRACKER_EVENTS.impression &&
+        eventtracker.method === TRACKER_METHODS.img
+      ) {
+        impressionTrackers.push(
+          replaceAuctionPrice(eventtracker.url, price, currency)
+        );
+      }
+    });
+
+    result.impressionTrackers = impressionTrackers;
 
     return result;
   } catch (e) {}

--- a/test/spec/modules/yandexBidAdapter_spec.js
+++ b/test/spec/modules/yandexBidAdapter_spec.js
@@ -434,6 +434,18 @@ describe('Yandex adapter', function () {
         });
       });
     });
+
+    it('should include eventtrackers in the native request', function () {
+      const nativeParams = buildRequestAndGetNativeParams({
+        mediaTypes: {
+          native: {
+            title: { required: true },
+          },
+        },
+      });
+
+      expect(nativeParams.eventtrackers).to.deep.equal([{ event: 1, methods: [1] }]);
+    });
   });
 
   describe('interpretResponse', function () {
@@ -584,6 +596,114 @@ describe('Yandex adapter', function () {
             height: 32,
           },
         });
+      });
+
+      it('should add eventtrackers urls to impressionTrackers', function () {
+        bannerRequest.bidRequest = {
+          mediaType: NATIVE,
+          bidId: 'bidid-1',
+        };
+
+        const nativeAdmResponse = getNativeAdmResponse();
+        nativeAdmResponse.native.eventtrackers = [
+          {
+            event: 1, // TRACKER_EVENTS.impression
+            method: 1, // TRACKER_METHODS.img
+            url: 'https://example.com/imp-event-tracker',
+          },
+          {
+            event: 2,
+            method: 2,
+            url: 'https://example.com/skip-me',
+          },
+        ];
+
+        const bannerResponse = {
+          body: {
+            seatbid: [
+              {
+                bid: [
+                  {
+                    impid: 1,
+                    price: 0.3,
+                    adm: JSON.stringify(nativeAdmResponse),
+                  },
+                ],
+              },
+            ],
+          },
+        };
+
+        const result = spec.interpretResponse(bannerResponse, bannerRequest);
+        const bid = result[0];
+
+        expect(bid.native.impressionTrackers).to.include(
+          'https://example.com/imptracker'
+        );
+        expect(bid.native.impressionTrackers).to.include(
+          'https://example.com/imp-event-tracker'
+        );
+        expect(bid.native.impressionTrackers).to.not.include('https://example.com/skip-me');
+      });
+
+      it('should handle missing imptrackers', function () {
+        bannerRequest.bidRequest = {
+          mediaType: NATIVE,
+          bidId: 'bidid-1',
+        };
+
+        const nativeAdmResponse = getNativeAdmResponse();
+        delete nativeAdmResponse.native.imptrackers;
+        nativeAdmResponse.native.eventtrackers = [{
+          event: 1,
+          method: 1,
+          url: 'https://example.com/fallback-tracker'
+        }];
+
+        const bannerResponse = {
+          body: {
+            seatbid: [{
+              bid: [{
+                impid: 1,
+                price: 0.3,
+                adm: JSON.stringify(nativeAdmResponse)
+              }]
+            }]
+          }
+        };
+
+        const result = spec.interpretResponse(bannerResponse, bannerRequest);
+        const bid = result[0];
+
+        expect(bid.native.impressionTrackers)
+          .to.deep.equal(['https://example.com/fallback-tracker']);
+      });
+
+      it('should handle missing eventtrackers', function () {
+        bannerRequest.bidRequest = {
+          mediaType: NATIVE,
+          bidId: 'bidid-1',
+        };
+
+        const nativeAdmResponse = getNativeAdmResponse();
+
+        const bannerResponse = {
+          body: {
+            seatbid: [{
+              bid: [{
+                impid: 1,
+                price: 0.3,
+                adm: JSON.stringify(nativeAdmResponse)
+              }]
+            }]
+          }
+        };
+
+        const result = spec.interpretResponse(bannerResponse, bannerRequest);
+        const bid = result[0];
+
+        expect(bid.native.impressionTrackers)
+          .to.deep.equal(['https://example.com/imptracker']);
       });
     });
   });


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter 

## Description of change
Ddd support for eventtrackers in native ads for Yandex

## Other information
Previous PR: https://github.com/prebid/Prebid.js/pull/13013
Reason: https://github.com/prebid/Prebid.js/pull/13014#issuecomment-2839565580