### PR TITLE
Build system: fix broken imports from NPM when not using typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Prebid.js is open source software that is offered for free as a convenience. Whi
 ## Usage (as a npm dependency)
 
 **Note**: versions prior to v10 required some Babel plugins to be configured when used as an NPM dependency -
-refer to [v9 README](https://github.com/prebid/Prebid.js/blob/9.43.0/README.md)
+refer to [v9 README](https://github.com/prebid/Prebid.js/blob/9.43.0/README.md).
 
 ```javascript
 import pbjs from 'prebid.js';
@@ -164,19 +164,6 @@ Since version 7.2.0, you may instruct the build to exclude code for some feature
 
 ```
 gulp build --disable NATIVE --modules=openxBidAdapter,rubiconBidAdapter,sovrnBidAdapter # substitute your module list
-```
-
-Or, if you are consuming Prebid through npm, with the `disableFeatures` option in your Prebid rule:
-
-```javascript
-  {
-    test: /.js$/,
-    include: new RegExp(`\\${path.sep}prebid\\.js`),
-    use: {
-      loader: 'babel-loader',
-      options: require('prebid.js/babelConfig.js')({disableFeatures: ['NATIVE']})
-    }
-  }
 ```
 
 Features that can be disabled this way are:

--- a/plugins/pbjsGlobals.js
+++ b/plugins/pbjsGlobals.js
@@ -43,6 +43,12 @@ module.exports = function(api, options) {
     return null;
   }
 
+  function translateToJs(path, state) {
+    if (path.node.source?.value?.endsWith('.ts')) {
+      path.node.source.value = path.node.source.value.replace(/\.ts$/, '.js');
+    }
+  }
+
   return {
     visitor: {
       Program(path, state) {
@@ -58,11 +64,8 @@ module.exports = function(api, options) {
           path.node.body.push(...api.parse(`${registerName}('${modName}');`, {filename: state.filename}).program.body);
         }
       },
-      ImportDeclaration(path, state) {
-        if (path.node.source.value.endsWith('.ts')) {
-          path.node.source.value = path.node.source.value.replace(/\.ts$/, '.js');
-        }
-      },
+      ImportDeclaration: translateToJs,
+      ExportDeclaration: translateToJs,
       StringLiteral(path) {
         Object.keys(replace).forEach(name => {
           if (path.node.value.includes(name)) {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Since 10 using prebid from npm only works if using typescript.

## Other information

https://github.com/prebid/Prebid.js/issues/13657
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
