### PR TITLE
OpenX Adapter: restore getDNT usage for DNT compatibility

### DIFF
--- a/libraries/dnt/index.js
+++ b/libraries/dnt/index.js
@@ -1,0 +1,7 @@
+/**
+ * DNT was deprecated by W3C; Prebid no longer supports DNT signals.
+ * Keep this helper for backwards compatibility with adapters that still invoke getDNT().
+ */
+export function getDNT() {
+  return false;
+}

--- a/modules/mileBidAdapter.ts
+++ b/modules/mileBidAdapter.ts
@@ -2,6 +2,7 @@ import { type BidderSpec, registerBidder } from '../src/adapters/bidderFactory.j
 import { BANNER } from '../src/mediaTypes.js';
 import { deepAccess, deepSetValue, generateUUID, logInfo, logError } from '../src/utils.js';
 import { ajax } from '../src/ajax.js';
+import { getDNT } from '../libraries/dnt/index.js';
 
 /**
  * Mile Bid Adapter
@@ -164,7 +165,7 @@ export const spec: BidderSpec<typeof BIDDER_CODE> = {
       device: {
         ua: navigator.userAgent,
         language: navigator.language?.split('-')[0] || 'en',
-        dnt: 0, // Prebid no longer supports DNT
+        dnt: getDNT() ? 1 : 0,
         w: window.screen?.width,
         h: window.screen?.height,
       },

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -4,6 +4,7 @@ import * as utils from '../src/utils.js';
 import {mergeDeep} from '../src/utils.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
 import {ortbConverter} from '../libraries/ortbConverter/converter.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const bidderConfig = 'hb_pb_ortb';
 const bidderVersion = '2.0';
@@ -61,6 +62,7 @@ const converter = ortbConverter({
     if (bid.params.coppa) {
       utils.deepSetValue(req, 'regs.coppa', 1);
     }
+    utils.deepSetValue(req, 'device.dnt', getDNT() ? 1 : 0);
     if (bid.params.platform) {
       utils.deepSetValue(req, 'ext.platform', bid.params.platform);
     }


### PR DESCRIPTION
### Motivation
- Restore a backward-compatible `getDNT()` helper and reintroduce its usage so adapters that still call `getDNT()` continue to function while DNT remains unsupported.
- Ensure adapters set the `device.dnt` field via the shared compatibility helper instead of removing the field entirely to avoid widespread adapter edits.

### Description
- Add `libraries/dnt/index.js` which exports `getDNT()` and always returns `false` as a compatibility shim.
- Update `modules/mileBidAdapter.ts` to import `getDNT` and set `device.dnt` to `getDNT() ? 1 : 0` in the OpenRTB device object.
- Update `modules/openxBidAdapter.js` to import `getDNT` and set `device.dnt` via `utils.deepSetValue(req, 'device.dnt', getDNT() ? 1 : 0)` during request construction.

### Testing
- Ran lint on the affected files with `npx gulp lint --files modules/openxBidAdapter.js,libraries/dnt/index.js` and it completed successfully.
- Ran the OpenX adapter unit spec with `npx gulp test --nolint --file test/spec/modules/openxBidAdapter_spec.js` and the test suite passed.
- Earlier changes to the Mile adapter were linted and its spec was run with `npx gulp test --nolint --file test/spec/modules/mileBidAdapter_spec.js` and those tests also passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698dfeefbcc0832ba4384015b8e9e2a5)