### PR TITLE
NodalsAi RTD Module: Prevent engine reference on auctions 2+

### DIFF
--- a/modules/nodalsAiRtdProvider.js
+++ b/modules/nodalsAiRtdProvider.js
@@ -11,7 +11,7 @@ const GVLID = 1360;
 const ENGINE_VESION = '1.x.x';
 const PUB_ENDPOINT_ORIGIN = 'https://nodals.io';
 const LOCAL_STORAGE_KEY = 'signals.nodals.ai';
-const STORAGE_TTL = 3600; // 1 hour in seconds
+const DEFAULT_STORAGE_TTL = 3600; // 1 hour in seconds
 
 const fillTemplate = (strings, ...keys) => {
   return function (values) {
@@ -204,7 +204,11 @@ class NodalsAiRtdProvider {
   }
 
   #getEngine() {
-    return window?.$nodals?.adTargetingEngine[ENGINE_VESION];
+    try {
+      return window?.$nodals?.adTargetingEngine?.[ENGINE_VESION];
+    } catch (error) {
+      return undefined;
+    }
   }
 
   #setOverrides(params) {
@@ -320,7 +324,7 @@ class NodalsAiRtdProvider {
   #dataIsStale(dataEnvelope) {
     const currentTime = Date.now();
     const dataTime = dataEnvelope.createdAt || 0;
-    const staleThreshold = this.#overrides?.storageTTL ?? dataEnvelope?.data?.meta?.ttl ?? STORAGE_TTL;
+    const staleThreshold = this.#overrides?.storageTTL ?? dataEnvelope?.data?.meta?.ttl ?? DEFAULT_STORAGE_TTL;
     return currentTime - dataTime >= (staleThreshold * 1000);
   }
 

--- a/test/spec/modules/nodalsAiRtdProvider_spec.js
+++ b/test/spec/modules/nodalsAiRtdProvider_spec.js
@@ -863,7 +863,6 @@ describe('NodalsAI RTD Provider', () => {
     });
   });
 
-
   describe('onAuctionEndEvent()', () => {
     it('should not proxy the call if we do not have user consent', () => {
       setDataInLocalStorage({
@@ -974,7 +973,7 @@ describe('NodalsAI RTD Provider', () => {
         data: successPubEndpointResponse,
         createdAt: Date.now(),
       });
-      
+
       delete window.$nodals;
       const result = nodalsAiRtdSubmodule.getTargetingData([], validConfig, permissiveUserConsent);
       expect(result).to.deep.equal({});
@@ -986,7 +985,7 @@ describe('NodalsAI RTD Provider', () => {
         data: successPubEndpointResponse,
         createdAt: Date.now(),
       });
-      
+
       window.$nodals = {};
       const result = nodalsAiRtdSubmodule.getTargetingData([], validConfig, permissiveUserConsent);
       expect(result).to.deep.equal({});
@@ -998,7 +997,7 @@ describe('NodalsAI RTD Provider', () => {
         data: successPubEndpointResponse,
         createdAt: Date.now(),
       });
-      
+
       window.$nodals = {
         adTargetingEngine: {}
       };
@@ -1012,7 +1011,7 @@ describe('NodalsAI RTD Provider', () => {
         data: successPubEndpointResponse,
         createdAt: Date.now(),
       });
-      
+
       Object.defineProperty(window, '$nodals', {
         get() {
           throw new Error('Access denied');

--- a/test/spec/modules/nodalsAiRtdProvider_spec.js
+++ b/test/spec/modules/nodalsAiRtdProvider_spec.js
@@ -863,6 +863,7 @@ describe('NodalsAI RTD Provider', () => {
     });
   });
 
+
   describe('onAuctionEndEvent()', () => {
     it('should not proxy the call if we do not have user consent', () => {
       setDataInLocalStorage({
@@ -963,6 +964,64 @@ describe('NodalsAI RTD Provider', () => {
       expect(args[2].facts).to.deep.include(successPubEndpointResponse.facts);
       expect(args[2].campaigns).to.deep.equal(successPubEndpointResponse.campaigns);
       expect(server.requests.length).to.equal(0);
+    });
+  });
+
+  describe('#getEngine()', () => {
+    it('should return undefined when $nodals object does not exist', () => {
+      // Setup data in storage to avoid triggering fetchData
+      setDataInLocalStorage({
+        data: successPubEndpointResponse,
+        createdAt: Date.now(),
+      });
+      
+      delete window.$nodals;
+      const result = nodalsAiRtdSubmodule.getTargetingData([], validConfig, permissiveUserConsent);
+      expect(result).to.deep.equal({});
+    });
+
+    it('should return undefined when adTargetingEngine object does not exist', () => {
+      // Setup data in storage to avoid triggering fetchData
+      setDataInLocalStorage({
+        data: successPubEndpointResponse,
+        createdAt: Date.now(),
+      });
+      
+      window.$nodals = {};
+      const result = nodalsAiRtdSubmodule.getTargetingData([], validConfig, permissiveUserConsent);
+      expect(result).to.deep.equal({});
+    });
+
+    it('should return undefined when specific engine version does not exist', () => {
+      // Setup data in storage to avoid triggering fetchData
+      setDataInLocalStorage({
+        data: successPubEndpointResponse,
+        createdAt: Date.now(),
+      });
+      
+      window.$nodals = {
+        adTargetingEngine: {}
+      };
+      const result = nodalsAiRtdSubmodule.getTargetingData([], validConfig, permissiveUserConsent);
+      expect(result).to.deep.equal({});
+    });
+
+    it('should return undefined when property access throws an error', () => {
+      // Setup data in storage to avoid triggering fetchData
+      setDataInLocalStorage({
+        data: successPubEndpointResponse,
+        createdAt: Date.now(),
+      });
+      
+      Object.defineProperty(window, '$nodals', {
+        get() {
+          throw new Error('Access denied');
+        },
+        configurable: true
+      });
+      const result = nodalsAiRtdSubmodule.getTargetingData([], validConfig, permissiveUserConsent);
+      expect(result).to.deep.equal({});
+      delete window.$nodals;
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
<!-- Describe the change proposed in this pull request -->
Address edge-case bug that manifests itself if the engine reference is still not available after the second auction has initialised due to the global `$nodals` namespace being created by the command queue utility method.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
