### PR TITLE
MSFT bid adapter - update endpoint query params

### DIFF
--- a/modules/msftBidAdapter.js
+++ b/modules/msftBidAdapter.js
@@ -452,13 +452,10 @@ function formatRequest(payload, bidderRequest) {
   }
 
   // check if member is defined in the bid params
-  const memberId = ((bidderRequest?.bids) || []).find(bid => bid.params && bid.params.member && isNumber(bid.params.member));
-  if (memberId) {
-    endpointUrl += (endpointUrl.indexOf('?') === -1 ? '?' : '&') + 'member_id=' + memberId;
+  const matchingBid = ((bidderRequest?.bids) || []).find(bid => bid.params && bid.params.member && isNumber(bid.params.member));
+  if (matchingBid) {
+    endpointUrl += (endpointUrl.indexOf('?') === -1 ? '?' : '&') + 'member_id=' + matchingBid.params.member;
   }
-
-  // temporary setting
-  endpointUrl += (endpointUrl.indexOf('?') === -1 ? '?' : '&') + 'eqt=1';
 
   if (getParameterByName("apn_test").toUpperCase() === "TRUE") {
     options.customHeaders = {

--- a/test/spec/modules/msftBidAdapter_spec.js
+++ b/test/spec/modules/msftBidAdapter_spec.js
@@ -297,6 +297,7 @@ describe('msftBidAdapter', function () {
         const request = spec.buildRequests(bidRequests, bidderRequest)[0];
         expect(request.method).to.equal('POST');
         expect(request.url).to.satisfy(url => url.startsWith(ENDPOINT_URL_NORMAL));
+        expect(request.url).to.satisfy(url => url.indexOf('member_id=123') !== -1);
         const data = request.data;
         expect(data.imp).to.have.lengthOf(1);
         expect(data.imp[0].native.request).to.equal(JSON.stringify(nativeRequest));


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 


## Description of change
This PR makes two changes to the query params that are included on the endpoint URL for the MSFT bid adapter.  It removes a noted temporary param and it fixes the member param (to properly pull the member value instead of the matching bid object).