### PR TITLE
Add depraction warning for getAllPrebidWinningBids API

### DIFF
--- a/src/prebid.js
+++ b/src/prebid.js
@@ -938,6 +938,7 @@ pbjsInstance.getAllWinningBids = function () {
  * @return {Array<AdapterBidResponse>} A list of bids that have won their respective auctions.
  */
 pbjsInstance.getAllPrebidWinningBids = function () {
+  logWarn('getAllPrebidWinningBids will be deprecated in a future version. Consider Using getAllWinningBids.');
   return auctionManager.getBidsReceived()
     .filter(bid => bid.status === BID_STATUS.BID_TARGETING_SET);
 };


### PR DESCRIPTION
## Type of change

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
For the [12895](https://github.com/prebid/Prebid.js/issues/12895) breaking changes / API cleanup, covered below point:

1. "getAllPrebidWinningBids" does not do what it says. 

Add a deprecation warning in getAllPrebidWinningBids function.


## Other information
Updated documentation for getAllPrebidWinningBids  API - [6069](https://github.com/prebid/prebid.github.io/pull/6069)
