### PR TITLE
stvAdapter: change userId handling to bidRequest.userIdAsEids, process userIds from euid.eu

### DIFF
--- a/modules/stvBidAdapter.js
+++ b/modules/stvBidAdapter.js
@@ -191,43 +191,48 @@ function serializeSChain(schain) {
 function serializeUids(bidRequest) {
   let uids = [];
 
-  let id5 = deepAccess(bidRequest, 'userId.id5id.uid');
+  if (bidRequest.userIdAsEids === undefined || !Array.isArray(bidRequest.userIdAsEids)) {
+    return '';
+  }
+
+  let buids = {};
+  bidRequest.userIdAsEids.forEach((src) => (buids[deepAccess(src, 'source')] = deepAccess(src, 'uids.0')));
+
+  let id5 = deepAccess(buids['id5-sync.com'], 'id');
   if (id5) {
     uids.push(encodeURIComponent('id5:' + id5));
-    let id5Linktype = deepAccess(bidRequest, 'userId.id5id.ext.linkType');
+    let id5Linktype = deepAccess(buids['id5-sync.com'], 'ext.linkType');
     if (id5Linktype) {
       uids.push(encodeURIComponent('id5_linktype:' + id5Linktype));
     }
   }
-  let netId = deepAccess(bidRequest, 'userId.netId');
+  let netId = deepAccess(buids['netid.de'], 'id');
   if (netId) {
     uids.push(encodeURIComponent('netid:' + netId));
   }
-  let uId2 = deepAccess(bidRequest, 'userId.uid2.id');
+  let uId2 = deepAccess(buids['uidapi.com'], 'id');
   if (uId2) {
     uids.push(encodeURIComponent('uid2:' + uId2));
   }
-  let sharedId = deepAccess(bidRequest, 'userId.sharedid.id');
+  let sharedId = deepAccess(buids['pubcid.org'], 'id');
   if (sharedId) {
     uids.push(encodeURIComponent('sharedid:' + sharedId));
   }
-  let liverampId = deepAccess(bidRequest, 'userId.idl_env');
+  let liverampId = deepAccess(buids['liveramp.com'], 'id');
   if (liverampId) {
     uids.push(encodeURIComponent('liverampid:' + liverampId));
   }
-  let criteoId = deepAccess(bidRequest, 'userId.criteoId');
+  let criteoId = deepAccess(buids['criteo.com'], 'id');
   if (criteoId) {
     uids.push(encodeURIComponent('criteoid:' + criteoId));
   }
-  // documentation missing...
-  let utiqId = deepAccess(bidRequest, 'userId.utiq.id');
+  let utiqId = deepAccess(buids['utiq.com'], 'id');
   if (utiqId) {
     uids.push(encodeURIComponent('utiq:' + utiqId));
-  } else {
-    utiqId = deepAccess(bidRequest, 'userId.utiq');
-    if (utiqId) {
-      uids.push(encodeURIComponent('utiq:' + utiqId));
-    }
+  }
+  let euidId = deepAccess(buids['euid.eu'], 'id');
+  if (euidId) {
+    uids.push(encodeURIComponent('euid:' + euidId));
   }
 
   return uids.join(',');

--- a/test/spec/modules/stvBidAdapter_spec.js
+++ b/test/spec/modules/stvBidAdapter_spec.js
@@ -72,24 +72,59 @@ describe('stvAdapter', function() {
             }
           ]
         },
-        'userId': {
-          'id5id': {
-            'uid': '1234',
-            'ext': {
-              'linkType': 'abc'
-            }
-          },
-          'netId': '2345',
-          'uid2': {
-            'id': '3456',
-          },
-          'sharedid': {
-            'id': '4567',
-          },
-          'idl_env': '5678',
-          'criteoId': '6789',
-          'utiq': '7890',
-        }
+        'userIdAsEids': [
+          {
+            'source': 'id5-sync.com',
+		    'uids': [{
+              'id': '1234',
+              'ext': {
+                'linkType': 'abc'
+              }
+            }]
+		  },
+          {
+            'source': 'netid.de',
+		    'uids': [{
+              'id': '2345'
+            }]
+		  },
+          {
+            'source': 'uidapi.com',
+		    'uids': [{
+              'id': '3456'
+            }]
+		  },
+          {
+            'source': 'pubcid.org',
+		    'uids': [{
+              'id': '4567'
+            }]
+		  },
+          {
+            'source': 'liveramp.com',
+		    'uids': [{
+              'id': '5678'
+            }]
+		  },
+          {
+            'source': 'criteo.com',
+		    'uids': [{
+              'id': '6789'
+            }]
+		  },
+          {
+            'source': 'utiq.com',
+		    'uids': [{
+              'id': '7890'
+            }]
+		  },
+          {
+            'source': 'euid.eu',
+		    'uids': [{
+              'id': '8901'
+            }]
+		  }
+        ]
       },
       {
         'bidder': 'stv',
@@ -103,26 +138,59 @@ describe('stvAdapter', function() {
         'bidId': '30b31c1838de1e2',
         'bidderRequestId': '22edbae2733bf62',
         'auctionId': '1d1a030790a476',
-        'userId': { // with other utiq variant
-          'id5id': {
-            'uid': '1234',
-            'ext': {
-              'linkType': 'abc'
-            }
-          },
-          'netId': '2345',
-          'uid2': {
-            'id': '3456',
-          },
-          'sharedid': {
-            'id': '4567',
-          },
-          'idl_env': '5678',
-          'criteoId': '6789',
-          'utiq': {
-            'id': '7890'
-          },
-        }
+        'userIdAsEids': [
+          {
+            'source': 'id5-sync.com',
+		    'uids': [{
+              'id': '1234',
+              'ext': {
+                'linkType': 'abc'
+              }
+            }]
+		  },
+          {
+            'source': 'netid.de',
+		    'uids': [{
+              'id': '2345'
+            }]
+		  },
+          {
+            'source': 'uidapi.com',
+		    'uids': [{
+              'id': '3456'
+            }]
+		  },
+          {
+            'source': 'pubcid.org',
+		    'uids': [{
+              'id': '4567'
+            }]
+		  },
+          {
+            'source': 'liveramp.com',
+		    'uids': [{
+              'id': '5678'
+            }]
+		  },
+          {
+            'source': 'criteo.com',
+		    'uids': [{
+              'id': '6789'
+            }]
+		  },
+          {
+            'source': 'utiq.com',
+		    'uids': [{
+              'id': '7890'
+            }]
+		  },
+          {
+            'source': 'euid.eu',
+		    'uids': [{
+              'id': '8901'
+            }]
+		  }
+        ]
       }, {
         'bidder': 'stv',
         'params': {
@@ -219,7 +287,7 @@ describe('stvAdapter', function() {
       expect(request1.method).to.equal('GET');
       expect(request1.url).to.equal(ENDPOINT_URL);
       let data = request1.data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid').replace(/pbver=.*?&/g, 'pbver=test&');
-      expect(data).to.equal('_f=html&alternative=prebid_js&_ps=6682&srw=300&srh=250&idt=100&bid_id=30b31c1838de1e1&pbver=test&schain=1.0,0!reseller.com,aaaaa,1,BidRequest4,,&uids=id5%3A1234,id5_linktype%3Aabc,netid%3A2345,uid2%3A3456,sharedid%3A4567,liverampid%3A5678,criteoid%3A6789,utiq%3A7890&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bgeo%5D%5Bcountry%5D=DE&gdpr_consent=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&gdpr=true&bcat=IAB2%2CIAB4&dvt=desktop&pbcode=testDiv1&media_types%5Bbanner%5D=300x250');
+      expect(data).to.equal('_f=html&alternative=prebid_js&_ps=6682&srw=300&srh=250&idt=100&bid_id=30b31c1838de1e1&pbver=test&schain=1.0,0!reseller.com,aaaaa,1,BidRequest4,,&uids=id5%3A1234,id5_linktype%3Aabc,netid%3A2345,uid2%3A3456,sharedid%3A4567,liverampid%3A5678,criteoid%3A6789,utiq%3A7890,euid%3A8901&pfilter%5Bfloorprice%5D=1000000&pfilter%5Bgeo%5D%5Bcountry%5D=DE&gdpr_consent=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&gdpr=true&bcat=IAB2%2CIAB4&dvt=desktop&pbcode=testDiv1&media_types%5Bbanner%5D=300x250');
     });
 
     var request2 = spec.buildRequests([bidRequests[1]], bidderRequest)[0];
@@ -227,7 +295,7 @@ describe('stvAdapter', function() {
       expect(request2.method).to.equal('GET');
       expect(request2.url).to.equal(ENDPOINT_URL);
       let data = request2.data.replace(/rnd=\d+\&/g, '').replace(/ref=.*\&bid/g, 'bid').replace(/pbver=.*?&/g, 'pbver=test&');
-      expect(data).to.equal('_f=html&alternative=prebid_js&_ps=101&srw=300&srh=250&idt=100&bid_id=30b31c1838de1e2&pbver=test&uids=id5%3A1234,id5_linktype%3Aabc,netid%3A2345,uid2%3A3456,sharedid%3A4567,liverampid%3A5678,criteoid%3A6789,utiq%3A7890&gdpr_consent=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&gdpr=true&prebidDevMode=1&media_types%5Bbanner%5D=300x250');
+      expect(data).to.equal('_f=html&alternative=prebid_js&_ps=101&srw=300&srh=250&idt=100&bid_id=30b31c1838de1e2&pbver=test&uids=id5%3A1234,id5_linktype%3Aabc,netid%3A2345,uid2%3A3456,sharedid%3A4567,liverampid%3A5678,criteoid%3A6789,utiq%3A7890,euid%3A8901&gdpr_consent=BOJ%2FP2HOJ%2FP2HABABMAAAAAZ%2BA%3D%3D&gdpr=true&prebidDevMode=1&media_types%5Bbanner%5D=300x250');
     });
 
     // Without gdprConsent


### PR DESCRIPTION
## Type of change
- [x ] Feature 
- [x ] Updated bidder adapter  

## Description of change
For userId detection we do not use bidRequest.userId any more, but bidRequest.userIdAsEids. As well, we utilize userIds from euid.eu now.
