### PR TITLE
Core: Remove getStatusCode and statusMessage from bid object

### DIFF
--- a/modules/adnuntiusAnalyticsAdapter.js
+++ b/modules/adnuntiusAnalyticsAdapter.js
@@ -1,7 +1,7 @@
 import { timestamp, logInfo } from '../src/utils.js';
 import {ajax} from '../src/ajax.js';
 import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
-import { EVENTS, STATUS } from '../src/constants.js';
+import { EVENTS } from '../src/constants.js';
 import adapterManager from '../src/adapterManager.js';
 
 const URL = 'https://analytics.adnuntius.com/prebid';
@@ -63,7 +63,7 @@ const adnAnalyticsAdapter = Object.assign(adapter({url: '', analyticsType: 'endp
         logInfo('ADN_BID_RESPONSE:', args);
 
         const bidResp = cache.auctions[args.auctionId].bids[args.requestId];
-        bidResp.isBid = args.getStatusCode() === STATUS.GOOD;
+        bidResp.isBid = true;
         bidResp.width = args.width;
         bidResp.height = args.height;
         bidResp.cpm = args.cpm;

--- a/modules/datawrkzBidAdapter.js
+++ b/modules/datawrkzBidAdapter.js
@@ -413,12 +413,12 @@ function buildBannerResponse(bidRequest, bidResponse) {
     let placementCode = '';
 
     if (bidRequest) {
-      let bidResponse = createBid(1);
+      let bidResponse = createBid();
       placementCode = bidRequest.placementCode;
       bidRequest.status = STATUS.GOOD;
       responseCPM = parseFloat(bidderBid.price);
       if (responseCPM === 0 || isNaN(responseCPM)) {
-        let bid = createBid(2);
+        let bid = createBid();
         bid.requestId = bidRequest.bidId;
         bid.bidderCode = bidRequest.bidder;
         bidResponses.push(bid);
@@ -454,12 +454,12 @@ function buildNativeResponse(bidRequest, response) {
     let placementCode = '';
 
     if (bidRequest) {
-      let bidResponse = createBid(1);
+      let bidResponse = createBid();
       placementCode = bidRequest.placementCode;
       bidRequest.status = STATUS.GOOD;
       responseCPM = parseFloat(bidderBid.price);
       if (responseCPM === 0 || isNaN(responseCPM)) {
-        let bid = createBid(2);
+        let bid = createBid();
         bid.requestId = bidRequest.bidId;
         bid.bidderCode = bidRequest.bidder;
         bidResponses.push(bid);
@@ -503,12 +503,12 @@ function buildVideoResponse(bidRequest, response) {
     let placementCode = '';
 
     if (bidRequest) {
-      let bidResponse = createBid(1);
+      let bidResponse = createBid();
       placementCode = bidRequest.placementCode;
       bidRequest.status = STATUS.GOOD;
       responseCPM = parseFloat(bidderBid.price);
       if (responseCPM === 0 || isNaN(responseCPM)) {
-        let bid = createBid(2);
+        let bid = createBid();
         bid.requestId = bidRequest.bidId;
         bid.bidderCode = bidRequest.bidder;
         bidResponses.push(bid);

--- a/modules/debugging/pbsInterceptor.js
+++ b/modules/debugging/pbsInterceptor.js
@@ -1,5 +1,4 @@
 import {deepClone, delayExecution} from '../../src/utils.js';
-import { STATUS } from '../../src/constants.js';
 
 export function makePbsInterceptor({createBid}) {
   return function pbsBidInterceptor(next, interceptBids, s2sBidRequest, bidRequests, ajax, {
@@ -17,7 +16,7 @@ export function makePbsInterceptor({createBid}) {
     function addBid(bid, bidRequest) {
       onBid({
         adUnit: bidRequest.adUnitCode,
-        bid: Object.assign(createBid(STATUS.GOOD, bidRequest), {requestBidder: bidRequest.bidder}, bid)
+        bid: Object.assign(createBid(bidRequest), {requestBidder: bidRequest.bidder}, bid)
       })
     }
     bidRequests = bidRequests

--- a/modules/livewrappedAnalyticsAdapter.js
+++ b/modules/livewrappedAnalyticsAdapter.js
@@ -1,7 +1,7 @@
 import { timestamp, logInfo } from '../src/utils.js';
 import {ajax} from '../src/ajax.js';
 import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
-import { EVENTS, STATUS } from '../src/constants.js';
+import { EVENTS } from '../src/constants.js';
 import adapterManager from '../src/adapterManager.js';
 import { getGlobal } from '../src/prebidGlobal.js';
 
@@ -78,7 +78,7 @@ let livewrappedAnalyticsAdapter = Object.assign(adapter({EMPTYURL, ANALYTICSTYPE
 
         let bidResponse = cache.auctions[args.auctionId].bids[args.requestId];
         if (bidResponse.cpm > args.cpm) break; // For now we only store the highest bid
-        bidResponse.isBid = args.getStatusCode() === STATUS.GOOD;
+        bidResponse.isBid = true;
         bidResponse.width = args.width;
         bidResponse.height = args.height;
         bidResponse.cpm = args.cpm;

--- a/modules/prebidServerBidAdapter/ortbConverter.js
+++ b/modules/prebidServerBidAdapter/ortbConverter.js
@@ -1,7 +1,7 @@
 import {ortbConverter} from '../../libraries/ortbConverter/converter.js';
 import {deepClone, deepSetValue, getBidRequest, logError, logWarn, mergeDeep, timestamp} from '../../src/utils.js';
 import {config} from '../../src/config.js';
-import {S2S, STATUS} from '../../src/constants.js';
+import {S2S} from '../../src/constants.js';
 import {createBid} from '../../src/bidfactory.js';
 import {pbsExtensions} from '../../libraries/pbsExtensions/pbsExtensions.js';
 import {setImpBidParams} from '../../libraries/pbsExtensions/processors/params.js';
@@ -110,7 +110,7 @@ const PBS_CONVERTER = ortbConverter({
     // because core has special treatment for PBS adapter responses, we need some additional processing
     bidResponse.requestTimestamp = context.requestTimestamp;
     return {
-      bid: Object.assign(createBid(STATUS.GOOD, {
+      bid: Object.assign(createBid({
         src: S2S.SRC,
         bidId: bidRequest ? (bidRequest.bidId || bidRequest.bid_Id) : null,
         transactionId: context.adUnit.transactionId,

--- a/modules/pubmaticAnalyticsAdapter.js
+++ b/modules/pubmaticAnalyticsAdapter.js
@@ -134,8 +134,8 @@ function copyRequiredBidDetails(bid) {
   ]);
 }
 
-function setBidStatus(bid, args) {
-  switch (args.getStatusCode()) {
+function setBidStatus(bid) {
+  switch (1) {
     case STATUS.GOOD:
       bid.status = SUCCESS;
       delete bid.error; // it's possible for this to be set by a previous timeout
@@ -670,7 +670,7 @@ function bidResponseHandler(args) {
 
   bid.adId = args.adId;
   bid.source = formatSource(bid.source || args.source);
-  setBidStatus(bid, args);
+  setBidStatus(bid);
   const latency = args?.timeToRespond || Date.now() - cache.auctions[args.auctionId].timestamp;
   const auctionTime = cache.auctions[args.auctionId].timeout;
   // Check if latency is greater than auctiontime+150, then log auctiontime+150 to avoid large numbers

--- a/modules/yuktamediaAnalyticsAdapter.js
+++ b/modules/yuktamediaAnalyticsAdapter.js
@@ -2,7 +2,7 @@ import {buildUrl, generateUUID, getWindowLocation, logError, logInfo, parseSizes
 import {ajax, fetch} from '../src/ajax.js';
 import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
 import adapterManager from '../src/adapterManager.js';
-import { EVENTS, STATUS } from '../src/constants.js';
+import { EVENTS } from '../src/constants.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {getRefererInfo} from '../src/refererDetection.js';
 import {includes as strIncludes} from '../src/polyfill.js';
@@ -140,7 +140,7 @@ var yuktamediaAnalyticsAdapter = Object.assign(adapter({ analyticsType: 'endpoin
               events.auctions[args.auctionId] = { bids: {} };
             } else if (Object.keys(events.auctions[args.auctionId]['bids']).length) {
               let bidResponse = events.auctions[args.auctionId]['bids'][args.requestId];
-              bidResponse.isBid = args.getStatusCode() === STATUS.GOOD;
+              bidResponse.isBid = true;
               bidResponse.cpm = args.cpm;
               bidResponse.currency = args.currency;
               bidResponse.netRevenue = args.netRevenue;

--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -5,7 +5,7 @@ import {createBid} from '../bidfactory.js';
 import {userSync} from '../userSync.js';
 import {nativeBidIsValid} from '../native.js';
 import {isValidVideoBid} from '../video.js';
-import {EVENTS, REJECTION_REASON, STATUS} from '../constants.js';
+import {EVENTS, REJECTION_REASON} from '../constants.js';
 import * as events from '../events.js';
 import {includes} from '../polyfill.js';
 import {
@@ -327,7 +327,7 @@ export function newBidder(spec) {
             bid.meta = bid.meta || Object.assign({}, bid[bidRequest.bidder]);
             bid.deferBilling = bidRequest.deferBilling;
             bid.deferRendering = bid.deferBilling && (bid.deferRendering ?? typeof spec.onBidBillable !== 'function');
-            const prebidBid = Object.assign(createBid(STATUS.GOOD, bidRequest), bid, pick(bidRequest, TIDS));
+            const prebidBid = Object.assign(createBid(bidRequest), bid, pick(bidRequest, TIDS));
             addBidWithCode(bidRequest.adUnitCode, prebidBid);
           } else {
             logWarn(`Bidder ${spec.code} made bid for unknown request ID: ${bid.requestId}. Ignoring.`);

--- a/src/bidfactory.js
+++ b/src/bidfactory.js
@@ -14,15 +14,13 @@ import { getUniqueIdentifierStr } from './utils.js';
  dealId,
  priceKeyString;
  */
-function Bid(statusCode, {src = 'client', bidder = '', bidId, transactionId, adUnitId, auctionId} = {}) {
+function Bid({src = 'client', bidder = '', bidId, transactionId, adUnitId, auctionId} = {}) {
   var _bidSrc = src;
-  var _statusCode = statusCode || 0;
 
   Object.assign(this, {
     bidderCode: bidder,
     width: 0,
     height: 0,
-    statusMessage: _getStatus(),
     adId: getUniqueIdentifierStr(),
     requestId: bidId,
     transactionId,
@@ -31,23 +29,6 @@ function Bid(statusCode, {src = 'client', bidder = '', bidId, transactionId, adU
     mediaType: 'banner',
     source: _bidSrc
   })
-
-  function _getStatus() {
-    switch (_statusCode) {
-      case 0:
-        return 'Pending';
-      case 1:
-        return 'Bid available';
-      case 2:
-        return 'Bid returned empty or error response';
-      case 3:
-        return 'Bid timed out';
-    }
-  }
-
-  this.getStatusCode = function () {
-    return _statusCode;
-  };
 
   // returns the size of the bid creative. Concatenation of width and height by ‘x’.
   this.getSize = function () {
@@ -67,6 +48,6 @@ function Bid(statusCode, {src = 'client', bidder = '', bidId, transactionId, adU
 }
 
 // Bid factory function.
-export function createBid(statusCode, identifiers) {
-  return new Bid(statusCode, identifiers);
+export function createBid(identifiers) {
+  return new Bid(identifiers);
 }

--- a/src/targeting.js
+++ b/src/targeting.js
@@ -8,7 +8,6 @@ import {
   EVENTS,
   JSON_MAPPING,
   NATIVE_KEYS,
-  STATUS,
   TARGETING_KEYS
 } from './constants.js';
 import * as events from './events.js';
@@ -55,7 +54,7 @@ const isUnusedBid = (bid) => bid && ((bid.status && !includes([BID_STATUS.RENDER
 
 export let filters = {
   isActualBid(bid) {
-    return bid.getStatusCode() === STATUS.GOOD
+    return true;
   },
   isBidNotExpired,
   isUnusedBid

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -1,5 +1,5 @@
 // jscs:disable
-import { TARGETING_KEYS, STATUS } from 'src/constants.js';
+import { TARGETING_KEYS } from 'src/constants.js';
 import {createBid} from '../../src/bidfactory.js';
 const utils = require('src/utils.js');
 
@@ -1324,7 +1324,7 @@ export function createBidReceived({bidder, cpm, auctionId, responseTimestamp, ad
   if (typeof status !== 'undefined') {
     bid.status = status;
   }
-  return Object.assign(createBid(STATUS.GOOD), bid);
+  return Object.assign(createBid(), bid);
 }
 
 export function getServerTestingsAds() {

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -596,7 +596,7 @@ describe('auctionmanager.js', function () {
 
     it('Standard bidCpmAdjustment changes the bid of any bidder', function () {
       const bid = Object.assign({},
-        createBid(2),
+        createBid(),
         fixtures.getBidResponses()[5]
       );
 
@@ -741,7 +741,7 @@ describe('auctionmanager.js', function () {
   describe('adjustBids', function () {
     it('should adjust bids if greater than zero and pass copy of bid object', function () {
       const bid = Object.assign({},
-        createBid(2),
+        createBid(),
         fixtures.getBidResponses()[5]
       );
 

--- a/test/spec/modules/consumableBidAdapter_spec.js
+++ b/test/spec/modules/consumableBidAdapter_spec.js
@@ -549,7 +549,7 @@ describe('Consumable BidAdapter', function () {
   describe('interpretResponse validation', function () {
     it('response should have valid bidderCode', function () {
       let bidRequest = spec.buildRequests(BIDDER_REQUEST_2.bidRequest, BIDDER_REQUEST_2);
-      let bid = createBid(1, bidRequest.bidRequest[0]);
+      let bid = createBid(bidRequest.bidRequest[0]);
 
       expect(bid.bidderCode).to.equal('consumable');
     });

--- a/test/spec/modules/currency_spec.js
+++ b/test/spec/modules/currency_spec.js
@@ -14,7 +14,7 @@ import {
 } from 'modules/currency.js';
 import {createBid} from '../../../src/bidfactory.js';
 import * as utils from 'src/utils.js';
-import {EVENTS, STATUS, REJECTION_REASON} from '../../../src/constants.js';
+import {EVENTS, REJECTION_REASON} from '../../../src/constants.js';
 import {server} from '../../mocks/xhr.js';
 import * as events from 'src/events.js';
 import { enrichFPD } from '../../../src/fpd/enrichment.js';
@@ -31,7 +31,7 @@ describe('currency', function () {
   let fn = sinon.spy();
 
   function makeBid(bidProps) {
-    return Object.assign(createBid(STATUS.GOOD), bidProps);
+    return Object.assign(createBid(), bidProps);
   }
 
   beforeEach(function () {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -3259,9 +3259,6 @@ describe('S2S Adapter', function () {
       expect(addBidResponse.firstCall.args[0]).to.equal('div-gpt-ad-1460505748561-0');
 
       expect(addBidResponse.firstCall.args[1]).to.have.property('requestId', '123');
-
-      expect(addBidResponse.firstCall.args[1])
-        .to.have.property('statusMessage', 'Bid available');
     });
 
     it('should have dealId in bidObject', function () {
@@ -3378,7 +3375,6 @@ describe('S2S Adapter', function () {
 
       sinon.assert.calledOnce(addBidResponse);
       const response = addBidResponse.firstCall.args[1];
-      expect(response).to.have.property('statusMessage', 'Bid available');
       expect(response).to.have.property('bidderCode', 'appnexus');
       expect(response).to.have.property('requestId', '123');
       expect(response).to.have.property('cpm', 0.5);
@@ -3492,7 +3488,6 @@ describe('S2S Adapter', function () {
 
         sinon.assert.calledOnce(addBidResponse);
         const response = addBidResponse.firstCall.args[1];
-        expect(response).to.have.property('statusMessage', 'Bid available');
         expect(response).to.have.property('vastXml', RESPONSE_OPENRTB_VIDEO.seatbid[0].bid[0].adm);
         expect(response).to.have.property('mediaType', 'video');
         expect(response).to.have.property('bidderCode', 'appnexus');
@@ -3526,7 +3521,6 @@ describe('S2S Adapter', function () {
         sinon.assert.calledOnce(addBidResponse);
         const response = addBidResponse.firstCall.args[1];
 
-        expect(response).to.have.property('statusMessage', 'Bid available');
         expect(response).to.have.property('videoCacheKey', 'abcd1234');
         expect(response).to.have.property('vastUrl', 'https://prebid-cache.net/cache?uuid=abcd1234');
       });
@@ -3593,7 +3587,6 @@ describe('S2S Adapter', function () {
         sinon.assert.calledOnce(addBidResponse);
         const response = addBidResponse.firstCall.args[1];
 
-        expect(response).to.have.property('statusMessage', 'Bid available');
         expect(response).to.have.property('videoCacheKey', 'a5ad3993');
         expect(response).to.have.property('vastUrl', 'https://prebid-cache.net/cache?uuid=a5ad3993');
       }
@@ -3673,7 +3666,6 @@ describe('S2S Adapter', function () {
 
         sinon.assert.calledOnce(addBidResponse);
         const response = addBidResponse.firstCall.args[1];
-        expect(response).to.have.property('statusMessage', 'Bid available');
         expect(response).to.have.property('adm').deep.equal(RESPONSE_OPENRTB_NATIVE.seatbid[0].bid[0].adm);
         expect(response).to.have.property('mediaType', 'native');
         expect(response).to.have.property('bidderCode', 'appnexus');

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 import * as utils from 'src/utils.js';
 import { getGlobal } from 'src/prebidGlobal.js';
-import { EVENTS, STATUS } from 'src/constants.js';
+import { EVENTS } from 'src/constants.js';
 import {
   FLOOR_SKIPPED_REASON,
   _floorDataForAuction,
@@ -2254,7 +2254,7 @@ describe('the price floors module', function () {
       let next = (adUnitCode, bid) => {
         returnedBidResponse = bid;
       };
-      addBidResponseHook(next, bidResp.adUnitCode, Object.assign(createBid(STATUS.GOOD, { auctionId: AUCTION_ID }), bidResp), reject);
+      addBidResponseHook(next, bidResp.adUnitCode, Object.assign(createBid({ auctionId: AUCTION_ID }), bidResp), reject);
     };
     it('continues with the auction if not floors data is present without any flooring', function () {
       runBidResponse();

--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -8,7 +8,7 @@ import {
 } from 'src/targeting.js';
 import {config} from 'src/config.js';
 import {createBidReceived} from 'test/fixtures/fixtures.js';
-import { DEFAULT_TARGETING_KEYS, JSON_MAPPING, NATIVE_KEYS, STATUS, TARGETING_KEYS } from 'src/constants.js';
+import { DEFAULT_TARGETING_KEYS, JSON_MAPPING, NATIVE_KEYS, TARGETING_KEYS } from 'src/constants.js';
 import {auctionManager} from 'src/auctionManager.js';
 import * as utils from 'src/utils.js';
 import {deepClone} from 'src/utils.js';
@@ -16,8 +16,8 @@ import {createBid} from '../../../../src/bidfactory.js';
 import { hook, setupBeforeHookFnOnce } from '../../../../src/hook.js';
 import {getHighestCpm} from '../../../../src/utils/reducers.js';
 
-function mkBid(bid, status = STATUS.GOOD) {
-  return Object.assign(createBid(status), bid);
+function mkBid(bid) {
+  return Object.assign(createBid(), bid);
 }
 
 const sampleBid = {


### PR DESCRIPTION

- [x] Other

## Description of change

For the [12895](https://github.com/prebid/Prebid.js/issues/12895) breaking changes / API cleanup, covered - remove bids' getStatusCode and statusMessage fields

The getStatusCode method consistently returns 1, and statusMessage is always 'Bid available', making both redundant. This change removes getStatusCode() and statusMessage from the Bid object. Consequently, the Bid() constructor and createBid() method in bidfactory no longer accept statusCode as a parameter.

Please go through your respective modules and accommodate these changes accordingly. For now, a constant fallback has been applied to ensure backward compatibility and prevent any runtime issues.


## Other information
[12895](https://github.com/prebid/Prebid.js/issues/12895)

Tagging maintainers : 

ops@adnuntius.com
pubops@datawrkz.com
info@livewrapped.com
info@yuktamedia.com
prebid@consumable.com