### PR TITLE
RTD Module (9.53.x) : Fix spread operator preventing RTD changes from persisting during auction

### DIFF
--- a/modules/rtdModule/index.js
+++ b/modules/rtdModule/index.js
@@ -316,7 +316,8 @@ export const setBidRequestsData = timedAuctionHook('rtd', function setBidRequest
 
   relevantSubModules.forEach(sm => {
     const fpdGuard = guardOrtb2Fragments(reqBidsConfigObj.ortb2Fragments || {}, activityParams(MODULE_TYPE_RTD, sm.name));
-    sm.getBidRequestData({...reqBidsConfigObj, ortb2Fragments: fpdGuard}, onGetBidRequestDataCallback.bind(sm), sm.config, _userConsent, timeout);
+    reqBidsConfigObj.ortb2Fragments = mergeDeep({}, reqBidsConfigObj.ortb2Fragments || {}, fpdGuard);
+    sm.getBidRequestData(reqBidsConfigObj, onGetBidRequestDataCallback.bind(sm), sm.config, _userConsent, timeout);
   });
 
   function onGetBidRequestDataCallback() {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
## Description of change
<!-- Describe the change proposed in this pull request -->
https://github.com/prebid/Prebid.js/pull/14108 had a fundamental issue: when RTD modules made changes to the reqBidsConfigObj object (which they expect to be able to mutate), those changes were lost because the spread operator created a new object that wasn't referenced by the auction logic

Solution
Changed the implementation to use mergeDeep to properly merge the guarded fragments while preserving the original object reference
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
