### PR TITLE
Nexx360 bidder: Remove gvlid from movingup alias

### DIFF
--- a/modules/nexx360BidAdapter.ts
+++ b/modules/nexx360BidAdapter.ts
@@ -57,7 +57,7 @@ const ALIASES = [
   { code: 'spm', gvlid: 965 },
   { code: 'bidstailamedia', gvlid: 965 },
   { code: 'scoremedia', gvlid: 965 },
-  { code: 'movingup', gvlid: 1416 },
+  { code: 'movingup' },
   { code: 'glomexbidder', gvlid: 967 },
   { code: 'pubxai', gvlid: 1485 },
   { code: 'ybidder', gvlid: 1253 },


### PR DESCRIPTION
deleted April 13 2026 as per https://vendor-list.consensu.org/v3/vendor-list.json#:~:text=1416%22%3A%20%7B%22id%22%3A%201416,dati%2Dpersonali%22%2C%20%22legIntClaim%22%3A