### PR TITLE
Pubmatic Bid adapter : add biddercode in translator payload for reporting purposes

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -110,7 +110,7 @@ const converter = ortbConverter({
     }
     reqLevelParams(request);
     updateUserSiteDevice(request, context?.bidRequests);
-    addExtenstionParams(request);
+    addExtenstionParams(request, bidderRequest)
     const marketPlaceEnabled = bidderRequest?.bidderCode
       ? bidderSettings.get(bidderRequest.bidderCode, 'allowAlternateBidderCodes') : undefined;
     if (marketPlaceEnabled) updateRequestExt(request, bidderRequest);
@@ -510,7 +510,7 @@ const updateResponseWithCustomFields = (res, bid, ctx) => {
   }
 }
 
-const addExtenstionParams = (req) => {
+const addExtenstionParams = (req, bidderRequest) => {
   const { profId, verId, wiid, transactionId } = conf;
   req.ext = {
     epoch: new Date().getTime(), // Sending epoch timestamp in request.ext object
@@ -520,7 +520,8 @@ const addExtenstionParams = (req) => {
       wiid: wiid,
       wv: '$$REPO_AND_VERSION$$',
       transactionId,
-      wp: 'pbjs'
+      wp: 'pbjs',
+      biddercode: bidderRequest?.bidderCode
     },
     cpmAdjustment: cpmAdjustment
   }

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -3,9 +3,11 @@ import { spec, cpmAdjustment, addViewabilityToImp } from 'modules/pubmaticBidAda
 import * as utils from 'src/utils.js';
 import { bidderSettings } from 'src/bidderSettings.js';
 import { config } from 'src/config.js';
+import {getGlobal} from '../../../src/prebidGlobal.js';
 
 describe('PubMatic adapter', () => {
-  let firstBid, videoBid, firstResponse, response, videoResponse;
+  let firstBid, videoBid, firstResponse, response, videoResponse, firstAliasBid;
+  const PUBMATIC_ALIAS_BIDDER = 'pubmaticAlias';
   const request = {};
   firstBid = {
     adUnitCode: 'Div1',
@@ -53,6 +55,89 @@ describe('PubMatic adapter', () => {
       },
       site: {domain: 'ebay.com', page: 'https://ebay.com', publisher: {id: '5670'}},
       source: {}
+    },
+    ortb2Imp: {
+      ext: {
+        tid: '92489f71-1bf2-49a0-adf9-000cea934729',
+        gpid: '/1111/homepage-leftnav',
+        data: {
+          pbadslot: '/1111/homepage-leftnav',
+          adserver: {
+            name: 'gam',
+            adslot: '/1111/homepage-leftnav'
+          },
+          customData: {
+            id: 'id-1'
+          }
+        }
+      }
+    },
+    rtd: {
+      jwplayer: {
+        targeting: {
+          content: {
+            id: 'jwplayer-content-id'
+          },
+          segments: [
+            'jwplayer-segment-1', 'jwplayer-segment-2'
+          ]
+        }
+      }
+    }
+  }
+  firstAliasBid = {
+    adUnitCode: 'Div1',
+    bidder: PUBMATIC_ALIAS_BIDDER,
+    mediaTypes: {
+      banner: {
+        sizes: [[728, 90], [160, 600]],
+        pos: 1
+      }
+    },
+    params: {
+      publisherId: '5670',
+      adSlot: '/15671365/DMDemo@300x250:0',
+      kadfloor: '1.2',
+      pmzoneid: 'aabc, ddef',
+      // kadpageurl: 'www.publisher.com',
+      yob: '1986',
+      gender: 'M',
+      lat: '12.3',
+      lon: '23.7',
+      wiid: '1234567890',
+      profId: '100',
+      verId: '200',
+      currency: 'AUD',
+      dctr: 'key1:val1,val2|key2:val1',
+      deals: ['deal-1', 'deal-2']
+    },
+    placementCode: '/19968336/header-bid-tag-1',
+    sizes: [
+      [300, 250],
+      [300, 600],
+      ['fluid']
+    ],
+    bidId: '3736271c3c4b27',
+    requestId: '0fb4905b-9456-4152-86be-c6f6d259ba99',
+    bidderRequestId: '1c56ad30b9b8ca8',
+    ortb2: {
+      device: {
+        w: 1200,
+        h: 1800,
+        sua: {},
+        language: 'en',
+        js: 1,
+        connectiontype: 6
+      },
+      site: {domain: 'ebay.com', page: 'https://ebay.com', publisher: {id: '5670'}},
+      source: {},
+      user: {
+        ext: {
+          data: {
+            im_segments: ['segment1', 'segment2']
+          }
+        }
+      }
     },
     ortb2Imp: {
       ext: {
@@ -143,6 +228,7 @@ describe('PubMatic adapter', () => {
     }
   }
   const validBidRequests = [firstBid];
+  const validAliasBidRequests = [firstAliasBid];
   const bidderRequest = {
     bids: [firstBid],
     auctionId: 'ee3074fe-97ce-4681-9235-d7622aede74c',
@@ -164,6 +250,38 @@ describe('PubMatic adapter', () => {
       },
       site: {domain: 'ebay.com', page: 'https://ebay.com'},
       source: {}
+    },
+    timeout: 2000,
+
+  };
+  const bidderAliasRequest = {
+    bids: [firstAliasBid],
+    auctionId: 'ee3074fe-97ce-4681-9235-d7622aede74c',
+    auctionStart: 1725514077194,
+    bidderCode: PUBMATIC_ALIAS_BIDDER,
+    bidderRequestId: '1c56ad30b9b8ca8',
+    refererInfo: {
+      page: 'https://ebay.com',
+      ref: ''
+    },
+    ortb2: {
+      device: {
+        w: 1200,
+        h: 1800,
+        sua: {},
+        language: 'en',
+        js: 1,
+        connectiontype: 6
+      },
+      site: {domain: 'ebay.com', page: 'https://ebay.com'},
+      source: {},
+      user: {
+        ext: {
+          data: {
+            im_segments: ['segment1', 'segment2']
+          }
+        }
+      }
     },
     timeout: 2000,
 
@@ -274,6 +392,13 @@ describe('PubMatic adapter', () => {
         expect(imp).to.be.an('array');
         expect(imp[0]).to.have.property('banner');
         expect(imp[0]).to.have.property('id').equal('3736271c3c4b27');
+      });
+
+      it('should have build request with alias bidder', () => {
+        getGlobal().aliasBidder('pubmatic', PUBMATIC_ALIAS_BIDDER);
+        const request = spec.buildRequests(validAliasBidRequests, bidderAliasRequest);
+        expect(request.data).to.have.property('ext').to.have.property('wrapper').to.have.property('biddercode');
+        expect(request.data.ext.wrapper.biddercode).to.equal(PUBMATIC_ALIAS_BIDDER);
       });
 
       it('should add pmp if deals are present in parameters', () => {
@@ -718,6 +843,8 @@ describe('PubMatic adapter', () => {
           expect(request.data).to.have.property('ext').to.have.property('wrapper').to.have.property('wiid');
           expect(request.data).to.have.property('ext').to.have.property('wrapper').to.have.property('wv');
           expect(request.data).to.have.property('ext').to.have.property('wrapper').to.have.property('wp');
+          expect(request.data).to.have.property('ext').to.have.property('wrapper').to.have.property('biddercode');
+          expect(request.data.ext.wrapper.biddercode).to.equal('pubmatic');
         });
 
         it('should have url with post method', () => {


### PR DESCRIPTION

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->

- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
Adding key 'biddercode' in payload for translator api calls for reporting purpose.
It checks if the call is made from pubmatic's alias or pubmatic
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
