### PR TITLE
GumGumBidAdapter: revert gg changes lost during prebid 11 commit

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -356,15 +356,22 @@ function isPubProvidedIdEid(eid) {
 
 function getEidsFromEidsArray(eids) {
   return (Array.isArray(eids) ? eids : []).reduce((ids, eid) => {
-    const uid = getFirstUid(eid);
-    if (!uid) return ids;
     const source = (eid.source || '').toLowerCase();
     if (source === 'uidapi.com') {
-      ids.uid2 = uid.id;
+      const uid = getFirstUid(eid);
+      if (uid) {
+        ids.uid2 = uid.id;
+      }
     } else if (source === 'liveramp.com') {
-      ids.idl_env = uid.id;
-    } else if (source === 'adserver.org' && uid.ext && uid.ext.rtiPartner === 'TDID') {
-      ids.tdid = uid.id;
+      const uid = getFirstUid(eid);
+      if (uid) {
+        ids.idl_env = uid.id;
+      }
+    } else if (source === 'adserver.org' && Array.isArray(eid.uids)) {
+      const tdidUid = eid.uids.find(uid => uid && uid.id && uid.ext && uid.ext.rtiPartner === 'TDID');
+      if (tdidUid) {
+        ids.tdid = tdidUid.id;
+      }
     }
     return ids;
   }, {});

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -362,9 +362,17 @@ function _getContentParams(ortb2Data) {
     if (content.producer.name) contentParams.cpname = content.producer.name;
   }
 
-  // Channel and network
-  if (content.channel) contentParams.cchannel = content.channel;
-  if (content.network) contentParams.cnetwork = content.network;
+  // Channel fields
+  if (content.channel) {
+    if (content.channel.id) contentParams.cchannelid = content.channel.id;
+    if (content.channel.name) contentParams.cchannel = content.channel.name;
+    if (content.channel.domain) contentParams.cchanneldomain = content.channel.domain;
+  }
+
+  // Network fields
+  if (content.network) {
+    if (content.network.name) contentParams.cnetwork = content.network.name;
+  }
 
   return contentParams;
 }

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -694,7 +694,7 @@ function interpretResponse(serverResponse, bidRequest) {
     if (mediaType === NATIVE && markup) {
       try {
         const nativeResponse = JSON.parse(markup);
-        bid.ortb = nativeResponse.native || nativeResponse;
+        bid.native = { ortb: nativeResponse.native || nativeResponse };
       } catch (e) {
         logError('[GumGum] Error parsing native ADM:', e);
       }

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -1,4 +1,4 @@
-import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { _each, deepAccess, getWinDimensions, logError, logWarn, parseSizesInput } from '../src/utils.js';
 import { getDevicePixelRatio } from '../libraries/devicePixelRatio/devicePixelRatio.js';
 
@@ -23,7 +23,7 @@ const storage = getStorageManager({ bidderCode: BIDDER_CODE });
 const ALIAS_BIDDER_CODE = ['gg'];
 const BID_ENDPOINT = `https://g2.gumgum.com/hbid/imp`;
 const JCSI = { t: 0, rq: 8, pbv: '$prebid.version$' }
-const SUPPORTED_MEDIA_TYPES = [BANNER, VIDEO];
+const SUPPORTED_MEDIA_TYPES = [BANNER, NATIVE, VIDEO];
 const TIME_TO_LIVE = 60;
 const DELAY_REQUEST_TIME = 1800000; // setting to 30 mins
 const pubProvidedIdSources = ['dac.co.jp', 'audigent.com', 'id5-sync.com', 'liveramp.com', 'intentiq.com', 'liveintent.com', 'crwdcntrl.net', 'quantcast.com', 'adserver.org', 'yahoo.com']
@@ -418,7 +418,9 @@ function buildRequests(validBidRequests, bidderRequest) {
     // ADTS-134 Retrieve ID envelopes
     for (const eid in eids) data[eid] = eids[eid];
 
-    if (mediaTypes.banner) {
+    if (mediaTypes.native) {
+      sizes = [1, 1];
+    } else if (mediaTypes.banner) {
       sizes = mediaTypes.banner.sizes;
     } else if (mediaTypes.video) {
       sizes = mediaTypes.video.playerSize;
@@ -456,6 +458,12 @@ function buildRequests(validBidRequests, bidderRequest) {
         data.si = params.slot;
         data.pi = 3;
         data.bf = sizes.reduce((acc, curSlotDim) => `${acc}${acc && ','}${curSlotDim[0]}x${curSlotDim[1]}`, '');
+      } else if (mediaTypes.native) {
+        data.pi = 5;
+        if (mediaTypes.native.ortb) {
+          data.nat = JSON.stringify(mediaTypes.native.ortb);
+        }
+        if (params.native) { data.ni = params.native; }
       } else if (params.native) {
         data.ni = params.native;
         data.pi = 5;
@@ -636,7 +644,8 @@ function interpretResponse(serverResponse, bidRequest) {
   } = Object.assign(defaultResponse, serverResponseBody);
   const data = bidRequest.data || {};
   const product = data.pi;
-  const mediaType = (product === 6 || product === 7) ? VIDEO : BANNER;
+  const mediaType = (product === 6 || product === 7) ? VIDEO
+    : (product === 5) ? NATIVE : BANNER;
   const isTestUnit = (product === 3 && data.si === 9);
   const metaData = {
     advertiserDomains: advertiserDomains || [],
@@ -667,9 +676,7 @@ function interpretResponse(serverResponse, bidRequest) {
   pageViewId = pvid
 
   if (creativeId) {
-    bidResponses.push({
-      // dealId: DEAL_ID,
-      // referrer: REFERER,
+    const bid = {
       ad: wrapper ? getWrapperCode(wrapper, Object.assign({}, serverResponseBody, { bidRequest })) : markup,
       ...(mediaType === VIDEO && { ad: markup, vastXml: markup }),
       mediaType,
@@ -682,7 +689,18 @@ function interpretResponse(serverResponse, bidRequest) {
       ttl: TIME_TO_LIVE,
       width,
       meta: metaData
-    })
+    };
+
+    if (mediaType === NATIVE && markup) {
+      try {
+        const nativeResponse = JSON.parse(markup);
+        bid.ortb = nativeResponse.native || nativeResponse;
+      } catch (e) {
+        logError('[GumGum] Error parsing native ADM:', e);
+      }
+    }
+
+    bidResponses.push(bid);
   }
   return bidResponses
 }

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -306,6 +306,67 @@ function _getDeviceData(ortb2Data) {
 }
 
 /**
+ * Retrieves content metadata from the ORTB2 object
+ * Supports both site.content and app.content (site takes priority)
+ * @param {Object} ortb2Data ORTB2 object
+ * @returns {Object} Content parameters
+ */
+function _getContentParams(ortb2Data) {
+  // Check site.content first, then app.content
+  const content = deepAccess(ortb2Data, 'site.content') || deepAccess(ortb2Data, 'app.content');
+
+  if (!content) {
+    return {};
+  }
+
+  const contentParams = {};
+
+  // Basic content fields
+  if (content.id) contentParams.cid = content.id;
+  if (content.episode !== undefined && content.episode !== null) contentParams.cepisode = content.episode;
+  if (content.title) contentParams.ctitle = content.title;
+  if (content.series) contentParams.cseries = content.series;
+  if (content.season) contentParams.cseason = content.season;
+  if (content.genre) contentParams.cgenre = content.genre;
+  if (content.contentrating) contentParams.crating = content.contentrating;
+  if (content.userrating) contentParams.cur = content.userrating;
+  if (content.context !== undefined && content.context !== null) contentParams.cctx = content.context;
+  if (content.livestream !== undefined && content.livestream !== null) contentParams.clive = content.livestream;
+  if (content.len !== undefined && content.len !== null) contentParams.clen = content.len;
+  if (content.language) contentParams.clang = content.language;
+  if (content.url) contentParams.curl = content.url;
+  if (content.cattax !== undefined && content.cattax !== null) contentParams.cattax = content.cattax;
+  if (content.prodq !== undefined && content.prodq !== null) contentParams.cprodq = content.prodq;
+  if (content.qagmediarating !== undefined && content.qagmediarating !== null) contentParams.cqag = content.qagmediarating;
+
+  // Handle keywords - can be string or array
+  if (content.keywords) {
+    if (Array.isArray(content.keywords)) {
+      contentParams.ckw = content.keywords.join(',');
+    } else if (typeof content.keywords === 'string') {
+      contentParams.ckw = content.keywords;
+    }
+  }
+
+  // Handle cat array
+  if (content.cat && Array.isArray(content.cat) && content.cat.length > 0) {
+    contentParams.ccat = content.cat.join(',');
+  }
+
+  // Handle producer fields
+  if (content.producer) {
+    if (content.producer.id) contentParams.cpid = content.producer.id;
+    if (content.producer.name) contentParams.cpname = content.producer.name;
+  }
+
+  // Channel and network
+  if (content.channel) contentParams.cchannel = content.channel;
+  if (content.network) contentParams.cnetwork = content.network;
+
+  return contentParams;
+}
+
+/**
  * loops through bannerSizes array to get greatest slot dimensions
  * @param {number[][]} sizes
  * @returns {number[]}
@@ -469,9 +530,10 @@ function buildRequests(validBidRequests, bidderRequest) {
     }
     if (bidderRequest && bidderRequest.ortb2 && bidderRequest.ortb2.site) {
       setIrisId(data, bidderRequest.ortb2.site, params);
-      const curl = bidderRequest.ortb2.site.content?.url;
-      if (curl) data.curl = curl;
     }
+    // Extract content metadata from ortb2
+    const contentParams = _getContentParams(bidderRequest?.ortb2);
+    Object.assign(data, contentParams);
     if (params.iriscat && typeof params.iriscat === 'string') {
       data.iriscat = params.iriscat;
     }

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -327,28 +327,39 @@ function getGreatestDimensions(sizes) {
   return [maxw, maxh];
 }
 
-function getEids(userId) {
-  const idProperties = [
-    'uid',
-    'eid',
-    'lipbid',
-    'envelope',
-    'id'
-  ];
+function getFirstUid(eid) {
+  if (!eid || !Array.isArray(eid.uids)) return null;
+  return eid.uids.find(uid => uid && uid.id);
+}
 
-  return Object.keys(userId).reduce(function (eids, provider) {
-    const eid = userId[provider];
-    switch (typeof eid) {
-      case 'string':
-        eids[provider] = eid;
-        break;
+function getUserEids(bidRequest) {
+  const bidEids = deepAccess(bidRequest, 'userIdAsEids');
+  if (Array.isArray(bidEids) && bidEids.length) {
+    return bidEids;
+  }
+  const ortb2Eids = deepAccess(bidRequest, 'user.ext.eids');
+  return Array.isArray(ortb2Eids) ? ortb2Eids : [];
+}
 
-      case 'object':
-        const idProp = idProperties.filter(prop => eid.hasOwnProperty(prop));
-        idProp.length && (eids[provider] = eid[idProp[0]]);
-        break;
+function isPubProvidedIdEid(eid) {
+  const source = (eid && eid.source) ? eid.source.toLowerCase() : '';
+  if (!source || !pubProvidedIdSources.includes(source) || !Array.isArray(eid.uids)) return false;
+  return eid.uids.some(uid => uid && uid.ext && uid.ext.stype);
+}
+
+function getEidsFromEidsArray(eids) {
+  return (Array.isArray(eids) ? eids : []).reduce((ids, eid) => {
+    const uid = getFirstUid(eid);
+    if (!uid) return ids;
+    const source = (eid.source || '').toLowerCase();
+    if (source === 'uidapi.com') {
+      ids.uid2 = uid.id;
+    } else if (source === 'liveramp.com') {
+      ids.idl_env = uid.id;
+    } else if (source === 'adserver.org' && uid.ext && uid.ext.rtiPartner === 'TDID') {
+      ids.tdid = uid.id;
     }
-    return eids;
+    return ids;
   }, {});
 }
 
@@ -372,12 +383,12 @@ function buildRequests(validBidRequests, bidderRequest) {
       bidId,
       mediaTypes = {},
       params = {},
-      userId = {},
       ortb2Imp,
       adUnitCode = ''
     } = bidRequest;
     const { currency, floor } = _getFloor(mediaTypes, params.bidfloor, bidRequest);
-    const eids = getEids(userId);
+    const userEids = getUserEids(bidRequest);
+    const eids = getEidsFromEidsArray(userEids);
     const gpid = deepAccess(ortb2Imp, 'ext.gpid');
     let sizes = [1, 1];
     let data = {};
@@ -401,16 +412,20 @@ function buildRequests(validBidRequests, bidderRequest) {
       }
     }
     // Send filtered pubProvidedId's
-    if (userId && userId.pubProvidedId) {
-      const filteredData = userId.pubProvidedId.filter(item => pubProvidedIdSources.includes(item.source));
+    if (userEids.length) {
+      const filteredData = userEids.filter(isPubProvidedIdEid);
       const maxLength = 1800; // replace this with your desired maximum length
       const truncatedJsonString = jsoStringifynWithMaxLength(filteredData, maxLength);
-      data.pubProvidedId = truncatedJsonString
+      if (filteredData.length) {
+        data.pubProvidedId = truncatedJsonString
+      }
     }
     // ADJS-1286 Read id5 id linktype field
-    if (userId && userId.id5id && userId.id5id.uid && userId.id5id.ext) {
-      data.id5Id = userId.id5id.uid || null
-      data.id5IdLinkType = userId.id5id.ext.linkType || null
+    const id5Eid = userEids.find(eid => (eid.source || '').toLowerCase() === 'id5-sync.com');
+    const id5Uid = getFirstUid(id5Eid);
+    if (id5Uid && id5Uid.ext) {
+      data.id5Id = id5Uid.id || null
+      data.id5IdLinkType = id5Uid.ext.linkType || null
     }
     // ADTS-169 add adUnitCode to requests
     if (adUnitCode) data.aun = adUnitCode;

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -332,13 +332,17 @@ function getFirstUid(eid) {
   return eid.uids.find(uid => uid && uid.id);
 }
 
-function getUserEids(bidRequest) {
+function getUserEids(bidRequest, bidderRequest) {
   const bidEids = deepAccess(bidRequest, 'userIdAsEids');
   if (Array.isArray(bidEids) && bidEids.length) {
     return bidEids;
   }
-  const ortb2Eids = deepAccess(bidRequest, 'user.ext.eids');
-  return Array.isArray(ortb2Eids) ? ortb2Eids : [];
+  const bidUserEids = deepAccess(bidRequest, 'user.ext.eids');
+  if (Array.isArray(bidUserEids) && bidUserEids.length) {
+    return bidUserEids;
+  }
+  const bidderRequestEids = deepAccess(bidderRequest, 'ortb2.user.ext.eids');
+  return Array.isArray(bidderRequestEids) ? bidderRequestEids : [];
 }
 
 function isPubProvidedIdEid(eid) {
@@ -387,7 +391,7 @@ function buildRequests(validBidRequests, bidderRequest) {
       adUnitCode = ''
     } = bidRequest;
     const { currency, floor } = _getFloor(mediaTypes, params.bidfloor, bidRequest);
-    const userEids = getUserEids(bidRequest);
+    const userEids = getUserEids(bidRequest, bidderRequest);
     const eids = getEidsFromEidsArray(userEids);
     const gpid = deepAccess(ortb2Imp, 'ext.gpid');
     let sizes = [1, 1];

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -333,6 +333,10 @@ function getFirstUid(eid) {
 }
 
 function getUserEids(bidRequest, bidderRequest) {
+  const bidderRequestEids = deepAccess(bidderRequest, 'ortb2.user.ext.eids');
+  if (Array.isArray(bidderRequestEids) && bidderRequestEids.length) {
+    return bidderRequestEids;
+  }
   const bidEids = deepAccess(bidRequest, 'userIdAsEids');
   if (Array.isArray(bidEids) && bidEids.length) {
     return bidEids;
@@ -341,8 +345,7 @@ function getUserEids(bidRequest, bidderRequest) {
   if (Array.isArray(bidUserEids) && bidUserEids.length) {
     return bidUserEids;
   }
-  const bidderRequestEids = deepAccess(bidderRequest, 'ortb2.user.ext.eids');
-  return Array.isArray(bidderRequestEids) ? bidderRequestEids : [];
+  return [];
 }
 
 function isPubProvidedIdEid(eid) {

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -313,13 +313,16 @@ function _getDeviceData(ortb2Data) {
  */
 function _getContentParams(ortb2Data) {
   // Check site.content first, then app.content
-  const content = deepAccess(ortb2Data, 'site.content') || deepAccess(ortb2Data, 'app.content');
+  const siteContent = deepAccess(ortb2Data, 'site.content');
+  const appContent = deepAccess(ortb2Data, 'app.content');
+  const content = siteContent || appContent;
 
   if (!content) {
     return {};
   }
 
   const contentParams = {};
+  contentParams.itype = siteContent ? 'site' : 'app';
 
   // Basic content fields
   if (content.id) contentParams.cid = content.id;

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -1,4 +1,4 @@
-import { BANNER, VIDEO } from 'src/mediaTypes.js';
+import { BANNER, NATIVE, VIDEO } from 'src/mediaTypes.js';
 
 import { config } from 'src/config.js';
 import { expect } from 'chai';
@@ -81,6 +81,28 @@ describe('gumgumAdapter', function () {
         'bidfloor': '0.50'
       };
       expect(spec.isBidRequestValid(invalidBid)).to.equal(false);
+    });
+
+    it('should return true when native bid request with zone param is valid', function () {
+      const nativeBid = {
+        bidder: 'gumgum',
+        params: { zone: 'native123' },
+        adUnitCode: 'native-div',
+        mediaTypes: {
+          native: {
+            ortb: {
+              assets: [
+                { id: 1, required: 1, img: { type: 3, w: 150, h: 50 } },
+                { id: 2, required: 1, title: { len: 80 } }
+              ]
+            }
+          }
+        },
+        bidId: '30b31c1838de1f',
+        bidderRequestId: '22edbae2733bf7',
+        auctionId: '1d1a030790a476'
+      };
+      expect(spec.isBidRequestValid(nativeBid)).to.equal(true);
     });
 
     it('should return false if invalid request id is found', function () {
@@ -362,6 +384,48 @@ describe('gumgumAdapter', function () {
         const request = { ...bidRequests[0], params: { ...zoneParam, native: 2 } };
         const bidRequest = spec.buildRequests([request])[0];
         expect(bidRequest.data.pi).to.equal(5);
+      });
+      it('should set pi=5 and send nat param when mediaTypes.native.ortb is present', function () {
+        const nativeOrtb = {
+          assets: [
+            { id: 1, required: 1, img: { type: 3, w: 150, h: 50 } },
+            { id: 2, required: 1, title: { len: 80 } },
+            { id: 3, required: 1, data: { type: 1 } }
+          ]
+        };
+        const request = {
+          ...bidRequests[0],
+          params: zoneParam,
+          mediaTypes: { native: { ortb: nativeOrtb } }
+        };
+        const bidRequest = spec.buildRequests([request])[0];
+        expect(bidRequest.data.pi).to.equal(5);
+        expect(bidRequest.data.nat).to.equal(JSON.stringify(nativeOrtb));
+        expect(bidRequest.sizes).to.deep.equal([1, 1]);
+      });
+      it('should send ni param alongside nat when both mediaTypes.native and params.native are present', function () {
+        const nativeOrtb = {
+          assets: [{ id: 1, required: 1, title: { len: 80 } }]
+        };
+        const request = {
+          ...bidRequests[0],
+          params: { ...zoneParam, native: 42 },
+          mediaTypes: { native: { ortb: nativeOrtb } }
+        };
+        const bidRequest = spec.buildRequests([request])[0];
+        expect(bidRequest.data.pi).to.equal(5);
+        expect(bidRequest.data.nat).to.equal(JSON.stringify(nativeOrtb));
+        expect(bidRequest.data.ni).to.equal(42);
+      });
+      it('should set pi=5 for mediaTypes.native without ortb property', function () {
+        const request = {
+          ...bidRequests[0],
+          params: zoneParam,
+          mediaTypes: { native: {} }
+        };
+        const bidRequest = spec.buildRequests([request])[0];
+        expect(bidRequest.data.pi).to.equal(5);
+        expect(bidRequest.data).to.not.have.property('nat');
       });
       it('should set the correct pi param for video', function () {
         const request = { ...bidRequests[0], params: zoneParam, mediaTypes: vidMediaTypes };
@@ -1126,6 +1190,70 @@ describe('gumgumAdapter', function () {
     it('sets a vastXml property if mediaType is video', function () {
       const videoBidResponse = spec.interpretResponse({ body: serverResponse }, { ...bidRequest, data: { pi: 7 } })[0];
       expect(videoBidResponse.vastXml).to.exist;
+    });
+
+    it('sets mediaType to NATIVE for product 5 responses', function () {
+      const nativeBidResponse = spec.interpretResponse({ body: serverResponse }, { ...bidRequest, data: { pi: 5 } })[0];
+      expect(nativeBidResponse.mediaType).to.equal(NATIVE);
+    });
+
+    it('sets ortb property from native ADM JSON with native wrapper', function () {
+      const nativeAdm = {
+        native: {
+          ver: '1.2',
+          assets: [
+            { id: 1, img: { type: 3, url: 'https://cdn.example.com/img.jpg', w: 150, h: 50 } },
+            { id: 2, title: { text: 'Ad Title', len: 80 } }
+          ],
+          link: {
+            url: 'https://advertiser.com/landing',
+            clicktrackers: ['https://g2.gumgum.com/ad/click/enc/test']
+          },
+          eventtrackers: [
+            { event: 1, method: 1, url: 'https://g2.gumgum.com/ad/view/enc/test' }
+          ]
+        }
+      };
+      const nativeServerResponse = {
+        ...serverResponse,
+        ad: { ...serverResponse.ad, markup: JSON.stringify(nativeAdm) }
+      };
+      const nativeBidRequest = { ...bidRequest, data: { pi: 5 } };
+      const result = spec.interpretResponse({ body: nativeServerResponse }, nativeBidRequest)[0];
+      expect(result.mediaType).to.equal(NATIVE);
+      expect(result.ortb).to.deep.equal(nativeAdm.native);
+      expect(result.ortb.ver).to.equal('1.2');
+      expect(result.ortb.assets).to.have.length(2);
+      expect(result.ortb.link.url).to.equal('https://advertiser.com/landing');
+    });
+
+    it('sets ortb property from native ADM JSON without native wrapper', function () {
+      const nativeAdm = {
+        ver: '1.2',
+        assets: [
+          { id: 1, title: { text: 'Ad Title', len: 80 } }
+        ],
+        link: { url: 'https://advertiser.com/landing' }
+      };
+      const nativeServerResponse = {
+        ...serverResponse,
+        ad: { ...serverResponse.ad, markup: JSON.stringify(nativeAdm) }
+      };
+      const nativeBidRequest = { ...bidRequest, data: { pi: 5 } };
+      const result = spec.interpretResponse({ body: nativeServerResponse }, nativeBidRequest)[0];
+      expect(result.mediaType).to.equal(NATIVE);
+      expect(result.ortb).to.deep.equal(nativeAdm);
+    });
+
+    it('handles invalid native ADM JSON gracefully', function () {
+      const nativeServerResponse = {
+        ...serverResponse,
+        ad: { ...serverResponse.ad, markup: 'not-valid-json' }
+      };
+      const nativeBidRequest = { ...bidRequest, data: { pi: 5 } };
+      const result = spec.interpretResponse({ body: nativeServerResponse }, nativeBidRequest)[0];
+      expect(result.mediaType).to.equal(NATIVE);
+      expect(result.ortb).to.be.undefined;
     });
   })
   describe('getUserSyncs', function () {

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -448,6 +448,255 @@ describe('gumgumAdapter', function () {
       const bidRequest = spec.buildRequests([request], bidderRequest)[0];
       expect(bidRequest.data).to.have.property('curl', 'http://pub.com/news');
     });
+
+    describe('content metadata extraction', function() {
+      it('should extract all site.content fields', function() {
+        const ortb2WithContent = {
+          site: {
+            content: {
+              id: 'content-id-123',
+              episode: 5,
+              title: 'Test Episode Title',
+              series: 'Test Series',
+              season: 'Season 2',
+              genre: 'Comedy',
+              contentrating: 'PG-13',
+              userrating: '4.5',
+              context: 1,
+              livestream: 1,
+              len: 1800,
+              language: 'en',
+              url: 'https://example.com/content',
+              cattax: 6,
+              prodq: 2,
+              qagmediarating: 1,
+              keywords: 'keyword1,keyword2,keyword3',
+              cat: ['IAB1-1', 'IAB1-2', 'IAB1-3'],
+              producer: {
+                id: 'producer-123',
+                name: 'Test Producer'
+              },
+              channel: 'Test Channel',
+              network: 'Test Network'
+            }
+          }
+        };
+        const request = { ...bidRequests[0] };
+        const bidRequest = spec.buildRequests([request], { ...bidderRequest, ortb2: ortb2WithContent })[0];
+
+        expect(bidRequest.data.cid).to.equal('content-id-123');
+        expect(bidRequest.data.cepisode).to.equal(5);
+        expect(bidRequest.data.ctitle).to.equal('Test Episode Title');
+        expect(bidRequest.data.cseries).to.equal('Test Series');
+        expect(bidRequest.data.cseason).to.equal('Season 2');
+        expect(bidRequest.data.cgenre).to.equal('Comedy');
+        expect(bidRequest.data.crating).to.equal('PG-13');
+        expect(bidRequest.data.cur).to.equal('4.5');
+        expect(bidRequest.data.cctx).to.equal(1);
+        expect(bidRequest.data.clive).to.equal(1);
+        expect(bidRequest.data.clen).to.equal(1800);
+        expect(bidRequest.data.clang).to.equal('en');
+        expect(bidRequest.data.curl).to.equal('https://example.com/content');
+        expect(bidRequest.data.cattax).to.equal(6);
+        expect(bidRequest.data.cprodq).to.equal(2);
+        expect(bidRequest.data.cqag).to.equal(1);
+        expect(bidRequest.data.ckw).to.equal('keyword1,keyword2,keyword3');
+        expect(bidRequest.data.ccat).to.equal('IAB1-1,IAB1-2,IAB1-3');
+        expect(bidRequest.data.cpid).to.equal('producer-123');
+        expect(bidRequest.data.cpname).to.equal('Test Producer');
+        expect(bidRequest.data.cchannel).to.equal('Test Channel');
+        expect(bidRequest.data.cnetwork).to.equal('Test Network');
+      });
+
+      it('should extract app.content fields when site.content is not present', function() {
+        const ortb2WithAppContent = {
+          app: {
+            content: {
+              id: 'app-content-id',
+              title: 'App Content Title',
+              series: 'App Series',
+              url: 'https://example.com/app-content'
+            }
+          }
+        };
+        const request = { ...bidRequests[0] };
+        const bidRequest = spec.buildRequests([request], { ortb2: ortb2WithAppContent })[0];
+
+        expect(bidRequest.data.cid).to.equal('app-content-id');
+        expect(bidRequest.data.ctitle).to.equal('App Content Title');
+        expect(bidRequest.data.cseries).to.equal('App Series');
+        expect(bidRequest.data.curl).to.equal('https://example.com/app-content');
+      });
+
+      it('should prioritize site.content over app.content', function() {
+        const ortb2WithBoth = {
+          site: {
+            content: {
+              id: 'site-content-id',
+              title: 'Site Content'
+            }
+          },
+          app: {
+            content: {
+              id: 'app-content-id',
+              title: 'App Content'
+            }
+          }
+        };
+        const request = { ...bidRequests[0] };
+        const bidRequest = spec.buildRequests([request], { ortb2: ortb2WithBoth })[0];
+
+        expect(bidRequest.data.cid).to.equal('site-content-id');
+        expect(bidRequest.data.ctitle).to.equal('Site Content');
+      });
+
+      it('should handle keywords as an array', function() {
+        const ortb2 = {
+          site: {
+            content: {
+              keywords: ['keyword1', 'keyword2', 'keyword3']
+            }
+          }
+        };
+        const request = { ...bidRequests[0] };
+        const bidRequest = spec.buildRequests([request], { ortb2 })[0];
+
+        expect(bidRequest.data.ckw).to.equal('keyword1,keyword2,keyword3');
+      });
+
+      it('should handle keywords as a string', function() {
+        const ortb2 = {
+          site: {
+            content: {
+              keywords: 'keyword1,keyword2,keyword3'
+            }
+          }
+        };
+        const request = { ...bidRequests[0] };
+        const bidRequest = spec.buildRequests([request], { ortb2 })[0];
+
+        expect(bidRequest.data.ckw).to.equal('keyword1,keyword2,keyword3');
+      });
+
+      it('should not include content params when content object is missing', function() {
+        const ortb2 = {
+          site: {
+            page: 'https://example.com'
+          }
+        };
+        const request = { ...bidRequests[0] };
+        const bidRequest = spec.buildRequests([request], { ortb2 })[0];
+
+        expect(bidRequest.data).to.not.have.property('cid');
+        expect(bidRequest.data).to.not.have.property('ctitle');
+        expect(bidRequest.data).to.not.have.property('curl');
+      });
+
+      it('should not include undefined or null content fields', function() {
+        const ortb2 = {
+          site: {
+            content: {
+              id: 'content-123',
+              title: undefined,
+              series: null,
+              season: ''
+            }
+          }
+        };
+        const request = { ...bidRequests[0] };
+        const bidRequest = spec.buildRequests([request], { ortb2 })[0];
+
+        expect(bidRequest.data.cid).to.equal('content-123');
+        expect(bidRequest.data).to.not.have.property('ctitle');
+        expect(bidRequest.data).to.not.have.property('cseries');
+        expect(bidRequest.data).to.not.have.property('cseason');
+      });
+
+      it('should handle zero values for numeric fields', function() {
+        const ortb2 = {
+          site: {
+            content: {
+              episode: 0,
+              context: 0,
+              livestream: 0,
+              len: 0,
+              cattax: 0,
+              prodq: 0,
+              qagmediarating: 0
+            }
+          }
+        };
+        const request = { ...bidRequests[0] };
+        const bidRequest = spec.buildRequests([request], { ortb2 })[0];
+
+        expect(bidRequest.data.cepisode).to.equal(0);
+        expect(bidRequest.data.cctx).to.equal(0);
+        expect(bidRequest.data.clive).to.equal(0);
+        expect(bidRequest.data.clen).to.equal(0);
+        expect(bidRequest.data.cattax).to.equal(0);
+        expect(bidRequest.data.cprodq).to.equal(0);
+        expect(bidRequest.data.cqag).to.equal(0);
+      });
+
+      it('should handle empty arrays for cat', function() {
+        const ortb2 = {
+          site: {
+            content: {
+              cat: []
+            }
+          }
+        };
+        const request = { ...bidRequests[0] };
+        const bidRequest = spec.buildRequests([request], { ortb2 })[0];
+
+        expect(bidRequest.data).to.not.have.property('ccat');
+      });
+
+      it('should handle partial producer data', function() {
+        const ortb2 = {
+          site: {
+            content: {
+              producer: {
+                id: 'producer-id-only'
+              }
+            }
+          }
+        };
+        const request = { ...bidRequests[0] };
+        const bidRequest = spec.buildRequests([request], { ortb2 })[0];
+
+        expect(bidRequest.data.cpid).to.equal('producer-id-only');
+        expect(bidRequest.data).to.not.have.property('cpname');
+      });
+
+      it('should handle episode as string', function() {
+        const ortb2 = {
+          site: {
+            content: {
+              episode: 'S01E05'
+            }
+          }
+        };
+        const request = { ...bidRequests[0] };
+        const bidRequest = spec.buildRequests([request], { ortb2 })[0];
+
+        expect(bidRequest.data.cepisode).to.equal('S01E05');
+      });
+
+      it('should not override existing curl from irisid extraction', function() {
+        const ortb2 = {
+          site: {
+            content: {
+              url: 'https://content-url.com'
+            }
+          }
+        };
+        const request = { ...bidRequests[0] };
+        const bidRequest = spec.buildRequests([request], { ...bidderRequest, ortb2 })[0];
+
+        expect(bidRequest.data.curl).to.equal('https://content-url.com');
+      });
+    });
     it('should not set the iriscat param when not found', function () {
       const request = { ...bidRequests[0] }
       const bidRequest = spec.buildRequests([request])[0];

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -299,6 +299,31 @@ describe('gumgumAdapter', function () {
       const bidRequest = spec.buildRequests([request], fakeBidderRequest)[0];
       expect(bidRequest.data.idl_env).to.equal('fallback-idl-env');
     });
+    it('should prioritize bidderRequest.ortb2.user.ext.eids over bid-level eids', function () {
+      const request = {
+        ...bidRequests[0],
+        userIdAsEids: [{
+          source: 'liveramp.com',
+          uids: [{ id: 'bid-level-idl-env' }]
+        }]
+      };
+      const fakeBidderRequest = {
+        ...bidderRequest,
+        ortb2: {
+          ...bidderRequest.ortb2,
+          user: {
+            ext: {
+              eids: [{
+                source: 'liveramp.com',
+                uids: [{ id: 'ortb2-level-idl-env' }]
+              }]
+            }
+          }
+        }
+      };
+      const bidRequest = spec.buildRequests([request], fakeBidderRequest)[0];
+      expect(bidRequest.data.idl_env).to.equal('ortb2-level-idl-env');
+    });
     it('should keep identity output consistent for prebid10 ortb2 eids input', function () {
       const request = { ...bidRequests[0], userIdAsEids: undefined };
       const fakeBidderRequest = {

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -484,6 +484,7 @@ describe('gumgumAdapter', function () {
         const request = { ...bidRequests[0] };
         const bidRequest = spec.buildRequests([request], { ...bidderRequest, ortb2: ortb2WithContent })[0];
 
+        expect(bidRequest.data.itype).to.equal('site');
         expect(bidRequest.data.cid).to.equal('content-id-123');
         expect(bidRequest.data.cepisode).to.equal(5);
         expect(bidRequest.data.ctitle).to.equal('Test Episode Title');
@@ -522,6 +523,7 @@ describe('gumgumAdapter', function () {
         const request = { ...bidRequests[0] };
         const bidRequest = spec.buildRequests([request], { ortb2: ortb2WithAppContent })[0];
 
+        expect(bidRequest.data.itype).to.equal('app');
         expect(bidRequest.data.cid).to.equal('app-content-id');
         expect(bidRequest.data.ctitle).to.equal('App Content Title');
         expect(bidRequest.data.cseries).to.equal('App Series');
@@ -546,6 +548,7 @@ describe('gumgumAdapter', function () {
         const request = { ...bidRequests[0] };
         const bidRequest = spec.buildRequests([request], { ortb2: ortb2WithBoth })[0];
 
+        expect(bidRequest.data.itype).to.equal('site');
         expect(bidRequest.data.cid).to.equal('site-content-id');
         expect(bidRequest.data.ctitle).to.equal('Site Content');
       });

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -272,6 +272,17 @@ describe('gumgumAdapter', function () {
       expect(pubProvidedIds.length).to.equal(1);
       expect(pubProvidedIds[0].source).to.equal('audigent.com');
     });
+    it('should not set pubProvidedId when all sources are filtered out', function () {
+      const filteredRequest = {
+        ...bidRequests[0],
+        userIdAsEids: [{
+          source: 'sonobi.com',
+          uids: [{ id: 'ppid-2', ext: { stype: 'ppuid' } }]
+        }]
+      };
+      const bidRequest = spec.buildRequests([filteredRequest])[0];
+      expect(bidRequest.data.pubProvidedId).to.equal(undefined);
+    });
     it('should set id5Id and id5IdLinkType if the uid and  linkType are available', function () {
       const request = { ...bidRequests[0] };
       const bidRequest = spec.buildRequests([request])[0];
@@ -891,6 +902,28 @@ describe('gumgumAdapter', function () {
       const request = Object.assign({}, bidRequests[0], { userIdAsEids: [...bidRequests[0].userIdAsEids, tdidEid] });
       const bidRequest = spec.buildRequests([request])[0];
       expect(bidRequest.data.tdid).to.eq(tdidEid.uids[0].id);
+    });
+    it('should add a tdid parameter when TDID uid is not the first uid in adserver.org', function () {
+      const tdidEid = {
+        source: 'adserver.org',
+        uids: [
+          {
+            id: 'non-tdid-first',
+            ext: {
+              rtiPartner: 'NOT_TDID'
+            }
+          },
+          {
+            id: 'tradedesk-id',
+            ext: {
+              rtiPartner: 'TDID'
+            }
+          }
+        ]
+      };
+      const request = Object.assign({}, bidRequests[0], { userIdAsEids: [tdidEid] });
+      const bidRequest = spec.buildRequests([request])[0];
+      expect(bidRequest.data.tdid).to.eq('tradedesk-id');
     });
     it('should not add a tdid parameter if unified id is not found', function () {
       const request = spec.buildRequests(bidRequests)[0];

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -476,8 +476,14 @@ describe('gumgumAdapter', function () {
                 id: 'producer-123',
                 name: 'Test Producer'
               },
-              channel: 'Test Channel',
-              network: 'Test Network'
+              channel: {
+                id: 'channel-123',
+                name: 'Test Channel',
+                domain: 'testchannel.com'
+              },
+              network: {
+                name: 'Test Network'
+              }
             }
           }
         };
@@ -505,7 +511,9 @@ describe('gumgumAdapter', function () {
         expect(bidRequest.data.ccat).to.equal('IAB1-1,IAB1-2,IAB1-3');
         expect(bidRequest.data.cpid).to.equal('producer-123');
         expect(bidRequest.data.cpname).to.equal('Test Producer');
+        expect(bidRequest.data.cchannelid).to.equal('channel-123');
         expect(bidRequest.data.cchannel).to.equal('Test Channel');
+        expect(bidRequest.data.cchanneldomain).to.equal('testchannel.com');
         expect(bidRequest.data.cnetwork).to.equal('Test Network');
       });
 

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -1197,7 +1197,7 @@ describe('gumgumAdapter', function () {
       expect(nativeBidResponse.mediaType).to.equal(NATIVE);
     });
 
-    it('sets ortb property from native ADM JSON with native wrapper', function () {
+    it('sets native.ortb property from native ADM JSON with native wrapper', function () {
       const nativeAdm = {
         native: {
           ver: '1.2',
@@ -1221,13 +1221,14 @@ describe('gumgumAdapter', function () {
       const nativeBidRequest = { ...bidRequest, data: { pi: 5 } };
       const result = spec.interpretResponse({ body: nativeServerResponse }, nativeBidRequest)[0];
       expect(result.mediaType).to.equal(NATIVE);
-      expect(result.ortb).to.deep.equal(nativeAdm.native);
-      expect(result.ortb.ver).to.equal('1.2');
-      expect(result.ortb.assets).to.have.length(2);
-      expect(result.ortb.link.url).to.equal('https://advertiser.com/landing');
+      expect(result.native).to.be.an('object');
+      expect(result.native.ortb).to.deep.equal(nativeAdm.native);
+      expect(result.native.ortb.ver).to.equal('1.2');
+      expect(result.native.ortb.assets).to.have.length(2);
+      expect(result.native.ortb.link.url).to.equal('https://advertiser.com/landing');
     });
 
-    it('sets ortb property from native ADM JSON without native wrapper', function () {
+    it('sets native.ortb property from native ADM JSON without native wrapper', function () {
       const nativeAdm = {
         ver: '1.2',
         assets: [
@@ -1242,7 +1243,8 @@ describe('gumgumAdapter', function () {
       const nativeBidRequest = { ...bidRequest, data: { pi: 5 } };
       const result = spec.interpretResponse({ body: nativeServerResponse }, nativeBidRequest)[0];
       expect(result.mediaType).to.equal(NATIVE);
-      expect(result.ortb).to.deep.equal(nativeAdm);
+      expect(result.native).to.be.an('object');
+      expect(result.native.ortb).to.deep.equal(nativeAdm);
     });
 
     it('handles invalid native ADM JSON gracefully', function () {
@@ -1253,7 +1255,7 @@ describe('gumgumAdapter', function () {
       const nativeBidRequest = { ...bidRequest, data: { pi: 5 } };
       const result = spec.interpretResponse({ body: nativeServerResponse }, nativeBidRequest)[0];
       expect(result.mediaType).to.equal(NATIVE);
-      expect(result.ortb).to.be.undefined;
+      expect(result.native).to.be.undefined;
     });
   })
   describe('getUserSyncs', function () {

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -253,6 +253,25 @@ describe('gumgumAdapter', function () {
       const bidRequest = spec.buildRequests([request])[0];
       expect(bidRequest.data.pubProvidedId).to.equal(JSON.stringify(pubProvidedIdEids));
     });
+    it('should filter pubProvidedId entries by allowed sources', function () {
+      const filteredRequest = {
+        ...bidRequests[0],
+        userIdAsEids: [
+          {
+            source: 'audigent.com',
+            uids: [{ id: 'ppid-1', ext: { stype: 'ppuid' } }]
+          },
+          {
+            source: 'sonobi.com',
+            uids: [{ id: 'ppid-2', ext: { stype: 'ppuid' } }]
+          }
+        ]
+      };
+      const bidRequest = spec.buildRequests([filteredRequest])[0];
+      const pubProvidedIds = JSON.parse(bidRequest.data.pubProvidedId);
+      expect(pubProvidedIds.length).to.equal(1);
+      expect(pubProvidedIds[0].source).to.equal('audigent.com');
+    });
     it('should set id5Id and id5IdLinkType if the uid and  linkType are available', function () {
       const request = { ...bidRequests[0] };
       const bidRequest = spec.buildRequests([request])[0];

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -278,6 +278,77 @@ describe('gumgumAdapter', function () {
       expect(bidRequest.data.id5Id).to.equal(id5Eid.uids[0].id);
       expect(bidRequest.data.id5IdLinkType).to.equal(id5Eid.uids[0].ext.linkType);
     });
+    it('should use bidderRequest.ortb2.user.ext.eids when bid-level eids are not available', function () {
+      const request = { ...bidRequests[0], userIdAsEids: undefined };
+      const fakeBidderRequest = {
+        ...bidderRequest,
+        ortb2: {
+          ...bidderRequest.ortb2,
+          user: {
+            ext: {
+              eids: [{
+                source: 'liveramp.com',
+                uids: [{
+                  id: 'fallback-idl-env'
+                }]
+              }]
+            }
+          }
+        }
+      };
+      const bidRequest = spec.buildRequests([request], fakeBidderRequest)[0];
+      expect(bidRequest.data.idl_env).to.equal('fallback-idl-env');
+    });
+    it('should keep identity output consistent for prebid10 ortb2 eids input', function () {
+      const request = { ...bidRequests[0], userIdAsEids: undefined };
+      const fakeBidderRequest = {
+        ...bidderRequest,
+        ortb2: {
+          ...bidderRequest.ortb2,
+          user: {
+            ext: {
+              eids: [
+                {
+                  source: 'uidapi.com',
+                  uids: [{ id: 'uid2-token', atype: 3 }]
+                },
+                {
+                  source: 'liveramp.com',
+                  uids: [{ id: 'idl-envelope', atype: 1 }]
+                },
+                {
+                  source: 'adserver.org',
+                  uids: [{ id: 'tdid-value', atype: 1, ext: { rtiPartner: 'TDID' } }]
+                },
+                {
+                  source: 'id5-sync.com',
+                  uids: [{ id: 'id5-value', atype: 1, ext: { linkType: 2 } }]
+                },
+                {
+                  source: 'audigent.com',
+                  uids: [{ id: 'ppid-1', atype: 1, ext: { stype: 'ppuid' } }]
+                },
+                {
+                  source: 'sonobi.com',
+                  uids: [{ id: 'ppid-2', atype: 1, ext: { stype: 'ppuid' } }]
+                }
+              ]
+            }
+          }
+        }
+      };
+      const bidRequest = spec.buildRequests([request], fakeBidderRequest)[0];
+
+      // Expected identity payload shape from legacy GumGum request fields.
+      expect(bidRequest.data.uid2).to.equal('uid2-token');
+      expect(bidRequest.data.idl_env).to.equal('idl-envelope');
+      expect(bidRequest.data.tdid).to.equal('tdid-value');
+      expect(bidRequest.data.id5Id).to.equal('id5-value');
+      expect(bidRequest.data.id5IdLinkType).to.equal(2);
+      const pubProvidedId = JSON.parse(bidRequest.data.pubProvidedId);
+      expect(pubProvidedId.length).to.equal(1);
+      expect(pubProvidedId[0].source).to.equal('audigent.com');
+    });
 
     it('should set pubId param if found', function () {
       const request = { ...bidRequests[0], params: pubIdParam };

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -122,6 +122,39 @@ describe('gumgumAdapter', function () {
 
   describe('buildRequests', function () {
     const sizesArray = [[300, 250], [300, 600]];
+    const id5Eid = {
+      source: 'id5-sync.com',
+      uids: [{
+        id: 'uid-string',
+        ext: {
+          linkType: 2
+        }
+      }]
+    };
+    const pubProvidedIdEids = [
+      {
+        uids: [
+          {
+            ext: {
+              stype: 'ppuid',
+            },
+            id: 'aac4504f-ef89-401b-a891-ada59db44336',
+          },
+        ],
+        source: 'audigent.com',
+      },
+      {
+        uids: [
+          {
+            ext: {
+              stype: 'ppuid',
+            },
+            id: 'y-zqTHmW9E2uG3jEETC6i6BjGcMhPXld2F~A',
+          },
+        ],
+        source: 'crwdcntrl.net',
+      },
+    ];
     const bidderRequest = {
       ortb2: {
         site: {
@@ -158,38 +191,7 @@ describe('gumgumAdapter', function () {
             sizes: sizesArray
           }
         },
-        userId: {
-          id5id: {
-            uid: 'uid-string',
-            ext: {
-              linkType: 2
-            }
-          }
-        },
-        pubProvidedId: [
-          {
-            uids: [
-              {
-                ext: {
-                  stype: 'ppuid',
-                },
-                id: 'aac4504f-ef89-401b-a891-ada59db44336',
-              },
-            ],
-            source: 'sonobi.com',
-          },
-          {
-            uids: [
-              {
-                ext: {
-                  stype: 'ppuid',
-                },
-                id: 'y-zqTHmW9E2uG3jEETC6i6BjGcMhPXld2F~A',
-              },
-            ],
-            source: 'aol.com',
-          },
-        ],
+        userIdAsEids: [id5Eid, ...pubProvidedIdEids],
         adUnitCode: 'adunit-code',
         sizes: sizesArray,
         bidId: '30b31c1838de1e',
@@ -249,13 +251,13 @@ describe('gumgumAdapter', function () {
     it('should set pubProvidedId if the uid and  pubProvidedId are available', function () {
       const request = { ...bidRequests[0] };
       const bidRequest = spec.buildRequests([request])[0];
-      expect(bidRequest.data.pubProvidedId).to.equal(JSON.stringify(bidRequests[0].userId.pubProvidedId));
+      expect(bidRequest.data.pubProvidedId).to.equal(JSON.stringify(pubProvidedIdEids));
     });
     it('should set id5Id and id5IdLinkType if the uid and  linkType are available', function () {
       const request = { ...bidRequests[0] };
       const bidRequest = spec.buildRequests([request])[0];
-      expect(bidRequest.data.id5Id).to.equal(bidRequests[0].userId.id5id.uid);
-      expect(bidRequest.data.id5IdLinkType).to.equal(bidRequests[0].userId.id5id.ext.linkType);
+      expect(bidRequest.data.id5Id).to.equal(id5Eid.uids[0].id);
+      expect(bidRequest.data.id5IdLinkType).to.equal(id5Eid.uids[0].ext.linkType);
     });
 
     it('should set pubId param if found', function () {
@@ -662,7 +664,7 @@ describe('gumgumAdapter', function () {
     it('should set pubProvidedId if the uid and  pubProvidedId are available', function () {
       const request = { ...bidRequests[0] };
       const bidRequest = spec.buildRequests([request])[0];
-      expect(bidRequest.data.pubProvidedId).to.equal(JSON.stringify(bidRequests[0].userId.pubProvidedId));
+      expect(bidRequest.data.pubProvidedId).to.equal(JSON.stringify(pubProvidedIdEids));
     });
 
     it('should add gdpr consent parameters if gdprConsent is present', function () {
@@ -762,14 +764,18 @@ describe('gumgumAdapter', function () {
       expect(bidRequest.data.uspConsent).to.eq(uspConsentObj.uspConsent);
     });
     it('should add a tdid parameter if request contains unified id from TradeDesk', function () {
-      const unifiedId = {
-        'userId': {
-          'tdid': 'tradedesk-id'
-        }
-      }
-      const request = Object.assign(unifiedId, bidRequests[0]);
+      const tdidEid = {
+        source: 'adserver.org',
+        uids: [{
+          id: 'tradedesk-id',
+          ext: {
+            rtiPartner: 'TDID'
+          }
+        }]
+      };
+      const request = Object.assign({}, bidRequests[0], { userIdAsEids: [...bidRequests[0].userIdAsEids, tdidEid] });
       const bidRequest = spec.buildRequests([request])[0];
-      expect(bidRequest.data.tdid).to.eq(unifiedId.userId.tdid);
+      expect(bidRequest.data.tdid).to.eq(tdidEid.uids[0].id);
     });
     it('should not add a tdid parameter if unified id is not found', function () {
       const request = spec.buildRequests(bidRequests)[0];
@@ -777,7 +783,8 @@ describe('gumgumAdapter', function () {
     });
     it('should send IDL envelope ID if available', function () {
       const idl_env = 'abc123';
-      const request = { ...bidRequests[0], userId: { idl_env } };
+      const idlEid = { source: 'liveramp.com', uids: [{ id: idl_env }] };
+      const request = { ...bidRequests[0], userIdAsEids: [idlEid] };
       const bidRequest = spec.buildRequests([request])[0];
 
       expect(bidRequest.data).to.have.property('idl_env');
@@ -791,7 +798,8 @@ describe('gumgumAdapter', function () {
     });
     it('should add a uid2 parameter if request contains uid2 id', function () {
       const uid2 = { id: 'sample-uid2' };
-      const request = { ...bidRequests[0], userId: { uid2 } };
+      const uid2Eid = { source: 'uidapi.com', uids: [{ id: uid2.id }] };
+      const request = { ...bidRequests[0], userIdAsEids: [uid2Eid] };
       const bidRequest = spec.buildRequests([request])[0];
 
       expect(bidRequest.data).to.have.property('uid2');


### PR DESCRIPTION
## Type of change
- [x] Feature


## Description of change
Reverted changes lost during this commit https://github.com/prebid/Prebid.js/commit/2366a67f5a72e37eb75f346a8e1071b0353e23dd (Prebid 11.0):

@patmmccann kindly let me know if changes are needed. I'm not sure why those changes were discarded in the above commit.



