### PR TITLE
BeOpBidAdapter: Refacto beopid cookie to caudid

### DIFF
--- a/modules/beopBidAdapter.js
+++ b/modules/beopBidAdapter.js
@@ -33,18 +33,23 @@ const validIdRegExp = /^[0-9a-fA-F]{24}$/;
 
 /**
  * Generates a 24-char hex string compatible with MongoDB ObjectId semantics
- * (4-byte timestamp + 12 random hex chars). Used for first-party user id (caudid).
+ * (4-byte timestamp + 16 random hex chars). Used for first-party user id (caudid).
+ * Timestamp is padded to 8 hex chars so that a client clock in the past (or mocked Date)
+ * cannot produce a shorter string that would fail the 24-char validation on later requests.
  * @see https://www.mongodb.com/docs/manual/reference/method/objectid/
  * @return {string}
  */
 function generateObjectId() {
-  const timestamp = (Math.floor(Date.now() / 1000)).toString(16);
+  const timestamp = (Math.floor(Date.now() / 1000)).toString(16).padStart(8, '0');
   const randomPart = Array.from({ length: 16 }, () =>
     (Math.floor(Math.random() * 16)).toString(16)
   ).join('');
   return (timestamp + randomPart).toLowerCase();
 }
 const storage = getStorageManager({ bidderCode: BIDDER_CODE });
