### PR TITLE
criteoBidAdapter: Enable GZIP compression

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -372,7 +372,15 @@ export const spec = {
     const data = CONVERTER.toORTB({bidderRequest, bidRequests, context});
 
     if (data) {
-      return { method: 'POST', url, data, bidRequests };
+      return {
+        method: 'POST',
+        url,
+        data,
+        bidRequests,
+        options: {
+          endpointCompression: true
+        }
+      };
     }
   },
 


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Enable GZIP compression for Criteo bid adapter

## Other information
https://docs.prebid.org/dev-docs/bidder-adaptor.html#compression-support-for-outgoing-requests
