### PR TITLE
Livewrapped Analytics Adapter: Clear Livewrapped analytics cache when pbjs.clearAllAuctions is called

### DIFF
--- a/modules/livewrappedAnalyticsAdapter.js
+++ b/modules/livewrappedAnalyticsAdapter.js
@@ -17,7 +17,6 @@ const ADRENDERFAILEDSENT = 16;
 let initOptions;
 const prebidGlobal = getGlobal();
 export const BID_WON_TIMEOUT = 500;
-const CACHE_CLEANUP_DELAY = BID_WON_TIMEOUT * 3;
 
 const cache = {
   auctions: {}
@@ -159,6 +158,7 @@ const livewrappedAnalyticsAdapter = Object.assign(adapter({ EMPTYURL, ANALYTICST
 // save the base class function
 livewrappedAnalyticsAdapter.originEnableAnalytics = livewrappedAnalyticsAdapter.enableAnalytics;
 livewrappedAnalyticsAdapter.allRequestEvents = [];
+const baseClearAllAuctions = prebidGlobal.clearAllAuctions;
 
 // override enableAnalytics so we can get access to the config passed in from the page
 livewrappedAnalyticsAdapter.enableAnalytics = function (config) {
@@ -190,12 +190,6 @@ livewrappedAnalyticsAdapter.sendEvents = function() {
   }
 
   ajax(initOptions.endpoint || URL, undefined, JSON.stringify(events), { method: 'POST' });
-
-  setTimeout(() => {
-    sentRequests.auctionIds.forEach(id => {
-      delete cache.auctions[id];
-    });
-  }, CACHE_CLEANUP_DELAY);
 };
 
 function getMediaTypeEnum(mediaType) {
@@ -429,6 +423,11 @@ function getbidAdUnits() {
   return bidAdUnits;
 }
 
+prebidGlobal.clearAllAuctions = function() {
+  cache.auctions = {};
+  baseClearAllAuctions();
+}
+
 adapterManager.registerAnalyticsAdapter({
   adapter: livewrappedAnalyticsAdapter,
   code: 'livewrapped'
@@ -437,7 +436,5 @@ adapterManager.registerAnalyticsAdapter({
 export function getAuctionCache() {
   return cache.auctions;
 }
-
-export { CACHE_CLEANUP_DELAY };
 
 export default livewrappedAnalyticsAdapter;

--- a/test/spec/modules/livewrappedAnalyticsAdapter_spec.js
+++ b/test/spec/modules/livewrappedAnalyticsAdapter_spec.js
@@ -3,6 +3,7 @@ import { AD_RENDER_FAILED_REASON, EVENTS, STATUS } from 'src/constants.js';
 import { config } from 'src/config.js';
 import { server } from 'test/mocks/xhr.js';
 import { setConfig } from 'modules/currency.js';
+import { getGlobal } from '../../../src/prebidGlobal.js';
 
 const events = require('src/events');
 const utils = require('src/utils');
@@ -377,12 +378,34 @@ describe('Livewrapped analytics adapter', function () {
       expect(message).to.deep.equal(ANALYTICS_MESSAGE);
     });
 
-    it('should clear auction cache after sending events', function () {
+    it('should clear auction cache when pbjs.clearAllAuctions is called', function () {
       performStandardAuction();
+      performSecondAuction();
 
-      clock.tick(BID_WON_TIMEOUT + CACHE_CLEANUP_DELAY + 100);
+      expect(Object.keys(getAuctionCache()).length).to.equal(2);
+      
+      getGlobal().clearAllAuctions();
 
       expect(Object.keys(getAuctionCache()).length).to.equal(0);
+
+      function performSecondAuction() {
+        events.emit(AUCTION_INIT, {
+          'auctionId': '35c6d7f5-699a-4bfc-87c9-996f915341fa',
+        });
+        events.emit(BID_REQUESTED, {
+          'bidder': 'livewrapped',
+          'auctionId': '35c6d7f5-699a-4bfc-87c9-996f915341fa',
+          'bidderRequestId': '2be65d7958826a',
+          'bids': [
+            {
+              'bidder': 'livewrapped',
+              'adUnitCode': 'panorama_d_1',
+              'bidId': '3ecff0db240757',
+            }
+          ],
+          'start': 1519149562216
+        });
+      }
     });
 
     it('should send batched message without BID_WON AND AD_RENDER_FAILED if necessary and further BID_WON and AD_RENDER_FAILED events individually', function () {

--- a/test/spec/modules/livewrappedAnalyticsAdapter_spec.js
+++ b/test/spec/modules/livewrappedAnalyticsAdapter_spec.js
@@ -383,7 +383,7 @@ describe('Livewrapped analytics adapter', function () {
       performSecondAuction();
 
       expect(Object.keys(getAuctionCache()).length).to.equal(2);
-      
+
       getGlobal().clearAllAuctions();
 
       expect(Object.keys(getAuctionCache()).length).to.equal(0);


### PR DESCRIPTION
## Type of change
- [x ] Bugfix
- [x ] Feature

## Description of change
A change was applied (https://github.com/prebid/Prebid.js/pull/13639) that broke the Livewrapped Analytics adapter. This will fix the issue and hopefully not trigger the robot again.

## Other information
https://github.com/prebid/Prebid.js/pull/13639
https://github.com/prebid/Prebid.js/pull/14870
