### PR TITLE
Update browsers.json: bump chrome legacy supported vesion

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -15,11 +15,11 @@
     "device": null,
     "os": "Windows"
   },
-  "bs_chrome_107_windows_10": {
+  "bs_chrome_109_windows_10": {
     "base": "BrowserStack",
     "os_version": "10",
     "browser": "chrome",
-    "browser_version": "107.0",
+    "browser_version": "109.0",
     "device": null,
     "os": "Windows"
   },

--- a/browsers.json
+++ b/browsers.json
@@ -43,7 +43,7 @@
     "base": "BrowserStack",
     "os_version": "Monterey",
     "browser": "safari",
-    "browser_version": "15.8",
+    "browser_version": "15.6",
     "device": null,
     "os": "OS X"
   }

--- a/browsers.json
+++ b/browsers.json
@@ -43,7 +43,7 @@
     "base": "BrowserStack",
     "os_version": "Monterey",
     "browser": "safari",
-    "browser_version": "15.6",
+    "browser_version": "15.8",
     "device": null,
     "os": "OS X"
   }


### PR DESCRIPTION
https://github.com/browserslist/caniuse-lite/blob/main/data/regions/US.js shows 109 at .4%, seems to be old chromebooks stuck on 109 or windows 7 users. Safari 15.6-15.8 is .85% of users, vast majority on 15.8, but 15.6 max avail 15 version on browserstack

fixes https://github.com/prebid/Prebid.js/issues/13071