### PR TITLE
Nexx360 Utils Library: add shared getGzipSetting helper

### DIFF
--- a/libraries/nexx360Utils/index.ts
+++ b/libraries/nexx360Utils/index.ts
@@ -1,5 +1,6 @@
-import { deepAccess, deepSetValue, generateUUID, logInfo } from '../../src/utils.js';
+import { deepAccess, deepSetValue, generateUUID, getParameterByName, logInfo } from '../../src/utils.js';
 import { Renderer } from '../../src/Renderer.js';
+import { config } from '../../src/config.js';
 import { getCurrencyFromBidderRequest } from '../ortb2Utils/currency.js';
 import { INSTREAM, OUTSTREAM } from '../../src/video.js';
 import { BANNER, MediaType, NATIVE, VIDEO } from '../../src/mediaTypes.js';
@@ -13,10 +14,10 @@ const OUTSTREAM_RENDERER_URL = 'https://acdn.adnxs.com/video/outstream/ANOutstre
 let sessionId:string | null = null;
 
 const getSessionId = ():string => {
-  if (!sessionId) {
-    sessionId = generateUUID();
-  }
-  return sessionId;
+  if (sessionId) return sessionId;
+  const id:string = generateUUID();
+  sessionId = id;
+  return id;
 }
 
 let lastPageUrl:string = '';
@@ -244,3 +245,15 @@ export const getAmxId = (
   const amxId = storage.getDataFromLocalStorage('__amuidpb');
   return amxId || null;
 }
+
+export const getGzipSetting = (
+  bidderCode: string,
+  defaultEnabled: boolean = true,
+): boolean => {
+  if (getParameterByName('nexx360_debug') === '1') return false;
+  const bidderConfig = config.getBidderConfig();
+  const gzipEnabled = bidderConfig[bidderCode]?.gzipEnabled;
+  if (gzipEnabled === true || gzipEnabled === 'true') return true;
+  if (gzipEnabled === false || gzipEnabled === 'false') return false;
+  return defaultEnabled;
+};

--- a/modules/adgridBidAdapter.ts
+++ b/modules/adgridBidAdapter.ts
@@ -4,7 +4,7 @@ import { AdapterRequest, BidderSpec, registerBidder } from '../src/adapters/bidd
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js'
 import { BidRequest, ClientBidderRequest } from '../src/adapterManager.js';
-import { interpretResponse, enrichImp, enrichRequest, getAmxId, getLocalStorageFunctionGenerator, getUserSyncs } from '../libraries/nexx360Utils/index.js';
+import { interpretResponse, enrichImp, enrichRequest, getAmxId, getGzipSetting, getLocalStorageFunctionGenerator, getUserSyncs } from '../libraries/nexx360Utils/index.js';
 import { ORTBRequest } from '../src/prebid.public.js';
 
 const BIDDER_CODE = 'adgrid';
@@ -85,6 +85,9 @@ const buildRequests = (
     method: 'POST',
     url: REQUEST_URL,
     data,
+    options: {
+      endpointCompression: getGzipSetting(BIDDER_CODE, true),
+    },
   }
   return adapterRequest;
 }

--- a/modules/insuradsBidAdapter.ts
+++ b/modules/insuradsBidAdapter.ts
@@ -4,11 +4,10 @@ import { AdapterRequest, BidderSpec, registerBidder } from '../src/adapters/bidd
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js'
 
-import { interpretResponse as nexxInterpretResponse, enrichImp, enrichRequest, getAmxId, getLocalStorageFunctionGenerator, getUserSyncs } from '../libraries/nexx360Utils/index.js';
+import { interpretResponse as nexxInterpretResponse, enrichImp, enrichRequest, getAmxId, getGzipSetting as libGetGzipSetting, getLocalStorageFunctionGenerator, getUserSyncs } from '../libraries/nexx360Utils/index.js';
 import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
 import { BidRequest, ClientBidderRequest } from '../src/adapterManager.js';
 import { ORTBImp, ORTBRequest } from '../src/prebid.public.js';
-import { config } from '../src/config.js';
 
 const BIDDER_CODE = 'insurads';
 const REQUEST_URL = 'https://fast.nexx360.io/booster';
