### PR TITLE
Fix several typos in comments and tests

### DIFF
--- a/modules/adtrueBidAdapter.js
+++ b/modules/adtrueBidAdapter.js
@@ -400,7 +400,7 @@ function _createImpressionObject(bid, conf) {
     }
   } else {
     // mediaTypes is not present, so this is a banner only impression
-    // this part of code is required for older testcases with no 'mediaTypes' to run succesfully.
+    // this part of code is required for older testcases with no 'mediaTypes' to run successfully.
     bannerObj = {
       pos: 0,
       w: bid.params.width,

--- a/test/spec/modules/mgidRtdProvider_spec.js
+++ b/test/spec/modules/mgidRtdProvider_spec.js
@@ -33,7 +33,7 @@ describe('Mgid RTD submodule', () => {
     expect(mgidSubmodule.init({})).to.be.false;
   });
 
-  it('getBidRequestData send all params to our endpoint and succesfully modifies ortb2', () => {
+  it('getBidRequestData send all params to our endpoint and successfully modifies ortb2', () => {
     const responseObj = {
       userSegments: ['100', '200'],
       userSegtax: 5,

--- a/test/spec/modules/rakutenBidAdapter_spec.js
+++ b/test/spec/modules/rakutenBidAdapter_spec.js
@@ -161,7 +161,7 @@ describe('rakutenBidAdapter', function() {
         pixelEnabled: true
       }
     });
-    it('sucess usersync url', function () {
+    it('success usersync url', function () {
       const result = [];
       result.push({type: 'image', url: 'https://rdn1.test/sync?uid=9876543210'});
       result.push({type: 'image', url: 'https://rdn2.test/sync?uid=9876543210'});

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -1815,7 +1815,7 @@ describe('the rubicon adapter', function () {
             })
           })
 
-          it('should send gpid and pbadslot since it is prefered over dfp code', function () {
+          it('should send gpid and pbadslot since it is preferred over dfp code', function () {
             bidderRequest.bids[0].ortb2Imp = {
               ext: {
                 gpid: '/1233/sports&div1',

--- a/test/spec/modules/theAdxBidAdapter_spec.js
+++ b/test/spec/modules/theAdxBidAdapter_spec.js
@@ -416,7 +416,7 @@ describe('TheAdxAdapter', function () {
       expect(result).to.eql([]);
     });
 
-    it('returns a valid bid response on sucessful banner request', function () {
+    it('returns a valid bid response on successful banner request', function () {
       const incomingRequestId = 'XXtestingXX';
       const responsePrice = 3.14
 
@@ -484,7 +484,7 @@ describe('TheAdxAdapter', function () {
       expect(processedBid.currency).to.equal(responseCurrency);
     });
 
-    it('returns a valid deal bid response on sucessful banner request with deal', function () {
+    it('returns a valid deal bid response on successful banner request with deal', function () {
       const incomingRequestId = 'XXtestingXX';
       const responsePrice = 3.14
 
@@ -556,7 +556,7 @@ describe('TheAdxAdapter', function () {
       expect(processedBid.dealId).to.equal(dealId);
     });
 
-    it('returns an valid bid response on sucessful video request', function () {
+    it('returns an valid bid response on successful video request', function () {
       const incomingRequestId = 'XXtesting-275XX';
       const responsePrice = 6
       const vast_url = 'https://theadx.com/vast?rid=a8ae0b48-a8db-4220-ba0c-7458f452b1f5&{FOR_COVARAGE}'
@@ -622,7 +622,7 @@ describe('TheAdxAdapter', function () {
       expect(processedBid.vastUrl).to.equal(vast_url);
     });
 
-    it('returns an valid bid response on sucessful native request', function () {
+    it('returns an valid bid response on successful native request', function () {
       const incomingRequestId = 'XXtesting-275XX';
       const responsePrice = 6
       const nurl = 'https://app.theadx.com/ixc?rid=02aefd80-2df9-11e9-896d-d33384d77f5c&time=v-1549888312715&sp=1WzMjcRpeyk%3D';


### PR DESCRIPTION
This PR fixes several common typos ('prefered', 'succesfully', 'sucessful', etc.) found in comments and test descriptions across the codebase.