### PR TITLE
Core: remove type declaration for `getStatusCode`

### DIFF
--- a/src/bidfactory.ts
+++ b/src/bidfactory.ts
@@ -135,7 +135,6 @@ export interface BaseBid extends ContextIdentifiers, Required<Pick<BaseBidRespon
   height: number;
   adId: Identifier;
   getSize(): string;
-  getStatusCode(): number;
   status?: (typeof BID_STATUS)[keyof typeof BID_STATUS]
   bidderCode: BidderCode;
   adapterCode?: BidderCode;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Bid's `getStatusCode` method was removed as useless in 10: https://github.com/prebid/Prebid.js/pull/13086

~~However, GPT will sometimes expect to find it and cause problems otherwise (I believe this is related to header bidding manager - uncovered by @robertrmartinez 's testing)~~

GPT no longer depends on `.getStatusCode` (see discussion below) - this PR now removes the stray type declaration for it

