### PR TITLE
Core: cleanup adloader callback/listener references

### DIFF
--- a/src/adloader.js
+++ b/src/adloader.js
@@ -78,6 +78,7 @@ export function loadExternalScript(url, moduleType, moduleCode, callback, doc, a
       for (let i = 0; i < cacheObject.callbacks.length; i++) {
         runCallback(cacheObject.callbacks[i], cacheObject.error);
       }
+      cacheObject.callbacks.length = 0;
     } catch (e) {
       logError('Error executing callback', 'adloader.js:loadExternalScript', e);
     }
@@ -104,6 +105,8 @@ export function loadExternalScript(url, moduleType, moduleCode, callback, doc, a
 
     function exit() {
       jptScript.removeEventListener('error', errorListener);
+      jptScript.onload = null;
+      jptScript.onreadystatechange = null;
       callback();
     }
 

--- a/test/spec/adloader_spec.js
+++ b/test/spec/adloader_spec.js
@@ -53,6 +53,13 @@ describe('adLoader', function () {
       sinon.assert.called(callback);
     });
 
+    it('cleans up script listeners once loaded', () => {
+      adLoader.loadExternalScript('test-cleanup', MODULE_TYPE_PREBID, 'debugging', sinon.stub());
+      scriptEl.onload();
+      expect(scriptEl.onload).to.equal(null);
+      expect(scriptEl.onreadystatechange).to.equal(null);
+    });
+
     it('should run callback as an object', () => {
       const callback = {
         success: sinon.stub()


### PR DESCRIPTION
### Motivation
- Fix a memory-management issue where `loadExternalScript` retained callback closures and event-listener references after script load or error, preventing GC of associated resources.

