### PR TITLE
Core: add argument to requestBids event

### DIFF
--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1624,6 +1624,40 @@ describe('Unit: Prebid Module', function () {
       sinon.assert.called(spec.onTimeout);
     });
 
+    describe('requestBids event', () => {
+      beforeEach(() =>  {
+        sandbox.stub(events, 'emit');
+      });
+
+      it('should be emitted with request', async () => {
+        const request = {
+          adUnits
+        }
+        await runAuction(request);
+        sinon.assert.calledWith(events.emit, EVENTS.REQUEST_BIDS, request);
+      });
+
+      it('should provide a request object when not supplied to requestBids()', async () => {
+        $$PREBID_GLOBAL$$.addAdUnits(adUnits);
+        try {
+          await runAuction();
+          sinon.assert.calledWith(events.emit, EVENTS.REQUEST_BIDS, sinon.match({
+            adUnits
+          }));
+        } finally {
+          adUnits.map(au => au.code).forEach($$PREBID_GLOBAL$$.removeAdUnit)
+        }
+      });
+
+      it('should not leak internal state', async () => {
+        const request = {
+          adUnits
+        };
+        await runAuction(Object.assign({}, request));
+        sinon.assert.calledWith(events.emit, EVENTS.REQUEST_BIDS, request);
+      })
+    })
+
     it('should execute `onSetTargeting` after setTargetingForGPTAsync', async function () {
       const bidId = 1;
       const auctionId = 1;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

This adds an argument to the `requestBids` event, which currently has none; the argument is the object passed to `pbjs.requestBids`, except that `adUnits` is filled in from `pbjs.adUnits` when not provided.

The timing of the event is also shifted so that it happens before anything else (for example, before priceFloors). I believe this is not breaking since currently the event, having no arguments, doesn't expose state that could be affected by the difference in timing - and the overall order of events remains unchanged. 

However analytics adapters that currently track `requestBids` would start the additional data. `growthCode`, `hadron` and `invisibly` do so explicitly with almost identical logic:

https://github.com/prebid/Prebid.js/blob/e967ff6e5d7a27ba5642dd054da1bcdab227ecf9/modules/hadronAnalyticsAdapter.js#L109-L112

where (after this change) `data` would no longer be an empty object. Other analytics adapters that just send event payloads to their endpoint would be similarly affected.




