### PR TITLE
51DegreesRtdProvider: populate device.hwv, improve device.model

### DIFF
--- a/modules/51DegreesRtdProvider.js
+++ b/modules/51DegreesRtdProvider.js
@@ -220,6 +220,8 @@ export const convert51DegreesDataToOrtb2 = (data51) => {
  * @param {string} [device.hardwarevendor] Hardware vendor
  * @param {string} [device.hardwaremodel] Hardware model
  * @param {string[]} [device.hardwarename] Hardware name
+ * @param {string} [device.hardwarenameprefix] Hardware name prefix (e.g. "iPhone" from "iPhone 12 Pro Max")
+ * @param {string} [device.hardwarenameversion] Hardware name version (e.g. "12 Pro Max" from "iPhone 12 Pro Max")
  * @param {string} [device.platformname] Platform name
  * @param {string} [device.platformversion] Platform version
  * @param {number} [device.screenpixelsheight] Screen height in pixels
@@ -240,6 +242,7 @@ export const convert51DegreesDeviceToOrtb2 = (device) => {
   }
 
   const deviceModel =
+    device.hardwarenameprefix ||
     device.hardwaremodel || (
       device.hardwarename && device.hardwarename.length
         ? device.hardwarename.join(',')
@@ -257,6 +260,7 @@ export const convert51DegreesDeviceToOrtb2 = (device) => {
   deepSetNotEmptyValue(ortb2Device, 'devicetype', ORTB_DEVICE_TYPE_MAP.get(device.devicetype));
   deepSetNotEmptyValue(ortb2Device, 'make', device.hardwarevendor);
   deepSetNotEmptyValue(ortb2Device, 'model', deviceModel);
+  deepSetNotEmptyValue(ortb2Device, 'hwv', device.hardwarenameversion);
   deepSetNotEmptyValue(ortb2Device, 'os', device.platformname);
   deepSetNotEmptyValue(ortb2Device, 'osv', device.platformversion);
   deepSetNotEmptyValue(ortb2Device, 'h', device.screenpixelsphysicalheight || device.screenpixelsheight);

--- a/modules/51DegreesRtdProvider.md
+++ b/modules/51DegreesRtdProvider.md
@@ -18,7 +18,7 @@ It also sets `device.ext.fod.tpc` key to a binary value to indicate whether thir
 
 The module supports on-premise and cloud device detection services, with free options for both.
 
-A free resource key for use with 51Degrees cloud service can be obtained from [51Degrees cloud configuration](https://configure.51degrees.com/7bL8jDGz). This is the simplest approach to trial the module.
+A free resource key for use with 51Degrees cloud service can be obtained from [51Degrees cloud configuration](https://configure.51degrees.com/jJqVnTJR). This is the simplest approach to trial the module.
 
 An interface-compatible self-hosted service can be used with .NET, Java, Node, PHP, and Python. See [51Degrees examples](https://51degrees.com/documentation/_examples__device_detection__getting_started__web__on_premise.html).
 
@@ -40,7 +40,7 @@ gulp build --modules=rtdModule,51DegreesRtdProvider,appnexusBidAdapter,...
 
 #### Resource Key
 
-In order to use the module, please first obtain a Resource Key using the [Configurator tool](https://configure.51degrees.com/7bL8jDGz) - choose the following properties:
+In order to use the module, please first obtain a Resource Key using the [Configurator tool](https://configure.51degrees.com/jJqVnTJR) - choose the following properties:
 
 * DeviceId
 * DeviceType
@@ -113,7 +113,7 @@ pbjs.setConfig({
                 waitForIt: true, // should be true, otherwise the auctionDelay will be ignored
                 params: {
                     resourceKey: '<YOUR_RESOURCE_KEY>',
-                    // Get your resource key from https://configure.51degrees.com/7bL8jDGz
+                    // Get your resource key from hhttps://configure.51degrees.com/jJqVnTJR
                     // alternatively, you can use the on-premise version of the 51Degrees service and connect to your chosen endpoint
                     // onPremiseJSUrl: 'https://localhost/51Degrees.core.js'
                 },

--- a/modules/51DegreesRtdProvider.md
+++ b/modules/51DegreesRtdProvider.md
@@ -113,7 +113,7 @@ pbjs.setConfig({
                 waitForIt: true, // should be true, otherwise the auctionDelay will be ignored
                 params: {
                     resourceKey: '<YOUR_RESOURCE_KEY>',
-                    // Get your resource key from hhttps://configure.51degrees.com/jJqVnTJR
+                    // Get your resource key from https://configure.51degrees.com/jJqVnTJR
                     // alternatively, you can use the on-premise version of the 51Degrees service and connect to your chosen endpoint
                     // onPremiseJSUrl: 'https://localhost/51Degrees.core.js'
                 },

--- a/modules/51DegreesRtdProvider.md
+++ b/modules/51DegreesRtdProvider.md
@@ -10,7 +10,7 @@
 
 51Degrees module enriches an OpenRTB request with [51Degrees Device Data](https://51degrees.com/documentation/index.html).
 
-51Degrees module sets the following fields of the device object: `devicetype`, `make`, `model`, `os`, `osv`, `h`, `w`, `ppi`, `pxratio`. Interested bidder adapters may use these fields as needed. 
+51Degrees module sets the following fields of the device object: `devicetype`, `make`, `model`, `hwv`, `os`, `osv`, `h`, `w`, `ppi`, `pxratio`. Interested bidder adapters may use these fields as needed. 
 
 The module also adds a `device.ext.fod` extension object (fod == fifty one degrees) and sets `device.ext.fod.deviceId` to a permanent device ID, which can be rapidly looked up in on-premise data, exposing over 250 properties, including device age, chipset, codec support, price, operating system and app/browser versions, age, and embedded features. 
 
@@ -46,6 +46,8 @@ In order to use the module, please first obtain a Resource Key using the [Config
 * DeviceType
 * HardwareVendor
 * HardwareName
+* HardwareNamePrefix
+* HardwareNameVersion
 * HardwareModel
 * PlatformName
 * PlatformVersion

--- a/test/spec/modules/51DegreesRtdProvider_spec.js
+++ b/test/spec/modules/51DegreesRtdProvider_spec.js
@@ -390,6 +390,42 @@ describe('51DegreesRtdProvider', function() {
       expect(convert51DegreesDeviceToOrtb2(device).device).to.not.have.any.keys('model');
     });
 
+    it('prefers hardwarenameprefix over hardwaremodel for model field', function() {
+      const device = { ...fiftyOneDegreesDevice, hardwarenameprefix: 'iPhone' };
+      expect(convert51DegreesDeviceToOrtb2(device).device).to.deep.include({ model: 'iPhone' });
+    });
+
+    it('falls back to hardwaremodel when hardwarenameprefix is not provided', function() {
+      const device = { ...fiftyOneDegreesDevice };
+      delete device.hardwarenameprefix;
+      expect(convert51DegreesDeviceToOrtb2(device).device).to.deep.include({ model: 'Macintosh' });
+    });
+
+    it('sets hwv from hardwarenameversion when provided', function() {
+      const device = { ...fiftyOneDegreesDevice, hardwarenameversion: '12 Pro Max' };
+      expect(convert51DegreesDeviceToOrtb2(device).device).to.deep.include({ hwv: '12 Pro Max' });
+    });
+
+    it('does not set hwv if hardwarenameversion is not provided', function() {
+      const device = { ...fiftyOneDegreesDevice };
+      delete device.hardwarenameversion;
+      expect(convert51DegreesDeviceToOrtb2(device).device).to.not.have.any.keys('hwv');
+    });
+
+    it('sets model from hardwarenameprefix independently of hwv from hardwarenameversion', function() {
+      const deviceWithPrefix = { ...fiftyOneDegreesDevice, hardwarenameprefix: 'iPhone' };
+      delete deviceWithPrefix.hardwarenameversion;
+      const resultWithPrefix = convert51DegreesDeviceToOrtb2(deviceWithPrefix).device;
+      expect(resultWithPrefix).to.deep.include({ model: 'iPhone' });
+      expect(resultWithPrefix).to.not.have.any.keys('hwv');
+
+      const deviceWithVersion = { ...fiftyOneDegreesDevice, hardwarenameversion: '12 Pro Max' };
+      delete deviceWithVersion.hardwarenameprefix;
+      const resultWithVersion = convert51DegreesDeviceToOrtb2(deviceWithVersion).device;
+      expect(resultWithVersion).to.deep.include({ hwv: '12 Pro Max' });
+      expect(resultWithVersion).to.deep.include({ model: 'Macintosh' });
+    });
+
     it('does not set the ppi if screeninchesheight is not provided', function() {
       const device = { ...fiftyOneDegreesDevice };
       delete device.screeninchesheight;


### PR DESCRIPTION
## Type of change
- [x] Feature

## Description of change
51DegreesRtdProvider now populates `device.hwv` and introduces smarter logic populating `device.model` with a less specific `HardwareNamePrefix` property that would exclude specific device version.  F.e. if `HardwareName` is `iPhone 12 Pro Max`, `HardwareNamePrefix` would be `iPhone` and `HardwareNameVersion` would be `12 Pro Max`.  
This PR should improve chances of correct targeting for bidders that expect a less specific model name and prefer receiving hardware version separately. 

## Other information
