### PR TITLE
Adagio RTD: stop stubbing Date.now in specs

### DIFF
--- a/test/spec/modules/adagioRtdProvider_spec.js
+++ b/test/spec/modules/adagioRtdProvider_spec.js
@@ -151,7 +151,7 @@ describe('Adagio Rtd Provider', function () {
       it('store new session data for further usage', function () {
         const storageValue = JSON.stringify({ abTest: {} });
         setStorageMethod('getDataFromLocalStorage', (key, cb) => cb(storageValue));
-        sandbox.stub(Date, 'now').returns(1714116520710);
+        clock.setSystemTime(1714116520710);
         sandbox.stub(Math, 'random').returns(0.8);
         sandbox.stub(utils, 'generateUUID').returns('uid-1234');
 
@@ -179,7 +179,7 @@ describe('Adagio Rtd Provider', function () {
       it('store existing session data for further usage', function () {
         const storageValue = JSON.stringify({ session: session, abTest: {} });
         setStorageMethod('getDataFromLocalStorage', (key, cb) => cb(storageValue));
-        sandbox.stub(Date, 'now').returns(1714116520710);
+        clock.setSystemTime(1714116520710);
         sandbox.stub(Math, 'random').returns(0.8);
 
         const spy = sandbox.spy(_internal.getAdagioNs().queue, 'push')
@@ -202,7 +202,7 @@ describe('Adagio Rtd Provider', function () {
 
       it('store new session if old session has expired data for further usage', function () {
         const storageValue = JSON.stringify({ session: session, abTest: {} });
-        sandbox.stub(Date, 'now').returns(1715679344351);
+        clock.setSystemTime(1715679344351);
         setStorageMethod('getDataFromLocalStorage', (key, cb) => cb(storageValue));
         sandbox.stub(Math, 'random').returns(0.8);
         sandbox.stub(utils, 'generateUUID').returns('uid-5678');
@@ -231,7 +231,7 @@ describe('Adagio Rtd Provider', function () {
       it('store new session data for further usage', function () {
         const storageValue = null;
         setStorageMethod('getDataFromLocalStorage', (key, cb) => cb(storageValue));
-        sandbox.stub(Date, 'now').returns(1714116520710);
+        clock.setSystemTime(1714116520710);
         sandbox.stub(Math, 'random').returns(0.8);
         sandbox.stub(utils, 'generateUUID').returns('uid-1234');
 
@@ -268,7 +268,7 @@ describe('Adagio Rtd Provider', function () {
           }
         });
         setStorageMethod('getDataFromLocalStorage', (key, cb) => cb(storageValue));
-        sandbox.stub(Date, 'now').returns(1714116520710);
+        clock.setSystemTime(1714116520710);
         sandbox.stub(Math, 'random').returns(0.8);
         sandbox.stub(utils, 'generateUUID').returns('uid-1234');
 
@@ -315,7 +315,7 @@ describe('Adagio Rtd Provider', function () {
           }
         });
         setStorageMethod('getDataFromLocalStorage', (key, cb) => cb(storageValue));
-        sandbox.stub(Date, 'now').returns(1714116520710);
+        clock.setSystemTime(1714116520710);
         sandbox.stub(Math, 'random').returns(0.8);
         sandbox.stub(utils, 'generateUUID').returns('uid-1234');
 
@@ -706,7 +706,7 @@ describe('Adagio Rtd Provider', function () {
 
     it('store a copy of computed property', function() {
       const spy = sandbox.spy(_internal.getAdagioNs().queue, 'push')
-      sandbox.stub(Date, 'now').returns(12345);
+      clock.setSystemTime(12345);
 
       _internal.getGuard().clear();
 


### PR DESCRIPTION
### Motivation
- Tests around Adagio RTD session handling were flaky and failing with `TypeError: object.hasOwnProperty is not a function` when `Date.now` was stubbed while Sinon fake timers were active. 
- Replace fragile stubs with the fake-timer API to make the specs stable and compatible with the existing `clock` fake-timer used in the suite.

### Description
- Updated `test/spec/modules/adagioRtdProvider_spec.js` to replace `sandbox.stub(Date, 'now').returns(...)` with `clock.setSystemTime(...)` in the session/localStorage related `init` tests and the `onBidRequestEvent` test. 
- Kept existing Sinon fake timer usage (`clock = sandbox.useFakeTimers()`) and other test doubles intact so tests continue to use a consistent time source. 
- No production code was modified; the change is limited to test spec fixes to avoid Sinon wrapping errors when stubbing `Date.now`.

### Testing
- Ran lint on the modified spec with `npx eslint --cache --cache-strategy content test/spec/modules/adagioRtdProvider_spec.js` which completed successfully. 
- Ran the affected unit tests with `npx gulp test --nolint --file test/spec/modules/adagioRtdProvider_spec.js` which completed successfully and all tests in that spec passed. 
- No other tests or source files were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc120ef0b0832bbc1b94177e204b8f)