### PR TITLE
Core: clear scheduled ttl purge timer correctly

### DIFF
--- a/src/utils/ttlCollection.ts
+++ b/src/utils/ttlCollection.ts
@@ -50,7 +50,7 @@ export function ttlCollection<T>(
   let nextPurge, task;
 
   function reschedulePurge() {
-    task && clearTimeout(task);
+    task && clearTimeout(task());
     if (pendingPurge.length > 0) {
       const now = timestamp();
       nextPurge = Math.max(now, pendingPurge[0].expiry + slack);


### PR DESCRIPTION
AI generated notes: the bugfix is simple


### Motivation
- The test suite produced a `FakeTimers: clearTimeout was invoked to clear a native timer...` warning because `ttlCollection` passed the timer-id getter returned by `setFocusTimeout` directly to `clearTimeout` instead of the actual timer id.

### Description
- Fix `reschedulePurge` in `src/utils/ttlCollection.ts` to call the getter returned by `setFocusTimeout` when clearing the scheduled purge so `clearTimeout` receives the real timer id (`clearTimeout(task())` instead of `clearTimeout(task)`).

### Testing
- Ran `npx eslint src/utils/ttlCollection.ts test/spec/unit/utils/ttlCollection_spec.js --cache --cache-strategy content` and it completed successfully.
- Ran `npx gulp test --nolint --file test/spec/unit/utils/ttlCollection_spec.js` and the spec passed.
- Ran `TEST_CHUNK=8 npx gulp test --nolint` and the chunked test run completed with the FakeTimers warning no longer appearing and all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dd36cab0c8832b8fe22c7ef5a90aca)