### PR TITLE
Onetag Bid Adapter : added native legacy support

### DIFF
--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -84,8 +84,7 @@ const isValidAsset = function(asset) {
   const hasValidContent = asset.title || asset.img || asset.data || asset.video;
   if (!hasValidContent) return false;
   if (asset.title && (!asset.title.len || !Number.isInteger(asset.title.len))) return false;
-  if (asset.img && ((!asset.img.wmin || !Number.isInteger(asset.img.wmin)) || (!asset.img.hmin || !Number.isInteger(asset.img.hmin)))) return false;
-  if (asset.data && !asset.data.type) return false;
+  if (asset.data && (!asset.data.type || !Number.isInteger(asset.data.type))) return false;
   if (asset.video && (!asset.video.mimes || !asset.video.minduration || !asset.video.maxduration || !asset.video.protocols)) return false;
   return true;
 }

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -167,7 +167,7 @@ describe('onetag', function () {
         nativeBid.mediaTypes.native = 30;
         expect(spec.isBidRequestValid(nativeBid)).to.be.false;
       });
-      it('Should return false when native.ortb is not an object', function () {
+      it('Should return false when native.ortb if defined but it isn\'t an object', function () {
         const nativeBid = createNativeBid();
         nativeBid.mediaTypes.native.ortb = 30 || 'string';
         expect(spec.isBidRequestValid(nativeBid)).to.be.false;
@@ -195,16 +195,6 @@ describe('onetag', function () {
       it('Should return false when native.ortb.assets[i] have title, but doesnt have \'len\' property', function () {
         const nativeBid = createNativeBid();
         Reflect.deleteProperty(nativeBid.mediaTypes.native.ortb.assets[0].title, 'len');
-        expect(spec.isBidRequestValid(nativeBid)).to.be.false;
-      });
-      it('Should return false when native.ortb.assets[i] is image but doesnt have \'wmin\' property', function () {
-        const nativeBid = createNativeBid();
-        Reflect.deleteProperty(nativeBid.mediaTypes.native.ortb.assets[1].img, 'wmin');
-        expect(spec.isBidRequestValid(nativeBid)).to.be.false;
-      });
-      it('Should return false when native.ortb.assets[i] is image but doesnt have \'hmin\' property', function () {
-        const nativeBid = createNativeBid();
-        Reflect.deleteProperty(nativeBid.mediaTypes.native.ortb.assets[1].img, 'hmin');
         expect(spec.isBidRequestValid(nativeBid)).to.be.false;
       });
       it('Should return false when native.ortb.assets[i] is data but doesnt have \'type\' property', function () {

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -4,6 +4,7 @@ import { find } from 'src/polyfill.js';
 import { BANNER, VIDEO, NATIVE } from 'src/mediaTypes.js';
 import { INSTREAM, OUTSTREAM } from 'src/video.js';
 import { toOrtbNativeRequest } from 'src/native.js';
+import { hasTypeNative } from '../../../modules/onetagBidAdapter';
 
 const NATIVE_SUFFIX = 'Ad';
 
@@ -203,11 +204,8 @@ describe('onetag', function () {
     });
     describe('banner bidRequest', function () {
       it('Should return false when the sizes array is empty', function () {
-        // TODO (dgirardi): this test used to pass because `bannerBid` was global state
-        // and other test code made it invalid for reasons other than sizes.
-        // cleaning up the setup code, it now (correctly) fails.
-        bannerBid.sizes = [];
-        // expect(spec.isBidRequestValid(bannerBid)).to.be.false;
+        bannerBid.mediaTypes.banner.sizes = [];
+        expect(spec.isBidRequestValid(bannerBid)).to.be.false;
       });
     });
     describe('native bidRequest', function () {
@@ -388,7 +386,7 @@ describe('onetag', function () {
   describe('buildRequests', function () {
     let serverRequest, data;
     before(() => {
-      serverRequest = spec.buildRequests([bannerBid, instreamVideoBid, nativeBid]);
+      serverRequest = spec.buildRequests([bannerBid, instreamVideoBid, nativeBid, nativeLegacyBid]);
       data = JSON.parse(serverRequest.data);
     });
 
@@ -451,6 +449,21 @@ describe('onetag', function () {
             'type',
             'priceFloors'
           );
+        } else if (hasTypeNative(bid)) {
+          expect(bid).to.have.all.keys(
+            'adUnitCode',
+            'auctionId',
+            'bidId',
+            'bidderRequestId',
+            'pubId',
+            'ortb2Imp',
+            'transactionId',
+            'mediaTypeInfo',
+            'sizes',
+            'type',
+            'priceFloors'
+          ) &&
+          expect(bid.mediaTypeInfo).to.have.key('ortb');
         } else if (isValid(BANNER, bid)) {
           expect(bid).to.have.all.keys(
             'adUnitCode',

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -54,7 +54,7 @@ describe('onetag', function () {
         assets: [{
           id: 1,
           required: 1,
-          title: {
+      title: {
             len: 140
           }
         },
@@ -81,7 +81,7 @@ describe('onetag', function () {
             minduration: 5,
             maxduration: 30,
             protocols: [2, 3]
-          }
+      }
         }],
         eventtrackers: [{
           event: 1,
@@ -224,28 +224,38 @@ describe('onetag', function () {
       });
       it('Should return false when native.ortb.eventtrackers is not an array', function () {
         const nativeBid = createNativeBid();
-        nativeBid.mediaTypes.native.ortb.eventtrackers = 30;
-        expect(spec.isBidRequestValid(nativeBid)).to.be.false;
+        if (nativeBid.mediaTypes.native.ortb.eventtrackers) {
+          nativeBid.mediaTypes.native.ortb.eventtrackers = 30;
+          expect(spec.isBidRequestValid(nativeBid)).to.be.false;
+        }
       });
       it('Should return false when native.ortb.eventtrackers[i].event is not a number', function () {
         const nativeBid = createNativeBid();
-        nativeBid.mediaTypes.native.ortb.eventtrackers[0].event = 'test-string';
-        expect(spec.isBidRequestValid(nativeBid)).to.be.false;
+        if (nativeBid.mediaTypes.native.ortb.eventtrackers) {
+          nativeBid.mediaTypes.native.ortb.eventtrackers[0].event = 'test-string';
+          expect(spec.isBidRequestValid(nativeBid)).to.be.false;
+        }
       });
       it('Should return false when native.ortb.eventtrackers[i].event is not defined', function () {
         const nativeBid = createNativeBid();
-        nativeBid.mediaTypes.native.ortb.eventtrackers[0].event = undefined;
-        expect(spec.isBidRequestValid(nativeBid)).to.be.false;
+        if (nativeBid.mediaTypes.native.ortb.eventtrackers) {
+          nativeBid.mediaTypes.native.ortb.eventtrackers[0].event = undefined;
+          expect(spec.isBidRequestValid(nativeBid)).to.be.false;
+        }
       });
       it('Should return false when native.ortb.eventtrackers[i].methods is not an array', function () {
         const nativeBid = createNativeBid();
-        nativeBid.mediaTypes.native.ortb.eventtrackers[0].methods = 30;
-        expect(spec.isBidRequestValid(nativeBid)).to.be.false;
+        if (nativeBid.mediaTypes.native.ortb.eventtrackers) {
+          nativeBid.mediaTypes.native.ortb.eventtrackers[0].methods = 30;
+          expect(spec.isBidRequestValid(nativeBid)).to.be.false;
+        }
       });
       it('Should return false when native.ortb.eventtrackers[i].methods is empty array', function () {
         const nativeBid = createNativeBid();
-        nativeBid.mediaTypes.native.ortb.eventtrackers[0].methods = [];
-        expect(spec.isBidRequestValid(nativeBid)).to.be.false;
+        if (nativeBid.mediaTypes.native.ortb.eventtrackers) {
+          nativeBid.mediaTypes.native.ortb.eventtrackers[0].methods = [];
+          expect(spec.isBidRequestValid(nativeBid)).to.be.false;
+        }
       });
     });
     describe('video bidRequest', function () {

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -249,42 +249,51 @@ describe('onetag', function () {
       it('Should return false when native.ortb.assets[i] doesnt have any of \'title\', \'img\', \'data\' and \'video\' properties', function () {
         const nativeBid = createNativeBid();
         const nativeLegacyBid = createNativeLegacyBid();
-        Reflect.deleteProperty(nativeBid.mediaTypes.native.ortb.assets[0], 'title');
-        Reflect.deleteProperty(nativeLegacyBid.mediaTypes.native.ortb.assets[0], 'title');
+        const titleIndex = nativeBid.mediaTypes.native.ortb.assets.findIndex(asset => asset.title);
+        const legacyTitleIndex = nativeLegacyBid.mediaTypes.native.ortb.assets.findIndex(asset => asset.title);
+        Reflect.deleteProperty(nativeBid.mediaTypes.native.ortb.assets[titleIndex], 'title');
+        Reflect.deleteProperty(nativeLegacyBid.mediaTypes.native.ortb.assets[legacyTitleIndex], 'title');
         expect(spec.isBidRequestValid(nativeBid)).to.be.false && expect(spec.isBidRequestValid(nativeLegacyBid)).to.be.false;
       });
       it('Should return false when native.ortb.assets[i] have title, but doesnt have \'len\' property', function () {
         const nativeBid = createNativeBid();
         const nativeLegacyBid = createNativeLegacyBid();
-        Reflect.deleteProperty(nativeBid.mediaTypes.native.ortb.assets[0].title, 'len');
-        Reflect.deleteProperty(nativeLegacyBid.mediaTypes.native.ortb.assets[0].title, 'len');
+        const titleIndex = nativeBid.mediaTypes.native.ortb.assets.findIndex(asset => asset.title);
+        const legacyTitleIndex = nativeLegacyBid.mediaTypes.native.ortb.assets.findIndex(asset => asset.title);
+        Reflect.deleteProperty(nativeBid.mediaTypes.native.ortb.assets[titleIndex].title, 'len');
+        Reflect.deleteProperty(nativeLegacyBid.mediaTypes.native.ortb.assets[legacyTitleIndex].title, 'len');
         expect(spec.isBidRequestValid(nativeBid)).to.be.false && expect(spec.isBidRequestValid(nativeLegacyBid)).to.be.false;
       });
       it('Should return false when native.ortb.assets[i] is data but doesnt have \'type\' property', function () {
         const nativeBid = createNativeBid();
         const nativeLegacyBid = createNativeLegacyBid();
-        Reflect.deleteProperty(nativeBid.mediaTypes.native.ortb.assets[2].data, 'type');
-        Reflect.deleteProperty(nativeLegacyBid.mediaTypes.native.ortb.assets[2].data, 'type');
+        const dataIndex = nativeBid.mediaTypes.native.ortb.assets.findIndex(asset => asset.data);
+        Reflect.deleteProperty(nativeBid.mediaTypes.native.ortb.assets[dataIndex].data, 'type');
+        Reflect.deleteProperty(nativeLegacyBid.mediaTypes.native.ortb.assets[dataIndex].data, 'type');
         expect(spec.isBidRequestValid(nativeBid)).to.be.false && expect(spec.isBidRequestValid(nativeLegacyBid)).to.be.false;
       });
       it('Should return false when native.ortb.assets[i] is video but doesnt have \'mimes\' property', function () {
         const nativeBid = createNativeBid();
-        Reflect.deleteProperty(nativeBid.mediaTypes.native.ortb.assets[3].video, 'mimes');
+        const videoIndex = nativeBid.mediaTypes.native.ortb.assets.findIndex(asset => asset.video);
+        Reflect.deleteProperty(nativeBid.mediaTypes.native.ortb.assets[videoIndex].video, 'mimes');
         expect(spec.isBidRequestValid(nativeBid)).to.be.false;
       });
       it('Should return false when native.ortb.assets[i] is video but doesnt have \'minduration\' property', function () {
         const nativeBid = createNativeBid();
-        Reflect.deleteProperty(nativeBid.mediaTypes.native.ortb.assets[3].video, 'minduration');
+        const videoIndex = nativeBid.mediaTypes.native.ortb.assets.findIndex(asset => asset.video);
+        Reflect.deleteProperty(nativeBid.mediaTypes.native.ortb.assets[videoIndex].video, 'minduration');
         expect(spec.isBidRequestValid(nativeBid)).to.be.false;
       });
       it('Should return false when native.ortb.assets[i] is video but doesnt have \'maxduration\' property', function () {
         const nativeBid = createNativeBid();
-        Reflect.deleteProperty(nativeBid.mediaTypes.native.ortb.assets[3].video, 'maxduration');
+        const videoIndex = nativeBid.mediaTypes.native.ortb.assets.findIndex(asset => asset.video);
+        Reflect.deleteProperty(nativeBid.mediaTypes.native.ortb.assets[videoIndex].video, 'maxduration');
         expect(spec.isBidRequestValid(nativeBid)).to.be.false;
       });
       it('Should return false when native.ortb.assets[i] is video but doesnt have \'protocols\' property', function () {
         const nativeBid = createNativeBid();
-        Reflect.deleteProperty(nativeBid.mediaTypes.native.ortb.assets[3].video, 'protocols');
+        const videoIndex = nativeBid.mediaTypes.native.ortb.assets.findIndex(asset => asset.video);
+        Reflect.deleteProperty(nativeBid.mediaTypes.native.ortb.assets[videoIndex].video, 'protocols');
         expect(spec.isBidRequestValid(nativeBid)).to.be.false;
       });
       it('Should return false when native.ortb.eventtrackers is not an array', function () {


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Added support to Native Legacy format