### PR TITLE
Core: tighten apntag shim typing

### DIFF
--- a/src/types/local/shim.d.ts
+++ b/src/types/local/shim.d.ts
@@ -4,7 +4,16 @@ declare global {
   function parseInt(n: number, radix?: number): number;
   function parseFloat(n: number): number;
 
+  interface ApnTag {
+    getTag?: (unit: string) => { keywords?: Record<string, string> } | undefined;
+    modifyTag?: (unit: string, tag: { keywords?: Record<string, string> }) => void;
+    setKeywords?: (targetId: string, keywords: Record<string, string>, options?: { overrideKeyValue?: boolean }) => void;
+    anq?: Array<() => void>;
+    onEvent?: (eventName: string, callback: () => void) => void;
+    [key: string]: unknown;
+  }
+
   interface Window {
-    apntag: any;
+    apntag?: ApnTag;
   }
 }

--- a/src/types/local/shim.d.ts
+++ b/src/types/local/shim.d.ts
@@ -5,9 +5,9 @@ declare global {
   function parseFloat(n: number): number;
 
   interface ApnTag {
-    getTag?: (unit: string) => { keywords?: Record<string, string> } | undefined;
-    modifyTag?: (unit: string, tag: { keywords?: Record<string, string> }) => void;
-    setKeywords?: (targetId: string, keywords: Record<string, string>, options?: { overrideKeyValue?: boolean }) => void;
+    getTag?: (unit: string) => { keywords?: Record<string, string | string[]> } | undefined;
+    modifyTag?: (unit: string, tag: { keywords?: Record<string, string | string[]> }) => void;
+    setKeywords?: (targetId: string, keywords: Record<string, string | string[]>, options?: { overrideKeyValue?: boolean }) => void;
     anq?: Array<() => void>;
     onEvent?: (eventName: string, callback: () => void) => void;
     [key: string]: unknown;


### PR DESCRIPTION
Ai generated ts compiler complaint fix

### Motivation
- TypeScript compilation failed when core code accessed `window.apntag.getTag().keywords` because `window.apntag` was typed as `any` and `getTag` returned `unknown` properties. 
- Provide a focused, maintainable shim for the `apntag` global so core targeting logic can rely on well-typed properties without losing runtime extensibility.

