### PR TITLE
adnow and distroscale bid adapters: Remove `gvlid` property

### DIFF
--- a/modules/adnowBidAdapter.js
+++ b/modules/adnowBidAdapter.js
@@ -5,7 +5,6 @@ import { deepAccess, parseQueryStringParameters, parseSizesInput } from '../src/
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 
 const BIDDER_CODE = 'adnow';
-const GVLID = 1210;
 const ENDPOINT = 'https://n.nnowa.com/a';
 
 /**
@@ -29,7 +28,6 @@ const ENDPOINT = 'https://n.nnowa.com/a';
 /** @type {BidderSpec} */
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: GVLID,
   supportedMediaTypes: [NATIVE, BANNER],
 
   /**

--- a/modules/distroscaleBidAdapter.js
+++ b/modules/distroscaleBidAdapter.js
@@ -9,7 +9,6 @@ const LOG_WARN_PREFIX = 'DistroScale: ';
 const ENDPOINT = 'https://hb.jsrdn.com/hb?from=pbjs';
 const DEFAULT_CURRENCY = 'USD';
 const AUCTION_TYPE = 1;
-const GVLID = 754;
 const UNDEF = undefined;
 
 const SUPPORTED_MEDIATYPES = [BANNER];
@@ -116,7 +115,6 @@ function _createImpressionObject(bid) {
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: GVLID,
   supportedMediaTypes: SUPPORTED_MEDIATYPES,
   aliases: [SHORT_CODE],
 


### PR DESCRIPTION
removed from gvl this week