### PR TITLE
Build system: fix tests failing on PRs from forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - master
       - '*-legacy'
   pull_request_target:
+    branches:
+      - master
+      - '*-legacy'
 
 concurrency:
   group: test-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - '*-legacy'
-  pull_request:
+  pull_request_target:
 
 concurrency:
   group: test-${{ github.ref }}


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes

## Description of change

PRs from forks do not have access to browserstack (github secrets) - apparently they should if we use `pull_request_target` instead of `pull_request`.

