### PR TITLE
Fix: Ensure failsafe logic in examples fails safely

### DIFF
--- a/integrationExamples/gpt/1plusXRtdProviderExample.html
+++ b/integrationExamples/gpt/1plusXRtdProviderExample.html
@@ -64,12 +64,16 @@
       if (pbjs.adserverRequestSent) return;
       pbjs.adserverRequestSent = true;
 
-      googletag.cmd.push(function () {
-        pbjs.que.push(function () {
-          pbjs.setTargetingForGPTAsync();
-          googletag.pubads().refresh();
-        });
-      });
+      googletag.cmd.push(function() {
+        if (pbjs.libLoaded) { // Check if Prebid library loaded
+            pbjs.que.push(function() {
+                pbjs.setTargetingForGPTAsync();
+                googletag.pubads().refresh();
+            });
+       } else {
+          googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+       }
+    });
     }
 
     setTimeout(function () {

--- a/integrationExamples/gpt/51DegreesRtdProvider_example.html
+++ b/integrationExamples/gpt/51DegreesRtdProvider_example.html
@@ -24,11 +24,15 @@
         function initAdserver() {
             if (pbjs.initAdserverSet) return;
 
-            googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
-                    googletag.pubads().refresh();
-                });
+            googletag.cmd.push(function() {
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
 
             pbjs.initAdserverSet = true;

--- a/integrationExamples/gpt/adUnitFloors.html
+++ b/integrationExamples/gpt/adUnitFloors.html
@@ -74,11 +74,15 @@
         function sendAdserverRequest() {
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
-            googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
-                    googletag.pubads().refresh();
-                });
+            googletag.cmd.push(function() {
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
         }
 

--- a/integrationExamples/gpt/adloox.html
+++ b/integrationExamples/gpt/adloox.html
@@ -108,9 +108,15 @@
                 pbjs.initAdserverSet = true;
 
                 googletag.cmd.push(function() {
-                    const adUnitCodes = adUnits.map(adUnit => adUnit.code);
-                    pbjs.setTargetingForGPTAsync(adUnitCodes);
-                    googletag.pubads().refresh();
+                    if (pbjs.libLoaded) { // Check if Prebid library loaded
+                        const adUnitCodes = adUnits.map(adUnit => adUnit.code);
+                        pbjs.que.push(function() {
+                            pbjs.setTargetingForGPTAsync(adUnitCodes);
+                            googletag.pubads().refresh();
+                        });
+                   } else {
+                      googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+                   }
                 });
 
                 var videoBids = bids[videoAdUnit.code];

--- a/integrationExamples/gpt/adnuntius_example.html
+++ b/integrationExamples/gpt/adnuntius_example.html
@@ -64,10 +64,14 @@
             if (pbjs.initAdserverSet) return;
             pbjs.initAdserverSet = true;
             googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync('div-gpt-ad-1683695049516-0');
-                    googletag.pubads().refresh();
-                });
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync('div-gpt-ad-1683695049516-0');
+                        googletag.pubads().refresh();
+                    });
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
         }
 

--- a/integrationExamples/gpt/adnuntius_multiformat_example.html
+++ b/integrationExamples/gpt/adnuntius_multiformat_example.html
@@ -95,10 +95,14 @@
             if (pbjs.initAdserverSet) return;
             pbjs.initAdserverSet = true;
             googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync('div-gpt-ad-1683695049516-0');
-                    googletag.pubads().refresh();
-                });
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync('div-gpt-ad-1683695049516-0');
+                        googletag.pubads().refresh();
+                    });
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
         }
 

