### PR TITLE
Gulp: Fix module resolution path and prevent duplicate Chunk processing during bundle task

### DIFF
--- a/gulpHelpers.js
+++ b/gulpHelpers.js
@@ -38,6 +38,12 @@ function isModuleDirectory(filePath) {
 }
 
 module.exports = {
+  getDevPath() {
+    return DEV_PATH
+  },
+  getBuildPath() {
+    return BUILD_PATH
+  },
   getSourceFolders() {
     return SOURCE_FOLDERS
   },
@@ -80,11 +86,11 @@ module.exports = {
 
     return modules;
   },
-  getModules: _.memoize(function(externalModules) {
+  getModules: _.memoize(function(externalModules, mPath) {
     externalModules = externalModules || [];
     var internalModules;
     try {
-      var absoluteModulePath = path.join(__dirname, MODULE_PATH);
+      var absoluteModulePath = path.join(__dirname, mPath ? mPath : MODULE_PATH);
       internalModules = fs.readdirSync(absoluteModulePath)
         .filter(file => (/^[^\.]+(\.js|\.tsx?)?$/).test(file))
         .reduce((memo, file) => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -226,7 +226,7 @@ function getModulesListToAddInBanner(modules) {
 }
 
 function gulpBundle(dev) {
-  return bundle(dev).pipe(gulp.dest('build/' + (dev ? 'dev' : 'dist')));
+  return bundle(dev, undefined, dev ? helpers.getDevPath() : helpers.getBuildPath()).pipe(gulp.dest('build/' + (dev ? 'dev' : 'dist')));
 }
 
 function nodeBundle(modules, dev = false) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -305,9 +305,9 @@ function disclosureSummary(modules, summaryFileName) {
 
 const MODULES_REQUIRING_METADATA = ['storageControl'];
 
-function bundle(dev, moduleArr) {
+function bundle(dev, moduleArr, mpath) {
   var modules = moduleArr || helpers.getArgModules();
-  var allModules = helpers.getModuleNames(modules);
+  var allModules = helpers.getModuleNames(modules, mpath);
   const sm = dev || argv.sourceMaps;
 
   if (modules.length === 0) {

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -140,7 +140,7 @@ module.exports = {
           })        }
       })
     ],
-    splitChunks: {
+    splitChunks: (argv._ && argv._.includes('bundle')) ? false : {
       chunks: 'initial',
       minChunks: 1,
       minSize: 0,


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes
## Description of change
<!-- Describe the change proposed in this pull request -->
**Corrected Module Resolution Path:**
Previously, the bundle process was incorrectly checking for module presence inside the `modules/` directory. This caused inconsistencies because the actual source of truth should be the `build/dist/` or `build/dev/` directories depending on the build environment. This issue has now been resolved.

**Avoid Duplicate chunk-core Generation:**
The `chunk-core` entry was being generated both during the build and again during the bundling phase. This led to unnecessary processing under the `splitChunk` logic in `webpack.conf.js`. The updated logic ensures that `chunk-core` is only handled during the actual build step, preventing redundant operations.


<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
