### PR TITLE
Core: fix typos in reducers comments

### DIFF
--- a/src/utils/reducers.js
+++ b/src/utils/reducers.js
@@ -35,10 +35,10 @@ const timestampCompare = keyCompare((bid) => bid.responseTimestamp);
 // This function will get highest cpm value bid, in case of tie it will return the bid with lowest timeToRespond
 export const getHighestCpm = maximum(tiebreakCompare(cpmCompare, reverseCompare(keyCompare((bid) => bid.timeToRespond))))
 
-// This function will get the oldest hightest cpm value bid, in case of tie it will return the bid which came in first
+// This function will get the oldest highest cpm value bid, in case of tie it will return the bid which came in first
 // Use case for tie: https://github.com/prebid/Prebid.js/issues/2448
 export const getOldestHighestCpmBid = maximum(tiebreakCompare(cpmCompare, reverseCompare(timestampCompare)))
 
-// This function will get the latest hightest cpm value bid, in case of tie it will return the bid which came in last
+// This function will get the latest highest cpm value bid, in case of tie it will return the bid which came in last
 // Use case for tie: https://github.com/prebid/Prebid.js/issues/2539
 export const getLatestHighestCpmBid = maximum(tiebreakCompare(cpmCompare, timestampCompare))


### PR DESCRIPTION
### Motivation
- Fix spelling mistakes in comments for clarity and maintainability in core reducers (`src/utils/reducers.js`).

### Description
- Corrected two occurrences of "hightest" to "highest" in comment lines describing oldest/latest highest CPM selection helpers, with no runtime logic changes.

### Testing
- Ran `npx eslint src/utils/reducers.js --cache --cache-strategy content` and `npx gulp test --nolint --file test/spec/unit/utils/reducers_spec.js`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e870ab4f48832b8c5d7557b31e948e)