### PR TITLE
PubMatic Bid Adapter : optimize impressions

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -73,6 +73,8 @@ const converter = ortbConverter({
     if (!imp.hasOwnProperty('banner') && !imp.hasOwnProperty('video') && !imp.hasOwnProperty('native')) {
       return null;
     }
+    imp.ext = imp.ext || {};
+    imp.ext.pbcode = adUnitCode;
     if (deals) addPMPDeals(imp, deals);
     if (dctr) addDealCustomTargetings(imp, dctr);
     if (rtd?.jwplayer) addJWPlayerSegmentData(imp, rtd.jwplayer);
@@ -95,7 +97,9 @@ const converter = ortbConverter({
     return imp;
   },
   request(buildRequest, imps, bidderRequest, context) {
-    const request = buildRequest(imps, bidderRequest, context);
+    // Optimize the imps array before building the request
+    const optimizedImps = optimizeImps(imps, bidderRequest);
+    const request = buildRequest(optimizedImps, bidderRequest, context);
     if (blockedIabCategories.length || request.bcat) {
       const validatedBCategories = validateBlockedCategories([...(blockedIabCategories || []), ...(request.bcat || [])]);
       if (validatedBCategories.length) request.bcat = validatedBCategories;
@@ -568,6 +572,46 @@ const getConnectionType = () => {
   let connection = window.navigator && (window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection);
   const types = { ethernet: 1, wifi: 2, 'slow-2g': 4, '2g': 4, '3g': 5, '4g': 6 };
   return types[connection?.effectiveType] || 0;
+}
+
+/**
+ * Optimizes the impressions array by consolidating impressions for the same ad unit and media type
+ * @param {Array} imps - Array of impression objects
+ * @param {Object} bidderRequest - The bidder request object
+ * @returns {Array} - Optimized impressions array
+ */
+function optimizeImps(imps, bidderRequest) {
+  const optimizedImps = {};
+
+  bidderRequest.bids.forEach(bid => {
+    const correspondingImp = imps.find(imp => imp.id === bid.bidId);
+    if (!correspondingImp) return;
+    const uniqueKey = bid.adUnitId;
+    if (!optimizedImps[uniqueKey]) {
+      optimizedImps[uniqueKey] = deepClone(correspondingImp);
+      return;
+    }
+    const baseImp = optimizedImps[uniqueKey];
+
+    if (isStr(correspondingImp.tagid)) {
+      baseImp.tagid = correspondingImp.tagid;
+    }
+
+    const copyPropertytoPath = (propPath, propName, toMerge) => {
+      if (!correspondingImp[propPath] || !correspondingImp[propPath][propName]) return;
+      if (!baseImp[propPath]) baseImp[propPath] = {};
+      if (toMerge) {
+        if (!baseImp[propPath][propName]) baseImp[propPath][propName] = [];
+        baseImp[propPath][propName] = [...baseImp[propPath][propName], ...correspondingImp[propPath][propName]];
+      } else {
+        baseImp[propPath][propName] = correspondingImp[propPath][propName];
+      }
+    };
+    copyPropertytoPath('ext', 'key_val', false);
+    copyPropertytoPath('ext', 'pmZoneId', false);
+    copyPropertytoPath('pmp', 'deals', true);
+  });
+  return Object.values(optimizedImps);
 }
 
 // BB stands for Blue BillyWig

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -345,6 +345,15 @@ describe('PubMatic adapter', () => {
         expect(imp[0]).to.have.property('ext').to.have.property('pmZoneId');
       });
 
+      it('should add pbcode in ext with adUnitCode value', () => {
+        const request = spec.buildRequests(validBidRequests, bidderRequest);
+        const { imp } = request?.data;
+        expect(imp).to.be.an('array');
+        expect(imp[0]).to.have.property('ext');
+        expect(imp[0].ext).to.have.property('pbcode');
+        expect(imp[0].ext.pbcode).to.equal(validBidRequests[0].adUnitCode);
+      });
+
       it('should add bidfloor if kadfloor is present in parameters', () => {
         const request = spec.buildRequests(validBidRequests, bidderRequest);
         const { imp } = request?.data;
@@ -1457,6 +1466,59 @@ describe('PubMatic adapter', () => {
     const request = spec.buildRequests([bidRequestWithKadPageUrl], bidderRequest);
     expect(request.data.site).to.exist;
     expect(request.data.site.page).to.equal('https://example.com/page');
+  });
+
+  describe('Impression optimization', () => {
+    it('should add pbcode to impression ext with adUnitCode value', () => {
+      const request = spec.buildRequests(validBidRequests, bidderRequest);
+      const { imp } = request?.data;
+
+      expect(imp).to.be.an('array');
+      expect(imp[0]).to.have.property('ext');
+      expect(imp[0].ext).to.have.property('pbcode');
+      expect(imp[0].ext.pbcode).to.equal(validBidRequests[0].adUnitCode);
+    });
+
+    it('should consolidate impressions with same adUnitCode and media type', () => {
+      // Create two banner bids with the same adUnitCode
+      const bid1 = utils.deepClone(validBidRequests[0]);
+      const bid2 = utils.deepClone(validBidRequests[0]);
+
+      bid1.bidId = 'bid-id-1';
+      bid2.bidId = 'bid-id-2';
+
+      // Set the same adUnitCode and adSlot to ensure they're treated as the same unit
+      const sharedAdUnitCode = 'shared-ad-unit';
+      bid1.adUnitCode = sharedAdUnitCode;
+      bid2.adUnitCode = sharedAdUnitCode;
+      bid1.params.adSlot = 'same_ad_slot';
+      bid2.params.adSlot = 'same_ad_slot';
+
+      bid1.mediaTypes = { banner: { sizes: [[300, 250]] } };
+      bid2.mediaTypes = { banner: { sizes: [[300, 250]] } };
+
+      bid1.params.pmzoneid = 'zone1';
+      bid2.params.pmzoneid = 'zone2';
+
+      const bidRequests = [bid1, bid2];
+      const combinedBidderRequest = utils.deepClone(bidderRequest);
+      combinedBidderRequest.bids = bidRequests;
+
+      const request = spec.buildRequests(bidRequests, combinedBidderRequest);
+      const { imp } = request?.data;
+
+      // Should be consolidated to a single impression
+      expect(imp).to.be.an('array');
+      expect(imp).to.have.lengthOf(1);
+
+      expect(imp[0].ext).to.have.property('pbcode');
+      expect(imp[0].ext.pbcode).to.equal(sharedAdUnitCode);
+
+      if (imp[0].ext.pmZoneId) {
+        expect(typeof imp[0].ext.pmZoneId).to.equal('string');
+        expect(imp[0].ext.pmZoneId).to.equal('zone2');
+      }
+    });
   });
 
   it('should set site.publisher.id from pubId', () => {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
This PR implements impression optimization in the PubMatic bid adapter to consolidate multiple impressions belonging to the same adUnitCode. This optimization reduces payload size and improves network efficiency.
Relates to : https://github.com/prebid/Prebid.js/pull/13791

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
