### PR TITLE
Core: limit circleci test conditions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,10 +79,36 @@ workflows:
   version: 2
   commit:
     jobs:
-      - build
+      # workflows run only on master, legacy branches, or branches beginning
+      # with prebid-. Updated by Codex agent.
+      - build:
+          filters:
+            branches:
+              only:
+                - master
+                - /.*legacy.*/
+                - /prebid-.*/
+            pull_requests:
+              branches:
+                only:
+                  - master
+                  - /.*legacy.*/
+                  - /prebid-.*/
       - e2etest:
           requires:
             - build
+          filters:
+            branches:
+              only:
+                - master
+                - /.*legacy.*/
+                - /prebid-.*/
+            pull_requests:
+              branches:
+                only:
+                  - master
+                  - /.*legacy.*/
+                  - /prebid-.*/
 
 experimental:
   pipelines: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,6 @@ workflows:
               only:
                 - master
                 - /.*legacy.*/
-                - /prebid-.*/
             pull_requests:
               branches:
                 only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ workflows:
   commit:
     jobs:
       # workflows run only on master, legacy branches, or branches beginning
-      # with prebid-. Updated by Codex agent.
+      # with prebid-.
       - build:
           filters:
             branches:


### PR DESCRIPTION
adds some filtering to when circleci should run. Not sure how to validate it works without merging. Reference: https://support.circleci.com/hc/en-us/articles/115015953868-Filter-workflows-by-branch