### PR TITLE
realTimeData: fix bug where setting circular references in FPD causes activity checks to get stuck in an infinite loop

### DIFF
--- a/libraries/objectGuard/objectGuard.js
+++ b/libraries/objectGuard/objectGuard.js
@@ -162,7 +162,10 @@ export function objectGuard(rules) {
       if (visited.has(obj)) return obj;
       visited.add(obj);
       Object.keys(obj).forEach(k => {
-        obj[k] = deref(obj[k], visited);
+        const sub = deref(obj[k], visited);
+        if (sub !== obj[k]) {
+          obj[k] = sub;
+        }
       })
       return obj;
     }

--- a/test/spec/activities/objectGuard_spec.js
+++ b/test/spec/activities/objectGuard_spec.js
@@ -155,8 +155,18 @@ describe('objectGuard', () => {
         prop: {
           val: 'foo'
         }
-      })
+      });
+    });
 
+    it('should not choke on immutable objects', () => {
+      const obj = {};
+      const guard = objectGuard([rule])(obj);
+      guard.prop = Object.freeze({val: 'foo'});
+      expect(obj).to.eql({
+        prop: {
+          val: 'foo'
+        }
+      })
     })
 
     it('should reject conflicting rules', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Related to https://github.com/prebid/Prebid.js/pull/14171: if an RTD module sets an FPD containing circular references, objectGuard can get stuck in an infinite recursion loop.
