### PR TITLE
Core: Dev Tools: Fix node version within dev container 

### DIFF
--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,5 +1,8 @@
 echo "Post Create Starting"
 
+export NVM_DIR="/usr/local/share/nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
 nvm install
 nvm use
 npm install gulp-cli -g


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
When starting up the dev container, I noticed the `npm ci` step getting the `BADENGINE` error on certain modules. I noticed that my container was using version 18 even though `.nvmrc` specified `20.13.1`. The `postCreate` script was getting a `command not found` error on the `nvm` lines.

This is because by default `nvm` is meant to be an interactive shell function, and isn't available in the path for scripts. I added a line that explicitly adds the `nvm` path, allowing the script to run `nvm` successfully.

Output before change:

```
.devcontainer/postCreate.sh: line 3: nvm: command not found
.devcontainer/postCreate.sh: line 4: nvm: command not found

added 80 packages in 3s

8 packages are looking for funding
  run `npm fund` for details
npm notice
npm notice New major version of npm available! 10.8.2 -> 11.6.2
npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.6.2
npm notice To update run: npm install -g npm@11.6.2
npm notice
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'prebid.js@10.16.0-pre',
npm warn EBADENGINE   required: { node: '>=20.0.0' },
npm warn EBADENGINE   current: { node: 'v18.20.8', npm: '10.8.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@isaacs/balanced-match@4.0.1',
npm warn EBADENGINE   required: { node: '20 || >=22' },
npm warn EBADENGINE   current: { node: 'v18.20.8', npm: '10.8.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: '@isaacs/brace-expansion@5.0.0',
npm warn EBADENGINE   required: { node: '20 || >=22' },
npm warn EBADENGINE   current: { node: 'v18.20.8', npm: '10.8.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'commander@14.0.0',
npm warn EBADENGINE   required: { node: '>=20' },
npm warn EBADENGINE   current: { node: 'v18.20.8', npm: '10.8.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'minimatch@10.0.3',
npm warn EBADENGINE   required: { node: '20 || >=22' },
npm warn EBADENGINE   current: { node: 'v18.20.8', npm: '10.8.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'live-connect-common@4.1.0',
npm warn EBADENGINE   required: { node: '>=20' },
npm warn EBADENGINE   current: { node: 'v18.20.8', npm: '10.8.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'live-connect-js@7.2.0',
npm warn EBADENGINE   required: { node: '>=20' },
npm warn EBADENGINE   current: { node: 'v18.20.8', npm: '10.8.2' }
npm warn EBADENGINE }
```

Output after change:

```
Post Create Starting
Found '/workspaces/Prebid.js/.nvmrc' with version <20.13.1>
Downloading and installing node v20.13.1...
Downloading https://nodejs.org/dist/v20.13.1/node-v20.13.1-linux-x64.tar.xz...
######################################################################### 100.0%
Computing checksum with sha256sum
Checksums matched!
Now using node v20.13.1 (npm v10.5.2)
Creating default alias: default -> 20.13.1 (-> v20.13.1)
Found '/workspaces/Prebid.js/.nvmrc' with version <20.13.1>
Now using node v20.13.1 (npm v10.5.2)

added 80 packages in 2s

8 packages are looking for funding
  run `npm fund` for details
npm notice 
npm notice New major version of npm available! 10.5.2 -> 11.6.2
npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.6.2
npm notice Run npm install -g npm@11.6.2 to update!
npm notice 

added 1821 packages, and audited 1822 packages in 25s

294 packages are looking for funding
  run `npm fund` for details

8 vulnerabilities (3 low, 3 moderate, 2 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
```
