### PR TITLE
TCF module: add TCF 2.3 tcData coverage to consent module tests

### DIFF
--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -227,6 +227,89 @@ describe('consentManagement', function () {
             expect(consent.vendorData).to.eql(consentData);
             expect(consentConfig.staticConsentData).to.be.equal(consentData);
           });
+
+          it('accepts static TCF 2.3 consent data with disclosedVendors', async () => {
+            const consentData = {
+              'tcString': 'COuqj-POu90rDBcBkBENAZCgAPzAAAPAACiQFwwBAABAA1ADEAbQC4YAYAAgAxAG0A',
+              'cmpId': 92,
+              'cmpVersion': 100,
+              'tcfPolicyVersion': 3,
+              'gdprApplies': true,
+              'isServiceSpecific': true,
+              'useNonStandardStacks': false,
+              'purposeOneTreatment': false,
+              'publisherCC': 'US',
+              'cmpStatus': 'loaded',
+              'eventStatus': 'tcloaded',
+              'outOfBand': {
+                'allowedVendors': {},
+                'discloseVendors': {}
+              },
+              'purpose': {
+                'consents': {
+                  '1': true,
+                  '2': true,
+                  '3': true
+                },
+                'legitimateInterests': {
+                  '1': false,
+                  '2': false,
+                  '3': false
+                }
+              },
+              'vendor': {
+                'consents': {
+                  '1': false,
+                  '2': true,
+                  '3': false
+                },
+                'legitimateInterests': {
+                  '1': false,
+                  '2': true,
+                  '3': false,
+                  '4': false,
+                  '5': false
+                }
+              },
+              'disclosedVendors': {
+                '1': true,
+                '2': true,
+                '3': false
+              },
+              'specialFeatureOptins': {
+                '1': false,
+                '2': false
+              },
+              'restrictions': {},
+              'publisher': {
+                'consents': {
+                  '1': false,
+                  '2': false,
+                  '3': false
+                },
+                'legitimateInterests': {
+                  '1': false,
+                  '2': false,
+                  '3': false
+                },
+                'customPurpose': {
+                  'consents': {},
+                  'legitimateInterests': {}
+                }
+              }
+            };
+
+            await setConsentConfig({
+              cmpApi: 'static',
+              timeout: 7500,
+              consentData: packageCfg(consentData)
+            });
+            const consent = gdprDataHandler.getConsentData();
+            expect(consent.consentString).to.eql(consentData.tcString);
+            expect(consent.vendorData).to.eql(consentData);
+            expect(consent.vendorData.disclosedVendors).to.eql(consentData.disclosedVendors);
+            expect(consent.vendorData.tcfPolicyVersion).to.eql(3);
+          });
         });
       });
     });

--- a/test/spec/modules/tcfControl_spec.js
+++ b/test/spec/modules/tcfControl_spec.js
@@ -110,8 +110,11 @@ describe('gdpr enforcement', function () {
   };
   let gvlids, sandbox;
 
-  function setupConsentData({ gdprApplies = true, apiVersion = 2 } = {}) {
+  function setupConsentData({ gdprApplies = true, apiVersion = 2, tcDataMutator } = {}) {
     const cd = utils.deepClone(staticConfig);
+    if (typeof tcDataMutator === 'function') {
+      tcDataMutator(cd.consentData.getTCData);
+    }
     const consent = {
       vendorData: cd.consentData.getTCData,
       gdprApplies,
@@ -207,6 +210,27 @@ describe('gdpr enforcement', function () {
         }
       });
       setupConsentData();
+      expectAllow(true, accessDeviceRule(activityParams(MODULE_TYPE_BIDDER, 'appnexus')));
+    });
+
+    it('should support TCF 2.3 tcData using disclosedVendors', function () {
+      gvlids.appnexus = 1;
+      setEnforcementConfig({
+        gdpr: {
+          rules: [{
+            purpose: 'storage',
+            enforcePurpose: true,
+            enforceVendor: true,
+            vendorExceptions: []
+          }]
+        }
+      });
+      setupConsentData({
+        tcDataMutator: (tcData) => {
+          tcData.tcfPolicyVersion = 3;
+          tcData.disclosedVendors = { '1': true, '2': true };
+        }
+      });
       expectAllow(true, accessDeviceRule(activityParams(MODULE_TYPE_BIDDER, 'appnexus')));
     });
 


### PR DESCRIPTION
- IAB updated the TCF TCData shape for TCF 2.3 (policy version bump and mandatory disclosed vendors), and tests for the GDPR/TCF modules need to accept and validate the new fields. 
- Ensure enforcement logic in `tcfControl` continues to evaluate correctly when TCData follows the TCF 2.3 shape.
