### PR TITLE
Multiple modules: remove GVL IDs that are missing or marked as deleted in the GVL

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -534,8 +534,9 @@ gulp.task('build-bundle-verbose', gulp.series(precompile(), 'build-creative-dev'
 
 // public tasks (dependencies are needed for each task since they can be ran on their own)
 gulp.task('update-browserslist', execaTask('npx update-browserslist-db@latest'));
-gulp.task('test-only-nobuild', testTaskMaker({coverage: true}))
-gulp.task('test-only', gulp.series('precompile', test));
+gulp.task('test-build-logic', execaTask('npx mocha ./test/build-logic'))
+gulp.task('test-only-nobuild', gulp.series('test-build-logic', testTaskMaker({coverage: true})))
+gulp.task('test-only', gulp.series('test-build-logic', 'precompile', test));
 
 gulp.task('test-all-features-disabled-nobuild', testTaskMaker({disableFeatures: helpers.getTestDisableFeatures(), oneBrowser: 'chrome', watch: false}));
 gulp.task('test-all-features-disabled', gulp.series('precompile-all-features-disabled', 'test-all-features-disabled-nobuild'));

--- a/metadata/gvl.mjs
+++ b/metadata/gvl.mjs
@@ -1,0 +1,22 @@
+const GVL_URL = 'https://vendor-list.consensu.org/v3/vendor-list.json';
+
+export const getGvl = (() => {
+  let gvl;
+  return function () {
+    if (gvl == null) {
+      gvl = fetch(GVL_URL)
+        .then(resp => resp.json())
+        .catch((err) => {
+          gvl = null;
+          return Promise.reject(err);
+        });
+    }
+    return gvl;
+  };
+})();
+
+export function isValidGvlId(gvlId, gvl = getGvl) {
+  return gvl().then(gvl => {
+    return !!(gvl.vendors[gvlId] && !gvl.vendors[gvlId].deletedDate);
+  })
+}

--- a/metadata/storageDisclosure.mjs
+++ b/metadata/storageDisclosure.mjs
@@ -1,31 +1,17 @@
 import fs from 'fs';
+import {getGvl, isValidGvlId} from './gvl.mjs';
 
-const GVL_URL = 'https://vendor-list.consensu.org/v3/vendor-list.json';
 const LOCAL_DISCLOSURE_PATTERN = /^local:\/\//;
 const LOCAL_DISCLOSURE_PATH = './metadata/disclosures/'
 const LOCAL_DISCLOSURES_URL = 'https://cdn.jsdelivr.net/gh/prebid/Prebid.js/metadata/disclosures/';
 
 const PARSE_ERROR_LINES = 20;
 
-export const getGvl = (() => {
-  let gvl;
-  return function () {
-    if (gvl == null) {
-      gvl = fetch(GVL_URL)
-        .then(resp => resp.json())
-        .catch((err) => {
-          gvl = null;
-          return Promise.reject(err);
-        });
-    }
-    return gvl;
-  };
-})();
 
-export function getDisclosureUrl(gvlId) {
-  return getGvl().then(gvl => {
-    return gvl.vendors[gvlId]?.deviceStorageDisclosureUrl;
-  });
+export async function getDisclosureUrl(gvlId, gvl = getGvl) {
+  if (await isValidGvlId(gvlId, gvl)) {
+    return (await gvl()).vendors[gvlId]?.deviceStorageDisclosureUrl;
+  }
 }
 
 function parseDisclosure(payload) {

--- a/modules/aidemBidAdapter.js
+++ b/modules/aidemBidAdapter.js
@@ -10,7 +10,6 @@ const BIDDER_CODE = 'aidem';
 const BASE_URL = 'https://zero.aidemsrv.com';
 const LOCAL_BASE_URL = 'http://127.0.0.1:8787';
 
-const GVLID = 1218
 const SUPPORTED_MEDIA_TYPES = [BANNER, VIDEO];
 const REQUIRED_VIDEO_PARAMS = [ 'mimes', 'protocols', 'context' ];
 
@@ -233,7 +232,6 @@ function hasValidParameters(bidRequest) {
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: GVLID,
   supportedMediaTypes: SUPPORTED_MEDIA_TYPES,
   isBidRequestValid: function(bidRequest) {
     logInfo('bid: ', bidRequest);

--- a/modules/ampliffyBidAdapter.js
+++ b/modules/ampliffyBidAdapter.js
@@ -2,7 +2,6 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {logError, logInfo, triggerPixel} from '../src/utils.js';
 
 const BIDDER_CODE = 'ampliffy';
-const GVLID = 1258;
 const DEFAULT_ENDPOINT = 'bidder.ampliffy.com';
 const TTL = 600; // Time-to-Live - how long (in seconds) Prebid can use this bid.
 const LOG_PREFIX = 'AmpliffyBidder: ';
@@ -400,7 +399,6 @@ function onTimeOut() {
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: GVLID,
   aliases: ['ampliffy', 'amp', 'videoffy', 'publiffy'],
   supportedMediaTypes: ['video', 'banner'],
   isBidRequestValid,

--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -13,7 +13,6 @@ import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import { getFirstSize, getOsVersion, getVideoSizes, getBannerSizes, isConnectedTV, getDoNotTrack, isMobile, isBannerBid, isVideoBid, getBannerBidFloor, getVideoBidFloor, getVideoTargetingParams, getTopWindowLocation } from '../libraries/advangUtils/index.js';
 
 const ADAPTER_VERSION = '1.21';
-const GVLID = 335;
 const ADAPTER_NAME = 'BFIO_PREBID';
 const OUTSTREAM = 'outstream';
 const CURRENCY = 'USD';
@@ -38,7 +37,6 @@ let appId = '';
 
 export const spec = {
   code: 'beachfront',
-  gvlid: GVLID,
   supportedMediaTypes: [ VIDEO, BANNER ],
 
   isBidRequestValid(bid) {

--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -13,6 +13,7 @@ import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import { getFirstSize, getOsVersion, getVideoSizes, getBannerSizes, isConnectedTV, getDoNotTrack, isMobile, isBannerBid, isVideoBid, getBannerBidFloor, getVideoBidFloor, getVideoTargetingParams, getTopWindowLocation } from '../libraries/advangUtils/index.js';
 
 const ADAPTER_VERSION = '1.21';
+const GVLID = 157;
 const ADAPTER_NAME = 'BFIO_PREBID';
 const OUTSTREAM = 'outstream';
 const CURRENCY = 'USD';
@@ -38,7 +39,7 @@ let appId = '';
 export const spec = {
   code: 'beachfront',
   supportedMediaTypes: [ VIDEO, BANNER ],
-
+  gvlid: GVLID,
   isBidRequestValid(bid) {
     if (isVideoBid(bid)) {
       if (!getVideoBidParam(bid, 'appId')) {

--- a/modules/cadent_aperture_mxBidAdapter.js
+++ b/modules/cadent_aperture_mxBidAdapter.js
@@ -19,10 +19,10 @@ const RENDERER_URL = 'https://js.brealtime.com/outstream/1.30.0/bundle.js';
 const ADAPTER_VERSION = '1.5.1';
 const DEFAULT_CUR = 'USD';
 const ALIASES = [
-  { code: 'emx_digital', gvlid: 183 },
-  { code: 'cadent', gvlid: 183 },
-  { code: 'emxdigital', gvlid: 183 },
-  { code: 'cadentaperturemx', gvlid: 183 },
+  { code: 'emx_digital'},
+  { code: 'cadent'},
+  { code: 'emxdigital'},
+  { code: 'cadentaperturemx'},
 ];
 
 const EIDS_SUPPORTED = [
@@ -222,7 +222,6 @@ export const cadentAdapter = {
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: 183,
   alias: ALIASES,
   supportedMediaTypes: [BANNER, VIDEO],
   isBidRequestValid: function (bid) {

--- a/modules/cadent_aperture_mxBidAdapter.js
+++ b/modules/cadent_aperture_mxBidAdapter.js
@@ -222,7 +222,7 @@ export const cadentAdapter = {
 
 export const spec = {
   code: BIDDER_CODE,
-  alias: ALIASES,
+  aliases: ALIASES,
   supportedMediaTypes: [BANNER, VIDEO],
   isBidRequestValid: function (bid) {
     if (!bid || !bid.params) {

--- a/modules/ccxBidAdapter.js
+++ b/modules/ccxBidAdapter.js
@@ -5,7 +5,6 @@ import {getStorageManager} from '../src/storageManager.js';
 const BIDDER_CODE = 'ccx'
 const storage = getStorageManager({bidderCode: BIDDER_CODE});
 const BID_URL = 'https://delivery.clickonometrics.pl/ortb/prebid/bid'
-const GVLID = 773;
 const SUPPORTED_VIDEO_PROTOCOLS = [2, 3, 5, 6]
 const SUPPORTED_VIDEO_MIMES = ['video/mp4', 'video/x-flv']
 const SUPPORTED_VIDEO_PLAYBACK_METHODS = [1, 2, 3, 4]
@@ -144,7 +143,6 @@ function _buildResponse (bid, currency, ttl) {
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: GVLID,
   supportedMediaTypes: ['banner', 'video'],
 
   isBidRequestValid: function (bid) {

--- a/modules/innityBidAdapter.js
+++ b/modules/innityBidAdapter.js
@@ -2,12 +2,10 @@ import { parseSizesInput, timestamp } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 
 const BIDDER_CODE = 'innity';
-const GVLID = 535;
 const ENDPOINT = 'https://as.innity.com/synd/';
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: GVLID,
   isBidRequestValid: function(bid) {
     return !!(bid.params && bid.params.pub && bid.params.zone);
   },

--- a/modules/luceadBidAdapter.js
+++ b/modules/luceadBidAdapter.js
@@ -7,7 +7,6 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {getUniqueIdentifierStr, deepSetValue, logInfo} from '../src/utils.js';
 import {fetch} from '../src/ajax.js';
 
-const gvlid = 1309;
 const bidderCode = 'lucead';
 const defaultCurrency = 'EUR';
 const defaultTtl = 500;
@@ -179,7 +178,6 @@ function onTimeout(timeoutData) {
 
 export const spec = {
   code: bidderCode,
-  gvlid,
   aliases,
   isBidRequestValid,
   buildRequests,

--- a/modules/mobilefuseBidAdapter.js
+++ b/modules/mobilefuseBidAdapter.js
@@ -12,7 +12,6 @@ const SYNC_URL = 'https://mfx.mobilefuse.com/usync';
 export const spec = {
   code: 'mobilefuse',
   supportedMediaTypes: [BANNER, VIDEO],
-  gvlid: 909,
   isBidRequestValid,
   buildRequests,
   interpretResponse,

--- a/modules/pwbidBidAdapter.js
+++ b/modules/pwbidBidAdapter.js
@@ -13,7 +13,6 @@ import { OUTSTREAM, INSTREAM } from '../src/video.js';
  */
 
 const VERSION = '0.3.0';
-const GVLID = 842;
 const NET_REVENUE = true;
 const UNDEFINED = undefined;
 const DEFAULT_CURRENCY = 'USD';
@@ -134,7 +133,6 @@ _each(NATIVE_ASSETS, anAsset => { NATIVE_ASSET_KEY_TO_ASSET_MAP[anAsset.KEY] = a
 export const spec = {
   code: BIDDER_CODE,
   aliases: ['pubwise'],
-  gvlid: GVLID,
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
   /**
    * Determines whether or not the given bid request is valid.

--- a/modules/qtBidAdapter.js
+++ b/modules/qtBidAdapter.js
@@ -3,13 +3,11 @@ import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { isBidRequestValid, buildRequests, interpretResponse, getUserSyncs } from '../libraries/teqblazeUtils/bidderUtils.js';
 
 const BIDDER_CODE = 'qt';
-const GVLID = 1331;
 const AD_URL = 'https://endpoint1.qt.io/pbjs';
 const SYNC_URL = 'https://cs.qt.io';
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: GVLID,
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 
   isBidRequestValid: isBidRequestValid(),

--- a/modules/raynRtdProvider.js
+++ b/modules/raynRtdProvider.js
@@ -13,7 +13,6 @@ import { deepAccess, deepSetValue, logError, logMessage, mergeDeep } from '../sr
 
 const MODULE_NAME = 'realTimeData';
 const SUBMODULE_NAME = 'rayn';
-const RAYN_TCF_ID = 1220;
 const RAYN_PERSONA_TAXONOMY_ID = 103015;
 const LOG_PREFIX = 'RaynJS: ';
 export const SEGMENTS_RESOLVER = 'rayn.io';
@@ -225,7 +224,6 @@ export const raynSubmodule = {
   name: SUBMODULE_NAME,
   init: init,
   getBidRequestData: alterBidRequests,
-  gvlid: RAYN_TCF_ID,
 };
 
 submodule(MODULE_NAME, raynSubmodule);

--- a/modules/retailspotBidAdapter.js
+++ b/modules/retailspotBidAdapter.js
@@ -9,7 +9,6 @@ import {BANNER, VIDEO} from '../src/mediaTypes.js';
  */
 
 const BIDDER_CODE = 'retailspot';
-const GVL_ID = 1319;
 
 const DEFAULT_SUBDOMAIN = 'hbapi';
 const PREPROD_SUBDOMAIN = 'hbapi-preprod';
@@ -19,7 +18,6 @@ const DEV_URL = 'http://localhost:3030/';
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: GVL_ID,
   supportedMediaTypes: [BANNER, VIDEO],
   aliases: ['rs'], // short code
   /**

--- a/modules/scatteredBidAdapter.js
+++ b/modules/scatteredBidAdapter.js
@@ -7,7 +7,6 @@ import { deepAccess, logInfo } from '../src/utils.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 
 const BIDDER_CODE = 'scattered';
-const GVLID = 1179;
 export const converter = ortbConverter({
   context: {
     mediaType: BANNER,
@@ -18,7 +17,6 @@ export const converter = ortbConverter({
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: GVLID,
   supportedMediaTypes: [BANNER],
 
   // 1.

--- a/modules/slimcutBidAdapter.js
+++ b/modules/slimcutBidAdapter.js
@@ -16,8 +16,7 @@ const BIDDER_CODE = 'slimcut';
 const ENDPOINT_URL = 'https://sb.freeskreen.com/pbr';
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: 102,
-  aliases: [{ code: 'scm', gvlid: 102 }],
+  aliases: [{ code: 'scm'}],
   supportedMediaTypes: ['video', 'banner'],
   /**
    * Determines whether or not the given bid request is valid.

--- a/modules/talkadsBidAdapter.js
+++ b/modules/talkadsBidAdapter.js
@@ -6,11 +6,9 @@ import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 
 const CURRENCY = 'EUR';
 const BIDDER_CODE = 'talkads';
-const GVLID = 1074;
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: GVLID,
   supportedMediaTypes: [ NATIVE, BANNER ],
 
   /**

--- a/modules/ucfunnelBidAdapter.js
+++ b/modules/ucfunnelBidAdapter.js
@@ -14,7 +14,6 @@ import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 const COOKIE_NAME = 'ucf_uid';
 const VER = 'ADGENT_PREBID-2018011501';
 const BIDDER_CODE = 'ucfunnel';
-const GVLID = 607;
 const CURRENCY = 'USD';
 const VIDEO_CONTEXT = {
   INSTREAM: 0,
@@ -24,7 +23,6 @@ const storage = getStorageManager({bidderCode: BIDDER_CODE});
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: GVLID,
   ENDPOINT: 'https://hb.aralego.com/header',
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
   /**

--- a/modules/videoreachBidAdapter.js
+++ b/modules/videoreachBidAdapter.js
@@ -2,11 +2,9 @@ import {getBidIdParameter, getValue} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 const BIDDER_CODE = 'videoreach';
 const ENDPOINT_URL = 'https://a.videoreach.com/hb/';
-const GVLID = 547;
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: GVLID,
   supportedMediaTypes: ['banner'],
 
   isBidRequestValid: function(bid) {

--- a/modules/viewdeosDXBidAdapter.js
+++ b/modules/viewdeosDXBidAdapter.js
@@ -23,7 +23,6 @@ const syncsCache = {};
 export const spec = {
   code: BIDDER_CODE,
   aliases: ['viewdeos'],
-  gvlid: 924,
   supportedMediaTypes,
   isBidRequestValid,
   getUserSyncs: function (syncOptions, serverResponses) {

--- a/modules/yieldliftBidAdapter.js
+++ b/modules/yieldliftBidAdapter.js
@@ -3,7 +3,6 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER} from '../src/mediaTypes.js';
 
 const ENDPOINT_URL = 'https://x.yieldlift.com/pbjs';
-const GVLID = 866;
 
 const DEFAULT_BID_TTL = 300;
 const DEFAULT_CURRENCY = 'USD';
@@ -11,7 +10,6 @@ const DEFAULT_NET_REVENUE = true;
 
 export const spec = {
   code: 'yieldlift',
-  gvlid: GVLID,
   aliases: ['yl'],
   supportedMediaTypes: [BANNER],
 

--- a/test/build-logic/disclosure_spec.mjs
+++ b/test/build-logic/disclosure_spec.mjs
@@ -23,5 +23,4 @@ describe('getDisclosureUrl', () => {
     const url = await getDisclosureUrl(123, getGvl);
     expect(url).to.not.exist;
   });
-
 });

--- a/test/build-logic/disclosure_spec.mjs
+++ b/test/build-logic/disclosure_spec.mjs
@@ -1,0 +1,27 @@
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {getDisclosureUrl} from '../../metadata/storageDisclosure.mjs';
+
+describe('getDisclosureUrl', () => {
+  let gvl;
+
+  beforeEach(() => {
+    gvl = null;
+  });
+
+  const getGvl = () => Promise.resolve(gvl);
+
+  it('should not return url from gvl when vendor has deletedDate', async () => {
+    gvl = {
+      vendors: {
+        '123': {
+          deviceStorageDisclosureUrl: 'disclosure.url',
+          deletedDate: '2024-06-11T00:00:00Z'
+        }
+      }
+    };
+    const url = await getDisclosureUrl(123, getGvl);
+    expect(url).to.not.exist;
+  });
+
+});

--- a/test/build-logic/gvl_spec.mjs
+++ b/test/build-logic/gvl_spec.mjs
@@ -1,0 +1,32 @@
+import {expect} from 'chai';
+import {describe, it} from 'mocha';
+import {isValidGvlId} from '../../metadata/gvl.mjs';
+
+describe('gvl build time checks', () => {
+  let gvl;
+  beforeEach(() => {
+    gvl = null;
+  });
+
+  function getGvl() {
+    return Promise.resolve(gvl);
+  }
+
+  describe('validateGvlId', async () => {
+    Object.entries({
+      'missing': null,
+      'deleted': {
+        deletedDate: '2024-06-11T00:00:00Z'
+      }
+    }).forEach(([t, vendor]) => {
+      it(`should reject gvl id when its vendor is ${t}`, async () => {
+        gvl = {
+          vendors: {
+            "123": vendor
+          }
+        }
+        expect(await isValidGvlId(123, getGvl)).to.be.false;
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes

## Description of change

This updates the `update-metadata` build task to check that GVL IDs provided by modules are present and not marked as deleted in the GVL;

this produced the following list of invalid GVL IDs, which were removed:

```
"bidder.aidem" provides a GVL ID that is deleted or missing: 1218                                                                                                                             
"bidder.ampliffy" provides a GVL ID that is deleted or missing: 1258                                                                                                                          
"bidder.beachfront" provides a GVL ID that is deleted or missing: 335                                                                                                                         
"bidder.cadent_aperture_mx" provides a GVL ID that is deleted or missing: 183                                                                                                                 
"bidder.ccx" provides a GVL ID that is deleted or missing: 773                                                                                                                                
"bidder.innity" provides a GVL ID that is deleted or missing: 535                                                                                                                             
"bidder.lucead" provides a GVL ID that is deleted or missing: 1309                                                                                                                            
"bidder.mobilefuse" provides a GVL ID that is deleted or missing: 909                                                                                                                         
"bidder.pwbid" provides a GVL ID that is deleted or missing: 842                                                                                                                              
"bidder.qt" provides a GVL ID that is deleted or missing: 1331                                                                                                                                
"bidder.retailspot" provides a GVL ID that is deleted or missing: 1319                                                                                                                        
"bidder.scattered" provides a GVL ID that is deleted or missing: 1179                                                                                                                         
"bidder.slimcut" provides a GVL ID that is deleted or missing: 102                                                                                                                            
"bidder.scm" provides a GVL ID that is deleted or missing: 102
"bidder.talkads" provides a GVL ID that is deleted or missing: 1074
"bidder.ucfunnel" provides a GVL ID that is deleted or missing: 607
"bidder.videoreach" provides a GVL ID that is deleted or missing: 547
"bidder.viewdeosDX" provides a GVL ID that is deleted or missing: 924
"bidder.yieldlift" provides a GVL ID that is deleted or missing: 866
"rtd.rayn" provides a GVL ID that is deleted or missing: 1220
```


## Other information

Closes https://github.com/prebid/Prebid.js/issues/13606
