### PR TITLE
ID5 Analytics Module : no buffering of events, allow replacing existing rules

### DIFF
--- a/modules/id5AnalyticsAdapter.js
+++ b/modules/id5AnalyticsAdapter.js
@@ -1,16 +1,14 @@
 import buildAdapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
-import { EVENTS } from '../src/constants.js';
+import {EVENTS} from '../src/constants.js';
 import adapterManager from '../src/adapterManager.js';
-import { ajax } from '../src/ajax.js';
-import { logInfo, logError } from '../src/utils.js';
+import {ajax} from '../src/ajax.js';
+import {logError, logInfo} from '../src/utils.js';
 import * as events from '../src/events.js';
 
 const {
   AUCTION_END,
   TCF2_ENFORCEMENT,
-  BID_WON,
-  BID_VIEWABLE,
-  AD_RENDER_FAILED
+  BID_WON
 } = EVENTS
 
 const GVLID = 131;
@@ -21,15 +19,6 @@ const STANDARD_EVENTS_TO_TRACK = [
   BID_WON,
 ];
 
-// These events cause the buffered events to be sent over
-const FLUSH_EVENTS = [
-  TCF2_ENFORCEMENT,
-  AUCTION_END,
-  BID_WON,
-  BID_VIEWABLE,
-  AD_RENDER_FAILED
-];
-
 const CONFIG_URL_PREFIX = 'https://api.id5-sync.com/analytics'
 const TZ = new Date().getTimezoneOffset();
 const PBJS_VERSION = 'v' + '$prebid.version$';