--- a/integrationExamples/gpt/advanced_size_mapping.html
+++ b/integrationExamples/gpt/advanced_size_mapping.html
@@ -111,11 +111,15 @@ Feel free to play around with different settings and configurations for size map
 		function sendAdserverRequest() {
 			if (pbjs.adserverRequestSent) return;
 			pbjs.adserverRequestSent = true;
-			googletag.cmd.push(function () {
-				pbjs.que.push(function () {
-					pbjs.setTargetingForGPTAsync();
-					googletag.pubads().refresh();
-				});
+			googletag.cmd.push(function() {
+				if (pbjs.libLoaded) { // Check if Prebid library loaded
+					pbjs.que.push(function() {
+						pbjs.setTargetingForGPTAsync();
+						googletag.pubads().refresh();
+					});
+			   } else {
+				  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+			   }
 			});
 		}
 

--- a/integrationExamples/gpt/airgridRtdProvider_example.html
+++ b/integrationExamples/gpt/airgridRtdProvider_example.html
@@ -90,11 +90,15 @@
 
         if (pbjs.adserverRequestSent) return;
         pbjs.adserverRequestSent = true;
-        googletag.cmd.push(function () {
-          pbjs.que.push(function () {
-            pbjs.setTargetingForGPTAsync();
-            googletag.pubads().refresh();
-          });
+        googletag.cmd.push(function() {
+            if (pbjs.libLoaded) { // Check if Prebid library loaded
+                pbjs.que.push(function() {
+                    pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+                });
+           } else {
+              googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+           }
         });
       }
 

--- a/integrationExamples/gpt/akamaidap_segments_example.html
+++ b/integrationExamples/gpt/akamaidap_segments_example.html
@@ -97,10 +97,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync();
-                    googletag.pubads().refresh();
-                });
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
         }
 

--- a/integrationExamples/gpt/anonymised_segments_example.html
+++ b/integrationExamples/gpt/anonymised_segments_example.html
@@ -78,10 +78,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync();
-                    googletag.pubads().refresh();
-                });
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
         }
 

--- a/integrationExamples/gpt/azerionedgeRtdProvider_example.html
+++ b/integrationExamples/gpt/azerionedgeRtdProvider_example.html
@@ -65,11 +65,15 @@
 
         if (pbjs.adserverRequestSent) return;
         pbjs.adserverRequestSent = true;
-        googletag.cmd.push(function () {
-          pbjs.que.push(function () {
-            pbjs.setTargetingForGPTAsync();
-            googletag.pubads().refresh();
-          });
+        googletag.cmd.push(function() {
+            if (pbjs.libLoaded) { // Check if Prebid library loaded
+                pbjs.que.push(function() {
+                    pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+                });
+           } else {
+              googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+           }
         });
       }
       setTimeout(sendAdserverRequest, FAILSAFE_TIMEOUT);

--- a/integrationExamples/gpt/blueconicRtdProvider_example.html
+++ b/integrationExamples/gpt/blueconicRtdProvider_example.html
@@ -71,10 +71,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync();
-                    googletag.pubads().refresh();
-                });
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
         }
 

--- a/integrationExamples/gpt/contxtfulRtdProvider_example.html
+++ b/integrationExamples/gpt/contxtfulRtdProvider_example.html
@@ -150,12 +150,16 @@ function refreshBids() {
 }
 
 function initAdserver() {
-  googletag.cmd.push(function () {
-    pbjs.que.push(function () {
-      pbjs.setTargetingForGPTAsync();
-      googletag.pubads().refresh();
-    });
-  });
+  googletag.cmd.push(function() {
+    if (pbjs.libLoaded) { // Check if Prebid library loaded
+        pbjs.que.push(function() {
+            pbjs.setTargetingForGPTAsync();
+            googletag.pubads().refresh();
+        });
+   } else {
+      googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+   }
+});
 }
 
 setTimeout(function () {

--- a/integrationExamples/gpt/esp_example.html
+++ b/integrationExamples/gpt/esp_example.html
@@ -124,12 +124,16 @@
         function initAdserver() {
             if (pbjs.initAdserverSet) return;
             pbjs.initAdserverSet = true;
-            googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
-                    pbjs.registerSignalSources();
-                    googletag.pubads().refresh();
-                });
+            googletag.cmd.push(function() {
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        pbjs.registerSignalSources();
+                        googletag.pubads().refresh();
+                    });
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
         }
         // in case PBJS doesn't load

