### PR TITLE
Core: break out dependabot security and version update rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "quarterly"
+    open-pull-requests-limit: 2
     versioning-strategy: increase
     allow:
       - dependency-name: 'iab-adcom'
@@ -21,3 +22,12 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+    groups:
+      all-security:
+        applies-to: security-updates
+        patterns: ["*"]


### PR DESCRIPTION
allows dependabot to get back to work