### PR TITLE
Build: drop @wdio/concise-reporter devDependency and update lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "@types/google-publisher-tag": "^1.20250210.0",
         "@wdio/browserstack-service": "^9.19.1",
         "@wdio/cli": "^9.19.1",
-        "@wdio/concise-reporter": "^8.29.0",
         "@wdio/local-runner": "^9.15.0",
         "@wdio/mocha-framework": "^9.12.6",
         "@wdio/spec-reporter": "^8.43.0",
@@ -5730,31 +5729,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@wdio/concise-reporter": {
-      "version": "8.38.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@wdio/reporter": "8.38.2",
-        "@wdio/types": "8.38.2",
-        "chalk": "^5.0.1",
-        "pretty-ms": "^7.0.1"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
-    "node_modules/@wdio/concise-reporter/node_modules/chalk": {
-      "version": "5.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/@wdio/config": {
       "version": "9.15.0",
       "dev": true,
@@ -6720,21 +6694,6 @@
         "node": ">=18.20.0"
       }
     },
-    "node_modules/@wdio/reporter": {
-      "version": "8.38.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0",
-        "@wdio/logger": "8.38.0",
-        "@wdio/types": "8.38.2",
-        "diff": "^5.0.0",
-        "object-inspect": "^1.12.0"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
-    },
     "node_modules/@wdio/runner": {
       "version": "9.15.0",
       "dev": true,
@@ -7069,17 +7028,6 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@wdio/types": {
-      "version": "8.38.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0"
-      },
-      "engines": {
-        "node": "^16.13 || >=18"
-      }
     },
     "node_modules/@wdio/utils": {
       "version": "9.12.6",
@@ -26561,22 +26509,6 @@
         }
       }
     },
-    "@wdio/concise-reporter": {
-      "version": "8.38.2",
-      "dev": true,
-      "requires": {
-        "@wdio/reporter": "8.38.2",
-        "@wdio/types": "8.38.2",
-        "chalk": "^5.0.1",
-        "pretty-ms": "^7.0.1"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "5.3.0",
-          "dev": true
-        }
-      }
-    },
     "@wdio/config": {
       "version": "9.15.0",
       "dev": true,
@@ -27227,17 +27159,6 @@
         "@types/node": "^20.1.0"
       }
     },
-    "@wdio/reporter": {
-      "version": "8.38.2",
-      "dev": true,
-      "requires": {
-        "@types/node": "^20.1.0",
-        "@wdio/logger": "8.38.0",
-        "@wdio/types": "8.38.2",
-        "diff": "^5.0.0",
-        "object-inspect": "^1.12.0"
-      }
-    },
     "@wdio/runner": {
       "version": "9.15.0",
       "dev": true,
@@ -27463,13 +27384,6 @@
           "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
           "dev": true
         }
-      }
-    },
-    "@wdio/types": {
-      "version": "8.38.2",
-      "dev": true,
-      "requires": {
-        "@types/node": "^20.1.0"
       }
     },
     "@wdio/utils": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@types/google-publisher-tag": "^1.20250210.0",
     "@wdio/browserstack-service": "^9.19.1",
     "@wdio/cli": "^9.19.1",
-    "@wdio/concise-reporter": "^8.29.0",
     "@wdio/local-runner": "^9.15.0",
     "@wdio/mocha-framework": "^9.12.6",
     "@wdio/spec-reporter": "^8.43.0",


### PR DESCRIPTION
### Motivation
- Remove an outdated WebdriverIO reporter dependency 