### PR TITLE
Yieldlab Bid Adapter: pass on net revenue info

### DIFF
--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -196,7 +196,7 @@ export const spec = {
           creativeId: '' + matchedBid.id,
           dealId: (matchedBid['c.dealid']) ? matchedBid['c.dealid'] : matchedBid.pid,
           currency: CURRENCY_CODE,
-          netRevenue: false,
+          netRevenue: matchedBid.netRevenue,
           ttl: BID_RESPONSE_TTL_SEC,
           referrer: '',
           ad: `<script src="${ENDPOINT}/d/${matchedBid.id}/${bidRequest.params.supplyId}/?ts=${timestamp}${extId}${gdprApplies}${gdprConsent}${pvId}${iabContent}"></script>`,

--- a/test/spec/modules/yieldlabBidAdapter_spec.js
+++ b/test/spec/modules/yieldlabBidAdapter_spec.js
@@ -170,6 +170,7 @@ const RESPONSE = {
   pid: 2222,
   adsize: '728x90',
   adtype: 'BANNER',
+  netRevenue: false,
 };
 
 const NATIVE_RESPONSE = Object.assign({}, RESPONSE, {
@@ -855,6 +856,16 @@ describe('yieldlabBidAdapter', () => {
       expect(result[0].meta.dsa.transparency[0].domain).to.equal('test.com');
       expect(result[0].meta.dsa.transparency[0].dsaparams).to.deep.equal([1, 2, 3]);
       expect(result[0].meta.dsa.adrender).to.equal(1);
+    });
+
+    it('should set netRevenue correctly', () => {
+      const NET_REVENUE_RESPONSE = {
+        ...RESPONSE,
+        netRevenue: true,
+      };
+      const result = spec.interpretResponse({body: [NET_REVENUE_RESPONSE]}, {validBidRequests: [bidRequest], queryParams: REQPARAMS});
+
+      expect(result[0].netRevenue).to.equal(true);
     });
   });
 


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [x] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Instead of setting `netRevenue` to a static value of `false`, it is taken from the server's response.

## Other information

Should be reviewed by @flanaras, @nkloeber, or @rey1128.
