### PR TITLE
Revert "criteoBidAdapter: Enable GZIP compression"

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -372,15 +372,7 @@ export const spec = {
     const data = CONVERTER.toORTB({bidderRequest, bidRequests, context});
 
     if (data) {
-      return {
-        method: 'POST',
-        url,
-        data,
-        bidRequests,
-        options: {
-          endpointCompression: true
-        }
-      };
+      return { method: 'POST', url, data, bidRequests };
     }
   },
 


### PR DESCRIPTION
Reverts prebid/Prebid.js#13265

I jumped the gun too fast, our backend doesn't support this yet.
I will re-push the enablement commit once we're good to go!