### PR TITLE
relayBidAdapter.js: remove gvl id

### DIFF
--- a/modules/relayBidAdapter.js
+++ b/modules/relayBidAdapter.js
@@ -5,7 +5,6 @@ import { BANNER, VIDEO, NATIVE } from '../src/mediaTypes.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js'
 
 const BIDDER_CODE = 'relay';
-const GVLID = 631;
 const METHOD = 'POST';
 const ENDPOINT_URL = 'https://e.relay.bid/p/openrtb2';
 

--- a/modules/relayBidAdapter.js
+++ b/modules/relayBidAdapter.js
@@ -81,7 +81,6 @@ function getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent) {
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: GVLID,
   isBidRequestValid,
   buildRequests,
   interpretResponse,


### PR DESCRIPTION
631 deleted on 4.27

https://vendor-list.consensu.org/v3/vendor-list.json

"631": {"id": 631, "name": "Relay42 Netherlands B.V.", "purposes": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11], "legIntPurposes": [], "flexiblePurposes": [], "specialPurposes": [], "features": [1, 2], "specialFeatures": [2], "deletedDate": "2026-04-27T08:52:09.013Z", "cookieMaxAgeSeconds": 63072000, "usesCookies": true, "cookieRefresh": false, "urls": [{"langId": "en", "privacy": "https://relay42.com/privacy", "legIntClaim": ""}], "usesNonCookieAccess": false, "dataRetention": {"stdRetention": 1096, "purposes": {}, "specialPurposes": {}}, "dataDeclaration": [1, 2, 3, 4, 6, 7, 10, 11], "deviceStorageDisclosureUrl": "https://relay42.com/hubfs/raw_assets/public/IAB.json"}, 