### PR TITLE
Welect Bid Adapter: add `mediaType` param to bid response

### DIFF
--- a/modules/welectBidAdapter.js
+++ b/modules/welectBidAdapter.js
@@ -119,6 +119,7 @@ export const spec = {
       ttl: responseBody.bidResponse.ttl,
       ad: responseBody.bidResponse.ad,
       vastUrl: responseBody.bidResponse.vastUrl,
+      mediaType: responseBody.bidResponse.mediaType,
       meta: {
         advertiserDomains: responseBody.bidResponse.meta.advertiserDomains
       }

--- a/test/spec/modules/welectBidAdapter_spec.js
+++ b/test/spec/modules/welectBidAdapter_spec.js
@@ -178,7 +178,8 @@ describe('WelectAdapter', function () {
           ttl: 120,
           vastUrl: 'some vast url',
           height: 640,
-          width: 320
+          width: 320,
+          mediaType: 'video'
         }
       }
     }
@@ -213,7 +214,8 @@ describe('WelectAdapter', function () {
       requestId: 'some bid id',
       ttl: 120,
       vastUrl: 'some vast url',
-      width: 320
+      width: 320,
+      mediaType: 'video'
     }
 
     it('if response reflects unavailability, should be empty', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This adds the `mediaType` param sent by our adserver to the bid response, preventing that all bids are marked as `'banner'` by default. 
An update to the documentation of the adapter is not necessary for this change.
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
