### PR TITLE
Semantiq RTD Provider: fix outdated cache

### DIFF
--- a/modules/semantiqRtdProvider.js
+++ b/modules/semantiqRtdProvider.js
@@ -25,13 +25,13 @@ export const storage = getStorageManager({
 });
 
 /**
- * Gets SemantIQ keywords from local storage.
+ * Gets SemantIQ keywords from session storage.
  * @param {string} pageUrl
  * @returns {Object.<string, string | string[]>}
  */
 const getStorageKeywords = (pageUrl) => {
   try {
-    const storageValue = JSON.parse(storage.getDataFromLocalStorage(STORAGE_KEY));
+    const storageValue = JSON.parse(storage.getDataFromSessionStorage(STORAGE_KEY));
 
     if (storageValue?.url === pageUrl) {
       return storageValue.keywords;
@@ -39,7 +39,7 @@ const getStorageKeywords = (pageUrl) => {
 
     return null;
   } catch (error) {
-    logError('Unable to get SemantiQ keywords from local storage', error);
+    logError('Unable to get SemantiQ keywords from session storage', error);
 
     return null;
   }
@@ -97,7 +97,7 @@ const getKeywords = (params) => new Promise((resolve, reject) => {
           throw new Error('Failed to parse the response');
         }
 
-        storage.setDataInLocalStorage(STORAGE_KEY, JSON.stringify({ url: pageUrl, keywords: data }));
+        storage.setDataInSessionStorage(STORAGE_KEY, JSON.stringify({ url: pageUrl, keywords: data }));
         resolve(data);
       } catch (error) {
         reject(error);

--- a/test/spec/modules/semantiqRtdProvider_spec.js
+++ b/test/spec/modules/semantiqRtdProvider_spec.js
@@ -5,18 +5,18 @@ import * as utils from '../../../src/utils.js';
 
 describe('semantiqRtdProvider', () => {
   let clock;
-  let getDataFromLocalStorageStub;
+  let getDataFromSessionStorage;
   let getWindowLocationStub;
 
   beforeEach(() => {
     clock = sinon.useFakeTimers();
-    getDataFromLocalStorageStub = sinon.stub(storage, 'getDataFromLocalStorage').returns(null);
+    getDataFromSessionStorage = sinon.stub(storage, 'getDataFromSessionStorage').returns(null);
     getWindowLocationStub = sinon.stub(utils, 'getWindowLocation').returns(new URL('https://example.com/article'));
   });
 
   afterEach(() => {
     clock.restore();
-    getDataFromLocalStorageStub.restore();
+    getDataFromSessionStorage.restore();
     getWindowLocationStub.restore();
   });
 
@@ -181,7 +181,7 @@ describe('semantiqRtdProvider', () => {
     });
 
     it('gets keywords from the cache if the data is present in the storage', async () => {
-      getDataFromLocalStorageStub.returns(JSON.stringify({ url: 'https://example.com/article', keywords: { sentiment: 'negative', ctx_segment: ['C001', 'C002'] } }));
+      getDataFromSessionStorage.returns(JSON.stringify({ url: 'https://example.com/article', keywords: { sentiment: 'negative', ctx_segment: ['C001', 'C002'] } }));
 
       const reqBidsConfigObj = {
         adUnits: [{ bids: [{ bidder: 'appnexus' }] }],
@@ -210,7 +210,7 @@ describe('semantiqRtdProvider', () => {
     });
 
     it('requests keywords from the server if the URL of the page is different from the cached one', async () => {
-      getDataFromLocalStorageStub.returns(JSON.stringify({ url: 'https://example.com/article', keywords: { cached: 'true' } }));
+      getDataFromSessionStorage.returns(JSON.stringify({ url: 'https://example.com/article', keywords: { cached: 'true' } }));
       getWindowLocationStub.returns(new URL('https://example.com/another-article'));
 
       const reqBidsConfigObj = {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Change the storage to session storage to prevent the use of data built on the outdated Semantiq configuration.
