### PR TITLE
UID2/EUID id submodules: add type definitions and update modules to use them

### DIFF
--- a/modules/euidIdSystem.js
+++ b/modules/euidIdSystem.js
@@ -13,10 +13,10 @@ import { MODULE_TYPE_UID } from '../src/activities/modules.js';
 import { Uid2GetId, Uid2CodeVersion, extractIdentityFromParams } from '../libraries/uid2IdSystemShared/uid2IdSystem_shared.js';
 
 /**
- * @typedef {import('../modules/userId/index.js').Submodule} Submodule
- * @typedef {import('../modules/userId/index.js').SubmoduleConfig} SubmoduleConfig
- * @typedef {import('../modules/userId/index.js').ConsentData} ConsentData
- * @typedef {import('../modules/userId/index.js').IdResponse} IdResponse
+ * @typedef {import('./uid2EuidIdSystemTypes.d.ts').EuidSubmodule} Submodule
+ * @typedef {import('./uid2EuidIdSystemTypes.d.ts').EuidSubmoduleConfig} SubmoduleConfig
+ * @typedef {import('./uid2EuidIdSystemTypes.d.ts').ConsentData} ConsentData
+ * @typedef {import('./uid2EuidIdSystemTypes.d.ts').IdResponse} IdResponse
  */
 
 const MODULE_NAME = 'euid';

--- a/modules/uid2EuidIdSystemTypes.d.ts
+++ b/modules/uid2EuidIdSystemTypes.d.ts
@@ -1,0 +1,19 @@
+import type { AllConsentData } from '../src/consentHandler.ts';
+import type { IdProviderSpec, ProviderResponse, UserIdConfig } from './userId/spec.ts';
+
+export interface uid2Id {
+  id?: string;
+  optout?: boolean;
+}
+
+export interface euidId {
+  id?: string;
+  optout?: boolean;
+}
+
+export type Uid2Submodule = IdProviderSpec<'uid2'>;
+export type Uid2SubmoduleConfig = UserIdConfig<'uid2'>;
+export type EuidSubmodule = IdProviderSpec<'euid'>;
+export type EuidSubmoduleConfig = UserIdConfig<'euid'>;
+export type ConsentData = AllConsentData;
+export type IdResponse = ProviderResponse;

--- a/modules/uid2IdSystem.js
+++ b/modules/uid2IdSystem.js
@@ -14,10 +14,10 @@ import { Uid2GetId, Uid2CodeVersion, extractIdentityFromParams } from '../librar
 import { UID2_EIDS } from '../libraries/uid2Eids/uid2Eids.js';
 
 /**
- * @typedef {import('../modules/userId/index.js').Submodule} Submodule
- * @typedef {import('../modules/userId/index.js').SubmoduleConfig} SubmoduleConfig
- * @typedef {import('../modules/userId/index.js').ConsentData} ConsentData
- * @typedef {import('../modules/userId/index.js').uid2Id} uid2Id
+ * @typedef {import('./uid2EuidIdSystemTypes.d.ts').Uid2Submodule} Submodule
+ * @typedef {import('./uid2EuidIdSystemTypes.d.ts').Uid2SubmoduleConfig} SubmoduleConfig
+ * @typedef {import('./uid2EuidIdSystemTypes.d.ts').ConsentData} ConsentData
+ * @typedef {import('./uid2EuidIdSystemTypes.d.ts').uid2Id} uid2Id
  */
 
 const MODULE_NAME = 'uid2';


### PR DESCRIPTION
### Motivation

- Centralize and share TypeScript/JSDoc typedefs for UID2 and EUID modules to avoid duplicated inline typedefs and improve type consistency.

### Description

- Add `modules/uid2EuidIdSystemTypes.d.ts` containing shared interfaces and type aliases including `uid2Id`, `euidId`, `Uid2Submodule`, `EuidSubmodule`, `ConsentData`, and `IdResponse`.
- Update `modules/uid2IdSystem.js` to import JSDoc typedefs from `./uid2EuidIdSystemTypes.d.ts` instead of referencing `userId` internals.
- Update `modules/euidIdSystem.js` to import its JSDoc typedefs from `./uid2EuidIdSystemTypes.d.ts` and align typedef names for EUID.
- Keep existing runtime logic and constants intact while switching documentation/type imports to the new shared file.

### Testing

- Ran the repository's automated unit test suite via `npm test`, which completed successfully.
- Ran linting via `npm run lint`, which passed without new issues.
- Ran a project build via `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0a1fdc9ac0832bad65ab7eb4b37059)