### PR TITLE
Ogury Bid Adapter: add instream video support

### DIFF
--- a/modules/oguryBidAdapter.js
+++ b/modules/oguryBidAdapter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { BANNER } from '../src/mediaTypes.js';
+import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { getWindowSelf, getWindowTop, isFn, deepAccess, isPlainObject, deepSetValue, mergeDeep } from '../src/utils.js';
 import { getDevicePixelRatio } from '../libraries/devicePixelRatio/devicePixelRatio.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
@@ -14,13 +14,12 @@ const DEFAULT_TIMEOUT = 1000;
 const BID_HOST = 'https://mweb-hb.presage.io/api/header-bidding-request';
 const TIMEOUT_MONITORING_HOST = 'https://ms-ads-monitoring-events.presage.io';
 const MS_COOKIE_SYNC_DOMAIN = 'https://ms-cookie-sync.presage.io';
-const ADAPTER_VERSION = '2.0.6';
+const ADAPTER_VERSION = '2.1.0';
 
 export const ortbConverterProps = {
   context: {
     netRevenue: true,
-    ttl: 60,
-    mediaType: 'banner'
+    ttl: 60
   },
 
   request(buildRequest, imps, bidderRequest, context) {
@@ -73,9 +72,13 @@ export const ortbConverterProps = {
 export const converter = ortbConverter(ortbConverterProps);
 
 function isBidRequestValid(bid) {
-  const adUnitSizes = getAdUnitSizes(bid);
+  const bannerSizes = getAdUnitSizes(bid);
+  const videoPlayerSize = deepAccess(bid, 'mediaTypes.video.playerSize');
 
-  const isValidSize = (Boolean(adUnitSizes) && adUnitSizes.length > 0);
+  const hasBannerSize = Array.isArray(bannerSizes) && bannerSizes.length > 0;
+  const hasVideoSize = Array.isArray(videoPlayerSize) && videoPlayerSize.length > 0;
+  const isValidSize = hasBannerSize || hasVideoSize;
+
   const hasAssetKeyAndAdUnitId = !!deepAccess(bid, 'params.adUnitId') && !!deepAccess(bid, 'params.assetKey');
   const hasPublisherIdAndAdUnitCode = !!deepAccess(bid, 'ortb2.site.publisher.id') && !!bid.adUnitCode;
 
@@ -128,13 +131,24 @@ function getFloor(bid) {
   if (!isFn(bid.getFloor)) {
     return 0;
   }
-  const floorResult = bid.getFloor({
-    currency: 'USD',
-    mediaType: 'banner',
-    size: '*'
-  });
 
-  return (isPlainObject(floorResult) && floorResult.currency === 'USD') ? floorResult.floor : 0;
+  // Detect banner from mediaTypes.banner rather than via getAdUnitSizes — Prebid
+  // populates bid.sizes from mediaTypes.video.playerSize for video-only adUnits,
+  // which would otherwise make hasBanner falsely true and route the floor query
+  // to the banner mediaType for an imp that has no banner.
+  const hasBanner = Boolean(deepAccess(bid, 'mediaTypes.banner'));
+  const videoPlayerSize = deepAccess(bid, 'mediaTypes.video.playerSize');
+  const hasVideo = Array.isArray(videoPlayerSize) && videoPlayerSize.length > 0;
+
+  // Video-only bid: query the video floor.
+  // Banner-only and mixed banner+video bids: query the banner floor with the
+  // historical `size: '*'` wildcard. This preserves the exact pre-video-support
+  // behaviour for every banner imp (no regression on banner revenue) and treats
+  // mixed imps conservatively as banner.
+  const mediaType = (hasVideo && !hasBanner) ? VIDEO : BANNER;
+  const result = bid.getFloor({ currency: 'USD', mediaType, size: '*' });
+
+  return (isPlainObject(result) && result.currency === 'USD') ? result.floor : 0;
 }
 
 function getWindowContext() {
@@ -163,7 +177,7 @@ function onTimeout(timeoutData) {
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
-  supportedMediaTypes: [BANNER],
+  supportedMediaTypes: [BANNER, VIDEO],
   isBidRequestValid,
   getUserSyncs,
   buildRequests,

--- a/modules/oguryBidAdapter.md
+++ b/modules/oguryBidAdapter.md
@@ -9,7 +9,7 @@ Maintainer: web.inventory@ogury.co
 # Description
 
 Module that connects to Ogury's SSP solution
-Ogury bid adapter supports Banner media type.
+Ogury bid adapter supports Banner and Video (instream) media types.
 
 # Test Parameters
 ```
@@ -30,6 +30,26 @@ Ogury bid adapter supports Banner media type.
                         xMargin?: 20
                         yMargin?: 20
                         gravity?: 'TOP_LEFT' || 'TOP_RIGHT' || 'BOTTOM_LEFT' || 'BOTTOM_RIGHT' || 'BOTTOM_CENTER' || 'TOP_CENTER' || 'CENTER'
+                    }
+                }
+            ]
+        },
+        {
+            code: 'test-video',
+            mediaTypes: {
+                video: {
+                    context: 'instream',
+                    playerSize: [[640, 480]],
+                    mimes: ['video/mp4'],
+                    protocols: [2, 3, 5, 6]
+                }
+            },
+            bids: [
+                {
+                    bidder: "ogury",
+                    params: {
+                        assetKey: 'OGY-CA41D116484F',
+                        adUnitId: '2c4d61d0-90aa-0139-0cda-0242ac120004'
                     }
                 }
             ]

--- a/test/spec/modules/oguryBidAdapter_spec.js
+++ b/test/spec/modules/oguryBidAdapter_spec.js
@@ -41,10 +41,10 @@ describe('OguryBidAdapter', () => {
           floor: 0
         };
 
-        if (mediaType === 'banner') {
-          floorResult.floor = 4;
-        } else {
+        if (mediaType === 'video') {
           floorResult.floor = 1000;
+        } else {
+          floorResult.floor = 4;
         }
 
         return floorResult;
@@ -676,7 +676,7 @@ describe('OguryBidAdapter', () => {
 
       expect(dataRequest.ext).to.deep.equal({
         prebidversion: '$prebid.version$',
-        adapterversion: '2.0.6'
+        adapterversion: '2.1.0'
       });
 
       expect(dataRequest.device).to.deep.equal({
@@ -815,6 +815,7 @@ describe('OguryBidAdapter', () => {
             id: 'advertId',
             impid: 'bidId',
             price: 100,
+            mtype: 1,
             nurl: 'url',
             adm: `<div><img style="width: 300px; height: 250px;" src="https://assets.afcdn.com/recipe/20190529/93153_w1024h768c1cx2220cy1728cxt0cyt0cxb4441cyb3456.jpg" alt="cookies" /></div>`,
             adomain: ['renault.fr'],
@@ -834,6 +835,7 @@ describe('OguryBidAdapter', () => {
             id: 'advertId2',
             impid: 'bidId2',
             price: 150,
+            mtype: 1,
             nurl: 'url2',
             adm: `<div><img style="width: 600px; height: 500px;" src="https://assets.afcdn.com/recipe/20190529/93153_w1024h768c1cx2220cy1728cxt0cyt0cxb4441cyb3456.jpg" alt="cookies" /></div>`,
             adomain: ['peugeot.fr'],
@@ -991,5 +993,289 @@ describe('OguryBidAdapter', () => {
       expect(requests[0].method).to.equal('POST');
       expect(JSON.parse(requests[0].requestBody).location).to.equal(window.location.href);
     })
+  });
+
+  describe('video support', () => {
+    let videoBidRequest;
+    let mixedBidRequest;
+    let windowTopStub;
+
+    beforeEach(() => {
+      videoBidRequest = {
+        adUnitCode: 'adUnitCodeVideo',
+        ortb2Imp: { ext: { gpid: 'gpidVideo' } },
+        auctionId: 'auctionId',
+        bidId: 'bidIdVideo',
+        bidder: 'ogury',
+        params: {
+          assetKey: 'OGY-assetkey',
+          adUnitId: 'adunitIdVideo'
+        },
+        mediaTypes: {
+          video: {
+            playerSize: [[640, 480]],
+            context: 'outstream',
+            mimes: ['video/mp4'],
+            protocols: [2, 3, 5, 6]
+          }
+        },
+        getFloor: ({ mediaType }) => ({
+          currency: 'USD',
+          floor: mediaType === 'video' ? 7 : 3
+        }),
+        transactionId: 'transactionIdVideo'
+      };
+
+      mixedBidRequest = utils.deepClone(bidRequests[0]);
+      mixedBidRequest.mediaTypes.video = {
+        playerSize: [[640, 480]],
+        context: 'outstream',
+        mimes: ['video/mp4']
+      };
+
+      windowTopStub = sinon.stub(utils, 'getWindowTop');
+      windowTopStub.returns({ location: { href: currentLocation }, devicePixelRatio: 1 });
+    });
+
+    afterEach(() => {
+      windowTopStub.restore();
+    });
+
+    describe('supportedMediaTypes', () => {
+      it('should declare both BANNER and VIDEO', () => {
+        expect(spec.supportedMediaTypes).to.include.members(['banner', 'video']);
+      });
+    });
+
+    describe('isBidRequestValid', () => {
+      it('should validate a video-only bid with playerSize', () => {
+        expect(spec.isBidRequestValid(videoBidRequest)).to.be.true;
+      });
+
+      it('should not validate a video-only bid without playerSize', () => {
+        const invalidBid = utils.deepClone(videoBidRequest);
+        delete invalidBid.mediaTypes.video.playerSize;
+        expect(spec.isBidRequestValid(invalidBid)).to.be.false;
+      });
+
+      it('should not validate a video-only bid with empty playerSize', () => {
+        const invalidBid = utils.deepClone(videoBidRequest);
+        invalidBid.mediaTypes.video.playerSize = [];
+        expect(spec.isBidRequestValid(invalidBid)).to.be.false;
+      });
+
+      it('should validate a mixed banner+video bid', () => {
+        expect(spec.isBidRequestValid(mixedBidRequest)).to.be.true;
+      });
+
+      it('should validate a video-only bid using publisherId + adUnitCode flow', () => {
+        const validBid = utils.deepClone(videoBidRequest);
+        delete validBid.params.adUnitId;
+        delete validBid.params.assetKey;
+        validBid.ortb2 = { site: { publisher: { id: 'publisherId' } } };
+        expect(spec.isBidRequestValid(validBid)).to.be.true;
+      });
+
+      it('should not validate a bid with empty mediaTypes.banner and no video', () => {
+        // Guard the edge case where mediaTypes.banner is declared but carries no
+        // sizes. isBidRequestValid must reject it — neither banner sizes nor
+        // video playerSize are present. This keeps getFloor's banner detection
+        // (Boolean(mediaTypes.banner)) safe: a malformed bid never reaches it.
+        const invalidBid = utils.deepClone(bidRequests[0]);
+        invalidBid.mediaTypes = { banner: {} };
+        delete invalidBid.sizes;
+        expect(spec.isBidRequestValid(invalidBid)).to.be.false;
+      });
+    });
+
+    if (FEATURES.VIDEO) {
+      describe('buildRequests', () => {
+        it('should build imp.video from mediaTypes.video.playerSize', () => {
+          const request = spec.buildRequests([videoBidRequest], { ...bidderRequestBase, bids: [videoBidRequest] });
+          expect(request.data.imp[0].video).to.exist;
+          expect(request.data.imp[0].video.w).to.equal(640);
+          expect(request.data.imp[0].video.h).to.equal(480);
+          expect(request.data.imp[0].banner).to.be.an('undefined');
+        });
+
+        it('should set imp.bidfloor from video floor for video-only bids', () => {
+          const request = spec.buildRequests([videoBidRequest], { ...bidderRequestBase, bids: [videoBidRequest] });
+          expect(request.data.imp[0].bidfloor).to.equal(7);
+        });
+
+        it('should build both imp.banner and imp.video for mixed bids', () => {
+          const request = spec.buildRequests([mixedBidRequest], { ...bidderRequestBase, bids: [mixedBidRequest] });
+          expect(request.data.imp[0].banner).to.exist;
+          expect(request.data.imp[0].video).to.exist;
+        });
+
+        it('should use banner floor on mixed banner+video bids (preserves pre-video banner behavior)', () => {
+          const request = spec.buildRequests([mixedBidRequest], { ...bidderRequestBase, bids: [mixedBidRequest] });
+          expect(request.data.imp[0].bidfloor).to.equal(4);
+        });
+
+        it('should use banner floor on mixed bids even when video floor is higher', () => {
+          const bid = utils.deepClone(mixedBidRequest);
+          bid.getFloor = ({ mediaType }) => ({
+            currency: 'USD',
+            floor: mediaType === 'video' ? 10 : 5
+          });
+
+          const request = spec.buildRequests([bid], { ...bidderRequestBase, bids: [bid] });
+          expect(request.data.imp[0].bidfloor).to.equal(5);
+        });
+
+        it('should not set imp.bidfloor on a video-only bid when getFloor is not a function', () => {
+          const bid = utils.deepClone(videoBidRequest);
+          bid.getFloor = undefined;
+
+          const request = spec.buildRequests([bid], { ...bidderRequestBase, bids: [bid] });
+          expect(request.data.imp[0].bidfloor).to.be.an('undefined');
+        });
+
+        it('should query video floor on a video-only bid even when bid.sizes is auto-populated from playerSize', () => {
+          // Prebid populates bid.sizes from mediaTypes.video.playerSize when no
+          // banner mediaType is declared. The adapter must not interpret that as
+          // a banner imp — banner detection lives on mediaTypes.banner, not on
+          // bid.sizes / getAdUnitSizes.
+          const bid = utils.deepClone(videoBidRequest);
+          bid.sizes = [[640, 480]];
+          bid.getFloor = ({ mediaType }) => ({
+            currency: 'USD',
+            floor: mediaType === 'video' ? 9 : 2
+          });
+
+          const request = spec.buildRequests([bid], { ...bidderRequestBase, bids: [bid] });
+          expect(request.data.imp[0].bidfloor).to.equal(9);
+        });
+
+        it('should not query video floor when mediaTypes.video is declared without playerSize', () => {
+          const bid = utils.deepClone(bidRequests[0]);
+          bid.mediaTypes.video = { context: 'outstream', mimes: ['video/mp4'] };
+          bid.getFloor = ({ mediaType }) => ({
+            currency: 'USD',
+            floor: mediaType === 'video' ? 1 : 6
+          });
+
+          const request = spec.buildRequests([bid], { ...bidderRequestBase, bids: [bid] });
+          expect(request.data.imp[0].bidfloor).to.equal(6);
+        });
+
+        it('should pass mediaType:"banner" to getFloor on a banner-only bid (ISO with pre-video behaviour)', () => {
+          // Blindage non-régression banner: detect that the new
+          // Boolean(mediaTypes.banner) check still routes pure banner bids to
+          // the banner floor query. If a future refactor reverses the
+          // hasBanner/hasVideo branching, this test will fail.
+          // We exercise spec.getFloor directly (not via buildRequests) to
+          // isolate the adapter's own getFloor invocation from the
+          // ortbConverter auto-floor processor (which also calls
+          // bid.getFloor when the priceFloors module is loaded by a sibling
+          // spec in the same Karma chunk).
+          const bid = utils.deepClone(bidRequests[0]);
+          const calls = [];
+          bid.getFloor = (args) => {
+            calls.push(args);
+            return { currency: 'USD', floor: 3 };
+          };
+
+          const floor = spec.getFloor(bid);
+          expect(calls).to.have.lengthOf(1);
+          expect(calls[0].mediaType).to.equal('banner');
+          expect(calls[0].size).to.equal('*');
+          expect(floor).to.equal(3);
+        });
+
+        it('should query banner floor with size:"*" (wildcard) rather than iterating per banner size', () => {
+          const bid = utils.deepClone(bidRequests[0]);
+          bid.mediaTypes.banner.sizes = [[300, 250], [728, 90]];
+          bid.getFloor = ({ size }) => {
+            if (size === '*') {
+              return { currency: 'USD', floor: 99 };
+            }
+            return { currency: 'USD', floor: 1 };
+          };
+
+          const request = spec.buildRequests([bid], { ...bidderRequestBase, bids: [bid] });
+          expect(request.data.imp[0].bidfloor).to.equal(99);
+        });
+      });
+
+      describe('interpretResponse', () => {
+        it('should mark bidResponse.mediaType as video for a video imp', () => {
+          const request = spec.buildRequests([videoBidRequest], { ...bidderRequestBase, bids: [videoBidRequest] });
+          const videoOrtbResponse = {
+            body: {
+              id: 'video_response',
+              seatbid: [{
+                bid: [{
+                  id: 'advertIdVideo',
+                  impid: 'bidIdVideo',
+                  price: 12,
+                  mtype: 2,
+                  nurl: 'urlVideo',
+                  adm: '<VAST version="3.0"><Ad></Ad></VAST>',
+                  adomain: ['ogury.com'],
+                  w: 640,
+                  h: 480
+                }]
+              }]
+            }
+          };
+
+          const result = spec.interpretResponse(videoOrtbResponse, request);
+          expect(result).to.have.lengthOf(1);
+          expect(result[0].mediaType).to.equal('video');
+          expect(result[0].vastXml).to.contain('<VAST');
+        });
+      });
+
+      describe('instream', () => {
+        let instreamBidRequest;
+
+        beforeEach(() => {
+          instreamBidRequest = utils.deepClone(videoBidRequest);
+          instreamBidRequest.mediaTypes.video.context = 'instream';
+        });
+
+        it('should validate an instream video bid with playerSize', () => {
+          expect(spec.isBidRequestValid(instreamBidRequest)).to.be.true;
+        });
+
+        it('should build imp.video from an instream bid', () => {
+          const request = spec.buildRequests([instreamBidRequest], { ...bidderRequestBase, bids: [instreamBidRequest] });
+          expect(request.data.imp[0].video).to.exist;
+          expect(request.data.imp[0].video.w).to.equal(640);
+          expect(request.data.imp[0].video.h).to.equal(480);
+          expect(request.data.imp[0].banner).to.be.an('undefined');
+        });
+
+        it('should return a video bid with vastXml from a VAST instream response', () => {
+          const request = spec.buildRequests([instreamBidRequest], { ...bidderRequestBase, bids: [instreamBidRequest] });
+          const instreamOrtbResponse = {
+            body: {
+              id: 'instream_response',
+              seatbid: [{
+                bid: [{
+                  id: 'advertIdInstream',
+                  impid: 'bidIdVideo',
+                  price: 15,
+                  mtype: 2,
+                  nurl: 'urlInstream',
+                  adm: '<VAST version="3.0"><Ad></Ad></VAST>',
+                  adomain: ['ogury.com'],
+                  w: 640,
+                  h: 480
+                }]
+              }]
+            }
+          };
+
+          const result = spec.interpretResponse(instreamOrtbResponse, request);
+          expect(result).to.have.lengthOf(1);
+          expect(result[0].mediaType).to.equal('video');
+          expect(result[0].vastXml).to.contain('<VAST');
+        });
+      });
+    }
   });
 });


### PR DESCRIPTION
## Type of change
  - [ ] Bugfix
  - [ ] Feature
  - [ ] New bidder adapter
  - [x] Updated bidder adapter
  - [ ] Code style update (formatting, local variables)
  - [ ] Refactoring (no functional changes, no api changes)
  - [ ] Build related changes
  - [ ] CI related changes

  - [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
  - [ ] Other
  
  ## Description of change

  Adds instream video support to the Ogury bid adapter. Banner behaviour is unchanged.

  - `supportedMediaTypes` now includes `VIDEO` alongside `BANNER`.
  - `isBidRequestValid` accepts a bid as long as it has either a banner size *or* a `mediaTypes.video.playerSize` — previously only banner sizes were considered valid.
  - ORTB converter no longer hard-codes `mediaType: 'banner'` in its context, so imps are built from the actual `mediaTypes` on the adUnit.
  - `getFloor` routes the floor query by media type:
    - **video-only** bids query the `video` floor,
    - **banner-only** and **mixed banner+video** bids keep the historical `banner` + `size: '*'` query, so no existing banner imp changes its floor lookup.
    - Banner detection uses `mediaTypes.banner` directly rather than `getAdUnitSizes`, because Prebid populates `bid.sizes` from `video.playerSize` on video-only adUnits and would otherwise misroute the floor
  query.
  - Adapter version bumped `2.0.6` → `2.1.0`.
  - `oguryBidAdapter.md` updated with an instream video test adUnit.
  - Test coverage added for video bid validation, request building, response parsing, and the new floor routing.

  Only `instream` is advertised; outstream is not part of this change.

  ## Other information
  
  Maintainer: web.inventory@ogury.co