### PR TITLE
Nodals RTD Module: Add support for publisher to override standard TCF…

### DIFF
--- a/modules/nodalsAiRtdProvider.js
+++ b/modules/nodalsAiRtdProvider.js
@@ -55,7 +55,7 @@ class NodalsAiRtdProvider {
     const params = config?.params || {};
     if (
       this.#isValidConfig(params) &&
-      this.#hasRequiredUserConsent(userConsent)
+      this.#hasRequiredUserConsent(userConsent, config)
     ) {
       this.#propertyId = params.propertyId;
       this.#userConsent = userConsent;
@@ -82,7 +82,7 @@ class NodalsAiRtdProvider {
    */
   getTargetingData(adUnitArray, config, userConsent) {
     let targetingData = {};
-    if (!this.#hasRequiredUserConsent(userConsent)) {
+    if (!this.#hasRequiredUserConsent(userConsent, config)) {
       return targetingData;
     }
     this.#userConsent = userConsent;
@@ -104,7 +104,7 @@ class NodalsAiRtdProvider {
   }
 
   getBidRequestData(reqBidsConfigObj, callback, config, userConsent) {
-    if (!this.#hasRequiredUserConsent(userConsent)) {
+    if (!this.#hasRequiredUserConsent(userConsent, config)) {
       callback();
       return;
     }
@@ -133,7 +133,7 @@ class NodalsAiRtdProvider {
   }
 
   onBidResponseEvent(bidResponse, config, userConsent) {
-    if (!this.#hasRequiredUserConsent(userConsent)) {
+    if (!this.#hasRequiredUserConsent(userConsent, config)) {
       return;
     }
     this.#userConsent = userConsent;
@@ -154,7 +154,7 @@ class NodalsAiRtdProvider {
   }
 
   onAuctionEndEvent(auctionDetails, config, userConsent) {
-    if (!this.#hasRequiredUserConsent(userConsent)) {
+    if (!this.#hasRequiredUserConsent(userConsent, config)) {
       return;
     }
     this.#userConsent = userConsent;
@@ -240,11 +240,12 @@ class NodalsAiRtdProvider {
   /**
    * Checks if the user has provided the required consent.
    * @param {Object} userConsent - User consent object.
+   * @param {Object} config - Configuration object for the module.
    * @returns {boolean} - True if the user consent is valid, false otherwise.
    */
 
-  #hasRequiredUserConsent(userConsent) {
-    if (!userConsent.gdpr || userConsent.gdpr?.gdprApplies === false) {
+  #hasRequiredUserConsent(userConsent, config) {
+    if (config?.params?.publisherProvidedConsent === true || !userConsent.gdpr || userConsent.gdpr?.gdprApplies === false) {
       return true;
     }
     if (


### PR DESCRIPTION
… consent checks

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
- [x] Feature

## Description of change
We are working with a publisher who have a different setup. 

No tcfControlModule installed and their position is that vendors "shouldn't seek to try to establish legal bases through the TCF as they are  operating on the legal basis established by the controller, i.e us". In a nutshell, this change allows a publisher to explicitly state that they have gathered consent, so we can proceed without running our usual TCF consent checks.

Whilst we've added support for this new configuration flag, we will not yet open it up in documentation. 

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
