### PR TITLE
GumGum Bid Adapter: forward ortb2 device.hwv in bid request

### DIFF
--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -288,6 +288,7 @@ function _getDeviceData(ortb2Data) {
     lang: _device.language,
     make: _device.make,
     model: _device.model,
+    hwv: _device.hwv,
     ppi: _device.ppi,
     pxratio: _device.pxratio,
     lmt: _device.lmt,

--- a/test/spec/modules/gumgumBidAdapter_spec.js
+++ b/test/spec/modules/gumgumBidAdapter_spec.js
@@ -1330,6 +1330,7 @@ describe('gumgumAdapter', function () {
           devicetype: 1,
           make: 'Apple',
           model: 'iPhone 12 Pro Max',
+          hwv: 'iPhone15,2',
           os: 'iOS',
           osv: '17.4',
           ext: { fiftyonedegrees_deviceId: '17595-133085-133468-18092' },
@@ -1350,6 +1351,7 @@ describe('gumgumAdapter', function () {
       expect(bidRequest.data.dt).to.equal(ortb2.device.devicetype);
       expect(bidRequest.data.make).to.equal(ortb2.device.make);
       expect(bidRequest.data.model).to.equal(ortb2.device.model);
+      expect(bidRequest.data.hwv).to.equal(ortb2.device.hwv);
       expect(bidRequest.data.os).to.equal(ortb2.device.os);
       expect(bidRequest.data.osv).to.equal(ortb2.device.osv);
       expect(bidRequest.data.foddid).to.equal(ortb2.device.ext.fiftyonedegrees_deviceId);


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [X] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Forward device.hwv (hardware version) from ortb2.device to the GumGum endpoint (query/bid request data), consistent with other device fields.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

The hwv field is an OpenRTB standard field that identifies the hardware version of the device (e.g. iPhone15,2). This value can be populated by RTD modules such as 51Degrees or WURFL, or set directly by the publisher via pbjs.setConfig({ ortb2: { device: { hwv: '...' } } }).

This change follows the same pattern established in AT-10850 for other device fields (make, model, os, osv, etc.) and is required to support downstream DSPs (e.g. DV360) that use device.hwv for targeting and reporting.

Related ticket: ADJS-1776 | AT-10929

Testing

Added hwv to the existing ORTB2 device data unit test fixture in gumgumBidAdapter_spec.js
Added assertion to verify hwv is forwarded correctly to bidRequest.data
All 99 existing GumGum adapter tests pass