### PR TITLE
StroeerCore Bid Adapter: use bid's meta as-is from server response

### DIFF
--- a/modules/stroeerCoreBidAdapter.js
+++ b/modules/stroeerCoreBidAdapter.js
@@ -1,7 +1,8 @@
-import { buildUrl, deepAccess, deepSetValue, generateUUID, getWinDimensions, getWindowSelf, getWindowTop, isEmpty, isStr, logWarn } from '../src/utils.js';
+import {buildUrl, deepAccess, deepSetValue, generateUUID, getWinDimensions, getWindowSelf, getWindowTop, isEmpty, isStr, logWarn} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
-import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
+import {getBoundingClientRect} from '../libraries/boundingClientRect/boundingClientRect.js';
+import {getGlobal} from '../src/prebidGlobal.js';
 
 const GVL_ID = 136;
 const BIDDER_CODE = 'stroeerCore';
@@ -55,7 +56,10 @@ export const spec = {
       mpa: isMainPageAccessible(),
       timeout: bidderRequest.timeout - (Date.now() - bidderRequest.auctionStart),
       url: refererInfo.page,
-      schain: anyBid.schain
+      schain: anyBid.schain,
+      ver: {
+        pb: getGlobal().version,
+      },
     };
 
     const eids = anyBid.userIdAsEids;
@@ -114,10 +118,7 @@ export const spec = {
           currency: 'EUR',
           netRevenue: true,
           creativeId: '',
-          meta: {
-            advertiserDomains: bidResponse.adomain,
-            dsa: bidResponse.dsa,
-            campaignType: bidResponse.campaignType},
+          meta: {...bidResponse.meta},
           mediaType,
         };
 

--- a/test/spec/modules/stroeerCoreBidAdapter_spec.js
+++ b/test/spec/modules/stroeerCoreBidAdapter_spec.js
@@ -7,14 +7,12 @@ import sinon from 'sinon';
 
 describe('stroeerCore bid adapter', function () {
   let sandbox;
-  let fakeServer;
   let bidderRequest;
   let clock;
 
   beforeEach(() => {
     bidderRequest = buildBidderRequest();
     sandbox = sinon.sandbox.create();
-    fakeServer = sandbox.useFakeServer();
     clock = sandbox.useFakeTimers();
   });
 

--- a/test/spec/modules/stroeerCoreBidAdapter_spec.js
+++ b/test/spec/modules/stroeerCoreBidAdapter_spec.js
@@ -2,6 +2,7 @@ import {assert} from 'chai';
 import {spec} from 'modules/stroeerCoreBidAdapter.js';
 import * as utils from 'src/utils.js';
 import {BANNER, VIDEO} from '../../../src/mediaTypes.js';
+import {getGlobal} from '../../../src/prebidGlobal.js';
 import sinon from 'sinon';
 
 describe('stroeerCore bid adapter', function () {
@@ -436,6 +437,9 @@ describe('stroeerCore bid adapter', function () {
           }],
           'user': {
             'eids': eids
+          },
+          'ver': {
+            'pb': getGlobal().version,
           }
         };
 
@@ -633,6 +637,7 @@ describe('stroeerCore bid adapter', function () {
           assert.deepEqual(serverRequestInfo.data.bids, [...expectedBannerBids, ...expectedVideoBids]);
         });
       });
+
       describe('optional fields', () => {
         it('should skip viz field when unable to determine visibility of placement', () => {
           placementElements.length = 0;
@@ -1005,15 +1010,7 @@ describe('stroeerCore bid adapter', function () {
       assertStandardFieldsOnVideoBid(videoBidResponse, 'bid1', '<vast>video</vast>', 800, 250, 4);
     })
 
-    it('should add advertiser domains to meta object', () => {
-      const response = buildBidderResponse();
-      response.bids[0] = Object.assign(response.bids[0], {adomain: ['website.org', 'domain.com']});
-      const result = spec.interpretResponse({body: response});
-      assert.deepPropertyVal(result[0].meta, 'advertiserDomains', ['website.org', 'domain.com']);
-      assert.propertyVal(result[1].meta, 'advertiserDomains', undefined);
-    });
-
-    it('should add dsa info to meta object', () => {
+    it('should set meta object', () => {
       const dsaResponse = {
         behalf: 'AdvertiserA',
         paid: 'AdvertiserB',
@@ -1021,26 +1018,28 @@ describe('stroeerCore bid adapter', function () {
           domain: 'dspexample.com',
           dsaparams: [1, 2],
         }],
-        adrender: 1
+        adrender: 1,
       };
 
       const response = buildBidderResponse();
-      response.bids[0] = Object.assign(response.bids[0], {dsa: utils.deepClone(dsaResponse)});
+      response.bids[0] = Object.assign(response.bids[0], {
+        meta: {
+          advertiserDomains: ['website.org', 'domain.com'],
+          dsa: utils.deepClone(dsaResponse),
+          campaignType: 'RTB',
+          another: 'thing',
+        },
+      });
 
       const result = spec.interpretResponse({body: response});
 
-      assert.deepPropertyVal(result[0].meta, 'dsa', dsaResponse);
-      assert.propertyVal(result[1].meta, 'dsa', undefined);
-    });
+      const firstBidMeta = result[0].meta;
+      assert.deepPropertyVal(firstBidMeta, 'advertiserDomains', ['website.org', 'domain.com']);
+      assert.deepPropertyVal(firstBidMeta, 'dsa', dsaResponse);
+      assert.propertyVal(firstBidMeta, 'campaignType', 'RTB');
+      assert.propertyVal(firstBidMeta, 'another', 'thing');
 
-    it('should add campaignType to meta object', () => {
-      const response = buildBidderResponse();
-      response.bids[1] = Object.assign(response.bids[1], {campaignType: 'RTB'});
-
-      const result = spec.interpretResponse({body: response});
-
-      assert.propertyVal(result[0].meta, 'campaignType', undefined);
-      assert.propertyVal(result[1].meta, 'campaignType', 'RTB');
+      assert.isEmpty(result[1].meta)
     });
   });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

* We use the entire meta object from the bid response (`serverResponse.bid[].meta`). Saves us from having to update the bidder when we add a new field. 
* The important fields, `advertiserDomains` and `dsa`, will be returned in meta.
* Backwards compatibility is maintained. The endpoint still returns the original `serverResponse.bid[].adomains`, `serverResponse.bid[].dsa` and `serverResponse.bid[].campaignType` to support older versions of prebid.js. Will eventually drop these (in favour of meta) hence the need to send the version.