### PR TITLE
WURFL RTD: remove usage of window.devicePixelRatio from LCE detection

### DIFF
--- a/modules/wurflRtdProvider.js
+++ b/modules/wurflRtdProvider.js
@@ -13,7 +13,7 @@ import { getGlobal } from '../src/prebidGlobal.js';
 // Constants
 const REAL_TIME_MODULE = 'realTimeData';
 const MODULE_NAME = 'wurfl';
-const MODULE_VERSION = '2.3.1';
+const MODULE_VERSION = '2.4.0';
 
 // WURFL_JS_HOST is the host for the WURFL service endpoints
 const WURFL_JS_HOST = 'https://prebid.wurflcloud.com';
@@ -915,17 +915,17 @@ const WurflLCEDevice = {
     return { deviceType: '', osName: '', osVersion: '' };
   },
 
-  _getDevicePixelRatioValue() {
-    if (window.devicePixelRatio) {
-      return window.devicePixelRatio;
+  _getDevicePixelRatioValue(osName) {
+    switch (osName) {
+      case 'Android':
+        return 2.0;
+      case 'iOS':
+        return 3.0;
+      case 'iPadOS':
+        return 2.0;
+      default:
+        return 1.0;
     }
-
-    // Assumes window.screen exists (caller checked)
-    if (window.screen.deviceXDPI && window.screen.logicalXDPI && window.screen.logicalXDPI > 0) {
-      return window.screen.deviceXDPI / window.screen.logicalXDPI;
-    }
-
-    return undefined;
   },
 
   _getMake(ua) {
@@ -967,9 +967,6 @@ const WurflLCEDevice = {
       return { js: 1 };
     }
 
-    // Check what globals are available upfront
-    const hasScreen = !!window.screen;
-
     const device = { js: 1 };
     const useragent = this._getUserAgent();
 
@@ -998,11 +995,9 @@ const WurflLCEDevice = {
         device.model = model;
         device.hwv = model;
       }
-    }
 
-    // Screen-dependent properties (independent of UA)
-    if (hasScreen) {
-      const pixelRatio = this._getDevicePixelRatioValue();
+      // Device pixel ratio based on OS
+      const pixelRatio = this._getDevicePixelRatioValue(deviceInfo.osName);
       if (pixelRatio !== undefined) {
         device.pxratio = pixelRatio;
       }

--- a/test/spec/modules/wurflRtdProvider_spec.js
+++ b/test/spec/modules/wurflRtdProvider_spec.js
@@ -1027,7 +1027,7 @@ describe('wurflRtdProvider', function () {
           expect(device.hwv).to.be.a('string');
         }
 
-        // pxratio from devicePixelRatio is acceptable (not a flagged fingerprinting API)
+        // pxratio uses OS-based hardcoded values (v2.4.0+), not window.devicePixelRatio (fingerprinting API)
         if (device.pxratio !== undefined) {
           expect(device.pxratio).to.be.a('number');
         }
@@ -1168,6 +1168,122 @@ describe('wurflRtdProvider', function () {
 
         const callback = () => {
           expect(reqBidsConfigObj.ortb2Fragments.global.device.ext.wurfl.is_robot).to.be.false;
+          done();
+        };
+
+        wurflSubmodule.getBidRequestData(reqBidsConfigObj, callback, { params: {} }, {});
+      });
+    });
+
+    describe('LCE pxratio (OS-based device pixel ratio)', () => {
+      let originalUserAgent;
+
+      beforeEach(() => {
+        // Setup empty cache to trigger LCE
+        sandbox.stub(storage, 'getDataFromLocalStorage').returns(null);
+        sandbox.stub(storage, 'localStorageIsEnabled').returns(true);
+        sandbox.stub(storage, 'hasLocalStorage').returns(true);
+
+        reqBidsConfigObj.ortb2Fragments.global.device = {};
+        reqBidsConfigObj.ortb2Fragments.bidder = {};
+
+        // Save original userAgent
+        originalUserAgent = navigator.userAgent;
+      });
+
+      afterEach(() => {
+        // Restore original userAgent
+        Object.defineProperty(navigator, 'userAgent', {
+          value: originalUserAgent,
+          configurable: true,
+          writable: true
+        });
+      });
+
+      it('should set pxratio to 2.0 for Android devices', (done) => {
+        Object.defineProperty(navigator, 'userAgent', {
+          value: 'Mozilla/5.0 (Linux; Android 10; SM-G973F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Mobile Safari/537.36',
+          configurable: true,
+          writable: true
+        });
+
+        const callback = () => {
+          const device = reqBidsConfigObj.ortb2Fragments.global.device;
+          expect(device.pxratio).to.equal(2.0);
+          expect(device.os).to.equal('Android');
+          expect(device.devicetype).to.equal(4); // PHONE
+          done();
+        };
+
+        wurflSubmodule.getBidRequestData(reqBidsConfigObj, callback, { params: {} }, {});
+      });
+
+      it('should set pxratio to 3.0 for iOS (iPhone) devices', (done) => {
+        Object.defineProperty(navigator, 'userAgent', {
+          value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+          configurable: true,
+          writable: true
+        });
+
+        const callback = () => {
+          const device = reqBidsConfigObj.ortb2Fragments.global.device;
+          expect(device.pxratio).to.equal(3.0);
+          expect(device.os).to.equal('iOS');
+          expect(device.devicetype).to.equal(4); // PHONE
+          done();
+        };
+
+        wurflSubmodule.getBidRequestData(reqBidsConfigObj, callback, { params: {} }, {});
+      });
+
+      it('should set pxratio to 2.0 for iPadOS (iPad) devices', (done) => {
+        Object.defineProperty(navigator, 'userAgent', {
+          value: 'Mozilla/5.0 (iPad; CPU OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1',
+          configurable: true,
+          writable: true
+        });
+
+        const callback = () => {
+          const device = reqBidsConfigObj.ortb2Fragments.global.device;
+          expect(device.pxratio).to.equal(2.0);
+          expect(device.os).to.equal('iPadOS');
+          expect(device.devicetype).to.equal(5); // TABLET
+          done();
+        };
+
+        wurflSubmodule.getBidRequestData(reqBidsConfigObj, callback, { params: {} }, {});
+      });
+
+      it('should set pxratio to 1.0 for desktop/other devices (default)', (done) => {
+        Object.defineProperty(navigator, 'userAgent', {
+          value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36',
+          configurable: true,
+          writable: true
+        });
+
+        const callback = () => {
+          const device = reqBidsConfigObj.ortb2Fragments.global.device;
+          expect(device.pxratio).to.equal(1.0);
+          expect(device.os).to.equal('Windows');
+          expect(device.devicetype).to.equal(2); // PERSONAL_COMPUTER
+          done();
+        };
+
+        wurflSubmodule.getBidRequestData(reqBidsConfigObj, callback, { params: {} }, {});
+      });
+
+      it('should set pxratio to 1.0 for macOS devices (default)', (done) => {
+        Object.defineProperty(navigator, 'userAgent', {
+          value: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36',
+          configurable: true,
+          writable: true
+        });
+
+        const callback = () => {
+          const device = reqBidsConfigObj.ortb2Fragments.global.device;
+          expect(device.pxratio).to.equal(1.0);
+          expect(device.os).to.equal('macOS');
+          expect(device.devicetype).to.equal(2); // PERSONAL_COMPUTER
           done();
         };
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Refactoring (no functional changes, no api changes)

## Description of change
<!-- Describe the change proposed in this pull request -->

This PR removes the usage of `window.devicePixelRatio` from LCE detection
