### PR TITLE
Onetag Bid Adapter: Removal of some unused fields

### DIFF
--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -8,7 +8,6 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { deepClone, logError, deepAccess, getWinDimensions } from '../src/utils.js';
 import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
 import { toOrtbNativeRequest } from '../src/native.js';
-import {getExtraWinDimensions} from '../libraries/extraWinDimensions/extraWinDimensions.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -279,7 +278,6 @@ function getDocumentVisibility(window) {
  */
 function getPageInfo(bidderRequest) {
   const winDimensions = getWinDimensions();
-  const extraDims = getExtraWinDimensions();
   const topmostFrame = getFrameNesting();
   return {
     location: deepAccess(bidderRequest, 'refererInfo.page', null),
@@ -288,12 +286,8 @@ function getPageInfo(bidderRequest) {
     numIframes: deepAccess(bidderRequest, 'refererInfo.numIframes', 0),
     wWidth: winDimensions.innerWidth,
     wHeight: winDimensions.innerHeight,
-    oWidth: extraDims.outerWidth,
-    oHeight: extraDims.outerHeight,
     sWidth: winDimensions.screen.width,
     sHeight: winDimensions.screen.height,
-    aWidth: extraDims.screen.availWidth,
-    aHeight: extraDims.screen.availHeight,
     sLeft: 'screenLeft' in topmostFrame ? topmostFrame.screenLeft : topmostFrame.screenX,
     sTop: 'screenTop' in topmostFrame ? topmostFrame.screenTop : topmostFrame.screenY,
     xOffset: topmostFrame.pageXOffset,
@@ -304,7 +298,7 @@ function getPageInfo(bidderRequest) {
     timing: getTiming(),
     version: {
       prebid: '$prebid.version$',
-      adapter: '1.1.4'
+      adapter: '1.1.5'
     }
   };
 }

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -491,7 +491,7 @@ describe('onetag', function () {
     });
     it('Should contain all keys', function () {
       expect(data).to.be.an('object');
-      expect(data).to.include.all.keys('location', 'referrer', 'stack', 'numIframes', 'sHeight', 'sWidth', 'docHeight', 'wHeight', 'wWidth', 'oHeight', 'oWidth', 'aWidth', 'aHeight', 'sLeft', 'sTop', 'hLength', 'bids', 'docHidden', 'xOffset', 'yOffset', 'networkConnectionType', 'networkEffectiveConnectionType', 'timing', 'version', 'fledgeEnabled');
+      expect(data).to.include.all.keys('location', 'referrer', 'stack', 'numIframes', 'sHeight', 'sWidth', 'docHeight', 'wHeight', 'wWidth', 'sLeft', 'sTop', 'hLength', 'bids', 'docHidden', 'xOffset', 'yOffset', 'networkConnectionType', 'networkEffectiveConnectionType', 'timing', 'version', 'fledgeEnabled');
       expect(data.location).to.satisfy(function (value) {
         return value === null || typeof value === 'string';
       });
@@ -502,10 +502,6 @@ describe('onetag', function () {
       expect(data.sWidth).to.be.a('number');
       expect(data.wWidth).to.be.a('number');
       expect(data.wHeight).to.be.a('number');
-      expect(data.oHeight).to.be.a('number');
-      expect(data.oWidth).to.be.a('number');
-      expect(data.aWidth).to.be.a('number');
-      expect(data.aHeight).to.be.a('number');
       expect(data.sLeft).to.be.a('number');
       expect(data.sTop).to.be.a('number');
       expect(data.hLength).to.be.a('number');
@@ -1135,12 +1131,8 @@ function getBannerVideoRequest() {
       masked: 0,
       wWidth: 860,
       wHeight: 949,
-      oWidth: 1853,
-      oHeight: 1053,
       sWidth: 1920,
       sHeight: 1080,
-      aWidth: 1920,
-      aHeight: 1053,
       sLeft: 1987,
       sTop: 27,
       xOffset: 0,


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Removed some unused fields
