### PR TITLE
Build system: combine coverage results for coveralls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,9 +123,15 @@ jobs:
         with:
           name: ${{ needs.test.outputs.coverage }}
 
+      - name: Combine coverage results
+        shell: bash
+        run: |
+          find build/coverage/chunks  -name 'lcov.info' -printf ' -a %p' | xargs lcov -o build/coverage/combined.info
+
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:
+          file: build/coverage/combined.info
           git-branch: ${{ needs.checkout.outputs.fork && format('{0}:{1}', needs.checkout.outputs.fork, needs.checkout.outputs.branch) || needs.checkout.outputs.branch }}
           git-commit: ${{ needs.checkout.outputs.commit }}
           compare-ref: ${{ needs.checkout.outputs.base-branch }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,6 +126,8 @@ jobs:
       - name: Combine coverage results
         shell: bash
         run: |
+          sudo apt-get update
+          sudo apt-get install lcov
           find build/coverage/chunks  -name 'lcov.info' -printf ' -a %p' | xargs lcov -o build/coverage/combined.info
 
       - name: Coveralls

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get update
-          sudo apt-get install lcov
+          sudo apt-get install lcov -y
           find build/coverage/chunks  -name 'lcov.info' -printf ' -a %p' | xargs lcov -o build/coverage/combined.info
 
       - name: Coveralls

--- a/gulp.precompilation.js
+++ b/gulp.precompilation.js
@@ -35,6 +35,7 @@ const babelPrecomp = _.memoize(
       })
         .pipe(babel(babelConfig))
         .pipe(tap(file => {
+          file.sourceMap.file = file.basename;
           file.sourceMap.sourceRoot = path.join(relativeSourceRoot, path.relative(file.dirname, sourceRoot))
         }))
         .pipe(gulp.dest(helpers.getPrecompiledPath(), {

--- a/gulp.precompilation.js
+++ b/gulp.precompilation.js
@@ -26,6 +26,8 @@ const babelPrecomp = _.memoize(
   function ({distUrlBase = null, disableFeatures = null, dev = false} = {}) {
     const babelConfig = require('./babelConfig.js')(getDefaults({distUrlBase, disableFeatures, dev}));
     return function () {
+      const sourceRoot = path.resolve('.');
+      const relativeSourceRoot = path.relative(helpers.getPrecompiledPath(), sourceRoot);
       return gulp.src(helpers.getSourcePatterns(), {
         base: '.',
         since: gulp.lastRun(babelPrecomp({distUrlBase, disableFeatures, dev})),
@@ -33,7 +35,7 @@ const babelPrecomp = _.memoize(
       })
         .pipe(babel(babelConfig))
         .pipe(tap(file => {
-          file.sourceMap.sources = file.sourceMap.sources.map(source => path.relative(path.dirname(helpers.getPrecompiledPath(source)), path.resolve('.', source)))
+          file.sourceMap.sourceRoot = path.join(relativeSourceRoot, path.relative(file.dirname, sourceRoot))
         }))
         .pipe(gulp.dest(helpers.getPrecompiledPath(), {
           sourcemaps: '.'


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Build related changes

## Description of change

Combine coverage results into a single file to send to coveralls.

Motivation is reports such as https://coveralls.io/jobs/181638438 contain multiple entries for the same file if they run in more than one test chunk.
