### PR TITLE
GPP control modules: add option to restrict more activities

### DIFF
--- a/libraries/mspa/activityControls.ts
+++ b/libraries/mspa/activityControls.ts
@@ -9,6 +9,22 @@ import {
 import { gppDataHandler } from '../../src/adapterManager.js';
 import { logInfo } from '../../src/utils.js';
 
+export interface MSPAConfig {
+  /**
+   * An optional list of additional activities to restrict when US national or state strings
+   * indicate that the user opted out.
+   * When specified, the listed activities are treated in the same way as 'syncUser', cfr.
+   * https://docs.prebid.org/features/mspa-usnat.html#interpreting-usnat-strings
+   */
+  restrictActivities?: string[]
+}
+
+declare module '../../modules/consentManagementGpp' {
+  interface GPPConfig {
+    mspa?: MSPAConfig;
+  }
+}
+
 // default interpretation for MSPA consent(s):
 // https://docs.prebid.org/features/mspa-usnat.html
 
@@ -135,7 +151,11 @@ function flatSection(subsections) {
   }, {});
 }
 
-export function setupRules(api, sids, normalizeConsent = (c) => c, rules = CONSENT_RULES, registerRule = registerActivityControl, getConsentData = () => gppDataHandler.getConsentData()) {
+export function getRules(restrictActivities) {
+  return Object.assign(Object.fromEntries((restrictActivities ?? []).map(activity => [activity, isConsentDenied])), CONSENT_RULES);
+}
+
+export function setupRules(api, sids, rules = CONSENT_RULES, normalizeConsent = (c) => c, registerRule = registerActivityControl, getConsentData = () => gppDataHandler.getConsentData()) {
   const unreg = [];
   const ruleName = `MSPA (GPP '${api}' for section${sids.length > 1 ? 's' : ''} ${sids.join(', ')})`;
   logInfo(`Enabling activity controls for ${ruleName}`)

--- a/modules/gppControl_usnat.js
+++ b/modules/gppControl_usnat.js
@@ -1,11 +1,11 @@
 import { config } from '../src/config.js';
-import { setupRules } from '../libraries/mspa/activityControls.js';
+import { getRules, setupRules } from '../libraries/mspa/activityControls.js';
 
-let setupDone = false;
+let unregister = null;
 
 config.getConfig('consentManagement', (cfg) => {
-  if (cfg?.consentManagement?.gpp != null && !setupDone) {
-    setupRules('usnat', [7]);
-    setupDone = true;
+  if (cfg?.consentManagement?.gpp != null) {
+    if (unregister != null) unregister();
+    unregister = setupRules('usnat', [7], getRules(cfg.consentManagement.gpp.mspa?.restrictActivities));
   }
 })

--- a/modules/gppControl_usstates.ts
+++ b/modules/gppControl_usstates.ts
@@ -1,5 +1,5 @@
 import { config } from '../src/config.js';
-import { setupRules } from '../libraries/mspa/activityControls.js';
+import { getRules, setupRules } from '../libraries/mspa/activityControls.js';
 import { deepSetValue, prefixLog } from '../src/utils.js';
 
 const FIELDS = {
@@ -171,31 +171,29 @@ export const getSections = (() => {
 
 const handles = [];
 
-declare module './consentManagementGpp' {
-  interface GPPConfig {
-    mspa?: {
-      /**
-       * GPP SIDs that should be covered by activity restrictions. Defaults to all US state SIDs.
-       */
-      sids?: number[];
-      /**
-       * Map from section ID to per-section configuration options
-       */
-      sections?: {
-        [sid: number]: {
-          /**
-           * GPP API name to use for the section. Defaults to the names listed in the GPP spec:
-           * https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/Section%20Information.md#section-ids
-           * This option would only be used if your CMP has named their sections in a non-standard way.y
-           */
-          name?: string;
-          /**
-           * Normalize the flags for this section as if it were the number provided.
-           * Cfr https://docs.prebid.org/features/mspa-usnat.html#interpreting-usnat-strings
-           * Each section defaults to its own ID.
-           */
-          normalizeAs?: number;
-        }
+declare module '../libraries/mspa/activityControls' {
+  interface MSPAConfig {
+    /**
+     * GPP SIDs that should be covered by activity restrictions. Defaults to all US state SIDs.
+     */
+    sids?: number[];
+    /**
+     * Map from section ID to per-section configuration options
+     */
+    sections?: {
+      [sid: number]: {
+        /**
+         * GPP API name to use for the section. Defaults to the names listed in the GPP spec:
+         * https://github.com/InteractiveAdvertisingBureau/Global-Privacy-Platform/blob/main/Sections/Section%20Information.md#section-ids
+         * This option would only be used if your CMP has named their sections in a non-standard way.y
+         */
+        name?: string;
+        /**
+         * Normalize the flags for this section as if it were the number provided.
+         * Cfr https://docs.prebid.org/features/mspa-usnat.html#interpreting-usnat-strings
+         * Each section defaults to its own ID.
+         */
+        normalizeAs?: number;
       }
     }
   }
@@ -208,6 +206,6 @@ config.getConfig('consentManagement', (cfg) => {
       handles.pop()();
     }
     getSections(gppConf?.mspa || {})
-      .forEach(([api, sids, normalize]) => handles.push(setupRules(api, sids, normalize)));
+      .forEach(([api, sids, normalize]) => handles.push(setupRules(api, sids, getRules(gppConf.mspa?.restrictActivities), normalize)));
   }
 });

--- a/test/spec/libraries/mspa/activityControls_spec.js
+++ b/test/spec/libraries/mspa/activityControls_spec.js
@@ -280,7 +280,7 @@ describe('setupRules', () => {
   });
 
   function runSetup(api, sids, normalize) {
-    return setupRules(api, sids, normalize, rules, registerRule, () => consent)
+    return setupRules(api, sids, rules, normalize, registerRule, () => consent)
   }
 
   it('should use flatten section data for the given api', () => {

--- a/test/spec/libraries/mspa/restrictActivities_spec.js
+++ b/test/spec/libraries/mspa/restrictActivities_spec.js
@@ -1,0 +1,37 @@
+import { config } from '../../../../src/config.js';
+import { uninstall } from '../../../../modules/tcfControl.js';
+import { isActivityAllowed } from '../../../../src/activities/rules.js';
+import { activityParams } from '../../../../src/activities/activityParams.js';
+import 'modules/consentManagementGpp.js'
+import 'modules/gppControl_usnat.js';
+import 'modules/gppControl_usstates.js';
+
+describe('restrictActivitites', () => {
+  Object.entries({
+    'usnat': 7,
+    'state': 8
+  }).forEach(([t, section]) => {
+    describe(`on ${t} strings`, () => {
+      afterEach(() => {
+        config.resetConfig();
+        uninstall(); // tcfControl, if included by other tests, activates when it sees any 'consentManagement' config
+      });
+      it('should block additional activities', () => {
+        config.setConfig({
+          consentManagement: {
+            gpp: {
+              cmpApi: 'static',
+              consentData: {
+                applicableSections: [section]
+              },
+              mspa: {
+                restrictActivities: ['mockActivity']
+              },
+            }
+          }
+        });
+        expect(isActivityAllowed('mockActivity', activityParams('bidder', 'mock'))).to.be.false;
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change

This adds a configuration option `consentManagement.gpp.mspa.restrictActivities`, an optional list of activity names. If set, the GPP control modules will treat the given activities the same way they treat `syncUser`.

## Other information

Closes https://github.com/prebid/Prebid.js/issues/14624