--- a/integrationExamples/gpt/gdpr_hello_world.html
+++ b/integrationExamples/gpt/gdpr_hello_world.html
@@ -70,11 +70,15 @@
           if (pbjs.adserverRequestSent) return;
           pbjs.adserverRequestSent = true;
           googletag.cmd.push(function() {
-            pbjs.que.push(function() {
-              pbjs.setTargetingForGPTAsync();
-              googletag.pubads().refresh();
-            });
-          });
+            if (pbjs.libLoaded) { // Check if Prebid library loaded
+                pbjs.que.push(function() {
+                    pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+                });
+           } else {
+              googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+           }
+        });
         }
 
         setTimeout(function() {

--- a/integrationExamples/gpt/gpp_us_hello_world.html
+++ b/integrationExamples/gpt/gpp_us_hello_world.html
@@ -86,12 +86,16 @@
     function sendAdserverRequest() {
       if (pbjs.adserverRequestSent) return;
       pbjs.adserverRequestSent = true;
-      googletag.cmd.push(function () {
-        pbjs.que.push(function () {
-          pbjs.setTargetingForGPTAsync();
-          googletag.pubads().refresh();
-        });
-      });
+      googletag.cmd.push(function() {
+        if (pbjs.libLoaded) { // Check if Prebid library loaded
+            pbjs.que.push(function() {
+                pbjs.setTargetingForGPTAsync();
+                googletag.pubads().refresh();
+            });
+       } else {
+          googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+       }
+    });
     }
 
     setTimeout(function () {

--- a/integrationExamples/gpt/growthcode.html
+++ b/integrationExamples/gpt/growthcode.html
@@ -101,11 +101,15 @@
       if (pbjs.adserverRequestSent) return;
       pbjs.adserverRequestSent = true;
       googletag.cmd.push(function() {
-        pbjs.que.push(function() {
-          pbjs.setTargetingForGPTAsync();
-          googletag.pubads().refresh();
-        });
-      });
+        if (pbjs.libLoaded) { // Check if Prebid library loaded
+            pbjs.que.push(function() {
+                pbjs.setTargetingForGPTAsync();
+                googletag.pubads().refresh();
+            });
+       } else {
+          googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+       }
+    });
     }
 
     setTimeout(function() {

--- a/integrationExamples/gpt/hadronRtdProvider_example.html
+++ b/integrationExamples/gpt/hadronRtdProvider_example.html
@@ -71,10 +71,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync();
-                    googletag.pubads().refresh();
-                });
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
         }
 

--- a/integrationExamples/gpt/hello_world.html
+++ b/integrationExamples/gpt/hello_world.html
@@ -58,11 +58,15 @@
         function sendAdserverRequest() {
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
-            googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
-                    googletag.pubads().refresh();
-                });
+            googletag.cmd.push(function() {
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
         }
 

--- a/integrationExamples/gpt/idImportLibrary_example.html
+++ b/integrationExamples/gpt/idImportLibrary_example.html
@@ -122,10 +122,14 @@
         if (pbjs.adserverRequestSent) return;
         pbjs.adserverRequestSent = true;
         googletag.cmd.push(function() {
-          pbjs.que.push(function() {
-            pbjs.setTargetingForGPTAsync();
-            googletag.pubads().refresh();
-          });
+            if (pbjs.libLoaded) { // Check if Prebid library loaded
+                pbjs.que.push(function() {
+                    pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+                });
+           } else {
+              googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+           }
         });
       }
       var FAILSAFE_TIMEOUT = 2000;

