### PR TITLE
Core: fix bug with accessRequestCredentials not controlling access to request credentials

### DIFF
--- a/modules/abtshieldIdSystem.js
+++ b/modules/abtshieldIdSystem.js
@@ -105,7 +105,7 @@ export const abtshieldIdSubmodule = {
             }
           },
           undefined,
-          AJAX_OPTIONS
+          { ...AJAX_OPTIONS }
         );
       }
     };

--- a/modules/abtshieldIdSystem.js
+++ b/modules/abtshieldIdSystem.js
@@ -6,8 +6,8 @@
  */
 
 import { submodule } from '../src/hook.js';
-import { logError, logInfo, logWarn, deepClone } from '../src/utils.js';
-import { ajaxBuilder, processRequestOptions } from '../src/ajax.js';
+import { deepClone, logError, logInfo, logWarn } from '../src/utils.js';
+import { ajaxBuilder } from '../src/ajax.js';
 import { MODULE_TYPE_UID } from '../src/activities/modules.js';
 
 const MODULE_NAME = 'abtshieldId';
@@ -105,7 +105,7 @@ export const abtshieldIdSubmodule = {
             }
           },
           undefined,
-          processRequestOptions({ ...AJAX_OPTIONS }, MODULE_TYPE_UID, MODULE_NAME)
+          AJAX_OPTIONS
         );
       }
     };

--- a/modules/tcfControl.ts
+++ b/modules/tcfControl.ts
@@ -33,7 +33,6 @@ import {
   ACTIVITY_TRANSMIT_PRECISE_GEO,
   ACTIVITY_TRANSMIT_UFPD
 } from '../src/activities/activities.js';
-import { processRequestOptions } from '../src/ajax.js';
 import type { TCFConsentData } from "./consentManagementTcf.ts";
 
 export const STRICT_STORAGE_ENFORCEMENT = 'strictStorageEnforcement';
@@ -307,6 +306,7 @@ export const enrichEidsRule = singlePurposeGdprRule(1, storageBlocked);
 export const fetchBidsRule = exceptPrebidModules(singlePurposeGdprRule(2, biddersBlocked));
 export const reportAnalyticsRule = singlePurposeGdprRule(7, analyticsBlocked, (params) => getGvlidFromAnalyticsAdapter(params[ACTIVITY_PARAM_COMPONENT_NAME], params[ACTIVITY_PARAM_ANL_CONFIG]));
 export const ufpdRule = singlePurposeGdprRule(4, ufpdBlocked);
