### PR TITLE
TNE Catalyst Bid Adapter: make all params optional

### DIFF
--- a/modules/tne_catalystBidAdapter.md
+++ b/modules/tne_catalystBidAdapter.md
@@ -1,0 +1,141 @@
+# TNE Catalyst
+
+## Overview
+
+TNE Catalyst is a programmatic exchange that manages demand relationships server-side. Publishers can integrate with a single `{ bidder: 'tne_catalyst' }` entry — no params are required. Publisher identity is resolved server-side from the page domain via sellers.json, and the slot key defaults to `adUnitCode`. TNE routes the request to its configured SSP partners and returns the winning bid. No SSP-specific IDs or configuration is required on the publisher side.
+
+## Bid Parameters
+
+All params are optional. Supply them to override the server-side defaults.
+
+| Param | Scope | Type | Description |
+|-------|-------|------|-------------|
+| `publisherId` | optional | string | Override domain-based publisher resolution (e.g. `NXS003`) |
+| `slot` | optional | string | Override the default slot key (defaults to `adUnitCode`) |
+| `bidfloor` | optional | number | Minimum acceptable CPM in USD (also read from the Floors module via `getFloor()`) |
+| `endpoint` | optional | string | Override the auction endpoint URL (testing / staging) |
+| `testMode` | optional | boolean | Marks the request as test traffic via `imp.ext.tne_catalyst.testMode` |
+
+## Supported Media Types
+
+- Banner
+- Native
+- Video (VAST)
+
+## Maintainer
+
+**The Nexus Engine**
+ops@thenexusengine.io
+
+## Privacy & Compliance
+
+| Feature | Supported |
+|---------|-----------|
+| TCF 2.0 (GDPR) | ✅ |
+| US Privacy (CCPA) | ✅ |
+| GPP | ✅ |
+| COPPA | via `regs.coppa` |
+| sChain | ✅ |
+| User IDs / EIDs | ✅ |
+| GVL ID | 1494 |
+
+## Example Ad Units
+
+### Banner (minimal — recommended)
+
+```javascript
+var adUnits = [
+  {
+    code: 'div-billboard',
+    mediaTypes: {
+      banner: { sizes: [[970, 250], [728, 90]] }
+    },
+    bids: [{ bidder: 'tne_catalyst' }]
+  },
+  {
+    code: 'div-rectangle',
+    mediaTypes: {
+      banner: { sizes: [[300, 250], [300, 600]] }
+    },
+    bids: [{ bidder: 'tne_catalyst' }]
+  }
+];
+```
+
+### Banner (with overrides)
+
+```javascript
+var adUnits = [{
+  code: 'div-billboard',
+  mediaTypes: { banner: { sizes: [[970, 250], [728, 90]] } },
+  bids: [{
+    bidder: 'tne_catalyst',
+    params: {
+      publisherId: 'NXS003',   // optional override
+      slot: 'billboard',       // optional override (defaults to adUnitCode)
+      bidfloor: 0.5            // optional
+    }
+  }]
+}];
+```
+
+### Native
+
+```javascript
+var adUnits = [{
+  code: 'div-native-feed',
+  mediaTypes: {
+    native: {
+      title:       { required: true,  len: 80 },
+      body:        { required: true },
+      image:       { required: true,  sizes: [{ min_width: 300, ratio_width: 2, ratio_height: 1 }] },
+      sponsoredBy: { required: true },
+      clickUrl:    { required: true },
+    }
+  },
+  bids: [{
+    bidder: 'tne_catalyst',
+    params: {
+      publisherId: 'NXS003',
+      slot: 'native-feed'
+    }
+  }]
+}];
+```
+
+### Video (Instream)
+
+```javascript
+var adUnits = [{
+  code: 'div-video-player',
+  mediaTypes: {
+    video: {
+      context:     'instream',
+      playerSize:  [[640, 480]],
+      mimes:       ['video/mp4'],
+      protocols:   [2, 3, 5, 6],
+      minduration: 5,
+      maxduration: 30,
+      startdelay:  0,
+      placement:   1,
+      linearity:   1,
+    }
+  },
+  bids: [{
+    bidder: 'tne_catalyst',
+    params: {
+      publisherId: 'NXS003',
+      slot: 'preroll'
+    }
+  }]
+}];
+```
+
+## User Sync
+
+User synchronisation is handled automatically via the TNE Catalyst cookie sync endpoint. No per-SSP configuration is required. Include the sync endpoint in your `s2sConfig` or allow iframe/pixel syncs via `pbjs.setConfig({ userSync: { ... } })`.
+
+## Contact
+
+For account setup, new publisher onboarding, or technical questions:
+**ops@thenexusengine.io**

