### PR TITLE
Build System: replace source-map-loader with webpack native extractSourceMap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,6 @@
         "puppeteer": "^24.10.0",
         "resolve-from": "^5.0.0",
         "sinon": "^20.0.0",
-        "source-map-loader": "^5.0.0",
         "through2": "^4.0.2",
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.26.1",
@@ -19772,47 +19771,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-loader": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-5.0.0.tgz",
-      "integrity": "sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA==",
-      "dev": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 18.12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.72.1"
-      }
-    },
-    "node_modules/source-map-loader/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-resolve": {
       "version": "0.6.0",
       "dev": true,
@@ -35476,33 +35434,6 @@
     "source-map": {
       "version": "0.6.1",
       "dev": true
-    },
-    "source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true
-    },
-    "source-map-loader": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-5.0.0.tgz",
-      "integrity": "sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA==",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "^0.6.3",
-        "source-map-js": "^1.0.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
     },
     "source-map-resolve": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "puppeteer": "^24.10.0",
     "resolve-from": "^5.0.0",
     "sinon": "^20.0.0",
-    "source-map-loader": "^5.0.0",
     "through2": "^4.0.2",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.26.1",

--- a/webpack.conf.js
+++ b/webpack.conf.js
@@ -65,8 +65,7 @@ module.exports = {
       {
         test: /\.js$/,
         exclude: path.resolve('./node_modules'),
-        enforce: "pre",
-        use: ["source-map-loader"],
+        extractSourceMap: true,
       },
       ...(() => {
         if (!isES5Mode) {

--- a/webpack.creative.js
+++ b/webpack.creative.js
@@ -27,7 +27,7 @@ module.exports = {
   },
   module: {
     rules: [{
-      use: 'source-map-loader'
+      extractSourceMap: true
     }]
   }
 }


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
- Replace `source-map-loader` ([archived by the owner on Aug 29, 2025](https://github.com/webpack-contrib/source-map-loader)) with webpack 5's native `extractSourceMap` rule option in `webpack.conf.js` and `webpack.creative.js`
- Remove `source-map-loader` from devDependencies, reducing supply-chain
                                                                                                                                            
- `source-map-loader` was introduced in #12879 to chain pre-existing source maps from the precompilation step into webpack's output. Webpack 5.100+ added a native `extractSourceMap` rule-level option that does the same thing without an external loader.

## Other information
- https://github.com/webpack-contrib/source-map-loader
- https://github.com/webpack/webpack/tree/main/examples/source-mapping-url
- https://webpack.js.org/configuration/module/#ruleextractsourcemap

- closes #14799