### PR TITLE
Liveramp ID Submodule: add try catch for atob in identitylink module

### DIFF
--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -160,6 +160,7 @@ export function getEnvelopeFromStorage() {
       return window.atob(rawEnvelope.replace(/-/g, '+').replace(/_/g, '/'));
     } catch (e2) {
       return undefined;
+      utils.logError('identityLink: invalid envelope format');
     }
   }
 }

--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -150,7 +150,18 @@ function setEnvelopeSource(src) {
 
 export function getEnvelopeFromStorage() {
   let rawEnvelope = storage.getCookie(liverampEnvelopeName) || storage.getDataFromLocalStorage(liverampEnvelopeName);
-  return rawEnvelope ? window.atob(rawEnvelope) : undefined;
+  if (!rawEnvelope) {
+    return undefined;
+  }
+  try {
+    return window.atob(rawEnvelope);
+  } catch (e) {
+    try {
+      return window.atob(rawEnvelope.replace(/-/g, '+').replace(/_/g, '/'));
+    } catch (e2) {
+      return undefined;
+    }
+  }
 }
 
 submodule('userId', identityLinkSubmodule);

--- a/modules/identityLinkIdSystem.js
+++ b/modules/identityLinkIdSystem.js
@@ -159,8 +159,8 @@ export function getEnvelopeFromStorage() {
     try {
       return window.atob(rawEnvelope.replace(/-/g, '+').replace(/_/g, '/'));
     } catch (e2) {
-      return undefined;
       utils.logError('identityLink: invalid envelope format');
+      return undefined;
     }
   }
 }

--- a/test/spec/modules/identityLinkIdSystem_spec.js
+++ b/test/spec/modules/identityLinkIdSystem_spec.js
@@ -208,6 +208,18 @@ describe('IdentityLinkId tests', function () {
     expect(callBackSpy.calledOnce).to.be.true;
   })
 
+  it('should replace invalid characters if initial atob fails', function () {
+    setTestEnvelopeCookie();
+    const realAtob = window.atob;
+    const stubAtob = sinon.stub(window, 'atob');
+    stubAtob.onFirstCall().throws(new Error('bad'));
+    stubAtob.onSecondCall().callsFake(realAtob);
+    let envelopeValueFromStorage = getEnvelopeFromStorage();
+    stubAtob.restore();
+    expect(stubAtob.calledTwice).to.be.true;
+    expect(envelopeValueFromStorage).to.equal(testEnvelopeValue);
+  })
+
   it('if there is no envelope in storage and ats is not present on a page try to call 3p url', function () {
     let envelopeValueFromStorage = getEnvelopeFromStorage();
     let callBackSpy = sinon.spy();


### PR DESCRIPTION
safari 17 for liveramp has many failing tests on invalid characters _ and - being passed to atob. This catches an error and subs out those characters. 

reference
https://stackoverflow.com/questions/69368185/why-does-atob-fail-in-safari-and-chrome-on-this-base-64-string