--- a/modules/tne_catalystBidAdapter.ts
+++ b/modules/tne_catalystBidAdapter.ts
@@ -1,0 +1,301 @@
+import { BidderSpec, registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
+import { generateUUID, deepAccess, isArray, isFn } from '../src/utils.js';
+
+/**
+ * TNE Catalyst Bid Adapter
+ *
+ * Single-bidder adapter for the TNE Catalyst exchange. TNE manages all SSP
+ * relationships and demand decisions server-side, so no SSP IDs are required
+ * or exposed.
+ *
+ * All params are optional. With no params at all, the adapter derives slot
+ * identity from `adUnitCode` and publisher identity from the page domain
+ * (resolved server-side via sellers.json). Publishers can still override:
+ *
+ *   - `publisherId` — override the server-side domain resolution
+ *   - `slot`        — override the default `adUnitCode` slot key
+ *   - `bidfloor`    — fallback floor when `getFloor()` is absent
+ *   - `endpoint`    — route to an alternate auction endpoint (testing)
+ *   - `testMode`    — flag the request as test traffic
+ *
+ * @see https://thenexusengine.io
+ * Maintainer: ops@thenexusengine.io
+ */
+
+const BIDDER_CODE = 'tne_catalyst';
+const ENDPOINT_URL = 'https://ads.thenexusengine.com/openrtb2/auction';
+const SYNC_URL = 'https://ads.thenexusengine.com/cookie_sync';
+const GVLID = 1494;
+
+interface TneCatalystBidParams {
+  publisherId?: string;
+  slot?: string;
+  bidfloor?: number;
+  endpoint?: string;
+  testMode?: boolean;
+}
+
+// Permits absent values; rejects supplied values of the wrong type.
+// eslint-disable-next-line valid-typeof
+const nullOrType = (value: unknown, type: string) => value == null || typeof value === type;
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    [BIDDER_CODE]: TneCatalystBidParams;
+  }
+}
+
+export const spec: BidderSpec<typeof BIDDER_CODE> = {
+  code: BIDDER_CODE,
+  gvlid: GVLID,
+  supportedMediaTypes: [BANNER, NATIVE, VIDEO],
+
+  isBidRequestValid(bid) {
+    // All params are optional. When supplied, they must be the right type —
+    // otherwise reject so a typo doesn't silently fall back to defaults.
+    if (!bid) return false;
+    const params = (bid as any).params || {};
+    return (
+      nullOrType(params.publisherId, 'string') &&
+      nullOrType(params.slot, 'string') &&
+      nullOrType(params.endpoint, 'string') &&
+      nullOrType(params.bidfloor, 'number') &&
+      nullOrType(params.testMode, 'boolean')
+    );
+  },
+
+  buildRequests(validBidRequests, bidderRequest) {
+    if (!validBidRequests || validBidRequests.length === 0) {
+      return [];
+    }
+
+    const firstParams = (validBidRequests[0] as any).params || {};
+    const publisherId: string | undefined = firstParams.publisherId;
+    const endpoint: string = firstParams.endpoint || ENDPOINT_URL;
+    const testMode: boolean = firstParams.testMode === true;
+
+    const imps = validBidRequests.map((bid: any) => {
+      const params = bid.params || {};
+      // Slot defaults to the Prebid adUnitCode (div ID). The server uses this
+      // as a placement key when no slot override is supplied — same pattern as
+      // AMX's `adUnitId` fallback.
+      const slot: string = params.slot || bid.adUnitCode;
+      const slotExt: any = { slot };
+      if (testMode) slotExt.testMode = true;
+      const imp: any = {
+        id: bid.bidId,
+        // OpenRTB tagid mirrors the slot key, giving the server two places to
+        // look without forcing publishers to set anything explicit.
+        tagid: slot,
+        ext: { tne_catalyst: slotExt }
+      };
+
+      const mediaTypes = bid.mediaTypes || {};
+
+      if (mediaTypes[BANNER]) {
+        const banner = mediaTypes[BANNER];
+        const sizes = banner.sizes || [];
+        imp.banner = {
+          format: sizes.map((s: [number, number]) => ({ w: s[0], h: s[1] })),
+          w: sizes.length > 0 ? sizes[0][0] : undefined,
+          h: sizes.length > 0 ? sizes[0][1] : undefined,
+        };
+      }
+
+      if (mediaTypes[VIDEO]) {
+        const video = mediaTypes[VIDEO];
+        const playerSize = video.playerSize;
+        const videoSize = playerSize ? (isArray(playerSize[0]) ? playerSize[0] : playerSize) : null;
+        imp.video = {
+          mimes: video.mimes || ['video/mp4'],
+          protocols: video.protocols || [2, 3, 5, 6],
+          w: videoSize ? videoSize[0] : undefined,
+          h: videoSize ? videoSize[1] : undefined,
+          minduration: video.minduration,
+          maxduration: video.maxduration,
+          startdelay: video.startdelay,
+          placement: video.placement,
+          linearity: video.linearity,
+        };
+        Object.keys(imp.video).forEach(k => imp.video[k] === undefined && delete imp.video[k]);
+      }
+
+      if (mediaTypes[NATIVE]) {
+        imp.native = { request: JSON.stringify(mediaTypes[NATIVE]) };
+      }
+
+      let floorApplied = false;
+      if (isFn(bid.getFloor)) {
+        const mediaType = imp.video ? VIDEO : imp.native ? NATIVE : BANNER;
+        const floorInfo = bid.getFloor({ currency: 'USD', mediaType, size: '*' });
+        if (floorInfo && floorInfo.currency === 'USD' && floorInfo.floor > 0) {
+          imp.bidfloor = floorInfo.floor;
+          imp.bidfloorcur = 'USD';
+          floorApplied = true;
+        }
+      }
+      if (!floorApplied && params.bidfloor) {
+        imp.bidfloor = params.bidfloor;
+        imp.bidfloorcur = 'USD';
+      }
+
+      return imp;
+    });
+
+    // Only set site.publisher.id when explicitly supplied. With no override,
+    // the server resolves the publisher from site.domain via sellers.json.
+    const site: any = publisherId ? { publisher: { id: publisherId } } : {};
+    const ri = deepAccess(bidderRequest, 'refererInfo');
+    if (ri) {
+      if (ri.page) site.page = ri.page;
+      if (ri.domain) site.domain = ri.domain;
+      if (ri.ref) site.ref = ri.ref;
+    }
+
+    const ortb2Site = deepAccess(bidderRequest, 'ortb2.site');
+    if (ortb2Site) {
+      Object.assign(site, ortb2Site);
+      // Preserve the explicit override; ortb2.site.publisher must not win.
+      if (publisherId) site.publisher = { id: publisherId };
+    }
+
+    const ortbRequest: any = {
+      id: generateUUID(),
+      imp: imps,
+      site,
+    };
+
+    if ((bidderRequest as any).timeout) {
+      ortbRequest.tmax = (bidderRequest as any).timeout;
+    }
+
+    const regsExt: any = {};
+    const gdpr = deepAccess(bidderRequest, 'gdprConsent');
+    if (gdpr) {
+      regsExt.gdpr = gdpr.gdprApplies ? 1 : 0;
+    }
+    const usp = deepAccess(bidderRequest, 'uspConsent');
+    if (usp) {
+      regsExt.us_privacy = usp;
+    }
+    const gpp = deepAccess(bidderRequest, 'gppConsent');
+    if (gpp && gpp.gppString) {
+      ortbRequest.regs = ortbRequest.regs || {};
+      ortbRequest.regs.gpp = gpp.gppString;
+      ortbRequest.regs.gpp_sid = gpp.applicableSections || [];
+    }
+    if (Object.keys(regsExt).length > 0) {
+      ortbRequest.regs = ortbRequest.regs || {};
+      ortbRequest.regs.ext = regsExt;
+    }
+
+    const userExt: any = {};
+    if (gdpr && gdpr.consentString) {
+      userExt.consent = gdpr.consentString;
+    }
+    const eids = deepAccess(validBidRequests[0], 'userIdAsEids');
+    if (isArray(eids) && eids.length > 0) {
+      ortbRequest.user = ortbRequest.user || {};
+      ortbRequest.user.eids = eids;
+    }
+    if (Object.keys(userExt).length > 0) {
+      ortbRequest.user = ortbRequest.user || {};
+      ortbRequest.user.ext = userExt;
+    }
+
+    const schain = deepAccess(validBidRequests[0], 'schain');
+    if (schain) {
+      ortbRequest.source = { schain };
+    }
+
+    return [{
+      method: 'POST',
+      url: endpoint,
+      data: ortbRequest,
+      // text/plain avoids the CORS preflight that application/json would
+      // trigger, keeping auction latency down.
+      options: { contentType: 'text/plain', withCredentials: true }
+    }];
+  },
+
+  interpretResponse(serverResponse, request) {
+    const body = deepAccess(serverResponse, 'body');
+    if (!body || !isArray(body.seatbid) || body.seatbid.length === 0) {
+      return [];
+    }
+
+    const bids: any[] = [];
+
+    body.seatbid.forEach((seatBid: any) => {
+      (seatBid.bid || []).forEach((bid: any) => {
+        if (!bid.price || bid.price <= 0) return;
+
+        const prebidBid: any = {
+          requestId: bid.impid,
+          cpm: bid.price,
+          currency: body.cur || 'USD',
+          width: bid.w || 0,
+          height: bid.h || 0,
+          ad: bid.adm || '',
+          creativeId: bid.crid || bid.id,
+          dealId: bid.dealid || '',
+          netRevenue: true,
+          ttl: 300,
+          meta: {
+            advertiserDomains: isArray(bid.adomain) ? bid.adomain : [],
+          },
+        };
+
+        if (bid.adm && bid.adm.startsWith('{')) {
+          prebidBid.mediaType = NATIVE;
+          try {
+            prebidBid.native = JSON.parse(bid.adm);
+          } catch (_) {
+            prebidBid.ad = bid.adm;
+            prebidBid.mediaType = BANNER;
+          }
+        } else if (bid.adm && (bid.adm.trim().startsWith('<VAST') || bid.adm.trim().startsWith('<?xml'))) {
+          prebidBid.mediaType = VIDEO;
+          prebidBid.vastXml = bid.adm;
+          prebidBid.ad = bid.adm;
+        } else if (bid.adUrl) {
+          prebidBid.mediaType = VIDEO;
+          prebidBid.vastUrl = bid.adUrl;
+        } else {
+          prebidBid.mediaType = BANNER;
+        }
+
+        bids.push(prebidBid);
+      });
+    });
+
+    return bids;
+  },
+
+  getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent) {
+    if (!syncOptions.iframeEnabled && !syncOptions.pixelEnabled) {
+      return [];
+    }
+
+    const params: string[] = [];
+    if (gdprConsent) {
+      params.push(`gdpr=${(gdprConsent as any).gdprApplies ? 1 : 0}`);
+      if ((gdprConsent as any).consentString) {
+        params.push(`gdpr_consent=${encodeURIComponent((gdprConsent as any).consentString)}`);
+      }
+    }
+    if (uspConsent) {
+      params.push(`us_privacy=${encodeURIComponent(uspConsent as any)}`);
+    }
+
+    const syncUrl = SYNC_URL + (params.length > 0 ? '?' + params.join('&') : '');
+
+    if (syncOptions.iframeEnabled) {
+      return [{ type: 'iframe', url: syncUrl }];
+    }
+    return [{ type: 'image', url: syncUrl }];
+  },
+};
+
+registerBidder(spec);

