### PR TITLE
LiveIntent/Hadron/PairID/33AcrossId: add typescript types for id providers

### DIFF
--- a/libraries/liveIntentId/externalIdSystem.js
+++ b/libraries/liveIntentId/externalIdSystem.js
@@ -3,6 +3,12 @@ import { gdprDataHandler, uspDataHandler, gppDataHandler } from '../../src/adapt
 import { submodule } from '../../src/hook.js';
 import { DEFAULT_AJAX_TIMEOUT, MODULE_NAME, parseRequestedAttributes, composeResult, eids, GVLID, PRIMARY_IDS, makeSourceEventToSend, setUpTreatment } from './shared.js'
 
+/**
+ * @typedef {import('../../modules/userId/index.js').Submodule} Submodule
+ * @typedef {import('../../modules/userId/spec.js').IdProviderSpec} IdProviderSpec
+ * @typedef {import('../../modules/liveIntentIdSystem.d.ts').LiveIntentIdSystemModuleName} LiveIntentIdSystemModuleName
+ */
+
 // Reference to the client for the liQHub.
 let cachedClientRef
 
@@ -115,15 +121,11 @@ function resolve(configParams, clientRef, callback) {
   })
 }
 
-/**
- * @typedef {import('../../modules/userId/index.js').Submodule} Submodule
- */
-
-/** @type {Submodule} */
+/** @type {IdProviderSpec<LiveIntentIdSystemModuleName>} */
 export const liveIntentExternalIdSubmodule = {
   /**
    * Used to link submodule with config.
-   * @type {string}
+   * @type {LiveIntentIdSystemModuleName}
    */
   name: MODULE_NAME,
   gvlid: GVLID,

--- a/libraries/liveIntentId/idSystem.js
+++ b/libraries/liveIntentId/idSystem.js
@@ -14,9 +14,11 @@ import { MODULE_TYPE_UID } from '../../src/activities/modules.js';
 import { DEFAULT_AJAX_TIMEOUT, MODULE_NAME, composeResult, eids, GVLID, DEFAULT_DELAY, PRIMARY_IDS, parseRequestedAttributes, makeSourceEventToSend, setUpTreatment } from './shared.js'
 
 /**
- * @typedef {import('../modules/userId/index.js').Submodule} Submodule
- * @typedef {import('../modules/userId/index.js').SubmoduleConfig} SubmoduleConfig
- * @typedef {import('../modules/userId/index.js').IdResponse} IdResponse
+ * @typedef {import('../../modules/userId/index.js').Submodule} Submodule
+ * @typedef {import('../../modules/userId/index.js').SubmoduleConfig} SubmoduleConfig
+ * @typedef {import('../../modules/userId/index.js').IdResponse} IdResponse
+ * @typedef {import('../../modules/userId/spec.js').IdProviderSpec} IdProviderSpec
+ * @typedef {import('../../modules/liveIntentIdSystem.d.ts').LiveIntentIdSystemModuleName} LiveIntentIdSystemModuleName
  */
 
 const EVENTS_TOPIC = 'pre_lips';
@@ -157,12 +159,12 @@ function tryFireEvent() {
   }
 }
 
-/** @type {Submodule} */
+/** @type {IdProviderSpec<LiveIntentIdSystemModuleName>} */
 export const liveIntentIdSubmodule = {
   moduleMode: '$$LIVE_INTENT_MODULE_MODE$$',
   /**
    * Used to link submodule with config.
-   * @type {string}
+   * @type {LiveIntentIdSystemModuleName}
    */
   name: MODULE_NAME,
   gvlid: GVLID,

--- a/modules/33acrossIdSystem.d.ts
+++ b/modules/33acrossIdSystem.d.ts
@@ -1,0 +1,40 @@
+export type ThirtyThreeAcrossIdSystemModuleName = '33acrossId';
+
+export type ThirtyThreeAcrossIdSystemParams = {
+  /**
+   * Partner ID (PID)
+   *
+   * Please reach out to PrebidUIM@33across.com and request your PID
+   */
+  pid: string;
+  /**
+   * Hashed email address in sha256 format
+   */
+  hem?: string;
+  /**
+   * Indicates whether a supplemental first-party ID may be stored to improve addressability
+   */
+  storeFpid?: boolean;
+  /**
+   * Indicates whether a supplemental third-party ID may be stored to improve addressability
+   */
+  storeTpid?: boolean;
+}
+
+declare module './userId/spec' {
+  interface UserId {
+    '33acrossId': {
+      envelope: string;
+    };
+  }
+
+  interface ProvidersToId {
+    '33acrossId': '33acrossId';
+  }
+
+  interface ProviderParams {
+    '33acrossId': ThirtyThreeAcrossIdSystemParams;
+  }
+}
+
+export {}

--- a/modules/33acrossIdSystem.js
+++ b/modules/33acrossIdSystem.js
@@ -17,8 +17,13 @@ import { domainOverrideToRootDomain } from '../libraries/domainOverrideToRootDom
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
  * @typedef {import('../modules/userId/index.js').SubmoduleConfig} SubmoduleConfig
  * @typedef {import('../modules/userId/index.js').IdResponse} IdResponse
+ * @typedef {import('../modules/userId/spec.js').IdProviderSpec} IdProviderSpec
+ * @typedef {import('../modules/33acrossIdSystem.d.ts').ThirtyThreeAcrossIdSystemModuleName} ThirtyThreeAcrossIdSystemModuleName
  */
 
+/**
+ * @type {ThirtyThreeAcrossIdSystemModuleName}
+ */
 const MODULE_NAME = '33acrossId';
 const API_URL = 'https://lexicon.33across.com/v1/envelope';
 const AJAX_TIMEOUT = 10000;
@@ -192,11 +197,11 @@ function handleSupplementalIds(ids, { enabledStorageTypes, expires, ...options }
   });
 }
 
