### PR TITLE
IntentIq ID Analytical Adapter: Check on report duplicates only when GAM prediction is enabled

### DIFF
--- a/modules/intentIqAnalyticsAdapter.js
+++ b/modules/intentIqAnalyticsAdapter.js
@@ -296,17 +296,19 @@ export function preparePayload(data) {
   }
   prepareData(data, result);
 
-  if (!reportList[result.placementId] || !reportList[result.placementId][result.prebidAuctionId]) {
-    reportList[result.placementId] = reportList[result.placementId]
-      ? { ...reportList[result.placementId], [result.prebidAuctionId]: 1 }
-      : { [result.prebidAuctionId]: 1 };
-    cleanReportsID = setTimeout(() => {
-      if (cleanReportsID) clearTimeout(cleanReportsID);
-      restoreReportList();
-    }, 1500); // clear object in 1.5 second after defining reporting list
-  } else {
-    logError('Duplication detected, report will be not sent');
-    return;
+  if (shouldSubscribeOnGAM()) {
+    if (!reportList[result.placementId] || !reportList[result.placementId][result.prebidAuctionId]) {
+      reportList[result.placementId] = reportList[result.placementId]
+        ? { ...reportList[result.placementId], [result.prebidAuctionId]: 1 }
+        : { [result.prebidAuctionId]: 1 };
+      cleanReportsID = setTimeout(() => {
+        if (cleanReportsID) clearTimeout(cleanReportsID);
+        restoreReportList();
+      }, 1500); // clear object in 1.5 second after defining reporting list
+    } else {
+      logError('Duplication detected, report will be not sent');
+      return;
+    }
   }
 
   fillEidsData(result);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
Check for duplicate reports only when GAM prediction is enabled.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
