### PR TITLE
Conversant Adapter: remove use of bidRequest.{}.userid

### DIFF
--- a/modules/conversantBidAdapter.js
+++ b/modules/conversantBidAdapter.js
@@ -1,20 +1,17 @@
 import {
   buildUrl,
   deepAccess,
-  deepSetValue,
   getBidIdParameter,
   isArray,
   isFn,
   isPlainObject,
   isStr,
-  logError,
   logWarn,
   mergeDeep,
   parseUrl,
 } from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
-import {getStorageManager} from '../src/storageManager.js';
 import {ortbConverter} from '../libraries/ortbConverter/converter.js';
 import {ORTB_MTYPES} from '../libraries/ortbConverter/processors/mediaType.js';
 
@@ -30,7 +27,6 @@ import {ORTB_MTYPES} from '../libraries/ortbConverter/processors/mediaType.js';
 const GVLID = 24;
 
 const BIDDER_CODE = 'conversant';
-export const storage = getStorageManager({gvlid: GVLID, bidderCode: BIDDER_CODE});
 const URL = 'https://web.hb.ad.cpe.dotomi.com/cvx/client/hb/ortb/25';
 
 function setSiteId(bidRequest, request) {
@@ -41,14 +37,6 @@ function setSiteId(bidRequest, request) {
     if (request.app) {
       request.app.id = bidRequest.params.site_id;
     }
-  }
-}
-
-function setPubcid(bidRequest, request) {
-  // Add common id if available
-  const pubcid = getPubcid(bidRequest);
-  if (pubcid) {
-    deepSetValue(request, 'user.ext.fpc', pubcid);
   }
 }
 
