### PR TITLE
Core: replace body-parser usage with express parsers

### DIFF
--- a/integrationExamples/topics/topics-server.js
+++ b/integrationExamples/topics/topics-server.js
@@ -1,7 +1,6 @@
 // This is an example of a server-side endpoint that is utilizing the Topics API header functionality.
-// Note: This test endpoint requires the following to run: node.js, npm, express, cors, body-parser
+// Note: This test endpoint requires the following to run: node.js, npm, express, cors
 
-const bodyParser = require('body-parser');
 const cors = require('cors');
 const express = require('express');
 
@@ -10,11 +9,11 @@ const port = process.env.PORT || 3000;
 const app = express();
 app.use(cors());
 app.use(
-  bodyParser.urlencoded({
+  express.urlencoded({
     extended: true,
   })
 );
-app.use(bodyParser.json());
+app.use(express.json());
 app.use(express.static('public'));
 app.set('port', port);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "assert": "^2.0.0",
         "babel-loader": "^8.4.1",
         "babel-plugin-istanbul": "^6.1.1",
-        "body-parser": "^1.19.0",
         "chai": "^4.2.0",
         "deep-equal": "^2.0.3",
         "eslint": "^9.31.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "assert": "^2.0.0",
     "babel-loader": "^8.4.1",
     "babel-plugin-istanbul": "^6.1.1",
-    "body-parser": "^1.19.0",
     "chai": "^4.2.0",
     "deep-equal": "^2.0.3",
     "eslint": "^9.31.0",

--- a/test/fake-server/index.js
+++ b/test/fake-server/index.js
@@ -2,7 +2,6 @@
 
 const express = require('express');
 const morgan = require('morgan');
-const bodyParser = require('body-parser');
 const argv = require('yargs').argv;
 const fakeResponder = require('./fake-responder.js');
 const bundleMaker = require('./bundle.js');
@@ -13,9 +12,9 @@ const PORT = argv.port || '4444';
 const app = express();
 
 // Middlewares
-app.use(bodyParser.urlencoded({ extended: false }));
-app.use(bodyParser.json());
-app.use(bodyParser.text({ type: 'text/plain' }));
+app.use(express.urlencoded({ extended: false }));
+app.use(express.json());
+app.use(express.text({ type: 'text/plain' }));
 app.use(morgan('dev')); // used to log incoming requests
 
 // Allow Cross Origin request from 'test.localhost:9999'


### PR DESCRIPTION
### Motivation
- Remove the direct `body-parser` devDependency and use the built-in Express body parsing middleware to simplify local test/example servers and reduce external dependency surface. 
- Keep the fake and example servers functioning the same while aligning with modern Express usage and repo dependency hygiene.
