### PR TITLE
LiveIntent ID Module: add support for nexxen id (9.53.x-legacy)

### DIFF
--- a/libraries/liveIntentId/shared.js
+++ b/libraries/liveIntentId/shared.js
@@ -129,6 +129,10 @@ function composeIdObject(value) {
     result.vidazoo = { 'id': value.vidazoo, ext: { provider: LI_PROVIDER_DOMAIN } }
   }
 
+  if (value.nexxen) {
+    result.nexxen = { 'id': value.nexxen, ext: { provider: LI_PROVIDER_DOMAIN } }
+  }
+
   return result
 }
 
@@ -313,5 +317,17 @@ export const eids = {
         return data.ext;
       }
     }
+  },
+  'nexxen': {
+      source: 'liveintent.unrulymedia.com',
+      atype: 3,
+      getValue: function(data) {
+        return data.id;
+      },
+      getUidExt: function(data) {
+        if (data.ext) {
+          return data.ext;
+        }
+      }
   }
 }

--- a/test/spec/modules/liveIntentExternalIdSystem_spec.js
+++ b/test/spec/modules/liveIntentExternalIdSystem_spec.js
@@ -430,6 +430,11 @@ describe('LiveIntentExternalId', function() {
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar'}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
+  it('should decode a nexxen id to a sTeparate object when present', function() {
+      const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', nexxen: 'bar' }, defaultConfigParams);
+      expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'nexxen': 'bar'}, 'nexxen': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
   it('should decode the segments as part of lipb', function() {
     const result = liveIntentExternalIdSubmodule.decode({ nonId: 'foo', 'segments': ['bar'] }, defaultConfigParams);
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'segments': ['bar']}});

--- a/test/spec/modules/liveIntentIdMinimalSystem_spec.js
+++ b/test/spec/modules/liveIntentIdMinimalSystem_spec.js
@@ -334,6 +334,11 @@ describe('LiveIntentMinimalId', function() {
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar'}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
+ it('should decode a nexxen id to a separate object when present', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', nexxen: 'bar' });
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'nexxen': 'bar'}, 'nexxen': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
   it('should decode the segments as part of lipb', function() {
     const result = liveIntentIdSubmodule.decode({ nonId: 'foo', 'segments': ['bar'] }, { params: defaultConfigParams });
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'segments': ['bar']}});

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -522,6 +522,11 @@ describe('LiveIntentId', function() {
     expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'vidazoo': 'bar'}, 'vidazoo': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
   });
 
+  it('should decode a nexxen id to a separate object when present', function() {
+    const result = liveIntentIdSubmodule.decode({ nonId: 'foo', nexxen: 'bar' }, defaultConfigParams);
+    expect(result).to.eql({'lipb': {'lipbid': 'foo', 'nonId': 'foo', 'nexxen': 'bar'}, 'nexxen': {'id': 'bar', 'ext': {'provider': 'liveintent.com'}}});
+  });
+
   it('getId does not set the global variables when liModuleEnabled, liTreatmentRate and activatePartialTreatment are undefined', function() {
     window.liModuleEnabled = undefined;
     window.liTreatmentRate = undefined;
@@ -1139,6 +1144,39 @@ describe('LiveIntentId', function() {
         }]
       });
     });
+
+    it('nexxen', function () {
+        const userId = {
+          nexxen: { 'id': 'sample_id' }
+        };
+        const newEids = createEidsArray(userId);
+        expect(newEids.length).to.equal(1);
+        expect(newEids[0]).to.deep.equal({
+          source: 'liveintent.unrulymedia.com',
+          uids: [{
+            id: 'sample_id',
+            atype: 3
+          }]
+        });
+      });
+
+      it('nexxen with ext', function () {
+        const userId = {
+          nexxen: { 'id': 'sample_id', 'ext': { 'provider': 'some.provider.com' } }
+        };
+        const newEids = createEidsArray(userId);
+        expect(newEids.length).to.equal(1);
+        expect(newEids[0]).to.deep.equal({
+          source: 'liveintent.unrulymedia.com',
+          uids: [{
+            id: 'sample_id',
+            atype: 3,
+            ext: {
+              provider: 'some.provider.com'
+            }
+          }]
+        });
+      });
 
     it('tdid sets matcher for liveintent', function() {
       const userId = {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This pull request adds an EID mapping for nexxen IDs that now can be resolved via the LiveIntent UserId module.
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
This change has been done in master:
* https://github.com/prebid/Prebid.js/pull/13627
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