--- a/modules/tne_catalystBidAdapter.ts
+++ b/modules/tne_catalystBidAdapter.ts
@@ -170,38 +170,57 @@ export const spec: BidderSpec<typeof BIDDER_CODE> = {
       ortbRequest.tmax = (bidderRequest as any).timeout;
     }
 
-    const regsExt: any = {};
+    // ortb2 passthrough — the wrapper's modern source of truth for user
+    // identity, compliance, device, and app context. Per Prebid module rules
+    // ("Bidder params should always only override that information coming on
+    // the request"), we treat ortb2.* as authoritative and only layer our
+    // derived overrides (consent strings synthesized from gdprConsent, etc.)
+    // when the wrapper hasn't already populated the same key.
+    const ortb2 = deepAccess(bidderRequest, 'ortb2') || {};
+    if (ortb2.user) ortbRequest.user = { ...ortb2.user };
+    if (ortb2.regs) ortbRequest.regs = { ...ortb2.regs };
+    if (ortb2.device) ortbRequest.device = { ...ortb2.device };
+    if (ortb2.app) ortbRequest.app = { ...ortb2.app };
+
     const gdpr = deepAccess(bidderRequest, 'gdprConsent');
-    if (gdpr) {
-      regsExt.gdpr = gdpr.gdprApplies ? 1 : 0;
-    }
     const usp = deepAccess(bidderRequest, 'uspConsent');
-    if (usp) {
-      regsExt.us_privacy = usp;
-    }
     const gpp = deepAccess(bidderRequest, 'gppConsent');
-    if (gpp && gpp.gppString) {
+
+    // regs.* — only set fields the wrapper didn't already supply via ortb2.
+    if (gdpr || usp || (gpp && gpp.gppString)) {
       ortbRequest.regs = ortbRequest.regs || {};
-      ortbRequest.regs.gpp = gpp.gppString;
-      ortbRequest.regs.gpp_sid = gpp.applicableSections || [];
-    }
-    if (Object.keys(regsExt).length > 0) {
-      ortbRequest.regs = ortbRequest.regs || {};
-      ortbRequest.regs.ext = regsExt;
+      if (gpp && gpp.gppString) {
+        if (ortbRequest.regs.gpp == null) ortbRequest.regs.gpp = gpp.gppString;
+        if (ortbRequest.regs.gpp_sid == null) ortbRequest.regs.gpp_sid = gpp.applicableSections || [];
+      }
+      if (gdpr || usp) {
+        const regsExt = { ...(ortbRequest.regs.ext || {}) };
+        if (gdpr && regsExt.gdpr == null) regsExt.gdpr = gdpr.gdprApplies ? 1 : 0;
+        if (usp && regsExt.us_privacy == null) regsExt.us_privacy = usp;
+        ortbRequest.regs.ext = regsExt;
+      }
     }
 
-    const userExt: any = {};
+    // user.eids — merge the legacy bid.userIdAsEids list with whatever the
+    // wrapper already put on ortb2.user.eids. De-duplicate by source so a
+    // legacy provider doesn't show up twice.
+    const legacyEids = deepAccess(validBidRequests[0], 'userIdAsEids');
+    if (isArray(legacyEids) && legacyEids.length > 0) {
+      ortbRequest.user = ortbRequest.user || {};
+      const existing: any[] = isArray(ortbRequest.user.eids) ? ortbRequest.user.eids : [];
+      const seen = new Set(existing.map((e: any) => e && e.source).filter(Boolean));
+      const merged = existing.concat(legacyEids.filter((e: any) => e && e.source && !seen.has(e.source)));
+      ortbRequest.user.eids = merged;
+    }
+
+    // user.ext.consent — synthesize from gdprConsent only when ortb2 didn't
+    // already carry one.
     if (gdpr && gdpr.consentString) {
-      userExt.consent = gdpr.consentString;
-    }
-    const eids = deepAccess(validBidRequests[0], 'userIdAsEids');
-    if (isArray(eids) && eids.length > 0) {
       ortbRequest.user = ortbRequest.user || {};
-      ortbRequest.user.eids = eids;
-    }
-    if (Object.keys(userExt).length > 0) {
-      ortbRequest.user = ortbRequest.user || {};
-      ortbRequest.user.ext = userExt;
+      ortbRequest.user.ext = { ...(ortbRequest.user.ext || {}) };
+      if (ortbRequest.user.ext.consent == null) {
+        ortbRequest.user.ext.consent = gdpr.consentString;
+      }
     }
 
     const schain = deepAccess(validBidRequests[0], 'schain');

--- a/test/spec/modules/tne_catalystBidAdapter_spec.js
+++ b/test/spec/modules/tne_catalystBidAdapter_spec.js
@@ -406,6 +406,78 @@ describe('TNE Catalyst Bid Adapter', () => {
       });
     });
 
