### PR TITLE
Readpeak bid adapter: Replace global.navigator with window.navigator

### DIFF
--- a/modules/readpeakBidAdapter.js
+++ b/modules/readpeakBidAdapter.js
@@ -294,12 +294,12 @@ function app(bidderRequest) {
 }
 
 function isMobile() {
-  return /(ios|ipod|ipad|iphone|android)/i.test(global.navigator.userAgent);
+  return /(ios|ipod|ipad|iphone|android)/i.test(window.navigator.userAgent);
 }
 
 function isConnectedTV() {
   return /(smart[-]?tv|hbbtv|appletv|googletv|hdmi|netcast\.tv|viera|nettv|roku|\bdtv\b|sonydtv|inettvbrowser|\btv\b)/i.test(
-    global.navigator.userAgent
+    window.navigator.userAgent
   );
 }
 


### PR DESCRIPTION
This throws exception since upgrading to Prebid 10+ (most likely has todo with different bundling story)
No other module is using global.navigator all references goes to window.navigator

## Type of change
- [x] Bugfix

## Description of change
Replacing the global (nodejs) notation, browsers has no variable global
