### PR TITLE
AdMatic Bid Adapter : add adrubi alias

### DIFF
--- a/modules/admaticBidAdapter.js
+++ b/modules/admaticBidAdapter.js
@@ -28,6 +28,7 @@ export const spec = {
     { code: 'monetixads', gvlid: 1281 },
     { code: 'netaddiction', gvlid: 1281 },
     { code: 'adt', gvlid: 779 },
+    { code: 'adrubi', gvlid: 779 },
     { code: 'yobee', gvlid: 1281 }
   ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other

Aliases for AdRubi were created within the AdMatic adapter.

PR on the docs repo -> https://github.com/prebid/prebid.github.io/pull/6444

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
