### PR TITLE
Core: remove use of document.write in rendering

### DIFF
--- a/src/adRendering.ts
+++ b/src/adRendering.ts
@@ -323,25 +323,20 @@ export function renderAdDirect(doc, adId, options) {
     }
   }
   const messageHandler = creativeMessageHandler({resizeFn});
+
   function renderFn(adData) {
-    if (adData.ad) {
-      doc.write(adData.ad);
-      doc.close();
-      emitAdRenderSucceeded({doc, bid, id: bid.adId});
-    } else {
-      getCreativeRenderer(bid)
-        .then(render => render(adData, {
-          sendMessage: (type, data) => messageHandler(type, data, bid),
-          mkFrame: createIframe,
-        }, doc.defaultView))
-        .then(
-          () => emitAdRenderSucceeded({doc, bid, id: bid.adId}),
-          (e) => {
-            fail(e?.reason || AD_RENDER_FAILED_REASON.EXCEPTION, e?.message)
-            e?.stack && logError(e);
-          }
-        );
-    }
+    getCreativeRenderer(bid)
+      .then(render => render(adData, {
+        sendMessage: (type, data) => messageHandler(type, data, bid),
+        mkFrame: createIframe,
+      }, doc.defaultView))
+      .then(
+        () => emitAdRenderSucceeded({doc, bid, id: bid.adId}),
+        (e) => {
+          fail(e?.reason || AD_RENDER_FAILED_REASON.EXCEPTION, e?.message)
+          e?.stack && logError(e);
+        }
+      );
     // TODO: this is almost certainly the wrong way to do this
     const creativeComment = document.createComment(`Creative ${bid.creativeId} served by ${bid.bidder} Prebid.js Header Bidding`);
     insertElement(creativeComment, doc, 'html');

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1281,13 +1281,14 @@ describe('Unit: Prebid Module', function () {
     });
 
     it('should write the ad to the doc', function () {
+      const ad = "<script type='text/javascript' src='http://server.example.com/ad/ad.js'></script>";
       pushBidResponseToAuction({
-        ad: "<script type='text/javascript' src='http://server.example.com/ad/ad.js'></script>"
+        ad
       });
-      adResponse.ad = "<script type='text/javascript' src='http://server.example.com/ad/ad.js'></script>";
+      const iframe = {};
+      doc.createElement.returns(iframe);
       return renderAd(doc, bidId).then(() => {
-        assert.ok(doc.write.calledWith(adResponse.ad), 'ad was written to doc');
-        assert.ok(doc.close.called, 'close method called');
+        expect(iframe.srcdoc).to.eql(ad);
       })
     });
 
@@ -1333,7 +1334,7 @@ describe('Unit: Prebid Module', function () {
         mediatype: 'video'
       });
       return renderAd(doc, bidId).then(() => {
-        sinon.assert.notCalled(doc.write);
+        sinon.assert.notCalled(doc.createElement);
       });
     });
 
@@ -1343,7 +1344,7 @@ describe('Unit: Prebid Module', function () {
       });
 
       var error = { message: 'doc write error' };
-      doc.write = sinon.stub().throws(error);
+      doc.createElement.throws(error);
 
       return renderAd(doc, bidId).then(() => {
         var errorMessage = `Error rendering ad (id: ${bidId}): doc write error`
@@ -1423,13 +1424,13 @@ describe('Unit: Prebid Module', function () {
         spyAddWinningBid.resetHistory();
         onWonEvent.resetHistory();
         onStaleEvent.resetHistory();
-        doc.write.resetHistory();
+        doc.createElement.resetHistory();
         return renderAd(doc, bidId);
       }).then(() => {
         // Second render should have a warning but still be rendered
         sinon.assert.calledWith(spyLogWarn, warning);
         sinon.assert.calledWith(onStaleEvent, adResponse);
-        sinon.assert.called(doc.write);
+        sinon.assert.called(doc.createElement);
 
         // Clean up
         pbjs.offEvent(EVENTS.BID_WON, onWonEvent);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

This removes the special case for bids providing `ad` (and not `adUrl`) that, when not in a safeframe, are rendered using `document.write`; replacing it with an iframe `srcdoc` instead (the same logic used in the safeframe case).

From my testing this fixes the GAM viewability issue reported in https://github.com/prebid/Prebid.js/issues/13836 without the need to turn off yielding.

## Other information
Related: https://github.com/prebid/Prebid.js/issues/8337

