### PR TITLE
ssp_geniee Adapter: use request-scoped client hints

### DIFF
--- a/modules/ssp_genieeBidAdapter.js
+++ b/modules/ssp_genieeBidAdapter.js
@@ -383,7 +383,6 @@ export const spec = {
     validBidRequests.forEach((bid) => {
       // const isNative = bid.mediaTypes?.native;
       const geparameter = window.geparams || {};
-      // NOTE: codex agent fix for #14574: obtain client hints from request-scoped ORTB2 device.sua.
       const sua = bid.ortb2?.device?.sua || bidderRequest?.ortb2?.device?.sua;
 
       serverRequests.push({

--- a/modules/ssp_genieeBidAdapter.js
+++ b/modules/ssp_genieeBidAdapter.js
@@ -2,9 +2,6 @@ import * as utils from '../src/utils.js';
 import { isPlainObject } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
-import { getStorageManager } from '../src/storageManager.js';
-import { MODULE_TYPE_ANALYTICS } from '../src/activities/modules.js';
-import { highEntropySUAAccessor } from '../src/fpd/sua.js';
 import { config } from '../src/config.js';
 
 /**
@@ -20,8 +17,6 @@ const SUPPORTED_MEDIA_TYPES = [BANNER];
 const DEFAULT_CURRENCY = 'JPY';
 const ALLOWED_CURRENCIES = ['USD', 'JPY'];
 const NET_REVENUE = true;
-const MODULE_NAME = `ssp_geniee`;
-export const storage = getStorageManager({ moduleType: MODULE_TYPE_ANALYTICS, moduleName: MODULE_NAME })
 
 /**
  * List of keys for geparams (parameters we use)
@@ -156,7 +151,7 @@ function getFloorPrice(bid, currency) {
  * making request data be used commonly banner and native
  * @see https://docs.prebid.org/dev-docs/bidder-adaptor.html#location-and-referrers
  */
-function makeCommonRequestData(bid, geparameter, refererInfo) {
+function makeCommonRequestData(bid, geparameter, refererInfo, sua) {
   const gpid = utils.deepAccess(bid, 'ortb2Imp.ext.gpid');
   const schain = utils.deepAccess(bid, 'ortb2.source.ext.schain');
   const currency = bid.params.hasOwnProperty('currency') ? bid.params.currency : DEFAULT_CURRENCY;
@@ -259,22 +254,21 @@ function makeCommonRequestData(bid, geparameter, refererInfo) {
 
   // makeUAQuery
   // To avoid double encoding, not using encodeURIComponent here
-  const ua = JSON.parse(getUserAgent());
-  if (ua && ua.fullVersionList) {
-    const fullVersionList = ua.fullVersionList.reduce((acc, cur) => {
+  if (Array.isArray(sua?.browsers)) {
+    const fullVersionList = sua.browsers.reduce((acc, cur) => {
       let str = acc;
       if (str) str += ',';
-      str += '"' + cur.brand + '";v="' + cur.version + '"';
+      str += '"' + cur.brand + '";v="' + (cur?.version || []).join('.') + '"';
       return str;
     }, '');
     data.ucfvl = fullVersionList;
   }
-  if (ua && ua.platform) data.ucp = '"' + ua.platform + '"';
-  if (ua && ua.architecture) data.ucarch = '"' + ua.architecture + '"';
-  if (ua && ua.platformVersion) data.ucpv = '"' + ua.platformVersion + '"';
-  if (ua && ua.bitness) data.ucbit = '"' + ua.bitness + '"';
-  data.ucmbl = '?' + (ua && ua.mobile ? '1' : '0');
-  if (ua && ua.model) data.ucmdl = '"' + ua.model + '"';
+  if (sua?.platform?.brand) data.ucp = '"' + sua.platform.brand + '"';
+  if (sua?.architecture) data.ucarch = '"' + sua.architecture + '"';
+  if (sua?.platform?.version) data.ucpv = '"' + sua.platform.version.join('.') + '"';
+  if (sua?.bitness) data.ucbit = '"' + sua.bitness + '"';
+  data.ucmbl = '?' + (sua?.mobile ? '1' : '0');
+  if (sua?.model) data.ucmdl = '"' + sua.model + '"';
 
   return data;
 }
@@ -282,8 +276,8 @@ function makeCommonRequestData(bid, geparameter, refererInfo) {
 /**
  * making request data for banner
  */
-function makeBannerRequestData(bid, geparameter, refererInfo) {
-  const data = makeCommonRequestData(bid, geparameter, refererInfo);
+function makeBannerRequestData(bid, geparameter, refererInfo, sua) {
+  const data = makeCommonRequestData(bid, geparameter, refererInfo, sua);
 
   // this query is not used in nad endpoint but used in ad_call endpoint
   if (hasParamsNotBlankString(geparameter, GEPARAMS_KEY.BUNDLE)) {
@@ -349,10 +343,6 @@ function makeBidResponseAd(innerHTML) {
   return '<body marginwidth="0" marginheight="0">' + innerHTML + '</body>';
 }
 
-function getUserAgent() {
-  return storage.getDataFromLocalStorage('key') || null;
-}
-
 export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: SUPPORTED_MEDIA_TYPES,
@@ -390,34 +380,16 @@ export const spec = {
   buildRequests: function (validBidRequests, bidderRequest) {
     const serverRequests = [];
 
-    const HIGH_ENTROPY_HINTS = [
-      'architecture',
-      'model',
-      'mobile',
-      'platform',
-      'bitness',
-      'platformVersion',
-      'fullVersionList',
-    ];
-
-    const uaData = window.navigator?.userAgentData;
-    if (uaData && uaData.getHighEntropyValues) {
-      const getHighEntropySUA = highEntropySUAAccessor(uaData);
-      getHighEntropySUA(HIGH_ENTROPY_HINTS).then((ua) => {
-        if (ua) {
-          storage.setDataInLocalStorage('ua', JSON.stringify(ua));
-        }
-      });
-    }
-
     validBidRequests.forEach((bid) => {
       // const isNative = bid.mediaTypes?.native;
       const geparameter = window.geparams || {};
+      // NOTE: codex agent fix for #14574: obtain client hints from request-scoped ORTB2 device.sua.
+      const sua = bid.ortb2?.device?.sua || bidderRequest?.ortb2?.device?.sua;
 
       serverRequests.push({
         method: 'GET',
         url: BANNER_ENDPOINT,
-        data: makeBannerRequestData(bid, geparameter, bidderRequest?.refererInfo),
+        data: makeBannerRequestData(bid, geparameter, bidderRequest?.refererInfo, sua),
         bid: bid,
       });
     });

--- a/test/spec/modules/ssp_genieeBidAdapter_spec.js
+++ b/test/spec/modules/ssp_genieeBidAdapter_spec.js
@@ -220,6 +220,57 @@ describe('ssp_genieeBidAdapter', function () {
         expect(request[1].data.cur).to.deep.equal('USD');
       });
 
+      it('should set UA client hints from bidderRequest.ortb2.device.sua', function () {
+        const request = spec.buildRequests([BANNER_BID], {
+          ortb2: {
+            device: {
+              sua: {
+                browsers: [{ brand: 'Chromium', version: ['123', '0', '6312', '86'] }],
+                platform: { brand: 'macOS', version: ['14', '4', '1'] },
+                architecture: 'arm',
+                bitness: '64',
+                mobile: 0,
+                model: 'MacBookPro'
+              }
+            }
+          }
+        });
+
+        expect(request[0].data.ucfvl).to.equal('"Chromium";v="123.0.6312.86"');
+        expect(request[0].data.ucp).to.equal('"macOS"');
+        expect(request[0].data.ucarch).to.equal('"arm"');
+        expect(request[0].data.ucpv).to.equal('"14.4.1"');
+        expect(request[0].data.ucbit).to.equal('"64"');
+        expect(request[0].data.ucmbl).to.equal('?0');
+        expect(request[0].data.ucmdl).to.equal('"MacBookPro"');
+      });
+
+      it('should prefer bid.ortb2.device.sua over bidderRequest.ortb2.device.sua', function () {
+        const request = spec.buildRequests([{
+          ...BANNER_BID,
+          ortb2: {
+            device: {
+              sua: {
+                platform: { brand: 'Android' },
+                mobile: 1
+              }
+            }
+          }
+        }], {
+          ortb2: {
+            device: {
+              sua: {
+                platform: { brand: 'macOS' },
+                mobile: 0
+              }
+            }
+          }
+        });
+
+        expect(request[0].data.ucp).to.equal('"Android"');
+        expect(request[0].data.ucmbl).to.equal('?1');
+      });
+
       it('should not sets the value of the adtk query when geparams.lat does not exist', function () {
         const request = spec.buildRequests([BANNER_BID]);
         expect(request[0].data).to.not.have.property('adtk');


### PR DESCRIPTION
### Motivation
- Fixes an issue where the adapter obtained UA client hints from `navigator.userAgentData.getHighEntropyValues` and localStorage instead of using the request-scoped ORTB2 client hints; the change ensures the adapter uses the `device.sua` provided on the request.
 #14574 