### PR TITLE
Core: fix bug where hb_cache_host is sometimes not set to the right host

### DIFF
--- a/src/auction.ts
+++ b/src/auction.ts
@@ -1032,11 +1032,12 @@ export function getStandardBidderSettings(mediaType, bidderCode) {
 
     // Adding hb_cache_host
     if (config.getConfig('cache.url') && (!bidderCode || bidderSettings.get(bidderCode, 'sendStandardTargeting') !== false)) {
-      const urlInfo = parseUrl(config.getConfig('cache.url'));
-
       if (typeof adserverTargeting.find(targetingKeyVal => targetingKeyVal.key === TARGETING_KEYS.CACHE_HOST) === 'undefined') {
         adserverTargeting.push(createKeyVal(TARGETING_KEYS.CACHE_HOST, function(bidResponse) {
-          return (bidResponse?.adserverTargeting?.[TARGETING_KEYS.CACHE_HOST] || urlInfo.hostname) as string;
+          if (bidResponse.cacheUrl) {
+            return parseUrl(bidResponse.cacheUrl).hostname
+          }
+          return bidResponse.adserverTargeting?.[TARGETING_KEYS.CACHE_HOST];
         }));
       }
     }

--- a/src/videoCache.ts
+++ b/src/videoCache.ts
@@ -96,6 +96,11 @@ declare module './bidfactory' {
      * The cache key that was used for this bid.
      */
     videoCacheKey?: string;
+    /**
+     * URL of the cache service Prebid used to cache this bid (`getConfig('cache.url')`). Undefined if Prebid did
+     * not cache this bid.
+     */
+    cacheUrl?: string;
   }
 }
 
@@ -237,8 +242,8 @@ export function store(bids: VideoBid[], done?: VideoCacheStoreCallback, getAjax 
   });
 }
 
-export function getCacheUrl(id) {
-  return `${config.getConfig('cache.url')}?uuid=${id}`;
+export function getCacheUrl(cacheUrl, id) {
+  return `${cacheUrl}?uuid=${id}`;
 }
 
 export const storeLocally = (bid) => {
@@ -307,6 +312,7 @@ export function storeBatch(batch) {
   function err(msg) {
     logError(`Failed to save to the video cache: ${msg}. Video bids will be discarded:`, bids)
   }
+  const cacheUrl = config.getConfig('cache.url');
   _internal.store(bids, function (error, cacheIds) {
     if (error) {
       err(error)
@@ -318,7 +324,8 @@ export function storeBatch(batch) {
         if (cacheId.uuid === '') {
           logWarn(`Supplied video cache key was already in use by Prebid Cache; caching attempt was rejected. Video bid must be discarded.`);
         } else {
-          assignVastUrlAndCacheId(bidResponse, getCacheUrl(cacheId.uuid), cacheId.uuid);
+          bidResponse.cacheUrl = cacheUrl;
+          assignVastUrlAndCacheId(bidResponse, getCacheUrl(cacheUrl, cacheId.uuid), cacheId.uuid);
           addBidToAuction(auctionInstance, bidResponse);
           afterBidAdded();
         }

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -278,13 +278,14 @@ describe('auctionmanager.js', function () {
       it('No bidder level configuration defined - default for video', function () {
         config.setConfig({
           cache: {
-            url: 'https://test.cache.url/endpoint'
+            url: 'ignored'
           }
         });
         getGlobal().bidderSettings = {};
         const videoBid = utils.deepClone(bid);
         videoBid.mediaType = 'video';
         videoBid.videoCacheKey = 'abc123def';
+        videoBid.cacheUrl = 'https://test.cache.url/endpoint';
 
         const expected = getDefaultExpected(videoBid);
         const response = getKeyValueTargetingPairs(videoBid.bidderCode, videoBid);
@@ -371,12 +372,13 @@ describe('auctionmanager.js', function () {
       it('Custom configuration for all bidders with video bid', function () {
         config.setConfig({
           cache: {
-            url: 'https://test.cache.url/endpoint'
+            url: 'ignored'
           }
         });
         const videoBid = utils.deepClone(bid);
         videoBid.mediaType = 'video';
         videoBid.videoCacheKey = 'abc123def';
+        videoBid.cacheUrl = 'https://test.cache.url/endpoint';
 
         getGlobal().bidderSettings =
           {

--- a/test/spec/videoCache_spec.js
+++ b/test/spec/videoCache_spec.js
@@ -365,7 +365,7 @@ describe('The video cache', function () {
       sinon.assert.notCalled(batch[0].afterBidAdded);
       sinon.assert.called(utils.logError);
     });
-    it('should set bids\' videoCacheKey and vastUrl', () => {
+    it('should set bids\' videoCacheKey, vastUrl, and cacheUrl', () => {
       config.setConfig({
         cache: {
           url: 'mock-cache'
@@ -376,7 +376,8 @@ describe('The video cache', function () {
       storeBatch([el]);
       sinon.assert.match(el.bidResponse, {
         videoCacheKey: 'mock-id',
-        vastUrl: 'mock-cache?uuid=mock-id'
+        vastUrl: 'mock-cache?uuid=mock-id',
+        cacheUrl: 'mock-cache',
       })
     });
   })
@@ -598,21 +599,11 @@ describe('The video cache', function () {
 });
 
 describe('The getCache function', function () {
-  beforeEach(function () {
-    config.setConfig({
-      cache: {
-        url: 'https://test.cache.url/endpoint'
-      }
-    })
-  });
-
-  afterEach(function () {
-    config.resetConfig();
-  });
+  const CACHE_URL = 'https://test.cache.url/endpoint';
 
   it('should return the expected URL', function () {
     const uuid = 'c488b101-af3e-4a99-b538-00423e5a3371';
-    const url = getCacheUrl(uuid);
+    const url = getCacheUrl(CACHE_URL, uuid);
     url.should.equal(`https://test.cache.url/endpoint?uuid=${uuid}`);
   });
 })


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

This fixes a bug where the `hb_cache_host` targeting key is not set correctly if an adapter sets `bidResponse.adserverTargeting.hb_cache_host` and the bid is later cached by Prebid.

## Other information

Fixes https://github.com/prebid/Prebid.js/issues/14795

