### PR TITLE
Add scaffold for LocID User ID submodule

### DIFF
--- a/modules/locIdSystem.js
+++ b/modules/locIdSystem.js
@@ -1,0 +1,365 @@
+/**
+ * This module adds LocID to the User ID module
+ * The {@link module:modules/userId} module is required.
+ * @module modules/locIdSystem
+ * @requires module:modules/userId
+ */
+
+import { logInfo, logWarn, logError, generateUUID, mergeDeep } from '../src/utils.js';
+import { submodule } from '../src/hook.js';
+import { getStorageManager } from '../src/storageManager.js';
+import { MODULE_TYPE_UID } from '../src/activities/modules.js';
+import { gppDataHandler, uspDataHandler } from '../src/adapterManager.js';
+import { ajax } from '../src/ajax.js';
+
+const MODULE_NAME = 'locid';
+const LOG_PREFIX = 'LocID: ';
+const STORAGE_KEY = '_locid';
+const DEFAULT_EXPIRATION_DAYS = 30;
+const DEFAULT_REFRESH_SECONDS = 86400; // 24 hours
+const HOLDOUT_RATE = 0.1; // 10% control group
+
+export const storage = getStorageManager({moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME});
+
+function createLogger(logger, prefix) {
+  return function (...args) {
+    logger(prefix + ' ', ...args);
+  }
+}
+
+const _logInfo = createLogger(logInfo, LOG_PREFIX);
+const _logWarn = createLogger(logWarn, LOG_PREFIX);
+const _logError = createLogger(logError, LOG_PREFIX);
+
+function isValidId(id) {
+  return typeof id === 'string' && id.length > 0 && id.length <= 256;
+}
+
+function simpleHash(str) {
+  let hash = 0;
+  if (str.length === 0) return hash;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash; // Convert to 32bit integer
+  }
+  return Math.abs(hash);
+}
+
+function isInHoldout(id, config) {
+  const holdoutOverride = config?.params?.holdoutOverride;
+  if (holdoutOverride === 'forceControl') return true;
+  if (holdoutOverride === 'forceTreatment') return false;
+
+  if (!id) return false; // never treat "no id" as control
+
+  // Deterministic holdout based on hash(id) mod 10
+  const hash = simpleHash(id);
+  return (hash % 10) < Math.round(HOLDOUT_RATE * 10);
+}
+
+function hasValidConsent(consentData) {
+  if (consentData?.gdpr?.gdprApplies === true) {
+    if (!consentData.gdpr.consentString || consentData.gdpr.consentString.length === 0) {
+      _logWarn('GDPR applies but no consent string provided, skipping storage operations');
+      return false;
+    }
+  }
+
+  const uspData = uspDataHandler.getConsentData();
+  if (uspData && uspData.length >= 3 && uspData.charAt(2) === 'Y') {
+    _logWarn('US Privacy opt-out detected, skipping storage operations');
+    return false;
+  }
+
+  const gppData = gppDataHandler.getConsentData();
+  if (gppData?.applicableSections?.includes(7) &&
+      gppData?.parsedSections?.usnat?.KnownChildSensitiveDataConsents?.includes(1)) {
+    _logWarn('GPP indicates opt-out, skipping storage operations');
+    return false;
+  }
+
+  return true;
+}
+
+function getStoredId(config) {
+  const storageConfig = config.storage;
+  if (!storageConfig) return null;
+
+  let storedValue = null;
+  const storageKey = storageConfig.name || STORAGE_KEY;
+
+  if (storageConfig.type === 'localStorage' || storageConfig.type === 'localStorage&cookie') {
+    if (storage.localStorageIsEnabled()) {
+      storedValue = storage.getDataFromLocalStorage(storageKey);
+    }
+  }
+
+  if (!storedValue && (storageConfig.type === 'cookie' || storageConfig.type === 'localStorage&cookie')) {
+    if (storage.cookiesAreEnabled()) {
+      storedValue = storage.getCookie(storageKey);
+    }
+  }
+
+  if (storedValue) {
+    try {
+      const parsed = JSON.parse(storedValue);
+      if (parsed.id && parsed.timestamp) {
+        const now = Date.now();
+        const expireTime = parsed.timestamp + ((storageConfig.expires || DEFAULT_EXPIRATION_DAYS) * 24 * 60 * 60 * 1000);
+
+        if (now < expireTime) {
+          const refreshTime = parsed.timestamp + ((storageConfig.refreshInSeconds || DEFAULT_REFRESH_SECONDS) * 1000);
+          return {
+            id: parsed.id,
+            timestamp: parsed.timestamp,
+            shouldRefresh: now > refreshTime
+          };
+        } else {
+          _logInfo('Stored ID has expired');
+        }
+      }
+    } catch (e) {
+      _logWarn('Failed to parse stored ID', e);
+    }
+  }
+
+  return null;
+}
+
+function storeId(config, id, consentData) {
+  if (!hasValidConsent(consentData)) {
+    return;
+  }
+
+  const storageConfig = config.storage;
+  if (!storageConfig) {
+    _logWarn('No storage configuration provided, ID will not be persisted');
+    return;
+  }
+
+  const storageKey = storageConfig.name || STORAGE_KEY;
+  const storageValue = JSON.stringify({
+    id: id,
+    timestamp: Date.now()
+  });
+
+  const expireDays = storageConfig.expires || DEFAULT_EXPIRATION_DAYS;
+
+  if (storageConfig.type === 'localStorage' || storageConfig.type === 'localStorage&cookie') {
+    if (storage.localStorageIsEnabled()) {
+      storage.setDataInLocalStorage(storageKey, storageValue);
+      _logInfo('ID stored in localStorage');
+    }
+  }
+
+  if (storageConfig.type === 'cookie' || storageConfig.type === 'localStorage&cookie') {
+    if (storage.cookiesAreEnabled()) {
+      const expires = new Date(Date.now() + expireDays * 24 * 60 * 60 * 1000).toUTCString();
+      storage.setCookie(storageKey, storageValue, expires);
+      _logInfo('ID stored in cookie');
+    }
+  }
+}
+
+function generateDeviceId() {
+  return generateUUID();
+}
+
+function logExposure(data, config) {
+  const endpoint = config?.params?.loggingEndpoint;
+  if (!endpoint) return;
+
+  try {
+    ajax(endpoint, null, JSON.stringify(data), {
+      method: 'POST',
+      contentType: 'application/json'
+    });
+  } catch (e) {
+    // Never throw - logging is best effort
+  }
+}
+
+function formatGamOutput(id, config) {
+  const gamConfig = config.params?.gam;
+  if (!gamConfig || !gamConfig.enabled) {
+    return null;
+  }
+
+  const maxLen = gamConfig.maxLen || 150;
+  const truncatedId = id.length > maxLen ? id.substring(0, maxLen) : id;
+
+  const result = {
+    key: gamConfig.key || 'locid'
+  };
+
+  if (gamConfig.mode === 'ppid') {
+    result.ppid = truncatedId;
+  } else if (gamConfig.mode === 'encryptedSignal') {
+    result.encryptedSignal = truncatedId;
+  }
+
+  return result;
+}
+
+export const locIdSubmodule = {
+  name: MODULE_NAME,
+
+  gvlid: undefined, // module does not register a GVL ID; consent gating handled internally
+
+  decode(value, config) {
+    try {
+      if (!isValidId(value)) {
+        _logWarn('Invalid stored value for decode:', value);
+        return undefined;
+      }
+
+      // Check holdout - return nothing if user is in control group
+      if (isInHoldout(value, config)) {
+        _logInfo('User in holdout control group, not returning ID');
+        return undefined;
+      }
+
+      const result = { locid: value };
+
+      const gamOutput = formatGamOutput(value, config);
+      if (gamOutput) {
+        result._gam = gamOutput;
+      }
+
+      _logInfo('LocID decode returned:', result);
+      return result;
+    } catch (e) {
+      _logError('Error in LocID decode:', e);
+      return undefined;
+    }
+  },
+
+  getId(config, consentData, storedId) {
+    try {
+      _logInfo('LocID getId called with config:', config);
+
+      // Check consent first
+      if (!hasValidConsent(consentData)) {
+        _logInfo('No valid consent, skipping LocID generation');
+        return;
+      }
+
+      const params = config?.params || {};
+      const source = params.source || 'device'; // Default to device if not specified
+
+      if (source === 'publisher') {
+        const providedId = storedId || params.value;
+        if (providedId && isValidId(providedId)) {
+          _logInfo('Using publisher-provided ID');
+          return { id: providedId };
+        } else {
+          _logWarn('Publisher source specified but no valid ID provided');
+          return;
+        }
+      }
+
+      const stored = getStoredId(config);
+      if (stored && !stored.shouldRefresh) {
+        _logInfo('Using stored ID (no refresh needed)');
+        return { id: stored.id };
+      }
+
+      if (source === 'device') {
+        const newId = generateDeviceId();
+        _logInfo('Generated new device ID');
+
+        storeId(config, newId, consentData);
+
+        return { id: newId };
+      }
+
+      // Endpoint source removed - first-party only
+      if (source === 'endpoint') {
+        _logWarn('Endpoint source no longer supported - LocID is first-party only');
+        return;
+      }
+
+      _logError('Unknown LocID source:', source);
+    } catch (e) {
+      _logError('Error in LocID getId:', e);
+      // Fail open - don't block auctions
+    }
+  },
+
+  extendId(config, consentData, storedId) {
+    try {
+      _logInfo('LocID extendId called for ORTB2 injection');
+
+      // Get the current ID
+      const idResult = this.getId(config, consentData, storedId);
+      if (!idResult?.id) {
+        _logInfo('No LocID available for ORTB2 injection');
+        return;
+      }
+
+      const locId = idResult.id;
+      const isHoldout = isInHoldout(locId, config);
+
+      // Calculate stability days from stored timestamp
+      const stored = getStoredId(config);
+      const stabilityDays = stored?.timestamp
+        ? Math.max(0, Math.floor((Date.now() - stored.timestamp) / (24 * 60 * 60 * 1000)))
+        : 0;
+
+      // Prepare ORTB2 data
+      const ortb2Data = {
+        locid_confidence: 1.0, // Constant for v1
+        locid_stability_days: stabilityDays,
+        locid_audiences: [] // Empty for v1
+      };
+
+      // Log exposure for lift measurement
+      const auctionId = config?.auctionId || 'unknown';
+      const exposureLog = {
+        auction_id: auctionId,
+        is_holdout: isHoldout,
+        locid_present: !isHoldout,
+        signals_emitted: isHoldout ? 0 : Object.keys(ortb2Data).length,
+        signal_names: isHoldout ? [] : Object.keys(ortb2Data),
+        timestamp: Date.now()
+      };
+
+      logExposure(exposureLog, config);
+
+      // Don't inject ORTB2 data if user is in holdout
+      if (isHoldout) {
+        _logInfo('User in holdout, skipping ORTB2 injection');
+        return;
+      }
+
+      // Safely merge into ORTB2 user.ext.data
+      const currentOrtb2 = config.ortb2 || {};
+      const updatedOrtb2 = mergeDeep({}, currentOrtb2, {
+        user: {
+          ext: {
+            data: ortb2Data
+          }
+        }
+      });
+
+      _logInfo('Injecting LocID ORTB2 data:', ortb2Data);
+      return { ortb2: updatedOrtb2 };
+    } catch (e) {
+      _logError('Error in LocID extendId:', e);
+      // Fail open - don't block auctions
+    }
+  },
+
+  eids: {
+    locid: {
+      source: 'locid.com',
+      atype: 1,
+      getValue: function(data) {
+        return data;
+      }
+    }
+  }
+};
+
+submodule(MODULE_TYPE_UID, locIdSubmodule);

