### PR TITLE
Microsoft Adapter: Add 152media alias

### DIFF
--- a/modules/msftBidAdapter.js
+++ b/modules/msftBidAdapter.js
@@ -319,7 +319,7 @@ const converter = ortbConverter({
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
-  aliases: [{ code: 'oftmsft', gvlid: 32 }], // TODO fill in after full transition or as seperately requested
+  aliases: [{ code: 'oftmsft', gvlid: 32 }], // TODO fill in after full transition or as separately requested
   supportedMediaTypes: [BANNER, NATIVE, VIDEO],
 
   isBidRequestValid: (bid) => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
As part of the transition to the new Microsoft adapter, we kindly request that our original alias ([code](https://github.com/152Media/fork_oftmedia_prebid.js/blob/99c6ec3def28d545c0431c0301a9ecb5aff9efd4/libraries/appnexusUtils/anUtils.js#L21)) from the AppNexus adapter be ported to the new Microsoft adapter to ensure continuity and consistency in bidder configuration and reporting. We propose using the new alias name "oftmsft" to prevent any conflicts with the existing alias associated with the legacy adapter during transition.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
@jsnellbaker @dgirardi