### PR TITLE
Equativ Bid Adapter: default imp.displaymanager / displaymanagerver

### DIFF
--- a/modules/equativBidAdapter.js
+++ b/modules/equativBidAdapter.js
@@ -200,6 +200,8 @@ export const converter = ortbConverter({
 
     imp.secure = 1;
     imp.tagid = bidRequest.adUnitCode;
+    imp.displaymanager ||= 'Prebid.js';
+    imp.displaymanagerver ||= '$prebid.version$';
 
     if (!deepAccess(bidRequest, 'ortb2Imp.rwdd') && deepAccess(bidRequest, 'mediaTypes.video.ext.rewarded')) {
       mergeDeep(imp, { rwdd: bidRequest.mediaTypes.video.ext.rewarded });

--- a/test/spec/modules/equativBidAdapter_spec.js
+++ b/test/spec/modules/equativBidAdapter_spec.js
@@ -484,6 +484,43 @@ describe('Equativ bid adapter tests', () => {
       expect(request.data.ext.equativprebidjsversion).to.equal('$prebid.version$');
     });
 
+    it('should default imp.displaymanager and imp.displaymanagerver to Prebid.js and prebid version', () => {
+      const request = spec.buildRequests(
+        DEFAULT_BANNER_BID_REQUESTS,
+        DEFAULT_BANNER_BIDDER_REQUEST
+      )[0];
+      expect(request.data.imp[0].displaymanager).to.equal('Prebid.js');
+      expect(request.data.imp[0].displaymanagerver).to.equal('$prebid.version$');
+    });
+
+    it('should preserve publisher-provided ortb2Imp.displaymanager', () => {
+      const bidRequests = [{
+        ...DEFAULT_BANNER_BID_REQUESTS[0],
+        ortb2Imp: {
+          ...DEFAULT_BANNER_BID_REQUESTS[0].ortb2Imp,
+          displaymanager: 'Smart RTB+',
+        },
+      }];
+      const bidderRequest = { ...DEFAULT_BANNER_BIDDER_REQUEST, bids: bidRequests };
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.imp[0].displaymanager).to.equal('Smart RTB+');
+      expect(request.data.imp[0].displaymanagerver).to.equal('$prebid.version$');
+    });
+
+    it('should preserve publisher-provided ortb2Imp.displaymanagerver', () => {
+      const bidRequests = [{
+        ...DEFAULT_BANNER_BID_REQUESTS[0],
+        ortb2Imp: {
+          ...DEFAULT_BANNER_BID_REQUESTS[0].ortb2Imp,
+          displaymanagerver: 'Android SDK7.20.2',
+        },
+      }];
+      const bidderRequest = { ...DEFAULT_BANNER_BIDDER_REQUEST, bids: bidRequests };
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.imp[0].displaymanager).to.equal('Prebid.js');
+      expect(request.data.imp[0].displaymanagerver).to.equal('Android SDK7.20.2');
+    });
+
     it('should build a video request properly under normal circumstances', () => {
       // ASSEMBLE
       if (FEATURES.VIDEO) {


### PR DESCRIPTION
<!--
  Thank you for your pull request!

  Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

  Please make sure this PR is scoped to one change or you may be asked to resubmit.

  Please make sure any added or changed code includes tests with greater than 80% code coverage.

  See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

  For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
  -->

  ## Type of change
  <!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
  - [x] Updated bidder adapter

  - [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?

  ## Description of change
  Sets `imp.displaymanager` and `imp.displaymanagerver` on outgoing ORTB requests in the Equativ bid adapter so downstream systems can identify the integration and version.

  - `modules/equativBidAdapter.js:203-204` — defaults `imp.displaymanager` to `'Prebid.js'` and `imp.displaymanagerver` to `'$prebid.version$'` using `||=`, so any value already provided via `ortb2Imp` (e.g. when Prebid.js runs inside an SDK
  wrapper) is preserved.

  Test coverage added in `test/spec/modules/equativBidAdapter_spec.js:487-522`:
  - defaults applied when publisher provides nothing
  - `ortb2Imp.displaymanager` preserved when set (e.g. `'Smart RTB+'`)
  - `ortb2Imp.displaymanagerver` preserved when set (e.g. `'Android SDK7.20.2'`)

  No changes to bidder parameters, so no docs PR is required.

  ## Other information
  Scoped to the Equativ adapter only. No changes to public APIs, build, or other modules.
  Smoke test passed locally