### PR TITLE
TeqBlaze demo adapter: map override to metadata component

### DIFF
--- a/metadata/overrides.mjs
+++ b/metadata/overrides.mjs
@@ -16,5 +16,6 @@ export default {
   operaadsIdSystem: 'operaId',
   relevadRtdProvider: 'RelevadRTDModule',
   sirdataRtdProvider: 'SirdataRTDModule',
-  fanBidAdapter: 'freedomadnetwork'
+  fanBidAdapter: 'freedomadnetwork',
+  teqBlazeDemoBidAdapter: 'tqblz_demo'
 }


### PR DESCRIPTION
### Motivation
- The metadata compilation step could not associate the new teqBlaze demo module file with its extracted bidder metadata, causing build failures during `gulp update-metadata`/`compile-metadata`.

### Description
- Add an override mapping in `metadata/overrides.mjs` that maps `teqBlazeDemoBidAdapter` to the bidder code `tqblz_demo` so the compiler can resolve the module to its metadata.

### Testing
- Ran `npx gulp lint` which completed successfully; `npx gulp compile-metadata` could not finish in this environment due to a network fetch error (`TypeError: fetch failed`) while attempting to fetch remote disclosure/GVL resources.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fabbfbdc30832ba466508c2663a9a5)