### PR TITLE
PubMatic Bid Adapter: Support Billing URL (burl) and implement onBidBillable handler

### DIFF
--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -1,4 +1,4 @@
-import { logWarn, isStr, isArray, deepAccess, deepSetValue, isBoolean, isInteger, logInfo, logError, deepClone, uniques, generateUUID, isPlainObject, isFn, getWindowTop } from '../src/utils.js';
+import { logWarn, isStr, isArray, deepAccess, deepSetValue, isBoolean, isInteger, logInfo, logError, deepClone, uniques, generateUUID, isPlainObject, isFn, getWindowTop, replaceAuctionPrice, triggerPixel } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO, NATIVE, ADPOD } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
@@ -311,7 +311,7 @@ const setFloorInImp = (imp, bid) => {
           const mediaTypeFloor = parseFloat(floorInfo.floor);
           if (isMultiFormatRequest && mediaType !== BANNER) {
             logInfo(LOG_WARN_PREFIX, 'floor from floor module returned for mediatype:', mediaType, 'is : ', mediaTypeFloor, 'with currency :', imp.bidfloorcur);
-            imp[mediaType]['ext'] = {'bidfloor': mediaTypeFloor, 'bidfloorcur': imp.bidfloorcur};
+            imp[mediaType]['ext'] = { 'bidfloor': mediaTypeFloor, 'bidfloorcur': imp.bidfloorcur };
           }
           logInfo(LOG_WARN_PREFIX, 'floor from floor module:', mediaTypeFloor, 'previous floor value', bidFloor, 'Min:', Math.min(mediaTypeFloor, bidFloor));
           bidFloor = bidFloor === -1 ? mediaTypeFloor : Math.min(mediaTypeFloor, bidFloor);
@@ -319,7 +319,7 @@ const setFloorInImp = (imp, bid) => {
         }
       });
       if (isMultiFormatRequest && mediaType === BANNER) {
-        imp[mediaType]['ext'] = {'bidfloor': bidFloor, 'bidfloorcur': imp.bidfloorcur};
+        imp[mediaType]['ext'] = { 'bidfloor': bidFloor, 'bidfloorcur': imp.bidfloorcur };
       }
     });
   }
@@ -469,6 +469,9 @@ const updateResponseWithCustomFields = (res, bid, ctx) => {
   }
   if (bid.ext?.marketplace) {
     res.bidderCode = bid.ext.marketplace;
+  }
+  if (bid.burl) {
+    res.burl = bid.burl;
   }
 
   // add meta fields
@@ -630,7 +633,7 @@ const BB_RENDERER = {
     else logWarn(`${LOG_WARN_PREFIX}: Couldn't find a renderer with ${rendererId}`);
   },
 
