### PR TITLE
fluct Bid Adapter: add remaining missing bid request signals

### DIFF
--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -267,7 +267,6 @@ export const spec = {
         data.bidfloorcur = highestFloorData.currency;
       }
 
-
       const searchParams = new URLSearchParams({
         dfpUnitCode: request.params.dfpUnitCode,
         tagId: request.params.tagId,

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -269,13 +269,6 @@ export const spec = {
 
       data.instl = deepAccess(request, 'ortb2Imp.instl') === 1 || request.params.instl === 1 ? 1 : 0;
 
-      const floorMeta = request.floorData;
-      if (floorMeta) {
-        data.floorData = {};
-        if (floorMeta.modelVersion != null) data.floorData.modelVersion = floorMeta.modelVersion;
-        if (floorMeta.location) data.floorData.location = floorMeta.location;
-        if (floorMeta.floorProvider) data.floorData.floorProvider = floorMeta.floorProvider;
-      }
 
       const searchParams = new URLSearchParams({
         dfpUnitCode: request.params.dfpUnitCode,

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -113,20 +113,14 @@ export const spec = {
     const serverRequests = [];
     const page = bidderRequest.refererInfo.page;
     const wrapperName = config.getConfig('fluct')?.wrapperName;
-    const customHeaders = {
-      'x-fluct-app': 'prebid/fluctBidAdapter',
-      'x-fluct-version': VERSION,
-      'x-openrtb-version': 2.5,
-    };
-    if (wrapperName) {
-      customHeaders['x-fluct-prebid-wrapper'] = wrapperName;
-    }
 
     _each(validBidRequests, (request) => {
       const impExt = request.ortb2Imp?.ext;
       const data = {};
 
       data.page = page;
+      data.adapterVersion = VERSION;
+      if (wrapperName) data.wrapperName = wrapperName;
 
       const ortb2Site = bidderRequest.ortb2?.site;
       if (ortb2Site) {
@@ -277,9 +271,7 @@ export const spec = {
         method: 'POST',
         url: END_POINT + '?' + searchParams.toString(),
         options: {
-          contentType: 'application/json',
           withCredentials: true,
-          customHeaders,
         },
         data: data
       });

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -140,7 +140,11 @@ export const spec = {
         if (ortb2Site.domain) data.site.domain = ortb2Site.domain;
         if (ortb2Site.ref) data.site.ref = ortb2Site.ref;
         if (ortb2Site.search) data.site.search = ortb2Site.search;
-        if (ortb2Site.publisher?.domain) data.site.publisher = { domain: ortb2Site.publisher.domain };
+        if (ortb2Site.publisher) {
+          data.site.publisher = {};
+          if (ortb2Site.publisher.id) data.site.publisher.id = ortb2Site.publisher.id;
+          if (ortb2Site.publisher.domain) data.site.publisher.domain = ortb2Site.publisher.domain;
+        }
         if (ortb2Site.ext?.data) data.site.ext = { data: ortb2Site.ext.data };
       }
 
@@ -154,7 +158,7 @@ export const spec = {
           ...(ortb2User?.ext?.eids ?? []),
         ],
       };
-      if (ortb2User?.yob) data.user.yob = ortb2User.yob;
+      if (ortb2User?.yob != null) data.user.yob = ortb2User.yob;
       if (ortb2User?.gender != null) data.user.gender = ortb2User.gender;
       if (ortb2User?.keywords) data.user.keywords = ortb2User.keywords;
       if (ortb2User?.ext?.data) data.user.ext = { data: ortb2User.ext.data };
@@ -200,7 +204,7 @@ export const spec = {
       if (bidderRequest.refererInfo?.canonicalUrl) data.canonicalUrl = bidderRequest.refererInfo.canonicalUrl;
       if (bidderRequest.refererInfo?.isAmp) data.isAmp = true;
       if (bidderRequest.refererInfo?.reachedTop != null) data.reachedTop = bidderRequest.refererInfo.reachedTop;
-      if (bidderRequest.refererInfo?.numIframes) data.numIframes = bidderRequest.refererInfo.numIframes;
+      if (bidderRequest.refererInfo?.numIframes != null) data.numIframes = bidderRequest.refererInfo.numIframes;
       if (bidderRequest.timeout != null) data.timeout = bidderRequest.timeout;
       if (bidderRequest.ortb2?.source?.tid) deepSetValue(data, 'source.tid', bidderRequest.ortb2.source.tid);
       if (bidderRequest.ortb2?.user?.ext?.data?.im_segments) {

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -243,6 +243,10 @@ export const spec = {
         data.bidfloorcur = highestFloorData.currency;
       }
 
+      if (request.ortb2Imp?.instl === 1) {
+        data.instl = request.ortb2Imp?.instl;
+      }
+
       const searchParams = new URLSearchParams({
         dfpUnitCode: request.params.dfpUnitCode,
         tagId: request.params.tagId,

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -251,6 +251,15 @@ export const spec = {
         groupId: request.params.groupId,
       });
 
+      const customHeaders = {
+        'x-fluct-app': 'prebid/fluctBidAdapter',
+        'x-fluct-version': VERSION,
+        'x-openrtb-version': 2.5,
+      };
+      if (wrapperName) {
+        customHeaders['x-fluct-prebid-wrapper'] = wrapperName;
+      }
+
       serverRequests.push({
         method: 'POST',
         url: END_POINT + '?' + searchParams.toString(),

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -243,9 +243,7 @@ export const spec = {
         data.bidfloorcur = highestFloorData.currency;
       }
 
-      if (request.ortb2Imp?.instl === 1) {
-        data.instl = request.ortb2Imp?.instl;
-      }
+      data.instl = deepAccess(request, 'ortb2Imp.instl') === 1 || request.params.instl === 1 ? 1 : 0;
 
       const searchParams = new URLSearchParams({
         dfpUnitCode: request.params.dfpUnitCode,

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -113,14 +113,20 @@ export const spec = {
     const serverRequests = [];
     const page = bidderRequest.refererInfo.page;
     const wrapperName = config.getConfig('fluct')?.wrapperName;
+    const customHeaders = {
+      'x-fluct-app': 'prebid/fluctBidAdapter',
+      'x-fluct-version': VERSION,
+      'x-openrtb-version': 2.5,
+    };
+    if (wrapperName) {
+      customHeaders['x-fluct-prebid-wrapper'] = wrapperName;
+    }
 
     _each(validBidRequests, (request) => {
       const impExt = request.ortb2Imp?.ext;
       const data = {};
 
       data.page = page;
-      data.adapterVersion = VERSION;
-      if (wrapperName) data.wrapperName = wrapperName;
 
       const ortb2Site = bidderRequest.ortb2?.site;
       if (ortb2Site) {
@@ -271,7 +277,9 @@ export const spec = {
         method: 'POST',
         url: END_POINT + '?' + searchParams.toString(),
         options: {
+          contentType: 'application/json',
           withCredentials: true,
+          customHeaders,
         },
         data: data
       });

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -10,7 +10,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 
 const BIDDER_CODE = 'fluct';
 const END_POINT = 'https://hb.adingo.jp/prebid/';
-const VERSION = '1.6';
+const VERSION = '1.7';
 const NET_REVENUE = true;
 const TTL = 300;
 const DEFAULT_CURRENCY = 'JPY';
@@ -131,6 +131,7 @@ export const spec = {
       const ortb2Site = bidderRequest.ortb2?.site;
       if (ortb2Site) {
         data.site = {};
+        if (ortb2Site.name) data.site.name = ortb2Site.name;
         if (ortb2Site.cat) data.site.cat = ortb2Site.cat;
         if (ortb2Site.sectioncat) data.site.sectioncat = ortb2Site.sectioncat;
         if (ortb2Site.pagecat) data.site.pagecat = ortb2Site.pagecat;
@@ -138,18 +139,25 @@ export const spec = {
         if (ortb2Site.content) data.site.content = ortb2Site.content;
         if (ortb2Site.domain) data.site.domain = ortb2Site.domain;
         if (ortb2Site.ref) data.site.ref = ortb2Site.ref;
+        if (ortb2Site.search) data.site.search = ortb2Site.search;
+        if (ortb2Site.publisher?.domain) data.site.publisher = { domain: ortb2Site.publisher.domain };
         if (ortb2Site.ext?.data) data.site.ext = { data: ortb2Site.ext.data };
       }
 
       data.adUnitCode = request.adUnitCode;
       data.bidId = request.bidId;
+      const ortb2User = bidderRequest.ortb2?.user;
       data.user = {
-        data: bidderRequest.ortb2?.user?.data ?? [],
+        data: ortb2User?.data ?? [],
         eids: [
           ...(request.userIdAsEids ?? []),
-          ...(bidderRequest.ortb2?.user?.ext?.eids ?? []),
+          ...(ortb2User?.ext?.eids ?? []),
         ],
       };
+      if (ortb2User?.yob) data.user.yob = ortb2User.yob;
+      if (ortb2User?.gender != null) data.user.gender = ortb2User.gender;
+      if (ortb2User?.keywords) data.user.keywords = ortb2User.keywords;
+      if (ortb2User?.ext?.data) data.user.ext = { data: ortb2User.ext.data };
 
       if (impExt) {
         data.transactionId = impExt.tid;
@@ -183,6 +191,18 @@ export const spec = {
           sid: bidderRequest.ortb2.regs.gpp_sid
         });
       }
+      if (bidderRequest.ortb2?.regs?.ext?.dsa) {
+        deepSetValue(data, 'regs.ext.dsa', bidderRequest.ortb2.regs.ext.dsa);
+      }
+      if (bidderRequest.ortb2?.regs?.ext?.gpc != null) {
+        deepSetValue(data, 'regs.ext.gpc', bidderRequest.ortb2.regs.ext.gpc);
+      }
+      if (bidderRequest.refererInfo?.canonicalUrl) data.canonicalUrl = bidderRequest.refererInfo.canonicalUrl;
+      if (bidderRequest.refererInfo?.isAmp) data.isAmp = true;
+      if (bidderRequest.refererInfo?.reachedTop != null) data.reachedTop = bidderRequest.refererInfo.reachedTop;
+      if (bidderRequest.refererInfo?.numIframes) data.numIframes = bidderRequest.refererInfo.numIframes;
+      if (bidderRequest.timeout != null) data.timeout = bidderRequest.timeout;
+      if (bidderRequest.ortb2?.source?.tid) deepSetValue(data, 'source.tid', bidderRequest.ortb2.source.tid);
       if (bidderRequest.ortb2?.user?.ext?.data?.im_segments) {
         deepSetValue(data, 'params.kv.imsids', bidderRequest.ortb2.user.ext.data.im_segments);
       }
@@ -244,6 +264,14 @@ export const spec = {
       }
 
       data.instl = deepAccess(request, 'ortb2Imp.instl') === 1 || request.params.instl === 1 ? 1 : 0;
+
+      const floorMeta = request.floorData;
+      if (floorMeta) {
+        data.floorData = {};
+        if (floorMeta.modelVersion != null) data.floorData.modelVersion = floorMeta.modelVersion;
+        if (floorMeta.location) data.floorData.location = floorMeta.location;
+        if (floorMeta.floorProvider) data.floorData.floorProvider = floorMeta.floorProvider;
+      }
 
       const searchParams = new URLSearchParams({
         dfpUnitCode: request.params.dfpUnitCode,

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -267,8 +267,6 @@ export const spec = {
         data.bidfloorcur = highestFloorData.currency;
       }
 
-      data.instl = deepAccess(request, 'ortb2Imp.instl') === 1 || request.params.instl === 1 ? 1 : 0;
-
 
       const searchParams = new URLSearchParams({
         dfpUnitCode: request.params.dfpUnitCode,

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -251,15 +251,6 @@ export const spec = {
         groupId: request.params.groupId,
       });
 
-      const customHeaders = {
-        'x-fluct-app': 'prebid/fluctBidAdapter',
-        'x-fluct-version': VERSION,
-        'x-openrtb-version': 2.5,
-      };
-      if (wrapperName) {
-        customHeaders['x-fluct-prebid-wrapper'] = wrapperName;
-      }
-
       serverRequests.push({
         method: 'POST',
         url: END_POINT + '?' + searchParams.toString(),

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -192,16 +192,31 @@ describe('fluctAdapter', function () {
       expect(request.data.regs).to.eql(undefined);
     });
 
-    it('does not include x-fluct-prebid-wrapper header by default', function () {
+    it('does not include wrapperName in data by default', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
-      expect(request.options.customHeaders['x-fluct-prebid-wrapper']).to.be.undefined;
+      expect(request.data.wrapperName).to.be.undefined;
     });
 
-    it('includes x-fluct-prebid-wrapper header when fluct.wrapperName is configured', function () {
+    it('includes wrapperName in data when fluct.wrapperName is configured', function () {
       sb.stub(config, 'getConfig').withArgs('fluct').returns({ wrapperName: 'boost' });
 
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
-      expect(request.options.customHeaders['x-fluct-prebid-wrapper']).to.equal('boost');
+      expect(request.data.wrapperName).to.equal('boost');
+    });
+
+    it('includes adapterVersion in data', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.adapterVersion).to.be.a('string').and.not.empty;
+    });
+
+    it('does not set application/json content type', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.options.contentType).to.be.undefined;
+    });
+
+    it('does not include custom headers', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.options.customHeaders).to.be.undefined;
     });
 
     it('includes filtered user.eids if any exists', function () {

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -952,22 +952,6 @@ describe('fluctAdapter', function () {
       expect(request.data.user.ext).to.eql(undefined);
     });
 
-    it('includes data.floorData from request.floorData', function () {
-      const floorBidRequests = bidRequests.map((req) => Object.assign({}, req, {
-        floorData: { modelVersion: 'v1', location: 'setConfig', floorProvider: 'pubmatic' },
-      }));
-      const request = spec.buildRequests(floorBidRequests, bidderRequest)[0];
-      expect(request.data.floorData).to.eql({
-        modelVersion: 'v1',
-        location: 'setConfig',
-        floorProvider: 'pubmatic',
-      });
-    });
-
-    it('does not include data.floorData when request.floorData is absent', function () {
-      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
-      expect(request.data.floorData).to.eql(undefined);
-    });
   });
 
   describe('should interpretResponse', function() {

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -192,31 +192,16 @@ describe('fluctAdapter', function () {
       expect(request.data.regs).to.eql(undefined);
     });
 
-    it('does not include wrapperName in data by default', function () {
+    it('does not include x-fluct-prebid-wrapper header by default', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
-      expect(request.data.wrapperName).to.be.undefined;
+      expect(request.options.customHeaders['x-fluct-prebid-wrapper']).to.be.undefined;
     });
 
-    it('includes wrapperName in data when fluct.wrapperName is configured', function () {
+    it('includes x-fluct-prebid-wrapper header when fluct.wrapperName is configured', function () {
       sb.stub(config, 'getConfig').withArgs('fluct').returns({ wrapperName: 'boost' });
 
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
-      expect(request.data.wrapperName).to.equal('boost');
-    });
-
-    it('includes adapterVersion in data', function () {
-      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
-      expect(request.data.adapterVersion).to.be.a('string').and.not.empty;
-    });
-
-    it('does not set application/json content type', function () {
-      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
-      expect(request.options.contentType).to.be.undefined;
-    });
-
-    it('does not include custom headers', function () {
-      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
-      expect(request.options.customHeaders).to.be.undefined;
+      expect(request.options.customHeaders['x-fluct-prebid-wrapper']).to.equal('boost');
     });
 
     it('includes filtered user.eids if any exists', function () {

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -951,7 +951,6 @@ describe('fluctAdapter', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.data.user.ext).to.eql(undefined);
     });
-
   });
 
   describe('should interpretResponse', function() {

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -451,6 +451,27 @@ describe('fluctAdapter', function () {
       expect(request.data.regs.gpp.sid).to.eql([1, 2, 3]);
     });
 
+    it('includes data.regs.ext.dsa if bidderRequest.ortb2.regs.ext.dsa exists', function () {
+      const dsa = {
+        dsarequired: 1,
+        pubrender: 0,
+        datatopub: 2,
+        transparency: [{ domain: 'example.com', dsaparams: [1, 2] }],
+      };
+      const request = spec.buildRequests(
+        bidRequests,
+        Object.assign({}, bidderRequest, {
+          ortb2: { regs: { ext: { dsa } } },
+        }),
+      )[0];
+      expect(request.data.regs.ext.dsa).to.eql(dsa);
+    });
+
+    it('does not include data.regs.ext.dsa when absent', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.regs?.ext?.dsa).to.eql(undefined);
+    });
+
     it('includes no data.site by default', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.data.site).to.eql(undefined);
@@ -795,6 +816,136 @@ describe('fluctAdapter', function () {
       const request = spec.buildRequests(bidRequests2, bidderRequest)[0];
       expect(request.data.bidfloor).to.eql(undefined);
       expect(request.data.bidfloorcur).to.eql(undefined);
+    });
+
+    it('includes data.regs.ext.gpc from ortb2.regs.ext.gpc', function () {
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        ortb2: { regs: { ext: { gpc: '1' } } },
+      }))[0];
+      expect(request.data.regs.ext.gpc).to.eql('1');
+    });
+
+    it('does not include data.regs.ext.gpc when absent', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.regs?.ext?.gpc).to.eql(undefined);
+    });
+
+    it('includes data.canonicalUrl from refererInfo.canonicalUrl', function () {
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        refererInfo: { page: 'http://example.com', canonicalUrl: 'https://example.com/canonical' },
+      }))[0];
+      expect(request.data.canonicalUrl).to.eql('https://example.com/canonical');
+    });
+
+    it('does not include data.canonicalUrl when absent', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.canonicalUrl).to.eql(undefined);
+    });
+
+    it('includes data.isAmp when refererInfo.isAmp is true', function () {
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        refererInfo: { page: 'http://example.com', isAmp: true },
+      }))[0];
+      expect(request.data.isAmp).to.eql(true);
+    });
+
+    it('does not include data.isAmp when refererInfo.isAmp is false', function () {
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        refererInfo: { page: 'http://example.com', isAmp: false },
+      }))[0];
+      expect(request.data.isAmp).to.eql(undefined);
+    });
+
+    it('includes data.reachedTop from refererInfo.reachedTop', function () {
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        refererInfo: { page: 'http://example.com', reachedTop: false },
+      }))[0];
+      expect(request.data.reachedTop).to.eql(false);
+    });
+
+    it('includes data.numIframes from refererInfo.numIframes', function () {
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        refererInfo: { page: 'http://example.com', numIframes: 2 },
+      }))[0];
+      expect(request.data.numIframes).to.eql(2);
+    });
+
+    it('includes data.timeout from bidderRequest.timeout', function () {
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        timeout: 3000,
+      }))[0];
+      expect(request.data.timeout).to.eql(3000);
+    });
+
+    it('does not include data.timeout when absent', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.timeout).to.eql(undefined);
+    });
+
+    it('includes data.source.tid from ortb2.source.tid', function () {
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        ortb2: { source: { tid: 'auction-tid-123' } },
+      }))[0];
+      expect(request.data.source.tid).to.eql('auction-tid-123');
+    });
+
+    it('does not include data.source.tid when absent', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.source?.tid).to.eql(undefined);
+    });
+
+    it('includes data.site.name and data.site.search and data.site.publisher.domain', function () {
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        ortb2: {
+          site: {
+            name: 'My Site',
+            search: 'prebid',
+            publisher: { domain: 'publisher.example.com' },
+          },
+        },
+      }))[0];
+      expect(request.data.site.name).to.eql('My Site');
+      expect(request.data.site.search).to.eql('prebid');
+      expect(request.data.site.publisher).to.eql({ domain: 'publisher.example.com' });
+    });
+
+    it('includes data.user.yob, data.user.gender, data.user.keywords', function () {
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        ortb2: { user: { yob: 1990, gender: 'M', keywords: 'sports,tech' } },
+      }))[0];
+      expect(request.data.user.yob).to.eql(1990);
+      expect(request.data.user.gender).to.eql('M');
+      expect(request.data.user.keywords).to.eql('sports,tech');
+    });
+
+    it('includes data.user.ext.data from ortb2.user.ext.data', function () {
+      const extData = { segment: ['A', 'B'], customAttr: 'value' };
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        ortb2: { user: { ext: { data: extData } } },
+      }))[0];
+      expect(request.data.user.ext.data).to.eql(extData);
+    });
+
+    it('does not include data.user.ext when ortb2.user.ext.data is absent', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.user.ext).to.eql(undefined);
+    });
+
+    it('includes data.floorData from request.floorData', function () {
+      const floorBidRequests = bidRequests.map((req) => Object.assign({}, req, {
+        floorData: { modelVersion: 'v1', location: 'setConfig', floorProvider: 'pubmatic' },
+      }));
+      const request = spec.buildRequests(floorBidRequests, bidderRequest)[0];
+      expect(request.data.floorData).to.eql({
+        modelVersion: 'v1',
+        location: 'setConfig',
+        floorProvider: 'pubmatic',
+      });
+    });
+
+    it('does not include data.floorData when request.floorData is absent', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.floorData).to.eql(undefined);
     });
   });
 

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -870,6 +870,13 @@ describe('fluctAdapter', function () {
       expect(request.data.numIframes).to.eql(2);
     });
 
