### PR TITLE
Rubicon Bid Adapter: Add safe checks on client hints to protect against invalid SUA

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -1031,7 +1031,7 @@ function applyFPD(bidRequest, mediaType, data) {
           const [ua, fullVer] = browsers.reduce((accum, browserData) => {
             accum[0].push(`"${browserData?.brand}"|v="${browserData?.version?.[0]}"`);
             // only set fullVer if long enough
-            if (browserData.version.length > 1) {
+            if (browserData?.version?.length > 1) {
               accum[1].push(`"${browserData?.brand}"|v="${browserData?.version?.join?.('.')}"`);
             }
             return accum;


### PR DESCRIPTION
## Type of change

- [x] Feature

## Description of change

Add safe checks when using the information from the SUA browsers object.

If a invalid SUA object is used without a browser's version then the Rubicon request is not sent because an error:

```
Prebid ERROR: rubicon Bid Adapter emitted an uncaught error when parsing their bidRequest
TypeError: Cannot read properties of undefined (reading 'length')
```

## Other information

- https://github.com/prebid/Prebid.js/pull/12740#issuecomment-2909482475
- https://github.com/prebid/Prebid.js/pull/12740#issuecomment-2910324208
- @robertrmartinez
