### PR TITLE
Adkernel Bid Adapter: add ReLoad alias

### DIFF
--- a/modules/adkernelBidAdapter.js
+++ b/modules/adkernelBidAdapter.js
@@ -108,7 +108,8 @@ export const spec = {
     { code: 'qohere' },
     { code: 'blutonic' },
     { code: 'appmonsta', gvlid: 1283 },
-    { code: 'intlscoop' }
+    { code: 'intlscoop' },
+    { code: 'reload' }
   ],
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter 

## Description of change

Added alias for ReLoad partner network


## Other information
https://github.com/prebid/prebid.github.io/pull/6572