### PR TITLE
Criteo Bid Adapter: Enable GZip Compression

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -1,4 +1,4 @@
-import {deepSetValue, isArray, logError, logWarn, parseUrl, triggerPixel} from '../src/utils.js';
+import {deepSetValue, isArray, logError, logWarn, parseUrl, triggerPixel, deepAccess, logInfo} from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
 import {getStorageManager} from '../src/storageManager.js';
@@ -9,6 +9,7 @@ import {OUTSTREAM} from '../src/video.js';
 import {ajax} from '../src/ajax.js';
 import {ortbConverter} from '../libraries/ortbConverter/converter.js';
 import {ortb25Translator} from '../libraries/ortb2.5Translator/translator.js';
+import {config} from '../src/config.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -32,6 +33,7 @@ const OPTOUT_COOKIE_NAME = 'cto_optout';
 const BUNDLE_COOKIE_NAME = 'cto_bundle';
 const GUID_RETENTION_TIME_HOUR = 24 * 30 * 13; // 13 months
 const OPTOUT_RETENTION_TIME_HOUR = 5 * 12 * 30 * 24; // 5 years
+const DEFAULT_GZIP_ENABLED = true;
 
 /**
  * Defines the generic oRTB converter and all customization functions.
@@ -372,7 +374,15 @@ export const spec = {
     const data = CONVERTER.toORTB({bidderRequest, bidRequests, context});
 
     if (data) {
-      return { method: 'POST', url, data, bidRequests };
+      return {
+        method: 'POST',
+        url,
+        data,
+        bidRequests,
+        options: {
+          endpointCompression: getGzipSetting()
+        },
+      };
     }
   },
 
@@ -418,6 +428,28 @@ export const spec = {
     }
   }
 };
+
+function getGzipSetting() {
+  try {
+    const gzipSetting = deepAccess(config.getBidderConfig(), 'criteo.gzipEnabled');
+
+    if (gzipSetting !== undefined) {
+      const gzipValue = String(gzipSetting).toLowerCase().trim();
+      if (gzipValue === 'true' || gzipValue === 'false') {
+        const parsedValue = gzipValue === 'true';
+        logInfo('Criteo: Using bidder-specific gzipEnabled setting:', parsedValue);
+        return parsedValue;
+      }
+
+      logWarn('Criteo: Invalid gzipEnabled value in bidder config:', gzipSetting);
+    }
+  } catch (e) {
+    logWarn('Criteo: Error accessing bidder config:', e);
+  }
+
+  logInfo('Criteo: Using default gzipEnabled setting:', DEFAULT_GZIP_ENABLED);
+  return DEFAULT_GZIP_ENABLED;
+}
 
 function readFromAllStorages(name) {
   const fromCookie = storage.getCookie(name);

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -665,8 +665,16 @@ describe('The Criteo bidding adapter', function () {
         apiVersion: 1,
       },
     };
+    const defaultBidRequests = [{
+      bidder: 'criteo',
+      adUnitCode: 'bid-123',
+      mediaTypes: {
+        banner: { sizes: [[728, 90]] }
+      },
+      params: {}
+    }]
 
-    let sandbox, localStorageIsEnabledStub;
+    let sandbox, localStorageIsEnabledStub, bidderConfigStub;
 
     before(() => {
       hook.ready();
@@ -675,6 +683,7 @@ describe('The Criteo bidding adapter', function () {
     this.beforeEach(function () {
       sandbox = sinon.createSandbox();
       localStorageIsEnabledStub = sandbox.stub(storage, 'localStorageIsEnabled');
+      bidderConfigStub = sandbox.stub(config, "getBidderConfig")
       localStorageIsEnabledStub.returns(true);
     });
 
@@ -1996,6 +2005,27 @@ describe('The Criteo bidding adapter', function () {
       const ortbRequest = request.data;
       expect(ortbRequest.device.ext.cdep).to.equal('cookieDeprecationLabel');
     });
+
+    it('should interpret correctly gzip configuration given as a string', async function() {
+      bidderConfigStub.returns({criteo: {gzipEnabled: 'false'}});
+
+      const request = spec.buildRequests(defaultBidRequests, await addFPDToBidderRequest(bidderRequest));
+      expect(request.options.endpointCompression).to.be.false;
+    });
+
+    it('should interpret correctly gzip configuration given as a boolean', async function () {
+      bidderConfigStub.returns({criteo: {gzipEnabled: false}});
+
+      const request = spec.buildRequests(defaultBidRequests, await addFPDToBidderRequest(bidderRequest));
+      expect(request.options.endpointCompression).to.be.false;
+    });
+
+    it('should default to true when it receives an invalid configuration', async function () {
+      bidderConfigStub.returns({criteo: {gzipEnabled: 'randomString'}});
+
+      const request = spec.buildRequests(defaultBidRequests, await addFPDToBidderRequest(bidderRequest));
+      expect(request.options.endpointCompression).to.be.true;
+    })
   });
 
   describe('interpretResponse', function () {


### PR DESCRIPTION
Enable GZip compression by default in the Criteo Bid Adapter, with the possibility of turning it off in the adapter configuration.