### PR TITLE
Core: restore getDNT payload mapping across adapters

### DIFF
--- a/libraries/advangUtils/index.js
+++ b/libraries/advangUtils/index.js
@@ -1,5 +1,6 @@
 import { generateUUID, isFn, parseSizesInput, parseUrl } from '../../src/utils.js';
 import { config } from '../../src/config.js';
+import {getDNT} from '../dnt/index.js';
 
 export const DEFAULT_MIMES = ['video/mp4', 'application/javascript'];
 
@@ -140,7 +141,7 @@ export function createRequestData(bid, bidderRequest, isVideo, getBidParam, getS
   const o = {
     'device': {
       'langauge': (global.navigator.language).split('-')[0],
-      'dnt': 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+      'dnt': getDNT() ? 1 : 0,
       'devicetype': isMobile() ? 4 : isConnectedTV() ? 3 : 2,
       'js': 1,
       'os': getOsVersion()
@@ -165,7 +166,7 @@ export function createRequestData(bid, bidderRequest, isVideo, getBidParam, getS
   o.site['ref'] = topReferrer;
   o.site['mobile'] = isMobile() ? 1 : 0;
   const secure = topLocation.protocol.indexOf('https') === 0 ? 1 : 0;
-  o.device['dnt'] = 0; /* DNT deprecated by W3C; Prebid no longer supports DNT */
+  o.device['dnt'] = getDNT() ? 1 : 0;
 
   findAndFillParam(o.site, 'name', function() {
     return global.top.document.title;

--- a/libraries/riseUtils/index.js
+++ b/libraries/riseUtils/index.js
@@ -15,6 +15,7 @@ import {config} from '../../src/config.js';
 import {ADAPTER_VERSION, DEFAULT_CURRENCY, DEFAULT_TTL, SUPPORTED_AD_TYPES} from './constants.js';
 
 import {getGlobalVarName} from '../../src/buildOptions.js';
+import {getDNT} from '../dnt/index.js';
 
 export const makeBaseSpec = (baseUrl, modes) => {
   return {
@@ -376,7 +377,7 @@ export function generateGeneralParams(generalObject, bidderRequest, adapterVersi
     publisher_id: generalBidParams.org,
     publisher_name: domain,
     site_domain: domain,
-    dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+    dnt: getDNT() ? 1 : 0,
     device_type: getDeviceType(navigator.userAgent),
     ua: navigator.userAgent,
     is_wrapper: !!generalBidParams.isWrapper,

--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -20,6 +20,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {config} from '../src/config.js';
 import {getAdUnitSizes} from '../libraries/sizeUtils/sizeUtils.js';
 import {getBidFloor} from '../libraries/adkernelUtils/adkernelUtils.js'
+import {getDNT} from '../libraries/dnt/index.js';
 
 /**
  * In case you're AdKernel whitelable platform's client who needs branded adapter to
@@ -416,7 +417,7 @@ function makeDevice(fpd) {
     'language': getLanguage()
   }, fpd.device || {});
   // DNT was deprecated by W3C; Prebid no longer supports DNT signals.
-  device.dnt = 0;
+  device.dnt = getDNT() ? 1 : 0;
   return {device: device};
 }
 

--- a/modules/adtrgtmeBidAdapter.js
+++ b/modules/adtrgtmeBidAdapter.js
@@ -11,6 +11,7 @@ import {
 } from '../src/utils.js';
 import { config } from '../src/config.js';
 import { hasPurpose1Consent } from '../src/utils/gdpr.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const BIDDER_CODE = 'adtrgtme';
 const BIDDER_VERSION = '1.0.7';
@@ -71,7 +72,7 @@ function createORTB(bR, bid) {
       ...site,
     },
     device: {
-      dnt: 0, // DNT deprecated by W3C; Prebid no longer supports DNT
+      dnt: getDNT() ? 1 : 0,
       ua: bid?.params?.ua || navigator.userAgent,
       ip,
     },

--- a/modules/adtrueBidAdapter.js
+++ b/modules/adtrueBidAdapter.js
@@ -4,6 +4,7 @@ import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
 import {config} from '../src/config.js';
 import {getStorageManager} from '../src/storageManager.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const BIDDER_CODE = 'adtrue';
 const storage = getStorageManager({bidderCode: BIDDER_CODE});
@@ -168,7 +169,7 @@ function _createOrtbTemplate(conf) {
       ua: navigator.userAgent,
       os: platform,
       js: 1,
-      dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+      dnt: getDNT() ? 1 : 0,
       h: screen.height,
       w: screen.width,
       language: _getLanguage(),

--- a/modules/alkimiBidAdapter.js
+++ b/modules/alkimiBidAdapter.js
@@ -4,6 +4,7 @@ import {ajax} from '../src/ajax.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {VIDEO, BANNER} from '../src/mediaTypes.js';
 import {config} from '../src/config.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const BIDDER_CODE = 'alkimi';
 const GVLID = 1169;
@@ -91,7 +92,7 @@ export const spec = {
       schain: validBidRequests[0]?.ortb2?.source?.ext?.schain,
       cpp: config.getConfig('coppa') ? 1 : 0,
       device: {
-        dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+        dnt: getDNT() ? 1 : 0,
         w: screen.width,
         h: screen.height
       },

--- a/modules/apacdexBidAdapter.js
+++ b/modules/apacdexBidAdapter.js
@@ -3,6 +3,7 @@ import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import {hasPurpose1Consent} from '../src/utils/gdpr.js';
 import {parseDomain} from '../src/refererDetection.js';
+import {getDNT} from '../libraries/dnt/index.js';
 const BIDDER_CODE = 'apacdex';
 const ENDPOINT = 'https://useast.quantumdex.io/auction/pbjs'
 const USERSYNC = 'https://sync.quantumdex.io/usersync/pbjs'
@@ -99,7 +100,7 @@ export const spec = {
     payload.device.ua = navigator.userAgent;
     payload.device.height = window.screen.height;
     payload.device.width = window.screen.width;
-    payload.device.dnt = 0; // DNT deprecated by W3C; Prebid no longer supports DNT
+    payload.device.dnt = getDNT() ? 1 : 0;
     payload.device.language = navigator.language;
 
     var pageUrl = _extractTopWindowUrlFromBidderRequest(bidderRequest);

--- a/modules/apstreamBidAdapter.js
+++ b/modules/apstreamBidAdapter.js
@@ -4,6 +4,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const CONSTANTS = {
   DSU_KEY: 'apr_dsu',
@@ -424,7 +425,7 @@ function buildRequests(bidRequests, bidderRequest) {
     // TODO: fix auctionId leak: https://github.com/prebid/Prebid.js/issues/9781
     auid: bidderRequest.auctionId,
     ref: document.referrer,
-    dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+    dnt: getDNT() ? 1 : 0,
     sr: getScreenParams()
   };
 

--- a/modules/axonixBidAdapter.js
+++ b/modules/axonixBidAdapter.js
@@ -4,6 +4,7 @@ import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {config} from '../src/config.js';
 import {ajax} from '../src/ajax.js';
 import { getConnectionInfo } from '../libraries/connectionInfo/connectionUtils.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const BIDDER_CODE = 'axonix';
 const BIDDER_VERSION = '1.0.2';
@@ -106,7 +107,7 @@ export const spec = {
         effectiveType,
         devicetype: isMobile() ? 1 : isConnectedTV() ? 3 : 2,
         bidfloor: getBidFloor(validBidRequest),
-        dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+        dnt: getDNT() ? 1 : 0,
         language: navigator.language,
         prebidVersion: '$prebid.version$',
         screenHeight: screen.height,

--- a/modules/beachfrontBidAdapter.js
+++ b/modules/beachfrontBidAdapter.js
@@ -12,6 +12,7 @@ import {Renderer} from '../src/Renderer.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import { getFirstSize, getOsVersion, getVideoSizes, getBannerSizes, isConnectedTV, isMobile, isBannerBid, isVideoBid, getBannerBidFloor, getVideoBidFloor, getVideoTargetingParams, getTopWindowLocation } from '../libraries/advangUtils/index.js';
 import { getConnectionInfo } from '../libraries/connectionInfo/connectionUtils.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const ADAPTER_VERSION = '1.21';
 const GVLID = 157;
@@ -305,7 +306,7 @@ function createVideoRequestData(bid, bidderRequest) {
       ua: navigator.userAgent,
       language: navigator.language,
       devicetype: isMobile() ? 1 : isConnectedTV() ? 3 : 2,
-      dnt: 0, // DNT deprecated by W3C; Prebid no longer supports DNT
+      dnt: getDNT() ? 1 : 0,
       js: 1,
       geo: {}
     },
@@ -371,7 +372,7 @@ function createBannerRequestData(bids, bidderRequest) {
     ua: navigator.userAgent,
     deviceOs: getOsVersion(),
     isMobile: isMobile() ? 1 : 0,
-    dnt: 0, // DNT deprecated by W3C; Prebid no longer supports DNT
+    dnt: getDNT() ? 1 : 0,
     adapterVersion: ADAPTER_VERSION,
     adapterName: ADAPTER_NAME
   };

--- a/modules/bmtmBidAdapter.js
+++ b/modules/bmtmBidAdapter.js
@@ -2,6 +2,7 @@ import { generateUUID, deepAccess, logWarn, deepSetValue, isPlainObject } from '
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const BIDDER_CODE = 'bmtm';
 const AD_URL = 'https://one.elitebidder.com/api/hb?sid=';
@@ -180,7 +181,7 @@ function buildDevice() {
     h: window.top.screen.height,
     js: 1,
     language: navigator.language,
-    dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+    dnt: getDNT() ? 1 : 0,
   }
 }
 

--- a/modules/cadent_aperture_mxBidAdapter.js
+++ b/modules/cadent_aperture_mxBidAdapter.js
@@ -12,6 +12,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {Renderer} from '../src/Renderer.js';
 import {parseDomain} from '../src/refererDetection.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const BIDDER_CODE = 'cadent_aperture_mx';
 const ENDPOINT = 'hb.emxdgt.com';
@@ -82,7 +83,7 @@ export const cadentAdapter = {
     return {
       ua: navigator.userAgent,
       js: 1,
-      dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+      dnt: getDNT() ? 1 : 0,
       h: screen.height,
       w: screen.width,
       devicetype: cadentAdapter.isMobile() ? 1 : cadentAdapter.isConnectedTV() ? 3 : 2,

--- a/modules/chtnwBidAdapter.js
+++ b/modules/chtnwBidAdapter.js
@@ -9,6 +9,7 @@ import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { ajax } from '../src/ajax.js';
 import {BANNER, VIDEO, NATIVE} from '../src/mediaTypes.js';
+import {getDNT} from '../libraries/dnt/index.js';
 const ENDPOINT_URL = 'https://prebid.cht.hinet.net/api/v1';
 const BIDDER_CODE = 'chtnw';
 const COOKIE_NAME = '__htid';
@@ -37,7 +38,7 @@ export const spec = {
     device.w = device.w || innerWidth;
     device.h = device.h || innerHeight;
     device.ua = device.ua || navigator.userAgent;
-    device.dnt = 0; // DNT deprecated by W3C; Prebid no longer supports DNT
+    device.dnt = getDNT() ? 1 : 0;
     device.language = (navigator && navigator.language) ? navigator.language.split('-')[0] : '';
     const bidParams = [];
     _each(validBidRequests, function(bid) {

--- a/modules/cointrafficBidAdapter.js
+++ b/modules/cointrafficBidAdapter.js
@@ -4,6 +4,7 @@ import { BANNER } from '../src/mediaTypes.js'
 import { config } from '../src/config.js'
 import { getCurrencyFromBidderRequest } from '../libraries/ortb2Utils/currency.js';
 import { getViewportSize } from '../libraries/viewport/viewport.js'
+import {getDNT} from '../libraries/dnt/index.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -78,7 +79,7 @@ export const spec = {
           width: width,
           height: height,
           user_agent: bidRequest.params.ua || navigator.userAgent,
-          dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+          dnt: getDNT() ? 1 : 0,
           language: getLanguage(),
         },
       };

--- a/modules/connectadBidAdapter.js
+++ b/modules/connectadBidAdapter.js
@@ -3,6 +3,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js'
 import {config} from '../src/config.js';
 import {tryAppendQueryString} from '../libraries/urlUtils/urlUtils.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const BIDDER_CODE = 'connectad';
 const BIDDER_CODE_ALIAS = 'connectadrealtime';
@@ -40,7 +41,7 @@ export const spec = {
       url: bidderRequest.refererInfo?.page,
       referrer: bidderRequest.refererInfo?.ref,
       screensize: getScreenSize(),
-      dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+      dnt: getDNT() ? 1 : 0,
       language: navigator.language,
       ua: navigator.userAgent,
       pversion: '$prebid.version$',

--- a/modules/deepintentBidAdapter.js
+++ b/modules/deepintentBidAdapter.js
@@ -3,6 +3,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { COMMON_ORTB_VIDEO_PARAMS, formatResponse } from '../libraries/deepintentUtils/index.js';
 import { addDealCustomTargetings, addPMPDeals } from '../libraries/dealUtils/dealUtils.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const LOG_WARN_PREFIX = 'DeepIntent: ';
 const BIDDER_CODE = 'deepintent';
@@ -281,7 +282,7 @@ function buildDevice() {
   return {
     ua: navigator.userAgent,
     js: 1,
-    dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+    dnt: getDNT() ? 1 : 0,
     h: screen.height,
     w: screen.width,
     language: navigator.language

--- a/modules/digitalMatterBidAdapter.js
+++ b/modules/digitalMatterBidAdapter.js
@@ -3,6 +3,7 @@ import {config} from '../src/config.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER} from '../src/mediaTypes.js';
 import {hasPurpose1Consent} from '../src/utils/gdpr.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const BIDDER_CODE = 'digitalMatter';
 const GVLID = 1345;
@@ -187,7 +188,7 @@ function hasBannerMediaType(bidRequest) {
 function getDevice(data) {
   let dnt = data.dnt;
   if (!dnt) {
-    dnt = 0; // DNT deprecated by W3C; Prebid no longer supports DNT
+    dnt = getDNT() ? 1 : 0;
   }
   const { innerWidth, innerHeight } = getWinDimensions();
 

--- a/modules/displayioBidAdapter.js
+++ b/modules/displayioBidAdapter.js
@@ -5,6 +5,7 @@ import {logWarn} from '../src/utils.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {getAllOrtbKeywords} from '../libraries/keywords/keywords.js';
 import { getConnectionInfo } from '../libraries/connectionInfo/connectionUtils.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const ADAPTER_VERSION = '1.1.0';
 const BIDDER_CODE = 'displayio';
@@ -119,7 +120,7 @@ function getPayload (bid, bidderRequest) {
       complianceData: {
         child: '-1',
         us_privacy: uspConsent,
-        dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+        dnt: getDNT() ? 1 : 0,
         iabConsent: {},
         mediation: {
           gdprConsent: mediation.gdprConsent,

--- a/modules/distroscaleBidAdapter.js
+++ b/modules/distroscaleBidAdapter.js
@@ -2,6 +2,7 @@ import { logWarn, isPlainObject, isStr, isArray, isFn, inIframe, mergeDeep, deep
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
 import { BANNER } from '../src/mediaTypes.js';
+import {getDNT} from '../libraries/dnt/index.js';
 const BIDDER_CODE = 'distroscale';
 const SHORT_CODE = 'ds';
 const LOG_WARN_PREFIX = 'DistroScale: ';
@@ -163,7 +164,7 @@ export const spec = {
         h: screen.height,
         w: screen.width,
         language: (navigator.language && navigator.language.replace(/-.*/, '')) || 'en',
-        dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */
+        dnt: getDNT() ? 1 : 0
       },
       imp: [],
       user: {},

--- a/modules/empowerBidAdapter.js
+++ b/modules/empowerBidAdapter.js
@@ -13,6 +13,7 @@ import { registerBidder } from "../src/adapters/bidderFactory.js";
 import { config } from "../src/config.js";
 import { VIDEO, BANNER } from "../src/mediaTypes.js";
 import { getConnectionType } from "../libraries/connectionInfo/connectionUtils.js";
+import {getDNT} from "../libraries/dnt/index.js";
 
 export const ENDPOINT = "https://bid.virgul.com/prebid";
 
@@ -44,8 +45,7 @@ export const spec = {
       device: {
         ua: navigator.userAgent,
         js: 1,
-        // DNT was deprecated by W3C; Prebid no longer supports DNT signals.
-        dnt: 0,
+        dnt: getDNT() ? 1 : 0,
         h: screen.height,
         w: screen.width,
         language: navigator.language,

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -7,6 +7,7 @@ import {getStorageManager} from '../src/storageManager.js';
 
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import { getConnectionInfo } from '../libraries/connectionInfo/connectionUtils.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -280,7 +281,7 @@ function _getDeviceData(ortb2Data) {
     ipv6: _device.ipv6,
     ua: _device.ua,
     sua: _device.sua ? JSON.stringify(_device.sua) : undefined,
-    dnt: 0, // DNT deprecated by W3C; Prebid no longer supports DNT
+    dnt: getDNT() ? 1 : 0,
     os: _device.os,
     osv: _device.osv,
     dt: _device.devicetype,

--- a/modules/impactifyBidAdapter.js
+++ b/modules/impactifyBidAdapter.js
@@ -5,6 +5,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
 import { ajax } from '../src/ajax.js';
 import { getStorageManager } from '../src/storageManager.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -154,7 +155,7 @@ function createOpenRtbRequest(validBidRequests, bidderRequest) {
     devicetype: helpers.getDeviceType(),
     ua: navigator.userAgent,
     js: 1,
-    dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+    dnt: getDNT() ? 1 : 0,
     language: ((navigator.language || navigator.userLanguage || '').split('-'))[0] || 'en',
   };
   request.site = { page: bidderRequest.refererInfo.page };

--- a/modules/jixieBidAdapter.js
+++ b/modules/jixieBidAdapter.js
@@ -6,6 +6,7 @@ import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {ajax} from '../src/ajax.js';
 import {getRefererInfo} from '../src/refererDetection.js';
 import {Renderer} from '../src/Renderer.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const ADAPTER_VERSION = '2.1.0';
 const PREBID_VERSION = '$prebid.version$';
@@ -107,7 +108,7 @@ function getDevice_() {
   device.w = device.w || getWinDimensions().innerWidth;
   device.h = device.h || getWinDimensions().innerHeight;
   device.ua = device.ua || navigator.userAgent;
-  device.dnt = 0; // DNT deprecated by W3C; Prebid no longer supports DNT
+  device.dnt = getDNT() ? 1 : 0;
   device.language = (navigator && navigator.language) ? navigator.language.split('-')[0] : '';
   return device;
 }

--- a/modules/jwplayerBidAdapter.js
+++ b/modules/jwplayerBidAdapter.js
@@ -3,6 +3,7 @@ import { VIDEO } from '../src/mediaTypes.js';
 import { isArray, isFn, deepAccess, deepSetValue, logError, logWarn } from '../src/utils.js';
 import { config } from '../src/config.js';
 import { hasPurpose1Consent } from '../src/utils/gdpr.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const BIDDER_CODE = 'jwplayer';
 const BASE_URL = 'https://vpb-server.jwplayer.com/';
@@ -324,7 +325,7 @@ function getBidAdapter() {
       h: screen.height,
       w: screen.width,
       ua: navigator.userAgent,
-      dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+      dnt: getDNT() ? 1 : 0,
       js: 1
     }, ortb2.device || {})
 

--- a/modules/lemmaDigitalBidAdapter.js
+++ b/modules/lemmaDigitalBidAdapter.js
@@ -2,6 +2,7 @@ import * as utils from '../src/utils.js';
 import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -448,7 +449,7 @@ export var spec = {
     var params = request && request.params ? request.params : null;
     if (params) {
       return {
-        dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+        dnt: getDNT() ? 1 : 0,
         ua: navigator.userAgent,
         language: (navigator.language || navigator.browserLanguage || navigator.userLanguage || navigator.systemLanguage),
         w: (utils.getWinDimensions().screen.width || utils.getWinDimensions().innerWidth),

--- a/modules/marsmediaBidAdapter.js
+++ b/modules/marsmediaBidAdapter.js
@@ -5,6 +5,7 @@ import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import {config} from '../src/config.js';
 import { percentInView } from '../libraries/percentInView/percentInView.js';
 import {getMinSize} from '../libraries/sizeUtils/sizeUtils.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 function MarsmediaAdapter() {
   this.code = 'marsmedia';
@@ -92,7 +93,7 @@ function MarsmediaAdapter() {
     return {
       ua: navigator.userAgent,
       ip: '', // Empty Ip string is required, server gets the ip from HTTP header
-      dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+      dnt: getDNT() ? 1 : 0,
     }
   }
 

--- a/modules/mediaforceBidAdapter.js
+++ b/modules/mediaforceBidAdapter.js
@@ -3,6 +3,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import { buildNativeRequest, parseNativeResponse } from '../libraries/nativeAssetsUtils.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -64,7 +65,7 @@ export const spec = {
     const referer = bidderRequest && bidderRequest.refererInfo ? encodeURIComponent(bidderRequest.refererInfo.ref) : '';
     const auctionId = bidderRequest && bidderRequest.auctionId;
     const timeout = bidderRequest && bidderRequest.timeout;
-    const dnt = 0; // DNT deprecated by W3C; Prebid no longer supports DNT
+    const dnt = getDNT() ? 1 : 0;
     const requestsMap = {};
     const requests = [];
     let isTest = false;

--- a/modules/mediakeysBidAdapter.js
+++ b/modules/mediakeysBidAdapter.js
@@ -20,6 +20,7 @@ import {registerBidder} from '../src/adapters/bidderFactory.js';
 import {config} from '../src/config.js';
 import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
 import {convertOrtbRequestToProprietaryNative} from '../src/native.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const AUCTION_TYPE = 1;
 const BIDDER_CODE = 'mediakeys';
@@ -183,7 +184,7 @@ function createOrtbTemplate() {
     device: {
       ip: '',
       js: 1,
-      dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+      dnt: getDNT() ? 1 : 0,
       ua: navigator.userAgent,
       devicetype: getDeviceType(),
       os: getOS(),

--- a/modules/mgidBidAdapter.js
+++ b/modules/mgidBidAdapter.js
@@ -24,6 +24,7 @@ import { getStorageManager } from '../src/storageManager.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import { getUserSyncs } from '../libraries/mgidUtils/mgidUtils.js'
 import { getCurrencyFromBidderRequest } from '../libraries/ortb2Utils/currency.js'
+import {getDNT} from '../libraries/dnt/index.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -252,7 +253,7 @@ export const spec = {
     }
     request.device.js = 1;
     if (!isInteger(deepAccess(request.device, 'dnt'))) {
-      request.device.dnt = 0; // DNT deprecated by W3C; Prebid no longer supports DNT
+      request.device.dnt = getDNT() ? 1 : 0;
     }
     if (!isInteger(deepAccess(request.device, 'h'))) {
       request.device.h = screen.height;

--- a/modules/nexverseBidAdapter.js
+++ b/modules/nexverseBidAdapter.js
@@ -8,6 +8,7 @@ import { getDeviceModel, buildEndpointUrl, isBidRequestValid, parseNativeRespons
 import {getStorageManager} from '../src/storageManager.js';
 import {MODULE_TYPE_UID} from '../src/activities/modules.js';
 import { config } from '../src/config.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const BIDDER_CODE = 'nexverse';
 const BIDDER_ENDPOINT = 'https://rtb.nexverse.ai';
@@ -305,7 +306,7 @@ function buildOpenRtbRequest(bid, bidderRequest) {
         lon: bid.params.geoLon || 0,
       },
       language: navigator.language || DEFAULT_LANG,
-      dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */, // Do Not Track flag
+      dnt: getDNT() ? 1 : 0, // Do Not Track flag
     },
     user: {
       id: getUid(storage),

--- a/modules/operaadsBidAdapter.js
+++ b/modules/operaadsBidAdapter.js
@@ -16,6 +16,7 @@ import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
 import {Renderer} from '../src/Renderer.js';
 import {OUTSTREAM} from '../src/video.js';
 import {convertOrtbRequestToProprietaryNative} from '../src/native.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -760,7 +761,7 @@ function getDevice() {
   device.ua = device.ua || navigator.userAgent;
   device.language = device.language || getLanguage();
   device.dnt = typeof device.dnt === 'number'
-    ? device.dnt : (0 /* DNT deprecated by W3C; Prebid no longer supports DNT */);
+    ? device.dnt : (getDNT() ? 1 : 0);
 
   return device;
 }

--- a/modules/panxoBidAdapter.js
+++ b/modules/panxoBidAdapter.js
@@ -8,6 +8,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
 import { deepAccess, logWarn, isFn, isPlainObject } from '../src/utils.js';
 import { getStorageManager } from '../src/storageManager.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const BIDDER_CODE = 'panxo';
 const ENDPOINT_URL = 'https://panxo-sys.com/openrtb/2.5/bid';
@@ -112,8 +113,7 @@ function buildDevice() {
     ua: navigator.userAgent,
     language: navigator.language,
     js: 1,
-    // DNT was deprecated by W3C; Prebid no longer supports DNT signals.
-    dnt: 0
+    dnt: getDNT() ? 1 : 0
   };
 
   if (typeof screen !== 'undefined') {

--- a/modules/pwbidBidAdapter.js
+++ b/modules/pwbidBidAdapter.js
@@ -4,6 +4,7 @@ import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import { OUTSTREAM, INSTREAM } from '../src/video.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -511,7 +512,7 @@ function _createOrtbTemplate(conf) {
     device: {
       ua: navigator.userAgent,
       js: 1,
-      dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+      dnt: getDNT() ? 1 : 0,
       h: screen.height,
       w: screen.width,
       language: navigator.language,

--- a/modules/rhythmoneBidAdapter.js
+++ b/modules/rhythmoneBidAdapter.js
@@ -3,6 +3,7 @@
 import { deepAccess, parseSizesInput, isArray } from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 function RhythmOneBidAdapter() {
   this.code = 'rhythmone';
@@ -71,7 +72,7 @@ function RhythmOneBidAdapter() {
     return {
       ua: navigator.userAgent,
       ip: '', // Empty Ip string is required, server gets the ip from HTTP header
-      dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+      dnt: getDNT() ? 1 : 0,
     }
   }
 

--- a/modules/scaliburBidAdapter.js
+++ b/modules/scaliburBidAdapter.js
@@ -3,6 +3,7 @@ import {config} from '../src/config.js';
 import {BANNER, VIDEO} from '../src/mediaTypes.js';
 import {getStorageManager} from '../src/storageManager.js';
 import {sizesToSizeTuples} from "../src/utils.js";
+import {getDNT} from '../libraries/dnt/index.js';
 
 const BIDDER_CODE = 'scalibur';
 const ENDPOINT_SERVER = new URLSearchParams(window.location.search).get('sclServer') || 'srv';
@@ -115,7 +116,7 @@ export const spec = {
         ua: ortb2Device.ua,
         language: ortb2Device.language,
         sua: ortb2Device.sua || {},
-        dnt: 0, // DNT deprecated by W3C; Prebid no longer supports DNT
+        dnt: getDNT() ? 1 : 0,
       },
       user: {
         eids,

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -5,6 +5,7 @@ import { config } from '../src/config.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { deepAccess, generateUUID, inIframe, isPlainObject, logWarn, mergeDeep } from '../src/utils.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const VERSION = '4.3.0';
 const BIDDER_CODE = 'sharethrough';
@@ -76,7 +77,7 @@ export const sharethroughAdapterSpec = {
         ua: navigator.userAgent,
         language: navigator.language,
         js: 1,
-        dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+        dnt: getDNT() ? 1 : 0,
         h: window.screen.height,
         w: window.screen.width,
         ext: {},

--- a/modules/smaatoBidAdapter.js
+++ b/modules/smaatoBidAdapter.js
@@ -5,6 +5,7 @@ import {BANNER, NATIVE, VIDEO} from '../src/mediaTypes.js';
 import {NATIVE_IMAGE_TYPES} from '../src/constants.js';
 import {getAdUnitSizes} from '../libraries/sizeUtils/sizeUtils.js';
 import {ortbConverter} from '../libraries/ortbConverter/converter.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -273,7 +274,7 @@ const converter = ortbConverter({
       request.device = {
         language: (navigator && navigator.language) ? navigator.language.split('-')[0] : '',
         ua: navigator.userAgent,
-        dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+        dnt: getDNT() ? 1 : 0,
         h: screen.height,
         w: screen.width
       }

--- a/modules/smartxBidAdapter.js
+++ b/modules/smartxBidAdapter.js
@@ -20,6 +20,7 @@ import {
 import {
   VIDEO
 } from '../src/mediaTypes.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -155,7 +156,7 @@ export const spec = {
       const device = {
         h: screen.height,
         w: screen.width,
-        dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+        dnt: getDNT() ? 1 : 0,
         language: navigator[language].split('-')[0],
         make: navigator.vendor ? navigator.vendor : '',
         ua: navigator.userAgent

--- a/modules/snigelBidAdapter.js
+++ b/modules/snigelBidAdapter.js
@@ -4,6 +4,7 @@ import {BANNER} from '../src/mediaTypes.js';
 import {deepAccess, isArray, isFn, isPlainObject, inIframe, generateUUID} from '../src/utils.js';
 import {getStorageManager} from '../src/storageManager.js';
 import { getViewportSize } from '../libraries/viewport/viewport.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const BIDDER_CODE = 'snigel';
 const GVLID = 1076;
@@ -63,7 +64,7 @@ export const spec = {
         device: {
           w,
           h,
-          dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+          dnt: getDNT() ? 1 : 0,
           language: getLanguage(),
         },
         placements: bidRequests.map((r) => {

--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -6,6 +6,7 @@ import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
 import { Renderer } from '../src/Renderer.js';
 import { parseDomain } from '../src/refererDetection.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -428,7 +429,7 @@ function buildOneRequest(validBidRequests, bidderRequest) {
   // Optional
   device.h = screen.height;
   device.w = screen.width;
-  device.dnt = 0; // DNT deprecated by W3C; Prebid no longer supports DNT
+  device.dnt = getDNT() ? 1 : 0;
   device.language = getLanguage();
   device.make = getVendor();
 

--- a/modules/theAdxBidAdapter.js
+++ b/modules/theAdxBidAdapter.js
@@ -9,6 +9,7 @@ import {
 } from '../src/adapters/bidderFactory.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import { getConnectionInfo } from '../libraries/connectionInfo/connectionUtils.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -371,7 +372,7 @@ const buildDeviceComponent = (bidRequest, bidderRequest) => {
     language: ('language' in navigator) ? navigator.language : null,
     ua: ('userAgent' in navigator) ? navigator.userAgent : null,
     devicetype: isMobile() ? 1 : isConnectedTV() ? 3 : 2,
-    dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+    dnt: getDNT() ? 1 : 0,
   };
   // Include connection info if available
   const connection = getConnectionInfo();

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -4,6 +4,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { isNumber } from '../src/utils.js';
 import { getConnectionType } from '../libraries/connectionInfo/connectionUtils.js'
+import {getDNT} from '../libraries/dnt/index.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -92,7 +93,7 @@ function getDevice(firstPartyData) {
   const language = navigator.language || navigator.browserLanguage || navigator.userLanguage || navigator.systemLanguage;
   const device = {
     ua: navigator.userAgent,
-    dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+    dnt: getDNT() ? 1 : 0,
     language: language,
     connectiontype: getConnectionType()
   };

--- a/modules/ucfunnelBidAdapter.js
+++ b/modules/ucfunnelBidAdapter.js
@@ -4,6 +4,7 @@ import {BANNER, VIDEO, NATIVE} from '../src/mediaTypes.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { config } from '../src/config.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -258,7 +259,7 @@ function getFormat(size) {
 function getRequestData(bid, bidderRequest) {
   const size = parseSizes(bid);
   const language = navigator.language;
-  const dnt = 0; // DNT deprecated by W3C; Prebid no longer supports DNT
+  const dnt = getDNT() ? 1 : 0;
   const userIdTdid = (bid.userId && bid.userId.tdid) ? bid.userId.tdid : '';
   const schain = bid?.ortb2?.source?.ext?.schain;
   const supplyChain = getSupplyChain(schain);

--- a/modules/yahooAdsBidAdapter.js
+++ b/modules/yahooAdsBidAdapter.js
@@ -4,6 +4,7 @@ import { deepAccess, isFn, isStr, isNumber, isArray, isEmpty, isPlainObject, gen
 import { config } from '../src/config.js';
 import { Renderer } from '../src/Renderer.js';
 import {hasPurpose1Consent} from '../src/utils/gdpr.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 const INTEGRATION_METHOD = 'prebid.js';
 const BIDDER_CODE = 'yahooAds';
@@ -273,7 +274,7 @@ function generateOpenRtbObject(bidderRequest, bid) {
         page: deepAccess(bidderRequest, 'refererInfo.page'),
       },
       device: {
-        dnt: 0, // DNT deprecated by W3C; Prebid no longer supports DNT
+        dnt: getDNT() ? 1 : 0,
         ua: navigator.userAgent,
         ip: deepAccess(bid, 'params.bidOverride.device.ip') || deepAccess(bid, 'params.ext.ip') || undefined,
         w: window.screen.width,

--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -17,6 +17,7 @@ import {
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { Renderer } from '../src/Renderer.js';
+import {getDNT} from '../libraries/dnt/index.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -83,7 +84,7 @@ export const spec = {
         // TODO: is 'page' the right value here?
         page_url: bidderRequest.refererInfo.page,
         bust: new Date().getTime().toString(),
-        dnt: 0 /* DNT deprecated by W3C; Prebid no longer supports DNT */,
+        dnt: getDNT() ? 1 : 0,
         description: getPageDescription(),
         tmax: bidderRequest.timeout || 400,
         userConsent: JSON.stringify({


### PR DESCRIPTION
### Motivation
- Reintroduce runtime DNT derivation where adapters and utility libraries previously used a hardcoded `dnt: 0`, restoring prior behavior to populate payload/device DNT from the shared `getDNT()` helper.
- Ensure consistent DNT signal computation across many adapters and the `riseUtils` / `advangUtils` libraries so outgoing requests reflect `getDNT() ? 1 : 0` rather than a static 0.
- Fix missing imports and small import-path placement issues that caused lint failures after the changes.

### Description
- Re-added `getDNT` imports and replaced hardcoded `dnt: 0` or `device.dnt = 0` assignments with `getDNT() ? 1 : 0` across adapter modules and utility libraries (representative files: `modules/adkernelBidAdapter.js`, `modules/adtrgtmeBidAdapter.js`, `modules/yahooAdsBidAdapter.js`, `modules/empowerBidAdapter.js`, `libraries/riseUtils/index.js`, `libraries/advangUtils/index.js`).
- Fixed import placement/path issues (adjusted `getDNT` import locations where necessary) so files parse and lint cleanly.
- Changes span the request-building codepaths for many adapters to ensure outgoing OpenRTB / proprietary payloads use the computed DNT value (overall ~45 files updated: imports + dnt mappings).

### Testing
- Ran lint on the changed files with `npx eslint --cache --cache-strategy content` and addressed import errors until the lint run completed successfully for the modified set of files.
- Executed focused unit tests with gulp for representative adapters using `npx gulp test --nolint --file <spec_file.js>` including `test/spec/modules/adkernelBidAdapter_spec.js`, `test/spec/modules/adtrgtmeBidAdapter_spec.js`, `test/spec/modules/riseBidAdapter_spec.js`, and `test/spec/modules/advangelistsBidAdapter_spec.js`, and all executed spec runs completed successfully.
- Performed iterative fixes (import path/placement) and re-ran lint/tests until there were no remaining errors for the changed files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698e05605958832ba7076882a71cd34e)