### PR TITLE
Screencore Bid Adapter: fix region routing and endpoint path

### DIFF
--- a/modules/screencoreBidAdapter.js
+++ b/modules/screencoreBidAdapter.js
@@ -25,7 +25,8 @@ const REGION_SUBDOMAIN_SUFFIX = {
  */
 function getRegionSubdomainSuffix() {
   try {
-    const region = getTimeZone().split('/')[0];
+    const tz = getTimeZone();
+    const region = tz.split('/')[0];
 
     switch (region) {
       case 'Asia':
@@ -40,6 +41,8 @@ function getRegionSubdomainSuffix() {
       case 'Arctic':
         return REGION_SUBDOMAIN_SUFFIX['EU'];
       case 'America':
+      case 'US':
+      case 'Canada':
         return REGION_SUBDOMAIN_SUFFIX['US'];
       default:
         return REGION_SUBDOMAIN_SUFFIX['EU'];
@@ -55,11 +58,10 @@ export function createDomain() {
   return `https://${subDomain}.screencore.io`;
 }
 
-const AD_URL = `${createDomain()}/prebid`;
-
 const placementProcessingFunction = buildPlacementProcessingFunction();
 
 const buildRequests = (validBidRequests = [], bidderRequest = {}) => {
+  const AD_URL = `${createDomain()}/pbjs`;
   return buildRequestsBase({ adUrl: AD_URL, validBidRequests, bidderRequest, placementProcessingFunction });
 };
 

--- a/test/spec/modules/screencoreBidAdapter_spec.js
+++ b/test/spec/modules/screencoreBidAdapter_spec.js
@@ -227,7 +227,7 @@ describe('screencore bid adapter', function () {
       const requests = adapter.buildRequests([BID], BIDDER_REQUEST);
       expect(requests).to.exist;
       expect(requests.method).to.equal('POST');
-      expect(requests.url).to.include('screencore.io/prebid');
+      expect(requests.url).to.include('screencore.io/pbjs');
       expect(requests.data).to.exist;
       expect(requests.data.placements).to.be.an('array');
       expect(requests.data.placements[0].bidId).to.equal(BID.bidId);
@@ -391,6 +391,39 @@ describe('screencore bid adapter', function () {
 
       const domain = createDomain();
       expect(domain).to.equal('https://taqapac.screencore.io');
+
+      stub.restore();
+    });
+
+    it('should return correct domain for US/ prefixed timezone', function () {
+      const stub = sinon.stub(Intl, 'DateTimeFormat').returns({
+        resolvedOptions: () => ({ timeZone: 'US/Eastern' })
+      });
+
+      const domain = createDomain();
+      expect(domain).to.equal('https://taqus.screencore.io');
+
+      stub.restore();
+    });
+
+    it('should return correct domain for Canada/ prefixed timezone', function () {
+      const stub = sinon.stub(Intl, 'DateTimeFormat').returns({
+        resolvedOptions: () => ({ timeZone: 'Canada/Eastern' })
+      });
+
+      const domain = createDomain();
+      expect(domain).to.equal('https://taqus.screencore.io');
+
+      stub.restore();
+    });
+
+    it('should return EU domain as default for unknown timezone', function () {
+      const stub = sinon.stub(Intl, 'DateTimeFormat').returns({
+        resolvedOptions: () => ({ timeZone: 'UTC' })
+      });
+
+      const domain = createDomain();
+      expect(domain).to.equal('https://taqeu.screencore.io');
 
       stub.restore();
     });


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Updated bidder adapter

## Description of change

Fixed two bugs in the Screencore bid adapter:

1. **Region routing**: `getRegionSubdomainSuffix()` was not handling `US/` and 
   `Canada/` prefixed IANA timezone strings (e.g. `US/Eastern`, `Canada/Eastern`), 
   causing users in those timezones to be incorrectly routed to the EU endpoint 
   instead of the US endpoint.

2. **Endpoint path**: corrected endpoint from `/prebid` to `/pbjs`.

3. **AD_URL**: moved `AD_URL` construction inside `buildRequests()` so the domain 
   is computed fresh per request rather than once at module load time.

## Other information
No API changes. No documentation update required.
```

---

A few notes on the checkboxes — Prebid reviewers will notice if `Updated bidder adapter` is checked without a docs PR link, but since these are pure bugfixes with no parameter changes, you can add a note like:
```
No bidder parameter changes — docs update not required.