### PR TITLE
CriteoId: Add typescript types through a .d.ts file

### DIFF
--- a/modules/criteoIdSystem.d.ts
+++ b/modules/criteoIdSystem.d.ts
@@ -1,0 +1,11 @@
+declare module './userId/spec' {
+  interface UserId {
+    criteo: string;
+  }
+
+  interface ProvidersToId {
+    criteo: 'criteo';
+  }
+}
+
+export {}

--- a/modules/criteoIdSystem.d.ts
+++ b/modules/criteoIdSystem.d.ts
@@ -1,3 +1,5 @@
+export type CriteoIdSystemModuleName = 'criteo';
+
 declare module './userId/spec' {
   interface UserId {
     criteo: string;
@@ -5,6 +7,10 @@ declare module './userId/spec' {
 
   interface ProvidersToId {
     criteo: 'criteo';
+  }
+
+  interface ProviderParams {
+    criteo: never
   }
 }
 

--- a/modules/criteoIdSystem.d.ts
+++ b/modules/criteoIdSystem.d.ts
@@ -2,11 +2,11 @@ export type CriteoIdSystemModuleName = 'criteo';
 
 declare module './userId/spec' {
   interface UserId {
-    criteo: string;
+    criteoId: string;
   }
 
   interface ProvidersToId {
-    criteo: 'criteo';
+    criteoId: 'criteoId';
   }
 
   interface ProviderParams {

--- a/modules/criteoIdSystem.js
+++ b/modules/criteoIdSystem.js
@@ -17,9 +17,14 @@ import { gdprDataHandler, uspDataHandler, gppDataHandler } from '../src/adapterM
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
  * @typedef {import('../modules/userId/index.js').SubmoduleConfig} SubmoduleConfig
  * @typedef {import('../modules/userId/index.js').ConsentData} ConsentData
+ * @typedef {import('../modules/userId/spec.js').IdProviderSpec} IdProviderSpec
+ * @typedef {import('./criteoIdSystem.d.ts').CriteoIdSystemModuleName} CriteoIdSystemModuleName
  */
 
 const gvlid = 91;
+/**
+ * @typedef CriteoIdSystemModuleName
+ */
 const bidderCode = 'criteo';
 export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: bidderCode });
 
@@ -205,11 +210,11 @@ function callCriteoUserSync(submoduleConfig, parsedCriteoData, callback) {
   ajax(url, callbacks, undefined, { method: 'GET', contentType: 'application/json', withCredentials: true });
 }
 
-/** @type {Submodule} */
+/** @type {IdProviderSpec<CriteoIdSystemModuleName>} */
 export const criteoIdSubmodule = {
   /**
    * used to link submodule with config
-   * @type {string}
+   * @type {CriteoIdSystemModuleName}
    */
   name: bidderCode,
   gvlid: gvlid,

--- a/modules/gemiusIdSystem.ts
+++ b/modules/gemiusIdSystem.ts
@@ -25,6 +25,9 @@ declare module './userId/spec' {
   interface ProvidersToId {
     gemiusId: 'gemiusId';
   }
+  interface ProviderParams {
+    gemiusId: never
+  }
 }
 
 function getTopAccessibleWindow(): Window {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Introduced a `.d.ts` files with typings for CriteoId.
This is more of a test PR to see if adding `.d.ts` files for modules that don't have it yet (and that I use in my own project) is accepted. This might avoid for me to having to maintain my own (extension of the) Prebid types.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
