### PR TITLE
Build system: fix source maps for coverage reports

### DIFF
--- a/gulp.precompilation.js
+++ b/gulp.precompilation.js
@@ -31,7 +31,9 @@ function babelPrecomp({distUrlBase = null, disableFeatures = null, dev = false} 
       return gulp.src(helpers.getSourcePatterns(), {base: '.', since: gulp.lastRun(precompile)})
         .pipe(sourcemaps.init())
         .pipe(babel(babelConfig))
-        .pipe(sourcemaps.write('.'))
+        .pipe(sourcemaps.write('.', {
+          sourceRoot: path.relative(helpers.getPrecompiledPath(), path.resolve('.'))
+        }))
         .pipe(gulp.dest(helpers.getPrecompiledPath()));
     }
     PRECOMP_TASKS.set(key, precompile)


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes

## Description of change

Adjust source map settings to allow coverage to find the actual source file (instead of the precompiled one).

## Other information

https://coveralls.io/github/prebid/Prebid.js
