### PR TITLE
Microsoft Adapter: Removed alias of 152Media from appnexus and add it to microsoft adapter

### DIFF
--- a/libraries/appnexusUtils/anUtils.js
+++ b/libraries/appnexusUtils/anUtils.js
@@ -17,7 +17,6 @@ export const appnexusAliases = [
   { code: 'newdream', gvlid: 32 },
   { code: 'matomy', gvlid: 32 },
   { code: 'featureforward', gvlid: 32 },
-  { code: 'oftmedia', gvlid: 32 },
   { code: 'adasta', gvlid: 32 },
   { code: 'beintoo', gvlid: 618 },
   { code: 'projectagora', gvlid: 1032 },

--- a/modules/msftBidAdapter.js
+++ b/modules/msftBidAdapter.js
@@ -315,7 +315,7 @@ const converter = ortbConverter({
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
-  aliases: [], // TODO fill in after full transition or as seperately requested
+  aliases: [{ code: 'oftmedia', gvlid: 32 }], // TODO fill in after full transition or as seperately requested
   supportedMediaTypes: [BANNER, NATIVE, VIDEO],
 
   isBidRequestValid: (bid) => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  
- [ ] Updated bidder adapter  
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
As part of the transition to the new Microsoft adapter, we kindly request that our original alias from the AppNexus adapter be ported to the new Microsoft adapter to ensure continuity and consistency in bidder configuration and reporting. 

