### PR TITLE
Core: bump serialize-javascript to 7.0.5 via npm override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18107,14 +18107,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "license": "MIT",
@@ -18932,11 +18924,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-index": {
@@ -32840,7 +32834,7 @@
         "log-symbols": "^4.1.0",
         "minimatch": "^5.1.6",
         "ms": "^2.1.3",
-        "serialize-javascript": "^6.0.2",
+        "serialize-javascript": "^7.0.5",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
         "workerpool": "^6.5.1",
@@ -33974,13 +33968,6 @@
       "version": "1.2.3",
       "dev": true
     },
-    "randombytes": {
-      "version": "2.1.0",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "range-parser": {
       "version": "1.2.1"
     },
@@ -34514,11 +34501,10 @@
       }
     },
     "serialize-javascript": {
-      "version": "6.0.2",
-      "dev": true,
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
+      "dev": true
     },
     "serve-index": {
       "version": "1.9.1",
@@ -35280,7 +35266,7 @@
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
         "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
+        "serialize-javascript": "^7.0.5",
         "terser": "^5.31.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -168,7 +168,8 @@
     "gulp-connect": {
       "send": "0.19.0"
     },
-    "send": "0.19.0"
+    "send": "0.19.0",
+    "serialize-javascript": "^7.0.5"
   },
   "peerDependencies": {
     "schema-utils": "^4.3.2"


### PR DESCRIPTION
resolves two security alerts


### Motivation
- The dependency tree was locking `serialize-javascript` at `6.0.2`, so pinning to a 7.0.5+ release is required to resolve the older, potentially vulnerable version.

### Description
- Added an npm `overrides` entry in `package.json` to force `serialize-javascript` to `^7.0.5` across the dependency graph.【F:package.json†L167-L173】
- Regenerated `package-lock.json` so the locked `serialize-javascript` package resolves to `7.0.5` and updated transitive references (notably under `mocha` and `terser-webpack-plugin`).【F:package-lock.json†L18926-L18934】【F:package-lock.json†L32837-L32837】【F:package-lock.json†L35265-L35270】
- Committed the updated `package.json` and `package-lock.json` to lock the new resolution.

### Testing
- Ran `npm install --package-lock-only` which completed successfully. 
- Verified the lockfile resolution with `node -e "const lock=require('./package-lock.json'); console.log(lock.packages['node_modules/serialize-javascript'].version)"` which prints `7.0.5`.
- Inspected the dependency graph with `npm ls serialize-javascript --all` and confirmed the lockfile now resolves `serialize-javascript` to the overridden `^7.0.5` entry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dd5dc95c98832b9b1fb47272c5e0f1)