### PR TITLE
Ogury Bid Adapter: reintroduce previous BID_WON logic to avoid some discrepancies

### DIFF
--- a/modules/oguryBidAdapter.js
+++ b/modules/oguryBidAdapter.js
@@ -13,9 +13,9 @@ const DEFAULT_TIMEOUT = 1000;
 const BID_HOST = 'https://mweb-hb.presage.io/api/header-bidding-request';
 const TIMEOUT_MONITORING_HOST = 'https://ms-ads-monitoring-events.presage.io';
 const MS_COOKIE_SYNC_DOMAIN = 'https://ms-cookie-sync.presage.io';
-const ADAPTER_VERSION = '2.0.0';
+const ADAPTER_VERSION = '2.0.3';
 
-export const converter = ortbConverter({
+export const ortbConverterProps = {
   context: {
     netRevenue: true,
     ttl: 60,
@@ -61,11 +61,18 @@ export const converter = ortbConverter({
   },
 
   bidResponse(buildBidResponse, bid, context) {
+    const nurl = bid.nurl;
+    delete bid.nurl;
+
     const bidResponse = buildBidResponse(bid, context);
     bidResponse.currency = 'USD';
+    bidResponse.nurl = nurl;
+
     return bidResponse;
   }
-});
+}
+
+export const converter = ortbConverter(ortbConverterProps);
 
 function isBidRequestValid(bid) {
   const adUnitSizes = getAdUnitSizes(bid);

--- a/test/spec/modules/oguryBidAdapter_spec.js
+++ b/test/spec/modules/oguryBidAdapter_spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { spec } from 'modules/oguryBidAdapter';
+import { spec, ortbConverterProps } from 'modules/oguryBidAdapter';
 import * as utils from 'src/utils.js';
 import { server } from '../../mocks/xhr.js';
 
@@ -720,7 +720,7 @@ describe('OguryBidAdapter', () => {
 
       expect(dataRequest.ext).to.deep.equal({
         prebidversion: '$prebid.version$',
-        adapterversion: '2.0.0'
+        adapterversion: '2.0.3'
       });
 
       expect(dataRequest.device).to.deep.equal({
@@ -919,16 +919,35 @@ describe('OguryBidAdapter', () => {
       expect(prebidBidResponse.width).to.equal(ortbResponse.w);
       expect(prebidBidResponse.height).to.equal(ortbResponse.h);
       expect(prebidBidResponse.ad).to.contain(ortbResponse.adm);
-      expect(prebidBidResponse.meta.advertiserDomains).to.equal(ortbResponse.adomain);
+      expect(prebidBidResponse.meta.advertiserDomains).to.deep.equal(ortbResponse.adomain);
       expect(prebidBidResponse.seatBidId).to.equal(ortbResponse.id);
+      expect(prebidBidResponse.nurl).to.equal(ortbResponse.nurl);
     }
 
     it('should correctly interpret bidResponse', () => {
       const request = spec.buildRequests(bidRequests, bidderRequestBase);
-      const result = spec.interpretResponse(openRtbBidResponse, request);
+      const result = spec.interpretResponse(utils.deepClone(openRtbBidResponse), request);
 
-      assertPrebidBidResponse(result[0], openRtbBidResponse.body.seatbid[0].bid[0])
-      assertPrebidBidResponse(result[1], openRtbBidResponse.body.seatbid[0].bid[1])
+      assertPrebidBidResponse(result[0], openRtbBidResponse.body.seatbid[0].bid[0]);
+      assertPrebidBidResponse(result[1], openRtbBidResponse.body.seatbid[0].bid[1]);
+    });
+  });
+
+  describe('ortbConverterProps.bidResponse', () => {
+    it('should call buildBidResponse without nurl and return nurl into bidResponse to call it via ajax', () => {
+      const bidResponse = { adUnitCode: 'adUnitCode', cpm: 10, adapterCode: 'ogury', width: 1, height: 1 };
+      const buildBidResponse = () => bidResponse;
+      const buildBidResponseSpy = sinon.spy(buildBidResponse);
+
+      const bid = { nurl: 'http://url.co/win' };
+
+      expect(ortbConverterProps.bidResponse(buildBidResponseSpy, utils.deepClone(bid), {})).to.deep.equal({ 
+        ...bidResponse,
+        currency: 'USD',
+        nurl: bid.nurl 
+      });
+
+      sinon.assert.calledWith(buildBidResponseSpy, {}, {});
     });
   });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Updated bidder adapter 
## Description of change
Reintroduce the previous bid_won logic to avoid some discrepancies between impression and bid_won generated by the latest change on Ogury bidder adapter.

## Other information
More info in the opened issue => https://github.com/prebid/Prebid.js/issues/13066
