### PR TITLE
JWPlayer RTD provider: Support cids outside of the ext

### DIFF
--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -340,7 +340,7 @@ export function getContentData(mediaId, segments) {
   };
 
   if (mediaId) {
-    contentData.ext.cids = [mediaId];
+    contentData.ext.cids = contentData.cids = [mediaId];
   }
 
   if (segments) {

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -768,6 +768,9 @@ describe('jwplayerRtdProvider', function() {
       const contentData = getContentData(testMediaId, testSegments);
       expect(contentData).to.have.property('name', 'jwplayer.com');
       expect(contentData.ext).to.have.property('segtax', 502);
+      expect(contentData).to.have.property('cids');
+      expect(contentData.cids).to.have.length(1);
+      expect(contentData.cids[0]).to.equal(testMediaId);
       expect(contentData.ext).to.have.property('cids');
       expect(contentData.ext.cids).to.have.length(1);
       expect(contentData.ext.cids[0]).to.equal(testMediaId);
@@ -779,6 +782,9 @@ describe('jwplayerRtdProvider', function() {
       const contentData = getContentData(testMediaId);
       expect(contentData).to.have.property('name', 'jwplayer.com');
       expect(contentData.ext.segtax).to.be.undefined;
+      expect(contentData).to.have.property('cids');
+      expect(contentData.cids).to.have.length(1);
+      expect(contentData.cids[0]).to.equal(testMediaId);
       expect(contentData.ext).to.have.property('cids');
       expect(contentData.ext.cids).to.have.length(1);
       expect(contentData.ext.cids[0]).to.equal(testMediaId);
@@ -790,6 +796,7 @@ describe('jwplayerRtdProvider', function() {
       const contentData = getContentData(null, testSegments);
       expect(contentData).to.have.property('name', 'jwplayer.com');
       expect(contentData.ext).to.have.property('segtax', 502);
+      expect(contentData).to.not.have.property('cids');
       expect(contentData.ext).to.not.have.property('cids');
       expect(contentData.segment).to.deep.equal(testSegments);
     });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature


## Description of change
`cids` are now officially part of the ORTB spec, therefore we are supporting it. We are keeping `ext.cids` for backwards compatibility until it can be safely removed. 

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
