### PR TITLE
TTD Bid Adapter: Add Optional Custom Bidder Endpoint Parameter

### DIFF
--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -14,7 +14,7 @@ import { getConnectionType } from '../libraries/connectionInfo/connectionUtils.j
  * @typedef {import('../src/adapters/bidderFactory.js').UserSync} UserSync
  */
 
-const BIDADAPTERVERSION = 'TTD-PREBID-2025.04.25';
+const BIDADAPTERVERSION = 'TTD-PREBID-2025.07.15';
 const BIDDER_CODE = 'ttd';
 const BIDDER_CODE_LONG = 'thetradedesk';
 const BIDDER_ENDPOINT = 'https://direct.adsrvr.org/bid/bidder/';
@@ -283,6 +283,10 @@ function video(bid) {
 }
 
 function selectEndpoint(params) {
+  if (params.customBidderEndpoint) {
+    return params.customBidderEndpoint
+  }
+
   if (params.useHttp2) {
     return BIDDER_ENDPOINT_HTTP2;
   }
@@ -334,6 +338,12 @@ export const spec = {
     const gpid = utils.deepAccess(bid, 'ortb2Imp.ext.gpid');
     if (!bid.params.placementId && !gpid) {
       utils.logWarn(BIDDER_CODE + ': one of params.placementId or gpid (via the GPT module https://docs.prebid.org/dev-docs/modules/gpt-pre-auction.html) must be passed');
+      return false;
+    }
+
+    if (bid.params.customBidderEndpoint &&
+        (!bid.params.customBidderEndpoint.startsWith('https://') || !bid.params.customBidderEndpoint.endsWith('/bid/bidder/'))) {
+      utils.logWarn(BIDDER_CODE + ': if params.customBidderEndpoint is provided, it must start with https:// and end with /bid/bidder/');
       return false;
     }
 

--- a/modules/ttdBidAdapter.md
+++ b/modules/ttdBidAdapter.md
@@ -54,6 +54,7 @@ The Trade Desk bid adapter supports Banner and Video.
                             banner: {
                                 expdir: [1, 3]
                             },
+                            customBidderEndpoint: 'https://customBidderEndpoint/bid/bidder/',
                         }
                     }
                 ]
@@ -109,7 +110,8 @@ The Trade Desk bid adapter supports Banner and Video.
                             supplySourceId: 'supplier',
                             publisherId: '1427ab10f2e448057ed3b422',
                             placementId: '/1111/home#header',
-                            bidfloor: 0.45
+                            bidfloor: 0.45,
+                            customBidderEndpoint: 'https://customBidderEndpoint/bid/bidder/',
                         }
                     }
                 ]

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -99,6 +99,24 @@ describe('ttdBidAdapter', function () {
         bid.params.bidfloor = 3.01;
         expect(spec.isBidRequestValid(bid)).to.equal(true);
       });
+
+      it('should return false if customBidderEndpoint is provided and does not start with https://', function () {
+        const bid = makeBid();
+        bid.params.customBidderEndpoint = 'customBidderEndpoint/bid/bidder/';
+        expect(spec.isBidRequestValid(bid)).to.equal(false);
+      });
+
+      it('should return false if customBidderEndpoint is provided and does not end with /bid/bidder/', function () {
+        const bid = makeBid();
+        bid.params.customBidderEndpoint = 'https://customBidderEndpoint/bid/bidder';
+        expect(spec.isBidRequestValid(bid)).to.equal(false);
+      });
+
+      it('should return true if customBidderEndpoint is provided that starts with https:// and ends with /bid/bidder/', function () {
+        const bid = makeBid();
+        bid.params.customBidderEndpoint = 'https://customBidderEndpoint/bid/bidder/';
+        expect(spec.isBidRequestValid(bid)).to.equal(true);
+      });
     });
 
     describe('banner', function () {
@@ -306,11 +324,18 @@ describe('ttdBidAdapter', function () {
       expect(url).to.equal('https://direct.adsrvr.org/bid/bidder/supplier');
     });
 
+    it('sends bid requests to the correct http2 endpoint', function () {
+      const bannerBidRequestsWithHttp2Endpoint = deepClone(baseBannerBidRequests);
+      bannerBidRequestsWithHttp2Endpoint[0].params.useHttp2 = true;
+      const url = testBuildRequests(bannerBidRequestsWithHttp2Endpoint, baseBidderRequest).url;
+      expect(url).to.equal('https://d2.adsrvr.org/bid/bidder/supplier');
+    });
+
     it('sends bid requests to the correct custom endpoint', function () {
       const bannerBidRequestsWithCustomEndpoint = deepClone(baseBannerBidRequests);
-      bannerBidRequestsWithCustomEndpoint[0].params.useHttp2 = true;
+      bannerBidRequestsWithCustomEndpoint[0].params.customBidderEndpoint = 'https://customBidderEndpoint/bid/bidder/';
       const url = testBuildRequests(bannerBidRequestsWithCustomEndpoint, baseBidderRequest).url;
-      expect(url).to.equal('https://d2.adsrvr.org/bid/bidder/supplier');
+      expect(url).to.equal('https://customBidderEndpoint/bid/bidder/supplier');
     });
 
     it('sends publisher id', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Updated bidder adapter

## Description of change
<!-- Describe the change proposed in this pull request -->
If TTD provides a User with a custom bidder endpoint, it should take precedent over the hard-coded endpoints, and all request should be send to customBidderEndpoint.

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
