### PR TITLE
Core: extract background scheduler helper for polite syncs

### DIFF
--- a/src/ajax.ts
+++ b/src/ajax.ts
@@ -3,7 +3,7 @@ import { activityParams } from './activities/activityParams.js';
 import { isActivityAllowed } from './activities/rules.js';
 import { config } from './config.js';
 import { hook } from './hook.js';
-import { buildUrl, hasDeviceAccess, insertUserSyncIframe, logError, parseUrl, triggerPixel } from './utils.js';
+import { buildUrl, hasDeviceAccess, insertUserSyncIframe, logError, parseUrl, runBackgroundTask, triggerPixel } from './utils.js';
 
 export const dep = {
   fetch: window.fetch.bind(window),
@@ -231,19 +231,6 @@ export function sendBeacon(url, data) {
  * Falls back to image-based loading when fetch or keepalive requests are unavailable.
  */
 export function politeTriggerPixel(url) {
-  const runBackgroundTask = (task) => {
-    const scheduler = (window as any).scheduler;
-    if (scheduler?.postTask) {
-      scheduler.postTask(task, { priority: 'background' }).catch(() => task());
-      return;
-    }
-    if (typeof window.requestIdleCallback === 'function') {
-      window.requestIdleCallback(() => task(), { timeout: 2000 });
-      return;
-    }
-    task();
-  }
-
   const triggerSync = () => {
     if (window.fetch && window.Request) {
       try {
@@ -264,19 +251,6 @@ export function politeTriggerPixel(url) {
 }
 
 export function politeInsertUserSyncIframe(url) {
-  const runBackgroundTask = (task) => {
-    const scheduler = (window as any).scheduler;
-    if (scheduler?.postTask) {
-      scheduler.postTask(task, { priority: 'background' }).catch(() => task());
-      return;
-    }
-    if (typeof window.requestIdleCallback === 'function') {
-      window.requestIdleCallback(() => task(), { timeout: 2000 });
-      return;
-    }
-    task();
-  };
-
   runBackgroundTask(() => insertUserSyncIframe(url));
 }
 export const ajax = ajaxBuilder();

--- a/src/utils.js
+++ b/src/utils.js
@@ -47,6 +47,7 @@ export const internal = {
   parseQS,
   formatQS,
   deepEqual,
+  runBackgroundTask,
 };
 
 const prebidInternal = {};
@@ -451,6 +452,23 @@ export function triggerPixel(url, done, timeout) {
     waitForElementToLoad(img, timeout).then(done);
   }
   img.src = url;
+}
+
+/**
+ * Run a task at low priority when supported by the browser, or immediately as fallback.
+ * @param {function} task
+ */
+export function runBackgroundTask(task) {
+  const scheduler = window.scheduler;
+  if (scheduler?.postTask) {
+    scheduler.postTask(task, { priority: 'background' }).catch(() => task());
+    return;
+  }
+  if (typeof window.requestIdleCallback === 'function') {
+    window.requestIdleCallback(() => task(), { timeout: 2000 });
+    return;
+  }
+  task();
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Reduce duplicated scheduler logic found in `src/ajax.ts` by centralizing background-task scheduling with existing utility helpers.
- Keep polite sync behavior (use `scheduler.postTask` → `requestIdleCallback` → immediate fallback) consistent and testable from one place.

### Description
- Added `runBackgroundTask(task)` to `src/utils.js` which runs a task via `scheduler.postTask` when available, then `requestIdleCallback`, then immediate fallback.
- Exported `runBackgroundTask` through the `internal` utilities object to match other reusable helpers and allow stubbing in tests.
- Updated `src/ajax.ts` to import and reuse `runBackgroundTask` and removed the duplicated inline scheduling blocks from `politeTriggerPixel` and `politeInsertUserSyncIframe`.
- Preserved existing behavior and fallbacks for polite pixel/iframe syncs and kept function signatures unchanged.

### Testing
- Ran lint on modified files with `npx eslint --cache --cache-strategy content src/ajax.ts src/utils.js`, which completed successfully.
- Ran the focused test file with `npx gulp test --nolint --file test/spec/ajax_spec.js`, and the test suite for that spec passed (`7 tests completed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a078de8ea9c832b994553ac6453f3e0)