@@ -37,9 +26,6 @@ const ID5_REDACTED = '__ID5_REDACTED__';
 const isArray = Array.isArray;
 
 const id5Analytics = Object.assign(buildAdapter({analyticsType: 'endpoint'}), {
-  // Keeps an array of events for each auction
-  eventBuffer: {},
-
   eventsToTrack: STANDARD_EVENTS_TO_TRACK,
 
   track: (event) => {
@@ -50,31 +36,16 @@ const id5Analytics = Object.assign(buildAdapter({analyticsType: 'endpoint'}), {
     }
 
     try {
-      const auctionId = event.args.auctionId;
-      _this.eventBuffer[auctionId] = _this.eventBuffer[auctionId] || [];
-
-      // Collect events and send them in a batch when the auction ends
-      const que = _this.eventBuffer[auctionId];
-      que.push(_this.makeEvent(event.eventType, event.args));
-
-      if (FLUSH_EVENTS.indexOf(event.eventType) >= 0) {
-        // Auction ended. Send the batch of collected events
-        _this.sendEvents(que);
-
-        // From now on just send events to server side as they come
-        que.push = (pushedEvent) => _this.sendEvents([pushedEvent]);
-      }
+      _this.sendEvent(_this.makeEvent(event.eventType, event.args));
     } catch (error) {
       logError('id5Analytics: ERROR', error);
       _this.sendErrorEvent(error);
     }
   },
 
-  sendEvents: (eventsToSend) => {
-    const _this = id5Analytics;
+  sendEvent: (eventToSend) => {
     // By giving some content this will be automatically a POST
-    eventsToSend.forEach((event) =>
-      ajax(_this.options.ingestUrl, null, JSON.stringify(event)));
+    ajax(id5Analytics.options.ingestUrl, null, JSON.stringify(eventToSend));
   },
 
   makeEvent: (event, payload) => {
@@ -96,7 +67,7 @@ const id5Analytics = Object.assign(buildAdapter({analyticsType: 'endpoint'}), {
 
   sendErrorEvent: (error) => {
     const _this = id5Analytics;
-    _this.sendEvents([
+    _this.sendEvent([
       _this.makeEvent('analyticsError', {
         message: error.message,
         stack: error.stack,
@@ -141,9 +112,6 @@ const ENABLE_FUNCTION = (config) => {
       // Init the module only if we got lucky
       logInfo('id5Analytics: Selected by sampling. Starting up!');
 
-      // Clean start
-      _this.eventBuffer = {};
-
       // Replay all events until now
       if (!config.disablePastEventsProcessing) {
         events.getEvents().forEach((event) => {
@@ -152,7 +120,10 @@ const ENABLE_FUNCTION = (config) => {
           }
         });
       }
-
+      // allow for replacing cleanup rules - remove existing ones and apply from server
+      if (configFromServer.replaceCleanupRules) {
+        cleanupRules = {};
+      }
       // Merge in additional cleanup rules
       if (configFromServer.additionalCleanupRules) {
         const newRules = configFromServer.additionalCleanupRules;
@@ -165,7 +136,11 @@ const ENABLE_FUNCTION = (config) => {
               (eventRules.apply in TRANSFORM_FUNCTIONS))
           ) {
             logInfo('id5Analytics: merging additional cleanup rules for event ' + key);
-            CLEANUP_RULES[key].push(...newRules[key]);
+            if (!Array.isArray(cleanupRules[key])) {
+              cleanupRules[key] = newRules[key];
+            } else {
+              cleanupRules[key].push(...newRules[key]);
+            }
           }
         });
       }
@@ -243,8 +218,8 @@ function deepTransformingClone(obj, transform, currentPath = []) {
 // In case of array, it represents alternatives which all would match.
 // Special path part '*' matches any subproperty or array index.
 // Prefixing a part with "!" makes it negative match (doesn't work with multiple alternatives)
-const CLEANUP_RULES = {};
-CLEANUP_RULES[AUCTION_END] = [{
+let cleanupRules = {};
+cleanupRules[AUCTION_END] = [{
   match: [['adUnits', 'bidderRequests'], '*', 'bids', '*', ['userId', 'crumbs'], '!id5id'],
   apply: 'redact'
 }, {
@@ -267,7 +242,7 @@ CLEANUP_RULES[AUCTION_END] = [{
   apply: 'redact'
 }];
 
-CLEANUP_RULES[BID_WON] = [{
+cleanupRules[BID_WON] = [{
   match: [['ad', 'native']],
   apply: 'erase'
 }];
@@ -279,7 +254,7 @@ const TRANSFORM_FUNCTIONS = {
 
 // Builds a rule function depending on the event type
 function transformFnFromCleanupRules(eventType) {
-  const rules = CLEANUP_RULES[eventType] || [];
+  const rules = cleanupRules[eventType] || [];
   return (path, obj, key) => {
     for (let i = 0; i < rules.length; i++) {
       let match = true;

--- a/modules/id5AnalyticsAdapter.js
+++ b/modules/id5AnalyticsAdapter.js
@@ -112,14 +112,6 @@ const ENABLE_FUNCTION = (config) => {
       // Init the module only if we got lucky
       logInfo('id5Analytics: Selected by sampling. Starting up!');
 
-      // Replay all events until now
-      if (!config.disablePastEventsProcessing) {
-        events.getEvents().forEach((event) => {
-          if (event && _this.eventsToTrack.indexOf(event.eventType) >= 0) {
-            _this.track(event);
-          }
-        });
-      }
       // allow for replacing cleanup rules - remove existing ones and apply from server
       if (configFromServer.replaceCleanupRules) {
         cleanupRules = {};
@@ -141,6 +133,15 @@ const ENABLE_FUNCTION = (config) => {
             } else {
               cleanupRules[key].push(...newRules[key]);
             }
+          }
+        });
+      }
+
+      // Replay all events until now
+      if (!config.disablePastEventsProcessing) {
+        events.getEvents().forEach((event) => {
+          if (event && _this.eventsToTrack.indexOf(event.eventType) >= 0) {
+            _this.track(event);
           }
         });
       }

--- a/test/spec/modules/id5AnalyticsAdapter_spec.js
+++ b/test/spec/modules/id5AnalyticsAdapter_spec.js
@@ -6,6 +6,7 @@ import { EVENTS } from '../../../src/constants.js';
 import { generateUUID } from '../../../src/utils.js';
 import {server} from '../../mocks/xhr.js';
 import {getGlobal} from '../../../src/prebidGlobal.js';
+import {enrichEidsRule} from "../../../modules/tcfControl.ts";
 
 const CONFIG_URL = 'https://api.id5-sync.com/analytics/12349/pbjs';
 const INGEST_URL = 'https://test.me/ingest';
@@ -14,6 +15,8 @@ describe('ID5 analytics adapter', () => {
   let config;
 
   beforeEach(() => {
+    // to enforce tcfControl initialization when running in single test mode
+    expect(enrichEidsRule).to.exist
     config = {
       options: {
         partnerId: 12349,
@@ -125,6 +128,27 @@ describe('ID5 analytics adapter', () => {
       expect(body2.meta.tz).to.be.a('number');
       expect(body2.payload).to.eql(auction);
     });
+
+    it('does not repeat already sent events on new events', () => {
+      id5AnalyticsAdapter.enableAnalytics(config);
+      server.respond();
+      events.emit(EVENTS.AUCTION_END, auction);
+      server.respond();
+      events.emit(EVENTS.BID_WON, auction);
+      server.respond();
+
+      // Why 4? 1: config, 2: tcfEnforcement, 3: auctionEnd 4: bidWon
+      expect(server.requests).to.have.length(4);
+
+      const body1 = JSON.parse(server.requests[1].requestBody);
+      expect(body1.event).to.equal('tcf2Enforcement');
+
+      const body2 = JSON.parse(server.requests[2].requestBody);
+      expect(body2.event).to.equal('auctionEnd');
+
+      const body3 = JSON.parse(server.requests[3].requestBody);
+      expect(body3.event).to.equal('bidWon');
+    })
 
     it('filters unwanted IDs from the events it sends', () => {
       auction.adUnits[0].bids = [{
@@ -452,6 +476,40 @@ describe('ID5 analytics adapter', () => {
       expect(body.payload.bidsReceived[1].requestId).to.equal(undefined);
       expect(body.payload.bidsReceived[0].bidderCode).to.equal('appnexus');
       expect(body.payload.bidsReceived[1].bidderCode).to.equal('ix');
+    });
+
+    it('can replace cleanup rules from server side', () => {
+      auction.bidsReceived = [{
+        'meta': {
+          'advertiserId': 4388779
+        }
+      }]
+      auction.adUnits[0].bids = [{
+        'bidder': 'appnexus',
+        'userId': {
+          'id5id': {
+            'uid': 'ID5-ZHMOQ99ulpk687Fd9xVwzxMsYtkQIJnI-qm3iWdtww!ID5*FSycZQy7v7zWXiKbEpPEWoB3_UiWdPGzh554ncYDvOkAAA3rajiR0yNrFAU7oDTu',
+            'ext': { 'linkType': 1 }
+          }
+        }
+      }];
+      server.respondWith('GET', CONFIG_URL, [200,
+        {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*'
+        },
+        `{ "sampling": 1, "ingestUrl": "${INGEST_URL}", "replaceCleanupRules":true, "additionalCleanupRules": {"auctionEnd": [{"match":["bidsReceived", "*", "meta"],"apply":"erase"}]} }`
+      ]);
+      id5AnalyticsAdapter.enableAnalytics(config);
+      server.respond();
+      events.emit(EVENTS.AUCTION_END, auction);
+      server.respond();
+
+      expect(server.requests).to.have.length(3);
+      const body = JSON.parse(server.requests[2].requestBody);
+      expect(body.event).to.equal('auctionEnd');
+      expect(body.payload.bidsReceived[0].meta).to.equal(undefined);    // new rule
+      expect(body.payload.adUnits[0].bids[0].userId.id5id.uid).to.equal(auction.adUnits[0].bids[0].userId.id5id.uid); // old, overridden rule
     });
   });
 });


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Feature


- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Buffering of events caused some events to be sent out multiple times, as buffer was never cleared. As events are sent one-by-one, the buffering does not bring much benefits either way, so we removed it to simplify the code. 

Introduced flag allowing for replacing of the cleanup rules - sometimes we need more fine grained control over those cleanup rules. 