### PR TITLE
Abtshield id system prebid

### DIFF
--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -2,6 +2,7 @@
   "parentModules": {
     "userId": [
       "33acrossIdSystem",
+      "abtshieldIdSystem",
       "admixerIdSystem",
       "adqueryIdSystem",
       "adplusIdSystem",

--- a/modules/abtshieldIdSystem.d.ts
+++ b/modules/abtshieldIdSystem.d.ts
@@ -11,10 +11,12 @@ export interface AbtshieldIdValue {
 export interface AbtshieldIdConfig {
   name: 'abtshieldId';
   params: AbtshieldIdParams;
-  storage?: {
+  storage: {
     type: 'cookie' | 'html5';
     name: string;
-    expires?: number;
+    /** TTL in days. Must be >= 1; the module rejects shorter TTLs to bound MCR request volume. */
+    expires: number;
+    /** Refresh interval in seconds. If set, must be >= 86400. */
     refreshInSeconds?: number;
   };
 }

--- a/modules/abtshieldIdSystem.d.ts
+++ b/modules/abtshieldIdSystem.d.ts
@@ -1,0 +1,22 @@
+export interface AbtshieldIdParams {
+  /** Required. Service ID obtained from abtshield.com (e.g. `pb.publisher-x`). */
+  sid: string;
+}
+
+export interface AbtshieldIdValue {
+  uuid: string;
+  segments?: string[];
+}
+
+export interface AbtshieldIdConfig {
+  name: 'abtshieldId';
+  params: AbtshieldIdParams;
+  storage?: {
+    type: 'cookie' | 'html5';
+    name: string;
+    expires?: number;
+    refreshInSeconds?: number;
+  };
+}
+
+export {};

--- a/modules/abtshieldIdSystem.js
+++ b/modules/abtshieldIdSystem.js
@@ -7,7 +7,8 @@
 
 import { submodule } from '../src/hook.js';
 import { logError, logInfo, logWarn, deepClone } from '../src/utils.js';
-import { ajax } from '../src/ajax.js';
+import { ajaxBuilder, processRequestOptions } from '../src/ajax.js';
+import { MODULE_TYPE_UID } from '../src/activities/modules.js';
 
 const MODULE_NAME = 'abtshieldId';
 const VENDOR_ID = 825;
@@ -15,6 +16,12 @@ const SOURCE = 'abtshield.com';
 const ENDPOINT = 'https://d1.abtshield.com/mcr';
 const AJAX_TIMEOUT_MS = 3000;
 const SIVT_SEGMENT = 'sivt';
+const ajax = ajaxBuilder(AJAX_TIMEOUT_MS, undefined, MODULE_TYPE_UID, MODULE_NAME);
+const AJAX_OPTIONS = {
+  method: 'GET',
+  withCredentials: true,
+  contentType: 'text/plain'
+};
 
 function buildEndpoint(sid) {
   return `${ENDPOINT}?sid=${encodeURIComponent(sid)}`;
@@ -85,12 +92,7 @@ export const abtshieldIdSubmodule = {
             }
           },
           undefined,
-          {
-            method: 'GET',
-            withCredentials: true,
-            contentType: 'text/plain',
-            timeout: AJAX_TIMEOUT_MS
-          }
+          processRequestOptions({ ...AJAX_OPTIONS }, MODULE_TYPE_UID, MODULE_NAME)
         );
       }
     };

--- a/modules/abtshieldIdSystem.js
+++ b/modules/abtshieldIdSystem.js
@@ -1,0 +1,111 @@
+/**
+ * This module adds abtshieldId to the User ID module.
+ * The {@link module:modules/userId} module is required.
+ * @module modules/abtshieldIdSystem
+ * @requires module:modules/userId
+ */
+
+import { submodule } from '../src/hook.js';
+import { logError, logInfo, logWarn, deepClone } from '../src/utils.js';
+import { ajax } from '../src/ajax.js';
+
+const MODULE_NAME = 'abtshieldId';
+const VENDOR_ID = 825;
+const SOURCE = 'abtshield.com';
+const ENDPOINT = 'https://d1.abtshield.com/mcr';
+const AJAX_TIMEOUT_MS = 3000;
+
+function buildEndpoint(sid) {
+  return `${ENDPOINT}?sid=${encodeURIComponent(sid)}`;
+}
+
+export function parseMcrResponse(body) {
+  if (!body) return null;
+  let parsed;
+  try {
+    parsed = typeof body === 'string' ? JSON.parse(body) : body;
+  } catch (e) {
+    logError(`${MODULE_NAME}: failed to parse MCR response`, e);
+    return null;
+  }
+  const id = parsed.iuid || parsed.uuid;
+  if (!id || typeof id !== 'string' || !id.length) {
+    return null;
+  }
+  const out = { uuid: id };
+  if (Array.isArray(parsed.t) && parsed.t.length) {
+    out.segments = parsed.t.filter((s) => typeof s === 'string' && s.length);
+    if (!out.segments.length) delete out.segments;
+  }
+  return out;
+}
+
+/** @type {import('../modules/userId/index.js').Submodule} */
+export const abtshieldIdSubmodule = {
+  name: MODULE_NAME,
+  gvlid: VENDOR_ID,
+
+  decode(value) {
+    if (!value || typeof value.uuid !== 'string' || !value.uuid.length) return undefined;
+    return { [MODULE_NAME]: deepClone(value) };
+  },
+
+  getId(config) {
+    const params = (config && config.params) || {};
+    const sid = typeof params.sid === 'string' ? params.sid.trim() : '';
+    if (!sid) {
+      logError(`${MODULE_NAME}: params.sid is required. Obtain a service ID at abtshield.com and set params: { sid: '<your-sid>' }.`);
+      return { callback: (done) => done(undefined) };
+    }
+    const url = buildEndpoint(sid);
+
+    return {
+      callback: (done) => {
+        ajax(
+          url,
+          {
+            success: (responseBody) => {
+              const value = parseMcrResponse(responseBody);
+              if (!value) {
+                logWarn(`${MODULE_NAME}: MCR response did not contain a usable uuid`);
+                done(undefined);
+                return;
+              }
+              logInfo(`${MODULE_NAME}: resolved uuid${value.segments ? ` with ${value.segments.length} segment(s)` : ''}`);
+              done(value);
+            },
+            error: (statusText, xhr) => {
+              logError(`${MODULE_NAME}: MCR request failed`, statusText, xhr && xhr.status);
+              done(undefined);
+            }
+          },
+          undefined,
+          {
+            method: 'GET',
+            withCredentials: true,
+            contentType: 'text/plain',
+            timeout: AJAX_TIMEOUT_MS
+          }
+        );
+      }
+    };
+  },
+
+  eids: {
+    [MODULE_NAME]: {
+      source: SOURCE,
+      atype: 1,
+      getValue(data) {
+        return data && data.uuid;
+      },
+      getUidExt(data) {
+        if (data && Array.isArray(data.segments) && data.segments.length) {
+          return { segments: data.segments };
+        }
+        return undefined;
+      }
+    }
+  }
+};
+
+submodule('userId', abtshieldIdSubmodule);

--- a/modules/abtshieldIdSystem.js
+++ b/modules/abtshieldIdSystem.js
@@ -14,6 +14,7 @@ const VENDOR_ID = 825;
 const SOURCE = 'abtshield.com';
 const ENDPOINT = 'https://d1.abtshield.com/mcr';
 const AJAX_TIMEOUT_MS = 3000;
+const SIVT_SEGMENT = 'sivt';
 
 function buildEndpoint(sid) {
   return `${ENDPOINT}?sid=${encodeURIComponent(sid)}`;
@@ -33,10 +34,14 @@ export function parseMcrResponse(body) {
     return null;
   }
   const out = { uuid: id };
+  const segments = [];
   if (Array.isArray(parsed.t) && parsed.t.length) {
-    out.segments = parsed.t.filter((s) => typeof s === 'string' && s.length);
-    if (!out.segments.length) delete out.segments;
+    segments.push(...parsed.t.filter((s) => typeof s === 'string' && s.length));
   }
+  if (parsed.b === 1 && !segments.includes(SIVT_SEGMENT)) {
+    segments.push(SIVT_SEGMENT);
+  }
+  if (segments.length) out.segments = segments;
   return out;
 }
 

--- a/modules/abtshieldIdSystem.js
+++ b/modules/abtshieldIdSystem.js
@@ -15,6 +15,7 @@ const VENDOR_ID = 825;
 const SOURCE = 'abtshield.com';
 const ENDPOINT = 'https://d1.abtshield.com/mcr';
 const AJAX_TIMEOUT_MS = 3000;
+const MIN_REFRESH_SECONDS = 86400;
 const SIVT_SEGMENT = 'sivt';
 const ajax = ajaxBuilder(AJAX_TIMEOUT_MS, undefined, MODULE_TYPE_UID, MODULE_NAME);
 const AJAX_OPTIONS = {
@@ -63,11 +64,23 @@ export const abtshieldIdSubmodule = {
   },
 
   getId(config) {
+    if (!config || !config.storage || !config.storage.type || !config.storage.name) {
+      logError(`${MODULE_NAME}: storage config is required. Set storage: { type: 'html5', name: 'abtshield_id', expires: 1 }.`);
+      return undefined;
+    }
+    if (typeof config.storage.expires !== 'number' || config.storage.expires < 1) {
+      logError(`${MODULE_NAME}: storage.expires must be a number >= 1 (days).`);
+      return undefined;
+    }
+    if (typeof config.storage.refreshInSeconds === 'number' && config.storage.refreshInSeconds < MIN_REFRESH_SECONDS) {
+      logError(`${MODULE_NAME}: storage.refreshInSeconds must be >= ${MIN_REFRESH_SECONDS} seconds.`);
+      return undefined;
+    }
     const params = (config && config.params) || {};
     const sid = typeof params.sid === 'string' ? params.sid.trim() : '';
     if (!sid) {
       logError(`${MODULE_NAME}: params.sid is required. Obtain a service ID at abtshield.com and set params: { sid: '<your-sid>' }.`);
-      return { callback: (done) => done(undefined) };
+      return undefined;
     }
     const url = buildEndpoint(sid);
 

--- a/modules/abtshieldIdSystem.md
+++ b/modules/abtshieldIdSystem.md
@@ -1,0 +1,83 @@
+# ABTShield User ID Submodule
+
+ABTShield provides cookie-less user identification and audience segmentation
+through its MCR endpoint. This submodule retrieves the ABTShield `uuid` and
+optional segment list and surfaces them to bid adapters through the standard
+Prebid.js User ID infrastructure.
+
+**Component category:** Module → Ad Request Enrichment (User ID submodule).
+The module enriches the outbound bid request with the ABTShield identifier
+and audience segments via `user.eids`.
+
+## Vendor
+
+- Source: `abtshield.com`
+- IAB GVL ID: `825`
+- Endpoint: `https://d1.abtshield.com/mcr`
+- Maintainer: `support@abtshield.com`
+
+## Prerequisites
+
+Before using this module you need:
+
+1. **A service ID (`sid`)** — register at [abtshield.com](https://abtshield.com) to obtain a unique identifier for your integration. The `sid` is required; the module will log an error and skip the ID fetch if it is absent or blank.
+
+2. **Domain whitelisting** — ABTShield's MCR endpoint validates the `Referer` header against the domain allowlist associated with your `sid`. Add every domain (and subdomain) from which the module will be loaded to your allowlist in the ABTShield dashboard. Requests arriving from non-whitelisted domains are rejected server-side regardless of the `sid` value.
+
+## Building Prebid
+
+Add the module to your build:
+
+```bash
+gulp build --modules=userId,abtshieldIdSystem
+```
+
+## Configuration
+
+```javascript
+pbjs.setConfig({
+  userSync: {
+    userIds: [{
+      name: 'abtshieldId',
+      params: {
+        // Required: service ID obtained from abtshield.com.
+        sid: 'pb.your-service-id'
+      },
+      storage: {
+        type: 'html5',
+        name: 'abtshield_id',
+        expires: 1            // Refresh once a day
+      }
+    }]
+  }
+});
+```
+
+| Param      | Scope    | Type   | Description                                                                     | Default |
+|------------|----------|--------|---------------------------------------------------------------------------------|---------|
+| name       | required | string | Must be `abtshieldId`.                                                          | -       |
+| params.sid | required | string | Service ID obtained from abtshield.com. Used to authenticate the integration and attribute traffic to the publisher. | - |
+| storage    | required | object | Standard Prebid User ID storage block. `html5` or `cookie` are allowed.        | -       |
+
+## Resulting EID
+
+A successful resolution adds the following entry to `user.eids`:
+
+```json
+{
+  "source": "abtshield.com",
+  "uids": [{
+    "id": "<iuid>",
+    "atype": 1,
+    "ext": { "segments": ["seg-1", "seg-2"] }
+  }]
+}
+```
+
+The `ext.segments` field is omitted when ABTShield returns no `t` field.
+
+## Network requirements
+
+Requests to the MCR endpoint are sent with credentials (cookies) using `withCredentials: true`. The ABTShield server must respond with `Access-Control-Allow-Credentials: true` and a specific (non-wildcard) `Access-Control-Allow-Origin` header. If these response headers are absent, the browser will silently block the response and the module will not resolve an ID.
+
+Publisher pages that set a `Referrer-Policy: no-referrer` header (or equivalent meta tag) will suppress the `Referer` header on outbound requests. Because ABTShield's MCR endpoint uses the `Referer` header to validate the requesting domain against the allowlist configured for your `sid`, a missing referrer will cause the server to reject the request regardless of whether the `sid` itself is correct.

--- a/modules/abtshieldIdSystem.md
+++ b/modules/abtshieldIdSystem.md
@@ -1,38 +1,40 @@
-# ABTShield User ID Submodule
+# ABTShield ID
 
-ABTShield provides cookie-less user identification and audience segmentation
-through its MCR endpoint. This submodule retrieves the ABTShield `uuid` and
-optional segment list and surfaces them to bid adapters through the standard
-Prebid.js User ID infrastructure.
+The ABTShield ID is a user ID submodule that retrieves an ABTShield identifier
+and optional audience or invalid-traffic segments from the ABTShield User ID
+endpoint. The submodule exposes the resolved identifier through the standard
+Prebid.js User ID infrastructure and adds it to bid requests as an EID with
+`source: "abtshield.com"`.
 
-**Component category:** Module → Ad Request Enrichment (User ID submodule).
-The module enriches the outbound bid request with the ABTShield identifier
-and audience segments via `user.eids`.
+The ABTShield ID module uses Prebid's User ID storage configuration to cache the
+ABTShield User ID response locally. It does not renew the cached value on every
+page view. To request a fresh ABTShield ID once per day, configure
+`storage.refreshInSeconds: 86400`.
 
-## Vendor
+## ABTShield ID Registration
 
-- Source: `abtshield.com`
-- IAB GVL ID: `825`
-- Endpoint: `https://d1.abtshield.com/mcr`
-- Maintainer: `support@abtshield.com`
+ABTShield requires a service ID (`sid`) for each integration. Register at
+[abtshield.com](https://abtshield.com) to obtain the `sid` value used in the
+module configuration.
 
-## Prerequisites
+ABTShield also validates the request `Referer` header against the domain
+allowlist associated with the configured `sid`. Add every domain and subdomain
+that will run this module to the allowlist in the ABTShield dashboard. Requests
+from non-allowlisted domains are rejected server-side even when the `sid` is
+valid.
 
-Before using this module you need:
+For support, contact [support@abtshield.com](mailto:support@abtshield.com).
 
-1. **A service ID (`sid`)** — register at [abtshield.com](https://abtshield.com) to obtain a unique identifier for your integration. The `sid` is required; the module will log an error and skip the ID fetch if it is absent or blank.
+## ABTShield ID Configuration
 
-2. **Domain whitelisting** — ABTShield's MCR endpoint validates the `Referer` header against the domain allowlist associated with your `sid`. Add every domain (and subdomain) from which the module will be loaded to your allowlist in the ABTShield dashboard. Requests arriving from non-whitelisted domains are rejected server-side regardless of the `sid` value.
+First, make sure to add the ABTShield ID submodule and the User ID module to
+your Prebid.js package with:
 
-## Building Prebid
-
-Add the module to your build:
-
-```bash
-gulp build --modules=userId,abtshieldIdSystem
+```
+gulp build --modules=abtshieldIdSystem,userId
 ```
 
-## Configuration
+The following configuration parameters are available:
 
 ```javascript
 pbjs.setConfig({
@@ -40,28 +42,43 @@ pbjs.setConfig({
     userIds: [{
       name: 'abtshieldId',
       params: {
-        // Required: service ID obtained from abtshield.com.
-        sid: 'pb.your-service-id'
+        sid: 'pb.your-service-id' // change to the service ID received from ABTShield
       },
       storage: {
-        type: 'html5',
-        name: 'abtshield_id',
-        expires: 1            // Refresh once a day
+        type: 'html5',             // "html5" or "cookie" are supported
+        name: 'abtshield_id',      // local storage or cookie key for the cached response
+        expires: 1,                // storage TTL in days; the module requires at least 1
+        refreshInSeconds: 86400    // refresh once per day
       }
-    }]
+    }],
+    auctionDelay: 50               // optional; applies to all userId modules
   }
 });
 ```
 
-| Param      | Scope    | Type   | Description                                                                     | Default |
-|------------|----------|--------|---------------------------------------------------------------------------------|---------|
-| name       | required | string | Must be `abtshieldId`.                                                          | -       |
-| params.sid | required | string | Service ID obtained from abtshield.com. Used to authenticate the integration and attribute traffic to the publisher. | - |
-| storage    | required | object | Standard Prebid User ID storage block. `html5` or `cookie` are allowed.        | -       |
+| Param under userSync.userIds[] | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| name | Required | String | The name of this module: `"abtshieldId"` | `"abtshieldId"` |
+| params | Required | Object | Details for the ABTShield ID request. | |
+| params.sid | Required | String | Service ID obtained from ABTShield. The module trims leading and trailing whitespace. If this value is missing or blank, the module logs an error and skips the ABTShield User ID request. | `"pb.your-service-id"` |
+| storage | Required | Object | Storage settings used by the User ID module to cache the ABTShield User ID response locally. | |
+| storage.type | Required | String | Where the cached response will be stored. ABTShield supports `"html5"` and `"cookie"`. | `"html5"` |
+| storage.name | Required | String | The local storage or cookie key used for the cached response. | `"abtshield_id"` |
+| storage.expires | Required | Number | How long, in days, the cached response may remain in storage. The module requires a value of `1` or greater and rejects missing, non-numeric, or shorter values. | `1` |
+| storage.refreshInSeconds | Optional | Number | How many seconds until Prebid should call ABTShield again while a cached ID still exists. If set, the value must be `86400` or greater. Set this to `86400` for once-per-day refresh. If omitted, Prebid waits until the stored value expires, consent changes, or the publisher explicitly refreshes user IDs before requesting a new ID. | `86400` |
 
-## Resulting EID
+**ATTENTION:** `storage.expires` and `storage.refreshInSeconds` are different
+controls. `storage.expires` is the maximum storage lifetime in days.
+`storage.refreshInSeconds` is the refresh interval used by Prebid while a stored
+ID still exists. The ABTShield module rejects `refreshInSeconds` values below
+`86400` to prevent refreshes more often than once per day. For a daily ABTShield
+ID refresh, set both `expires: 1` and `refreshInSeconds: 86400`. The ABTShield
+module does not implement `extendId`, so cached IDs are not re-saved on every
+page view and the refresh interval is not reset by normal reads.
 
-A successful resolution adds the following entry to `user.eids`:
+## Provided EID
+
+The module provides the following EID:
 
 ```json
 {
@@ -74,10 +91,69 @@ A successful resolution adds the following entry to `user.eids`:
 }
 ```
 
-The `ext.segments` field is omitted when ABTShield returns no `t` field.
+The `id` value is taken from the ABTShield User ID response `iuid` field. The
+module also accepts `uuid` as a fallback response field.
 
-## Network requirements
+The `ext.segments` field contains string values from the ABTShield User ID
+response `t` field. When the ABTShield response contains `b: 1`, the module
+also adds the `sivt` segment. The `ext.segments` field is omitted when there
+are no string `t` segments and `b` is not `1`.
 
-Requests to the MCR endpoint are sent with credentials (cookies) using `withCredentials: true`. The ABTShield server must respond with `Access-Control-Allow-Credentials: true` and a specific (non-wildcard) `Access-Control-Allow-Origin` header. If these response headers are absent, the browser will silently block the response and the module will not resolve an ID.
+## Caching and Refresh Behavior
 
-Publisher pages that set a `Referrer-Policy: no-referrer` header (or equivalent meta tag) will suppress the `Referer` header on outbound requests. Because ABTShield's MCR endpoint uses the `Referer` header to validate the requesting domain against the allowlist configured for your `sid`, a missing referrer will cause the server to reject the request regardless of whether the `sid` itself is correct.
+The ABTShield ID module requires a `storage` block. If `storage.type`,
+`storage.name`, or a valid `storage.expires` value is missing, the module logs
+an error and does not call the ABTShield User ID endpoint. The module also skips
+the request when `storage.expires` is less than `1`, or when
+`storage.refreshInSeconds` is set below `86400`.
+
+On the first page view where no cached ABTShield ID exists, Prebid calls the
+ABTShield User ID endpoint and stores the response returned by the module. On
+later page views, Prebid decodes the cached response and exposes it through
+`userId` and `user.eids` without another network call until one of the following
+happens:
+
+- the stored value expires according to `storage.expires`
+- the configured `storage.refreshInSeconds` interval has elapsed
+- consent data changes
+- the publisher explicitly calls `refreshUserIds`
+
+For once-per-day refresh, use:
+
+```javascript
+storage: {
+  type: 'html5',
+  name: 'abtshield_id',
+  expires: 1,
+  refreshInSeconds: 86400
+}
+```
+
+This configuration lets Prebid reuse the cached ABTShield ID within the day and
+call the ABTShield User ID endpoint again after 24 hours. Because this submodule
+does not return a value from `extendId`, reading a cached ID does not re-save
+the cached response or reset the refresh timing.
+
+Publishers should not set `refreshInSeconds` below `86400`; the module treats
+that as invalid configuration and skips the ABTShield User ID request.
+
+## Network Requirements
+
+Requests to the ABTShield User ID endpoint are sent with credentials using
+`withCredentials: true`. The ABTShield server must respond with
+`Access-Control-Allow-Credentials: true` and a specific, non-wildcard
+`Access-Control-Allow-Origin` header. If these response headers are absent, the
+browser will block the response and the module will not resolve an ID.
+
+Publisher pages that set a `Referrer-Policy: no-referrer` header or equivalent
+meta tag suppress the `Referer` header on outbound requests. Because ABTShield's
+User ID endpoint uses the `Referer` header to validate the requesting domain
+against the allowlist configured for the `sid`, a missing referrer will cause
+the server to reject the request regardless of whether the `sid` itself is
+correct.
+
+## Vendor Details
+
+- Source: `abtshield.com`
+- IAB GVL ID: `825`
+- Maintainer: [support@abtshield.com](mailto:support@abtshield.com)

--- a/modules/userId/eids.md
+++ b/modules/userId/eids.md
@@ -10,6 +10,16 @@ userIdAsEids = [
         }]
     },
     {
+        source: 'abtshield.com',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 1,
+            ext: {
+                segments: ['seg-1', 'seg-2']
+            }
+        }]
+    },
+    {
         source: 'utiq.com',
         uids: [{
             id: 'some-random-id-value',

--- a/modules/userId/userId.md
+++ b/modules/userId/userId.md
@@ -27,7 +27,8 @@ pbjs.setConfig({
             storage: {
                 type: "cookie",
                 name: "abtshieldId",
-                expires: 1
+                expires: 1,
+                refreshInSeconds: 86400
             }
         }, {
             name: "pubCommonId",

--- a/modules/userId/userId.md
+++ b/modules/userId/userId.md
@@ -20,6 +20,16 @@ pbjs.setConfig({
                 pid: "0010b00002GYU4eBAH" // Example ID
             }
         }, {
+            name: "abtshieldId",
+            params: {
+                sid: "pb.your-service-id"
+            },
+            storage: {
+                type: "cookie",
+                name: "abtshieldId",
+                expires: 1
+            }
+        }, {
             name: "pubCommonId",
             storage: {
                 type: "cookie",

--- a/test/spec/modules/abtshieldIdSystem_spec.js
+++ b/test/spec/modules/abtshieldIdSystem_spec.js
@@ -1,0 +1,235 @@
+import { abtshieldIdSubmodule, parseMcrResponse } from 'modules/abtshieldIdSystem.js';
+import { server } from 'test/mocks/xhr.js';
+import { createEidsArray } from '../../../modules/userId/eids.js';
+import { attachIdSystem } from '../../../modules/userId/index.js';
+import { expect } from 'chai';
+
+const MODULE_NAME = 'abtshieldId';
+
+describe('abtshieldIdSystem', function () {
+  describe('name', function () {
+    it('should expose the module name', function () {
+      expect(abtshieldIdSubmodule.name).to.equal(MODULE_NAME);
+    });
+  });
+
+  describe('gvlid', function () {
+    it('should expose vendor id 825', function () {
+      expect(abtshieldIdSubmodule.gvlid).to.equal(825);
+    });
+  });
+
+  // parseMcrResponse
+
+  describe('parseMcrResponse', function () {
+    it('returns null for empty input', function () {
+      expect(parseMcrResponse(null)).to.be.null;
+      expect(parseMcrResponse('')).to.be.null;
+      expect(parseMcrResponse(undefined)).to.be.null;
+    });
+
+    it('returns null when uuid is missing', function () {
+      expect(parseMcrResponse('{"t":["seg1"]}')).to.be.null;
+    });
+
+    it('returns null when uuid is empty string', function () {
+      expect(parseMcrResponse('{"uuid":""}')).to.be.null;
+    });
+
+    it('returns null for malformed JSON', function () {
+      expect(parseMcrResponse('not json')).to.be.null;
+    });
+
+    it('returns object with uuid from iuid field (actual API response field)', function () {
+      const result = parseMcrResponse('{"scr":10000,"iuid":"abc-123","b":-1,"t":-1}');
+      expect(result).to.deep.equal({ uuid: 'abc-123' });
+    });
+
+    it('returns object with uuid from uuid field (fallback)', function () {
+      const result = parseMcrResponse('{"uuid":"abc-123"}');
+      expect(result).to.deep.equal({ uuid: 'abc-123' });
+    });
+
+    it('prefers iuid over uuid when both present', function () {
+      const result = parseMcrResponse('{"iuid":"from-iuid","uuid":"from-uuid"}');
+      expect(result).to.deep.equal({ uuid: 'from-iuid' });
+    });
+
+    it('returns object with uuid and segments when present', function () {
+      const result = parseMcrResponse('{"uuid":"abc-123","t":["seg1","seg2"]}');
+      expect(result).to.deep.equal({ uuid: 'abc-123', segments: ['seg1', 'seg2'] });
+    });
+
+    it('omits segments when the t array is empty', function () {
+      const result = parseMcrResponse('{"uuid":"abc-123","t":[]}');
+      expect(result).to.deep.equal({ uuid: 'abc-123' });
+      expect(result).to.not.have.property('segments');
+    });
+
+    it('filters non-string entries from the t array', function () {
+      const result = parseMcrResponse('{"uuid":"abc-123","t":[1,"seg1",null,"seg2"]}');
+      expect(result.segments).to.deep.equal(['seg1', 'seg2']);
+    });
+
+    it('accepts an already-parsed object', function () {
+      const result = parseMcrResponse({ uuid: 'abc-123', t: ['seg1'] });
+      expect(result).to.deep.equal({ uuid: 'abc-123', segments: ['seg1'] });
+    });
+  });
+
+  // getId
+
+  describe('getId', function () {
+    beforeEach(function () {
+      server.requests.length = 0;
+    });
+
+    afterEach(function () {
+      sinon.restore();
+    });
+
+    it('skips the request and invokes callback with undefined when params.sid is absent', function () {
+      const cb = sinon.spy();
+      const { callback } = abtshieldIdSubmodule.getId({});
+      callback(cb);
+
+      expect(server.requests).to.have.length(0);
+      expect(cb.calledOnceWith(undefined)).to.be.true;
+    });
+
+    it('skips the request and invokes callback with undefined when params.sid is blank', function () {
+      const cb = sinon.spy();
+      const { callback } = abtshieldIdSubmodule.getId({ params: { sid: '   ' } });
+      callback(cb);
+
+      expect(server.requests).to.have.length(0);
+      expect(cb.calledOnceWith(undefined)).to.be.true;
+    });
+
+    it('calls the default MCR endpoint with the provided sid', function () {
+      const cb = sinon.spy();
+      const { callback } = abtshieldIdSubmodule.getId({ params: { sid: 'pb.publisher-x' } });
+      callback(cb);
+
+      const [req] = server.requests;
+      expect(req.method).to.equal('GET');
+      expect(req.url).to.equal('https://d1.abtshield.com/mcr?sid=pb.publisher-x');
+      expect(req.withCredentials).to.be.true;
+    });
+
+    it('trims whitespace from sid before using it in the URL', function () {
+      const cb = sinon.spy();
+      const { callback } = abtshieldIdSubmodule.getId({ params: { sid: '  pb.publisher-x  ' } });
+      callback(cb);
+
+      const [req] = server.requests;
+      expect(req.url).to.equal('https://d1.abtshield.com/mcr?sid=pb.publisher-x');
+    });
+
+    it('invokes callback with the parsed value on success', function () {
+      const cb = sinon.spy();
+      const { callback } = abtshieldIdSubmodule.getId({ params: { sid: 'pb.publisher-x' } });
+      callback(cb);
+
+      server.requests[0].respond(
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({ scr: 10000, iuid: 'test-uuid', b: -1, t: -1 })
+      );
+
+      expect(cb.calledOnce).to.be.true;
+      expect(cb.firstCall.args[0]).to.deep.equal({ uuid: 'test-uuid' });
+    });
+
+    it('invokes callback with undefined when response has no uuid', function () {
+      const cb = sinon.spy();
+      const { callback } = abtshieldIdSubmodule.getId({ params: { sid: 'pb.publisher-x' } });
+      callback(cb);
+
+      server.requests[0].respond(
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({ foo: 'bar' })
+      );
+
+      expect(cb.calledOnce).to.be.true;
+      expect(cb.firstCall.args[0]).to.be.undefined;
+    });
+
+    it('invokes callback with undefined on request error', function () {
+      const cb = sinon.spy();
+      const { callback } = abtshieldIdSubmodule.getId({ params: { sid: 'pb.publisher-x' } });
+      callback(cb);
+
+      server.requests[0].error();
+
+      expect(cb.calledOnce).to.be.true;
+      expect(cb.firstCall.args[0]).to.be.undefined;
+    });
+  });
+
+  // decode
+
+  describe('decode', function () {
+    it('returns undefined for falsy input', function () {
+      expect(abtshieldIdSubmodule.decode(null)).to.be.undefined;
+      expect(abtshieldIdSubmodule.decode(undefined)).to.be.undefined;
+      expect(abtshieldIdSubmodule.decode('')).to.be.undefined;
+    });
+
+    it('returns undefined when object has no uuid', function () {
+      expect(abtshieldIdSubmodule.decode({ segments: ['seg1'] })).to.be.undefined;
+    });
+
+    it('decodes a uuid-only object', function () {
+      const result = abtshieldIdSubmodule.decode({ uuid: 'abc-123' });
+      expect(result).to.deep.equal({ [MODULE_NAME]: { uuid: 'abc-123' } });
+    });
+
+    it('decodes an object with uuid and segments', function () {
+      const result = abtshieldIdSubmodule.decode({ uuid: 'abc-123', segments: ['s1', 's2'] });
+      expect(result).to.deep.equal({ [MODULE_NAME]: { uuid: 'abc-123', segments: ['s1', 's2'] } });
+    });
+
+    it('returns a deep clone so callers cannot mutate cached state', function () {
+      const value = { uuid: 'abc-123', segments: ['s1'] };
+      const result = abtshieldIdSubmodule.decode(value);
+      result[MODULE_NAME].segments.push('mutated');
+      expect(value.segments).to.deep.equal(['s1']);
+    });
+  });
+
+  // EID output
+
+  describe('eid', function () {
+    before(function () {
+      attachIdSystem(abtshieldIdSubmodule);
+    });
+
+    it('produces a valid EID without segments', function () {
+      const userId = { [MODULE_NAME]: { uuid: 'some-uuid' } };
+      const eids = createEidsArray(userId);
+      expect(eids).to.have.length(1);
+      expect(eids[0]).to.deep.equal({
+        source: 'abtshield.com',
+        uids: [{ id: 'some-uuid', atype: 1 }]
+      });
+    });
+
+    it('produces a valid EID with segments in uid ext', function () {
+      const userId = { [MODULE_NAME]: { uuid: 'some-uuid', segments: ['seg1', 'seg2'] } };
+      const eids = createEidsArray(userId);
+      expect(eids).to.have.length(1);
+      expect(eids[0]).to.deep.equal({
+        source: 'abtshield.com',
+        uids: [{ id: 'some-uuid', atype: 1, ext: { segments: ['seg1', 'seg2'] } }]
+      });
+    });
+
+    it('omits uid ext when segments array is empty', function () {
+      const userId = { [MODULE_NAME]: { uuid: 'some-uuid', segments: [] } };
+      const eids = createEidsArray(userId);
+      expect(eids[0].uids[0]).to.not.have.property('ext');
+    });
+  });
+});

--- a/test/spec/modules/abtshieldIdSystem_spec.js
+++ b/test/spec/modules/abtshieldIdSystem_spec.js
@@ -60,6 +60,21 @@ describe('abtshieldIdSystem', function () {
       expect(result).to.deep.equal({ uuid: 'abc-123', segments: ['seg1', 'seg2'] });
     });
 
+    it('adds sivt segment when b is 1', function () {
+      const result = parseMcrResponse('{"uuid":"abc-123","b":1}');
+      expect(result).to.deep.equal({ uuid: 'abc-123', segments: ['sivt'] });
+    });
+
+    it('adds sivt segment to t segments when b is 1', function () {
+      const result = parseMcrResponse('{"uuid":"abc-123","b":1,"t":["foo"]}');
+      expect(result).to.deep.equal({ uuid: 'abc-123', segments: ['foo', 'sivt'] });
+    });
+
+    it('does not duplicate sivt when already present in t segments', function () {
+      const result = parseMcrResponse('{"uuid":"abc-123","b":1,"t":["foo","sivt"]}');
+      expect(result).to.deep.equal({ uuid: 'abc-123', segments: ['foo', 'sivt'] });
+    });
+
     it('omits segments when the t array is empty', function () {
       const result = parseMcrResponse('{"uuid":"abc-123","t":[]}');
       expect(result).to.deep.equal({ uuid: 'abc-123' });
@@ -139,6 +154,21 @@ describe('abtshieldIdSystem', function () {
 
       expect(cb.calledOnce).to.be.true;
       expect(cb.firstCall.args[0]).to.deep.equal({ uuid: 'test-uuid' });
+    });
+
+    it('invokes callback with sivt segment when b is 1', function () {
+      const cb = sinon.spy();
+      const { callback } = abtshieldIdSubmodule.getId({ params: { sid: 'pb.publisher-x' } });
+      callback(cb);
+
+      server.requests[0].respond(
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({ scr: 8000, iuid: 'test-uuid', b: 1, t: ['foo'] })
+      );
+
+      expect(cb.calledOnce).to.be.true;
+      expect(cb.firstCall.args[0]).to.deep.equal({ uuid: 'test-uuid', segments: ['foo', 'sivt'] });
     });
 
     it('invokes callback with undefined when response has no uuid', function () {

--- a/test/spec/modules/abtshieldIdSystem_spec.js
+++ b/test/spec/modules/abtshieldIdSystem_spec.js
@@ -7,6 +7,7 @@ import { expect } from 'chai';
 import '../../../modules/allowActivities.js';
 
 const MODULE_NAME = 'abtshieldId';
+const STORAGE = { type: 'html5', name: 'abtshield_id', expires: 1 };
 
 describe('abtshieldIdSystem', function () {
   describe('name', function () {
@@ -106,27 +107,48 @@ describe('abtshieldIdSystem', function () {
       config.resetConfig();
     });
 
-    it('skips the request and invokes callback with undefined when params.sid is absent', function () {
-      const cb = sinon.spy();
-      const { callback } = abtshieldIdSubmodule.getId({});
-      callback(cb);
-
+    it('returns undefined when storage.expires is below the 1-day floor', function () {
+      const result = abtshieldIdSubmodule.getId({
+        params: { sid: 'pb.publisher-x' },
+        storage: { type: 'html5', name: 'abtshield_id', expires: 0.5 }
+      });
+      expect(result).to.be.undefined;
       expect(server.requests).to.have.length(0);
-      expect(cb.calledOnceWith(undefined)).to.be.true;
     });
 
-    it('skips the request and invokes callback with undefined when params.sid is blank', function () {
-      const cb = sinon.spy();
-      const { callback } = abtshieldIdSubmodule.getId({ params: { sid: '   ' } });
-      callback(cb);
-
+    it('returns undefined when storage.expires is not a number', function () {
+      const result = abtshieldIdSubmodule.getId({
+        params: { sid: 'pb.publisher-x' },
+        storage: { type: 'html5', name: 'abtshield_id', expires: '1' }
+      });
+      expect(result).to.be.undefined;
       expect(server.requests).to.have.length(0);
-      expect(cb.calledOnceWith(undefined)).to.be.true;
+    });
+
+    it('returns undefined when storage.refreshInSeconds is below the 1-day floor', function () {
+      const result = abtshieldIdSubmodule.getId({
+        params: { sid: 'pb.publisher-x' },
+        storage: { type: 'html5', name: 'abtshield_id', expires: 1, refreshInSeconds: 1 }
+      });
+      expect(result).to.be.undefined;
+      expect(server.requests).to.have.length(0);
+    });
+
+    it('returns undefined and skips the request when params.sid is absent', function () {
+      const result = abtshieldIdSubmodule.getId({ storage: STORAGE });
+      expect(result).to.be.undefined;
+      expect(server.requests).to.have.length(0);
+    });
+
+    it('returns undefined and skips the request when params.sid is blank', function () {
+      const result = abtshieldIdSubmodule.getId({ storage: STORAGE, params: { sid: '   ' } });
+      expect(result).to.be.undefined;
+      expect(server.requests).to.have.length(0);
     });
 
     it('calls the default MCR endpoint with the provided sid', function () {
       const cb = sinon.spy();
-      const { callback } = abtshieldIdSubmodule.getId({ params: { sid: 'pb.publisher-x' } });
+      const { callback } = abtshieldIdSubmodule.getId({ storage: STORAGE, params: { sid: 'pb.publisher-x' } });
       callback(cb);
 
       const [req] = server.requests;
@@ -150,7 +172,7 @@ describe('abtshieldIdSystem', function () {
       });
 
       const cb = sinon.spy();
-      const { callback } = abtshieldIdSubmodule.getId({ params: { sid: 'pb.publisher-x' } });
+      const { callback } = abtshieldIdSubmodule.getId({ storage: STORAGE, params: { sid: 'pb.publisher-x' } });
       callback(cb);
 
       const [req] = server.requests;
@@ -159,7 +181,7 @@ describe('abtshieldIdSystem', function () {
 
     it('trims whitespace from sid before using it in the URL', function () {
       const cb = sinon.spy();
-      const { callback } = abtshieldIdSubmodule.getId({ params: { sid: '  pb.publisher-x  ' } });
+      const { callback } = abtshieldIdSubmodule.getId({ storage: STORAGE, params: { sid: '  pb.publisher-x  ' } });
       callback(cb);
 
       const [req] = server.requests;
@@ -168,7 +190,7 @@ describe('abtshieldIdSystem', function () {
 
     it('invokes callback with the parsed value on success', function () {
       const cb = sinon.spy();
-      const { callback } = abtshieldIdSubmodule.getId({ params: { sid: 'pb.publisher-x' } });
+      const { callback } = abtshieldIdSubmodule.getId({ storage: STORAGE, params: { sid: 'pb.publisher-x' } });
       callback(cb);
 
       server.requests[0].respond(
@@ -183,7 +205,7 @@ describe('abtshieldIdSystem', function () {
 
     it('invokes callback with sivt segment when b is 1', function () {
       const cb = sinon.spy();
-      const { callback } = abtshieldIdSubmodule.getId({ params: { sid: 'pb.publisher-x' } });
+      const { callback } = abtshieldIdSubmodule.getId({ storage: STORAGE, params: { sid: 'pb.publisher-x' } });
       callback(cb);
 
       server.requests[0].respond(
@@ -198,7 +220,7 @@ describe('abtshieldIdSystem', function () {
 
     it('invokes callback with undefined when response has no uuid', function () {
       const cb = sinon.spy();
-      const { callback } = abtshieldIdSubmodule.getId({ params: { sid: 'pb.publisher-x' } });
+      const { callback } = abtshieldIdSubmodule.getId({ storage: STORAGE, params: { sid: 'pb.publisher-x' } });
       callback(cb);
 
       server.requests[0].respond(
@@ -213,7 +235,7 @@ describe('abtshieldIdSystem', function () {
 
     it('invokes callback with undefined on request error', function () {
       const cb = sinon.spy();
-      const { callback } = abtshieldIdSubmodule.getId({ params: { sid: 'pb.publisher-x' } });
+      const { callback } = abtshieldIdSubmodule.getId({ storage: STORAGE, params: { sid: 'pb.publisher-x' } });
       callback(cb);
 
       server.requests[0].error();

--- a/test/spec/modules/abtshieldIdSystem_spec.js
+++ b/test/spec/modules/abtshieldIdSystem_spec.js
@@ -2,7 +2,9 @@ import { abtshieldIdSubmodule, parseMcrResponse } from 'modules/abtshieldIdSyste
 import { server } from 'test/mocks/xhr.js';
 import { createEidsArray } from '../../../modules/userId/eids.js';
 import { attachIdSystem } from '../../../modules/userId/index.js';
+import { config } from '../../../src/config.js';
 import { expect } from 'chai';
+import '../../../modules/allowActivities.js';
 
 const MODULE_NAME = 'abtshieldId';
 
@@ -101,6 +103,7 @@ describe('abtshieldIdSystem', function () {
 
     afterEach(function () {
       sinon.restore();
+      config.resetConfig();
     });
 
     it('skips the request and invokes callback with undefined when params.sid is absent', function () {
@@ -130,6 +133,28 @@ describe('abtshieldIdSystem', function () {
       expect(req.method).to.equal('GET');
       expect(req.url).to.equal('https://d1.abtshield.com/mcr?sid=pb.publisher-x');
       expect(req.withCredentials).to.be.true;
+    });
+
+    it('scopes credential access to the abtshieldId component', function () {
+      config.setConfig({
+        allowActivities: {
+          accessRequestCredentials: {
+            rules: [{
+              condition({ componentType, componentName }) {
+                return componentType === 'userId' && componentName === MODULE_NAME;
+              },
+              allow: false
+            }]
+          }
+        }
+      });
+
+      const cb = sinon.spy();
+      const { callback } = abtshieldIdSubmodule.getId({ params: { sid: 'pb.publisher-x' } });
+      callback(cb);
+
+      const [req] = server.requests;
+      expect(req.withCredentials).to.be.false;
     });
 
     it('trims whitespace from sid before using it in the URL', function () {


### PR DESCRIPTION
## Type of change
  - [x] Feature
  - [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
  - [x] Other: New User ID submodule

  ## Description of change

  Adds the ABTShield User ID submodule for the Prebid.js User ID module.

  This change:
  - registers `abtshieldIdSystem` as a `userId` submodule in `modules/.submodules.json:5`
  - adds the ABTShield ID module implementation in `modules/abtshieldIdSystem.js:23`
  - supports fetching an ABTShield identifier from the MCR endpoint using publisher-provided
  `params.sid`
  - decodes stored values under `abtshieldId`
  - exposes ABTShield IDs through `user.eids` with source `abtshield.com`
  - includes optional segment output in `uid.ext.segments`
  - maps `b: 1` MCR responses to the `sivt` segment
  - adds TypeScript config/value interfaces in `modules/abtshieldIdSystem.d.ts:1`
  - adds module documentation and User ID examples in `modules/abtshieldIdSystem.md:1`, `modules/userId/
  userId.md:23`, and `modules/userId/eids.md:13`
  - adds unit coverage for parsing, request behavior, decoding, EID output, and SIVT segment handling in
  `test/spec/modules/abtshieldIdSystem_spec.js:24`

  Maintainer contact: `support@abtshield.com`

  Example configuration:

  ```javascript
  pbjs.setConfig({
    userSync: {
      userIds: [{
        name: 'abtshieldId',
        params: {
          sid: 'pb.your-service-id'
        },
        storage: {
          type: 'html5',
          name: 'abtshield_id',
          expires: 1
        }
      }]
    }
  });
```
  Docs PR: https://github.com/prebid/prebid.github.io/pull/6559
