### PR TITLE
New Adapter: Panxo - AI traffic monetization SSP

### DIFF
--- a/modules/panxoBidAdapter.js
+++ b/modules/panxoBidAdapter.js
@@ -1,0 +1,357 @@
+/**
+ * @module modules/panxoBidAdapter
+ * @description Bid Adapter for Prebid.js - AI-referred traffic monetization
+ * @see https://docs.panxo.ai for Signal script installation
+ */
+
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER } from '../src/mediaTypes.js';
+import { deepAccess, logWarn, isFn, isPlainObject } from '../src/utils.js';
+import { getStorageManager } from '../src/storageManager.js';
+
+const BIDDER_CODE = 'panxo';
+const ENDPOINT_URL = 'https://panxo-sys.com/openrtb/2.5/bid';
+const USER_ID_KEY = 'panxo_uid';
+const SYNC_URL = 'https://panxo-sys.com/usersync';
+const DEFAULT_CURRENCY = 'USD';
+const TTL = 300;
+const NET_REVENUE = true;
+
+export const storage = getStorageManager({ bidderCode: BIDDER_CODE });
+
+export function getPanxoUserId() {
+  try {
+    return storage.getDataFromLocalStorage(USER_ID_KEY);
+  } catch (e) {
+    // storageManager handles errors internally
+  }
+  return null;
+}
+
+function buildBanner(bid) {
+  const sizes = deepAccess(bid, 'mediaTypes.banner.sizes') || bid.sizes || [];
+  if (sizes.length === 0) return null;
+
+  return {
+    format: sizes.map(size => ({ w: size[0], h: size[1] })),
+    w: sizes[0][0],
+    h: sizes[0][1]
+  };
+}
+
+function getFloorPrice(bid, size) {
+  if (isFn(bid.getFloor)) {
+    try {
+      const floorInfo = bid.getFloor({
+        currency: DEFAULT_CURRENCY,
+        mediaType: BANNER,
+        size: size
+      });
+      if (floorInfo && floorInfo.floor) {
+        return floorInfo.floor;
+      }
+    } catch (e) {
+      // Floor module error
+    }
+  }
+  return deepAccess(bid, 'params.floor') || 0;
+}
+
+function buildUser(panxoUid, bidderRequest) {
+  const user = { buyeruid: panxoUid };
+
+  // GDPR consent
+  const gdprConsent = deepAccess(bidderRequest, 'gdprConsent');
+  if (gdprConsent && gdprConsent.consentString) {
+    user.ext = { consent: gdprConsent.consentString };
+  }
+
+  // First Party Data - user
+  const fpd = deepAccess(bidderRequest, 'ortb2.user');
+  if (isPlainObject(fpd)) {
+    user.ext = { ...user.ext, ...fpd.ext };
+    if (fpd.data) user.data = fpd.data;
+  }
+
+  return user;
+}
+
+function buildRegs(bidderRequest) {
+  const regs = { ext: {} };
+
+  // GDPR - only set when gdprApplies is explicitly true or false, not undefined
+  const gdprConsent = deepAccess(bidderRequest, 'gdprConsent');
+  if (gdprConsent && typeof gdprConsent.gdprApplies === 'boolean') {
+    regs.ext.gdpr = gdprConsent.gdprApplies ? 1 : 0;
+  }
+
+  // CCPA / US Privacy
+  const uspConsent = deepAccess(bidderRequest, 'uspConsent');
+  if (uspConsent) {
+    regs.ext.us_privacy = uspConsent;
+  }
+
+  // GPP
+  const gppConsent = deepAccess(bidderRequest, 'gppConsent');
+  if (gppConsent) {
+    regs.ext.gpp = gppConsent.gppString;
+    regs.ext.gpp_sid = gppConsent.applicableSections;
+  }
+
+  // COPPA
+  const coppa = deepAccess(bidderRequest, 'ortb2.regs.coppa');
+  if (coppa) {
+    regs.coppa = 1;
+  }
+
+  return regs;
+}
+
+function buildDevice() {
+  const device = {
+    ua: navigator.userAgent,
+    language: navigator.language,
+    js: 1,
+    dnt: navigator.doNotTrack === '1' ? 1 : 0
+  };
+
+  if (typeof screen !== 'undefined') {
+    device.w = screen.width;
+    device.h = screen.height;
+  }
+
+  return device;
+}
+
+function buildSite(bidderRequest) {
+  const site = {
+    page: deepAccess(bidderRequest, 'refererInfo.page') || '',
+    domain: deepAccess(bidderRequest, 'refererInfo.domain') || '',
+    ref: deepAccess(bidderRequest, 'refererInfo.ref') || ''
+  };
+
+  // First Party Data - site
+  const fpd = deepAccess(bidderRequest, 'ortb2.site');
+  if (isPlainObject(fpd)) {
+    Object.assign(site, {
+      name: fpd.name,
+      cat: fpd.cat,
+      sectioncat: fpd.sectioncat,
+      pagecat: fpd.pagecat,
+      content: fpd.content
+    });
+    if (fpd.ext) site.ext = fpd.ext;
+  }
+
+  return site;
+}
+
+function buildSource(bidderRequest) {
+  const source = {
+    tid: deepAccess(bidderRequest, 'ortb2.source.tid') || bidderRequest.auctionId
+  };
+
+  // Supply Chain (schain) - read from ortb2 where Prebid normalizes it
+  const schain = deepAccess(bidderRequest, 'ortb2.source.ext.schain');
+  if (isPlainObject(schain)) {
+    source.ext = { schain: schain };
+  }
+
+  return source;
+}
+
+export const spec = {
+  code: BIDDER_CODE,
+  gvlid: 1527, // IAB TCF Global Vendor List ID
+  supportedMediaTypes: [BANNER],
+
+  isBidRequestValid(bid) {
+    const propertyKey = deepAccess(bid, 'params.propertyKey');
+    if (!propertyKey) {
+      logWarn('Panxo: Missing required param "propertyKey"');
+      return false;
+    }
+    if (!deepAccess(bid, 'mediaTypes.banner')) {
+      logWarn('Panxo: Only banner mediaType is supported');
+      return false;
+    }
+    return true;
+  },
+
+  buildRequests(validBidRequests, bidderRequest) {
+    const panxoUid = getPanxoUserId();
+    if (!panxoUid) {
+      logWarn('Panxo: panxo_uid not found. Ensure Signal script is loaded before Prebid.');
+      return [];
+    }
+
+    // Group bids by propertyKey to handle multiple properties on same page
+    const bidsByPropertyKey = {};
+    validBidRequests.forEach(bid => {
+      const key = deepAccess(bid, 'params.propertyKey');
+      if (!bidsByPropertyKey[key]) {
+        bidsByPropertyKey[key] = [];
+      }
+      bidsByPropertyKey[key].push(bid);
+    });
+
+    // Build one request per propertyKey
+    const requests = [];
+    Object.keys(bidsByPropertyKey).forEach(propertyKey => {
+      const bidsForKey = bidsByPropertyKey[propertyKey];
+
+      const impressions = bidsForKey.map((bid) => {
+        const banner = buildBanner(bid);
+        if (!banner) return null;
+
+        const sizes = deepAccess(bid, 'mediaTypes.banner.sizes') || [];
+        const primarySize = sizes[0] || [300, 250];
+
+        // Build impression object
+        const imp = {
+          id: bid.bidId,
+          banner: banner,
+          bidfloor: getFloorPrice(bid, primarySize),
+          bidfloorcur: DEFAULT_CURRENCY,
+          secure: 1,
+          tagid: bid.adUnitCode
+        };
+
+        // Merge full ortb2Imp object (instl, pmp, ext, etc.)
+        const ortb2Imp = deepAccess(bid, 'ortb2Imp');
+        if (isPlainObject(ortb2Imp)) {
+          Object.keys(ortb2Imp).forEach(key => {
+            if (key === 'ext') {
+              imp.ext = { ...imp.ext, ...ortb2Imp.ext };
+            } else if (imp[key] === undefined) {
+              imp[key] = ortb2Imp[key];
+            }
+          });
+        }
+
+        return imp;
+      }).filter(Boolean);
+
+      if (impressions.length === 0) return;
+
+      const openrtbRequest = {
+        id: bidderRequest.bidderRequestId,
+        imp: impressions,
+        site: buildSite(bidderRequest),
+        device: buildDevice(),
+        user: buildUser(panxoUid, bidderRequest),
+        regs: buildRegs(bidderRequest),
+        source: buildSource(bidderRequest),
+        at: 1,
+        cur: [DEFAULT_CURRENCY],
+        tmax: bidderRequest.timeout || 1000
+      };
+
+      requests.push({
+        method: 'POST',
+        url: `${ENDPOINT_URL}?key=${encodeURIComponent(propertyKey)}&source=prebid`,
+        data: openrtbRequest,
+        options: { contentType: 'text/plain', withCredentials: false },
+        bidderRequest: bidderRequest
+      });
+    });
+
+    return requests;
+  },
+
+  interpretResponse(serverResponse, request) {
+    const bids = [];
+    const response = serverResponse.body;
+
+    if (!response || !response.seatbid) return bids;
+
+    const bidRequestMap = {};
+    if (request.bidderRequest && request.bidderRequest.bids) {
+      request.bidderRequest.bids.forEach(bid => {
+        bidRequestMap[bid.bidId] = bid;
+      });
+    }
+
+    response.seatbid.forEach(seatbid => {
+      if (!seatbid.bid) return;
+
+      seatbid.bid.forEach(bid => {
+        const originalBid = bidRequestMap[bid.impid];
+        if (!originalBid) return;
+
+        bids.push({
+          requestId: bid.impid,
+          cpm: bid.price,
+          currency: response.cur || DEFAULT_CURRENCY,
+          width: bid.w,
+          height: bid.h,
+          creativeId: bid.crid || bid.id,
+          dealId: bid.dealid || null,
+          netRevenue: NET_REVENUE,
+          ttl: bid.exp || TTL,
+          ad: bid.adm,
+          nurl: bid.nurl,
+          meta: {
+            advertiserDomains: bid.adomain || [],
+            mediaType: BANNER
+          }
+        });
+      });
+    });
+
+    return bids;
+  },
+
+  getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) {
+    const syncs = [];
+
+    if (syncOptions.pixelEnabled) {
+      let syncUrl = SYNC_URL + '?source=prebid';
+
+      // GDPR - only include when gdprApplies is explicitly true or false
+      if (gdprConsent) {
+        if (typeof gdprConsent.gdprApplies === 'boolean') {
+          syncUrl += `&gdpr=${gdprConsent.gdprApplies ? 1 : 0}`;
+        }
+        if (gdprConsent.consentString) {
+          syncUrl += `&gdpr_consent=${encodeURIComponent(gdprConsent.consentString)}`;
+        }
+      }
+
+      // US Privacy
+      if (uspConsent) {
+        syncUrl += `&us_privacy=${encodeURIComponent(uspConsent)}`;
+      }
+
+      // GPP
+      if (gppConsent) {
+        if (gppConsent.gppString) {
+          syncUrl += `&gpp=${encodeURIComponent(gppConsent.gppString)}`;
+        }
+        if (gppConsent.applicableSections) {
+          syncUrl += `&gpp_sid=${encodeURIComponent(gppConsent.applicableSections.join(','))}`;
+        }
+      }
+
+      syncs.push({ type: 'image', url: syncUrl });
+    }
+
+    return syncs;
+  },
+
+  onBidWon(bid) {
+    if (bid.nurl) {
+      const winUrl = bid.nurl.replace(/\$\{AUCTION_PRICE\}/g, bid.cpm);
+      const img = document.createElement('img');
+      img.src = winUrl;
+      img.style.display = 'none';
+      document.body.appendChild(img);
+    }
+  },
+
+  onTimeout(timeoutData) {
+    logWarn('Panxo: Bid timeout', timeoutData);
+  }
+};
+
+registerBidder(spec);

