### PR TITLE
Impactify Bid Adapter: Removing unused logger on onBidderError.

### DIFF
--- a/modules/impactifyBidAdapter.js
+++ b/modules/impactifyBidAdapter.js
@@ -386,6 +386,5 @@ export const spec = {
 
     return true;
   },
-  
 };
 registerBidder(spec);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Updated bidder adapter

## Description of change
We were logging errors for metrics purposes, however, that is no longer the case and we have discontinued it. We are removing this bit of logging to prevent errors from popping up when a bidder error occurs.
