### PR TITLE
auction.js : getPrimaryCatId must return a string or the first value of the array

### DIFF
--- a/src/auction.js
+++ b/src/auction.js
@@ -782,7 +782,7 @@ export const getDSP = () => {
  * This function returns a function to get the primary category id from bid response meta
  * @returns {function}
  */
-export const getPrimaryCatId = () => { 
+export const getPrimaryCatId = () => {
   return (bid) => {
     const catId = bid?.meta?.primaryCatId;
     if (Array.isArray(catId)) {

--- a/src/auction.js
+++ b/src/auction.js
@@ -782,10 +782,14 @@ export const getDSP = () => {
  * This function returns a function to get the primary category id from bid response meta
  * @returns {function}
  */
-export const getPrimaryCatId = () => {
+export const getPrimaryCatId = () => { 
   return (bid) => {
-    return (bid.meta && bid.meta.primaryCatId) ? bid.meta.primaryCatId : '';
-  }
+    const catId = bid?.meta?.primaryCatId;
+    if (Array.isArray(catId)) {
+      return catId[0] || '';
+    }
+    return catId || '';
+  };
 }
 
 // factory for key value objs


### PR DESCRIPTION
## Type of change
- [ x ] Bugfix

## Description of change
I noticed that some bidders will respond to primaryCatId meta with multiple values in an array instead of a string.

I saw this from some teqblaze bidders:
`  "meta": {
    "networkId": 716,
    "advertiserDomains": [],
    "primaryCatId": [
      "IAB18-6",
      "IAB8",
      "IAB18-1",
      "IAB7"
    ],
    "mediaType": "banner"
  }`

While setting GAM key value `hb_acat` still works, since GAM takes an array of strings as values, it will impact other things, like the bidFiltering module, which expects to be a string: [https://github.com/prebid/Prebid.js/blob/master/modules/bidResponseFilter/index.js#L41](https://github.com/prebid/Prebid.js/blob/master/modules/bidResponseFilter/index.js#L41)

On our end this creates an issue with analytics and breaks our DB schema.

Some bidders breakdown the entries into primaryCatIds and secondaryCatIds, which is good, but others don't do it. I do not think we should rely on bidders returning and validating meta data.

Probably there are more things to take in account and maybe other meta should be validated, this fixes only the primaryCatId, in case is an array to pick up the first value. 