--- a/integrationExamples/gpt/id_lift_measurement.html
+++ b/integrationExamples/gpt/id_lift_measurement.html
@@ -88,9 +88,13 @@
         function sendAdserverRequest() {
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
-            googletag.cmd.push(function () {
-                pbjs.setTargetingForGPTAsync();
-                googletag.pubads().refresh();
+            googletag.cmd.push(function() {
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
         }
 

--- a/integrationExamples/gpt/imRtdProvider_example.html
+++ b/integrationExamples/gpt/imRtdProvider_example.html
@@ -63,10 +63,14 @@
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
             googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync();
-                    googletag.pubads().refresh();
-                });
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
         }
 

--- a/integrationExamples/gpt/ixMultiFormat.html
+++ b/integrationExamples/gpt/ixMultiFormat.html
@@ -79,11 +79,15 @@
         function sendAdserverRequest() {
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
-            googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
-                    googletag.pubads().refresh();
-                });
+            googletag.cmd.push(function() {
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
         }
 

--- a/integrationExamples/gpt/liveIntentRtdProviderExample.html
+++ b/integrationExamples/gpt/liveIntentRtdProviderExample.html
@@ -119,10 +119,14 @@
             if (pbjs.initAdserverSet) return;
             pbjs.initAdserverSet = true;
             googletag.cmd.push(function() {
-                pbjs.que.push(function() {
-                    pbjs.setTargetingForGPTAsync();
-                    googletag.pubads().refresh();
-                });
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
         }
         // in case PBJS doesn't load

--- a/integrationExamples/gpt/mgidRtdProvider_example.html
+++ b/integrationExamples/gpt/mgidRtdProvider_example.html
@@ -110,9 +110,15 @@
       function initAdserver() {
         if (pbjs.initAdserverSet) return;
         pbjs.initAdserverSet = true;
-        googletag.cmd.push(function () {
-          pbjs.setTargetingForGPTAsync && pbjs.setTargetingForGPTAsync();
-          googletag.pubads().refresh();
+        googletag.cmd.push(function() {
+            if (pbjs.libLoaded) { // Check if Prebid library loaded
+                pbjs.que.push(function() {
+                    pbjs.setTargetingForGPTAsync && pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+                });
+           } else {
+              googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+           }
         });
       }
 

--- a/integrationExamples/gpt/neuwoRtdProvider_example.html
+++ b/integrationExamples/gpt/neuwoRtdProvider_example.html
@@ -135,10 +135,14 @@
                 if (pbjs.initAdserverSet) return;
                 pbjs.initAdserverSet = true;
                 googletag.cmd.push(function() {
-                    pbjs.que.push(function() {
-                        pbjs.setTargetingForGPTAsync();
-                        googletag.pubads().refresh();
-                    });
+                    if (pbjs.libLoaded) { // Check if Prebid library loaded
+                        pbjs.que.push(function() {
+                            pbjs.setTargetingForGPTAsync();
+                            googletag.pubads().refresh();
+                        });
+                   } else {
+                      googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+                   }
                 });
             }
 

--- a/integrationExamples/gpt/nexverse.html
+++ b/integrationExamples/gpt/nexverse.html
@@ -81,11 +81,15 @@
         function sendAdserverRequest() {
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
-            googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
-                    googletag.pubads().refresh();
-                });
+            googletag.cmd.push(function() {
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
         }
 

--- a/integrationExamples/gpt/optableRtdProvider_example.html
+++ b/integrationExamples/gpt/optableRtdProvider_example.html
@@ -69,11 +69,15 @@
         function initAdserver() {
             if (pbjs.initAdserverSet) return;
 
-            googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
-                    googletag.pubads().refresh();
-                });
+            googletag.cmd.push(function() {
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
 
             pbjs.initAdserverSet = true;

--- a/integrationExamples/gpt/optimeraRtdProvider_example.html
+++ b/integrationExamples/gpt/optimeraRtdProvider_example.html
@@ -97,10 +97,14 @@
       if (pbjs.initAdserverSet) return;
       pbjs.initAdserverSet = true;
       googletag.cmd.push(function() {
-          pbjs.que.push(function() {
-              pbjs.setTargetingForGPTAsync();
-              googletag.pubads().refresh();
-          });
+          if (pbjs.libLoaded) { // Check if Prebid library loaded
+              pbjs.que.push(function() {
+                  pbjs.setTargetingForGPTAsync();
+                  googletag.pubads().refresh();
+              });
+         } else {
+            googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+         }
       });
   }
   // in case PBJS doesn't load

--- a/integrationExamples/gpt/paapi_example.html
+++ b/integrationExamples/gpt/paapi_example.html
@@ -63,11 +63,15 @@
         if (pbjs.adserverRequestSent) return;
         pbjs.adserverRequestSent = true;
         googletag.cmd.push(function() {
-          pbjs.que.push(function() {
-            pbjs.setTargetingForGPTAsync();
-            pbjs.setPAAPIConfigForGPT();
-            googletag.pubads().refresh();
-          });
+            if (pbjs.libLoaded) { // Check if Prebid library loaded
+                pbjs.que.push(function() {
+                    pbjs.setTargetingForGPTAsync();
+                    pbjs.setPAAPIConfigForGPT();
+                    googletag.pubads().refresh();
+                });
+           } else {
+              googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+           }
         });
       }
 

--- a/integrationExamples/gpt/permutiveRtdProvider_example.html
+++ b/integrationExamples/gpt/permutiveRtdProvider_example.html
@@ -227,10 +227,14 @@
                 if (pbjs.initAdserverSet) return;
                 pbjs.initAdserverSet = true;
                 googletag.cmd.push(function() {
-                    pbjs.que.push(function() {
-                        pbjs.setTargetingForGPTAsync();
-                        googletag.pubads().refresh();
-                    });
+                    if (pbjs.libLoaded) { // Check if Prebid library loaded
+                        pbjs.que.push(function() {
+                            pbjs.setTargetingForGPTAsync();
+                            googletag.pubads().refresh();
+                        });
+                   } else {
+                      googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+                   }
                 });
             }
             // in case PBJS doesn't load

--- a/integrationExamples/gpt/prebidServer_example.html
+++ b/integrationExamples/gpt/prebidServer_example.html
@@ -85,9 +85,14 @@
     googletag.cmd.push(function() {
         var rightSlot = googletag.defineSlot('/19968336/header-bid-tag-0', [[300, 250]], 'div-gpt-ad-1460505748561-0').addService(googletag.pubads());
 
-        pbjs.que.push(function() {
-            pbjs.setTargetingForGPTAsync();
-        });
+        if (pbjs.libLoaded) { // Check if Prebid library loaded
+            pbjs.que.push(function() {
+                pbjs.setTargetingForGPTAsync();
+                googletag.pubads().refresh(); // Added refresh as per standard pattern
+            });
+        } else {
+            googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+        }
 
         googletag.pubads().enableSingleRequest();
         googletag.enableServices();

--- a/integrationExamples/gpt/prebidServer_native_example.html
+++ b/integrationExamples/gpt/prebidServer_native_example.html
@@ -19,12 +19,16 @@
     function initAdserver() {
       if (pbjs.initAdserverSet) return;
 
-      googletag.cmd.push(function () {
-        pbjs.que.push(function () {
-          pbjs.setTargetingForGPTAsync();
-          googletag.pubads().refresh();
-        });
-      });
+      googletag.cmd.push(function() {
+        if (pbjs.libLoaded) { // Check if Prebid library loaded
+            pbjs.que.push(function() {
+                pbjs.setTargetingForGPTAsync();
+                googletag.pubads().refresh();
+            });
+       } else {
+          googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+       }
+    });
 
       pbjs.initAdserverSet = true;
     }

--- a/integrationExamples/gpt/prebidServer_paapi_example.html
+++ b/integrationExamples/gpt/prebidServer_paapi_example.html
@@ -68,10 +68,14 @@
         if (pbjs.adserverRequestSent) return;
         pbjs.adserverRequestSent = true;
         googletag.cmd.push(function() {
-          pbjs.que.push(function() {
-            pbjs.setTargetingForGPTAsync();
-            googletag.pubads().refresh();
-          });
+            if (pbjs.libLoaded) { // Check if Prebid library loaded
+                pbjs.que.push(function() {
+                    pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+                });
+           } else {
+              googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+           }
         });
       }
 

--- a/integrationExamples/gpt/proxistore_example.html
+++ b/integrationExamples/gpt/proxistore_example.html
@@ -79,11 +79,15 @@
         function sendAdserverRequest() {
             if (pbjs.adserverRequestSent) return;
             pbjs.adserverRequestSent = true;
-            googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync();
-                    googletag.pubads().refresh();
-                });
+            googletag.cmd.push(function() {
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync();
+                        googletag.pubads().refresh();
+                    });
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
         }
 

