### PR TITLE
Build system: fail earlier on cache errors

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           path: .
           key: build-${{ inputs.build-cmd }}-${{ github.run_id }}
+          lookup-only: true
           fail-on-cache-miss: true
 
   chunk-1:

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -51,6 +51,13 @@ jobs:
           path: .
           key: build-${{ inputs.build-cmd }}-${{ github.run_id }}
 
+      - name: Verify cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .
+          key: build-${{ inputs.build-cmd }}-${{ github.run_id }}
+          fail-on-cache-miss: true
+
   chunk-1:
     needs: build
     name: Run tests (chunk 1 of 4)

--- a/.github/workflows/test-chunk.yml
+++ b/.github/workflows/test-chunk.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           path: .
           key: test-${{ inputs.cmd }}-${{ inputs.chunk-no }}-${{ github.run_id }}
+          lookup-only: true
           fail-on-cache-miss: true
 
 

--- a/.github/workflows/test-chunk.yml
+++ b/.github/workflows/test-chunk.yml
@@ -68,3 +68,11 @@ jobs:
           path: .
           key: test-${{ inputs.cmd }}-${{ inputs.chunk-no }}-${{ github.run_id }}
 
+      - name: Verify cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .
+          key: test-${{ inputs.cmd }}-${{ inputs.chunk-no }}-${{ github.run_id }}
+          fail-on-cache-miss: true
+
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           path: .
           key: source-${{ github.run_id }}
+          lookup-only: true
           fail-on-cache-miss: true
 
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,13 @@ jobs:
           path: .
           key: source-${{ github.run_id }}
 
+      - name: Verify cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .
+          key: source-${{ github.run_id }}
+          fail-on-cache-miss: true
+
   lint:
     name: "Run linter"
     needs: checkout


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes

## Description of change

At the end of each test step we save the working directory to cache so that it can be picked up by the next step. If the save fails the step still completes successfully, only for the next one to fail in a way that can't be recovered without restarting the whole run (since what really failed is the previous step).

This adds a cache load immediately after every save so that hopefully the right step fails allowing it to be restarted in isolation.

