### PR TITLE
Prebid 12: remove showheroes-bs shim adapter

### DIFF
--- a/modules/showheroes-bsBidAdapter.js
+++ b/modules/showheroes-bsBidAdapter.js
@@ -1,9 +1,0 @@
-// This file exists for backwards compatibility only.
-// The adapter has been renamed to showheroesBidAdapter.
-// Please update your build configuration to use showheroesBidAdapter instead.
-// This file will be removed in a future release.
-import { spec as newSpec } from './showheroesBidAdapter.js'; // eslint-disable-line prebid/validate-imports
-import { registerBidder } from '../src/adapters/bidderFactory.js';
-
-export const spec = { ...newSpec, code: 'showheroes-bs' };
-registerBidder(spec);


### PR DESCRIPTION
## Type of change
- [x] Refactoring (no functional changes, no api changes)

## Description
Closes #14751

Removes `modules/showheroes-bsBidAdapter.js`, the backwards-compatibility 
shim left in place when the adapter was renamed in #14644 (v11.7).

Per Prebid's rename policy, the old file was kept to avoid breaking 
publisher builds. This PR completes phase 2 of that rename for Prebid 12.

## Testing
- `gulp test --file test/spec/modules/showheroesBidAdapter_spec.js` — ✅ 15 tests passed
- Lint — ✅ clean