@@ -16,8 +15,6 @@ const PAGE_VIEW_ID = generateUUID();
 const BIDDER_VERSION = '7.1';
 const GVLID = 596;
 const ALT_KEY = 'nexx360_storage';
-
-const DEFAULT_GZIP_ENABLED = false;
 
 type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
   Omit<T, Keys> & {
@@ -56,15 +53,7 @@ export const getInsurAdsLocalStorage = getLocalStorageFunctionGenerator<{ nexx36
   'nexx360Id'
 );
 
-export const getGzipSetting = (): boolean => {
-  const bidderConfig = config.getBidderConfig();
-  const gzipEnabled = bidderConfig.insurads?.gzipEnabled;
-
-  if (gzipEnabled === true || gzipEnabled === 'true') {
-    return true;
-  }
-  return DEFAULT_GZIP_ENABLED;
-}
+export const getGzipSetting = (): boolean => libGetGzipSetting(BIDDER_CODE, false);
 
 const converter = ortbConverter({
   context: {

--- a/modules/nexx360BidAdapter.ts
+++ b/modules/nexx360BidAdapter.ts
@@ -72,7 +72,7 @@ export const getNexx360LocalStorage = getLocalStorageFunctionGenerator<{ nexx360
   'nexx360Id'
 );
 
-export const getGzipSetting = (): boolean => libGetGzipSetting(BIDDER_CODE, true);
+export const getGzipSetting = (bidderCode: string = BIDDER_CODE): boolean => libGetGzipSetting(bidderCode, true);
 
 const converter = ortbConverter({
   context: {

--- a/modules/nexx360BidAdapter.ts
+++ b/modules/nexx360BidAdapter.ts
@@ -4,20 +4,17 @@ import { AdapterRequest, BidderSpec, registerBidder } from '../src/adapters/bidd
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js'
 
-import { interpretResponse, enrichImp, enrichRequest, getAmxId, getLocalStorageFunctionGenerator, getUserSyncs } from '../libraries/nexx360Utils/index.js';
+import { interpretResponse, enrichImp, enrichRequest, getAmxId, getGzipSetting as libGetGzipSetting, getLocalStorageFunctionGenerator, getUserSyncs } from '../libraries/nexx360Utils/index.js';
 import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
 import { BidRequest, ClientBidderRequest } from '../src/adapterManager.js';
 import { ORTBImp, ORTBRequest } from '../src/prebid.public.js';
-import { config } from '../src/config.js';
 
 const BIDDER_CODE = 'nexx360';
 const REQUEST_URL = 'https://fast.nexx360.io/booster';
 const PAGE_VIEW_ID = generateUUID();
-const BIDDER_VERSION = '7.1';
+const BIDDER_VERSION = '8.0';
 const GVLID = 965;
 const NEXXID_KEY = 'nexx360_storage';
-
-const DEFAULT_GZIP_ENABLED = false;
 
 type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
   Omit<T, Keys> & {
@@ -75,13 +72,7 @@ export const getNexx360LocalStorage = getLocalStorageFunctionGenerator<{ nexx360
   'nexx360Id'
 );
 
-export const getGzipSetting = (): boolean => {
-  const getBidderConfig = config.getBidderConfig();
-  if (getBidderConfig.nexx360?.gzipEnabled === 'true') {
-    return getBidderConfig.nexx360?.gzipEnabled === 'true';
-  }
-  return DEFAULT_GZIP_ENABLED;
-}
+export const getGzipSetting = (): boolean => libGetGzipSetting(BIDDER_CODE, true);
 
 const converter = ortbConverter({
   context: {

--- a/modules/revnewBidAdapter.ts
+++ b/modules/revnewBidAdapter.ts
@@ -4,7 +4,7 @@ import { AdapterRequest, BidderSpec, registerBidder } from '../src/adapters/bidd
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js'
 
-import { interpretResponse, enrichImp, enrichRequest, getAmxId, getLocalStorageFunctionGenerator, getUserSyncs } from '../libraries/nexx360Utils/index.js';
+import { interpretResponse, enrichImp, enrichRequest, getAmxId, getGzipSetting, getLocalStorageFunctionGenerator, getUserSyncs } from '../libraries/nexx360Utils/index.js';
 import { BidRequest, ClientBidderRequest } from '../src/adapterManager.js';
 import { ORTBImp, ORTBRequest } from '../src/prebid.public.js';
 
@@ -80,6 +80,9 @@ const buildRequests = (
     method: 'POST',
     url: REQUEST_URL,
     data,
+    options: {
+      endpointCompression: getGzipSetting(BIDDER_CODE, true),
+    },
   }
   return adapterRequest;
 };

--- a/test/spec/libraries/nexx360Utils/getGzipSetting_spec.js
+++ b/test/spec/libraries/nexx360Utils/getGzipSetting_spec.js
@@ -1,0 +1,70 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { getGzipSetting } from '../../../../libraries/nexx360Utils/index.js';
+import { config } from 'src/config.js';
+import * as utils from 'src/utils.js';
+
+const sandbox = sinon.createSandbox();
+
+describe('nexx360Utils getGzipSetting', () => {
+  let getParamStub;
+
+  beforeEach(() => {
+    config.resetConfig();
+    getParamStub = sandbox.stub(utils, 'getParameterByName').returns('');
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('returns defaultEnabled when no config and no URL override', () => {
+    expect(getGzipSetting('nexx360', true)).to.equal(true);
+    expect(getGzipSetting('insurads', false)).to.equal(false);
+  });
+
+  it('returns false when bidder config gzipEnabled is the string "false"', () => {
+    config.setBidderConfig({ bidders: ['nexx360'], config: { gzipEnabled: 'false' } });
+    expect(getGzipSetting('nexx360', true)).to.equal(false);
+  });
+
+  it('returns true when bidder config gzipEnabled is the string "true"', () => {
+    config.setBidderConfig({ bidders: ['nexx360'], config: { gzipEnabled: 'true' } });
+    expect(getGzipSetting('nexx360', true)).to.equal(true);
+  });
+
+  it('returns true when bidder config gzipEnabled is the boolean true', () => {
+    config.setBidderConfig({ bidders: ['insurads'], config: { gzipEnabled: true } });
+    expect(getGzipSetting('insurads', false)).to.equal(true);
+  });
+
+  it('returns false when bidder config gzipEnabled is the boolean false', () => {
+    config.setBidderConfig({ bidders: ['nexx360'], config: { gzipEnabled: false } });
+    expect(getGzipSetting('nexx360', true)).to.equal(false);
+  });
+
+  it('returns false when URL nexx360_debug=1, overriding enabled config', () => {
+    getParamStub.withArgs('nexx360_debug').returns('1');
+    config.setBidderConfig({ bidders: ['nexx360'], config: { gzipEnabled: 'true' } });
+    expect(getGzipSetting('nexx360', true)).to.equal(false);
+  });
+
+  it('ignores URL nexx360_debug when its value is not "1"', () => {
+    getParamStub.withArgs('nexx360_debug').returns('0');
+    expect(getGzipSetting('nexx360', true)).to.equal(true);
+  });
+
+  it('applies nexx360_debug=1 across all aliases regardless of defaultEnabled', () => {
+    getParamStub.withArgs('nexx360_debug').returns('1');
+    expect(getGzipSetting('mtc', true)).to.equal(false);
+    expect(getGzipSetting('adgrid', true)).to.equal(false);
+    expect(getGzipSetting('revnew', true)).to.equal(false);
+    expect(getGzipSetting('insurads', false)).to.equal(false);
+  });
+
+  it('reads config keyed by the bidderCode argument', () => {
+    config.setBidderConfig({ bidders: ['mtc'], config: { gzipEnabled: 'false' } });
+    expect(getGzipSetting('mtc', true)).to.equal(false);
+    expect(getGzipSetting('nexx360', true)).to.equal(true);
+  });
+});

--- a/test/spec/modules/nexx360BidAdapter_spec.js
+++ b/test/spec/modules/nexx360BidAdapter_spec.js
@@ -4,6 +4,8 @@ import {
 } from 'modules/nexx360BidAdapter.js';
 import sinon from 'sinon';
 import { getAmxId } from '../../../libraries/nexx360Utils/index.js';
+import { config } from 'src/config.js';
+import * as utils from 'src/utils.js';
 const sandbox = sinon.createSandbox();
 
 describe('Nexx360 bid adapter tests', () => {
@@ -33,9 +35,45 @@ describe('Nexx360 bid adapter tests', () => {
     },
   };
 
-  it('We test getGzipSettings', () => {
-    const output = getGzipSetting();
-    expect(output).to.be.a('boolean');
+  describe('getGzipSetting', () => {
+    let getParamStub;
+    beforeEach(() => {
+      config.resetConfig();
+      getParamStub = sandbox.stub(utils, 'getParameterByName').returns('');
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('defaults to true when no config and no URL override', () => {
+      expect(getGzipSetting()).to.equal(true);
+    });
+
+    it('returns false when bidder config gzipEnabled is the string "false"', () => {
+      config.setBidderConfig({ bidders: ['nexx360'], config: { gzipEnabled: 'false' } });
+      expect(getGzipSetting()).to.equal(false);
+    });
+
+    it('returns true when bidder config gzipEnabled is the string "true"', () => {
+      config.setBidderConfig({ bidders: ['nexx360'], config: { gzipEnabled: 'true' } });
+      expect(getGzipSetting()).to.equal(true);
+    });
+
+    it('returns true when bidder config gzipEnabled is the boolean true', () => {
+      config.setBidderConfig({ bidders: ['nexx360'], config: { gzipEnabled: true } });
+      expect(getGzipSetting()).to.equal(true);
+    });
+
+    it('returns false when URL has nexx360_debug=1, even if config would enable gzip', () => {
+      getParamStub.withArgs('nexx360_debug').returns('1');
+      config.setBidderConfig({ bidders: ['nexx360'], config: { gzipEnabled: 'true' } });
+      expect(getGzipSetting()).to.equal(false);
+    });
+
+    it('returns true when URL has nexx360_debug with a value other than 1', () => {
+      getParamStub.withArgs('nexx360_debug').returns('0');
+      expect(getGzipSetting()).to.equal(true);
+    });
   });
 
   describe('isBidRequestValid()', () => {
@@ -344,7 +382,7 @@ describe('Nexx360 bid adapter tests', () => {
             version: requestContent.ext.version,
             source: 'prebid.js',
             pageViewId: requestContent.ext.pageViewId,
-            bidderVersion: '7.1',
+            bidderVersion: '8.0',
             localStorage: { amxId: 'abcdef' },
             sessionId: requestContent.ext.sessionId,
             requestCounter: 0,


### PR DESCRIPTION
## Type of change                                                                                                                            
  - [x] Updated bidder adapter           
  - [x] Refactoring (no functional changes, no api changes)
                                    
  - [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
                                                                                                                                                 
  ## Description of change               
  Extracts `getGzipSetting` into `libraries/nexx360Utils` so every Nexx360-library adapter (`nexx360`, `insurads`, `adgrid`, `revnew`) shares one
   implementation.                                                                                                                               
                                  
  Behavior:                                                                                                                                      
  - per-bidder default via argument (`true` for `nexx360`/`adgrid`/`revnew`, `false` for `insurads` — preserves each adapter's prior default),   
  - per-bidder `bidderConfig[<code>].gzipEnabled` override, accepting boolean or string,
  - global `?nexx360_debug=1` URL kill-switch that disables gzip for every alias (was `?nexx360_unzip=1`, previously limited to `nexx360`).      
                                                                                                                                               
  Removes the duplicate helper from `nexx360BidAdapter.ts` and `insuradsBidAdapter.ts`, and wires `endpointCompression` into `adgridBidAdapter`  
  and `revnewBidAdapter` (both POST to `fast.nexx360.io/*` which already accepts gzip, so they were paying an avoidable payload cost).         
                                                                                                                                                 
  fallback, and the multi-alias debug case.                                                                                                    
                                                                                                                                                 
  `gulp lint` — clean on touched files.                                                                                                          
                                                                                                                                                 
  Per-spec test runs, all passing:                                                                                                               
  - `getGzipSetting_spec.js` — 9                                                                                                                 
  - `nexx360BidAdapter_spec.js` — 32                                                                                                             
  - `insuradsBidAdapter_spec.js` — 24                                                                                                            
  - `adgridBidAdapter_spec.js` — 19      
  - `revnewBidAdapter_spec.js` — 21                                                                                                              
                                                                                                                                                 
  ## Other information                   
  No upstream docs change needed — behavior change is an internal debug switch (`?nexx360_debug=1`), not a publisher-facing API.           