### PR TITLE
Magnite Analytics Adapter: fix falsy meta.mediaType overriding valid mediaType

### DIFF
--- a/modules/magniteAnalyticsAdapter.js
+++ b/modules/magniteAnalyticsAdapter.js
@@ -264,7 +264,7 @@ export const parseBidResponse = (bid, previousBidResponse) => {
   return pick(bid, [
     'bidPriceUSD', () => responsePrice,
     'dealId', dealId => dealId || undefined,
-    'mediaType', () => bid?.meta?.mediaType ?? bid.mediaType,
+    'mediaType', () => bid?.meta?.mediaType || bid.mediaType,
     'ogMediaType', () => bid?.meta?.mediaType && bid.mediaType !== bid?.meta?.mediaType ? bid.mediaType : undefined,
     'dimensions', () => {
       const width = bid.width || bid.playerWidth;


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix

## Description of change
Fixes an issue where falsy values (like null) in bid.meta?.mediaType were incorrectly prioritized over valid bid.mediaType due to use of the nullish coalescing operator (??). This caused mediaType to be dropped from some winning bids starting around 2025-04-28 05:00:00, as reported by the Finance team.

The logic now correctly falls back to bid.mediaType only when bid.meta?.mediaType is falsy (undefined, null, '', etc.) by using the logical OR (||) operator.

This restores correct mediaType population in the analytics adapter for affected bids.
