### PR TITLE
EX.CO Adapter: Triggering pixels update

### DIFF
--- a/modules/excoBidAdapter.js
+++ b/modules/excoBidAdapter.js
@@ -21,7 +21,7 @@ export const ENDPOINT = 'https://v.ex.co/se/openrtb/hb/pbjs';
 const SYNC_URL = 'https://cdn.ex.co/sync/e15e216-l/cookie_sync.html';
 
 export const BIDDER_CODE = 'exco';
-const VERSION = '0.0.2';
+const VERSION = '0.0.3';
 const CURRENCY = 'USD';
 
 const SYNC = {
@@ -122,9 +122,10 @@ export class AdapterHelpers {
   adoptBidResponse(bidResponse, bid, context) {
     bidResponse.bidderCode = BIDDER_CODE;
 
-    bidResponse.vastXml = bidResponse.ad || bid.adm;
+    if (!bid.vastXml && bid.mediaType === VIDEO) {
+      bidResponse.vastXml = bidResponse.ad || bid.adm;
+    }
 
-    bidResponse.ad = bid.ad;
     bidResponse.adUrl = bid.adUrl;
     bidResponse.nurl = bid.nurl;
 
@@ -246,10 +247,7 @@ export class AdapterHelpers {
   }
 
   triggerUrl(url) {
-    fetch(url, {
-      keepalive: true,
-      credentials: 'include'
-    });
+    fetch(url, { keepalive: true });
   }
 
   log(severity, message) {
@@ -473,9 +471,9 @@ export const spec = {
     }
 
     if (bid.hasOwnProperty('nurl') && bid.nurl.length > 0) {
-      helpers.triggerUrl(
-        helpers.replaceMacro(bid.nurl)
-      );
+      const url = helpers.replaceMacro(bid.nurl)
+        .replace('ad_auction_won', 'ext_auction_won');
+      helpers.triggerUrl(url);
     }
   },
 };

--- a/test/spec/modules/excoBidAdapter_spec.js
+++ b/test/spec/modules/excoBidAdapter_spec.js
@@ -1,8 +1,7 @@
 import { expect } from 'chai';
 import { spec as adapter, AdapterHelpers, SID, ENDPOINT, BIDDER_CODE } from 'modules/excoBidAdapter';
-import { BANNER } from '../../../src/mediaTypes';
+import { BANNER, VIDEO } from '../../../src/mediaTypes';
 import { config } from '../../../src/config';
-import * as utils from '../../../src/utils.js';
 import sinon from 'sinon';
 
 describe('ExcoBidAdapter', function () {
@@ -161,7 +160,7 @@ describe('ExcoBidAdapter', function () {
                 id: 'b7b6eddb-9924-425e-aa52-5eba56689abe',
                 impid: BID.bidId,
                 cpm: 10.56,
-                ad: '<iframe>console.log("hello world")</iframe>',
+                adm: '<iframe>console.log("hello world")</iframe>',
                 lurl: 'https://ads-ssp-stg.hit.buzz/loss?loss=${AUCTION_LOSS}&min_to_win=${AUCTION_MIN_TO_WIN}',
                 nurl: 'http://example.com/win/1234',
                 adomain: ['crest.com'],
@@ -211,11 +210,10 @@ describe('ExcoBidAdapter', function () {
           ],
           mediaType: BANNER
         },
-        ad: '<iframe>console.log("hello world")</iframe>',
+        ad: '<div style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="http://example.com/win/1234"></div><iframe>console.log("hello world")</iframe>',
         netRevenue: true,
         nurl: 'http://example.com/win/1234',
         currency: 'USD',
-        vastXml: undefined,
         adUrl: undefined,
       });
     });
@@ -316,12 +314,13 @@ describe('ExcoBidAdapter', function () {
       expect(adapter.onBidWon).to.exist.and.to.be.a('function');
     });
 
-    it('Should trigger event if bid nurl', function() {
+    it('Should trigger nurl pixel', function() {
       const bid = {
         bidder: adapter.code,
         adUnitCode: 'adunit-code',
         sizes: [[300, 250]],
         nurl: 'http://example.com/win/1234',
+        mediaType: VIDEO,
         params: {
           accountId: 'accountId',
           publisherId: 'publisherId',
@@ -331,6 +330,26 @@ describe('ExcoBidAdapter', function () {
 
       adapter.onBidWon(bid);
       expect(stubbedFetch.callCount).to.equal(1);
+    });
+
+    it('Should trigger nurl pixel with correct parameters', function() {
+      const bid = {
+        bidder: adapter.code,
+        adUnitCode: 'adunit-code',
+        sizes: [[300, 250]],
+        nurl: 'http://example.com/win/1234?ad_auction_won',
+        mediaType: VIDEO,
+        params: {
+          accountId: 'accountId',
+          publisherId: 'publisherId',
+          tagId: 'tagId',
+        }
+      };
+
+      adapter.onBidWon(bid);
+
+      expect(stubbedFetch.callCount).to.equal(1);
+      expect(stubbedFetch.firstCall.args[0]).to.contain('ext_auction_won');
     });
 
     it('Should not trigger pixel if no bid nurl', function() {


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter

## Description of change
- Removed `credentials: include` mode for triggered pixels
- Update event parameter of `nurl` pixel triggered from within `onBidWon` handler