### PR TITLE
Sharethrough Bid Adapter: try reading user.ext.eids before getUserIdsAsEids

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -113,7 +113,7 @@ export const sharethroughAdapterSpec = {
 
     req.user = nullish(firstPartyData.user, {});
     if (!req.user.ext) req.user.ext = {};
-    req.user.ext.eids = bidRequests[0].userIdAsEids || [];
+    req.user.ext.eids = bidRequests?.[0]?.user?.ext?.eids || bidRequests[0].userIdAsEids || [];
 
     if (bidderRequest.gdprConsent) {
       const gdprApplies = bidderRequest.gdprConsent.gdprApplies === true;


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
As an RTD modules, optable inserts eids into user.ext.eids.
Sharethrough Bid Adapter specifically looks for .getUserIdsAsEids, dropping RTDs user.ext.eids in the process.
This PR first tries to look for user.ext.eids, before looking for .getUserIdsAsEids, and then defaulting to an empty array [].

