### PR TITLE
BidViewability: Refactored the init function

### DIFF
--- a/modules/bidViewability.js
+++ b/modules/bidViewability.js
@@ -79,24 +79,21 @@ export let impressionViewableHandler = (globalModuleConfig, slot, event) => {
   }
 };
 
-export let init = () => {
-  events.on(EVENTS.AUCTION_INIT, () => {
-    // read the config for the module
-    const globalModuleConfig = config.getConfig(MODULE_NAME) || {};
-    // do nothing if module-config.enabled is not set to true
-    // this way we are adding a way for bidders to know (using pbjs.getConfig('bidViewability').enabled === true) whether this module is added in build and is enabled
-    if (globalModuleConfig[CONFIG_ENABLED] !== true) {
-      return;
-    }
-    // add the GPT event listener
-    window.googletag = window.googletag || {};
-    window.googletag.cmd = window.googletag.cmd || [];
-    window.googletag.cmd.push(() => {
-      window.googletag.pubads().addEventListener(GPT_IMPRESSION_VIEWABLE_EVENT, function(event) {
-        impressionViewableHandler(globalModuleConfig, event.slot, event);
-      });
+const handleSetConfig = (config) => {
+  const globalModuleConfig = config || {};
+  // do nothing if module-config.enabled is not set to true
+  // this way we are adding a way for bidders to know (using pbjs.getConfig('bidViewability').enabled === true) whether this module is added in build and is enabled
+  if (globalModuleConfig[CONFIG_ENABLED] !== true) {
+    return;
+  }
+  // add the GPT event listener
+  window.googletag = window.googletag || {};
+  window.googletag.cmd = window.googletag.cmd || [];
+  window.googletag.cmd.push(() => {
+    window.googletag.pubads().addEventListener(GPT_IMPRESSION_VIEWABLE_EVENT, function(event) {
+      impressionViewableHandler(globalModuleConfig, event.slot, event);
     });
   });
 }
 
-init()
+config.getConfig(MODULE_NAME, config => handleSetConfig(config[MODULE_NAME]));


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
Previously, the module was initialized by adding a listener to the AUCTION_INIT event. With this refactor, the listener is registered during module initialization, improving efficiency and aligning with standard initialization practices.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


