### PR TITLE
AdsInteractive Adapter: Add alias from old adsinteractive adapter

### DIFF
--- a/modules/ads_interactiveBidAdapter.js
+++ b/modules/ads_interactiveBidAdapter.js
@@ -10,6 +10,9 @@ const GVLID = 1212;
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
+  aliases: [
+    'adsinteractive'
+  ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 
   isBidRequestValid: isBidRequestValid(),


### PR DESCRIPTION

## Type of change
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 

## Description of change
Add alias for `adsinteractive`
