### PR TITLE
Start.io Bid Adapter : implement support for coppa, usp, floors and ortb_blocking features

### DIFF
--- a/modules/startioBidAdapter.js
+++ b/modules/startioBidAdapter.js
@@ -1,6 +1,7 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO, NATIVE } from '../src/mediaTypes.js';
-import { logError } from '../src/utils.js';
+import { config } from '../src/config.js';
+import { logError, isFn, isPlainObject } from '../src/utils.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js'
 import { ortb25Translator } from '../libraries/ortb2.5Translator/translator.js';
 
@@ -18,11 +19,18 @@ const converter = ortbConverter({
       imp.banner.h ??= imp.banner.format[0]?.h;
     }
 
+    const floor = getBidFloor(bidRequest);
+    if (floor) {
+      imp.bidfloor = floor;
+      imp.bidfloorcur = 'USD';
+    }
+
     return imp;
   },
   request(buildRequest, imps, bidderRequest, context) {
     const request = buildRequest(imps, bidderRequest, context);
-    const publisherId = bidderRequest?.bids?.[0]?.params?.publisherId;
+    const bidParams = context?.bidParams;
+    const publisherId = bidParams?.publisherId;
     if (request?.site) {
       request.site.publisher = request.site.publisher || {};
       request.site.publisher.id = publisherId;
@@ -32,6 +40,25 @@ const converter = ortbConverter({
     }
     request.ext = request.ext || {};
     request.ext.prebid = request.ext.prebid || {};
+
+    request.regs ??= {};
+    request.regs.coppa = config.getConfig('coppa') === true ? 1 : 0;
+
+    if (bidderRequest.uspConsent) {
+      request.regs.ext ??= {};
+      request.regs.ext.us_privacy = bidderRequest.uspConsent;
+    }
+
+    const ortb = bidderRequest.ortb2;
+    request.bcat = ortb?.bcat || bidParams?.bcat;
+    request.badv = ortb?.badv || bidParams?.badv;
+    request.bapp = ortb?.bapp || bidParams?.bapp;
+
+    spec.supportedMediaTypes.forEach(mediaType => {
+      if (request.imp[0].hasOwnProperty(mediaType)) {
+        request.imp[0][mediaType].battr ??= ortb?.[mediaType]?.battr || bidParams?.battr;
+      }
+    })
 
     return request;
   },
@@ -56,16 +83,38 @@ const converter = ortbConverter({
   translator: ortb25Translator()
 });
 
+function getBidFloor(bid) {
+  if (isFn(bid.getFloor)) {
+    const floor = bid.getFloor({
+      currency: 'USD',
+      mediaType: '*',
+      size: '*'
+    });
+    if (isPlainObject(floor) && !isNaN(floor.floor) && floor.currency === 'USD') {
+      return floor.floor;
+    }
+  }
+  return bid.params?.floor;
+}
+
+function isValidBidFloorCurrency(bid) {
+  return !bid.ortb2Imp?.bidfloorcur || bid.ortb2Imp.bidfloorcur === 'USD';
+}
+
 export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: [VIDEO, BANNER, NATIVE],
   gvlid: GVLID,
-  isBidRequestValid: (bid) => !!bid,
+  isBidRequestValid: (bid) => !!bid && isValidBidFloorCurrency(bid),
 
   buildRequests: (bidRequests, bidderRequest) => {
     return bidRequests.map((bidRequest) => {
       const mediaType = Object.keys(bidRequest.mediaTypes || {})[0] || BANNER;
-      const data = converter.toORTB({ bidRequests: [bidRequest], bidderRequest, context: { mediaType } });
+      const data = converter.toORTB({
+        bidRequests: [bidRequest],
+        bidderRequest,
+        context: {mediaType, bidParams: bidRequest.params}
+      });
 
       return {
         method: METHOD,

--- a/modules/startioBidAdapter.js
+++ b/modules/startioBidAdapter.js
@@ -1,6 +1,5 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO, NATIVE } from '../src/mediaTypes.js';
-import { config } from '../src/config.js';
 import { logError, isFn, isPlainObject } from '../src/utils.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js'
 import { ortb25Translator } from '../libraries/ortb2.5Translator/translator.js';
@@ -41,15 +40,15 @@ const converter = ortbConverter({
     request.ext = request.ext || {};
     request.ext.prebid = request.ext.prebid || {};
 
+    const ortb = bidderRequest.ortb2;
     request.regs ??= {};
-    request.regs.coppa = config.getConfig('coppa') === true ? 1 : 0;
+    request.regs.coppa = ortb?.regs?.coppa;
 
     if (bidderRequest.uspConsent) {
       request.regs.ext ??= {};
       request.regs.ext.us_privacy = bidderRequest.uspConsent;
     }
 
-    const ortb = bidderRequest.ortb2;
     request.bcat = ortb?.bcat || bidParams?.bcat;
     request.badv = ortb?.badv || bidParams?.badv;
     request.bapp = ortb?.bapp || bidParams?.bapp;

--- a/test/spec/modules/startioBidAdapter_spec.js
+++ b/test/spec/modules/startioBidAdapter_spec.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import { spec } from 'modules/startioBidAdapter.js';
 import { BANNER, VIDEO, NATIVE } from 'src/mediaTypes.js';
 import {deepClone} from '../../../src/utils';
-import {config} from '../../../src/config';
 
 const DEFAULT_REQUEST_DATA = {
   adUnitCode: 'test-div',
@@ -249,13 +248,14 @@ describe('Prebid Adapter: Startio', function () {
       expect(request.regs.ext.us_privacy).to.equal('1YYN');
     });
 
-    it('should provide coppa according to config', () => {
-      config.setConfig({ coppa: false });
-      let request = spec.buildRequests([DEFAULT_REQUEST_DATA], DEFAULT_BIDDER_REQUEST)[0].data;
+    it('should provide coppa', () => {
+      let bidderRequest = deepClone(DEFAULT_BIDDER_REQUEST);
+      bidderRequest.ortb2 = {regs: {coppa: 0}};
+      let request = spec.buildRequests([DEFAULT_REQUEST_DATA], bidderRequest)[0].data;
       expect(request.regs.coppa).to.equal(0);
 
-      config.setConfig({ coppa: true });
-      request = spec.buildRequests([DEFAULT_REQUEST_DATA], DEFAULT_BIDDER_REQUEST)[0].data;
+      bidderRequest.ortb2 = {regs: {coppa: 1}};
+      request = spec.buildRequests([DEFAULT_REQUEST_DATA], bidderRequest)[0].data;
       expect(request.regs.coppa).to.equal(1);
     });
 

--- a/test/spec/modules/startioBidAdapter_spec.js
+++ b/test/spec/modules/startioBidAdapter_spec.js
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import { spec } from 'modules/startioBidAdapter.js';
 import { BANNER, VIDEO, NATIVE } from 'src/mediaTypes.js';
+import {deepClone} from '../../../src/utils';
+import {config} from '../../../src/config';
 
 const DEFAULT_REQUEST_DATA = {
   adUnitCode: 'test-div',
@@ -61,6 +63,10 @@ const VALID_MEDIA_TYPES_REQUESTS = {
     },
   }]
 }
+
+const DEFAULT_BIDDER_REQUEST = {
+  refererInfo: { referer: 'https://example.com' },
+};
 
 const VALID_BIDDER_REQUEST = {
   auctionId: '19c97f22-5bd1-4b16-a128-80f75fb0a8a0',
@@ -180,16 +186,30 @@ describe('Prebid Adapter: Startio', function () {
       };
       expect(spec.isBidRequestValid(bidRequest)).to.eql(true);
     });
+    it('should verify bidFloorCur for bid request', function () {
+      const bidRequestUSD = {
+        bidder: 'startio',
+        ortb2Imp: {
+          bidfloorcur: 'USD'
+        }
+      };
+      expect(spec.isBidRequestValid(bidRequestUSD)).to.eql(true);
+
+      const bidRequestEUR = {
+        bidder: 'startio',
+        ortb2Imp: {
+          bidfloorcur: 'EUR'
+        }
+      };
+      expect(spec.isBidRequestValid(bidRequestEUR)).to.eql(false);
+    });
   });
 
   describe('buildRequests', function () {
     it('should build request for banner media type', function () {
       const bidRequest = VALID_MEDIA_TYPES_REQUESTS[BANNER][0];
-      const bidderRequest = {
-        refererInfo: { referer: 'https://example.com' },
-      };
 
-      const requests = spec.buildRequests([bidRequest], bidderRequest);
+      const requests = spec.buildRequests([bidRequest], DEFAULT_BIDDER_REQUEST);
 
       expect(requests).to.have.lengthOf(1);
       const request = requests[0];
@@ -198,14 +218,80 @@ describe('Prebid Adapter: Startio', function () {
       expect(request.data.imp[0].banner.w).to.equal(300);
       expect(request.data.imp[0].banner.h).to.equal(250);
     });
+
+    it('should provide bidfloor when either bid param or getFloor function exists', function () {
+      let bidRequest = deepClone(DEFAULT_REQUEST_DATA);
+
+      // with no param or getFloor bidfloor is not specified
+      let request = spec.buildRequests([bidRequest], DEFAULT_BIDDER_REQUEST)[0].data;
+      expect(request.imp[0].bidfloor).to.not.exist;
+      expect(request.imp[0].bidfloorcur).to.not.exist;
+
+      // with param and no getFloor bidfloor uses value from param
+      bidRequest.params.floor = 1.3;
+      request = spec.buildRequests([bidRequest], DEFAULT_BIDDER_REQUEST)[0].data;
+      expect(request.imp[0].bidfloor).to.equal(1.3);
+      expect(request.imp[0].bidfloorcur).to.equal('USD');
+
+      // with param and getFloor bidfloor uses value form getFloor
+      bidRequest.getFloor = () => { return { currency: 'USD', floor: 2.4 }; };
+      request = spec.buildRequests([bidRequest], DEFAULT_BIDDER_REQUEST)[0].data;
+      expect(request.imp[0].bidfloor).to.equal(2.4);
+      expect(request.imp[0].bidfloorcur).to.equal('USD');
+    });
+
+    it('should provide us_privacy', function () {
+      let bidderRequest = deepClone(DEFAULT_BIDDER_REQUEST);
+
+      bidderRequest.uspConsent = '1YYN';
+      const request = spec.buildRequests([DEFAULT_REQUEST_DATA], bidderRequest)[0].data;
+
+      expect(request.regs.ext.us_privacy).to.equal('1YYN');
+    });
+
+    it('should provide coppa according to config', () => {
+      config.setConfig({ coppa: false });
+      let request = spec.buildRequests([DEFAULT_REQUEST_DATA], DEFAULT_BIDDER_REQUEST)[0].data;
+      expect(request.regs.coppa).to.equal(0);
+
+      config.setConfig({ coppa: true });
+      request = spec.buildRequests([DEFAULT_REQUEST_DATA], DEFAULT_BIDDER_REQUEST)[0].data;
+      expect(request.regs.coppa).to.equal(1);
+    });
+
+    it('should provide blocked parameters', function () {
+      let bidRequest = deepClone(DEFAULT_REQUEST_DATA);
+      let bidderRequest = deepClone(DEFAULT_BIDDER_REQUEST);
+
+      bidRequest.params.bcat = ['IAB25', 'IAB7-39'];
+      bidRequest.params.bapp = ['com.bad.app1'];
+      bidRequest.params.badv = ['competitor1.com', 'badsite1.net'];
+      bidRequest.params.battr = [1, 2];
+
+      let request = spec.buildRequests([bidRequest], bidderRequest)[0].data;
+      expect(request.bcat).to.deep.equal(['IAB25', 'IAB7-39']);
+      expect(request.bapp).to.deep.equal(['com.bad.app1']);
+      expect(request.badv).to.deep.equal(['competitor1.com', 'badsite1.net']);
+      expect(request.imp[0].banner.battr).to.deep.equal([1, 2]);
+
+      bidderRequest.ortb2 = {
+        bcat: ['IAB1', 'IAB2'],
+        bapp: ['com.bad.app2'],
+        badv: ['competitor2.com', 'badsite2.net'],
+        banner: { battr: [3, 4] }
+      };
+      request = spec.buildRequests([bidRequest], bidderRequest)[0].data;
+      expect(request.bcat).to.deep.equal(['IAB1', 'IAB2']);
+      expect(request.bapp).to.deep.equal(['com.bad.app2']);
+      expect(request.badv).to.deep.equal(['competitor2.com', 'badsite2.net']);
+      expect(request.imp[0].banner.battr).to.deep.equal([3, 4]);
+    });
+
     if (FEATURES.VIDEO) {
       it('should build request for video media type', function () {
         const bidRequest = VALID_MEDIA_TYPES_REQUESTS[VIDEO][0];
-        const bidderRequest = {
-          refererInfo: { referer: 'https://example.com' },
-        };
 
-        const requests = spec.buildRequests([bidRequest], bidderRequest);
+        const requests = spec.buildRequests([bidRequest], DEFAULT_BIDDER_REQUEST);
 
         expect(requests).to.have.lengthOf(1);
         const request = requests[0];
@@ -219,11 +305,8 @@ describe('Prebid Adapter: Startio', function () {
     if (FEATURES.NATIVE) {
       it('should build request for native media type', function () {
         const bidRequest = VALID_MEDIA_TYPES_REQUESTS[NATIVE][0];
-        const bidderRequest = {
-          refererInfo: { referer: 'https://example.com' },
-        };
 
-        const requests = spec.buildRequests([bidRequest], bidderRequest);
+        const requests = spec.buildRequests([bidRequest], DEFAULT_BIDDER_REQUEST);
 
         expect(requests).to.have.lengthOf(1);
         const request = requests[0];


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [x] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Implement support for the following features:
- `coppa_supported`
- `floors_supported`
- `usp_supported`
- `ortb_blocking_supported`

Maintainer: [prebid@start.io](mailto:prebid@start.io)

## Other information
- Docs - https://github.com/prebid/prebid.github.io/pull/6110
