### PR TITLE
iPROM Bid Adapter: support ortb/endpoint params and relax dimension requirement

### DIFF
--- a/modules/ipromBidAdapter.js
+++ b/modules/ipromBidAdapter.js
@@ -264,7 +264,7 @@ export const spec = {
 
   interpretResponse: function (serverResponse, request) {
     if (request?.ortb) {
-      return converter.fromORTB({response: serverResponse?.body, request: request.data}).bids ?? [];
+      return converter.fromORTB({ response: serverResponse?.body, request: request.data }).bids ?? [];
     }
 
     const bids = Array.isArray(serverResponse?.body) ? serverResponse.body : [];

--- a/test/spec/modules/ipromBidAdapter_spec.js
+++ b/test/spec/modules/ipromBidAdapter_spec.js
@@ -1,6 +1,6 @@
-import {expect} from 'chai';
-import {config} from 'src/config.js';
-import {spec} from 'modules/ipromBidAdapter.js';
+import { expect } from 'chai';
+import { config } from 'src/config.js';
+import { spec } from 'modules/ipromBidAdapter.js';
 
 describe('iPROM Adapter', function () {
   let bidRequests;
@@ -476,7 +476,7 @@ describe('iPROM Adapter', function () {
         user: {
           data: [{
             name: 'taxonomy',
-            segment: [{id: 'segment-id'}]
+            segment: [{ id: 'segment-id' }]
           }]
         }
       };
@@ -491,7 +491,7 @@ describe('iPROM Adapter', function () {
         user: {
           data: [{
             name: 'taxonomy',
-            segment: [{id: 'segment-id'}]
+            segment: [{ id: 'segment-id' }]
           }]
         }
       });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
- [x] Updated bidder adapter

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
<!-- Describe the change proposed in this pull request -->
Updates to iPROM bid adapter:

- Dimension parameter is no longer required, allowing more flexible 
  ad unit configurations
- Added `ortb` parameter to control the shape of the bid request payload
- Added `endpoint` parameter for per-page endpoint configuration 
  via setBidderConfig



## Other information
- documentation pr https://github.com/prebid/prebid.github.io/pull/6475
