### PR TITLE
OMS Bid Adapter: add instl flag to imp in request

### DIFF
--- a/modules/omsBidAdapter.js
+++ b/modules/omsBidAdapter.js
@@ -8,6 +8,7 @@ import {
   getBidIdParameter,
   getUniqueIdentifierStr,
   formatQS,
+  deepAccess,
 } from '../src/utils.js';
 import {registerBidder} from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
@@ -71,6 +72,10 @@ function buildRequests(bidReqs, bidderRequest) {
         imp.video = {
           ...bid.mediaTypes.video,
         }
+      }
+
+      if (deepAccess(bid, 'ortb2Imp.instl') === 1) {
+        imp.instl = 1;
       }
 
       const bidFloor = getBidFloor(bid);

--- a/test/spec/modules/omsBidAdapter_spec.js
+++ b/test/spec/modules/omsBidAdapter_spec.js
@@ -267,6 +267,16 @@ describe('omsBidAdapter', function () {
       expect(data.regs.coppa).to.equal(1);
     });
 
+    it('sends instl property when ortb2Imp.instl = 1', function () {
+      const data = JSON.parse(spec.buildRequests([{ ...bidRequests[0], ortb2Imp: { instl: 1 }}]).data);
+      expect(data.imp[0].instl).to.equal(1);
+    });
+
+    it('ignores instl property when ortb2Imp.instl is falsy', function () {
+      const data = JSON.parse(spec.buildRequests(bidRequests).data);
+      expect(data.imp[0].instl).to.be.undefined;
+    });
+
     it('sends schain', function () {
       const data = JSON.parse(spec.buildRequests(bidRequests).data);
       expect(data).to.not.be.undefined;


### PR DESCRIPTION
## Type of change
- [x] Other

## Description of change
Add **instl** property to imp in reqeust when `ortb2Imp.instl` = 1
