### PR TITLE
Sirdata RTD Module: set targeting on ad units

### DIFF
--- a/modules/sirdataRtdProvider.js
+++ b/modules/sirdataRtdProvider.js
@@ -661,16 +661,17 @@ export function addSegmentData(reqBids, data, adUnits, onDone) {
   }
 
   // Google targeting
+  let sirdataMergedList = [...sirdataData.segments, ...sirdataData.categories];
+  if (params.setGptKeyValues) {
+    const gptCurationId = params.gptCurationId || biddersId.sdRtdForGpt;
+    if (gptCurationId && data.shared_taxonomy?.[gptCurationId]) {
+      const gamCurationData = getSegAndCatsArray(data.shared_taxonomy[gptCurationId], params.contextualMinRelevancyScore, '');
+      sirdataMergedList = [...sirdataMergedList, ...gamCurationData.segments, ...gamCurationData.categories];
+    }
+  }
+  const setAdserverTargeting = params.setGptKeyValues && sirdataMergedList.length > 0;
   if (typeof window.googletag !== 'undefined' && params.setGptKeyValues) {
     try {
-      const gptCurationId = params.gptCurationId || biddersId.sdRtdForGpt;
-      let sirdataMergedList = [...sirdataData.segments, ...sirdataData.categories];
-
-      if (gptCurationId && data.shared_taxonomy?.[gptCurationId]) {
-        const gamCurationData = getSegAndCatsArray(data.shared_taxonomy[gptCurationId], params.contextualMinRelevancyScore, '');
-        sirdataMergedList = [...sirdataMergedList, ...gamCurationData.segments, ...gamCurationData.categories];
-      }
-
       window.googletag.cmd.push(() => {
         window.googletag.pubads().getSlots().forEach(slot => {
           if (typeof slot.setTargeting !== 'undefined' && sirdataMergedList.length > 0) {
@@ -684,6 +685,9 @@ export function addSegmentData(reqBids, data, adUnits, onDone) {
   }
 
   adUnits.forEach(adUnit => {
+    if (setAdserverTargeting) {
+      deepSetValue(adUnit, 'adserverTargeting.sd_rtd', sirdataMergedList);
+    }
     return adUnit.bids?.forEach(bid => {
       const bidderIndex = params.bidders.findIndex(function (i) { return i.bidder === bid.bidder; });
       try {

--- a/test/spec/modules/sirdataRtdProvider_spec.js
+++ b/test/spec/modules/sirdataRtdProvider_spec.js
@@ -180,6 +180,7 @@ describe('sirdataRtdProvider', function () {
       }
       addSegmentData(firstReqBidsConfigObj, firstData, adUnits, function() { return true; });
       expect(firstReqBidsConfigObj.ortb2Fragments.global.user.data[0].ext.segtax).to.equal(4);
+      expect(adUnits[0].adserverTargeting.sd_rtd).to.deep.equal(['111111', '222222', '333333', '444444', '555555', '666666']);
     });
   });
 


### PR DESCRIPTION
### Motivation
- Ensure Sirdata RTD attaches legacy ad-server targeting to each Prebid ad unit (so `sd_rtd` is available on the ad unit), aligning behavior with recent RTD targeting changes (e.g. PR #14711) instead of only pushing to GPT slots.
