### PR TITLE
Medianet Analytics Adapter: pass ext from Prebid Server Response and Prebid 10 Updates

### DIFF
--- a/libraries/medianetUtils/logKeys.js
+++ b/libraries/medianetUtils/logKeys.js
@@ -125,6 +125,7 @@ export const KeysMap = {
       'floorData.floorRule as flrrule',
       'floorRuleValue as flrRulePrice',
       'serverLatencyMillis as rtime',
+      'pbsExt',
       'creativeId as pcrid',
       'dbf',
       'latestTargetedAuctionId as lacid',

--- a/libraries/pbsExtensions/processors/pbs.js
+++ b/libraries/pbsExtensions/processors/pbs.js
@@ -82,20 +82,37 @@ export const PBS_PROCESSORS = {
   },
   [RESPONSE]: {
     serverSideStats: {
-      // updates bidderRequest and bidRequests with serverErrors from ext.errors and serverResponseTimeMs from ext.responsetimemillis
+      // updates bidderRequest and bidRequests with fields from response.ext
+      // - bidder-scoped for 'errors' and 'responsetimemillis'
+      // - copy-as-is for all other fields
       fn(response, ortbResponse, context) {
-        Object.entries({
+        const bidder = context.bidderRequest?.bidderCode;
+        const ext = ortbResponse?.ext;
+        if (!ext) return;
+
+        const FIELD_MAP = {
           errors: 'serverErrors',
           responsetimemillis: 'serverResponseTimeMs'
-        }).forEach(([serverName, clientName]) => {
-          const value = deepAccess(ortbResponse, `ext.${serverName}.${context.bidderRequest.bidderCode}`);
-          if (value) {
-            context.bidderRequest[clientName] = value;
-            context.bidRequests.forEach(bid => {
-              bid[clientName] = value;
-            });
+        };
+
+        Object.entries(ext).forEach(([field, extValue]) => {
+          if (FIELD_MAP[field]) {
+            if (!bidder) return;
+            const value = extValue?.[bidder];
+            if (value !== undefined) {
+              const clientName = FIELD_MAP[field];
+              context.bidderRequest[clientName] = value;
+              context.bidRequests?.forEach(bid => {
+                bid[clientName] = value;
+              });
+            }
+          } else {
+            if (extValue !== undefined) {
+              context.bidderRequest.pbsExt = context.bidderRequest.pbsExt || {};
+              context.bidderRequest.pbsExt[field] = extValue;
+            }
           }
-        })
+        });
       }
     },
   }


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Updated analytics adapter 

## Description of change

In the Prebid Server Bid Adapter response, server-side statistics from the `ext` object are passed into both `bidderRequest` and `bidRequest`.

The complete `ext` object is now included in `bidderRequest` without altering the existing structure, enabling its use for logging within the `MedianetAnalyticsAdapter`.

The implementation has been updated to use `pbjs.getUserIds` instead of consuming user IDs from the `bid` object.

AdUnit context is now passed in the VAST error tracker URL.

