### PR TITLE
Bridgewell Bid Adapter: adopt userIdAsEids

### DIFF
--- a/modules/bridgewellBidAdapter.js
+++ b/modules/bridgewellBidAdapter.js
@@ -46,36 +46,25 @@ export const spec = {
 
     const adUnits = [];
     var bidderUrl = REQUEST_ENDPOINT + Math.random();
-    var userIds;
 
     _each(validBidRequests, function (bid) {
-      userIds = bid.userId;
-
+      const adUnit = {
+        adUnitCode: bid.adUnitCode,
+        requestId: bid.bidId,
+        mediaTypes: bid.mediaTypes || {
+          banner: {
+            sizes: bid.sizes
+          }
+        },
+        userIds: bid.userId || {},
+        userIdAsEids: bid.userIdAsEids || {}
+      };
       if (bid.params.cid) {
-        adUnits.push({
-          cid: bid.params.cid,
-          adUnitCode: bid.adUnitCode,
-          requestId: bid.bidId,
-          mediaTypes: bid.mediaTypes || {
-            banner: {
-              sizes: bid.sizes
-            }
-          },
-          userIds: userIds || {}
-        });
+        adUnit.cid = bid.params.cid;
       } else {
-        adUnits.push({
-          ChannelID: bid.params.ChannelID,
-          adUnitCode: bid.adUnitCode,
-          requestId: bid.bidId,
-          mediaTypes: bid.mediaTypes || {
-            banner: {
-              sizes: bid.sizes
-            }
-          },
-          userIds: userIds || {}
-        });
+        adUnit.ChannelID = bid.params.ChannelID;
       }
+      adUnits.push(adUnit);
     });
 
     let topUrl = '';

--- a/test/spec/modules/bridgewellBidAdapter_spec.js
+++ b/test/spec/modules/bridgewellBidAdapter_spec.js
@@ -8,6 +8,16 @@ const userId = {
   'sharedid': {'id': '01F61MX53D786DSB2WYD38ZVM7', 'third': '01F61MX53D786DSB2WYD38ZVM7'},
   'uid2': {'id': 'eb33b0cb-8d35-1234-b9c0-1a31d4064777'},
 }
+const userIdAsEids = [{
+  source: 'test.org',
+  uids: [{
+    id: '01**********',
+    atype: 1,
+    ext: {
+      third: '01***********'
+    }
+  }]
+}];
 
 describe('bridgewellBidAdapter', function () {
   const adapter = newBidder(spec);
@@ -95,6 +105,7 @@ describe('bridgewellBidAdapter', function () {
         'bidderRequestId': '22edbae2733bf6',
         'auctionId': '1d1a030790a475',
         'userId': userId,
+        'userIdAsEids': userIdAsEids,
       },
       {
         'bidder': 'bridgewell',
@@ -135,6 +146,7 @@ describe('bridgewellBidAdapter', function () {
         'bidderRequestId': '22edbae2733bf6',
         'auctionId': '1d1a030790a475',
         'userId': userId,
+        'userIdAsEids': userIdAsEids,
       }
     ];
 
@@ -161,6 +173,8 @@ describe('bridgewellBidAdapter', function () {
         expect(u).to.have.property('requestId').and.to.equal('3150ccb55da321');
         expect(u).to.have.property('userIds');
         expect(u.userIds).to.deep.equal(userId);
+        expect(u).to.have.property('userIdAsEids');
+        expect(u.userIdAsEids).to.deep.equal(userIdAsEids);
       }
     });
 
@@ -188,7 +202,8 @@ describe('bridgewellBidAdapter', function () {
           'bidId': '3150ccb55da321',
           'bidderRequestId': '22edbae2733bf6',
           'auctionId': '1d1a030790a475',
-          'userId': userId
+          'userId': userId,
+          'userIdAsEids': userIdAsEids,
         },
       ];
 
@@ -206,6 +221,8 @@ describe('bridgewellBidAdapter', function () {
         expect(u).to.have.property('requestId').and.to.equal('3150ccb55da321');
         expect(u).to.have.property('userIds');
         expect(u.userIds).to.deep.equal(userId);
+        expect(u).to.have.property('userIdAsEids');
+        expect(u.userIdAsEids).to.deep.equal(userIdAsEids);
       }
     });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 

## Description of change
<!-- Describe the change proposed in this pull request -->
Adopt `userIdAsEids` in Bridgewell Bid Adapter

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
- issue:  https://github.com/prebid/Prebid.js/issues/11377#issuecomment-2891730744