### PR TITLE
Sirdata RTD Module: use shared targeting helper instead of direct GPT calls

### DIFF
--- a/modules/sirdataRtdProvider.js
+++ b/modules/sirdataRtdProvider.js
@@ -18,6 +18,7 @@ import { getRefererInfo } from '../src/refererDetection.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { MODULE_TYPE_RTD } from '../src/activities/modules.js';
 import { submodule } from '../src/hook.js';
+import { setKeyValue } from '../libraries/gptUtils/gptUtils.js';
 
 /** @type {string} */
 const MODULE_NAME = 'realTimeData';
@@ -671,13 +672,9 @@ export function addSegmentData(reqBids, data, adUnits, onDone) {
         sirdataMergedList = [...sirdataMergedList, ...gamCurationData.segments, ...gamCurationData.categories];
       }
 
-      window.googletag.cmd.push(() => {
-        window.googletag.pubads().getSlots().forEach(slot => {
-          if (typeof slot.setTargeting !== 'undefined' && sirdataMergedList.length > 0) {
-            slot.setTargeting('sd_rtd', sirdataMergedList);
-          }
-        });
-      });
+      if (sirdataMergedList.length > 0) {
+        setKeyValue('sd_rtd', sirdataMergedList);
+      }
     } catch (e) {
       logError(LOG_PREFIX, e);
     }

--- a/test/spec/modules/sirdataRtdProvider_spec.js
+++ b/test/spec/modules/sirdataRtdProvider_spec.js
@@ -119,6 +119,26 @@ describe('sirdataRtdProvider', function () {
   });
 
   describe('Add Segment Data', function () {
+    let originalGoogletag;
+    let setTargetingSpy;
+
+    beforeEach(function () {
+      originalGoogletag = window.googletag;
+      setTargetingSpy = sinon.spy();
+      window.googletag = {
+        cmd: {
+          push: (fn) => fn()
+        },
+        pubads: () => ({
+          setTargeting: setTargetingSpy
+        })
+      };
+    });
+
+    afterEach(function () {
+      window.googletag = originalGoogletag;
+    });
+
     it('adds segment data', function () {
       const firstConfig = {
         params: {
@@ -180,6 +200,7 @@ describe('sirdataRtdProvider', function () {
       }
       addSegmentData(firstReqBidsConfigObj, firstData, adUnits, function() { return true; });
       expect(firstReqBidsConfigObj.ortb2Fragments.global.user.data[0].ext.segtax).to.equal(4);
+      expect(setTargetingSpy.calledOnceWithExactly('sd_rtd', ['111111', '222222', '333333', '444444', '555555', '666666'])).to.equal(true);
     });
   });
 


### PR DESCRIPTION
Half of solution to #14706 


AI generated noted below


### Motivation

- Avoid direct per-slot GPT manipulation from the Sirdata RTD module and route GAM updates through Prebid's shared targeting helpers to follow project conventions.  
- Keep existing segment/category merging and ORTB2 behavior unchanged while consolidating how page-level targeting is applied.

### Description

- Replaced direct GPT slot iteration and `slot.setTargeting` calls with the shared helper `setKeyValue('sd_rtd', ...)` by importing `setKeyValue` from `libraries/gptUtils/gptUtils.js` in `modules/sirdataRtdProvider.js`.  
- Preserved the existing curation/taxonomy merge logic that builds `sirdataMergedList` before applying targeting.  
- Added test scaffolding in `test/spec/modules/sirdataRtdProvider_spec.js` to stub `window.googletag.pubads().setTargeting` and assert the merged `sd_rtd` values are sent via the shared targeting path.  
- Modified files: `modules/sirdataRtdProvider.js` and `test/spec/modules/sirdataRtdProvider_spec.js`.

### Testing

- Ran lint on the changed files with `npx eslint --cache --cache-strategy content modules/sirdataRtdProvider.js test/spec/modules/sirdataRtdProvider_spec.js` and it completed successfully.  
- Ran the module unit spec with `npx gulp test --nolint --file test/spec/modules/sirdataRtdProvider_spec.js` and the spec completed successfully (the spec bundle ran and reported the tests passed).  
- The updated spec asserts that `sd_rtd` is passed through the targeting helper and the relevant tests in the spec suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dd44eeaa44832b85544a105b44e05d)