### PR TITLE
Rubicon Bid Adapter : allow multiple user syncs per prebid load

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -771,12 +771,11 @@ export const spec = {
     }
   },
   getUserSyncs: function (syncOptions, responses, gdprConsent, uspConsent, gppConsent) {
-    if (!hasSynced && syncOptions.iframeEnabled) {
+    if (syncOptions.iframeEnabled) {
       // data is only assigned if params are available to pass to syncEndpoint
       let params = getUserSyncParams(gdprConsent, uspConsent, gppConsent);
       params = Object.keys(params).length ? `?${formatQS(params)}` : '';
 
-      hasSynced = true;
       return {
         type: 'iframe',
         url: `https://${rubiConf.syncHost || 'eus'}.rubiconproject.com/usync.html` + params
@@ -1309,12 +1308,6 @@ function partitionArray(array, size) {
     result.push(array.slice(i, i + size));
   }
   return result;
-}
-
-var hasSynced = false;
-
-export function resetUserSync() {
-  hasSynced = false;
 }
 
 /**

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -3,7 +3,6 @@ import {
   spec,
   getPriceGranularity,
   masSizeOrdering,
-  resetUserSync,
   classifiedAsVideo,
   resetRubiConf,
   resetImpIdMap,
@@ -4450,10 +4449,6 @@ describe('the rubicon adapter', function () {
   describe('user sync', function () {
     const emilyUrl = 'https://eus.rubiconproject.com/usync.html';
 
-    beforeEach(function () {
-      resetUserSync();
-    });
-
     it('should register the Emily iframe', function () {
       const syncs = spec.getUserSyncs({
         iframeEnabled: true
@@ -4462,15 +4457,17 @@ describe('the rubicon adapter', function () {
       expect(syncs).to.deep.equal({type: 'iframe', url: emilyUrl});
     });
 
-    it('should not register the Emily iframe more than once', function () {
+    it('should register the Emily iframe more than once', function () {
       let syncs = spec.getUserSyncs({
         iframeEnabled: true
       });
       expect(syncs).to.deep.equal({type: 'iframe', url: emilyUrl});
 
       // when called again, should still have only been called once
-      syncs = spec.getUserSyncs();
-      expect(syncs).to.equal(undefined);
+      syncs = spec.getUserSyncs({
+        iframeEnabled: true
+      });
+      expect(syncs).to.deep.equal({type: 'iframe', url: emilyUrl});
     });
 
     it('should pass gdpr params if consent is true', function () {
@@ -4723,10 +4720,6 @@ describe('the rubicon adapter', function () {
         }
       });
       config.resetConfig();
-    });
-
-    beforeEach(function () {
-      resetUserSync();
     });
 
     it('should update fastlane endpoint if', function () {


### PR DESCRIPTION
## Type of change
- [X] Other

## Description of change
Rubicon Bid Adapter only was calling its userSync endpoint once per load of the module.

This will allow it to call multiple times whenever getUserSyncs is called.

Our sync script does its own version of throttling.