### PR TITLE
datablocks bid adapter: Remove colorDepth and availheight and width

### DIFF
--- a/modules/datablocksBidAdapter.js
+++ b/modules/datablocksBidAdapter.js
@@ -208,8 +208,8 @@ export const spec = {
     return {
       'wiw': windowDimensions.innerWidth,
       'wih': windowDimensions.innerHeight,
-      'saw': windowDimensions.screen.availWidth,
-      'sah': windowDimensions.screen.availHeight,
+      'saw': null,
+      'sah': null,
       'scd': null,
       'sw': windowDimensions.screen.width,
       'sh': windowDimensions.screen.height,


### PR DESCRIPTION
colordepth no longer allowed as per #12060 