### PR TITLE
OMS Bid Adapter: add banner media type check in buildRequests

### DIFF
--- a/modules/omsBidAdapter.js
+++ b/modules/omsBidAdapter.js
@@ -51,17 +51,20 @@ function buildRequests(bidReqs, bidderRequest) {
 
       const imp = {
         id: bid.bidId,
-        banner: {
-          format: processedSizes,
-          ext: {
-            viewability: viewabilityAmountRounded,
-          }
-        },
         ext: {
           ...gpidData
         },
         tagid: String(bid.adUnitCode)
       };
+
+      if (bid?.mediaTypes?.banner) {
+        imp.banner = {
+          format: processedSizes,
+          ext: {
+            viewability: viewabilityAmountRounded,
+          }
+        }
+      }
 
       if (bid?.mediaTypes?.video) {
         imp.video = {


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description of change
Right now, we add banner by default even if only video was requested. We want to prevent it and add to request only requested media types. 
