### PR TITLE
Adnuntius Bid Adapter: Better test failure messages

### DIFF
--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -58,7 +58,17 @@ describe('adnuntiusBidAdapter', function () {
     const e = utils.parseUrl(expected);
     expect(a.protocol + '://' + a.host + a.pathname).to.equal(e.protocol + '://' + e.host + e.pathname);
     const sortEntries = obj => Object.entries(obj).sort();
-    expect(sortEntries(a.search)).to.deep.equal(sortEntries(e.search));
+    const sortedExpectations = sortEntries(a.search);
+    const sortedActuals = sortEntries(e.search);
+    for (let i = 0; i < sortedExpectations.length; i++) {
+      const expectation = sortedExpectations[i];
+      const actual = sortedActuals[i];
+
+      const expectationAsString = expectation[0] + ":" + expectation[1];
+      const actualAsString = actual[0] + ":" + actual[1];
+      expect(expectationAsString).to.equal(actualAsString);
+    }
+    expect(sortedExpectations.length).to.equal(sortedActuals.length);
   }
 
   const adapter = newBidder(spec);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Update to tests in order to better pinpoint why intermittent failures are happening.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
