### PR TITLE
Freepassbidadaptor/feat allow credential when req

### DIFF
--- a/modules/freepassBidAdapter.js
+++ b/modules/freepassBidAdapter.js
@@ -68,8 +68,10 @@ export const spec = {
     logMessage('FreePass BidAdapter interpreted ORTB bid request as ', data);
 
     const freepassIdObj = validBidRequests[0].userIdAsEids?.find(eid => eid.source === 'freepass.jp');
-    data.user = injectIdsToUser(data.user, freepassIdObj.uids[0]);
-    data.device = injectIPtoDevice(data.device, freepassIdObj.uids[0]);
+    if (freepassIdObj) {
+      data.user = injectIdsToUser(data.user, freepassIdObj.uids[0]);
+      data.device = injectIPtoDevice(data.device, freepassIdObj.uids[0]);
+    }
 
     // set site.page & site.publisher
     data.site = data.site || {};
@@ -99,7 +101,7 @@ export const spec = {
       method: 'POST',
       url: BIDDER_SERVICE_URL,
       data,
-      options: { withCredentials: false }
+      options: { withCredentials: true }
     };
   },
 

--- a/test/spec/modules/freepassBidAdapter_spec.js
+++ b/test/spec/modules/freepassBidAdapter_spec.js
@@ -75,10 +75,10 @@ describe('FreePass adapter', function () {
       expect(bidRequest.length).to.equal(0);
     });
 
-    it('should handle missing userIdAsEids gracefully', function () {
+    it('should handle missing userIdAsEids', function () {
       let localBidRequests = [JSON.parse(JSON.stringify(bidRequests[0]))];
       delete localBidRequests[0].userIdAsEids;
-      expect(() => spec.buildRequests(localBidRequests, bidderRequest)).to.throw();
+      expect(() => spec.buildRequests(localBidRequests, bidderRequest)).to.not.throw();
     });
 
     it('should return a valid bid request object', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
- Check eid undefined or not to stop undefined exception
- Allow FreepassBidAdaptor to send cookies(`withCredentials `)

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
