### PR TITLE
Encypher RTD Provider: C2PA content provenance signals

### DIFF
--- a/libraries/encypherUtils/encypherUtils.ts
+++ b/libraries/encypherUtils/encypherUtils.ts
@@ -1,0 +1,20 @@
+/**
+ * Resolve the canonical URL for the current page.
+ * Prefers <link rel="canonical">, falls back to location.href stripped of hash/query.
+ */
+export function getCanonicalUrl(): string {
+  const link = document.querySelector('link[rel="canonical"]') as HTMLLinkElement | null;
+  if (link && link.href) return link.href;
+  return window.location.href.split('#')[0].split('?')[0];
+}
+
+/**
+ * djb2 hash. Returns a hex string suitable for use as a cache key.
+ */
+export function hashUrl(url: string): string {
+  let h = 0;
+  for (let i = 0; i < url.length; i++) {
+    h = ((h << 5) - h + url.charCodeAt(i)) | 0;
+  }
+  return (h >>> 0).toString(16);
+}

--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -132,7 +132,8 @@
       "symitriDapRtdProvider",
       "timeoutRtdProvider",
       "weboramaRtdProvider",
-      "wurflRtdProvider"
+      "wurflRtdProvider",
+      "encypherRtdProvider"
     ],
     "fpdModule": [
       "validationFpdModule",

--- a/modules/encypherRtdProvider.js
+++ b/modules/encypherRtdProvider.js
@@ -1,0 +1,378 @@
+import { MODULE_TYPE_RTD } from '../src/activities/modules.js';
+import { submodule } from '../src/hook.js';
+import { ajax } from '../src/ajax.js';
+import { deepSetValue, logError, logInfo, logWarn } from '../src/utils.js';
+import { getStorageManager } from '../src/storageManager.js';
+
+const REAL_TIME_MODULE = 'realTimeData';
+export const MODULE_NAME = 'encypher';
+const LOG_PREFIX = '[EncypherRTD]: ';
+const STORAGE_KEY = 'encypher_provenance_v1';
+const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+const DEFAULT_API_BASE = 'https://api.encypher.com';
+const MAX_CONTENT_LENGTH = 50000; // ~50KB ceiling for POST body
+const MIN_CONTENT_LENGTH = 50; // minimum chars to consider as article content
+
+export const storage = getStorageManager({
+  moduleType: MODULE_TYPE_RTD,
+  moduleName: MODULE_NAME,
+});
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the canonical URL for the current page.
+ * Prefers <link rel="canonical">, falls back to location.href stripped of hash/query.
+ */
+export function getCanonicalUrl() {
+  const link = document.querySelector('link[rel="canonical"]');
+  if (link && link.href) return link.href;
+  return window.location.href.split('#')[0].split('?')[0];
+}
+
+/**
+ * djb2 hash (same algorithm as provenance-utils.js hashText).
+ * Returns a hex string suitable for use as a cache key.
+ */
+export function hashUrl(url) {
+  let h = 0;
+  for (let i = 0; i < url.length; i++) {
+    h = ((h << 5) - h + url.charCodeAt(i)) | 0;
+  }
+  return (h >>> 0).toString(16);
+}
+
+// ---------------------------------------------------------------------------
+// Cache (localStorage via Prebid storageManager for GDPR consent enforcement)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a cached provenance payload for the given URL hash.
+ * Returns the payload object or null if missing/expired/unavailable.
+ */
+export function readCache(urlHash) {
+  if (!storage.localStorageIsEnabled()) return null;
+  try {
+    const raw = storage.getDataFromLocalStorage(STORAGE_KEY);
+    if (!raw) return null;
+    const store = JSON.parse(raw);
+    const entry = store[urlHash];
+    if (!entry) return null;
+    if (Date.now() > entry.expires_at) {
+      delete store[urlHash];
+      storage.setDataInLocalStorage(STORAGE_KEY, JSON.stringify(store));
+      return null;
+    }
+    return entry.payload;
+  } catch (e) {
+    logWarn(LOG_PREFIX, 'Cache read error', e);
+    return null;
+  }
+}
+
+/**
+ * Write a provenance payload to cache, keyed by URL hash.
+ */
+export function writeCache(urlHash, payload) {
+  if (!storage.localStorageIsEnabled()) return;
+  try {
+    const raw = storage.getDataFromLocalStorage(STORAGE_KEY);
+    const store = raw ? JSON.parse(raw) : {};
+    store[urlHash] = { payload, expires_at: Date.now() + CACHE_TTL_MS };
+    storage.setDataInLocalStorage(STORAGE_KEY, JSON.stringify(store));
+  } catch (e) {
+    logWarn(LOG_PREFIX, 'Cache write error', e);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Content extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract structured metadata from a JSON-LD item.
+ * Returns a flat object with only non-empty string/number values.
+ */
+function extractMetadata(item) {
+  const meta = {};
+
+  // Author (string or Person/Organization object)
+  const author = item.author;
+  if (author) {
+    if (typeof author === 'string') {
+      meta.author = author;
+    } else if (author.name) {
+      meta.author = author.name;
+    } else if (Array.isArray(author) && author[0]) {
+      meta.author = author[0].name || (typeof author[0] === 'string' ? author[0] : undefined);
+    }
+  }
+
+  if (item.datePublished) meta.datePublished = item.datePublished;
+  if (item.dateModified) meta.dateModified = item.dateModified;
+  if (item.articleSection) meta.section = item.articleSection;
+  if (item.wordCount) meta.wordCount = Number(item.wordCount) || undefined;
+
+  // Keywords (string or array)
+  if (item.keywords) {
+    meta.keywords = Array.isArray(item.keywords)
+      ? item.keywords.join(',')
+      : String(item.keywords);
+  }
+
+  // Publisher name
+  const pub = item.publisher;
+  if (pub && pub.name) meta.publisher = pub.name;
+
+  // Language
+  if (item.inLanguage) meta.language = item.inLanguage;
+
+  return Object.keys(meta).length > 0 ? meta : null;
+}
+
+/**
+ * Extract article text from the DOM in priority order:
+ *   1. JSON-LD schema.org Article/NewsArticle/BlogPosting articleBody
+ *   2. <article> element innerText
+ *   3. [role="main"] element innerText
+ *
+ * Returns { text: string, source: string, metadata: object|null }
+ * or null if no usable content found.
+ */
+export function extractContent() {
+  // 1. JSON-LD structured data
+  const scripts = document.querySelectorAll('script[type="application/ld+json"]');
+  for (let i = 0; i < scripts.length; i++) {
+    try {
+      let data = JSON.parse(scripts[i].textContent);
+      // Handle @graph arrays
+      if (data['@graph'] && Array.isArray(data['@graph'])) {
+        data = data['@graph'];
+      }
+      const items = Array.isArray(data) ? data : [data];
+      for (let j = 0; j < items.length; j++) {
+        const item = items[j];
+        const type = item['@type'] || '';
+        if (/Article|NewsArticle|BlogPosting|Report/i.test(type)) {
+          const body = item.articleBody || item.text || '';
+          if (body.length >= MIN_CONTENT_LENGTH) {
+            return {
+              text: body.slice(0, MAX_CONTENT_LENGTH),
+              source: 'json-ld',
+              metadata: extractMetadata(item),
+            };
+          }
+        }
+      }
+    } catch (_) { /* malformed JSON-LD, skip */ }
+  }
+
+  // 2. <article> element
+  const article = document.querySelector('article');
+  if (article) {
+    const text = article.textContent.trim();
+    if (text.length >= MIN_CONTENT_LENGTH) {
+      return { text: text.slice(0, MAX_CONTENT_LENGTH), source: 'article-element', metadata: null };
+    }
+  }
+
+  // 3. [role="main"]
+  const main = document.querySelector('[role="main"]');
+  if (main) {
+    const text = main.textContent.trim();
+    if (text.length >= MIN_CONTENT_LENGTH) {
+      return { text: text.slice(0, MAX_CONTENT_LENGTH), source: 'role-main', metadata: null };
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Path A helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the OpenRTB payload from a fetched manifest (Path A).
+ */
+function buildManifestPayload(manifest, manifestUrl) {
+  return {
+    manifest_url: manifestUrl,
+    verified: manifest.status === 'ok',
+    signer_tier: manifest.signerTier || 'local',
+    action: (manifest.actions && manifest.actions[0] && manifest.actions[0].action) || undefined,
+    signed_at: manifest.signedAt || undefined,
+    source: 'cms',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Path C helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * POST article content to the Encypher signing API.
+ * Calls cb(err, response) on completion.
+ */
+function signContent(text, apiBase, pageUrl, metadata, cb) {
+  const payload = {
+    text: text,
+    page_url: pageUrl,
+    document_title: document.title || undefined,
+  };
+  if (metadata) {
+    payload.metadata = metadata;
+  }
+  const body = JSON.stringify(payload);
+
+  ajax(
+    apiBase + '/api/v1/public/prebid/sign',
+    {
+      success(responseText) {
+        try {
+          cb(null, JSON.parse(responseText));
+        } catch (e) {
+          cb(e, null);
+        }
+      },
+      error(error) {
+        cb(error, null);
+      },
+    },
+    body,
+    {
+      method: 'POST',
+      contentType: 'application/json',
+      customHeaders: {
+        Accept: 'application/json',
+      },
+    }
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Submodule interface
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {Object} config - Provider config ({ name, waitForIt, params })
+ * @param {Object} userConsent
+ * @returns {boolean} - false disables the module
+ */
+const init = (config, userConsent) => {
+  return true;
+};
+
+/**
+ * Three execution paths in strict priority:
+ *
+ *   Path A (CMS): <meta name="c2pa-manifest-url"> or params.manifestUrl
+ *     -> Fetch manifest JSON, inject site.ext.data.c2pa
+ *
+ *   Path B (Cache): localStorage hit for canonical URL hash
+ *     -> Inject from cache, no network call
+ *
+ *   Path C (Auto-sign): Extract article text from DOM, POST to Encypher API
+ *     -> Cache result, inject site.ext.data.c2pa
+ *
+ * Every path and every error branch calls callback(). The module never blocks
+ * an auction.
+ *
+ * @param {Object} reqBidsConfigObj - Proxied StartAuctionOptions
+ * @param {Function} callback - MUST always be called
+ * @param {Object} moduleConfig - Provider config with .params
+ * @param {Object} userConsent
+ */
+const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, userConsent) => {
+  const params = (moduleConfig && moduleConfig.params) || {};
+  const apiBase = params.apiBase || DEFAULT_API_BASE;
+  const canonicalUrl = getCanonicalUrl();
+  const urlHash = hashUrl(canonicalUrl);
+
+  // -- Path A: CMS meta tag or manual manifestUrl override -----------------
+  const metaTag = document.querySelector('meta[name="c2pa-manifest-url"]');
+  const manifestUrl = (metaTag && metaTag.content) || params.manifestUrl || null;
+
+  if (manifestUrl) {
+    logInfo(LOG_PREFIX, 'Path A: fetching manifest from', manifestUrl);
+    ajax(
+      manifestUrl,
+      {
+        success(responseText) {
+          try {
+            const manifest = JSON.parse(responseText);
+            const payload = buildManifestPayload(manifest, manifestUrl);
+            deepSetValue(reqBidsConfigObj.ortb2Fragments.global, 'site.ext.data.c2pa', payload);
+            logInfo(LOG_PREFIX, 'Path A: provenance injected');
+          } catch (e) {
+            logError(LOG_PREFIX, 'Path A: manifest parse error', e);
+          }
+          callback();
+        },
+        error(e) {
+          logError(LOG_PREFIX, 'Path A: manifest fetch error', e);
+          callback();
+        },
+      },
+      null,
+      { method: 'GET', customHeaders: { Accept: 'application/json' } }
+    );
+    return;
+  }
+
+  // -- Path B: localStorage cache hit --------------------------------------
+  const cached = readCache(urlHash);
+  if (cached) {
+    logInfo(LOG_PREFIX, 'Path B: cache hit for', canonicalUrl);
+    const payload = Object.assign({}, cached, { source: 'cache' });
+    deepSetValue(reqBidsConfigObj.ortb2Fragments.global, 'site.ext.data.c2pa', payload);
+    callback();
+    return;
+  }
+
+  // -- Path C: auto-sign via Encypher API ----------------------------------
+  const content = extractContent();
+  if (!content) {
+    logInfo(LOG_PREFIX, 'Path C: no extractable content, skipping');
+    callback();
+    return;
+  }
+
+  logInfo(LOG_PREFIX, 'Path C: signing content via', content.source);
+  signContent(content.text, apiBase, canonicalUrl, content.metadata, (err, resp) => {
+    if (err || !resp || !resp.success) {
+      logWarn(LOG_PREFIX, 'Path C: sign API error, continuing without provenance', err);
+      callback();
+      return;
+    }
+
+    const payload = {
+      manifest_url: resp.manifest_url,
+      verified: true,
+      signer_tier: resp.signer_tier || 'encypher_free',
+      signed_at: resp.signed_at,
+      content_hash: resp.content_hash,
+      extraction_method: content.source,
+    };
+
+    writeCache(urlHash, payload);
+    deepSetValue(
+      reqBidsConfigObj.ortb2Fragments.global,
+      'site.ext.data.c2pa',
+      Object.assign({}, payload, { source: 'auto' })
+    );
+    logInfo(LOG_PREFIX, 'Path C: provenance signed and injected');
+    callback();
+  });
+};
+
+/** @type {import('../src/hook.js').SubmoduleConfig} */
+export const encypherSubmodule = {
+  name: MODULE_NAME,
+  init,
+  getBidRequestData,
+};
+
+submodule(REAL_TIME_MODULE, encypherSubmodule);

--- a/modules/encypherRtdProvider.js
+++ b/modules/encypherRtdProvider.js
@@ -10,8 +10,10 @@ const LOG_PREFIX = '[EncypherRTD]: ';
 const STORAGE_KEY = 'encypher_provenance_v1';
 const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 const DEFAULT_API_BASE = 'https://api.encypher.com';
+const ALLOWED_API_HOSTS = ['api.encypher.com', 'staging-api.encypher.com'];
 const MAX_CONTENT_LENGTH = 50000; // ~50KB ceiling for POST body
 const MIN_CONTENT_LENGTH = 50; // minimum chars to consider as article content
+const AJAX_TIMEOUT_MS = 2000; // max wait for API calls before calling callback
 
 export const storage = getStorageManager({
   moduleType: MODULE_TYPE_RTD,
@@ -257,6 +259,31 @@ function signContent(text, apiBase, pageUrl, metadata, cb) {
 // ---------------------------------------------------------------------------
 
 /**
+ * Validate that a URL uses HTTPS and belongs to an allowed host.
+ */
+function isAllowedApiUrl(url) {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:') return false;
+    return ALLOWED_API_HOSTS.indexOf(parsed.hostname) !== -1;
+  } catch (_) {
+    return false;
+  }
+}
+
+/**
+ * Check if GDPR consent allows data transmission.
+ * Returns true if consent is granted or if no GDPR applies.
+ */
+function hasConsentForDataTransmission(userConsent) {
+  if (!userConsent || !userConsent.gdpr) return true;
+  const gdpr = userConsent.gdpr;
+  if (!gdpr.gdprApplies) return true;
+  // If GDPR applies, require consent string to be present
+  return !!(gdpr.consentString);
+}
+
+/**
  * @param {Object} config - Provider config ({ name, waitForIt, params })
  * @param {Object} userConsent
  * @returns {boolean} - false disables the module
@@ -291,6 +318,27 @@ const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, userConsent
   const canonicalUrl = getCanonicalUrl();
   const urlHash = hashUrl(canonicalUrl);
 
+  // Callback-once guard: ensure callback is never invoked twice
+  let callbackFired = false;
+  function done() {
+    if (callbackFired) return;
+    callbackFired = true;
+    callback();
+  }
+
+  // Safety timeout: never block the auction longer than AJAX_TIMEOUT_MS
+  const timer = setTimeout(() => {
+    if (!callbackFired) {
+      logWarn(LOG_PREFIX, 'Timeout reached, continuing without provenance');
+      done();
+    }
+  }, AJAX_TIMEOUT_MS);
+
+  function finish() {
+    clearTimeout(timer);
+    done();
+  }
+
   // -- Path A: CMS meta tag or manual manifestUrl override -----------------
   const metaTag = document.querySelector('meta[name="c2pa-manifest-url"]');
   const manifestUrl = (metaTag && metaTag.content) || params.manifestUrl || null;
@@ -309,11 +357,11 @@ const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, userConsent
           } catch (e) {
             logError(LOG_PREFIX, 'Path A: manifest parse error', e);
           }
-          callback();
+          finish();
         },
         error(e) {
           logError(LOG_PREFIX, 'Path A: manifest fetch error', e);
-          callback();
+          finish();
         },
       },
       null,
@@ -328,15 +376,30 @@ const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, userConsent
     logInfo(LOG_PREFIX, 'Path B: cache hit for', canonicalUrl);
     const payload = Object.assign({}, cached, { source: 'cache' });
     deepSetValue(reqBidsConfigObj.ortb2Fragments.global, 'site.ext.data.c2pa', payload);
-    callback();
+    finish();
     return;
   }
 
   // -- Path C: auto-sign via Encypher API ----------------------------------
+
+  // Consent gate: do not transmit page content without consent
+  if (!hasConsentForDataTransmission(userConsent)) {
+    logInfo(LOG_PREFIX, 'Path C: skipping, no consent for data transmission');
+    finish();
+    return;
+  }
+
+  // Validate API base URL against allowlist
+  if (!isAllowedApiUrl(apiBase + '/api/v1/public/prebid/sign')) {
+    logWarn(LOG_PREFIX, 'Path C: apiBase not in allowed hosts, skipping');
+    finish();
+    return;
+  }
+
   const content = extractContent();
   if (!content) {
     logInfo(LOG_PREFIX, 'Path C: no extractable content, skipping');
-    callback();
+    finish();
     return;
   }
 
@@ -344,7 +407,7 @@ const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, userConsent
   signContent(content.text, apiBase, canonicalUrl, content.metadata, (err, resp) => {
     if (err || !resp || !resp.success) {
       logWarn(LOG_PREFIX, 'Path C: sign API error, continuing without provenance', err);
-      callback();
+      finish();
       return;
     }
 
@@ -364,7 +427,7 @@ const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, userConsent
       Object.assign({}, payload, { source: 'auto' })
     );
     logInfo(LOG_PREFIX, 'Path C: provenance signed and injected');
-    callback();
+    finish();
   });
 };
 

--- a/modules/encypherRtdProvider.md
+++ b/modules/encypherRtdProvider.md
@@ -1,0 +1,106 @@
+# Overview
+
+Module Name: Encypher RTD Provider
+Module Type: Rtd Provider
+Maintainer: engineering@encypher.com
+
+# Description
+
+This module injects C2PA content provenance signals into OpenRTB bid requests at `site.ext.data.c2pa`. It enables DSPs to factor verified publisher identity and content integrity into bidding decisions.
+
+The module runs once per page load through three paths in strict priority:
+
+1. **Manifest Shortcut (Path A):** If a `<meta name="c2pa-manifest-url">` tag or `params.manifestUrl` is present, fetches the manifest directly without calling the signing API. This is an optional optimization for publishers who already expose manifest URLs.
+
+2. **Cache (Path B):** Serves previously obtained provenance from localStorage (30-day TTL, keyed by canonical URL hash). No network call.
+
+3. **API Signing and Verification (Path C):** Extracts article text from the DOM and sends it to the Encypher API. The API detects whether the content already contains embedded C2PA provenance markers. If markers are present, it verifies them and returns the existing provenance data (including the original signer tier). If no markers are found, it signs the content fresh and returns a new manifest. The result is cached and injected into the bid request.
+
+**Key behavior:** Content signed at the CMS or CDN layer carries invisible provenance markers that survive DOM rendering. When the module sends this text to the API, the markers are detected and verified server-side. Publishers who sign at publish time receive their authenticated `signer_tier` (e.g., `connected` or `byok`) in the bid request, which is a stronger signal than the `encypher_free` tier assigned to auto-signed content.
+
+No external JavaScript is loaded. The module uses only Prebid.js core imports. Every code path, including all error branches, calls `callback()`. The module never blocks an auction.
+
+Free tier: 1,000 unique content signatures per publisher domain per month. Re-requests for the same content (deduped by content hash) do not count against quota. Verification of already-signed content does not count against quota. Quota exceeded returns gracefully with no provenance data (fail-open).
+
+# Integration
+
+```bash
+gulp build -modules=rtdModule,encypherRtdProvider
+```
+
+```javascript
+pbjs.setConfig({
+  realTimeData: {
+    auctionDelay: 300,
+    dataProviders: [{
+      name: 'encypher',
+      waitForIt: true,
+      params: {
+        // All optional. Free tier works with zero config.
+        apiBase: 'https://api.encypher.com',  // override for staging/dev
+        manifestUrl: 'https://...'            // manual manifest URL (skips API call)
+      }
+    }]
+  }
+});
+```
+
+No configuration is required. The module extracts article text from the page and sends it to the Encypher API, which handles both verification of existing provenance and fresh signing.
+
+For publishers who prefer to skip the API call entirely, output a meta tag pointing to the manifest URL:
+
+```html
+<meta name="c2pa-manifest-url" content="https://api.encypher.com/api/v1/public/prebid/manifest/abc123">
+```
+
+# Data Injected
+
+The following object is placed at `ortb2Fragments.global.site.ext.data.c2pa`:
+
+```json
+{
+  "manifest_url": "https://api.encypher.com/api/v1/public/prebid/manifest/abc123",
+  "verified": true,
+  "signer_tier": "connected",
+  "signed_at": "2026-04-01T10:00:00Z",
+  "content_hash": "a1b2c3d4e5f6",
+  "source": "auto",
+  "extraction_method": "json-ld"
+}
+```
+
+| Field | Type | Description |
+|-|-|-|
+| `manifest_url` | string | URL to retrieve the C2PA manifest |
+| `verified` | boolean | `true` if the content's provenance was successfully verified or signed |
+| `signer_tier` | string | Signing identity tier: `local`, `encypher_free`, `connected`, `byok`. Content signed at CMS/CDN level returns the publisher's authenticated tier. |
+| `signed_at` | string | ISO 8601 timestamp of signing |
+| `content_hash` | string | SHA-256 hash of article text |
+| `source` | string | How provenance was obtained: `cms` (Path A), `cache` (Path B), or `auto` (Path C) |
+| `extraction_method` | string | DOM extraction method used (Path C): `json-ld`, `article-element`, or `role-main` |
+| `action` | string | First C2PA action from manifest (Path A only, e.g., `c2pa.created`) |
+
+# Signer Tiers
+
+The `signer_tier` field tells DSPs how the content was authenticated:
+
+| Tier | Meaning |
+|-|-|
+| `byok` | Publisher signed with their own key (strongest identity) |
+| `connected` | Publisher authenticated with Encypher and signed at publish time |
+| `encypher_free` | Content was auto-signed by Encypher at first pageview (no publisher authentication) |
+| `local` | Manifest fetched from a local/self-hosted endpoint (Path A) |
+
+DSPs can use this field for differential bidding: content signed by authenticated publishers carries stronger brand-safety guarantees than content attested by a third party at pageview time.
+
+# Content Extraction
+
+The module extracts article text from the DOM in this priority order:
+
+1. **JSON-LD structured data:** Looks for `application/ld+json` scripts containing schema.org types `Article`, `NewsArticle`, `BlogPosting`, or `Report`. Uses `articleBody` or `text` field. Handles `@graph` arrays.
+2. **`<article>` element:** Uses `textContent` of the first `<article>` element.
+3. **`[role="main"]` element:** Uses `textContent` of the first element with `role="main"`.
+
+Content shorter than 50 characters is skipped. Content longer than 50,000 characters is truncated. If no usable content is found, the module calls callback without injecting provenance data.
+
+When extracting from JSON-LD, the module also collects article metadata (author, datePublished, dateModified, section, wordCount, keywords, publisher, language) and includes it in the signing request. This metadata is used for analytics only and is not injected into the bid request.

--- a/modules/encypherRtdProvider.md
+++ b/modules/encypherRtdProvider.md
@@ -18,7 +18,7 @@ The module runs once per page load through three paths in strict priority:
 
 **Key behavior:** Content signed at the CMS or CDN layer carries invisible provenance markers that survive DOM rendering. When the module sends this text to the API, the markers are detected and verified server-side. Publishers who sign at publish time receive their authenticated `signer_tier` (e.g., `connected` or `byok`) in the bid request, which is a stronger signal than the `encypher_free` tier assigned to auto-signed content.
 
-No external JavaScript is loaded. The module uses only Prebid.js core imports. Every code path, including all error branches, calls `callback()`. The module never blocks an auction.
+No external JavaScript is loaded. The module uses only Prebid.js core imports. Every code path, including all error branches, calls `callback()`. A 2-second safety timeout ensures the module never blocks an auction. Path C requires GDPR consent before transmitting page content and validates the API endpoint against an allowlist of permitted hosts.
 
 Free tier: 1,000 unique content signatures per publisher domain per month. Re-requests for the same content (deduped by content hash) do not count against quota. Verification of already-signed content does not count against quota. Quota exceeded returns gracefully with no provenance data (fail-open).
 

--- a/modules/encypherRtdProvider.ts
+++ b/modules/encypherRtdProvider.ts
@@ -3,6 +3,10 @@ import { submodule } from '../src/hook.js';
 import { ajax } from '../src/ajax.js';
 import { deepSetValue, logError, logInfo, logWarn } from '../src/utils.js';
 import { getStorageManager } from '../src/storageManager.js';
+import { getCanonicalUrl, hashUrl } from '../libraries/encypherUtils/encypherUtils.ts';
+import type { AllConsentData } from '../src/consentHandler.ts';
+import type { RTDProviderConfig, RtdProviderSpec } from './rtdModule/spec.ts';
+import type { StartAuctionOptions } from '../src/prebid.ts';
 
 const REAL_TIME_MODULE = 'realTimeData';
 export const MODULE_NAME = 'encypher';
@@ -11,9 +15,49 @@ const STORAGE_KEY = 'encypher_provenance_v1';
 const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 const DEFAULT_API_BASE = 'https://api.encypher.com';
 const ALLOWED_API_HOSTS = ['api.encypher.com', 'staging-api.encypher.com'];
-const MAX_CONTENT_LENGTH = 50000; // ~50KB ceiling for POST body
-const MIN_CONTENT_LENGTH = 50; // minimum chars to consider as article content
-const AJAX_TIMEOUT_MS = 2000; // max wait for API calls before calling callback
+const MAX_CONTENT_LENGTH = 50000;
+const MIN_CONTENT_LENGTH = 50;
+const AJAX_TIMEOUT_MS = 2000;
+
+// ---------------------------------------------------------------------------
+// Public interface types
+// ---------------------------------------------------------------------------
+
+export interface EncypherRtdParams {
+  /** Override API base URL (default: https://api.encypher.com). */
+  apiBase?: string;
+  /** Manual manifest URL; skips the signing API call (Path A). */
+  manifestUrl?: string;
+}
+
+declare module './rtdModule/spec.ts' {
+  interface ProviderConfig {
+    encypher: {
+      params?: EncypherRtdParams;
+    };
+  }
+}
+
+export interface C2paPayload {
+  manifest_url: string;
+  verified: boolean;
+  signer_tier: string;
+  signed_at?: string;
+  content_hash?: string;
+  source: 'cms' | 'cache' | 'auto';
+  extraction_method?: 'json-ld' | 'article-element' | 'role-main';
+  action?: string;
+}
+
+interface ContentExtraction {
+  text: string;
+  source: 'json-ld' | 'article-element' | 'role-main';
+  metadata: Record<string, any> | null;
+}
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
 
 export const storage = getStorageManager({
   moduleType: MODULE_TYPE_RTD,
@@ -21,40 +65,10 @@ export const storage = getStorageManager({
 });
 
 // ---------------------------------------------------------------------------
-// Utilities
+// Cache (localStorage via Prebid storageManager for consent enforcement)
 // ---------------------------------------------------------------------------
 
-/**
- * Resolve the canonical URL for the current page.
- * Prefers <link rel="canonical">, falls back to location.href stripped of hash/query.
- */
-export function getCanonicalUrl() {
-  const link = document.querySelector('link[rel="canonical"]');
-  if (link && link.href) return link.href;
-  return window.location.href.split('#')[0].split('?')[0];
-}
-
-/**
- * djb2 hash (same algorithm as provenance-utils.js hashText).
- * Returns a hex string suitable for use as a cache key.
- */
-export function hashUrl(url) {
-  let h = 0;
-  for (let i = 0; i < url.length; i++) {
-    h = ((h << 5) - h + url.charCodeAt(i)) | 0;
-  }
-  return (h >>> 0).toString(16);
-}
-
-// ---------------------------------------------------------------------------
-// Cache (localStorage via Prebid storageManager for GDPR consent enforcement)
-// ---------------------------------------------------------------------------
-
-/**
- * Read a cached provenance payload for the given URL hash.
- * Returns the payload object or null if missing/expired/unavailable.
- */
-export function readCache(urlHash) {
+export function readCache(urlHash: string): Record<string, any> | null {
   if (!storage.localStorageIsEnabled()) return null;
   try {
     const raw = storage.getDataFromLocalStorage(STORAGE_KEY);
@@ -74,10 +88,7 @@ export function readCache(urlHash) {
   }
 }
 
-/**
- * Write a provenance payload to cache, keyed by URL hash.
- */
-export function writeCache(urlHash, payload) {
+export function writeCache(urlHash: string, payload: Record<string, any>): void {
   if (!storage.localStorageIsEnabled()) return;
   try {
     const raw = storage.getDataFromLocalStorage(STORAGE_KEY);
@@ -93,14 +104,9 @@ export function writeCache(urlHash, payload) {
 // Content extraction
 // ---------------------------------------------------------------------------
 
-/**
- * Extract structured metadata from a JSON-LD item.
- * Returns a flat object with only non-empty string/number values.
- */
-function extractMetadata(item) {
-  const meta = {};
+function extractMetadata(item: Record<string, any>): Record<string, any> | null {
+  const meta: Record<string, any> = {};
 
-  // Author (string or Person/Organization object)
   const author = item.author;
   if (author) {
     if (typeof author === 'string') {
@@ -117,39 +123,26 @@ function extractMetadata(item) {
   if (item.articleSection) meta.section = item.articleSection;
   if (item.wordCount) meta.wordCount = Number(item.wordCount) || undefined;
 
-  // Keywords (string or array)
   if (item.keywords) {
     meta.keywords = Array.isArray(item.keywords)
       ? item.keywords.join(',')
       : String(item.keywords);
   }
 
-  // Publisher name
   const pub = item.publisher;
   if (pub && pub.name) meta.publisher = pub.name;
 
-  // Language
   if (item.inLanguage) meta.language = item.inLanguage;
 
   return Object.keys(meta).length > 0 ? meta : null;
 }
 
-/**
- * Extract article text from the DOM in priority order:
- *   1. JSON-LD schema.org Article/NewsArticle/BlogPosting articleBody
- *   2. <article> element innerText
- *   3. [role="main"] element innerText
- *
- * Returns { text: string, source: string, metadata: object|null }
- * or null if no usable content found.
- */
-export function extractContent() {
+export function extractContent(): ContentExtraction | null {
   // 1. JSON-LD structured data
   const scripts = document.querySelectorAll('script[type="application/ld+json"]');
   for (let i = 0; i < scripts.length; i++) {
     try {
-      let data = JSON.parse(scripts[i].textContent);
-      // Handle @graph arrays
+      let data = JSON.parse(scripts[i].textContent || '');
       if (data['@graph'] && Array.isArray(data['@graph'])) {
         data = data['@graph'];
       }
@@ -174,7 +167,7 @@ export function extractContent() {
   // 2. <article> element
   const article = document.querySelector('article');
   if (article) {
-    const text = article.textContent.trim();
+    const text = (article.textContent || '').trim();
     if (text.length >= MIN_CONTENT_LENGTH) {
       return { text: text.slice(0, MAX_CONTENT_LENGTH), source: 'article-element', metadata: null };
     }
@@ -183,7 +176,7 @@ export function extractContent() {
   // 3. [role="main"]
   const main = document.querySelector('[role="main"]');
   if (main) {
-    const text = main.textContent.trim();
+    const text = (main.textContent || '').trim();
     if (text.length >= MIN_CONTENT_LENGTH) {
       return { text: text.slice(0, MAX_CONTENT_LENGTH), source: 'role-main', metadata: null };
     }
@@ -196,10 +189,7 @@ export function extractContent() {
 // Path A helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Build the OpenRTB payload from a fetched manifest (Path A).
- */
-function buildManifestPayload(manifest, manifestUrl) {
+function buildManifestPayload(manifest: Record<string, any>, manifestUrl: string): Partial<C2paPayload> {
   return {
     manifest_url: manifestUrl,
     verified: manifest.status === 'ok',
@@ -214,13 +204,15 @@ function buildManifestPayload(manifest, manifestUrl) {
 // Path C helpers
 // ---------------------------------------------------------------------------
 
-/**
- * POST article content to the Encypher signing API.
- * Calls cb(err, response) on completion.
- */
-function signContent(text, apiBase, pageUrl, metadata, cb) {
-  const payload = {
-    text: text,
+function signContent(
+  text: string,
+  apiBase: string,
+  pageUrl: string,
+  metadata: Record<string, any> | null,
+  cb: (err: any, resp: any) => void
+): void {
+  const payload: Record<string, any> = {
+    text,
     page_url: pageUrl,
     document_title: document.title || undefined,
   };
@@ -232,24 +224,20 @@ function signContent(text, apiBase, pageUrl, metadata, cb) {
   ajax(
     apiBase + '/api/v1/public/prebid/sign',
     {
-      success(responseText) {
+      success(responseText: string) {
         try {
           cb(null, JSON.parse(responseText));
         } catch (e) {
           cb(e, null);
         }
       },
-      error(error) {
+      error(error: any) {
         cb(error, null);
       },
     },
     body,
     {
       method: 'POST',
-      contentType: 'application/json',
-      customHeaders: {
-        Accept: 'application/json',
-      },
     }
   );
 }
@@ -258,10 +246,7 @@ function signContent(text, apiBase, pageUrl, metadata, cb) {
 // Submodule interface
 // ---------------------------------------------------------------------------
 
-/**
- * Validate that a URL uses HTTPS and belongs to an allowed host.
- */
-function isAllowedApiUrl(url) {
+function isAllowedApiUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
     if (parsed.protocol !== 'https:') return false;
@@ -272,23 +257,32 @@ function isAllowedApiUrl(url) {
 }
 
 /**
- * Check if GDPR consent allows data transmission.
- * Returns true if consent is granted or if no GDPR applies.
+ * Check if privacy signals allow data transmission.
+ * Returns false when any applicable regulation indicates opt-out or restriction.
  */
-function hasConsentForDataTransmission(userConsent) {
-  if (!userConsent || !userConsent.gdpr) return true;
-  const gdpr = userConsent.gdpr;
-  if (!gdpr.gdprApplies) return true;
-  // If GDPR applies, require consent string to be present
-  return !!(gdpr.consentString);
+function hasConsentForDataTransmission(userConsent: AllConsentData | null | undefined): boolean {
+  if (!userConsent) return true;
+
+  // COPPA: children's data must never be transmitted
+  if (userConsent.coppa === true) return false;
+
+  // USP/CCPA: position 2 is the opt-out-sale flag; 'Y' means user opted out
+  if (userConsent.usp && typeof userConsent.usp === 'string') {
+    if (userConsent.usp[2] === 'Y') return false;
+  }
+
+  // GDPR: require a consent string when GDPR applies
+  if (userConsent.gdpr) {
+    if (userConsent.gdpr.gdprApplies && !userConsent.gdpr.consentString) return false;
+  }
+
+  return true;
 }
 
-/**
- * @param {Object} config - Provider config ({ name, waitForIt, params })
- * @param {Object} userConsent
- * @returns {boolean} - false disables the module
- */
-const init = (config, userConsent) => {
+const init = (
+  _config: RTDProviderConfig<'encypher'>,
+  _userConsent: AllConsentData
+): boolean => {
   return true;
 };
 
@@ -296,29 +290,22 @@ const init = (config, userConsent) => {
  * Three execution paths in strict priority:
  *
  *   Path A (CMS): <meta name="c2pa-manifest-url"> or params.manifestUrl
- *     -> Fetch manifest JSON, inject site.ext.data.c2pa
- *
  *   Path B (Cache): localStorage hit for canonical URL hash
- *     -> Inject from cache, no network call
- *
  *   Path C (Auto-sign): Extract article text from DOM, POST to Encypher API
- *     -> Cache result, inject site.ext.data.c2pa
  *
- * Every path and every error branch calls callback(). The module never blocks
- * an auction.
- *
- * @param {Object} reqBidsConfigObj - Proxied StartAuctionOptions
- * @param {Function} callback - MUST always be called
- * @param {Object} moduleConfig - Provider config with .params
- * @param {Object} userConsent
+ * Every path and every error branch calls callback().
  */
-const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, userConsent) => {
+const getBidRequestData = (
+  reqBidsConfigObj: StartAuctionOptions,
+  callback: () => void,
+  moduleConfig: RTDProviderConfig<'encypher'>,
+  userConsent: AllConsentData
+): void => {
   const params = (moduleConfig && moduleConfig.params) || {};
   const apiBase = params.apiBase || DEFAULT_API_BASE;
   const canonicalUrl = getCanonicalUrl();
   const urlHash = hashUrl(canonicalUrl);
 
-  // Callback-once guard: ensure callback is never invoked twice
   let callbackFired = false;
   function done() {
     if (callbackFired) return;
@@ -326,7 +313,6 @@ const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, userConsent
     callback();
   }
 
-  // Safety timeout: never block the auction longer than AJAX_TIMEOUT_MS
   const timer = setTimeout(() => {
     if (!callbackFired) {
       logWarn(LOG_PREFIX, 'Timeout reached, continuing without provenance');
@@ -340,15 +326,26 @@ const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, userConsent
   }
 
   // -- Path A: CMS meta tag or manual manifestUrl override -----------------
-  const metaTag = document.querySelector('meta[name="c2pa-manifest-url"]');
+  const metaTag = document.querySelector('meta[name="c2pa-manifest-url"]') as HTMLMetaElement | null;
   const manifestUrl = (metaTag && metaTag.content) || params.manifestUrl || null;
 
   if (manifestUrl) {
+    try {
+      if (new URL(manifestUrl).protocol !== 'https:') {
+        logWarn(LOG_PREFIX, 'Path A: manifestUrl must use HTTPS, skipping');
+        finish();
+        return;
+      }
+    } catch (_) {
+      logWarn(LOG_PREFIX, 'Path A: invalid manifestUrl, skipping');
+      finish();
+      return;
+    }
     logInfo(LOG_PREFIX, 'Path A: fetching manifest from', manifestUrl);
     ajax(
       manifestUrl,
       {
-        success(responseText) {
+        success(responseText: string) {
           try {
             const manifest = JSON.parse(responseText);
             const payload = buildManifestPayload(manifest, manifestUrl);
@@ -359,13 +356,13 @@ const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, userConsent
           }
           finish();
         },
-        error(e) {
+        error(e: any) {
           logError(LOG_PREFIX, 'Path A: manifest fetch error', e);
           finish();
         },
       },
       null,
-      { method: 'GET', customHeaders: { Accept: 'application/json' } }
+      { method: 'GET' }
     );
     return;
   }
@@ -382,14 +379,12 @@ const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, userConsent
 
   // -- Path C: auto-sign via Encypher API ----------------------------------
 
-  // Consent gate: do not transmit page content without consent
   if (!hasConsentForDataTransmission(userConsent)) {
     logInfo(LOG_PREFIX, 'Path C: skipping, no consent for data transmission');
     finish();
     return;
   }
 
-  // Validate API base URL against allowlist
   if (!isAllowedApiUrl(apiBase + '/api/v1/public/prebid/sign')) {
     logWarn(LOG_PREFIX, 'Path C: apiBase not in allowed hosts, skipping');
     finish();
@@ -411,31 +406,29 @@ const getBidRequestData = (reqBidsConfigObj, callback, moduleConfig, userConsent
       return;
     }
 
-    const payload = {
+    const payload: C2paPayload = {
       manifest_url: resp.manifest_url,
       verified: true,
       signer_tier: resp.signer_tier || 'encypher_free',
       signed_at: resp.signed_at,
       content_hash: resp.content_hash,
       extraction_method: content.source,
+      source: 'auto',
     };
 
     writeCache(urlHash, payload);
-    deepSetValue(
-      reqBidsConfigObj.ortb2Fragments.global,
-      'site.ext.data.c2pa',
-      Object.assign({}, payload, { source: 'auto' })
-    );
+    deepSetValue(reqBidsConfigObj.ortb2Fragments.global, 'site.ext.data.c2pa', payload);
     logInfo(LOG_PREFIX, 'Path C: provenance signed and injected');
     finish();
   });
 };
 
-/** @type {import('../src/hook.js').SubmoduleConfig} */
-export const encypherSubmodule = {
-  name: MODULE_NAME,
+export const encypherSubmodule: RtdProviderSpec<'encypher'> = {
+  name: MODULE_NAME as 'encypher',
   init,
   getBidRequestData,
 };
 
 submodule(REAL_TIME_MODULE, encypherSubmodule);
+
+export { getCanonicalUrl, hashUrl };

--- a/test/spec/modules/encypherRtdProvider_spec.js
+++ b/test/spec/modules/encypherRtdProvider_spec.js
@@ -8,7 +8,7 @@ import {
   writeCache,
   extractContent,
   storage,
-} from 'modules/encypherRtdProvider.js';
+} from 'modules/encypherRtdProvider.ts';
 import { server } from 'test/mocks/xhr.js';
 
 describe('encypherRtdProvider', () => {
@@ -176,6 +176,18 @@ describe('encypherRtdProvider', () => {
       );
     });
 
+    it('rejects non-HTTPS manifest URLs', (done) => {
+      addMeta('http://publisher.com/manifest/42');
+      const req = makeReqBidsConfigObj();
+      const requestCountBefore = server.requests.length;
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        assert.strictEqual(req.ortb2Fragments.global.site, undefined);
+        assert.strictEqual(server.requests.length, requestCountBefore);
+        done();
+      }, { params: {} });
+    });
+
     it('sets verified to false when manifest status is not ok', (done) => {
       addMeta(manifestUrl);
       const badManifest = Object.assign({}, fakeManifest, { status: 'error' });
@@ -281,6 +293,21 @@ describe('encypherRtdProvider', () => {
       assert.ok(body.text.length >= 50);
       assert.ok(body.page_url);
 
+      lastReq.respond(200, fakeHeaders, JSON.stringify(fakeSignResponse));
+    });
+
+    it('does not set Content-Type: application/json or custom Accept header (CORS preflight avoidance)', (done) => {
+      addArticle('A'.repeat(100));
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        done();
+      }, { params: { apiBase: 'https://api.encypher.com' } });
+
+      const lastReq = server.requests[server.requests.length - 1];
+      const headers = lastReq.requestHeaders;
+      assert.notStrictEqual(headers['Content-Type'], 'application/json');
+      assert.strictEqual(headers['Accept'], undefined);
       lastReq.respond(200, fakeHeaders, JSON.stringify(fakeSignResponse));
     });
 
@@ -466,6 +493,56 @@ describe('encypherRtdProvider', () => {
       }, { params: {} }, null);
 
       const lastReq = server.requests[server.requests.length - 1];
+      lastReq.respond(200, fakeHeaders, JSON.stringify(fakeSignResponse));
+    });
+
+    it('skips Path C when USP string indicates opt-out (position 2 = Y)', (done) => {
+      addArticle('A'.repeat(100));
+      const req = makeReqBidsConfigObj();
+      const requestCountBefore = server.requests.length;
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        assert.strictEqual(req.ortb2Fragments.global.site, undefined);
+        assert.strictEqual(server.requests.length, requestCountBefore);
+        done();
+      }, { params: {} }, { usp: '1YYN' });
+    });
+
+    it('allows Path C when USP notice given but no opt-out', (done) => {
+      addArticle('A'.repeat(100));
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        done();
+      }, { params: { apiBase: 'https://api.encypher.com' } }, { usp: '1YNN' });
+
+      const lastReq = server.requests[server.requests.length - 1];
+      assert.strictEqual(lastReq.method, 'POST');
+      lastReq.respond(200, fakeHeaders, JSON.stringify(fakeSignResponse));
+    });
+
+    it('skips Path C when COPPA applies', (done) => {
+      addArticle('A'.repeat(100));
+      const req = makeReqBidsConfigObj();
+      const requestCountBefore = server.requests.length;
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        assert.strictEqual(req.ortb2Fragments.global.site, undefined);
+        assert.strictEqual(server.requests.length, requestCountBefore);
+        done();
+      }, { params: {} }, { coppa: true });
+    });
+
+    it('allows Path C when COPPA is false', (done) => {
+      addArticle('A'.repeat(100));
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        done();
+      }, { params: { apiBase: 'https://api.encypher.com' } }, { coppa: false });
+
+      const lastReq = server.requests[server.requests.length - 1];
+      assert.strictEqual(lastReq.method, 'POST');
       lastReq.respond(200, fakeHeaders, JSON.stringify(fakeSignResponse));
     });
 

--- a/test/spec/modules/encypherRtdProvider_spec.js
+++ b/test/spec/modules/encypherRtdProvider_spec.js
@@ -242,7 +242,7 @@ describe('encypherRtdProvider', () => {
         const c2pa = req.ortb2Fragments.global.site.ext.data.c2pa;
         assert.strictEqual(c2pa.source, 'auto');
         done();
-      }, { params: { apiBase: 'https://test.encypher.com' } });
+      }, { params: { apiBase: 'https://api.encypher.com' } });
 
       // Path C fires a POST request
       const lastReq = server.requests[server.requests.length - 1];
@@ -271,7 +271,7 @@ describe('encypherRtdProvider', () => {
         assert.strictEqual(c2pa.source, 'auto');
         assert.strictEqual(c2pa.extraction_method, 'article-element');
         done();
-      }, { params: { apiBase: 'https://test.encypher.com' } });
+      }, { params: { apiBase: 'https://api.encypher.com' } });
 
       const lastReq = server.requests[server.requests.length - 1];
       assert.strictEqual(lastReq.method, 'POST');
@@ -297,7 +297,7 @@ describe('encypherRtdProvider', () => {
         const c2pa = req.ortb2Fragments.global.site.ext.data.c2pa;
         assert.strictEqual(c2pa.extraction_method, 'json-ld');
         done();
-      }, { params: { apiBase: 'https://test.encypher.com' } });
+      }, { params: { apiBase: 'https://api.encypher.com' } });
 
       const lastReq = server.requests[server.requests.length - 1];
       const body = JSON.parse(lastReq.requestBody);
@@ -322,7 +322,7 @@ describe('encypherRtdProvider', () => {
 
       encypherSubmodule.getBidRequestData(req, () => {
         done();
-      }, { params: { apiBase: 'https://test.encypher.com' } });
+      }, { params: { apiBase: 'https://api.encypher.com' } });
 
       const lastReq = server.requests[server.requests.length - 1];
       const body = JSON.parse(lastReq.requestBody);
@@ -344,7 +344,7 @@ describe('encypherRtdProvider', () => {
 
       encypherSubmodule.getBidRequestData(req, () => {
         done();
-      }, { params: { apiBase: 'https://test.encypher.com' } });
+      }, { params: { apiBase: 'https://api.encypher.com' } });
 
       const lastReq = server.requests[server.requests.length - 1];
       const body = JSON.parse(lastReq.requestBody);
@@ -361,7 +361,7 @@ describe('encypherRtdProvider', () => {
         const c2pa = req.ortb2Fragments.global.site.ext.data.c2pa;
         assert.strictEqual(c2pa.extraction_method, 'role-main');
         done();
-      }, { params: { apiBase: 'https://test.encypher.com' } });
+      }, { params: { apiBase: 'https://api.encypher.com' } });
 
       const lastReq = server.requests[server.requests.length - 1];
       lastReq.respond(200, fakeHeaders, JSON.stringify(fakeSignResponse));
@@ -374,7 +374,7 @@ describe('encypherRtdProvider', () => {
       encypherSubmodule.getBidRequestData(req, () => {
         assert.strictEqual(req.ortb2Fragments.global.site, undefined);
         done();
-      }, { params: { apiBase: 'https://test.encypher.com' } });
+      }, { params: { apiBase: 'https://api.encypher.com' } });
 
       server.requests[server.requests.length - 1].respond(
         500, fakeHeaders, 'Internal Server Error'
@@ -388,7 +388,7 @@ describe('encypherRtdProvider', () => {
       encypherSubmodule.getBidRequestData(req, () => {
         assert.strictEqual(req.ortb2Fragments.global.site, undefined);
         done();
-      }, { params: { apiBase: 'https://test.encypher.com' } });
+      }, { params: { apiBase: 'https://api.encypher.com' } });
 
       server.requests[server.requests.length - 1].respond(
         200, fakeHeaders, JSON.stringify({ success: false, error: 'quota_exceeded' })
@@ -419,11 +419,78 @@ describe('encypherRtdProvider', () => {
         assert.strictEqual(cached.manifest_url, fakeSignResponse.manifest_url);
         assert.strictEqual(cached.signer_tier, 'encypher_free');
         done();
-      }, { params: { apiBase: 'https://test.encypher.com' } });
+      }, { params: { apiBase: 'https://api.encypher.com' } });
 
       server.requests[server.requests.length - 1].respond(
         200, fakeHeaders, JSON.stringify(fakeSignResponse)
       );
+    });
+  });
+
+  // =========================================================================
+  // Security guards
+  // =========================================================================
+
+  describe('security guards', () => {
+    it('skips Path C when GDPR applies but no consent string', (done) => {
+      addArticle('A'.repeat(100));
+      const req = makeReqBidsConfigObj();
+      const requestCountBefore = server.requests.length;
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        assert.strictEqual(req.ortb2Fragments.global.site, undefined);
+        assert.strictEqual(server.requests.length, requestCountBefore);
+        done();
+      }, { params: {} }, { gdpr: { gdprApplies: true, consentString: '' } });
+    });
+
+    it('allows Path C when GDPR applies and consent string is present', (done) => {
+      addArticle('A'.repeat(100));
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        done();
+      }, { params: {} }, { gdpr: { gdprApplies: true, consentString: 'BOEFEAyOEFEAyAHABDENAI4AAAB9vABAASA' } });
+
+      const lastReq = server.requests[server.requests.length - 1];
+      assert.strictEqual(lastReq.method, 'POST');
+      lastReq.respond(200, fakeHeaders, JSON.stringify(fakeSignResponse));
+    });
+
+    it('allows Path C when no GDPR object present', (done) => {
+      addArticle('A'.repeat(100));
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        done();
+      }, { params: {} }, null);
+
+      const lastReq = server.requests[server.requests.length - 1];
+      lastReq.respond(200, fakeHeaders, JSON.stringify(fakeSignResponse));
+    });
+
+    it('skips Path C when apiBase is not in allowed hosts', (done) => {
+      addArticle('A'.repeat(100));
+      const req = makeReqBidsConfigObj();
+      const requestCountBefore = server.requests.length;
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        assert.strictEqual(req.ortb2Fragments.global.site, undefined);
+        assert.strictEqual(server.requests.length, requestCountBefore);
+        done();
+      }, { params: { apiBase: 'https://evil.example.com' } });
+    });
+
+    it('skips Path C when apiBase uses HTTP instead of HTTPS', (done) => {
+      addArticle('A'.repeat(100));
+      const req = makeReqBidsConfigObj();
+      const requestCountBefore = server.requests.length;
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        assert.strictEqual(req.ortb2Fragments.global.site, undefined);
+        assert.strictEqual(server.requests.length, requestCountBefore);
+        done();
+      }, { params: { apiBase: 'http://api.encypher.com' } });
     });
   });
 
@@ -466,7 +533,7 @@ describe('encypherRtdProvider', () => {
         assert.ok(c2pa.extraction_method);
         assert.strictEqual(c2pa.source, 'auto');
         done();
-      }, { params: { apiBase: 'https://test.encypher.com' } });
+      }, { params: { apiBase: 'https://api.encypher.com' } });
 
       server.requests[server.requests.length - 1].respond(
         200, fakeHeaders, JSON.stringify(fakeSignResponse)

--- a/test/spec/modules/encypherRtdProvider_spec.js
+++ b/test/spec/modules/encypherRtdProvider_spec.js
@@ -1,0 +1,540 @@
+import assert from 'assert';
+import {
+  encypherSubmodule,
+  MODULE_NAME,
+  getCanonicalUrl,
+  hashUrl,
+  readCache,
+  writeCache,
+  extractContent,
+  storage,
+} from 'modules/encypherRtdProvider.js';
+import { server } from 'test/mocks/xhr.js';
+
+describe('encypherRtdProvider', () => {
+  const fakeHeaders = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+  };
+
+  const fakeManifest = {
+    status: 'ok',
+    signerTier: 'connected',
+    actions: [{ action: 'c2pa.created' }],
+    signedAt: '2026-04-01T10:00:00Z',
+  };
+
+  const fakeSignResponse = {
+    success: true,
+    manifest_url: 'https://api.encypher.com/api/v1/public/prebid/manifest/abc123',
+    signer_tier: 'encypher_free',
+    signed_at: '2026-04-01T10:00:00Z',
+    content_hash: 'a1b2c3d4e5f6',
+  };
+
+  const manifestUrl = 'https://publisher.com/wp-json/c2pa-provenance/v1/images/manifest/42';
+
+  function makeReqBidsConfigObj() {
+    return { ortb2Fragments: { global: {} } };
+  }
+
+  // -- DOM helpers ----------------------------------------------------------
+
+  let cleanups = [];
+
+  function addMeta(url) {
+    const m = document.createElement('meta');
+    m.name = 'c2pa-manifest-url';
+    m.content = url;
+    document.head.appendChild(m);
+    cleanups.push(() => m.parentNode && m.parentNode.removeChild(m));
+    return m;
+  }
+
+  function addArticle(text) {
+    const el = document.createElement('article');
+    el.textContent = text;
+    document.body.appendChild(el);
+    cleanups.push(() => el.parentNode && el.parentNode.removeChild(el));
+    return el;
+  }
+
+  function addJsonLd(data) {
+    const script = document.createElement('script');
+    script.type = 'application/ld+json';
+    script.textContent = JSON.stringify(data);
+    document.head.appendChild(script);
+    cleanups.push(() => script.parentNode && script.parentNode.removeChild(script));
+    return script;
+  }
+
+  function addMain(text) {
+    const el = document.createElement('div');
+    el.setAttribute('role', 'main');
+    el.textContent = text;
+    document.body.appendChild(el);
+    cleanups.push(() => el.parentNode && el.parentNode.removeChild(el));
+    return el;
+  }
+
+  function clearStorageKey() {
+    try { localStorage.removeItem('encypher_provenance_v1'); } catch (_) {}
+  }
+
+  afterEach(() => {
+    cleanups.forEach(fn => fn());
+    cleanups = [];
+    clearStorageKey();
+  });
+
+  // =========================================================================
+  // init
+  // =========================================================================
+
+  describe('init', () => {
+    it('returns true', () => {
+      assert.strictEqual(encypherSubmodule.init({}), true);
+    });
+
+    it('has the correct module name', () => {
+      assert.strictEqual(encypherSubmodule.name, 'encypher');
+      assert.strictEqual(MODULE_NAME, 'encypher');
+    });
+
+    it('exposes getBidRequestData', () => {
+      assert.strictEqual(typeof encypherSubmodule.getBidRequestData, 'function');
+    });
+  });
+
+  // =========================================================================
+  // Path A -- CMS meta tag
+  // =========================================================================
+
+  describe('Path A -- CMS meta tag', () => {
+    it('fetches manifest from meta tag and injects site.ext.data.c2pa', (done) => {
+      addMeta(manifestUrl);
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        const c2pa = req.ortb2Fragments.global.site.ext.data.c2pa;
+        assert.strictEqual(c2pa.manifest_url, manifestUrl);
+        assert.strictEqual(c2pa.verified, true);
+        assert.strictEqual(c2pa.signer_tier, 'connected');
+        assert.strictEqual(c2pa.action, 'c2pa.created');
+        assert.strictEqual(c2pa.signed_at, '2026-04-01T10:00:00Z');
+        assert.strictEqual(c2pa.source, 'cms');
+        done();
+      }, { params: {} });
+
+      server.requests[server.requests.length - 1].respond(
+        200, fakeHeaders, JSON.stringify(fakeManifest)
+      );
+    });
+
+    it('uses params.manifestUrl when meta tag is absent', (done) => {
+      const configUrl = 'https://example.com/manifest/99';
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        const c2pa = req.ortb2Fragments.global.site.ext.data.c2pa;
+        assert.strictEqual(c2pa.manifest_url, configUrl);
+        assert.strictEqual(c2pa.verified, true);
+        assert.strictEqual(c2pa.source, 'cms');
+        done();
+      }, { params: { manifestUrl: configUrl } });
+
+      server.requests[server.requests.length - 1].respond(
+        200, fakeHeaders, JSON.stringify(fakeManifest)
+      );
+    });
+
+    it('calls callback on HTTP 500 without injecting (fail-open)', (done) => {
+      addMeta(manifestUrl);
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        assert.strictEqual(req.ortb2Fragments.global.site, undefined);
+        done();
+      }, { params: {} });
+
+      server.requests[server.requests.length - 1].respond(
+        500, fakeHeaders, 'Internal Server Error'
+      );
+    });
+
+    it('calls callback on malformed JSON without throwing', (done) => {
+      addMeta(manifestUrl);
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        assert.strictEqual(req.ortb2Fragments.global.site, undefined);
+        done();
+      }, { params: {} });
+
+      server.requests[server.requests.length - 1].respond(
+        200, fakeHeaders, 'not-json'
+      );
+    });
+
+    it('sets verified to false when manifest status is not ok', (done) => {
+      addMeta(manifestUrl);
+      const badManifest = Object.assign({}, fakeManifest, { status: 'error' });
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        const c2pa = req.ortb2Fragments.global.site.ext.data.c2pa;
+        assert.strictEqual(c2pa.verified, false);
+        done();
+      }, { params: {} });
+
+      server.requests[server.requests.length - 1].respond(
+        200, fakeHeaders, JSON.stringify(badManifest)
+      );
+    });
+  });
+
+  // =========================================================================
+  // Path B -- cache hit
+  // =========================================================================
+
+  describe('Path B -- cache hit', () => {
+    it('injects from cache with source "cache" and makes no XHR', (done) => {
+      const cachedPayload = {
+        manifest_url: 'https://api.encypher.com/manifest/cached',
+        verified: true,
+        signer_tier: 'encypher_free',
+        signed_at: '2026-03-31T00:00:00Z',
+        content_hash: 'deadbeef',
+      };
+      const urlHash = hashUrl(getCanonicalUrl());
+      writeCache(urlHash, cachedPayload);
+
+      const req = makeReqBidsConfigObj();
+      const requestCountBefore = server.requests.length;
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        const c2pa = req.ortb2Fragments.global.site.ext.data.c2pa;
+        assert.strictEqual(c2pa.manifest_url, 'https://api.encypher.com/manifest/cached');
+        assert.strictEqual(c2pa.source, 'cache');
+        assert.strictEqual(c2pa.signer_tier, 'encypher_free');
+        // No new XHR requests
+        assert.strictEqual(server.requests.length, requestCountBefore);
+        done();
+      }, { params: {} });
+    });
+
+    it('falls through to Path C when cache entry is expired', (done) => {
+      // Write an expired cache entry
+      const urlHash = hashUrl(getCanonicalUrl());
+      const raw = {};
+      raw[urlHash] = {
+        payload: { manifest_url: 'https://old.com/manifest' },
+        expires_at: Date.now() - 1000, // expired
+      };
+      localStorage.setItem('encypher_provenance_v1', JSON.stringify(raw));
+
+      // Add article content so Path C has something to sign
+      addArticle('A'.repeat(100));
+
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        const c2pa = req.ortb2Fragments.global.site.ext.data.c2pa;
+        assert.strictEqual(c2pa.source, 'auto');
+        done();
+      }, { params: { apiBase: 'https://test.encypher.com' } });
+
+      // Path C fires a POST request
+      const lastReq = server.requests[server.requests.length - 1];
+      assert.strictEqual(lastReq.method, 'POST');
+      lastReq.respond(200, fakeHeaders, JSON.stringify(fakeSignResponse));
+    });
+  });
+
+  // =========================================================================
+  // Path C -- auto-sign
+  // =========================================================================
+
+  describe('Path C -- auto-sign', () => {
+    it('extracts <article> text and signs via API', (done) => {
+      const articleText = 'This is a real article with enough content to pass the minimum length threshold for extraction.';
+      addArticle(articleText);
+
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        const c2pa = req.ortb2Fragments.global.site.ext.data.c2pa;
+        assert.strictEqual(c2pa.manifest_url, fakeSignResponse.manifest_url);
+        assert.strictEqual(c2pa.verified, true);
+        assert.strictEqual(c2pa.signer_tier, 'encypher_free');
+        assert.strictEqual(c2pa.content_hash, 'a1b2c3d4e5f6');
+        assert.strictEqual(c2pa.source, 'auto');
+        assert.strictEqual(c2pa.extraction_method, 'article-element');
+        done();
+      }, { params: { apiBase: 'https://test.encypher.com' } });
+
+      const lastReq = server.requests[server.requests.length - 1];
+      assert.strictEqual(lastReq.method, 'POST');
+      assert.ok(lastReq.url.includes('/api/v1/public/prebid/sign'));
+
+      const body = JSON.parse(lastReq.requestBody);
+      assert.ok(body.text.length >= 50);
+      assert.ok(body.page_url);
+
+      lastReq.respond(200, fakeHeaders, JSON.stringify(fakeSignResponse));
+    });
+
+    it('prefers JSON-LD articleBody over <article> element', (done) => {
+      addJsonLd({
+        '@type': 'NewsArticle',
+        articleBody: 'This is the JSON-LD article body which should take priority over the article element text content.',
+      });
+      addArticle('This is the fallback article element text that should not be used when JSON-LD is available.');
+
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        const c2pa = req.ortb2Fragments.global.site.ext.data.c2pa;
+        assert.strictEqual(c2pa.extraction_method, 'json-ld');
+        done();
+      }, { params: { apiBase: 'https://test.encypher.com' } });
+
+      const lastReq = server.requests[server.requests.length - 1];
+      const body = JSON.parse(lastReq.requestBody);
+      assert.ok(body.text.includes('JSON-LD article body'));
+      lastReq.respond(200, fakeHeaders, JSON.stringify(fakeSignResponse));
+    });
+
+    it('sends JSON-LD metadata in the sign request body', (done) => {
+      addJsonLd({
+        '@type': 'NewsArticle',
+        articleBody: 'This article body is long enough to pass the minimum content length threshold for extraction.',
+        author: { '@type': 'Person', name: 'Jane Reporter' },
+        datePublished: '2026-04-25T09:00:00Z',
+        articleSection: 'Technology',
+        wordCount: 1200,
+        keywords: ['AI', 'provenance', 'publishing'],
+        publisher: { '@type': 'Organization', name: 'Example News' },
+        inLanguage: 'en',
+      });
+
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        done();
+      }, { params: { apiBase: 'https://test.encypher.com' } });
+
+      const lastReq = server.requests[server.requests.length - 1];
+      const body = JSON.parse(lastReq.requestBody);
+      assert.ok(body.metadata);
+      assert.strictEqual(body.metadata.author, 'Jane Reporter');
+      assert.strictEqual(body.metadata.datePublished, '2026-04-25T09:00:00Z');
+      assert.strictEqual(body.metadata.section, 'Technology');
+      assert.strictEqual(body.metadata.wordCount, 1200);
+      assert.strictEqual(body.metadata.keywords, 'AI,provenance,publishing');
+      assert.strictEqual(body.metadata.publisher, 'Example News');
+      assert.strictEqual(body.metadata.language, 'en');
+      lastReq.respond(200, fakeHeaders, JSON.stringify(fakeSignResponse));
+    });
+
+    it('does not send metadata field when extraction is from <article> element', (done) => {
+      addArticle('This is plain article element text with enough content to pass the minimum length threshold.');
+
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        done();
+      }, { params: { apiBase: 'https://test.encypher.com' } });
+
+      const lastReq = server.requests[server.requests.length - 1];
+      const body = JSON.parse(lastReq.requestBody);
+      assert.strictEqual(body.metadata, undefined);
+      lastReq.respond(200, fakeHeaders, JSON.stringify(fakeSignResponse));
+    });
+
+    it('uses [role="main"] when no <article> element', (done) => {
+      addMain('This is the main content area that serves as a fallback when no article element is present on the page.');
+
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        const c2pa = req.ortb2Fragments.global.site.ext.data.c2pa;
+        assert.strictEqual(c2pa.extraction_method, 'role-main');
+        done();
+      }, { params: { apiBase: 'https://test.encypher.com' } });
+
+      const lastReq = server.requests[server.requests.length - 1];
+      lastReq.respond(200, fakeHeaders, JSON.stringify(fakeSignResponse));
+    });
+
+    it('calls callback on API error without injecting (fail-open)', (done) => {
+      addArticle('A'.repeat(100));
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        assert.strictEqual(req.ortb2Fragments.global.site, undefined);
+        done();
+      }, { params: { apiBase: 'https://test.encypher.com' } });
+
+      server.requests[server.requests.length - 1].respond(
+        500, fakeHeaders, 'Internal Server Error'
+      );
+    });
+
+    it('calls callback on API success with success=false (fail-open)', (done) => {
+      addArticle('A'.repeat(100));
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        assert.strictEqual(req.ortb2Fragments.global.site, undefined);
+        done();
+      }, { params: { apiBase: 'https://test.encypher.com' } });
+
+      server.requests[server.requests.length - 1].respond(
+        200, fakeHeaders, JSON.stringify({ success: false, error: 'quota_exceeded' })
+      );
+    });
+
+    it('calls callback without signing when no extractable content', (done) => {
+      // No article, no JSON-LD, no [role="main"]
+      const req = makeReqBidsConfigObj();
+      const requestCountBefore = server.requests.length;
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        assert.strictEqual(req.ortb2Fragments.global.site, undefined);
+        assert.strictEqual(server.requests.length, requestCountBefore);
+        done();
+      }, { params: {} });
+    });
+
+    it('writes to cache after successful signing', (done) => {
+      addArticle('A'.repeat(100));
+      const urlHash = hashUrl(getCanonicalUrl());
+
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        const cached = readCache(urlHash);
+        assert.ok(cached);
+        assert.strictEqual(cached.manifest_url, fakeSignResponse.manifest_url);
+        assert.strictEqual(cached.signer_tier, 'encypher_free');
+        done();
+      }, { params: { apiBase: 'https://test.encypher.com' } });
+
+      server.requests[server.requests.length - 1].respond(
+        200, fakeHeaders, JSON.stringify(fakeSignResponse)
+      );
+    });
+  });
+
+  // =========================================================================
+  // Payload shape
+  // =========================================================================
+
+  describe('payload shape', () => {
+    it('Path A payload has expected fields', (done) => {
+      addMeta(manifestUrl);
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        const c2pa = req.ortb2Fragments.global.site.ext.data.c2pa;
+        const keys = Object.keys(c2pa).sort();
+        assert.ok(keys.includes('manifest_url'));
+        assert.ok(keys.includes('verified'));
+        assert.ok(keys.includes('signer_tier'));
+        assert.ok(keys.includes('source'));
+        assert.strictEqual(c2pa.source, 'cms');
+        done();
+      }, { params: {} });
+
+      server.requests[server.requests.length - 1].respond(
+        200, fakeHeaders, JSON.stringify(fakeManifest)
+      );
+    });
+
+    it('Path C payload has expected fields including extraction_method', (done) => {
+      addArticle('A'.repeat(100));
+      const req = makeReqBidsConfigObj();
+
+      encypherSubmodule.getBidRequestData(req, () => {
+        const c2pa = req.ortb2Fragments.global.site.ext.data.c2pa;
+        assert.ok(c2pa.manifest_url);
+        assert.strictEqual(c2pa.verified, true);
+        assert.ok(c2pa.signer_tier);
+        assert.ok(c2pa.signed_at);
+        assert.ok(c2pa.content_hash);
+        assert.ok(c2pa.extraction_method);
+        assert.strictEqual(c2pa.source, 'auto');
+        done();
+      }, { params: { apiBase: 'https://test.encypher.com' } });
+
+      server.requests[server.requests.length - 1].respond(
+        200, fakeHeaders, JSON.stringify(fakeSignResponse)
+      );
+    });
+  });
+
+  // =========================================================================
+  // Utility functions
+  // =========================================================================
+
+  describe('utilities', () => {
+    it('hashUrl returns consistent hex string', () => {
+      const h1 = hashUrl('https://example.com/article/1');
+      const h2 = hashUrl('https://example.com/article/1');
+      assert.strictEqual(h1, h2);
+      assert.ok(/^[0-9a-f]+$/.test(h1));
+    });
+
+    it('hashUrl produces different hashes for different URLs', () => {
+      const h1 = hashUrl('https://example.com/article/1');
+      const h2 = hashUrl('https://example.com/article/2');
+      assert.notStrictEqual(h1, h2);
+    });
+
+    it('extractContent returns null when no content elements exist', () => {
+      assert.strictEqual(extractContent(), null);
+    });
+
+    it('extractContent skips short content (<50 chars)', () => {
+      addArticle('Short text');
+      assert.strictEqual(extractContent(), null);
+    });
+
+    it('extractContent returns metadata from JSON-LD', () => {
+      addJsonLd({
+        '@type': 'Article',
+        articleBody: 'A'.repeat(100),
+        author: 'John Smith',
+        datePublished: '2026-04-20',
+        articleSection: 'Science',
+      });
+      const result = extractContent();
+      assert.ok(result);
+      assert.strictEqual(result.source, 'json-ld');
+      assert.ok(result.metadata);
+      assert.strictEqual(result.metadata.author, 'John Smith');
+      assert.strictEqual(result.metadata.datePublished, '2026-04-20');
+      assert.strictEqual(result.metadata.section, 'Science');
+    });
+
+    it('extractContent returns null metadata for <article> element', () => {
+      addArticle('A'.repeat(100));
+      const result = extractContent();
+      assert.ok(result);
+      assert.strictEqual(result.source, 'article-element');
+      assert.strictEqual(result.metadata, null);
+    });
+
+    it('extractContent handles author as array of Person objects', () => {
+      addJsonLd({
+        '@type': 'NewsArticle',
+        articleBody: 'A'.repeat(100),
+        author: [{ '@type': 'Person', name: 'First Author' }, { '@type': 'Person', name: 'Second Author' }],
+      });
+      const result = extractContent();
+      assert.ok(result.metadata);
+      assert.strictEqual(result.metadata.author, 'First Author');
+    });
+  });
+});


