### PR TITLE
HypelabBidAdapter: fixing spec file

### DIFF
--- a/test/spec/modules/hypelabBidAdapter_spec.js
+++ b/test/spec/modules/hypelabBidAdapter_spec.js
@@ -114,11 +114,11 @@ const mockBidRequest = {
 
 describe('hypelabBidAdapter', function () {
   describe('mediaSize', function () {
-    describe('when given an invalid media object', function () {
+    it('when given an invalid media object', function () {
       expect(mediaSize({})).to.eql({ width: 0, height: 0 });
     });
 
-    describe('when given a valid media object', function () {
+    it('when given a valid media object', function () {
       expect(
         mediaSize({ creative_set: { image: { width: 728, height: 90 } } })
       ).to.eql({ width: 728, height: 90 });
@@ -126,29 +126,35 @@ describe('hypelabBidAdapter', function () {
   });
 
   describe('isBidRequestValid', function () {
-    describe('when given an invalid bid request', function () {
+    it('when given an invalid bid request', function () {
       expect(spec.isBidRequestValid({})).to.equal(false);
     });
 
-    describe('when given a valid bid request', function () {
+    it('when given a valid bid request', function () {
       expect(spec.isBidRequestValid(mockValidBidRequest)).to.equal(true);
     });
   });
 
   describe('Bidder code valid', function () {
-    expect(spec.code).to.equal(BIDDER_CODE);
+    it('should match BIDDER_CODE', function () {
+      expect(spec.code).to.equal(BIDDER_CODE);
+    });
   });
 
   describe('Media types valid', function () {
-    expect(spec.supportedMediaTypes).to.contain(BANNER);
+    it('should contain BANNER', function () {
+      expect(spec.supportedMediaTypes).to.contain(BANNER);
+    });
   });
 
   describe('Bid request valid', function () {
-    expect(spec.isBidRequestValid(mockValidBidRequest)).to.equal(true);
+    it('should validate correctly', function () {
+      expect(spec.isBidRequestValid(mockValidBidRequest)).to.equal(true);
+    });
   });
 
   describe('buildRequests', () => {
-    describe('returns a valid request', function () {
+    it('returns a valid request', function () {
       const result = spec.buildRequests(
         mockValidBidRequests,
         mockBidderRequest
@@ -200,7 +206,7 @@ describe('hypelabBidAdapter', function () {
       expect(data.pp).to.deep.equal(null);
     });
 
-    describe('should set uuid to the first id in userIdAsEids', () => {
+    it('should set uuid to the first id in userIdAsEids', () => {
       mockValidBidRequests[0].userIdAsEids = [
         {
           source: 'pubcid.org',
@@ -231,7 +237,7 @@ describe('hypelabBidAdapter', function () {
   });
 
   describe('interpretResponse', () => {
-    describe('successfully interpret a valid response', function () {
+    it('successfully interpret a valid response', function () {
       const result = spec.interpretResponse(mockServerResponse, mockBidRequest);
 
       expect(result).to.be.an('array');
@@ -252,7 +258,7 @@ describe('hypelabBidAdapter', function () {
       expect(data.meta.advertiserDomains[0]).to.be.a('string');
     });
 
-    describe('should return a blank array if cpm is not set', () => {
+    it('should return a blank array if cpm is not set', () => {
       mockServerResponse.body.data.cpm = undefined;
       const result = spec.interpretResponse(mockServerResponse, mockBidRequest);
       expect(result).to.eql([]);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
