### PR TITLE
[CARPET-6134] Change logic of specified currency bid-params

### DIFF
--- a/modules/ssp_genieeBidAdapter.js
+++ b/modules/ssp_genieeBidAdapter.js
@@ -349,13 +349,13 @@ export const spec = {
 
     if (bidCurrency) {
       if (ALLOWED_CURRENCIES.indexOf(bidCurrency) === -1) {
-        utils.logError(`[${BIDDER_CODE}] Currency "${bidCurrency}" in bid params is not supported. Supported currencies are: ${ALLOWED_CURRENCIES.join(', ')}.`);
+        utils.logError(`[${BIDDER_CODE}] Currency "${bidCurrency}" in bid params is not supported. Supported are: ${ALLOWED_CURRENCIES.join(', ')}.`);
         return false;
       }
     } else {
       const adServerCurrency = config.getConfig('currency.adServerCurrency');
       if (typeof adServerCurrency === 'string' && ALLOWED_CURRENCIES.indexOf(adServerCurrency) === -1) {
-        utils.logError(`[${BIDDER_CODE}] adServerCurrency "${adServerCurrency}" is not supported. Supported currencies are: ${ALLOWED_CURRENCIES.join(', ')}.`);
+        utils.logError(`[${BIDDER_CODE}] adServerCurrency "${adServerCurrency}" is not supported. Supported are: ${ALLOWED_CURRENCIES.join(', ')}.`);
         return false;
       }
     }

--- a/test/spec/modules/ssp_genieeBidAdapter_spec.js
+++ b/test/spec/modules/ssp_genieeBidAdapter_spec.js
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+import { expect, assert } from 'chai';
 import {
   spec,
   BANNER_ENDPOINT,
@@ -86,50 +86,50 @@ describe('ssp_genieeBidAdapter', function () {
 
   describe('isBidRequestValid', function () {
     it('should return false when params.zoneId does not exist', function () {
-      expect(spec.isBidRequestValid({ ...BANNER_BID, params: {} })).to.be.false;
+      assert.isFalse(spec.isBidRequestValid({ ...BANNER_BID, params: {} }));
     });
 
     describe('when params.currency is specified', function() {
       it('should return true if currency is USD', function() {
         const bid = { ...BANNER_BID, params: { ...BANNER_BID.params, currency: 'USD' } };
-        expect(spec.isBidRequestValid(bid)).to.be.true;
+        assert.isTrue(spec.isBidRequestValid(bid));
       });
 
       it('should return true if currency is JPY', function() {
         const bid = { ...BANNER_BID, params: { ...BANNER_BID.params, currency: 'JPY' } };
-        expect(spec.isBidRequestValid(bid)).to.be.true;
+        assert.isTrue(spec.isBidRequestValid(bid));
       });
 
       it('should return false if currency is not supported (e.g., EUR)', function() {
         const bid = { ...BANNER_BID, params: { ...BANNER_BID.params, currency: 'EUR' } };
-        expect(spec.isBidRequestValid(bid)).to.be.false;
+        assert.isFalse(spec.isBidRequestValid(bid));
       });
 
       it('should return true if currency is valid, ignoring adServerCurrency', function() {
         config.setConfig({ currency: { adServerCurrency: 'EUR' } });
         const bid = { ...BANNER_BID, params: { ...BANNER_BID.params, currency: 'USD' } };
-        expect(spec.isBidRequestValid(bid)).to.be.true;
+        assert.isTrue(spec.isBidRequestValid(bid));
       });
     });
 
     describe('when params.currency is NOT specified (fallback to adServerCurrency)', function() {
       it('should return true if adServerCurrency is not set', function() {
-        expect(spec.isBidRequestValid(BANNER_BID)).to.be.true;
+        assert.isTrue(spec.isBidRequestValid(BANNER_BID));
       });
 
       it('should return true if adServerCurrency is JPY', function() {
         config.setConfig({ currency: { adServerCurrency: 'JPY' } });
-        expect(spec.isBidRequestValid(BANNER_BID)).to.be.true;
+        assert.isTrue(spec.isBidRequestValid(BANNER_BID));
       });
 
       it('should return true if adServerCurrency is USD', function() {
         config.setConfig({ currency: { adServerCurrency: 'USD' } });
-        expect(spec.isBidRequestValid(BANNER_BID)).to.be.true;
+        assert.isTrue(spec.isBidRequestValid(BANNER_BID));
       });
 
       it('should return false if adServerCurrency is not supported (e.g., EUR)', function() {
         config.setConfig({ currency: { adServerCurrency: 'EUR' } });
-        expect(spec.isBidRequestValid(BANNER_BID)).to.be.false;
+        assert.isFalse(spec.isBidRequestValid(BANNER_BID));
       });
     });
   });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
