### PR TITLE
Tappx Bid Adapter: Fix advertiserDomains assignment

### DIFF
--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -1,12 +1,12 @@
 'use strict';
 
-import {getDNT} from '../libraries/dnt/index.js';
-import { logWarn, deepAccess, isFn, isPlainObject, isBoolean, isNumber, isStr, isArray } from '../src/utils.js';
+import { getDNT } from '../libraries/dnt/index.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
-import { Renderer } from '../src/Renderer.js';
+import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { parseDomain } from '../src/refererDetection.js';
+import { Renderer } from '../src/Renderer.js';
+import { deepAccess, isArray, isBoolean, isFn, isNumber, isPlainObject, isStr, logWarn } from '../src/utils.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -231,7 +231,7 @@ function interpretBid(serverBid, request) {
   }
 
   if (typeof bidReturned.adomain !== 'undefined' || bidReturned.adomain !== null) {
-    bidReturned.meta = { advertiserDomains: bidReturned?.adomain };
+    bidReturned.meta = { advertiserDomains: serverBid?.adomain };
   }
 
   return bidReturned;


### PR DESCRIPTION
…rpretBid function

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  
- [x] Updated bidder adapter 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

This PR fixes a bug in the `interpretResponse` function of the **Tappx Bid Adapter**, where the `advertiserDomains` field was incorrectly assigned from `request.bid.adomain`.

Since `request.bid.adomain` is not defined in this context, the correct source for the advertiser domain data is the server bid response (`serverBid.adomain`), which contains the actual advertiser information returned by the SSP.

 
### ✅ Fix applied:
```js
// Old code (incorrect):
bidReturned.meta = { advertiserDomains: request.bid?.adomain };

// New code (correct):
bidReturned.meta = { advertiserDomains: serverBid?.adomain };

 
 