+
+/** Exported for unit tests (caudid / caudid_date cookie behavior). */
+export const __storage = storage;
 
 export const spec = {
   code: BIDDER_CODE,
@@ -86,7 +91,7 @@ export const spec = {
     const keywords = getAllOrtbKeywords(bidderRequest.ortb2, kwdsFromRequest);
 
     let caudid = '';
-    if (storage.cookiesAreEnabled) {
+    if (storage.cookiesAreEnabled()) {
       caudid = storage.getCookie(COOKIE_NAME, undefined);
       if (!caudid || !validIdRegExp.test(caudid)) {
         caudid = generateObjectId();

--- a/test/spec/modules/beopBidAdapter_spec.js
+++ b/test/spec/modules/beopBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { spec } from 'modules/beopBidAdapter.js';
+import { spec, __storage } from 'modules/beopBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
 import { config } from 'src/config.js';
 import { setConfig as setCurrencyConfig } from '../../../modules/currency.js';
@@ -380,14 +380,112 @@ describe('BeOp Bid Adapter tests', () => {
 
   describe('Ensure first party cookie is well managed', function () {
     const bidRequests = [];
+    let sandbox;
+
+    beforeEach(function () {
+      sandbox = sinon.createSandbox();
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
 
     it('should set fg to a 24-char hex ObjectID (caudid) when no cookie present', function () {
+      sandbox.stub(__storage, 'cookiesAreEnabled').returns(true);
+      sandbox.stub(__storage, 'getCookie').returns(undefined);
       const bid = Object.assign({}, validBid);
-      bidRequests.push(bid);
-      const request = spec.buildRequests(bidRequests, {});
+      const request = spec.buildRequests([bid], {});
       const payload = JSON.parse(request.data);
       expect(payload.fg).to.exist;
       expect(payload.fg).to.match(/^[0-9a-f]{24}$/);
+    });
+
+    it('should set both caudid and caudid_date cookies when generating a new id', function () {
+      sandbox.stub(__storage, 'cookiesAreEnabled').returns(true);
+      sandbox.stub(__storage, 'getCookie').returns(undefined);
+      const setCookieSpy = sandbox.stub(__storage, 'setCookie');
+
+      const bid = Object.assign({}, validBid);
+      const request = spec.buildRequests([bid], {});
+      const payload = JSON.parse(request.data);
+
+      expect(setCookieSpy.calledTwice).to.be.true;
+      expect(setCookieSpy.firstCall.args[0]).to.equal('caudid');
+      expect(setCookieSpy.firstCall.args[1]).to.match(/^[0-9a-f]{24}$/);
+      expect(setCookieSpy.secondCall.args[0]).to.equal('caudid_date');
+      expect(setCookieSpy.secondCall.args[1]).to.match(/^\d+$/);
+      expect(Number(setCookieSpy.secondCall.args[1])).to.be.closeTo(Date.now(), 5000);
+      expect(payload.fg).to.equal(setCookieSpy.firstCall.args[1]);
+    });
+
+    it('should always produce 24-char caudid when clock is in the past (timestamp padding)', function () {
+      sandbox.stub(__storage, 'cookiesAreEnabled').returns(true);
+      sandbox.stub(__storage, 'getCookie').returns(undefined);
+      const setCookieSpy = sandbox.stub(__storage, 'setCookie');
+      // Unix epoch 0 → hex "0"; without padding that would yield 1 + 16 = 17 chars and fail validIdRegExp
+      sandbox.stub(Date, 'now').returns(0);
+
+      const bid = Object.assign({}, validBid);
+      const request = spec.buildRequests([bid], {});
+      const payload = JSON.parse(request.data);
+
+      const caudid = setCookieSpy.firstCall.args[1];
+      expect(caudid).to.have.lengthOf(24);
+      expect(caudid).to.match(/^[0-9a-f]{24}$/);
+      expect(caudid.substring(0, 8)).to.equal('00000000');
+      expect(payload.fg).to.equal(caudid);
+    });
+
+    it('should not set cookies when a valid caudid cookie already exists', function () {
+      const existingCaudid = '674a1b2c3d4e5f6789abcdef';
+      sandbox.stub(__storage, 'cookiesAreEnabled').returns(true);
+      sandbox.stub(__storage, 'getCookie').callsFake((name) =>
+        name === 'caudid' ? existingCaudid : undefined
+      );
+      const setCookieSpy = sandbox.stub(__storage, 'setCookie');
+
+      const bid = Object.assign({}, validBid);
+      const request = spec.buildRequests([bid], {});
+      const payload = JSON.parse(request.data);
+
+      expect(setCookieSpy.called).to.be.false;
+      expect(payload.fg).to.equal(existingCaudid);
+    });
+
+    it('should regenerate caudid and set both cookies when existing caudid is invalid format', function () {
+      sandbox.stub(__storage, 'cookiesAreEnabled').returns(true);
+      sandbox.stub(__storage, 'getCookie').callsFake((name) =>
+        name === 'caudid' ? 'invalid-uuid-format' : undefined
+      );
+      const setCookieSpy = sandbox.stub(__storage, 'setCookie');
+
+      const bid = Object.assign({}, validBid);
+      const request = spec.buildRequests([bid], {});
+      const payload = JSON.parse(request.data);
+
+      expect(setCookieSpy.calledTwice).to.be.true;
+      expect(setCookieSpy.firstCall.args[0]).to.equal('caudid');
+      expect(setCookieSpy.firstCall.args[1]).to.match(/^[0-9a-f]{24}$/);
+      expect(setCookieSpy.secondCall.args[0]).to.equal('caudid_date');
+      expect(payload.fg).to.equal(setCookieSpy.firstCall.args[1]);
+    });
+
+    it('should clear both caudid and caudid_date when cookies are disabled', function () {
+      sandbox.stub(__storage, 'cookiesAreEnabled').returns(false);
+      const setCookieSpy = sandbox.stub(__storage, 'setCookie');
+
+      const bid = Object.assign({}, validBid);
+      const request = spec.buildRequests([bid], {});
+      const payload = JSON.parse(request.data);
+
+      expect(setCookieSpy.calledTwice).to.be.true;
+      expect(setCookieSpy.firstCall.args[0]).to.equal('caudid');
+      expect(setCookieSpy.firstCall.args[1]).to.equal('');
+      expect(setCookieSpy.firstCall.args[2]).to.equal(0);
+      expect(setCookieSpy.secondCall.args[0]).to.equal('caudid_date');
+      expect(setCookieSpy.secondCall.args[1]).to.equal('');
+      expect(setCookieSpy.secondCall.args[2]).to.equal(0);
+      expect(payload.fg).to.equal('');
     });
   });
   describe('slot name normalization', function () {


### PR DESCRIPTION
## Type of change

- [x] Refactoring (no functional changes, no api changes)

## Description of change

`beopid` became an obsolet cookie. We managed the update to `caudid` which is an ObjectId into our system, instead of the UUID before for the `beopid`