### PR TITLE
ixBidAdapter: avoid looping over all properties of the array

### DIFF
--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -1704,8 +1704,9 @@ export const spec = {
     validBidRequests.forEach((validBidRequest) => {
       const adUnitMediaTypes = Object.keys(deepAccess(validBidRequest, 'mediaTypes', {}));
 
-      for (const type in adUnitMediaTypes) {
-        switch (adUnitMediaTypes[type]) {
+      for (let index = 0; index < adUnitMediaTypes.length; index++) {
+        const mediaType = adUnitMediaTypes[index];
+        switch (mediaType) {
           case BANNER:
             createBannerImps(validBidRequest, missingBannerSizes, bannerImps, bidderRequest);
             break;
@@ -1716,7 +1717,7 @@ export const spec = {
             createNativeImps(validBidRequest, nativeImps)
             break;
           default:
-            logWarn(`IX Bid Adapter: ad unit mediaTypes ${type} is not supported`)
+            logWarn(`IX Bid Adapter: ad unit mediaTypes ${mediaType} is not supported`)
         }
       }
     });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Switched from a for...in loop to an indexed for loop in the ixBidAdapter to loop over the values in an array.

We got warnings like

> IX Bid Adapter: ad unit mediaTypes average is not supported

The root cause is another JS library which is messing around with the `Array` prototype, and adds additional functions on it. The for...in loop picks those up, and starts logging warnings.

As there is no real reason to use a for...in loop to iterate over an array, I switched it to a regular indexed for loop which avoids the problem.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
