### PR TITLE
debugging module: Added type definitions

### DIFF
--- a/modules/debugging/debugging.js
+++ b/modules/debugging/debugging.js
@@ -2,10 +2,17 @@ import { makebidInterceptor } from './bidInterceptor.js';
 import { makePbsInterceptor } from './pbsInterceptor.js';
 import { addHooks, removeHooks } from './legacy.js';
 
+/**
+ * @typedef {import('./debuggingModule.d.ts').DebugModuleConfiguration} DebugModuleConfiguration
+ */
+
 const interceptorHooks = [];
 let bidInterceptor;
 let enabled = false;
 
+/**
+ * @param {DebugModuleConfiguration} debugConfig Configuration of the debug module
+ */
 function enableDebugging(debugConfig, { fromSession = false, config, hook, logger }) {
   config.setConfig({ debug: true });
   bidInterceptor.updateConfig(debugConfig);

--- a/modules/debugging/debuggingModule.d.ts
+++ b/modules/debugging/debuggingModule.d.ts
@@ -1,0 +1,75 @@
+import type { BidRequest } from "../../src/adapterManager";
+import type { Bid } from "../../src/bidfactory";
+import type { BidderCode } from "../../src/types/common";
+
+export type DebugModuleConfiguration = {
+  enabled?: boolean;
+  /**
+   * Rules are evaluated on each bid in the order they are provided: the first one that has a matching when definition takes the bid out of the normal auction flow and replaces it according to its then definition.
+   */
+  intercept: InterceptRule[]
+}
+
+export type InterceptRule = {
+  /**
+   * Decides which bids should be intercepted by this rule
+   */
+  when: MatchRule;
+  /**
+   * Decides the contents of the bids that are intercepted by this rule
+   */
+  then?: ReplaceRule;
+  options?: RuleOptions;
+}
+
+  type MatchRule =
+    /**
+     * The match rule can be provided as a function that takes the bid request as its only argument and returns `true` if the bid should be intercepted, `false` otherwise.
+     */
+    | ((bidRequest: BidRequest<BidderCode | null>) => boolean)
+    /**
+     * Alternatively, the rule can be expressed as an `object`, and it matches if for each key-value pair:
+     * - `bidRequest[key] === value`, or
+     * - `value` is a function and `value(bidRequest[key])` is `true`, or
+     * - `value` is a regular expression and it matches `bidRequest[key]`.
+     */
+    | {
+      [K in keyof BidRequest<BidderCode | null>]?: BidRequest<BidderCode | null>[K] | ((value: BidRequest<BidderCode | null>[K]) => boolean) | RegExp
+    };
+
+  type ReplaceRule =
+    /**
+     * The replace rule can be provided as a function that takes the bid request as its only argument and returns an object with the desired response properties
+     */
+    | ((bidRequest: BidRequest<BidderCode | null>) => Partial<Bid>)
+    /**
+     * Alternatively, the rule can be expressed as an `object`, and its key-value pairs will appear in the response as follows:
+     * - if `value` is a function, then `bidResponse[key]` will be set to `value(bidRequest)`;
+     * - otherwise, `bidResponse[key]` will be set to `value`.
+     */
+    | {
+      [K in keyof Bid]?: Bid[K] | ((request: BidRequest<BidderCode | null>) => Bid[K]);
+    };
+
+  type RuleOptions = {
+    /**
+     * Delay (in milliseconds) before intercepted bids are injected into the auction.
+     * Can be used to simulate network latency.
+     *
+     * Defaults to zero.
+     */
+    delay?: number
+  }
+
+declare module '../../src/config' {
+  interface Config {
+    /**
+     * This module allows to “intercept” bids and replace their contents with arbitrary data for the purposes of testing and development.
+     *
+     * Bids intercepted in this way are never seen by bid adapters or their backend SSPs, but they are nonetheless injected into the auction as if they originated from them.
+     */
+    debugging?: DebugModuleConfiguration;
+  }
+}
+
+export {}

--- a/modules/debugging/debuggingModule.d.ts
+++ b/modules/debugging/debuggingModule.d.ts
@@ -7,7 +7,7 @@ export type DebugModuleConfiguration = {
   /**
    * Rules are evaluated on each bid in the order they are provided: the first one that has a matching when definition takes the bid out of the normal auction flow and replaces it according to its then definition.
    */
-  intercept: InterceptRule[]
+  intercept?: InterceptRule[]
 }
 
 export type InterceptRule = {

--- a/modules/debugging/debuggingModule.d.ts
+++ b/modules/debugging/debuggingModule.d.ts
@@ -39,9 +39,10 @@ export type InterceptRule = {
 
   type ReplaceRule =
     /**
-     * The replace rule can be provided as a function that takes the bid request as its only argument and returns an object with the desired response properties
+     * The replace rule can be provided as a function that takes the bid request as its only argument and returns an object with the desired response properties.
+     * The function can return `null` to indicate that there is no bid.
      */
-    | ((bidRequest: BidRequest<BidderCode | null>) => Partial<Bid>)
+    | ((bidRequest: BidRequest<BidderCode | null>) => Partial<Bid> | null)
     /**
      * Alternatively, the rule can be expressed as an `object`, and its key-value pairs will appear in the response as follows:
      * - if `value` is a function, then `bidResponse[key]` will be set to `value(bidRequest)`;
@@ -49,7 +50,11 @@ export type InterceptRule = {
      */
     | {
       [K in keyof Bid]?: Bid[K] | ((request: BidRequest<BidderCode | null>) => Bid[K]);
-    };
+    }
+    /**
+     * Indicates no bid.
+     */
+    | null;
 
   type RuleOptions = {
     /**


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Created type definitions for the debugging module based on what is [written in the docs](https://docs.prebid.org/dev-docs/modules/debugging.html).
I tested every example from the docs against my types, and everything worked (except for [this](https://github.com/prebid/prebid.github.io/pull/6571), but that is a problem with the example, not my typings).

Note that, when creating a build and trying to actually use those typings through:
```typescript
import type { PrebidJS} from 'prebid.js/types.d.ts';

function configureDebugModule(pbjs: PrebidJS){
    pbjs.setConfig({
      debugging: {...}
    });
}
```
doesn't work. It doesn't seem to pick up these new typings, despite the fact that they are present in the `modules.d.ts` file.
So either there is still something wrong with my typings, or with the way I tried to use them in the example above. For now, I'm assuming it might have the same root cause as [this issue](https://github.com/prebid/Prebid.js/issues/14895).


<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
