### PR TITLE
Core: bump IAB type package versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,9 @@
         "fun-hooks": "^1.1.0",
         "gulp-babel": "^8.0.0",
         "gulp-wrap": "^0.15.0",
-        "iab-adcom": "^1.0.6",
-        "iab-native": "^1.0.0",
-        "iab-openrtb": "^1.0.1",
+        "iab-adcom": "^2.0.1",
+        "iab-native": "^1.0.1",
+        "iab-openrtb": "^2.1.0",
         "klona": "^2.0.6",
         "live-connect-js": "^7.2.0"
       },
@@ -13801,27 +13801,30 @@
       }
     },
     "node_modules/iab-adcom": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/iab-adcom/-/iab-adcom-1.0.6.tgz",
-      "integrity": "sha512-XAJdidfrFgZNKmHqcXD3Zhqik2rdSmOs+PGgeVfPWgthxvzNBQxkZnKkW3QAau6mrLjtJc8yOQC6awcEv7gryA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/iab-adcom/-/iab-adcom-2.0.1.tgz",
+      "integrity": "sha512-iLMQoxoeuZaOBhNX8lKD96abjLRbveKhSnu+L6MAyJ6DBz756qQjIKqddplRwO7/TCflAMRCSHFfTxYDqMPtEw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/iab-native": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/iab-native/-/iab-native-1.0.0.tgz",
-      "integrity": "sha512-AxGYpKGRcyG5pbEAqj+ssxNwZAfxC0pRwyKc0MYoKjm0UeOoUNCWrZV0HGimcQii6ebe6MRqBQEeENyHM4qTdQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/iab-native/-/iab-native-1.0.1.tgz",
+      "integrity": "sha512-CrutbUqcP1h4ZKeCO1cOzYmcPRs4MqMSLz4hCUvU3wRlPoOVm6ErKJUifwomke9L9SQazKZx4NXcoiSNR2fXWw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/iab-openrtb": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/iab-openrtb/-/iab-openrtb-1.0.1.tgz",
-      "integrity": "sha512-egawJx6+pMh/6uA/hak1y+R2+XCSH2jxteSkWlY98/XdQQftaMUMllUFNMKrHwq9lgCI70Me06g4JCCnV6E62g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/iab-openrtb/-/iab-openrtb-2.1.0.tgz",
+      "integrity": "sha512-qxKlUbogYm6/Yef1jVQhLNm7/aNApnv1ZxmlLE8ZWU6SN/SsKfb0ygHfxvxeNCoSJQk9Ph7wLEwXBm+HEYH52Q==",
+      "license": "MIT",
       "dependencies": {
-        "iab-adcom": "1.0.6"
+        "iab-adcom": "2.0.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -31663,21 +31666,21 @@
       "dev": true
     },
     "iab-adcom": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/iab-adcom/-/iab-adcom-1.0.6.tgz",
-      "integrity": "sha512-XAJdidfrFgZNKmHqcXD3Zhqik2rdSmOs+PGgeVfPWgthxvzNBQxkZnKkW3QAau6mrLjtJc8yOQC6awcEv7gryA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/iab-adcom/-/iab-adcom-2.0.1.tgz",
+      "integrity": "sha512-iLMQoxoeuZaOBhNX8lKD96abjLRbveKhSnu+L6MAyJ6DBz756qQjIKqddplRwO7/TCflAMRCSHFfTxYDqMPtEw=="
     },
     "iab-native": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/iab-native/-/iab-native-1.0.0.tgz",
-      "integrity": "sha512-AxGYpKGRcyG5pbEAqj+ssxNwZAfxC0pRwyKc0MYoKjm0UeOoUNCWrZV0HGimcQii6ebe6MRqBQEeENyHM4qTdQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/iab-native/-/iab-native-1.0.1.tgz",
+      "integrity": "sha512-CrutbUqcP1h4ZKeCO1cOzYmcPRs4MqMSLz4hCUvU3wRlPoOVm6ErKJUifwomke9L9SQazKZx4NXcoiSNR2fXWw=="
     },
     "iab-openrtb": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/iab-openrtb/-/iab-openrtb-1.0.1.tgz",
-      "integrity": "sha512-egawJx6+pMh/6uA/hak1y+R2+XCSH2jxteSkWlY98/XdQQftaMUMllUFNMKrHwq9lgCI70Me06g4JCCnV6E62g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/iab-openrtb/-/iab-openrtb-2.1.0.tgz",
+      "integrity": "sha512-qxKlUbogYm6/Yef1jVQhLNm7/aNApnv1ZxmlLE8ZWU6SN/SsKfb0ygHfxvxeNCoSJQk9Ph7wLEwXBm+HEYH52Q==",
       "requires": {
-        "iab-adcom": "1.0.6"
+        "iab-adcom": "2.0.1"
       }
     },
     "iconv-lite": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,9 @@
         "express": "^4.15.4",
         "fun-hooks": "^1.1.0",
         "gulp-babel": "^8.0.0",
-        "iab-adcom": "^1.0.6",
-        "iab-native": "^1.0.0",
-        "iab-openrtb": "^1.0.1",
+        "iab-adcom": "^2.0.1",
+        "iab-native": "^1.0.1",
+        "iab-openrtb": "^2.1.0",
         "klona": "^2.0.6",
         "live-connect-js": "^7.2.0"
       },
@@ -13995,27 +13995,30 @@
       }
     },
     "node_modules/iab-adcom": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/iab-adcom/-/iab-adcom-1.0.6.tgz",
