### PR TITLE
Prebid 11: remove bidAccepted event emission

### DIFF
--- a/modules/rtdModule/index.ts
+++ b/modules/rtdModule/index.ts
@@ -53,8 +53,7 @@ const setEventsListeners = (function () {
         [EVENTS.AUCTION_INIT]: ['onAuctionInitEvent'],
         [EVENTS.AUCTION_END]: ['onAuctionEndEvent', getAdUnitTargeting],
         [EVENTS.BID_RESPONSE]: ['onBidResponseEvent'],
-        [EVENTS.BID_REQUESTED]: ['onBidRequestEvent'],
-        [EVENTS.BID_ACCEPTED]: ['onBidAcceptedEvent']
+        [EVENTS.BID_REQUESTED]: ['onBidRequestEvent']
       }).forEach(([ev, [handler, preprocess]]) => {
         events.on(ev as any, (args) => {
           preprocess && (preprocess as any)(args);

--- a/modules/rtdModule/spec.ts
+++ b/modules/rtdModule/spec.ts
@@ -32,8 +32,7 @@ export type RTDProviderConfig<P extends RTDProvider> = BaseConfig<P> & (
 type RTDEvent = typeof EVENTS.AUCTION_INIT |
     typeof EVENTS.AUCTION_END |
     typeof EVENTS.BID_RESPONSE |
-    typeof EVENTS.BID_REQUESTED |
-    typeof EVENTS.BID_ACCEPTED;
+    typeof EVENTS.BID_REQUESTED;
 
 type EventHandlers<P extends RTDProvider> = {
   [EV in RTDEvent]: (payload: EventPayload<EV>, config: RTDProviderConfig<P>, consent: AllConsentData) => void;

--- a/src/auction.ts
+++ b/src/auction.ts
@@ -101,10 +101,6 @@ declare module './events' {
      */
     [EVENTS.BID_TIMEOUT]: [BidRequest<BidderCode>[]];
     /**
-     * Fired when a bid is received.
-     */
-    [EVENTS.BID_ACCEPTED]: [Partial<Bid>];
-    /**
      * Fired when a bid is rejected.
      */
     [EVENTS.BID_REJECTED]: [Partial<Bid>];
@@ -530,7 +526,6 @@ export function auctionCallbacks(auctionDone, auctionInstance, {index = auctionM
   function acceptBidResponse(adUnitCode: string, bid: Partial<Bid>) {
     handleBidResponse(adUnitCode, bid, (done) => {
       const bidResponse = getPreparedBidForAuction(bid);
-      events.emit(EVENTS.BID_ACCEPTED, bidResponse);
       if ((FEATURES.VIDEO && bidResponse.mediaType === VIDEO) || (FEATURES.AUDIO && bidResponse.mediaType === AUDIO)) {
         tryAddVideoAudioBid(auctionInstance, bidResponse, done);
       } else {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,7 +42,6 @@ export const EVENTS = {
   STALE_RENDER: 'staleRender',
   EXPIRED_RENDER: 'expiredRender',
   BILLABLE_EVENT: 'billableEvent',
-  BID_ACCEPTED: 'bidAccepted',
   PBS_ANALYTICS: 'pbsAnalytics',
   BEFORE_PBS_HTTP: 'beforePBSHttp',
   BROWSI_INIT: 'browsiInit',

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -3242,14 +3242,6 @@ describe('Unit: Prebid Module', function () {
       assert.ok(spyEventsOn.calledWith('bidWon', Function));
       events.on.restore();
     });
-
-    it('should emit event BID_ACCEPTED when invoked', function () {
-      var callback = sinon.spy();
-      pbjs.onEvent('bidAccepted', callback);
-      events.emit(EVENTS.BID_ACCEPTED);
-      sinon.assert.calledOnce(callback);
-    });
-
     describe('beforeRequestBids', function () {
       let bidRequestedHandler;
       let beforeRequestBidsHandler;


### PR DESCRIPTION
### Motivation
- Remove the legacy `bidAccepted` event from core because it is redundant with the existing bid lifecycle and leaks an extra event name into the public events API. 
- Prevent RTD submodules and users from relying on an event that is no longer needed and simplify event surface area.

### Description
- Deleted `BID_ACCEPTED` from the global `EVENTS` map so `bidAccepted` is no longer a supported event name (`src/constants.ts`).
- Removed the `BID_ACCEPTED` event typing from auction event declarations and removed the runtime `events.emit(EVENTS.BID_ACCEPTED, ...)` call in the bid acceptance path (`src/auction.ts`).
- Stopped wiring RTD providers to `onBidAcceptedEvent` and adjusted RTD typings so providers no longer receive `BID_ACCEPTED` (`modules/rtdModule/index.ts`, `modules/rtdModule/spec.ts`).
- Removed the unit test that asserted `bidAccepted` callback behavior from `pbjs_api_spec.js` (`test/spec/unit/pbjs_api_spec.js`).

### Testing
- Ran targeted linting: `gulp lint --files src/constants.ts,src/auction.ts,modules/rtdModule/index.ts,modules/rtdModule/spec.ts,test/spec/unit/pbjs_api_spec.js` and it completed successfully. ✅
- Ran the affected unit spec: `gulp test --nolint --file test/spec/unit/pbjs_api_spec.js` and the test chunk completed successfully (all tests passed). ✅
- Ran a local `npx eslint --cache --cache-strategy content` on the changed files and webpack/karma test execution for the spec bundle completed without failures. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ba8d6872c832b9e4bf709d8509245)

part of https://github.com/prebid/Prebid.js/issues/13042