### PR TITLE
IX bid adapter: support device.geo, e.g. from geolocationRtdProvider

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -1188,6 +1188,11 @@ function addFPD(bidderRequest, r, fpd, site, user) {
     if (ipv6) {
       deepSetValue(r, 'device.ipv6', ipv6);
     }
+
+    const geo = fpd.device.geo;
+    if (geo) {
+      deepSetValue(r, 'device.geo', geo);
+    }
   }
 
   // regulations from ortb2

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -5432,6 +5432,32 @@ describe('IndexexchangeAdapter', function () {
       expect(payload.device.ip).to.be.undefined;
       expect(payload.device.ip6).to.be.undefined;
     });
+
+    it('should add device.geo if available in fpd', () => {
+      const ortb2 = {
+        device: {
+          geo: {
+            lat: 1,
+            lon: 2,
+            lastfix: 1,
+            type: 1
+          }
+        }
+      };
+      const request = spec.buildRequests(DEFAULT_BANNER_VALID_BID, { ortb2 })[0];
+      const payload = extractPayload(request);
+      expect(payload.device.geo.lat).to.equal(1);
+      expect(payload.device.geo.lon).to.equal(2);
+      expect(payload.device.geo.lastfix).to.equal(1);
+      expect(payload.device.geo.type).to.equal(1);
+    });
+
+    it('should not add device.geo if it does not exist', () => {
+      const ortb2 = {device: {}};
+      const request = spec.buildRequests(DEFAULT_BANNER_VALID_BID, { ortb2 })[0];
+      const payload = extractPayload(request);
+      expect(payload.device.geo).to.be.undefined;
+    });
   });
 
   describe('fetch requests', function () {


### PR DESCRIPTION
Add support for `device.geo` in the IX bid adapter, e.g. when the geolocationRtdProvider has set it in ortb2Fragments.

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
