### PR TITLE
userId: reintroduce `userIdAsEids` into adUnit bids (9.53.x-legacy)

### DIFF
--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -745,14 +745,14 @@ export function adUnitEidsHook(next, auction) {
   // they are not subject to the same activity checks (since they are not intended for bid adapters)
 
   const eidsByBidder = {};
-  const globalEids = auction.getFPD().global?.user?.ext?.eids ?? [];
+  const globalEids = auction.getFPD()?.global?.user?.ext?.eids ?? [];
   function getEids(bidderCode) {
     if (bidderCode == null) return globalEids;
     if (!eidsByBidder.hasOwnProperty(bidderCode)) {
       eidsByBidder[bidderCode] = mergeDeep(
         {eids: []},
         {eids: globalEids},
-        {eids: auction.getFPD().bidder?.[bidderCode]?.user?.ext?.eids ?? []}
+        {eids: auction.getFPD()?.bidder?.[bidderCode]?.user?.ext?.eids ?? []}
       ).eids;
     }
     return eidsByBidder[bidderCode];

--- a/modules/userId/index.js
+++ b/modules/userId/index.js
@@ -141,7 +141,7 @@ import {
   isPlainObject,
   logError,
   logInfo,
-  logWarn
+  logWarn, mergeDeep
 } from '../../src/utils.js';
 import {getPPID as coreGetPPID} from '../../src/adserver.js';
 import {defer, PbPromise, delay} from '../../src/utils/promise.js';
@@ -154,6 +154,7 @@ import {ACTIVITY_ENRICH_EIDS} from '../../src/activities/activities.js';
 import {activityParams} from '../../src/activities/activityParams.js';
 import {USERSYNC_DEFAULT_CONFIG} from '../../src/userSync.js';
 import {startAuction} from '../../src/prebid.js';
+import {beforeInitAuction} from '../../src/auction.js';
 
 const MODULE_NAME = 'User ID';
 const COOKIE = STORAGE_TYPE_COOKIES;
@@ -737,6 +738,35 @@ function aliasEidsHook(next, bidderRequests) {
   next(bidderRequests);
 }
 
+export function adUnitEidsHook(next, auction) {
+  // for backwards-compat, add `userIdAsEids` to ad units' bid objects
+  // before auction events are fired
+  // these are computed similarly to bid requests' `ortb2`, but unlike them,
+  // they are not subject to the same activity checks (since they are not intended for bid adapters)
+
+  const eidsByBidder = {};
+  const globalEids = auction.getFPD().global?.user?.ext?.eids ?? [];
+  function getEids(bidderCode) {
+    if (bidderCode == null) return globalEids;
+    if (!eidsByBidder.hasOwnProperty(bidderCode)) {
+      eidsByBidder[bidderCode] = mergeDeep(
+        {eids: []},
+        {eids: globalEids},
+        {eids: auction.getFPD().bidder?.[bidderCode]?.user?.ext?.eids ?? []}
+      ).eids;
+    }
+    return eidsByBidder[bidderCode];
+  }
+  auction.getAdUnits()
+    .flatMap(au => au.bids)
+    .forEach(bid => {
+      const eids = getEids(bid.bidder);
+      if (eids.length > 0) {
+        bid.userIdAsEids = eids;
+      }
+    });
+  next(auction);
+}
 /**
  * Is startAuctionHook added
  * @returns {boolean}
@@ -1262,6 +1292,7 @@ export function init(config, {mkDelay = delay} = {}) {
     }
   });
   adapterManager.makeBidRequests.after(aliasEidsHook);
+  beforeInitAuction.before(adUnitEidsHook);
 
   // exposing getUserIds function in global-name-space so that userIds stored in Prebid can be used by external codes.
   (getGlobal()).getUserIds = getUserIds;

--- a/src/auction.js
+++ b/src/auction.js
@@ -124,6 +124,8 @@ export function resetAuctionState() {
   [outstandingRequests, sourceInfo].forEach((ob) => Object.keys(ob).forEach((k) => { delete ob[k] }));
 }
 
+export const beforeInitAuction = hook('sync', (auction) => {})
+
 /**
  * Creates new auction instance
  *
@@ -293,6 +295,7 @@ export function newAuction({adUnits, adUnitCodes, callback, cbTimeout, labels, a
     let call = {
       bidRequests,
       run: () => {
+        beforeInitAuction(this);
         startAuctionTimer();
 
         _auctionStatus = AUCTION_IN_PROGRESS;

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -11,7 +11,7 @@ import {
   requestDataDeletion,
   setStoredValue,
   setSubmoduleRegistry,
-  syncDelay,
+  syncDelay, adUnitEidsHook,
 } from 'modules/userId/index.js';
 import {UID1_EIDS} from 'libraries/uid1Eids/uid1Eids.js';
 import {createEidsArray, EID_CONFIG} from 'modules/userId/eids.js';
@@ -2974,6 +2974,92 @@ describe('User ID', function () {
 
         unregisterRule();
       });
+    })
+  });
+  describe('adUnitEidsHook', () => {
+    let next, auction, adUnits, ortb2Fragments;
+    beforeEach(() => {
+      next = sinon.stub();
+      adUnits = [
+        {
+          code: 'au1',
+          bids: [
+            {
+              bidder: 'bidderA'
+            },
+            {
+              bidder: 'bidderB'
+            }
+          ]
+        },
+        {
+          code: 'au2',
+          bids: [
+            {
+              bidder: 'bidderC'
+            }
+          ]
+        }
+      ]
+      ortb2Fragments = {}
+      auction = {
+        getAdUnits: () => adUnits,
+        getFPD: () => ortb2Fragments
+      }
+    });
+    it('should not set userIdAsEids when no eids are provided', () => {
+      adUnitEidsHook(next, auction);
+      auction.getAdUnits().flatMap(au => au.bids).forEach(bid => {
+        expect(bid.userIdAsEids).to.not.exist;
+      })
+    });
+    it('should add global eids', () => {
+      ortb2Fragments.global = {
+        user: {
+          ext: {
+            eids: ['some-eid']
+          }
+        }
+      };
+      adUnitEidsHook(next, auction);
+      auction.getAdUnits().flatMap(au => au.bids).forEach(bid => {
+        expect(bid.userIdAsEids).to.eql(['some-eid']);
+      })
+    })
+    it('should add bidder-specific eids', () => {
+      ortb2Fragments.global = {
+        user: {
+          ext: {
+            eids: ['global']
+          }
+        }
+      };
+      ortb2Fragments.bidder = {
+        bidderA: {
+          user: {
+            ext: {
+              eids: ['bidder']
+            }
+          }
+        }
+      }
+      adUnitEidsHook(next, auction);
+      auction.getAdUnits().flatMap(au => au.bids).forEach(bid => {
+        const expected = bid.bidder === 'bidderA' ? ['global', 'bidder'] : ['global'];
+        expect(bid.userIdAsEids).to.eql(expected);
+      })
+    });
+    it('should add global eids to bidderless bids', () => {
+      ortb2Fragments.global = {
+        user: {
+          ext: {
+            eids: ['global']
+          }
+        }
+      }
+      delete adUnits[0].bids[0].bidder;
+      adUnitEidsHook(next, auction);
+      expect(adUnits[0].bids[0].userIdAsEids).to.eql(['global']);
     })
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

With https://github.com/prebid/Prebid.js/pull/13679, ad units exposed by events such as AUCTION_INIT no longer have the `bids[].userIdAsEids` property.

## Other information

Closes https://github.com/prebid/Prebid.js/issues/13730
