### PR TITLE
Core: add site IAB validation coverage

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -42,7 +42,9 @@ const allowedImports = {
   // even innocuous imports can become problematic if the source changes,
   // and it's too easy to forget this is a problem for debugging-standalone.
   'modules/debugging': [false],
-  libraries: [],
+  libraries: [
+    'iab-adcom'
+  ],
   creative: [],
 }
 

--- a/libraries/ortb2.5StrictTranslator/dsl.js
+++ b/libraries/ortb2.5StrictTranslator/dsl.js
@@ -42,10 +42,15 @@ export function Arr(def) {
 }
 
 export function IntEnum(min, max) {
+  return EnumValues(Array.from({ length: max - min + 1 }, (v, i) => min + i));
+}
+
+export function EnumValues(values) {
+  const validValues = new Set(Array.isArray(values) ? values : Object.values(values));
   return (path, parent, field, value, onError) => {
     const errno = (() => {
       if (!Number.isInteger(value)) return ERR_TYPE;
-      if (value > max || value < min) return ERR_ENUM;
+      if (!validValues.has(value)) return ERR_ENUM;
     })();
     if (errno != null) {
       onError(errno, path, parent, field, value);

--- a/libraries/ortb2.5StrictTranslator/spec.js
+++ b/libraries/ortb2.5StrictTranslator/spec.js
@@ -1,4 +1,5 @@
-import { Arr, extend, ID, IntEnum, Named, Obj } from './dsl.js';
+import { ContentContext, MediaRating, ProductionQuality } from 'iab-adcom/enum';
+import { Arr, EnumValues, extend, ID, IntEnum, Named, Obj } from './dsl.js';
 
 const CatDomain = Named[extend](['cat', 'domain']);
 const Segment = Named[extend](['value']);
@@ -8,10 +9,10 @@ const Data = Named[extend]([], {
 const Content = ID[extend](['episode', 'title', 'series', 'season', 'artist', 'genre', 'album', 'isrc', 'url', 'cat', 'contentrating', 'userrating', 'keywords', 'livestream', 'sourcerelationship', 'len', 'language', 'embeddable'], {
   producer: CatDomain,
   data: Arr(Data),
-  prodq: IntEnum(0, 3),
-  videoquality: IntEnum(0, 3),
-  context: IntEnum(1, 7),
-  qagmediarating: IntEnum(1, 3),
+  prodq: EnumValues(ProductionQuality),
+  videoquality: EnumValues(ProductionQuality),
+  context: EnumValues(ContentContext),
+  qagmediarating: EnumValues(MediaRating),
 });
 
 const Client = CatDomain[extend](['sectioncat', 'pagecat', 'privacypolicy', 'keywords'], {

--- a/modules/validationFpdModule/config.js
+++ b/modules/validationFpdModule/config.js
@@ -1,4 +1,4 @@
-import { ConnectionType, DeviceType, LocationType } from 'iab-adcom/enum';
+import { CategoryTaxonomy, ConnectionType, ContentContext, DeviceType, LocationType, MediaRating, ProductionQuality } from 'iab-adcom/enum';
 
 /**
  * Data type map
@@ -52,12 +52,26 @@ export const ORTB_MAP = {
   site: {
     type: TYPES.object,
     children: {
+      id: { type: TYPES.string },
       name: { type: TYPES.string },
       domain: { type: TYPES.string },
+      cattax: { type: TYPES.integer, enum: CategoryTaxonomy },
       page: { type: TYPES.string },
       ref: { type: TYPES.string },
       keywords: { type: TYPES.string },
+      kwarray: {
+        type: TYPES.object,
+        isArray: true,
+        childType: TYPES.string
+      },
       search: { type: TYPES.string },
+      mobile: { type: TYPES.integer, enum: { NO: 0, YES: 1 } },
+      privacypolicy: { type: TYPES.integer, enum: { NO: 0, YES: 1 } },
+      inventorypartnerdomain: { type: TYPES.string },
+      ext: {
+        type: TYPES.object,
+        isArray: false
+      },
       cat: {
         type: TYPES.object,
         isArray: true,
@@ -77,24 +91,127 @@ export const ORTB_MAP = {
         type: TYPES.object,
         isArray: false,
         children: {
+          id: { type: TYPES.string },
+          episode: { type: TYPES.integer },
+          title: { type: TYPES.string },
+          series: { type: TYPES.string },
+          season: { type: TYPES.string },
+          artist: { type: TYPES.string },
+          genre: { type: TYPES.string },
+          album: { type: TYPES.string },
+          isrc: { type: TYPES.string },
+          url: { type: TYPES.string },
+          cattax: { type: TYPES.integer, enum: CategoryTaxonomy },
+          cat: {
+            type: TYPES.object,
+            isArray: true,
+            childType: TYPES.string
+          },
+          prodq: { type: TYPES.integer, enum: ProductionQuality },
+          context: { type: TYPES.integer, enum: ContentContext },
+          contentrating: { type: TYPES.string },
+          userrating: { type: TYPES.string },
+          qagmediarating: { type: TYPES.integer, enum: MediaRating },
+          keywords: { type: TYPES.string },
+          kwarray: {
+            type: TYPES.object,
+            isArray: true,
+            childType: TYPES.string
+          },
+          livestream: { type: TYPES.integer, enum: { NO: 0, YES: 1 } },
+          sourcerelationship: { type: TYPES.integer, enum: { INDIRECT: 0, DIRECT: 1 } },
+          len: { type: TYPES.integer },
+          language: { type: TYPES.string },
+          langb: { type: TYPES.string },
+          genres: {
+            type: TYPES.object,
+            isArray: true,
+            childType: TYPES.string
+          },
+          gtax: { type: TYPES.integer },
+          embeddable: { type: TYPES.integer, enum: { NO: 0, YES: 1 } },
+          producer: {
+            type: TYPES.object,
+            isArray: false,
+            children: {
+              id: { type: TYPES.string },
+              name: { type: TYPES.string },
+              cattax: { type: TYPES.integer, enum: CategoryTaxonomy },
+              cat: {
+                type: TYPES.object,
+                isArray: true,
+                childType: TYPES.string
+              },
+              domain: { type: TYPES.string },
+              ext: {
+                type: TYPES.object,
+                isArray: false
+              }
+            }
+          },
           data: {
             type: TYPES.object,
             isArray: true,
             childType: TYPES.object,
             required: ['name', 'segment'],
             children: {
+              id: { type: TYPES.string },
               segment: {
                 type: TYPES.object,
                 isArray: true,
                 childType: TYPES.object,
                 required: ['id'],
                 children: {
-                  id: { type: TYPES.string }
+                  id: { type: TYPES.string },
+                  name: { type: TYPES.string },
+                  value: { type: TYPES.string },
+                  ext: {
+                    type: TYPES.object,
+                    isArray: false
+                  }
                 }
               },
               name: { type: TYPES.string },
-              ext: { type: TYPES.object },
+              cids: {
+                type: TYPES.object,
+                isArray: true,
+                childType: TYPES.string
+              },
+              ext: {
+                type: TYPES.object,
+                isArray: false
+              },
             }
+          },
+          network: {
+            type: TYPES.object,
+            isArray: false,
+            children: {
+              id: { type: TYPES.string },
+              name: { type: TYPES.string },
+              domain: { type: TYPES.string },
+              ext: {
+                type: TYPES.object,
+                isArray: false
+              }
+            }
+          },
+          channel: {
+            type: TYPES.object,
+            isArray: false,
+            children: {
+              id: { type: TYPES.string },
+              name: { type: TYPES.string },
+              domain: { type: TYPES.string },
+              ext: {
+                type: TYPES.object,
+                isArray: false
+              }
+            }
+          },
+          ext: {
+            type: TYPES.object,
+            isArray: false
           }
         }
       },
@@ -104,6 +221,7 @@ export const ORTB_MAP = {
         children: {
           id: { type: TYPES.string },
           name: { type: TYPES.string },
+          cattax: { type: TYPES.integer, enum: CategoryTaxonomy },
           cat: {
             type: TYPES.object,
             isArray: true,

--- a/test/spec/modules/validationFpdModule_spec.js
+++ b/test/spec/modules/validationFpdModule_spec.js
@@ -416,6 +416,119 @@ describe('the first party data validation module', function () {
       expect(validated).to.deep.equal(expected);
     });
 
+    it('validates additional OpenRTB site and content fields with IAB enum values', function () {
+      const duplicate = utils.deepClone(ortb2);
+      duplicate.site = {
+        id: 'site-id',
+        cattax: 6,
+        mobile: 1,
+        privacypolicy: 0,
+        inventorypartnerdomain: 'partner.example',
+        kwarray: ['sports', 'news'],
+        ext: { inventory: 'premium' },
+        content: {
+          id: 'content-id',
+          episode: 3,
+          cattax: 7,
+          cat: ['IAB1'],
+          prodq: 1,
+          context: 5,
+          qagmediarating: 2,
+          livestream: 0,
+          sourcerelationship: 1,
+          embeddable: 1,
+          kwarray: ['article'],
+          producer: {
+            id: 'producer-id',
+            cattax: 6,
+            cat: ['IAB2'],
+            domain: 'producer.example'
+          },
+          data: [{
+            id: 'provider-id',
+            name: 'content',
+            segment: [{ id: 'test', name: 'seg', value: 'value', ext: { foo: 'bar' } }],
+            cids: ['cid-1']
+          }],
+          network: { id: 'net-id', name: 'network', domain: 'network.example' },
+          channel: { id: 'channel-id', name: 'channel', domain: 'channel.example' }
+        },
+        publisher: {
+          id: 'pub-id',
+          cattax: 6,
+          cat: ['IAB3'],
+          name: 'publisher'
+        }
+      };
+
+      const validated = validateFpd(duplicate);
+      expect(validated.site).to.deep.equal(duplicate.site);
+    });
+
+    it('filters invalid additional OpenRTB site and content field types and enum values', function () {
+      const duplicate = utils.deepClone(ortb2);
+      duplicate.site = {
+        id: 123,
+        cattax: 99,
+        mobile: 2,
+        privacypolicy: '1',
+        inventorypartnerdomain: ['partner.example'],
+        kwarray: ['sports', 12],
+        content: {
+          episode: '3',
+          cattax: 99,
+          cat: ['IAB1', 2],
+          prodq: 99,
+          context: 99,
+          qagmediarating: 99,
+          livestream: '0',
+          sourcerelationship: 2,
+          embeddable: 2,
+          kwarray: ['article', {}],
+          producer: {
+            cattax: '6',
+            cat: ['IAB2', false],
+            domain: ['producer.example']
+          },
+          data: [{
+            name: 'content',
+            segment: [{ id: 'test', name: 1, value: 2, ext: 'bad' }],
+            cids: ['cid-1', 1]
+          }],
+          network: { id: 1, name: 'network', domain: ['network.example'] },
+          channel: { id: 'channel-id', name: 2, domain: 'channel.example' }
+        },
+        publisher: {
+          cattax: '6',
+          cat: ['IAB3', {}],
+          name: 'publisher'
+        }
+      };
+
+      const validated = validateFpd(duplicate);
+      expect(validated.site).to.deep.equal({
+        kwarray: ['sports'],
+        content: {
+          cat: ['IAB1'],
+          kwarray: ['article'],
+          producer: {
+            cat: ['IAB2']
+          },
+          data: [{
+            name: 'content',
+            segment: [{ id: 'test' }],
+            cids: ['cid-1']
+          }],
+          network: { name: 'network' },
+          channel: { id: 'channel-id', domain: 'channel.example' }
+        },
+        publisher: {
+          cat: ['IAB3'],
+          name: 'publisher'
+        }
+      });
+    });
+
     it('filters site.publisher object properties for invalid data type', function () {
       const duplicate = utils.deepClone(ortb2);
       duplicate.site.publisher = {

--- a/test/spec/ortb2.5StrictTranslator/translator_spec.js
+++ b/test/spec/ortb2.5StrictTranslator/translator_spec.js
@@ -18,4 +18,37 @@ describe('toOrtb25Strict', () => {
   it('removes non-integer enum fields', () => {
     expect(toOrtb25Strict({ device: { devicetype: 1.5, connectiontype: 2, geo: { type: 2.5 } } }, translator)).to.eql({ device: { connectiontype: 2, geo: {} } });
   });
+
+  it('validates site content enum values with IAB AdCOM enums', () => {
+    expect(toOrtb25Strict({
+      site: {
+        content: {
+          prodq: 1,
+          context: 5,
+          qagmediarating: 2,
+          videoquality: 3
+        }
+      }
+    }, translator)).to.eql({
+      site: {
+        content: {
+          prodq: 1,
+          context: 5,
+          qagmediarating: 2,
+          videoquality: 3
+        }
+      }
+    });
+
+    expect(toOrtb25Strict({
+      site: {
+        content: {
+          prodq: 99,
+          context: 99,
+          qagmediarating: 99,
+          videoquality: 99
+        }
+      }
+    }, translator)).to.eql({ site: { content: {} } });
+  });
 });


### PR DESCRIPTION
### Motivation
- Improve first-party data (FPD) validation for `ortb2.site` and nested `site.content` properties by validating more OpenRTB/IAB fields and using canonical IAB enums where available.
- Make the strict ORTB translator use the same authoritative enum values so translation/validation behavior is consistent with AdCOM/OpenRTB definitions.

### Description
- Extended `ORTB_MAP` in `modules/validationFpdModule/config.js` to validate additional `site` fields and nested `content` properties (ids, `cattax`, `kwarray`, `mobile`, `privacypolicy`, `inventorypartnerdomain`, `producer`, `data.segment`, `network`, `channel`, `publisher`, etc.) and wired relevant enum checks to IAB enums via `iab-adcom/enum`.
- Added a reusable `EnumValues` helper to `libraries/ortb2.5StrictTranslator/dsl.js` and updated `libraries/ortb2.5StrictTranslator/spec.js` to use IAB AdCOM enums (e.g., `ProductionQuality`, `ContentContext`, `MediaRating`) instead of hard-coded ranges for site/content enum validation.
- Allowed `iab-adcom` imports from `libraries` by updating `eslint.config.js` so translator and validation code can consume the repo dependency.
- Added unit tests covering valid and invalid additional site/content fields in `test/spec/modules/validationFpdModule_spec.js` and added strict-translator enum tests to `test/spec/ortb2.5StrictTranslator/translator_spec.js`.

### Testing
- Ran ESLint on the modified files with `npx eslint --cache --cache-strategy content modules/validationFpdModule/config.js modules/validationFpdModule/index.ts libraries/ortb2.5StrictTranslator/dsl.js libraries/ortb2.5StrictTranslator/spec.js test/spec/modules/validationFpdModule_spec.js test/spec/ortb2.5StrictTranslator/translator_spec.js`, which completed without lint errors (aside from an npm env warning).
- Ran the validation module spec with `npx gulp test --nolint --file test/spec/modules/validationFpdModule_spec.js`, which passed (`✔ 17 tests completed`).
- Ran the strict translator spec with `npx gulp test --nolint --file test/spec/ortb2.5StrictTranslator/translator_spec.js`, which passed (`✔ 4 tests completed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a18cbfa234c832bb5e2ac8de723f2dd)