### PR TITLE
Sparteo Bid Adapter: fix consent handling

### DIFF
--- a/modules/sparteoBidAdapter.js
+++ b/modules/sparteoBidAdapter.js
@@ -25,11 +25,6 @@ const converter = ortbConverter({
   request(buildRequest, imps, bidderRequest, context) {
     const request = buildRequest(imps, bidderRequest, context);
 
-    if (!!(bidderRequest?.ortb2?.site) && !!(bidderRequest?.ortb2?.app)) {
-      request.site = bidderRequest.ortb2.site;
-      delete request.app;
-    }
-
     const hasSite = !!request.site;
     const hasApp = !!request.app;
     const root = hasSite ? 'site' : (hasApp ? 'app' : null);
@@ -51,7 +46,7 @@ const converter = ortbConverter({
   imp(buildImp, bidRequest, context) {
     const imp = buildImp(bidRequest, context);
 
-    deepSetValue(imp, 'ext.sparteo.params', bidRequest.params);
+    deepSetValue(imp, 'ext.sparteo.params', { ...bidRequest.params });
     imp.ext.sparteo.params.adUnitCode = bidRequest.adUnitCode;
 
     return imp;
@@ -63,7 +58,10 @@ const converter = ortbConverter({
 
     if (context.mediaType === 'video') {
       response.nurl = bid.nurl;
-      response.vastUrl = deepAccess(bid, 'ext.prebid.cache.vastXml.url') ?? null;
+      const cacheUrl = deepAccess(bid, 'ext.prebid.cache.vastXml.url');
+      if (cacheUrl) {
+        response.vastUrl = cacheUrl;
+      }
     }
 
     // extract renderer config, if present, and create Prebid renderer
@@ -245,7 +243,7 @@ export const spec = {
     return bids;
   },
 
-  getUserSyncs: function (syncOptions, serverResponses, gdprConsent, uspConsent) {
+  getUserSyncs: function (syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) {
     let syncurl = '';
 
     if (!isSynced && !window.sparteoCrossfire?.started) {
@@ -254,8 +252,12 @@ export const spec = {
         syncurl += '&gdpr=' + (gdprConsent.gdprApplies ? 1 : 0);
         syncurl += '&gdpr_consent=' + encodeURIComponent(gdprConsent.consentString || '');
       }
-      if (uspConsent && uspConsent.consentString) {
-        syncurl += `&usp_consent=${uspConsent.consentString}`;
+      if (uspConsent) {
+        syncurl += '&usp_consent=' + encodeURIComponent(uspConsent);
+      }
+      if (gppConsent) {
+        syncurl += '&gpp=' + encodeURIComponent(gppConsent.gppString || '');
+        syncurl += '&gpp_sid=' + encodeURIComponent((gppConsent.applicableSections || []).join(','));
       }
 
       if (syncOptions.iframeEnabled) {

--- a/test/spec/modules/sparteoBidAdapter_spec.js
+++ b/test/spec/modules/sparteoBidAdapter_spec.js
@@ -408,6 +408,44 @@ describe('SparteoAdapter', function () {
       });
 
       if (FEATURES.VIDEO) {
+        it('should fallback to nurl as vastUrl when no cache URL is present', function () {
+          const response = {
+            body: {
+              'id': '63f4d300-6896-4bdc-8561-0932f73148b1',
+              'cur': 'EUR',
+              'seatbid': [
+                {
+                  'seat': 'sparteo',
+                  'group': 0,
+                  'bid': [
+                    {
+                      'id': 'cdbb6982-a269-40c7-84e5-04797f11d87b',
+                      'impid': '5e6f7g8h',
+                      'price': 5,
+                      'ext': {
+                        'prebid': {
+                          'type': 'video'
+                        }
+                      },
+                      'adm': 'tag',
+                      'crid': 'crid',
+                      'w': 640,
+                      'h': 480,
+                      'nurl': 'https://t.bidder.sparteo.com/vast'
+                    }
+                  ]
+                }
+              ]
+            }
+          };
+
+          const request = adapter.buildRequests([VALID_BID_VIDEO], BIDDER_REQUEST_VIDEO);
+          const bids = adapter.interpretResponse(response, request);
+
+          expect(bids[0].vastUrl).to.equal('https://t.bidder.sparteo.com/vast');
+          expect(bids[0].nurl).to.equal('https://t.bidder.sparteo.com/vast');
+        });
+
         it('should interprete renderer config', function () {
           let response = {
             body: {
@@ -515,8 +553,12 @@ describe('SparteoAdapter', function () {
   });
 
   describe('getUserSyncs', function () {
+    beforeEach(function () {
+      delete window.sparteoCrossfire;
+    });
+
     describe('Check methods succeed', function () {
-      it('should return the sync url', function () {
+      it('should return the sync url with GDPR, USP and GPP consent params', function () {
         const syncOptions = {
           'iframeEnabled': true,
           'pixelEnabled': false
@@ -525,16 +567,18 @@ describe('SparteoAdapter', function () {
           gdprApplies: 1,
           consentString: 'tcfv2'
         };
-        const uspConsent = {
-          consentString: '1Y---'
+        const uspConsent = '1Y---';
+        const gppConsent = {
+          gppString: 'DBACNYA~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA',
+          applicableSections: [2, 6]
         };
 
         const syncUrls = [{
           type: 'iframe',
-          url: USER_SYNC_URL_IFRAME + '&gdpr=1&gdpr_consent=tcfv2&usp_consent=1Y---'
+          url: USER_SYNC_URL_IFRAME + '&gdpr=1&gdpr_consent=tcfv2&usp_consent=1Y---&gpp=' + encodeURIComponent('DBACNYA~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA') + '&gpp_sid=' + encodeURIComponent('2,6')
         }];
 
-        expect(adapter.getUserSyncs(syncOptions, null, gdprConsent, uspConsent)).to.deep.equal(syncUrls);
+        expect(adapter.getUserSyncs(syncOptions, null, gdprConsent, uspConsent, gppConsent)).to.deep.equal(syncUrls);
       });
     });
   });
@@ -710,7 +754,7 @@ describe('SparteoAdapter', function () {
       );
     });
 
-    it('prefers site over app when both are present', function () {
+    it('prefers app over site when both are present (ortbConverter default)', function () {
       const ENDPOINT = 'https://bid.sparteo.com/auction?network_id=${NETWORK_ID}${SITE_DOMAIN_QUERY}${APP_DOMAIN_QUERY}${BUNDLE_QUERY}';
       const bid = deepClone(VALID_BID_BANNER);
       bid.params.endpoint = ENDPOINT;
@@ -727,10 +771,10 @@ describe('SparteoAdapter', function () {
       delete req.data.id;
 
       expect(req.url).to.equal(
-        'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&site_domain=site.sparteo.com'
+        'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&app_domain=app.sparteo.com&bundle=com.sparteo.app'
       );
-      expect(req.data.site?.publisher?.ext?.params?.networkId).to.equal('1234567a-eb1b-1fae-1d23-e1fbaef234cf');
-      expect(req.data.app).to.be.undefined;
+      expect(req.data.app?.publisher?.ext?.params?.networkId).to.equal('1234567a-eb1b-1fae-1d23-e1fbaef234cf');
+      expect(req.data.site).to.be.undefined;
     });
 
     ['', '   ', 'null', 'NuLl'].forEach((val) => {
@@ -856,6 +900,7 @@ describe('SparteoAdapter', function () {
       delete req.data.id;
 
       expect(req.data.imp[0]?.ext?.sparteo?.params?.adUnitCode).to.equal(bid.adUnitCode);
+      expect(bid.params.adUnitCode).to.be.undefined;
     });
 
     it('sets pbjsVersion and networkId under site root', function () {


### PR DESCRIPTION
Hi Team :-)

Please, we would like to submit this update to our Bid Adapter.

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

fix consent handling, vastUrl clobber, params mutation, and dead code

- Add GPP consent support to getUserSyncs (5th parameter)
- Fix USP consent: treat as plain string, not object (matching Prebid contract)
- Encode USP value with encodeURIComponent for consistency
- Fix vastUrl being clobbered to null when no cache URL exists (preserve ortbConverter nurl fallback)
- Shallow-copy bidRequest.params to avoid mutating the original object
- Remove dead site+app conflict resolution (ortbConverter's clientSectionChecker already handles this)
- Update tests to match all fixes