### PR TITLE
Add auctionOptions to reject unknown/invalid bid mediaTypes and update validation

### DIFF
--- a/src/adapters/bidderFactory.ts
+++ b/src/adapters/bidderFactory.ts
@@ -675,13 +675,18 @@ export function isValid(adUnitCode: string, bid: Bid, { index = auctionManager.i
     return false;
   }
 
-  if (responseMediaType != null) {
-    const mediaTypes = index.getMediaTypes(bid);
-    if (mediaTypes && Object.keys(mediaTypes).length > 0) {
-      if (!mediaTypes.hasOwnProperty(responseMediaType)) {
-        logError(errorMessage(`Bid mediaType '${responseMediaType}' is not supported by the ad unit. Allowed: ${Object.keys(mediaTypes).join(', ')}`));
-        return false;
-      }
+  const auctionOptions = config.getConfig('auctionOptions') || {};
+  const rejectUnknownMediaTypes = auctionOptions.rejectUnknownMediaTypes === true;
+  const rejectInvalidMediaTypes = auctionOptions.rejectInvalidMediaTypes !== false;
+  const mediaTypes = index.getMediaTypes(bid);
+  if (mediaTypes && Object.keys(mediaTypes).length > 0) {
+    if (responseMediaType == null && rejectUnknownMediaTypes) {
+      logError(errorMessage(`Bid mediaType is required. Allowed: ${Object.keys(mediaTypes).join(', ')}`));
+      return false;
+    }
+    if (responseMediaType != null && rejectInvalidMediaTypes && !mediaTypes.hasOwnProperty(responseMediaType)) {
+      logError(errorMessage(`Bid mediaType '${responseMediaType}' is not supported by the ad unit. Allowed: ${Object.keys(mediaTypes).join(', ')}`));
+      return false;
     }
   }
 

--- a/src/auction.ts
+++ b/src/auction.ts
@@ -143,6 +143,18 @@ export interface AuctionOptionsConfig {
    * to pre-10.12 rendering logic.
    */
   legacyRender?: boolean;
+
+  /**
+   * When true, reject bids without a response `mediaType` when the ad unit has an explicit mediaTypes list.
+   * Default is false to preserve legacy behavior for responses that omit mediaType.
+   */
+  rejectUnknownMediaTypes?: boolean;
+
+  /**
+   * When true, reject bids with a response `mediaType` that does not match the ad unit's explicit mediaTypes list.
+   * Default is true; set to false to keep mismatched mediaType responses.
+   */
+  rejectInvalidMediaTypes?: boolean;
 }
 
 export interface PriceBucketConfig {

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,7 +63,7 @@ function attachProperties(config, useDefaultValues = true) {
   } : {}
 
   const validateauctionOptions = (() => {
-    const boolKeys = ['secondaryBidders', 'suppressStaleRender', 'suppressExpiredRender', 'legacyRender'];
+    const boolKeys = ['suppressStaleRender', 'suppressExpiredRender', 'legacyRender', 'rejectUnknownMediaTypes', 'rejectInvalidMediaTypes'];
     const arrKeys = ['secondaryBidders']
     const allKeys = [].concat(boolKeys).concat(arrKeys);
 

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -1746,6 +1746,58 @@ describe('bidderFactory', () => {
 
         expect(checkValid(mkResponse({ mediaType: 'banner' }), { responseMediaType: null })).to.be.true;
       });
+
+      it('should reject unknown media type when configured and adapter omits mediaType', () => {
+        req.mediaTypes = {
+          video: { context: 'instream' }
+        };
+        config.setConfig({
+          auctionOptions: {
+            rejectUnknownMediaTypes: true
+          }
+        });
+
+        expect(checkValid(mkResponse({ mediaType: 'banner' }), { responseMediaType: null })).to.be.false;
+      });
+
+      it('should keep legacy behavior when rejectUnknownMediaTypes is disabled', () => {
+        req.mediaTypes = {
+          video: { context: 'instream' }
+        };
+        config.setConfig({
+          auctionOptions: {
+            rejectUnknownMediaTypes: false
+          }
+        });
+
+        expect(checkValid(mkResponse({ mediaType: 'banner' }), { responseMediaType: null })).to.be.true;
+      });
+
+      it('should allow mismatched media type when rejectInvalidMediaTypes is disabled', () => {
+        req.mediaTypes = {
+          banner: { sizes: [[1, 2]] }
+        };
+        config.setConfig({
+          auctionOptions: {
+            rejectInvalidMediaTypes: false
+          }
+        });
+
+        expect(checkValid(mkResponse({ mediaType: 'video' }))).to.be.true;
+      });
+
+      it('should reject mismatched media type when rejectInvalidMediaTypes is enabled', () => {
+        req.mediaTypes = {
+          banner: { sizes: [[1, 2]] }
+        };
+        config.setConfig({
+          auctionOptions: {
+            rejectInvalidMediaTypes: true
+          }
+        });
+
+        expect(checkValid(mkResponse({ mediaType: 'video' }))).to.be.false;
+      });
     });
   });
 


### PR DESCRIPTION
### Motivation
- Allow publishers to opt into stricter validation of bid `mediaType` values when an ad unit declares explicit `mediaTypes` to avoid accepting ambiguous or mismatched responses.
- Preserve legacy behavior by making the stricter checks disabled by default except for invalid media types, while exposing config toggles to change that behavior.

### Description
- Added two new auction options to the public config: `rejectUnknownMediaTypes` and `rejectInvalidMediaTypes`, and exposed them in `AuctionOptionsConfig` and the config typing.
- Updated `isValid` in `src/adapters/bidderFactory.ts` to read `auctionOptions` via `config.getConfig('auctionOptions')` and to conditionally reject bids when `responseMediaType` is missing or does not match the ad unit's explicit `mediaTypes` according to the new flags.
- Extended config validation in `src/config.ts` to accept the new boolean keys and adjusted the validation list so `secondaryBidders` is treated as an array key.
- Added unit tests in `test/spec/unit/core/bidderFactory_spec.js` covering the new behaviors for both `rejectUnknownMediaTypes` and `rejectInvalidMediaTypes` (enabled and disabled cases).

### Testing
- Added unit tests in `test/spec/unit/core/bidderFactory_spec.js` to cover rejecting unknown media types and rejecting mismatched media types; these tests were executed as part of the unit test suite.
- Ran the automated unit tests via the project's test runner (`npm test`) and the updated `bidderFactory` specs passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af25aafa7c832bad21ce4814617814)