### PR TITLE
Marsmedia Bid Adapter: remove coffee-style lint suppression

### DIFF
--- a/modules/marsmediaBidAdapter.js
+++ b/modules/marsmediaBidAdapter.js
@@ -99,10 +99,9 @@ function MarsmediaAdapter() {
   }
 
   function getValidSizeSet(dimensionList) {
-    const w = parseInt(dimensionList[0]);
-    const h = parseInt(dimensionList[1]);
-    // clever check for NaN
-    if (! (w !== w || h !== h)) {  // eslint-disable-line
+    const w = parseInt(dimensionList[0], 10);
+    const h = parseInt(dimensionList[1], 10);
+    if (!Number.isNaN(w) && !Number.isNaN(h)) {
       return [w, h];
     }
     return false;

--- a/src/utils/reducers.js
+++ b/src/utils/reducers.js
@@ -35,10 +35,10 @@ const timestampCompare = keyCompare((bid) => bid.responseTimestamp);
 // This function will get highest cpm value bid, in case of tie it will return the bid with lowest timeToRespond
 export const getHighestCpm = maximum(tiebreakCompare(cpmCompare, reverseCompare(keyCompare((bid) => bid.timeToRespond))))
 
-// This function will get the oldest hightest cpm value bid, in case of tie it will return the bid which came in first
+// This function will get the oldest highest cpm value bid, in case of tie it will return the bid which came in first
 // Use case for tie: https://github.com/prebid/Prebid.js/issues/2448
 export const getOldestHighestCpmBid = maximum(tiebreakCompare(cpmCompare, reverseCompare(timestampCompare)))
 
-// This function will get the latest hightest cpm value bid, in case of tie it will return the bid which came in last
+// This function will get the latest highest cpm value bid, in case of tie it will return the bid which came in last
 // Use case for tie: https://github.com/prebid/Prebid.js/issues/2539
 export const getLatestHighestCpmBid = maximum(tiebreakCompare(cpmCompare, timestampCompare))


### PR DESCRIPTION
### Motivation
- Remove a CoffeeScript-style NaN check and its inline ESLint suppression in the Marsmedia adapter to satisfy lint rules and use clearer, standards-compliant checks.
- Use radix-aware parsing to avoid parseInt pitfalls and make intent explicit.

### Description
- Updated `getValidSizeSet` in `modules/marsmediaBidAdapter.js` to call `parseInt(..., 10)` for both width and height.
- Replaced the `w !== w` NaN trick with explicit `Number.isNaN` checks and removed the `eslint-disable-line` suppression.
- Preserved the adapter behavior by returning the same `[w, h]` result when parsing succeeds.

### Testing
- Ran `npx eslint --cache --cache-strategy content modules/marsmediaBidAdapter.js`, which completed successfully.
- Ran `npx gulp test --nolint --file test/spec/modules/marsmediaBidAdapter_spec.js`, which completed with the spec bundle and reported `36 tests completed` (test run finished successfully despite unrelated Karma logged unhandled-rejection messages).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e879fbbab4832bbfe4a692cac9cc41)