### PR TITLE
Core: make transaction IDs bidder-specific (9.53.x-legacy)

### DIFF
--- a/src/adapters/bidderFactory.js
+++ b/src/adapters/bidderFactory.js
@@ -328,8 +328,8 @@ export function newBidder(spec) {
             bid.originalCurrency = bid.currency;
             bid.meta = bid.meta || Object.assign({}, bid[bidRequest.bidder]);
             bid.deferBilling = bidRequest.deferBilling;
-            bid.deferRendering = bid.deferBilling && (bidResponse.deferRendering ?? typeof spec.onBidBillable !== 'function');
-            const prebidBid = Object.assign(createBid(bidRequest), bid, pick(bidRequest, Object.keys(TIDS)));
+            bid.deferRendering = bid.deferBilling && (bid.deferRendering ?? typeof spec.onBidBillable !== 'function');
+            const prebidBid = Object.assign(createBid(STATUS.GOOD, bidRequest), bid, pick(bidRequest, Object.keys(TIDS)));
             addBidWithCode(bidRequest.adUnitCode, prebidBid);
           } else {
             logWarn(`Bidder ${spec.code} made bid for unknown request ID: ${bid.requestId}. Ignoring.`);

--- a/src/prebid.js
+++ b/src/prebid.js
@@ -689,7 +689,6 @@ export const startAuction = hook('async', function ({ bidsBackHandler, timeout: 
         tids[au.code] = tid;
       }
       au.transactionId = tid;
-      deepSetValue(au, 'ortb2Imp.ext.tid', tid);
     });
     const auction = auctionManager.createAuction({
       adUnits,

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -660,6 +660,7 @@ export function getAdUnits() {
   return [
     {
       'code': '/19968336/header-bid-tag1',
+      transactionId: 'au1',
       'mediaTypes': {
         'banner': {
           'sizes': [[728, 90], [970, 90]]
@@ -689,6 +690,7 @@ export function getAdUnits() {
       ]
     },
     {
+      transactionId: 'au2',
       'code': '/19968336/header-bid-tag-0',
       'mediaTypes': {
         'banner': {

--- a/test/spec/modules/paapi_spec.js
+++ b/test/spec/modules/paapi_spec.js
@@ -1280,13 +1280,28 @@ describe('paapi module', () => {
           bidId: 'bidId',
           adUnitCode: 'au',
           auctionId: 'aid',
+          ortb2: {
+            source: {
+              tid: 'aid'
+            },
+          },
           mediaTypes: {
             banner: {
               sizes: [[123, 321]]
             }
           }
         }];
-        bidderRequest = {auctionId: 'aid', bidderCode: 'mockBidder', paapi: {enabled: true}, bids};
+        bidderRequest = {
+          auctionId: 'aid',
+          bidderCode: 'mockBidder',
+          paapi: {enabled: true},
+          bids,
+          ortb2: {
+            source: {
+              tid: 'aid'
+            }
+          }
+        };
         restOfTheArgs = [{more: 'args'}];
         mockConfig = {
           seller: 'mock.seller',

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -4,7 +4,7 @@ import adapterManager, {
   coppaDataHandler,
   _partitionBidders,
   PARTITIONS,
-  getS2SBidderSet, _filterBidsForAdUnit, dep
+  getS2SBidderSet, _filterBidsForAdUnit, dep, partitionBidders
 } from 'src/adapterManager.js';
 import {
   getAdUnits,
@@ -2098,7 +2098,7 @@ describe('adapterManager tests', function () {
       });
     });
 
-    describe('source.tid', () => {
+    describe('transaction IDs', () => {
       beforeEach(() => {
         sinon.stub(dep, 'redact').returns({
           ortb2: (o) => o,
@@ -2109,9 +2109,79 @@ describe('adapterManager tests', function () {
         dep.redact.restore();
       });
 
-      it('should be populated with auctionId', () => {
-        const reqs = adapterManager.makeBidRequests(adUnits, 0, 'mockAuctionId', 1000, [], {global: {}});
-        expect(reqs[0].ortb2.source.tid).to.equal('mockAuctionId');
+      function makeRequests(ortb2Fragments = {}) {
+        return adapterManager.makeBidRequests(adUnits, 0, 'mockAuctionId', 1000, [], ortb2Fragments);
+      }
+
+      it('should NOT populate source.tid with auctionId', () => {
+        const reqs = makeRequests();
+        expect(reqs[0].ortb2.source.tid).to.not.equal('mockAuctionId');
+      });
+      it('should override source.tid if specified in FPD', () => {
+        const reqs = makeRequests({
+          global: {
+            source: {
+              tid: 'tid'
+            }
+          },
+          rubicon: {
+            source: {
+              tid: 'tid'
+            }
+          }
+        });
+        reqs.forEach(req => {
+          expect(req.ortb2.source.tid).to.exist;
+          expect(req.ortb2.source.tid).to.not.eql('tid');
+        });
+        expect(reqs[0].ortb2.source.tid).to.not.eql(reqs[1].ortb2.source.tid);
+      });
+      it('should generate ortb2Imp.ext.tid', () => {
+        const reqs = makeRequests();
+        const tids = new Set(reqs.flatMap(br => br.bids).map(b => b.ortb2Imp?.ext?.tid));
+        expect(tids.size).to.eql(3);
+      });
+      it('should override ortb2Imp.ext.tid if specified in FPD', () => {
+        adUnits[0].ortb2Imp = adUnits[1].ortb2Imp = {
+          ext: {
+            tid: 'tid'
+          }
+        };
+        const reqs = makeRequests();
+        expect(reqs[0].bids[0].ortb2Imp.ext.tid).to.not.eql('tid');
+      });
+      it('should use matching ext.tid if transactionId match', () => {
+        adUnits[1].transactionId = adUnits[0].transactionId;
+        const reqs = makeRequests();
+        reqs.forEach(br => {
+          expect(new Set(br.bids.map(b => b.ortb2Imp.ext.tid)).size).to.eql(1);
+        })
+      });
+      describe('when the same bidder is routed to both client and server', () => {
+        function route(next) {
+          next.bail({
+            [PARTITIONS.CLIENT]: ['rubicon'],
+            [PARTITIONS.SERVER]: ['rubicon']
+          })
+        }
+        before(() => {
+          partitionBidders.before(route, 99)
+        });
+        after(() => {
+          partitionBidders.getHooks({hook: route}).remove();
+        });
+        beforeEach(() => {
+          config.setConfig({
+            s2sConfig: {
+              enabled: true,
+              bidders: ['rubicon']
+            }
+          })
+        })
+        it('should use the same source.tid', () => {
+          const reqs = makeRequests();
+          expect(reqs[0].ortb2.source.tid).to.eql(reqs[1].ortb2.source.tid);
+        })
       })
     });
 

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -21,19 +21,17 @@ const MOCK_BIDS_REQUEST = {
   bids: [
     {
       bidId: 1,
-      auctionId: 'first-bid-id',
       adUnitCode: 'mock/placement',
       params: {
         param: 5
-      }
+      },
     },
     {
       bidId: 2,
-      auctionId: 'second-bid-id',
       adUnitCode: 'mock/placement2',
       params: {
         badParam: 6
-      }
+      },
     }
   ]
 }
@@ -236,20 +234,27 @@ describe('bidderFactory', () => {
         });
 
         Object.entries({
-          'be hidden': false,
-          'not be hidden': true,
-        }).forEach(([t, allowed]) => {
-          const expectation = allowed ? (val) => expect(val).to.exist : (val) => expect(val).to.not.exist;
-
-          function checkBidRequest(br) {
-            ['auctionId', 'transactionId'].forEach((prop) => expectation(br[prop]));
-          }
-
-          function checkBidderRequest(br) {
-            expectation(br.auctionId);
-            br.bids.forEach(checkBidRequest);
-          }
-
+          'be hidden': {
+            allowed: false,
+            checkBidderRequest(br) {
+              expect(br.auctionId).to.not.exist;
+            },
+            checkBidRequest(br) {
+              expect(br.auctionId).to.not.exist;
+              expect(br.transactionId).to.not.exist;
+            },
+          },
+          'be an alias to the bidder specific tid': {
+            allowed: true,
+            checkBidderRequest(br) {
+              expect(br.auctionId).to.eql('bidder-tid');
+            },
+            checkBidRequest(br) {
+              expect(br.auctionId).to.eql('bidder-tid');
+              expect(br.transactionId).to.eql('bidder-ext-tid');
+            },
+          },
+        }).forEach(([t, {allowed, checkBidderRequest, checkBidRequest}]) => {
           it(`should ${t} from the spec logic when the transmitTid activity is${allowed ? '' : ' not'} allowed`, () => {
             spec.isBidRequestValid.callsFake(br => {
               checkBidRequest(br);
@@ -267,12 +272,27 @@ describe('bidderFactory', () => {
             bidder.callBids({
               bidderCode: 'mockBidder',
               auctionId: 'aid',
+              ortb2: {
+                source: {
+                  tid: 'bidder-tid'
+                }
+              },
               bids: [
                 {
                   adUnitCode: 'mockAU',
                   bidId: 'bid',
                   transactionId: 'tid',
-                  auctionId: 'aid'
+                  auctionId: 'aid',
+                  ortb2: {
+                    source: {
+                      tid: 'bidder-tid'
+                    },
+                  },
+                  ortb2Imp: {
+                    ext: {
+                      tid: 'bidder-ext-tid'
+                    }
+                  }
                 }
               ]
             }, addBidResponseStub, doneStub, ajaxStub, onTimelyResponseStub, wrappedCallback);

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -2203,7 +2203,7 @@ describe('Unit: Prebid Module', function () {
             }
           })
         });
-        it('should be copied to ortb2Imp.ext.tid, if not specified', async () => {
+        it('should NOT be copied to ortb2Imp.ext.tid, if not specified', async () => {
           await runAuction({
             adUnits: [
               adUnit
@@ -2211,11 +2211,11 @@ describe('Unit: Prebid Module', function () {
           });
           const tid = auctionArgs.adUnits[0].transactionId;
           expect(tid).to.exist;
-          expect(auctionArgs.adUnits[0].ortb2Imp.ext.tid).to.eql(tid);
+          expect(auctionArgs.adUnits[0].ortb2Imp?.ext?.tid).to.not.exist;
         });
       });
 
-      it('should always set ortb2.ext.tid same as transactionId in adUnits', async function () {
+      it('should NOT set ortb2.ext.tid same as transactionId in adUnits', async function () {
         await runAuction({
           adUnits: [
             {
@@ -2231,11 +2231,9 @@ describe('Unit: Prebid Module', function () {
         });
 
         expect(auctionArgs.adUnits[0]).to.have.property('transactionId');
-        expect(auctionArgs.adUnits[0]).to.have.property('ortb2Imp');
-        expect(auctionArgs.adUnits[0].transactionId).to.equal(auctionArgs.adUnits[0].ortb2Imp.ext.tid);
+        expect(auctionArgs.adUnits[0].ortb2Imp?.ext?.tid).to.not.exist;
         expect(auctionArgs.adUnits[1]).to.have.property('transactionId');
-        expect(auctionArgs.adUnits[1]).to.have.property('ortb2Imp');
-        expect(auctionArgs.adUnits[1].transactionId).to.equal(auctionArgs.adUnits[1].ortb2Imp.ext.tid);
+        expect(auctionArgs.adUnits[0].ortb2Imp?.ext?.tid).to.not.exist;
       });
 
       it('should notify targeting of the latest auction for each adUnit', async function () {


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

Backport of https://github.com/prebid/Prebid.js/pull/13800
