### PR TITLE
Neuwo Rtd Module: Add url cleaning feature to Neuwo RTD module 

### DIFF
--- a/integrationExamples/gpt/neuwoRtdProvider_example.html
+++ b/integrationExamples/gpt/neuwoRtdProvider_example.html
@@ -121,6 +121,10 @@
             const inputIabContentTaxonomyVersion = document.getElementById('iab-content-taxonomy-version');
             const iabContentTaxonomyVersion = inputIabContentTaxonomyVersion ? inputIabContentTaxonomyVersion.value : undefined;
 
+            // Cache Option
+            const inputEnableCache = document.getElementById('enable-cache');
+            const enableCache = inputEnableCache ? inputEnableCache.checked : undefined;
+
             // URL Stripping Options
             const inputStripAllQueryParams = document.getElementById('strip-all-query-params');
             const stripAllQueryParams = inputStripAllQueryParams ? inputStripAllQueryParams.checked : undefined;
@@ -150,6 +154,7 @@
                                     neuwoApiToken,
                                     websiteToAnalyseUrl,
                                     iabContentTaxonomyVersion,
+                                    enableCache,
                                     stripAllQueryParams,
                                     stripQueryParamsForDomains,
                                     stripQueryParams,
@@ -216,6 +221,14 @@
         <h3>IAB Content Taxonomy Options</h3>
         <div style="margin-bottom: 10px;">
             <input type="text" placeholder="IAB Content Taxonomy Version (default 3.0)" id="iab-content-taxonomy-version" style="width: 400px;" />
+        </div>
+
+        <h3>Cache Options</h3>
+        <div style="margin-bottom: 10px;">
+            <label>
+                <input type="checkbox" id="enable-cache" checked />
+                Enable API response caching (default: enabled)
+            </label>
         </div>
 
         <h3>URL Cleaning Options</h3>
@@ -294,6 +307,7 @@
             neuwoApiUrl: document.getElementById('neuwo-api-url')?.value || '',
             websiteToAnalyseUrl: document.getElementById('website-to-analyse-url')?.value || '',
             iabContentTaxonomyVersion: document.getElementById('iab-content-taxonomy-version')?.value || '',
+            enableCache: document.getElementById('enable-cache')?.checked !== false,
             stripAllQueryParams: document.getElementById('strip-all-query-params')?.checked || false,
             stripQueryParamsForDomains: document.getElementById('strip-query-params-for-domains')?.value || '',
             stripQueryParams: document.getElementById('strip-query-params')?.value || '',
@@ -318,6 +332,7 @@
             if (config.stripQueryParams) document.getElementById('strip-query-params').value = config.stripQueryParams;
 
             // Restore checkboxes
+            document.getElementById('enable-cache').checked = config.enableCache !== false;
             document.getElementById('strip-all-query-params').checked = config.stripAllQueryParams;
             document.getElementById('strip-fragments').checked = config.stripFragments;
         } catch (e) {
@@ -337,6 +352,7 @@
         ];
 
         const checkboxIds = [
+            'enable-cache',
             'strip-all-query-params',
             'strip-fragments'
         ];

--- a/modules/neuwoRtdProvider.md
+++ b/modules/neuwoRtdProvider.md
@@ -83,6 +83,7 @@ pbjs.setConfig({
           neuwoApiUrl: "<Your Neuwo Edge API Endpoint URL>",
           neuwoApiToken: "<Your Neuwo API Token>",
           iabContentTaxonomyVersion: "3.0",
+          enableCache: true, // Default: true. Caches API responses to avoid redundant requests
         },
       },
     ],
@@ -99,14 +100,19 @@ pbjs.setConfig({
 | `params.neuwoApiUrl`                | String   | Yes      |         | The endpoint URL for the Neuwo Edge API.                                                                                                                                                                                                                                                                                   |
 | `params.neuwoApiToken`              | String   | Yes      |         | Your unique API token provided by Neuwo.                                                                                                                                                                                                                                                                                   |
 | `params.iabContentTaxonomyVersion`  | String   | No       | `'3.0'` | Specifies the version of the IAB Content Taxonomy to be used. Supported values: `'2.2'`, `'3.0'`.                                                                                                                                                                                                                          |
+| `params.enableCache`                | Boolean  | No       | `true`  | If `true`, caches API responses to avoid redundant requests for the same page during the session. Set to `false` to disable caching and make a fresh API call on every bid request.                                                                                                                                        |
 | `params.stripAllQueryParams`        | Boolean  | No       | `false` | If `true`, strips all query parameters from the URL before analysis. Takes precedence over other stripping options.                                                                                                                                                                                                        |
 | `params.stripQueryParamsForDomains` | String[] | No       | `[]`    | List of domains for which to strip **all** query parameters. When a domain matches, all query params are removed for that domain and all its subdomains (e.g., `'example.com'` strips params for both `'example.com'` and `'sub.example.com'`). This option takes precedence over `stripQueryParams` for matching domains. |
 | `params.stripQueryParams`           | String[] | No       | `[]`    | List of specific query parameter names to strip from the URL (e.g., `['utm_source', 'fbclid']`). Other parameters are preserved. Only applies when the domain does not match `stripQueryParamsForDomains`.                                                                                                                 |
 | `params.stripFragments`             | Boolean  | No       | `false` | If `true`, strips URL fragments (hash, e.g., `#section`) from the URL before analysis.                                                                                                                                                                                                                                     |
 
+### API Response Caching
+
+By default, the module caches API responses during the page session to optimise performance and reduce redundant API calls. This behaviour can be disabled by setting `enableCache: false` if needed for dynamic content scenarios.
+
 ### URL Cleaning Options
 
-The module provides optional URL cleaning capabilities to strip query parameters and/or fragments from the analyzed URL before sending it to the Neuwo API. This can be useful for privacy, caching, or analytics purposes.
+The module provides optional URL cleaning capabilities to strip query parameters and/or fragments from the analysed URL before sending it to the Neuwo API. This can be useful for privacy, caching, or analytics purposes.
 
 **Example with URL cleaning:**
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

URL cleaning feature logic is mostly contained in `cleanUrl` function. The list of changes:
- Add configurable URL cleaning options to strip query parameters and fragments before sending URLs to Neuwo API:
  - stripAllQueryParams: removes all query parameters
  - stripQueryParamsForDomains: removes all params for specific domains/subdomains
  - stripQueryParams: removes specific named parameters
  - stripFragments: removes URL hash fragments
- Add test cases for cleanUrl function covering:
  - Query parameter stripping (all, domain-specific, selective)
  - Fragment stripping and combinations
  - Edge cases (malformed URLs, encoding, delimiters)
  - Domain/subdomain matching logic
  - Option priority and fallthrough behavior
  - Integration tests with getBidRequestData
- update documentation
- update example page

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
