### PR TITLE
Core: Add type declaration for customGptSlotMatching

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -264,7 +264,7 @@ export interface Config {
   /**
    * Customize how a GPT slot is matched to an ad unit code during targeting.
    */
-  customGptSlotMatching?: (slot: googletag.Slot) => (adUnitCode: string) => boolean;
+  customGptSlotMatching?: (slot: googletag.Slot) => ((adUnitCode: string) => boolean) | undefined;
   /**
    * List of fingerprinting APIs to disable. When an API is listed, the corresponding library
    * returns a safe default instead of reading the real value. Supported: 'devicepixelratio', 'webdriver', 'resolvedoptions'.

--- a/src/config.ts
+++ b/src/config.ts
@@ -262,6 +262,10 @@ export interface Config {
    */
   bidTargetingExclusion?: (bid: Bid, bids: Bid[]) => boolean;
   /**
+   * Customize how a GPT slot is matched to an ad unit code during targeting.
+   */
+  customGptSlotMatching?: (slot: googletag.Slot) => (adUnitCode: string) => boolean;
+  /**
    * List of fingerprinting APIs to disable. When an API is listed, the corresponding library
    * returns a safe default instead of reading the real value. Supported: 'devicepixelratio', 'webdriver', 'resolvedoptions'.
    */


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Added the type declaration for the `customGptSlotMatching` config variable introduced in Prebid 11 and documented here : https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html#customGptSlotMatching
