### PR TITLE
ortbConverter: prepend nurl to creative markup

### DIFF
--- a/libraries/ortbConverter/processors/banner.js
+++ b/libraries/ortbConverter/processors/banner.js
@@ -34,8 +34,7 @@ export function bannerResponseProcessor({createPixel = (url) => createTrackPixel
   return function fillBannerResponse(bidResponse, bid) {
     if (bidResponse.mediaType === BANNER) {
       if (bid.adm && bid.nurl) {
-        bidResponse.ad = bid.adm;
-        bidResponse.ad += createPixel(bid.nurl);
+        bidResponse.ad = createPixel(bid.nurl) + bid.adm;
       } else if (bid.adm) {
         bidResponse.ad = bid.adm;
       } else if (bid.nurl) {

--- a/test/spec/modules/a1MediaBidAdapter_spec.js
+++ b/test/spec/modules/a1MediaBidAdapter_spec.js
@@ -240,7 +240,7 @@ describe('a1MediaBidAdapter', function() {
         const interpretedRes = spec.interpretResponse(bidderResponse, bidRequest);
 
         const expectedResPrice = 9;
-        const expectedAd = replaceAuctionPrice(macroAdm, expectedResPrice) + replaceAuctionPrice(interpretedNurl, expectedResPrice);
+        const expectedAd = replaceAuctionPrice(interpretedNurl, expectedResPrice) + replaceAuctionPrice(macroAdm, expectedResPrice);
 
         expect(interpretedRes[0].ad).equal(expectedAd);
       });

--- a/test/spec/modules/conversantBidAdapter_spec.js
+++ b/test/spec/modules/conversantBidAdapter_spec.js
@@ -485,7 +485,7 @@ describe('Conversant adapter tests', function() {
       expect(bid).to.have.property('width', 300);
       expect(bid).to.have.property('height', 250);
       expect(bid.meta.advertiserDomains).to.deep.equal(['https://example.com']);
-      expect(bid).to.have.property('ad', 'markup000<div style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="notify000"></div>');
+      expect(bid).to.have.property('ad', '<div style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="notify000"></div>markup000');
       expect(bid).to.have.property('ttl', 300);
       expect(bid).to.have.property('netRevenue', true);
     });
@@ -499,7 +499,7 @@ describe('Conversant adapter tests', function() {
       expect(bid).to.have.property('creativeId', '1002');
       expect(bid).to.have.property('width', 300);
       expect(bid).to.have.property('height', 600);
-      expect(bid).to.have.property('ad', 'markup002<div style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="notify002"></div>');
+      expect(bid).to.have.property('ad', '<div style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="notify002"></div>markup002');
       expect(bid).to.have.property('ttl', 300);
       expect(bid).to.have.property('netRevenue', true);
     });

--- a/test/spec/modules/kimberliteBidAdapter_spec.js
+++ b/test/spec/modules/kimberliteBidAdapter_spec.js
@@ -217,7 +217,7 @@ describe('kimberliteBidAdapter', function () {
             creativeId: 1,
             ttl: 300,
             netRevenue: true,
-            ad: bannerAdm + nurlPixel,
+            ad: nurlPixel + bannerAdm,
             meta: {}
           },
           {

--- a/test/spec/modules/scatteredBidAdapter_spec.js
+++ b/test/spec/modules/scatteredBidAdapter_spec.js
@@ -192,7 +192,7 @@ describe('interpretResponse', function () {
   it('should set proper values', function () {
     const results = spec.interpretResponse(serverResponse, request);
     const expected = {
-      ad: '<html><img src="https://some_banner.jpeg></img></html><div style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="https://scattered.eu/nurl"></div>',
+      ad: '<div style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="https://scattered.eu/nurl"></div><html><img src="https://some_banner.jpeg></img></html>',
       cpm: '34.2',
       creativeId: '2345-2345-23',
       currency: 'PLN',

--- a/test/spec/modules/sparteoBidAdapter_spec.js
+++ b/test/spec/modules/sparteoBidAdapter_spec.js
@@ -365,7 +365,7 @@ describe('SparteoAdapter', function () {
             ttl: TTL,
             mediaType: 'banner',
             meta: {},
-            ad: 'script<div style=\"position:absolute;left:0px;top:0px;visibility:hidden;\"><img src=\"https://t.bidder.sparteo.com/img\"></div>'
+            ad: '<div style=\"position:absolute;left:0px;top:0px;visibility:hidden;\"><img src=\"https://t.bidder.sparteo.com/img\"></div>script'
           }
         ];
 

--- a/test/spec/ortbConverter/banner_spec.js
+++ b/test/spec/ortbConverter/banner_spec.js
@@ -195,7 +195,7 @@ describe('ortb -> pbjs banner conversion', () => {
       },
       expected: {
         mediaType: BANNER,
-        ad: 'mockAdmmockUrlPixel'
+        ad: 'mockUrlPixelmockAdm'
       }
     },
     {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

This updates ortbConverter to prepend `nurl` to `adm` instead of appending it, to avoid giving the creative the opportunity to break the document before the tracker runs.

## Other information

https://github.com/prebid/Prebid.js/issues/13066
