### PR TITLE
gam video module: Include us_privacy based on gpp when downloading VAST for the IMA player

### DIFF
--- a/modules/gamAdServerVideo.js
+++ b/modules/gamAdServerVideo.js
@@ -353,11 +353,11 @@ function retrieveUspInfoFromGpp(gpp) {
       let saleOptOutNotice;
       Object.values(parsedSections).forEach(parsedSection => {
         (Array.isArray(parsedSection) ? parsedSection : [parsedSection]).forEach(ps => {
-          if (saleOptOut === undefined) {
-            saleOptOut = ps.SaleOptOut;
-          }
-          if (saleOptOutNotice === undefined) {
-            saleOptOutNotice = ps.SaleOptOutNotice;
+          const sectionSaleOptOut = ps.SaleOptOut;
+          const sectionSaleOptOutNotice = ps.SaleOptOutNotice;
+          if (saleOptOut === undefined && saleOptOutNotice === undefined && sectionSaleOptOut != null && sectionSaleOptOutNotice != null) {
+            saleOptOut = sectionSaleOptOut;
+            saleOptOutNotice = sectionSaleOptOutNotice;
           }
         });
       });

--- a/test/spec/modules/gamAdServerVideo_spec.js
+++ b/test/spec/modules/gamAdServerVideo_spec.js
@@ -1033,6 +1033,104 @@ describe('The DFP video support module', function () {
       const usPrivacyFromRequest = await obtainUsPrivacyInVastXmlRequest();
       expect(usPrivacyFromRequest).to.equal('1YNY');
     })
+    it('no us_privacy when either SaleOptOutNotice or SaleOptOut is missing', async () => {
+      // Missing SaleOptOutNotice
+      mockGpp(wrapParsedSectionsIntoGPPData({
+        "usnat": {
+          "Version": 1,
+          "SharingNotice": 2,
+          "SharingOptOutNotice": 0,
+          "TargetedAdvertisingOptOutNotice": 2,
+          "SensitiveDataProcessingOptOutNotice": 1,
+          "SensitiveDataLimitUseNotice": 1,
+          "SaleOptOut": 1,
+          "SharingOptOut": 2,
+          "TargetedAdvertisingOptOut": 2,
+          "SensitiveDataProcessing": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          "KnownChildSensitiveDataConsents": [
+            0,
+            0,
+            0
+          ],
+          "PersonalDataConsents": 0,
+          "MspaCoveredTransaction": 1,
+          "MspaOptOutOptionMode": 0,
+          "MspaServiceProviderMode": 0,
+          "GpcSegmentType": 1,
+          "Gpc": false
+        }
+      }));
+
+      const usPrivacyFromRequest = await obtainUsPrivacyInVastXmlRequest();
+      expect(usPrivacyFromRequest).to.be.null;
+    })
+    it('no us_privacy when either SaleOptOutNotice or SaleOptOut is null', async () => {
+      // null SaleOptOut
+      mockGpp(wrapParsedSectionsIntoGPPData({
+        "usnat": {
+          "Version": 1,
+          "SharingNotice": 2,
+          "SaleOptOutNotice": 1,
+          "SharingOptOutNotice": 0,
+          "TargetedAdvertisingOptOutNotice": 2,
+          "SensitiveDataProcessingOptOutNotice": 1,
+          "SensitiveDataLimitUseNotice": 1,
+          "SaleOptOut": null,
+          "SharingOptOut": 2,
+          "TargetedAdvertisingOptOut": 2,
+          "SensitiveDataProcessing": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          "KnownChildSensitiveDataConsents": [
+            0,
+            0,
+            0
+          ],
+          "PersonalDataConsents": 0,
+          "MspaCoveredTransaction": 1,
+          "MspaOptOutOptionMode": 0,
+          "MspaServiceProviderMode": 0,
+          "GpcSegmentType": 1,
+          "Gpc": false
+        }
+      }));
+
+      const usPrivacyFromRequest = await obtainUsPrivacyInVastXmlRequest();
+      expect(usPrivacyFromRequest).to.be.null;
+    })
+
     it('can retrieve from usca section in gpp', async () => {
       mockGpp(wrapParsedSectionsIntoGPPData({
         "usca": {


### PR DESCRIPTION
IMA player has no support for GPP, but does support uspapi. If you happen to use a CMP which only exposes `gpp` but not `usp`, the `us_privacy` VAST param wouldn't be included in the request to GAM when downloading a VAST document.

When on `window`, there is only `__gpp`, we can still pass a US Privacy string by deriving the string from the `__gpp` data.

Note: I haven't experimented yet whether this actually increases revenue.

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
