### PR TITLE
Core Typescript types: Add bidCacheFilterFunction to types

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -221,9 +221,9 @@ export interface Config {
    */
   useBidCache?: boolean;
   /**
-   * When Bid Caching is turned on, a custom Filter Function can be defined to gain more granular control over which “cached” bids can be used. 
-   * This function will only be called for “cached” bids from previous auctions, not “current” bids from the most recent auction. 
-   * The function should take a single bid object argument, and return true to use the cached bid, or false to not use the cached bid. 
+   * When Bid Caching is turned on, a custom Filter Function can be defined to gain more granular control over which “cached” bids can be used.
+   * This function will only be called for “cached” bids from previous auctions, not “current” bids from the most recent auction.
+   * The function should take a single bid object argument, and return true to use the cached bid, or false to not use the cached bid.
    *
    * For Example, to turn on Bid Caching, but exclude cached video bids, you could do this:
    *

--- a/src/config.ts
+++ b/src/config.ts
@@ -221,6 +221,21 @@ export interface Config {
    */
   useBidCache?: boolean;
   /**
+   * When Bid Caching is turned on, a custom Filter Function can be defined to gain more granular control over which “cached” bids can be used. 
+   * This function will only be called for “cached” bids from previous auctions, not “current” bids from the most recent auction. 
+   * The function should take a single bid object argument, and return true to use the cached bid, or false to not use the cached bid. 
+   *
+   * For Example, to turn on Bid Caching, but exclude cached video bids, you could do this:
+   *
+   * ```
+   * pbjs.setConfig({
+   *   useBidCache: true,
+   *   bidCacheFilterFunction: bid => bid.mediaType !== 'video'
+   * });
+   * ```
+   */
+  bidCacheFilterFunction?: (bid: Bid) => boolean;
+  /**
    * You can prevent Prebid.js from reading or writing cookies or HTML localstorage by setting this to false.
    */
   deviceAccess?: boolean;


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->

The `bidCacheFilterFunction` was missing from the Typescript types.
This PR adds is, as well as the documentation from https://docs.prebid.org/dev-docs/publisher-api-reference/setConfig.html in the JS doc of the method

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
