### PR TITLE
Kobler bid adapter: differentiate missing permissions data from not given.

### DIFF
--- a/modules/koblerBidAdapter.js
+++ b/modules/koblerBidAdapter.js
@@ -134,6 +134,18 @@ function getPageUrlFromRefererInfo() {
     : window.location.href;
 }
 
+function getPurposeStatus(purposeData, purposeField, purposeNumber) {
+  if (!purposeData) {
+    return false;
+  }
+
+  if (!purposeData[purposeField]) {
+    return false;
+  }
+
+  return purposeData[purposeField][purposeNumber] === true;
+}
+
 function buildOpenRtbBidRequestPayload(validBidRequests, bidderRequest) {
   const imps = validBidRequests.map(buildOpenRtbImpObject);
   const timeout = bidderRequest.timeout;
@@ -149,13 +161,10 @@ function buildOpenRtbBidRequestPayload(validBidRequests, bidderRequest) {
     const purposeData = vendorData.purpose;
     const restrictions = vendorData.publisher ? vendorData.publisher.restrictions : null;
     const restrictionForPurpose2 = restrictions ? (restrictions[2] ? Object.values(restrictions[2])[0] : null) : null;
-    purpose2Given = restrictionForPurpose2 === 1 ? (
-      purposeData && purposeData.consents && purposeData.consents[2]
-    ) : (
-      restrictionForPurpose2 === 0
-        ? false : (purposeData && purposeData.legitimateInterests && purposeData.legitimateInterests[2])
+    purpose2Given = restrictionForPurpose2 === 1 ? getPurposeStatus(purposeData, 'consents', 2) : (
+      restrictionForPurpose2 === 0 ? false : getPurposeStatus(purposeData, 'legitimateInterests', 2)
     );
-    purpose3Given = purposeData && purposeData.consents && purposeData.consents[3];
+    purpose3Given = getPurposeStatus(purposeData, 'consents', 3);
   }
   const request = {
     id: bidderRequest.bidderRequestId,


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
When a user doesn't give a certain TCF permission, it doesn't show up at all as a field in the data available to the adapters. For example, `bidderRequest.gdprConsent.vendorData.purpose.consents[2]` is `undefined` in these cases instead of `false`. This could result in imprecise data in our bidder.