### PR TITLE
MSFT Bid Adapter - support video.placement and video.plcmt

### DIFF
--- a/modules/msftBidAdapter.js
+++ b/modules/msftBidAdapter.js
@@ -146,11 +146,6 @@ const converter = ortbConverter({
       if (deepAccess(bidRequest, 'mediaTypes.video.context') === 'instream') {
         extANData.require_asset_url = true;
       }
-
-      if (imp.video.plcmt) {
-        imp.video.placement = imp.video.plcmt;
-        delete imp.video.plcmt;
-      }
     }
 
     if (bidderParams) {

--- a/test/spec/modules/msftBidAdapter_spec.js
+++ b/test/spec/modules/msftBidAdapter_spec.js
@@ -231,6 +231,7 @@ describe('msftBidAdapter', function () {
                 [640, 480]
               ],
               plcmt: 4,
+              placement: 1,
               mimes: ['video/mp4'],
               protocols: [2, 3],
               api: [2]
@@ -248,7 +249,8 @@ describe('msftBidAdapter', function () {
         expect(data).to.exist;
         expect(data.imp).to.have.lengthOf(1);
         expect(data.imp[0].video).to.exist;
-        expect(data.imp[0].video.placement).to.equal(4);
+        expect(data.imp[0].video.plcmt).to.equal(4);
+        expect(data.imp[0].video.placement).to.equal(1);
         expect(data.imp[0].video.w).to.equal(640);
         expect(data.imp[0].video.h).to.equal(480);
         expect(data.imp[0].ext.appnexus.require_asset_url).to.be.true;
@@ -545,6 +547,7 @@ describe('msftBidAdapter', function () {
             ],
             "w": 640,
             "h": 360,
+            "plcmt": 4,
             "placement": 1,
             "maxextended": -1,
             "boxingallowed": 1,
@@ -594,6 +597,7 @@ describe('msftBidAdapter', function () {
               ]
             ],
             "context": "instream",
+            "plcmt": 4,
             "placement": 1,
             "startdelay": 0
           }
@@ -825,7 +829,8 @@ describe('msftBidAdapter', function () {
             ],
             "w": 640,
             "h": 480,
-            "plcmt": 4
+            "plcmt": 4,
+            "placement": 1
           },
           "ext": {
             "data": {
@@ -858,6 +863,7 @@ describe('msftBidAdapter', function () {
               8
             ],
             "plcmt": 4,
+            "placement": 1,
             "w": 640,
             "h": 480
           }


### PR DESCRIPTION

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature


## Description of change
With some new changes on back-end, our MSFT adapter's endpoint is now capable of supporting both video.plcmt and video.placement fields.  I am removing the extra logic in the adapter for these fields, so that the publisher's values will just pass through as they defined in the outgoing request.
