### PR TITLE
Rubicon Bid Adapter: new rubicon apex url

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -30,7 +30,7 @@ import {getUserSyncParams} from '../libraries/userSyncUtils/userSyncUtils.js';
 
 const DEFAULT_INTEGRATION = 'pbjs_lite';
 const DEFAULT_PBS_INTEGRATION = 'pbjs';
-const DEFAULT_RENDERER_URL = 'https://video-outstream.rubiconproject.com/apex-2.2.1.js';
+const DEFAULT_RENDERER_URL = 'https://video-outstream.rubiconproject.com/apex-2.3.7.js';
 // renderer code at https://github.com/rubicon-project/apex2
 
 let rubiConf = config.getConfig('rubicon') || {};


### PR DESCRIPTION
 ## Type of change
- [X] Bugfix

## Description of change
Bump up the default APEX Renderer url for rubicon
- Fixed handling of ad unit elements with circular references in Magnite bid renderer

Publishers can update their renderer to this version via setConfig without upgrading to the latest prebid version.

We recommend doing so if you have outstream spend flowing through the rubiconBidAdapter!

```js
pbjs.setConfig({
  rubicon: {
    rendererUrl: 'https://video-outstream.rubiconproject.com/apex-2.3.7.js'
  }
});
```