### PR TITLE
TTD Bid Adapter: Remove setting buyeruid legacy 9.53.x

### DIFF
--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -110,11 +110,6 @@ function getUser(bidderRequest, firstPartyData) {
   var eids = utils.deepAccess(bidderRequest, 'bids.0.userIdAsEids')
   if (eids && eids.length) {
     utils.deepSetValue(user, 'ext.eids', eids);
-
-    const tdid = eids.find(eid => eid.source == 'adserver.org')?.uids?.[0]?.id;
-    if (tdid) {
-      user.buyeruid = tdid
-    }
   }
 
   utils.mergeDeep(user, firstPartyData.user)

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -559,16 +559,6 @@ describe('ttdBidAdapter', function () {
       expect(requestBody.source.ext.schain).to.deep.equal(schain);
     });
 
-    it('no longer uses userId', function () {
-      const TDID = '00000000-0000-0000-0000-000000000000';
-      let clonedBannerRequests = deepClone(baseBannerBidRequests);
-      clonedBannerRequests[0].userId = {
-        tdid: TDID
-      };
-
-      const requestBody = testBuildRequests(clonedBannerRequests, baseBidderRequest).data;
-    });
-
     it('adds unified ID and UID2 info to user.ext.eids in the request', function () {
       const TDID = '00000000-0000-0000-0000-000000000000';
       const UID2 = '99999999-9999-9999-9999-999999999999';

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -567,7 +567,6 @@ describe('ttdBidAdapter', function () {
       };
 
       const requestBody = testBuildRequests(clonedBannerRequests, baseBidderRequest).data;
-      expect(requestBody.user.buyeruid).to.be.undefined;
     });
 
     it('adds unified ID and UID2 info to user.ext.eids in the request', function () {
@@ -601,28 +600,6 @@ describe('ttdBidAdapter', function () {
 
       const requestBody = testBuildRequests(clonedBannerRequests, baseBidderRequest).data;
       expect(requestBody.user.ext.eids).to.deep.equal(expectedEids);
-      expect(requestBody.user.buyeruid).to.equal(TDID);
-    });
-
-    it('has an empty buyeruid if tdid not found in userIdAsEids', function () {
-      const UID2 = '99999999-9999-9999-9999-999999999999';
-      let clonedBannerRequests = deepClone(baseBannerBidRequests);
-      clonedBannerRequests[0].userIdAsEids = [
-        {
-          source: 'uidapi.com',
-          uids: [
-            {
-              atype: 3,
-              id: UID2
-            }
-          ]
-        }
-      ];
-      const expectedEids = clonedBannerRequests[0].userIdAsEids;
-
-      const requestBody = testBuildRequests(clonedBannerRequests, baseBidderRequest).data;
-      expect(requestBody.user.ext.eids).to.deep.equal(expectedEids);
-      expect(requestBody.user.buyeruid).to.be.undefined;
     });
 
     it('adds first party site data to the request', function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Removing setting the buyeruid field on TTD bid requests. 
