### PR TITLE
Core: make transaction IDs bidder-specific

### DIFF
--- a/src/adapterManager.ts
+++ b/src/adapterManager.ts
@@ -219,7 +219,8 @@ type GetBidsOptions<SRC extends BidSource, BIDDER extends BidderCode | null> = {
   bidderRequestId: Identifier;
   adUnits: (SRC extends typeof S2S.SRC ? PBSAdUnit : AdUnit)[]
   src: SRC;
-  metrics: Metrics
+  metrics: Metrics,
+  tids: { [bidderCode: BidderCode]: string };
 }
 
 export type AliasBidderOptions = {
@@ -243,7 +244,7 @@ export type AnalyticsAdapter<P extends AnalyticsProvider> = StorageDisclosure & 
   gvlid?: number | ((config: AnalyticsConfig<P>) => number);
 }
 
-function getBids<SRC extends BidSource, BIDDER extends BidderCode | null>({bidderCode, auctionId, bidderRequestId, adUnits, src, metrics}: GetBidsOptions<SRC, BIDDER>): BidRequest<BIDDER>[] {
+function getBids<SRC extends BidSource, BIDDER extends BidderCode | null>({bidderCode, auctionId, bidderRequestId, adUnits, src, metrics, tids}: GetBidsOptions<SRC, BIDDER>): BidRequest<BIDDER>[] {
   return adUnits.reduce((result, adUnit) => {
     const bids = adUnit.bids.filter(bid => bid.bidder === bidderCode);
     if (bidderCode == null && bids.length === 0 && (adUnit as PBSAdUnit).s2sBid != null) {
@@ -251,9 +252,12 @@ function getBids<SRC extends BidSource, BIDDER extends BidderCode | null>({bidde
     }
     result.push(
       bids.reduce((bids: BidRequest<BIDDER>[], bid: BidRequest<BIDDER>) => {
+        if (!tids.hasOwnProperty(adUnit.transactionId)) {
+          tids[adUnit.transactionId] = generateUUID();
+        }
         bid = Object.assign({}, bid,
-          {ortb2Imp: mergeDeep({}, adUnit.ortb2Imp, bid.ortb2Imp)},
-          getDefinedParams(adUnit, ADUNIT_BID_PROPERTIES)
+          {ortb2Imp: mergeDeep({}, adUnit.ortb2Imp, bid.ortb2Imp, {ext: {tid: tids[adUnit.transactionId]}})},
+          getDefinedParams(adUnit, ADUNIT_BID_PROPERTIES),
         );
 
         const mediaTypes = bid.mediaTypes == null ? adUnit.mediaTypes : bid.mediaTypes
@@ -489,13 +493,30 @@ const adapterManager = {
     const ortb2 = ortb2Fragments.global || {};
     const bidderOrtb2 = ortb2Fragments.bidder || {};
 
+    const sourceTids: any = {};
+    const extTids: any = {};
+
+    function tidFor(tids, bidderCode, makeTid) {
+      const tid = tids.hasOwnProperty(bidderCode) ? tids[bidderCode] : makeTid();
+      if (bidderCode != null) {
+        tids[bidderCode] = tid;
+      }
+      return tid;
+    }
+
     function addOrtb2<T extends BidderRequest<any>>(bidderRequest: Partial<T>, s2sActivityParams?): T {
       const redact = dep.redact(
         s2sActivityParams != null
           ? s2sActivityParams
           : activityParams(MODULE_TYPE_BIDDER, bidderRequest.bidderCode)
       );
-      const fpd = Object.freeze(redact.ortb2(mergeDeep({source: {tid: auctionId}}, ortb2, bidderOrtb2[bidderRequest.bidderCode])));
+      const tid = tidFor(sourceTids, bidderRequest.bidderCode, generateUUID);
+      const fpd = Object.freeze(redact.ortb2(mergeDeep(
+        {},
+        ortb2,
+        bidderOrtb2[bidderRequest.bidderCode],
+        {source: {tid}}
+      )));
       bidderRequest.ortb2 = fpd;
       bidderRequest.bids = bidderRequest.bids.map((bid) => {
         bid.ortb2 = fpd;
@@ -513,6 +534,7 @@ const adapterManager = {
         const uniquePbsTid = generateUUID();
 
         (serverBidders.length === 0 && hasModuleBids ? [null] : serverBidders).forEach(bidderCode => {
+          const tids = tidFor(extTids, bidderCode, () => ({}));
           const bidderRequestId = generateUUID();
           const metrics = auctionMetrics.fork();
           const bidderRequest = addOrtb2({
@@ -520,7 +542,15 @@ const adapterManager = {
             auctionId,
             bidderRequestId,
             uniquePbsTid,
-            bids: getBids({ bidderCode, auctionId, bidderRequestId, 'adUnits': deepClone(adUnitsS2SCopy), src: S2S.SRC, metrics }),
+            bids: getBids({
+              bidderCode,
+              auctionId,
+              bidderRequestId,
+              'adUnits': deepClone(adUnitsS2SCopy),
+              src: S2S.SRC,
+              metrics,
+              tids
+            }),
             auctionStart: auctionStart,
             timeout: s2sConfig.timeout,
             src: S2S.SRC,
@@ -552,13 +582,22 @@ const adapterManager = {
     // client adapters
     const adUnitsClientCopy = getAdUnitCopyForClientAdapters(adUnits);
     clientBidders.forEach(bidderCode => {
+      const tids = tidFor(extTids, bidderCode, () => ({}));
       const bidderRequestId = generateUUID();
       const metrics = auctionMetrics.fork();
       const bidderRequest = addOrtb2({
         bidderCode,
         auctionId,
         bidderRequestId,
-        bids: getBids({bidderCode, auctionId, bidderRequestId, 'adUnits': deepClone(adUnitsClientCopy), src: 'client', metrics}),
+        bids: getBids({
+          bidderCode,
+          auctionId,
+          bidderRequestId,
+          'adUnits': deepClone(adUnitsClientCopy),
+          src: 'client',
+          metrics,
+          tids
+        }),
         auctionStart: auctionStart,
         timeout: cbTimeout,
         refererInfo,

--- a/src/adapters/bidderFactory.ts
+++ b/src/adapters/bidderFactory.ts
@@ -95,7 +95,10 @@ import {CONSENT_GDPR, CONSENT_GPP, CONSENT_USP, type ConsentData} from "../conse
 
 // common params for all mediaTypes
 const COMMON_BID_RESPONSE_KEYS = ['cpm', 'ttl', 'creativeId', 'netRevenue', 'currency'];
-const TIDS = ['auctionId', 'transactionId'];
+const TIDS = {
+  auctionId: (request) => request.ortb2?.source?.tid,
+  transactionId: (request) => request.ortb2Imp?.ext?.tid
+}
 
 export interface AdapterRequest {
   url: string;
@@ -187,15 +190,10 @@ export function registerBidder<B extends BidderCode>(spec: BidderSpec<B>) {
 }
 
 export const guardTids: any = memoize(({bidderCode}) => {
-  if (isActivityAllowed(ACTIVITY_TRANSMIT_TID, activityParams(MODULE_TYPE_BIDDER, bidderCode))) {
-    return {
-      bidRequest: (br) => br,
-      bidderRequest: (br) => br
-    };
-  }
+  const tidsAllowed = isActivityAllowed(ACTIVITY_TRANSMIT_TID, activityParams(MODULE_TYPE_BIDDER, bidderCode));
   function get(target, prop, receiver) {
-    if (TIDS.includes(prop)) {
-      return null;
+    if (TIDS.hasOwnProperty(prop)) {
+      return tidsAllowed ? TIDS[prop](target) : null;
     }
     return Reflect.get(target, prop, receiver);
   }
@@ -346,7 +344,7 @@ export function newBidder<B extends BidderCode>(spec: BidderSpec<B>) {
             bid.meta = bidResponse.meta || Object.assign({}, bidResponse[bidRequest.bidder]);
             bid.deferBilling = bidRequest.deferBilling;
             bid.deferRendering = bid.deferBilling && (bidResponse.deferRendering ?? typeof spec.onBidBillable !== 'function');
-            const prebidBid: Bid = Object.assign(createBid(bidRequest), bid, pick(bidRequest, TIDS));
+            const prebidBid: Bid = Object.assign(createBid(bidRequest), bid, pick(bidRequest, Object.keys(TIDS)));
             addBidWithCode(bidRequest.adUnitCode, prebidBid);
           } else {
             logWarn(`Bidder ${spec.code} made bid for unknown request ID: ${bidResponse.requestId}. Ignoring.`);

--- a/src/prebid.ts
+++ b/src/prebid.ts
@@ -891,7 +891,6 @@ export const startAuction = hook('async', function ({ bidsBackHandler, timeout: 
         tids[au.code] = tid;
       }
       au.transactionId = tid;
-      deepSetValue(au, 'ortb2Imp.ext.tid', tid);
     });
     const auction = auctionManager.createAuction({
       adUnits,

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -660,6 +660,7 @@ export function getAdUnits() {
   return [
     {
       'code': '/19968336/header-bid-tag1',
+      transactionId: 'au1',
       'mediaTypes': {
         'banner': {
           'sizes': [[728, 90], [970, 90]]
@@ -689,6 +690,7 @@ export function getAdUnits() {
       ]
     },
     {
+      transactionId: 'au2',
       'code': '/19968336/header-bid-tag-0',
       'mediaTypes': {
         'banner': {

--- a/test/spec/modules/paapi_spec.js
+++ b/test/spec/modules/paapi_spec.js
@@ -1280,13 +1280,28 @@ describe('paapi module', () => {
           bidId: 'bidId',
           adUnitCode: 'au',
           auctionId: 'aid',
+          ortb2: {
+            source: {
+              tid: 'aid'
+            },
+          },
           mediaTypes: {
             banner: {
               sizes: [[123, 321]]
             }
           }
         }];
-        bidderRequest = {auctionId: 'aid', bidderCode: 'mockBidder', paapi: {enabled: true}, bids};
+        bidderRequest = {
+          auctionId: 'aid',
+          bidderCode: 'mockBidder',
+          paapi: {enabled: true},
+          bids,
+          ortb2: {
+            source: {
+              tid: 'aid'
+            }
+          }
+        };
         restOfTheArgs = [{more: 'args'}];
         mockConfig = {
           seller: 'mock.seller',

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -2229,7 +2229,7 @@ describe('Unit: Prebid Module', function () {
             }
           })
         });
-        it('should be copied to ortb2Imp.ext.tid, if not specified', async () => {
+        it('should NOT be copied to ortb2Imp.ext.tid, if not specified', async () => {
           await runAuction({
             adUnits: [
               adUnit
@@ -2237,11 +2237,11 @@ describe('Unit: Prebid Module', function () {
           });
           const tid = auctionArgs.adUnits[0].transactionId;
           expect(tid).to.exist;
-          expect(auctionArgs.adUnits[0].ortb2Imp.ext.tid).to.eql(tid);
+          expect(auctionArgs.adUnits[0].ortb2Imp?.ext?.tid).to.not.exist;
         });
       });
 
-      it('should always set ortb2.ext.tid same as transactionId in adUnits', async function () {
+      it('should NOT set ortb2.ext.tid same as transactionId in adUnits', async function () {
         await runAuction({
           adUnits: [
             {
@@ -2257,11 +2257,9 @@ describe('Unit: Prebid Module', function () {
         });
 
         expect(auctionArgs.adUnits[0]).to.have.property('transactionId');
-        expect(auctionArgs.adUnits[0]).to.have.property('ortb2Imp');
-        expect(auctionArgs.adUnits[0].transactionId).to.equal(auctionArgs.adUnits[0].ortb2Imp.ext.tid);
+        expect(auctionArgs.adUnits[0].ortb2Imp?.ext?.tid).to.not.exist;
         expect(auctionArgs.adUnits[1]).to.have.property('transactionId');
-        expect(auctionArgs.adUnits[1]).to.have.property('ortb2Imp');
-        expect(auctionArgs.adUnits[1].transactionId).to.equal(auctionArgs.adUnits[1].ortb2Imp.ext.tid);
+        expect(auctionArgs.adUnits[0].ortb2Imp?.ext?.tid).to.not.exist;
       });
 
       it('should notify targeting of the latest auction for each adUnit', async function () {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

Update TID related logic so that they are unique for each bidder:

 - `ortb2Imp.ext.tid` is now generated for bid requests, not ad units, and unique for each bidder/transactionId pair;
 - `ortb2.source.tid` is now unique for each bidder;
 - both now ignore what was passed in as first party data, if any;
 - the `.auctionId` and `.transactionId` properties of bid requests, as seen by bid adapters, are now references to `ortb2.source.tid` and `ortb2Imp.ext.tid` respectively.

Note that this does not affect prebid server; since there's only one place for `source.tid` / `ext.tid` in a prebid server request, the same logic needs to happen server side.
