### PR TITLE
33across Adapter: stabilize getId storage cleanup tests

### DIFF
--- a/test/spec/modules/33acrossIdSystem_spec.js
+++ b/test/spec/modules/33acrossIdSystem_spec.js
@@ -21,6 +21,10 @@ describe('33acrossIdSystem', () => {
   });
 
   describe('getId', () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
     it('should call endpoint', () => {
       const completeCallback = sinon.spy();
 
@@ -96,6 +100,7 @@ describe('33acrossIdSystem', () => {
 
         const removeDataFromLocalStorage = sinon.stub(storage, 'removeDataFromLocalStorage');
         const setCookie = sinon.stub(storage, 'setCookie');
+        sinon.stub(storage, 'cookiesAreEnabled').returns(true);
         sinon.stub(domainUtils, 'domainOverride').returns('foo.com');
 
         request.respond(200, {
@@ -110,10 +115,6 @@ describe('33acrossIdSystem', () => {
 
         expect(removeDataFromLocalStorage.calledWithExactly('33acrossIdHm')).to.be.false;
         expect(setCookie.calledWithExactly('33acrossIdHm', '', sinon.match.string, 'Lax', 'foo.com')).to.be.false;
-
-        removeDataFromLocalStorage.restore();
-        setCookie.restore();
-        domainUtils.domainOverride.restore();
       });
     });
 
@@ -614,6 +615,7 @@ describe('33acrossIdSystem', () => {
 
         const removeDataFromLocalStorage = sinon.stub(storage, 'removeDataFromLocalStorage');
         const setCookie = sinon.stub(storage, 'setCookie');
+        sinon.stub(storage, 'cookiesAreEnabled').returns(true);
         sinon.stub(domainUtils, 'domainOverride').returns('foo.com');
 
         request.respond(200, {
@@ -630,10 +632,6 @@ describe('33acrossIdSystem', () => {
           expect(removeDataFromLocalStorage.calledWith(`33acrossId${suffix}`)).to.be.true;
           expect(setCookie.calledWithExactly(`33acrossId${suffix}`, '', sinon.match.string, 'Lax', 'foo.com')).to.be.true;
         });
-
-        removeDataFromLocalStorage.restore();
-        setCookie.restore();
-        domainUtils.domainOverride.restore();
       });
     });
 


### PR DESCRIPTION
### Motivation
- Fix intermittent test failures caused by leaked Sinon stubs/wrappers and missing cookie-enabled guard in storage-wipe assertions.

### Description
- Add a `describe('getId')`-level `afterEach(() => sinon.restore())` to ensure all stubs/spies are cleaned up between tests and prevent duplicate-wrap errors.
- Stub `storage.cookiesAreEnabled()` in the envelope-absent and hashed-email wipe tests so cookie-deletion assertions follow the module's `deleteFromStorage()` guard and are deterministic.
- Remove redundant per-test manual `restore()` calls in the updated tests to rely on centralized cleanup (test file: `test/spec/modules/33acrossIdSystem_spec.js`).

### Testing
- Ran linter for the modified spec: `npx eslint --cache --cache-strategy content test/spec/modules/33acrossIdSystem_spec.js` — passed.
- Ran the spec tests: `npx gulp test --nolint --file test/spec/modules/33acrossIdSystem_spec.js` — passed (all tests in that file succeeded).
- Ran full lint task: `npx gulp lint` — passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698cb21b5234832b9cc2dadaab73bc68)