### PR TITLE
JWPlayer Video Provider: Remove redundant content.data[i].value

### DIFF
--- a/modules/jwplayerVideoProvider.js
+++ b/modules/jwplayerVideoProvider.js
@@ -836,7 +836,6 @@ export const utils = {
     const formattedSegments = jwpsegs.reduce((convertedSegments, rawSegment) => {
       convertedSegments.push({
         id: rawSegment,
-        value: rawSegment
       });
       return convertedSegments;
     }, []);

--- a/test/spec/modules/videoModule/submodules/jwplayerVideoProvider_spec.js
+++ b/test/spec/modules/videoModule/submodules/jwplayerVideoProvider_spec.js
@@ -1018,8 +1018,8 @@ describe('utils', function () {
     it('should convert segments to objects', function () {
       const segs = ['a', 'b'];
       expect(getSegments(segs)).to.deep.equal([
-        {id: 'a', value: 'a'},
-        {id: 'b', value: 'b'}
+        {id: 'a'},
+        {id: 'b'}
       ]);
     });
   });
@@ -1031,7 +1031,7 @@ describe('utils', function () {
     });
 
     it('should set media id and segments', function () {
-      const segments = [{id: 'x', value: 'x'}];
+      const segments = [{id: 'x'}];
       expect(getContentDatum('id1', segments)).to.deep.equal({
         name: 'jwplayer.com',
         segment: segments,


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix


## Description of change
`content.data[i].segment[i].value` is redundant since the same data is passed in `content.data[i].segment[i].id`. Due to the high amount of targeting segments passed, this results in significant bloat. 



Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
addresses https://github.com/prebid/Prebid.js/issues/13541
