### PR TITLE
Dependabot: clean up configuration error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: "monthly"
   - package-ecosystem: "npm"
     directory: "/"
-    target-branch: "dependabot"
+    target-branch: "dependabotTarget"
     schedule:
       interval: "quarterly"
     open-pull-requests-limit: 2


### PR DESCRIPTION
if we use npm target twice, it has to be on a different branch