### PR TITLE
Clickio Bid Adapter: add IAB GVL ID and TCFEU support

### DIFF
--- a/modules/clickioBidAdapter.js
+++ b/modules/clickioBidAdapter.js
@@ -4,6 +4,7 @@ import {ortbConverter} from '../libraries/ortbConverter/converter.js';
 import {BANNER} from '../src/mediaTypes.js';
 
 const BIDDER_CODE = 'clickio';
+const IAB_GVL_ID = 1500;
 
 export const converter = ortbConverter({
   context: {
@@ -19,6 +20,7 @@ export const converter = ortbConverter({
 
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: IAB_GVL_ID,
   supportedMediaTypes: [BANNER],
   buildRequests(bidRequests, bidderRequest) {
     const data = converter.toORTB({bidRequests, bidderRequest})

--- a/modules/clickioBidAdapter.md
+++ b/modules/clickioBidAdapter.md
@@ -5,6 +5,8 @@ description: Clickio Bidder Adapter
 biddercode: clickio
 media_types: banner
 gdpr_supported: true
+tcfeu_supported: true
+gvl_id: 1500
 usp_supported: true
 gpp_supported: true
 schain_supported: true


### PR DESCRIPTION
## Type of change

- [x] Updated bidder adapter  

## Description of change

This PR adds IAB Global Vendor List (GVL) ID and TCF EU support to the Clickio Bid Adapter.

**Changes:**
- Added IAB GVL ID constant (`IAB_GVL_ID = 1500`) and `gvlid` property to `modules/clickioBidAdapter.js`
- Updated adapter documentation (`modules/clickioBidAdapter.md`) to include:
  - `tcfeu_supported: true` - indicates TCF EU (Transparency and Consent Framework EU) support
  - `gvl_id: 1500` - the IAB Global Vendor List identifier