### PR TITLE
Price Floors: Fix modelGroups typo in Typescript types

### DIFF
--- a/modules/priceFloors.ts
+++ b/modules/priceFloors.ts
@@ -742,7 +742,7 @@ export type Schema1FloorData = FloorsDef & BaseFloorData & {
 
 export type Schema2FloorData = BaseFloorData & {
   floorsSchemaVersion: 2;
-  modelGrups: (FloorsDef & {
+  modelGroups: (FloorsDef & {
     /**
      * Used by the module to determine when to apply the specific model.
      */
@@ -768,7 +768,7 @@ export type FloorsConfig = Pick<Schema1FloorData, 'skipRate' | 'floorProvider'> 
    * The Price Floors Module will take the greater of floorMin and the matched rule CPM when evaluating getFloor() and enforcing floors.
    */
   floorMin?: number;
-  enforcement?: Pick<Schema2FloorData['modelGrups'][0], 'noFloorSignalBidders'> & {
+  enforcement?: Pick<Schema2FloorData['modelGroups'][0], 'noFloorSignalBidders'> & {
     /**
      * If set to true (the default), the Price Floors Module will provide floors to bid adapters for bid request
      * matched rules and suppress any bids not exceeding a matching floor.


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->

Hello, 
This change fixes a typo in the Typescript type `Schema2FloorData`, changing `modelGrups` to `modelGroups` like in this documentation : https://docs.prebid.org/dev-docs/modules/floors.html#schema-2

