### PR TITLE
Mobian RTD Module: add new integer-valued keys

### DIFF
--- a/modules/mobianRtdProvider.js
+++ b/modules/mobianRtdProvider.js
@@ -43,6 +43,8 @@ export const EMOTIONS = 'emotions';
 export const GENRES = 'genres';
 export const RISK = 'risk';
 export const SENTIMENT = 'sentiment';
+export const TQ = 'tq';
+export const TG = 'tg';
 export const THEMES = 'themes';
 export const TONES = 'tones';
 
@@ -53,6 +55,8 @@ export const CONTEXT_KEYS = [
   GENRES,
   RISK,
   SENTIMENT,
+  TQ,
+  TG,
   THEMES,
   TONES
 ];
@@ -116,8 +120,9 @@ export function makeContextDataToKeyValuesReducer(config) {
         if (!value?.[apKey]?.length) return;
         keyValues.push([`${prefix}_ap_${apKey}`, value[apKey].map((v) => String(v))]);
       });
-    }
-    if (value?.length) {
+    } else if ((key === TQ || key === TG) && value != null) {
+      keyValues.push([`${prefix}_${key}`, value]);
+    } else if (value?.length) {
       keyValues.push([`${prefix}_${key}`, value]);
     }
     return keyValues;
@@ -181,6 +186,8 @@ export function makeDataFromResponse(contextData) {
     [GENRES]: results.mobianGenres,
     [RISK]: results.mobianRisk || 'unknown',
     [SENTIMENT]: results.mobianSentiment || 'unknown',
+    [TQ]: results.mobian_tq,
+    [TG]: results.mobian_tg,
     [THEMES]: results.mobianThemes,
     [TONES]: results.mobianTones,
   };

