### PR TITLE
AdOcean Bid Adapter: support for optional, extra emitter parameters

### DIFF
--- a/modules/adoceanBidAdapter.js
+++ b/modules/adoceanBidAdapter.js
@@ -1,4 +1,4 @@
-import { _each, isStr, isArray, parseSizesInput } from '../src/utils.js';
+import { _each, isStr, isArray, isPlainObject, parseSizesInput } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 
@@ -8,14 +8,18 @@ const URL_SAFE_FIELDS = {
   slaves: true
 };
 
-function buildEndpointUrl(emitter, payloadMap) {
+function buildEndpointUrl(emitter, payloadMap, emitterRequestParams) {
   const payload = [];
   _each(payloadMap, function(v, k) {
     payload.push(k + '=' + (URL_SAFE_FIELDS[k] ? v : encodeURIComponent(v)));
   });
 
   const randomizedPart = Math.random().toString().slice(2);
-  return 'https://' + emitter + '/_' + randomizedPart + '/ad.json?' + payload.join('&');
+  let request = 'https://' + emitter + '/_' + randomizedPart + '/ad.json?' + payload.join('&');
+  if (emitterRequestParams.length) {
+    request += '&' + emitterRequestParams.join('&');
+  }
+  return request;
 }
 
 function buildRequest(bid, gdprConsent) {
@@ -33,6 +37,13 @@ function buildRequest(bid, gdprConsent) {
 
   if (bid.userId && bid.userId.gemiusId) {
     payload.aouserid = bid.userId.gemiusId;
+  }
+
+  const emitterRequestParams = [];
+  if (bid.params.emitterRequestParams) {
+    _each(bid.params.emitterRequestParams, function(v, k) {
+      emitterRequestParams.push(encodeURIComponent(k) + '=' + encodeURIComponent(v));
+    });
   }
 
   const bidIdMap = {};
@@ -60,7 +71,7 @@ function buildRequest(bid, gdprConsent) {
 
   return {
     method: 'GET',
-    url: buildEndpointUrl(emitter, payload),
+    url: buildEndpointUrl(emitter, payload, emitterRequestParams),
     data: '',
     bidIdMap: bidIdMap
   };
@@ -107,6 +118,10 @@ export const spec = {
   isBidRequestValid: function(bid) {
     const requiredParams = ['slaveId', 'masterId', 'emitter'];
     if (requiredParams.some(name => !isStr(bid.params[name]) || !bid.params[name].length)) {
+      return false;
+    }
+
+    if (bid.params.emitterRequestParams && !isPlainObject(bid.params.emitterRequestParams)) {
       return false;
     }
 

--- a/modules/adoceanBidAdapter.md
+++ b/modules/adoceanBidAdapter.md
@@ -25,7 +25,10 @@ Banner and video formats are supported.
                     params: {
                         slaveId: 'adoceanmyaotcpiltmmnj',
                         masterId: 'ek1AWtSWh3BOa_x2P1vlMQ_uXXJpJcbhsHAY5PFQjWD.D7',
-                        emitter: 'myao.adocean.pl'
+                        emitter: 'myao.adocean.pl',
+                        emitterRequestParams: { // optional, extra parameters
+                            "test_parameter": "1"
+                        }
                     }
                 }
             ]
@@ -49,7 +52,10 @@ Banner and video formats are supported.
                     params: {
                         slaveId: 'adoceanmyaonenfcoqfnd',
                         masterId: '2k6gA7RWl08Zn0bi42RV8LNCANpKb6LqhvKzbmK3pzP.U7',
-                        emitter: 'myao.adocean.pl'
+                        emitter: 'myao.adocean.pl',
+                        emitterRequestParams: { // optional, extra parameters
+                            "test_parameter": "1"
+                        }
                     }
                 }
             ]

--- a/test/spec/modules/adoceanBidAdapter_spec.js
+++ b/test/spec/modules/adoceanBidAdapter_spec.js
@@ -85,6 +85,31 @@ describe('AdoceanAdapter', function () {
     it('should return false for outstream video', function () {
       expect(spec.isBidRequestValid(videoOutstreamBid)).to.equal(false);
     });
+
+    it('should return true when emitterRequestParams is a plain object', function () {
+      const bid = Object.assign({}, bannerBid, {
+        params: Object.assign({}, bannerBid.params, { emitterRequestParams: { foo: 'bar' } })
+      });
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should return true when emitterRequestParams is not provided', function () {
+      expect(spec.isBidRequestValid(bannerBid)).to.equal(true);
+    });
+
+    it('should return false when emitterRequestParams is an array', function () {
+      const bid = Object.assign({}, bannerBid, {
+        params: Object.assign({}, bannerBid.params, { emitterRequestParams: ['foo', 'bar'] })
+      });
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('should return false when emitterRequestParams is a string', function () {
+      const bid = Object.assign({}, bannerBid, {
+        params: Object.assign({}, bannerBid.params, { emitterRequestParams: 'foo=bar' })
+      });
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
   });
 
   describe('buildRequests', function () {
@@ -210,6 +235,21 @@ describe('AdoceanAdapter', function () {
       expect(request.url).to.include('dur=60');
       expect(request.url).to.include('maxdur=60');
       expect(request.url).to.include('mindur=10');
+    });
+
+    it('should attach emitterRequestParams to url', function () {
+      const bidWithParams = deepClone(bidRequests[0]);
+      bidWithParams.params.emitterRequestParams = { myParam: 'myValue', another: 'test' };
+      const request = spec.buildRequests([bidWithParams], bidderRequest)[0];
+      expect(request.url).to.include('myParam=myValue');
+      expect(request.url).to.include('another=test');
+    });
+
+    it('should encode emitterRequestParams keys and values', function () {
+      const bidWithParams = deepClone(bidRequests[0]);
+      bidWithParams.params.emitterRequestParams = { 'special key': 'special value' };
+      const request = spec.buildRequests([bidWithParams], bidderRequest)[0];
+      expect(request.url).to.include('special%20key=special%20value');
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
New parameter: "emitterRequestParams" which allows to provide additional data for targeting. 

## Documentation
https://github.com/prebid/prebid.github.io/pull/6586