### PR TITLE
Github Actions: auto-label module source file additions as feature

### DIFF
--- a/.github/workflows/PR-assignment.yml
+++ b/.github/workflows/PR-assignment.yml
@@ -65,3 +65,17 @@ jobs:
             const assignReviewers = require('./.github/workflows/scripts/assignReviewers.js')
             const reviewers = await assignReviewers({github, context, prData: ${{ steps.get-props.outputs.result }} });
             console.log('Assigned reviewers:', JSON.stringify(reviewers, null, 2));
+      - name: Add feature label
+        if: ${{ fromJSON(steps.get-props.outputs.result).labels.feature }}
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ steps.token.outputs.token }}
+          script: |
+            const prNo = ${{ fromJSON(steps.get-props.outputs.result).pr }};
+            await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/labels', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNo,
+              labels: ['feature']
+            });
+            console.log(`Feature label applied to PR #${prNo}`);

--- a/.github/workflows/scripts/getPRProperties.js
+++ b/.github/workflows/scripts/getPRProperties.js
@@ -14,6 +14,9 @@ const EXCLUDE_PATTERNS = [
   /^integrationExamples\//
 ]
 const LIBRARY_PATTERN = /^libraries\/([^\/]+)\//;
+const MODULE_SOURCE_FILE_PATTERN = /^modules\/.*\.(js|ts)$/;
+const MODULE_TYPES_FILE_PATTERN = /^modules\/.*\.d\.ts$/;
+const ADAPTER_TYPES_DEFINITION_FILE_PATTERN = /^modules\/([^\/]+)(Bid|Analytics|Rtd|Id)AdapterTypes\.d\.ts$/;
 
 function extractVendor(chunkName) {
   for (const pat of MODULE_PATTERNS) {
@@ -51,6 +54,18 @@ function isCoreFile(path) {
     // a library is "core" if it's used by more than one vendor
     return getLibraryRefs(lib[1]).size > 1;
   }
+  return true;
+}
+
+function requiresFeatureLabel(path) {
+  if (!MODULE_SOURCE_FILE_PATTERN.test(path)) {
+    return false;
+  }
+
+  if (MODULE_TYPES_FILE_PATTERN.test(path)) {
+    return !ADAPTER_TYPES_DEFINITION_FILE_PATTERN.test(path);
+  }
+
   return true;
 }
 
@@ -92,7 +107,15 @@ async function getPRProperties({github, context, prNo, reviewerTeam, engTeam, au
   prebidEngineers = prebidEngineers.data.map(datum=> datum.login);
   authorizedReviewers = authorizedReviewers.data.map(datum=> datum.login);
   let isCoreChange = false;
-  files = files.data.map(datum => datum.filename).map(file => {
+  let shouldAddFeatureLabel = false;
+  files = files.data
+    .filter(datum => datum.status === 'added' || datum.status === 'renamed')
+    .map(datum => datum.filename)
+    .map(file => {
+      if (requiresFeatureLabel(file)) {
+        shouldAddFeatureLabel = true;
+      }
+
     const core = isCoreFile(file);
     if (core) isCoreChange = true;
     return {
@@ -143,6 +166,9 @@ async function getPRProperties({github, context, prNo, reviewerTeam, engTeam, au
     prebidReviewers,
     prebidEngineers,
     review,
+    labels: {
+      feature: shouldAddFeatureLabel,
+    }
   }
   data.review.requires = reviewRequirements(data);
   data.review.ok = satisfiesReviewRequirements(data.review);


### PR DESCRIPTION
### Motivation
- Automatically mark PRs that add new module source files as `feature` to ensure new modules are surfaced in release notes while excluding adapter type-definition additions that shouldn't be treated as new functionality.
