### PR TITLE
Core: fix spurious validation warnings on mediaType / ortb2Imp

### DIFF
--- a/src/prebid.ts
+++ b/src/prebid.ts
@@ -156,7 +156,7 @@ export function syncOrtb2(adUnit, mediaType) {
       deepSetValue(adUnit, `mediaTypes.${mediaType}.${key}`, ortbFieldValue);
     } else if (ortbFieldValue === undefined) {
       deepSetValue(adUnit, `ortb2Imp.${mediaType}.${key}`, mediaTypesFieldValue);
-    } else {
+    } else if (!deepEqual(mediaTypesFieldValue, ortbFieldValue)) {
       logWarn(`adUnit ${adUnit.code}: specifies conflicting ortb2Imp.${mediaType}.${key} and mediaTypes.${mediaType}.${key}, the latter will be ignored`, adUnit);
       deepSetValue(adUnit, `mediaTypes.${mediaType}.${key}`, ortbFieldValue);
     }

--- a/test/spec/banner_spec.js
+++ b/test/spec/banner_spec.js
@@ -127,6 +127,23 @@ describe('banner', () => {
       assert.ok(logWarnSpy.calledOnce, 'expected warning was logged due to conflicting btype');
     });
 
+    it('should not warn if fields match', () => {
+      const adUnit = {
+        mediaTypes: {
+          banner: {
+            format: [{wratio: 1, hratio: 1}]
+          }
+        },
+        ortb2Imp: {
+          banner: {
+            format: [{wratio: 1, hratio: 1}]
+          }
+        }
+      }
+      syncOrtb2(adUnit, 'banner');
+      sinon.assert.notCalled(logWarnSpy);
+    })
+
     it('should omit sync if mediaType not present on adUnit', () => {
       const adUnit = {
         mediaTypes: {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fixes spurious warnings like "adUnit specifies conflicting mediaTypes.field and ortb2Imp.field" when they are in fact not conflicting.

