### PR TITLE
ID5 User Id module: generate targeting tags on the server side

### DIFF
--- a/modules/id5IdSystem.js
+++ b/modules/id5IdSystem.js
@@ -570,36 +570,16 @@ function incrementNb(cachedObj) {
 
 function updateTargeting(fetchResponse, config) {
   if (config.params.gamTargetingPrefix) {
-    const tags = {};
-    let universalUid = fetchResponse.universal_uid;
-    if (universalUid.startsWith('ID5*')) {
-      tags.id = "y";
+    const tags = fetchResponse.tags;
+    if (tags) {
+      window.googletag = window.googletag || {cmd: []};
+      window.googletag.cmd = window.googletag.cmd || [];
+      window.googletag.cmd.push(() => {
+        for (const tag in tags) {
+          window.googletag.pubads().setTargeting(config.params.gamTargetingPrefix + '_' + tag, tags[tag]);
+        }
+      });
     }
-    let abTestingResult = fetchResponse.ab_testing?.result;
-    switch (abTestingResult) {
-      case 'control':
-        tags.ab = 'c';
-        break;
-      case 'normal':
-        tags.ab = 'n';
-        break;
-    }
-    let enrichment = fetchResponse.enrichment;
-    if (enrichment?.enriched === true) {
-      tags.enrich = 'y';
-    } else if (enrichment?.enrichment_selected === true) {
-      tags.enrich = 's';
-    } else if (enrichment?.enrichment_selected === false) {
-      tags.enrich = 'c';
-    }
-
-    window.googletag = window.googletag || {cmd: []};
-    window.googletag.cmd = window.googletag.cmd || [];
-    window.googletag.cmd.push(() => {
-      for (const tag in tags) {
-        window.googletag.pubads().setTargeting(config.params.gamTargetingPrefix + '_' + tag, tags[tag]);
-      }
-    });
   }
 }
 

--- a/test/spec/modules/id5IdSystem_spec.js
+++ b/test/spec/modules/id5IdSystem_spec.js
@@ -1381,10 +1381,6 @@ describe('ID5 ID System', function () {
       id5System.id5IdSubmodule._reset()
     });
 
-    function verifyTagging(tagName, tagValue) {
-      verifyMultipleTagging({[tagName]: tagValue})
-    }
-
     function verifyMultipleTagging(tagsObj) {
       expect(window.googletag.cmd.length).to.be.at.least(1);
       window.googletag.cmd.forEach(cmd => cmd());
@@ -1410,69 +1406,27 @@ describe('ID5 ID System', function () {
       expect(window.googletag.cmd).to.have.lengthOf(0)
     })
 
-    it('should set GAM targeting for id tag when universal_uid starts with ID5*', function () {
+    it('should not set GAM targeting if not returned from the server', function () {
+      let config = utils.deepClone(getId5FetchConfig());
+      config.params.gamTargetingPrefix = "id5";
+      id5System.id5IdSubmodule.decode(storedObject, getId5FetchConfig());
+      expect(window.googletag.cmd).to.have.lengthOf(0)
+    })
+
+    it('should set GAM targeting when tags returned if fetch response', function () {
       // Setup
       let config = utils.deepClone(getId5FetchConfig());
       config.params.gamTargetingPrefix = "id5";
-      let testObj = {...storedObject, universal_uid: 'ID5*test123'};
-      id5System.id5IdSubmodule.decode(testObj, config);
-
-      verifyTagging('id', 'y');
-    })
-
-    it('should set GAM targeting for ab tag with control value', function () {
-      // Setup
-      let testObj = {...storedObject, ab_testing: {result: 'control'}};
-      id5System.id5IdSubmodule.decode(testObj, targetingEnabledConfig);
-
-      verifyTagging('ab', 'c');
-    })
-
-    it('should set GAM targeting for ab tag with normal value', function () {
-      // Setup
-      let testObj = {...storedObject, ab_testing: {result: 'normal'}};
-      id5System.id5IdSubmodule.decode(testObj, targetingEnabledConfig);
-
-      verifyTagging('ab', 'n');
-    })
-
-    it('should set GAM targeting for enrich tag with enriched=true', function () {
-      // Setup
-      let testObj = {...storedObject, enrichment: {enriched: true}};
-      id5System.id5IdSubmodule.decode(testObj, targetingEnabledConfig);
-
-      verifyTagging('enrich', 'y');
-    })
-
-    it('should set GAM targeting for enrich tag with enrichment_selected=true', function () {
-      // Setup
-      let testObj = {...storedObject, enrichment: {enrichment_selected: true}};
-      id5System.id5IdSubmodule.decode(testObj, targetingEnabledConfig);
-
-      verifyTagging('enrich', 's');
-    })
-
-    it('should set GAM targeting for enrich tag with enrichment_selected=false', function () {
-      // Setup
-      let testObj = {...storedObject, enrichment: {enrichment_selected: false}};
-      id5System.id5IdSubmodule.decode(testObj, targetingEnabledConfig);
-
-      verifyTagging('enrich', 'c');
-    })
-
-    it('should set GAM targeting for multiple tags when all conditions are met', function () {
-      // Setup
       let testObj = {
         ...storedObject,
-        universal_uid: 'ID5*test123',
-        ab_testing: {result: 'normal'},
-        enrichment: {enriched: true}
+        "tags": {
+          "id": "y",
+          "ab": "n",
+          "enrich": "y"
+        }
       };
+      id5System.id5IdSubmodule.decode(testObj, config);
 
-      // Call decode once with the combined test object
-      id5System.id5IdSubmodule.decode(testObj, targetingEnabledConfig);
-
-      // Verify all tags were set correctly
       verifyMultipleTagging({
         'id': 'y',
         'ab': 'n',


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->

- [x ] Feature

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Including the tags in GAM is still controlled from the module configuration level. Generating them on the server side gives us more flexibility and simplifies user module.
