### PR TITLE
ID5 ID module: add option to use gam targeting

### DIFF
--- a/modules/id5IdSystem.md
+++ b/modules/id5IdSystem.md
@@ -32,7 +32,8 @@ pbjs.setConfig({
           controlGroupPct: 0.1   // valid values are 0.0 - 1.0 (inclusive)
         },
         disableExtensions: false,// optional
-        canCookieSync: true      // optional, has effect only when externalModuleUrl is used 
+        canCookieSync: true,      // optional, has effect only when externalModuleUrl is used 
+        gamTargetingPrefix: "id5" // optional, when set the ID5 module will set gam targeting paramaters with this prefix
       },
       storage: {
         type: 'html5',           // "html5" is the required storage type
@@ -59,6 +60,7 @@ pbjs.setConfig({
 | params.abTesting.controlGroupPct | Optional | Number | Must be a number between `0.0` and `1.0` (inclusive) and is used to determine the percentage of requests that fall into the control group (and thus not exposing the ID5 ID). For example, a value of `0.20` will result in 20% of requests without an ID5 ID and 80% with an ID.  | `0.1` |
 | params.disableExtensions | Optional | Boolean | Set this to `true` to force turn off extensions call. Default `false`                                                                                                                                                                                                              | `true` or `false` |
 | params.canCookieSync | Optional | Boolean | Set this to `true` to enable cookie syncing with other ID5 partners. See [our documentation](https://wiki.id5.io/docs/initiate-cookie-sync-to-id5) for details. Default `false`                                                                                                    | `true` or `false` |
+| params.gamTargetingPrefix | Optional | String  | When this parameter is set the ID5 module will set appropriate GAM pubads targeting tags                                                                                                                                                                                            | `id5`                                               |
 | storage | Required | Object | Storage settings for how the User ID module will cache the ID5 ID locally                                                                                                                                                                                                          | |
 | storage.type | Required | String | This is where the results of the user ID will be stored. ID5 **requires** `"html5"`.                                                                                                                                                                                               | `"html5"` |
 | storage.name | Required | String | The name of the local storage where the user ID will be stored. ID5 **requires** `"id5id"`.                                                                                                                                                                                        | `"id5id"` |

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -1291,7 +1291,7 @@ describe('ID5 ID System', function () {
       let testObj = {...storedObject, universal_uid: 'ID5*test123'};
       id5System.id5IdSubmodule.decode(testObj, config);
 
-      verifyTagging('id5_id', 'y');
+      verifyTagging('id', 'y');
     })
 
     it('should set GAM targeting for ab tag with control value', function () {
@@ -1299,7 +1299,7 @@ describe('ID5 ID System', function () {
       let testObj = {...storedObject, ab_testing: {result: 'control'}};
       id5System.id5IdSubmodule.decode(testObj, targetingEnabledConfig);
 
-      verifyTagging('id5_ab', 'c');
+      verifyTagging('ab', 'c');
     })
 
     it('should set GAM targeting for ab tag with normal value', function () {
@@ -1307,7 +1307,7 @@ describe('ID5 ID System', function () {
       let testObj = {...storedObject, ab_testing: {result: 'normal'}};
       id5System.id5IdSubmodule.decode(testObj, targetingEnabledConfig);
 
-      verifyTagging('id5_ab', 'n');
+      verifyTagging('ab', 'n');
     })
 
     it('should set GAM targeting for enrich tag with enriched=true', function () {
@@ -1315,7 +1315,7 @@ describe('ID5 ID System', function () {
       let testObj = {...storedObject, enrichment: {enriched: true}};
       id5System.id5IdSubmodule.decode(testObj, targetingEnabledConfig);
 
-      verifyTagging('id5_enrich', 'y');
+      verifyTagging('enrich', 'y');
     })
 
     it('should set GAM targeting for enrich tag with enrichment_selected=true', function () {
@@ -1323,7 +1323,7 @@ describe('ID5 ID System', function () {
       let testObj = {...storedObject, enrichment: {enrichment_selected: true}};
       id5System.id5IdSubmodule.decode(testObj, targetingEnabledConfig);
 
-      verifyTagging('id5_enrich', 's');
+      verifyTagging('enrich', 's');
     })
 
     it('should set GAM targeting for enrich tag with enrichment_selected=false', function () {
@@ -1331,7 +1331,7 @@ describe('ID5 ID System', function () {
       let testObj = {...storedObject, enrichment: {enrichment_selected: false}};
       id5System.id5IdSubmodule.decode(testObj, targetingEnabledConfig);
 
-      verifyTagging('id5_enrich', 'c');
+      verifyTagging('enrich', 'c');
     })
 
     it('should set GAM targeting for multiple tags when all conditions are met', function () {

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -28,7 +28,6 @@ describe('ID5 ID System', function () {
     logInfoStub.restore();
   });
   const ID5_MODULE_NAME = 'id5Id';
-  const ID5_EIDS_NAME = ID5_MODULE_NAME.toLowerCase();
   const ID5_SOURCE = 'id5-sync.com';
   const TRUE_LINK_SOURCE = 'true-link-id5-sync.com';
   const ID5_TEST_PARTNER_ID = 173;
@@ -167,7 +166,7 @@ describe('ID5 ID System', function () {
     return {
       name: ID5_MODULE_NAME,
       params: {
-        partner
+        partner: partner
       },
       storage: {
         name: storageName,
@@ -1224,6 +1223,137 @@ describe('ID5 ID System', function () {
       });
     });
   });
+
+  describe('Decode should also update GAM tagging if configured', function () {
+    let origGoogletag, setTargetingStub, storedObject;
+    const targetingEnabledConfig = getId5FetchConfig();
+    targetingEnabledConfig.params.gamTargetingPrefix = 'id5';
+
+    beforeEach(function () {
+      // Save original window.googletag if it exists
+      origGoogletag = window.googletag;
+      setTargetingStub = sinon.stub();
+      window.googletag = {
+        cmd: [],
+        pubads: function () {
+          return {
+            setTargeting: setTargetingStub
+          };
+        }
+      };
+      sinon.spy(window.googletag, 'pubads');
+      storedObject = utils.deepClone(ID5_STORED_OBJ);
+    });
+
+    afterEach(function () {
+      // Restore original window.googletag
+      if (origGoogletag) {
+        window.googletag = origGoogletag;
+      } else {
+        delete window.googletag;
+      }
+      id5System.id5IdSubmodule._reset()
+    });
+
+    function verifyTagging(tagName, tagValue) {
+      verifyMultipleTagging({[tagName]: tagValue})
+    }
+
+    function verifyMultipleTagging(tagsObj) {
+      expect(window.googletag.cmd.length).to.be.at.least(1);
+      window.googletag.cmd.forEach(cmd => cmd());
+
+      const tagCount = Object.keys(tagsObj).length;
+      expect(setTargetingStub.callCount).to.equal(tagCount);
+
+      for (const [tagName, tagValue] of Object.entries(tagsObj)) {
+        const fullTagName = `${targetingEnabledConfig.params.gamTargetingPrefix}_${tagName}`;
+
+        const matchingCall = setTargetingStub.getCalls().find(call => call.args[0] === fullTagName);
+        expect(matchingCall, `Tag ${fullTagName} was not set`).to.exist;
+        expect(matchingCall.args[1]).to.equal(tagValue);
+      }
+
+      window.googletag.cmd = [];
+      setTargetingStub.reset();
+      window.googletag.pubads.resetHistory();
+    }
+
+    it('should not set GAM targeting if it is not enabled', function () {
+      id5System.id5IdSubmodule.decode(storedObject, getId5FetchConfig());
+      expect(window.googletag.cmd).to.have.lengthOf(0)
+    })
+
+    it('should set GAM targeting for id tag when universal_uid starts with ID5*', function () {
+      // Setup
+      let config = utils.deepClone(getId5FetchConfig());
+      config.params.gamTargetingPrefix = "id5";
+      let testObj = {...storedObject, universal_uid: 'ID5*test123'};
+      id5System.id5IdSubmodule.decode(testObj, config);
+
+      verifyTagging('id5_id', 'y');
+    })
+
+    it('should set GAM targeting for ab tag with control value', function () {
+      // Setup
+      let testObj = {...storedObject, ab_testing: {result: 'control'}};
+      id5System.id5IdSubmodule.decode(testObj, targetingEnabledConfig);
+
+      verifyTagging('id5_ab', 'c');
+    })
+
+    it('should set GAM targeting for ab tag with normal value', function () {
+      // Setup
+      let testObj = {...storedObject, ab_testing: {result: 'normal'}};
+      id5System.id5IdSubmodule.decode(testObj, targetingEnabledConfig);
+
+      verifyTagging('id5_ab', 'n');
+    })
+
+    it('should set GAM targeting for enrich tag with enriched=true', function () {
+      // Setup
+      let testObj = {...storedObject, enrichment: {enriched: true}};
+      id5System.id5IdSubmodule.decode(testObj, targetingEnabledConfig);
+
+      verifyTagging('id5_enrich', 'y');
+    })
+
+    it('should set GAM targeting for enrich tag with enrichment_selected=true', function () {
+      // Setup
+      let testObj = {...storedObject, enrichment: {enrichment_selected: true}};
+      id5System.id5IdSubmodule.decode(testObj, targetingEnabledConfig);
+
+      verifyTagging('id5_enrich', 's');
+    })
+
+    it('should set GAM targeting for enrich tag with enrichment_selected=false', function () {
+      // Setup
+      let testObj = {...storedObject, enrichment: {enrichment_selected: false}};
+      id5System.id5IdSubmodule.decode(testObj, targetingEnabledConfig);
+
+      verifyTagging('id5_enrich', 'c');
+    })
+
+    it('should set GAM targeting for multiple tags when all conditions are met', function () {
+      // Setup
+      let testObj = {
+        ...storedObject,
+        universal_uid: 'ID5*test123',
+        ab_testing: {result: 'normal'},
+        enrichment: {enriched: true}
+      };
+
+      // Call decode once with the combined test object
+      id5System.id5IdSubmodule.decode(testObj, targetingEnabledConfig);
+
+      // Verify all tags were set correctly
+      verifyMultipleTagging({
+        'id': 'y',
+        'ab': 'n',
+        'enrich': 'y'
+      });
+    })
+  })
 
   describe('A/B Testing', function () {
     const expectedDecodedObjectWithIdAbOff = {id5id: {uid: ID5_STORED_ID, ext: {linkType: ID5_STORED_LINK_TYPE}}};


### PR DESCRIPTION


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->

- [x] Feature


- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Added an option to set gamTargetingPrefix param for ID5 module which, if provided, will cause the module to set appropriate GAM targeting tags for A/B testing purposes.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
