### PR TITLE
Core: add release drafter category for core-tagged PRs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,6 +6,9 @@ autolabeler:
     title:
       - '/^(?!.*(bug|initial|release|fix)).*$/i'
 categories:
+  - title: '🏛 Core PRs'
+    labels:
+      - 'core'
   - title: '🚀 New Features'
     label: 'feature'
   - title: '🐛 Bug Fixes'
@@ -13,9 +16,6 @@ categories:
       - 'fix'
       - 'bugfix'
       - 'bug'
-  - title: '🏛 Core PRs'
-    labels:
-      - 'core'
   - title: '🛠 Maintenance'
     labels: []
 change-template: '- $TITLE (#$NUMBER)'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,6 +13,9 @@ categories:
       - 'fix'
       - 'bugfix'
       - 'bug'
+  - title: '🏛 Core PRs'
+    labels:
+      - 'core'
   - title: '🛠 Maintenance'
     labels: []
 change-template: '- $TITLE (#$NUMBER)'


### PR DESCRIPTION
### Motivation
- Ensure PRs labeled `core` are grouped explicitly in generated release notes so core repository changes are clearly visible in releases.

### Description
- Add a new `🏛 Core PRs` category with the `core` label to `.github/release-drafter.yml` so release drafter includes core-tagged PRs in their own section.

### Testing
- No automated tests were run for this configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f21dd74b0c832bab4903010eb484c8)