### PR TITLE
Onetag Bid Adapter: fix inverted dealId condition in interpretResponse

### DIFF
--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -291,7 +291,7 @@ function getPageInfo(bidderRequest) {
     timing: getTiming(),
     version: {
       prebid: '$prebid.version$',
-      adapter: '1.1.6'
+      adapter: '1.1.7'
     }
   };
 }

--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -171,7 +171,7 @@ function interpretResponse(serverResponse, bidderRequest) {
       width: bid.width,
       height: bid.height,
       creativeId: bid.creativeId,
-      dealId: bid.dealId == null ? bid.dealId : '',
+      dealId: bid.dealId != null ? bid.dealId : undefined,
       currency: bid.currency,
       netRevenue: bid.netRevenue || false,
       mediaType: (bid.mediaType === NATIVE + NATIVE_SUFFIX) ? NATIVE : bid.mediaType,

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -842,6 +842,18 @@ describe('onetag', function () {
       const serverResponse = spec.interpretResponse(responseWithDsa, request);
       serverResponse.forEach(bid => expect(bid.meta.dsa).to.deep.equals(dsaResponseObj));
     });
+    it('Returns dealId when present in server response', function () {
+      const interpretedResponse = spec.interpretResponse(response, request);
+      const bannerBid = interpretedResponse.find(bid => bid.requestId === 'banner');
+      expect(bannerBid.dealId).to.equal('dishfo');
+    });
+    it('Returns undefined dealId when absent from server response', function () {
+      const responseWithoutDealId = getBannerVideoNativeResponse();
+      responseWithoutDealId.body.bids.forEach(bid => delete bid.dealId);
+      const interpretedResponse = spec.interpretResponse(responseWithoutDealId, request);
+      const bannerBid = interpretedResponse.find(bid => bid.requestId === 'banner');
+      expect(bannerBid.dealId).to.be.undefined;
+    });
   });
   describe('getUserSyncs', function () {
     const sync_endpoint = 'https://onetag-sys.com/usync/';


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
The dealId assignment in interpretResponse had an inverted null-check, causing a server-provided deal ID to be overwritten with an empty string '' instead of being passed through.

The Onetag server does not currently send dealId, so this fix has no observable effect on existing behaviour. It is shipped ahead of the server-side change to ensure publishers have time to adopt the corrected adapter before dealId is enabled server-side.

Two unit tests added to cover both the present and absent dealId cases.