### PR TITLE
Cwire Bid Adapter: refine user sync url

### DIFF
--- a/modules/cwireBidAdapter.js
+++ b/modules/cwireBidAdapter.js
@@ -254,7 +254,7 @@ export const spec = {
       if (type) {
         syncs.push({
           type: type,
-          url: 'https://ib.adnxs.com/getuid?https://prebid.cwi.re/v1/cookiesync?xandrId=$UID&gdpr=1&gdpr_consent=' + gdprConsent.consentString,
+          url: `https://ib.adnxs.com/getuid?https://prebid.cwi.re/v1/cookiesync?xandrId=$UID&gdpr=${gdprConsent.gdprApplies ? 1 : 0}&gdpr_consent=${gdprConsent.consentString}`,
         })
       }
     }

--- a/test/spec/modules/cwireBidAdapter_spec.js
+++ b/test/spec/modules/cwireBidAdapter_spec.js
@@ -343,14 +343,14 @@ describe('C-WIRE bid adapter', () => {
             consents: 1
           }
         },
-        gdprApplies: false,
+        gdprApplies: true,
         consentString: 'abc123'
       };
       let synOptions = {iframeEnabled: true};
       const userSyncs = spec.getUserSyncs(synOptions, {}, gdprConsent, {});
 
       expect(userSyncs[0].type).to.equal('iframe');
-      expect(userSyncs[0].url).to.equal('https://ib.adnxs.com/getuid?https://prebid.cwi.re/v1/cookiesync?xandrId=$UID&gdpr=0&gdpr_consent=abc123');    
+      expect(userSyncs[0].url).to.equal('https://ib.adnxs.com/getuid?https://prebid.cwi.re/v1/cookiesync?xandrId=$UID&gdpr=1&gdpr_consent=abc123');    
     })
   })
 });

--- a/test/spec/modules/cwireBidAdapter_spec.js
+++ b/test/spec/modules/cwireBidAdapter_spec.js
@@ -326,21 +326,23 @@ describe('C-WIRE bid adapter', () => {
             consents: 1
           }
         },
-        gdprApplies: true,
+        gdprApplies: false,
         consentString: 'testConsentString'
       };
       let synOptions = {pixelEnabled: true, iframeEnabled: true};
       const userSyncs = spec.getUserSyncs(synOptions, {}, gdprConsent, {});
 
       expect(userSyncs[0].type).to.equal('image');
-      expect(userSyncs[0].url).to.equal('https://ib.adnxs.com/getuid?https://prebid.cwi.re/v1/cookiesync?xandrId=$UID&gdpr=1&gdpr_consent=testConsentString');    
+      expect(userSyncs[0].url).to.equal('https://ib.adnxs.com/getuid?https://prebid.cwi.re/v1/cookiesync?xandrId=$UID&gdpr=0&gdpr_consent=testConsentString');    
     })
 
     it('user-syncs with enabled iframe option', function () {
       let gdprConsent = {
         vendorData: {
           purpose: {
-            consents: 1
+            consents: {
+              1: true
+            }
           }
         },
         gdprApplies: true,

--- a/test/spec/modules/cwireBidAdapter_spec.js
+++ b/test/spec/modules/cwireBidAdapter_spec.js
@@ -311,6 +311,7 @@ describe('C-WIRE bid adapter', () => {
             consents: 1
           }
         },
+        gdprApplies: false,
         consentString: 'testConsentString'
       };
       const userSyncs = spec.getUserSyncs({}, {}, gdprConsent, {});
@@ -325,13 +326,14 @@ describe('C-WIRE bid adapter', () => {
             consents: 1
           }
         },
+        gdprApplies: false,
         consentString: 'testConsentString'
       };
       let synOptions = {pixelEnabled: true, iframeEnabled: true};
       const userSyncs = spec.getUserSyncs(synOptions, {}, gdprConsent, {});
 
       expect(userSyncs[0].type).to.equal('image');
-      expect(userSyncs[0].url).to.equal('https://ib.adnxs.com/getuid?https://prebid.cwi.re/v1/cookiesync?xandrId=$UID&gdpr=1&gdpr_consent=testConsentString');    
+      expect(userSyncs[0].url).to.equal('https://ib.adnxs.com/getuid?https://prebid.cwi.re/v1/cookiesync?xandrId=$UID&gdpr=0&gdpr_consent=testConsentString');    
     })
 
     it('user-syncs with enabled iframe option', function () {
@@ -341,6 +343,7 @@ describe('C-WIRE bid adapter', () => {
             consents: 1
           }
         },
+        gdprApplies: true,
         consentString: 'abc123'
       };
       let synOptions = {iframeEnabled: true};

--- a/test/spec/modules/cwireBidAdapter_spec.js
+++ b/test/spec/modules/cwireBidAdapter_spec.js
@@ -326,14 +326,14 @@ describe('C-WIRE bid adapter', () => {
             consents: 1
           }
         },
-        gdprApplies: false,
+        gdprApplies: true,
         consentString: 'testConsentString'
       };
       let synOptions = {pixelEnabled: true, iframeEnabled: true};
       const userSyncs = spec.getUserSyncs(synOptions, {}, gdprConsent, {});
 
       expect(userSyncs[0].type).to.equal('image');
-      expect(userSyncs[0].url).to.equal('https://ib.adnxs.com/getuid?https://prebid.cwi.re/v1/cookiesync?xandrId=$UID&gdpr=0&gdpr_consent=testConsentString');    
+      expect(userSyncs[0].url).to.equal('https://ib.adnxs.com/getuid?https://prebid.cwi.re/v1/cookiesync?xandrId=$UID&gdpr=1&gdpr_consent=testConsentString');    
     })
 
     it('user-syncs with enabled iframe option', function () {
@@ -343,14 +343,14 @@ describe('C-WIRE bid adapter', () => {
             consents: 1
           }
         },
-        gdprApplies: true,
+        gdprApplies: false,
         consentString: 'abc123'
       };
       let synOptions = {iframeEnabled: true};
       const userSyncs = spec.getUserSyncs(synOptions, {}, gdprConsent, {});
 
       expect(userSyncs[0].type).to.equal('iframe');
-      expect(userSyncs[0].url).to.equal('https://ib.adnxs.com/getuid?https://prebid.cwi.re/v1/cookiesync?xandrId=$UID&gdpr=1&gdpr_consent=abc123');    
+      expect(userSyncs[0].url).to.equal('https://ib.adnxs.com/getuid?https://prebid.cwi.re/v1/cookiesync?xandrId=$UID&gdpr=0&gdpr_consent=abc123');    
     })
   })
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Updated bidder adapter

## Description of change

In the user sync call gdpr was always set to 1 no matter if gdpr applied or not, now that is fixed.