### PR TITLE
Core: fix GPT targeting reset for slot.setConfig

### DIFF
--- a/src/targeting.ts
+++ b/src/targeting.ts
@@ -310,8 +310,6 @@ export function newTargeting(auctionManager) {
       // get our ad unit codes
       const targetingSet: ByAdUnit<GPTTargetingValues> = targeting.getAllTargeting(adUnit);
 
-      const resetMap = Object.fromEntries(pbTargetingKeys.map(key => [key, null]));
-
       Object.entries(getGPTSlotsForAdUnits(Object.keys(targetingSet), customSlotMatching)).forEach(([targetId, slots]) => {
         slots.forEach(slot => {
           // now set new targeting keys
@@ -324,8 +322,8 @@ export function newTargeting(auctionManager) {
             targetingSet[targetId][key] = value;
           });
           logMessage(`Attempting to set targeting-map for slot: ${slot.getSlotElementId()} with targeting-map:`, targetingSet[targetId]);
-          const targetingMap = Object.assign({}, resetMap, targetingSet[targetId]);
-          slot.setConfig({targeting: targetingMap} as any);
+          pbTargetingKeys.forEach((key) => slot.clearTargeting(key));
+          slot.setConfig({targeting: targetingSet[targetId]} as any);
           lock.lock(targetingSet[targetId]);
         })
       })

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -100,8 +100,12 @@ var Slot = function Slot(elementId, pathId) {
       }
     },
 
-    clearTargeting: function clearTargeting() {
-      this.targeting = {};
+    clearTargeting: function clearTargeting(key) {
+      if (key == null) {
+        this.targeting = {};
+      } else {
+        delete this.targeting[key];
+      }
       return this;
     },
 


### PR DESCRIPTION
AI generated bugfix to #14503 


### Motivation
- Prevent runtime errors seen in issue #14503 where clearing Prebid targeting by passing `null` values via `slot.setConfig({targeting: ...})` led to GPT internals throwing `includes is not a function`.
- Ensure Prebid resets GPT targeting in a way compatible with GPT slot APIs instead of sending null-valued keys.

### Description
- Instead of composing a targeting map with `null` entries, call `slot.clearTargeting(key)` for each Prebid key and then apply the new targeting with `slot.setConfig({targeting: targetingSet[targetId]})` in `src/targeting.ts` (replaces the previous `Object.assign({}, resetMap, ...)` approach).
- Remove the unused `resetMap` construction and avoid passing `null` entries to GPT.
- Update the test GPT slot double in `test/spec/unit/pbjs_api_spec.js` to support `clearTargeting(key)` behavior so unit tests reflect the new reset flow.

### Testing
- Ran `npx eslint --cache --cache-strategy content src/targeting.ts test/spec/unit/pbjs_api_spec.js` which completed without errors.
- Ran `npx gulp test --nolint --file test/spec/unit/pbjs_api_spec.js` and the targeted unit tests passed (file-level tests completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699c6556dcb8832bab65d9c26968c454)