### PR TITLE
Various Adapters : apply failsafe logic to remaining integration examples (Jules Bot)

### DIFF
--- a/integrationExamples/gpt/afpGamExample.html
+++ b/integrationExamples/gpt/afpGamExample.html
@@ -73,16 +73,22 @@
       pbjs.requestBids({ bidsBackHandler: sendAdServerRequest });
     });
 
-    function sendAdServerRequest() {
-      googletag.cmd.push(() => {
-        pbjs.que.push(() => {
-          pbjs.setTargetingForGPTAsync('div-gpt-ad-1574864639578-0');
-          pbjs.setTargetingForGPTAsync('div-gpt-ad-1574864639578-1');
-          pbjs.setTargetingForGPTAsync('div-gpt-ad-1574864639578-2');
-          googletag.pubads().refresh();
-        });
+function sendAdServerRequest() {
+  if (pbjs.adserverRequestSent) return;
+  pbjs.adserverRequestSent = true;
+  googletag.cmd.push(function() {
+    if (pbjs.libLoaded) { // Check if Prebid.js is loaded
+      pbjs.que.push(function() {
+        pbjs.setTargetingForGPTAsync('div-gpt-ad-1574864639578-0');
+        pbjs.setTargetingForGPTAsync('div-gpt-ad-1574864639578-1');
+        pbjs.setTargetingForGPTAsync('div-gpt-ad-1574864639578-2');
+        googletag.pubads().refresh();
       });
+    } else {
+      googletag.pubads().refresh();
     }
+  });
+}
 
     googletag.cmd.push(() => {
       googletag

--- a/integrationExamples/gpt/prebidServer_example.html
+++ b/integrationExamples/gpt/prebidServer_example.html
@@ -82,16 +82,21 @@
 </script>
 
 <script>
-    googletag.cmd.push(function() {
-        var rightSlot = googletag.defineSlot('/19968336/header-bid-tag-0', [[300, 250]], 'div-gpt-ad-1460505748561-0').addService(googletag.pubads());
+googletag.cmd.push(function() {
+    var rightSlot = googletag.defineSlot('/19968336/header-bid-tag-0', [[300, 250]], 'div-gpt-ad-1460505748561-0').addService(googletag.pubads());
 
+    if (pbjs.libLoaded) { // Check if Prebid.js is loaded
         pbjs.que.push(function() {
             pbjs.setTargetingForGPTAsync();
+            googletag.pubads().refresh();
         });
+    } else {
+        googletag.pubads().refresh();
+    }
 
-        googletag.pubads().enableSingleRequest();
-        googletag.enableServices();
-    });
+    googletag.pubads().enableSingleRequest();
+    googletag.enableServices();
+});
     </script>
 </head>
 

--- a/integrationExamples/gpt/prebidServer_native_example.html
+++ b/integrationExamples/gpt/prebidServer_native_example.html
@@ -16,18 +16,22 @@
 
     var date = new Date().getTime();
 
-    function initAdserver() {
-      if (pbjs.initAdserverSet) return;
+function initAdserver() {
+  if (pbjs.initAdserverSet) return;
 
-      googletag.cmd.push(function () {
-        pbjs.que.push(function () {
-          pbjs.setTargetingForGPTAsync();
-          googletag.pubads().refresh();
-        });
+  googletag.cmd.push(function () {
+    if (pbjs.libLoaded) { // Check if Prebid.js is loaded
+      pbjs.que.push(function () {
+        pbjs.setTargetingForGPTAsync();
+        googletag.pubads().refresh();
       });
-
-      pbjs.initAdserverSet = true;
+    } else {
+      googletag.pubads().refresh();
     }
+  });
+
+  pbjs.initAdserverSet = true;
+}
 
     // Load GPT when timeout is reached.
     // setTimeout(initAdserver, PREBID_TIMEOUT);

--- a/integrationExamples/gpt/pubxaiRtdProvider_example.html
+++ b/integrationExamples/gpt/pubxaiRtdProvider_example.html
@@ -83,18 +83,22 @@
         googletag.enableServices();
       });
 
-      function refreshBid() {
-        pbjs.que.push(function () {
-          pbjs.requestBids({
-            timeout: PREBID_TIMEOUT,
-            adUnitCodes: ["/19968336/header-bid-tag-0"],
-            bidsBackHandler: function () {
-              pbjs.setTargetingForGPTAsync(["/19968336/header-bid-tag-0"]);
-              googletag.pubads().refresh([slot1]);
-            },
-          });
-        });
-      }
+function refreshBid() {
+  pbjs.que.push(function () {
+    pbjs.requestBids({
+      timeout: PREBID_TIMEOUT,
+      adUnitCodes: ["/19968336/header-bid-tag-0"],
+      bidsBackHandler: function () {
+        if (pbjs.libLoaded) { // Check if Prebid.js is loaded
+          pbjs.setTargetingForGPTAsync(["/19968336/header-bid-tag-0"]);
+          googletag.pubads().refresh([slot1]);
+        } else {
+          googletag.pubads().refresh([slot1]);
+        }
+      },
+    });
+  });
+}
     </script>
   </head>
 


### PR DESCRIPTION
This change applies the failsafe logic to the following integration examples:
- integrationExamples/gpt/afpGamExample.html
- integrationExamples/gpt/prebidServer_example.html
- integrationExamples/gpt/prebidServer_native_example.html
- integrationExamples/gpt/pubxaiRtdProvider_example.html

The failsafe logic ensures that targeting is only set if Prebid.js has loaded successfully. If not, it proceeds to refresh ads without setting targeting.

