### PR TITLE
CI: do not auto-assign reviewers on draft PRs

### DIFF
--- a/.github/workflows/PR-assignment-deps.yml
+++ b/.github/workflows/PR-assignment-deps.yml
@@ -1,7 +1,7 @@
 name: Compile dependencies.json for PR assignment checks
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/scripts/getPRProperties.js
+++ b/.github/workflows/scripts/getPRProperties.js
@@ -13,6 +13,7 @@ const EXCLUDE_PATTERNS = [
   /^test\//,
   /^integrationExamples\//,
   /^[^\/]+$/,
+  /^.github\//,
 ]
 
 const LIBRARY_PATTERN = /^libraries\/([^\/]+)\//;
@@ -136,6 +137,7 @@ async function getPRProperties({github, context, prNo, reviewerTeam, engTeam, au
     });
   const data = {
     pr: prNo,
+    draft: pr.data.draft,
     author: {
       login: author,
       isPrebidMember: await isPrebidMember(author)
@@ -147,7 +149,7 @@ async function getPRProperties({github, context, prNo, reviewerTeam, engTeam, au
     review,
   }
   data.review.requires = reviewRequirements(data);
-  data.review.ok = satisfiesReviewRequirements(data.review);
+  data.review.ok = data.draft || satisfiesReviewRequirements(data.review);
   return data;
 }
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] CI related changes

## Description of change

Update the PR assignment workflow to:

 - skip assignments on draft PRs
 - not consider files in `.github` as core
