### PR TITLE
Build system: update browserslist only on release

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -552,8 +552,8 @@ gulp.task('coveralls', gulp.series('test-coverage', coveralls));
 
 // npm will by default use .gitignore, so create an .npmignore that is a copy of it except it includes "dist"
 gulp.task('setup-npmignore', execaTask("sed 's/^\\/\\?dist\\/\\?$//g;w .npmignore' .gitignore", {quiet: true}));
-gulp.task('build', gulp.series(clean, 'update-browserslist', 'build-bundle-prod', updateCreativeExample, setupDist));
-gulp.task('build-release', gulp.series('build', 'setup-npmignore'));
+gulp.task('build', gulp.series(clean, 'build-bundle-prod', updateCreativeExample, setupDist));
+gulp.task('build-release', gulp.series('build', 'update-browserslist', 'setup-npmignore'));
 gulp.task('build-postbid', gulp.series(escapePostbidConfig, buildPostbid));
 
 gulp.task('serve', gulp.series(clean, lint, precompile(), gulp.parallel('build-bundle-dev-no-precomp', watch, test)));


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes

## Description of change

This moves `update-browserslist` from `build` to `build-release` so that it happens only in preparation for a release.
