### PR TITLE
Showheroes Bid Adapter: enable gzip compression and remove callbacks

### DIFF
--- a/modules/showheroesBidAdapter.js
+++ b/modules/showheroesBidAdapter.js
@@ -1,18 +1,18 @@
 import {
   deepAccess,
   deepSetValue,
-  triggerPixel,
   isFn,
-  logInfo
 } from '../src/utils.js';
 import { Renderer } from '../src/Renderer.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import { config } from '../src/config.js';
 
 const ENDPOINT = 'https://ads.viralize.tv/openrtb2/auction/';
 const BIDDER_CODE = 'showheroes';
 const TTL = 300;
+const DEFAULT_GZIP_ENABLED = true;
 
 const converter = ortbConverter({
   context: {
@@ -64,7 +64,6 @@ const converter = ortbConverter({
         bidResponse.renderer = createRenderer(bidResponse, renderConfig);
       }
     }
-    bidResponse.callbacks = bid.ext?.callbacks;
     bidResponse.extra = bid.ext?.extra;
     return bidResponse;
   },
@@ -89,6 +88,9 @@ export const spec = {
       url: QA?.endpoint || ENDPOINT,
       method: 'POST',
       data: ortbData,
+      options: {
+        endpointCompression: getGzipSetting(),
+      }
     };
   },
   interpretResponse: (response, request) => {
@@ -127,15 +129,6 @@ export const spec = {
 
     return syncs;
   },
-
-  onBidWon(bid) {
-    if (bid.callbacks) {
-      triggerPixel(bid.callbacks.won);
-    }
-    logInfo(
-      `Showheroes adapter won the auction. Bid id: ${bid.bidId || bid.requestId}`
-    );
-  },
 };
 
 function outstreamRender(response, renderConfig) {
@@ -165,6 +158,19 @@ function createRenderer(bid, renderConfig) {
     return outstreamRender(render, renderConfig);
   });
   return renderer;
+}
+
+function getGzipSetting() {
+  const gzipSetting = deepAccess(config.getBidderConfig(), 'showheroes.gzipEnabled');
+
+  if (gzipSetting === true || gzipSetting === "true") {
+    return true;
+  }
+  if (gzipSetting === false || gzipSetting === "false") {
+    return false;
+  }
+
+  return DEFAULT_GZIP_ENABLED;
 }
 
 registerBidder(spec);

--- a/test/spec/modules/showheroesBidAdapter_spec.js
+++ b/test/spec/modules/showheroesBidAdapter_spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import { spec } from 'modules/showheroesBidAdapter.js'
 import { addFPDToBidderRequest } from '../../helpers/fpd.js';
+import { config } from 'src/config.js';
 import { getGlobal } from '../../../src/prebidGlobal.js';
 import 'modules/priceFloors.js';
 import 'modules/consentManagementTcf.js';
@@ -147,7 +148,6 @@ describe('shBidAdapter', () => {
   describe('interpretResponse', function () {
     const vastXml = '<?xml version="1.0" encoding="utf-8"?><VAST version="3.0"><Error><![CDATA[https://static.showheroes.com/shim.gif]]></Error></VAST>'
 
-    const callback_won = 'https://test.com/track/?ver=15&session_id=01ecd03ce381505ccdeb88e555b05001&category=request_session&type=event&request_session_id=01ecd03ce381505ccdeb88e555b05001&label=prebid_won&reason=ok'
     const basicResponse = {
       cur: 'EUR',
       seatbid: [{
@@ -161,9 +161,6 @@ describe('shBidAdapter', () => {
           mtype: 2, // 2 = video
           adomain: adomain,
           ext: {
-            callbacks: {
-              won: [callback_won],
-            },
             extra: 'test',
           },
         }],
@@ -193,9 +190,6 @@ describe('shBidAdapter', () => {
               advertiserDomains: adomain
             },
             vastXml: vastXml,
-            callbacks: {
-              won: [callback_won],
-            },
             extra: 'test',
           }
         ]
@@ -285,9 +279,6 @@ describe('shBidAdapter', () => {
             mtype: 1, // 1 = banner
             adomain: adomain,
             ext: {
-              callbacks: {
-                won: [callback_won],
-              },
               extra: 'test',
             },
           }],
@@ -311,9 +302,6 @@ describe('shBidAdapter', () => {
             advertiserDomains: adomain,
           },
           ad: '<div>test banner</div>',
-          callbacks: {
-            won: [callback_won],
-          },
           extra: 'test',
         }
       ];
@@ -357,6 +345,76 @@ describe('shBidAdapter', () => {
 
       expect(result[0].type).to.equal('image');
       expect(result[0].url).to.equal('https://sync.showheroes.com/pixel');
+    });
+  });
+
+  describe('Gzip Configuration', () => {
+    let configStub;
+    let bidderConfigStub;
+
+    beforeEach(() => {
+      configStub = sinon.stub(config, 'getConfig');
+      bidderConfigStub = sinon.stub(config, 'getBidderConfig');
+    });
+
+    afterEach(() => {
+      configStub.restore();
+      if (bidderConfigStub && bidderConfigStub.restore) {
+        bidderConfigStub.restore();
+      }
+    });
+
+    it('should enable gzip compression by default', () => {
+      // No specific configuration set, should use default
+      const request = spec.buildRequests([bidRequestVideoV2], bidderRequest);
+      expect(request.options.endpointCompression).to.be.true;
+    });
+
+    it('should respect bidder-specific boolean configuration set via setBidderConfig', () => {
+      // Mock bidder-specific config to return false
+      bidderConfigStub.returns({
+        showheroes: {
+          gzipEnabled: false
+        }
+      });
+
+      const request = spec.buildRequests([bidRequestVideoV2], bidderRequest);
+      expect(request.options.endpointCompression).to.be.false;
+    });
+
+    it('should handle bidder-specific string configuration ("true")', () => {
+      bidderConfigStub.returns({
+        showheroes: {
+          gzipEnabled: 'true'
+        }
+      });
+
+      const request = spec.buildRequests([bidRequestVideoV2], bidderRequest);
+      expect(request.options.endpointCompression).to.be.true;
+    });
+
+    it('should handle bidder-specific string configuration ("false")', () => {
+      bidderConfigStub.returns({
+        showheroes: {
+          gzipEnabled: 'false'
+        }
+      });
+
+      const request = spec.buildRequests([bidRequestVideoV2], bidderRequest);
+      expect(request.options.endpointCompression).to.be.false;
+    });
+
+    it('should fall back to default when bidder-specific value is invalid', () => {
+      // Mock bidder-specific config to return invalid value
+      bidderConfigStub.returns({
+        showheroes: {
+          gzipEnabled: 'invalid'
+        }
+      });
+
+      const request = spec.buildRequests([bidRequestVideoV2], bidderRequest);
+      // Should fall back to default (true)
+      expect(request.options.endpointCompression).to.be.true;
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

This PR has 2 changes:
- enables `gzip` compression
- removes `callbacks` on `bidWon` event


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
