### PR TITLE
UID2 Module: logError() to catch errors but not spam tests

### DIFF
--- a/libraries/uid2IdSystemShared/uid2IdSystem_shared.js
+++ b/libraries/uid2IdSystemShared/uid2IdSystem_shared.js
@@ -1,5 +1,5 @@
 import { ajax } from '../../src/ajax.js'
-import { cyrb53Hash } from '../../src/utils.js';
+import { cyrb53Hash, logError } from '../../src/utils.js';
 
 export const Uid2CodeVersion = '1.1';
 
@@ -746,7 +746,9 @@ export function Uid2GetId(config, prebidStorageManager, _logInfo, _logWarn) {
           promise.then((result) => {
             logInfo('Token generation responded, passing the new token on.', result);
             cb(result);
-          }).catch(() => {});
+          }).catch((e) => {
+												logError('error generating token: ', e);
+										});
         } };
       }
     }
@@ -766,14 +768,18 @@ export function Uid2GetId(config, prebidStorageManager, _logInfo, _logWarn) {
       promise.then((result) => {
         logInfo('Refresh reponded, passing the updated token on.', result);
         cb(result);
-      }).catch(() => {});
+      }).catch((e) => {
+								logError('error refreshing token: ', e);
+						});
     } };
   }
   // If should refresh (but don't need to), refresh in the background.
   if (Date.now() > newestAvailableToken.refresh_from) {
     logInfo(`Refreshing token in background with low priority.`);
     refreshTokenAndStore(config.apiBaseUrl, newestAvailableToken, config.clientId, storageManager, logInfo, _logWarn)
-      .catch(() => {});
+      .catch((e) => {
+								logError('error refreshing token in background: ', e);
+						});
   }
   const tokens = {
     originalToken: suppliedToken ?? storedTokens?.originalToken,


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
- [X] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This changes adds logging of errors that are caught during token generation and refresh.  There was a recent change to catch the error so it stops spamming the test files, but the errors were not being logged anywhere in test or production.  Adding the logError function in the catch statements to log the error keeps them silent in the tests.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
