### PR TITLE
pubmatic Rtd Provider: relax unit test condition

### DIFF
--- a/test/spec/modules/pubmaticRtdProvider_spec.js
+++ b/test/spec/modules/pubmaticRtdProvider_spec.js
@@ -474,15 +474,14 @@ describe('Pubmatic RTD Provider', () => {
             fetchStub.resolves(new Response('Invalid JSON', { status: 200 }));
 
             await fetchData('1234', '123', 'FLOORS');
-            expect(logErrorStub.called).to.be.true;
-            expect(logErrorStub.firstCall.args[0]).to.include('Error while fetching FLOORS');
+            expect(logErrorStub.calledWith(sinon.match(/Error while fetching\s*FLOORS/))).to.be.true;
         });
 
         it('should log error when response is not ok', async () => {
             fetchStub.resolves(new Response(null, { status: 500 }));
 
             await fetchData('1234', '123', 'FLOORS');
-            expect(logErrorStub.firstCall.args[0]).to.include('Error while fetching FLOORS');
+            expect(logErrorStub.calledWith(sinon.match(/Error while fetching\s*FLOORS/))).to.be.true;
         });
 
         it('should log error on network failure', async () => {
@@ -490,7 +489,7 @@ describe('Pubmatic RTD Provider', () => {
 
             await fetchData('1234', '123', 'FLOORS');
             expect(logErrorStub.called).to.be.true;
-            expect(logErrorStub.firstCall.args[0]).to.include('Error while fetching FLOORS');
+            expect(logErrorStub.calledWith(sinon.match(/Error while fetching\s*FLOORS/))).to.be.true;
         });
     });
 


### PR DESCRIPTION
relaxes the formattting requirement a tad of the error message