+export const accessRequestCredentialsRule = singlePurposeGdprRule(1, storageBlocked);
 
 export const transmitEidsRule = exceptPrebidModules((() => {
   // Transmit EID special case:
@@ -424,7 +424,7 @@ export function setEnforcementConfig(config) {
       RULE_HANDLES.push(registerActivityControl(ACTIVITY_ACCESS_DEVICE, RULE_NAME, accessDeviceRule));
       RULE_HANDLES.push(registerActivityControl(ACTIVITY_SYNC_USER, RULE_NAME, syncUserRule));
       RULE_HANDLES.push(registerActivityControl(ACTIVITY_ENRICH_EIDS, RULE_NAME, enrichEidsRule));
-      processRequestOptions.after(checkIfCredentialsAllowed);
+      RULE_HANDLES.push(registerActivityControl(ACTIVITY_ACCESS_REQUEST_CREDENTIALS, RULE_NAME, accessRequestCredentialsRule));
     }
     if (ACTIVE_RULES.purpose[2] != null) {
       RULE_HANDLES.push(registerActivityControl(ACTIVITY_FETCH_BIDS, RULE_NAME, fetchBidsRule));
@@ -445,26 +445,8 @@ export function setEnforcementConfig(config) {
   }
 }
 
-export function checkIfCredentialsAllowed(next, options: { withCredentials?: boolean } = {}, moduleType?: string, moduleName?: string) {
-  if (!options.withCredentials || (moduleType && moduleName)) {
-    next(options);
-    return;
-  }
-  const consentData = gdprDataHandler.getConsentData();
-  const rule = ACTIVE_RULES.purpose[1];
-  const ruleOptions = CONFIGURABLE_RULES[rule.purpose];
-  const { purpose } = getConsent(consentData, ruleOptions.type, ruleOptions.id, null);
-
-  if (!purpose && rule.enforcePurpose) {
-    options.withCredentials = false;
-    logWarn(`${RULE_NAME} denied ${ACTIVITY_ACCESS_REQUEST_CREDENTIALS}`);
-  }
-  next(options);
-}
-
 export function uninstall() {
   while (RULE_HANDLES.length) RULE_HANDLES.pop()();
-  processRequestOptions.getHooks({ hook: checkIfCredentialsAllowed }).remove();
   hooksAdded = false;
 }
 

--- a/src/adapterManager.ts
+++ b/src/adapterManager.ts
@@ -745,7 +745,7 @@ const adapterManager = {
         const s2sAjax = ajaxBuilder(requestBidsTimeout, requestCallbacks ? {
           request: requestCallbacks.request.bind(null, 's2s'),
           done: requestCallbacks.done
-        } : undefined);
+        } : undefined, MODULE_TYPE_PREBID, PBS_ADAPTER_NAME);
         const adaptersServerSide = s2sConfig.bidders;
         const s2sAdapter = _bidderRegistry[s2sConfig.adapter];
         const uniquePbsTid = uniqueServerBidRequests[counter].uniquePbsTid;
@@ -802,7 +802,7 @@ const adapterManager = {
       const ajax = ajaxBuilder(requestBidsTimeout, requestCallbacks ? {
         request: requestCallbacks.request.bind(null, bidderRequest.bidderCode),
         done: requestCallbacks.done
-      } : undefined);
+      } : undefined, MODULE_TYPE_BIDDER, bidderRequest.bidderCode);
       const adapterDone = doneCb.bind(bidderRequest);
       try {
         config.runWithBidder(

--- a/src/ajax.ts
+++ b/src/ajax.ts
@@ -59,19 +59,6 @@ export interface AjaxOptions {
   suppressTopicsEnrollmentWarning?: boolean;
 }
 
-export const processRequest = hook('async', function (request, moduleType, moduleName) {
-  if (
-    request.credentials === 'include' && (
-      !hasDeviceAccess() || (
-        moduleType && moduleName && !isActivityAllowed(ACTIVITY_ACCESS_REQUEST_CREDENTIALS, activityParams(moduleType, moduleName))
-      )
-    )
-  ) {
-    return dep.makeRequest(request, { credentials: 'same-origin' });
-  }
-  return request;
-}, 'processRequestOptions');
-
 /**
  * transform legacy `ajax` parameters into a fetch request.
  * @returns {Request}

--- a/src/ajax.ts
+++ b/src/ajax.ts
@@ -122,7 +122,10 @@ export function fetcherFactory(timeout = 3000, { request, done }: any = {}, modu
         )
       )
     ) {
-      request = dep.makeRequest(request, { credentials: 'same-origin' });
+      request = dep.makeRequest(request, {
+        keepalive: request.keepalive, // According to MDN this should be unnecessary, but Firefox will lose `keepalive` without itt
+        credentials: 'same-origin'
+      });
     }
     let pm = dep.fetch(request);
     if (to?.done != null) pm = pm.finally(to.done);

--- a/src/ajax.ts
+++ b/src/ajax.ts
@@ -2,7 +2,6 @@ import { ACTIVITY_ACCESS_REQUEST_CREDENTIALS } from './activities/activities.js'
 import { activityParams } from './activities/activityParams.js';
 import { isActivityAllowed } from './activities/rules.js';
 import { config } from './config.js';
-import { hook } from './hook.js';
 import { buildUrl, hasDeviceAccess, logError, parseUrl } from './utils.js';
 
 export const dep = {

--- a/src/ajax.ts
+++ b/src/ajax.ts
@@ -59,11 +59,17 @@ export interface AjaxOptions {
   suppressTopicsEnrollmentWarning?: boolean;
 }
 
-export const processRequestOptions = hook('async', function(options = {}, moduleType, moduleName) {
-  if (options.withCredentials) {
-    options.withCredentials = (moduleType && moduleName) ? isActivityAllowed(ACTIVITY_ACCESS_REQUEST_CREDENTIALS, activityParams(moduleType, moduleName)) : hasDeviceAccess();
+export const processRequest = hook('async', function (request, moduleType, moduleName) {
+  if (
+    request.credentials === 'include' && (
+      !hasDeviceAccess() || (
+        moduleType && moduleName && !isActivityAllowed(ACTIVITY_ACCESS_REQUEST_CREDENTIALS, activityParams(moduleType, moduleName))
+      )
+    )
+  ) {
+    return dep.makeRequest(request, { credentials: 'same-origin' });
   }
-  return options;
+  return request;
 }, 'processRequestOptions');
 
 /**
@@ -121,10 +127,18 @@ export function fetcherFactory(timeout = 3000, { request, done }: any = {}, modu
       to = dep.timeout(timeout, resource);
       options = Object.assign({ signal: to.signal }, options);
     }
+    let request = dep.makeRequest(resource, options);
 
-    processRequestOptions(options, moduleType, moduleName);
-
-    let pm = dep.fetch(resource, options);
+    if (
+      request.credentials === 'include' && (
+        !hasDeviceAccess() || (
+          moduleType && moduleName && !isActivityAllowed(ACTIVITY_ACCESS_REQUEST_CREDENTIALS, activityParams(moduleType, moduleName))
+        )
+      )
+    ) {
+      request = dep.makeRequest(request, { credentials: 'same-origin' });
+    }
+    let pm = dep.fetch(request);
     if (to?.done != null) pm = pm.finally(to.done);
     return pm;
   };

--- a/test/mocks/xhr.js
+++ b/test/mocks/xhr.js
@@ -17,7 +17,10 @@ function mockFetchServer() {
 
   function makeRequest(resource, options) {
     const requestBody = options?.body || bodies.get(resource);
-    const request = new Request(resource, options);
+    const request = new Request(resource, Object.assign({
+      // firefox will lose keepalive otherwise
+      keepalive: resource?.keepalive
+    }, options));
     bodies.set(request, requestBody);
     return request;
   }

--- a/test/spec/modules/tcfControl_spec.js
+++ b/test/spec/modules/tcfControl_spec.js
@@ -1,8 +1,9 @@
 import {
-  accessDeviceRule,
+  accessDeviceRule, accessRequestCredentialsRule,
   ACTIVE_RULES,
   enrichEidsRule,
-  fetchBidsRule, getAcceptableFlags,
+  fetchBidsRule,
+  getAcceptableFlags,
   getGvlid,
   getGvlidFromAnalyticsAdapter,
   reportAnalyticsRule,
@@ -13,7 +14,6 @@ import {
   transmitPreciseGeoRule,
   ufpdRule,
   validateRules
-  , checkIfCredentialsAllowed
 } from 'modules/tcfControl.js';
 import { config } from 'src/config.js';
 import adapterManager, { gdprDataHandler } from 'src/adapterManager.js';
@@ -224,116 +224,121 @@ describe('gdpr enforcement', function () {
     })
   });
 
-  describe('deviceAccessRule', () => {
-    afterEach(() => {
-      config.resetConfig();
-    });
+  Object.entries({
+    accessDeviceRule,
+    accessRequestCredentialsRule
+  }).forEach(([name, rule]) => {
+    describe(name, () => {
+      afterEach(() => {
+        config.resetConfig();
+      });
 
-    it('should not check for consent when enforcePurpose and enforceVendor are false', function () {
-      Object.assign(gvlids, {
-        appnexus: 1,
-        rubicon: 5
+      it('should not check for consent when enforcePurpose and enforceVendor are false', function () {
+        Object.assign(gvlids, {
+          appnexus: 1,
+          rubicon: 5
+        });
+        setEnforcementConfig({
+          gdpr: {
+            rules: [{
+              purpose: 'storage',
+              enforcePurpose: false,
+              enforceVendor: false,
+              vendorExceptions: ['appnexus']
+            }]
+          }
+        });
+        setupConsentData();
+        ['appnexus', 'rubicon'].forEach(bidder => expectAllow(true, rule(activityParams(MODULE_TYPE_BIDDER, bidder))));
       });
-      setEnforcementConfig({
-        gdpr: {
-          rules: [{
-            purpose: 'storage',
-            enforcePurpose: false,
-            enforceVendor: false,
-            vendorExceptions: ['appnexus']
-          }]
-        }
-      });
-      setupConsentData();
-      ['appnexus', 'rubicon'].forEach(bidder => expectAllow(true, accessDeviceRule(activityParams(MODULE_TYPE_BIDDER, bidder))));
-    });
 
-    it('should check consent for all vendors when enforcePurpose and enforceVendor are true', function () {
-      Object.assign(gvlids, {
-        appnexus: 1,
-        rubicon: 3
+      it('should check consent for all vendors when enforcePurpose and enforceVendor are true', function () {
+        Object.assign(gvlids, {
+          appnexus: 1,
+          rubicon: 3
+        });
+        setEnforcementConfig({
+          gdpr: {
+            rules: [{
+              purpose: 'storage',
+              enforcePurpose: true,
+              enforceVendor: true,
+            }]
+          }
+        });
+        setupConsentData();
+        Object.entries({
+          appnexus: true,
+          rubicon: false
+        }).forEach(([bidder, isAllowed]) => {
+          expectAllow(isAllowed, rule(activityParams(MODULE_TYPE_BIDDER, bidder)));
+        })
       });
-      setEnforcementConfig({
-        gdpr: {
-          rules: [{
-            purpose: 'storage',
-            enforcePurpose: true,
-            enforceVendor: true,
-          }]
-        }
-      });
-      setupConsentData();
-      Object.entries({
-        appnexus: true,
-        rubicon: false
-      }).forEach(([bidder, isAllowed]) => {
-        expectAllow(isAllowed, accessDeviceRule(activityParams(MODULE_TYPE_BIDDER, bidder)));
-      })
-    });
 
-    it('should allow device access when gdprApplies is false and hasDeviceAccess flag is true', function () {
-      gvlids.appnexus = 1;
-      setEnforcementConfig({
-        gdpr: {
-          rules: [{
-            purpose: 'storage',
-            enforcePurpose: true,
-            enforceVendor: true,
-            vendorExceptions: []
-          }]
-        }
+      it('should allow device access when gdprApplies is false and hasDeviceAccess flag is true', function () {
+        gvlids.appnexus = 1;
+        setEnforcementConfig({
+          gdpr: {
+            rules: [{
+              purpose: 'storage',
+              enforcePurpose: true,
+              enforceVendor: true,
+              vendorExceptions: []
+            }]
+          }
+        });
+        setupConsentData();
+        expectAllow(true, rule(activityParams(MODULE_TYPE_BIDDER, 'appnexus')));
       });
-      setupConsentData();
-      expectAllow(true, accessDeviceRule(activityParams(MODULE_TYPE_BIDDER, 'appnexus')));
-    });
 
-    it('should support TCF 2.3 tcData using disclosedVendors', function () {
-      gvlids.appnexus = 1;
-      setEnforcementConfig({
-        gdpr: {
-          rules: [{
-            purpose: 'storage',
-            enforcePurpose: true,
-            enforceVendor: true,
-            vendorExceptions: []
-          }]
-        }
+      it('should support TCF 2.3 tcData using disclosedVendors', function () {
+        gvlids.appnexus = 1;
+        setEnforcementConfig({
+          gdpr: {
+            rules: [{
+              purpose: 'storage',
+              enforcePurpose: true,
+              enforceVendor: true,
+              vendorExceptions: []
+            }]
+          }
+        });
+        setupConsentData({
+          tcDataMutator: (tcData) => {
+            tcData.tcfPolicyVersion = 3;
+            tcData.disclosedVendors = { '1': true, '2': true };
+          }
+        });
+        expectAllow(true, rule(activityParams(MODULE_TYPE_BIDDER, 'appnexus')));
       });
-      setupConsentData({
-        tcDataMutator: (tcData) => {
-          tcData.tcfPolicyVersion = 3;
-          tcData.disclosedVendors = { '1': true, '2': true };
-        }
-      });
-      expectAllow(true, accessDeviceRule(activityParams(MODULE_TYPE_BIDDER, 'appnexus')));
-    });
 
-    it('should use gvlMapping set by publisher', function() {
-      config.setConfig({
-        'gvlMapping': {
-          'appnexus': 4
-        }
+      it('should use gvlMapping set by publisher', function() {
+        config.setConfig({
+          'gvlMapping': {
+            'appnexus': 4
+          }
+        });
+        setEnforcementConfig({
+          gdpr: {
+            rules: [{
+              purpose: 'storage',
+              enforcePurpose: true,
+              enforceVendor: true,
+              vendorExceptions: []
+            }]
+          }
+        });
+        setupConsentData();
+        expectAllow(true, rule(activityParams(MODULE_TYPE_BIDDER, 'appnexus')));
       });
-      setEnforcementConfig({
-        gdpr: {
-          rules: [{
-            purpose: 'storage',
-            enforcePurpose: true,
-            enforceVendor: true,
-            vendorExceptions: []
-          }]
-        }
-      });
-      setupConsentData();
-      expectAllow(true, accessDeviceRule(activityParams(MODULE_TYPE_BIDDER, 'appnexus')));
-    });
-
-    it(`should not enforce consent for vendorless modules if ${STRICT_STORAGE_ENFORCEMENT} is not set`, () => {
-      setEnforcementConfig({});
-      setupConsentData();
-      expectAllow(true, accessDeviceRule(activityParams(MODULE_TYPE_PREBID, 'mockCoreModule')));
     })
   });
+
+  it(`accessDeviceRule should not enforce consent for vendorless modules if ${STRICT_STORAGE_ENFORCEMENT} is not set`, () => {
+    setEnforcementConfig({});
+    setupConsentData();
+    expectAllow(true, accessDeviceRule(activityParams(MODULE_TYPE_PREBID, 'mockCoreModule')));
+  })
 
   describe('syncUserRule', () => {
     it('should allow bidder to do user sync if consent is true', function () {
@@ -1235,28 +1240,5 @@ describe('gdpr enforcement', function () {
         expect(getGvlidFromAnalyticsAdapter('analytics')).to.not.be.ok;
       });
     });
-  })
-  describe('checkIfCredentialsAllowed', () => {
-    it('should not allow access credentials for lack of purpose consent 1', () => {
-      const logWarn = sinon.spy(utils, 'logWarn');
-      const rules = [{
-        purpose: 'storage',
-        enforcePurpose: true,
-        enforceVendor: false
-      }]
-      setEnforcementConfig({ gdpr: { rules } });
-      const consent = setupConsentData({ gdprApplies: false });
-      consent.vendorData.purpose.consents['1'] = false;
-      const nextSpy = sinon.spy();
-      const options = {
-        withCredentials: true
-      }
-
-      checkIfCredentialsAllowed(nextSpy, options);
-
-      sinon.assert.calledWith(nextSpy, { withCredentials: false });
-      expect(logWarn.calledOnce).to.equal(true);
-      logWarn.restore();
-    })
   })
 });

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -26,7 +26,13 @@ import { hook } from '../../../../src/hook.js';
 import { auctionManager } from '../../../../src/auctionManager.js';
 import { GDPR_GVLIDS } from '../../../../src/consentHandler.js';
 import { MODULE_TYPE_ANALYTICS, MODULE_TYPE_BIDDER } from '../../../../src/activities/modules.js';
-import { ACTIVITY_FETCH_BIDS, ACTIVITY_REPORT_ANALYTICS } from '../../../../src/activities/activities.js';
+import { server } from '../../../mocks/xhr.js';
+
+import {
+  ACTIVITY_ACCESS_REQUEST_CREDENTIALS,
+  ACTIVITY_FETCH_BIDS,
+  ACTIVITY_REPORT_ANALYTICS
+} from '../../../../src/activities/activities.js';
 import { reset as resetAdUnitCounters } from '../../../../src/adUnits.js';
 import {
   EVENT_TYPE_IMPRESSION,
@@ -35,6 +41,7 @@ import {
   TRACKER_METHOD_JS
 } from '../../../../src/eventTrackers.js';
 import 'src/prebid.js';
+import { registerActivityControl } from '../../../../src/activities/rules.js';
 
 var events = require('../../../../src/events.js');
 
@@ -140,6 +147,35 @@ describe('adapterManager tests', function () {
       delete adapterManager.bidderRegistry['rubicon'];
       delete adapterManager.bidderRegistry['badBidder'];
       config.resetConfig();
+    });
+
+    describe('withCredentials', () => {
+      let unregRule;
+      beforeEach(() => {
+        unregRule = registerActivityControl(ACTIVITY_ACCESS_REQUEST_CREDENTIALS, 'test',
+          ({ componentName, componentTypeType }) => {
+            if (componentType === 'bidder' && componentName === 'appnexus') {
+              return { allow: false };
+            }
+          });
+      });
+      afterEach(() => {
+        unregRule();
+      });
+      it('should pass through accessRequestCredentials', () => {
+        const adUnits = [{
+          code: 'test',
+          bids: [
+            { bidder: 'appnexus' }
+          ]
+        }];
+        const bidRequests = adapterManager.makeBidRequests(adUnits);
+        adapterManager.bidderRegistry['appnexus'].callBids.callsFake((_1, _2, _3, ajax) => {
+          ajax('https://example.com', null, null, { withCredentials: true });
+        })
+        adapterManager.callBids(adUnits, bidRequests, () => {}, () => {});
+        expect(server.requests[0].fetch.request.credentials).to.eql('same-origin');
+      });
     });
 
     it('should log an error if a bidder is used that does not exist', function () {

--- a/test/spec/unit/core/ajax_spec.js
+++ b/test/spec/unit/core/ajax_spec.js
@@ -3,6 +3,8 @@ import { config } from 'src/config.js';
 import { server } from '../../../mocks/xhr.js';
 import * as utils from 'src/utils.js';
 import { logError } from 'src/utils.js';
+import { registerActivityControl } from '../../../../src/activities/rules.js';
+import { ACTIVITY_ACCESS_REQUEST_CREDENTIALS } from '../../../../src/activities/activities.js';
 
 const EXAMPLE_URL = 'https://www.example.com';
 
@@ -34,6 +36,42 @@ describe('fetcherFactory', () => {
       resp.catch(() => done());
     });
   });
+
+  describe('credentials', () => {
+    let resetRule, arqRule, denyCreds;
+    beforeEach(() => {
+      denyCreds = false;
+      arqRule = sinon.stub().callsFake(() => {
+        if (denyCreds) {
+          return { allow: false };
+        }
+      })
+      resetRule = registerActivityControl(ACTIVITY_ACCESS_REQUEST_CREDENTIALS, 'test', arqRule)
+    })
+    afterEach(() => {
+      resetRule();
+      config.resetConfig();
+    })
+    Object.entries({
+      'URL': [EXAMPLE_URL, { credentials: 'include' }],
+      'request object': [new Request(EXAMPLE_URL, { credentials: 'include' })],
+    }).forEach(([t, args]) => {
+      it('should be excluded when deviceAccess is false', () => {
+        config.setConfig({ deviceAccess: false });
+        fetcherFactory()(...args);
+        expect(server.requests[0].fetch.request.credentials).to.eql('same-origin');
+      });
+      it('should be excluded when accessRequestCredentials is denied', () => {
+        denyCreds = true;
+        fetcherFactory(1000, undefined, 'prebid', 'test')(...args);
+        sinon.assert.calledWith(arqRule, sinon.match({
+          componentType: 'prebid',
+          componentName: 'test'
+        }));
+        expect(server.requests[0].fetch.request.credentials).to.eql('same-origin');
+      })
+    })
+  })
 
   it('does not timeout after it completes', () => {
     const fetch = fetcherFactory(1000);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

The `accessRequestCredentials` activity controls the `withCredentials` flag when it should control the `credentials` fetch option.

## Other information

Bugged since first implementation: https://github.com/prebid/Prebid.js/pull/13094
