### PR TITLE
AppNexus Bid Adapter - refactor userId code for Prebid 10

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -352,25 +352,21 @@ export const spec = {
       }
     }
 
-    if (bidRequests[0].userId) {
+    if (bidRequests[0].userIdAsEids?.length > 0) {
       let eids = [];
-      const processEids = (uids) => {
-        uids.forEach(eid => {
-          if (!eid || !eid.uids || eid.uids.length < 1) { return; }
-          eid.uids.forEach(uid => {
-            let tmp = {'source': eid.source, 'id': uid.id};
-            if (eid.source == 'adserver.org') {
-              tmp.rti_partner = 'TDID';
-            } else if (eid.source == 'uidapi.com') {
-              tmp.rti_partner = 'UID2';
-            }
-            eids.push(tmp);
-          });
+      bidRequests[0].userIdAsEids.forEach(eid => {
+        if (!eid || !eid.uids || eid.uids.length < 1) { return; }
+        eid.uids.forEach(uid => {
+          let tmp = {'source': eid.source, 'id': uid.id};
+          if (eid.source == 'adserver.org') {
+            tmp.rti_partner = 'TDID';
+          } else if (eid.source == 'uidapi.com') {
+            tmp.rti_partner = 'UID2';
+          }
+          eids.push(tmp);
         });
-      }
-      if (bidRequests[0].userIdAsEids) {
-        processEids(bidRequests[0].userIdAsEids);
-      }
+      });
+
       if (eids.length) {
         payload.eids = eids;
       }

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -1632,30 +1632,6 @@ describe('AppNexusAdapter', function () {
 
     it('should populate eids when supported userIds are available', function () {
       const bidRequest = Object.assign({}, bidRequests[0], {
-        userId: {
-          tdid: 'sample-userid',
-          uid2: { id: 'sample-uid2-value' },
-          criteoId: 'sample-criteo-userid',
-          netId: 'sample-netId-userid',
-          idl_env: 'sample-idl-userid',
-          pubProvidedId: [{
-            source: 'puburl.com',
-            uids: [{
-              id: 'pubid1',
-              atype: 1,
-              ext: {
-                stype: 'ppuid'
-              }
-            }]
-          }, {
-            source: 'puburl2.com',
-            uids: [{
-              id: 'pubid2'
-            }, {
-              id: 'pubid2-123'
-            }]
-          }]
-        },
         userIdAsEids: [{
           source: 'adserver.org',
           uids: [{ id: 'sample-userid' }]


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Refactors the userId logic in the appnexusBidAdapter buildRequests function.  

The adapter wasn't actually reading the userId data from this field, it was pulling the data from the userIdAsEids field.  However, the main if check for this section was still referring to the userId (for some reason); this part has been changed to the userIdAsEids field and I simplified some of the remaining logic accordingly.

## Other information
Related to #https://github.com/prebid/Prebid.js/issues/11377