### PR TITLE
Build system: fix missing yargs dependency (9.53.x-legacy)

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,8 +123,7 @@
     "webpack": "^5.70.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-manifest-plugin": "^5.0.0",
-    "webpack-stream": "^7.0.0",
-    "yargs": "^1.3.1"
+    "webpack-stream": "^7.0.0"
   },
   "dependencies": {
     "@babel/core": "^7.27.4",
@@ -139,7 +138,8 @@
     "fun-hooks": "^1.1.0",
     "gulp-wrap": "^0.15.0",
     "klona": "^2.0.6",
-    "live-connect-js": "^7.2.0"
+    "live-connect-js": "^7.2.0",
+    "yargs": "^1.3.1"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

With https://github.com/prebid/Prebid.js/pull/13436 `yargs` needs to be a runtime dependency 

## Other information

Related: https://github.com/prebid/Prebid.js/pull/13519

 
