### PR TITLE
UnifiedId Adapter: require partner or url in types

### DIFF
--- a/modules/unifiedIdSystem.d.ts
+++ b/modules/unifiedIdSystem.d.ts
@@ -1,4 +1,5 @@
 import type { Ext } from '../src/types/ortb/common';
+import type { RequireAtLeastOne } from '../src/types/objects';
 
 export type UnifiedIdSystemModuleName = 'unifiedId';
 
@@ -9,10 +10,16 @@ export interface UnifiedIdObject {
 
 export type UnifiedId = string | UnifiedIdObject;
 
-export interface UnifiedIdConfig {
+export type UnifiedIdConfig = RequireAtLeastOne<{
+  /**
+   * This is the partner ID value obtained from registering with The Trade Desk or working with a Prebid.js managed services provider.
+   */
   partner?: string;
+  /**
+   * If specified for UnifiedId, overrides the default Trade Desk URL.
+   */
   url?: string;
-}
+}, 'partner' | 'url'>;
 
 declare module './userId/spec' {
   interface UserId {

--- a/src/types/objects.d.ts
+++ b/src/types/objects.d.ts
@@ -1,3 +1,9 @@
+export type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
+  Omit<T, Keys> & {
+    [K in Keys]-?: Required<Pick<T, K>> &
+    Partial<Pick<T, Exclude<Keys, K>>>
+  }[Keys];
+
 export type DeepPartial<T> = {
   [K in keyof T]?: T[K] extends object ? DeepPartial<T[K]> : T[K];
 };


### PR DESCRIPTION
### Motivation
- Ensure the `UnifiedId` userId provider config reflects the module's runtime requirement that at least one of `partner` or `url` be provided, addressing review feedback.

### Description
- Added a reusable `RequireAtLeastOne` type in `src/types/objects.d.ts` and changed `UnifiedIdConfig` in `modules/unifiedIdSystem.d.ts` to `RequireAtLeastOne<{ partner?: string; url?: string }, 'partner' | 'url'>`, and imported the utility into the unified id declarations.

### Testing
- Ran `npx eslint --cache --cache-strategy content modules/unifiedIdSystem.js modules/unifiedIdSystem.d.ts src/types/objects.d.ts` and `npx gulp test --nolint --file test/spec/modules/unifiedIdSystem_spec.js`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a184dec87dc832b89370ef76520525b)