### PR TITLE
missenaBidAdapter - Add GPP consent support to user sync URL

### DIFF
--- a/modules/missenaBidAdapter.js
+++ b/modules/missenaBidAdapter.js
@@ -157,6 +157,7 @@ export const spec = {
     serverResponses,
     gdprConsent = {},
     uspConsent,
+    gppConsent,
   ) {
     if (!syncOptions.iframeEnabled || !this.msnaApiKey) {
       return [];
@@ -171,6 +172,13 @@ export const spec = {
     }
     if (uspConsent) {
       url.searchParams.append('us_privacy', uspConsent);
+    }
+    if (gppConsent?.gppString) {
+      url.searchParams.append('gpp', gppConsent.gppString);
+      url.searchParams.append(
+        'gpp_sid',
+        (gppConsent.applicableSections || []).join(','),
+      );
     }
 
     return [{ type: 'iframe', url: url.href }];

--- a/test/spec/modules/missenaBidAdapter_spec.js
+++ b/test/spec/modules/missenaBidAdapter_spec.js
@@ -367,5 +367,69 @@ describe('Missena Adapter', function () {
       expect(userSync[0].type).to.be.equal('iframe');
       expect(userSync[0].url).to.be.equal(expectedUrl);
     });
+
+    it('sync frame url should contain gpp data when present', function () {
+      const gppConsent = {
+        gppString: 'DBACNYA~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA',
+        applicableSections: [7, 8],
+      };
+      const userSync = spec.getUserSyncs(
+        iframeEnabledOptions,
+        [],
+        {},
+        undefined,
+        gppConsent,
+      );
+      expect(userSync.length).to.be.equal(1);
+      expect(userSync[0].type).to.be.equal('iframe');
+      const syncUrl = new URL(userSync[0].url);
+      expect(syncUrl.searchParams.get('gpp')).to.equal(gppConsent.gppString);
+      expect(syncUrl.searchParams.get('gpp_sid')).to.equal('7,8');
+    });
+
+    it('sync frame url should not contain gpp data when gppConsent is undefined', function () {
+      const userSync = spec.getUserSyncs(
+        iframeEnabledOptions,
+        [],
+        {},
+        undefined,
+        undefined,
+      );
+      expect(userSync.length).to.be.equal(1);
+      expect(userSync[0].url).to.not.contain('gpp');
+    });
+
+    it('sync frame url should not contain gpp data when gppString is empty', function () {
+      const userSync = spec.getUserSyncs(
+        iframeEnabledOptions,
+        [],
+        {},
+        undefined,
+        { gppString: '', applicableSections: [7] },
+      );
+      expect(userSync.length).to.be.equal(1);
+      expect(userSync[0].url).to.not.contain('gpp');
+    });
+
+    it('sync frame url should contain all consent params together', function () {
+      const gppConsent = {
+        gppString: 'DBACNYA~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA',
+        applicableSections: [7],
+      };
+      const userSync = spec.getUserSyncs(
+        iframeEnabledOptions,
+        [],
+        { gdprApplies: true, consentString },
+        '1YNN',
+        gppConsent,
+      );
+      expect(userSync.length).to.be.equal(1);
+      const syncUrl = new URL(userSync[0].url);
+      expect(syncUrl.searchParams.get('gdpr')).to.equal('1');
+      expect(syncUrl.searchParams.get('gdpr_consent')).to.equal(consentString);
+      expect(syncUrl.searchParams.get('us_privacy')).to.equal('1YNN');
+      expect(syncUrl.searchParams.get('gpp')).to.equal(gppConsent.gppString);
+      expect(syncUrl.searchParams.get('gpp_sid')).to.equal('7');
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit.

Please make sure any added or changed code includes tests with greater than 80% code coverage.

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter
- [x] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Add GPP (Global Privacy Platform) consent support to the Missena bid adapter's `getUserSyncs` method.

### Changes

- Accept `gppConsent` as the 5th parameter of `getUserSyncs` (passed by the `consentManagementGpp` module)
- When `gppConsent.gppString` is present, append `gpp` and `gpp_sid` (comma-joined `applicableSections`) to the user sync iframe URL
- Existing `gdpr`, `gdpr_consent`, and `us_privacy` parameters are unaffected

### Tests

4 new unit tests added covering:
- GPP data present with multiple applicable sections
- `gppConsent` undefined (no GPP params added)
- Empty `gppString` (no GPP params added)
- All consent params together (GDPR + USP + GPP coexistence)

### Lint & test results

```
✔ 38 tests completed
✖ 0 tests failed
```

## Other information

- A follow-up PR will be submitted to [prebid.github.io](https://github.com/prebid/prebid.github.io) to add `gpp_sids: tcfeu, tcfca, usnat, usstate_all, usp` to `dev-docs/bidders/missena.md`
- References: [Prebid consentManagementGpp module](https://docs.prebid.org/dev-docs/modules/consentManagementGpp.html)