### PR TITLE
Pubmatic bid adapter: remove extra transactionId from bidder request

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -511,7 +511,6 @@ const updateResponseWithCustomFields = (res, bid, ctx) => {
 }
 
 const addExtenstionParams = (req, bidderRequest) => {
-  // const { profId, verId, wiid, transactionId } = conf;
   const { profId, verId, wiid } = conf;
   req.ext = {
     epoch: new Date().getTime(), // Sending epoch timestamp in request.ext object
@@ -520,7 +519,6 @@ const addExtenstionParams = (req, bidderRequest) => {
       version: verId ? parseInt(verId) : undefined,
       wiid: wiid,
       wv: '$$REPO_AND_VERSION$$',
-      // transactionId,
       wp: 'pbjs',
       biddercode: bidderRequest?.bidderCode
     },
@@ -834,7 +832,6 @@ export const spec = {
       originalBid.params.wiid = originalBid.params.wiid || bidderRequest.auctionId || wiid;
       bid = deepClone(originalBid);
       _handleCustomParams(bid.params, conf);
-      // conf.transactionId = bid.ortb2Imp?.ext?.tid;
       const { bcat, acat } = bid.params;
       if (bcat) {
         blockedIabCategories = blockedIabCategories.concat(bcat);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

## Description of change

Removed code for passing transactionId at req.ext.wrapper.transactionId from bidder request
