### PR TITLE
appnexus bid adapter - add support for tid

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -284,6 +284,18 @@ export const spec = {
       payload.keywords = auctionKeywords;
     }
 
+    if (ortb2?.source?.tid) {
+      if (!payload.source) {
+        payload.source = {
+          tid: ortb2.source.tid
+        };
+      } else {
+        Object.assign({}, payload.source, {
+          tid: ortb2.source.tid
+        });
+      }
+    }
+
     if (config.getConfig('adpod.brandCategoryExclusion')) {
       payload.brand_category_uniqueness = true;
     }
@@ -912,6 +924,11 @@ function bidToTag(bid) {
   let gpid = deepAccess(bid, 'ortb2Imp.ext.gpid');
   if (gpid) {
     tag.gpid = gpid;
+  }
+
+  let tid = deepAccess(bid, 'ortb2Imp.ext.tid');
+  if (tid) {
+    tag.tid = tid;
   }
 
   if (FEATURES.NATIVE && (bid.mediaType === NATIVE || deepAccess(bid, `mediaTypes.${NATIVE}`))) {

--- a/test/spec/modules/appnexusBidAdapter_spec.js
+++ b/test/spec/modules/appnexusBidAdapter_spec.js
@@ -1218,7 +1218,7 @@ describe('AppNexusAdapter', function () {
       const request = spec.buildRequests([bidRequest]);
       const payload = JSON.parse(request.data);
 
-      expect(payload.tags[0].gpid).to.exist.and.equal(testGpid)
+      expect(payload.tags[0].gpid).to.exist.and.equal(testGpid);
     });
 
     it('should add backup gpid to the request', function () {
@@ -1229,7 +1229,33 @@ describe('AppNexusAdapter', function () {
       const request = spec.buildRequests([bidRequest]);
       const payload = JSON.parse(request.data);
 
-      expect(payload.tags[0].gpid).to.exist.and.equal(testGpid)
+      expect(payload.tags[0].gpid).to.exist.and.equal(testGpid);
+    });
+
+    it('should add tid to the request', function () {
+      const testTid = '1234test';
+      let bidRequest = deepClone(bidRequests[0]);
+      bidRequest.ortb2Imp = { ext: { tid: testTid } };
+      // bidRequest.ortb2 = { source: { tid: testTid } };
+
+      const bidderRequest = {
+        'bidderCode': 'appnexus',
+        'auctionId': '1d1a030790a475',
+        'bidderRequestId': '22edbae2733bf6',
+        'timeout': 3000,
+        ortb2: {
+          source: {
+            tid: testTid
+          }
+        }
+      };
+      bidderRequest.bids = [bidRequest];
+
+      const request = spec.buildRequests([bidRequest], bidderRequest);
+      const payload = JSON.parse(request.data);
+
+      expect(payload.tags[0].tid).to.exist.and.equal(testTid);
+      expect(payload.source.tid).to.exist.and.equal(testTid);
     });
 
     it('should add gdpr consent information to the request', function () {


### PR DESCRIPTION


## Type of change
- [x] Updated bidder adapter 

## Description of change
This PR adds support to read the transactionID values set by Prebid.js and pass them along in the adserver request.