-      "integrity": "sha512-XAJdidfrFgZNKmHqcXD3Zhqik2rdSmOs+PGgeVfPWgthxvzNBQxkZnKkW3QAau6mrLjtJc8yOQC6awcEv7gryA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/iab-adcom/-/iab-adcom-2.0.1.tgz",
+      "integrity": "sha512-iLMQoxoeuZaOBhNX8lKD96abjLRbveKhSnu+L6MAyJ6DBz756qQjIKqddplRwO7/TCflAMRCSHFfTxYDqMPtEw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/iab-native": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/iab-native/-/iab-native-1.0.0.tgz",
-      "integrity": "sha512-AxGYpKGRcyG5pbEAqj+ssxNwZAfxC0pRwyKc0MYoKjm0UeOoUNCWrZV0HGimcQii6ebe6MRqBQEeENyHM4qTdQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/iab-native/-/iab-native-1.0.1.tgz",
+      "integrity": "sha512-CrutbUqcP1h4ZKeCO1cOzYmcPRs4MqMSLz4hCUvU3wRlPoOVm6ErKJUifwomke9L9SQazKZx4NXcoiSNR2fXWw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/iab-openrtb": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/iab-openrtb/-/iab-openrtb-1.0.1.tgz",
-      "integrity": "sha512-egawJx6+pMh/6uA/hak1y+R2+XCSH2jxteSkWlY98/XdQQftaMUMllUFNMKrHwq9lgCI70Me06g4JCCnV6E62g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/iab-openrtb/-/iab-openrtb-2.1.0.tgz",
+      "integrity": "sha512-qxKlUbogYm6/Yef1jVQhLNm7/aNApnv1ZxmlLE8ZWU6SN/SsKfb0ygHfxvxeNCoSJQk9Ph7wLEwXBm+HEYH52Q==",
+      "license": "MIT",
       "dependencies": {
-        "iab-adcom": "1.0.6"
+        "iab-adcom": "2.0.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -31981,21 +31984,21 @@
       "dev": true
     },
     "iab-adcom": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/iab-adcom/-/iab-adcom-1.0.6.tgz",
-      "integrity": "sha512-XAJdidfrFgZNKmHqcXD3Zhqik2rdSmOs+PGgeVfPWgthxvzNBQxkZnKkW3QAau6mrLjtJc8yOQC6awcEv7gryA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/iab-adcom/-/iab-adcom-2.0.1.tgz",
+      "integrity": "sha512-iLMQoxoeuZaOBhNX8lKD96abjLRbveKhSnu+L6MAyJ6DBz756qQjIKqddplRwO7/TCflAMRCSHFfTxYDqMPtEw=="
     },
     "iab-native": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/iab-native/-/iab-native-1.0.0.tgz",
-      "integrity": "sha512-AxGYpKGRcyG5pbEAqj+ssxNwZAfxC0pRwyKc0MYoKjm0UeOoUNCWrZV0HGimcQii6ebe6MRqBQEeENyHM4qTdQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/iab-native/-/iab-native-1.0.1.tgz",
+      "integrity": "sha512-CrutbUqcP1h4ZKeCO1cOzYmcPRs4MqMSLz4hCUvU3wRlPoOVm6ErKJUifwomke9L9SQazKZx4NXcoiSNR2fXWw=="
     },
     "iab-openrtb": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/iab-openrtb/-/iab-openrtb-1.0.1.tgz",
-      "integrity": "sha512-egawJx6+pMh/6uA/hak1y+R2+XCSH2jxteSkWlY98/XdQQftaMUMllUFNMKrHwq9lgCI70Me06g4JCCnV6E62g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/iab-openrtb/-/iab-openrtb-2.1.0.tgz",
+      "integrity": "sha512-qxKlUbogYm6/Yef1jVQhLNm7/aNApnv1ZxmlLE8ZWU6SN/SsKfb0ygHfxvxeNCoSJQk9Ph7wLEwXBm+HEYH52Q==",
       "requires": {
-        "iab-adcom": "1.0.6"
+        "iab-adcom": "2.0.1"
       }
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -154,9 +154,9 @@
     "fun-hooks": "^1.1.0",
     "gulp-babel": "^8.0.0",
     "gulp-wrap": "^0.15.0",
-    "iab-adcom": "^1.0.6",
-    "iab-native": "^1.0.0",
-    "iab-openrtb": "^1.0.1",
+    "iab-adcom": "^2.0.1",
+    "iab-native": "^1.0.1",
+    "iab-openrtb": "^2.1.0",
     "klona": "^2.0.6",
     "live-connect-js": "^7.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -150,9 +150,9 @@
     "express": "^4.15.4",
     "fun-hooks": "^1.1.0",
     "gulp-babel": "^8.0.0",
-    "iab-adcom": "^1.0.6",
-    "iab-native": "^1.0.0",
-    "iab-openrtb": "^1.0.1",
+    "iab-adcom": "^2.0.1",
+    "iab-native": "^1.0.1",
+    "iab-openrtb": "^2.1.0",
     "klona": "^2.0.6",
     "live-connect-js": "^7.2.0"
   },


### PR DESCRIPTION
AI generated notes:

### Motivation
- Update IAB type packages to the latest published releases to pick up fixes and updated type definitions.

### Description
- Updated `iab-adcom` from `^1.0.6` to `^2.0.1`, `iab-native` from `^1.0.0` to `^1.0.1`, and `iab-openrtb` from `^1.0.1` to `^2.1.0` in `package.json` and refreshed `package-lock.json` entries to reflect the new resolved versions and dependency linkage (notably `iab-openrtb` -> `iab-adcom@2.0.1`).

### Testing
- Ran `npx eslint --cache --cache-strategy content`, `npx gulp lint`, and `npx gulp test --nolint --file test/spec/unit/pbjs_api_spec.js`, and all completed successfully; `npm install` was used to update the lockfile prior to verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfa365bab8832b9c3b9d986283c426)