### PR TITLE
Core: reintroduce the bidAccepted event

### DIFF
--- a/modules/rtdModule/index.ts
+++ b/modules/rtdModule/index.ts
@@ -53,7 +53,8 @@ const setEventsListeners = (function () {
         [EVENTS.AUCTION_INIT]: ['onAuctionInitEvent'],
         [EVENTS.AUCTION_END]: ['onAuctionEndEvent', getAdUnitTargeting],
         [EVENTS.BID_RESPONSE]: ['onBidResponseEvent'],
-        [EVENTS.BID_REQUESTED]: ['onBidRequestEvent']
+        [EVENTS.BID_REQUESTED]: ['onBidRequestEvent'],
+        [EVENTS.BID_ACCEPTED]: ['onBidAcceptedEvent'],
       }).forEach(([ev, [handler, preprocess]]) => {
         events.on(ev as any, (args) => {
           preprocess && (preprocess as any)(args);

--- a/modules/rtdModule/spec.ts
+++ b/modules/rtdModule/spec.ts
@@ -32,7 +32,8 @@ export type RTDProviderConfig<P extends RTDProvider> = BaseConfig<P> & (
 type RTDEvent = typeof EVENTS.AUCTION_INIT |
     typeof EVENTS.AUCTION_END |
     typeof EVENTS.BID_RESPONSE |
-    typeof EVENTS.BID_REQUESTED;
+    typeof EVENTS.BID_REQUESTED |
+    typeof EVENTS.BID_ACCEPTED;
 
 type EventHandlers<P extends RTDProvider> = {
   [EV in RTDEvent]: (payload: EventPayload<EV>, config: RTDProviderConfig<P>, consent: AllConsentData) => void;

--- a/src/auction.ts
+++ b/src/auction.ts
@@ -110,13 +110,18 @@ declare module './events' {
      */
     [EVENTS.NO_BID]: [BidRequest<BidderCode>];
     /**
-     * Fired when a bid is received.
+     * Fired when a bid is received and added to the auction.
      */
     [EVENTS.BID_RESPONSE]: [Bid];
     /**
      * Fired once for each bid, immediately after its adjustment (see bidCpmAdjustment).
      */
     [EVENTS.BID_ADJUSTMENT]: [Partial<Bid>];
+    /**
+     * Fired when a bid is received and slated to the added to the auction, after `bidAdjustment`, but before targeting
+     * is calculated and before VAST caching (in the case of video or audio bids).
+     */
+    [EVENTS.BID_ACCEPTED]: [Partial<Bid>];
   }
 }
 
@@ -542,6 +547,7 @@ export function auctionCallbacks(auctionDone, auctionInstance, { index = auction
   function acceptBidResponse(adUnitCode: string, bid: Partial<Bid>) {
     handleBidResponse(adUnitCode, bid, (done) => {
       const bidResponse = getPreparedBidForAuction(bid);
+      events.emit(EVENTS.BID_ACCEPTED, bidResponse);
       if ((FEATURES.VIDEO && bidResponse.mediaType === VIDEO) || (FEATURES.AUDIO && bidResponse.mediaType === AUDIO)) {
         tryAddVideoAudioBid(auctionInstance, bidResponse, done);
       } else {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,6 +23,7 @@ export const EVENTS = {
   BID_TIMEOUT: 'bidTimeout',
   BID_REQUESTED: 'bidRequested',
   BID_RESPONSE: 'bidResponse',
+  BID_ACCEPTED: 'bidAccepted',
   BID_REJECTED: 'bidRejected',
   NO_BID: 'noBid',
   BID_WON: 'bidWon',

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -12,7 +12,7 @@ import * as auctionModule from 'src/auction.js';
 import { registerBidder } from 'src/adapters/bidderFactory.js';
 import { createBid } from 'src/bidfactory.js';
 import { config } from 'src/config.js';
-import { _internal as store } from 'src/videoCache.js';
+import { _internal as store, callPrebidCache, updateVast } from 'src/videoCache.js';
 import * as ajaxLib from 'src/ajax.js';
 import { server } from 'test/mocks/xhr.js';
 import { hook } from '../../src/hook.js';
@@ -1154,6 +1154,47 @@ describe('auctionmanager.js', function () {
         assert.equal(registeredBid.adserverTargeting[TARGETING_KEYS.BIDDER], BIDDER_CODE);
         assert.equal(registeredBid.adserverTargeting.extra, 'stuff');
       });
+
+      if (FEATURES.VIDEO) {
+        describe('BID_ACCEPTED', () => {
+          let updateVastHook, sandbox;
+          before(() => {
+            sandbox = sinon.createSandbox();
+            sandbox.stub(events, 'emit');
+            updateVastHook = sinon.stub();
+            updateVast.before(updateVastHook);
+            config.setConfig({
+              cache: {
+                useLocal: true,
+              }
+            });
+          });
+          after(() => {
+            updateVast.getHooks({ hook: updateVastHook }).remove();
+            sandbox.restore();
+          });
+          it('should be fired before video caching', () => {
+            bids = [Object.assign(bids[0], {
+              mediaType: 'video',
+              vastXml: 'mock-vast'
+            })];
+            spec.interpretResponse.returns(bids);
+            const pm =  new Promise((resolve, reject) => {
+              updateVastHook.callsFake((next, bid) => {
+                try {
+                  sinon.assert.calledWith(events.emit, EVENTS.BID_ACCEPTED, bid);
+                  resolve()
+                } catch (e) {
+                  reject(e);
+                }
+              });
+            })
+            auction.callBids();
+            return pm;
+          });
+        });
+      }
+
       it('should add the bidResponse to the collection before calling BID_RESPONSE', function () {
         let hasBid = false;
         const eventHandler = function(bid) {

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -12,7 +12,7 @@ import * as auctionModule from 'src/auction.js';
 import { registerBidder } from 'src/adapters/bidderFactory.js';
 import { createBid } from 'src/bidfactory.js';
 import { config } from 'src/config.js';
-import { _internal as store, callPrebidCache, updateVast } from 'src/videoCache.js';
+import { _internal as store, updateVast } from 'src/videoCache.js';
 import * as ajaxLib from 'src/ajax.js';
 import { server } from 'test/mocks/xhr.js';
 import { hook } from '../../src/hook.js';
@@ -1179,7 +1179,7 @@ describe('auctionmanager.js', function () {
               vastXml: 'mock-vast'
             })];
             spec.interpretResponse.returns(bids);
-            const pm =  new Promise((resolve, reject) => {
+            const pm = new Promise((resolve, reject) => {
               updateVastHook.callsFake((next, bid) => {
                 try {
                   sinon.assert.calledWith(events.emit, EVENTS.BID_ACCEPTED, bid);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

The `bidAccepted` event was removed in 11 as superfluous (https://github.com/prebid/Prebid.js/issues/13042), but it does serve the purpose of exposing a partial bid before video caching (https://github.com/prebid/Prebid.js/pull/10685), at a time when trackers can still be added.

