### PR TITLE
TTD Bid Adapter: accept 64 character publisher id

### DIFF
--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -319,8 +319,8 @@ export const spec = {
       utils.logWarn(BIDDER_CODE + ': Missing required parameter params.publisherId');
       return false;
     }
-    if (bid.params.publisherId.length > 32) {
-      utils.logWarn(BIDDER_CODE + ': params.publisherId must be 32 characters or less');
+    if (bid.params.publisherId.length > 64) {
+      utils.logWarn(BIDDER_CODE + ': params.publisherId must be 64 characters or less');
       return false;
     }
 

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -55,8 +55,14 @@ describe('ttdBidAdapter', function () {
 
       it('should return false when publisherId is longer than 64 characters', function () {
         let bid = makeBid();
-        bid.params.publisherId = '1111111111111111111111111111111111111111111111111111111111111111111111';
+        bid.params.publisherId = '1'.repeat(65);
         expect(spec.isBidRequestValid(bid)).to.equal(false);
+      });
+
+      it('should return true when publisherId is equal to 64 characters', function () {
+        let bid = makeBid();
+        bid.params.publisherId = '1'.repeat(64);
+        expect(spec.isBidRequestValid(bid)).to.equal(true);
       });
 
       it('should return true if placementId is not passed and gpid is passed', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
Modifying the TTD prebid adapter validation logic to increase the allowed publisherId length from 32 to 64 characters.