-  newRenderer: function(rendererCode, adUnitCode) {
+  newRenderer: function (rendererCode, adUnitCode) {
     const rendererUrl = RENDERER_URL.replace('$RENDERER', rendererCode);
     const renderer = Renderer.install({ url: rendererUrl, loaded: false, adUnitCode });
     try {
@@ -641,11 +644,11 @@ const BB_RENDERER = {
     return renderer;
   },
 
-  outstreamRender: function(bid) {
+  outstreamRender: function (bid) {
     bid.renderer.push(() => BB_RENDERER.bootstrapPlayer(bid));
   },
 
-  getRendererId: function(pub, renderer) {
+  getRendererId: function (pub, renderer) {
     return `${pub}-${renderer}`; // NB convention!
   }
 };
@@ -786,7 +789,7 @@ export const spec = {
         return false;
       }
       if (videoMediaTypes.context === 'outstream' && !isStr(bid.params.outstreamAU) &&
-!bid.renderer && !videoMediaTypes.renderer) {
+        !bid.renderer && !videoMediaTypes.renderer) {
         if (mediaTypes.hasOwnProperty(BANNER) || mediaTypes.hasOwnProperty(NATIVE)) {
           delete mediaTypes[VIDEO];
           logWarn(`${LOG_WARN_PREFIX}: for "outstream" bids either outstreamAU parameter must be provided or ad unit supplied renderer is required. Rejecting mediatype Video of bid: `, bid);
@@ -902,6 +905,12 @@ export const spec = {
 
   onBidWon: (bid) => {
     _calculateBidCpmAdjustment(bid);
+  },
+
+  onBidBillable: function (bid) {
+    if (bid.burl && !bid.deferBilling) {
+      triggerPixel(replaceAuctionPrice(bid.burl, bid.cpm));
+    }
   }
 };
 

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -608,7 +608,7 @@ function optimizeImps(imps, bidderRequest) {
 }
 // BB stands for Blue BillyWig
 const BB_RENDERER = {
-  bootstrapPlayer: function(bid) {
+  bootstrapPlayer: function (bid) {
     const config = {
       code: bid.adUnitCode,
       vastXml: bid.vastXml || null,

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -3,7 +3,7 @@ import { spec, cpmAdjustment, addViewabilityToImp, shouldAddDealTargeting } from
 import * as utils from 'src/utils.js';
 import { bidderSettings } from 'src/bidderSettings.js';
 import { config } from 'src/config.js';
-import {getGlobal} from '../../../src/prebidGlobal.js';
+import { getGlobal } from '../../../src/prebidGlobal.js';
 
 describe('PubMatic adapter', () => {
   let firstBid, videoBid, firstResponse, response, videoResponse, firstAliasBid;
@@ -53,7 +53,7 @@ describe('PubMatic adapter', () => {
         js: 1,
         connectiontype: 6
       },
-      site: {domain: 'ebay.com', page: 'https://ebay.com', publisher: {id: '5670'}},
+      site: { domain: 'ebay.com', page: 'https://ebay.com', publisher: { id: '5670' } },
       source: {},
       user: {
         ext: {
@@ -136,7 +136,7 @@ describe('PubMatic adapter', () => {
         js: 1,
         connectiontype: 6
       },
-      site: {domain: 'ebay.com', page: 'https://ebay.com', publisher: {id: '5670'}},
+      site: { domain: 'ebay.com', page: 'https://ebay.com', publisher: { id: '5670' } },
       source: {},
       user: {
         ext: {
@@ -195,7 +195,7 @@ describe('PubMatic adapter', () => {
       },
       'dealid': 'PUBDEAL1',
       'mtype': 2,
-      'params': {'outstreamAU': 'outstreamAU', 'renderer': 'renderer_test_pubmatic'}
+      'params': { 'outstreamAU': 'outstreamAU', 'renderer': 'renderer_test_pubmatic' }
     }]
   };
   firstResponse = {
@@ -255,7 +255,7 @@ describe('PubMatic adapter', () => {
         js: 1,
         connectiontype: 6
       },
-      site: {domain: 'ebay.com', page: 'https://ebay.com'},
+      site: { domain: 'ebay.com', page: 'https://ebay.com' },
       source: {},
       user: {
         ext: {
@@ -287,7 +287,7 @@ describe('PubMatic adapter', () => {
         js: 1,
         connectiontype: 6
       },
-      site: {domain: 'ebay.com', page: 'https://ebay.com'},
+      site: { domain: 'ebay.com', page: 'https://ebay.com' },
       source: {},
       user: {
         ext: {
@@ -778,28 +778,28 @@ describe('PubMatic adapter', () => {
           expect(request.data).to.have.property('bcat').to.deep.equal(['IAB1', 'IAB2']);
         });
 
-        it('should contain string values with length greater than 3', function() {
+        it('should contain string values with length greater than 3', function () {
           validBidRequests[0].params.bcat = ['AB', 'CD', 'IAB1', 'IAB2'];
           const request = spec.buildRequests(validBidRequests, bidderRequest);
           expect(request.data).to.have.property('bcat');
           expect(request.data).to.have.property('bcat').to.deep.equal(['IAB1', 'IAB2']);
         });
 
-        it('should trim strings', function() {
+        it('should trim strings', function () {
           validBidRequests[0].params.bcat = ['   IAB1    ', '   IAB2   '];
           const request = spec.buildRequests(validBidRequests, bidderRequest);
           expect(request.data).to.have.property('bcat');
           expect(request.data).to.have.property('bcat').to.deep.equal(['IAB1', 'IAB2']);
         });
 
-        it('should pass unique strings', function() {
+        it('should pass unique strings', function () {
           validBidRequests[0].params.bcat = ['IAB1', 'IAB2', 'IAB1', 'IAB2', 'IAB1', 'IAB2'];
           const request = spec.buildRequests(validBidRequests, bidderRequest);
           expect(request.data).to.have.property('bcat');
           expect(request.data).to.have.property('bcat').to.deep.equal(['IAB1', 'IAB2']);
         });
 
-        it('should fail if validations are not met', function() {
+        it('should fail if validations are not met', function () {
           validBidRequests[0].params.bcat = ['', 'IA', 'IB'];
           const request = spec.buildRequests(validBidRequests, bidderRequest);
           expect(request.data).to.not.have.property('bcat');
@@ -1123,7 +1123,7 @@ describe('PubMatic adapter', () => {
           ]
         };
         beforeEach(() => {
-          bidderRequest.ortb2.regs = {ext: { dsa }};
+          bidderRequest.ortb2.regs = { ext: { dsa } };
         });
 
         it('should have DSA in regs.ext', () => {
@@ -1232,7 +1232,7 @@ describe('PubMatic adapter', () => {
             currency: 'EUR',
             mediaType: 'banner',
             meta: { mediaType: 'banner' },
-            getCpmInNewCurrency: function(currency) {
+            getCpmInNewCurrency: function (currency) {
               return currency === 'EUR' ? 2.8 : this.cpm;
             }
           };
@@ -1281,6 +1281,60 @@ describe('PubMatic adapter', () => {
           expect(cpmAdjustment.adjustment[0].originalCpm).to.equal(2);
         });
       });
+    });
+  });
+
+  describe('onBidBillable', () => {
+    let triggerPixelStub;
+    let replaceAuctionPriceStub;
+
+    beforeEach(() => {
+      triggerPixelStub = sinon.stub(utils, 'triggerPixel');
+      replaceAuctionPriceStub = sinon.stub(utils, 'replaceAuctionPrice');
+    });
+
+    afterEach(() => {
+      triggerPixelStub.restore();
+      replaceAuctionPriceStub.restore();
+    });
+
+    it('should trigger pixel when bid has burl and deferBilling is false', () => {
+      const bid = {
+        burl: 'http://example.com/burl',
+        deferBilling: false,
+        cpm: 1.5
+      };
+
+      replaceAuctionPriceStub.withArgs(bid.burl, bid.cpm).returns('http://example.com/burl_replaced');
+
+      spec.onBidBillable(bid);
+
+      expect(triggerPixelStub.calledOnce).to.be.true;
+      expect(triggerPixelStub.calledWith('http://example.com/burl_replaced')).to.be.true;
+      expect(replaceAuctionPriceStub.calledWith(bid.burl, bid.cpm)).to.be.true;
+    });
+
+    it('should not trigger pixel when bid does not have burl', () => {
+      const bid = {
+        deferBilling: false,
+        cpm: 1.5
+      };
+
+      spec.onBidBillable(bid);
+
+      expect(triggerPixelStub.called).to.be.false;
+    });
+
+    it('should not trigger pixel when bid has deferBilling set to true', () => {
+      const bid = {
+        burl: 'http://example.com/burl',
+        deferBilling: true,
+        cpm: 1.5
+      };
+
+      spec.onBidBillable(bid);
+
+      expect(triggerPixelStub.called).to.be.false;
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
<!-- Describe the change proposed in this pull request -->
This PR updates the PubMatic adapter to correctly handle billing URLs (burl) and billing events.

- Capture burl from Bid Response
- Triggers the billing pixel (burl) when a bid becomes billable.

Logic: The pixel is fired only if:
- bid.burl exists.
- bid.deferBilling is false (or falsy).

Macro Replacement: Ensures replaceAuctionPrice is called on the burl to substitute the winning CPM before firing the pixel.
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