+    describe('ortb2 passthrough', () => {
+      it('passes ortb2.user through unchanged', () => {
+        const ortb2 = {
+          user: {
+            eids: [{ source: 'uidapi.com', uids: [{ id: 'uid2-token' }] }],
+            ext: { consent: 'WRAPPER_CONSENT_STRING' },
+            data: [{ name: 'contxtful', segment: [{ id: 'seg-1' }] }]
+          }
+        };
+        const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest({ ortb2 }));
+        expect(reqs[0].data.user.eids).to.deep.equal(ortb2.user.eids);
+        expect(reqs[0].data.user.data).to.deep.equal(ortb2.user.data);
+        expect(reqs[0].data.user.ext.consent).to.equal('WRAPPER_CONSENT_STRING');
+      });
+
+      it('passes ortb2.regs through and preserves gpp/gpp_sid from wrapper', () => {
+        const ortb2 = { regs: { gpp: 'WRAPPER_GPP', gpp_sid: [7, 8], coppa: 0 } };
+        const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest({ ortb2 }));
+        expect(reqs[0].data.regs.gpp).to.equal('WRAPPER_GPP');
+        expect(reqs[0].data.regs.gpp_sid).to.deep.equal([7, 8]);
+        expect(reqs[0].data.regs.coppa).to.equal(0);
+      });
+
+      it('passes ortb2.device through unchanged', () => {
+        const ortb2 = { device: { ua: 'Mozilla/5.0', devicetype: 1, language: 'en' } };
+        const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest({ ortb2 }));
+        expect(reqs[0].data.device).to.deep.equal(ortb2.device);
+      });
+
+      it('passes ortb2.app through for in-app/CTV traffic', () => {
+        const ortb2 = { app: { bundle: 'com.example.app', name: 'Example App' } };
+        const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest({ ortb2 }));
+        expect(reqs[0].data.app).to.deep.equal(ortb2.app);
+      });
+
+      it('does not override wrapper-set ortb2.user.ext.consent with derived gdprConsent', () => {
+        const ortb2 = { user: { ext: { consent: 'WRAPPER_WINS' } } };
+        const br = makeBidderRequest({ ortb2, gdprConsent: { gdprApplies: true, consentString: 'DERIVED_LOSES' } });
+        const reqs = spec.buildRequests([makeBidRequest()], br);
+        expect(reqs[0].data.user.ext.consent).to.equal('WRAPPER_WINS');
+      });
+
+      it('falls back to derived gdprConsent when ortb2 has no consent', () => {
+        const br = makeBidderRequest({ gdprConsent: { gdprApplies: true, consentString: 'DERIVED_CONSENT' } });
+        const reqs = spec.buildRequests([makeBidRequest()], br);
+        expect(reqs[0].data.user.ext.consent).to.equal('DERIVED_CONSENT');
+      });
+
+      it('merges legacy bid.userIdAsEids with ortb2.user.eids without duplicates', () => {
+        const ortb2 = { user: { eids: [{ source: 'uidapi.com', uids: [{ id: 'wrapper-uid2' }] }] } };
+        const bid = makeBidRequest({
+          userIdAsEids: [
+            { source: 'uidapi.com', uids: [{ id: 'legacy-uid2' }] },        // dup source — wrapper wins
+            { source: 'id5-sync.com', uids: [{ id: 'legacy-id5' }] }       // new source — included
+          ]
+        });
+        const reqs = spec.buildRequests([bid], makeBidderRequest({ ortb2 }));
+        const eids = reqs[0].data.user.eids;
+        expect(eids).to.have.length(2);
+        expect(eids.find(e => e.source === 'uidapi.com').uids[0].id).to.equal('wrapper-uid2');
+        expect(eids.find(e => e.source === 'id5-sync.com')).to.exist;
+      });
+
+      it('does not override wrapper-set ortb2.regs.gpp with derived gppConsent', () => {
+        const ortb2 = { regs: { gpp: 'WRAPPER_GPP', gpp_sid: [7] } };
+        const br = makeBidderRequest({ ortb2, gppConsent: { gppString: 'DERIVED_GPP', applicableSections: [8] } });
+        const reqs = spec.buildRequests([makeBidRequest()], br);
+        expect(reqs[0].data.regs.gpp).to.equal('WRAPPER_GPP');
+        expect(reqs[0].data.regs.gpp_sid).to.deep.equal([7]);
+      });
+    });
+
     describe('GDPR', () => {
       it('sets regs.ext.gdpr=1 when gdprApplies is true', () => {
         const br = makeBidderRequest({ gdprConsent: { gdprApplies: true, consentString: 'CONSENT_STRING' } });

--- a/test/spec/modules/tne_catalystBidAdapter_spec.js
+++ b/test/spec/modules/tne_catalystBidAdapter_spec.js
@@ -1,0 +1,709 @@
+import { expect } from 'chai';
+import { spec } from 'modules/tne_catalystBidAdapter.ts';
+import { newBidder } from 'src/adapters/bidderFactory.js';
+import { BANNER, NATIVE, VIDEO } from 'src/mediaTypes.js';
+
+const ENDPOINT = 'https://ads.thenexusengine.com/openrtb2/auction';
+const SYNC_URL = 'https://ads.thenexusengine.com/cookie_sync';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeBidRequest(overrides = {}) {
+  return Object.assign({
+    bidder: 'tne_catalyst',
+    bidId: 'bid-001',
+    auctionId: 'auction-001',
+    transactionId: 'txn-001',
+    params: {
+      publisherId: 'NXS003',
+      slot: 'billboard',
+    },
+    mediaTypes: {
+      banner: { sizes: [[970, 250], [728, 90]] }
+    },
+    sizes: [[970, 250], [728, 90]],
+  }, overrides);
+}
+
+function makeBidderRequest(overrides = {}) {
+  return Object.assign({
+    bidderCode: 'tne_catalyst',
+    auctionId: 'auction-001',
+    timeout: 1500,
+    refererInfo: {
+      page: 'https://gotsoccer.com/tournaments',
+      domain: 'gotsoccer.com',
+      ref: 'https://google.com',
+    },
+  }, overrides);
+}
+
+function makeServerResponse(bids = []) {
+  return {
+    body: {
+      id: 'response-001',
+      cur: 'USD',
+      seatbid: bids.length > 0 ? [{
+        seat: 'rubicon',
+        bid: bids,
+      }] : [],
+    }
+  };
+}
+
+function makeBid(overrides = {}) {
+  return Object.assign({
+    id: 'bid-id-001',
+    impid: 'bid-001',
+    price: 3.50,
+    adm: '<div>ad creative</div>',
+    crid: 'creative-001',
+    w: 970,
+    h: 250,
+    adomain: ['advertiser.com'],
+    dealid: '',
+  }, overrides);
+}
+
+function makeVideoBidRequest(overrides = {}) {
+  return Object.assign({
+    bidder: 'tne_catalyst',
+    bidId: 'bid-video-001',
+    auctionId: 'auction-001',
+    transactionId: 'txn-001',
+    params: {
+      publisherId: 'NXS003',
+      slot: 'preroll',
+    },
+    mediaTypes: {
+      video: {
+        playerSize: [[640, 480]],
+        mimes: ['video/mp4'],
+        protocols: [2, 3, 5, 6],
+        minduration: 5,
+        maxduration: 30,
+        startdelay: 0,
+        placement: 1,
+        linearity: 1,
+      }
+    },
+  }, overrides);
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('TNE Catalyst Bid Adapter', () => {
+  const adapter = newBidder(spec);
+
+  describe('inherited functions', () => {
+    it('exists and is a function', () => {
+      expect(adapter.callBids).to.be.a('function');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // isBidRequestValid
+  // -------------------------------------------------------------------------
+  describe('isBidRequestValid', () => {
+    it('returns true for a fully-specified bid', () => {
+      expect(spec.isBidRequestValid(makeBidRequest())).to.equal(true);
+    });
+
+    it('returns true when params is missing entirely', () => {
+      const bid = makeBidRequest();
+      delete bid.params;
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('returns true when params is an empty object', () => {
+      expect(spec.isBidRequestValid(makeBidRequest({ params: {} }))).to.equal(true);
+    });
+
+    it('returns true with only publisherId', () => {
+      expect(spec.isBidRequestValid(makeBidRequest({ params: { publisherId: 'NXS003' } }))).to.equal(true);
+    });
+
+    it('returns true with only slot', () => {
+      expect(spec.isBidRequestValid(makeBidRequest({ params: { slot: 'billboard' } }))).to.equal(true);
+    });
+
+    it('returns false when publisherId is the wrong type', () => {
+      expect(spec.isBidRequestValid(makeBidRequest({ params: { publisherId: 123 } }))).to.equal(false);
+    });
+
+    it('returns false when slot is the wrong type', () => {
+      expect(spec.isBidRequestValid(makeBidRequest({ params: { slot: 42 } }))).to.equal(false);
+    });
+
+    it('returns false when bidfloor is the wrong type', () => {
+      expect(spec.isBidRequestValid(makeBidRequest({ params: { bidfloor: 'free' } }))).to.equal(false);
+    });
+
+    it('returns false when testMode is the wrong type', () => {
+      expect(spec.isBidRequestValid(makeBidRequest({ params: { testMode: 'yes' } }))).to.equal(false);
+    });
+
+    it('returns false for a null bid', () => {
+      expect(spec.isBidRequestValid(null)).to.equal(false);
+    });
+
+    it('returns false for an undefined bid', () => {
+      expect(spec.isBidRequestValid(undefined)).to.equal(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // buildRequests
+  // -------------------------------------------------------------------------
+  describe('buildRequests', () => {
+    it('returns empty array when given no bids', () => {
+      expect(spec.buildRequests([], makeBidderRequest())).to.deep.equal([]);
+    });
+
+    it('returns a single POST request', () => {
+      const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest());
+      expect(reqs).to.have.length(1);
+      expect(reqs[0].method).to.equal('POST');
+      expect(reqs[0].url).to.equal(ENDPOINT);
+    });
+
+    it('sets content-type to text/plain (avoids CORS preflight)', () => {
+      const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest());
+      expect(reqs[0].options.contentType).to.equal('text/plain');
+    });
+
+    it('sets withCredentials to true', () => {
+      const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest());
+      expect(reqs[0].options.withCredentials).to.equal(true);
+    });
+
+    describe('impression', () => {
+      it('sets imp.id from bidId', () => {
+        const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest());
+        expect(reqs[0].data.imp[0].id).to.equal('bid-001');
+      });
+
+      it('sets imp.ext.tne_catalyst.slot from params.slot', () => {
+        const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest());
+        expect(reqs[0].data.imp[0].ext.tne_catalyst.slot).to.equal('billboard');
+      });
+
+      it('builds banner format from mediaTypes.banner.sizes', () => {
+        const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest());
+        const imp = reqs[0].data.imp[0];
+        expect(imp.banner.format).to.deep.equal([{ w: 970, h: 250 }, { w: 728, h: 90 }]);
+      });
+
+      it('sets banner w/h from first size', () => {
+        const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest());
+        const imp = reqs[0].data.imp[0];
+        expect(imp.banner.w).to.equal(970);
+        expect(imp.banner.h).to.equal(250);
+      });
+
+      it('includes native when mediaTypes.native is present', () => {
+        const bid = makeBidRequest({
+          mediaTypes: {
+            banner: { sizes: [[300, 250]] },
+            native: { title: { required: true } }
+          }
+        });
+        const reqs = spec.buildRequests([bid], makeBidderRequest());
+        expect(reqs[0].data.imp[0].native).to.exist;
+        expect(reqs[0].data.imp[0].native.request).to.be.a('string');
+      });
+
+      it('builds video imp from mediaTypes.video', () => {
+        const reqs = spec.buildRequests([makeVideoBidRequest()], makeBidderRequest());
+        const imp = reqs[0].data.imp[0];
+        expect(imp.video).to.exist;
+        expect(imp.video.mimes).to.deep.equal(['video/mp4']);
+        expect(imp.video.protocols).to.deep.equal([2, 3, 5, 6]);
+        expect(imp.video.w).to.equal(640);
+        expect(imp.video.h).to.equal(480);
+        expect(imp.video.minduration).to.equal(5);
+        expect(imp.video.maxduration).to.equal(30);
+        expect(imp.video.startdelay).to.equal(0);
+        expect(imp.video.placement).to.equal(1);
+        expect(imp.video.linearity).to.equal(1);
+      });
+
+      it('defaults mimes and protocols when omitted from mediaTypes.video', () => {
+        const bid = makeVideoBidRequest({
+          mediaTypes: { video: { playerSize: [[640, 480]] } }
+        });
+        const reqs = spec.buildRequests([bid], makeBidderRequest());
+        const imp = reqs[0].data.imp[0];
+        expect(imp.video.mimes).to.deep.equal(['video/mp4']);
+        expect(imp.video.protocols).to.deep.equal([2, 3, 5, 6]);
+      });
+
+      it('sets bidfloor when provided in params', () => {
+        const bid = makeBidRequest({ params: { publisherId: 'NXS003', slot: 'billboard', bidfloor: 1.50 } });
+        const reqs = spec.buildRequests([bid], makeBidderRequest());
+        expect(reqs[0].data.imp[0].bidfloor).to.equal(1.50);
+        expect(reqs[0].data.imp[0].bidfloorcur).to.equal('USD');
+      });
+
+      it('omits bidfloor when not in params', () => {
+        const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest());
+        expect(reqs[0].data.imp[0].bidfloor).to.be.undefined;
+      });
+
+      it('uses getFloor() result when Floors module is active', () => {
+        const bid = makeBidRequest();
+        bid.getFloor = () => ({ currency: 'USD', floor: 2.75 });
+        const reqs = spec.buildRequests([bid], makeBidderRequest());
+        expect(reqs[0].data.imp[0].bidfloor).to.equal(2.75);
+        expect(reqs[0].data.imp[0].bidfloorcur).to.equal('USD');
+      });
+
+      it('prefers getFloor() over params.bidfloor', () => {
+        const bid = makeBidRequest({ params: { publisherId: 'NXS003', slot: 'billboard', bidfloor: 1.00 } });
+        bid.getFloor = () => ({ currency: 'USD', floor: 2.00 });
+        const reqs = spec.buildRequests([bid], makeBidderRequest());
+        expect(reqs[0].data.imp[0].bidfloor).to.equal(2.00);
+      });
+
+      it('falls back to params.bidfloor when getFloor() returns invalid currency', () => {
+        const bid = makeBidRequest({ params: { publisherId: 'NXS003', slot: 'billboard', bidfloor: 1.00 } });
+        bid.getFloor = () => ({ currency: 'EUR', floor: 2.00 });
+        const reqs = spec.buildRequests([bid], makeBidderRequest());
+        expect(reqs[0].data.imp[0].bidfloor).to.equal(1.00);
+      });
+
+      it('ignores getFloor() when it returns a zero floor', () => {
+        const bid = makeBidRequest({ params: { publisherId: 'NXS003', slot: 'billboard', bidfloor: 1.00 } });
+        bid.getFloor = () => ({ currency: 'USD', floor: 0 });
+        const reqs = spec.buildRequests([bid], makeBidderRequest());
+        expect(reqs[0].data.imp[0].bidfloor).to.equal(1.00);
+      });
+
+      it('passes correct mediaType to getFloor() for video imp', () => {
+        const bid = makeVideoBidRequest();
+        const calls = [];
+        bid.getFloor = (args) => { calls.push(args); return { currency: 'USD', floor: 3.00 }; };
+        spec.buildRequests([bid], makeBidderRequest());
+        expect(calls[0].mediaType).to.equal('video');
+      });
+    });
+
+    describe('multiple impressions', () => {
+      it('creates one imp per bid request', () => {
+        const bids = [
+          makeBidRequest({ bidId: 'bid-001', params: { publisherId: 'NXS003', slot: 'billboard' } }),
+          makeBidRequest({ bidId: 'bid-002', params: { publisherId: 'NXS003', slot: 'rectangle' } }),
+        ];
+        const reqs = spec.buildRequests(bids, makeBidderRequest());
+        expect(reqs[0].data.imp).to.have.length(2);
+        expect(reqs[0].data.imp[0].id).to.equal('bid-001');
+        expect(reqs[0].data.imp[1].id).to.equal('bid-002');
+      });
+    });
+
+    describe('site', () => {
+      it('sets site.publisher.id from publisherId param', () => {
+        const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest());
+        expect(reqs[0].data.site.publisher.id).to.equal('NXS003');
+      });
+
+      it('sets site.page from refererInfo.page', () => {
+        const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest());
+        expect(reqs[0].data.site.page).to.equal('https://gotsoccer.com/tournaments');
+      });
+
+      it('sets site.domain from refererInfo.domain', () => {
+        const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest());
+        expect(reqs[0].data.site.domain).to.equal('gotsoccer.com');
+      });
+
+      it('sets site.ref from refererInfo.ref', () => {
+        const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest());
+        expect(reqs[0].data.site.ref).to.equal('https://google.com');
+      });
+
+      it('preserves publisher.id when ortb2.site is provided', () => {
+        const br = makeBidderRequest({ ortb2: { site: { cat: ['IAB1'] } } });
+        const reqs = spec.buildRequests([makeBidRequest()], br);
+        expect(reqs[0].data.site.publisher.id).to.equal('NXS003');
+        expect(reqs[0].data.site.cat).to.deep.equal(['IAB1']);
+      });
+    });
+
+    describe('timeout', () => {
+      it('sets tmax from bidderRequest.timeout', () => {
+        const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest({ timeout: 2000 }));
+        expect(reqs[0].data.tmax).to.equal(2000);
+      });
+    });
+
+    describe('permissive params (AMX-style)', () => {
+      it('falls back to adUnitCode when params.slot is absent', () => {
+        const bid = makeBidRequest({
+          params: { publisherId: 'NXS003' },
+          adUnitCode: 'div-billboard',
+        });
+        const reqs = spec.buildRequests([bid], makeBidderRequest());
+        expect(reqs[0].data.imp[0].ext.tne_catalyst.slot).to.equal('div-billboard');
+      });
+
+      it('mirrors the resolved slot into imp.tagid', () => {
+        const bid = makeBidRequest({
+          params: {},
+          adUnitCode: 'div-leaderboard',
+        });
+        const reqs = spec.buildRequests([bid], makeBidderRequest());
+        expect(reqs[0].data.imp[0].tagid).to.equal('div-leaderboard');
+      });
+
+      it('explicit params.slot wins over adUnitCode', () => {
+        const bid = makeBidRequest({
+          params: { slot: 'override-slot' },
+          adUnitCode: 'div-billboard',
+        });
+        const reqs = spec.buildRequests([bid], makeBidderRequest());
+        expect(reqs[0].data.imp[0].ext.tne_catalyst.slot).to.equal('override-slot');
+        expect(reqs[0].data.imp[0].tagid).to.equal('override-slot');
+      });
+
+      it('omits site.publisher when publisherId is absent', () => {
+        const bid = makeBidRequest({ params: { slot: 'billboard' } });
+        const reqs = spec.buildRequests([bid], makeBidderRequest());
+        expect(reqs[0].data.site.publisher).to.be.undefined;
+      });
+
+      it('still merges ortb2.site fields when publisherId is absent', () => {
+        const bid = makeBidRequest({ params: { slot: 'billboard' } });
+        const br = makeBidderRequest({ ortb2: { site: { cat: ['IAB1'] } } });
+        const reqs = spec.buildRequests([bid], br);
+        expect(reqs[0].data.site.cat).to.deep.equal(['IAB1']);
+        expect(reqs[0].data.site.publisher).to.be.undefined;
+      });
+
+      it('uses params.endpoint when provided', () => {
+        const bid = makeBidRequest({
+          params: { endpoint: 'https://staging.thenexusengine.com/openrtb2/auction' },
+        });
+        const reqs = spec.buildRequests([bid], makeBidderRequest());
+        expect(reqs[0].url).to.equal('https://staging.thenexusengine.com/openrtb2/auction');
+      });
+
+      it('marks the request as test mode when params.testMode is true', () => {
+        const bid = makeBidRequest({
+          params: { publisherId: 'NXS003', slot: 'billboard', testMode: true },
+        });
+        const reqs = spec.buildRequests([bid], makeBidderRequest());
+        expect(reqs[0].data.imp[0].ext.tne_catalyst.testMode).to.equal(true);
+      });
+
+      it('does not set testMode flag when params.testMode is absent or false', () => {
+        const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest());
+        expect(reqs[0].data.imp[0].ext.tne_catalyst.testMode).to.be.undefined;
+      });
+    });
+
+    describe('GDPR', () => {
+      it('sets regs.ext.gdpr=1 when gdprApplies is true', () => {
+        const br = makeBidderRequest({ gdprConsent: { gdprApplies: true, consentString: 'CONSENT_STRING' } });
+        const reqs = spec.buildRequests([makeBidRequest()], br);
+        expect(reqs[0].data.regs.ext.gdpr).to.equal(1);
+      });
+
+      it('sets regs.ext.gdpr=0 when gdprApplies is false', () => {
+        const br = makeBidderRequest({ gdprConsent: { gdprApplies: false, consentString: '' } });
+        const reqs = spec.buildRequests([makeBidRequest()], br);
+        expect(reqs[0].data.regs.ext.gdpr).to.equal(0);
+      });
+
+      it('sets user.ext.consent from consentString', () => {
+        const br = makeBidderRequest({ gdprConsent: { gdprApplies: true, consentString: 'CONSENT_STRING' } });
+        const reqs = spec.buildRequests([makeBidRequest()], br);
+        expect(reqs[0].data.user.ext.consent).to.equal('CONSENT_STRING');
+      });
+
+      it('omits user.ext.consent when consentString is absent', () => {
+        const br = makeBidderRequest({ gdprConsent: { gdprApplies: true } });
+        const reqs = spec.buildRequests([makeBidRequest()], br);
+        expect(reqs[0].data.user).to.be.undefined;
+      });
+    });
+
+    describe('CCPA', () => {
+      it('sets regs.ext.us_privacy from uspConsent', () => {
+        const br = makeBidderRequest({ uspConsent: '1YNN' });
+        const reqs = spec.buildRequests([makeBidRequest()], br);
+        expect(reqs[0].data.regs.ext.us_privacy).to.equal('1YNN');
+      });
+    });
+
+    describe('GPP', () => {
+      it('sets regs.gpp and regs.gpp_sid when gppConsent is present', () => {
+        const br = makeBidderRequest({ gppConsent: { gppString: 'GPP_STRING', applicableSections: [7] } });
+        const reqs = spec.buildRequests([makeBidRequest()], br);
+        expect(reqs[0].data.regs.gpp).to.equal('GPP_STRING');
+        expect(reqs[0].data.regs.gpp_sid).to.deep.equal([7]);
+      });
+    });
+
+    describe('user EIDs', () => {
+      it('forwards userIdAsEids to user.eids', () => {
+        const eids = [{ source: 'rubiconproject.com', uids: [{ id: 'user-123' }] }];
+        const bid = makeBidRequest({ userIdAsEids: eids });
+        const reqs = spec.buildRequests([bid], makeBidderRequest());
+        expect(reqs[0].data.user.eids).to.deep.equal(eids);
+      });
+
+      it('omits user.eids when userIdAsEids is empty', () => {
+        const bid = makeBidRequest({ userIdAsEids: [] });
+        const reqs = spec.buildRequests([bid], makeBidderRequest());
+        expect(reqs[0].data.user).to.be.undefined;
+      });
+    });
+
+    describe('schain', () => {
+      it('sets source.schain when schain is present on the bid', () => {
+        const schain = { ver: '1.0', complete: 1, nodes: [{ asi: 'thenexusengine.io', sid: 'NXS003' }] };
+        const bid = makeBidRequest({ schain });
+        const reqs = spec.buildRequests([bid], makeBidderRequest());
+        expect(reqs[0].data.source.schain).to.deep.equal(schain);
+      });
+
+      it('omits source when schain is absent', () => {
+        const reqs = spec.buildRequests([makeBidRequest()], makeBidderRequest());
+        expect(reqs[0].data.source).to.be.undefined;
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // interpretResponse
+  // -------------------------------------------------------------------------
+  describe('interpretResponse', () => {
+    it('returns an array of bid objects for a valid response', () => {
+      const resp = makeServerResponse([makeBid()]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids).to.have.length(1);
+    });
+
+    it('maps requestId from bid.impid', () => {
+      const resp = makeServerResponse([makeBid({ impid: 'bid-001' })]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids[0].requestId).to.equal('bid-001');
+    });
+
+    it('maps cpm from bid.price', () => {
+      const resp = makeServerResponse([makeBid({ price: 4.20 })]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids[0].cpm).to.equal(4.20);
+    });
+
+    it('maps dimensions from bid.w and bid.h', () => {
+      const resp = makeServerResponse([makeBid({ w: 728, h: 90 })]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids[0].width).to.equal(728);
+      expect(bids[0].height).to.equal(90);
+    });
+
+    it('maps ad creative from bid.adm', () => {
+      const resp = makeServerResponse([makeBid({ adm: '<div>creative</div>' })]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids[0].ad).to.equal('<div>creative</div>');
+    });
+
+    it('maps creativeId from bid.crid', () => {
+      const resp = makeServerResponse([makeBid({ crid: 'crid-abc' })]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids[0].creativeId).to.equal('crid-abc');
+    });
+
+    it('maps advertiserDomains from bid.adomain', () => {
+      const resp = makeServerResponse([makeBid({ adomain: ['example.com'] })]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids[0].meta.advertiserDomains).to.deep.equal(['example.com']);
+    });
+
+    it('sets advertiserDomains to empty array when adomain is absent', () => {
+      const resp = makeServerResponse([makeBid({ adomain: undefined })]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids[0].meta.advertiserDomains).to.deep.equal([]);
+    });
+
+    it('sets netRevenue to true', () => {
+      const resp = makeServerResponse([makeBid()]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids[0].netRevenue).to.equal(true);
+    });
+
+    it('sets ttl to 300', () => {
+      const resp = makeServerResponse([makeBid()]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids[0].ttl).to.equal(300);
+    });
+
+    it('uses response body currency', () => {
+      const resp = makeServerResponse([makeBid()]);
+      resp.body.cur = 'GBP';
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids[0].currency).to.equal('GBP');
+    });
+
+    it('defaults currency to USD when absent', () => {
+      const resp = makeServerResponse([makeBid()]);
+      delete resp.body.cur;
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids[0].currency).to.equal('USD');
+    });
+
+    it('ignores bids with price of zero', () => {
+      const resp = makeServerResponse([makeBid({ price: 0 })]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids).to.have.length(0);
+    });
+
+    it('ignores bids with negative price', () => {
+      const resp = makeServerResponse([makeBid({ price: -1 })]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids).to.have.length(0);
+    });
+
+    it('returns empty array when seatbid is empty', () => {
+      const resp = makeServerResponse([]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids).to.deep.equal([]);
+    });
+
+    it('returns empty array when body is absent', () => {
+      const bids = spec.interpretResponse({}, {});
+      expect(bids).to.deep.equal([]);
+    });
+
+    it('returns empty array when serverResponse is null', () => {
+      const bids = spec.interpretResponse(null, {});
+      expect(bids).to.deep.equal([]);
+    });
+
+    it('handles multiple seatbids', () => {
+      const resp = {
+        body: {
+          id: 'resp-001',
+          cur: 'USD',
+          seatbid: [
+            { seat: 'rubicon', bid: [makeBid({ impid: 'bid-001', price: 3.00 })] },
+            { seat: 'pubmatic', bid: [makeBid({ impid: 'bid-002', price: 2.50 })] },
+          ]
+        }
+      };
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids).to.have.length(2);
+    });
+
+    it('detects native mediaType for JSON adm', () => {
+      const nativeAdm = JSON.stringify({ link: { url: 'https://example.com' }, title: { text: 'Title' } });
+      const resp = makeServerResponse([makeBid({ adm: nativeAdm })]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids[0].mediaType).to.equal(NATIVE);
+    });
+
+    it('detects banner mediaType for HTML adm', () => {
+      const resp = makeServerResponse([makeBid({ adm: '<div>banner</div>' })]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids[0].mediaType).to.equal(BANNER);
+    });
+
+    it('detects video mediaType for VAST XML adm', () => {
+      const vastXml = '<VAST version="3.0"><Ad></Ad></VAST>';
+      const resp = makeServerResponse([makeBid({ adm: vastXml, w: 640, h: 480 })]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids[0].mediaType).to.equal(VIDEO);
+      expect(bids[0].vastXml).to.equal(vastXml);
+    });
+
+    it('detects video mediaType for XML declaration VAST', () => {
+      const vastXml = '<?xml version="1.0"?><VAST version="4.0"></VAST>';
+      const resp = makeServerResponse([makeBid({ adm: vastXml })]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids[0].mediaType).to.equal(VIDEO);
+    });
+
+    it('detects video mediaType from adUrl (VAST URL)', () => {
+      const resp = makeServerResponse([makeBid({ adm: undefined, adUrl: 'https://example.com/vast.xml' })]);
+      const bids = spec.interpretResponse(resp, {});
+      expect(bids[0].mediaType).to.equal(VIDEO);
+      expect(bids[0].vastUrl).to.equal('https://example.com/vast.xml');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getUserSyncs
+  // -------------------------------------------------------------------------
+  describe('getUserSyncs', () => {
+    it('returns iframe sync when iframeEnabled', () => {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true, pixelEnabled: false }, [], null, null);
+      expect(syncs).to.have.length(1);
+      expect(syncs[0].type).to.equal('iframe');
+      expect(syncs[0].url).to.include(SYNC_URL);
+    });
+
+    it('returns image sync when only pixelEnabled', () => {
+      const syncs = spec.getUserSyncs({ iframeEnabled: false, pixelEnabled: true }, [], null, null);
+      expect(syncs).to.have.length(1);
+      expect(syncs[0].type).to.equal('image');
+    });
+
+    it('prefers iframe over pixel when both enabled', () => {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true, pixelEnabled: true }, [], null, null);
+      expect(syncs[0].type).to.equal('iframe');
+    });
+
+    it('returns empty array when both sync types are disabled', () => {
+      const syncs = spec.getUserSyncs({ iframeEnabled: false, pixelEnabled: false }, [], null, null);
+      expect(syncs).to.deep.equal([]);
+    });
+
+    it('appends gdpr params when gdprApplies is true', () => {
+      const gdpr = { gdprApplies: true, consentString: 'CONSENT' };
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, [], gdpr, null);
+      expect(syncs[0].url).to.include('gdpr=1');
+      expect(syncs[0].url).to.include('gdpr_consent=CONSENT');
+    });
+
+    it('appends gdpr=0 when gdprApplies is false', () => {
+      const gdpr = { gdprApplies: false, consentString: '' };
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, [], gdpr, null);
+      expect(syncs[0].url).to.include('gdpr=0');
+    });
+
+    it('appends us_privacy param when uspConsent is provided', () => {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, [], null, '1YNN');
+      expect(syncs[0].url).to.include('us_privacy=1YNN');
+    });
+
+    it('returns plain sync URL when no privacy params', () => {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, [], null, null);
+      expect(syncs[0].url).to.equal(SYNC_URL);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Adapter metadata
+  // -------------------------------------------------------------------------
+  describe('spec properties', () => {
+    it('has correct bidder code', () => {
+      expect(spec.code).to.equal('tne_catalyst');
+    });
+
+    it('has GVL ID 1494', () => {
+      expect(spec.gvlid).to.equal(1494);
+    });
+
+    it('supports banner, native, and video media types', () => {
+      expect(spec.supportedMediaTypes).to.include(BANNER);
+      expect(spec.supportedMediaTypes).to.include(NATIVE);
+      expect(spec.supportedMediaTypes).to.include(VIDEO);
+    });
+  });
+});


### PR DESCRIPTION
## Type of issue
Feature — adapter ergonomics

## Description
Refactors `tne_catalystBidAdapter`. Publishers can now integrate with a single `{ bidder: 'tne_catalyst' }` entry — no `publisherId` or `slot` required.

When params are absent, the adapter derives identity from standard signals already on the request:
- `slot` falls back to `bid.adUnitCode` (modules/tne_catalystBidAdapter.ts:80-86) and is mirrored into `imp.tagid` so the exchange has two places to look
- `site.publisher.id` is omitted (modules/tne_catalystBidAdapter.ts:150-152); the exchange resolves the publisher from `site.domain` via sellers.json
- Explicit `params.publisherId` / `params.slot` still override
- New optional `params.endpoint` overrides the auction URL for staging/QA
- New optional `params.testMode` adds `imp.ext.tne_catalyst.testMode: true`

`isBidRequestValid` is now permissive: it returns true for a bid with no params, but rejects bids where a supplied param is the wrong type, using a `nullOrType` helper modeled on AMX (modules/tne_catalystBidAdapter.ts:30-32, 47-58).

This honours the module-rules guidance that bidder params should only *override* information already available in standard ORTB / Prebid fields.

## Steps to reproduce
N/A — feature change, fully backward compatible. Existing configurations with `params: { publisherId, slot }` continue to work.

## Test page
N/A

### Expected results
- `{ bidder: 'tne_catalyst' }` with no params is a valid bid
- Slot key defaults to `adUnitCode`
- `site.publisher` is omitted when `publisherId` is not provided
- Supplying a wrong-typed param (e.g. `slot: 42`) is rejected

### Actual results
All of the above, verified by 89 passing tests in `test/spec/modules/tne_catalystBidAdapter_spec.js`.

## Platform details
Node 20, npm 10, repo HEAD as of this PR.

## Other information

### Programmatic checks
- `npx eslint modules/tne_catalystBidAdapter.ts test/spec/modules/tne_catalystBidAdapter_spec.js --cache --cache-strategy content` — clean, no output
- `npx gulp test --nolint --file test/spec/modules/tne_catalystBidAdapter_spec.js` — `✔ 89 tests completed`

### Files changed
- `modules/tne_catalystBidAdapter.ts` — adapter refactor
- `modules/tne_catalystBidAdapter.md` — docs updated to show single-line integration
- `test/spec/modules/tne_catalystBidAdapter_spec.js` — new permissive-params tests, updated existing `isBidRequestValid` cases

### Release labels
- `feature`
- `minor` (additive, backward-compatible)