### PR TITLE
ttd Bid Adapter : remove imp.video overwrite

### DIFF
--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -172,7 +172,8 @@ function getImpression(bidRequest) {
   const secure = utils.deepAccess(bidRequest, 'ortb2Imp.secure');
   impression.secure = isNumber(secure) ? secure : 1
 
-  utils.mergeDeep(impression, bidRequest.ortb2Imp)
+  const {video: _, ...ortb2ImpWithoutVideo} = bidRequest.ortb2Imp; // if enabled, video is already assigned above
+  utils.mergeDeep(impression, ortb2ImpWithoutVideo)
 
   return impression;
 }


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Since [Prebid 9.23.0](https://github.com/prebid/Prebid.js/releases/tag/9.23.0) if ad unit has `mediaType` video, video prop is appended to ad units `ortb2Imp` object. `ttdBidAdapter` appends `ortb2Imp` to the bid request causing 'video' being requested when disabled on bidder level.

### Pre-conditions:
- Ad unit has mediaType video on ad unit level `adUnit.mediaTypes = {video: {sizes...}, banner: {...}}`
- ttd does not have mediaType video enabled on bidder level `adUnit.bids = [{bidder: 'ttd', sizeConfig: [{relevantMediaTypes: ['banner']...}]}]`

### Expected result:
- Only 'banner' media type is requested.
### Actual result:
- 'banner' and 'video' media types are requested. On attempt to render video bid received, 'adRenderFailed' error is thrown with the message 'Cannot render video ad without a renderer'.

## Change
Assign all `ortb2Impl` fields except 'video'.

## Other information
PR with ortb params sync: https://github.com/prebid/Prebid.js/pull/12423