### PR TITLE
Price Floors: Fix TypeError when adUnit.bids is undefined

### DIFF
--- a/modules/priceFloors.ts
+++ b/modules/priceFloors.ts
@@ -448,7 +448,8 @@ export function updateAdUnitsForAuction(adUnits, floorData, auctionId) {
   const noFloorSignalBiddersArray = getNoFloorSignalBidersArray(floorData)
 
   adUnits.forEach((adUnit) => {
-    adUnit.bids.forEach(bid => {
+    // adUnit.bids can be undefined
+    adUnit.bids?.forEach(bid => {
       // check if the bidder is in the no signal list
       const isNoFloorSignaled = noFloorSignalBiddersArray.some(bidderName => bidderName === bid.bidder)
       if (floorData.skipped || isNoFloorSignaled) {

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -689,6 +689,11 @@ describe('the price floors module', function () {
       const skipRate = utils.deepAccess(adUnits, '0.bids.0.floorData.skipRate');
       expect(skipRate).to.equal(undefined);
     });
+
+    it('should not throw when adUnit.bids is undefined', function() {
+      const adUnitsWithNoBids = [{ code: 'test-ad-unit', mediaTypes: { banner: { sizes: [[300, 250]] } } }];
+      expect(() => updateAdUnitsForAuction(adUnitsWithNoBids, inputFloorData, 'id')).to.not.throw();
+    });
   });
 
   describe('createFloorsDataForAuction', function() {


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

This PR fixes a TypeError that occurs in the priceFloors module when `adUnit.bids` is undefined.

Error at updateAdUnitsForAuction
```
TypeError: Cannot read properties of undefined (reading 'forEach')
```

## Other information

This PR solves https://github.com/prebid/Prebid.js/issues/14359