### PR TITLE
Limelight Digital Bid Adapter: new alias

### DIFF
--- a/modules/limelightDigitalBidAdapter.js
+++ b/modules/limelightDigitalBidAdapter.js
@@ -115,8 +115,8 @@ export const spec = {
     const imageSyncs = [];
     for (let i = 0; i < serverResponses.length; i++) {
       const serverResponseHeaders = serverResponses[i].headers;
-      const imgSync = (serverResponseHeaders != null && syncOptions.pixelEnabled) ? serverResponseHeaders.get('x-pll-usersync-image') : null
-      const iframeSync = (serverResponseHeaders != null && syncOptions.iframeEnabled) ? serverResponseHeaders.get('x-pll-usersync-iframe') : null
+      const imgSync = (serverResponseHeaders != null && syncOptions.pixelEnabled) ? serverResponseHeaders.get('X-PLL-UserSync-Image') : null
+      const iframeSync = (serverResponseHeaders != null && syncOptions.iframeEnabled) ? serverResponseHeaders.get('X-PLL-UserSync-Iframe') : null
       if (iframeSync != null) {
         iframeSyncs.push(iframeSync)
       } else if (imgSync != null) {

--- a/test/spec/modules/limelightDigitalBidAdapter_spec.js
+++ b/test/spec/modules/limelightDigitalBidAdapter_spec.js
@@ -516,10 +516,10 @@ describe('limelightDigitalAdapter', function () {
         {
           headers: {
             get: function (header) {
-              if (header === 'x-pll-usersync-image') {
+              if (header === 'X-PLL-UserSync-Image') {
                 return 'https://tracker-lm.ortb.net/sync';
               }
-              if (header === 'x-pll-usersync-iframe') {
+              if (header === 'X-PLL-UserSync-Iframe') {
                 return 'https://tracker-lm.ortb.net/sync.html';
               }
             }
@@ -543,10 +543,10 @@ describe('limelightDigitalAdapter', function () {
         {
           headers: {
             get: function (header) {
-              if (header === 'x-pll-usersync-image') {
+              if (header === 'X-PLL-UserSync-Image') {
                 return 'https://tracker-1.ortb.net/sync';
               }
-              if (header === 'x-pll-usersync-iframe') {
+              if (header === 'X-PLL-UserSync-Iframe') {
                 return 'https://tracker-1.ortb.net/sync.html';
               }
             }
@@ -578,10 +578,10 @@ describe('limelightDigitalAdapter', function () {
         {
           headers: {
             get: function (header) {
-              if (header === 'x-pll-usersync-image') {
+              if (header === 'X-PLL-UserSync-Image') {
                 return 'https://tracker-lm.ortb.net/sync';
               }
-              if (header === 'x-pll-usersync-iframe') {
+              if (header === 'X-PLL-UserSync-Iframe') {
                 return 'https://tracker-lm.ortb.net/sync.html';
               }
             }
@@ -605,10 +605,10 @@ describe('limelightDigitalAdapter', function () {
         {
           headers: {
             get: function (header) {
-              if (header === 'x-pll-usersync-image') {
+              if (header === 'X-PLL-UserSync-Image') {
                 return 'https://tracker-1.ortb.net/sync';
               }
-              if (header === 'x-pll-usersync-iframe') {
+              if (header === 'X-PLL-UserSync-Iframe') {
                 return 'https://tracker-1.ortb.net/sync.html';
               }
             }
@@ -618,10 +618,10 @@ describe('limelightDigitalAdapter', function () {
         {
           headers: {
             get: function (header) {
-              if (header === 'x-pll-usersync-image') {
+              if (header === 'X-PLL-UserSync-Image') {
                 return 'https://tracker-2.ortb.net/sync';
               }
-              if (header === 'x-pll-usersync-iframe') {
+              if (header === 'X-PLL-UserSync-Iframe') {
                 return 'https://tracker-2.ortb.net/sync.html';
               }
             }
@@ -649,10 +649,10 @@ describe('limelightDigitalAdapter', function () {
         {
           headers: {
             get: function (header) {
-              if (header === 'x-pll-usersync-image') {
+              if (header === 'X-PLL-UserSync-Image') {
                 return 'https://tracker-lm.ortb.net/sync';
               }
-              if (header === 'x-pll-usersync-iframe') {
+              if (header === 'X-PLL-UserSync-Iframe') {
                 return 'https://tracker-lm.ortb.net/sync.html';
               }
             }
@@ -662,10 +662,10 @@ describe('limelightDigitalAdapter', function () {
         {
           headers: {
             get: function (header) {
-              if (header === 'x-pll-usersync-image') {
+              if (header === 'X-PLL-UserSync-Image') {
                 return 'https://tracker-lm.ortb.net/sync';
               }
-              if (header === 'x-pll-usersync-iframe') {
+              if (header === 'X-PLL-UserSync-Iframe') {
                 return 'https://tracker-lm.ortb.net/sync.html';
               }
             }
@@ -689,10 +689,10 @@ describe('limelightDigitalAdapter', function () {
         {
           headers: {
             get: function (header) {
-              if (header === 'x-pll-usersync-image') {
+              if (header === 'X-PLL-UserSync-Image') {
                 return 'https://tracker-lm.ortb.net/sync';
               }
-              if (header === 'x-pll-usersync-iframe') {
+              if (header === 'X-PLL-UserSync-Iframe') {
                 return 'https://tracker-lm.ortb.net/sync.html';
               }
             }


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
