### PR TITLE
Build Config: Add ES5 flag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,21 @@ gulp build-bundle-dev --modules=bidderA,module1,...
 
 The results will be in build/dev/prebid.js.
 
+## ES5 Output Support
+
+For compatibility with older parsers or environments that require ES5 syntax, you can generate ES5-compatible output using the `--ES5` flag:
+
+```bash
+gulp build-bundle-dev --modules=bidderA,module1,... --ES5
+```
+
+This will:
+- Transpile all code to ES5 syntax using CommonJS modules
+- Target browsers: IE11+, Chrome 50+, Firefox 50+, Safari 10+
+- Ensure compatibility with older JavaScript parsers
+
+**Note:** Without the `--ES5` flag, the build will use modern ES6+ syntax by default for better performance and smaller bundle sizes.
+
 ## Test locally
 
 To lint the code:

--- a/babelConfig.js
+++ b/babelConfig.js
@@ -1,5 +1,6 @@
 
 let path = require('path');
+var argv = require('yargs').argv;
 
 function useLocal(module) {
   return require.resolve(module, {
@@ -10,6 +11,9 @@ function useLocal(module) {
 }
 
 module.exports = function (options = {}) {
+
+  const isES5Mode = argv.ES5 || options.ES5;
+
   return {
     'presets': [
       [
@@ -17,8 +21,13 @@ module.exports = function (options = {}) {
         {
           'useBuiltIns': 'entry',
           'corejs': '3.42.0',
-          // a lot of tests use sinon.stub & others that stopped working on ES6 modules with webpack 5
-          'modules': options.test ? 'commonjs' : 'auto',
+          // Use ES5 mode if requested, otherwise use original logic
+          'modules': isES5Mode ? 'commonjs' : (options.test ? 'commonjs' : 'auto'),
+          ...(isES5Mode && {
+            'targets': {
+              'browsers': ['ie >= 11', 'chrome >= 50', 'firefox >= 50', 'safari >= 10']
+            }
+          })
         }
       ]
     ],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -165,8 +165,12 @@ function makeDevpackPkg(config = webpackConfig) {
       mode: 'development'
     })
 
-    const babelConfig = require('./babelConfig.js')({disableFeatures: helpers.getDisabledFeatures(), prebidDistUrlBase: argv.distUrlBase || '/build/dev/'});
-
+    const babelConfig = require('./babelConfig.js')({
+      disableFeatures: helpers.getDisabledFeatures(), 
+      prebidDistUrlBase: argv.distUrlBase || '/build/dev/',
+      ES5: argv.ES5 // Pass ES5 flag to babel config
+    });
+    
     // update babel config to set local dist url
     cloned.module.rules
       .flatMap((rule) => rule.use)

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -10,6 +10,9 @@ const fs = require('fs');
 const babelConfig = require('./babelConfig.js')({disableFeatures: helpers.getDisabledFeatures(), prebidDistUrlBase: argv.distUrlBase});
 const {WebpackManifestPlugin} = require('webpack-manifest-plugin')
 
+// Check if ES5 mode is requested
+const isES5Mode = argv.ES5;
+
 var plugins = [
   new webpack.EnvironmentPlugin({'LiveConnectMode': null}),
   new WebpackManifestPlugin({
@@ -41,6 +44,7 @@ if (argv.analyze) {
 module.exports = {
   mode: 'production',
   devtool: 'source-map',
+  target: isES5Mode ? ['web', 'es5'] : 'web',
   cache: {
     type: 'filesystem',
     cacheDirectory: path.resolve(__dirname, '.cache/webpack')
@@ -79,7 +83,7 @@ module.exports = {
     rules: [
       {
         test: /\.js$/,
-        exclude: path.resolve('./node_modules'), // required to prevent loader from choking non-Prebid.js node_modules
+        exclude: isES5Mode ? [] : path.resolve('./node_modules'), // In ES5 mode, process all files
         use: [
           {
             loader: 'babel-loader',
@@ -91,8 +95,8 @@ module.exports = {
           }
         ]
       },
-      { // This makes sure babel-loader is ran on our intended Prebid.js modules that happen to be in node_modules
-        test: /\.js$/,
+      // Only apply the second rule if not in ES5 mode
+      ...(isES5Mode ? [] : [{
         include: helpers.getArgModules().map(module => new RegExp('node_modules/' + module + '/')),
         use: [
           {
@@ -100,7 +104,7 @@ module.exports = {
             options: Object.assign({cacheDirectory: cacheDir, cacheCompression: false}, babelConfig)
           }
         ],
-      }
+      }])
     ]
   },
   optimization: {
@@ -110,8 +114,16 @@ module.exports = {
       new TerserPlugin({
         extractComments: false, // do not generate unhelpful LICENSE comment
         terserOptions: {
-          module: true, // do not prepend every module with 'use strict'; allow mangling of top-level locals
-        }
+          module: isES5Mode ? false : true, // Force ES5 output if ES5 mode is enabled
+          ...(isES5Mode && {
+            ecma: 5, // Target ES5
+            compress: {
+              ecma: 5 // Ensure compression targets ES5
+            },
+            mangle: {
+              safari10: true // Ensure compatibility with older browsers
+            }
+          })        }
       })
     ],
     splitChunks: {


### PR DESCRIPTION
- Added support for an ES5 mode in babelConfig.js, allowing for transpilation to ES5 syntax when the `--ES5` flag is used.
- Updated gulpfile.js and webpack.conf.js to pass the ES5 flag and adjust module handling accordingly.
- Enhanced README.md to document the new ES5 output feature and its usage.

This change improves compatibility with older browsers and environments requiring ES5 syntax.

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
This pull request introduces an optional ES5 transpilation mode for Prebid.js.

- Adds support for an `--ES5` flag in `babelConfig.js`, enabling output compatible with ES5 environments.
- Updates `gulpfile.js` and `webpack.conf.js` to conditionally handle ES5 builds.
- Enhances `README.md` to document the ES5 build process and usage instructions.

This change improves compatibility with older browsers that do not support ES6+ features.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
N/A
