### PR TITLE
Adkernel Bid Adapter: add bluTonic alias

### DIFF
--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -106,7 +106,8 @@ export const spec = {
     {code: 'urekamedia'},
     {code: 'smartyexchange'},
     {code: 'infinety'},
-    {code: 'qohere'}
+    {code: 'qohere'},
+    {code: 'blutonic'}
   ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter 

## Description of change

Added alias for bluTonic partner network


## Other information
https://github.com/prebid/prebid.github.io/pull/6312