### PR TITLE
in case the eids are undefined return an empty array

### DIFF
--- a/modules/userId/index.ts
+++ b/modules/userId/index.ts
@@ -615,7 +615,7 @@ function aliasEidsHook(next, bidderRequests) {
       Object.defineProperty(bid, 'userIdAsEids', {
         configurable: true,
         get() {
-          return bidderRequest.ortb2.user?.ext?.eids;
+          return bidderRequest.ortb2.user?.ext?.eids ?? [];
         }
       })
     )


### PR DESCRIPTION
- [x] Bugfix

when bidders try to to access(/iterate over) the userIdAsEids but it's undefined, as created by this PR https://github.com/prebid/Prebid.js/pull/13535 these adapters could fail by lacking current null check behavior, causing bid-requests to be constructed