### PR TITLE
Core: update storage disclosure for prebid.storage

### DIFF
--- a/metadata/core.json
+++ b/metadata/core.json
@@ -13,6 +13,12 @@
     },
     {
       "componentType": "prebid",
+      "componentName": "storage",
+      "moduleName": "prebid-core",
+      "disclosureURL": "local://prebid/probes.json"
+    },
+    {
+      "componentType": "prebid",
       "componentName": "debugging",
       "moduleName": "prebid-core",
       "disclosureURL": "local://prebid/debugging.json"

--- a/metadata/disclosures/prebid/probes.json
+++ b/metadata/disclosures/prebid/probes.json
@@ -22,7 +22,7 @@
   "domains": [
     {
       "domain": "*",
-      "use": "Temporary 'probing' cookies are written (and deleted) to determine the top-level domain; likewise, probes are temporarily written to local and sessionStorage to determine their availability"
+      "use": "Temporary 'probing' cookies are written (and deleted) to determine the top-level domain and availability of cookies; likewise, probes are temporarily written to local and sessionStorage to determine their availability"
     }
   ]
 }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

With #14125, core uses storage identifying as the component 'prebid.storage', which is not one of the disclosed components.


