### PR TITLE
sevioBidAdapter: keyword fixes in legacy branch 9.53.x-legacy

### DIFF
--- a/modules/sevioBidAdapter.js
+++ b/modules/sevioBidAdapter.js
@@ -74,6 +74,24 @@ function getDomComplexity(document) {
   return document?.querySelectorAll('*')?.length ?? -1;
 }
 
+const normalizeKeywords = (input) => {
+  if (!input) return [];
+
+  if (Array.isArray(input)) {
+    return input.map(k => k.trim()).filter(Boolean);
+  }
+
+  if (typeof input === 'string') {
+    return input
+      .split(',')
+      .map(k => k.trim())
+      .filter(Boolean);
+  }
+
+  // Any other type → ignore
+  return [];
+};
+
 const detectAdType = (bid) =>
   (
     ["native", "banner"].find((t) => bid.mediaTypes?.[t]) || "unknown"
@@ -285,7 +303,12 @@ export const spec = {
             ...(isNative && { nativeRequest: { ver: "1.2", assets: processedAssets || {}} })
           },
         ],
-        keywords: { tokens: ortbRequest?.site?.keywords || bidRequest.params?.keywords || [] },
+        keywords: {
+          tokens: normalizeKeywords(
+            ortbRequest?.site?.keywords ||
+            bidRequest.params?.keywords
+          )
+        },
         privacy: {
           gpp: gpp?.consentString || "",
           tcfeu: gdpr?.consentString || "",

--- a/test/spec/modules/sevioBidAdapter_spec.js
+++ b/test/spec/modules/sevioBidAdapter_spec.js
@@ -497,5 +497,17 @@ describe('sevioBidAdapter', function () {
 
       expect(payload).to.not.have.property('currency');
     });
+    it('parses comma-separated keywords string into tokens array', function () {
+      const singleBidRequest = [{
+        bidder: 'sevio',
+        params: { zone: 'zoneId', keywords: 'play, games,  fun ' }, // string CSV
+        mediaTypes: { banner: { sizes: [[728, 90]] } },
+        bidId: 'bid-kw-str'
+      }];
+      const requests = spec.buildRequests(singleBidRequest, baseBidderRequest);
+      expect(requests).to.be.an('array').that.is.not.empty;
+      expect(requests[0].data).to.have.nested.property('keywords.tokens');
+      expect(requests[0].data.keywords.tokens).to.deep.equal(['play', 'games', 'fun']);
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
The keywords from enrichments come as comma separated values. Our BE is strictly allowing only arrays. Added function to normalize and convert those to arrays in the bid adapter. This is a fix for the legacy branch 9.53.x-legacy that is being used by some of our partners.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
