### PR TITLE
Shaping rules: Make some TypeScript fields optional

### DIFF
--- a/modules/rules/index.ts
+++ b/modules/rules/index.ts
@@ -82,7 +82,7 @@ interface ModelGroup {
    */
   rules: [{
     /** Conditions that must be met for the rule to apply */
-    condition: string[];
+    conditions: string[];
     /** Resulting actions triggered when conditions are met */
     results: [
       {


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
This PR makes certain Shaping Rules config fields optional to avoid TypeScript warnings.

- `selected` is assigned internally by the module and should not be required from the publisher when calling `setConfig`.
- `timestamp` is described as optional in the JS doc
- `args` is optional according to the last doc example here : https://docs.prebid.org/dev-docs/modules/shapingRulesModule.html
- `condition` becomes `conditions` to fix a bug in `checkConditions` where conditions is undefined