@@ -64,7 +52,6 @@ const converter = ortbConverter({
     if (context.bidRequests) {
       const bidRequest = context.bidRequests[0];
       setSiteId(bidRequest, request);
-      setPubcid(bidRequest, request);
     }
 
     return request;
@@ -224,14 +211,6 @@ export const spec = {
   }
 };
 
-function getPubcid(bidRequest) {
-  const pubcid = Number(bidRequest.userIdAsEids?.pubcid?.[0].uids?.[0].id);
-  if (pubcid) return pubcid;
-  if (bidRequest.crumbs?.pubcid) return bidRequest.crumbs.pubcid;
-  const pubcidName = getBidIdParameter('pubcid_name', bidRequest.params) || '_pubcid';
-  return readStoredValue(pubcidName);
-}
-
 /**
  * Check if it's a video bid request
  *
@@ -253,37 +232,6 @@ function copyOptProperty(src, dst, dstName) {
   if (src) {
     dst[dstName] = src;
   }
-}
-
-/**
- * Look for a stored value from both cookie and local storage and return the first value found.
- * @param key Key for the search
- * @return {string} Stored value
- */
-function readStoredValue(key) {
-  let storedValue;
-  try {
-    // check cookies first
-    storedValue = storage.getCookie(key);
-
-    if (!storedValue) {
-      // check expiration time before reading local storage
-      const storedValueExp = storage.getDataFromLocalStorage(`${key}_exp`);
-      if (storedValueExp === '' || (storedValueExp && (new Date(storedValueExp)).getTime() - Date.now() > 0)) {
-        storedValue = storage.getDataFromLocalStorage(key);
-        storedValue = storedValue ? decodeURIComponent(storedValue) : storedValue;
-      }
-    }
-
-    // deserialize JSON if needed
-    if (isStr(storedValue) && storedValue.charAt(0) === '{') {
-      storedValue = JSON.parse(storedValue);
-    }
-  } catch (e) {
-    logError(e);
-  }
-
-  return storedValue;
 }
 
 /**

--- a/modules/conversantBidAdapter.js
+++ b/modules/conversantBidAdapter.js
@@ -225,17 +225,11 @@ export const spec = {
 };
 
 function getPubcid(bidRequest) {
-  let pubcid = null;
-  if (bidRequest.userId && bidRequest.userId.pubcid) {
-    pubcid = bidRequest.userId.pubcid;
-  } else if (bidRequest.crumbs && bidRequest.crumbs.pubcid) {
-    pubcid = bidRequest.crumbs.pubcid;
-  }
-  if (!pubcid) {
-    const pubcidName = getBidIdParameter('pubcid_name', bidRequest.params) || '_pubcid';
-    pubcid = readStoredValue(pubcidName);
-  }
-  return pubcid;
+  const pubcid = Number(bidRequest.userIdAsEids?.pubcid?.[0].uids?.[0].id);
+  if (pubcid) return pubcid;
+  if (bidRequest.crumbs?.pubcid) return bidRequest.crumbs.pubcid;
+  const pubcidName = getBidIdParameter('pubcid_name', bidRequest.params) || '_pubcid';
+  return readStoredValue(pubcidName);
 }
 
 /**

--- a/test/spec/modules/conversantBidAdapter_spec.js
+++ b/test/spec/modules/conversantBidAdapter_spec.js
@@ -606,14 +606,22 @@ describe('Conversant adapter tests', function() {
     expect(payload).to.not.have.nested.property('user.ext.eids');
   });
 
+  const userId = {
+    pubcid: [{
+      source: 'pubcid.org',
+      uids: [{
+        id: '67890'
+      }]
+    }]
+  };
   it('Verify User ID publisher commond id support', function() {
     // clone bidRequests
     let requests = utils.deepClone(bidRequests);
 
     // add pubcid to every entry
     requests.forEach((unit) => {
-      Object.assign(unit, {userId: {pubcid: 67890}});
-      Object.assign(unit, {userIdAsEids: createEidsArray(unit.userId)});
+      // Object.assign(unit, {userId: {pubcid: 67890}});
+      Object.assign(unit, {userIdAsEids: userId});
     });
     //  construct http post payload
     const payload = spec.buildRequests(requests, {}).data;

--- a/test/spec/modules/conversantBidAdapter_spec.js
+++ b/test/spec/modules/conversantBidAdapter_spec.js
@@ -620,7 +620,6 @@ describe('Conversant adapter tests', function() {
 
     // add pubcid to every entry
     requests.forEach((unit) => {
-      // Object.assign(unit, {userId: {pubcid: 67890}});
       Object.assign(unit, {userIdAsEids: userId});
     });
     //  construct http post payload

--- a/test/spec/modules/conversantBidAdapter_spec.js
+++ b/test/spec/modules/conversantBidAdapter_spec.js
@@ -1,7 +1,6 @@
 import {expect} from 'chai';
-import {spec, storage} from 'modules/conversantBidAdapter.js';
+import {spec} from 'modules/conversantBidAdapter.js';
 import * as utils from 'src/utils.js';
-import {createEidsArray} from 'modules/userId/eids.js';
 import {deepAccess} from 'src/utils';
 // load modules that register ORTB processors
 import 'src/prebid.js'
@@ -592,42 +591,6 @@ describe('Conversant adapter tests', function() {
     }
   })
 
-  it('Verify publisher commond id support', function() {
-    // clone bidRequests
-    let requests = utils.deepClone(bidRequests);
-
-    // add pubcid to every entry
-    requests.forEach((unit) => {
-      Object.assign(unit, {crumbs: {pubcid: 12345}});
-    });
-    //  construct http post payload
-    const payload = spec.buildRequests(requests, {}).data;
-    expect(payload).to.have.deep.nested.property('user.ext.fpc', 12345);
-    expect(payload).to.not.have.nested.property('user.ext.eids');
-  });
-
-  const userId = {
-    pubcid: [{
-      source: 'pubcid.org',
-      uids: [{
-        id: '67890'
-      }]
-    }]
-  };
-  it('Verify User ID publisher commond id support', function() {
-    // clone bidRequests
-    let requests = utils.deepClone(bidRequests);
-
-    // add pubcid to every entry
-    requests.forEach((unit) => {
-      Object.assign(unit, {userIdAsEids: userId});
-    });
-    //  construct http post payload
-    const payload = spec.buildRequests(requests, {}).data;
-    expect(payload).to.have.deep.nested.property('user.ext.fpc', 67890);
-    expect(payload).to.not.have.nested.property('user.ext.eids');
-  });
-
   describe('Extended ID', function() {
     it('Verify unifiedid and liveramp', function() {
       // clone bidRequests
@@ -641,114 +604,6 @@ describe('Conversant adapter tests', function() {
         {source: 'pubcid.org', uids: [{id: '112233', atype: 1}]},
         {source: 'liveramp.com', uids: [{id: '334455', atype: 3}]}
       ]);
-    });
-  });
-
-  describe('direct reading pubcid', function() {
-    const ID_NAME = '_pubcid';
-    const CUSTOM_ID_NAME = 'myid';
-    const EXP = '_exp';
-    const TIMEOUT = 2000;
-
-    function cleanUp(key) {
-      window.document.cookie = key + '=; expires=Thu, 01 Jan 1970 00:00:01 GMT;';
-      localStorage.removeItem(key);
-      localStorage.removeItem(key + EXP);
-    }
-
-    function expStr(timeout) {
-      return (new Date(Date.now() + timeout * 60 * 60 * 24 * 1000)).toUTCString();
-    }
-
-    beforeEach(() => {
-      $$PREBID_GLOBAL$$.bidderSettings = {
-        conversant: {
-          storageAllowed: true
-        }
-      };
-    });
-    afterEach(() => {
-      $$PREBID_GLOBAL$$.bidderSettings = {};
-      cleanUp(ID_NAME);
-      cleanUp(CUSTOM_ID_NAME);
-    });
-
-    it('reading cookie', function() {
-      // clone bidRequests
-      const requests = utils.deepClone(bidRequests);
-
-      // add a pubcid cookie
-      storage.setCookie(ID_NAME, '12345', expStr(TIMEOUT));
-
-      //  construct http post payload
-      const payload = spec.buildRequests(requests, {}).data;
-      expect(payload).to.have.deep.nested.property('user.ext.fpc', '12345');
-    });
-
-    it('reading custom cookie', function() {
-      // clone bidRequests
-      const requests = utils.deepClone(bidRequests);
-      requests[0].params.pubcid_name = CUSTOM_ID_NAME;
-
-      // add a pubcid cookie
-      storage.setCookie(CUSTOM_ID_NAME, '12345', expStr(TIMEOUT));
-
-      //  construct http post payload
-      const payload = spec.buildRequests(requests, {}).data;
-      expect(payload).to.have.deep.nested.property('user.ext.fpc', '12345');
-    });
-
-    it('reading local storage with empty exp time', function() {
-      // clone bidRequests
-      const requests = utils.deepClone(bidRequests);
-
-      // add a pubcid in local storage
-      storage.setDataInLocalStorage(ID_NAME + EXP, '');
-      storage.setDataInLocalStorage(ID_NAME, 'abcde');
-
-      //  construct http post payload
-      const payload = spec.buildRequests(requests, {}).data;
-      expect(payload).to.have.deep.nested.property('user.ext.fpc', 'abcde');
-    });
-
-    it('reading local storage with valid exp time', function() {
-      // clone bidRequests
-      const requests = utils.deepClone(bidRequests);
-
-      // add a pubcid in local storage
-      storage.setDataInLocalStorage(ID_NAME + EXP, expStr(TIMEOUT));
-      storage.setDataInLocalStorage(ID_NAME, 'fghijk');
-
-      //  construct http post payload
-      const payload = spec.buildRequests(requests, {}).data;
-      expect(payload).to.have.deep.nested.property('user.ext.fpc', 'fghijk');
-    });
-
-    it('reading expired local storage', function() {
-      // clone bidRequests
-      const requests = utils.deepClone(bidRequests);
-
-      // add a pubcid in local storage
-      storage.setDataInLocalStorage(ID_NAME + EXP, expStr(-TIMEOUT));
-      storage.setDataInLocalStorage(ID_NAME, 'lmnopq');
-
-      //  construct http post payload
-      const payload = spec.buildRequests(requests, {}).data;
-      expect(payload).to.not.have.deep.nested.property('user.ext.fpc');
-    });
-
-    it('reading local storage with custom name', function() {
-      // clone bidRequests
-      const requests = utils.deepClone(bidRequests);
-      requests[0].params.pubcid_name = CUSTOM_ID_NAME;
-
-      // add a pubcid in local storage
-      storage.setDataInLocalStorage(CUSTOM_ID_NAME + EXP, expStr(TIMEOUT));
-      storage.setDataInLocalStorage(CUSTOM_ID_NAME, 'fghijk');
-
-      //  construct http post payload
-      const payload = spec.buildRequests(requests, {}).data;
-      expect(payload).to.have.deep.nested.property('user.ext.fpc', 'fghijk');
     });
   });
 


### PR DESCRIPTION
## Type of change

- [ X ] Updated bidder adapter  

## Description of change
Dont use bidrequest.{}.userid since it's going away in PB10.  This is related to #11377 

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
