### PR TITLE
Missena Bid Adapter: update version schema

### DIFF
--- a/modules/missenaBidAdapter.js
+++ b/modules/missenaBidAdapter.js
@@ -65,7 +65,7 @@ function toPayload(bidRequest, bidderRequest) {
   payload.params = bidRequest.params;
 
   payload.userEids = bidRequest.userIdAsEids || [];
-  payload.version = '$prebid.version$';
+  payload.version = 'prebid.js@$prebid.version$';
 
   const bidFloor = getFloor(bidRequest);
   payload.floor = bidFloor?.floor;

--- a/test/spec/modules/missenaBidAdapter_spec.js
+++ b/test/spec/modules/missenaBidAdapter_spec.js
@@ -265,7 +265,7 @@ describe('Missena Adapter', function () {
     });
 
     it('should send the prebid version', function () {
-      expect(payload.version).to.equal('$prebid.version$');
+      expect(payload.version).to.equal('prebid.js@$prebid.version$');
     });
 
     it('should send cookie deprecation', function () {


### PR DESCRIPTION
 

## Type of change
 
- [x] Other

## Description of change

The schema for the version string updated on the server receiving the calls and now it needs an explicit part related to regular prebid installs.

This change has no impact on the use of the bidAdapter and is only relevant in our server analytics.