### PR TITLE
Weborama RTD: update gdpr validation for TCF v2.3

### DIFF
--- a/modules/weboramaRtdProvider.js
+++ b/modules/weboramaRtdProvider.js
@@ -419,8 +419,7 @@ class WeboramaRtdProvider {
       'vendorData.publisher.restrictions',
     );
     const disclosedVendors =
-      deepAccess(gdpr, 'vendorData.vendor.disclosedVendors') ||
-      deepAccess(gdpr, 'vendorData.outOfBand.disclosedVendors');
+      deepAccess(gdpr, 'vendorData.vendor.disclosedVendors');
 
     const consentPurposeIDSet = new Set([1, 3, 4, 5, 6]);
     const legitimateInterestPurposeIDSet = new Set([2, 7, 8, 9, 10, 11]);

--- a/test/spec/modules/weboramaRtdProvider_spec.js
+++ b/test/spec/modules/weboramaRtdProvider_spec.js
@@ -211,56 +211,6 @@ describe('weboramaRtdProvider', function () {
           false,
         );
       });
-      it('should NOT initialize if gdpr applies and disclosedVendors (on alternate location) does not allow weborama', function () {
-        const moduleConfig = {
-          params: {
-            weboUserDataConf: {},
-          },
-        };
-        const userConsent = {
-          gdpr: {
-            gdprApplies: true,
-            vendorData: {
-              purpose: {
-                consents: {
-                  1: true,
-                  3: true,
-                  4: true,
-                  5: true,
-                  6: true,
-                },
-                legitimateInterests: {
-                  2: true,
-                  7: true,
-                  8: true,
-                  9: true,
-                  10: true,
-                  11: true,
-                },
-              },
-              specialFeatureOptins: {
-                1: true,
-              },
-              vendor: {
-                consents: {
-                  284: true,
-                },
-                legitimateInterests: {
-                  284: true,
-                },
-              },
-              outOfBand: {
-                disclosedVendors: {
-                  284: false,
-                },
-              },
-            },
-          },
-        };
-        expect(weboramaSubmodule.init(moduleConfig, userConsent)).to.equal(
-          false,
-        );
-      });
       it('should NOT initialize if gdpr applies and consent is nok: miss legitimate interests vendor id', function () {
         const moduleConfig = {
           params: {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Feature
- [X] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)

## Description of change

The purpose of this pull request is update the gdpr consent validation to be compatible with TCF v2.3. We need to verify if our vendor id is present on Vendors Disclosed if it is available.

We note that some tcdata consent objects may have a different structure than the one defined in the specification, Didomi for instance is using `outOfBand` field to handle the vendors disclosed instead `vendor` and we believe this should be fixed on their side at some point.

