### PR TITLE
Showheroes Bid Adapter: rename showheroes bid adapter

### DIFF
--- a/modules/showheroes-bsBidAdapter.js
+++ b/modules/showheroes-bsBidAdapter.js
@@ -1,0 +1,9 @@
+// This file exists for backwards compatibility only.
+// The adapter has been renamed to showheroesBidAdapter.
+// Please update your build configuration to use showheroesBidAdapter instead.
+// This file will be removed in a future release.
+import { spec as newSpec } from './showheroesBidAdapter.js'; // eslint-disable-line prebid/validate-imports
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+
+export const spec = { ...newSpec, code: 'showheroes-bs' };
+registerBidder(spec);

--- a/modules/showheroesBidAdapter.js
+++ b/modules/showheroesBidAdapter.js
@@ -11,7 +11,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 
 const ENDPOINT = 'https://ads.viralize.tv/openrtb2/auction/';
-const BIDDER_CODE = 'showheroes-bs';
+const BIDDER_CODE = 'showheroes';
 const TTL = 300;
 
 const converter = ortbConverter({
@@ -75,7 +75,7 @@ const GVLID = 111;
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
-  aliases: ['showheroesBs'],
+  aliases: ['showheroesBs', 'showheroes-bs'],
   supportedMediaTypes: [VIDEO, BANNER],
   isBidRequestValid: (bid) => {
     return !!bid.params.unitId;

--- a/modules/showheroesBidAdapter.js
+++ b/modules/showheroesBidAdapter.js
@@ -75,7 +75,7 @@ const GVLID = 111;
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
-  aliases: ['showheroesBs', 'showheroes-bs'],
+  aliases: ['showheroesBs'],
   supportedMediaTypes: [VIDEO, BANNER],
   isBidRequestValid: (bid) => {
     return !!bid.params.unitId;

--- a/modules/showheroesBidAdapter.md
+++ b/modules/showheroesBidAdapter.md
@@ -23,7 +23,7 @@ A module that connects to ShowHeroes demand source to fetch bids.
                },
                bids: [
                    {
-                       bidder: "showheroes-bs",
+                       bidder: "showheroes",
                        params: {
                            unitId: '1234abcd-5678efgh',
                        }
@@ -40,7 +40,7 @@ A module that connects to ShowHeroes demand source to fetch bids.
                },
                bids: [
                    {
-                       bidder: "showheroes-bs",
+                       bidder: "showheroes",
                        params: {
                            unitId: '1234abcd-5678efgh',
                        }

--- a/test/spec/modules/showheroesBidAdapter_spec.js
+++ b/test/spec/modules/showheroesBidAdapter_spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { spec } from 'modules/showheroes-bsBidAdapter.js'
+import { spec } from 'modules/showheroesBidAdapter.js'
 import { addFPDToBidderRequest } from '../../helpers/fpd.js';
 import { getGlobal } from '../../../src/prebidGlobal.js';
 import 'modules/priceFloors.js';
@@ -45,7 +45,7 @@ const schain = {
 }
 
 const bidRequestCommonParamsV2 = {
-  bidder: 'showheroes-bs',
+  bidder: 'showheroes',
   params: {
     unitId: 'AACBWAcof-611K4U',
   },


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 

- [x] Refactoring (no functional changes, no api changes)

## Description of change

Rename `showheroes-bs` to just `showheroes`, but keep the `showheroes-bs` as an alias for backwards compatibility.