### PR TITLE
ceeIdSystem: clean up test output

### DIFF
--- a/modules/ceeIdSystem.js
+++ b/modules/ceeIdSystem.js
@@ -52,7 +52,8 @@ export function fetchCeeIdToken(requestData) {
             reject(error);
           }
         },
-        error: (error) => {
+        error: (statusText, xhr) => {
+          const error = statusText || 'Network Error';
           logError(`${MODULE_NAME}: ID fetch encountered an error`, error);
           reject(error);
         }

--- a/test/spec/modules/ceeIdSystem_spec.js
+++ b/test/spec/modules/ceeIdSystem_spec.js
@@ -1,7 +1,7 @@
 import { ceeIdSubmodule, storage, readId, fetchCeeIdToken } from 'modules/ceeIdSystem.js';
 import { expect } from 'chai';
 import { server } from 'test/mocks/xhr.js';
-import { logError } from 'src/utils.js';
+import * as utils from 'src/utils.js';
 import sinon from 'sinon';
 
 describe('ceeIdSystem', () => {
@@ -137,16 +137,15 @@ describe('ceeIdSystem', () => {
       };
       const responseBody = JSON.stringify({});
 
-      fetchCeeIdToken(requestData).then(() => {
+      const tokenPromise = fetchCeeIdToken(requestData);
+      const request = server.requests[0];
+      request.respond(200, { 'Content-Type': 'application/json' }, responseBody);
+
+      return tokenPromise.then(() => {
         throw new Error('Promise should not be resolved');
       }).catch((error) => {
         expect(error.message).to.equal('No token in response');
       });
-
-      setTimeout(() => {
-        const request = server.requests[0];
-        request.respond(200, { 'Content-Type': 'application/json' }, responseBody);
-      }, 0);
     });
 
     it('should reject if the response is not valid JSON', () => {
@@ -161,20 +160,19 @@ describe('ceeIdSystem', () => {
       };
       const responseBody = 'Invalid JSON';
 
-      fetchCeeIdToken(requestData).then(() => {
+      const tokenPromise = fetchCeeIdToken(requestData);
+      const request = server.requests[0];
+      expect(request).to.not.be.undefined;
+      request.respond(400, { 'Content-Type': 'application/json' }, responseBody);
+
+      return tokenPromise.then(() => {
         throw new Error('Promise should not be resolved');
       }).catch((error) => {
-        expect(error.message).to.equal('Unexpected token I in JSON at position 0');
+        expect(error).to.equal('Bad Request');
       });
-
-      setTimeout(() => {
-        const request = server.requests[0];
-        expect(request).to.not.be.undefined;
-        request.respond(400, { 'Content-Type': 'application/json' }, responseBody);
-      }, 0);
     });
 
-    it('should reject if the request encounters an error', (done) => {
+    it('should reject if the request encounters an error', async () => {
       const consentString = 'testConsentString';
       const requestData = {
         publisherId: 'testPublisher',
@@ -185,43 +183,37 @@ describe('ceeIdSystem', () => {
         },
       };
 
-      fetchCeeIdToken(requestData).then(() => {
+      const tokenPromise = fetchCeeIdToken(requestData);
+      const request = server.requests[0];
+      expect(request).to.not.be.undefined;
+      request.error();
+
+      await tokenPromise.then(() => {
         throw new Error('Promise should not be resolved');
       }).catch((error) => {
-        expect(error.message).to.equal('Network Error');
+        expect(error).to.equal('Network Error');
       });
-
-      setTimeout(() => {
-        const request = server.requests[0];
-        expect(request).to.not.be.undefined;
-        request.error();
-        done();
-      }, 0);
     });
 
-    it('should handle fetchCeeIdToken network error and log it', (done) => {
+    it('should handle fetchCeeIdToken network error and log it', async () => {
       const requestData = {
         publisherId: 'testPublisher',
         type: 'testType',
         value: 'testValue'
       };
-      const logErrorSpy = sinon.spy(logError);
+      const logErrorSpy = sandbox.spy(utils, 'logError');
+      const tokenPromise = fetchCeeIdToken(requestData);
+      const request = server.requests[0];
+      expect(request).to.not.be.undefined;
+      request.error();
 
-      fetchCeeIdToken(requestData).then(() => {
+      await tokenPromise.then(() => {
         throw new Error('Promise should not be resolved');
       }).catch((error) => {
-        expect(error.message).to.equal('Network Error');
+        expect(error).to.equal('Network Error');
         expect(logErrorSpy.calledOnce).to.be.true;
-        expect(logErrorSpy.calledWith(`${MODULE_NAME}: ID fetch encountered an error`, sinon.match.instanceOf(Error))).to.be.true;
-        done();
+        expect(logErrorSpy.calledWith(`${MODULE_NAME}: ID fetch encountered an error`, 'Network Error')).to.be.true;
       });
-
-      setTimeout(() => {
-        const request = server.requests[0];
-        expect(request).to.not.be.undefined;
-        request.error();
-        done();
-      }, 0);
     });
   });
 


### PR DESCRIPTION
Cleans up tests on ceeId

AI written misc info below


### Motivation
- Ensure the AJAX error callback receives and logs the actual status text or a sensible fallback instead of assuming an Error object.
- Make tests deterministic by removing reliance on deferred `setTimeout` flows and aligning expectations with the updated error handling.
- Modernize tests to use direct `server.requests[0]` interaction and async/promise patterns for clarity and reliability.

### Description
- Change the `ajax` error callback in `modules/ceeIdSystem.js` to the `(statusText, xhr)` signature and normalize the error to `statusText || 'Network Error'` before logging and rejecting.
- Update the `logError` invocations to pass the normalized error string to match the new handler behavior.
- Revise `test/spec/modules/ceeIdSystem_spec.js` to import `logError` via `* as utils` for spying, convert several tests to use promise/`async` patterns, and interact immediately with `server.requests[0]` instead of using `setTimeout`.
- Adjust test assertions to expect error strings (e.g. `'Network Error'` or `'Bad Request'`) and to verify `logError` was called with the normalized message.

### Testing
- Ran the updated unit tests in `test/spec/modules/ceeIdSystem_spec.js` covering token fetch success, missing-token response, invalid JSON response, and network error, and all tests passed.
- Verified that the `logError` spy assertions execute and confirm the normalized error message is logged as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dd2b8f66c8832b96ca4e5090605f37)