### PR TITLE
Yieldmo Bid Adapter: Removing devicePixelRatio in Bid Request

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -112,7 +112,6 @@ export const spec = {
 
       if (canAccessTopWindow()) {
         serverRequest.pr = (LOCAL_WINDOW.document && LOCAL_WINDOW.document.referrer) || '';
-        serverRequest.scrd = LOCAL_WINDOW.devicePixelRatio || 0;
         serverRequest.title = LOCAL_WINDOW.document.title || '';
         serverRequest.w = getWinDimensions().innerWidth;
         serverRequest.h = getWinDimensions().innerHeight;

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -209,7 +209,6 @@ describe('YieldmoAdapter', function () {
         expect(data.hasOwnProperty('page_url')).to.be.true;
         expect(data.hasOwnProperty('bust')).to.be.true;
         expect(data.hasOwnProperty('pr')).to.be.true;
-        expect(data.hasOwnProperty('scrd')).to.be.true;
         expect(data.dnt).to.be.false;
         expect(data.hasOwnProperty('description')).to.be.true;
         expect(data.hasOwnProperty('title')).to.be.true;


### PR DESCRIPTION

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Removing devicePixelRatio parameter in Bid Request.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