-/** @type {Submodule} */
+/** @type {IdProviderSpec<ThirtyThreeAcrossIdSystemModuleName>} */
 export const thirtyThreeAcrossIdSubmodule = {
   /**
    * used to link submodule with config
-   * @type {string}
+   * @type {ThirtyThreeAcrossIdSystemModuleName}
    */
   name: MODULE_NAME,
 

--- a/modules/hadronIdSystem.d.ts
+++ b/modules/hadronIdSystem.d.ts
@@ -1,0 +1,24 @@
+export type HadronIdSystemModuleName = 'hadronId';
+
+export type HadronIdSystemParams = {
+  /**
+   * Audigent Partner ID obtained from Audigent.
+   */
+  partnerId: number;
+}
+
+declare module './userId/spec' {
+  interface UserId {
+    hadronId: string;
+  }
+
+  interface ProvidersToId {
+    hadronId: 'hadronId';
+  }
+
+  interface ProviderParams {
+    hadronId: HadronIdSystemParams;
+  }
+}
+
+export {}

--- a/modules/hadronIdSystem.js
+++ b/modules/hadronIdSystem.js
@@ -17,8 +17,13 @@ import { gdprDataHandler, uspDataHandler, gppDataHandler } from '../src/adapterM
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
  * @typedef {import('../modules/userId/index.js').SubmoduleConfig} SubmoduleConfig
  * @typedef {import('../modules/userId/index.js').IdResponse} IdResponse
+ * @typedef {import('../modules/userId/spec.js').IdProviderSpec} IdProviderSpec
+ * @typedef {import('../modules/hadronIdSystem.d.ts').HadronIdSystemModuleName} HadronIdSystemModuleName
  */
 
+/**
+ * @type {HadronIdSystemModuleName}
+ */
 export const MODULE_NAME = 'hadronId';
 const LOG_PREFIX = `[${MODULE_NAME}System]`;
 export const LS_TAM_KEY = 'auHadronId';
@@ -53,11 +58,11 @@ const urlAddParams = (url, params) => {
 
 const isDebug = config.getConfig('debug') || false;
 
-/** @type {Submodule} */
+/** @type {IdProviderSpec<HadronIdSystemModuleName>} */
 export const hadronIdSubmodule = {
   /**
    * used to link submodule with config
-   * @type {string}
+   * @type {HadronIdSystemModuleName}
    */
   name: MODULE_NAME,
   gvlid: AU_GVLID,

--- a/modules/liveIntentIdSystem.d.ts
+++ b/modules/liveIntentIdSystem.d.ts
@@ -1,0 +1,135 @@
+export type LiveIntentIdSystemModuleName = 'liveIntentId';
+
+export interface LiveIntentCollectConfig {
+  /**
+   * This parameter defines whether the first-party identifiers that LiveConnect creates and updates are stored in a cookie jar, or in local storage.
+   * If nothing is set, default behaviour would be `cookie`.
+   */
+  fpiStorageStrategy?: 'cookie' | 'ls' | 'none';
+  /**
+   * This configuration parameter defines the maximum duration of a call to the collector endpoint.
+   * By default, 5000 milliseconds.
+   */
+  ajaxTimeout?: number;
+  /**
+   * The expiration time of an identifier created and updated by LiveConnect.
+   * By default, 730 days.
+   */
+  fpiExpirationDays?: number;
+  /**
+   * The parameter defines where the signal pixels are pointing to.
+   * The params and paths will be defined subsequently.
+   * If the parameter is not set, LiveConnect will by default emit the signal towards https://rp.liadm.com.
+   */
+  collectorUrl?: string;
+  /**
+   * LiveIntent’s media business entity application ID.
+   */
+  appId?: string;
+}
+
+export type LiveIntentRequestedAttributesOverrides = Partial<{
+  nonId: boolean;
+  uid2: boolean;
+  medianet: boolean;
+  magnite: boolean;
+  bidswitch: boolean;
+  pubmatic: boolean;
+  openx: boolean;
+  sovrn: boolean;
+  index: boolean;
+  thetradedesk: boolean;
+  tdif: boolean;
+  sharethrough: boolean;
+  vidazoo: boolean;
+  zetassp: boolean;
+  triplelift: boolean;
+  segments: boolean;
+  nexxen: boolean;
+  fpid: boolean
+}>;
+
+export type LiveIntentFpid = {
+  /**
+   * The cookie/localstorage key name
+   */
+  name?: string;
+  /**
+   * The parameter defines where to get the identifier from.
+   * Either from the cookie jar, `cookie`, or from the local storage, `html5`.
+   */
+  strategy?: 'cookie' | 'html5';
+}
+
+export type LiveIntentIdSystemParams = {
+  /**
+   * The unique identifier for each publisher (for existing LiveIntent customers)
+   */
+  publisherId?: string;
+  /**
+   * The unique identifier for each distributor (for existing LiveIntent customers).
+   * It will be ignored if `liCollectConfig.appId` is provided.
+   */
+  distributorId?: string;
+  /**
+   * This configuration parameter defines the maximum duration of a call to the IdentityResolution endpoint.
+   * By default, 5000 milliseconds.
+   */
+  ajaxTimeout?: number;
+  /**
+   * The name of the partner whose data will be returned in the response.
+   */
+  partner?: string;
+  /**
+   * Used to send additional identifiers in the request for LiveIntent to resolve against the LiveIntent ID and additional attributes.
+   */
+  identifiersToResolve?: string[];
+  requestedAttributesOverrides?: LiveIntentRequestedAttributesOverrides;
+  /**
+   * The hashed email address of a user.
+   * We can accept the hashes, which use the following hashing algorithms: md5, sha1, sha2.
+   */
+  emailHash?: string;
+  /**
+   * The IPv4 address of a user.
+   */
+  ipv4?: string;
+  /**
+   * The IPv6 address of a user.
+   */
+  ipv6?: string;
+  /**
+   * The user agent of a user.
+   */
+  userAgent?: string;
+  /**
+   * Use this to change the default endpoint URL if you can call the LiveIntent Identity Exchange within your own domain.
+   */
+  url?: string;
+  /**
+   * Container of all collector params.
+   */
+  liCollectConfig?: LiveIntentCollectConfig;
+  fpid?: LiveIntentFpid;
+}
+
+declare module './userId/spec' {
+  interface UserId {
+    lipb: {
+      lipbid?: string;
+      nonId?: string;
+      segments?: string[];
+      [key: string]: unknown;
+    };
+  }
+
+  interface ProvidersToId {
+    liveIntentId: 'lipb';
+  }
+
+  interface ProviderParams {
+    liveIntentId: LiveIntentIdSystemParams;
+  }
+}
+
+export {}

--- a/modules/liveIntentIdSystem.d.ts
+++ b/modules/liveIntentIdSystem.d.ts
@@ -110,6 +110,9 @@ export type LiveIntentIdSystemParams = {
    * Container of all collector params.
    */
   liCollectConfig?: LiveIntentCollectConfig;
+  /**
+   * First party identifier
+   */
   fpid?: LiveIntentFpid;
 }
 

--- a/modules/pairIdSystem.d.ts
+++ b/modules/pairIdSystem.d.ts
@@ -1,0 +1,31 @@
+export type PairIdSystemModuleName = 'pairId';
+
+export interface PairIdLiverampParams {
+  /**
+   * storage key to fetch liveramp provided PAIR Id, the default value is `_lr_pairId`
+   */
+  storageKey?: string;
+}
+
+export type PairIdSystemParams = {
+  /**
+   * Container of all liveramp cleanroom specified params.
+   */
+  liveramp?: PairIdLiverampParams;
+}
+
+declare module './userId/spec' {
+  interface UserId {
+    pairId: string[];
+  }
+
+  interface ProvidersToId {
+    pairId: 'pairId';
+  }
+
+  interface ProviderParams {
+    pairId: PairIdSystemParams;
+  }
+}
+
+export {}

--- a/modules/pairIdSystem.js
+++ b/modules/pairIdSystem.js
@@ -12,8 +12,13 @@ import { MODULE_TYPE_UID } from '../src/activities/modules.js';
 
 /**
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
+ * @typedef {import('../modules/userId/spec.js').IdProviderSpec} IdProviderSpec
+ * @typedef {import('../modules/pairIdSystem.d.ts').PairIdSystemModuleName} PairIdSystemModuleName
  */
 
+/**
+ * @type {PairIdSystemModuleName}
+ */
 const MODULE_NAME = 'pairId';
 const PAIR_ID_KEY = 'pairId';
 const DEFAULT_LIVERAMP_PAIR_ID_KEY = '_lr_pairId';
@@ -28,11 +33,11 @@ function pairIdFromCookie(key) {
   return storage.cookiesAreEnabled() ? storage.getCookie(key) : null;
 }
 
-/** @type {Submodule} */
+/** @type {IdProviderSpec<PairIdSystemModuleName>} */
 export const pairIdSubmodule = {
   /**
    * used to link submodule with config
-   * @type {string}
+   * @type {PairIdSystemModuleName}
    */
   name: MODULE_NAME,
   /**

--- a/test/spec/modules/liveIntentExternalIdSystem_spec.js
+++ b/test/spec/modules/liveIntentExternalIdSystem_spec.js
@@ -291,7 +291,7 @@ describe('LiveIntentExternalId', function() {
     liveIntentExternalIdSubmodule.getId({
       params: {
         ...defaultConfigParams.params,
-        ...{ requestedAttributesOverrides: { 'foo': true, 'bar': false } }
+        ...{ requestedAttributesOverrides: { 'sovrn': true, 'openx': false } }
       }
     }).callback(() => {});
 
@@ -316,7 +316,7 @@ describe('LiveIntentExternalId', function() {
     expect(resolveCommand).to.eql({
       clientRef: {},
       onSuccess: [{ type: 'callback' }],
-      requestedAttributes: ['nonId', 'foo'],
+      requestedAttributes: ['nonId', 'sovrn'],
       type: 'resolve'
     })
   });

--- a/test/spec/modules/liveIntentIdMinimalSystem_spec.js
+++ b/test/spec/modules/liveIntentIdMinimalSystem_spec.js
@@ -234,12 +234,12 @@ describe('LiveIntentMinimalId', function() {
     const submoduleCallback = liveIntentIdSubmodule.getId({
       params: {
         ...defaultConfigParams.params,
-        ...{ requestedAttributesOverrides: { 'foo': true, 'bar': false } }
+        ...{ requestedAttributesOverrides: { 'sovrn': true, 'openx': false } }
       }
     }).callback;
     submoduleCallback(callBackSpy);
     const request = server.requests[0];
-    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?resolve=nonId&resolve=foo`);
+    expect(request.url).to.be.eq(`https://idx.liadm.com/idex/prebid/89899?resolve=nonId&resolve=sovrn`);
     request.respond(
       200,
       responseHeader,

--- a/test/spec/modules/liveIntentIdSystem_spec.js
+++ b/test/spec/modules/liveIntentIdSystem_spec.js
@@ -420,12 +420,12 @@ describe('LiveIntentId', function() {
     const submoduleCallback = liveIntentIdSubmodule.getId({
       params: {
         ...defaultConfigParams.params,
-        ...{ requestedAttributesOverrides: { 'foo': true, 'bar': false } }
+        ...{ requestedAttributesOverrides: { 'sovrn': true, 'openx': false } }
       }
     }).callback;
     submoduleCallback(callBackSpy);
     const request = idxRequests()[0];
-    expect(request.url).to.match(/https:\/\/idx.liadm.com\/idex\/prebid\/89899\?.*cd=.localhost.*&resolve=nonId.*&resolve=foo.*/);
+    expect(request.url).to.match(/https:\/\/idx.liadm.com\/idex\/prebid\/89899\?.*cd=.localhost.*&resolve=nonId.*&resolve=sovrn.*/);
     request.respond(
       200,
       responseHeader,


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

Added `.d.ts` files for a few more identity providers.
The typings are limited to what is described in the public docs of those identity providers.

Note: most of the code was AI generated, but I went over all of it.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
