### PR TITLE
Acxiom's realid userID prebid module (GCD-559)

### DIFF
--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -3,6 +3,7 @@
     "userId": [
       "33acrossIdSystem",
       "abtshieldIdSystem",
+      "acxiomRealIdSystem",
       "admixerIdSystem",
       "adqueryIdSystem",
       "adplusIdSystem",

--- a/modules/acxiomRealIdSystem.js
+++ b/modules/acxiomRealIdSystem.js
@@ -19,9 +19,8 @@ import { logError, logInfo } from '../src/utils.js';
  */
 
 const MODULE_NAME = 'acxiomRealId';
-const DEFAULT_API_URL = 'https://gc-pixel.growthcode.io';
+const DEFAULT_API_URL = 'https://ids.api.gcprivacy.id/e/l';
 const DEFAULT_SOURCE_ID = 'acxiom.id';
-const LOOKUP_PATH = '/v1/eid/lookup';
 const LOG_PREFIX = 'AcxiomRealId: ';
 
 export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME });
@@ -59,16 +58,8 @@ function deleteStoredToken(config) {
   logInfo(LOG_PREFIX + 'Stored token deleted.');
 }
 
-function buildLookupUrl(apiUrl, partnerId, hem, sourceId) {
-  const base = (apiUrl || DEFAULT_API_URL).replace(/\/+$/, '');
-  const params = [
-    `partnerId=${encodeURIComponent(partnerId)}`,
-    `sourceId=${encodeURIComponent(sourceId || DEFAULT_SOURCE_ID)}`
-  ];
-  if (hem) {
-    params.push(`hem=${encodeURIComponent(hem)}`);
-  }
-  return `${base}${LOOKUP_PATH}?${params.join('&')}`;
+function buildLookupUrl(apiUrl) {
+  return (apiUrl || DEFAULT_API_URL).replace(/\/+$/, '');
 }
 
 /** @type {Submodule} */
@@ -87,7 +78,7 @@ export const acxiomRealIdSubmodule = {
 
   getId(config, consentData) {
     const configParams = (config && config.params) || {};
-    const { partnerId, hem, apiUrl, sourceId } = configParams;
+    const { partnerId, apiUrl, sourceId, hem } = configParams;
 
     if (!partnerId) {
       logError(LOG_PREFIX + 'partnerId is required.');
@@ -99,7 +90,17 @@ export const acxiomRealIdSubmodule = {
       return undefined;
     }
 
-    const url = buildLookupUrl(apiUrl, partnerId, hem, sourceId);
+    const url = buildLookupUrl(apiUrl);
+    const payload = {
+      partnerId,
+      ip: '',
+      userAgent: navigator.userAgent,
+      sourceId: sourceId || DEFAULT_SOURCE_ID
+    };
+    if (hem) {
+      payload.hem = hem;
+    }
+    const body = JSON.stringify(payload);
 
     return {
       callback: (cb) => {
@@ -127,9 +128,9 @@ export const acxiomRealIdSubmodule = {
               cb();
             }
           },
-          null,
+          body,
           {
-            method: 'GET',
+            method: 'POST',
             contentType: 'application/json',
             withCredentials: true
           }

--- a/modules/acxiomRealIdSystem.js
+++ b/modules/acxiomRealIdSystem.js
@@ -10,6 +10,7 @@ import { ajaxBuilder } from '../src/ajax.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { MODULE_TYPE_UID } from '../src/activities/modules.js';
 import { logError } from '../src/utils.js';
+import { gdprDataHandler, uspDataHandler, gppDataHandler } from '../src/adapterManager.js';
 
 /**
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
@@ -23,6 +24,35 @@ const DEFAULT_API_URL = 'https://ids.api.gcprivacy.id/v1/eid/l';
 const DEFAULT_SOURCE_ID = 'acxiom.id';
 export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME });
 
+const US_GPP_SID_API = {
+  7: 'usnat',
+  8: 'usca',
+  9: 'usva',
+  10: 'usco',
+  11: 'usut',
+  12: 'usct'
+};
+
+function flatSection(subsections) {
+  if (!Array.isArray(subsections)) return subsections;
+  return subsections.reduceRight((merged, section) => Object.assign(section, merged), {});
+}
+
+function isGppOptedOut(gppData) {
+  if (!gppData || !gppData.applicableSections || !gppData.parsedSections) {
+    return false;
+  }
+  for (const sid of gppData.applicableSections) {
+    const apiName = US_GPP_SID_API[sid];
+    if (!apiName) continue;
+    const sectionData = flatSection(gppData.parsedSections[apiName]);
+    if (sectionData && (sectionData.SaleOptOut === 1 || sectionData.SharingOptOut === 1)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function isConsentBlocked(consentData) {
   if (!consentData) {
     return false;
@@ -34,12 +64,33 @@ function isConsentBlocked(consentData) {
     return true;
   }
 
-  // CCPA: us_privacy position 3 = Y → opted out of sale
+  // CCPA: us_privacy opt-out of sale (position 3, 0-indexed charAt(2))
   const usp = consentData.usp;
   if (usp && typeof usp === 'string' && usp.length >= 3 && usp.charAt(2) === 'Y') {
     return true;
   }
 
+  // GPP: US state sections — suppress on Sale or Sharing opt-out
+  if (isGppOptedOut(consentData.gpp)) {
+    return true;
+  }
+
+  return false;
+}
+
+function isConsentBlockedByHandlers() {
+  const gdpr = gdprDataHandler.getConsentData();
+  if (gdpr && (gdpr.gdprApplies || gdpr.consentString)) {
+    return true;
+  }
+  const usp = uspDataHandler.getConsentData();
+  if (usp && typeof usp === 'string' && usp.length >= 3 && usp.charAt(2) === 'Y') {
+    return true;
+  }
+  const gpp = gppDataHandler.getConsentData();
+  if (isGppOptedOut(gpp)) {
+    return true;
+  }
   return false;
 }
 
@@ -61,7 +112,11 @@ function buildLookupUrl(apiUrl) {
 export const acxiomRealIdSubmodule = {
   name: MODULE_NAME,
 
-  decode(value) {
+  decode(value, config) {
+    if (isConsentBlockedByHandlers()) {
+      deleteStoredToken(config);
+      return undefined;
+    }
     if (value && typeof value === 'string') {
       return { acxiomRealId: { id: value, atype: 1 } };
     }
@@ -113,7 +168,7 @@ export const acxiomRealIdSubmodule = {
                 const eids = parsed && parsed.user && parsed.user.eids;
                 const uid = eids && eids[0] && eids[0].uids && eids[0].uids[0];
                 if (uid && uid.id) {
-                  cb(uid.id);
+                  cb({ id: uid.id, atype: uid.atype });
                 } else {
                   cb();
                 }

--- a/modules/acxiomRealIdSystem.js
+++ b/modules/acxiomRealIdSystem.js
@@ -96,11 +96,16 @@ function isConsentBlockedByHandlers() {
 
 function deleteStoredToken(config) {
   const storageName = (config && config.storage && config.storage.name) || MODULE_NAME;
+  const expired = new Date(0).toUTCString();
   if (storage.localStorageIsEnabled()) {
-    storage.removeDataFromLocalStorage(storageName);
+    ['', '_exp', '_cst', '_last'].forEach(suffix => {
+      storage.removeDataFromLocalStorage(`${storageName}${suffix}`);
+    });
   }
   if (storage.cookiesAreEnabled()) {
-    storage.setCookie(storageName, '', new Date(0).toUTCString());
+    ['', '_cst', '_last'].forEach(suffix => {
+      storage.setCookie(`${storageName}${suffix}`, '', expired);
+    });
   }
 }
 

--- a/modules/acxiomRealIdSystem.js
+++ b/modules/acxiomRealIdSystem.js
@@ -19,7 +19,7 @@ import { logError } from '../src/utils.js';
  */
 
 const MODULE_NAME = 'acxiomRealId';
-const DEFAULT_API_URL = 'https://ids.api.gcprivacy.id/e/l';
+const DEFAULT_API_URL = 'https://ids.api.gcprivacy.id/v1/eid/l';
 const DEFAULT_SOURCE_ID = 'acxiom.id';
 export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME });
 

--- a/modules/acxiomRealIdSystem.js
+++ b/modules/acxiomRealIdSystem.js
@@ -9,7 +9,7 @@ import { submodule } from '../src/hook.js';
 import { ajaxBuilder } from '../src/ajax.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { MODULE_TYPE_UID } from '../src/activities/modules.js';
-import { logError } from '../src/utils.js';
+import { logError, getWindowSelf } from '../src/utils.js';
 import { gdprDataHandler, uspDataHandler, gppDataHandler } from '../src/adapterManager.js';
 
 /**
@@ -153,7 +153,7 @@ export const acxiomRealIdSubmodule = {
     const payload = {
       partnerId,
       ip: '',
-      userAgent: navigator.userAgent,
+      userAgent: getWindowSelf().navigator?.userAgent || '',
       sourceId: sourceId || DEFAULT_SOURCE_ID
     };
     if (hem) {

--- a/modules/acxiomRealIdSystem.js
+++ b/modules/acxiomRealIdSystem.js
@@ -19,6 +19,31 @@ import { gdprDataHandler, uspDataHandler, gppDataHandler } from '../src/adapterM
  * @typedef {import('../modules/userId/index.js').IdResponse} IdResponse
  */
 
+/**
+ * @typedef {Object} AcxiomRealIdParams
+ * @property {string} partnerId - Partner ID issued by GrowthCode on behalf of Acxiom
+ * @property {string} [hem] - SHA-256 hashed email for improved match rate
+ * @property {string} [sourceId] - EID source to request from the lookup API. Defaults to 'acxiom.id'
+ * @property {string} [apiUrl] - Override the full API endpoint URL
+ */
+
+/**
+ * @typedef {Object} AcxiomRealIdValue
+ * @property {string} id - The resolved Acxiom Real ID token
+ * @property {number} atype - Agent type per OpenRTB spec (1 = cookie/device, 2 = in-app, 3 = person-based)
+ */
+
+/**
+ * @typedef {Object} AcxiomRealIdConfig
+ * @property {'acxiomRealId'} name - Module identifier
+ * @property {AcxiomRealIdParams} params - Module configuration parameters
+ * @property {Object} [storage] - Storage configuration
+ * @property {'html5'|'cookie'} [storage.type] - Storage method
+ * @property {string} [storage.name] - Storage key name
+ * @property {number} [storage.expires] - TTL in days
+ * @property {number} [storage.refreshInSeconds] - How often to re-fetch the ID in seconds
+ */
+
 const MODULE_NAME = 'acxiomRealId';
 const DEFAULT_API_URL = 'https://ids.api.gcprivacy.id/v1/eid/l';
 const DEFAULT_SOURCE_ID = 'acxiom.id';

--- a/modules/acxiomRealIdSystem.js
+++ b/modules/acxiomRealIdSystem.js
@@ -62,16 +62,16 @@ export const acxiomRealIdSubmodule = {
   name: MODULE_NAME,
 
   decode(value) {
-    if (value && typeof value === 'object' && value.id) {
-      return { acxiomRealId: value };
-    }
     if (value && typeof value === 'string') {
       return { acxiomRealId: { id: value, atype: 1 } };
+    }
+    if (value && typeof value === 'object' && value.id) {
+      return { acxiomRealId: { id: value.id, atype: value.atype || 1 } };
     }
     return undefined;
   },
 
-  getId(config, consentData) {
+  getId(config, consentData, storedId) {
     const configParams = (config && config.params) || {};
     const { partnerId, apiUrl, sourceId, hem } = configParams;
 
@@ -83,6 +83,10 @@ export const acxiomRealIdSubmodule = {
     if (isConsentBlocked(consentData)) {
       deleteStoredToken(config);
       return undefined;
+    }
+
+    if (storedId) {
+      return { id: storedId };
     }
 
     const url = buildLookupUrl(apiUrl);
@@ -109,7 +113,7 @@ export const acxiomRealIdSubmodule = {
                 const eids = parsed && parsed.user && parsed.user.eids;
                 const uid = eids && eids[0] && eids[0].uids && eids[0].uids[0];
                 if (uid && uid.id) {
-                  cb({ id: uid.id, atype: uid.atype });
+                  cb(uid.id);
                 } else {
                   cb();
                 }

--- a/modules/acxiomRealIdSystem.js
+++ b/modules/acxiomRealIdSystem.js
@@ -9,7 +9,7 @@ import { submodule } from '../src/hook.js';
 import { ajaxBuilder } from '../src/ajax.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { MODULE_TYPE_UID } from '../src/activities/modules.js';
-import { logError, logInfo } from '../src/utils.js';
+import { logError } from '../src/utils.js';
 
 /**
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
@@ -21,8 +21,6 @@ import { logError, logInfo } from '../src/utils.js';
 const MODULE_NAME = 'acxiomRealId';
 const DEFAULT_API_URL = 'https://ids.api.gcprivacy.id/e/l';
 const DEFAULT_SOURCE_ID = 'acxiom.id';
-const LOG_PREFIX = 'AcxiomRealId: ';
-
 export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME });
 
 function isConsentBlocked(consentData) {
@@ -33,14 +31,12 @@ function isConsentBlocked(consentData) {
   // EU/UK passive suppression: TCF string present → do not fire
   const gdpr = consentData.gdpr;
   if (gdpr && (gdpr.gdprApplies || gdpr.consentString)) {
-    logInfo(LOG_PREFIX + 'TCF consent string detected, suppressing.');
     return true;
   }
 
   // CCPA: us_privacy position 3 = Y → opted out of sale
   const usp = consentData.usp;
   if (usp && typeof usp === 'string' && usp.length >= 3 && usp.charAt(2) === 'Y') {
-    logInfo(LOG_PREFIX + 'CCPA opt-out detected, suppressing.');
     return true;
   }
 
@@ -55,7 +51,6 @@ function deleteStoredToken(config) {
   if (storage.cookiesAreEnabled()) {
     storage.setCookie(storageName, '', new Date(0).toUTCString());
   }
-  logInfo(LOG_PREFIX + 'Stored token deleted.');
 }
 
 function buildLookupUrl(apiUrl) {
@@ -81,7 +76,7 @@ export const acxiomRealIdSubmodule = {
     const { partnerId, apiUrl, sourceId, hem } = configParams;
 
     if (!partnerId) {
-      logError(LOG_PREFIX + 'partnerId is required.');
+      logError('AcxiomRealId: partnerId is required.');
       return undefined;
     }
 
@@ -119,12 +114,10 @@ export const acxiomRealIdSubmodule = {
                   cb();
                 }
               } catch (e) {
-                logError(LOG_PREFIX + 'Failed to parse response.', e);
                 cb();
               }
             },
             error: () => {
-              logError(LOG_PREFIX + 'Lookup request failed.');
               cb();
             }
           },

--- a/modules/acxiomRealIdSystem.js
+++ b/modules/acxiomRealIdSystem.js
@@ -1,0 +1,155 @@
+/**
+ * This module adds Acxiom Real ID to the User ID module
+ * The {@link module:modules/userId} module is required
+ * @module modules/acxiomRealIdSystem
+ * @requires module:modules/userId
+ */
+
+import { submodule } from '../src/hook.js';
+import { ajaxBuilder } from '../src/ajax.js';
+import { getStorageManager } from '../src/storageManager.js';
+import { MODULE_TYPE_UID } from '../src/activities/modules.js';
+import { logError, logInfo } from '../src/utils.js';
+
+/**
+ * @typedef {import('../modules/userId/index.js').Submodule} Submodule
+ * @typedef {import('../modules/userId/index.js').SubmoduleConfig} SubmoduleConfig
+ * @typedef {import('../modules/userId/index.js').ConsentData} ConsentData
+ * @typedef {import('../modules/userId/index.js').IdResponse} IdResponse
+ */
+
+const MODULE_NAME = 'acxiomRealId';
+const DEFAULT_API_URL = 'https://gc-pixel.growthcode.io';
+const DEFAULT_SOURCE_ID = 'acxiom.id';
+const LOOKUP_PATH = '/v1/eid/lookup';
+const LOG_PREFIX = 'AcxiomRealId: ';
+
+export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME });
+
+function isConsentBlocked(consentData) {
+  if (!consentData) {
+    return false;
+  }
+
+  // EU/UK passive suppression: TCF string present → do not fire
+  const gdpr = consentData.gdpr;
+  if (gdpr && (gdpr.gdprApplies || gdpr.consentString)) {
+    logInfo(LOG_PREFIX + 'TCF consent string detected, suppressing.');
+    return true;
+  }
+
+  // CCPA: us_privacy position 3 = Y → opted out of sale
+  const usp = consentData.usp;
+  if (usp && typeof usp === 'string' && usp.length >= 3 && usp.charAt(2) === 'Y') {
+    logInfo(LOG_PREFIX + 'CCPA opt-out detected, suppressing.');
+    return true;
+  }
+
+  return false;
+}
+
+function deleteStoredToken(config) {
+  const storageName = (config && config.storage && config.storage.name) || MODULE_NAME;
+  if (storage.localStorageIsEnabled()) {
+    storage.removeDataFromLocalStorage(storageName);
+  }
+  if (storage.cookiesAreEnabled()) {
+    storage.setCookie(storageName, '', new Date(0).toUTCString());
+  }
+  logInfo(LOG_PREFIX + 'Stored token deleted.');
+}
+
+function buildLookupUrl(apiUrl, partnerId, hem, sourceId) {
+  const base = (apiUrl || DEFAULT_API_URL).replace(/\/+$/, '');
+  const params = [
+    `partnerId=${encodeURIComponent(partnerId)}`,
+    `sourceId=${encodeURIComponent(sourceId || DEFAULT_SOURCE_ID)}`
+  ];
+  if (hem) {
+    params.push(`hem=${encodeURIComponent(hem)}`);
+  }
+  return `${base}${LOOKUP_PATH}?${params.join('&')}`;
+}
+
+/** @type {Submodule} */
+export const acxiomRealIdSubmodule = {
+  name: MODULE_NAME,
+
+  decode(value) {
+    if (value && typeof value === 'object' && value.id) {
+      return { acxiomRealId: value };
+    }
+    if (value && typeof value === 'string') {
+      return { acxiomRealId: { id: value, atype: 1 } };
+    }
+    return undefined;
+  },
+
+  getId(config, consentData) {
+    const configParams = (config && config.params) || {};
+    const { partnerId, hem, apiUrl, sourceId } = configParams;
+
+    if (!partnerId) {
+      logError(LOG_PREFIX + 'partnerId is required.');
+      return undefined;
+    }
+
+    if (isConsentBlocked(consentData)) {
+      deleteStoredToken(config);
+      return undefined;
+    }
+
+    const url = buildLookupUrl(apiUrl, partnerId, hem, sourceId);
+
+    return {
+      callback: (cb) => {
+        const ajax = ajaxBuilder();
+        ajax(
+          url,
+          {
+            success: (response) => {
+              try {
+                const parsed = JSON.parse(response);
+                const eids = parsed && parsed.user && parsed.user.eids;
+                const uid = eids && eids[0] && eids[0].uids && eids[0].uids[0];
+                if (uid && uid.id) {
+                  cb({ id: uid.id, atype: uid.atype });
+                } else {
+                  cb();
+                }
+              } catch (e) {
+                logError(LOG_PREFIX + 'Failed to parse response.', e);
+                cb();
+              }
+            },
+            error: () => {
+              logError(LOG_PREFIX + 'Lookup request failed.');
+              cb();
+            }
+          },
+          null,
+          {
+            method: 'GET',
+            contentType: 'application/json',
+            withCredentials: true
+          }
+        );
+      }
+    };
+  },
+
+  onDataDeletionRequest(config) {
+    deleteStoredToken(config);
+  },
+
+  eids: {
+    'acxiomRealId': (values) => {
+      return values.map(data => ({
+        source: DEFAULT_SOURCE_ID,
+        uids: [{ id: data.id, atype: data.atype }]
+      }));
+    }
+  }
+};
+
+submodule('userId', acxiomRealIdSubmodule);

--- a/modules/acxiomRealIdSystem.md
+++ b/modules/acxiomRealIdSystem.md
@@ -1,6 +1,6 @@
 ## Acxiom Real ID Submodule
 
-Acxiom Real ID module surfaces an Acxiom Real ID in the bid request via the Prebid User ID system.
+Acxiom Real ID module surfaces an Acxiom Real ID in the bid request via the Prebid User ID system. The module sends a POST request to the lookup API with the partner ID, source ID, and user agent, and stores the returned token for use in bid requests.
 
 ## Building Prebid with Acxiom Real ID Support
 
@@ -21,7 +21,7 @@ The following configuration parameters are available:
 | params.partnerId | Required | String | Partner ID issued by GrowthCode on behalf of Acxiom | `'ABC123'` |
 | params.hem | Optional | String | SHA-256 hashed email for improved match rate | `'a1b2c3...'` |
 | params.sourceId | Optional | String | EID source to request from the lookup API. Defaults to `'acxiom.id'` | `'acxiom.id'` |
-| params.apiUrl | Optional | String | Override the default API base URL | `'https://gc-pixel.growthcode.io'` |
+| params.apiUrl | Optional | String | Override the full API endpoint URL | `'https://ids.api.gcprivacy.id/e/l'` |
 | storage | Required | Object | Storage configuration | |
 | storage.type | Required | String | Storage type | `'html5'` |
 | storage.name | Required | String | Storage key | `'acxiomRealId'` |
@@ -47,7 +47,7 @@ pbjs.setConfig({
 });
 ```
 
-### Configuration with Hashed Email
+### Configuration with Custom API URL and Hashed Email
 
 ```javascript
 pbjs.setConfig({
@@ -56,7 +56,8 @@ pbjs.setConfig({
       name: 'acxiomRealId',
       params: {
         partnerId: 'YOUR_PARTNER_ID',
-        hem: 'sha256_hashed_email_here'
+        hem: 'sha256_hashed_email_here',
+        apiUrl: 'https://ids.api.gcprivacy.id/e/l'
       },
       storage: {
         type: 'html5',

--- a/modules/acxiomRealIdSystem.md
+++ b/modules/acxiomRealIdSystem.md
@@ -1,0 +1,83 @@
+## Acxiom Real ID Submodule
+
+Acxiom Real ID module surfaces an Acxiom Real ID in the bid request via the Prebid User ID system.
+
+## Building Prebid with Acxiom Real ID Support
+
+Add the Acxiom Real ID submodule to your Prebid.js package:
+
+```
+gulp build --modules=acxiomRealIdSystem,userId
+```
+
+## Configuration
+
+The following configuration parameters are available:
+
+| Param | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| name | Required | String | Module identifier | `'acxiomRealId'` |
+| params | Required | Object | Module configuration | |
+| params.partnerId | Required | String | Partner ID issued by GrowthCode on behalf of Acxiom | `'ABC123'` |
+| params.hem | Optional | String | SHA-256 hashed email for improved match rate | `'a1b2c3...'` |
+| params.sourceId | Optional | String | EID source to request from the lookup API. Defaults to `'acxiom.id'` | `'acxiom.id'` |
+| params.apiUrl | Optional | String | Override the default API base URL | `'https://gc-pixel.growthcode.io'` |
+| storage | Required | Object | Storage configuration | |
+| storage.type | Required | String | Storage type | `'html5'` |
+| storage.name | Required | String | Storage key | `'acxiomRealId'` |
+| storage.expires | Required | Number | TTL in days | `7` |
+
+### Example Configuration
+
+```javascript
+pbjs.setConfig({
+  userSync: {
+    userIds: [{
+      name: 'acxiomRealId',
+      params: {
+        partnerId: 'YOUR_PARTNER_ID'
+      },
+      storage: {
+        type: 'html5',
+        name: 'acxiomRealId',
+        expires: 7
+      }
+    }]
+  }
+});
+```
+
+### Configuration with Hashed Email
+
+```javascript
+pbjs.setConfig({
+  userSync: {
+    userIds: [{
+      name: 'acxiomRealId',
+      params: {
+        partnerId: 'YOUR_PARTNER_ID',
+        hem: 'sha256_hashed_email_here'
+      },
+      storage: {
+        type: 'html5',
+        name: 'acxiomRealId',
+        expires: 7
+      }
+    }]
+  }
+});
+```
+
+### EID Output
+
+The module produces the following EID structure in `user.ext.eids`:
+
+```json
+{
+  "source": "acxiom.id",
+  "uids": [{
+    "id": "<real_id_token>",
+    "atype": 1
+  }]
+}
+```

--- a/modules/acxiomRealIdSystem.md
+++ b/modules/acxiomRealIdSystem.md
@@ -21,7 +21,7 @@ The following configuration parameters are available:
 | params.partnerId | Required | String | Partner ID issued by GrowthCode on behalf of Acxiom | `'ABC123'` |
 | params.hem | Optional | String | SHA-256 hashed email for improved match rate | `'a1b2c3...'` |
 | params.sourceId | Optional | String | EID source to request from the lookup API. Defaults to `'acxiom.id'` | `'acxiom.id'` |
-| params.apiUrl | Optional | String | Override the full API endpoint URL | `'https://ids.api.gcprivacy.id/e/l'` |
+| params.apiUrl | Optional | String | Override the full API endpoint URL | `'https://ids.api.gcprivacy.id/v1/eid/l'` |
 | storage | Required | Object | Storage configuration | |
 | storage.type | Required | String | Storage type | `'html5'` |
 | storage.name | Required | String | Storage key | `'acxiomRealId'` |
@@ -57,7 +57,7 @@ pbjs.setConfig({
       params: {
         partnerId: 'YOUR_PARTNER_ID',
         hem: 'sha256_hashed_email_here',
-        apiUrl: 'https://ids.api.gcprivacy.id/e/l'
+        apiUrl: 'https://ids.api.gcprivacy.id/v1/eid/l'
       },
       storage: {
         type: 'html5',

--- a/modules/acxiomRealIdSystem.ts
+++ b/modules/acxiomRealIdSystem.ts
@@ -12,44 +12,45 @@ import { MODULE_TYPE_UID } from '../src/activities/modules.js';
 import { logError, getWindowSelf } from '../src/utils.js';
 import { gdprDataHandler, uspDataHandler, gppDataHandler } from '../src/adapterManager.js';
 
-/**
- * @typedef {import('../modules/userId/index.js').Submodule} Submodule
- * @typedef {import('../modules/userId/index.js').SubmoduleConfig} SubmoduleConfig
- * @typedef {import('../modules/userId/index.js').ConsentData} ConsentData
- * @typedef {import('../modules/userId/index.js').IdResponse} IdResponse
- */
+import type { IdProviderSpec, UserIdConfig, EID } from './userId/spec.ts';
+import type { AllConsentData } from '../src/consentHandler.ts';
 
-/**
- * @typedef {Object} AcxiomRealIdParams
- * @property {string} partnerId - Partner ID issued by GrowthCode on behalf of Acxiom
- * @property {string} [hem] - SHA-256 hashed email for improved match rate
- * @property {string} [sourceId] - EID source to request from the lookup API. Defaults to 'acxiom.id'
- * @property {string} [apiUrl] - Override the full API endpoint URL
- */
-
-/**
- * @typedef {Object} AcxiomRealIdValue
- * @property {string} id - The resolved Acxiom Real ID token
- * @property {number} atype - Agent type per OpenRTB spec (1 = cookie/device, 2 = in-app, 3 = person-based)
- */
-
-/**
- * @typedef {Object} AcxiomRealIdConfig
- * @property {'acxiomRealId'} name - Module identifier
- * @property {AcxiomRealIdParams} params - Module configuration parameters
- * @property {Object} [storage] - Storage configuration
- * @property {'html5'|'cookie'} [storage.type] - Storage method
- * @property {string} [storage.name] - Storage key name
- * @property {number} [storage.expires] - TTL in days
- * @property {number} [storage.refreshInSeconds] - How often to re-fetch the ID in seconds
- */
-
-const MODULE_NAME = 'acxiomRealId';
+const MODULE_NAME = 'acxiomRealId' as const;
 const DEFAULT_API_URL = 'https://ids.api.gcprivacy.id/v1/eid/l';
 const DEFAULT_SOURCE_ID = 'acxiom.id';
 export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME });
 
-const US_GPP_SID_API = {
+export type AcxiomRealIdParams = {
+  /** Partner ID issued by GrowthCode on behalf of Acxiom */
+  partnerId: string;
+  /** SHA-256 hashed email for improved match rate */
+  hem?: string;
+  /** EID source to request from the lookup API. Defaults to 'acxiom.id' */
+  sourceId?: string;
+  /** Override the full API endpoint URL */
+  apiUrl?: string;
+}
+
+export type AcxiomRealIdValue = {
+  /** The resolved Acxiom Real ID token */
+  id: string;
+  /** Agent type per OpenRTB spec (1 = cookie/device, 2 = in-app, 3 = person-based) */
+  atype: number;
+}
+
+declare module './userId/spec' {
+  interface UserId {
+    acxiomRealId: AcxiomRealIdValue;
+  }
+  interface ProvidersToId {
+    acxiomRealId: 'acxiomRealId';
+  }
+  interface ProviderParams {
+    acxiomRealId: AcxiomRealIdParams;
+  }
+}
+
+const US_GPP_SID_API: Record<number, string> = {
   7: 'usnat',
   8: 'usca',
   9: 'usva',
@@ -58,12 +59,23 @@ const US_GPP_SID_API = {
   12: 'usct'
 };
 
-function flatSection(subsections) {
-  if (!Array.isArray(subsections)) return subsections;
-  return subsections.reduceRight((merged, section) => Object.assign(section, merged), {});
+interface GppSectionData {
+  SaleOptOut?: number;
+  SharingOptOut?: number;
+  [key: string]: unknown;
 }
 
-function isGppOptedOut(gppData) {
+interface GppData {
+  applicableSections?: number[];
+  parsedSections?: Record<string, GppSectionData | GppSectionData[]>;
+}
+
+function flatSection(subsections: GppSectionData | GppSectionData[]): GppSectionData {
+  if (!Array.isArray(subsections)) return subsections;
+  return subsections.reduceRight((merged, section) => Object.assign(section, merged), {} as GppSectionData);
+}
+
+function isGppOptedOut(gppData: GppData | null | undefined): boolean {
   if (!gppData || !gppData.applicableSections || !gppData.parsedSections) {
     return false;
   }
@@ -78,32 +90,29 @@ function isGppOptedOut(gppData) {
   return false;
 }
 
-function isConsentBlocked(consentData) {
+function isConsentBlocked(consentData: Partial<AllConsentData> | undefined): boolean {
   if (!consentData) {
     return false;
   }
 
-  // EU/UK passive suppression: TCF string present → do not fire
   const gdpr = consentData.gdpr;
   if (gdpr && (gdpr.gdprApplies || gdpr.consentString)) {
     return true;
   }
 
-  // CCPA: us_privacy opt-out of sale (position 3, 0-indexed charAt(2))
   const usp = consentData.usp;
   if (usp && typeof usp === 'string' && usp.length >= 3 && usp.charAt(2) === 'Y') {
     return true;
   }
 
-  // GPP: US state sections — suppress on Sale or Sharing opt-out
-  if (isGppOptedOut(consentData.gpp)) {
+  if (isGppOptedOut(consentData.gpp as GppData)) {
     return true;
   }
 
   return false;
 }
 
-function isConsentBlockedByHandlers() {
+function isConsentBlockedByHandlers(): boolean {
   const gdpr = gdprDataHandler.getConsentData();
   if (gdpr && (gdpr.gdprApplies || gdpr.consentString)) {
     return true;
@@ -113,14 +122,14 @@ function isConsentBlockedByHandlers() {
     return true;
   }
   const gpp = gppDataHandler.getConsentData();
-  if (isGppOptedOut(gpp)) {
+  if (isGppOptedOut(gpp as GppData)) {
     return true;
   }
   return false;
 }
 
-function deleteStoredToken(config) {
-  const storageName = (config && config.storage && config.storage.name) || MODULE_NAME;
+function deleteStoredToken(config: UserIdConfig<typeof MODULE_NAME>) {
+  const storageName = config?.storage?.name || MODULE_NAME;
   const expired = new Date(0).toUTCString();
   if (storage.localStorageIsEnabled()) {
     ['', '_exp', '_cst', '_last'].forEach(suffix => {
@@ -134,12 +143,11 @@ function deleteStoredToken(config) {
   }
 }
 
-function buildLookupUrl(apiUrl) {
+function buildLookupUrl(apiUrl: string | undefined): string {
   return (apiUrl || DEFAULT_API_URL).replace(/\/+$/, '');
 }
 
-/** @type {Submodule} */
-export const acxiomRealIdSubmodule = {
+export const acxiomRealIdSubmodule: IdProviderSpec<typeof MODULE_NAME> = {
   name: MODULE_NAME,
 
   decode(value, config) {
@@ -150,14 +158,15 @@ export const acxiomRealIdSubmodule = {
     if (value && typeof value === 'string') {
       return { acxiomRealId: { id: value, atype: 1 } };
     }
-    if (value && typeof value === 'object' && value.id) {
-      return { acxiomRealId: { id: value.id, atype: value.atype || 1 } };
+    if (value && typeof value === 'object' && (value as AcxiomRealIdValue).id) {
+      const v = value as AcxiomRealIdValue;
+      return { acxiomRealId: { id: v.id, atype: v.atype || 1 } };
     }
     return undefined;
   },
 
   getId(config, consentData, storedId) {
-    const configParams = (config && config.params) || {};
+    const configParams = config?.params || {} as AcxiomRealIdParams;
     const { partnerId, apiUrl, sourceId, hem } = configParams;
 
     if (!partnerId) {
@@ -175,7 +184,7 @@ export const acxiomRealIdSubmodule = {
     }
 
     const url = buildLookupUrl(apiUrl);
-    const payload = {
+    const payload: Record<string, string> = {
       partnerId,
       ip: '',
       userAgent: getWindowSelf().navigator?.userAgent || '',
@@ -195,19 +204,19 @@ export const acxiomRealIdSubmodule = {
             success: (response) => {
               try {
                 const parsed = JSON.parse(response);
-                const eids = parsed && parsed.user && parsed.user.eids;
-                const uid = eids && eids[0] && eids[0].uids && eids[0].uids[0];
-                if (uid && uid.id) {
+                const eids = parsed?.user?.eids;
+                const uid = eids?.[0]?.uids?.[0];
+                if (uid?.id) {
                   cb({ id: uid.id, atype: uid.atype });
                 } else {
-                  cb();
+                  cb(undefined);
                 }
               } catch (e) {
-                cb();
+                cb(undefined);
               }
             },
             error: () => {
-              cb();
+              cb(undefined);
             }
           },
           body,
@@ -229,7 +238,7 @@ export const acxiomRealIdSubmodule = {
     'acxiomRealId': (values) => {
       return values.map(data => ({
         source: DEFAULT_SOURCE_ID,
-        uids: [{ id: data.id, atype: data.atype }]
+        uids: [{ id: data.id, atype: data.atype as EID['uids'][number]['atype'] }]
       }));
     }
   }

--- a/modules/userId/eids.md
+++ b/modules/userId/eids.md
@@ -20,6 +20,13 @@ userIdAsEids = [
         }]
     },
     {
+        source: 'acxiom.id',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 1
+        }]
+    },
+    {
         source: 'utiq.com',
         uids: [{
             id: 'some-random-id-value',

--- a/modules/userId/userId.md
+++ b/modules/userId/userId.md
@@ -9,6 +9,16 @@ pbjs.setConfig({
             uid2: ['uid2', 'liveIntentId']
         }
         userIds: [{
+            name: "acxiomRealId",
+            params: {
+                partnerId: "YOUR_PARTNER_ID" // Example Partner ID
+            },
+            storage: {
+                type: "html5",
+                name: "acxiomRealId",
+                expires: 7
+            }
+        }, {
             name: "33acrossId",
             storage: {
                 type: "cookie",

--- a/test/spec/modules/acxiomRealIdSystem_spec.js
+++ b/test/spec/modules/acxiomRealIdSystem_spec.js
@@ -95,23 +95,30 @@ describe('acxiomRealIdSystem', () => {
         expect(result).to.deep.equal({ acxiomRealId: { id: REAL_ID_TOKEN, atype: 1 } });
       });
 
-      it('should suppress and delete token when GDPR handler reports gdprApplies', () => {
+      it('should suppress and delete token with all suffixes when GDPR handler reports gdprApplies', () => {
         gdprStub.returns({ gdprApplies: true, consentString: 'BOtest' });
         const config = { storage: { name: STORAGE_NAME } };
         const result = acxiomRealIdSubmodule.decode(REAL_ID_TOKEN, config);
         expect(result).to.be.undefined;
-        expect(removeLocalStorageStub.calledWith(STORAGE_NAME)).to.be.true;
+        ['', '_exp', '_cst', '_last'].forEach(suffix => {
+          expect(removeLocalStorageStub.calledWith(`${STORAGE_NAME}${suffix}`)).to.be.true;
+        });
+        ['', '_cst', '_last'].forEach(suffix => {
+          expect(setCookieStub.calledWith(`${STORAGE_NAME}${suffix}`)).to.be.true;
+        });
       });
 
-      it('should suppress and delete token when USP handler reports opt-out', () => {
+      it('should suppress and delete token with all suffixes when USP handler reports opt-out', () => {
         uspStub.returns('1YYN');
         const config = { storage: { name: STORAGE_NAME } };
         const result = acxiomRealIdSubmodule.decode(REAL_ID_TOKEN, config);
         expect(result).to.be.undefined;
-        expect(removeLocalStorageStub.calledWith(STORAGE_NAME)).to.be.true;
+        ['', '_exp', '_cst', '_last'].forEach(suffix => {
+          expect(removeLocalStorageStub.calledWith(`${STORAGE_NAME}${suffix}`)).to.be.true;
+        });
       });
 
-      it('should suppress and delete token when GPP handler reports SaleOptOut', () => {
+      it('should suppress and delete token with all suffixes when GPP handler reports SaleOptOut', () => {
         gppStub.returns({
           applicableSections: [7],
           parsedSections: { usnat: { Version: 1, SaleOptOut: 1, SharingOptOut: 2 } }
@@ -119,10 +126,12 @@ describe('acxiomRealIdSystem', () => {
         const config = { storage: { name: STORAGE_NAME } };
         const result = acxiomRealIdSubmodule.decode(REAL_ID_TOKEN, config);
         expect(result).to.be.undefined;
-        expect(removeLocalStorageStub.calledWith(STORAGE_NAME)).to.be.true;
+        ['', '_exp', '_cst', '_last'].forEach(suffix => {
+          expect(removeLocalStorageStub.calledWith(`${STORAGE_NAME}${suffix}`)).to.be.true;
+        });
       });
 
-      it('should suppress and delete token when GPP handler reports SharingOptOut', () => {
+      it('should suppress and delete token with all suffixes when GPP handler reports SharingOptOut', () => {
         gppStub.returns({
           applicableSections: [8],
           parsedSections: { usca: { Version: 1, SaleOptOut: 2, SharingOptOut: 1 } }
@@ -130,7 +139,9 @@ describe('acxiomRealIdSystem', () => {
         const config = { storage: { name: STORAGE_NAME } };
         const result = acxiomRealIdSubmodule.decode(REAL_ID_TOKEN, config);
         expect(result).to.be.undefined;
-        expect(removeLocalStorageStub.calledWith(STORAGE_NAME)).to.be.true;
+        ['', '_exp', '_cst', '_last'].forEach(suffix => {
+          expect(removeLocalStorageStub.calledWith(`${STORAGE_NAME}${suffix}`)).to.be.true;
+        });
       });
     });
   });
@@ -303,13 +314,17 @@ describe('acxiomRealIdSystem', () => {
           sinon.restore();
         });
 
-        it('should delete stored token when consent is blocked', () => {
+        it('should delete stored token and all suffixes when consent is blocked', () => {
           acxiomRealIdSubmodule.getId(
             { params: { partnerId: PARTNER_ID }, storage: { name: STORAGE_NAME } },
             { usp: '1YYN' }
           );
-          expect(removeLocalStorageStub.calledWith(STORAGE_NAME)).to.be.true;
-          expect(setCookieStub.called).to.be.true;
+          ['', '_exp', '_cst', '_last'].forEach(suffix => {
+            expect(removeLocalStorageStub.calledWith(`${STORAGE_NAME}${suffix}`)).to.be.true;
+          });
+          ['', '_cst', '_last'].forEach(suffix => {
+            expect(setCookieStub.calledWith(`${STORAGE_NAME}${suffix}`)).to.be.true;
+          });
         });
       });
 
@@ -578,17 +593,23 @@ describe('acxiomRealIdSystem', () => {
       sinon.restore();
     });
 
-    it('should delete token from localStorage and cookies', () => {
+    it('should delete token and all suffixes from localStorage and cookies', () => {
       acxiomRealIdSubmodule.onDataDeletionRequest(
         { storage: { name: STORAGE_NAME } }
       );
-      expect(removeLocalStorageStub.calledWith(STORAGE_NAME)).to.be.true;
-      expect(setCookieStub.called).to.be.true;
+      ['', '_exp', '_cst', '_last'].forEach(suffix => {
+        expect(removeLocalStorageStub.calledWith(`${STORAGE_NAME}${suffix}`)).to.be.true;
+      });
+      ['', '_cst', '_last'].forEach(suffix => {
+        expect(setCookieStub.calledWith(`${STORAGE_NAME}${suffix}`)).to.be.true;
+      });
     });
 
-    it('should use module name as fallback when storage name is not configured', () => {
+    it('should use module name as fallback and delete all suffixes when storage name is not configured', () => {
       acxiomRealIdSubmodule.onDataDeletionRequest({});
-      expect(removeLocalStorageStub.calledWith('acxiomRealId')).to.be.true;
+      ['', '_exp', '_cst', '_last'].forEach(suffix => {
+        expect(removeLocalStorageStub.calledWith(`acxiomRealId${suffix}`)).to.be.true;
+      });
     });
   });
 

--- a/test/spec/modules/acxiomRealIdSystem_spec.js
+++ b/test/spec/modules/acxiomRealIdSystem_spec.js
@@ -1,4 +1,4 @@
-import { acxiomRealIdSubmodule, storage } from 'modules/acxiomRealIdSystem.js';
+import { acxiomRealIdSubmodule, storage } from 'modules/acxiomRealIdSystem.ts';
 import * as ajaxLib from 'src/ajax.js';
 import { gdprDataHandler, uspDataHandler, gppDataHandler } from 'src/adapterManager.js';
 import { expect } from 'chai';

--- a/test/spec/modules/acxiomRealIdSystem_spec.js
+++ b/test/spec/modules/acxiomRealIdSystem_spec.js
@@ -203,7 +203,7 @@ describe('acxiomRealIdSystem', () => {
         );
 
         result.callback((id) => {
-          expect(capturedUrl).to.equal('https://ids.api.gcprivacy.id/e/l');
+          expect(capturedUrl).to.equal('https://ids.api.gcprivacy.id/v1/eid/l');
           const payload = JSON.parse(capturedBody);
           expect(payload.partnerId).to.equal(PARTNER_ID);
           expect(payload.sourceId).to.equal('acxiom.id');
@@ -285,7 +285,7 @@ describe('acxiomRealIdSystem', () => {
 
       it('should use custom API URL when provided', (done) => {
         let capturedUrl;
-        const customUrl = 'https://custom.example.com/e/l';
+        const customUrl = 'https://custom.example.com/v1/eid/l';
         ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
           (url, callbacks) => {
             capturedUrl = url;
@@ -315,12 +315,12 @@ describe('acxiomRealIdSystem', () => {
         );
 
         const result = acxiomRealIdSubmodule.getId(
-          { params: { partnerId: PARTNER_ID, apiUrl: 'https://custom.example.com/e/l///' } },
+          { params: { partnerId: PARTNER_ID, apiUrl: 'https://custom.example.com/v1/eid/l///' } },
           {}
         );
 
         result.callback(() => {
-          expect(capturedUrl).to.equal('https://custom.example.com/e/l');
+          expect(capturedUrl).to.equal('https://custom.example.com/v1/eid/l');
           done();
         });
       });

--- a/test/spec/modules/acxiomRealIdSystem_spec.js
+++ b/test/spec/modules/acxiomRealIdSystem_spec.js
@@ -186,11 +186,13 @@ describe('acxiomRealIdSystem', () => {
         }
       });
 
-      it('should call the default API URL with partnerId and default sourceId', (done) => {
-        let capturedUrl;
+      it('should POST to the default API URL with partnerId and default sourceId in body', (done) => {
+        let capturedUrl, capturedBody, capturedOptions;
         ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
-          (url, callbacks) => {
+          (url, callbacks, body, options) => {
             capturedUrl = url;
+            capturedBody = body;
+            capturedOptions = options;
             callbacks.success(makeEidResponse(REAL_ID_TOKEN, 1));
           }
         );
@@ -201,20 +203,25 @@ describe('acxiomRealIdSystem', () => {
         );
 
         result.callback((id) => {
-          expect(capturedUrl).to.include('/v1/eid/lookup');
-          expect(capturedUrl).to.include(`partnerId=${PARTNER_ID}`);
-          expect(capturedUrl).to.include('sourceId=acxiom.id');
-          expect(capturedUrl).to.include('gc-pixel.growthcode.io');
+          expect(capturedUrl).to.equal('https://ids.api.gcprivacy.id/e/l');
+          const payload = JSON.parse(capturedBody);
+          expect(payload.partnerId).to.equal(PARTNER_ID);
+          expect(payload.sourceId).to.equal('acxiom.id');
+          expect(payload.userAgent).to.be.a('string');
+          expect(payload.ip).to.equal('');
+          expect(capturedOptions.method).to.equal('POST');
+          expect(capturedOptions.contentType).to.equal('application/json');
+          expect(capturedOptions.withCredentials).to.be.true;
           expect(id).to.deep.equal({ id: REAL_ID_TOKEN, atype: 1 });
           done();
         });
       });
 
-      it('should include HEM parameter when provided', (done) => {
-        let capturedUrl;
+      it('should include HEM in POST body when provided', (done) => {
+        let capturedBody;
         ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
-          (url, callbacks) => {
-            capturedUrl = url;
+          (url, callbacks, body) => {
+            capturedBody = body;
             callbacks.success(makeEidResponse(REAL_ID_TOKEN, 1));
           }
         );
@@ -225,18 +232,40 @@ describe('acxiomRealIdSystem', () => {
         );
 
         result.callback((id) => {
-          expect(capturedUrl).to.include(`hem=${encodeURIComponent(HEM)}`);
+          const payload = JSON.parse(capturedBody);
+          expect(payload.hem).to.equal(HEM);
           expect(id).to.deep.equal({ id: REAL_ID_TOKEN, atype: 1 });
           done();
         });
       });
 
-      it('should use custom sourceId when provided', (done) => {
-        let capturedUrl;
+      it('should not include HEM in POST body when not provided', (done) => {
+        let capturedBody;
+        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+          (url, callbacks, body) => {
+            capturedBody = body;
+            callbacks.success(makeEidResponse(REAL_ID_TOKEN, 1));
+          }
+        );
+
+        const result = acxiomRealIdSubmodule.getId(
+          { params: { partnerId: PARTNER_ID } },
+          {}
+        );
+
+        result.callback(() => {
+          const payload = JSON.parse(capturedBody);
+          expect(payload).to.not.have.property('hem');
+          done();
+        });
+      });
+
+      it('should use custom sourceId in POST body when provided', (done) => {
+        let capturedBody;
         const customSourceId = 'custom.source';
         ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
-          (url, callbacks) => {
-            capturedUrl = url;
+          (url, callbacks, body) => {
+            capturedBody = body;
             callbacks.success(makeEidResponse(REAL_ID_TOKEN, 1));
           }
         );
@@ -247,7 +276,8 @@ describe('acxiomRealIdSystem', () => {
         );
 
         result.callback((id) => {
-          expect(capturedUrl).to.include(`sourceId=${encodeURIComponent(customSourceId)}`);
+          const payload = JSON.parse(capturedBody);
+          expect(payload.sourceId).to.equal(customSourceId);
           expect(id).to.deep.equal({ id: REAL_ID_TOKEN, atype: 1 });
           done();
         });
@@ -255,7 +285,7 @@ describe('acxiomRealIdSystem', () => {
 
       it('should use custom API URL when provided', (done) => {
         let capturedUrl;
-        const customUrl = 'https://custom.example.com';
+        const customUrl = 'https://custom.example.com/e/l';
         ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
           (url, callbacks) => {
             capturedUrl = url;
@@ -269,9 +299,28 @@ describe('acxiomRealIdSystem', () => {
         );
 
         result.callback((id) => {
-          expect(capturedUrl).to.include('custom.example.com');
-          expect(capturedUrl).to.include('/v1/eid/lookup');
+          expect(capturedUrl).to.equal(customUrl);
           expect(id).to.deep.equal({ id: REAL_ID_TOKEN, atype: 1 });
+          done();
+        });
+      });
+
+      it('should strip trailing slashes from custom API URL', (done) => {
+        let capturedUrl;
+        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+          (url, callbacks) => {
+            capturedUrl = url;
+            callbacks.success(makeEidResponse(REAL_ID_TOKEN, 1));
+          }
+        );
+
+        const result = acxiomRealIdSubmodule.getId(
+          { params: { partnerId: PARTNER_ID, apiUrl: 'https://custom.example.com/e/l///' } },
+          {}
+        );
+
+        result.callback(() => {
+          expect(capturedUrl).to.equal('https://custom.example.com/e/l');
           done();
         });
       });

--- a/test/spec/modules/acxiomRealIdSystem_spec.js
+++ b/test/spec/modules/acxiomRealIdSystem_spec.js
@@ -1,0 +1,424 @@
+import { acxiomRealIdSubmodule, storage } from 'modules/acxiomRealIdSystem.js';
+import * as ajaxLib from 'src/ajax.js';
+import { expect } from 'chai';
+
+const PARTNER_ID = 'TEST_PARTNER_01';
+const REAL_ID_TOKEN = 'acxiom-real-id-token-abc123';
+const HEM = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+const STORAGE_NAME = 'acxiomRealId';
+
+function makeEidResponse(token, atype) {
+  return JSON.stringify({
+    requestId: '4b61d73a-test',
+    generatedAt: '2026-01-27T19:27:40Z',
+    expiresAt: '2026-02-26T19:27:40Z',
+    user: {
+      eids: [{
+        source: 'acxiom.id',
+        uids: [{ id: token, atype: atype || 1 }]
+      }]
+    }
+  });
+}
+
+function makeEmptyResponse() {
+  return JSON.stringify({
+    requestId: '4b61d73a-test',
+    generatedAt: '2026-01-27T19:27:40Z',
+    user: {
+      eids: []
+    }
+  });
+}
+
+describe('acxiomRealIdSystem', () => {
+  describe('name', () => {
+    it('should expose the correct module name', () => {
+      expect(acxiomRealIdSubmodule.name).to.equal('acxiomRealId');
+    });
+  });
+
+  describe('decode', () => {
+    it('should return acxiomRealId object when given an object with id and atype', () => {
+      const stored = { id: REAL_ID_TOKEN, atype: 1 };
+      const result = acxiomRealIdSubmodule.decode(stored);
+      expect(result).to.deep.equal({ acxiomRealId: { id: REAL_ID_TOKEN, atype: 1 } });
+    });
+
+    it('should handle legacy string values with default atype', () => {
+      const result = acxiomRealIdSubmodule.decode(REAL_ID_TOKEN);
+      expect(result).to.deep.equal({ acxiomRealId: { id: REAL_ID_TOKEN, atype: 1 } });
+    });
+
+    it('should preserve atype from stored object', () => {
+      const stored = { id: REAL_ID_TOKEN, atype: 3 };
+      const result = acxiomRealIdSubmodule.decode(stored);
+      expect(result).to.deep.equal({ acxiomRealId: { id: REAL_ID_TOKEN, atype: 3 } });
+    });
+
+    it('should return undefined for null', () => {
+      expect(acxiomRealIdSubmodule.decode(null)).to.be.undefined;
+    });
+
+    it('should return undefined for empty string', () => {
+      expect(acxiomRealIdSubmodule.decode('')).to.be.undefined;
+    });
+
+    it('should return undefined for object without id', () => {
+      expect(acxiomRealIdSubmodule.decode({ atype: 1 })).to.be.undefined;
+    });
+  });
+
+  describe('getId', () => {
+    it('should return undefined when partnerId is missing', () => {
+      const result = acxiomRealIdSubmodule.getId({ params: {} });
+      expect(result).to.be.undefined;
+    });
+
+    it('should return undefined when params are missing', () => {
+      const result = acxiomRealIdSubmodule.getId({});
+      expect(result).to.be.undefined;
+    });
+
+    it('should return a callback function', () => {
+      const result = acxiomRealIdSubmodule.getId(
+        { params: { partnerId: PARTNER_ID } },
+        {}
+      );
+      expect(result).to.have.property('callback');
+      expect(result.callback).to.be.a('function');
+    });
+
+    describe('consent suppression', () => {
+      describe('EU/UK — TCF passive suppression', () => {
+        it('should suppress when gdprApplies is true and consentString is present', () => {
+          const result = acxiomRealIdSubmodule.getId(
+            { params: { partnerId: PARTNER_ID } },
+            { gdpr: { gdprApplies: true, consentString: 'BOtest' } }
+          );
+          expect(result).to.be.undefined;
+        });
+
+        it('should suppress when gdprApplies is true even without consentString', () => {
+          const result = acxiomRealIdSubmodule.getId(
+            { params: { partnerId: PARTNER_ID } },
+            { gdpr: { gdprApplies: true } }
+          );
+          expect(result).to.be.undefined;
+        });
+
+        it('should suppress when consentString is present even if gdprApplies is false', () => {
+          const result = acxiomRealIdSubmodule.getId(
+            { params: { partnerId: PARTNER_ID } },
+            { gdpr: { gdprApplies: false, consentString: 'BOtest' } }
+          );
+          expect(result).to.be.undefined;
+        });
+      });
+
+      describe('US — CCPA', () => {
+        it('should suppress when us_privacy position 3 = Y (opted out of sale)', () => {
+          const result = acxiomRealIdSubmodule.getId(
+            { params: { partnerId: PARTNER_ID } },
+            { usp: '1YYN' }
+          );
+          expect(result).to.be.undefined;
+        });
+
+        it('should not suppress when us_privacy position 3 = N (not opted out)', () => {
+          const result = acxiomRealIdSubmodule.getId(
+            { params: { partnerId: PARTNER_ID } },
+            { usp: '1YNN' }
+          );
+          expect(result).to.have.property('callback');
+        });
+
+        it('should not suppress when us_privacy string is too short', () => {
+          const result = acxiomRealIdSubmodule.getId(
+            { params: { partnerId: PARTNER_ID } },
+            { usp: '1Y' }
+          );
+          expect(result).to.have.property('callback');
+        });
+      });
+
+      describe('token deletion on consent block', () => {
+        let removeLocalStorageStub;
+        let setCookieStub;
+
+        beforeEach(() => {
+          removeLocalStorageStub = sinon.stub(storage, 'removeDataFromLocalStorage');
+          setCookieStub = sinon.stub(storage, 'setCookie');
+          sinon.stub(storage, 'localStorageIsEnabled').returns(true);
+          sinon.stub(storage, 'cookiesAreEnabled').returns(true);
+        });
+
+        afterEach(() => {
+          sinon.restore();
+        });
+
+        it('should delete stored token when consent is blocked', () => {
+          acxiomRealIdSubmodule.getId(
+            { params: { partnerId: PARTNER_ID }, storage: { name: STORAGE_NAME } },
+            { usp: '1YYN' }
+          );
+          expect(removeLocalStorageStub.calledWith(STORAGE_NAME)).to.be.true;
+          expect(setCookieStub.called).to.be.true;
+        });
+      });
+
+      it('should not suppress when no consent data is provided', () => {
+        const result = acxiomRealIdSubmodule.getId(
+          { params: { partnerId: PARTNER_ID } },
+          {}
+        );
+        expect(result).to.have.property('callback');
+      });
+    });
+
+    describe('API call', () => {
+      let ajaxBuilderStub;
+
+      afterEach(() => {
+        if (ajaxBuilderStub) {
+          ajaxBuilderStub.restore();
+          ajaxBuilderStub = null;
+        }
+      });
+
+      it('should call the default API URL with partnerId and default sourceId', (done) => {
+        let capturedUrl;
+        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+          (url, callbacks) => {
+            capturedUrl = url;
+            callbacks.success(makeEidResponse(REAL_ID_TOKEN, 1));
+          }
+        );
+
+        const result = acxiomRealIdSubmodule.getId(
+          { params: { partnerId: PARTNER_ID } },
+          {}
+        );
+
+        result.callback((id) => {
+          expect(capturedUrl).to.include('/v1/eid/lookup');
+          expect(capturedUrl).to.include(`partnerId=${PARTNER_ID}`);
+          expect(capturedUrl).to.include('sourceId=acxiom.id');
+          expect(capturedUrl).to.include('gc-pixel.growthcode.io');
+          expect(id).to.deep.equal({ id: REAL_ID_TOKEN, atype: 1 });
+          done();
+        });
+      });
+
+      it('should include HEM parameter when provided', (done) => {
+        let capturedUrl;
+        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+          (url, callbacks) => {
+            capturedUrl = url;
+            callbacks.success(makeEidResponse(REAL_ID_TOKEN, 1));
+          }
+        );
+
+        const result = acxiomRealIdSubmodule.getId(
+          { params: { partnerId: PARTNER_ID, hem: HEM } },
+          {}
+        );
+
+        result.callback((id) => {
+          expect(capturedUrl).to.include(`hem=${encodeURIComponent(HEM)}`);
+          expect(id).to.deep.equal({ id: REAL_ID_TOKEN, atype: 1 });
+          done();
+        });
+      });
+
+      it('should use custom sourceId when provided', (done) => {
+        let capturedUrl;
+        const customSourceId = 'custom.source';
+        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+          (url, callbacks) => {
+            capturedUrl = url;
+            callbacks.success(makeEidResponse(REAL_ID_TOKEN, 1));
+          }
+        );
+
+        const result = acxiomRealIdSubmodule.getId(
+          { params: { partnerId: PARTNER_ID, sourceId: customSourceId } },
+          {}
+        );
+
+        result.callback((id) => {
+          expect(capturedUrl).to.include(`sourceId=${encodeURIComponent(customSourceId)}`);
+          expect(id).to.deep.equal({ id: REAL_ID_TOKEN, atype: 1 });
+          done();
+        });
+      });
+
+      it('should use custom API URL when provided', (done) => {
+        let capturedUrl;
+        const customUrl = 'https://custom.example.com';
+        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+          (url, callbacks) => {
+            capturedUrl = url;
+            callbacks.success(makeEidResponse(REAL_ID_TOKEN, 1));
+          }
+        );
+
+        const result = acxiomRealIdSubmodule.getId(
+          { params: { partnerId: PARTNER_ID, apiUrl: customUrl } },
+          {}
+        );
+
+        result.callback((id) => {
+          expect(capturedUrl).to.include('custom.example.com');
+          expect(capturedUrl).to.include('/v1/eid/lookup');
+          expect(id).to.deep.equal({ id: REAL_ID_TOKEN, atype: 1 });
+          done();
+        });
+      });
+
+      it('should preserve atype from API response', (done) => {
+        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+          (url, callbacks) => {
+            callbacks.success(makeEidResponse(REAL_ID_TOKEN, 3));
+          }
+        );
+
+        const result = acxiomRealIdSubmodule.getId(
+          { params: { partnerId: PARTNER_ID } },
+          {}
+        );
+
+        result.callback((id) => {
+          expect(id).to.deep.equal({ id: REAL_ID_TOKEN, atype: 3 });
+          done();
+        });
+      });
+
+      it('should call callback with undefined on no-match response', (done) => {
+        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+          (url, callbacks) => {
+            callbacks.success(JSON.stringify({ requestId: 'test', user: {} }));
+          }
+        );
+
+        const result = acxiomRealIdSubmodule.getId(
+          { params: { partnerId: PARTNER_ID } },
+          {}
+        );
+
+        result.callback((id) => {
+          expect(id).to.be.undefined;
+          done();
+        });
+      });
+
+      it('should call callback with undefined when eids array is empty', (done) => {
+        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+          (url, callbacks) => {
+            callbacks.success(makeEmptyResponse());
+          }
+        );
+
+        const result = acxiomRealIdSubmodule.getId(
+          { params: { partnerId: PARTNER_ID } },
+          {}
+        );
+
+        result.callback((id) => {
+          expect(id).to.be.undefined;
+          done();
+        });
+      });
+
+      it('should call callback with undefined on API error', (done) => {
+        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+          (url, callbacks) => {
+            callbacks.error('server error');
+          }
+        );
+
+        const result = acxiomRealIdSubmodule.getId(
+          { params: { partnerId: PARTNER_ID } },
+          {}
+        );
+
+        result.callback((id) => {
+          expect(id).to.be.undefined;
+          done();
+        });
+      });
+
+      it('should call callback with undefined on malformed JSON response', (done) => {
+        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+          (url, callbacks) => {
+            callbacks.success('not json');
+          }
+        );
+
+        const result = acxiomRealIdSubmodule.getId(
+          { params: { partnerId: PARTNER_ID } },
+          {}
+        );
+
+        result.callback((id) => {
+          expect(id).to.be.undefined;
+          done();
+        });
+      });
+    });
+  });
+
+  describe('onDataDeletionRequest', () => {
+    let removeLocalStorageStub;
+    let setCookieStub;
+
+    beforeEach(() => {
+      removeLocalStorageStub = sinon.stub(storage, 'removeDataFromLocalStorage');
+      setCookieStub = sinon.stub(storage, 'setCookie');
+      sinon.stub(storage, 'localStorageIsEnabled').returns(true);
+      sinon.stub(storage, 'cookiesAreEnabled').returns(true);
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should delete token from localStorage and cookies', () => {
+      acxiomRealIdSubmodule.onDataDeletionRequest(
+        { storage: { name: STORAGE_NAME } }
+      );
+      expect(removeLocalStorageStub.calledWith(STORAGE_NAME)).to.be.true;
+      expect(setCookieStub.called).to.be.true;
+    });
+
+    it('should use module name as fallback when storage name is not configured', () => {
+      acxiomRealIdSubmodule.onDataDeletionRequest({});
+      expect(removeLocalStorageStub.calledWith('acxiomRealId')).to.be.true;
+    });
+  });
+
+  describe('eids', () => {
+    it('should be a function that builds EID from decoded data', () => {
+      const eidFn = acxiomRealIdSubmodule.eids.acxiomRealId;
+      expect(eidFn).to.be.a('function');
+    });
+
+    it('should produce correct EID with atype from data', () => {
+      const eidFn = acxiomRealIdSubmodule.eids.acxiomRealId;
+      const result = eidFn([{ id: REAL_ID_TOKEN, atype: 1 }]);
+      expect(result).to.deep.equal([{
+        source: 'acxiom.id',
+        uids: [{ id: REAL_ID_TOKEN, atype: 1 }]
+      }]);
+    });
+
+    it('should preserve atype 3 from data', () => {
+      const eidFn = acxiomRealIdSubmodule.eids.acxiomRealId;
+      const result = eidFn([{ id: REAL_ID_TOKEN, atype: 3 }]);
+      expect(result).to.deep.equal([{
+        source: 'acxiom.id',
+        uids: [{ id: REAL_ID_TOKEN, atype: 3 }]
+      }]);
+    });
+  });
+});

--- a/test/spec/modules/acxiomRealIdSystem_spec.js
+++ b/test/spec/modules/acxiomRealIdSystem_spec.js
@@ -1,5 +1,6 @@
 import { acxiomRealIdSubmodule, storage } from 'modules/acxiomRealIdSystem.js';
 import * as ajaxLib from 'src/ajax.js';
+import { gdprDataHandler, uspDataHandler, gppDataHandler } from 'src/adapterManager.js';
 import { expect } from 'chai';
 
 const PARTNER_ID = 'TEST_PARTNER_01';
@@ -66,6 +67,71 @@ describe('acxiomRealIdSystem', () => {
 
     it('should return undefined for object without id', () => {
       expect(acxiomRealIdSubmodule.decode({ atype: 1 })).to.be.undefined;
+    });
+
+    describe('post-load consent suppression', () => {
+      let gdprStub, uspStub, gppStub;
+      let removeLocalStorageStub, setCookieStub;
+
+      beforeEach(() => {
+        gdprStub = sinon.stub(gdprDataHandler, 'getConsentData');
+        uspStub = sinon.stub(uspDataHandler, 'getConsentData');
+        gppStub = sinon.stub(gppDataHandler, 'getConsentData');
+        gdprStub.returns(null);
+        uspStub.returns(null);
+        gppStub.returns(null);
+        removeLocalStorageStub = sinon.stub(storage, 'removeDataFromLocalStorage');
+        setCookieStub = sinon.stub(storage, 'setCookie');
+        sinon.stub(storage, 'localStorageIsEnabled').returns(true);
+        sinon.stub(storage, 'cookiesAreEnabled').returns(true);
+      });
+
+      afterEach(() => {
+        sinon.restore();
+      });
+
+      it('should return EID when no consent signals block', () => {
+        const result = acxiomRealIdSubmodule.decode(REAL_ID_TOKEN);
+        expect(result).to.deep.equal({ acxiomRealId: { id: REAL_ID_TOKEN, atype: 1 } });
+      });
+
+      it('should suppress and delete token when GDPR handler reports gdprApplies', () => {
+        gdprStub.returns({ gdprApplies: true, consentString: 'BOtest' });
+        const config = { storage: { name: STORAGE_NAME } };
+        const result = acxiomRealIdSubmodule.decode(REAL_ID_TOKEN, config);
+        expect(result).to.be.undefined;
+        expect(removeLocalStorageStub.calledWith(STORAGE_NAME)).to.be.true;
+      });
+
+      it('should suppress and delete token when USP handler reports opt-out', () => {
+        uspStub.returns('1YYN');
+        const config = { storage: { name: STORAGE_NAME } };
+        const result = acxiomRealIdSubmodule.decode(REAL_ID_TOKEN, config);
+        expect(result).to.be.undefined;
+        expect(removeLocalStorageStub.calledWith(STORAGE_NAME)).to.be.true;
+      });
+
+      it('should suppress and delete token when GPP handler reports SaleOptOut', () => {
+        gppStub.returns({
+          applicableSections: [7],
+          parsedSections: { usnat: { Version: 1, SaleOptOut: 1, SharingOptOut: 2 } }
+        });
+        const config = { storage: { name: STORAGE_NAME } };
+        const result = acxiomRealIdSubmodule.decode(REAL_ID_TOKEN, config);
+        expect(result).to.be.undefined;
+        expect(removeLocalStorageStub.calledWith(STORAGE_NAME)).to.be.true;
+      });
+
+      it('should suppress and delete token when GPP handler reports SharingOptOut', () => {
+        gppStub.returns({
+          applicableSections: [8],
+          parsedSections: { usca: { Version: 1, SaleOptOut: 2, SharingOptOut: 1 } }
+        });
+        const config = { storage: { name: STORAGE_NAME } };
+        const result = acxiomRealIdSubmodule.decode(REAL_ID_TOKEN, config);
+        expect(result).to.be.undefined;
+        expect(removeLocalStorageStub.calledWith(STORAGE_NAME)).to.be.true;
+      });
     });
   });
 
@@ -139,6 +205,86 @@ describe('acxiomRealIdSystem', () => {
             { usp: '1Y' }
           );
           expect(result).to.have.property('callback');
+        });
+      });
+
+      describe('US — GPP', () => {
+        it('should suppress when GPP usnat SaleOptOut = 1', () => {
+          const result = acxiomRealIdSubmodule.getId(
+            { params: { partnerId: PARTNER_ID } },
+            {
+              gpp: {
+                applicableSections: [7],
+                parsedSections: { usnat: { Version: 1, SaleOptOut: 1, SharingOptOut: 2 } }
+              }
+            }
+          );
+          expect(result).to.be.undefined;
+        });
+
+        it('should suppress when GPP usnat SharingOptOut = 1', () => {
+          const result = acxiomRealIdSubmodule.getId(
+            { params: { partnerId: PARTNER_ID } },
+            {
+              gpp: {
+                applicableSections: [7],
+                parsedSections: { usnat: { Version: 1, SaleOptOut: 2, SharingOptOut: 1 } }
+              }
+            }
+          );
+          expect(result).to.be.undefined;
+        });
+
+        it('should suppress when GPP usca (California) SaleOptOut = 1', () => {
+          const result = acxiomRealIdSubmodule.getId(
+            { params: { partnerId: PARTNER_ID } },
+            {
+              gpp: {
+                applicableSections: [8],
+                parsedSections: { usca: { Version: 1, SaleOptOut: 1, SharingOptOut: 2 } }
+              }
+            }
+          );
+          expect(result).to.be.undefined;
+        });
+
+        it('should not suppress when GPP section has no opt-out', () => {
+          const result = acxiomRealIdSubmodule.getId(
+            { params: { partnerId: PARTNER_ID } },
+            {
+              gpp: {
+                applicableSections: [7],
+                parsedSections: { usnat: { Version: 1, SaleOptOut: 2, SharingOptOut: 2 } }
+              }
+            }
+          );
+          expect(result).to.have.property('callback');
+        });
+
+        it('should not suppress when applicable section is non-US', () => {
+          const result = acxiomRealIdSubmodule.getId(
+            { params: { partnerId: PARTNER_ID } },
+            {
+              gpp: {
+                applicableSections: [2],
+                parsedSections: {}
+              }
+            }
+          );
+          expect(result).to.have.property('callback');
+        });
+
+        it('should handle subsection arrays by flattening', () => {
+          const result = acxiomRealIdSubmodule.getId(
+            { params: { partnerId: PARTNER_ID } },
+            {
+              gpp: {
+                applicableSections: [7],
+                parsedSections: { usnat: [{ Version: 1, SaleOptOut: 2 }, { SaleOptOut: 1 }] }
+              }
+            }
+          );
+          expect(result).to.be.undefined;
         });
       });
 


### PR DESCRIPTION
## Type of change
- [x] Other - User ID Module

## Description of change
Adds a new User ID submodule for https://www.acxiom.com/, enabling publishers to resolve Acxiom Real IDs via the GrowthCode identity lookup API and surface them in bid requests as user.ext.eids in standard OpenRTB 2.x format.                                 
   
  How it works:                                                                                                                                                                                                                                                     
  - On page load, the module sends a POST request to /v1/eid/lookup with the publisher's partnerId, sourceId, and optional hashed email (hem)
  - The API returns an EID-formatted response; the module extracts the first matching uid and caches it via Prebid's userId storage                                                                                                                                 
  - On subsequent auctions, the cached Acxiom Real ID is injected into user.ext.eids with source: "acxiom.id" and the atype returned by the API
                                                                                                                                                                                                                                                                    
  Privacy / consent handling:                                                                                                                                                                                                                                       
  - EU/UK: passively suppressed when a TCF consent string is present or gdprApplies is true                                                                                                                                                                         
  - US: suppressed when CCPA us_privacy position 3 is Y (user opted out of sale)                                                                                                                                                                                    
  - Stored tokens are proactively deleted when consent is blocked               
  - Implements onDataDeletionRequest for GDPR right-to-erasure                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                    
  Files changed:                                                                                                                                                                                                                                                    
  - modules/acxiomRealIdSystem.js — submodule implementation                                                                                                                                                                                                        
  - modules/acxiomRealIdSystem.md — configuration documentation                                                                                                                                                                                                     
  - modules/.submodules.json — registered under userId                                                                                                                                                                                                              
  - modules/userId/eids.md — added Acxiom EID example                                                                                                                                                                                                               
  - modules/userId/userId.md — added Acxiom config example
  - test/spec/modules/acxiomRealIdSystem_spec.js — 34 unit tests, all passing                                                                                                                                                                                       
                                                                                                                                                                                                                                                         
  EID output in user.ext.eids:                                                                                                                                                                                                                                      
  {                                                                                                                                                                                                                                                                 
    "source": "acxiom.id",                                                                                                                                                                                                                                          
    "uids": [{ "id": "<real_id_token>", "atype": 1 }]       
  }     

Primary Contact: Chris Southern, Head of Technology at GrowthCode [chris@growthcode.io](mailto:chris@growthcode.io)
Rameez Israr, Developer at GrowthCode [rameez@growthcode.io](mailto:rameez@growthcode.io)

### Note                                                                                 
This submission is made on behalf of Acxiom and its parent company, Omnicom. GrowthCode is submitting this module as their authorized representative. If you have questions or need to speak with someone directly, please reach out to any of the following:

Nan Zhang Senior Director, Products [nan.zhang1@acxiom.com](mailto:nan.zhang1@acxiom.com)
Sumedh Deshprabhu Cloud Architect [Sumedh.Deshprabhu@acxiom.com](mailto:Sumedh.Deshprabhu@acxiom.com)
Thuy Kim Omnipath Project Consultant [thuy.kim@acxiom.com](mailto:thuy.kim@acxiom.com)

## Other information
 - For testing please use PartnerID:  9CH473PU8
 - Updates to the docs site will follow.