### PR TITLE
33acrossId System: stabilize missing supplemental ID storage tests

### DIFF
--- a/test/spec/modules/33acrossIdSystem_spec.js
+++ b/test/spec/modules/33acrossIdSystem_spec.js
@@ -260,6 +260,7 @@ describe('33acrossIdSystem', () => {
 
             const removeDataFromLocalStorage = sinon.stub(storage, 'removeDataFromLocalStorage');
             const setCookie = sinon.stub(storage, 'setCookie');
+            const cookiesAreEnabled = sinon.stub(storage, 'cookiesAreEnabled').returns(true);
             sinon.stub(domainUtils, 'domainOverride').returns('foo.com');
 
             request.respond(200, {
@@ -277,6 +278,7 @@ describe('33acrossIdSystem', () => {
 
             removeDataFromLocalStorage.restore();
             setCookie.restore();
+            cookiesAreEnabled.restore();
             domainUtils.domainOverride.restore();
           });
         });
@@ -419,6 +421,7 @@ describe('33acrossIdSystem', () => {
 
             const removeDataFromLocalStorage = sinon.stub(storage, 'removeDataFromLocalStorage');
             const setCookie = sinon.stub(storage, 'setCookie');
+            const cookiesAreEnabled = sinon.stub(storage, 'cookiesAreEnabled').returns(true);
             sinon.stub(domainUtils, 'domainOverride').returns('foo.com');
 
             request.respond(200, {
@@ -436,6 +439,7 @@ describe('33acrossIdSystem', () => {
 
             removeDataFromLocalStorage.restore();
             setCookie.restore();
+            cookiesAreEnabled.restore();
             domainUtils.domainOverride.restore();
           });
         });


### PR DESCRIPTION
### Motivation
- Two unit tests that assert cookie deletion when the Lexicon response omits `fp`/`tp` were flaky because `storage.cookiesAreEnabled()` can differ across browser environments, causing intermittent failures.

eg at https://github.com/prebid/Prebid.js/actions/runs/21871398640/job/63127760756

### Description
- Made the cookie-availability check deterministic in the failing tests by stubbing `storage.cookiesAreEnabled()` to return `true` in the first-party and third-party supplemental ID wipe test cases in `test/spec/modules/33acrossIdSystem_spec.js`.
- Restored the stubbed methods after each test to avoid test pollution.
- This is a test-only change; no production code was modified.

### Testing
- Ran lint on the test file with `npx eslint --cache --cache-strategy content test/spec/modules/33acrossIdSystem_spec.js` and it passed. ✅
- Ran the unit test for the file with `npx gulp test --nolint --file test/spec/modules/33acrossIdSystem_spec.js` and the test chunk passed. ✅
- Ran `npx gulp lint --files test/spec/modules/33acrossIdSystem_spec.js` and it completed successfully. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698b531041e4832ba9fe13fd052043a6)