--- a/modules/locIdSystem.md
+++ b/modules/locIdSystem.md
@@ -1,0 +1,416 @@
+# LocID User ID Submodule
+
+The LocID User ID submodule provides ORTB2-first identity solutions for display advertising with deterministic holdout for lift measurement. **Version 2.0** is first-party only with no remote calls.
+
+## Overview
+
+LocID offers two identity generation strategies:
+- **Publisher**: Use existing LocID values provided by the publisher  
+- **Device**: Generate and persist first-party device IDs (default)
+
+The module follows privacy-safe practices with no PII collection, no fingerprinting, respects consent frameworks, and includes deterministic A/B testing with exposure logging.
+
+## Key Features (v2.0)
+
+✅ **ORTB2-first**: Injects identity signals into `ortb2.user.ext.data`  
+✅ **First-party only**: No remote endpoints or third-party calls  
+✅ **Deterministic holdout**: 90/10 split for lift measurement  
+✅ **Exposure logging**: Best-effort beacon/fetch logging for analytics  
+✅ **Non-blocking**: Error handling ensures auctions never fail  
+✅ **Consent-safe**: Full GDPR, CCPA, and GPP support
+
+## Module Configuration
+
+### Basic Configuration
+
+```javascript
+pbjs.setConfig({
+  userSync: {
+    userIds: [{
+      name: 'locId',
+      params: {
+        source: 'device', // 'publisher' or 'device' (default)
+        // Holdout configuration (optional)
+        holdoutOverride: undefined, // 'forceControl', 'forceTreatment', or undefined for 90/10 split
+        // Exposure logging (optional)
+        loggingEndpoint: 'https://your-analytics-endpoint.com/log'
+      },
+      storage: {
+        type: 'localStorage', // 'localStorage', 'cookie', or 'localStorage&cookie'
+        name: '_locid',
+        expires: 30, // days
+        refreshInSeconds: 86400 // 24 hours
+      }
+    }]
+  }
+});
+```
+
+### Publisher Source Configuration
+
+Use when you have existing LocID values to provide directly:
+
+```javascript
+pbjs.setConfig({
+  userSync: {
+    userIds: [{
+      name: 'locId',
+      params: {
+        source: 'publisher'
+      },
+      value: 'your-existing-locid-value'
+      // No storage needed for publisher source
+    }]
+  }
+});
+```
+
+### Device Source Configuration
+
+Generates and persists first-party device identifiers:
+
+```javascript
+pbjs.setConfig({
+  userSync: {
+    userIds: [{
+      name: 'locId',
+      params: {
+        source: 'device'
+      },
+      storage: {
+        type: 'localStorage&cookie', // Fallback from localStorage to cookie
+        name: '_locid',
+        expires: 30,
+        refreshInSeconds: 86400 // Refresh daily
+      }
+    }]
+  }
+});
+```
+
+## ORTB2 Data Output
+
+LocID automatically injects the following into `ortb2.user.ext.data`:
+
+```javascript
+{
+  "locid_confidence": 1.0,           // ID confidence (constant 1.0 in v2.0)
+  "locid_stability_days": 15,        // Days since ID was first stored  
+  "locid_audiences": []              // Audience segments (empty in v2.0)
+}
+```
+
+**Holdout Behavior:**
+- 90% of users (treatment): Get ORTB2 data injection + exposure logging
+- 10% of users (control): Get no ORTB2 data + control logging
+- Deterministic assignment based on `hash(locid) mod 10`
+
+## Storage Configuration
+
+### Storage Types
+- `localStorage`: HTML5 localStorage only
+- `cookie`: HTTP cookies only  
+- `localStorage&cookie`: Try localStorage first, fallback to cookies
+- `cookie&localStorage`: Try cookies first, fallback to localStorage
+
+### Storage Parameters
+- `name`: Storage key name (default: `_locid`)
+- `expires`: Expiration in days (default: 30)
+- `refreshInSeconds`: Time before refresh in seconds (default: 86400)
+
+## Exposure Logging for Lift Measurement
+
+LocID logs exposure data for A/B testing analysis when `loggingEndpoint` is configured:
+
+```javascript
+// Example log payload sent via navigator.sendBeacon()
+{
+  "auction_id": "abc123",
+  "is_holdout": false,
+  "locid_present": true,
+  "signals_emitted": 3,
+  "signal_names": ["locid_confidence", "locid_stability_days", "locid_audiences"],
+  "timestamp": 1640995200000
+}
+```
+
+**Fallback Strategy:**
+1. `navigator.sendBeacon()` (preferred)
+2. `fetch()` with `keepalive: true` 
+3. Skip logging (never blocks)
+
+## GAM Integration
+
+### PPID (Publisher Provided ID) Integration
+
+Configure LocID to output GAM-compatible PPID format:
+
+```javascript
+pbjs.setConfig({
+  userSync: {
+    userIds: [{
+      name: 'locId',
+      params: {
+        source: 'device',
+        gam: {
+          enabled: true,
+          mode: 'ppid',
+          key: 'locid',
+          maxLen: 150
+        }
+      },
+      storage: { /* storage config */ }
+    }]
+  }
+});
+```
+
+Then wire into GAM in your page:
+
+```javascript
+// Wait for LocID to be available
+pbjs.getUserIds((userIds) => {
+  if (userIds.locId && userIds._gam && userIds._gam.ppid) {
+    googletag.cmd.push(() => {
+      googletag.pubads().setPublisherProvidedId({
+        source: 'locid.com',
+        value: userIds._gam.ppid
+      });
+    });
+  }
+});
+
+// Or check before ad requests
+googletag.cmd.push(() => {
+  const userIds = pbjs.getUserIds();
+  if (userIds.locId && userIds._gam && userIds._gam.ppid) {
+    googletag.pubads().setPublisherProvidedId({
+      source: 'locid.com', 
+      value: userIds._gam.ppid
+    });
+  }
+  // Define ad slots and display ads
+});
+```
+
+### Encrypted Signals Integration (Future)
+
+Configure for GAM encrypted signals:
+
+```javascript
+pbjs.setConfig({
+  userSync: {
+    userIds: [{
+      name: 'locId',
+      params: {
+        source: 'device',
+        gam: {
+          enabled: true,
+          mode: 'encryptedSignal',
+          key: 'locid_encrypted'
+        }
+      },
+      storage: { /* storage config */ }
+    }]
+  }
+});
+```
+
+Publisher integration snippet:
+
+```javascript
+// Wait for LocID encrypted signal
+pbjs.getUserIds((userIds) => {
+  if (userIds.locId && userIds._gam && userIds._gam.encryptedSignal) {
+    googletag.cmd.push(() => {
+      googletag.pubads().setEncryptedSignalProviders([{
+        id: 'locid.com',
+        signalSource: userIds._gam.encryptedSignal
+      }]);
+    });
+  }
+});
+```
+
+## Consent Handling
+
+LocID respects privacy consent frameworks:
+
+### GDPR/TCF
+- When GDPR applies and consent is missing/denied, storage operations are skipped
+- ID generation still works for `source: 'publisher'` (no storage required)
+- Publisher-provided IDs can still be passed through when legally permissible
+
+### US Privacy (CCPA)
+- Detects US Privacy opt-out signal (`1Y--`)
+- Skips storage operations when opt-out is detected
+- ID generation continues for non-storage sources
+
+### GPP (Global Privacy Platform)
+- Monitors GPP signals for opt-out indicators
+- Respects child-sensitive data consent requirements
+- Integrates with Prebid's consent management
+
+### Example with Consent Handling
+
+```javascript
+pbjs.setConfig({
+  userSync: {
+    userIds: [{
+      name: 'locId',
+      params: {
+        source: 'device'
+      },
+      storage: {
+        type: 'localStorage',
+        name: '_locid',
+        expires: 30
+      }
+    }]
+  }
+});
+
+// LocID will automatically:
+// 1. Check GDPR consent status
+// 2. Check US Privacy opt-out
+// 3. Check GPP signals
+// 4. Only store IDs when consent allows
+// 5. Generate IDs regardless (for immediate use)
+```
+
+## Bidder Integration
+
+LocID automatically provides standardized userId and EID formats:
+
+### userId Object
+```javascript
+{
+  locId: "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+### EID Format
+```javascript
+{
+  source: "locid.com",
+  uids: [{
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    atype: 1
+  }]
+}
+```
+
+## Advanced Configuration Examples
+
+### Multi-Storage with Refresh Logic
+```javascript
+pbjs.setConfig({
+  userSync: {
+    userIds: [{
+      name: 'locId',
+      params: {
+        source: 'device'
+      },
+      storage: {
+        type: 'localStorage&cookie',
+        name: '_locid_primary',
+        expires: 30,
+        refreshInSeconds: 3600 // Refresh every hour
+      }
+    }]
+  }
+});
+```
+
+### Holdout Override for Testing
+```javascript
+pbjs.setConfig({
+  userSync: {
+    userIds: [{
+      name: 'locId',
+      params: {
+        source: 'device',
+        holdoutOverride: 'forceTreatment', // Force into treatment for testing
+        loggingEndpoint: 'https://your-analytics.com/log'
+      },
+      storage: {
+        type: 'localStorage',
+        name: '_locid_test',
+        expires: 30
+      }
+    }]
+  }
+});
+```
+
+## Troubleshooting
+
+### Enable Debug Logging
+LocID uses Prebid's standard logging. Enable with:
+
+```javascript
+pbjs.setConfig({
+  debug: true
+});
+```
+
+Look for log messages prefixed with "LocID:" in the browser console.
+
+### Common Issues
+
+**Issue**: No ORTB2 data appearing
+- **Check**: Verify user is not in holdout control group (check `holdoutOverride`)
+- **Check**: Ensure valid consent exists (GDPR/CCPA/GPP)
+- **Check**: Console for LocID error messages about ID generation
+
+**Issue**: ID not persisting
+- **Check**: Verify storage configuration is correct
+- **Check**: Check browser's privacy settings allow localStorage/cookies
+- **Check**: Verify consent status (GDPR/CCPA/GPP)
+
+**Issue**: Exposure logging not working
+- **Check**: Verify `loggingEndpoint` is configured correctly
+- **Check**: Check browser developer tools Network tab for beacon/fetch calls
+- **Check**: Ensure endpoint accepts POST requests with JSON data
+
+**Issue**: GAM integration not working
+- **Check**: Verify GAM configuration has `enabled: true`
+- **Check**: Ensure GPT integration code runs after Prebid user ID resolution
+- **Check**: Confirm userIds object has both `locId` and `_gam` properties
+
+### Console Commands for Testing
+
+```javascript
+// Check current LocID value
+pbjs.getUserIds();
+
+// Force refresh user IDs
+pbjs.refreshUserIds();
+
+// Check stored values (browser dev tools)
+localStorage.getItem('_locid'); // For localStorage
+document.cookie; // For cookies
+
+// Clear stored ID for testing
+localStorage.removeItem('_locid');
+```
+
+## Extension Points for Future Features
+
+The LocID module is designed with extension points for:
+
+1. **Video Support**: EID configurations can be extended for video-specific sources
+2. **CTV Integration**: Additional endpoints and storage mechanisms for Connected TV
+3. **Enhanced GAM Signals**: Expanded encrypted signal formats and processing
+4. **Real-time Updates**: WebSocket or Server-Sent Events for dynamic ID updates
+
+## Module Implementation Reference
+
+Reference implementation: **AMX ID System** (`modules/amxIdSystem.js`)
+
+Key design patterns followed:
+- Storage manager usage with proper consent checks
+- Configurable endpoint calls with timeout handling  
+- localStorage and cookie fallback logic
+- EID format standardization
+- Comprehensive error handling and logging

--- a/test/spec/modules/locIdSystem_spec.js
+++ b/test/spec/modules/locIdSystem_spec.js
@@ -1,0 +1,587 @@
+import { locIdSubmodule, storage } from 'modules/locIdSystem.js';
+import { server } from 'test/mocks/xhr.js';
+import * as utils from 'src/utils.js';
+import * as ajax from 'src/ajax.js';
+import { uspDataHandler, gppDataHandler } from 'src/adapterManager.js';
+import { expect } from 'chai/index.mjs';
+
+const TEST_ID = '550e8400-e29b-41d4-a716-446655440000';
+const TEST_PUBLISHER_ID = 'pub-12345';
+const TEST_ENDPOINT_URL = 'https://api.locid.com/v1/id';
+
+describe('LocID System', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(storage, 'localStorageIsEnabled').returns(true);
+    sandbox.stub(storage, 'cookiesAreEnabled').returns(true);
+    sandbox.stub(storage, 'getDataFromLocalStorage');
+    sandbox.stub(storage, 'setDataInLocalStorage');
+    sandbox.stub(storage, 'getCookie');
+    sandbox.stub(storage, 'setCookie');
+    sandbox.stub(utils, 'generateUUID').returns(TEST_ID);
+    sandbox.stub(uspDataHandler, 'getConsentData').returns(null);
+    sandbox.stub(gppDataHandler, 'getConsentData').returns(null);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('module properties', () => {
+    it('should expose correct module name', () => {
+      expect(locIdSubmodule.name).to.equal('locid');
+    });
+
+    it('should not have gvlid defined', () => {
+      expect(locIdSubmodule.gvlid).to.be.undefined;
+    });
+
+    it('should have eids configuration', () => {
+      expect(locIdSubmodule.eids).to.be.an('object');
+      expect(locIdSubmodule.eids.locid).to.be.an('object');
+      expect(locIdSubmodule.eids.locid.source).to.equal('locid.com');
+      expect(locIdSubmodule.eids.locid.atype).to.equal(1);
+    });
+  });
+
+  describe('decode', () => {
+    it('should decode valid ID correctly', () => {
+      const result = locIdSubmodule.decode(TEST_ID, {});
+      expect(result).to.deep.equal({
+        locid: TEST_ID
+      });
+    });
+
+    it('should include GAM output when configured', () => {
+      const config = {
+        params: {
+          gam: {
+            enabled: true,
+            mode: 'ppid',
+            key: 'locid'
+          }
+        }
+      };
+      const result = locIdSubmodule.decode(TEST_ID, config);
+      expect(result).to.deep.equal({
+        locid: TEST_ID,
+        _gam: {
+          key: 'locid',
+          ppid: TEST_ID
+        }
+      });
+    });
+
+    it('should return undefined for users in holdout control group', () => {
+      const config = {
+        params: {
+          holdoutOverride: 'forceControl'
+        }
+      };
+      const result = locIdSubmodule.decode(TEST_ID, config);
+      expect(result).to.be.undefined;
+    });
+
+    it('should decode for users forced into treatment', () => {
+      const config = {
+        params: {
+          holdoutOverride: 'forceTreatment'
+        }
+      };
+      const result = locIdSubmodule.decode(TEST_ID, config);
+      expect(result).to.deep.equal({
+        locid: TEST_ID
+      });
+    });
+
+    it('should handle errors gracefully and return undefined', () => {
+      // Force an error by passing a value that causes internal issues
+      // The decode function has a try-catch that returns undefined on errors
+      sandbox.stub(utils, 'logError');
+
+      // Pass an object that stringifies but causes issues in isValidId
+      const badValue = { toString: () => { throw new Error('test error'); } };
+      const result = locIdSubmodule.decode(badValue, {});
+      expect(result).to.be.undefined;
+    });
+
+    it('should return undefined for invalid values', () => {
+      [null, undefined, '', {}, [], 123].forEach(value => {
+        expect(locIdSubmodule.decode(value, {})).to.be.undefined;
+      });
+    });
+  });
+
+  describe('getId with publisher source', () => {
+    const config = {
+      params: {
+        source: 'publisher',
+        value: TEST_PUBLISHER_ID
+      }
+    };
+
+    it('should return publisher-provided ID', () => {
+      const result = locIdSubmodule.getId(config, {});
+      expect(result).to.deep.equal({
+        id: TEST_PUBLISHER_ID
+      });
+    });
+
+    it('should use storedId when no value in params', () => {
+      const configNoValue = {
+        params: {
+          source: 'publisher'
+        }
+      };
+      const result = locIdSubmodule.getId(configNoValue, {}, TEST_PUBLISHER_ID);
+      expect(result).to.deep.equal({
+        id: TEST_PUBLISHER_ID
+      });
+    });
+
+    it('should return undefined when no valid ID provided', () => {
+      const configNoValue = {
+        params: {
+          source: 'publisher'
+        }
+      };
+      const result = locIdSubmodule.getId(configNoValue, {});
+      expect(result).to.be.undefined;
+    });
+  });
+
+  describe('getId with device source', () => {
+    const config = {
+      params: {
+        source: 'device'
+      },
+      storage: {
+        type: 'localStorage',
+        name: '_locid_test',
+        expires: 30
+      }
+    };
+
+    it('should generate new device ID', () => {
+      storage.getDataFromLocalStorage.returns(null);
+
+      const result = locIdSubmodule.getId(config, {});
+      expect(result).to.deep.equal({
+        id: TEST_ID
+      });
+      expect(storage.setDataInLocalStorage.calledOnce).to.be.true;
+    });
+
+    it('should use stored ID when not expired', () => {
+      const storedData = JSON.stringify({
+        id: 'stored-id-123',
+        timestamp: Date.now() - 1000
+      });
+      storage.getDataFromLocalStorage.returns(storedData);
+
+      const result = locIdSubmodule.getId(config, {});
+      expect(result).to.deep.equal({
+        id: 'stored-id-123'
+      });
+    });
+
+    it('should refresh expired stored ID', () => {
+      const storedData = JSON.stringify({
+        id: 'stored-id-123',
+        timestamp: Date.now() - (31 * 24 * 60 * 60 * 1000) // 31 days ago
+      });
+      storage.getDataFromLocalStorage.returns(storedData);
+
+      const result = locIdSubmodule.getId(config, {});
+      expect(result).to.deep.equal({
+        id: TEST_ID
+      });
+      expect(storage.setDataInLocalStorage.calledOnce).to.be.true;
+    });
+
+    it('should return undefined when GDPR applies without consent', () => {
+      storage.getDataFromLocalStorage.returns(null);
+      const consentData = {
+        gdpr: {
+          gdprApplies: true,
+          consentString: ''
+        }
+      };
+
+      const result = locIdSubmodule.getId(config, consentData);
+      expect(result).to.be.undefined;
+      expect(storage.setDataInLocalStorage.called).to.be.false;
+    });
+
+    it('should return undefined when US Privacy opt-out applies', () => {
+      storage.getDataFromLocalStorage.returns(null);
+      uspDataHandler.getConsentData.returns('1-Y-');
+
+      const result = locIdSubmodule.getId(config, {});
+      expect(result).to.be.undefined;
+      expect(storage.setDataInLocalStorage.called).to.be.false;
+    });
+  });
+
+  describe('getId with endpoint source (deprecated)', () => {
+    it('should warn that endpoint source is no longer supported', () => {
+      const config = {
+        params: {
+          source: 'endpoint'
+        }
+      };
+
+      const result = locIdSubmodule.getId(config, {});
+      expect(result).to.be.undefined;
+    });
+  });
+
+  describe('extendId for ORTB2 injection', () => {
+    let ajaxStub;
+
+    beforeEach(() => {
+      ajaxStub = sandbox.stub(ajax, 'ajax');
+      storage.getDataFromLocalStorage.returns(null);
+    });
+
+    it('should inject ORTB2 data when ID is available and user not in holdout', () => {
+      const config = {
+        params: {
+          source: 'device',
+          holdoutOverride: 'forceTreatment',
+          loggingEndpoint: 'https://test-logging.com'
+        },
+        auctionId: 'test-auction-123'
+      };
+
+      const result = locIdSubmodule.extendId(config, {}, null);
+
+      expect(result).to.have.property('ortb2');
+      expect(result.ortb2.user.ext.data).to.deep.include({
+        locid_confidence: 1.0,
+        locid_audiences: []
+      });
+      expect(result.ortb2.user.ext.data).to.have.property('locid_stability_days');
+    });
+
+    it('should not inject ORTB2 data when user is in holdout', () => {
+      const config = {
+        params: {
+          source: 'device',
+          holdoutOverride: 'forceControl',
+          loggingEndpoint: 'https://test-logging.com'
+        },
+        auctionId: 'test-auction-123'
+      };
+
+      const result = locIdSubmodule.extendId(config, {}, null);
+      expect(result).to.be.undefined;
+    });
+
+    it('should merge ORTB2 data without overwriting existing data', () => {
+      const config = {
+        params: {
+          source: 'device',
+          holdoutOverride: 'forceTreatment'
+        },
+        ortb2: {
+          user: {
+            ext: {
+              data: {
+                existing_field: 'existing_value'
+              }
+            }
+          }
+        }
+      };
+
+      const result = locIdSubmodule.extendId(config, {}, null);
+
+      expect(result.ortb2.user.ext.data).to.have.property('existing_field', 'existing_value');
+      expect(result.ortb2.user.ext.data).to.have.property('locid_confidence', 1.0);
+    });
+
+    it('should log exposure data when logging endpoint is configured', () => {
+      const config = {
+        params: {
+          source: 'device',
+          holdoutOverride: 'forceTreatment',
+          loggingEndpoint: 'https://test-logging.com'
+        },
+        auctionId: 'test-auction-123'
+      };
+
+      locIdSubmodule.extendId(config, {}, null);
+
+      expect(ajaxStub.calledOnce).to.be.true;
+      const logData = JSON.parse(ajaxStub.firstCall.args[2]);
+      expect(logData).to.include({
+        auction_id: 'test-auction-123',
+        is_holdout: false,
+        locid_present: true
+      });
+    });
+
+    it('should handle errors gracefully and return undefined', () => {
+      const config = {
+        params: {
+          source: 'device'
+        }
+      };
+
+      // Force an error by making getId throw
+      sandbox.stub(locIdSubmodule, 'getId').throws(new Error('test error'));
+
+      const result = locIdSubmodule.extendId(config, {}, null);
+      expect(result).to.be.undefined;
+    });
+
+    it('should not inject when no consent', () => {
+      const config = {
+        params: {
+          source: 'device',
+          holdoutOverride: 'forceTreatment'
+        }
+      };
+
+      const consentData = {
+        gdpr: {
+          gdprApplies: true,
+          consentString: ''
+        }
+      };
+
+      const result = locIdSubmodule.extendId(config, consentData, null);
+      expect(result).to.be.undefined;
+    });
+  });
+
+  describe('storage configuration', () => {
+    const deviceConfig = {
+      params: { source: 'device' }
+    };
+
+    it('should support localStorage storage', () => {
+      const config = {
+        ...deviceConfig,
+        storage: {
+          type: 'localStorage',
+          name: '_test_locid',
+          expires: 7
+        }
+      };
+
+      storage.getDataFromLocalStorage.returns(null);
+      locIdSubmodule.getId(config, {});
+
+      expect(storage.setDataInLocalStorage.calledWith('_test_locid')).to.be.true;
+      expect(storage.setCookie.called).to.be.false;
+    });
+
+    it('should support cookie storage', () => {
+      const config = {
+        ...deviceConfig,
+        storage: {
+          type: 'cookie',
+          name: '_test_locid',
+          expires: 7
+        }
+      };
+
+      storage.getCookie.returns(null);
+      locIdSubmodule.getId(config, {});
+
+      expect(storage.setCookie.calledWith('_test_locid')).to.be.true;
+      expect(storage.setDataInLocalStorage.called).to.be.false;
+    });
+
+    it('should support combined localStorage&cookie storage', () => {
+      const config = {
+        ...deviceConfig,
+        storage: {
+          type: 'localStorage&cookie',
+          name: '_test_locid',
+          expires: 7
+        }
+      };
+
+      storage.getDataFromLocalStorage.returns(null);
+      storage.getCookie.returns(null);
+      locIdSubmodule.getId(config, {});
+
+      expect(storage.setDataInLocalStorage.calledWith('_test_locid')).to.be.true;
+      expect(storage.setCookie.calledWith('_test_locid')).to.be.true;
+    });
+  });
+
+  describe('refresh logic', () => {
+    const config = {
+      params: { source: 'device' },
+      storage: {
+        type: 'localStorage',
+        name: '_locid_test',
+        expires: 30,
+        refreshInSeconds: 3600 // 1 hour
+      }
+    };
+
+    it('should refresh ID when refresh time exceeded', () => {
+      const storedData = JSON.stringify({
+        id: 'old-id',
+        timestamp: Date.now() - (2 * 60 * 60 * 1000) // 2 hours ago
+      });
+      storage.getDataFromLocalStorage.returns(storedData);
+
+      const result = locIdSubmodule.getId(config, {});
+      expect(result).to.deep.equal({
+        id: TEST_ID // New generated ID
+      });
+      expect(storage.setDataInLocalStorage.calledOnce).to.be.true;
+    });
+
+    it('should not refresh ID when refresh time not exceeded', () => {
+      const storedData = JSON.stringify({
+        id: 'current-id',
+        timestamp: Date.now() - (30 * 60 * 1000) // 30 minutes ago
+      });
+      storage.getDataFromLocalStorage.returns(storedData);
+
+      const result = locIdSubmodule.getId(config, {});
+      expect(result).to.deep.equal({
+        id: 'current-id' // Existing ID used
+      });
+      expect(storage.setDataInLocalStorage.called).to.be.false;
+    });
+  });
+
+  describe('error handling', () => {
+    it('should default to device source when source not specified', () => {
+      const config = {
+        params: {},
+        storage: {
+          type: 'localStorage',
+          name: '_locid_test'
+        }
+      };
+      storage.getDataFromLocalStorage.returns(null);
+
+      const result = locIdSubmodule.getId(config, {});
+      expect(result).to.deep.equal({
+        id: TEST_ID
+      });
+    });
+
+    it('should handle unknown source', () => {
+      const config = {
+        params: {
+          source: 'unknown'
+        }
+      };
+
+      const result = locIdSubmodule.getId(config, {});
+      expect(result).to.be.undefined;
+    });
+
+    it('should handle corrupted stored data gracefully', () => {
+      const config = {
+        params: { source: 'device' },
+        storage: {
+          type: 'localStorage',
+          name: '_locid_test'
+        }
+      };
+
+      storage.getDataFromLocalStorage.returns('invalid-json');
+
+      const result = locIdSubmodule.getId(config, {});
+      expect(result).to.deep.equal({
+        id: TEST_ID
+      });
+    });
+  });
+
+  describe('consent handling', () => {
+    const config = {
+      params: { source: 'device' },
+      storage: {
+        type: 'localStorage',
+        name: '_locid_test',
+        expires: 30
+      }
+    };
+
+    it('should store ID with valid GDPR consent', () => {
+      storage.getDataFromLocalStorage.returns(null);
+      const consentData = {
+        gdpr: {
+          gdprApplies: true,
+          consentString: 'valid-consent-string'
+        }
+      };
+
+      const result = locIdSubmodule.getId(config, consentData);
+      expect(result).to.deep.equal({
+        id: TEST_ID
+      });
+      expect(storage.setDataInLocalStorage.calledOnce).to.be.true;
+    });
+
+    it('should store ID when GDPR does not apply', () => {
+      storage.getDataFromLocalStorage.returns(null);
+      const consentData = {
+        gdpr: {
+          gdprApplies: false,
+          consentString: ''
+        }
+      };
+
+      const result = locIdSubmodule.getId(config, consentData);
+      expect(result).to.deep.equal({
+        id: TEST_ID
+      });
+      expect(storage.setDataInLocalStorage.calledOnce).to.be.true;
+    });
+
+    it('should return undefined for publisher source when consent is missing', () => {
+      const publisherConfig = {
+        params: {
+          source: 'publisher',
+          value: TEST_PUBLISHER_ID
+        }
+      };
+
+      const consentData = {
+        gdpr: {
+          gdprApplies: true,
+          consentString: ''
+        }
+      };
+
+      const result = locIdSubmodule.getId(publisherConfig, consentData);
+      expect(result).to.be.undefined;
+    });
+
+    it('should work with publisher source when consent is valid', () => {
+      const publisherConfig = {
+        params: {
+          source: 'publisher',
+          value: TEST_PUBLISHER_ID
+        }
+      };
+
+      const consentData = {
+        gdpr: {
+          gdprApplies: true,
+          consentString: 'valid-consent-string'
+        }
+      };
+
+      const result = locIdSubmodule.getId(publisherConfig, consentData);
+      expect(result).to.deep.equal({
+        id: TEST_PUBLISHER_ID
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description
Adds an initial scaffold for a LocID User ID submodule.

This PR establishes registration, first-party storage, consent gating (GDPR / US Privacy / GPP), and non-blocking fail-open behavior. No buyer-visible signals, ORTB2 enrichment, syncing, or network calls are included.

Follow-up PRs will introduce enrichment and measurement.

## Testing
- Added unit tests for storage, consent handling, and error cases
- Existing test suite passes