### PR TITLE
[sevioBidAdapter] - Fix mappings for the natives according to the standard

### DIFF
--- a/modules/sevioBidAdapter.js
+++ b/modules/sevioBidAdapter.js
@@ -26,18 +26,18 @@ const parseNativeAd = function (bid) {
       if (asset.data) {
         const value = asset.data.value;
         switch (asset.data.type) {
-          case 1: if (value) native.sponsoredBy = value; break;
-          case 2: if (value) native.body = value; break;
+          case 1: if (value) native.sponsored = value; break;
+          case 2: if (value) native.desc = value; break;
           case 3: if (value) native.rating = value; break;
           case 4: if (value) native.likes = value; break;
           case 5: if (value) native.downloads = value; break;
           case 6: if (value) native.price = value; break;
-          case 7: if (value) native.salePrice = value; break;
+          case 7: if (value) native.saleprice = value; break;
           case 8: if (value) native.phone = value; break;
           case 9: if (value) native.address = value; break;
-          case 10: if (value) native.body2 = value; break;
-          case 11: if (value) native.displayUrl = value; break;
-          case 12: if (value) native.cta = value; break;
+          case 10: if (value) native.desc2 = value; break;
+          case 11: if (value) native.displayurl = value; break;
+          case 12: if (value) native.ctatext = value; break;
           default: break;
         }
       }


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
We realized that the mappings is not following the standard and we would like to have this fixes. Thanks

Standard according to the documentation 
<img width="865" height="743" alt="Screenshot 2025-10-22 at 13 05 38" src="https://github.com/user-attachments/assets/37e40e52-4ea4-48a8-b8cb-2f1f6b73ad6d" />



<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
