### PR TITLE
Criteo Bid Adapter : Ensure we dont register an event listener for every single sync call

### DIFF
--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -260,7 +260,7 @@ export const spec = {
         version: '$prebid.version$'.replace(/\./g, '_'),
       };
 
-      window.addEventListener('message', function handler(event) {
+      function handleGumMessage(event) {
         if (!event.data || event.origin != 'https://gum.criteo.com') {
           return;
         }
@@ -269,7 +269,7 @@ export const spec = {
           return;
         }
 
-        this.removeEventListener('message', handler);
+        window.removeEventListener('message', handleGumMessage, true);
 
         event.stopImmediatePropagation();
 
@@ -286,7 +286,10 @@ export const spec = {
 
           response?.callbacks?.forEach?.(triggerPixel);
         }
-      }, true);
+      }
+
+      window.removeEventListener('message', handleGumMessage, true);
+      window.addEventListener('message', handleGumMessage, true);
 
       const jsonHashSerialized = JSON.stringify(jsonHash).replace(/"/g, '%22');
 


### PR DESCRIPTION
## Type of change
- [X] Bugfix

## Description of change
Reduced the number of event listener registered by our bid adapter.

