### PR TITLE
Backport #14749 to 10.29.x-legacy: Remove gvlid from movingup alias

### DIFF
--- a/modules/nexx360BidAdapter.ts
+++ b/modules/nexx360BidAdapter.ts
@@ -57,7 +57,7 @@ const ALIASES = [
   { code: 'spm', gvlid: 965 },
   { code: 'bidstailamedia', gvlid: 965 },
   { code: 'scoremedia', gvlid: 965 },
-  { code: 'movingup', gvlid: 1416 },
+  { code: 'movingup' },
   { code: 'glomexbidder', gvlid: 967 },
   { code: 'pubxai', gvlid: 1485 },
   { code: 'ybidder', gvlid: 1253 },


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Other (backport)

## Description of change
Backport of #14749 to the `10.29.x-legacy` branch.

The `movingup` alias in `modules/nexx360BidAdapter.ts` declares `gvlid: 1416`, which has been removed from the IAB Global Vendor List. Builds that run `gulp update-metadata` against this branch now fail:

      "bidder.movingup" provides a GVL ID that is deleted or missing: 1416
      [...] Error: One or more GVL IDs are invalid

Master already has this fix (#14749); this one-line cherry-pick unblocks metadata compilation on `10.29.x-legacy`.

## Other information

Cherry-picked from commit `de781416da8dd7bfdd5b535868d2f73a3fec3587` (squash-merge of PR #14749 on master).