### PR TITLE
acxiomRtd: fix tests

### DIFF
--- a/modules/acxiomRealIdSystem.ts
+++ b/modules/acxiomRealIdSystem.ts
@@ -19,6 +19,9 @@ const MODULE_NAME = 'acxiomRealId' as const;
 const DEFAULT_API_URL = 'https://ids.api.gcprivacy.id/v1/eid/l';
 const DEFAULT_SOURCE_ID = 'acxiom.id';
 export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME });
+export const dep = {
+  ajaxBuilder
+}
 
 export type AcxiomRealIdParams = {
   /** Partner ID issued by GrowthCode on behalf of Acxiom */
@@ -197,7 +200,7 @@ export const acxiomRealIdSubmodule: IdProviderSpec<typeof MODULE_NAME> = {
 
     return {
       callback: (cb) => {
-        const ajax = ajaxBuilder();
+        const ajax = dep.ajaxBuilder();
         ajax(
           url,
           {

--- a/plugins/callerContext.js
+++ b/plugins/callerContext.js
@@ -32,7 +32,7 @@ const getCallers = (() => {
         cache[filename] = callers.callers;
       } else {
         console.warn(`WARNING: cannot determine moduleType/moduleName to associate with '${filename}'. If this is a new adapter it may need metadata to be updated.  ${message}`)
-        cache[filename] = null;
+        cache[filename] = [];
       }
     }
     return cache[filename];

--- a/test/spec/modules/acxiomRealIdSystem_spec.js
+++ b/test/spec/modules/acxiomRealIdSystem_spec.js
@@ -1,5 +1,4 @@
-import { acxiomRealIdSubmodule, storage } from 'modules/acxiomRealIdSystem.ts';
-import * as ajaxLib from 'src/ajax.js';
+import { acxiomRealIdSubmodule, dep, storage } from 'modules/acxiomRealIdSystem.ts';
 import { gdprDataHandler, uspDataHandler, gppDataHandler } from 'src/adapterManager.js';
 import { expect } from 'chai';
 
@@ -349,7 +348,7 @@ describe('acxiomRealIdSystem', () => {
 
       it('should POST to the default API URL with partnerId and default sourceId in body', (done) => {
         let capturedUrl, capturedBody, capturedOptions;
-        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+        ajaxBuilderStub = sinon.stub(dep, 'ajaxBuilder').returns(
           (url, callbacks, body, options) => {
             capturedUrl = url;
             capturedBody = body;
@@ -380,7 +379,7 @@ describe('acxiomRealIdSystem', () => {
 
       it('should include HEM in POST body when provided', (done) => {
         let capturedBody;
-        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+        ajaxBuilderStub = sinon.stub(dep, 'ajaxBuilder').returns(
           (url, callbacks, body) => {
             capturedBody = body;
             callbacks.success(makeEidResponse(REAL_ID_TOKEN, 1));
@@ -402,7 +401,7 @@ describe('acxiomRealIdSystem', () => {
 
       it('should not include HEM in POST body when not provided', (done) => {
         let capturedBody;
-        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+        ajaxBuilderStub = sinon.stub(dep, 'ajaxBuilder').returns(
           (url, callbacks, body) => {
             capturedBody = body;
             callbacks.success(makeEidResponse(REAL_ID_TOKEN, 1));
@@ -424,7 +423,7 @@ describe('acxiomRealIdSystem', () => {
       it('should use custom sourceId in POST body when provided', (done) => {
         let capturedBody;
         const customSourceId = 'custom.source';
-        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+        ajaxBuilderStub = sinon.stub(dep, 'ajaxBuilder').returns(
           (url, callbacks, body) => {
             capturedBody = body;
             callbacks.success(makeEidResponse(REAL_ID_TOKEN, 1));
@@ -447,7 +446,7 @@ describe('acxiomRealIdSystem', () => {
       it('should use custom API URL when provided', (done) => {
         let capturedUrl;
         const customUrl = 'https://custom.example.com/v1/eid/l';
-        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+        ajaxBuilderStub = sinon.stub(dep, 'ajaxBuilder').returns(
           (url, callbacks) => {
             capturedUrl = url;
             callbacks.success(makeEidResponse(REAL_ID_TOKEN, 1));
@@ -468,7 +467,7 @@ describe('acxiomRealIdSystem', () => {
 
       it('should strip trailing slashes from custom API URL', (done) => {
         let capturedUrl;
-        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+        ajaxBuilderStub = sinon.stub(dep, 'ajaxBuilder').returns(
           (url, callbacks) => {
             capturedUrl = url;
             callbacks.success(makeEidResponse(REAL_ID_TOKEN, 1));
@@ -487,7 +486,7 @@ describe('acxiomRealIdSystem', () => {
       });
 
       it('should preserve atype from API response', (done) => {
-        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+        ajaxBuilderStub = sinon.stub(dep, 'ajaxBuilder').returns(
           (url, callbacks) => {
             callbacks.success(makeEidResponse(REAL_ID_TOKEN, 3));
           }
@@ -505,7 +504,7 @@ describe('acxiomRealIdSystem', () => {
       });
 
       it('should call callback with undefined on no-match response', (done) => {
-        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+        ajaxBuilderStub = sinon.stub(dep, 'ajaxBuilder').returns(
           (url, callbacks) => {
             callbacks.success(JSON.stringify({ requestId: 'test', user: {} }));
           }
@@ -523,7 +522,7 @@ describe('acxiomRealIdSystem', () => {
       });
 
       it('should call callback with undefined when eids array is empty', (done) => {
-        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+        ajaxBuilderStub = sinon.stub(dep, 'ajaxBuilder').returns(
           (url, callbacks) => {
             callbacks.success(makeEmptyResponse());
           }
@@ -541,7 +540,7 @@ describe('acxiomRealIdSystem', () => {
       });
 
       it('should call callback with undefined on API error', (done) => {
-        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+        ajaxBuilderStub = sinon.stub(dep, 'ajaxBuilder').returns(
           (url, callbacks) => {
             callbacks.error('server error');
           }
@@ -559,7 +558,7 @@ describe('acxiomRealIdSystem', () => {
       });
 
       it('should call callback with undefined on malformed JSON response', (done) => {
-        ajaxBuilderStub = sinon.stub(ajaxLib, 'ajaxBuilder').returns(
+        ajaxBuilderStub = sinon.stub(dep, 'ajaxBuilder').returns(
           (url, callbacks) => {
             callbacks.success('not json');
           }


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

After https://github.com/prebid/Prebid.js/pull/14935, tests cannot stub out `ajax` directly - since the calls are replaced during precompilation. However, the replacement does not happen if we cannot find metadata for the caller's file. 

That allows new adapters that have no metadata yet to stub out `ajax` in tests and have them pass - until metadata is updated.

