### PR TITLE
CI: set metadata override for ringieraxelspringer

### DIFF
--- a/metadata/overrides.mjs
+++ b/metadata/overrides.mjs
@@ -17,5 +17,6 @@ export default {
   relevadRtdProvider: 'RelevadRTDModule',
   sirdataRtdProvider: 'SirdataRTDModule',
   fanBidAdapter: 'freedomadnetwork',
-  uniquestWidgetBidAdapter: 'uniquest_widget'
+  uniquestWidgetBidAdapter: 'uniquest_widget',
+  ringieraxelspringerBidAdapter: 'das'
 }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

After https://github.com/prebid/Prebid.js/pull/14106 the `compile-metadata` build step gets confused about how to assign metadata to `ringieraxelspringer`; add an override to address it.