+    it('includes data.numIframes = 0 when page is at top level', function () {
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        refererInfo: { page: 'http://example.com', numIframes: 0 },
+      }))[0];
+      expect(request.data.numIframes).to.eql(0);
+    });
+
     it('includes data.timeout from bidderRequest.timeout', function () {
       const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
         timeout: 3000,
@@ -907,6 +914,20 @@ describe('fluctAdapter', function () {
       expect(request.data.site.name).to.eql('My Site');
       expect(request.data.site.search).to.eql('prebid');
       expect(request.data.site.publisher).to.eql({ domain: 'publisher.example.com' });
+    });
+
+    it('includes data.site.publisher.id even when domain is absent', function () {
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        ortb2: { site: { publisher: { id: 'pub-123' } } },
+      }))[0];
+      expect(request.data.site.publisher).to.eql({ id: 'pub-123' });
+    });
+
+    it('includes both id and domain in data.site.publisher when both present', function () {
+      const request = spec.buildRequests(bidRequests, Object.assign({}, bidderRequest, {
+        ortb2: { site: { publisher: { id: 'pub-123', domain: 'example.com' } } },
+      }))[0];
+      expect(request.data.site.publisher).to.eql({ id: 'pub-123', domain: 'example.com' });
     });
 
     it('includes data.user.yob, data.user.gender, data.user.keywords', function () {


### PR DESCRIPTION
## Type of issue

Enhancement / feature — existing bid adapter update

## Description

The fluct bid adapter is missing several signals that Prebid.js makes available via `bidderRequest.ortb2` and `refererInfo`. This PR forwards them to the fluct server to improve DSP targeting accuracy, privacy compliance, and fill rate.

**Regulation / privacy:**
- `regs.ext.dsa` — Digital Services Act (EU); EU DSPs may skip bidding without it
- `regs.ext.gpc` — Global Privacy Control

**User attributes:**
- `user.yob`, `user.gender`, `user.keywords` — demographic / interest targeting
- `user.ext.data` — all user-level first-party data (previously only `im_segments` was extracted individually)

**Site metadata:**
- `site.name`, `site.search` — additional site context
- `site.publisher.id`, `site.publisher.domain` — publisher identity for inventory quality evaluation

**Auction context:**
- `refererInfo.canonicalUrl` — more reliable page URL than raw `refererInfo.page`
- `refererInfo.isAmp`, `reachedTop`, `numIframes` — page environment signals
- `bidderRequest.timeout` — lets fluct server optimize response timing
- `ortb2.source.tid` — auction-level transaction ID

## Steps to reproduce

1. Configure a Prebid.js auction with the fluct bid adapter and set any of the above ortb2 fields
2. Observe the POST request to `https://hb.adingo.jp/prebid/`
3. Note that the above fields are absent from the request body even though Prebid.js has populated them

## Test page

Standard Prebid.js integration with the fluct adapter. See `integrationExamples/gpt/hello_world.html`.

## Expected results

The fluct server receives all the above signals when they are available in `bidderRequest.ortb2` / `refererInfo`.

## Actual results

The signals are absent from the bid request, reducing DSP targeting accuracy and compliance coverage.

## Platform details

- Adapter: `modules/fluctBidAdapter.js` (VERSION 1.5 → 1.7)
- Tests: `test/spec/modules/fluctBidAdapter_spec.js`

```
gulp test --nolint --file test/spec/modules/fluctBidAdapter_spec.js
✔ 82 tests completed
```

> Note: `gulp lint` is currently broken due to an ESM/CJS conflict introduced in upstream commit `4c42b2eb5` (#14932). This PR's changes are unrelated to that issue.

## Other information

> **Draft** — waiting for https://github.com/prebid/Prebid.js/pull/14957 to merge before marking ready, to avoid VERSION conflict (that PR uses 1.6; this PR uses 1.7).

Part of a series of PRs adding missing signals to the fluct bid adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)