--- a/modules/panxoBidAdapter.md
+++ b/modules/panxoBidAdapter.md
@@ -1,0 +1,229 @@
+# Overview
+
+```
+Module Name: Panxo Bid Adapter
+Module Type: Bidder Adapter
+Maintainer: tech@panxo.ai
+```
+
+# Description
+
+Panxo is a specialized SSP for AI-referred traffic monetization. This adapter enables publishers to monetize traffic coming from AI assistants like ChatGPT, Perplexity, Claude, and Gemini through Prebid.js header bidding.
+
+**Important**: This adapter requires the Panxo Signal script to be installed on the publisher's page. The Signal script must load before Prebid.js to ensure proper user identification and AI traffic detection.
+
+# Prerequisites
+
+1. Register your property at [app.panxo.ai](https://app.panxo.ai)
+2. Obtain your `propertyKey` from the Panxo dashboard
+3. Install the Panxo Signal script in your page's `<head>`:
+
+```html
+<script async src="https://cdn.panxo-sys.com/o/{YOUR_ENDPOINT_KEY}"></script>
+```
+
+# Bid Params
+
+| Name | Scope | Description | Example | Type |
+|------|-------|-------------|---------|------|
+| `propertyKey` | required | Your unique property identifier from Panxo dashboard | `'abc123def456'` | `string` |
+| `floor` | optional | Minimum CPM floor price in USD | `0.50` | `number` |
+
+# Configuration Example
+
+```javascript
+var adUnits = [{
+    code: 'banner-ad',
+    mediaTypes: {
+        banner: {
+            sizes: [[300, 250], [728, 90]]
+        }
+    },
+    bids: [{
+        bidder: 'panxo',
+        params: {
+            propertyKey: 'your-property-key-here'
+        }
+    }]
+}];
+```
+
+# Full Page Example
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+    <!-- Step 1: Panxo Signal Script (MUST load before Prebid) -->
+    <script async src="https://cdn.panxo-sys.com/o/your-endpoint-key"></script>
+    
+    <!-- Step 2: Prebid.js -->
+    <script async src="prebid.js"></script>
+    
+    <script>
+        var pbjs = pbjs || {};
+        pbjs.que = pbjs.que || [];
+        
+        pbjs.que.push(function() {
+            pbjs.addAdUnits([{
+                code: 'div-ad-1',
+                mediaTypes: {
+                    banner: { sizes: [[300, 250]] }
+                },
+                bids: [{
+                    bidder: 'panxo',
+                    params: {
+                        propertyKey: 'your-property-key'
+                    }
+                }]
+            }]);
+            
+            pbjs.requestBids({
+                bidsBackHandler: function() {
+                    // Handle bids
+                }
+            });
+        });
+    </script>
+</head>
+<body>
+    <div id="div-ad-1"></div>
+</body>
+</html>
+```
+
+# Supported Media Types
+
+| Type | Support |
+|------|---------|
+| Banner | Yes |
+| Video | No |
+| Native | No |
+
+# Privacy & Consent
+
+**IAB TCF Global Vendor List ID: 1527**
+
+This adapter is registered with the IAB Europe Transparency and Consent Framework. Publishers using a CMP (Consent Management Platform) should ensure Panxo (Vendor ID 1527) is included in their vendor list.
+
+This adapter supports:
+
+- **GDPR/TCF 2.0**: Consent string is passed in bid requests. GVL ID: 1527
+- **CCPA/US Privacy**: USP string is passed in bid requests  
+- **GPP**: Global Privacy Platform strings are supported
+- **COPPA**: Child-directed content flags are respected
+
+## CMP Configuration
+
+If you use a Consent Management Platform (Cookiebot, OneTrust, Quantcast Choice, etc.), ensure that:
+
+1. Panxo (Vendor ID: 1527) is included in your vendor list
+2. Users can grant/deny consent specifically for Panxo
+3. The CMP loads before Prebid.js to ensure consent is available
+
+Example TCF configuration with Prebid:
+
+```javascript
+pbjs.setConfig({
+    consentManagement: {
+        gdpr: {
+            cmpApi: 'iab',
+            timeout: 8000,
+            defaultGdprScope: true
+        },
+        usp: {
+            cmpApi: 'iab',
+            timeout: 1000
+        }
+    }
+});
+```
+
+# User Sync
+
+Panxo supports pixel-based user sync. Enable it in your Prebid configuration:
+
+```javascript
+pbjs.setConfig({
+    userSync: {
+        filterSettings: {
+            pixel: {
+                bidders: ['panxo'],
+                filter: 'include'
+            }
+        }
+    }
+});
+```
+
+# First Party Data
+
+This adapter supports First Party Data via the `ortb2` configuration:
+
+```javascript
+pbjs.setConfig({
+    ortb2: {
+        site: {
+            name: 'Example Site',
+            cat: ['IAB1'],
+            content: {
+                keywords: 'technology, ai'
+            }
+        },
+        user: {
+            data: [{
+                name: 'example-data-provider',
+                segment: [{ id: 'segment-1' }]
+            }]
+        }
+    }
+});
+```
+
+# Supply Chain (schain)
+
+Supply chain information is automatically passed when configured:
+
+```javascript
+pbjs.setConfig({
+    schain: {
+        validation: 'relaxed',
+        config: {
+            ver: '1.0',
+            complete: 1,
+            nodes: [{
+                asi: 'publisher-domain.com',
+                sid: '12345',
+                hp: 1
+            }]
+        }
+    }
+});
+```
+
+# Floor Prices
+
+This adapter supports the Prebid Price Floors Module. Configure floors as needed:
+
+```javascript
+pbjs.setConfig({
+    floors: {
+        enforcement: { floorDeals: true },
+        data: {
+            default: 0.50,
+            schema: { fields: ['mediaType'] },
+            values: { 'banner': 0.50 }
+        }
+    }
+});
+```
+
+# Win Notifications
+
+This adapter automatically fires win notification URLs (nurl) when a bid wins the auction. No additional configuration is required.
+
+# Contact
+
+For support or questions:
+- Email: tech@panxo.ai
+- Documentation: https://docs.panxo.ai

--- a/test/spec/modules/panxoBidAdapter_spec.js
+++ b/test/spec/modules/panxoBidAdapter_spec.js
@@ -1,0 +1,346 @@
+import { expect } from 'chai';
+import { spec, storage } from 'modules/panxoBidAdapter.js';
+import { BANNER } from 'src/mediaTypes.js';
+
+describe('PanxoBidAdapter', function () {
+  const PROPERTY_KEY = 'abc123def456';
+  const USER_ID = 'test-user-id-12345';
+
+  // Mock storage.getDataFromLocalStorage
+  let getDataStub;
+
+  beforeEach(function () {
+    getDataStub = sinon.stub(storage, 'getDataFromLocalStorage');
+    getDataStub.withArgs('panxo_uid').returns(USER_ID);
+  });
+
+  afterEach(function () {
+    getDataStub.restore();
+  });
+
+  describe('isBidRequestValid', function () {
+    it('should return true when propertyKey is present', function () {
+      const bid = {
+        bidder: 'panxo',
+        params: { propertyKey: PROPERTY_KEY },
+        mediaTypes: { banner: { sizes: [[300, 250]] } }
+      };
+      expect(spec.isBidRequestValid(bid)).to.be.true;
+    });
+
+    it('should return false when propertyKey is missing', function () {
+      const bid = {
+        bidder: 'panxo',
+        params: {},
+        mediaTypes: { banner: { sizes: [[300, 250]] } }
+      };
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+    });
+
+    it('should return false when banner mediaType is missing', function () {
+      const bid = {
+        bidder: 'panxo',
+        params: { propertyKey: PROPERTY_KEY },
+        mediaTypes: { video: {} }
+      };
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+    });
+  });
+
+  describe('buildRequests', function () {
+    const bidderRequest = {
+      bidderRequestId: 'test-request-id',
+      auctionId: 'test-auction-id',
+      timeout: 1500,
+      refererInfo: {
+        page: 'https://example.com/page',
+        domain: 'example.com',
+        ref: 'https://google.com'
+      }
+    };
+
+    const validBidRequests = [{
+      bidder: 'panxo',
+      bidId: 'bid-id-1',
+      adUnitCode: 'ad-unit-1',
+      params: { propertyKey: PROPERTY_KEY },
+      mediaTypes: { banner: { sizes: [[300, 250], [728, 90]] } }
+    }];
+
+    it('should build a valid OpenRTB request', function () {
+      const requests = spec.buildRequests(validBidRequests, bidderRequest);
+
+      expect(requests).to.be.an('array').with.lengthOf(1);
+      expect(requests[0].method).to.equal('POST');
+      expect(requests[0].url).to.include('panxo-sys.com/openrtb/2.5/bid');
+      expect(requests[0].url).to.include(`key=${PROPERTY_KEY}`);
+      expect(requests[0].data).to.be.an('object');
+    });
+
+    it('should include user.buyeruid from localStorage', function () {
+      const requests = spec.buildRequests(validBidRequests, bidderRequest);
+
+      expect(requests[0].data.user).to.be.an('object');
+      expect(requests[0].data.user.buyeruid).to.equal(USER_ID);
+    });
+
+    it('should build correct impressions', function () {
+      const requests = spec.buildRequests(validBidRequests, bidderRequest);
+
+      expect(requests[0].data.imp).to.be.an('array');
+      expect(requests[0].data.imp[0].id).to.equal('bid-id-1');
+      expect(requests[0].data.imp[0].banner.format).to.have.lengthOf(2);
+      expect(requests[0].data.imp[0].tagid).to.equal('ad-unit-1');
+    });
+
+    it('should return empty array when panxo_uid is not found', function () {
+      getDataStub.withArgs('panxo_uid').returns(null);
+      const requests = spec.buildRequests(validBidRequests, bidderRequest);
+
+      expect(requests).to.be.an('array').that.is.empty;
+    });
+
+    it('should include GDPR consent when gdprApplies is true', function () {
+      const gdprBidderRequest = {
+        ...bidderRequest,
+        gdprConsent: {
+          gdprApplies: true,
+          consentString: 'CO-test-consent-string'
+        }
+      };
+      const requests = spec.buildRequests(validBidRequests, gdprBidderRequest);
+
+      expect(requests[0].data.regs.ext.gdpr).to.equal(1);
+      expect(requests[0].data.user.ext.consent).to.equal('CO-test-consent-string');
+    });
+
+    it('should not include gdpr flag when gdprApplies is undefined', function () {
+      const gdprBidderRequest = {
+        ...bidderRequest,
+        gdprConsent: {
+          gdprApplies: undefined,
+          consentString: 'CO-test-consent-string'
+        }
+      };
+      const requests = spec.buildRequests(validBidRequests, gdprBidderRequest);
+
+      expect(requests[0].data.regs.ext.gdpr).to.be.undefined;
+      expect(requests[0].data.user.ext.consent).to.equal('CO-test-consent-string');
+    });
+
+    it('should include USP consent when available', function () {
+      const uspBidderRequest = {
+        ...bidderRequest,
+        uspConsent: '1YNN'
+      };
+      const requests = spec.buildRequests(validBidRequests, uspBidderRequest);
+
+      expect(requests[0].data.regs.ext.us_privacy).to.equal('1YNN');
+    });
+
+    it('should include schain when available', function () {
+      const schainBidderRequest = {
+        ...bidderRequest,
+        ortb2: {
+          source: {
+            ext: {
+              schain: {
+                ver: '1.0',
+                complete: 1,
+                nodes: [{ asi: 'example.com', sid: '12345', hp: 1 }]
+              }
+            }
+          }
+        }
+      };
+      const requests = spec.buildRequests(validBidRequests, schainBidderRequest);
+
+      expect(requests[0].data.source.ext.schain).to.deep.equal(schainBidderRequest.ortb2.source.ext.schain);
+    });
+
+    it('should use floor from getFloor function', function () {
+      const bidWithFloor = [{
+        ...validBidRequests[0],
+        getFloor: () => ({ currency: 'USD', floor: 1.50 })
+      }];
+      const requests = spec.buildRequests(bidWithFloor, bidderRequest);
+
+      expect(requests[0].data.imp[0].bidfloor).to.equal(1.50);
+    });
+
+    it('should include full ortb2Imp object in impression', function () {
+      const bidWithOrtb2Imp = [{
+        ...validBidRequests[0],
+        ortb2Imp: {
+          instl: 1,
+          ext: { data: { customField: 'value' } }
+        }
+      }];
+      const requests = spec.buildRequests(bidWithOrtb2Imp, bidderRequest);
+
+      expect(requests[0].data.imp[0].instl).to.equal(1);
+      expect(requests[0].data.imp[0].ext.data.customField).to.equal('value');
+    });
+
+    it('should split requests by different propertyKeys', function () {
+      const multiPropertyBids = [
+        {
+          bidder: 'panxo',
+          bidId: 'bid-id-1',
+          adUnitCode: 'ad-unit-1',
+          params: { propertyKey: 'property-a' },
+          mediaTypes: { banner: { sizes: [[300, 250]] } }
+        },
+        {
+          bidder: 'panxo',
+          bidId: 'bid-id-2',
+          adUnitCode: 'ad-unit-2',
+          params: { propertyKey: 'property-b' },
+          mediaTypes: { banner: { sizes: [[728, 90]] } }
+        }
+      ];
+      const requests = spec.buildRequests(multiPropertyBids, bidderRequest);
+
+      expect(requests).to.have.lengthOf(2);
+      expect(requests[0].url).to.include('key=property-a');
+      expect(requests[1].url).to.include('key=property-b');
+    });
+  });
+
+  describe('interpretResponse', function () {
+    const request = {
+      bidderRequest: {
+        bids: [{ bidId: 'bid-id-1', adUnitCode: 'ad-unit-1' }]
+      }
+    };
+
+    const serverResponse = {
+      body: {
+        id: 'response-id',
+        seatbid: [{
+          seat: 'panxo',
+          bid: [{
+            impid: 'bid-id-1',
+            price: 2.50,
+            w: 300,
+            h: 250,
+            adm: '<div>Ad creative</div>',
+            crid: 'creative-123',
+            adomain: ['advertiser.com'],
+            nurl: 'https://panxo-sys.com/win?price=${AUCTION_PRICE}'
+          }]
+        }],
+        cur: 'USD'
+      }
+    };
+
+    it('should parse valid bid response', function () {
+      const bids = spec.interpretResponse(serverResponse, request);
+
+      expect(bids).to.have.lengthOf(1);
+      expect(bids[0].requestId).to.equal('bid-id-1');
+      expect(bids[0].cpm).to.equal(2.50);
+      expect(bids[0].width).to.equal(300);
+      expect(bids[0].height).to.equal(250);
+      expect(bids[0].currency).to.equal('USD');
+      expect(bids[0].netRevenue).to.be.true;
+      expect(bids[0].ad).to.equal('<div>Ad creative</div>');
+      expect(bids[0].meta.advertiserDomains).to.include('advertiser.com');
+    });
+
+    it('should return empty array for empty response', function () {
+      const emptyResponse = { body: {} };
+      const bids = spec.interpretResponse(emptyResponse, request);
+
+      expect(bids).to.be.an('array').that.is.empty;
+    });
+
+    it('should return empty array for no seatbid', function () {
+      const noSeatbidResponse = { body: { id: 'test', seatbid: [] } };
+      const bids = spec.interpretResponse(noSeatbidResponse, request);
+
+      expect(bids).to.be.an('array').that.is.empty;
+    });
+
+    it('should include nurl in bid response', function () {
+      const bids = spec.interpretResponse(serverResponse, request);
+
+      expect(bids[0].nurl).to.include('panxo-sys.com/win');
+    });
+  });
+
+  describe('getUserSyncs', function () {
+    it('should return pixel sync when enabled', function () {
+      const syncOptions = { pixelEnabled: true };
+      const syncs = spec.getUserSyncs(syncOptions);
+
+      expect(syncs).to.have.lengthOf(1);
+      expect(syncs[0].type).to.equal('image');
+      expect(syncs[0].url).to.include('panxo-sys.com/usersync');
+    });
+
+    it('should return empty array when pixel sync disabled', function () {
+      const syncOptions = { pixelEnabled: false };
+      const syncs = spec.getUserSyncs(syncOptions);
+
+      expect(syncs).to.be.an('array').that.is.empty;
+    });
+
+    it('should include GDPR params when gdprApplies is true', function () {
+      const syncOptions = { pixelEnabled: true };
+      const gdprConsent = { gdprApplies: true, consentString: 'test-consent' };
+      const syncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
+
+      expect(syncs[0].url).to.include('gdpr=1');
+      expect(syncs[0].url).to.include('gdpr_consent=test-consent');
+    });
+
+    it('should not include gdpr flag when gdprApplies is undefined', function () {
+      const syncOptions = { pixelEnabled: true };
+      const gdprConsent = { gdprApplies: undefined, consentString: 'test-consent' };
+      const syncs = spec.getUserSyncs(syncOptions, [], gdprConsent);
+
+      expect(syncs[0].url).to.not.include('gdpr=');
+      expect(syncs[0].url).to.include('gdpr_consent=test-consent');
+    });
+
+    it('should include USP params when available', function () {
+      const syncOptions = { pixelEnabled: true };
+      const uspConsent = '1YNN';
+      const syncs = spec.getUserSyncs(syncOptions, [], null, uspConsent);
+
+      expect(syncs[0].url).to.include('us_privacy=1YNN');
+    });
+  });
+
+  describe('onBidWon', function () {
+    it('should fire win notification pixel', function () {
+      const bid = {
+        nurl: 'https://panxo-sys.com/win?price=${AUCTION_PRICE}',
+        cpm: 2.50
+      };
+
+      // Mock document.createElement
+      const imgStub = { src: '', style: {} };
+      const createElementStub = sinon.stub(document, 'createElement').returns(imgStub);
+      const appendChildStub = sinon.stub(document.body, 'appendChild');
+
+      spec.onBidWon(bid);
+
+      expect(imgStub.src).to.include('price=2.5');
+
+      createElementStub.restore();
+      appendChildStub.restore();
+    });
+  });
+
+  describe('spec properties', function () {
+    it('should have correct bidder code', function () {
+      expect(spec.code).to.equal('panxo');
+    });
+
+    it('should support banner media type', function () {
+      expect(spec.supportedMediaTypes).to.include(BANNER);
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [x] New Bidder Adapter

## Description of change
This adapter enables publishers to monetize AI-referred traffic (from ChatGPT, Perplexity, Claude, Gemini, etc.) through Prebid.js header bidding.

## Adapter Details
- **Bidder code**: `panxo`
- **GVL ID**: 1527
- **Media types**: Banner
- **Bid endpoint**: `https://panxo-sys.com/openrtb/2.5/bid`

## Features
- GDPR/TCF 2.0 support (GVL ID: 1527)
- CCPA/US Privacy support
- GPP support
- COPPA compliance
- Supply Chain (schain) support
- First Party Data (ortb2) support
- Prebid Price Floors Module support
- Pixel-based user sync

## Prerequisites
This adapter requires the Panxo Signal script to be installed on the publisher's page before Prebid.js loads.

## Configuration Example
```javascript
{
    bidder: 'panxo',
    params: {
        propertyKey: 'your-property-key'
    }
}
```

## Testing
- Unit tests included in `test/spec/modules/panxoBidAdapter_spec.js`
- All tests passing locally

## Contact
- **Maintainer**: tech@panxo.ai
- **Website**: https://panxo.ai
- **Documentation**: https://docs.panxo.ai