--- a/integrationExamples/gpt/publir_hello_world.html
+++ b/integrationExamples/gpt/publir_hello_world.html
@@ -47,11 +47,15 @@
         });
 
         function sendAdserverRequest() {
-            googletag.cmd.push(function () {
-                pbjs.que.push(function () {
-                    pbjs.setTargetingForGPTAsync('div-gpt-ad-1460505748561-0');
-                    googletag.pubads().refresh();
-                });
+            googletag.cmd.push(function() {
+                if (pbjs.libLoaded) { // Check if Prebid library loaded
+                    pbjs.que.push(function() {
+                        pbjs.setTargetingForGPTAsync('div-gpt-ad-1460505748561-0');
+                        googletag.pubads().refresh();
+                    });
+               } else {
+                  googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+               }
             });
         }
 

--- a/integrationExamples/gpt/raveltechRtdProvider_example.html
+++ b/integrationExamples/gpt/raveltechRtdProvider_example.html
@@ -323,11 +323,15 @@
     function sendAdserverRequest() {
       if (pbjs.adserverRequestSent) return;
       pbjs.adserverRequestSent = true;
-      googletag.cmd.push(function () {
-        pbjs.que.push(function () {
-          pbjs.setTargetingForGPTAsync();
-          googletag.pubads().refresh();
-        });
+      googletag.cmd.push(function() {
+          if (pbjs.libLoaded) { // Check if Prebid library loaded
+              pbjs.que.push(function() {
+                  pbjs.setTargetingForGPTAsync();
+                  googletag.pubads().refresh();
+              });
+         } else {
+            googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+         }
       });
     }
 

--- a/integrationExamples/gpt/raynRtdProvider_example.html
+++ b/integrationExamples/gpt/raynRtdProvider_example.html
@@ -118,11 +118,15 @@
 
         if (pbjs.adserverRequestSent) return;
         pbjs.adserverRequestSent = true;
-        googletag.cmd.push(function () {
-          pbjs.que.push(function () {
-            pbjs.setTargetingForGPTAsync();
-            googletag.pubads().refresh();
-          });
+        googletag.cmd.push(function() {
+            if (pbjs.libLoaded) { // Check if Prebid library loaded
+                pbjs.que.push(function() {
+                    pbjs.setTargetingForGPTAsync();
+                    googletag.pubads().refresh();
+                });
+           } else {
+              googletag.pubads().refresh(); // If Prebidlib not loaded, just refresh ads
+           }
         });
       }
 


### PR DESCRIPTION
The failsafe timeout in many GPT integration examples was intended to refresh ads via `googletag.pubads().refresh()` if Prebid.js didn't load or respond in time. However, the original implementation of the failsafe function
(typically `sendAdserverRequest` or `initAdserver`) still attempted to call Prebid.js functions like
`pbjs.setTargetingForGPTAsync()`, which would fail if Prebid.js itself hadn't loaded.

This change modifies these failsafe functions to check for `pbjs.libLoaded` before attempting to call Prebid-specific functions.
- If `pbjs.libLoaded` is true, the original logic of calling `pbjs.setTargetingForGPTAsync()` and then `googletag.pubads().refresh()` is executed.
- If `pbjs.libLoaded` is false, only `googletag.pubads().refresh()` is called, truly acting as a failsafe for the ad server call.

This fix has been applied to 38 files within the
`integrationExamples/gpt/` directory that exhibited this pattern.

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
