### PR TITLE
Docs: add pgamdirectBidAdapter.md (missing companion to #14763) + note GVL 1353

### DIFF
--- a/modules/pgamdirectBidAdapter.md
+++ b/modules/pgamdirectBidAdapter.md
@@ -43,7 +43,7 @@ var adUnits = [{
 
 # Privacy + Consent
 
-- TCF v2.2 — adapter forwards consent strings; PGAM Media LLC is registered
+- TCF v2.3 — adapter forwards consent strings; PGAM Media LLC is registered
   as GVL Vendor ID 1353.
 - GPP — supported for `tcfeu`, `usnat`, `usstate_all`.
 - US Privacy / CCPA — passed through unchanged.

--- a/modules/pgamdirectBidAdapter.md
+++ b/modules/pgamdirectBidAdapter.md
@@ -3,7 +3,7 @@
 ```
 Module Name:  PGAM Direct Bid Adapter
 Module Type:  Bidder Adapter
-Maintainer:   [email protected]
+Maintainer:   info@pgammedia.com
 ```
 
 # Description

--- a/modules/pgamdirectBidAdapter.md
+++ b/modules/pgamdirectBidAdapter.md
@@ -47,5 +47,7 @@ var adUnits = [{
   as GVL Vendor ID 1353.
 - GPP — supported for `tcfeu`, `usnat`, `usstate_all`.
 - US Privacy / CCPA — passed through unchanged.
-- COPPA — honoured; suppresses the request when the COPPA flag is set on a
-  publisher's inventory.
+- COPPA — the COPPA flag from `regs.coppa` is forwarded unchanged on every
+  outbound bid request. Downstream DSPs are responsible for filtering
+  child-directed inventory under their own contracts; the adapter does not
+  short-circuit on the publisher side.

--- a/modules/pgamdirectBidAdapter.md
+++ b/modules/pgamdirectBidAdapter.md
@@ -1,0 +1,51 @@
+# Overview
+
+```
+Module Name:  PGAM Direct Bid Adapter
+Module Type:  Bidder Adapter
+Maintainer:   [email protected]
+```
+
+# Description
+
+Server-to-server OpenRTB 2.6 adapter from PGAM Media — direct supply-side
+platform with dynamic floors, transparent margins, and supply-chain
+integrity. Multi-region endpoint at `https://rtb.pgammedia.com/rtb/v1/auction`.
+
+Companion modules merged in the same release series:
+- `pgamdirectAnalyticsAdapter` — analytics events
+- (cookie sync handled via `getUserSyncs` in this adapter)
+
+Bidder code: `pgamdirect`. GVL Vendor ID: 1353 (PGAM Media LLC).
+
+# Bid Params
+
+| Name          | Scope    | Description                                                              | Example              | Type     |
+|---------------|----------|--------------------------------------------------------------------------|----------------------|----------|
+| `orgId`       | required | The publisher's PGAM organisation slug, assigned at onboarding           | `"acme-publisher"`   | `string` |
+| `placementId` | required | Slot reference; lands on `imp.tagid`                                     | `"homepage-leader"`  | `string` |
+
+# Sample Ad Unit
+
+```javascript
+var adUnits = [{
+  code: "div-leaderboard",
+  mediaTypes: { banner: { sizes: [[728, 90], [300, 250]] } },
+  bids: [{
+    bidder: "pgamdirect",
+    params: {
+      orgId: "acme-publisher",
+      placementId: "homepage-leader"
+    }
+  }]
+}];
+```
+
+# Privacy + Consent
+
+- TCF v2.2 — adapter forwards consent strings; PGAM Media LLC is registered
+  as GVL Vendor ID 1353.
+- GPP — supported for `tcfeu`, `usnat`, `usstate_all`.
+- US Privacy / CCPA — passed through unchanged.
+- COPPA — honoured; suppresses the request when the COPPA flag is set on a
+  publisher's inventory.


### PR DESCRIPTION
## Type of change

- [x] Documentation

## Description of change

PR #14763 (New Bidder: PGAM Direct, merged 2026-04-22) added the
adapter (`modules/pgamdirectBidAdapter.ts`) and its test spec, but
did not include the companion `modules/pgamdirectBidAdapter.md`
overview README that most adapters in this directory ship with. This
PR adds that file.

Content:
- Module name + maintainer block (matches the convention used by
  `pgamsspBidAdapter.md` and others in this directory).
- Description, bid params table, sample ad unit, privacy/consent
  summary.
- Notes that PGAM Media LLC is now a registered IAB Europe TCF v2.2
  vendor (**GVL Vendor ID 1353**, verified live against
  https://vendor-list.consensu.org/v3/vendor-list.json
  vendorListVersion 158, last updated 2026-05-07). The full
  metadata-formatted bidder page lives at
  `dev-docs/bidders/pgamdirect.md` in `prebid/prebid.github.io`
  (companion PR filed separately).

## Tests

No code changes — docs only. `modules/pgamdirectBidAdapter.js` and
its spec are unchanged from #14763.

## Other information

Maintainer email + repo unchanged from the original submission.