### PR TITLE
Build System: remove unused opn dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,6 @@ var connect = require('gulp-connect');
 var webpack = require('webpack');
 var webpackStream = require('webpack-stream');
 var gulpClean = require('gulp-clean');
-var opens = require('opn');
 var webpackConfig = require('./webpack.conf.js');
 const standaloneDebuggingConfig = require('./webpack.debugging.js');
 var helpers = require('./gulpHelpers.js');

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,6 @@
         "neostandard": "^0.12.2",
         "nise": "^6.1.1",
         "node-html-parser": "^6.1.5",
-        "opn": "^5.4.0",
         "plugin-error": "^2.0.1",
         "puppeteer": "^24.10.0",
         "resolve-from": "^5.0.0",
@@ -17279,25 +17278,6 @@
         "opener": "bin/opener-bin.js"
       }
     },
-    "node_modules/opn": {
-      "version": "5.5.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-wsl": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/opn/node_modules/is-wsl": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "dev": true,
@@ -33457,19 +33437,6 @@
     "opener": {
       "version": "1.5.2",
       "dev": true
-    },
-    "opn": {
-      "version": "5.5.0",
-      "dev": true,
-      "requires": {
-        "is-wsl": "^1.1.0"
-      },
-      "dependencies": {
-        "is-wsl": {
-          "version": "1.1.0",
-          "dev": true
-        }
-      }
     },
     "optionator": {
       "version": "0.9.4",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "neostandard": "^0.12.2",
     "nise": "^6.1.1",
     "node-html-parser": "^6.1.5",
-    "opn": "^5.4.0",
     "plugin-error": "^2.0.1",
     "puppeteer": "^24.10.0",
     "resolve-from": "^5.0.0",


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

- remove unused `opn` dependency to reduce supply-chain