### PR TITLE
Build system: update GH workflows to fail on cache miss

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           path: .
           key: source-${{ github.run_id }}
+          fail-on-cache-miss: true
 
       - name: Build
         run: ${{ inputs.build-cmd }}

--- a/.github/workflows/test-chunk.yml
+++ b/.github/workflows/test-chunk.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           path: .
           key: ${{ inputs.wdir }}
+          fail-on-cache-miss: true
 
       - name: Run tests
         uses: nick-fields/retry@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           path: .
           key: source-${{ github.run_id }}
+          fail-on-cache-miss: true
       - name: lint
         run: npx eslint
       
@@ -95,6 +96,7 @@ jobs:
         with:
           path: .
           key: source-${{ github.run_id }}
+          fail-on-cache-miss: true
       - name: Run tests
         uses: nick-fields/retry@v3
         with:
@@ -112,5 +114,6 @@ jobs:
         with:
           path: .
           key: ${{ needs.test.outputs.wdir }}
+          fail-on-cache-miss: true
       - name: Coveralls
         uses: coverallsapp/github-action@v2


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes

## Description of change

This updates the test workflow so that temporary failures in actions/cache (such as [this](https://github.com/prebid/Prebid.js/actions/runs/16146503491/job/45567041887)) cause the job to fail in the "restore working directory" step instead of giving an obscure error.
