### PR TITLE
ADBRO Bid Adapter: backport to 9.53.x-legacy Branch

### DIFF
--- a/modules/adbroBidAdapter.js
+++ b/modules/adbroBidAdapter.js
@@ -26,6 +26,7 @@ const converter = ortbConverter({
   request(buildRequest, imps, bidderRequest, context) {
     const request = buildRequest(imps, bidderRequest, context);
 
+    request.device ||= {};
     request.device.js = 1;
 
     return request;

--- a/test/spec/modules/adbroBidAdapter_spec.js
+++ b/test/spec/modules/adbroBidAdapter_spec.js
@@ -105,6 +105,18 @@ describe('adbroBidAdapter', function () {
     });
   });
 
+  describe('buildRequests without device', function () {
+    let serverRequests = spec.buildRequests([validBid], {refererInfo: {page: 'https://test.com'}});
+
+    it('Should not fail when device is undefined', function () {
+      const serverRequest = serverRequests[0];
+      expect(serverRequest).to.exist;
+      expect(serverRequest).to.have.property('data').that.is.an('object');
+      expect(serverRequest.data).to.have.property('device').that.is.an('object');
+      expect(serverRequest.data.device).to.have.property('js', 1);
+    });
+  });
+
   describe('interpretResponse', function () {
     it('Should interpret banner response', function () {
       const responseBid = {


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change

The entire ADBRO Bid Adapter is being backported from master branch to 9.53.x-legacy

