### PR TITLE
Hubvisor Bid Adapter: initial release

### DIFF
--- a/modules/hubvisorBidAdapter.md
+++ b/modules/hubvisorBidAdapter.md
@@ -1,0 +1,65 @@
+# Overview
+
+**Module Name**: Hubvisor Bidder Adapter
+**Module Type**: Bidder Adapter
+**Maintainer**: prebid@hubvisor.io
+
+# Description
+
+Hubvisor Bidder Adapter for Prebid.js. Supports banner and video (instream/outstream) media types.
+
+Contact [prebid@hubvisor.io](mailto:prebid@hubvisor.io) for setup and to obtain a placement ID.
+
+# Parameters
+
+| Name | Scope | Description | Example | Type |
+|------|-------|-------------|---------|------|
+| `placementId` | optional | Hubvisor placement identifier provided by Hubvisor. | `'my-placement-id'` | String |
+| `video.maxWidth` | optional | Maximum player width in pixels for outstream video. | `640` | Number |
+| `video.targetRatio` | optional | Target aspect ratio for outstream video (e.g. `16/9`). | `1.777` | Number |
+| `video.selector` | optional | CSS selector for a custom outstream player container element. | `'#my-video-container'` | String |
+
+# Test Parameters
+
+```javascript
+var adUnits = [
+  // Banner adUnit
+  {
+    code: 'test-div-banner',
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250], [728, 90]]
+      }
+    },
+    bids: [{
+      bidder: 'hubvisor',
+      params: {
+        placementId: 'test-placement-banner'
+      }
+    }]
+  },
+  // Outstream video adUnit
+  {
+    code: 'test-div-video',
+    mediaTypes: {
+      video: {
+        context: 'outstream',
+        playerSize: [[640, 480]],
+        mimes: ['video/mp4'],
+        protocols: [1, 2, 3, 4, 5, 6],
+        playbackmethod: [2]
+      }
+    },
+    bids: [{
+      bidder: 'hubvisor',
+      params: {
+        placementId: 'test-placement-video',
+        video: {
+          maxWidth: 640,
+          targetRatio: 1.777
+        }
+      }
+    }]
+  }
+];
+```

