### PR TITLE
Oftmedia RTD Provider : add 'oftmedia' to the approved external JS list 

### DIFF
--- a/src/adloader.js
+++ b/src/adloader.js
@@ -37,6 +37,7 @@ const _approvedLoadExternalJSList = [
   'nodalsAi',
   'anonymised',
   'optable',
+  'oftmedia',
   // UserId Submodules
   'justtag',
   'tncId',


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

This pull fixes the error "not whitelisted for loading external JavaScript". Adds the Oftmedia RTD external script to the _approvedLoadExternalJSList in src/adloader.js, allowing the module to load its third-party data enrichment script as part of the approved external resources. This change is required to enable full functionality of the Oftmedia RTD provider following the initial module integration (PR #[13527](https://github.com/prebid/Prebid.js/pull/13527)).

