### PR TITLE
AdGeneration Bid Adapter: Fix currency handling bug

### DIFF
--- a/modules/adgenerationBidAdapter.js
+++ b/modules/adgenerationBidAdapter.js
@@ -16,7 +16,7 @@ const adgLogger = prefixLog('Adgeneration: ');
  */
 
 const ADG_BIDDER_CODE = 'adgeneration';
-const ADGENE_PREBID_VERSION = '1.6.4';
+const ADGENE_PREBID_VERSION = '1.6.5';
 const DEBUG_URL = 'https://api-test.scaleout.jp/adgen/prebid';
 const URL = 'https://d.socdm.com/adgen/prebid';
 
@@ -139,7 +139,8 @@ export const spec = {
     const adResult = body?.results[0];
     const targetImp = bidRequests?.data?.ortb?.imp[0];
     const requestId = targetImp?.id;
-
+        
+    
     const bidResponse = {
       requestId: requestId,
       cpm: adResult.cpm || 0,
@@ -147,7 +148,7 @@ export const spec = {
       height: adResult.h ? adResult.h : 1,
       creativeId: adResult.creativeid || '',
       dealId: adResult.dealid || '',
-      currency: getCurrencyType(bidRequests.bidderRequest),
+      currency: bidRequests?.data?.currency || 'JPY',
       netRevenue: true,
       ttl: adResult.ttl || 10,
     };

--- a/modules/adgenerationBidAdapter.js
+++ b/modules/adgenerationBidAdapter.js
@@ -30,7 +30,6 @@ const converter = ortbConverter({
     const imp = buildImp(bidRequest, context);
     deepSetValue(imp, 'ext.params', bidRequest.params);
     deepSetValue(imp, 'ext.mediaTypes', bidRequest.mediaTypes);
-    deepSetValue(imp, 'ext.novatiqSyncResponse', bidRequest?.userId?.novatiq?.snowflake?.syncResponse);
     return imp;
   },
   request(buildRequest, imps, bidderRequest, context) {
@@ -69,13 +68,6 @@ export const spec = {
       const customParams = impObj?.ext?.params;
       const id = getBidIdParameter('id', customParams);
       const additionalParams = JSON.parse(JSON.stringify(rest));
-
-      // hyperIDが有効ではない場合、パラメータから削除する
-      if (!impObj?.ext?.novatiqSyncResponse || impObj?.ext?.novatiqSyncResponse !== 1) {
-        if (additionalParams?.user?.ext?.eids && Array.isArray(additionalParams?.user?.ext?.eids)) {
-          additionalParams.user.ext.eids = additionalParams?.user?.ext?.eids.filter((eid) => eid?.source !== 'novatiq.com');
-        }
-      }
 
       let urlParams = ``;
       urlParams = tryAppendQueryString(urlParams, 'id', id);

--- a/modules/adgenerationBidAdapter.js
+++ b/modules/adgenerationBidAdapter.js
@@ -131,8 +131,7 @@ export const spec = {
     const adResult = body?.results[0];
     const targetImp = bidRequests?.data?.ortb?.imp[0];
     const requestId = targetImp?.id;
-        
-    
+
     const bidResponse = {
       requestId: requestId,
       cpm: adResult.cpm || 0,

--- a/test/spec/modules/adgenerationBidAdapter_spec.js
+++ b/test/spec/modules/adgenerationBidAdapter_spec.js
@@ -117,23 +117,6 @@ describe('AdgenerationAdapter', function () {
         auctionId: '4aae9f05-18c6-4fcd-80cf-282708cd584a',
         transactionTd: 'f76f6dfd-d64f-4645-a29f-682bac7f431a'
       },
-      { // bannerWithHyperId
-        bidder: 'adg',
-        params: {
-          id: '58278', // banner
-        },
-        adUnitCode: 'adunit-code',
-        sizes: [[320, 100]],
-        bidId: '2f6ac468a9c15e',
-        bidderRequestId: '14a9f773e30243',
-        auctionId: '4aae9f05-18c6-4fcd-80cf-282708cd584a',
-        transactionTd: 'f76f6dfd-d64f-4645-a29f-682bac7f431a',
-        userId: {
-          novatiq: {
-            snowflake: {'id': 'novatiqId', syncResponse: 1}
-          }
-        }
-      },
       { // bannerWithAdgextCriteoId
         bidder: 'adg',
         params: {
@@ -296,32 +279,8 @@ describe('AdgenerationAdapter', function () {
       expect(request.data.sdkname).to.equal('prebidjs');
       expect(request.data.adapterver).to.equal(ADGENE_PREBID_VERSION);
       expect(request.data.ortb.imp[0].id).to.equal('2f6ac468a9c15e');
-      expect(request.data.ortb.imp[0].ext.novatiqSyncResponse).to.equal(undefined);
       expect(request.data.ortb.imp[0].ext.params.id).to.equal('58278');
       expect(request.data.ortb.imp[0].ext.mediaTypes).to.deep.equal(expectedMediaTypes);
-    });
-
-    it('should attache params to the bannerWithHyperId request', function () {
-      const hyperIdParams = {
-        user: {
-          ext: {
-            eids: [
-              {
-                source: 'novatiq.com',
-                uids: [
-                  {
-                    'id': 'xxxxxx'
-                  }
-                ]
-              },
-            ]
-          }
-        }
-      }
-      const request = spec.buildRequests(bidRequests, {...bidderRequest, ortb2: hyperIdParams})[2];
-
-      expect(request.data.ortb.imp[0].ext.novatiqSyncResponse).to.equal(1);
-      expect(request.data.ortb.user).to.deep.equal(hyperIdParams.user);
     });
 
     it('should attache params to the bannerWithAdgextCriteoId request', function () {
@@ -395,7 +354,7 @@ describe('AdgenerationAdapter', function () {
           }
         },
       }
-      const request = spec.buildRequests(bidRequests, {...bidderRequest, ortb2: idparams})[4];
+      const request = spec.buildRequests(bidRequests, {...bidderRequest, ortb2: idparams})[3];
       expect(request.data.ortb.user).to.deep.equal(idparams.user);
 
       // gpid
@@ -668,8 +627,7 @@ describe('AdgenerationAdapter', function () {
                         'sendId': false
                       }
                     }
-                  },
-                  'novatiqSyncResponse': 2
+                  }
                 },
                 'id': '2f6ac468a9c15e',
                 'native': {
@@ -833,8 +791,7 @@ describe('AdgenerationAdapter', function () {
                         ]
                       ]
                     }
-                  },
-                  'novatiqSyncResponse': 2
+                  }
                 },
                 'id': '2f6ac468a9c15e',
                 'banner': {

--- a/test/spec/modules/adgenerationBidAdapter_spec.js
+++ b/test/spec/modules/adgenerationBidAdapter_spec.js
@@ -1193,7 +1193,7 @@ describe('AdgenerationAdapter', function () {
       };
       return addFPDToBidderRequest(bidderRequest).then(res => {
         const sr = {body: serverResponse.normal.upperBillboard};
-        const br = {  bidderRequest: res, ...bidRequests.upperBillboard };
+        const br = { bidderRequest: res, ...bidRequests.upperBillboard };
 
         const result = spec.interpretResponse(sr, br)[0];
         expect(result.requestId).to.equal(bidResponses.normal.upperBillboard.requestId);
@@ -1335,7 +1335,7 @@ describe('AdgenerationAdapter', function () {
             }]
           }
         };
-        
+
         const result = spec.interpretResponse(serverResponse, bidRequest)[0];
         expect(result.currency).to.equal('USD');
         expect(result.cpm).to.equal(100);
@@ -1373,7 +1373,7 @@ describe('AdgenerationAdapter', function () {
             }]
           }
         };
-        
+
         const result = spec.interpretResponse(serverResponse, requestWithoutCurrency)[0];
         expect(result.currency).to.equal('JPY');
       });
@@ -1412,7 +1412,7 @@ describe('AdgenerationAdapter', function () {
             }]
           }
         };
-        
+
         const result = spec.interpretResponse(serverResponse, bidRequestWithJPY)[0];
         expect(result.currency).to.equal('JPY');
       });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->

- Fixes a bug where USD CPMs were incorrectly treated as JPY.
- Removes support for novatiqId.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