### PR DESCRIPTION
## Type of change

- [x] Feature

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change

New Real-Time Data submodule that injects C2PA content provenance signals into OpenRTB bid requests at `site.ext.data.c2pa`. This gives DSPs a cryptographic content-integrity signal they can use for brand safety and inventory quality decisioning.

**Three execution paths (strict priority):**

1. **Path A (CMS):** Reads `<meta name="c2pa-manifest-url">` or `params.manifestUrl`. Fetches the manifest and injects verification status, signer tier, and timestamp.
2. **Path B (Cache):** Serves previously signed provenance from localStorage (30-day TTL). No network call.
3. **Path C (Auto-sign):** Extracts article text from the DOM (JSON-LD > `<article>` > `[role="main"]`), signs it via Encypher's public API, caches the result, and injects provenance data.

**Key properties:**
- No external scripts loaded (Prebid.js core imports only)
- Every code path calls `callback()` -- never blocks an auction
- GDPR-compliant via Prebid `getStorageManager`
- Free tier: 1,000 unique content signatures per publisher domain per month
- Deduped by content hash (re-requests do not count against quota)
- Quota exceeded fails open gracefully (no provenance injected, auction continues)

**Maintainer contact:** github@encypher.com

**Test parameters:**
```javascript
pbjs.setConfig({
  realTimeData: {
    auctionDelay: 300,
    dataProviders: [{
      name: 'encypher',
      waitForIt: true,
      params: {
        // All optional. Free tier works with zero config.
        apiBase: 'https://api.encypher.com',
        manifestUrl: 'https://...'  // manual override (skips Path B/C)
      }
    }]
  }
});
```

## Other information

Encypher is the commercial implementer behind C2PA Section A.7 (text provenance). This module enables publishers to attach verifiable content-integrity signals to their programmatic inventory at zero cost and zero configuration.

A docs PR will be submitted to prebid/prebid.github.io with the RTD provider documentation.