### PR TITLE
Build system: fix bug where NPM consumers see modules removed by webpack's tree shaking

### DIFF
--- a/gulp.precompilation.js
+++ b/gulp.precompilation.js
@@ -77,7 +77,6 @@ function copyVerbatim() {
     `${name}/**/*.json`,
     `${name}/**/*.d.ts`,
   ]).concat([
-    './package.json',
     '!./src/types/local/**/*' // exclude "local", type definitions that should not be visible to consumers
   ]), {base: '.', since: gulp.lastRun(copyVerbatim)})
     .pipe(gulp.dest(helpers.getPrecompiledPath()))

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "dist/src/prebid.js",
     "dist/src/prebid.public.js",
     "dist/src/public/**/*.js",
-    "dist/src/modules/**/*.js"
+    "dist/src/modules/**/*.js",
+    "dist/src/metadata/**/*.js"
   ],
   "browserslist": [
     "> 0.25%",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
     "url": "https://github.com/prebid/Prebid.js.git"
   },
   "sideEffects": [
-    "src/prebid.js",
-    "modules/*.js",
-    "modules/*/index.js"
+    "dist/src/prebid.js",
+    "dist/src/prebid.public.js",
+    "dist/src/public/**/*.js",
+    "dist/src/modules/**/*.js"
   ],
   "browserslist": [
     "> 0.25%",

--- a/test/spec/modules/adgenerationBidAdapter_spec.js
+++ b/test/spec/modules/adgenerationBidAdapter_spec.js
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import {spec} from 'modules/adgenerationBidAdapter.js';
 import {newBidder} from 'src/adapters/bidderFactory.js';
 import {NATIVE} from 'src/mediaTypes.js';
-import prebid from '../../../package.json';
+import prebid from 'package.json';
 import { setConfig as setCurrencyConfig } from '../../../modules/currency.js';
 import { addFPDToBidderRequest } from '../../helpers/fpd.js';
 

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -3,7 +3,7 @@ import { tripleliftAdapterSpec, storage } from 'modules/tripleliftBidAdapter.js'
 import { newBidder } from 'src/adapters/bidderFactory.js';
 import { deepClone } from 'src/utils.js';
 import { config } from 'src/config.js';
-import prebid from '../../../package.json';
+import prebid from 'package.json';
 import * as utils from 'src/utils.js';
 import {getGlobal} from '../../../src/prebidGlobal.js';
 

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -54,6 +54,11 @@ module.exports = {
       helpers.getPrecompiledPath(),
       'node_modules'
     ],
+    alias: {
+      // alias package.json instead of including it as part of precompilation output;
+      // a simple copy does not work as it contains relative paths (e.g. sideEffects)
+      'package.json': path.resolve(__dirname, 'package.json')
+    }
   },
   module: {
     rules: [


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fixes https://github.com/prebid/Prebid.js/issues/13771
