### PR TITLE
🐛 Criteo Id System: store raw bidId values

### DIFF
--- a/modules/criteoIdSystem.js
+++ b/modules/criteoIdSystem.js
@@ -34,6 +34,34 @@ const STORAGE_TYPE_COOKIES = 'cookie';
 const pastDateString = new Date(0).toString();
 const expirationString = new Date(timestamp() + cookiesMaxAge).toString();
 
+function normalizeBidId(value) {
+  let bidId = value;
+  let previousBidId;
+
+  do {
+    previousBidId = bidId;
+
+    if (bidId && typeof bidId === 'object' && typeof bidId.criteoId === 'string') {
+      bidId = bidId.criteoId;
+    } else if (typeof bidId === 'string' && bidId.trim().charAt(0) === '{') {
+      try {
+        const parsedBidId = JSON.parse(bidId);
+        if (parsedBidId && typeof parsedBidId.criteoId === 'string') {
+          bidId = parsedBidId.criteoId;
+        } else {
+          return bidId;
+        }
+      } catch (error) {
+        break;
+      }
+    } else {
+      break;
+    }
+  } while (bidId !== previousBidId);
+
+  return typeof bidId === 'string' && bidId ? bidId : undefined;
+}
+
 function extractProtocolHost(url, returnOnlyHost = false) {
   const parsedUrl = parseUrl(url, { noDecodeWholeURL: true })
   return returnOnlyHost
@@ -95,7 +123,7 @@ function getCriteoDataFromStorage(submoduleConfig) {
   return {
     bundle: getFromStorage(submoduleConfig, bundleStorageKey),
     dnaBundle: getFromStorage(submoduleConfig, dnaBundleStorageKey),
-    bidId: getFromStorage(submoduleConfig, bididStorageKey),
+    bidId: normalizeBidId(getFromStorage(submoduleConfig, bididStorageKey)),
   }
 }
 
@@ -189,8 +217,7 @@ function callCriteoUserSync(submoduleConfig, parsedCriteoData, callback) {
 
       if (jsonResponse.bidId) {
         saveOnStorage(submoduleConfig, bididStorageKey, jsonResponse.bidId, domain);
-        const criteoId = { criteoId: jsonResponse.bidId };
-        callback(criteoId);
+        callback(jsonResponse.bidId);
       } else {
         deleteFromAllStorages(bididStorageKey, domain);
         callback();
@@ -219,13 +246,14 @@ export const criteoIdSubmodule = {
    * @returns {{criteoId: string} | undefined}
    */
   decode(bidId) {
-    return bidId;
+    const normalizedBidId = normalizeBidId(bidId);
+    return normalizedBidId ? { criteoId: normalizedBidId } : undefined;
   },
   /**
    * get the Criteo Id from local storages and initiate a new user sync
    * @function
    * @param {SubmoduleConfig} [submoduleConfig]
-   * @returns {{id: {criteoId: string} | undefined}}}
+   * @returns {{id: string | undefined, callback: function}}
    */
   getId(submoduleConfig) {
     const localData = getCriteoDataFromStorage(submoduleConfig);
@@ -233,7 +261,7 @@ export const criteoIdSubmodule = {
     const result = (callback) => callCriteoUserSync(submoduleConfig, localData, callback);
 
     return {
-      id: localData.bidId ? { criteoId: localData.bidId } : undefined,
+      id: localData.bidId,
       callback: result
     }
   },

--- a/test/spec/modules/criteoIdSystem_spec.js
+++ b/test/spec/modules/criteoIdSystem_spec.js
@@ -8,6 +8,16 @@ import { expect } from 'chai/index.mjs';
 
 const pastDateString = new Date(0).toString()
 
+function wrapCriteoId(value, depth) {
+  let wrappedValue = value;
+
+  for (let i = 0; i < depth; i++) {
+    wrappedValue = JSON.stringify({ criteoId: wrappedValue });
+  }
+
+  return wrappedValue;
+}
+
 describe('CriteoId module', function () {
   const cookiesMaxAge = 13 * 30 * 24 * 60 * 60 * 1000;
 
@@ -63,6 +73,10 @@ describe('CriteoId module', function () {
     { submoduleConfig: { storage: { type: 'cookie' } }, cookie: undefined, localStorage: 'bidId2', expected: undefined },
     { submoduleConfig: { storage: { type: 'html5' } }, cookie: 'bidId', localStorage: 'bidId2', expected: 'bidId2' },
     { submoduleConfig: { storage: { type: 'html5' } }, cookie: 'bidId', localStorage: undefined, expected: undefined },
+    { submoduleConfig: undefined, cookie: '{"criteoId":"bidId"}', localStorage: undefined, expected: 'bidId' },
+    { submoduleConfig: undefined, cookie: '{"criteoId":"{\\"criteoId\\":\\"bidId\\"}"}', localStorage: undefined, expected: 'bidId' },
+    { submoduleConfig: undefined, cookie: wrapCriteoId('bidId', 11), localStorage: undefined, expected: 'bidId' },
+    { submoduleConfig: { storage: { type: 'html5' } }, cookie: 'bidId', localStorage: { criteoId: 'bidId2' }, expected: 'bidId2' },
   ]
 
   storageTestCases.forEach(testCase => it('getId() should return the user id depending on the storage type enabled and the data available', function () {
@@ -70,13 +84,28 @@ describe('CriteoId module', function () {
     getLocalStorageStub.withArgs('cto_bidid').returns(testCase.localStorage);
 
     const result = criteoIdSubmodule.getId(testCase.submoduleConfig);
-    expect(result.id).to.be.deep.equal(testCase.expected ? { criteoId: testCase.expected } : undefined);
+    expect(result.id).to.equal(testCase.expected);
     expect(result.callback).to.be.a('function');
   }))
 
   it('decode() should return the bidId when it exists in local storages', function () {
     const id = criteoIdSubmodule.decode('testDecode');
-    expect(id).to.equal('testDecode')
+    expect(id).to.deep.equal({ criteoId: 'testDecode' })
+  });
+
+  it('decode() should unwrap serialized bidId values', function () {
+    const id = criteoIdSubmodule.decode('{"criteoId":"rawBidId"}');
+    expect(id).to.deep.equal({ criteoId: 'rawBidId' })
+  });
+
+  it('decode() should unwrap deeply nested serialized bidId values', function () {
+    const id = criteoIdSubmodule.decode(wrapCriteoId('rawBidId', 11));
+    expect(id).to.deep.equal({ criteoId: 'rawBidId' })
+  });
+
+  it('decode() should not throw on invalid serialized bidId values', function () {
+    const id = criteoIdSubmodule.decode('{"criteoId":');
+    expect(id).to.deep.equal({ criteoId: '{"criteoId":' })
   });
 
   it('should call user sync url with the right params', function () {
@@ -121,7 +150,7 @@ describe('CriteoId module', function () {
     it('should save bidId if it exists', function () {
       const result = criteoIdSubmodule.getId(response.submoduleConfig);
       result.callback((id) => {
-        expect(id).to.be.deep.equal(response.bidId ? { criteoId: response.bidId } : undefined);
+        expect(id).to.equal(response.bidId);
       });
 
       const request = server.requests[0];


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Fixes the Criteo User ID submodule storage shape so `getId()` and async callbacks return the raw bidId string for Prebid generic userId storage, while `decode()` exposes the public `{ criteoId: bidId }` object.

This prevents `cto_bidid` from growing when a publisher configures Criteo userId storage with `name: "cto_bidid"`. Legacy object-shaped and nested serialized values such as `{"criteoId":"..."}` are normalized back to the raw bidId.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
