### PR TITLE
Prebid Server Bid Adapter: Fixed schains field population from bidder settings

### DIFF
--- a/modules/prebidServerBidAdapter/ortbConverter.js
+++ b/modules/prebidServerBidAdapter/ortbConverter.js
@@ -217,7 +217,7 @@ const PBS_CONVERTER = ortbConverter({
               .filter((req) => !chainBidders.has(req.bidderCode)) // schain defined in s2sConfig.extPrebid takes precedence
               .map((req) => ({
                 bidders: [req.bidderCode],
-                schain: req?.bids?.[0]?.ortb2?.source?.schain
+                schain: req?.bids?.[0]?.ortb2?.source?.ext?.schain
               })))
             .filter(({bidders, schain}) => bidders?.length > 0 && schain)
             .reduce((chains, {bidders, schain}) => {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->

Since [Prebid 10.0.0 ](https://github.com/prebid/Prebid.js/releases/tag/10.0.0) schain data path has changed to `ortb2.source.ext.schain`.
`PrebidServerBidAdapter` was not updated to read bidder level schain config from new path resulting in server auction failures with following error:
`Invalid request format: Stored request processing failed: Cannot invoke "java.util.List.stream()" because the return value of "org.prebid.server.proto.openrtb.ext.request.ExtRequestPrebid.getSchains()" is null`. This PR updates PrebidServerBidAdapter to read bidder level `schain` from proper path.