--- a/modules/hubvisorBidAdapter.ts
+++ b/modules/hubvisorBidAdapter.ts
@@ -1,0 +1,249 @@
+import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import { registerBidder, type AdapterRequest, type BidderSpec, type ServerResponse, type ExtendedResponse } from '../src/adapters/bidderFactory.js';
+import { config } from '../src/config.js';
+import { isStr, isFn, logInfo, logWarn, logError, deepSetValue } from '../src/utils.js';
+import { Renderer } from '../src/Renderer.js';
+import { ortbConverter } from '../libraries/ortbConverter/converter.js';
+import type { BidRequest, ClientBidderRequest } from '../src/adapterManager.js';
+import type { SyncType } from '../src/userSync.js';
+
+const BIDDER_CODE = 'hubvisor' as const;
+const SYNC_ENDPOINT = 'https://relay.hubvisor.io/v1/sync/pbjs';
+const AUCTION_ENDPOINT = 'https://relay.hubvisor.io/v1/auction/pbjs';
+const HUBVISOR_PLAYER_URL = 'https://cdn.hubvisor.io/wrapper/common/player.js';
+
+const SYNC_TYPE_MAP: Record<string, SyncType> = {
+  image: 'image',
+  redirect: 'image',
+  iframe: 'iframe',
+};
+
+/** Bidder params for the Hubvisor adapter. */
+export type HubvisorBidParams = {
+  /** Hubvisor placement identifier. */
+  placementId?: string;
+  /** Optional outstream video rendering configuration. */
+  video?: {
+    /** Maximum player width in pixels. */
+    maxWidth?: number;
+    /** Target aspect ratio (e.g. 16/9). */
+    targetRatio?: number;
+    /** CSS selector for the player container element. */
+    selector?: string;
+  };
+};
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    [BIDDER_CODE]: HubvisorBidParams;
+  }
+}
+
+/** Extended adapter request carrying internal state between buildRequests and interpretResponse. */
+interface HubvisorAdapterRequest extends AdapterRequest {
+  internal?: {
+    bidRequestsById: Record<string, BidRequest<typeof BIDDER_CODE>>;
+  };
+}
+
+interface SyncResponseBody {
+  bidders?: Array<{ type: string; url: string }>;
+}
+
+const converter = ortbConverter({
+  context: {
+    netRevenue: true,
+    ttl: 30,
+  },
+  request(buildRequest, imps, bidderRequest, context) {
+    const request = buildRequest(imps, bidderRequest, context);
+    const req = request as any;
+    if (req.site) {
+      req.site.publisher = req.publisher;
+    }
+    delete req.publisher;
+    req.test = isTest() ? 1 : 0;
+    return request;
+  },
+  imp(buildImp, bidRequest, context) {
+    const imp = buildImp(bidRequest, context);
+    deepSetValue(imp, 'ext.hubvisor.placementId', getPlacementIdFromBidRequest(bidRequest as BidRequest<typeof BIDDER_CODE>));
+    return imp;
+  },
+});
+
+function isTest(): boolean {
+  return config.getConfig('test') === true;
+}
+
+function getPlacementIdFromBidRequest(bidRequest: BidRequest<typeof BIDDER_CODE>): string | undefined {
+  return bidRequest.params?.placementId;
+}
+
+function makeOutstreamRenderer(bid: any, videoParameters: HubvisorBidParams['video'] = {}): any {
+  const { id } = bid;
+  const { maxWidth, targetRatio, selector } = videoParameters;
+  const renderer = Renderer.install({
+    id,
+    url: HUBVISOR_PLAYER_URL,
+    loaded: false,
+    config: { maxWidth, targetRatio, selector },
+  });
+  renderer.setRender(render);
+  return renderer;
+}
+
+function render(bid: any): void {
+  const cfg = bid.renderer.getConfig();
+  bid.renderer.push(() => {
+    const { vastXml, vastUrl, width: targetWidth, height: targetHeight } = bid;
+    const { maxWidth, targetRatio } = cfg;
+    playOutstream(getSelector(cfg, bid), {
+      vastXml,
+      vastUrl,
+      targetWidth,
+      targetHeight,
+      maxWidth,
+      targetRatio,
+      expand: 'no-lazy-load',
+      onEvent: (event: string) => {
+        switch (event) {
+          case 'impression':
+            logInfo(`Video impression for ad unit ${bid.adUnitCode}`);
+            break;
+          case 'error':
+            logWarn(`Error while playing video for ad unit ${bid.adUnitCode}`);
+            break;
+        }
+      },
+    });
+  });
+}
+
+function getSelector(cfg: HubvisorBidParams['video'], bid: any): string | (() => Element | null) {
+  if (cfg?.selector) {
+    return cfg.selector;
+  }
+  if (window.CSS) {
+    return `#${window.CSS.escape(bid.adUnitCode)}`;
+  }
+  return `#${bid.adUnitCode}`;
+}
+
+function playOutstream(containerOrSelector: string | (() => Element | null), options: Record<string, unknown>): void {
+  const container = getContainer(containerOrSelector);
+  const player = (window as any).HbvPlayer;
+  if (!player) {
+    logError('Failed to load player!');
+    return;
+  }
+  player.playOutstream(container, options);
+}
+
+function getContainer(containerOrSelector: string | (() => Element | null)): Element | null | undefined {
+  if (isStr(containerOrSelector)) {
+    const container = document.querySelector(containerOrSelector as string);
+    if (container) {
+      return container;
+    }
+    logError(`Player container not found for selector ${containerOrSelector}`);
+    return undefined;
+  }
+  if (isFn(containerOrSelector)) {
+    const container = (containerOrSelector as () => Element | null)();
+    if (container) {
+      return container;
+    }
+    logError('Player container not found for selector function');
+    return undefined;
+  }
+  return containerOrSelector as unknown as Element;
+}
+
+export const spec: BidderSpec<typeof BIDDER_CODE> = {
+  code: BIDDER_CODE,
+  gvlid: 1112,
+  supportedMediaTypes: [BANNER, VIDEO],
+
+  isBidRequestValid(_bid: BidRequest<typeof BIDDER_CODE>): boolean {
+    return true;
+  },
+
+  buildRequests(
+    bidRequests: BidRequest<typeof BIDDER_CODE>[],
+    bidderRequest: ClientBidderRequest<typeof BIDDER_CODE>
+  ): HubvisorAdapterRequest[] {
+    const { gdprConsent = {} as { gdprApplies?: boolean; consentString?: string } } = bidderRequest as any;
+    const placementIds = bidRequests
+      .map(getPlacementIdFromBidRequest)
+      .filter((id): id is string => !!id);
+    const auctionRequest = converter.toORTB({ bidRequests, bidderRequest });
+    const bidRequestsById = bidRequests.reduce<Record<string, BidRequest<typeof BIDDER_CODE>>>((acc, bidRequest) => {
+      acc[bidRequest.bidId] = bidRequest;
+      return acc;
+    }, {});
+    const syncData: Record<string, unknown> = {
+      gdpr: gdprConsent.gdprApplies ?? false,
+      placement_ids: placementIds.join(','),
+    };
+    if (gdprConsent.consentString) {
+      syncData.gdpr_consent = gdprConsent.consentString;
+    }
+    return [
+      {
+        method: 'GET',
+        url: SYNC_ENDPOINT,
+        data: syncData,
+      },
+      {
+        method: 'POST',
+        url: AUCTION_ENDPOINT,
+        data: auctionRequest,
+        internal: { bidRequestsById },
+      },
+    ];
+  },
+
+  interpretResponse(response: ServerResponse, request: AdapterRequest): any[] {
+    const hubvisorRequest = request as HubvisorAdapterRequest;
+    const { bidRequestsById } = hubvisorRequest.internal ?? {};
+    if (!bidRequestsById) {
+      return [];
+    }
+    const bids = (converter.fromORTB({
+      response: response.body,
+      request: request.data,
+    }) as ExtendedResponse).bids ?? [];
+    for (const bid of bids) {
+      const bidRequest = bidRequestsById[bid.requestId];
+      if (bid.mediaType === 'video') {
+        const video = bidRequest?.mediaTypes?.video;
+        if (video?.context === 'outstream') {
+          const videoParameters = bidRequest.params?.video;
+          bid.renderer = makeOutstreamRenderer(bid, videoParameters);
+        }
+      }
+    }
+    return bids;
+  },
+
+  getUserSyncs(
+    _syncOptions: { iframeEnabled: boolean; pixelEnabled: boolean },
+    serverResponses: ServerResponse[]
+  ): { type: SyncType; url: string }[] {
+    if (serverResponses.length !== 2) {
+      return [];
+    }
+    const [syncResponse] = serverResponses;
+    const body = syncResponse.body as SyncResponseBody | undefined;
+    return (body?.bidders ?? []).reduce<{ type: SyncType; url: string }[]>((acc, { type, url }) => {
+      const syncType = SYNC_TYPE_MAP[type];
+      if (!syncType || !url) {
+        return acc;
+      }
+      return acc.concat({ type: syncType, url });
+    }, []);
+  },
+};
+
+registerBidder(spec);

