### PR TITLE
TopOn Bid Adapter: add user syncs

### DIFF
--- a/modules/toponBidAdapter.js
+++ b/modules/toponBidAdapter.js
@@ -9,6 +9,10 @@ const LOG_PREFIX = "TopOn";
 const GVLID = 1305;
 const ENDPOINT = "https://web-rtb.anyrtb.com/ortb/prebid";
 const DEFAULT_TTL = 360;
+const USER_SYNC_URL = "https://pb.anyrtb.com/pb/page/prebidUserSyncs.html";
+const USER_SYNC_IMG_URL = "https://cm.anyrtb.com/cm/sync";
+
+let lastPubid;
 
 const converter = ortbConverter({
   context: {
@@ -98,6 +102,7 @@ export const spec = {
   },
   buildRequests: (validBidRequests, bidderRequest) => {
     const { pubid } = bidderRequest?.bids?.[0]?.params || {};
+    lastPubid = pubid;
     const ortbRequest = converter.toORTB({ validBidRequests, bidderRequest });
 
     const url = ENDPOINT + "?pubid=" + pubid;
@@ -156,13 +161,64 @@ export const spec = {
 
     return bids;
   },
-  getUserSyncs: (
+  getUserSyncs: function (
     syncOptions,
     responses,
     gdprConsent,
     uspConsent,
     gppConsent
-  ) => {},
+  ) {
+    const pubid = lastPubid;
+    const syncs = [];
+    const params = [];
+
+    if (typeof pubid === "string" && pubid.length > 0) {
+      params.push(`pubid=tpn${encodeURIComponent(pubid)}`);
+    }
+    if (gdprConsent) {
+      if (typeof gdprConsent.gdprApplies === "boolean") {
+        params.push(`gdpr=${Number(gdprConsent.gdprApplies)}`);
+      }
+      if (typeof gdprConsent.consentString === "string") {
+        params.push(`consent=${encodeURIComponent(gdprConsent.consentString)}`);
+      }
+    }
+    if (uspConsent) {
+      params.push(`us_privacy=${encodeURIComponent(uspConsent)}`);
+    }
+    if (gppConsent) {
+      if (typeof gppConsent.gppString === "string") {
+        params.push(`gpp=${encodeURIComponent(gppConsent.gppString)}`);
+      }
+      if (Array.isArray(gppConsent.applicableSections)) {
+        params.push(
+          `gpp_sid=${encodeURIComponent(
+            gppConsent.applicableSections.join(",")
+          )}`
+        );
+      }
+    }
+    if (syncOptions?.iframeEnabled) {
+      const syncUrl = `${USER_SYNC_URL}${
+        params.length > 0 ? "?" + params.join("&") : ""
+      }`;
+
+      syncs.push({
+        type: "iframe",
+        url: syncUrl,
+      });
+    } else if (syncOptions?.pixelEnabled) {
+      const syncUrl = `${USER_SYNC_IMG_URL}${
+        params.length > 0 ? "?" + params.join("&") : ""
+      }`;
+
+      syncs.push({
+        type: "image",
+        url: syncUrl,
+      });
+    }
+    return syncs;
+  },
   onBidWon: (bid) => {
     logWarn(`[${LOG_PREFIX}] Bid won: ${JSON.stringify(bid)}`);
   },

--- a/test/spec/modules/toponBidAdapter_spec.js
+++ b/test/spec/modules/toponBidAdapter_spec.js
@@ -1,6 +1,8 @@
 import { expect } from "chai";
 import { spec } from "modules/toponBidAdapter.js";
 import * as utils from "src/utils.js";
+const USER_SYNC_URL = "https://pb.anyrtb.com/pb/page/prebidUserSyncs.html";
+const USER_SYNC_IMG_URL = "https://cm.anyrtb.com/cm/sync";
 
 describe("TopOn Adapter", function () {
   const PREBID_VERSION = "$prebid.version$";
@@ -117,6 +119,98 @@ describe("TopOn Adapter", function () {
       expect(bidResponses[0].mediaType).to.equal("banner");
       expect(bidResponses[0].width).to.equal(300);
       expect(bidResponses[0].height).to.equal(250);
+    });
+  });
+
+  describe("GetUserSyncs", function () {
+    it("should return correct sync URLs when iframeEnabled is true", function () {
+      const syncOptions = {
+        iframeEnabled: true,
+        pixelEnabled: true,
+      };
+
+      spec.buildRequests(validBidRequests, bidderRequest);
+      const result = spec.getUserSyncs(syncOptions, [], {});
+
+      expect(result).to.be.an("array");
+      expect(result[0].type).to.equal("iframe");
+      expect(result[0].url).to.include(USER_SYNC_URL);
+      expect(result[0].url).to.include("pubid=tpnpub-uuid");
+    });
+
+    it("should return correct sync URLs when pixelEnabled is true", function () {
+      const syncOptions = {
+        iframeEnabled: false,
+        pixelEnabled: true,
+      };
+
+      spec.buildRequests(validBidRequests, bidderRequest);
+      const result = spec.getUserSyncs(syncOptions, [], {});
+
+      expect(result).to.be.an("array");
+      expect(result[0].type).to.equal("image");
+      expect(result[0].url).to.include(USER_SYNC_IMG_URL);
+      expect(result[0].url).to.include("pubid=tpnpub-uuid");
+    });
+
+    it("should respect gdpr consent data", function () {
+      const gdprConsent = {
+        gdprApplies: true,
+        consentString: "test-consent-string",
+      };
+
+      spec.buildRequests(validBidRequests, bidderRequest);
+      const result = spec.getUserSyncs(
+        { iframeEnabled: true },
+        [],
+        gdprConsent
+      );
+      expect(result[0].url).to.include("gdpr=1");
+      expect(result[0].url).to.include("consent=test-consent-string");
+    });
+
+    it("should handle US Privacy consent", function () {
+      const uspConsent = "1YNN";
+
+      spec.buildRequests(validBidRequests, bidderRequest);
+      const result = spec.getUserSyncs(
+        { iframeEnabled: true },
+        [],
+        {},
+        uspConsent
+      );
+
+      expect(result[0].url).to.include("us_privacy=1YNN");
+    });
+
+    it("should handle GPP", function () {
+      const gppConsent = {
+        applicableSections: [7],
+        gppString: "test-consent-string",
+      };
+
+      spec.buildRequests(validBidRequests, bidderRequest);
+      const result = spec.getUserSyncs(
+        { iframeEnabled: true },
+        [],
+        {},
+        "",
+        gppConsent
+      );
+
+      expect(result[0].url).to.include("gpp=test-consent-string");
+      expect(result[0].url).to.include("gpp_sid=7");
+    });
+
+    it("should return empty array when sync is not enabled", function () {
+      const syncOptions = {
+        iframeEnabled: false,
+        pixelEnabled: false,
+      };
+
+      const result = spec.getUserSyncs(syncOptions, [], {});
+
+      expect(result).to.be.an("array").that.is.empty;
     });
   });
 });


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  
- [x] Updated bidder adapter 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Add user sync support to toponBidAdapter, including both image and iframe sync types, and append GDPR / US Privacy / GPP-related parameters to the user sync URL.

## Contact email of the adapter’s maintainer
[fens@toponad.com](mailto:fens@toponad.com)

## Other information
