### PR TITLE
Various adapters: spelling fixes

### DIFF
--- a/modules/adtrueBidAdapter.js
+++ b/modules/adtrueBidAdapter.js
@@ -220,7 +220,7 @@ function _parseNativeResponse(bid, newBid) {
     try {
       adm = JSON.parse(bid.adm.replace(/\\/g, ''));
     } catch (ex) {
-      // logWarn(LOG_WARN_PREFIX + 'Error: Cannot parse native reponse for ad response: ' + newBid.adm);
+      // logWarn(LOG_WARN_PREFIX + 'Error: Cannot parse native response for ad response: ' + newBid.adm);
       return;
     }
     if (adm && adm.native && adm.native.assets && adm.native.assets.length > 0) {
@@ -359,7 +359,7 @@ function _checkMediaType(adm, newBid) {
         newBid.mediaType = NATIVE;
       }
     } catch (e) {
-      logWarn(LOG_WARN_PREFIX + 'Error: Cannot parse native reponse for ad response: ' + adm);
+      logWarn(LOG_WARN_PREFIX + 'Error: Cannot parse native response for ad response: ' + adm);
     }
   }
 }

--- a/modules/pwbidBidAdapter.js
+++ b/modules/pwbidBidAdapter.js
@@ -395,7 +395,7 @@ function _checkMediaType(bid, newBid) {
           newBid.mediaType = NATIVE;
         }
       } catch (e) {
-        _logWarn('Error: Cannot parse native reponse for ad response: ', adm);
+        _logWarn('Error: Cannot parse native response for ad response: ', adm);
       }
     } else if (videoRegex.test(adm)) {
       newBid.mediaType = VIDEO;
@@ -412,7 +412,7 @@ function _parseNativeResponse(bid, newBid) {
     try {
       adm = JSON.parse(bid.adm.replace(/\\/g, ''));
     } catch (ex) {
-      _logWarn('Error: Cannot parse native reponse for ad response: ' + newBid.adm);
+      _logWarn('Error: Cannot parse native response for ad response: ' + newBid.adm);
       return;
     }
     if (adm && adm.assets && adm.assets.length > 0) {

--- a/test/spec/modules/eskimiBidAdapter_spec.js
+++ b/test/spec/modules/eskimiBidAdapter_spec.js
@@ -208,7 +208,7 @@ describe('Eskimi bid adapter', function () {
         expect(spec.isBidRequestValid(bid)).to.equal(false);
       });
 
-      it('should reutrn false if player size is not set', () => {
+      it('should return false if player size is not set', () => {
         const bid = utils.deepClone(VIDEO_BID);
         delete bid.mediaTypes.video.playerSize;
 

--- a/test/spec/modules/invibesBidAdapter_spec.js
+++ b/test/spec/modules/invibesBidAdapter_spec.js
@@ -512,7 +512,7 @@ describe('invibesBidAdapter:', function () {
       expect(request.data.invibbvlog).to.equal(true);
     });
 
-    it('does not send query string params from localstorage if unknwon', function () {
+    it('does not send query string params from localstorage if unknown', function () {
       localStorage.ivbs = JSON.stringify({ someparam: true });
       const request = spec.buildRequests(bidRequests, bidderRequestWithPageInfo);
       expect(request.data.someparam).to.be.undefined;

--- a/test/spec/modules/ixBidAdapter_spec.js
+++ b/test/spec/modules/ixBidAdapter_spec.js
@@ -4137,7 +4137,7 @@ describe('IndexexchangeAdapter', function () {
       expect(videoResult[0].ttl).to.equal(200);
     });
 
-    it('should default bid[].ttl if seat[].bid[].exp is not in the resposne', function () {
+    it('should default bid[].ttl if seat[].bid[].exp is not in the response', function () {
       const bannerResult = spec.interpretResponse({ body: DEFAULT_BANNER_BID_RESPONSE }, bannerBidderRequest);
       const videoResult = spec.interpretResponse({ body: DEFAULT_VIDEO_BID_RESPONSE }, videoBidderRequest);
 

--- a/test/spec/modules/silverpushBidAdapter_spec.js
+++ b/test/spec/modules/silverpushBidAdapter_spec.js
@@ -158,7 +158,7 @@ describe('Silverpush Adapter', function () {
       expect(spec.isBidRequestValid(bid)).to.equal(false);
     });
 
-    it('should reutrn false if player size is not set', () => {
+    it('should return false if player size is not set', () => {
       const bid = utils.deepClone(videoBid);
       delete bid.mediaTypes.video.playerSize;
 

--- a/test/spec/modules/tpmnBidAdapter_spec.js
+++ b/test/spec/modules/tpmnBidAdapter_spec.js
@@ -236,7 +236,7 @@ describe('tpmnAdapterTests', function () {
       }
 
       if (FEATURES.VIDEO) {
-        it('should reutrn false if player size is not set', () => {
+        it('should return false if player size is not set', () => {
           const bid = utils.deepClone(VIDEO_BID);
           delete bid.mediaTypes.video.playerSize;
 


### PR DESCRIPTION

- Clean up misspellings in adapter code and unit-test descriptions to improve clarity and avoid confusing log messages.
- These are typo-only edits and do not change runtime behavior or logic.

