### PR TITLE
Nativery Bid Adapter: track auction events

### DIFF
--- a/modules/nativeryBidAdapter.js
+++ b/modules/nativeryBidAdapter.js
@@ -182,7 +182,7 @@ function reportEvent(event, data, sampling = null) {
       event,
       data,
     };
-    ajax(EVENT_TRACKER_URL, undefined, safeJSONEncode(payload), { method: 'POST', withCredentials: true, keepalive: true, contentType: 'application/json' });
+    ajax(EVENT_TRACKER_URL, undefined, safeJSONEncode(payload), { method: 'POST', withCredentials: true, keepalive: true });
   }
 }
 

--- a/test/spec/modules/nativeryBidAdapter_spec.js
+++ b/test/spec/modules/nativeryBidAdapter_spec.js
@@ -285,7 +285,7 @@ const assertTrackEvent = (ajaxStub, event, data) => {
   expect(url).to.equal('https://hb.nativery.com/openrtb2/track-event');
   expect(callback).to.be.undefined;
   expect(body).to.be.a('string');
-  expect(options).to.deep.equal({ method: 'POST', withCredentials: true, keepalive: true, contentType: 'application/json' });
+  expect(options).to.deep.equal({ method: 'POST', withCredentials: true, keepalive: true });
 
   const payload = JSON.parse(body);
   expect(payload.event).to.equal(event);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [X] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Registering adapter to auction events: `onBidWon`, `onAdRenderSucceeded`, `onTimeout` and `onBidderError`
