### PR TITLE
GPT Targeting: Add warning when setting the same targeting on multiple slots

### DIFF
--- a/src/targeting.js
+++ b/src/targeting.js
@@ -497,6 +497,10 @@ export function newTargeting(auctionManager) {
     let resetMap = Object.fromEntries(pbTargetingKeys.map(key => [key, null]));
 
     Object.entries(getGPTSlotsForAdUnits(Object.keys(targetingSet), customSlotMatching)).forEach(([targetId, slots]) => {
+       if (slots.length > 1) {
+        // This can lead to duplicate impressions. This is existing behavior and changing to only target one slot could be a breaking change for existing integrations.
+        logWarn(`Multiple slots found matching: ${targetId}. Targeting will be set on all matching slots, which can lead to duplicate impressions if more than one are requested from GAM. To resolve this, ensure the arguments to setTargetingForGPTAsync resolve to a single slot by explicitly matching the desired slotElementID.`);
+      }
       slots.forEach(slot => {
       // now set new targeting keys
         Object.keys(targetingSet[targetId]).forEach(key => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Added a warning when pbjs is setting the same targeting on multiple slots. Updated the unit tests in targeting.js and pbjs_api_spec.js make this behavior clearer. 

Alternative considered was to change the behavior to match the [docs for setTargetingForGPTAsync](https://docs.prebid.org/dev-docs/publisher-api-reference/setTargetingForGPTAsync.html) - which currently say it will set on the first matching slot. Chose not to do this because it could cause unexpected behavior for publisher integrations relying on the current behavior, and it is not obvious that the first slot defined is the one that should be targeted. Open to changing this in the future if there is a safe path. More info in comments + Google doc in https://github.com/prebid/Prebid.js/issues/13060 
