### PR TITLE
Nexx360 Bid Adapter: default to non-gzipped requests and honor per-alias opt-in

### DIFF
--- a/modules/nexx360BidAdapter.ts
+++ b/modules/nexx360BidAdapter.ts
@@ -71,7 +71,7 @@ export const getNexx360LocalStorage = getLocalStorageFunctionGenerator<{ nexx360
   'nexx360Id'
 );
 
-export const getGzipSetting = (bidderCode: string = BIDDER_CODE): boolean => libGetGzipSetting(bidderCode, true);
+export const getGzipSetting = (bidderCode: string = BIDDER_CODE): boolean => libGetGzipSetting(bidderCode, false);
 
 const converter = ortbConverter({
   context: {

--- a/modules/nexx360BidAdapter.ts
+++ b/modules/nexx360BidAdapter.ts
@@ -138,7 +138,7 @@ const buildRequests = (
     url: REQUEST_URL,
     data,
     options: {
-      endpointCompression: getGzipSetting()
+      endpointCompression: getGzipSetting(bidderRequest.bidderCode)
     },
   }
   return adapterRequest;

--- a/test/spec/modules/nexx360BidAdapter_spec.js
+++ b/test/spec/modules/nexx360BidAdapter_spec.js
@@ -74,6 +74,13 @@ describe('Nexx360 bid adapter tests', () => {
       getParamStub.withArgs('nexx360_debug').returns('0');
       expect(getGzipSetting()).to.equal(false);
     });
+
+    it('reads the config of the passed alias bidder code', () => {
+      config.setBidderConfig({ bidders: ['revenuemaker'], config: { gzipEnabled: true } });
+      expect(getGzipSetting('revenuemaker')).to.equal(true);
+      // the nexx360 bucket is untouched, so it falls back to the default
+      expect(getGzipSetting('nexx360')).to.equal(false);
+    });
   });
 
   describe('isBidRequestValid()', () => {

--- a/test/spec/modules/nexx360BidAdapter_spec.js
+++ b/test/spec/modules/nexx360BidAdapter_spec.js
@@ -45,8 +45,8 @@ describe('Nexx360 bid adapter tests', () => {
       sandbox.restore();
     });
 
-    it('defaults to true when no config and no URL override', () => {
-      expect(getGzipSetting()).to.equal(true);
+    it('defaults to false when no config and no URL override', () => {
+      expect(getGzipSetting()).to.equal(false);
     });
 
     it('returns false when bidder config gzipEnabled is the string "false"', () => {
@@ -70,9 +70,9 @@ describe('Nexx360 bid adapter tests', () => {
       expect(getGzipSetting()).to.equal(false);
     });
 
-    it('returns true when URL has nexx360_debug with a value other than 1', () => {
+    it('returns false (the default) when URL has nexx360_debug with a value other than 1', () => {
       getParamStub.withArgs('nexx360_debug').returns('0');
-      expect(getGzipSetting()).to.equal(true);
+      expect(getGzipSetting()).to.equal(false);
     });
   });
 


### PR DESCRIPTION
Two related changes to gzip handling in the Nexx360 adapter:

1. **Flip the default of `getGzipSetting` from `true` to `false`** so the main `nexx360` bidder and all 16 aliases send uncompressed requests unless the publisher opts in via `setBidderConfig({ ..., config: { gzipEnabled: true } })`.

2. **Honor the per-alias opt-in.** `buildRequests` previously called `getGzipSetting()` with no argument, so the `gzipEnabled` lookup always read the `nexx360` config bucket. For alias auctions (e.g. `revenuemaker`), per-alias `setBidderConfig` was silently ignored — and with the new `false` default this meant an alias publisher who explicitly opted in still got uncompressed requests, defeating the advertised opt-in path. `buildRequests` now passes `bidderRequest.bidderCode` through to `getGzipSetting`, so the alias's own config is read.

## Type of change
- [x] Bugfix
- [x] Code style update (formatting, local variables)

## Description of change
- `modules/nexx360BidAdapter.ts`: `getGzipSetting` default `true` → `false`; `buildRequests` passes `bidderRequest.bidderCode` to `getGzipSetting`.
- `test/spec/modules/nexx360BidAdapter_spec.js`: updated default-behavior tests; added a test asserting the alias bidder code's config is read.

`gulp lint` and the adapter spec (`gulp test --file test/spec/modules/nexx360BidAdapter_spec.js`, 33 tests) pass.