### PR TITLE
Adverxo Bid Adapter : allow adUnitId to be a string

### DIFF
--- a/modules/adverxoBidAdapter.js
+++ b/modules/adverxoBidAdapter.js
@@ -181,7 +181,7 @@ const adverxoUtils = {
     bidRequests.forEach(bidRequest => {
       const adUnit = {
         host: bidRequest.params.host,
-        id: bidRequest.params.adUnitId,
+        id: Number(bidRequest.params.adUnitId),
         auth: bidRequest.params.auth,
       };
 
@@ -229,8 +229,8 @@ export const spec = {
       return false;
     }
 
-    if (!bid.params.adUnitId || typeof bid.params.adUnitId !== 'number') {
-      utils.logWarn('Adverxo Bid Adapter: adUnitId bid param is required and must be a number');
+    if (!bid.params.adUnitId || isNaN(Number(bid.params.adUnitId)) || bid.params.adUnitId <= 0) {
+      utils.logWarn('Adverxo Bid Adapter: adUnitId bid param is required and must be a positive number');
       return false;
     }
 

--- a/test/spec/modules/adverxoBidAdapter_spec.js
+++ b/test/spec/modules/adverxoBidAdapter_spec.js
@@ -156,9 +156,21 @@ describe('Adverxo Bid Adapter', () => {
   });
 
   describe('isBidRequestValid', function () {
-    it('should validate bid request with valid params', () => {
+    it('should validate bid request with valid params (adUnit as number)', () => {
       const validBid = makeBidRequestWithParams({
         adUnitId: 1,
+        auth: 'authExample',
+        host: 'www.bidExample.com'
+      });
+
+      const isValid = spec.isBidRequestValid(validBid);
+
+      expect(isValid).to.be.true;
+    });
+
+    it('should validate bid request with valid params (adUnit as string)', () => {
+      const validBid = makeBidRequestWithParams({
+        adUnitId: "1",
         auth: 'authExample',
         host: 'www.bidExample.com'
       });
@@ -178,6 +190,18 @@ describe('Adverxo Bid Adapter', () => {
 
     it('should not validate bid request with missing param(adUnitId)', () => {
       const invalidBid = makeBidRequestWithParams({
+        auth: 'authExample',
+        host: 'www.bidExample.com'
+      });
+
+      const isValid = spec.isBidRequestValid(invalidBid);
+
+      expect(isValid).to.be.false;
+    });
+
+    it('should not validate bid request with invalid param(adUnitId)', () => {
+      const invalidBid = makeBidRequestWithParams({
+        adUnitId: "1a",
         auth: 'authExample',
         host: 'www.bidExample.com'
       });


### PR DESCRIPTION
## Type of change
- [X] Updated bidder adapter

## Description of change
Allow adUnitId param to be a numeric string.
