### PR TITLE
Agent guidelines: Document common adapter types and references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,12 @@ This file contains instructions for the Codex agent and its friends when working
 
 ## Additional context
 - for additional context on repo history, consult https://github.com/prebid/github-activity-db/blob/main/CLAUDE.md on how to download and access repo history in a database you can search locally.
+
+## Common adapter types
+- When bid adapter changes need shared type references, look in the core source modules first:
+- `src/adapters/bidderFactory.js` for bidder registration/build and bidder-spec wiring concepts.
+- `src/userSync.js` for user sync interfaces, sync option handling, and sync registration behavior.
+- `src/adapterManager.js` for adapter manager orchestration and type usage patterns around bidder lifecycle.
+- Prefer importing or mirroring conventions from these modules instead of redefining local ad-hoc shapes.
+- Use imported types for id, analytics, and rtd modules as well whenever possible.
+- Always define types for public interface to an adapter, eg each bidder parameter.


### PR DESCRIPTION
Added guidelines for common adapter types and type references.
