### PR TITLE
userId: alias requests' `.userIdAsEids` to `ortb2.user.ext.eids`

### DIFF
--- a/modules/userId/index.ts
+++ b/modules/userId/index.ts
@@ -607,6 +607,7 @@ function aliasEidsHook(next, bidderRequests) {
     bidderRequests.forEach(bidderRequest => {
         bidderRequest.bids.forEach(bid =>
             Object.defineProperty(bid, 'userIdAsEids', {
+                configurable: true,
                 get() {
                     return bidderRequest.ortb2.user?.ext?.eids;
                 }

--- a/test/spec/modules/idxIdSystem_spec.js
+++ b/test/spec/modules/idxIdSystem_spec.js
@@ -1,8 +1,5 @@
-import { expect } from 'chai';
-import { config } from 'src/config.js';
-import { init, startAuctionHook, setSubmoduleRegistry } from 'modules/userId/index.js';
-import { storage, idxIdSubmodule } from 'modules/idxIdSystem.js';
-import {mockGdprConsent} from '../../helpers/consentData.js';
+import {expect} from 'chai';
+import {idxIdSubmodule, storage} from 'modules/idxIdSystem.js';
 import 'src/prebid.js';
 
 const IDX_COOKIE_NAME = '_idx';
@@ -10,32 +7,6 @@ const IDX_DUMMY_VALUE = 'idx value for testing';
 const IDX_COOKIE_STORED = '{ "idx": "' + IDX_DUMMY_VALUE + '" }';
 const ID_COOKIE_OBJECT = { id: IDX_DUMMY_VALUE };
 const IDX_COOKIE_OBJECT = { idx: IDX_DUMMY_VALUE };
-
-function getConfigMock() {
-  return {
-    userSync: {
-      syncDelay: 0,
-      userIds: [{
-        name: 'idx'
-      }]
-    }
-  }
-}
-
-function getAdUnitMock(code = 'adUnit-code') {
-  return {
-    code,
-    mediaTypes: {banner: {}, native: {}},
-    sizes: [
-      [300, 200],
-      [300, 600]
-    ],
-    bids: [{
-      bidder: 'sampleBidder',
-      params: { placementId: 'banner-only-bidder' }
-    }]
-  };
-}
 
 describe('IDx ID System', () => {
   let getDataFromLocalStorageStub, localStorageIsEnabledStub;
@@ -81,48 +52,6 @@ describe('IDx ID System', () => {
 
     it('provides the IDx from a stored string', () => {
       expect(idxIdSubmodule.decode(IDX_DUMMY_VALUE)).to.deep.equal(IDX_COOKIE_OBJECT);
-    });
-  });
-
-  describe('requestBids hook', () => {
-    let adUnits;
-    let sandbox;
-
-    beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      mockGdprConsent(sandbox);
-      adUnits = [getAdUnitMock()];
-      init(config);
-      setSubmoduleRegistry([idxIdSubmodule]);
-      getCookieStub.withArgs(IDX_COOKIE_NAME).returns(IDX_COOKIE_STORED);
-      config.setConfig(getConfigMock());
-    });
-
-    afterEach(() => {
-      sandbox.restore();
-      config.resetConfig();
-    })
-
-    after(() => {
-      init(config);
-    })
-
-    it('when a stored IDx exists it is added to bids', (done) => {
-      startAuctionHook(() => {
-        adUnits.forEach(unit => {
-          unit.bids.forEach(bid => {
-            const idxIdAsEid = bid.userIdAsEids.find(e => e.source == 'idx.lat');
-            expect(idxIdAsEid).to.deep.equal({
-              source: 'idx.lat',
-              uids: [{
-                id: IDX_DUMMY_VALUE,
-                atype: 1,
-              }]
-            });
-          });
-        });
-        done();
-      }, { adUnits });
     });
   });
 });

--- a/test/spec/modules/lmpIdSystem_spec.js
+++ b/test/spec/modules/lmpIdSystem_spec.js
@@ -1,35 +1,5 @@
-import { expect } from 'chai';
-import { config } from 'src/config.js';
-import {init, startAuctionHook, setSubmoduleRegistry, resetUserIds} from 'modules/userId/index.js';
-import { storage, lmpIdSubmodule } from 'modules/lmpIdSystem.js';
-import { mockGdprConsent } from '../../helpers/consentData.js';
-import 'src/prebid.js';
-
-function getConfigMock() {
-  return {
-    userSync: {
-      syncDelay: 0,
-      userIds: [{
-        name: 'lmpid'
-      }]
-    }
-  }
-}
-
-function getAdUnitMock(code = 'adUnit-code') {
-  return {
-    code,
-    mediaTypes: { banner: {}, native: {} },
-    sizes: [
-      [300, 200],
-      [300, 600]
-    ],
-    bids: [{
-      bidder: 'sampleBidder',
-      params: { placementId: 'banner-only-bidder' }
-    }]
-  };
-}
+import {expect} from 'chai';
+import {lmpIdSubmodule, storage} from 'modules/lmpIdSystem.js';
 
 describe('LMPID System', () => {
   let getDataFromLocalStorageStub, localStorageIsEnabledStub;
@@ -79,53 +49,6 @@ describe('LMPID System', () => {
   describe('LMPID: test "decode" method', () => {
     it('provides the lmpid from a stored object', () => {
       expect(lmpIdSubmodule.decode('lmpid')).to.deep.equal({ lmpid: 'lmpid' });
-    });
-  });
-
-  describe('LMPID: requestBids hook', () => {
-    let adUnits;
-    let sandbox;
-
-    beforeEach(() => {
-      sandbox = sinon.createSandbox();
-      mockGdprConsent(sandbox);
-      adUnits = [getAdUnitMock()];
-      init(config);
-      setSubmoduleRegistry([lmpIdSubmodule]);
-      getDataFromLocalStorageStub.withArgs('__lmpid').returns('stored-lmpid');
-      localStorageIsEnabledStub.returns(true);
-      config.setConfig(getConfigMock());
-    });
-
-    afterEach(() => {
-      sandbox.restore();
-      config.resetConfig();
-    });
-
-    after(() => {
-      init(config);
-    })
-
-    after(() => {
-      resetUserIds();
-    })
-
-    it('when a stored LMPID exists it is added to bids', (done) => {
-      startAuctionHook(() => {
-        adUnits.forEach(unit => {
-          unit.bids.forEach(bid => {
-            const lmpidAsEid = bid.userIdAsEids.find(e => e.source == 'loblawmedia.ca');
-            expect(lmpidAsEid).to.deep.equal({
-              source: 'loblawmedia.ca',
-              uids: [{
-                id: 'stored-lmpid',
-                atype: 3,
-              }]
-            });
-          });
-        });
-        done();
-      }, { adUnits });
     });
   });
 });

--- a/test/spec/modules/sharedIdSystem_spec.js
+++ b/test/spec/modules/sharedIdSystem_spec.js
@@ -1,10 +1,10 @@
-import {sharedIdSystemSubmodule, storage} from 'modules/sharedIdSystem.js';
+import {sharedIdSystemSubmodule} from 'modules/sharedIdSystem.js';
 import {config} from 'src/config.js';
 
 import sinon from 'sinon';
 import * as utils from 'src/utils.js';
 import {createEidsArray} from '../../../modules/userId/eids.js';
-import {attachIdSystem, init} from '../../../modules/userId/index.js';
+import {attachIdSystem} from '../../../modules/userId/index.js';
 import {getGlobal} from '../../../src/prebidGlobal.js';
 
 let expect = require('chai').expect;
@@ -117,7 +117,7 @@ describe('SharedId System', function () {
           }]
         }
       });
-      await getGlobal().getUserIdsAsync();
+      await getGlobal().refreshUserIds();
       const eids = getGlobal().getUserIdsAsEids();
       sinon.assert.match(eids[0], {
         source: 'pubcid.org',

--- a/test/spec/modules/uid2IdSystem_helpers.js
+++ b/test/spec/modules/uid2IdSystem_helpers.js
@@ -12,6 +12,9 @@ export const cookieHelpers = {
 }
 
 export const runAuction = async () => {
+  // FIXME: this should preferably not call into base userId logic
+  // (it already has its own tests, so this makes it harder to refactor it)
+
   const adUnits = [{
     code: 'adUnit-code',
     mediaTypes: {banner: {}, native: {}},

--- a/test/spec/modules/uid2IdSystem_helpers.js
+++ b/test/spec/modules/uid2IdSystem_helpers.js
@@ -18,10 +18,13 @@ export const runAuction = async () => {
     sizes: [[300, 200], [300, 600]],
     bids: [{bidder: 'sampleBidder', params: {placementId: 'banner-only-bidder'}}]
   }];
+  const ortb2Fragments = {global: {}, bidder: {}};
   return new Promise(function(resolve) {
     startAuctionHook(function() {
-      resolve(adUnits[0].bids[0]);
-    }, {adUnits});
+      const bid = Object.assign({}, adUnits[0].bids[0]);
+      bid.userIdAsEids = (ortb2Fragments.global.user?.ext?.eids ?? []).concat(ortb2Fragments.bidder[bid.bidder]?.user?.ext?.eids ?? []);
+      resolve(bid);
+    }, {adUnits, ortb2Fragments});
   });
 }
 

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -3165,17 +3165,14 @@ describe('User ID', function () {
     });
 
     it('should warn and allow userId module to store data for enforceStorageType unset', () => {
-      const initialCookie = document.cookie;
       config.setConfig({userSync});
       const storage = getStorageManager({moduleType: MODULE_TYPE_UID, moduleName: UID_MODULE_NAME});
       storage.setCookie('cookieName', 'value', 20000);
       sinon.assert.calledWith(warnLogSpy, `${UID_MODULE_NAME} attempts to store data in ${STORAGE_TYPE_COOKIES} while configuration allows ${STORAGE_TYPE_LOCALSTORAGE}.`);
-      expect(initialCookie).to.not.deep.eql(document.cookie);
-      expect(document.cookie).to.deep.include('cookieName');
+      expect(storage.getCookie('cookieName')).to.eql('value');
     });
 
     it('should not allow userId module to store data for enforceStorageType set to true', () => {
-      const initialCookie = document.cookie;
       config.setConfig({
         userSync: {
           enforceStorageType: true,
@@ -3184,7 +3181,7 @@ describe('User ID', function () {
       })
       const storage = getStorageManager({moduleType: MODULE_TYPE_UID, moduleName: UID_MODULE_NAME});
       storage.setCookie('data', 'value', 20000);
-      expect(initialCookie).to.deep.eql(document.cookie);
+      expect(storage.getCookie('data')).to.not.exist;
     });
   });
 });

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -8,14 +8,13 @@ import {
   init,
   PBJS_USER_ID_OPTOUT_NAME,
   startAuctionHook,
-  addUserIdsHook,
   requestDataDeletion,
   setStoredValue,
   setSubmoduleRegistry,
   syncDelay, COOKIE_SUFFIXES, HTML5_SUFFIXES,
 } from 'modules/userId/index.js';
 import {UID1_EIDS} from 'libraries/uid1Eids/uid1Eids.js';
-import {createEidsArray, EID_CONFIG} from 'modules/userId/eids.js';
+import {createEidsArray, EID_CONFIG, getEids} from 'modules/userId/eids.js';
 import {config} from 'src/config.js';
 import * as utils from 'src/utils.js';
 import * as events from 'src/events.js';
@@ -177,7 +176,6 @@ describe('User ID', function () {
     sandbox.restore();
     config.resetConfig();
     startAuction.getHooks({hook: startAuctionHook}).remove();
-    startAuction.getHooks({hook: addUserIdsHook}).remove();
   });
 
   after(() => {
@@ -281,12 +279,12 @@ describe('User ID', function () {
       coreStorage.setCookie('pubcid_alt', '', EXPIRED_COOKIE_DATE);
     });
 
-    it('Check same cookie behavior', function () {
-      let adUnits1 = [getAdUnitMock()];
-      let adUnits2 = [getAdUnitMock()];
-      let innerAdUnits1;
-      let innerAdUnits2;
+    function getGlobalEids() {
+      const ortb2Fragments = {global: {}};
+      return expectImmediateBidHook(sinon.stub(), {ortb2Fragments}).then(() => ortb2Fragments.global.user?.ext?.eids);
+    }
 
+    it('Check same cookie behavior', async function () {
       let pubcid = coreStorage.getCookie('pubcid');
       expect(pubcid).to.be.null; // there should be no cookie initially
 
@@ -294,34 +292,19 @@ describe('User ID', function () {
       setSubmoduleRegistry([sharedIdSystemSubmodule]);
 
       config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie']));
-
-      return expectImmediateBidHook(config => {
-        innerAdUnits1 = config.adUnits
-      }, {adUnits: adUnits1}).then(() => {
-        pubcid = coreStorage.getCookie('pubcid'); // cookies is created after requestbidHook
-
-        innerAdUnits1.forEach(unit => {
-          unit.bids.forEach(bid => {
-            expect(bid.userIdAsEids[0]).to.deep.equal({
-              source: 'pubcid.org',
-              uids: [{id: pubcid, atype: 1}]
-            });
-          });
-        });
-
-        return expectImmediateBidHook(config => {
-          innerAdUnits2 = config.adUnits
-        }, {adUnits: adUnits2}).then(() => {
-          assert.deepEqual(innerAdUnits1, innerAdUnits2);
-        });
-      });
+      const eids1 = await getGlobalEids();
+      pubcid = coreStorage.getCookie('pubcid'); // cookies is created after requestbidHook
+      expect(eids1).to.eql([
+        {
+          source: 'pubcid.org',
+          uids: [{id: pubcid, atype: 1}]
+        }
+      ])
+      const eids2 = await getGlobalEids();
+      assert.deepEqual(eids1, eids2);
     });
 
-    it('Check different cookies', function () {
-      let adUnits1 = [getAdUnitMock()];
-      let adUnits2 = [getAdUnitMock()];
-      let innerAdUnits1;
-      let innerAdUnits2;
+    it('Check different cookies', async function () {
       let pubcid1;
       let pubcid2;
 
@@ -329,69 +312,41 @@ describe('User ID', function () {
       setSubmoduleRegistry([sharedIdSystemSubmodule]);
 
       config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie']));
-      return expectImmediateBidHook((config) => {
-        innerAdUnits1 = config.adUnits
-      }, {adUnits: adUnits1}).then(() => {
-        pubcid1 = coreStorage.getCookie('pubcid'); // get first cookie
-        coreStorage.setCookie('pubcid', '', EXPIRED_COOKIE_DATE); // erase cookie
 
-        innerAdUnits1.forEach((unit) => {
-          unit.bids.forEach((bid) => {
-            expect(bid.userIdAsEids[0]).to.deep.equal({
-              source: 'pubcid.org',
-              uids: [{id: pubcid1, atype: 1}]
-            });
-          });
-        });
+      const eids1 = await getGlobalEids()
+      pubcid1 = coreStorage.getCookie('pubcid'); // get first cookie
+      coreStorage.setCookie('pubcid', '', EXPIRED_COOKIE_DATE); // erase cookie
+      expect(eids1).to.eql([{
+        source: 'pubcid.org',
+        uids: [{id: pubcid1, atype: 1}]
+      }])
 
-        init(config);
-        setSubmoduleRegistry([sharedIdSystemSubmodule]);
+      init(config);
+      setSubmoduleRegistry([sharedIdSystemSubmodule]);
+      config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie']));
 
-        config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie']));
-        return expectImmediateBidHook((config) => {
-          innerAdUnits2 = config.adUnits
-        }, {adUnits: adUnits2}).then(() => {
-          pubcid2 = coreStorage.getCookie('pubcid'); // get second cookie
-
-          innerAdUnits2.forEach((unit) => {
-            unit.bids.forEach((bid) => {
-              expect(bid.userIdAsEids[0]).to.deep.equal({
-                source: 'pubcid.org',
-                uids: [{id: pubcid2, atype: 1}]
-              });
-            });
-          });
-
-          expect(pubcid1).to.not.equal(pubcid2);
-        });
-      });
+      const eids2 = await getGlobalEids();
+      pubcid2 = coreStorage.getCookie('pubcid'); // get second cookie
+      expect(eids2).to.eql([{
+        source: 'pubcid.org',
+        uids: [{id: pubcid2, atype: 1}]
+      }])
+      expect(pubcid1).to.not.equal(pubcid2);
     });
 
-    it('Use existing cookie', function () {
-      let adUnits = [getAdUnitMock()];
-      let innerAdUnits;
-
+    it('Use existing cookie', async function () {
       init(config);
       setSubmoduleRegistry([sharedIdSystemSubmodule]);
 
       config.setConfig(getConfigMock(['pubCommonId', 'pubcid_alt', 'cookie']));
-      return expectImmediateBidHook((config) => {
-        innerAdUnits = config.adUnits
-      }, {adUnits}).then(() => {
-        innerAdUnits.forEach((unit) => {
-          unit.bids.forEach((bid) => {
-            expect(bid.userIdAsEids[0]).to.deep.equal({
-              source: 'pubcid.org',
-              uids: [{id: 'altpubcid200000', atype: 1}]
-            });
-          });
-        });
-      });
+      const eids = await getGlobalEids();
+      expect(eids).to.eql([{
+        source: 'pubcid.org',
+        uids: [{id: 'altpubcid200000', atype: 1}]
+      }])
     });
 
-    it('Extend cookie', function () {
-      let adUnits = [getAdUnitMock()];
-      let innerAdUnits;
+    it('Extend cookie', async function () {
       let customConfig = getConfigMock(['pubCommonId', 'pubcid_alt', 'cookie']);
       customConfig = addConfig(customConfig, 'params', {extend: true});
 
@@ -399,23 +354,15 @@ describe('User ID', function () {
       setSubmoduleRegistry([sharedIdSystemSubmodule]);
 
       config.setConfig(customConfig);
-      return expectImmediateBidHook((config) => {
-        innerAdUnits = config.adUnits
-      }, {adUnits}).then(() => {
-        innerAdUnits.forEach((unit) => {
-          unit.bids.forEach((bid) => {
-            expect(bid.userIdAsEids[0]).to.deep.equal({
-              source: 'pubcid.org',
-              uids: [{id: 'altpubcid200000', atype: 1}]
-            });
-          });
-        });
-      });
+      const fpd = {};
+      const eids = await getGlobalEids();
+      expect(eids).to.deep.equal([{
+        source: 'pubcid.org',
+        uids: [{id: 'altpubcid200000', atype: 1}]
+      }]);
     });
 
-    it('Disable auto create', function () {
-      let adUnits = [getAdUnitMock()];
-      let innerAdUnits;
+    it('Disable auto create', async function () {
       let customConfig = getConfigMock(['pubCommonId', 'pubcid', 'cookie']);
       customConfig = addConfig(customConfig, 'params', {create: false});
 
@@ -423,15 +370,8 @@ describe('User ID', function () {
       setSubmoduleRegistry([sharedIdSystemSubmodule]);
 
       config.setConfig(customConfig);
-      return expectImmediateBidHook((config) => {
-        innerAdUnits = config.adUnits
-      }, {adUnits}).then(() => {
-        innerAdUnits.forEach((unit) => {
-          unit.bids.forEach((bid) => {
-            expect(bid).to.not.have.deep.nested.property('userIdAsEids');
-          });
-        });
-      });
+      const eids = await getGlobalEids();
+      expect(eids).to.not.exist;
     });
 
     describe('createEidsArray', () => {
@@ -1827,68 +1767,39 @@ describe('User ID', function () {
       });
     });
 
-    describe('Start auction hook appends userId to bid objs in adapters', function () {
+    describe('Start auction hook appends userId to first party data', function () {
       let adUnits;
 
       beforeEach(function () {
         adUnits = [getAdUnitMock()];
       });
 
-      it('should include pub-provided eids in userIdAsEids', (done) => {
-        init(config);
-        setSubmoduleRegistry([createMockIdSubmodule('mockId', {id: {mockId: 'id'}}, null, {mockId: {source: 'mockid.com', atype: 1}})]);
-        config.setConfig({
-          userSync: {
-            userIds: [
-              {name: 'mockId'}
-            ]
-          }
-        });
-        startAuctionHook(({adUnits}) => {
-          adUnits[0].bids.forEach(bid => {
-            expect(bid.userIdAsEids.find(eid => eid.source === 'mockid.com')).to.exist;
-            const bidderEid = bid.userIdAsEids.find(eid => eid.bidder === 'pub-provided');
-            expect(bidderEid != null).to.eql(bid.bidder === 'sampleBidder');
-            expect(bid.userIdAsEids.find(eid => eid.id === 'pub-provided')).to.exist;
-          })
-          done();
-        }, {
-          adUnits,
-          ortb2Fragments: {
-            global: {
-              user: {ext: {eids: [{id: 'pub-provided'}]}}
-            },
-            bidder: {
-              sampleBidder: {
-                user: {ext: {eids: [{bidder: 'pub-provided'}]}}
-              }
-            }
-          }
+      function getGlobalEids() {
+        return new Promise((resolve) => {
+          startAuctionHook(function ({ortb2Fragments}) {
+            resolve(ortb2Fragments.global.user?.ext?.eids);
+          }, {ortb2Fragments: { global: {} }})
         })
-      })
+      }
 
-      it('test hook from pubcommonid cookie', function (done) {
+      it('test hook from pubcommonid cookie', async function () {
         coreStorage.setCookie('pubcid', 'testpubcid', (new Date(Date.now() + 100000).toUTCString()));
 
         init(config);
         setSubmoduleRegistry([sharedIdSystemSubmodule]);
         config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie']));
-
-        startAuctionHook(function () {
-          adUnits.forEach(unit => {
-            unit.bids.forEach(bid => {
-              expect(bid.userIdAsEids[0]).to.deep.equal({
-                source: 'pubcid.org',
-                uids: [{id: 'testpubcid', atype: 1}]
-              });
-            });
-          });
+        try {
+          const eids = await getGlobalEids();
+          expect(eids).to.eql([{
+            source: 'pubcid.org',
+            uids: [{id: 'testpubcid', atype: 1}]
+          }])
+        } finally {
           coreStorage.setCookie('pubcid', '', EXPIRED_COOKIE_DATE);
-          done();
-        }, {adUnits});
+        }
       });
 
-      it('test hook from pubcommonid html5', function (done) {
+      it('test hook from pubcommonid html5', async function () {
         // simulate existing browser local storage values
         localStorage.setItem('pubcid', 'testpubcid');
         localStorage.setItem('pubcid_exp', new Date(Date.now() + 100000).toUTCString());
@@ -1897,22 +1808,20 @@ describe('User ID', function () {
         setSubmoduleRegistry([sharedIdSystemSubmodule]);
         config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'html5']));
 
-        startAuctionHook(function () {
-          adUnits.forEach(unit => {
-            unit.bids.forEach(bid => {
-              expect(bid.userIdAsEids[0]).to.deep.equal({
-                source: 'pubcid.org',
-                uids: [{id: 'testpubcid', atype: 1}]
-              });
-            });
-          });
+        try {
+          const eids = await getGlobalEids();
+          expect(eids).to.eql([{
+            source: 'pubcid.org',
+            uids: [{id: 'testpubcid', atype: 1}]
+          }])
+
+        } finally {
           localStorage.removeItem('pubcid');
           localStorage.removeItem('pubcid_exp');
-          done();
-        }, {adUnits});
+        }
       });
 
-      it('test hook from pubcommonid cookie&html5', function (done) {
+      it('test hook from pubcommonid cookie&html5', async function () {
         const expiration = new Date(Date.now() + 100000).toUTCString();
         coreStorage.setCookie('pubcid', 'testpubcid', expiration);
         localStorage.setItem('pubcid', 'testpubcid');
@@ -1922,25 +1831,20 @@ describe('User ID', function () {
         setSubmoduleRegistry([sharedIdSystemSubmodule]);
         config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie&html5']));
 
-        startAuctionHook(function () {
-          adUnits.forEach(unit => {
-            unit.bids.forEach(bid => {
-              expect(bid.userIdAsEids[0]).to.deep.equal({
-                source: 'pubcid.org',
-                uids: [{id: 'testpubcid', atype: 1}]
-              });
-            });
-          });
-
+        try {
+          const eids = await getGlobalEids();
+          expect(eids).to.eql([{
+            source: 'pubcid.org',
+            uids: [{id: 'testpubcid', atype: 1}]
+          }]);
+        } finally {
           coreStorage.setCookie('pubcid', '', EXPIRED_COOKIE_DATE);
           localStorage.removeItem('pubcid');
           localStorage.removeItem('pubcid_exp');
-
-          done();
-        }, {adUnits});
+        }
       });
 
-      it('test hook from pubcommonid cookie&html5, no cookie present', function (done) {
+      it('test hook from pubcommonid cookie&html5, no cookie present', async function () {
         localStorage.setItem('pubcid', 'testpubcid');
         localStorage.setItem('pubcid_exp', new Date(Date.now() + 100000).toUTCString());
 
@@ -1948,62 +1852,44 @@ describe('User ID', function () {
         setSubmoduleRegistry([sharedIdSystemSubmodule]);
         config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie&html5']));
 
-        startAuctionHook(function () {
-          adUnits.forEach(unit => {
-            unit.bids.forEach(bid => {
-              expect(bid.userIdAsEids[0]).to.deep.equal({
-                source: 'pubcid.org',
-                uids: [{id: 'testpubcid', atype: 1}]
-              });
-            });
-          });
-
+        try {
+          const eids = await getGlobalEids();
+          expect(eids).to.eql([{
+            source: 'pubcid.org',
+            uids: [{id: 'testpubcid', atype: 1}]
+          }])
+        } finally {
           localStorage.removeItem('pubcid');
           localStorage.removeItem('pubcid_exp');
-
-          done();
-        }, {adUnits});
+        }
       });
 
-      it('test hook from pubcommonid cookie&html5, no local storage entry', function (done) {
+      it('test hook from pubcommonid cookie&html5, no local storage entry', async function () {
         coreStorage.setCookie('pubcid', 'testpubcid', (new Date(Date.now() + 100000).toUTCString()));
 
         init(config);
         setSubmoduleRegistry([sharedIdSystemSubmodule]);
         config.setConfig(getConfigMock(['pubCommonId', 'pubcid', 'cookie&html5']));
 
-        startAuctionHook(function () {
-          adUnits.forEach(unit => {
-            unit.bids.forEach(bid => {
-              expect(bid.userIdAsEids[0]).to.deep.equal({
-                source: 'pubcid.org',
-                uids: [{id: 'testpubcid', atype: 1}]
-              });
-            });
-          });
-
+        try {
+          const eids = await getGlobalEids();
+          expect(eids).to.eql([{
+            source: 'pubcid.org',
+            uids: [{id: 'testpubcid', atype: 1}]
+          }]);
+        } finally {
           coreStorage.setCookie('pubcid', '', EXPIRED_COOKIE_DATE);
-
-          done();
-        }, {adUnits});
+        }
       });
 
-      it('test hook from pubcommonid config value object', function (done) {
+      it('test hook from pubcommonid config value object', async function () {
         init(config);
         setSubmoduleRegistry([sharedIdSystemSubmodule]);
         config.setConfig(getConfigValueMock('pubCommonId', {'pubcidvalue': 'testpubcidvalue'}));
-
-        startAuctionHook(function () {
-          adUnits.forEach(unit => {
-            unit.bids.forEach(bid => {
-              expect(bid.userIdAsEids).to.not.exist; // "pubcidvalue" is an un-known submodule for USER_IDS_CONFIG in eids.js
-            });
-          });
-          done();
-        }, {adUnits});
+        expect(await getGlobalEids()).to.not.exist; // "pubcidvalue" is an un-known submodule for USER_IDS_CONFIG in eids.js
       });
 
-      it('test hook from pubProvidedId config params', function (done) {
+      it('test hook from pubProvidedId config params', async function () {
         init(config);
         setSubmoduleRegistry([pubProvidedIdSubmodule]);
         config.setConfig({
@@ -2046,34 +1932,29 @@ describe('User ID', function () {
           }
         });
 
-        startAuctionHook(function () {
-          adUnits.forEach(unit => {
-            unit.bids.forEach(bid => {
-              expect(bid.userIdAsEids[0]).to.deep.equal({
-                source: 'example.com',
-                uids: [{
-                  id: 'value read from cookie or local storage',
-                  ext: {
-                    stype: 'ppuid'
-                  }
-                }]
-              });
-              expect(bid.userIdAsEids[2]).to.deep.equal({
-                source: 'provider.com',
-                uids: [{
-                  id: 'value read from cookie or local storage',
-                  ext: {
-                    stype: 'sha256email'
-                  }
-                }]
-              });
-            });
+        const eids = await getGlobalEids();
+        expect(eids).to.deep.contain(
+          {
+            source: 'example.com',
+            uids: [{
+              id: 'value read from cookie or local storage',
+              ext: {
+                stype: 'ppuid'
+              }
+            }]
           });
-          done();
-        }, {adUnits});
+        expect(eids).to.deep.contain({
+          source: 'provider.com',
+          uids: [{
+            id: 'value read from cookie or local storage',
+            ext: {
+              stype: 'sha256email'
+            }
+          }]
+        });
       });
 
-      it('should add new id system ', function (done) {
+      it('should add new id system ', async function () {
         coreStorage.setCookie('pubcid', 'testpubcid', (new Date(Date.now() + 5000).toUTCString()));
 
         init(config);
@@ -2101,20 +1982,16 @@ describe('User ID', function () {
           getId: function (config, consentData, storedId) {
             if (storedId) return {};
             return {id: {'MOCKID': '1234'}};
+          },
+          eids: {
+            mid: {
+              source: 'mockid'
+            }
           }
         });
 
-        startAuctionHook(function () {
-          adUnits.forEach(unit => {
-            unit.bids.forEach(bid => {
-              // check id data was copied to bid
-              expect(bid).to.have.property('userIdAsEids');
-            });
-          });
-          coreStorage.setCookie('pubcid', '', EXPIRED_COOKIE_DATE);
-          coreStorage.setCookie('MOCKID', '', EXPIRED_COOKIE_DATE);
-          done();
-        }, {adUnits});
+        const eids = await getGlobalEids();
+        expect(eids.find(eid => eid.source === 'mockid')).to.exist;
       });
 
       describe('storage disclosure', () => {
@@ -2563,62 +2440,6 @@ describe('User ID', function () {
           })
         })
       })
-    });
-
-    describe('submodules not added', () => {
-      const eid = {
-        source: 'example.com',
-        uids: [{id: '1234', atype: 3}]
-      };
-      let adUnits;
-      let startAuctionStub;
-      function saHook(fn, ...args) {
-        return startAuctionStub(...args);
-      }
-      beforeEach(() => {
-        adUnits = [{code: 'au1', bids: [{bidder: 'sampleBidder'}]}];
-        startAuctionStub = sinon.stub();
-        startAuction.before(saHook);
-        config.resetConfig();
-      });
-      afterEach(() => {
-        startAuction.getHooks({hook: saHook}).remove();
-      })
-
-      it('addUserIdsHook', function (done) {
-        addUserIdsHook(function () {
-          adUnits.forEach(unit => {
-            unit.bids.forEach(bid => {
-              expect(bid).to.have.deep.nested.property('userIdAsEids.0.source');
-              expect(bid).to.have.deep.nested.property('userIdAsEids.0.uids.0.id');
-              expect(bid.userIdAsEids[0].source).to.equal('example.com');
-              expect(bid.userIdAsEids[0].uids[0].id).to.equal('1234');
-            });
-          });
-          done();
-        }, {
-          adUnits,
-          ortb2Fragments: {
-            global: {user: {ext: {eids: [eid]}}},
-            bidder: {}
-          }
-        });
-      });
-
-      it('should add userIdAsEids and merge ortb2.user.ext.eids even if no User ID submodules', async () => {
-        init(config);
-        expect(startAuction.getHooks({hook: startAuctionHook}).length).equal(0);
-        expect(startAuction.getHooks({hook: addUserIdsHook}).length).equal(1);
-        addUserIdsHook(sinon.stub(), {
-          adUnits,
-          ortb2Fragments: {
-            global: {
-              user: {ext: {eids: [eid]}}
-            }
-          }
-        });
-        expect(adUnits[0].bids[0].userIdAsEids[0]).to.eql(eid);
-      });
     });
   });
 
@@ -3220,12 +3041,6 @@ describe('User ID', function () {
       });
 
       return getGlobal().getUserIdsAsync().then(() => {
-        const adUnits = [{
-          bids: [
-            { bidder: 'bidderA' },
-            { bidder: 'bidderB' },
-          ]
-        }];
         const ortb2Fragments = {
           global: {
             user: {}
@@ -3239,13 +3054,7 @@ describe('User ID', function () {
             }
           }
         };
-        addIdData({ adUnits, ortb2Fragments });
-
-        adUnits[0].bids.forEach(({userIdAsEids}) => {
-          const userIdModules = (userIdAsEids || []).map(eid => eid.source.replace('.com', ''));
-          expect(userIdModules).to.include(ALLOWED_MODULE);
-          expect(userIdModules).to.not.include(UNALLOWED_MODULE);
-        });
+        addIdData({ ortb2Fragments });
 
         bidders.forEach((bidderName) => {
           const userIdModules = ortb2Fragments.bidder[bidderName].user.ext.eids.map(eid => eid.source);

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -1813,8 +1813,7 @@ describe('User ID', function () {
           expect(eids).to.eql([{
             source: 'pubcid.org',
             uids: [{id: 'testpubcid', atype: 1}]
-          }])
-
+          }]);
         } finally {
           localStorage.removeItem('pubcid');
           localStorage.removeItem('pubcid_exp');

--- a/test/spec/modules/zeotapIdPlusIdSystem_spec.js
+++ b/test/spec/modules/zeotapIdPlusIdSystem_spec.js
@@ -1,7 +1,6 @@
-import { expect } from 'chai';
-import { config } from 'src/config.js';
-import {attachIdSystem, init, startAuctionHook, setSubmoduleRegistry} from 'modules/userId/index.js';
-import { storage, getStorage, zeotapIdPlusSubmodule } from 'modules/zeotapIdPlusIdSystem.js';
+import {expect} from 'chai';
+import {attachIdSystem} from 'modules/userId/index.js';
+import {getStorage, storage, zeotapIdPlusSubmodule} from 'modules/zeotapIdPlusIdSystem.js';
 import * as storageManager from 'src/storageManager.js';
 import {MODULE_TYPE_UID} from '../../../src/activities/modules.js';
 import {createEidsArray} from '../../../modules/userId/eids.js';
@@ -10,32 +9,6 @@ import 'src/prebid.js';
 const ZEOTAP_COOKIE_NAME = 'IDP';
 const ZEOTAP_COOKIE = 'THIS-IS-A-DUMMY-COOKIE';
 const ENCODED_ZEOTAP_COOKIE = btoa(JSON.stringify(ZEOTAP_COOKIE));
-
-function getConfigMock() {
-  return {
-    userSync: {
-      syncDelay: 0,
-      userIds: [{
-        name: 'zeotapIdPlus'
-      }]
-    }
-  }
-}
-
-function getAdUnitMock(code = 'adUnit-code') {
-  return {
-    code,
-    mediaTypes: {banner: {}, native: {}},
-    sizes: [
-      [300, 200],
-      [300, 600]
-    ],
-    bids: [{
-      bidder: 'sampleBidder',
-      params: { placementId: 'banner-only-bidder' }
-    }]
-  };
-}
 
 function unsetCookie() {
   storage.setCookie(ZEOTAP_COOKIE_NAME, '');
@@ -155,43 +128,6 @@ describe('Zeotap ID System', function() {
     });
   });
 
-  describe('requestBids hook', function() {
-    let adUnits;
-
-    beforeEach(function() {
-      adUnits = [getAdUnitMock()];
-      storage.setCookie(
-        ZEOTAP_COOKIE_NAME,
-        ENCODED_ZEOTAP_COOKIE
-      );
-      init(config);
-      setSubmoduleRegistry([zeotapIdPlusSubmodule]);
-      config.setConfig(getConfigMock());
-    });
-
-    afterEach(function() {
-      unsetCookie();
-      unsetLocalStorage();
-    });
-
-    it('when a stored Zeotap ID exists it is added to bids', function(done) {
-      startAuctionHook(function() {
-        adUnits.forEach(unit => {
-          unit.bids.forEach(bid => {
-            const zeotapIdAsEid = bid.userIdAsEids.find(e => e.source == 'zeotap.com');
-            expect(zeotapIdAsEid).to.deep.equal({
-              source: 'zeotap.com',
-              uids: [{
-                id: ZEOTAP_COOKIE,
-                atype: 1,
-              }]
-            });
-          });
-        });
-        done();
-      }, { adUnits });
-    });
-  });
   describe('eids', () => {
     before(() => {
       attachIdSystem(zeotapIdPlusSubmodule);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

This changes bid requests' `.userIdAsEids` to a lazily evaluated reference to `.ortb2.user.ext.eids` (instead of a copy)

This is so that it reflects EIDs in first party data regardless of when they were added to it. For example, RTD modules run after userId, and can add EIDs.

## Other information

Related: https://github.com/prebid/Prebid.js/pull/13528
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
