### PR TITLE
gppControl modules: add missing transmitUfpd check

### DIFF
--- a/libraries/mspa/activityControls.js
+++ b/libraries/mspa/activityControls.js
@@ -3,7 +3,8 @@ import {
   ACTIVITY_ENRICH_EIDS,
   ACTIVITY_ENRICH_UFPD,
   ACTIVITY_SYNC_USER,
-  ACTIVITY_TRANSMIT_PRECISE_GEO, ACTIVITY_TRANSMIT_UFPD
+  ACTIVITY_TRANSMIT_PRECISE_GEO,
+  ACTIVITY_TRANSMIT_UFPD
 } from '../../src/activities/activities.js';
 import { gppDataHandler } from '../../src/adapterManager.js';
 import { logInfo } from '../../src/utils.js';


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change

According to the [spec](https://docs.google.com/document/d/1yPEVx3bBdSkIw-QNkQR5qi1ztmn9zoXk-LaGQB6iw7Q), `gppControl_usnat` and `gppControl_usstates` should set up two different rules on `enrichUfpd` and `transmitUfpd`. 
Instead, the current version is using the `transmitUfpd` logic for `enrichEid`, and not doing any check on `transmitUfpd`.

Fixes https://github.com/prebid/Prebid.js/issues/14601

