### PR TITLE
aceex and yandex bidders: type the public interface

### DIFF
--- a/modules/aceexBidAdapter.js
+++ b/modules/aceexBidAdapter.js
@@ -7,10 +7,21 @@ import {
 
 import { deepAccess } from '../src/utils.js';
 
+/**
+ * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
+ * @typedef {import('./aceexBidAdapterTypes.d.ts').AceexBidderParams} AceexBidderParams
+ * @typedef {BidRequest & { params: AceexBidderParams }} AceexBidRequest
+ */
+
 const BIDDER_CODE = 'aceex';
 const GVLID = 1387;
 const AD_REQUEST_URL = 'https://bl-us.aceex.io/?secret_key=prebidjs';
 
+/**
+ * @param {AceexBidRequest} bid
+ * @param bidderRequest
+ * @param placement
+ */
 const addCustomFieldsToPlacement = (bid, bidderRequest, placement) => {
   placement.trafficType = placement.adFormat;
   placement.publisherId = bid.params.publisherId;
@@ -24,6 +35,9 @@ export const spec = {
   gvlid: GVLID,
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 
+  /**
+   * @param {AceexBidRequest} bid
+   */
   isBidRequestValid: (bid) => {
     return !!(bid.bidId && bid.params?.publisherId && bid.params?.trafficType);
   },

--- a/modules/aceexBidAdapterTypes.d.ts
+++ b/modules/aceexBidAdapterTypes.d.ts
@@ -10,11 +10,11 @@ export interface AceexBidderParams {
   /**
    * Publisher hash on platform.
    */
-  internalKey: string;
+  internalKey?: string;
   /**
    * Bid floor value.
    */
-  bidfloor: number;
+  bidfloor?: number;
 }
 
 declare module '../src/adUnits' {

--- a/modules/aceexBidAdapterTypes.d.ts
+++ b/modules/aceexBidAdapterTypes.d.ts
@@ -1,0 +1,24 @@
+export interface AceexBidderParams {
+  /**
+   * Publisher ID on platform.
+   */
+  publisherId: number;
+  /**
+   * Configures the media type used for the placement.
+   */
+  trafficType: 'banner' | 'native' | 'video';
+  /**
+   * Publisher hash on platform.
+   */
+  internalKey: string;
+  /**
+   * Bid floor value.
+   */
+  bidfloor: number;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    aceex: AceexBidderParams;
+  }
+}

--- a/modules/yandexBidAdapter.js
+++ b/modules/yandexBidAdapter.js
@@ -21,6 +21,7 @@ import { getAdUnitElement } from '../src/utils/adUnits.js';
  * @typedef {import('../src/mediaTypes.js').MediaType} MediaType
  * @typedef {import('../src/utils.js').MediaTypes} MediaTypes
  * @typedef {import('../modules/priceFloors.js').getFloor} GetFloor
+ * @typedef {import('./yandexBidAdapterTypes.d.ts').YandexBidRequestParams} YandexBidRequestParams
  */
 
 /**
@@ -30,15 +31,6 @@ import { getAdUnitElement } from '../src/utils/adUnits.js';
 
 /**
  * @typedef {ServerRequest & CustomServerRequestFields} YandexServerRequest
- */
-
-/**
- * Yandex bidder-specific params which the publisher used in their bid request.
- *
- * @typedef {Object} YandexBidRequestParams
- * @property {string} placementId Possible formats: `R-I-123456-2`, `R-123456-1`, `123456-789`.
- * @property {number} [pageId] Deprecated. Please use `placementId` instead.
- * @property {number} [impId] Deprecated. Please use `placementId` instead.
  */
 
 /**

--- a/modules/yandexBidAdapterTypes.d.ts
+++ b/modules/yandexBidAdapterTypes.d.ts
@@ -1,22 +1,45 @@
-export interface YandexBidRequestParams {
-  /**
-   * Placement ID.
-   * Possible formats: `R-I-123456-2`, `R-123456-1`, `123456-789`.
-   */
-  placementId: string;
+interface YandexBaseParams {
   /**
    * Bid currency. Defaults to `EUR`.
    */
   cur?: string;
   /**
-   * Deprecated. Please use `placementId` instead.
+   * Target reference URL.
    */
-  pageId?: number;
+  targetRef?: string;
   /**
-   * Deprecated. Please use `placementId` instead.
+   * Whether to send credentials with requests. Defaults to `true`.
    */
-  impId?: number;
+  withCredentials?: boolean;
+  /**
+   * Custom container element ID for the ad unit.
+   */
+  pubcontainerid?: string;
 }
+
+interface YandexPlacementIdParams extends YandexBaseParams {
+  /**
+   * Placement ID.
+   * Possible formats: `R-I-123456-2`, `R-123456-1`, `123456-789`.
+   */
+  placementId: string;
+  pageId?: never;
+  impId?: never;
+}
+
+interface YandexLegacyParams extends YandexBaseParams {
+  placementId?: never;
+  /**
+   * @deprecated Please use `placementId` instead.
+   */
+  pageId: number;
+  /**
+   * @deprecated Please use `placementId` instead.
+   */
+  impId: number;
+}
+
+export type YandexBidRequestParams = YandexPlacementIdParams | YandexLegacyParams;
 
 declare module '../src/adUnits' {
   interface BidderParams {

--- a/modules/yandexBidAdapterTypes.d.ts
+++ b/modules/yandexBidAdapterTypes.d.ts
@@ -1,0 +1,25 @@
+export interface YandexBidRequestParams {
+  /**
+   * Placement ID.
+   * Possible formats: `R-I-123456-2`, `R-123456-1`, `123456-789`.
+   */
+  placementId: string;
+  /**
+   * Bid currency. Defaults to `EUR`.
+   */
+  cur?: string;
+  /**
+   * Deprecated. Please use `placementId` instead.
+   */
+  pageId?: number;
+  /**
+   * Deprecated. Please use `placementId` instead.
+   */
+  impId?: number;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    yandex: YandexBidRequestParams;
+  }
+}


### PR DESCRIPTION
Goal is to demonstrate with a pr how to type the public interface which is mandatory in adapters since prebid 11