### PR TITLE
Build system: wait for DOM to load before starting tests

### DIFF
--- a/test/test_deps.js
+++ b/test/test_deps.js
@@ -1,3 +1,14 @@
+window.__karma__.loaded = ((orig) => {
+  // for some reason, tests sometimes run before the DOM is ready
+  return function () {
+    if (document.readyState === "complete") {
+      orig();
+    } else {
+      window.onload = orig;
+    }
+  }
+})(window.__karma__.loaded.bind(window.__karma__));
+
 window.process = {
   env: {
     NODE_ENV: 'production'


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes

## Description of change

This attempts to address cases when some test attempts to use the DOM before it's ready, doesn't clean up after failing, and causes a cascade of failures as in https://app.circleci.com/pipelines/github/prebid/Prebid.js/25591/workflows/f57e41a7-79f6-48eb-909d-e6c992cf5c77/jobs/44929