--- a/test/spec/modules/mobianRtdProvider_spec.js
+++ b/test/spec/modules/mobianRtdProvider_spec.js
@@ -11,6 +11,8 @@ import {
   MAX_CACHE_SIZE,
   RISK,
   SENTIMENT,
+  TQ,
+  TG,
   THEMES,
   TONES,
   extendBidRequestConfig,
@@ -40,6 +42,8 @@ describe('Mobian RTD Submodule', function () {
       mobianGenres: [],
       mobianRisk: 'low',
       mobianSentiment: 'positive',
+      mobian_tq: 1,
+      mobian_tg: 3,
       mobianThemes: [],
       mobianTones: [],
     }
@@ -52,6 +56,8 @@ describe('Mobian RTD Submodule', function () {
     [GENRES]: [],
     [RISK]: 'low',
     [SENTIMENT]: 'positive',
+    [TQ]: 1,
+    [TG]: 3,
     [THEMES]: [],
     [TONES]: [],
   }
@@ -63,12 +69,14 @@ describe('Mobian RTD Submodule', function () {
     'mobian_emotions': ['affection'],
     'mobian_risk': 'low',
     'mobian_sentiment': 'positive',
+    'mobian_tq': 1,
+    'mobian_tg': 3,
   }
 
   const mockConfig = {
     prefix: 'mobian',
-    publisherTargeting: [AP_VALUES, EMOTIONS, RISK, SENTIMENT, THEMES, TONES, GENRES],
-    advertiserTargeting: [AP_VALUES, EMOTIONS, RISK, SENTIMENT, THEMES, TONES, GENRES],
+    publisherTargeting: [AP_VALUES, EMOTIONS, RISK, SENTIMENT, TQ, TG, THEMES, TONES, GENRES],
+    advertiserTargeting: [AP_VALUES, EMOTIONS, RISK, SENTIMENT, TQ, TG, THEMES, TONES, GENRES],
   }
 
   beforeEach(function () {
@@ -125,17 +133,19 @@ describe('Mobian RTD Submodule', function () {
     it('should set targeting key-value pairs as per config', function () {
       const parsedConfig = {
         prefix: 'mobian',
-        publisherTargeting: [AP_VALUES, EMOTIONS, RISK, SENTIMENT, THEMES, TONES, GENRES],
+        publisherTargeting: [AP_VALUES, EMOTIONS, RISK, SENTIMENT, TQ, TG, THEMES, TONES, GENRES],
       };
       setTargeting(parsedConfig, mockContextData);
 
-      expect(setKeyValueSpy.callCount).to.equal(6);
+      expect(setKeyValueSpy.callCount).to.equal(8);
       expect(setKeyValueSpy.calledWith('mobian_ap_a1', ['2313', '12'])).to.equal(true);
       expect(setKeyValueSpy.calledWith('mobian_ap_p0', ['1231231', '212'])).to.equal(true);
       expect(setKeyValueSpy.calledWith('mobian_ap_p1', ['231', '419'])).to.equal(true);
       expect(setKeyValueSpy.calledWith('mobian_emotions', ['affection'])).to.equal(true);
       expect(setKeyValueSpy.calledWith('mobian_risk', 'low')).to.equal(true);
       expect(setKeyValueSpy.calledWith('mobian_sentiment', 'positive')).to.equal(true);
+      expect(setKeyValueSpy.calledWith('mobian_tq', 1)).to.equal(true);
+      expect(setKeyValueSpy.calledWith('mobian_tg', 3)).to.equal(true);
 
       expect(setKeyValueSpy.calledWith('mobian_ap_a0')).to.equal(false);
       expect(setKeyValueSpy.calledWith('mobian_themes')).to.equal(false);
@@ -146,7 +156,7 @@ describe('Mobian RTD Submodule', function () {
     it('should not set key-value pairs if context data is empty', function () {
       const parsedConfig = {
         prefix: 'mobian',
-        publisherTargeting: [AP_VALUES, EMOTIONS, RISK, SENTIMENT, THEMES, TONES, GENRES],
+        publisherTargeting: [AP_VALUES, EMOTIONS, RISK, SENTIMENT, TQ, TG, THEMES, TONES, GENRES],
       };
       setTargeting(parsedConfig, {});
 
@@ -156,14 +166,15 @@ describe('Mobian RTD Submodule', function () {
     it('should only set key-value pairs for the keys specified in config', function () {
       const parsedConfig = {
         prefix: 'mobian',
-        publisherTargeting: [EMOTIONS, RISK],
+        publisherTargeting: [EMOTIONS, RISK, TQ],
       };
 
       setTargeting(parsedConfig, mockContextData);
 
-      expect(setKeyValueSpy.callCount).to.equal(2);
+      expect(setKeyValueSpy.callCount).to.equal(3);
       expect(setKeyValueSpy.calledWith('mobian_emotions', ['affection'])).to.equal(true);
       expect(setKeyValueSpy.calledWith('mobian_risk', 'low')).to.equal(true);
+      expect(setKeyValueSpy.calledWith('mobian_tq', 1)).to.equal(true);
 
       expect(setKeyValueSpy.calledWith('mobian_ap_a0')).to.equal(false);
       expect(setKeyValueSpy.calledWith('mobian_ap_a1')).to.equal(false);
@@ -172,6 +183,7 @@ describe('Mobian RTD Submodule', function () {
       expect(setKeyValueSpy.calledWith('mobian_themes')).to.equal(false);
       expect(setKeyValueSpy.calledWith('mobian_tones')).to.equal(false);
       expect(setKeyValueSpy.calledWith('mobian_genres')).to.equal(false);
+      expect(setKeyValueSpy.calledWith('mobian_tg')).to.equal(false);
     });
   });
 
@@ -278,6 +290,29 @@ describe('Mobian RTD Submodule', function () {
       const keyValues = Object.entries(mockContextData).reduce(makeContextDataToKeyValuesReducer(config), []);
       const keyValuesObject = Object.fromEntries(keyValues);
       expect(keyValuesObject).to.deep.equal(mockKeyValues);
+    });
+
+    it('should add scalar tq and tg values when called directly with those entries', function () {
+      const config = getConfig({
+        name: 'mobianBrandSafety',
+        params: {
+          prefix: 'mobian',
+          publisherTargeting: true,
+          advertiserTargeting: true,
+        }
+      });
+      const reducer = makeContextDataToKeyValuesReducer(config);
+
+      const keyValues = [
+        [TQ, 1],
+        [TG, 3],
+        [TG, null],
+      ].reduce(reducer, []);
+
+      expect(keyValues).to.deep.equal([
+        ['mobian_tq', 1],
+        ['mobian_tg', 3],
+      ]);
     });
   });
 


### PR DESCRIPTION

## Type of change

- [ x] Feature

## Description of change

The Mobian API hit by the pre-existing module is releasing two new scores, mobian_tq and mobian_tg, which we want to push into GAM for clients.