### PR TITLE
Core: reduce allocations in metrics.getMetrics

### DIFF
--- a/src/utils/perfMetrics.ts
+++ b/src/utils/perfMetrics.ts
@@ -179,10 +179,18 @@ export function metricsFactory({ now = getTime, mkNode = makeNode, mkTimer = mak
        * Get all registered metrics.
        */
       function getMetrics(): { [name: string]: unknown } {
-        let result = {}
+        const result = {};
         self.dfWalk({
           visit(edge, node) {
-            result = Object.assign({}, !edge || edge.includeGroups ? node.groups : null, node.metrics, result);
+            const addMetric = (name, value) => {
+              if (!Object.prototype.hasOwnProperty.call(result, name)) {
+                result[name] = value;
+              }
+            };
+            Object.entries(node.metrics).forEach(([name, value]) => addMetric(name, value));
+            if (!edge || edge.includeGroups) {
+              Object.entries(node.groups).forEach(([name, value]) => addMetric(name, value));
+            }
           }
         });
         return result;


### PR DESCRIPTION
### Motivation
- `getMetrics()` allocated a new object for each visited node during depth-first traversal which increased GC pressure on hot paths that repeatedly call metrics aggregation.

### Description
- Replace the per-node `Object.assign({}, ...)` allocations with a single mutable accumulator object and guarded writes via `hasOwnProperty` so nearest metrics keep precedence and `includeGroups` behavior is preserved.
- Change made in `src/utils/perfMetrics.ts` (metrics aggregation path only).

### Testing
- Ran `npx eslint --cache --cache-strategy content src/utils/perfMetrics.ts test/spec/unit/utils/perfMetrics_spec.js` and it passed.
- Ran `npx gulp test --nolint --file test/spec/unit/utils/perfMetrics_spec.js` and the spec suite passed (49 tests completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e870e39884832bb1c36bdea1d8a057)