### PR TITLE
Core: validate ORTB device fields

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,7 +42,9 @@ const allowedImports = {
   // even innocuous imports can become problematic if the source changes,
   // and it's too easy to forget this is a problem for debugging-standalone.
   'modules/debugging': [false],
-  libraries: [],
+  libraries: [
+    'iab-adcom'
+  ],
   creative: [],
 }
 

--- a/libraries/ortb2.5StrictTranslator/dsl.js
+++ b/libraries/ortb2.5StrictTranslator/dsl.js
@@ -28,6 +28,43 @@ export function Obj(primitiveFields, spec = {}) {
   return scan;
 }
 
+export function Str() {
+  return (path, parent, field, value, onError) => {
+    if (typeof value !== 'string') {
+      onError(ERR_TYPE, path, parent, field, value);
+    }
+  };
+}
+
+export function Num() {
+  return (path, parent, field, value, onError) => {
+    if (typeof value !== 'number' || !isFinite(value)) {
+      onError(ERR_TYPE, path, parent, field, value);
+    }
+  };
+}
+
+export function Int() {
+  return (path, parent, field, value, onError) => {
+    if (!Number.isInteger(value)) {
+      onError(ERR_TYPE, path, parent, field, value);
+    }
+  };
+}
+
+export function IntEnumValues(values) {
+  const allowed = new Set(Object.values(values));
+  return (path, parent, field, value, onError) => {
+    const errno = (() => {
+      if (!Number.isInteger(value)) return ERR_TYPE;
+      if (!allowed.has(value)) return ERR_ENUM;
+    })();
+    if (errno != null) {
+      onError(errno, path, parent, field, value);
+    }
+  };
+}
+
 export const ID = Obj(['id']);
 export const Named = ID[extend](['name']);
 

--- a/libraries/ortb2.5StrictTranslator/spec.js
+++ b/libraries/ortb2.5StrictTranslator/spec.js
@@ -1,6 +1,8 @@
-import { Arr, extend, ID, IntEnum, Named, Obj } from './dsl.js';
+import { ConnectionType, DeviceType, IPLocationService, LocationType } from 'iab-adcom';
+import { Arr, extend, ID, IntEnum, IntEnumValues, Named, Num, Obj, Str } from './dsl.js';
 
 const CatDomain = Named[extend](['cat', 'domain']);
