### PR TITLE
Native renderer: use documentElement.scrollHeight if body.offsetHeight is 0

### DIFF
--- a/creative/renderers/native/renderer.js
+++ b/creative/renderers/native/renderer.js
@@ -80,7 +80,7 @@ export function render({adId, native}, {sendMessage}, win, getMarkup = getAdMark
     body.style.display = 'block';
     sendMessage(MESSAGE_NATIVE, {
       action: ACTION_RESIZE,
-      height: body.offsetHeight,
+      height: body.offsetHeight || win.document.documentElement.scrollHeight,
       width: body.offsetWidth
     });
   }

--- a/test/spec/creative/nativeRenderer_spec.js
+++ b/test/spec/creative/nativeRenderer_spec.js
@@ -299,6 +299,15 @@ describe('Native creative renderer', () => {
           win.onload();
           sinon.assert.calledWith(sendMessage, MESSAGE_NATIVE, {action: ACTION_RESIZE, height: 123, width: 321});
         })
+      });
+
+      it('uses scrollHeight if offsetHeight is 0', () => {
+        win.document.body.offsetHeight = 0;
+        win.document.documentElement = {scrollHeight: 200};
+        return runRender().then(() => {
+          win.onload();
+          sinon.assert.calledWith(sendMessage, MESSAGE_NATIVE, sinon.match({action: ACTION_RESIZE, height: 200}))
+        })
       })
     })
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

See https://github.com/prebid/Prebid.js/issues/13749

