### PR TITLE
Validation FPD Module: add device enum validation

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,7 @@ function sourcePattern(name) {
 const allowedImports = {
   modules: [
     'crypto-js',
+    'iab-adcom',
     'live-connect' // Maintained by LiveIntent : https://github.com/liveintent-berlin/live-connect/
   ],
   src: [

--- a/libraries/ortb2.5StrictTranslator/dsl.js
+++ b/libraries/ortb2.5StrictTranslator/dsl.js
@@ -1,4 +1,4 @@
-export const ERR_TYPE = 0; // field has wrong type (only objects, enums, and arrays of objects or enums are checked)
+export const ERR_TYPE = 0; // field has wrong type (only objects, integer enums, and arrays of objects or integer enums are checked)
 export const ERR_UNKNOWN_FIELD = 1; // field is not defined in ORTB 2.5 spec
 export const ERR_ENUM = 2; // field is an enum and its value is not one of those listed in the ORTB 2.5 spec
 
@@ -44,8 +44,8 @@ export function Arr(def) {
 export function IntEnum(min, max) {
   return (path, parent, field, value, onError) => {
     const errno = (() => {
-      if (typeof value !== 'number') return ERR_TYPE;
-      if (isNaN(value) || value > max || value < min) return ERR_ENUM;
+      if (!Number.isInteger(value)) return ERR_TYPE;
+      if (value > max || value < min) return ERR_ENUM;
     })();
     if (errno != null) {
       onError(errno, path, parent, field, value);

--- a/libraries/ortb2.5StrictTranslator/spec.js
+++ b/libraries/ortb2.5StrictTranslator/spec.js
@@ -25,7 +25,7 @@ const Geo = Obj(['lat', 'lon', 'accuracy', 'lastfix', 'country', 'region', 'regi
   ipservice: IntEnum(1, 4)
 });
 const Device = Obj(['ua', 'dnt', 'lmt', 'ip', 'ipv6', 'make', 'model', 'os', 'osv', 'hwv', 'h', 'w', 'ppi', 'pxratio', 'js', 'geofetch', 'flashver', 'language', 'carrier', 'mccmnc', 'ifa', 'didsha1', 'didmd5', 'dpidsha1', 'dpidmd5', 'macsha1', 'macmd5'], {
-  geo: Geo, devicetype: IntEnum(1, 7), connectiontype: IntEnum(0, 6)
+  geo: Geo, devicetype: IntEnum(1, 7), connectiontype: IntEnum(0, 7)
 });
 const User = ID[extend](['buyeruid', 'yob', 'gender', 'keywords', 'customdata'], {
   geo: Geo, data: Arr(Data),

--- a/modules/validationFpdModule/config.js
+++ b/modules/validationFpdModule/config.js
@@ -1,3 +1,6 @@
+// eslint-disable-next-line prebid/validate-imports
+import { ConnectionType, DeviceType, LocationType } from 'iab-adcom/enum';
+
 /**
  * Data type map
  */
@@ -5,6 +8,7 @@ const TYPES = {
   string: 'string',
   object: 'object',
   number: 'number',
+  integer: 'integer',
 };
 
 /**
@@ -12,6 +16,7 @@ const TYPES = {
  * Accepted fields:
  * -- invalid - {Boolean} if true, field is not valid
  * -- type - {String} valid data type of field
+ * -- enum - {Object} valid values enum for the field
  * -- isArray - {Boolean} if true, field must be an array
  * -- childType - {String} used in conjuction with isArray: true, defines valid type of array indices
  * -- children - {Object} defines child properties needed to be validated (used only if type: object)
@@ -31,7 +36,18 @@ export const ORTB_MAP = {
     type: TYPES.object,
     children: {
       w: { type: TYPES.number },
-      h: { type: TYPES.number }
+      h: { type: TYPES.number },
+      devicetype: { type: TYPES.integer, enum: DeviceType },
+      connectiontype: { type: TYPES.integer, enum: ConnectionType },
+      geo: {
+        type: TYPES.object,
+        isArray: false,
+        children: {
+          lat: { type: TYPES.number },
+          lon: { type: TYPES.number },
+          type: { type: TYPES.integer, enum: LocationType }
+        }
+      }
     }
   },
   site: {

--- a/modules/validationFpdModule/config.js
+++ b/modules/validationFpdModule/config.js
@@ -10,6 +10,11 @@ const TYPES = {
   integer: 'integer',
 };
 
+const CONNECTION_TYPES = {
+  UNKNOWN: 0,
+  ...ConnectionType
+};
+
 /**
  * Template to define what ortb2 attributes should be validated
  * Accepted fields:
@@ -37,7 +42,7 @@ export const ORTB_MAP = {
       w: { type: TYPES.number },
       h: { type: TYPES.number },
       devicetype: { type: TYPES.integer, enum: DeviceType },
-      connectiontype: { type: TYPES.integer, enum: ConnectionType },
+      connectiontype: { type: TYPES.integer, enum: CONNECTION_TYPES },
       geo: {
         type: TYPES.object,
         isArray: false,

--- a/modules/validationFpdModule/config.js
+++ b/modules/validationFpdModule/config.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line prebid/validate-imports
 import { ConnectionType, DeviceType, LocationType } from 'iab-adcom/enum';
 
 /**

--- a/modules/validationFpdModule/index.ts
+++ b/modules/validationFpdModule/index.ts
@@ -65,6 +65,9 @@ function typeValidation(data, mapping) {
     case 'number':
       if (typeof data === 'number' && isFinite(data)) check = true;
       break;
+    case 'integer':
+      if (Number.isInteger(data)) check = true;
+      break;
     case 'object':
       if (typeof data === 'object') {
         if ((Array.isArray(data) && mapping.isArray) || (!Array.isArray(data) && !mapping.isArray)) check = true;
@@ -156,13 +159,21 @@ export function validateFpd(fpd, path = '', parent = '') {
     return false;
   }).filter(key => {
     const mapping = deepAccess(ORTB_MAP, path + key);
-    // let typeBool = false;
-    const typeBool = (mapping) ? typeValidation(fpd[key], { type: mapping.type, isArray: mapping.isArray }) : true;
+    if (!mapping) return key;
 
-    if (typeBool || !mapping) return key;
+    const typeBool = typeValidation(fpd[key], { type: mapping.type, isArray: mapping.isArray });
 
-    logWarn(`Filtered ${parent}${key} property in ortb2 data: expected type ${(mapping.isArray) ? 'array' : mapping.type}`);
-    return false;
+    if (!typeBool) {
+      logWarn(`Filtered ${parent}${key} property in ortb2 data: expected type ${(mapping.isArray) ? 'array' : mapping.type}`);
+      return false;
+    }
+
+    if (mapping.enum && !Object.values(mapping.enum).includes(fpd[key])) {
+      logWarn(`Filtered ${parent}${key} property in ortb2 data: expected value from ${Object.values(mapping.enum).join(', ')}`);
+      return false;
+    }
+
+    return key;
   }).reduce((result, key) => {
     const mapping = deepAccess(ORTB_MAP, path + key);
     let modified = {};

--- a/test/spec/modules/validationFpdModule_spec.js
+++ b/test/spec/modules/validationFpdModule_spec.js
@@ -327,7 +327,7 @@ describe('the first party data validation module', function () {
         h: 911,
         w: 1733,
         devicetype: 2,
-        connectiontype: 2,
+        connectiontype: 0,
         geo: {
           lat: 12.34,
           lon: 56.78,
@@ -337,6 +337,14 @@ describe('the first party data validation module', function () {
 
       const validated = validateFpd(duplicate);
       expect(validated.device).to.deep.equal(duplicate.device);
+    });
+
+    it('keeps valid 5g connection type in device fields', function () {
+      const duplicate = utils.deepClone(ortb2);
+      duplicate.device.connectiontype = 7;
+
+      const validated = validateFpd(duplicate);
+      expect(validated.device.connectiontype).to.equal(7);
     });
 
     it('filters cur for invalid data type', function () {

--- a/test/spec/modules/validationFpdModule_spec.js
+++ b/test/spec/modules/validationFpdModule_spec.js
@@ -271,6 +271,74 @@ describe('the first party data validation module', function () {
       expect(validated).to.deep.equal(expected);
     });
 
+    it('filters device fields for invalid iab enum values and integer data types', function () {
+      const duplicate = utils.deepClone(ortb2);
+      duplicate.device = {
+        h: 911,
+        w: 1733,
+        devicetype: 2.5,
+        connectiontype: 99,
+        geo: {
+          lat: 12.34,
+          lon: 56.78,
+          type: '1'
+        }
+      };
+
+      const expected = {
+        device: {
+          h: 911,
+          w: 1733,
+          geo: {
+            lat: 12.34,
+            lon: 56.78
+          }
+        },
+        user: {
+          data: [{
+            segment: [{
+              id: 'foo'
+            }],
+            name: 'bar'
+          }]
+        },
+        site: {
+          content: {
+            data: [{
+              segment: [{
+                id: 'test'
+              }],
+              name: 'content',
+              ext: {
+                foo: 'bar'
+              }
+            }]
+          }
+        }
+      };
+
+      const validated = validateFpd(duplicate);
+      expect(validated).to.deep.equal(expected);
+    });
+
+    it('keeps valid iab enum values in device fields', function () {
+      const duplicate = utils.deepClone(ortb2);
+      duplicate.device = {
+        h: 911,
+        w: 1733,
+        devicetype: 2,
+        connectiontype: 2,
+        geo: {
+          lat: 12.34,
+          lon: 56.78,
+          type: 1
+        }
+      };
+
+      const validated = validateFpd(duplicate);
+      expect(validated.device).to.deep.equal(duplicate.device);
+    });
+
     it('filters cur for invalid data type', function () {
       let validated;
       const duplicate = utils.deepClone(ortb2);

--- a/test/spec/ortb2.5StrictTranslator/dsl_spec.js
+++ b/test/spec/ortb2.5StrictTranslator/dsl_spec.js
@@ -54,7 +54,7 @@ describe('DSL', () => {
           const obj = { inner: { enum: val } };
           scan(obj);
           sinon.assert.calledOnce(onError);
-          sinon.assert.calledWith(onError, ERR_ENUM, 'inner.enum', obj.inner, 'enum', val);
+          sinon.assert.calledWith(onError, ERR_TYPE, 'inner.enum', obj.inner, 'enum', val);
         });
       });
       it('accepts arrays of enums that are in range', () => {
@@ -73,6 +73,12 @@ describe('DSL', () => {
         sinon.assert.calledOnce(onError);
         sinon.assert.calledWith(onError, ERR_TYPE, 'inner.enum', obj.inner, 'enum', 'err');
       })
+      it('detects enum values that are not integers', () => {
+        const obj = { inner: { enum: 12.5 } };
+        scan(obj);
+        sinon.assert.calledOnce(onError);
+        sinon.assert.calledWith(onError, ERR_TYPE, 'inner.enum', obj.inner, 'enum', 12.5);
+      })
       it('detects arrays of enums that are out of range', () => {
         const obj = { inner: { enumArray: [12, 13, -1, 14] } };
         scan(obj);
@@ -90,6 +96,12 @@ describe('DSL', () => {
         scan(obj);
         sinon.assert.calledOnce(onError);
         sinon.assert.calledWith(onError, ERR_TYPE, 'inner.enumArray.1', obj.inner.enumArray, 1, 'err');
+      })
+      it('detects items within enum arrays that are not integers', () => {
+        const obj = { inner: { enumArray: [12, 13.5, 14] } };
+        scan(obj);
+        sinon.assert.calledOnce(onError);
+        sinon.assert.calledWith(onError, ERR_TYPE, 'inner.enumArray.1', obj.inner.enumArray, 1, 13.5);
       })
     });
     describe('into arrays', () => {

--- a/test/spec/ortb2.5StrictTranslator/translator_spec.js
+++ b/test/spec/ortb2.5StrictTranslator/translator_spec.js
@@ -14,4 +14,8 @@ describe('toOrtb25Strict', () => {
   it('removes fields out of spec', () => {
     expect(toOrtb25Strict({ unk: 'field', imp: ['err', {}] }, translator)).to.eql({ imp: [{}] });
   });
+
+  it('removes non-integer enum fields', () => {
+    expect(toOrtb25Strict({ device: { devicetype: 1.5, connectiontype: 2, geo: { type: 2.5 } } }, translator)).to.eql({ device: { connectiontype: 2, geo: {} } });
+  });
 });

--- a/test/spec/ortb2.5StrictTranslator/translator_spec.js
+++ b/test/spec/ortb2.5StrictTranslator/translator_spec.js
@@ -18,4 +18,13 @@ describe('toOrtb25Strict', () => {
   it('removes non-integer enum fields', () => {
     expect(toOrtb25Strict({ device: { devicetype: 1.5, connectiontype: 2, geo: { type: 2.5 } } }, translator)).to.eql({ device: { connectiontype: 2, geo: {} } });
   });
+
+  it('keeps connectiontype unknown and 5g values', () => {
+    expect(toOrtb25Strict({ device: { connectiontype: 0 } }, translator)).to.eql({ device: { connectiontype: 0 } });
+    expect(toOrtb25Strict({ device: { connectiontype: 7 } }, translator)).to.eql({ device: { connectiontype: 7 } });
+  });
+
+  it('removes devicetype values outside ORTB 2.5 range', () => {
+    expect(toOrtb25Strict({ device: { devicetype: 8 } }, translator)).to.eql({ device: {} });
+  });
 });


### PR DESCRIPTION
### Motivation
- Strengthen FPD validation for common OpenRTB device fields by ensuring `devicetype` is an integer and that device-related fields use known IAB enums.
- Reduce downstream errors from incorrectly-typed or out-of-range device values sent in ortb2 first-party data.
 see #14952 