### PR TITLE
TargetingControls : Fix TypeScript error in targetingControls.allowTargetingKeys typing

### DIFF
--- a/src/targeting.ts
+++ b/src/targeting.ts
@@ -176,15 +176,15 @@ export interface TargetingControlsConfig {
   /**
    * Selects supported default targeting keys.
    */
-  allowTargetingKeys?: (keyof DefaultTargeting)[];
+  allowTargetingKeys?: (keyof typeof TARGETING_KEYS)[];
   /**
    * Selects targeting keys to be supported in addition to the default ones
    */
-  addTargetingKeys?: (keyof DefaultTargeting)[];
+  addTargetingKeys?: (keyof typeof TARGETING_KEYS)[];
   /**
    * Selects supported default targeting keys.
    */
-  allowSendAllBidsTargetingKeys?: (keyof DefaultTargeting)[];
+  allowSendAllBidsTargetingKeys?: (keyof typeof TARGETING_KEYS)[];
   /**
    * Set to false to prevent custom targeting values from being set for non-winning bids
    */


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Refactoring (no functional changes, no api changes)

## Description of change
targetingControls.allowTargetingKeys is typed as (keyof DefaultTargeting)[], causing a TS2322: Type "BIDDER" is not assignable to type keyof DefaultTargeting error when using CONSTANTS.TARGETING_KEYS values (e.g., "BIDDER", "AD_ID") despite being valid per documentation.

Update the TypeScript type of targetingControls.allowTargetingKeys to (keyof typeof TARGETING_KEYS)[] to match CONSTANTS.TARGETING_KEYS values, allowing values like "BIDDER", "AD_ID", etc without TypeScript errors.