### PR TITLE
Intenze Adapter: stabilize endpoint URL assertions in tests

### DIFF
--- a/test/spec/modules/intenzeBidAdapter_spec.js
+++ b/test/spec/modules/intenzeBidAdapter_spec.js
@@ -70,6 +70,8 @@ const bidRequest = {
   }
 }
 
+const ENDPOINT_URL_PATTERN = /^https:\/\/(lb-east|n2)\.intenze\.co\/bid\?pass=accountId&integration=prebidjs$/;
+
 const VIDEO_BID_REQUEST = {
   code: 'video1',
   sizes: [640, 480],
@@ -235,7 +237,7 @@ describe('IntenzeAdapter', function () {
     });
 
     it('Returns valid URL', function () {
-      expect(request.url).to.equal('https://lb-east.intenze.co/bid?pass=accountId&integration=prebidjs');
+      expect(request.url).to.match(ENDPOINT_URL_PATTERN);
     });
 
     it('Returns empty data if no valid requests are passed', function () {
@@ -265,7 +267,7 @@ describe('IntenzeAdapter', function () {
     });
 
     it('Returns valid URL', function () {
-      expect(request.url).to.equal('https://lb-east.intenze.co/bid?pass=accountId&integration=prebidjs');
+      expect(request.url).to.match(ENDPOINT_URL_PATTERN);
     });
   });
 
@@ -284,7 +286,7 @@ describe('IntenzeAdapter', function () {
     });
 
     it('Returns valid URL', function () {
-      expect(request.url).to.equal('https://lb-east.intenze.co/bid?pass=accountId&integration=prebidjs');
+      expect(request.url).to.match(ENDPOINT_URL_PATTERN);
     });
   });
 


### PR DESCRIPTION

- Tests for the Intenze adapter were flaky because they asserted a single hard-coded subdomain (`lb-east`) while runtime logic can produce `n2` for Europe based on timezone resolution.
See #14658 

