### PR TITLE
storage control strict: remove null callback placeholders from storage manager reads/writes

### DIFF
--- a/libraries/vidazooUtils/bidderUtils.js
+++ b/libraries/vidazooUtils/bidderUtils.js
@@ -64,7 +64,7 @@ export function setStorageItem(storage, key, value, timestamp) {
 
 export function getStorageItem(storage, key) {
   try {
-    return tryParseJSON(storage.getDataFromLocalStorage(key, null));
+    return tryParseJSON(storage.getDataFromLocalStorage(key));
   } catch (e) {
   }
 
@@ -72,10 +72,10 @@ export function getStorageItem(storage, key) {
 }
 
 export function getCacheOpt(storage, useKey) {
-  let data = storage.getDataFromLocalStorage(useKey, null);
+  let data = storage.getDataFromLocalStorage(useKey);
   if (!data) {
     data = String(Date.now());
-    storage.setDataInLocalStorage(useKey, data, null);
+    storage.setDataInLocalStorage(useKey, data);
   }
 
   return data;

--- a/modules/sirdataRtdProvider.js
+++ b/modules/sirdataRtdProvider.js
@@ -107,7 +107,7 @@ export function setCookieOnTopDomain(key, value, hostname, deleteCookie) {
     try {
       STORAGE.setCookie(key, value, expTime.toUTCString(), 'Lax', '.' + domain);
       // Try to read the cookie to check if we wrote it
-      if (STORAGE.getCookie(key, null) === value) return true; // Check if the cookie was set, and if so top domain was found. If deletion with expire date -1 will parse until complete host
+      if (STORAGE.getCookie(key) === value) return true; // Check if the cookie was set, and if so top domain was found. If deletion with expire date -1 will parse until complete host
     } catch (e) {
       logError(LOG_PREFIX, e);
     }
@@ -120,10 +120,10 @@ export function setCookieOnTopDomain(key, value, hostname, deleteCookie) {
  * @returns {Array|null} - Array of UID objects or null if no UID found
  */
 export function getUidFromStorage() {
-  let cUid = STORAGE.getCookie(EUIDS_STORAGE_NAME, null);
-  const lsUid = STORAGE.getDataFromLocalStorage(EUIDS_STORAGE_NAME, null);
+  let cUid = STORAGE.getCookie(EUIDS_STORAGE_NAME);
+  const lsUid = STORAGE.getDataFromLocalStorage(EUIDS_STORAGE_NAME);
   if (cUid && (!lsUid || cUid !== lsUid)) {
-    STORAGE.setDataInLocalStorage(EUIDS_STORAGE_NAME, cUid, null);
+    STORAGE.setDataInLocalStorage(EUIDS_STORAGE_NAME, cUid);
   } else if (lsUid && !cUid) {
     setCookieOnTopDomain(EUIDS_STORAGE_NAME, lsUid, cookieDomain, false);
     cUid = lsUid;
@@ -140,7 +140,7 @@ export function setUidInStorage(sddanId) {
   if (!sddanId) return false;
   sddanId = encodeURI(sddanId.toString());
   setCookieOnTopDomain(EUIDS_STORAGE_NAME, sddanId, cookieDomain, false);
-  STORAGE.setDataInLocalStorage(EUIDS_STORAGE_NAME, sddanId, null);
+  STORAGE.setDataInLocalStorage(EUIDS_STORAGE_NAME, sddanId);
   return true;
 }
 


### PR DESCRIPTION
### Motivation

- Tests reported storage reads returning `null` and destructuring failures when a `null` callback placeholder was passed to `StorageManager` read APIs, so synchronous usage paths need to call the storage APIs without trailing `null` arguments.

### Description

- Updated `getStorageItem` and `getCacheOpt` in `libraries/vidazooUtils/bidderUtils.js` to call `storage.getDataFromLocalStorage(key)` / `storage.setDataInLocalStorage(useKey, data)` without the trailing `null` callback placeholder.
- Updated cookie/localStorage flows in `modules/sirdataRtdProvider.js` to call `STORAGE.getCookie`, `STORAGE.getDataFromLocalStorage`, and `STORAGE.setDataInLocalStorage` without passing `null`, and adjusted the cookie-read check in `setCookieOnTopDomain` accordingly.
- The changes normalize synchronous storage reads/writes so helper functions return expected values in unit-test environments.

### Testing

- Ran linter on modified files with `npx eslint --cache --cache-strategy content libraries/vidazooUtils/bidderUtils.js modules/sirdataRtdProvider.js` and it succeeded.
- Ran affected unit specs with `npx gulp test --nolint --file test/spec/modules/programmaticXBidAdapter_spec.js --file test/spec/modules/sirdataRtdProvider_spec.js` and the test run completed successfully (all tests in those specs passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698cbfe7a5b8832b837a1222f2f28233)