### PR TITLE
draft changes in for disabling gzip request

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -696,6 +696,28 @@ export const addViewabilityToImp = (imp, adUnitCode, sizes) => {
   };
 };
 
+export const getGzipSetting = (bid) => {
+  // Check bidder-level setting first
+  if (bid && bid.params && typeof bid.params.gzipEnabled === 'boolean') {
+    return bid.params.gzipEnabled;
+  }
+  
+  // Check bidder-specific global setting
+  const pubmaticConfig = config.getConfig('pubmatic') || {};
+  if (typeof pubmaticConfig.gzipEnabled === 'boolean') {
+    return pubmaticConfig.gzipEnabled;
+  }
+  
+  // Check global compression setting
+  const compressionConfig = config.getConfig('compression') || {};
+  if (typeof compressionConfig.gzipEnabled === 'boolean') {
+    return compressionConfig.gzipEnabled;
+  }
+  
+  // Default to true if not specified
+  return DEFAULT_GZIP_ENABLED;
+};
+
 export const spec = {
   code: BIDDER_CODE,
   gvlid: 76,

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -696,14 +696,30 @@ export const addViewabilityToImp = (imp, adUnitCode, sizes) => {
   };
 };
 
+/**
+ * Determines if gzip compression should be enabled for requests
+ * Checks in order:
+ * 1. Bidder-level setting from bid.params.gzipEnabled
+ * 2. Bidder-specific compression setting from config.pubmatic.compression.gzipEnabled
+ * 3. Bidder-specific legacy setting from config.pubmatic.gzipEnabled (for backward compatibility)
+ * 4. Global setting from config.compression.gzipEnabled
+ * 5. Default value (true)
+ * @param {Object} bid - The bid object
+ * @returns {boolean} - Whether gzip compression should be enabled
+ */
 export const getGzipSetting = (bid) => {
   // Check bidder-level setting first
   if (bid && bid.params && typeof bid.params.gzipEnabled === 'boolean') {
     return bid.params.gzipEnabled;
   }
   
-  // Check bidder-specific global setting
+  // Check bidder-specific compression setting
   const pubmaticConfig = config.getConfig('pubmatic') || {};
+  if (pubmaticConfig.compression && typeof pubmaticConfig.compression.gzipEnabled === 'boolean') {
+    return pubmaticConfig.compression.gzipEnabled;
+  }
+  
+  // Check bidder-specific legacy setting (for backward compatibility)
   if (typeof pubmaticConfig.gzipEnabled === 'boolean') {
     return pubmaticConfig.gzipEnabled;
   }

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -30,15 +30,13 @@ const RENDERER_URL = 'https://pubmatic.bbvms.com/r/'.concat('$RENDERER', '.js');
 const MSG_VIDEO_PLCMT_MISSING = 'Video.plcmt param missing';
 const PREBID_NATIVE_DATA_KEY_VALUES = Object.values(PREBID_NATIVE_DATA_KEYS_TO_ORTB);
 const DEFAULT_TTL = 360;
-const DEFAULT_GZIP_ENABLED = true;
 const CUSTOM_PARAMS = {
   'kadpageurl': '', // Custom page url
   'gender': '', // User gender
   'yob': '', // User year of birth
   'lat': '', // User location - Latitude
   'lon': '', // User Location - Longitude
-  'wiid': '', // OpenWrap Wrapper Impression ID
-  'gzipEnabled': '' // Enable/disable gzip compression
+  'wiid': '' // OpenWrap Wrapper Impression ID
 };
 
 const dealChannel = {
@@ -615,10 +613,6 @@ const BB_RENDERER = {
 
 function _parseSlotParam(paramName, paramValue) {
   if (!isStr(paramValue)) {
-    // Special handling for boolean parameters - only for gzipEnabled
-    if (paramName === 'gzipEnabled' && typeof paramValue === 'boolean') {
-      return paramValue;
-    }
     paramValue && logWarn(LOG_WARN_PREFIX + 'Ignoring param key: ' + paramName + ', expects string-value, found ' + typeof paramValue);
     return UNDEFINED;
   }
@@ -646,31 +640,6 @@ const getPublisherId = (bids) =>
   Array.isArray(bids) && bids.length > 0
     ? bids.find(bid => bid.params?.publisherId?.trim())?.params.publisherId || null
     : null;
-
-/**
- * Determines if gzip compression should be enabled for requests
- * Checks in order:
- * 1. Bidder-level setting from bid.params.gzipEnabled
- * 2. Global setting from config.pubmatic.gzipEnabled
- * 3. Default value (true)
- * @param {Object} bid - The bid object
- * @returns {boolean} - Whether gzip compression should be enabled
- */
-function getGzipSetting(bid) {
-  // Check bidder-level setting first
-  if (bid && bid.params && typeof bid.params.gzipEnabled === 'boolean') {
-    return bid.params.gzipEnabled;
-  }
-  
-  // Check global setting
-  const pubmaticConfig = config.getConfig('pubmatic') || {};
-  if (typeof pubmaticConfig.gzipEnabled === 'boolean') {
-    return pubmaticConfig.gzipEnabled;
-  }
-  
-  // Default to true if not specified
-  return DEFAULT_GZIP_ENABLED;
-}
 
 const _handleCustomParams = (params, conf) => {
   Object.keys(CUSTOM_PARAMS).forEach(key => {
@@ -816,7 +785,7 @@ export const spec = {
       data: data,
       bidderRequest: bidderRequest,
       options: {
-        endpointCompression: getGzipSetting(validBidRequests[0])
+        endpointCompression: true
       },
     };
     return data?.imp?.length ? serverRequest : null;

--- a/src/config.ts
+++ b/src/config.ts
@@ -249,6 +249,15 @@ export interface Config {
      * https://docs.prebid.org/features/firstPartyData.html
      */
     ortb2?: DeepPartial<ORTBRequest>;
+    /**
+     * Configure compression settings for bid requests
+     */
+    compression?: {
+        /**
+         * Enable/disable gzip compression globally
+         */
+        gzipEnabled?: boolean
+    };
 }
 
 type PartialConfig = Partial<Config> & { [setting: string]: unknown };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1293,6 +1293,44 @@ export function extractDomainFromHost(pageHost) {
   return domain;
 }
 
+/**
+ * Determines if gzip compression should be enabled for requests
+ * Checks in order:
+ * 1. Bidder-level setting from bid.params.gzipEnabled
+ * 2. Bidder-specific setting from bidder config
+ * 3. Global setting from config.compression.gzipEnabled
+ * 4. Default value (true)
+ * 
+ * @param {string} bidderCode - The bidder code
+ * @param {Object} [bidRequest] - The bid request object that may contain bidder-specific settings
+ * @returns {boolean} - Whether gzip compression should be enabled
+ */
+export function shouldUseCompression(bidderCode, bidRequest = null) {
+  const DEFAULT_GZIP_ENABLED = true;
+  
+  // Check bidder-specific settings in the bid request
+  if (bidRequest && 
+      bidRequest.params && 
+      typeof bidRequest.params.gzipEnabled === 'boolean') {
+    return bidRequest.params.gzipEnabled;
+  }
+  
+  // Check bidder-specific settings in the global config
+  const bidderConfig = config.getBidderConfig()[bidderCode];
+  if (bidderConfig?.compression?.gzipEnabled !== undefined) {
+    return bidderConfig.compression.gzipEnabled;
+  }
+  
+  // Check global settings
+  const globalConfig = config.getConfig('compression') || {};
+  if (typeof globalConfig.gzipEnabled === 'boolean') {
+    return globalConfig.gzipEnabled;
+  }
+  
+  // Default to true if not specified
+  return DEFAULT_GZIP_ENABLED;
+}
+
 export function triggerNurlWithCpm(bid, cpm) {
   if (isStr(bid.nurl) && bid.nurl !== '') {
     bid.nurl = bid.nurl.replace(

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -639,38 +639,6 @@ describe('PubMatic adapter', () => {
           const request = spec.buildRequests(validBidRequests, bidderRequest);
           expect(request.data).to.have.property('tmax').to.equal(2000);
         });
-        
-        describe('Gzip Configuration', () => {
-          let configStub;
-          
-          beforeEach(() => {
-            configStub = sinon.stub(config, 'getConfig');
-          });
-          
-          afterEach(() => {
-            configStub.restore();
-          });
-          
-          it('should enable gzip compression by default', () => {
-            configStub.withArgs('pubmatic').returns({});
-            const request = spec.buildRequests(validBidRequests, bidderRequest);
-            expect(request.options.endpointCompression).to.be.true;
-          });
-          
-          it('should respect global pubmatic.gzipEnabled config', () => {
-            configStub.withArgs('pubmatic').returns({ gzipEnabled: false });
-            const request = spec.buildRequests(validBidRequests, bidderRequest);
-            expect(request.options.endpointCompression).to.be.false;
-          });
-          
-          it('should prioritize bidder-level gzipEnabled setting over global setting', () => {
-            configStub.withArgs('pubmatic').returns({ gzipEnabled: true });
-            const modifiedBidRequests = utils.deepClone(validBidRequests);
-            modifiedBidRequests[0].params.gzipEnabled = false;
-            const request = spec.buildRequests(modifiedBidRequests, bidderRequest);
-            expect(request.options.endpointCompression).to.be.false;
-          });
-        });
 
         it('should remove test if pubmaticTest is not set', () => {
           const request = spec.buildRequests(validBidRequests, bidderRequest);

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -639,6 +639,38 @@ describe('PubMatic adapter', () => {
           const request = spec.buildRequests(validBidRequests, bidderRequest);
           expect(request.data).to.have.property('tmax').to.equal(2000);
         });
+        
+        describe('Gzip Configuration', () => {
+          let configStub;
+          
+          beforeEach(() => {
+            configStub = sinon.stub(config, 'getConfig');
+          });
+          
+          afterEach(() => {
+            configStub.restore();
+          });
+          
+          it('should enable gzip compression by default', () => {
+            configStub.withArgs('pubmatic').returns({});
+            const request = spec.buildRequests(validBidRequests, bidderRequest);
+            expect(request.options.endpointCompression).to.be.true;
+          });
+          
+          it('should respect global pubmatic.gzipEnabled config', () => {
+            configStub.withArgs('pubmatic').returns({ gzipEnabled: false });
+            const request = spec.buildRequests(validBidRequests, bidderRequest);
+            expect(request.options.endpointCompression).to.be.false;
+          });
+          
+          it('should prioritize bidder-level gzipEnabled setting over global setting', () => {
+            configStub.withArgs('pubmatic').returns({ gzipEnabled: true });
+            const modifiedBidRequests = utils.deepClone(validBidRequests);
+            modifiedBidRequests[0].params.gzipEnabled = false;
+            const request = spec.buildRequests(modifiedBidRequests, bidderRequest);
+            expect(request.options.endpointCompression).to.be.false;
+          });
+        });
 
         it('should remove test if pubmaticTest is not set', () => {
           const request = spec.buildRequests(validBidRequests, bidderRequest);

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -703,7 +703,14 @@ describe('PubMatic adapter', () => {
             expect(request.options.endpointCompression).to.be.true;
           });
           
-          it('should respect global pubmatic.gzipEnabled config', () => {
+          it('should respect bidder-specific pubmatic.compression.gzipEnabled config', () => {
+            configStub.withArgs('pubmatic').returns({ compression: { gzipEnabled: false } });
+            configStub.withArgs('compression').returns({});
+            const request = spec.buildRequests(validBidRequests, bidderRequest);
+            expect(request.options.endpointCompression).to.be.false;
+          });
+          
+          it('should respect legacy pubmatic.gzipEnabled config for backward compatibility', () => {
             configStub.withArgs('pubmatic').returns({ gzipEnabled: false });
             configStub.withArgs('compression').returns({});
             const request = spec.buildRequests(validBidRequests, bidderRequest);
@@ -723,6 +730,13 @@ describe('PubMatic adapter', () => {
             const modifiedBidRequests = utils.deepClone(validBidRequests);
             modifiedBidRequests[0].params.gzipEnabled = false;
             const request = spec.buildRequests(modifiedBidRequests, bidderRequest);
+            expect(request.options.endpointCompression).to.be.false;
+          });
+          
+          it('should prioritize pubmatic.compression.gzipEnabled over pubmatic.gzipEnabled', () => {
+            configStub.withArgs('pubmatic').returns({ compression: { gzipEnabled: false }, gzipEnabled: true });
+            configStub.withArgs('compression').returns({});
+            const request = spec.buildRequests(validBidRequests, bidderRequest);
             expect(request.options.endpointCompression).to.be.false;
           });
           


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
