### PR TITLE
Gam video module: Always include us_privacy from gpp when working with the IMA player

### DIFF
--- a/modules/gamAdServerVideo.js
+++ b/modules/gamAdServerVideo.js
@@ -119,6 +119,22 @@ export function buildGamVideoUrl(options) {
     gdprParams()
   );
 
+  // The IMA player adds usp info, but not gpp info
+  // For cases where the CMP only exposes gpp but not usp,
+  // it is better to derive an usp string from the gpp info and include it in the url
+  if (window.google?.ima) {
+    const usPrivacy = uspDataHandler.getConsentData?.();
+    const gpp = gppDataHandler.getConsentData?.();
+
+    if (!usPrivacy && gpp) {
+      // Extract an usPrivacy string from the GPP string if possible
+      const uspFromGpp = retrieveUspInfoFromGpp(gpp);
+      if (uspFromGpp) {
+        queryParams['us_privacy'] = uspFromGpp;
+      }
+    }
+  }
+
   const descriptionUrl = getDescriptionUrl(bid, options, 'params');
   if (descriptionUrl) { queryParams.description_url = descriptionUrl; }
 
@@ -299,7 +315,6 @@ export async function getVastXml(options, localCacheMap = vastLocalCache) {
   const video = adUnit?.mediaTypes?.video;
   const sdkApis = (video?.api || []).join(',');
   const usPrivacy = uspDataHandler.getConsentData?.();
-  const gpp = gppDataHandler.getConsentData?.();
   // Adding parameters required by ima
   if (config.getConfig('cache.useLocal') && window.google?.ima) {
     vastUrl = new URL(vastUrl);
@@ -311,14 +326,7 @@ export async function getVastXml(options, localCacheMap = vastLocalCache) {
     }
     if (usPrivacy) {
       vastUrl.searchParams.set('us_privacy', usPrivacy);
-    } else if (gpp) {
-      // Extract an usPrivacy string from the GPP string if possible
-      const uspFromGpp = retrieveUspInfoFromGpp(gpp);
-      if (uspFromGpp) {
-        vastUrl.searchParams.set('us_privacy', uspFromGpp)
-      }
     }
-
     vastUrl = vastUrl.toString();
   }
 

--- a/test/spec/modules/gamAdServerVideo_spec.js
+++ b/test/spec/modules/gamAdServerVideo_spec.js
@@ -872,7 +872,7 @@ describe('The DFP video support module', function () {
     server.respond();
   });
 
-  describe('Retrieve US Privacy string from GPP when using the IMA player and downloading VAST XMLs', () => {
+  describe('Retrieve US Privacy string from GPP when using the IMA player', () => {
     beforeEach(() => {
       config.setConfig({cache: { useLocal: true }});
       // Install a fake IMA object, because the us_privacy is only set when IMA is available
@@ -901,7 +901,7 @@ describe('The DFP video support module', function () {
       );
       server.respondWith(gamWrapper);
 
-      const result = getVastXml({url, adUnit: {}, bid: {}}, []).then(() => {
+      const result = getVastXml({url, adUnit: {}, bid: {}, params: {iu: '/19968336/prebid_cache_video_adunit'}}, []).then(() => {
         const request = server.requests[0];
         const url = new URL(request.url);
         return url.searchParams.get('us_privacy');
@@ -909,6 +909,11 @@ describe('The DFP video support module', function () {
       server.respond();
 
       return result;
+    }
+
+    function obtainUsPrivacyInGamVideoUrl() {
+      const url = 'https://pubads.g.doubleclick.net/gampad/ads'
+      return new URLSearchParams(buildDfpVideoUrl({url, adUnit: {}, bid: {}, params: {iu: '/19968336/prebid_cache_video_adunit'}})).get('us_privacy');
     }
 
     function mockGpp(gpp) {
@@ -936,12 +941,20 @@ describe('The DFP video support module', function () {
       }));
 
       const usPrivacyFromRequest = await obtainUsPrivacyInVastXmlRequest();
-      expect(usPrivacyFromRequest).to.equal(usPrivacy)
+      expect(usPrivacyFromRequest).to.equal(usPrivacy);
+
+      // In this case, the IMA player will add the us_privacy string
+      // It is not included in the URL returned by Prebid
+      const usPrivacyFromUrl = obtainUsPrivacyInGamVideoUrl();
+      expect(usPrivacyFromUrl).to.be.null;
     })
 
     it('no us_privacy when neither usp nor gpp is present', async () => {
       const usPrivacyFromRequqest = await obtainUsPrivacyInVastXmlRequest();
       expect(usPrivacyFromRequqest).to.be.null;
+
+      const usPrivacyFromUrl = obtainUsPrivacyInGamVideoUrl();
+      expect(usPrivacyFromUrl).to.be.null;
     })
 
     it('can retrieve from usp section in gpp', async () => {
@@ -955,7 +968,10 @@ describe('The DFP video support module', function () {
       }));
 
       const usPrivacyFromRequest = await obtainUsPrivacyInVastXmlRequest();
-      expect(usPrivacyFromRequest).to.equal('1YNY')
+      expect(usPrivacyFromRequest).to.equal('1YNY');
+
+      const usPrivacyFromUrl = obtainUsPrivacyInGamVideoUrl();
+      expect(usPrivacyFromUrl).to.equal('1YNY');
     })
     it('can retrieve from usnat section in gpp', async () => {
       mockGpp(wrapParsedSectionsIntoGPPData({
@@ -1004,6 +1020,9 @@ describe('The DFP video support module', function () {
 
       const usPrivacyFromRequest = await obtainUsPrivacyInVastXmlRequest();
       expect(usPrivacyFromRequest).to.equal('1YYY');
+
+      const usPrivacyFromUrl = obtainUsPrivacyInGamVideoUrl();
+      expect(usPrivacyFromUrl).to.equal('1YYY');
     })
     it('can retrieve from usnat section in gpp when usnat is an array', async() => {
       mockGpp(wrapParsedSectionsIntoGPPData({
@@ -1032,6 +1051,9 @@ describe('The DFP video support module', function () {
 
       const usPrivacyFromRequest = await obtainUsPrivacyInVastXmlRequest();
       expect(usPrivacyFromRequest).to.equal('1YNY');
+
+      const usPrivacyFromUrl = obtainUsPrivacyInGamVideoUrl();
+      expect(usPrivacyFromUrl).to.equal('1YNY');
     })
     it('no us_privacy when either SaleOptOutNotice or SaleOptOut is missing', async () => {
       // Missing SaleOptOutNotice
@@ -1080,6 +1102,9 @@ describe('The DFP video support module', function () {
 
       const usPrivacyFromRequest = await obtainUsPrivacyInVastXmlRequest();
       expect(usPrivacyFromRequest).to.be.null;
+
+      const usPrivacyFromUrl = obtainUsPrivacyInGamVideoUrl();
+      expect(usPrivacyFromUrl).to.be.null;
     })
     it('no us_privacy when either SaleOptOutNotice or SaleOptOut is null', async () => {
       // null SaleOptOut
@@ -1129,6 +1154,9 @@ describe('The DFP video support module', function () {
 
       const usPrivacyFromRequest = await obtainUsPrivacyInVastXmlRequest();
       expect(usPrivacyFromRequest).to.be.null;
+
+      const usPrivacyFromUrl = obtainUsPrivacyInGamVideoUrl();
+      expect(usPrivacyFromUrl).to.be.null;
     })
 
     it('can retrieve from usca section in gpp', async () => {
@@ -1165,6 +1193,9 @@ describe('The DFP video support module', function () {
 
       const usPrivacyFromRequest = await obtainUsPrivacyInVastXmlRequest();
       expect(usPrivacyFromRequest).to.equal('1YNY');
+
+      const usPrivacyFromUrl = obtainUsPrivacyInGamVideoUrl();
+      expect(usPrivacyFromUrl).to.equal('1YNY');
     })
   });
 });


### PR DESCRIPTION
In a previous commit, I added the `us_privacy` query param to the URL which we use to download the VAST XML document.

The scenario was having a CMP which adds gpp but not usp.
And since GAM only supports usp but not gpp, that previous commit derived a USP string from the GPP string and added it to the URL.

Now, we've experimented with this and we see a positive effect on our revenue:

- When we add that `us_privacy` string when using the local cache (and hence Prebid goes to GAM to download the VAST XML), which is what was done in my previous commit
- When we add that `us_privacy` string when asking Prebid for a URL which we pass to the IMA player, and let the IMA player make a request to GAM. That is what this commit is about

It moves that code to derive the usp string from the gpp info into the general `buildGamVideoUrl` method so that it covers both scenarios.

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
