### PR TITLE
PubMatic Bid Adapter : get benefits from previous auction info module

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -105,6 +105,9 @@ const converter = ortbConverter({
     const marketPlaceEnabled = bidderRequest?.bidderCode
       ? bidderSettings.get(bidderRequest.bidderCode, 'allowAlternateBidderCodes') : undefined;
     if (marketPlaceEnabled) updateRequestExt(request, bidderRequest);
+    if (bidderRequest?.ortb2?.ext?.prebid?.previousauctioninfo) {
+      deepSetValue(request, 'ext.previousAuctionInfo', bidderRequest.ortb2.ext.prebid.previousauctioninfo);
+    }
     return request;
   },
   bidResponse(buildBidResponse, bid, context) {

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -222,6 +222,24 @@ describe('PubMatic adapter', () => {
 
   describe('Request formation', () => {
     describe('IMP', () => {
+      it('should include previousAuctionInfo in request when available', () => {
+        const bidRequestWithPrevAuction = utils.deepClone(validBidRequests[0]);
+        bidRequestWithPrevAuction.ortb2 = {
+          ext: {
+            prebid: {
+              previousauctioninfo: {
+                bidderRequestId: 'bidder-request-id',
+              }
+            }
+          }
+        };
+        const request = spec.buildRequests([bidRequestWithPrevAuction], bidderRequest);
+        expect(request.data.ext).to.have.property('previousAuctionInfo');
+        expect(request.data.ext.previousAuctionInfo).to.deep.equal({
+          bidderRequestId: 'bidder-request-id'
+        });
+      });
+      
       it('should generate request with banner', () => {
         const request = spec.buildRequests(validBidRequests, bidderRequest);
         const { imp } = request?.data;


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
With this change PubMatic Bid Adapter will pass information of previous auction to server using previous auction module

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
