### PR TITLE
Core: remove deprecated wretry usage

### DIFF
--- a/.github/actions/load/action.yml
+++ b/.github/actions/load/action.yml
@@ -23,15 +23,12 @@ runs:
       run: |
         rm -r "$(pwd)"/*
 
-    - name: Download artifact
-      uses: Wandalen/wretry.action@v3.8.0
+    - name: Restore working directory cache
+      uses: actions/cache/restore@v4
       with:
-        action: actions/download-artifact@v7
-        attempt_limit: 2
-        attempt_delay: 10000
-        with: |
-          path: '${{ runner.temp }}'
-          name: '${{ inputs.name }}'
+        path: '${{ runner.temp }}/${{ inputs.name }}.tar'
+        key: '${{ inputs.name }}'
+        fail-on-cache-miss: true
 
     - name: 'Untar working directory'
       shell: bash

--- a/.github/actions/load/action.yml
+++ b/.github/actions/load/action.yml
@@ -23,12 +23,11 @@ runs:
       run: |
         rm -r "$(pwd)"/*
 
-    - name: Restore working directory cache
-      uses: actions/cache/restore@v4
+    - name: Download artifact
+      uses: actions/download-artifact@v7
       with:
-        path: '${{ runner.temp }}/${{ inputs.name }}.tar'
-        key: '${{ inputs.name }}'
-        fail-on-cache-miss: true
+        path: '${{ runner.temp }}'
+        name: '${{ inputs.name }}'
 
     - name: 'Untar working directory'
       shell: bash

--- a/.github/actions/save/action.yml
+++ b/.github/actions/save/action.yml
@@ -33,9 +33,8 @@ runs:
         parent="$(dirname "$wdir")"
         target="$(basename "$wdir")"
         tar ${{ fromJSON(steps.platform.outputs.result).platform == 'win32' && '--force-local' || '' }} -C "$parent" -cf "${{ runner.temp }}/${{ fromJSON(steps.platform.outputs.result).name }}.tar" "$target"
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
+    - name: Save working directory cache
+      uses: actions/cache/save@v4
       with:
         path: '${{ runner.temp }}/${{ fromJSON(steps.platform.outputs.result).name }}.tar'
-        name: ${{ fromJSON(steps.platform.outputs.result).name }}
-        overwrite: true
+        key: ${{ fromJSON(steps.platform.outputs.result).name }}

--- a/.github/actions/save/action.yml
+++ b/.github/actions/save/action.yml
@@ -33,8 +33,9 @@ runs:
         parent="$(dirname "$wdir")"
         target="$(basename "$wdir")"
         tar ${{ fromJSON(steps.platform.outputs.result).platform == 'win32' && '--force-local' || '' }} -C "$parent" -cf "${{ runner.temp }}/${{ fromJSON(steps.platform.outputs.result).name }}.tar" "$target"
-    - name: Save working directory cache
-      uses: actions/cache/save@v4
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
       with:
         path: '${{ runner.temp }}/${{ fromJSON(steps.platform.outputs.result).name }}.tar'
-        key: ${{ fromJSON(steps.platform.outputs.result).name }}
+        name: ${{ fromJSON(steps.platform.outputs.result).name }}
+        overwrite: true


### PR DESCRIPTION
Fixes #14708 
- The `Wandalen/wretry.action` wrapper is deprecated so the workflow should stop depending on it and use maintained first-party cache actions instead.
