### PR TITLE
adQuery Bid Adapter: standardize adapter request and response handling

### DIFF
--- a/modules/adqueryBidAdapter.js
+++ b/modules/adqueryBidAdapter.js
@@ -6,7 +6,8 @@ import {
   logMessage,
   parseSizesInput,
   triggerPixel,
-  deepSetValue
+  deepSetValue,
+  deepAccess
 } from '../src/utils.js';
 
 /**
@@ -102,68 +103,58 @@ export const spec = {
   interpretResponse: (response, request) => {
     const bidResponses = [];
 
-    if (response?.body?.seatbid) {
-      response.body.seatbid.forEach(seat => {
+    const seatbids = deepAccess(response, 'body.seatbid');
+    if (seatbids) {
+      seatbids.forEach(seat => {
         seat.bid.forEach(bid => {
           logMessage('bidObj', bid);
 
-          const bidResponse = {
+          bidResponses.push({
             requestId: bid.impid,
-            mediaType: 'video',
+            mediaType: VIDEO,
             cpm: bid.price,
-            currency: response.body.cur || 'USD',
-            ttl: 3600, // video żyje dłużej
+            currency: deepAccess(response, 'body.cur') || 'USD',
+            ttl: 3600,
             creativeId: bid.crid || bid.id,
             netRevenue: true,
-            dealId: bid.dealid || undefined,
-            nurl: bid.nurl || undefined,
-
-            // VAST – priority: inline XML > admurl > nurl as a wrapper
+            dealId: bid.dealid,
+            nurl: bid.nurl,
             vastXml: bid.adm || null,
             vastUrl: bid.admurl || null,
-
             width: bid.w || 640,
             height: bid.h || 360,
-
             meta: {
-              advertiserDomains: bid.adomain && bid.adomain.length ? bid.adomain : [],
-              networkName: seat.seat || undefined,
-              mediaType: 'video'
-            }
-          };
-
-          bidResponses.push(bidResponse);
+              advertiserDomains: deepAccess(bid, 'adomain') || [],
+              networkName: seat.seat,
+              mediaType: VIDEO,
+            },
+          });
         });
       });
     }
 
-    const res = response && response.body && response.body.data;
+    const res = deepAccess(response, 'body.data');
+    if (!res) return bidResponses;
 
-    if (!res) {
-      return bidResponses;
-    }
-
-    const bidResponse = {
+    bidResponses.push({
       requestId: res.requestId,
       cpm: res.cpm,
-      width: res.mediaType.width,
-      height: res.mediaType.height,
+      width: deepAccess(res, 'mediaType.width'),
+      height: deepAccess(res, 'mediaType.height'),
       creativeId: res.creationId,
       dealId: res.dealid || '',
       currency: res.currency || ADQUERY_DEFAULT_CURRENCY,
       netRevenue: ADQUERY_NET_REVENUE,
       ttl: ADQUERY_TTL,
-      referrer: '',
-      ad: '<script src="' + res.adqLib + '"></script>' + res.tag,
-      mediaType: res.mediaType.name || 'banner',
+      ad: `<script src="${res.adqLib}"></script>${res.tag}`,
+      mediaType: deepAccess(res, 'mediaType.name') || BANNER,
       meta: {
-        advertiserDomains: res.adDomains && res.adDomains.length ? res.adDomains : [],
-        mediaType: res.mediaType.name || 'banner',
-      }
-    };
-    bidResponses.push(bidResponse);
-    logInfo('bidResponses', bidResponses);
+        advertiserDomains: deepAccess(res, 'adDomains') || [],
+        mediaType: deepAccess(res, 'mediaType.name') || BANNER,
+      },
+    });
 
+    logInfo('bidResponses', bidResponses);
     return bidResponses;
   },
 
@@ -202,11 +193,11 @@ export const spec = {
       return
     }
 
-    const copyOfBid = { ...bid };
+    const copyOfBid = { ...bid }
 
     const uuidMatch = copyOfBid.ad && typeof copyOfBid.ad === 'string' ? copyOfBid.ad.match(/data-uuid="([^"]*)"/) : null;
     copyOfBid.uuid = uuidMatch ? uuidMatch[1] : null;
-    delete copyOfBid.ad;
+    delete copyOfBid.ad
     const shortBidString = JSON.stringify(copyOfBid);
     const encodedBuf = window.btoa(shortBidString);
 
@@ -264,10 +255,6 @@ export const spec = {
       'ccpa_consent': uspConsent && uspConsent.uspConsent ? uspConsent.uspConsent : '',
     };
 
-    if (window.qid) { // only for new users (new qid)
-      syncData.qid = window.qid;
-    }
-
     const syncUrlObject = {
       protocol: ADQUERY_BIDDER_DOMAIN_PROTOCOL,
       hostname: ADQUERY_USER_SYNC_DOMAIN,
@@ -295,24 +282,22 @@ export const spec = {
 
 function buildRequest(bid, bidderRequest, isVideo = false) {
   let userId = null;
-  if (window.qid) {
-    userId = window.qid;
-  }
 
-  if (bid.userId && bid.userId.qid) {
-    userId = bid.userId.qid
+  const eids = bid.userIdAsEids;
+  if (Array.isArray(eids)) {
+    const adqueryEid = eids.find(eid => eid.source === 'adquery.io');
+    userId = adqueryEid?.uids?.[0]?.id;
+
+    if (!userId) {
+      userId = eids[0]?.uids?.[0]?.id;
+    }
   }
 
   if (!userId) {
-    userId = bid.ortb2?.user.ext.eids.find(eid => eid.source === "adquery.io")?.uids[0]?.id;
-  }
-
-  if (!userId) {
-    // onetime User ID
-    const ramdomValues = Array.from(window.crypto.getRandomValues(new Uint32Array(4)));
-    userId = ramdomValues.map(val => val.toString(36)).join('').substring(0, 20);
+    const randomValues = Array.from(window.crypto.getRandomValues(new Uint32Array(4)));
+    const randomPart = randomValues.map(val => val.toString(36)).join('').substring(0, 26);
+    userId = `qd_${randomPart}`;
     logMessage('generated onetime User ID: ', userId);
-    window.qid = userId;
   }
 
   let pageUrl = '';
@@ -332,6 +317,14 @@ function buildRequest(bid, bidderRequest, isVideo = false) {
 
     deepSetValue(videoRequest, 'site.ext.bidder', bid.params);
     videoRequest.id = bid.bidId
+
+    if (bidderRequest?.gdprConsent?.consentString) {
+      deepSetValue(videoRequest, 'regs.ext.gdpr', bidderRequest.gdprConsent.gdprApplies ? 1 : 0);
+      deepSetValue(videoRequest, 'user.consent', bidderRequest.gdprConsent.consentString);
+    }
+    if (bidderRequest?.uspConsent) {
+      deepSetValue(videoRequest, 'regs.ext.us_privacy', bidderRequest.uspConsent);
+    }
 
     let currency = bid?.ortb2?.ext?.prebid?.adServerCurrency || "PLN";
     videoRequest.cur = [currency]
@@ -369,6 +362,9 @@ function buildRequest(bid, bidderRequest, isVideo = false) {
     bidRequestsCount: bid.bidRequestsCount,
     bidderRequestsCount: bid.bidderRequestsCount,
     sizes: parseSizesInput(bid.mediaTypes.banner.sizes).toString(),
+    gdpr: bidderRequest?.gdprConsent?.gdprApplies ? 1 : 0,
+    gdpr_consent: bidderRequest?.gdprConsent?.consentString || '',
+    us_privacy: bidderRequest?.uspConsent || '',
   };
 }
 

--- a/test/spec/modules/adqueryBidAdapter_spec.js
+++ b/test/spec/modules/adqueryBidAdapter_spec.js
@@ -969,6 +969,111 @@ describe('adqueryBidAdapter', function () {
     it('data with floor must have video bidfloorcur property', function () {
       expect(req_video_for_floor.data.imp[0].video.bidfloorcur).eq("USD");
     })
+
+    describe('GDPR and USP consent in banner requests', function () {
+      it('should set gdpr=1 and gdpr_consent when gdprApplies is true', function () {
+        const req = spec.buildRequests([bidRequest], {
+          refererInfo: {},
+          gdprConsent: { gdprApplies: true, consentString: 'test-consent-string' }
+        })[0];
+        expect(req.data.gdpr).to.equal(1);
+        expect(req.data.gdpr_consent).to.equal('test-consent-string');
+      });
+
+      it('should set gdpr=0 when gdprApplies is false', function () {
+        const req = spec.buildRequests([bidRequest], {
+          refererInfo: {},
+          gdprConsent: { gdprApplies: false, consentString: 'test-consent-string' }
+        })[0];
+        expect(req.data.gdpr).to.equal(0);
+      });
+
+      it('should default gdpr=0 and empty strings when no consent provided', function () {
+        const req = spec.buildRequests([bidRequest], { refererInfo: {} })[0];
+        expect(req.data.gdpr).to.equal(0);
+        expect(req.data.gdpr_consent).to.equal('');
+        expect(req.data.us_privacy).to.equal('');
+      });
+
+      it('should set us_privacy when uspConsent provided', function () {
+        const req = spec.buildRequests([bidRequest], {
+          refererInfo: {},
+          uspConsent: '1YNN'
+        })[0];
+        expect(req.data.us_privacy).to.equal('1YNN');
+      });
+    });
+
+    describe('GDPR and USP consent in video requests', function () {
+      const minimalVideoBid = {
+        bidder: 'adquery',
+        params: { placementId: 'test-placement-id' },
+        mediaTypes: {
+          video: { context: 'outstream', playerSize: [[640, 360]] }
+        },
+        ortb2Imp: { video: { w: 640, h: 360 } },
+        ortb2: {},
+        bidId: 'test-bid-id-video'
+      };
+
+      it('should set regs.ext.gdpr and user.consent in video request when gdprConsent provided', function () {
+        const req = spec.buildRequests([minimalVideoBid], {
+          refererInfo: {},
+          gdprConsent: { gdprApplies: true, consentString: 'video-consent-string' }
+        })[0];
+        expect(req.data.regs.ext.gdpr).to.equal(1);
+        expect(req.data.user.consent).to.equal('video-consent-string');
+      });
+
+      it('should set regs.ext.gdpr=0 when gdprApplies is false for video', function () {
+        const req = spec.buildRequests([minimalVideoBid], {
+          refererInfo: {},
+          gdprConsent: { gdprApplies: false, consentString: 'video-consent-string' }
+        })[0];
+        expect(req.data.regs.ext.gdpr).to.equal(0);
+      });
+
+      it('should not set regs when no gdprConsent or uspConsent for video', function () {
+        const req = spec.buildRequests([minimalVideoBid], { refererInfo: {} })[0];
+        expect(req.data.regs).to.be.undefined;
+      });
+
+      it('should set regs.ext.us_privacy in video request when uspConsent provided', function () {
+        const req = spec.buildRequests([minimalVideoBid], {
+          refererInfo: {},
+          uspConsent: '1YNN'
+        })[0];
+        expect(req.data.regs.ext.us_privacy).to.equal('1YNN');
+      });
+    });
+
+    describe('userId resolution via userIdAsEids', function () {
+      it('should use adquery.io EID as userId when available', function () {
+        const bid = Object.assign({}, bidRequest, {
+          userIdAsEids: [
+            { source: 'other.com', uids: [{ id: 'other-id' }] },
+            { source: 'adquery.io', uids: [{ id: 'qd_adquery-id' }] }
+          ]
+        });
+        const req = spec.buildRequests([bid], { refererInfo: {} })[0];
+        expect(req.data.bidQid).to.equal('qd_adquery-id');
+      });
+
+      it('should fall back to first EID when no adquery.io EID available', function () {
+        const bid = Object.assign({}, bidRequest, {
+          userIdAsEids: [
+            { source: 'other.com', uids: [{ id: 'fallback-id' }] }
+          ]
+        });
+        const req = spec.buildRequests([bid], { refererInfo: {} })[0];
+        expect(req.data.bidQid).to.equal('fallback-id');
+      });
+
+      it('should generate qd_ prefixed userId when no userIdAsEids present', function () {
+        const req = spec.buildRequests([bidRequest], { refererInfo: {} })[0];
+        expect(req.data.bidQid).to.match(/^qd_/);
+      });
+    });
   })
 
   describe('interpretResponse', function () {
@@ -1051,6 +1156,12 @@ describe('adqueryBidAdapter', function () {
       expect(newResponse[0].nurl).to.be.equal("https://bidder.adquery.io/openrtb2/uuid/nurl/d")
       expect(newResponse[0].vastXml).to.be.equal("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VAST version=\"2.0\"><\/VAST>\n")
     });
+
+    it('should not include referrer field in banner bid response', function () {
+      const result = spec.interpretResponse(expectedResponse);
+      const bannerBid = result[result.length - 1];
+      expect(bannerBid.referrer).to.be.undefined;
+    });
   })
 
   describe('getUserSyncs', function () {
@@ -1098,6 +1209,17 @@ describe('adqueryBidAdapter', function () {
       expect(syncData[0]).to.be.an('object')
       expect(syncData[0].type).to.be.a('string')
       expect(syncData[0].type).to.equal('image')
+    });
+
+    it('should not include qid in sync URL even when window.qid is set', function () {
+      const originalQid = window.qid;
+      window.qid = 'test-qid-value';
+      try {
+        const sync = spec.getUserSyncs({ pixelEnabled: true }, {}, {}, {});
+        expect(sync[0].url).to.not.include('qid');
+      } finally {
+        window.qid = originalQid;
+      }
     });
   })
 


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter

## Description of change
Standardizes adapter logic by updating user ID handling, consent propagation, user sync payload, and response parsing to use consistent and modern structures.