### PR TITLE
Core: do not poll for some window dimensions

### DIFF
--- a/libraries/extraWinDimensions/extraWinDimensions.js
+++ b/libraries/extraWinDimensions/extraWinDimensions.js
@@ -1,4 +1,4 @@
-import {canAccessWindowTop, getWindowSelf, getWindowTop} from '../../src/utils.js';
+import {canAccessWindowTop, internal as utilsInternals} from '../../src/utils.js';
 import {cachedGetter, internal as dimInternals} from '../../src/utils/winDimensions.js';
 
 export const internal = {
@@ -7,14 +7,14 @@ export const internal = {
 
 const extraDims = cachedGetter(() => internal.fetchExtraDimensions());
 /**
- * Using these dimensions may flag you as a fingerprinting library
+ * Using these dimensions may flag you as a fingerprinting tool
  * cfr. https://github.com/duckduckgo/tracker-radar/blob/main/build-data/generated/api_fingerprint_weights.json
  */
 export const getExtraWinDimensions = extraDims.get;
 dimInternals.resetters.push(extraDims.reset);
 
 function fetchExtraDimensions() {
-  const win = canAccessWindowTop() ? getWindowTop() : getWindowSelf();
+  const win = canAccessWindowTop() ? utilsInternals.getWindowTop() : utilsInternals.getWindowSelf();
   return {
     outerWidth: win.outerWidth,
     outerHeight: win.outerHeight,

--- a/libraries/extraWinDimensions/extraWinDimensions.js
+++ b/libraries/extraWinDimensions/extraWinDimensions.js
@@ -1,0 +1,27 @@
+import {canAccessWindowTop, getWindowSelf, getWindowTop} from '../../src/utils.js';
+import {cachedGetter, internal as dimInternals} from '../../src/utils/winDimensions.js';
+
+export const internal = {
+  fetchExtraDimensions
+};
+
+const extraDims = cachedGetter(() => internal.fetchExtraDimensions());
+/**
+ * Using these dimensions may flag you as a fingerprinting library
+ * cfr. https://github.com/duckduckgo/tracker-radar/blob/main/build-data/generated/api_fingerprint_weights.json
+ */
+export const getExtraWinDimensions = extraDims.get;
+dimInternals.resetters.push(extraDims.reset);
+
+function fetchExtraDimensions() {
+  const win = canAccessWindowTop() ? getWindowTop() : getWindowSelf();
+  return {
+    outerWidth: win.outerWidth,
+    outerHeight: win.outerHeight,
+    screen: {
+      availWidth: win.screen?.availWidth,
+      availHeight: win.screen?.availHeight,
+      colorDepth: win.screen?.colorDepth,
+    }
+  };
+}

--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -5,6 +5,7 @@ import { config } from '../src/config.js';
 import { getStorageManager } from '../src/storageManager.js';
 import {toLegacyResponse, toOrtbNativeRequest} from '../src/native.js';
 import {getGlobal} from '../src/prebidGlobal.js';
+import {getExtraWinDimensions} from '../libraries/extraWinDimensions/extraWinDimensions.js';
 
 const BIDDER_CODE = 'adnuntius';
 const BIDDER_CODE_DEAL_ALIAS_BASE = 'adndeal';
@@ -293,9 +294,9 @@ export const spec = {
       queryParamsAndValues.push('consentString=' + consentString);
       queryParamsAndValues.push('gdpr=' + flag);
     }
-    const win = getWindowTop() || window;
-    if (win.screen && win.screen.availHeight) {
-      queryParamsAndValues.push('screen=' + win.screen.availWidth + 'x' + win.screen.availHeight);
+    const extraDims = getExtraWinDimensions();
+    if (extraDims.screen.availHeight) {
+      queryParamsAndValues.push('screen=' + extraDims.screen.availWidth + 'x' + extraDims.screen.availHeight);
     }
 
     const { innerWidth, innerHeight } = getWinDimensions();

--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -1,8 +1,17 @@
-import { registerBidder } from '../src/adapters/bidderFactory.js';
-import {BANNER, VIDEO, NATIVE} from '../src/mediaTypes.js';
-import {isStr, isEmpty, deepAccess, isArray, getUnixTimestampFromNow, convertObjectToArray, getWindowTop, deepClone, getWinDimensions} from '../src/utils.js';
-import { config } from '../src/config.js';
-import { getStorageManager } from '../src/storageManager.js';
+import {registerBidder} from '../src/adapters/bidderFactory.js';
+import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
+import {
+  convertObjectToArray,
+  deepAccess,
+  deepClone,
+  getUnixTimestampFromNow,
+  getWinDimensions,
+  isArray,
+  isEmpty,
+  isStr
+} from '../src/utils.js';
+import {config} from '../src/config.js';
+import {getStorageManager} from '../src/storageManager.js';
 import {toLegacyResponse, toOrtbNativeRequest} from '../src/native.js';
 import {getGlobal} from '../src/prebidGlobal.js';
 import {getExtraWinDimensions} from '../libraries/extraWinDimensions/extraWinDimensions.js';

--- a/modules/datablocksBidAdapter.js
+++ b/modules/datablocksBidAdapter.js
@@ -6,6 +6,7 @@ import {getStorageManager} from '../src/storageManager.js';
 import {ajax} from '../src/ajax.js';
 import {convertOrtbRequestToProprietaryNative} from '../src/native.js';
 import {getAdUnitSizes} from '../libraries/sizeUtils/sizeUtils.js';
+import {getExtraWinDimensions} from '../libraries/extraWinDimensions/extraWinDimensions.js';
 
 export const storage = getStorageManager({bidderCode: 'datablocks'});
 
@@ -204,12 +205,13 @@ export const spec = {
     const botTest = new BotClientTests();
     const win = getWindowTop();
     const windowDimensions = getWinDimensions();
+    const extraDims = getExtraWinDimensions();
     return {
       'wiw': windowDimensions.innerWidth,
       'wih': windowDimensions.innerHeight,
-      'saw': windowDimensions.screen.availWidth,
-      'sah': windowDimensions.screen.availHeight,
-      'scd': screen ? screen.colorDepth : null,
+      'saw': extraDims.screen.availWidth,
+      'sah': extraDims.screen.availHeight,
+      'scd': extraDims.screen.colorDepth,
       'sw': windowDimensions.screen.width,
       'sh': windowDimensions.screen.height,
       'whl': win.history.length,

--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -8,6 +8,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { deepClone, logError, deepAccess, getWinDimensions } from '../src/utils.js';
 import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
 import { toOrtbNativeRequest } from '../src/native.js';
+import {getExtraWinDimensions} from '../libraries/extraWinDimensions/extraWinDimensions.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -278,20 +279,21 @@ function getDocumentVisibility(window) {
  */
 function getPageInfo(bidderRequest) {
   const winDimensions = getWinDimensions();
+  const extraDims = getExtraWinDimensions();
   const topmostFrame = getFrameNesting();
   return {
     location: deepAccess(bidderRequest, 'refererInfo.page', null),
     referrer: deepAccess(bidderRequest, 'refererInfo.ref', null),
     stack: deepAccess(bidderRequest, 'refererInfo.stack', []),
     numIframes: deepAccess(bidderRequest, 'refererInfo.numIframes', 0),
-    wWidth: getWinDimensions().innerWidth,
-    wHeight: getWinDimensions().innerHeight,
-    oWidth: winDimensions.outerWidth,
-    oHeight: winDimensions.outerHeight,
+    wWidth: winDimensions.innerWidth,
+    wHeight: winDimensions.innerHeight,
+    oWidth: extraDims.outerWidth,
+    oHeight: extraDims.outerHeight,
     sWidth: winDimensions.screen.width,
     sHeight: winDimensions.screen.height,
-    aWidth: winDimensions.screen.availWidth,
-    aHeight: winDimensions.screen.availHeight,
+    aWidth: extraDims.screen.availWidth,
+    aHeight: extraDims.screen.availHeight,
     sLeft: 'screenLeft' in topmostFrame ? topmostFrame.screenLeft : topmostFrame.screenX,
     sTop: 'screenTop' in topmostFrame ? topmostFrame.screenTop : topmostFrame.screenY,
     xOffset: topmostFrame.pageXOffset,

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,6 +8,7 @@ import {isArray, isFn, isStr, isPlainObject} from './utils/objects.js';
 export { deepAccess };
 export { dset as deepSetValue } from 'dset';
 export * from './utils/objects.js'
+export {getWinDimensions, resetWinDimensions} from './utils/winDimensions.js';
 
 const consoleExists = Boolean(window.console);
 const consoleLogExists = Boolean(consoleExists && window.console.log);
@@ -16,7 +17,6 @@ const consoleWarnExists = Boolean(consoleExists && window.console.warn);
 const consoleErrorExists = Boolean(consoleExists && window.console.error);
 
 let eventEmitter;
-let windowDimensions;
 
 export function _setEventEmitter(emitFn) {
   // called from events.js - this hoop is to avoid circular imports
@@ -27,54 +27,6 @@ function emitEvent(...args) {
   if (eventEmitter != null) {
     eventEmitter(...args);
   }
-}
-
-export const getWinDimensions = (function() {
-  let lastCheckTimestamp;
-  const CHECK_INTERVAL_MS = 20;
-  return () => {
-    if (!windowDimensions || !lastCheckTimestamp || (Date.now() - lastCheckTimestamp > CHECK_INTERVAL_MS)) {
-      internal.resetWinDimensions();
-      lastCheckTimestamp = Date.now();
-    }
-    return windowDimensions;
-  }
-})();
-
-export function resetWinDimensions() {
-  const top = canAccessWindowTop() ? internal.getWindowTop() : internal.getWindowSelf();
-
-  windowDimensions = {
-    screen: {
-      width: top.screen?.width,
-      height: top.screen?.height,
-      availWidth: top.screen?.availWidth,
-      availHeight: top.screen?.availHeight,
-      colorDepth: top.screen?.colorDepth,
-    },
-    innerHeight: top.innerHeight,
-    innerWidth: top.innerWidth,
-    outerWidth: top.outerWidth,
-    outerHeight: top.outerHeight,
-    visualViewport: {
-      height: top.visualViewport?.height,
-      width: top.visualViewport?.width,
-    },
-    document: {
-      documentElement: {
-        clientWidth: top.document?.documentElement?.clientWidth,
-        clientHeight: top.document?.documentElement?.clientHeight,
-        scrollTop: top.document?.documentElement?.scrollTop,
-        scrollLeft: top.document?.documentElement?.scrollLeft,
-      },
-      body: {
-        scrollTop: document.body?.scrollTop,
-        scrollLeft: document.body?.scrollLeft,
-        clientWidth: document.body?.clientWidth,
-        clientHeight: document.body?.clientHeight,
-      },
-    }
-  };
 }
 
 // this allows stubbing of utility functions that are used internally by other utility functions
@@ -96,7 +48,6 @@ export const internal = {
   parseQS,
   formatQS,
   deepEqual,
-  resetWinDimensions
 };
 
 const prebidInternal = {};

--- a/src/utils/winDimensions.js
+++ b/src/utils/winDimensions.js
@@ -1,0 +1,68 @@
+import {canAccessWindowTop, getWindowTop, getWindowSelf} from '../utils.js';
+
+const CHECK_INTERVAL_MS = 20;
+
+export function cachedGetter(getter) {
+  let value, lastCheckTimestamp;
+  return {
+    get: function () {
+      if (!value || !lastCheckTimestamp || (Date.now() - lastCheckTimestamp > CHECK_INTERVAL_MS)) {
+        value = getter();
+        lastCheckTimestamp = Date.now();
+      }
+      return value;
+    },
+    reset: function () {
+      value = getter();
+    }
+  }
+}
+
+function fetchWinDimensions() {
+  const top = canAccessWindowTop() ? getWindowTop() : getWindowSelf();
+
+  return {
+    screen: {
+      width: top.screen?.width,
+      height: top.screen?.height,
+      availWidth: top.screen?.availWidth,
+      availHeight: top.screen?.availHeight,
+      colorDepth: top.screen?.colorDepth,
+    },
+    innerHeight: top.innerHeight,
+    innerWidth: top.innerWidth,
+    outerWidth: top.outerWidth,
+    outerHeight: top.outerHeight,
+    visualViewport: {
+      height: top.visualViewport?.height,
+      width: top.visualViewport?.width,
+    },
+    document: {
+      documentElement: {
+        clientWidth: top.document?.documentElement?.clientWidth,
+        clientHeight: top.document?.documentElement?.clientHeight,
+        scrollTop: top.document?.documentElement?.scrollTop,
+        scrollLeft: top.document?.documentElement?.scrollLeft,
+      },
+      body: {
+        scrollTop: document.body?.scrollTop,
+        scrollLeft: document.body?.scrollLeft,
+        clientWidth: document.body?.clientWidth,
+        clientHeight: document.body?.clientHeight,
+      },
+    }
+  };
+}
+export const internal = {
+  fetchWinDimensions,
+  resetters: []
+};
+
+const winDimensions = cachedGetter(() => internal.fetchWinDimensions());
+
+export const getWinDimensions = winDimensions.get;
+internal.resetters.push(winDimensions.reset);
+
+export function resetWinDimensions() {
+  internal.resetters.forEach(fn => fn());
+}

--- a/src/utils/winDimensions.js
+++ b/src/utils/winDimensions.js
@@ -1,4 +1,4 @@
-import {canAccessWindowTop, getWindowTop, getWindowSelf} from '../utils.js';
+import {canAccessWindowTop, internal as utilsInternals} from '../utils.js';
 
 const CHECK_INTERVAL_MS = 20;
 
@@ -19,7 +19,7 @@ export function cachedGetter(getter) {
 }
 
 function fetchWinDimensions() {
-  const top = canAccessWindowTop() ? getWindowTop() : getWindowSelf();
+  const top = canAccessWindowTop() ? utilsInternals.getWindowTop() : utilsInternals.getWindowSelf();
 
   return {
     screen: {

--- a/src/utils/winDimensions.js
+++ b/src/utils/winDimensions.js
@@ -24,15 +24,10 @@ function fetchWinDimensions() {
   return {
     screen: {
       width: top.screen?.width,
-      height: top.screen?.height,
-      availWidth: top.screen?.availWidth,
-      availHeight: top.screen?.availHeight,
-      colorDepth: top.screen?.colorDepth,
+      height: top.screen?.height
     },
     innerHeight: top.innerHeight,
     innerWidth: top.innerWidth,
-    outerWidth: top.outerWidth,
-    outerHeight: top.outerHeight,
     visualViewport: {
       height: top.visualViewport?.height,
       width: top.visualViewport?.width,

--- a/test/spec/fpd/enrichment_spec.js
+++ b/test/spec/fpd/enrichment_spec.js
@@ -3,6 +3,7 @@ import {hook} from '../../../src/hook.js';
 import {expect} from 'chai/index.mjs';
 import {config} from 'src/config.js';
 import * as utils from 'src/utils.js';
+import * as winDimensions from 'src/utils/winDimensions.js';
 import * as activities from 'src/activities/rules.js'
 import {CLIENT_SECTIONS} from '../../../src/fpd/oneClient.js';
 import {ACTIVITY_ACCESS_DEVICE} from '../../../src/activities/activities.js';
@@ -172,7 +173,7 @@ describe('FPD enrichment', () => {
     });
     testWindows(() => win, () => {
       it('sets w/h', () => {
-        const getWinDimensionsStub = sandbox.stub(utils, 'getWinDimensions');
+        const getWinDimensionsStub = sandbox.stub(winDimensions, 'getWinDimensions');
 
         getWinDimensionsStub.returns({screen: {width: 321, height: 123}});
         return fpd().then(ortb2 => {
@@ -185,7 +186,7 @@ describe('FPD enrichment', () => {
       });
 
       it('sets ext.vpw/vph', () => {
-        const getWinDimensionsStub = sandbox.stub(utils, 'getWinDimensions');
+        const getWinDimensionsStub = sandbox.stub(winDimensions, 'getWinDimensions');
         getWinDimensionsStub.returns({innerWidth: 12, innerHeight: 21, screen: {}});
         return fpd().then(ortb2 => {
           sinon.assert.match(ortb2.device.ext, {

--- a/test/spec/libraries/extraWinDimensions_spec.js
+++ b/test/spec/libraries/extraWinDimensions_spec.js
@@ -17,4 +17,3 @@ describe('extraWinDimensions', () => {
     sinon.assert.called(resetSpy);
   })
 });
-

--- a/test/spec/libraries/extraWinDimensions_spec.js
+++ b/test/spec/libraries/extraWinDimensions_spec.js
@@ -1,0 +1,20 @@
+import {resetWinDimensions} from '../../../src/utils.js';
+import * as extraWinDimensions from '../../../libraries/extraWinDimensions/extraWinDimensions.js';
+
+describe('extraWinDimensions', () => {
+  let sandbox;
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.stub()
+  })
+
+  it('should reset together with basic dimensions', () => {
+    const resetSpy = sinon.spy(extraWinDimensions.internal, 'fetchExtraDimensions');
+    resetWinDimensions();
+    sinon.assert.called(resetSpy);
+  })
+});
+

--- a/test/spec/modules/adnuntiusBidAdapter_spec.js
+++ b/test/spec/modules/adnuntiusBidAdapter_spec.js
@@ -9,6 +9,7 @@ import {deepClone, getUnixTimestampFromNow} from 'src/utils.js';
 import { getWinDimensions } from '../../../src/utils.js';
 
 import {getGlobalVarName} from '../../../src/buildOptions.js';
+import {getExtraWinDimensions} from '../../../libraries/extraWinDimensions/extraWinDimensions.js';
 
 describe('adnuntiusBidAdapter', function () {
   const sandbox = sinon.createSandbox();
@@ -61,7 +62,8 @@ describe('adnuntiusBidAdapter', function () {
 
   function resetExpectedUrls() {
     const winDimensions = getWinDimensions();
-    screen = winDimensions.screen.availWidth + 'x' + winDimensions.screen.availHeight;
+    const extraDims = getExtraWinDimensions();
+    screen = extraDims.screen.availWidth + 'x' + extraDims.screen.availHeight;
     viewport = winDimensions.innerWidth + 'x' + winDimensions.innerHeight;
     ENDPOINT_URL_BASE = `${URL}${tzo}&format=prebid&pbv=${prebidVersion}&screen=${screen}&viewport=${viewport}`;
     ENDPOINT_URL = `${ENDPOINT_URL_BASE}&userId=${usi}`;
@@ -886,7 +888,8 @@ describe('adnuntiusBidAdapter', function () {
   describe('buildRequests', function () {
     it('Test requests', function () {
       const winDimensions = getWinDimensions();
-      const screen = winDimensions.screen.availWidth + 'x' + winDimensions.screen.availHeight;
+      const extraDims = getExtraWinDimensions();
+      const screen = extraDims.screen.availWidth + 'x' + extraDims.screen.availHeight;
       const viewport = winDimensions.innerWidth + 'x' + winDimensions.innerHeight;
       const prebidVersion = window[getGlobalVarName()].version;
       const tzo = new Date().getTimezoneOffset();

--- a/test/spec/modules/connatixBidAdapter_spec.js
+++ b/test/spec/modules/connatixBidAdapter_spec.js
@@ -18,6 +18,7 @@ import adapterManager from '../../../src/adapterManager.js';
 import * as ajax from '../../../src/ajax.js';
 import { ADPOD, BANNER, VIDEO } from '../../../src/mediaTypes.js';
 import * as utils from '../../../src/utils.js';
+import * as winDimensions from '../../../src/utils/winDimensions.js';
 
 const BIDDER_CODE = 'connatix';
 
@@ -179,7 +180,7 @@ describe('connatixBidAdapter', function () {
     it('should return the correct percentage if the element is partially in view', () => {
       const boundingBox = { left: 700, top: 500, right: 900, bottom: 700, width: 200, height: 200 };
       getBoundingClientRectStub.returns(boundingBox);
-      const getWinDimensionsStub = sinon.stub(utils, 'getWinDimensions');
+      const getWinDimensionsStub = sinon.stub(winDimensions, 'getWinDimensions');
       getWinDimensionsStub.returns({ innerWidth: topWinMock.innerWidth, innerHeight: topWinMock.innerHeight});
 
       const viewability = connatixGetViewability(element, topWinMock);
@@ -189,7 +190,7 @@ describe('connatixBidAdapter', function () {
     });
 
     it('should return 0% if the element is not in view', () => {
-      const getWinDimensionsStub = sinon.stub(utils, 'getWinDimensions');
+      const getWinDimensionsStub = sinon.stub(winDimensions, 'getWinDimensions');
       getWinDimensionsStub.returns({ innerWidth: topWinMock.innerWidth, innerHeight: topWinMock.innerHeight});
       const boundingBox = { left: 900, top: 700, right: 1100, bottom: 900, width: 200, height: 200 };
       getBoundingClientRectStub.returns(boundingBox);

--- a/test/spec/modules/omsBidAdapter_spec.js
+++ b/test/spec/modules/omsBidAdapter_spec.js
@@ -2,8 +2,7 @@ import {expect} from 'chai';
 import * as utils from 'src/utils.js';
 import {spec} from 'modules/omsBidAdapter';
 import {newBidder} from 'src/adapters/bidderFactory.js';
-import {config} from '../../../src/config.js';
-import { internal, resetWinDimensions } from '../../../src/utils.js';
+import * as winDimensions from 'src/utils/winDimensions.js';
 
 const URL = 'https://rt.marphezis.com/hb';
 
@@ -348,7 +347,7 @@ describe('omsBidAdapter', function () {
 
     context('when element is partially in view', function () {
       it('returns percentage', function () {
-        const getWinDimensionsStub = sandbox.stub(utils, 'getWinDimensions')
+        const getWinDimensionsStub = sandbox.stub(winDimensions, 'getWinDimensions')
         getWinDimensionsStub.returns({ innerHeight: win.innerHeight, innerWidth: win.innerWidth });
         Object.assign(element, {width: 800, height: 800});
         const request = spec.buildRequests(bidRequests);
@@ -359,7 +358,7 @@ describe('omsBidAdapter', function () {
 
     context('when width or height of the element is zero', function () {
       it('try to use alternative values', function () {
-        const getWinDimensionsStub = sandbox.stub(utils, 'getWinDimensions')
+        const getWinDimensionsStub = sandbox.stub(winDimensions, 'getWinDimensions')
         getWinDimensionsStub.returns({ innerHeight: win.innerHeight, innerWidth: win.innerWidth });
         Object.assign(element, {width: 0, height: 0});
         bidRequests[0].mediaTypes.banner.sizes = [[800, 2400]];

--- a/test/spec/modules/onomagicBidAdapter_spec.js
+++ b/test/spec/modules/onomagicBidAdapter_spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import * as utils from 'src/utils.js';
 import { spec } from 'modules/onomagicBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
+import * as winDimensions from 'src/utils/winDimensions.js';
 
 const URL = 'https://bidder.onomagic.com/hb';
 
@@ -161,7 +162,7 @@ describe('onomagicBidAdapter', function() {
 
     context('when element is partially in view', function() {
       it('returns percentage', function() {
-        const getWinDimensionsStub = sandbox.stub(utils, 'getWinDimensions')
+        const getWinDimensionsStub = sandbox.stub(winDimensions, 'getWinDimensions')
         getWinDimensionsStub.returns({ innerHeight: win.innerHeight, innerWidth: win.innerWidth });
         Object.assign(element, { width: 800, height: 800 });
         const request = spec.buildRequests(bidRequests);
@@ -172,7 +173,7 @@ describe('onomagicBidAdapter', function() {
 
     context('when width or height of the element is zero', function() {
       it('try to use alternative values', function() {
-        const getWinDimensionsStub = sandbox.stub(utils, 'getWinDimensions')
+        const getWinDimensionsStub = sandbox.stub(winDimensions, 'getWinDimensions')
         getWinDimensionsStub.returns({ innerHeight: win.innerHeight, innerWidth: win.innerWidth });
         Object.assign(element, { width: 0, height: 0 });
         bidRequests[0].mediaTypes.banner.sizes = [[800, 2400]];

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -5,6 +5,7 @@ import * as utils from 'src/utils.js';
 import {binarySearch, deepEqual, encodeMacroURI, memoize, sizesToSizeTuples, waitForElementToLoad} from 'src/utils.js';
 import {convertCamelToUnderscore} from '../../libraries/appnexusUtils/anUtils.js';
 import { getWinDimensions, internal } from '../../src/utils.js';
+import * as winDimensions from '../../src/utils/winDimensions.js';
 
 var assert = require('assert');
 
@@ -1444,8 +1445,8 @@ describe('getWinDimensions', () => {
     clock.restore();
   });
 
-  it('should invoke resetWinDimensions once per 20ms', () => {
-    const resetWinDimensionsSpy = sinon.spy(internal, 'resetWinDimensions');
+  it('should invoke fetchWinDimensions once per 20ms', () => {
+    const resetWinDimensionsSpy = sinon.spy(winDimensions.internal, 'fetchWinDimensions');
     getWinDimensions();
     clock.tick(1);
     getWinDimensions();


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

With https://github.com/prebid/Prebid.js/pull/12925 core always polls for every window dimension. Some of them (`outerHeight`/`outerWidth`, `availHeight`/`availWidth` and `colorDepth`) are more likely to be considered fingerprinting tools in https://github.com/duckduckgo/tracker-radar/blob/main/build-data/generated/api_fingerprint_weights.json

This PR breaks them out to their own library, `extraWinDimensions`, so that they do not appear in Prebid bundles that do not need them.

## Other information
Related: https://github.com/prebid/Prebid.js/issues/12060

<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