+const Flag = IntEnum(0, 1);
 const Segment = Named[extend](['value']);
 const Data = Named[extend]([], {
   segment: Arr(Segment)
@@ -20,12 +22,52 @@ const Client = CatDomain[extend](['sectioncat', 'pagecat', 'privacypolicy', 'key
 const Site = Client[extend](['page', 'ref', 'search', 'mobile']);
 const App = Client[extend](['bundle', 'storeurl', 'ver', 'paid']);
 
-const Geo = Obj(['lat', 'lon', 'accuracy', 'lastfix', 'country', 'region', 'regionfips104', 'metro', 'city', 'zip', 'utcoffset'], {
-  type: IntEnum(1, 3),
-  ipservice: IntEnum(1, 4)
+const Geo = Obj([], {
+  lat: Num(),
+  lon: Num(),
+  type: IntEnumValues(LocationType),
+  accuracy: Num(),
+  lastfix: Num(),
+  ipservice: IntEnumValues(IPLocationService),
+  country: Str(),
+  region: Str(),
+  regionfips104: Str(),
+  metro: Str(),
+  city: Str(),
+  zip: Str(),
+  utcoffset: Num()
 });
-const Device = Obj(['ua', 'dnt', 'lmt', 'ip', 'ipv6', 'make', 'model', 'os', 'osv', 'hwv', 'h', 'w', 'ppi', 'pxratio', 'js', 'geofetch', 'flashver', 'language', 'carrier', 'mccmnc', 'ifa', 'didsha1', 'didmd5', 'dpidsha1', 'dpidmd5', 'macsha1', 'macmd5'], {
-  geo: Geo, devicetype: IntEnum(1, 7), connectiontype: IntEnum(0, 6)
+const Device = Obj([], {
+  ua: Str(),
+  geo: Geo,
+  dnt: Flag,
+  lmt: Flag,
+  ip: Str(),
+  ipv6: Str(),
+  devicetype: IntEnumValues(DeviceType),
+  make: Str(),
+  model: Str(),
+  os: Str(),
+  osv: Str(),
+  hwv: Str(),
+  h: Num(),
+  w: Num(),
+  ppi: Num(),
+  pxratio: Num(),
+  js: Flag,
+  geofetch: Flag,
+  flashver: Str(),
+  language: Str(),
+  carrier: Str(),
+  mccmnc: Str(),
+  connectiontype: IntEnumValues(ConnectionType),
+  ifa: Str(),
+  didsha1: Str(),
+  didmd5: Str(),
+  dpidsha1: Str(),
+  dpidmd5: Str(),
+  macsha1: Str(),
+  macmd5: Str()
 });
 const User = ID[extend](['buyeruid', 'yob', 'gender', 'keywords', 'customdata'], {
   geo: Geo, data: Arr(Data),

--- a/modules/validationFpdModule/config.js
+++ b/modules/validationFpdModule/config.js
@@ -1,4 +1,4 @@
-import { ConnectionType, DeviceType, LocationType } from 'iab-adcom/enum';
+import { ConnectionType, DeviceType, IPLocationService, LocationType } from 'iab-adcom/enum';
 
 /**
  * Data type map
@@ -9,6 +9,11 @@ const TYPES = {
   number: 'number',
   integer: 'integer',
 };
+
+const SIGNAL = Object.freeze({
+  NO: 0,
+  YES: 1
+});
 
 /**
  * Template to define what ortb2 attributes should be validated
@@ -34,17 +39,54 @@ export const ORTB_MAP = {
   device: {
     type: TYPES.object,
     children: {
-      w: { type: TYPES.number },
-      h: { type: TYPES.number },
+      ua: { type: TYPES.string },
+      dnt: { type: TYPES.integer, enum: SIGNAL },
+      lmt: { type: TYPES.integer, enum: SIGNAL },
+      ip: { type: TYPES.string },
+      ipv6: { type: TYPES.string },
       devicetype: { type: TYPES.integer, enum: DeviceType },
+      make: { type: TYPES.string },
+      model: { type: TYPES.string },
+      os: { type: TYPES.string },
+      osv: { type: TYPES.string },
+      hwv: { type: TYPES.string },
+      h: { type: TYPES.number },
+      w: { type: TYPES.number },
+      ppi: { type: TYPES.number },
+      pxratio: { type: TYPES.number },
+      js: { type: TYPES.integer, enum: SIGNAL },
+      geofetch: { type: TYPES.integer, enum: SIGNAL },
+      flashver: { type: TYPES.string },
+      language: { type: TYPES.string },
+      carrier: { type: TYPES.string },
+      mccmnc: { type: TYPES.string },
       connectiontype: { type: TYPES.integer, enum: ConnectionType },
+      ifa: { type: TYPES.string },
+      didsha1: { type: TYPES.string },
+      didmd5: { type: TYPES.string },
+      dpidsha1: { type: TYPES.string },
+      dpidmd5: { type: TYPES.string },
+      macsha1: { type: TYPES.string },
+      macmd5: { type: TYPES.string },
+      ext: { type: TYPES.object },
       geo: {
         type: TYPES.object,
         isArray: false,
         children: {
           lat: { type: TYPES.number },
           lon: { type: TYPES.number },
-          type: { type: TYPES.integer, enum: LocationType }
+          type: { type: TYPES.integer, enum: LocationType },
+          accuracy: { type: TYPES.number },
+          lastfix: { type: TYPES.number },
+          ipservice: { type: TYPES.integer, enum: IPLocationService },
+          country: { type: TYPES.string },
+          region: { type: TYPES.string },
+          regionfips104: { type: TYPES.string },
+          metro: { type: TYPES.string },
+          city: { type: TYPES.string },
+          zip: { type: TYPES.string },
+          utcoffset: { type: TYPES.number },
+          ext: { type: TYPES.object }
         }
       }
     }

--- a/test/spec/modules/validationFpdModule_spec.js
+++ b/test/spec/modules/validationFpdModule_spec.js
@@ -339,6 +339,89 @@ describe('the first party data validation module', function () {
       expect(validated.device).to.deep.equal(duplicate.device);
     });
 
+    it('filters expanded device fields for invalid OpenRTB types', function () {
+      const duplicate = utils.deepClone(ortb2);
+      duplicate.device = {
+        ua: 'Mozilla/5.0',
+        dnt: 1,
+        lmt: 2,
+        ip: 123,
+        ipv6: '2001:db8::1',
+        make: 'Apple',
+        model: ['iPhone'],
+        os: 'iOS',
+        osv: 17,
+        hwv: '15,2',
+        h: 911,
+        w: 1733,
+        ppi: '460',
+        pxratio: 3,
+        js: 1,
+        geofetch: 0,
+        flashver: null,
+        language: 'en',
+        carrier: 'Example Carrier',
+        mccmnc: 310260,
+        ifa: 'ifa',
+        didsha1: {},
+        didmd5: 'did-md5',
+        dpidsha1: 'dpid-sha1',
+        dpidmd5: 10,
+        macsha1: 'mac-sha1',
+        macmd5: false,
+        ext: { foo: 'bar' },
+        geo: {
+          lat: 12.34,
+          lon: 56.78,
+          accuracy: 10,
+          lastfix: 'old',
+          ipservice: 2,
+          country: 'USA',
+          region: 6,
+          regionfips104: 'US06',
+          metro: '807',
+          city: 'LAX',
+          zip: 90001,
+          utcoffset: -480,
+          ext: { source: 'test' }
+        }
+      };
+
+      const validated = validateFpd(duplicate);
+      expect(validated.device).to.deep.equal({
+        ua: 'Mozilla/5.0',
+        dnt: 1,
+        ipv6: '2001:db8::1',
+        make: 'Apple',
+        os: 'iOS',
+        hwv: '15,2',
+        h: 911,
+        w: 1733,
+        pxratio: 3,
+        js: 1,
+        geofetch: 0,
+        language: 'en',
+        carrier: 'Example Carrier',
+        ifa: 'ifa',
+        didmd5: 'did-md5',
+        dpidsha1: 'dpid-sha1',
+        macsha1: 'mac-sha1',
+        ext: { foo: 'bar' },
+        geo: {
+          lat: 12.34,
+          lon: 56.78,
+          accuracy: 10,
+          ipservice: 2,
+          country: 'USA',
+          regionfips104: 'US06',
+          metro: '807',
+          city: 'LAX',
+          utcoffset: -480,
+          ext: { source: 'test' }
+        }
+      });
+    });
+
     it('filters cur for invalid data type', function () {
       let validated;
       const duplicate = utils.deepClone(ortb2);

--- a/test/spec/ortb2.5StrictTranslator/translator_spec.js
+++ b/test/spec/ortb2.5StrictTranslator/translator_spec.js
@@ -18,4 +18,80 @@ describe('toOrtb25Strict', () => {
   it('removes non-integer enum fields', () => {
     expect(toOrtb25Strict({ device: { devicetype: 1.5, connectiontype: 2, geo: { type: 2.5 } } }, translator)).to.eql({ device: { connectiontype: 2, geo: {} } });
   });
+
+  it('removes device and geo fields with invalid OpenRTB primitive types', () => {
+    expect(toOrtb25Strict({
+      device: {
+        ua: 'Mozilla/5.0',
+        dnt: 1,
+        lmt: 2,
+        ip: 123,
+        ipv6: '2001:db8::1',
+        make: 'Apple',
+        model: ['iPhone'],
+        os: 'iOS',
+        osv: 17,
+        hwv: '15,2',
+        h: 911,
+        w: '1733',
+        ppi: 460,
+        pxratio: 3,
+        js: 0,
+        geofetch: true,
+        language: 'en',
+        carrier: 'Example Carrier',
+        mccmnc: 310260,
+        ifa: 'ifa',
+        didsha1: {},
+        didmd5: 'did-md5',
+        dpidsha1: 'dpid-sha1',
+        dpidmd5: 10,
+        macsha1: 'mac-sha1',
+        macmd5: false,
+        geo: {
+          lat: 12.34,
+          lon: '56.78',
+          accuracy: 10,
+          lastfix: 'old',
+          ipservice: 2,
+          country: 'USA',
+          region: 6,
+          regionfips104: 'US06',
+          metro: '807',
+          city: 'LAX',
+          zip: 90001,
+          utcoffset: -480
+        }
+      }
+    }, translator)).to.eql({
+      device: {
+        ua: 'Mozilla/5.0',
+        dnt: 1,
+        ipv6: '2001:db8::1',
+        make: 'Apple',
+        os: 'iOS',
+        hwv: '15,2',
+        h: 911,
+        ppi: 460,
+        pxratio: 3,
+        js: 0,
+        language: 'en',
+        carrier: 'Example Carrier',
+        ifa: 'ifa',
+        didmd5: 'did-md5',
+        dpidsha1: 'dpid-sha1',
+        macsha1: 'mac-sha1',
+        geo: {
+          lat: 12.34,
+          accuracy: 10,
+          ipservice: 2,
+          country: 'USA',
+          regionfips104: 'US06',
+          metro: '807',
+          city: 'LAX',
+          utcoffset: -480
+        }
+      }
+    });
+  });
 });


### PR DESCRIPTION
### Motivation

- Strengthen runtime validation for `device` and nested `device.geo` fields so first-party data and ORTB translations drop invalid primitives and respect IAB enum sets. 
- Reuse existing `iab-adcom` enum definitions where available to avoid ad-hoc numeric ranges and to keep validation aligned with IAB/AdCOM types.

### Description

- Expanded the `ORTB_MAP` in `modules/validationFpdModule/config.js` to validate many more `device` scalar properties (e.g. `ua`, `dnt`, `lmt`, `ip`, `ipv6`, `make`, `model`, `os`, `osv`, `hwv`, screen metrics, signal flags, `ifa`, hashed IDs, `ext`) and to validate nested `device.geo` fields (including `accuracy`, `lastfix`, `ipservice`, `country`, `region*`, `metro`, `city`, `zip`, `utcoffset`).
- Added a `SIGNAL` constant for boolean-like signal flags and imported `IPLocationService` alongside `DeviceType`, `ConnectionType`, and `LocationType` from `iab-adcom/enum` for enum-based checks in the validation map.
- Added scalar validators and enum-from-values support to the strict ORTB translator DSL in `libraries/ortb2.5StrictTranslator/dsl.js` by introducing `Str()`, `Num()`, `Int()`, and `IntEnumValues()` to allow runtime type checks and to accept enum constants from `iab-adcom`.
- Updated the strict translator spec in `libraries/ortb2.5StrictTranslator/spec.js` to use the new scalar validators and `IntEnumValues(...)` with IAB AdCOM enums for `Device` and `Geo` validation.
- Allowed importing `iab-adcom` in library lint rules by adding it to `libraries` in `eslint.config.js` so the translator spec can reference the dependency safely.
- Added unit tests to cover the expanded validation behavior in `test/spec/modules/validationFpdModule_spec.js` and the strict ORTB translator filtering in `test/spec/ortb2.5StrictTranslator/translator_spec.js`.

### Testing

- Ran lint for the changed files with `npx eslint --cache --cache-strategy content modules/validationFpdModule/config.js libraries/ortb2.5StrictTranslator/dsl.js libraries/ortb2.5StrictTranslator/spec.js test/spec/modules/validationFpdModule_spec.js test/spec/ortb2.5StrictTranslator/translator_spec.js` and it passed.
- Ran the module unit tests with `npx gulp test --nolint --file test/spec/modules/validationFpdModule_spec.js` which completed successfully (16 tests passed for that spec).
- Ran the strict translator unit tests with `npx gulp test --nolint --file test/spec/ortb2.5StrictTranslator/translator_spec.js` which completed successfully (4 tests passed for that spec).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a18cc064648832b91a35d76c3803f9b)