### PR TITLE
Ogury Bid Adapter: Update User Sync Pixel

### DIFF
--- a/modules/oguryBidAdapter.js
+++ b/modules/oguryBidAdapter.js
@@ -13,7 +13,7 @@ const DEFAULT_TIMEOUT = 1000;
 const BID_HOST = 'https://mweb-hb.presage.io/api/header-bidding-request';
 const TIMEOUT_MONITORING_HOST = 'https://ms-ads-monitoring-events.presage.io';
 const MS_COOKIE_SYNC_DOMAIN = 'https://ms-cookie-sync.presage.io';
-const ADAPTER_VERSION = '2.0.4';
+const ADAPTER_VERSION = '2.0.5';
 
 export const ortbConverterProps = {
   context: {
@@ -99,15 +99,7 @@ function getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent, gpp
     return [
       {
         type: 'image',
-        url: `${MS_COOKIE_SYNC_DOMAIN}/v1/init-sync/bid-switch?iab_string=${consent}&source=prebid&gpp=${gpp}&gpp_sid=${gppSid}`
-      },
-      {
-        type: 'image',
-        url: `${MS_COOKIE_SYNC_DOMAIN}/ttd/init-sync?iab_string=${consent}&source=prebid&gpp=${gpp}&gpp_sid=${gppSid}`
-      },
-      {
-        type: 'image',
-        url: `${MS_COOKIE_SYNC_DOMAIN}/xandr/init-sync?iab_string=${consent}&source=prebid&gpp=${gpp}&gpp_sid=${gppSid}`
+        url: `${MS_COOKIE_SYNC_DOMAIN}/user-sync?source=prebid&gdpr_consent=${consent}&gpp=${gpp}&gpp_sid=${gppSid}`
       }
     ];
   }

--- a/test/spec/modules/oguryBidAdapter_spec.js
+++ b/test/spec/modules/oguryBidAdapter_spec.js
@@ -121,34 +121,34 @@ describe('OguryBidAdapter', () => {
 
   describe('isBidRequestValid', () => {
     it('should validate correct bid', () => {
-      const validBid = utils.deepClone(bidRequests[0]);
+      let validBid = utils.deepClone(bidRequests[0]);
 
-      const isValid = spec.isBidRequestValid(validBid);
+      let isValid = spec.isBidRequestValid(validBid);
       expect(isValid).to.true;
     });
 
     it('should not validate when sizes is not defined', () => {
-      const invalidBid = utils.deepClone(bidRequests[0]);
+      let invalidBid = utils.deepClone(bidRequests[0]);
       delete invalidBid.sizes;
       delete invalidBid.mediaTypes;
 
-      const isValid = spec.isBidRequestValid(invalidBid);
+      let isValid = spec.isBidRequestValid(invalidBid);
       expect(isValid).to.be.false;
     });
 
     it('should not validate bid when adunit is not defined', () => {
-      const invalidBid = utils.deepClone(bidRequests[0]);
+      let invalidBid = utils.deepClone(bidRequests[0]);
       delete invalidBid.params.adUnitId;
 
-      const isValid = spec.isBidRequestValid(invalidBid);
+      let isValid = spec.isBidRequestValid(invalidBid);
       expect(isValid).to.to.be.false;
     });
 
     it('should not validate bid when assetKey is not defined', () => {
-      const invalidBid = utils.deepClone(bidRequests[0]);
+      let invalidBid = utils.deepClone(bidRequests[0]);
       delete invalidBid.params.assetKey;
 
-      const isValid = spec.isBidRequestValid(invalidBid);
+      let isValid = spec.isBidRequestValid(invalidBid);
       expect(isValid).to.be.false;
     });
 
@@ -201,16 +201,12 @@ describe('OguryBidAdapter', () => {
         syncOptions = { pixelEnabled: true };
       });
 
-      it('should return syncs array with three elements of type image', () => {
+      it('should return syncs array with one element of type image', () => {
         const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent, [], gppConsent);
 
-        expect(userSyncs).to.have.lengthOf(3);
+        expect(userSyncs).to.have.lengthOf(1);
         expect(userSyncs[0].type).to.equal('image');
-        expect(userSyncs[0].url).to.contain('https://ms-cookie-sync.presage.io/v1/init-sync/bid-switch');
-        expect(userSyncs[1].type).to.equal('image');
-        expect(userSyncs[1].url).to.contain('https://ms-cookie-sync.presage.io/ttd/init-sync');
-        expect(userSyncs[2].type).to.equal('image');
-        expect(userSyncs[2].url).to.contain('https://ms-cookie-sync.presage.io/xandr/init-sync');
+        expect(userSyncs[0].url).to.contain('https://ms-cookie-sync.presage.io/user-sync');
       });
 
       it('should set the source as query param', () => {
@@ -220,23 +216,17 @@ describe('OguryBidAdapter', () => {
 
       it('should set the tcString as query param', () => {
         const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent, [], gppConsent);
-        expect(new URL(userSyncs[0].url).searchParams.get('iab_string')).to.equal(gdprConsent.consentString)
-        expect(new URL(userSyncs[1].url).searchParams.get('iab_string')).to.equal(gdprConsent.consentString)
-        expect(new URL(userSyncs[2].url).searchParams.get('iab_string')).to.equal(gdprConsent.consentString)
+        expect(new URL(userSyncs[0].url).searchParams.get('gdpr_consent')).to.equal(gdprConsent.consentString)
       });
 
       it('should set the gppString as query param', () => {
         const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent, [], gppConsent);
         expect(new URL(userSyncs[0].url).searchParams.get('gpp')).to.equal(gppConsent.gppString)
-        expect(new URL(userSyncs[1].url).searchParams.get('gpp')).to.equal(gppConsent.gppString)
-        expect(new URL(userSyncs[2].url).searchParams.get('gpp')).to.equal(gppConsent.gppString)
       });
 
       it('should set the gpp_sid as query param', () => {
         const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent, [], gppConsent);
         expect(new URL(userSyncs[0].url).searchParams.get('gpp_sid')).to.equal(gppConsent.applicableSections.toString())
-        expect(new URL(userSyncs[1].url).searchParams.get('gpp_sid')).to.equal(gppConsent.applicableSections.toString())
-        expect(new URL(userSyncs[2].url).searchParams.get('gpp_sid')).to.equal(gppConsent.applicableSections.toString())
       });
 
       it('should return an empty array when pixel is disable', () => {
@@ -251,13 +241,9 @@ describe('OguryBidAdapter', () => {
         };
 
         const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent, [], gppConsent);
-        expect(userSyncs).to.have.lengthOf(3);
+        expect(userSyncs).to.have.lengthOf(1);
         expect(userSyncs[0].type).to.equal('image');
-        expect(new URL(userSyncs[0].url).searchParams.get('iab_string')).to.equal('')
-        expect(userSyncs[1].type).to.equal('image');
-        expect(new URL(userSyncs[1].url).searchParams.get('iab_string')).to.equal('')
-        expect(userSyncs[2].type).to.equal('image');
-        expect(new URL(userSyncs[2].url).searchParams.get('iab_string')).to.equal('')
+        expect(new URL(userSyncs[0].url).searchParams.get('gdpr_consent')).to.equal('')
       });
 
       it('should return syncs array with three elements of type image when consentString is null', () => {
@@ -267,39 +253,27 @@ describe('OguryBidAdapter', () => {
         };
 
         const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent, [], gppConsent);
-        expect(userSyncs).to.have.lengthOf(3);
+        expect(userSyncs).to.have.lengthOf(1);
         expect(userSyncs[0].type).to.equal('image');
-        expect(new URL(userSyncs[0].url).searchParams.get('iab_string')).to.equal('')
-        expect(userSyncs[1].type).to.equal('image');
-        expect(new URL(userSyncs[1].url).searchParams.get('iab_string')).to.equal('')
-        expect(userSyncs[2].type).to.equal('image');
-        expect(new URL(userSyncs[2].url).searchParams.get('iab_string')).to.equal('')
+        expect(new URL(userSyncs[0].url).searchParams.get('gdpr_consent')).to.equal('')
       });
 
       it('should return syncs array with three elements of type image when gdprConsent is undefined', () => {
         gdprConsent = undefined;
 
         const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent, [], gppConsent);
-        expect(userSyncs).to.have.lengthOf(3);
+        expect(userSyncs).to.have.lengthOf(1);
         expect(userSyncs[0].type).to.equal('image');
-        expect(new URL(userSyncs[0].url).searchParams.get('iab_string')).to.equal('')
-        expect(userSyncs[1].type).to.equal('image');
-        expect(new URL(userSyncs[1].url).searchParams.get('iab_string')).to.equal('')
-        expect(userSyncs[2].type).to.equal('image');
-        expect(new URL(userSyncs[2].url).searchParams.get('iab_string')).to.equal('')
+        expect(new URL(userSyncs[0].url).searchParams.get('gdpr_consent')).to.equal('')
       });
 
       it('should return syncs array with three elements of type image when gdprConsent is null', () => {
         gdprConsent = null;
 
         const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent, [], gppConsent);
-        expect(userSyncs).to.have.lengthOf(3);
+        expect(userSyncs).to.have.lengthOf(1);
         expect(userSyncs[0].type).to.equal('image');
-        expect(new URL(userSyncs[0].url).searchParams.get('iab_string')).to.equal('')
-        expect(userSyncs[1].type).to.equal('image');
-        expect(new URL(userSyncs[1].url).searchParams.get('iab_string')).to.equal('')
-        expect(userSyncs[2].type).to.equal('image');
-        expect(new URL(userSyncs[2].url).searchParams.get('iab_string')).to.equal('')
+        expect(new URL(userSyncs[0].url).searchParams.get('gdpr_consent')).to.equal('')
       });
 
       it('should return syncs array with three elements of type image when gdprConsent is null and gdprApplies is false', () => {
@@ -309,13 +283,9 @@ describe('OguryBidAdapter', () => {
         };
 
         const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent, [], gppConsent);
-        expect(userSyncs).to.have.lengthOf(3);
+        expect(userSyncs).to.have.lengthOf(1);
         expect(userSyncs[0].type).to.equal('image');
-        expect(new URL(userSyncs[0].url).searchParams.get('iab_string')).to.equal('')
-        expect(userSyncs[1].type).to.equal('image');
-        expect(new URL(userSyncs[1].url).searchParams.get('iab_string')).to.equal('')
-        expect(userSyncs[2].type).to.equal('image');
-        expect(new URL(userSyncs[2].url).searchParams.get('iab_string')).to.equal('')
+        expect(new URL(userSyncs[0].url).searchParams.get('gdpr_consent')).to.equal('')
       });
 
       it('should return syncs array with three elements of type image when gdprConsent is empty string and gdprApplies is false', () => {
@@ -325,13 +295,9 @@ describe('OguryBidAdapter', () => {
         };
 
         const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent, [], gppConsent);
-        expect(userSyncs).to.have.lengthOf(3);
+        expect(userSyncs).to.have.lengthOf(1);
         expect(userSyncs[0].type).to.equal('image');
-        expect(new URL(userSyncs[0].url).searchParams.get('iab_string')).to.equal('')
-        expect(userSyncs[1].type).to.equal('image');
-        expect(new URL(userSyncs[1].url).searchParams.get('iab_string')).to.equal('')
-        expect(userSyncs[2].type).to.equal('image');
-        expect(new URL(userSyncs[2].url).searchParams.get('iab_string')).to.equal('')
+        expect(new URL(userSyncs[0].url).searchParams.get('gdpr_consent')).to.equal('')
       });
 
       it('should return syncs array with three elements of type image when gppString is undefined', () => {
@@ -341,22 +307,12 @@ describe('OguryBidAdapter', () => {
         };
 
         const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent, [], gppConsent);
-        expect(userSyncs).to.have.lengthOf(3);
+        expect(userSyncs).to.have.lengthOf(1);
         expect(userSyncs[0].type).to.equal('image');
-        expect(userSyncs[1].type).to.equal('image');
-        expect(userSyncs[2].type).to.equal('image');
 
         const firstUrlSync = new URL(userSyncs[0].url).searchParams
         expect(firstUrlSync.get('gpp')).to.equal('')
         expect(firstUrlSync.get('gpp_sid')).to.equal(gppConsent.applicableSections.toString())
-
-        const secondtUrlSync = new URL(userSyncs[1].url).searchParams
-        expect(secondtUrlSync.get('gpp')).to.equal('')
-        expect(secondtUrlSync.get('gpp_sid')).to.equal(gppConsent.applicableSections.toString())
-
-        const thirdUrlSync = new URL(userSyncs[2].url).searchParams
-        expect(thirdUrlSync.get('gpp')).to.equal('')
-        expect(thirdUrlSync.get('gpp_sid')).to.equal(gppConsent.applicableSections.toString())
       });
 
       it('should return syncs array with three elements of type image when gppString is null', () => {
@@ -366,66 +322,36 @@ describe('OguryBidAdapter', () => {
         };
 
         const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent, [], gppConsent);
-        expect(userSyncs).to.have.lengthOf(3);
+        expect(userSyncs).to.have.lengthOf(1);
         expect(userSyncs[0].type).to.equal('image');
-        expect(userSyncs[1].type).to.equal('image');
-        expect(userSyncs[2].type).to.equal('image');
 
         const firstUrlSync = new URL(userSyncs[0].url).searchParams
         expect(firstUrlSync.get('gpp')).to.equal('')
         expect(firstUrlSync.get('gpp_sid')).to.equal(gppConsent.applicableSections.toString())
-
-        const secondtUrlSync = new URL(userSyncs[1].url).searchParams
-        expect(secondtUrlSync.get('gpp')).to.equal('')
-        expect(secondtUrlSync.get('gpp_sid')).to.equal(gppConsent.applicableSections.toString())
-
-        const thirdUrlSync = new URL(userSyncs[2].url).searchParams
-        expect(thirdUrlSync.get('gpp')).to.equal('')
-        expect(thirdUrlSync.get('gpp_sid')).to.equal(gppConsent.applicableSections.toString())
       });
 
       it('should return syncs array with three elements of type image when gppConsent is undefined', () => {
         gppConsent = undefined;
 
         const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent, [], gppConsent);
-        expect(userSyncs).to.have.lengthOf(3);
+        expect(userSyncs).to.have.lengthOf(1);
         expect(userSyncs[0].type).to.equal('image');
-        expect(userSyncs[1].type).to.equal('image');
-        expect(userSyncs[2].type).to.equal('image');
 
         const firstUrlSync = new URL(userSyncs[0].url).searchParams
         expect(firstUrlSync.get('gpp')).to.equal('')
         expect(firstUrlSync.get('gpp_sid')).to.equal('')
-
-        const secondtUrlSync = new URL(userSyncs[1].url).searchParams
-        expect(secondtUrlSync.get('gpp')).to.equal('')
-        expect(secondtUrlSync.get('gpp_sid')).to.equal('')
-
-        const thirdUrlSync = new URL(userSyncs[2].url).searchParams
-        expect(thirdUrlSync.get('gpp')).to.equal('')
-        expect(thirdUrlSync.get('gpp_sid')).to.equal('')
       });
 
       it('should return syncs array with three elements of type image when gppConsent is null', () => {
         gppConsent = null;
 
         const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent, [], gppConsent);
-        expect(userSyncs).to.have.lengthOf(3);
+        expect(userSyncs).to.have.lengthOf(1);
         expect(userSyncs[0].type).to.equal('image');
-        expect(userSyncs[1].type).to.equal('image');
-        expect(userSyncs[2].type).to.equal('image');
 
         const firstUrlSync = new URL(userSyncs[0].url).searchParams
         expect(firstUrlSync.get('gpp')).to.equal('')
         expect(firstUrlSync.get('gpp_sid')).to.equal('')
-
-        const secondtUrlSync = new URL(userSyncs[1].url).searchParams
-        expect(secondtUrlSync.get('gpp')).to.equal('')
-        expect(secondtUrlSync.get('gpp_sid')).to.equal('')
-
-        const thirdUrlSync = new URL(userSyncs[2].url).searchParams
-        expect(thirdUrlSync.get('gpp')).to.equal('')
-        expect(thirdUrlSync.get('gpp_sid')).to.equal('')
       });
 
       it('should return syncs array with three elements of type image when gppConsent is null and applicableSections is empty', () => {
@@ -435,22 +361,12 @@ describe('OguryBidAdapter', () => {
         };
 
         const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent, [], gppConsent);
-        expect(userSyncs).to.have.lengthOf(3);
+        expect(userSyncs).to.have.lengthOf(1);
         expect(userSyncs[0].type).to.equal('image');
-        expect(userSyncs[1].type).to.equal('image');
-        expect(userSyncs[2].type).to.equal('image');
 
         const firstUrlSync = new URL(userSyncs[0].url).searchParams
         expect(firstUrlSync.get('gpp')).to.equal('')
         expect(firstUrlSync.get('gpp_sid')).to.equal('')
-
-        const secondtUrlSync = new URL(userSyncs[1].url).searchParams
-        expect(secondtUrlSync.get('gpp')).to.equal('')
-        expect(secondtUrlSync.get('gpp_sid')).to.equal('')
-
-        const thirdUrlSync = new URL(userSyncs[2].url).searchParams
-        expect(thirdUrlSync.get('gpp')).to.equal('')
-        expect(thirdUrlSync.get('gpp_sid')).to.equal('')
       });
 
       it('should return syncs array with three elements of type image when gppString is empty string and applicableSections is empty', () => {
@@ -460,22 +376,12 @@ describe('OguryBidAdapter', () => {
         };
 
         const userSyncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
-        expect(userSyncs).to.have.lengthOf(3);
+        expect(userSyncs).to.have.lengthOf(1);
         expect(userSyncs[0].type).to.equal('image');
-        expect(userSyncs[1].type).to.equal('image');
-        expect(userSyncs[2].type).to.equal('image');
 
         const firstUrlSync = new URL(userSyncs[0].url).searchParams
         expect(firstUrlSync.get('gpp')).to.equal('')
         expect(firstUrlSync.get('gpp_sid')).to.equal('')
-
-        const secondtUrlSync = new URL(userSyncs[1].url).searchParams
-        expect(secondtUrlSync.get('gpp')).to.equal('')
-        expect(secondtUrlSync.get('gpp_sid')).to.equal('')
-
-        const thirdUrlSync = new URL(userSyncs[2].url).searchParams
-        expect(thirdUrlSync.get('gpp')).to.equal('')
-        expect(thirdUrlSync.get('gpp_sid')).to.equal('')
       });
     });
 
@@ -719,7 +625,7 @@ describe('OguryBidAdapter', () => {
 
       expect(dataRequest.ext).to.deep.equal({
         prebidversion: '$prebid.version$',
-        adapterversion: '2.0.4'
+        adapterversion: '2.0.5'
       });
 
       expect(dataRequest.device).to.deep.equal({
@@ -851,7 +757,7 @@ describe('OguryBidAdapter', () => {
   });
 
   describe('interpretResponse', function () {
-    const openRtbBidResponse = {
+    let openRtbBidResponse = {
       body: {
         id: 'id_of_bid_response',
         seatbid: [{


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->
Consolidate the user sync pixel implementation from three separate endpoints (bid-switch, ttd, xandr) into a single unified /user-sync endpoint, and update the parameter name from iab_string to gdpr_consent.
Version bump from 2.0.4 to 2.0.5
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
No Impact on the API.