### PR TITLE
Flipp Bid Adapter: Update return ad dimensions

### DIFF
--- a/modules/flippBidAdapter.js
+++ b/modules/flippBidAdapter.js
@@ -26,6 +26,8 @@ const VALID_CREATIVE_TYPES = ['DTX', 'NativeX'];
 const FLIPP_USER_KEY = 'flipp-uid';
 const COMPACT_DEFAULT_HEIGHT = 600;
 const STANDARD_DEFAULT_HEIGHT = 1800;
+const MOBILE_DEFAULT_WIDTH = 300;
+const DESKTOP_DEFAULT_WIDTH = 600;
 
 let userKey = null;
 export const storage = getStorageManager({ bidderCode: BIDDER_CODE });
@@ -168,14 +170,16 @@ export const spec = {
       return res.decisions.inline.map(decision => {
         const placement = placements.find(p => p.prebid.requestId === decision.prebid?.requestId);
         const customData = decision.contents[0]?.data?.customData;
-        const height = placement.options?.startCompact
+        const isCompact = placement.options?.startCompact;
+        const height = isCompact
           ? customData?.compactHeight ?? COMPACT_DEFAULT_HEIGHT
           : customData?.standardHeight ?? STANDARD_DEFAULT_HEIGHT;
+        const width = isCompact ? MOBILE_DEFAULT_WIDTH : DESKTOP_DEFAULT_WIDTH;
         return {
           bidderCode: BIDDER_CODE,
           requestId: decision.prebid?.requestId,
           cpm: decision.prebid?.cpm,
-          width: decision.width,
+          width,
           height,
           creativeId: decision.adId,
           currency: DEFAULT_CURRENCY,

--- a/test/spec/modules/flippBidAdapter_spec.js
+++ b/test/spec/modules/flippBidAdapter_spec.js
@@ -92,22 +92,20 @@ describe('flippAdapter', function () {
             'inline': [{
               'bidCpm': 1,
               'adId': 262838368,
-              'height': 600,
-              'width': 300,
               'storefront': { 'flyer_id': 5435567 },
               'prebid': {
                 'requestId': '237f4d1a293f99',
                 'cpm': 1.11,
                 'creative': 'Returned from server',
               },
-              'contents': {
+              'contents': [{
                 'data': {
                   'customData': {
                     'compactHeight': 600,
                     'standardHeight': 1800
                   }
                 }
-              }
+              }]
             }]
           },
           'location': { 'city': 'Oakville' },
@@ -121,7 +119,7 @@ describe('flippAdapter', function () {
           currency: 'USD',
           cpm: 1.11,
           netRevenue: true,
-          width: 300,
+          width: 600,
           height: 1800,
           creativeId: 262838368,
           ttl: 30,
@@ -132,6 +130,115 @@ describe('flippAdapter', function () {
       const result = spec.interpretResponse(serverResponse, bidRequest);
       expect(result).to.have.lengthOf(1);
       expect(result).to.deep.have.same.members(expectedResponse);
+    });
+
+    it('should return desktop width (600) and standard height from customData when not compact', function() {
+      const bidRequest = {
+        method: 'POST',
+        url: ENDPOINT,
+        data: {
+          placements: [{
+            divName: 'slot',
+            networkId: 12345,
+            siteId: 12345,
+            adTypes: [12345],
+            count: 1,
+            options: { startCompact: false },
+            prebid: { requestId: '237f4d1a293f99' },
+          }],
+          url: 'http://example.com',
+        },
+      };
+      const serverResponse = {
+        body: {
+          decisions: {
+            inline: [{
+              adId: 111,
+              prebid: { requestId: '237f4d1a293f99', cpm: 1, creative: 'ad' },
+              contents: [{ data: { customData: { compactHeight: 500, standardHeight: 2000 } } }],
+            }]
+          }
+        }
+      };
+      const result = spec.interpretResponse(serverResponse, bidRequest);
+      expect(result[0].width).to.equal(600);
+      expect(result[0].height).to.equal(2000);
+    });
+
+    it('should return mobile width (300) and compact height from customData when compact', function() {
+      const bidRequest = {
+        method: 'POST',
+        url: ENDPOINT,
+        data: {
+          placements: [{
+            divName: 'slot',
+            networkId: 12345,
+            siteId: 12345,
+            adTypes: [12345],
+            count: 1,
+            options: { startCompact: true },
+            prebid: { requestId: '237f4d1a293f99' },
+          }],
+          url: 'http://example.com',
+        },
+      };
+      const serverResponse = {
+        body: {
+          decisions: {
+            inline: [{
+              adId: 111,
+              prebid: { requestId: '237f4d1a293f99', cpm: 1, creative: 'ad' },
+              contents: [{ data: { customData: { compactHeight: 500, standardHeight: 2000 } } }],
+            }]
+          }
+        }
+      };
+      const result = spec.interpretResponse(serverResponse, bidRequest);
+      expect(result[0].width).to.equal(300);
+      expect(result[0].height).to.equal(500);
+    });
+
+    it('should fall back to default dimensions when customData is absent', function() {
+      const bidRequest = {
+        method: 'POST',
+        url: ENDPOINT,
+        data: {
+          placements: [
+            {
+              options: { startCompact: false },
+              prebid: { requestId: 'req-desktop' },
+            },
+            {
+              options: { startCompact: true },
+              prebid: { requestId: 'req-mobile' },
+            },
+          ],
+          url: 'http://example.com',
+        },
+      };
+      const serverResponse = {
+        body: {
+          decisions: {
+            inline: [
+              {
+                adId: 1,
+                prebid: { requestId: 'req-desktop', cpm: 1, creative: 'ad' },
+                contents: [],
+              },
+              {
+                adId: 2,
+                prebid: { requestId: 'req-mobile', cpm: 1, creative: 'ad' },
+                contents: [],
+              },
+            ]
+          }
+        }
+      };
+      const result = spec.interpretResponse(serverResponse, bidRequest);
+      expect(result[0].width).to.equal(600);
+      expect(result[0].height).to.equal(1800);
+      expect(result[1].width).to.equal(300);
+      expect(result[1].height).to.equal(600);
     });
 
     it('should get empty bid response when no ad is returned', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Update default return dimensions in interpretResponse:
- Height: 600 (compact), 1800 (non-compact)
- Width: 300 (mobile/compact), 600 (desktop/non-compact)

Width now uses fixed defaults based on compact/desktop mode 
instead of the server-returned decision.width.



## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
