### PR TITLE
GPTUtils: Prevent caching empty slot info in gptUtils and add empty i…

### DIFF
--- a/libraries/gptUtils/gptUtils.js
+++ b/libraries/gptUtils/gptUtils.js
@@ -1,5 +1,5 @@
 import { CLIENT_SECTIONS } from '../../src/fpd/oneClient.js';
-import {compareCodeAndSlot, deepAccess, isGptPubadsDefined, uniques} from '../../src/utils.js';
+import {compareCodeAndSlot, deepAccess, isGptPubadsDefined, uniques, isEmpty} from '../../src/utils.js';
 
 const slotInfoCache = new Map();
 
@@ -55,7 +55,7 @@ export function getGptSlotInfoForAdUnitCode(adUnitCode) {
       divId: matchingSlot.getSlotElementId()
     };
   }
-  slotInfoCache.set(adUnitCode, info);
+  !isEmpty(info) && slotInfoCache.set(adUnitCode, info);
   return info;
 }
 

--- a/test/spec/libraries/gptUtils_spec.js
+++ b/test/spec/libraries/gptUtils_spec.js
@@ -15,5 +15,7 @@ describe('gptUtils', () => {
     const second = gptUtils.getGptSlotInfoForAdUnitCode('code');
     expect(first).to.deep.equal({ gptSlot: 'code', divId: 'div-id' });
     expect(second).to.deep.equal(first);
+    const third = gptUtils.getGptSlotInfoForAdUnitCode('code1'); // not found
+    expect(third).to.deep.equal({});
   });
 });


### PR DESCRIPTION
…nfo test cases

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
**PR: Optimize GPT Slot Info Caching**
**Changes**
- Added a check to prevent caching empty slot information objects in getGptSlotInfoForAdUnitCode
- Only cache slot information when it contains actual data

**Why**
- Previously, empty objects were being cached when no matching GPT slot was found
- This led to stale information being returned on subsequent calls, even if the slot became available later

**Benefits**
- Ensures fresh slot information is fetched on each call when previous attempts returned no data
- Prevents unnecessary cache entries for non-existent slots
- Improves accuracy of ad unit to GPT slot mapping over time as slots become available

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
