### PR TITLE
ShinezRtb Adapter: stabilize unique deal id spec timing

### DIFF
--- a/test/spec/modules/shinezRtbBidAdapter_spec.js
+++ b/test/spec/modules/shinezRtbBidAdapter_spec.js
@@ -692,12 +692,13 @@ describe('ShinezRtbBidAdapter', function () {
     after(function () {
       getGlobal().bidderSettings = {};
     });
-    const key = 'myKey';
+    let key;
     let uniqueDealId;
     beforeEach(() => {
       clock = useFakeTimers({
         now: Date.now()
       });
+      key = `myKey_${Date.now()}`;
       uniqueDealId = getUniqueDealId(storage, key, 0);
     });
 


### PR DESCRIPTION
### Motivation
- The `unique deal id` unit test was flaky because a fixed storage key could retain state across runs, causing timestamp-mismatch assertions when `getUniqueDealId` returned a previously-stored id.

### Description
- Use a per-test storage key by replacing `const key = 'myKey'` with a `let key` and assigning `key = `myKey_${Date.now()}`` in `beforeEach` in `test/spec/modules/shinezRtbBidAdapter_spec.js` so each spec run isolates localStorage state while keeping test intent unchanged.

### Testing
- Ran `npx eslint --cache --cache-strategy content`, `npx eslint test/spec/modules/shinezRtbBidAdapter_spec.js --cache --cache-strategy content`, and `npx gulp test --nolint --file test/spec/modules/shinezRtbBidAdapter_spec.js`, and the test bundle completed successfully (`42 tests completed`) with build-logic checks passing (`4 passing`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698cbfdcca5c832bb3f3ab3184bbc9cd)