### PR TITLE
OMS Bid Adapter: fix response for video (add vastXml), fix banner size in request (remove video size), update tests

### DIFF
--- a/modules/omsBidAdapter.js
+++ b/modules/omsBidAdapter.js
@@ -38,7 +38,7 @@ export const spec = {
 function buildRequests(bidReqs, bidderRequest) {
   try {
     const impressions = bidReqs.map(bid => {
-      let bidSizes = bid?.mediaTypes?.banner?.sizes || bid?.mediaTypes?.video?.playerSize || bid.sizes;
+      let bidSizes = bid?.mediaTypes?.banner?.sizes || bid.sizes || [];
       bidSizes = ((isArray(bidSizes) && isArray(bidSizes[0])) ? bidSizes : [bidSizes]);
       bidSizes = bidSizes.filter(size => isArray(size));
       const processedSizes = bidSizes.map(size => ({w: parseInt(size[0], 10), h: parseInt(size[1], 10)}));
@@ -175,7 +175,6 @@ function interpretResponse(serverResponse) {
           creativeId: bid.crid || bid.id,
           currency: 'USD',
           netRevenue: true,
-          ad: _getAdMarkup(bid),
           ttl: 300,
           meta: {
             advertiserDomains: bid?.adomain || []
@@ -184,8 +183,10 @@ function interpretResponse(serverResponse) {
 
         if (bid.mtype === 2) {
           bidResponse.mediaType = VIDEO;
+          bidResponse.vastXml = bid.adm;
         } else {
           bidResponse.mediaType = BANNER;
+          bidResponse.ad = _getAdMarkup(bid);
         }
 
         return bidResponse;

--- a/test/spec/modules/omsBidAdapter_spec.js
+++ b/test/spec/modules/omsBidAdapter_spec.js
@@ -451,7 +451,7 @@ describe('omsBidAdapter', function () {
         'currency': 'USD',
         'netRevenue': true,
         'mediaType': 'video',
-        'ad': `<!-- Creative --><div style="position:absolute;left:0px;top:0px;visibility:hidden;"><img src="${encodeURI('<!-- NURL -->')}"></div>`,
+        'vastXml': `<!-- Creative -->`,
         'ttl': 300,
         'meta': {
           'advertiserDomains': ['example.com']


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change

1. interpretResponse: for video set ad to vastXml property instead of ad
2. buildRequests: remove video player sizes from banner request
3. Update tests


