### PR TITLE
Currency: fix bug where conversion rates are sometimes reset to defaultRates

### DIFF
--- a/modules/currency.ts
+++ b/modules/currency.ts
@@ -97,7 +97,7 @@ export function setConfig(config: CurrencyConfig) {
     needToCallForCurrencyFile = false; // don't call if rates are already specified
   }
 
-  if (config.defaultRates !== null && typeof config.defaultRates === 'object') {
+  if (!currencyRates.conversions && config.defaultRates !== null && typeof config.defaultRates === 'object') {
     defaultRates = config.defaultRates;
 
     // set up the default rates to be used if the rate file doesn't get loaded in time

--- a/modules/currency.ts
+++ b/modules/currency.ts
@@ -28,6 +28,7 @@ export var currencySupportEnabled = false;
 export var currencyRates = {} as any;
 let bidderCurrencyDefault = {};
 let defaultRates;
+let shouldUseDefaults = true;
 
 export let responseReady = defer<void>();
 
@@ -93,11 +94,12 @@ export function setConfig(config: CurrencyConfig) {
 
   if (config.rates !== null && typeof config.rates === 'object') {
     currencyRates.conversions = config.rates;
+    shouldUseDefaults = false;
     currencyRatesLoaded = true;
     needToCallForCurrencyFile = false; // don't call if rates are already specified
   }
 
-  if (!currencyRates.conversions && config.defaultRates !== null && typeof config.defaultRates === 'object') {
+  if (shouldUseDefaults && config.defaultRates !== null && typeof config.defaultRates === 'object') {
     defaultRates = config.defaultRates;
 
     // set up the default rates to be used if the rate file doesn't get loaded in time
@@ -167,6 +169,7 @@ function loadRates() {
             logInfo('currencyRates set to ' + JSON.stringify(currencyRates));
             conversionCache = {};
             currencyRatesLoaded = true;
+            shouldUseDefaults = false;
             processBidResponseQueue();
             delayedAuctions.resume();
           } catch (e) {
@@ -231,6 +234,7 @@ export function resetCurrency() {
     currencySupportEnabled = false;
     currencyRatesLoaded = false;
     needToCallForCurrencyFile = true;
+    shouldUseDefaults = true;
     currencyRates = {};
     bidderCurrencyDefault = {};
     responseReady = defer();

--- a/test/spec/modules/currency_spec.js
+++ b/test/spec/modules/currency_spec.js
@@ -81,6 +81,22 @@ describe('currency', function () {
       fakeCurrencyFileServer.respond();
       setConfig(config);
       expect(currencyRates.conversions).to.eql(getCurrencyRates().conversions);
+    });
+
+    it('uses latest defaultRates when no other rates are available', () => {
+      setConfig({
+        defaultRates: {
+          'USD': { 'JPY': 1 }
+        }
+      });
+      setConfig({
+        defaultRates: {
+          'USD': { 'JPY': 2 }
+        }
+      });
+      expect(currencyRates.conversions).to.eql({
+        'USD': { 'JPY': 2 }
+      })
     })
 
     it('currency file is called even when default rates are specified', function() {

--- a/test/spec/modules/currency_spec.js
+++ b/test/spec/modules/currency_spec.js
@@ -69,6 +69,20 @@ describe('currency', function () {
       expect(currencySupportEnabled).to.equal(true);
     });
 
+    it('does not lose loaded rates when reconfigured', () => {
+      const config = {
+        adServerCurrency: 'USD',
+        defaultRates: {
+          'USD': { 'JPY': 1 }
+        }
+      }
+      fakeCurrencyFileServer.respondWith(JSON.stringify(getCurrencyRates()));
+      setConfig(config);
+      fakeCurrencyFileServer.respond();
+      setConfig(config);
+      expect(currencyRates.conversions).to.eql(getCurrencyRates().conversions);
+    })
+
     it('currency file is called even when default rates are specified', function() {
       // RESET to request currency file (specifically url value for this test)
       setConfig({ 'adServerCurrency': undefined });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

This fixes a bug where providing `defaultRates` to the currency module will override any previously set rates.

## Other information

Fixes #14877
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
