### PR TITLE
Shared ID: share system public types

### DIFF
--- a/modules/sharedIdSystem.ts
+++ b/modules/sharedIdSystem.ts
@@ -20,7 +20,9 @@ const LOCAL_STORAGE = 'html5';
 const OPTOUT_NAME = '_pubcid_optout';
 const PUB_COMMON_ID = 'PublisherCommonId';
 
-type SharedIdParams = {
+export type SharedIdSystemModuleName = 'sharedId' | 'pubCommonId';
+
+export type SharedIdParams = {
   /**
    * If true, then an id is created automatically if it’s missing.
    * Default is true. If your server has a component that generates the id instead, then this should be set to false


### PR DESCRIPTION
### Motivation
- Make shared ID provider name and params types importable so typed integrations can reuse canonical identifiers and config shapes without duplicating local declarations.

### Description
- Export `SharedIdSystemModuleName` and `SharedIdParams` from `modules/sharedIdSystem.ts` and keep the existing `ProviderParams` augmentation pointed at `SharedIdParams` to preserve behaviour.

### Testing
- Ran `npx eslint --cache --cache-strategy content modules/sharedIdSystem.ts` which completed successfully.
- Ran `npx gulp test --nolint --file test/spec/modules/sharedIdSystem_spec.js` and the spec passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0a21042660832b80fc16e62fb52a75)