### PR TITLE
Sparteo   backport adapter changes

### DIFF
--- a/test/spec/modules/sparteoBidAdapter_spec.js
+++ b/test/spec/modules/sparteoBidAdapter_spec.js
@@ -1,11 +1,11 @@
-import {expect} from 'chai';
+import { expect } from 'chai';
 import { deepClone, mergeDeep } from 'src/utils';
-import {spec as adapter} from 'modules/sparteoBidAdapter';
+import { spec as adapter } from 'modules/sparteoBidAdapter';
 
 const CURRENCY = 'EUR';
 const TTL = 60;
 const HTTP_METHOD = 'POST';
-const REQUEST_URL = 'https://bid.sparteo.com/auction';
+const REQUEST_URL = 'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&site_domain=dev.sparteo.com';
 const USER_SYNC_URL_IFRAME = 'https://sync.sparteo.com/sync/iframe.html?from=prebidjs';
 
 const VALID_BID_BANNER = {
@@ -79,6 +79,7 @@ const VALID_REQUEST_BANNER = {
       }
     }],
     'site': {
+      'domain': 'dev.sparteo.com',
       'publisher': {
         'ext': {
           'params': {
@@ -123,6 +124,7 @@ const VALID_REQUEST_VIDEO = {
       }
     }],
     'site': {
+      'domain': 'dev.sparteo.com',
       'publisher': {
         'ext': {
           'params': {
@@ -186,6 +188,7 @@ const VALID_REQUEST = {
       }
     }],
     'site': {
+      'domain': 'dev.sparteo.com',
       'publisher': {
         'ext': {
           'params': {
@@ -199,17 +202,26 @@ const VALID_REQUEST = {
   }
 };
 
+const ORTB2_GLOBAL = {
+  site: {
+    domain: 'dev.sparteo.com'
+  }
+};
+
 const BIDDER_REQUEST = {
-  bids: [VALID_BID_BANNER, VALID_BID_VIDEO]
-}
+  bids: [VALID_BID_BANNER, VALID_BID_VIDEO],
+  ortb2: ORTB2_GLOBAL
+};
 
 const BIDDER_REQUEST_BANNER = {
-  bids: [VALID_BID_BANNER]
-}
+  bids: [VALID_BID_BANNER],
+  ortb2: ORTB2_GLOBAL
+};
 
 const BIDDER_REQUEST_VIDEO = {
-  bids: [VALID_BID_VIDEO]
-}
+  bids: [VALID_BID_VIDEO],
+  ortb2: ORTB2_GLOBAL
+};
 
 describe('SparteoAdapter', function () {
   describe('isBidRequestValid', function () {
@@ -250,55 +262,50 @@ describe('SparteoAdapter', function () {
 
   describe('buildRequests', function () {
     describe('Check method return', function () {
-      if (FEATURES.VIDEO) {
-        it('should return the right formatted requests', function() {
-          const request = adapter.buildRequests([VALID_BID_BANNER, VALID_BID_VIDEO], BIDDER_REQUEST);
-          delete request.data.id;
-
-          expect(request).to.deep.equal(VALID_REQUEST);
-        });
-      }
-
-      it('should return the right formatted banner requests', function() {
+      it('should return the right formatted banner requests', function () {
         const request = adapter.buildRequests([VALID_BID_BANNER], BIDDER_REQUEST_BANNER);
         delete request.data.id;
 
         expect(request).to.deep.equal(VALID_REQUEST_BANNER);
       });
-
       if (FEATURES.VIDEO) {
-        it('should return the right formatted video requests', function() {
+        it('should return the right formatted requests', function () {
+          const request = adapter.buildRequests([VALID_BID_BANNER, VALID_BID_VIDEO], BIDDER_REQUEST);
+          delete request.data.id;
+
+          expect(request).to.deep.equal(VALID_REQUEST);
+        });
+
+        it('should return the right formatted video requests', function () {
           const request = adapter.buildRequests([VALID_BID_VIDEO], BIDDER_REQUEST_VIDEO);
           delete request.data.id;
 
           expect(request).to.deep.equal(VALID_REQUEST_VIDEO);
         });
-      }
 
-      it('should return the right formatted request with endpoint test', function() {
-        let endpoint = 'https://bid-test.sparteo.com/auction';
+        it('should return the right formatted request with endpoint test', function () {
+          const endpoint = 'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&site_domain=dev.sparteo.com';
 
-        let bids = mergeDeep(deepClone([VALID_BID_BANNER, VALID_BID_VIDEO]), {
-          params: {
-            endpoint: endpoint
-          }
+          const bids = deepClone([VALID_BID_BANNER, VALID_BID_VIDEO]);
+          bids[0].params.endpoint = endpoint;
+
+          const expectedRequest = deepClone(VALID_REQUEST);
+          expectedRequest.url = endpoint;
+          expectedRequest.data.imp[0].ext.sparteo.params.endpoint = endpoint;
+
+          const request = adapter.buildRequests(bids, BIDDER_REQUEST);
+          delete request.data.id;
+
+          expect(request).to.deep.equal(expectedRequest);
         });
-
-        let requests = mergeDeep(deepClone(VALID_REQUEST));
-
-        const request = adapter.buildRequests(bids, BIDDER_REQUEST);
-        requests.url = endpoint;
-        delete request.data.id;
-
-        expect(requests).to.deep.equal(requests);
-      });
+      }
     });
   });
 
-  describe('interpretResponse', function() {
+  describe('interpretResponse', function () {
     describe('Check method return', function () {
-      it('should return the right formatted response', function() {
-        let response = {
+      it('should return the right formatted response', function () {
+        const response = {
           body: {
             'id': '63f4d300-6896-4bdc-8561-0932f73148b1',
             'cur': 'EUR',
@@ -458,10 +465,10 @@ describe('SparteoAdapter', function () {
     });
   });
 
-  describe('onBidWon', function() {
+  describe('onBidWon', function () {
     describe('Check methods succeed', function () {
-      it('should not throw error', function() {
-        let bids = [
+      it('should not throw error', function () {
+        const bids = [
           {
             requestId: '1a2b3c4d',
             seatBidId: 'cdbb6982-a269-40c7-84e5-04797f11d87a',
@@ -500,16 +507,16 @@ describe('SparteoAdapter', function () {
           }
         ];
 
-        bids.forEach(function(bid) {
+        bids.forEach(function (bid) {
           expect(adapter.onBidWon.bind(adapter, bid)).to.not.throw();
         });
       });
     });
   });
 
-  describe('getUserSyncs', function() {
+  describe('getUserSyncs', function () {
     describe('Check methods succeed', function () {
-      it('should return the sync url', function() {
+      it('should return the sync url', function () {
         const syncOptions = {
           'iframeEnabled': true,
           'pixelEnabled': false
@@ -528,6 +535,428 @@ describe('SparteoAdapter', function () {
         }];
 
         expect(adapter.getUserSyncs(syncOptions, null, gdprConsent, uspConsent)).to.deep.equal(syncUrls);
+      });
+    });
+  });
+
+  describe('replaceMacros via buildRequests', function () {
+    const ENDPOINT = 'https://bid.sparteo.com/auction?network_id=${NETWORK_ID}${SITE_DOMAIN_QUERY}${APP_DOMAIN_QUERY}${BUNDLE_QUERY}';
+
+    it('replaces macros for site traffic (site_domain only)', function () {
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+      bid.params.networkId = '1234567a-eb1b-1fae-1d23-e1fbaef234cf';
+
+      const bidderReq = {
+        bids: [bid],
+        ortb2: {
+          site: {
+            domain: 'site.sparteo.com',
+            publisher: { domain: 'dev.sparteo.com' }
+          }
+        }
+      };
+
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      expect(req.url).to.equal(
+        'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&site_domain=site.sparteo.com'
+      );
+    });
+
+    it('uses site.page hostname when site.domain is missing', function () {
+      const ENDPOINT2 = 'https://bid.sparteo.com/auction?network_id=${NETWORK_ID}${SITE_DOMAIN_QUERY}';
+
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT2;
+      bid.params.networkId = '1234567a-eb1b-1fae-1d23-e1fbaef234cf';
+
+      const bidderReq = {
+        bids: [bid],
+        ortb2: {
+          site: {
+            page: 'https://www.dev.sparteo.com:3000/p/some?x=1'
+          }
+        }
+      };
+
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      expect(req.url).to.equal(
+        'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&site_domain=dev.sparteo.com'
+      );
+    });
+
+    it('omits domain query and leaves network_id empty when neither site nor app is present', function () {
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+      bid.params.networkId = '1234567a-eb1b-1fae-1d23-e1fbaef234cf';
+
+      const bidderReq = { bids: [bid], ortb2: {} };
+
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      expect(req.url).to.equal(
+        'https://bid.sparteo.com/auction?network_id='
+      );
+    });
+
+    it('sets site_domain=unknown when site.domain is null', function () {
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+
+      const bidderReq = {
+        bids: [bid],
+        ortb2: {
+          site: {
+            domain: null
+          }
+        }
+      };
+
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      expect(req.url).to.equal(
+        'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&site_domain=unknown'
+      );
+    });
+
+    it('replaces ${NETWORK_ID} with empty when undefined', function () {
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+      delete bid.params.networkId;
+
+      const bidderReq = {
+        bids: [bid],
+        ortb2: {
+          site: {
+            domain: 'dev.sparteo.com'
+          }
+        }
+      };
+
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      expect(req.url).to.equal(
+        'https://bid.sparteo.com/auction?network_id=&site_domain=dev.sparteo.com'
+      );
+    });
+
+    it('replaces ${NETWORK_ID} with empty when null', function () {
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+      bid.params.networkId = null;
+
+      const bidderReq = {
+        bids: [bid],
+        ortb2: {
+          site: {
+            domain: 'dev.sparteo.com'
+          }
+        }
+      };
+
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      expect(req.url).to.equal(
+        'https://bid.sparteo.com/auction?network_id=&site_domain=dev.sparteo.com'
+      );
+    });
+
+    it('appends &bundle=... and uses app_domain when app.bundle is present', function () {
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+
+      const bidderReq = {
+        bids: [bid],
+        ortb2: {
+          app: {
+            domain: 'dev.sparteo.com',
+            bundle: 'com.sparteo.app'
+          }
+        }
+      };
+
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      expect(req.url).to.equal(
+        'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&app_domain=dev.sparteo.com&bundle=com.sparteo.app'
+      );
+    });
+
+    it('does not append &bundle when app is missing; uses site_domain when site exists', function () {
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+
+      const bidderReq = {
+        bids: [bid],
+        ortb2: {
+          site: { domain: 'dev.sparteo.com' }
+        }
+      };
+
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      expect(req.url).to.equal(
+        'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&site_domain=dev.sparteo.com'
+      );
+    });
+
+    it('prefers site over app when both are present', function () {
+      const ENDPOINT = 'https://bid.sparteo.com/auction?network_id=${NETWORK_ID}${SITE_DOMAIN_QUERY}${APP_DOMAIN_QUERY}${BUNDLE_QUERY}';
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+
+      const bidderReq = {
+        bids: [bid],
+        ortb2: {
+          site: { domain: 'site.sparteo.com' },
+          app: { domain: 'app.sparteo.com', bundle: 'com.sparteo.app' }
+        }
+      };
+
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      expect(req.url).to.equal(
+        'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&site_domain=site.sparteo.com'
+      );
+      expect(req.data.site?.publisher?.ext?.params?.networkId).to.equal('1234567a-eb1b-1fae-1d23-e1fbaef234cf');
+      expect(req.data.app).to.be.undefined;
+    });
+
+    ['', '   ', 'null', 'NuLl'].forEach((val) => {
+      it(`app bundle "${val}" produces &bundle=unknown`, function () {
+        const ENDPOINT = 'https://bid.sparteo.com/auction?network_id=${NETWORK_ID}${APP_DOMAIN_QUERY}${BUNDLE_QUERY}';
+        const bid = deepClone(VALID_BID_BANNER);
+        bid.params.endpoint = ENDPOINT;
+
+        const bidderReq = {
+          bids: [bid],
+          ortb2: { app: { domain: 'dev.sparteo.com', bundle: val } }
+        };
+
+        const req = adapter.buildRequests([bid], bidderReq);
+        delete req.data.id;
+
+        expect(req.url).to.equal(
+          'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&app_domain=dev.sparteo.com&bundle=unknown'
+        );
+      });
+    });
+
+    it('app domain missing becomes app_domain=unknown while keeping bundle', function () {
+      const ENDPOINT = 'https://bid.sparteo.com/auction?network_id=${NETWORK_ID}${APP_DOMAIN_QUERY}${BUNDLE_QUERY}';
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+
+      const bidderReq = {
+        bids: [bid],
+        ortb2: { app: { domain: '', bundle: 'com.sparteo.app' } }
+      };
+
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      expect(req.url).to.equal(
+        'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&app_domain=unknown&bundle=com.sparteo.app'
+      );
+    });
+
+    it('uses network_id from app.publisher.ext for app-only traffic', function () {
+      const ENDPOINT = 'https://bid.sparteo.com/auction?network_id=${NETWORK_ID}${APP_DOMAIN_QUERY}${BUNDLE_QUERY}';
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+
+      const bidderReq = {
+        bids: [bid],
+        ortb2: { app: { domain: 'dev.sparteo.com', bundle: 'com.sparteo.app' } }
+      };
+
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      expect(req.data.site).to.be.undefined;
+      expect(req.data.app?.publisher?.ext?.params?.networkId).to.equal('1234567a-eb1b-1fae-1d23-e1fbaef234cf');
+      expect(req.url).to.equal(
+        'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&app_domain=dev.sparteo.com&bundle=com.sparteo.app'
+      );
+    });
+
+    it('unparsable site.page yields site_domain=unknown', function () {
+      const ENDPOINT = 'https://bid.sparteo.com/auction?network_id=${NETWORK_ID}${SITE_DOMAIN_QUERY}';
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+
+      const bidderReq = {
+        bids: [bid],
+        ortb2: { site: { page: 'not a url' } }
+      };
+
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      expect(req.url).to.equal(
+        'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&site_domain=unknown'
+      );
+    });
+
+    it('literal "null" in site.page yields site_domain=unknown', function () {
+      const ENDPOINT = 'https://bid.sparteo.com/auction?network_id=${NETWORK_ID}${SITE_DOMAIN_QUERY}';
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+
+      const bidderReq = {
+        bids: [bid],
+        ortb2: { site: { domain: '', page: 'null' } }
+      };
+
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      expect(req.url).to.equal(
+        'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&site_domain=unknown'
+      );
+    });
+
+    it('does not create site on app-only request', function () {
+      const ENDPOINT = 'https://bid.sparteo.com/auction?network_id=${NETWORK_ID}${APP_DOMAIN_QUERY}${BUNDLE_QUERY}';
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+
+      const bidderReq = {
+        bids: [bid],
+        ortb2: { app: { domain: 'dev.sparteo.com', bundle: 'com.sparteo.app' } }
+      };
+
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      expect(req.data.site).to.be.undefined;
+      expect(req.data.app).to.exist;
+      expect(req.url).to.equal(
+        'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&app_domain=dev.sparteo.com&bundle=com.sparteo.app'
+      );
+    });
+
+    it('propagates adUnitCode into imp.ext.sparteo.params.adUnitCode', function () {
+      const ENDPOINT = 'https://bid.sparteo.com/auction?network_id=${NETWORK_ID}${SITE_DOMAIN_QUERY}';
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+
+      const req = adapter.buildRequests([bid], { bids: [bid], ortb2: { site: { domain: 'dev.sparteo.com' } } });
+      delete req.data.id;
+
+      expect(req.data.imp[0]?.ext?.sparteo?.params?.adUnitCode).to.equal(bid.adUnitCode);
+    });
+
+    it('sets pbjsVersion and networkId under site root', function () {
+      const ENDPOINT = 'https://bid.sparteo.com/auction?network_id=${NETWORK_ID}${SITE_DOMAIN_QUERY}';
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+
+      const bidderReq = { bids: [bid], ortb2: { site: { domain: 'dev.sparteo.com' } } };
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      const params = req.data.site?.publisher?.ext?.params;
+      expect(params?.pbjsVersion).to.equal('$prebid.version$');
+      expect(params?.networkId).to.equal('1234567a-eb1b-1fae-1d23-e1fbaef234cf');
+      expect(req.data.app?.publisher?.ext?.params?.pbjsVersion).to.be.undefined;
+    });
+
+    it('sets pbjsVersion and networkId under app root', function () {
+      const ENDPOINT = 'https://bid.sparteo.com/auction?network_id=${NETWORK_ID}${APP_DOMAIN_QUERY}${BUNDLE_QUERY}';
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+
+      const bidderReq = { bids: [bid], ortb2: { app: { domain: 'dev.sparteo.com', bundle: 'com.sparteo.app' } } };
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      const params = req.data.app?.publisher?.ext?.params;
+      expect(params?.pbjsVersion).to.equal('$prebid.version$');
+      expect(params?.networkId).to.equal('1234567a-eb1b-1fae-1d23-e1fbaef234cf');
+      expect(req.data.site).to.be.undefined;
+    });
+
+    it('app-only without networkId leaves network_id empty', function () {
+      const ENDPOINT = 'https://bid.sparteo.com/auction?network_id=${NETWORK_ID}${APP_DOMAIN_QUERY}${BUNDLE_QUERY}';
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+      delete bid.params.networkId;
+
+      const bidderReq = { bids: [bid], ortb2: { app: { domain: 'dev.sparteo.com', bundle: 'com.sparteo.app' } } };
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      expect(req.url).to.equal(
+        'https://bid.sparteo.com/auction?network_id=&app_domain=dev.sparteo.com&bundle=com.sparteo.app'
+      );
+    });
+  });
+
+  describe('domain normalization (strip www., port, path, trim)', function () {
+    const ENDPOINT = 'https://bid.sparteo.com/auction?network_id=${NETWORK_ID}${SITE_DOMAIN_QUERY}';
+
+    const CASES = [
+      {
+        label: 'strips leading "www." from site.domain',
+        site: { domain: 'www.dev.sparteo.com' },
+        expected: 'dev.sparteo.com'
+      },
+      {
+        label: 'trims whitespace and strips "www."',
+        site: { domain: '   www.dev.sparteo.com   ' },
+        expected: 'dev.sparteo.com'
+      },
+      {
+        label: 'preserves non-"www" prefixes like "www2."',
+        site: { domain: 'www2.dev.sparteo.com' },
+        expected: 'www2.dev.sparteo.com'
+      },
+      {
+        label: 'removes port from site.page',
+        site: { page: 'https://dev.sparteo.com:8080/path?q=1' },
+        expected: 'dev.sparteo.com'
+      },
+      {
+        label: 'removes "www." and path from site.page',
+        site: { page: 'http://www.dev.sparteo.com/p?q=1' },
+        expected: 'dev.sparteo.com'
+      },
+      {
+        label: 'removes port when it appears in site.domain',
+        site: { domain: 'dev.sparteo.com:8443' },
+        expected: 'dev.sparteo.com'
+      },
+      {
+        label: 'removes accidental path in site.domain',
+        site: { domain: 'dev.sparteo.com/some/path' },
+        expected: 'dev.sparteo.com'
+      }
+    ];
+
+    CASES.forEach(({ label, site, expected }) => {
+      it(label, function () {
+        const bid = deepClone(VALID_BID_BANNER);
+        bid.params.endpoint = ENDPOINT;
+        const bidderReq = { bids: [bid], ortb2: { site } };
+
+        const req = adapter.buildRequests([bid], bidderReq);
+        delete req.data.id;
+
+        expect(req.url).to.equal(
+          `https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&site_domain=${expected}`
+        );
       });
     });
   });


### PR DESCRIPTION
## Type of change
- [X] Updated bidder adapter

## Description of change
Backport adapter 10.X changes: 
- [Sparteo Bid Adapter: support new optional query params](https://github.com/prebid/Prebid.js/pull/13986)
- [Sparteo Bid Adapter: add Outstream support with custom video renderer, configured by bidResponse](https://github.com/prebid/Prebid.js/pull/13512)

## Other information
Hi team, 
we would like to backport these adapter changes to the 9.53.X version. 
If these PR is not necessary, feel free to close it.
