### PR TITLE
OMS Bid Adapter: remove bidderRequest.userId

### DIFF
--- a/modules/omsBidAdapter.js
+++ b/modules/omsBidAdapter.js
@@ -126,10 +126,6 @@ function buildRequests(bidReqs, bidderRequest) {
       deepSetValue(payload, 'user.ext.eids', bidReqs[0].userIdAsEids || [])
     }
 
-    if (bidReqs?.[0].userId) {
-      deepSetValue(payload, 'user.ext.ids', bidReqs[0].userId || [])
-    }
-
     if (bidderRequest?.ortb2?.site?.content) {
       deepSetValue(payload, 'site.content', bidderRequest.ortb2.site.content)
     }

--- a/test/spec/modules/omsBidAdapter_spec.js
+++ b/test/spec/modules/omsBidAdapter_spec.js
@@ -273,22 +273,6 @@ describe('omsBidAdapter', function () {
       expect(data.user.ext.eids).to.deep.equal(bidRequests[0].userIdAsEids);
     });
 
-    it('sends user id parameters', function () {
-      const userId = {
-        sharedid: {
-          id: '01*******',
-          third: '01E*******'
-        }
-      };
-
-      bidRequests[0].userId = userId;
-
-      const data = JSON.parse(spec.buildRequests(bidRequests).data);
-      expect(data.user).to.not.be.undefined;
-      expect(data.user.ext).to.not.be.undefined;
-      expect(data.user.ext.ids).is.deep.equal(userId);
-    });
-
     it('sends gpid parameters', function () {
       bidRequests[0].ortb2Imp = {
         'ext': {


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter 

## Description of change
We received email with next message:
> This is as a reminder that bidderRequest.{}.userId will be deprecated in our upcoming release of Prebid 10.0 later this month. We recommend utilizing bidderRequest.{}.userIdAsEids instead as this is prefered. 

So, we remove userId and leave only userIdAsEids in adapter code and tests.
