### PR TITLE
YahooAdsAdapter: fix user.ext merging to prevent nested structure in legacy

### DIFF
--- a/modules/yahooAdsBidAdapter.js
+++ b/modules/yahooAdsBidAdapter.js
@@ -496,6 +496,14 @@ function appendFirstPartyData(outBoundBidRequest, bid) {
     outBoundBidRequest.user = validateAppendObject('number', allowedUserNumbers, userObject, outBoundBidRequest.user);
     outBoundBidRequest.user = validateAppendObject('array', allowedUserArrays, userObject, outBoundBidRequest.user);
     outBoundBidRequest.user.ext = validateAppendObject('object', allowedUserObjects, userObject, outBoundBidRequest.user.ext);
+
+    // Merge ext properties from ortb2.user.ext into existing user.ext instead of nesting
+    if (userObject.ext && isPlainObject(userObject.ext)) {
+      outBoundBidRequest.user.ext = {
+        ...outBoundBidRequest.user.ext,
+        ...userObject.ext
+      };
+    }
   };
 
   return outBoundBidRequest;

--- a/test/spec/modules/yahooAdsBidAdapter_spec.js
+++ b/test/spec/modules/yahooAdsBidAdapter_spec.js
@@ -688,7 +688,8 @@ describe('Yahoo Advertising Bid Adapter:', () => {
         const data = spec.buildRequests(validBidRequests, bidderRequest)[0].data;
         const user = data.user;
         expect(user[param]).to.be.a('object');
-        expect(user[param]).to.be.deep.include({[param]: {a: '123', b: '456'}});
+        // Properties from ortb2.user.ext should be merged into user.ext, not nested
+        expect(user[param]).to.be.deep.include({a: '123', b: '456'});
       });
     });
 


### PR DESCRIPTION
Summary
Fixes a critical bug in the Yahoo Ads bid adapter where ortb2.user.ext properties were being nested as user.ext.ext instead of being merged into user.ext, causing malformed OpenRTB requests.

Root Cause
The bug has existed in the adapter since its initial release (v5.18.0, October 2021) but was dormant until Prebid.js v9.53.2. PR https://github.com/prebid/Prebid.js/pull/13679 backported the userId aliasing feature that started populating ortb2.user.ext.eids, which exposed
the latent merge bug in appendFirstPartyData() (modules/yahooAdsBidAdapter.js:497).


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
