### PR TITLE
CI: set localIdentifier for browserstack tests

### DIFF
--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -97,7 +97,7 @@ function setBrowsers(karmaConf, browserstack) {
       accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
       build: process.env.BROWSERSTACK_BUILD_NAME
     }
-    if (process.env.TRAVIS) {
+    if (process.env.BROWSERSTACK_LOCAL_IDENTIFIER) {
       karmaConf.browserStack.startTunnel = false;
       karmaConf.browserStack.tunnelIdentifier = process.env.BROWSERSTACK_LOCAL_IDENTIFIER;
     }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] CI related changes

## Description of change

Browserstack tests appear to pick up stray sessions from other tests (e.g. https://github.com/prebid/Prebid.js/actions/runs/19553623079/job/55994667049)

Set `tunnelIdentifier` to see if it puts a stop to it.

