### PR TITLE
Update gulpfile.js: calculate coverage in one pass

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -440,7 +440,8 @@ function testCoverage(done) {
     watch: false,
     file: argv.file,
     env: {
-      NODE_OPTIONS: '--max-old-space-size=8096'
+      NODE_OPTIONS: '--max-old-space-size=8096',
+      TEST_CHUNKS: '1'
     }
   }, done);
 }


### PR DESCRIPTION
https://coveralls.io/builds/73901957 was showing 7% coverage drop because of the chunks