### PR TITLE
Adrino Bid Adapter: userIdsAsEids(bidderRequest) for Prebid 10 compatibility

### DIFF
--- a/modules/adrinoBidAdapter.js
+++ b/modules/adrinoBidAdapter.js
@@ -38,7 +38,7 @@ export const spec = {
         adUnitCode: validBidRequests[i].adUnitCode,
         bidId: validBidRequests[i].bidId,
         placementHash: validBidRequests[i].params.hash,
-        userId: validBidRequests[i].userId,
+        eids: validBidRequests[i].userIdAsEids,
         referer: bidderRequest.refererInfo.page,
         userAgent: navigator.userAgent,
       }

--- a/test/spec/modules/adrinoBidAdapter_spec.js
+++ b/test/spec/modules/adrinoBidAdapter_spec.js
@@ -66,7 +66,10 @@ describe('adrinoBidAdapter', function () {
         }
       },
       sizes: [[300, 250], [970, 250]],
-      userId: { criteoId: '2xqi3F94aHdwWnM3', pubcid: '3ec0b202-7697' },
+      userIdAsEids: [
+        {source: 'src1.org', uids: [{id: '1234', atype: 1}]},
+        {source: 'src2.org', uids: [{id: '5678', atype: 1}]}
+      ],
       adUnitCode: 'adunit-code-2',
       bidId: '12345678901234',
       bidderRequestId: '98765432109876',
@@ -88,9 +91,16 @@ describe('adrinoBidAdapter', function () {
       expect(result[0].data[0].userAgent).to.equal(navigator.userAgent);
       expect(result[0].data[0]).to.have.property('bannerParams');
       expect(result[0].data[0].bannerParams.sizes.length).to.equal(2);
-      expect(result[0].data[0]).to.have.property('userId');
-      expect(result[0].data[0].userId.criteoId).to.equal('2xqi3F94aHdwWnM3');
-      expect(result[0].data[0].userId.pubcid).to.equal('3ec0b202-7697');
+      expect(result[0].data[0]).to.have.property('eids');
+      expect(result[0].data[0].eids).to.be.an('array').with.lengthOf(2);
+      expect(result[0].data[0].eids).to.deep.include({
+        source: 'src1.org',
+        uids: [{id: '1234', atype: 1}]
+      });
+      expect(result[0].data[0].eids).to.deep.include({
+        source: 'src2.org',
+        uids: [{id: '5678', atype: 1}]
+      });
     });
   });
 
@@ -120,7 +130,10 @@ describe('adrinoBidAdapter', function () {
           sizes: [[300, 150], [300, 210]]
         }
       },
-      userId: { criteoId: '2xqi3F94aHdwWnM3', pubcid: '3ec0b202-7697' },
+      userIdAsEids: [
+        {source: 'src1.org', uids: [{id: '1234', atype: 1}]},
+        {source: 'src2.org', uids: [{id: '5678', atype: 1}]}
+      ],
       adUnitCode: 'adunit-code',
       bidId: '12345678901234',
       bidderRequestId: '98765432109876',
@@ -143,9 +156,16 @@ describe('adrinoBidAdapter', function () {
       expect(result[0].data[0].userAgent).to.equal(navigator.userAgent);
       expect(result[0].data[0]).to.have.property('nativeParams');
       expect(result[0].data[0]).not.to.have.property('gdprConsent');
-      expect(result[0].data[0]).to.have.property('userId');
-      expect(result[0].data[0].userId.criteoId).to.equal('2xqi3F94aHdwWnM3');
-      expect(result[0].data[0].userId.pubcid).to.equal('3ec0b202-7697');
+      expect(result[0].data[0]).to.have.property('eids');
+      expect(result[0].data[0].eids).to.be.an('array').with.lengthOf(2);
+      expect(result[0].data[0].eids).to.deep.include({
+        source: 'src1.org',
+        uids: [{id: '1234', atype: 1}]
+      });
+      expect(result[0].data[0].eids).to.deep.include({
+        source: 'src2.org',
+        uids: [{id: '5678', atype: 1}]
+      });
     });
 
     it('should build the request correctly with gdpr', function () {
@@ -163,9 +183,16 @@ describe('adrinoBidAdapter', function () {
       expect(result[0].data[0].userAgent).to.equal(navigator.userAgent);
       expect(result[0].data[0]).to.have.property('nativeParams');
       expect(result[0].data[0]).to.have.property('gdprConsent');
-      expect(result[0].data[0]).to.have.property('userId');
-      expect(result[0].data[0].userId.criteoId).to.equal('2xqi3F94aHdwWnM3');
-      expect(result[0].data[0].userId.pubcid).to.equal('3ec0b202-7697');
+      expect(result[0].data[0]).to.have.property('eids');
+      expect(result[0].data[0].eids).to.be.an('array').with.lengthOf(2);
+      expect(result[0].data[0].eids).to.deep.include({
+        source: 'src1.org',
+        uids: [{id: '1234', atype: 1}]
+      });
+      expect(result[0].data[0].eids).to.deep.include({
+        source: 'src2.org',
+        uids: [{id: '5678', atype: 1}]
+      });
     });
 
     it('should build the request correctly without gdpr', function () {
@@ -183,9 +210,16 @@ describe('adrinoBidAdapter', function () {
       expect(result[0].data[0].userAgent).to.equal(navigator.userAgent);
       expect(result[0].data[0]).to.have.property('nativeParams');
       expect(result[0].data[0]).not.to.have.property('gdprConsent');
-      expect(result[0].data[0]).to.have.property('userId');
-      expect(result[0].data[0].userId.criteoId).to.equal('2xqi3F94aHdwWnM3');
-      expect(result[0].data[0].userId.pubcid).to.equal('3ec0b202-7697');
+      expect(result[0].data[0]).to.have.property('eids');
+      expect(result[0].data[0].eids).to.be.an('array').with.lengthOf(2);
+      expect(result[0].data[0].eids).to.deep.include({
+        source: 'src1.org',
+        uids: [{id: '1234', atype: 1}]
+      });
+      expect(result[0].data[0].eids).to.deep.include({
+        source: 'src2.org',
+        uids: [{id: '5678', atype: 1}]
+      });
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter

## Description of change
This PR updates the Adrino bidder adapter to comply with changes introduced in Prebid.js v10. Specifically, it replaces usage of the deprecated `bidderRequest.userId` object with `bidderRequest.userIdsAsEids` to retrieve user ID information in EIDs format.

The adapter now populates a `eids` field with the EIDs returned from `bidderRequest.userIdsAsEids` and has updated tests accordingly.

## Other information
Related to internal preparations for Prebid.js v10 compatibility
@tmielcarz 