### PR TITLE
Core: limit mergeConfig notifications to updated topics

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -586,8 +586,12 @@ export function newConfig() {
     }
 
     const mergedConfig = mergeDeep(_getConfig(), config);
+    const updatedConfig = Object.keys(config).reduce((accumulator, topic) => {
+      accumulator[topic] = mergedConfig[topic];
+      return accumulator;
+    }, {});
 
-    setConfig({ ...mergedConfig });
+    setConfig(updatedConfig);
     return mergedConfig;
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -587,7 +587,9 @@ export function newConfig() {
 
     const mergedConfig = mergeDeep(_getConfig(), config);
     const updatedConfig = Object.keys(config).reduce((accumulator, topic) => {
-      accumulator[topic] = mergedConfig[topic];
+      if (Object.prototype.hasOwnProperty.call(mergedConfig, topic)) {
+        accumulator[topic] = mergedConfig[topic];
+      }
       return accumulator;
     }, {});
 

--- a/test/spec/config_spec.js
+++ b/test/spec/config_spec.js
@@ -487,6 +487,61 @@ describe('config API', function () {
     expect(getConfig('ortb2')).to.deep.equal(expected);
   });
 
+  it('mergeConfig only notifies updated topics', function () {
+    const baseOrtb2 = {
+      user: {
+        ext: {
+          data: {
+            registered: false
+          }
+        }
+      }
+    };
+    const updateOrtb2 = {
+      site: {
+        name: 'example'
+      }
+    };
+
+    setConfig({
+      currency: { adServerCurrency: 'USD' },
+      ortb2: baseOrtb2
+    });
+
+    const ortb2Listener = sinon.spy();
+    const currencyListener = sinon.spy();
+    const allTopicsListener = sinon.spy();
+
+    getConfig('ortb2', ortb2Listener);
+    getConfig('currency', currencyListener);
+    getConfig(allTopicsListener);
+
+    const result = mergeConfig({ ortb2: updateOrtb2 });
+    const expected = {
+      user: {
+        ext: {
+          data: {
+            registered: false
+          }
+        }
+      },
+      site: {
+        name: 'example'
+      }
+    };
+
+    sinon.assert.calledOnce(ortb2Listener);
+    sinon.assert.calledWithExactly(ortb2Listener, { ortb2: expected });
+    sinon.assert.notCalled(currencyListener);
+    sinon.assert.calledOnce(allTopicsListener);
+    const allTopicsPayload = allTopicsListener.firstCall.args[0];
+    expect(Object.keys(allTopicsPayload)).to.deep.equal(['ortb2']);
+    expect(allTopicsPayload.ortb2).to.deep.equal(expected);
+
+    expect(result.ortb2).to.deep.equal(expected);
+    expect(result.currency).to.deep.equal({ adServerCurrency: 'USD' });
+  });
+
   it('should log error for a non-object value passed in', function () {
     mergeConfig('invalid object');
     expect(logErrorSpy.calledOnce).to.equal(true);


### PR DESCRIPTION

## Type of change
- [X] Bugfix
- [ ] Feature
- [ ] New bidder adapter 
- [ ] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
- Limit `mergeConfig` notifications to input topics while preserving merged return
- Add spec for topic-only notifications and merged return
- Benefit: reduces unnecessary listener invocations (less work, fewer side effects) and avoids accidental resets in modules that react to unrelated config updates.

## Other information
- Related prior issue: https://github.com/prebid/Prebid.js/issues/10546
- Motivation: `mergeConfig` was triggering the currency listener after the currency module had loaded, resetting rates to defaults/empty.

## Steps to reproduce
1. Subscribe to a `currency` listener.
2. Call `mergeConfig({ ortb2: ... })`.
3. Observe the `currency` listener firing.

### Expected results
Only the `ortb2` listener and ALL_TOPICS listener should fire, with payload limited to `ortb2`.

### Actual results
Unrelated listeners (e.g., `currency`) are triggered.