### PR TITLE
Alliance Gravity: update of parameter name

### DIFF
--- a/modules/alliance_gravityBidAdapter.md
+++ b/modules/alliance_gravityBidAdapter.md
@@ -25,7 +25,7 @@ var adUnits = [
     bids: [{
         bidder: 'alliance_gravity',
         params: {
-          srid: "test-id"
+          placementId: "test-id"
         }
       }]
   },

--- a/modules/alliance_gravityBidAdapter.ts
+++ b/modules/alliance_gravityBidAdapter.ts
@@ -16,7 +16,7 @@ const DEFAULT_GZIP_ENABLED = false;
 
 declare module '../src/adUnits' {
   interface BidderParams {
-    srid: string
+    placementId: string
   }
 }
 
@@ -37,7 +37,7 @@ const converter = ortbConverter({
       deepSetValue(imp, 'ext.dimensions.cssMaxW', slotEl.style?.maxWidth);
       deepSetValue(imp, 'ext.dimensions.cssMaxH', slotEl.style?.maxHeight);
     }
-    deepSetValue(imp, 'ext.prebid.storedrequest.id', bidRequest.params.srid);
+    deepSetValue(imp, 'ext.prebid.storedrequest.id', bidRequest.params.placementId);
     return imp;
   },
   request(buildRequest, imps, bidderRequest, context) {
@@ -46,7 +46,7 @@ const converter = ortbConverter({
 });
 
 const isBidRequestValid = (bid:BidRequest<typeof BIDDER_CODE>): boolean => {
-  if (!bid.params.srid || typeof bid.params.srid !== 'string' || bid.params.srid === '') {
+  if (!bid.params.placementId || typeof bid.params.placementId !== 'string' || bid.params.placementId === '') {
     return false;
   }
   return true;

--- a/test/spec/modules/alliance_gravityBidAdapter_spec.js
+++ b/test/spec/modules/alliance_gravityBidAdapter_spec.js
@@ -31,28 +31,28 @@ describe('Alliance Gravity bid adapter tests', () => {
       }
     });
 
-    it('No srid', () => {
+    it('No placementId', () => {
       bannerBid.params = {};
       expect(spec.isBidRequestValid(bannerBid)).to.be.equal(false);
     });
 
-    it('Invalid srid type (number)', () => {
-      bannerBid.params = { srid: 1234 };
+    it('Invalid placementId type (number)', () => {
+      bannerBid.params = { placementId: 1234 };
       expect(spec.isBidRequestValid(bannerBid)).to.be.equal(false);
     });
 
-    it('Invalid srid type (object', () => {
-      bannerBid.params = { srid: {} };
+    it('Invalid placementId type (object)', () => {
+      bannerBid.params = { placementId: {} };
       expect(spec.isBidRequestValid(bannerBid)).to.be.equal(false);
     });
 
-    it('Empty srid', () => {
-      bannerBid.params = { srid: '' };
+    it('Empty placementId', () => {
+      bannerBid.params = { placementId: '' };
       expect(spec.isBidRequestValid(bannerBid)).to.be.equal(false);
     });
 
-    it('Valid srid', () => {
-      bannerBid.params = { srid: '12345' };
+    it('Valid placementId', () => {
+      bannerBid.params = { placementId: '12345' };
       expect(spec.isBidRequestValid(bannerBid)).to.be.equal(true);
     });
   });
@@ -75,7 +75,7 @@ describe('Alliance Gravity bid adapter tests', () => {
         {
           bidder: 'alliance_gravity',
           params: {
-            srid: "12345"
+            placementId: "12345"
           },
           adUnitCode: 'header-ad-1234',
           transactionId: '469a570d-f187-488d-b1cb-48c1a2009be9',
@@ -87,7 +87,7 @@ describe('Alliance Gravity bid adapter tests', () => {
         {
           bidder: 'alliance_gravity',
           params: {
-            srid: '67890',
+            placementId: '67890',
           },
           mediaTypes: {
             banner: {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

This PR updates the name of a parameter. No technical changes are involved otherwise.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information

https://github.com/prebid/prebid.github.io/pull/6547
https://github.com/prebid/prebid-server/pull/4757