--- a/modules/hubvisorBidAdapter.ts
+++ b/modules/hubvisorBidAdapter.ts
@@ -58,7 +58,7 @@ const converter = ortbConverter({
   request(buildRequest, imps, bidderRequest, context) {
     const request = buildRequest(imps, bidderRequest, context);
     const req = request as any;
-    if (req.site) {
+    if (req.site && req.publisher) {
       req.site.publisher = req.publisher;
     }
     delete req.publisher;
@@ -231,12 +231,12 @@ export const spec: BidderSpec<typeof BIDDER_CODE> = {
     _syncOptions: { iframeEnabled: boolean; pixelEnabled: boolean },
     serverResponses: ServerResponse[]
   ): { type: SyncType; url: string }[] {
-    if (serverResponses.length !== 2) {
+    const syncResponse = serverResponses.find(r => Array.isArray((r.body as SyncResponseBody)?.bidders));
+    if (!syncResponse) {
       return [];
     }
-    const [syncResponse] = serverResponses;
-    const body = syncResponse.body as SyncResponseBody | undefined;
-    return (body?.bidders ?? []).reduce<{ type: SyncType; url: string }[]>((acc, { type, url }) => {
+    const body = syncResponse.body as SyncResponseBody;
+    return (body.bidders ?? []).reduce<{ type: SyncType; url: string }[]>((acc, { type, url }) => {
       const syncType = SYNC_TYPE_MAP[type];
       if (!syncType || !url) {
         return acc;

--- a/test/spec/modules/hubvisorBidAdapter_spec.js
+++ b/test/spec/modules/hubvisorBidAdapter_spec.js
@@ -1,0 +1,369 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { spec } from 'modules/hubvisorBidAdapter.js';
+import { config } from 'src/config.js';
+
+const BIDDER_CODE = 'hubvisor';
+
+function makeBannerBidRequest(overrides = {}) {
+  return Object.assign({
+    bidder: BIDDER_CODE,
+    bidId: 'bid-id-banner-1',
+    bidderRequestId: 'bidder-request-1',
+    auctionId: 'auction-id-1',
+    adUnitCode: 'div-banner',
+    params: { placementId: 'test-placement-1' },
+    mediaTypes: {
+      banner: { sizes: [[300, 250], [728, 90]] }
+    },
+    sizes: [[300, 250], [728, 90]],
+  }, overrides);
+}
+
+function makeVideoBidRequest(context = 'outstream', overrides = {}) {
+  return Object.assign({
+    bidder: BIDDER_CODE,
+    bidId: 'bid-id-video-1',
+    bidderRequestId: 'bidder-request-1',
+    auctionId: 'auction-id-1',
+    adUnitCode: 'div-video',
+    params: {
+      placementId: 'test-placement-2',
+      video: { maxWidth: 640, targetRatio: 1.777 },
+    },
+    mediaTypes: {
+      video: {
+        context,
+        playerSize: [[640, 480]],
+        mimes: ['video/mp4'],
+        protocols: [1, 2, 3, 4, 5, 6],
+        playbackmethod: [2],
+      }
+    },
+  }, overrides);
+}
+
+function makeBidderRequest(overrides = {}) {
+  return Object.assign({
+    bidderCode: BIDDER_CODE,
+    auctionId: 'auction-id-1',
+    bidderRequestId: 'bidder-request-1',
+    refererInfo: { page: 'https://example.com', domain: 'example.com' },
+    gdprConsent: {
+      gdprApplies: true,
+      consentString: 'test-consent-string',
+    },
+  }, overrides);
+}
+
+describe('Hubvisor Bid Adapter', () => {
+  describe('spec metadata', () => {
+    it('should have the correct bidder code', () => {
+      expect(spec.code).to.equal(BIDDER_CODE);
+    });
+
+    it('should have gvlid 1112', () => {
+      expect(spec.gvlid).to.equal(1112);
+    });
+
+    it('should support BANNER and VIDEO media types', () => {
+      expect(spec.supportedMediaTypes).to.include('banner');
+      expect(spec.supportedMediaTypes).to.include('video');
+    });
+  });
+
+  describe('isBidRequestValid()', () => {
+    it('should return true for a valid banner bid', () => {
+      expect(spec.isBidRequestValid(makeBannerBidRequest())).to.be.true;
+    });
+
+    it('should return true for a bid with no placementId (it is optional)', () => {
+      const bid = makeBannerBidRequest({ params: {} });
+      expect(spec.isBidRequestValid(bid)).to.be.true;
+    });
+
+    it('should return true for a valid video bid', () => {
+      expect(spec.isBidRequestValid(makeVideoBidRequest())).to.be.true;
+    });
+  });
+
+  describe('buildRequests()', () => {
+    let bidRequests;
+    let bidderRequest;
+
+    beforeEach(() => {
+      bidRequests = [makeBannerBidRequest()];
+      bidderRequest = makeBidderRequest();
+    });
+
+    it('should return an array of two requests', () => {
+      const requests = spec.buildRequests(bidRequests, bidderRequest);
+      expect(requests).to.be.an('array').with.length(2);
+    });
+
+    describe('sync request (first element)', () => {
+      it('should be a GET request to the sync endpoint', () => {
+        const [syncReq] = spec.buildRequests(bidRequests, bidderRequest);
+        expect(syncReq.method).to.equal('GET');
+        expect(syncReq.url).to.equal('https://relay.hubvisor.io/v1/sync/pbjs');
+      });
+
+      it('should include gdpr and placement_ids in sync request data', () => {
+        const [syncReq] = spec.buildRequests(bidRequests, bidderRequest);
+        expect(syncReq.data.gdpr).to.equal(true);
+        expect(syncReq.data.gdpr_consent).to.equal('test-consent-string');
+        expect(syncReq.data.placement_ids).to.equal('test-placement-1');
+      });
+
+      it('should not include gdpr_consent when no consent string is provided', () => {
+        bidderRequest.gdprConsent = { gdprApplies: true };
+        const [syncReq] = spec.buildRequests(bidRequests, bidderRequest);
+        expect(syncReq.data).to.not.have.property('gdpr_consent');
+      });
+
+      it('should default gdpr to false when gdprConsent is absent', () => {
+        const request = makeBidderRequest({ gdprConsent: undefined });
+        const [syncReq] = spec.buildRequests(bidRequests, request);
+        expect(syncReq.data.gdpr).to.equal(false);
+      });
+
+      it('should join multiple placement IDs with commas', () => {
+        bidRequests = [
+          makeBannerBidRequest({ bidId: 'id1', params: { placementId: 'p1' } }),
+          makeBannerBidRequest({ bidId: 'id2', params: { placementId: 'p2' } }),
+        ];
+        const [syncReq] = spec.buildRequests(bidRequests, bidderRequest);
+        expect(syncReq.data.placement_ids).to.equal('p1,p2');
+      });
+
+      it('should omit undefined placement IDs from the sync request', () => {
+        bidRequests = [
+          makeBannerBidRequest({ bidId: 'id1', params: {} }),
+        ];
+        const [syncReq] = spec.buildRequests(bidRequests, bidderRequest);
+        expect(syncReq.data.placement_ids).to.equal('');
+      });
+    });
+
+    describe('auction request (second element)', () => {
+      it('should be a POST request to the auction endpoint', () => {
+        const [, auctionReq] = spec.buildRequests(bidRequests, bidderRequest);
+        expect(auctionReq.method).to.equal('POST');
+        expect(auctionReq.url).to.equal('https://relay.hubvisor.io/v1/auction/pbjs');
+      });
+
+      it('should include an ORTB request body', () => {
+        const [, auctionReq] = spec.buildRequests(bidRequests, bidderRequest);
+        expect(auctionReq.data).to.be.an('object');
+        expect(auctionReq.data.imp).to.be.an('array').with.length(1);
+      });
+
+      it('should set imp.ext.hubvisor.placementId', () => {
+        const [, auctionReq] = spec.buildRequests(bidRequests, bidderRequest);
+        expect(auctionReq.data.imp[0].ext.hubvisor.placementId).to.equal('test-placement-1');
+      });
+
+      it('should store bidRequestsById in internal field', () => {
+        const [, auctionReq] = spec.buildRequests(bidRequests, bidderRequest);
+        expect(auctionReq.internal).to.be.an('object');
+        expect(auctionReq.internal.bidRequestsById).to.have.key('bid-id-banner-1');
+      });
+
+      it('should set test=1 when config test is true', () => {
+        config.setConfig({ test: true });
+        const [, auctionReq] = spec.buildRequests(bidRequests, bidderRequest);
+        expect(auctionReq.data.test).to.equal(1);
+        config.resetConfig();
+      });
+
+      it('should set test=0 when config test is not set', () => {
+        config.resetConfig();
+        const [, auctionReq] = spec.buildRequests(bidRequests, bidderRequest);
+        expect(auctionReq.data.test).to.equal(0);
+      });
+    });
+  });
+
+  describe('interpretResponse()', () => {
+    let bidRequests;
+    let bidderRequest;
+    let requests;
+
+    beforeEach(() => {
+      bidRequests = [makeBannerBidRequest()];
+      bidderRequest = makeBidderRequest();
+      requests = spec.buildRequests(bidRequests, bidderRequest);
+    });
+
+    it('should return empty array when internal is missing', () => {
+      const response = { body: {} };
+      const result = spec.interpretResponse(response, { data: {}, url: '' });
+      expect(result).to.be.an('array').with.length(0);
+    });
+
+    it('should parse a banner bid response', () => {
+      const [, auctionReq] = requests;
+      const response = {
+        body: {
+          id: 'resp-1',
+          cur: 'USD',
+          seatbid: [{
+            bid: [{
+              id: 'b1',
+              impid: 'bid-id-banner-1',
+              mtype: 1, // BANNER
+              price: 2.5,
+              adm: '<div>ad</div>',
+              adomain: ['advertiser.com'],
+              crid: 'creative-1',
+              w: 300,
+              h: 250,
+            }]
+          }]
+        }
+      };
+      const bids = spec.interpretResponse(response, auctionReq);
+      expect(bids).to.have.length(1);
+      expect(bids[0].requestId).to.equal('bid-id-banner-1');
+      expect(bids[0].cpm).to.equal(2.5);
+      expect(bids[0].width).to.equal(300);
+      expect(bids[0].height).to.equal(250);
+      expect(bids[0].ad).to.equal('<div>ad</div>');
+      expect(bids[0].currency).to.equal('USD');
+    });
+
+    if (FEATURES.VIDEO) {
+      it('should attach an outstream renderer to video bids with outstream context', () => {
+        const videoBid = makeVideoBidRequest('outstream');
+        const videoRequests = spec.buildRequests([videoBid], bidderRequest);
+        const [, auctionReq] = videoRequests;
+        const response = {
+          body: {
+            id: 'resp-2',
+            cur: 'USD',
+            seatbid: [{
+              bid: [{
+                id: 'b2',
+                impid: 'bid-id-video-1',
+                mtype: 2, // VIDEO
+                price: 5.0,
+                adm: '<VAST version="2.0"></VAST>',
+                adomain: ['video-advertiser.com'],
+                crid: 'creative-video',
+                w: 640,
+                h: 480,
+              }]
+            }]
+          }
+        };
+        const bids = spec.interpretResponse(response, auctionReq);
+        expect(bids).to.have.length(1);
+        expect(bids[0].renderer).to.exist;
+      });
+
+      it('should NOT attach a renderer for instream video bids', () => {
+        const videoBid = makeVideoBidRequest('instream');
+        videoBid.bidId = 'bid-id-instream-1';
+        const videoRequests = spec.buildRequests([videoBid], bidderRequest);
+        const [, auctionReq] = videoRequests;
+        const response = {
+          body: {
+            id: 'resp-3',
+            cur: 'USD',
+            seatbid: [{
+              bid: [{
+                id: 'b3',
+                impid: 'bid-id-instream-1',
+                mtype: 2, // VIDEO
+                price: 5.0,
+                adm: '<VAST version="2.0"></VAST>',
+                adomain: ['video-advertiser.com'],
+                crid: 'creative-instream',
+                w: 640,
+                h: 480,
+              }]
+            }]
+          }
+        };
+        const bids = spec.interpretResponse(response, auctionReq);
+        expect(bids).to.have.length(1);
+        expect(bids[0].renderer).to.not.exist;
+      });
+    }
+  });
+
+  describe('getUserSyncs()', () => {
+    it('should return empty array when serverResponses does not have exactly 2 entries', () => {
+      expect(spec.getUserSyncs({}, [])).to.eql([]);
+      expect(spec.getUserSyncs({}, [{ body: {} }])).to.eql([]);
+      expect(spec.getUserSyncs({}, [{ body: {} }, { body: {} }, { body: {} }])).to.eql([]);
+    });
+
+    it('should return empty array when sync response has no bidders', () => {
+      const responses = [{ body: {} }, { body: {} }];
+      expect(spec.getUserSyncs({}, responses)).to.eql([]);
+    });
+
+    it('should map image type syncs', () => {
+      const responses = [
+        { body: { bidders: [{ type: 'image', url: 'https://sync.example.com/pixel' }] } },
+        { body: {} },
+      ];
+      const syncs = spec.getUserSyncs({}, responses);
+      expect(syncs).to.eql([{ type: 'image', url: 'https://sync.example.com/pixel' }]);
+    });
+
+    it('should map redirect type syncs to image', () => {
+      const responses = [
+        { body: { bidders: [{ type: 'redirect', url: 'https://sync.example.com/redirect' }] } },
+        { body: {} },
+      ];
+      const syncs = spec.getUserSyncs({}, responses);
+      expect(syncs).to.eql([{ type: 'image', url: 'https://sync.example.com/redirect' }]);
+    });
+
+    it('should map iframe type syncs', () => {
+      const responses = [
+        { body: { bidders: [{ type: 'iframe', url: 'https://sync.example.com/iframe' }] } },
+        { body: {} },
+      ];
+      const syncs = spec.getUserSyncs({}, responses);
+      expect(syncs).to.eql([{ type: 'iframe', url: 'https://sync.example.com/iframe' }]);
+    });
+
+    it('should skip entries with unknown type or missing url', () => {
+      const responses = [
+        {
+          body: {
+            bidders: [
+              { type: 'unknown', url: 'https://sync.example.com/unknown' },
+              { type: 'image', url: '' },
+              { type: 'image', url: 'https://sync.example.com/valid' },
+            ]
+          }
+        },
+        { body: {} },
+      ];
+      const syncs = spec.getUserSyncs({}, responses);
+      expect(syncs).to.eql([{ type: 'image', url: 'https://sync.example.com/valid' }]);
+    });
+
+    it('should return multiple syncs from multiple bidders', () => {
+      const responses = [
+        {
+          body: {
+            bidders: [
+              { type: 'image', url: 'https://sync1.example.com' },
+              { type: 'iframe', url: 'https://sync2.example.com' },
+            ]
+          }
+        },
+        { body: {} },
+      ];
+      const syncs = spec.getUserSyncs({}, responses);
+      expect(syncs).to.have.length(2);
+      expect(syncs[0]).to.eql({ type: 'image', url: 'https://sync1.example.com' });
+      expect(syncs[1]).to.eql({ type: 'iframe', url: 'https://sync2.example.com' });
+    });
+  });
+});

--- a/test/spec/modules/hubvisorBidAdapter_spec.js
+++ b/test/spec/modules/hubvisorBidAdapter_spec.js
@@ -293,10 +293,27 @@ describe('Hubvisor Bid Adapter', () => {
   });
 
   describe('getUserSyncs()', () => {
-    it('should return empty array when serverResponses does not have exactly 2 entries', () => {
+    it('should return empty array when no response has a bidders array', () => {
       expect(spec.getUserSyncs({}, [])).to.eql([]);
       expect(spec.getUserSyncs({}, [{ body: {} }])).to.eql([]);
-      expect(spec.getUserSyncs({}, [{ body: {} }, { body: {} }, { body: {} }])).to.eql([]);
+      expect(spec.getUserSyncs({}, [{ body: {} }, { body: {} }])).to.eql([]);
+    });
+
+    it('should find the sync response by shape regardless of position', () => {
+      const responses = [
+        { body: { id: 'ortb-auction-resp', seatbid: [] } },
+        { body: { bidders: [{ type: 'image', url: 'https://sync.example.com/pixel' }] } },
+      ];
+      const syncs = spec.getUserSyncs({}, responses);
+      expect(syncs).to.eql([{ type: 'image', url: 'https://sync.example.com/pixel' }]);
+    });
+
+    it('should work with only the sync response present (e.g. auction failed)', () => {
+      const responses = [
+        { body: { bidders: [{ type: 'image', url: 'https://sync.example.com/pixel' }] } },
+      ];
+      const syncs = spec.getUserSyncs({}, responses);
+      expect(syncs).to.eql([{ type: 'image', url: 'https://sync.example.com/pixel' }]);
     });
 
     it('should return empty array when sync response has no bidders', () => {


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter

## Description of change

New bid adapter for Hubvisor.

- Maintainer contact: prebid@hubvisor.io
- GVL ID: 1112
- Supported media types: banner, video (instream / outstream)

### Test parameters

```javascript
var adUnits = [
  {
    code: 'test-div-banner',
    mediaTypes: {
      banner: { sizes: [[300, 250], [728, 90]] }
    },
    bids: [{
      bidder: 'hubvisor',
      params: { placementId: 'test-placement-banner' }
    }]
  },
  {
    code: 'test-div-video',
    mediaTypes: {
      video: {
        context: 'outstream',
        playerSize: [[640, 480]],
        mimes: ['video/mp4'],
        protocols: [1, 2, 3, 4, 5, 6],
        playbackmethod: [2]
      }
    },
    bids: [{
      bidder: 'hubvisor',
      params: {
        placementId: 'test-placement-video',
        video: { maxWidth: 640, targetRatio: 1.777 }
      }
    }]
  }
];
```

## Other information

gulp lint ✅
gulp test ✅ (30 tests, all passing in both all-features-disabled and all-features-enabled modes)