### PR TITLE
IntimateMerger Analytics Adapter : fix cache

### DIFF
--- a/modules/imAnalyticsAdapter.js
+++ b/modules/imAnalyticsAdapter.js
@@ -256,7 +256,6 @@ const imAnalyticsAdapter = Object.assign(
       auction.wonBidsTimer = null;
 
       if (auction.wonBids.length === 0) {
-        delete cache.auctions[auctionId];
         return;
       }
 
@@ -264,7 +263,7 @@ const imAnalyticsAdapter = Object.assign(
       const ts = auction.auctionInitTimestamp || Date.now();
       const bids = auction.wonBids;
       const uid = auction.imUid;
-      delete cache.auctions[auctionId];
+      auction.wonBids = [];
       sendToApi(buildApiUrlWithOptions(this.options, 'won', auctionId), {
         bids,
         ts,

--- a/test/spec/modules/imAnalyticsAdapter_spec.js
+++ b/test/spec/modules/imAnalyticsAdapter_spec.js
@@ -203,7 +203,7 @@ describe('imAnalyticsAdapter', function() {
         expect(requests[0].url).to.include('/won');
       });
 
-      it('should drop BID_WON for an auction whose cache entry has been cleaned up', function() {
+      it('should send subsequent BID_WON immediately after initial batch', function() {
         const clock = sandbox.useFakeTimers();
 
         imAnalyticsAdapter.track({
@@ -222,17 +222,16 @@ describe('imAnalyticsAdapter', function() {
           args: { auctionId: 'auc-1' }
         });
 
-        // initial batch sends and deletes cache entry
         clock.tick(BID_WON_TIMEOUT + 10);
         expect(requests.length).to.equal(1);
 
-        // BID_WON after cache cleanup is dropped
+        // subsequent BID_WON sent immediately via lightweight cache state
         imAnalyticsAdapter.track({
           eventType: EVENTS.BID_WON,
           args: { ...bidWonArgs, requestId: 'req-2' }
         });
 
-        expect(requests.length).to.equal(1);
+        expect(requests.length).to.equal(2);
       });
 
       it('should deduplicate won bids with same requestId', function() {
@@ -347,7 +346,7 @@ describe('imAnalyticsAdapter', function() {
         expect(requests.length).to.equal(0);
       });
 
-      it('should drop BID_WON that arrives after timer fired with no bids', function() {
+      it('should send BID_WON immediately when it arrives after timer fired with no bids', function() {
         const clock = sandbox.useFakeTimers();
 
         imAnalyticsAdapter.track({
@@ -361,17 +360,18 @@ describe('imAnalyticsAdapter', function() {
           args: { auctionId: 'auc-1' }
         });
 
-        // timer fires with no bids, cache entry is deleted
+        // timer fires with no bids, lightweight cache state is kept
         clock.tick(BID_WON_TIMEOUT + 10);
         expect(requests.length).to.equal(0);
 
-        // late BID_WON is dropped after cache cleanup
+        // late BID_WON sent immediately via lightweight cache state
         imAnalyticsAdapter.track({
           eventType: EVENTS.BID_WON,
           args: { ...bidWonArgs, requestId: 'req-1' }
         });
 
-        expect(requests.length).to.equal(0);
+        expect(requests.length).to.equal(1);
+        expect(requests[0].url).to.include('/won');
       });
     });
   });


### PR DESCRIPTION
修正前挙動
```
1回目の BID_WON (wonSent=true 後)
  → L206: cacheWonBid → wonBids に追加
  → L210: sendWonBidsData 呼び出し
  → L267: delete cache.auctions[auctionId]  ← キャッシュ削除

2回目以降の BID_WON
  → L202: cache.auctions[auctionId] === undefined
  → L204: !auction → return  ← ここで落とされる
wonSent=true 後は 1件目のみ送信され、2件目以降はドロップされる。
```

修正後
```
AUCTION_INIT ──→ /pv エンドポイントへ即時送信
     ↓
 BID_WON × N ──→ cache に蓄積（待機）
     ↓
AUCTION_END ──→ 1500ms タイマー起動
     ↓（タイマー発火）
             ──→ /won エンドポイントへまとめて送信
                 以降の BID_WON は即時送信
```