### PR TITLE
Kargo Bid Adapter: Remove dupe fields + utilize generateUUID from utils

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -317,7 +317,6 @@ function getExtensions(ortb2, refererInfo) {
   return ext;
 }
 
-
 function _getCrb() {
   let localStorageCrb = getCrbFromLocalStorage();
   if (Object.keys(localStorageCrb).length) {

--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -1,4 +1,4 @@
-import { _each, isEmpty, buildUrl, deepAccess, pick, logError, isPlainObject } from '../src/utils.js';
+import { _each, isEmpty, buildUrl, deepAccess, pick, logError, isPlainObject, generateUUID, deepClone } from '../src/utils.js';
 import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { getStorageManager } from '../src/storageManager.js';
@@ -261,7 +261,7 @@ function interpretResponse(response, bidRequest) {
 
 function getUserSyncs(syncOptions, _, gdprConsent, usPrivacy, gppConsent) {
   const syncs = [];
-  const seed = _generateRandomUUID();
+  const seed = generateUUID();
   const clientId = getClientId();
 
   var gdpr = (gdprConsent && gdprConsent.gdprApplies) ? 1 : 0;
@@ -301,26 +301,22 @@ function onTimeout(timeoutData) {
 
 function getExtensions(ortb2, refererInfo) {
   const ext = {};
-  if (ortb2) ext.ortb2 = ortb2;
-  if (refererInfo) ext.refererInfo = refererInfo;
+
+  if (ortb2) {
+    ext.ortb2 = deepClone(ortb2);
+
+    if (ext.ortb2.user && ext.ortb2.user.ext) {
+      delete ext.ortb2.user.ext.eids;
+    }
+  }
+
+  if (refererInfo) {
+    ext.refererInfo = refererInfo;
+  }
+
   return ext;
 }
 
-function _generateRandomUUID() {
-  try {
-    // crypto.getRandomValues is supported everywhere but Opera Mini for years
-    var buffer = new Uint8Array(16);
-    crypto.getRandomValues(buffer);
-    buffer[6] = (buffer[6] & ~176) | 64;
-    buffer[8] = (buffer[8] & ~64) | 128;
-    var hex = Array.prototype.map.call(new Uint8Array(buffer), function(x) {
-      return ('00' + x.toString(16)).slice(-2);
-    }).join('');
-    return hex.slice(0, 8) + '-' + hex.slice(8, 12) + '-' + hex.slice(12, 16) + '-' + hex.slice(16, 20) + '-' + hex.slice(20);
-  } catch (e) {
-    return '';
-  }
-}
 
 function _getCrb() {
   let localStorageCrb = getCrbFromLocalStorage();
@@ -332,7 +328,7 @@ function _getCrb() {
 
 function _getSessionId() {
   if (!sessionId) {
-    sessionId = _generateRandomUUID();
+    sessionId = generateUUID();
   }
   return sessionId;
 }


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Addresses lint issue raised here: https://github.com/prebid/Prebid.js/pull/13392#discussion_r2150025373

Removes duplicate eids. When there's a lot this adds quite a lot to the bid request. Main source of eids is under user.sharedIdEids. 