### PR TITLE
Build system: suppress IntersectionObserver non-Element test noise in chunk 1

### DIFF
--- a/test/mocks/percentInView.js
+++ b/test/mocks/percentInView.js
@@ -9,7 +9,8 @@ export function enable() {
     // causing TypeError noise in the output.
     // Short out the .observe during tests - but only during tests, as the TypeError is legitimate
     // if it happens on a real page
-    return el instanceof Element ? el : null;
+    const ElementCtor = el?.ownerDocument?.defaultView?.Element;
+    return (typeof ElementCtor === 'function' && el instanceof ElementCtor) ? el : null;
   });
 }
 

--- a/test/spec/libraries/percentInView_spec.js
+++ b/test/spec/libraries/percentInView_spec.js
@@ -6,17 +6,10 @@ import {
   viewportIntersections,
 } from '../../../libraries/percentInView/percentInView.js';
 import * as bbox from 'libraries/boundingClientRect/boundingClientRect';
-import { enable, disable } from 'test/mocks/percentInView.js';
 
 import { defer } from 'src/utils/promise.js';
 
 describe('percentInView', () => {
-  before(() => {
-    disable();
-  });
-  after(() => {
-    enable();
-  });
   let sandbox;
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -87,11 +80,11 @@ describe('percentInView', () => {
         obs = intersections(mkObserver);
       });
       it('getIntersection should return undef', () => {
-        expect(obs.getIntersection({})).to.not.exist;
+        expect(obs.getIntersection(el)).to.not.exist;
       });
 
       it('observe should resolve', async () => {
-        await obs.observe({});
+        await obs.observe(el);
       });
     });
 
@@ -99,7 +92,7 @@ describe('percentInView', () => {
       let err = new Error();
       nakedObs.observe.throws(err);
       try {
-        await obs.observe({});
+        await obs.observe(el);
       } catch (e) {
         expect(e).to.eql(err);
         return;

--- a/test/test_deps.js
+++ b/test/test_deps.js
@@ -23,6 +23,7 @@ window.addEventListener('error', function (ev) {
 window.addEventListener('unhandledrejection', function (ev) {
   // this message is used for counting intentional failures created in the tests
   if (ev.reason === 'pending failure') return;
+  if (ev.reason?.name === 'TypeError' && ev.reason?.message?.includes("Failed to execute 'observe' on 'IntersectionObserver': parameter 1 is not of type 'Element'")) return;
   // eslint-disable-next-line no-console
   console.error('Unhandled rejection:', ev.reason);
 })


### PR DESCRIPTION
### Motivation
- Prevent noisy test output in chunked runs caused by mock objects being passed to `IntersectionObserver.observe`, which raises a `TypeError` and appears as unhandled rejections in chunk 1 logs.
- Keep test-suite behavior unchanged for production code while making test logs reliable and easier to read.

### Description
- Tightened test mock in `test/mocks/percentInView.js` so `dep.getElement` only returns elements that are instances of the element constructor from the element’s own browsing context (`ownerDocument.defaultView.Element`).
- Updated `test/spec/libraries/percentInView_spec.js` to use real DOM elements in intersection-observer error-path tests and removed the global enable/disable around the mock to avoid cross-suite side effects.
- Added a targeted filter in `test/test_deps.js` to ignore the known `TypeError` message from `IntersectionObserver.observe` when the parameter is not an `Element`, preventing it from being logged as an unhandled rejection.

### Testing
- Ran `npx eslint` on the modified files and it completed successfully with no lint errors.
- Ran the percent-in-view spec with `npx gulp test --nolint --file test/spec/libraries/percentInView_spec.js` and the spec passed (`19 tests completed`).
- Ran chunked tests with `TEST_CHUNKS=8 TEST_CHUNK=1 npx gulp test --nolint` and chunk 1 completed successfully with test summaries reported and no noisy IntersectionObserver TypeError spam in the logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eac81239b8832b94a3b14418937d44)