### PR TITLE
Ogury Bid Adapter: Replace Deprecated bidderRequest.{}.userId

### DIFF
--- a/modules/oguryBidAdapter.js
+++ b/modules/oguryBidAdapter.js
@@ -13,7 +13,7 @@ const DEFAULT_TIMEOUT = 1000;
 const BID_HOST = 'https://mweb-hb.presage.io/api/header-bidding-request';
 const TIMEOUT_MONITORING_HOST = 'https://ms-ads-monitoring-events.presage.io';
 const MS_COOKIE_SYNC_DOMAIN = 'https://ms-cookie-sync.presage.io';
-const ADAPTER_VERSION = '2.0.3';
+const ADAPTER_VERSION = '2.0.4';
 
 export const ortbConverterProps = {
   context: {
@@ -35,9 +35,6 @@ export const ortbConverterProps = {
 
     const bidWithAssetKey = bidderRequest.bids.find(bid => Boolean(deepAccess(bid, 'params.assetKey', false)));
     if (bidWithAssetKey) deepSetValue(req, 'site.id', bidWithAssetKey.params.assetKey);
-
-    const bidWithUserIds = bidderRequest.bids.find(bid => Boolean(bid.userId));
-    if (bidWithUserIds) deepSetValue(req, 'user.ext.uids', bidWithUserIds.userId);
 
     return req;
   },

--- a/test/spec/modules/oguryBidAdapter_spec.js
+++ b/test/spec/modules/oguryBidAdapter_spec.js
@@ -713,14 +713,13 @@ describe('OguryBidAdapter', () => {
 
       expect(dataRequest.user).to.deep.equal({
         ext: {
-          ...ortb2.user.ext,
-          uids: bidRequests[0].userId
+          ...ortb2.user.ext
         }
       });
 
       expect(dataRequest.ext).to.deep.equal({
         prebidversion: '$prebid.version$',
-        adapterversion: '2.0.3'
+        adapterversion: '2.0.4'
       });
 
       expect(dataRequest.device).to.deep.equal({
@@ -775,15 +774,6 @@ describe('OguryBidAdapter', () => {
 
       const request = spec.buildRequests(validBidRequests, bidderRequest);
       expect(request.data.site.id).to.be.an('undefined');
-    });
-
-    it('should not set user.ext.uids when userId is not present', () => {
-      const bidderRequest = utils.deepClone(bidderRequestBase);
-      const validBidRequests = bidderRequest.bids;
-      delete validBidRequests[0].userId;
-
-      const request = spec.buildRequests(validBidRequests, bidderRequest);
-      expect(request.data.user.ext.uids).to.be.an('undefined');
     });
 
     it('should handle bidFloor undefined', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->
Applying the change after receiving this message:

> This is as a reminder that bidderRequest.{}.userId will be deprecated in our upcoming release of Prebid 10.0 later this month. We recommend utilizing bidderRequest.{}.userIdAsEids instead as this is prefered. It appears your adapter is utilizing the .userId in some way so this could impact your adapter's inclusion into the Prebid 10 release. Please review your adapter's use of this field and make the necessary updates in the next 2 weeks to insure you are not impacted by this. Apologies, if this is a false positive regarding your adapter or your adapter has already been updated for this change.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
