### PR TITLE
Prebid 11: percentInView: add timeout, adjust intersection thresholds

### DIFF
--- a/libraries/percentInView/percentInView.js
+++ b/libraries/percentInView/percentInView.js
@@ -1,6 +1,6 @@
 import { getWinDimensions, inIframe } from '../../src/utils.js';
 import { getBoundingClientRect } from '../boundingClientRect/boundingClientRect.js';
-import { defer, PbPromise } from '../../src/utils/promise.js';
+import { defer, PbPromise, delay } from '../../src/utils/promise.js';
 import { startAuction } from '../../src/prebid.js';
 import { getAdUnitElement } from '../../src/utils/adUnits.js';
 
@@ -169,13 +169,23 @@ export function intersections(mkObserver) {
   }
 }
 
-export const viewportIntersections = intersections((callback) => new IntersectionObserver(callback));
+export const viewportIntersections = intersections((callback) => new IntersectionObserver(callback, {
+  // update percentInView when visibility varies by 1%
+  threshold: Array.from({ length: 101 }, (e, i) => i / 100)
+}));
 
 export function mkIntersectionHook(intersections = viewportIntersections) {
   return function (next, request) {
-    PbPromise.allSettled((request.adUnits ?? []).map(adUnit =>
-      intersections.observe(getAdUnitElement(adUnit))
-    )).then(() => next.call(this, request));
+    PbPromise.race([
+      PbPromise.allSettled((request.adUnits ?? []).map(adUnit =>
+        intersections.observe(getAdUnitElement(adUnit))
+      )),
+      // according to MDN, with threshold 0 "the callback will be run as soon as the target element intersects or touches the boundary of the root, even if no pixels are yet visible"
+      // https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
+      // However, browsers appear to run it even when the element is outside the DOM
+      // just to be sure, cap the amount of time we wait for intersections
+      delay(20)
+    ]).then(() => next.call(this, request));
   }
 }
 

--- a/test/spec/libraries/percentInView_spec.js
+++ b/test/spec/libraries/percentInView_spec.js
@@ -56,8 +56,8 @@ describe('percentInView', () => {
     });
   });
 
-  async function delay() {
-    await new Promise(resolve => setTimeout(resolve, 10));
+  async function delay(ms = 10) {
+    await new Promise(resolve => setTimeout(resolve, ms));
   }
 
   describe('intersections', () => {
@@ -227,6 +227,19 @@ describe('percentInView', () => {
         await delay();
         sinon.assert.calledWith(next, request);
       });
+
+      it('should continue if promises never resolve', async () => {
+        hook(next, request);
+        await delay(100);
+        sinon.assert.called(next);
+      });
+
+      it('should not delay if there are no elements to observe', async () => {
+        request.adUnits = [];
+        hook(next, request);
+        await delay();
+        sinon.assert.called(next);
+      })
     });
   });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

With https://github.com/prebid/Prebid.js/pull/14525, `percentInView` uses `IntersectionObserver` and pauses auctions to get an intersection ratio for each ad unit. Although Chrome and Firefox both provide one for any element (even those outside the DOM), the [spec](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#threshold) suggests that it may only happen after "the target element intersects or touches the boundary of the root".

This adds a fixed timeout of 20ms so that auctions continue even if not intersection ratio is obtained. Also adjusts the observer's `threshold` to make sure it runs every time it varies by 1%.

