### PR TITLE
Core: disable user syncs in Firefox and Webkit Chrome

### DIFF
--- a/modules/livewrappedBidAdapter.js
+++ b/modules/livewrappedBidAdapter.js
@@ -1,4 +1,4 @@
-import { deepAccess, getWindowTop, isSafariBrowser, mergeDeep, isFn, isPlainObject, getWinDimensions } from '../src/utils.js';
+import { deepAccess, getWindowTop, isSafariBrowser, isFirefoxBrowser, isChromeIOSBrowser, mergeDeep, isFn, isPlainObject, getWinDimensions } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
@@ -96,7 +96,7 @@ export const spec = {
       gdprConsent: bidderRequest.gdprConsent ? bidderRequest.gdprConsent.consentString : undefined,
       coppa: getCoppa(),
       usPrivacy: bidderRequest.uspConsent,
-      cookieSupport: !isSafariBrowser() && storage.cookiesAreEnabled(),
+      cookieSupport: !isSafariBrowser() && !isFirefoxBrowser() && !isChromeIOSBrowser() && storage.cookiesAreEnabled(),
       rcv: getAdblockerRecovered(),
       adRequests: [...adRequests],
       rtbData: ortb2,

--- a/src/userSync.ts
+++ b/src/userSync.ts
@@ -1,6 +1,6 @@
 import {
   deepClone, isPlainObject, logError, shuffle, logMessage, triggerPixel, insertUserSyncIframe, isArray,
-  logWarn, isStr, isSafariBrowser, isFirefoxBrowser
+  logWarn, isStr, isSafariBrowser, isFirefoxBrowser, isChromeIOSBrowser
 } from './utils.js';
 import { config } from './config.js';
 
@@ -388,7 +388,7 @@ export const userSync = newUserSync(Object.defineProperties({
   browserSupportsCookies: {
     get: function() {
       // call storage lazily to give time for consent data to be available
-      return !isSafariBrowser() && !isFirefoxBrowser() && storage.cookiesAreEnabled();
+      return !isSafariBrowser() && !isFirefoxBrowser() && !isChromeIOSBrowser() && storage.cookiesAreEnabled();
     }
   }
 }));

--- a/src/userSync.ts
+++ b/src/userSync.ts
@@ -1,6 +1,6 @@
 import {
   deepClone, isPlainObject, logError, shuffle, logMessage, triggerPixel, insertUserSyncIframe, isArray,
-  logWarn, isStr, isSafariBrowser
+  logWarn, isStr, isSafariBrowser, isFirefoxBrowser
 } from './utils.js';
 import { config } from './config.js';
 
@@ -388,7 +388,7 @@ export const userSync = newUserSync(Object.defineProperties({
   browserSupportsCookies: {
     get: function() {
       // call storage lazily to give time for consent data to be available
-      return !isSafariBrowser() && storage.cookiesAreEnabled();
+      return !isSafariBrowser() && !isFirefoxBrowser() && storage.cookiesAreEnabled();
     }
   }
 }));

--- a/src/utils.js
+++ b/src/utils.js
@@ -658,6 +658,10 @@ export function isFirefoxBrowser() {
   return /firefox|fxios/i.test(navigator.userAgent);
 }
 
+export function isChromeIOSBrowser() {
+  return /crios|crmo/i.test(navigator.userAgent);
+}
+
 export function replaceMacros(str, subs) {
   if (!str) return;
   return Object.entries(subs).reduce((str, [key, val]) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -654,6 +654,10 @@ export function isSafariBrowser() {
   return /^((?!chrome|android|crios|fxios).)*safari/i.test(navigator.userAgent);
 }
 
+export function isFirefoxBrowser() {
+  return /firefox|fxios/i.test(navigator.userAgent);
+}
+
 export function replaceMacros(str, subs) {
   if (!str) return;
   return Object.entries(subs).reduce((str, [key, val]) => {

--- a/test/spec/modules/livewrappedBidAdapter_spec.js
+++ b/test/spec/modules/livewrappedBidAdapter_spec.js
@@ -13,6 +13,8 @@ describe('Livewrapped adapter tests', function () {
 
   beforeEach(function () {
     sandbox = sinon.createSandbox();
+    sandbox.stub(utils, 'isFirefoxBrowser').callsFake(() => false);
+    sandbox.stub(utils, 'isChromeIOSBrowser').callsFake(() => false);
 
     window.livewrapped = undefined;
 
@@ -893,7 +895,7 @@ describe('Livewrapped adapter tests', function () {
 
     it('should pass no cookie support Firefox', function() {
       sandbox.stub(storage, 'cookiesAreEnabled').callsFake(() => true);
-      sandbox.stub(utils, 'isFirefoxBrowser').callsFake(() => true);
+      utils.isFirefoxBrowser.callsFake(() => true);
       const result = spec.buildRequests(bidderRequest.bids, bidderRequest);
       const data = JSON.parse(result.data);
 
@@ -903,7 +905,7 @@ describe('Livewrapped adapter tests', function () {
 
     it('should pass no cookie support Chrome on iOS', function() {
       sandbox.stub(storage, 'cookiesAreEnabled').callsFake(() => true);
-      sandbox.stub(utils, 'isChromeIOSBrowser').callsFake(() => true);
+      utils.isChromeIOSBrowser.callsFake(() => true);
       const result = spec.buildRequests(bidderRequest.bids, bidderRequest);
       const data = JSON.parse(result.data);
 

--- a/test/spec/modules/livewrappedBidAdapter_spec.js
+++ b/test/spec/modules/livewrappedBidAdapter_spec.js
@@ -891,6 +891,26 @@ describe('Livewrapped adapter tests', function () {
       expect(data).to.deep.equal(expectedQuery);
     });
 
+    it('should pass no cookie support Firefox', function() {
+      sandbox.stub(storage, 'cookiesAreEnabled').callsFake(() => true);
+      sandbox.stub(utils, 'isFirefoxBrowser').callsFake(() => true);
+      const result = spec.buildRequests(bidderRequest.bids, bidderRequest);
+      const data = JSON.parse(result.data);
+
+      expect(result.url).to.equal('https://lwadm.com/ad');
+      expect(data.cookieSupport).to.equal(false);
+    });
+
+    it('should pass no cookie support Chrome on iOS', function() {
+      sandbox.stub(storage, 'cookiesAreEnabled').callsFake(() => true);
+      sandbox.stub(utils, 'isChromeIOSBrowser').callsFake(() => true);
+      const result = spec.buildRequests(bidderRequest.bids, bidderRequest);
+      const data = JSON.parse(result.data);
+
+      expect(result.url).to.equal('https://lwadm.com/ad');
+      expect(data.cookieSupport).to.equal(false);
+    });
+
     it('should use params.url, then bidderRequest.refererInfo.page', function() {
       const testRequest = clone(bidderRequest);
       testRequest.refererInfo = { page: 'https://www.topurl.com' };

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -947,6 +947,36 @@ describe('Utils', function () {
     });
   });
 
+  describe('isFirefoxBrowser', function () {
+    let userAgentStub;
+    let userAgent;
+
+    before(function () {
+      userAgentStub = sinon.stub(navigator, 'userAgent').get(function () {
+        return userAgent;
+      });
+    });
+
+    after(function () {
+      userAgentStub.restore();
+    });
+
+    it('properly detects Firefox on desktop', function () {
+      userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:125.0) Gecko/20100101 Firefox/125.0';
+      expect(utils.isFirefoxBrowser()).to.equal(true);
+    });
+
+    it('properly detects Firefox on iOS', function () {
+      userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/125.0 Mobile/15E148 Safari/605.1.15';
+      expect(utils.isFirefoxBrowser()).to.equal(true);
+    });
+
+    it('does not flag Safari', function () {
+      userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_5) AppleWebKit/536.25 (KHTML, like Gecko) Version/6.0 Safari/536.25';
+      expect(utils.isFirefoxBrowser()).to.equal(false);
+    });
+  });
+
   describe('mergeDeep', function() {
     it('properly merge objects that share same property names', function() {
       const object1 = {

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -977,6 +977,36 @@ describe('Utils', function () {
     });
   });
 
+  describe('isChromeIOSBrowser', function () {
+    let userAgentStub;
+    let userAgent;
+
+    before(function () {
+      userAgentStub = sinon.stub(navigator, 'userAgent').get(function () {
+        return userAgent;
+      });
+    });
+
+    after(function () {
+      userAgentStub.restore();
+    });
+
+    it('properly detects Chrome on iOS', function () {
+      userAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/80.0.3987.95 Mobile/15E148 Safari/604.1';
+      expect(utils.isChromeIOSBrowser()).to.equal(true);
+    });
+
+    it('does not flag Chrome on desktop', function () {
+      userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36';
+      expect(utils.isChromeIOSBrowser()).to.equal(false);
+    });
+
+    it('does not flag Opera on desktop', function () {
+      userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36 OPR/130.0.0.0';
+      expect(utils.isChromeIOSBrowser()).to.equal(false);
+    });
+  });
+
   describe('mergeDeep', function() {
     it('properly merge objects that share same property names', function() {
       const object1 = {


### PR DESCRIPTION
### Motivation
- User syncs were gated for Safari and storage-unavailable cases but still ran in Firefox, so Firefox should be treated like Safari to avoid firing syncs in browsers with restrictive storage policies.
see #12992 
