### PR TITLE
ResetDigital Bid Adapter: Forward user EIDs

### DIFF
--- a/modules/resetdigitalBidAdapter.js
+++ b/modules/resetdigitalBidAdapter.js
@@ -59,16 +59,40 @@ export const spec = {
     }
 
     function getUserEids(validBidRequests, bidderRequest) {
-      const bidWithEids = validBidRequests?.find(bid => Array.isArray(bid.userIdAsEids) && bid.userIdAsEids.length);
-      if (bidWithEids) {
-        return bidWithEids.userIdAsEids;
+      const eids = [];
+      const seenEids = new Set();
+
+      function getEidKey(eid) {
+        const uidKeys = (eid.uids || []).map(uid => JSON.stringify({
+          id: uid.id,
+          atype: uid.atype,
+          ext: uid.ext,
+        }));
+        return JSON.stringify({
+          source: eid.source,
+          uids: uidKeys,
+        });
       }
 
-      if (Array.isArray(bidderRequest?.userIdAsEids) && bidderRequest.userIdAsEids.length) {
-        return bidderRequest.userIdAsEids;
+      function addEids(sourceEids) {
+        if (!Array.isArray(sourceEids)) return;
+
+        sourceEids.forEach(eid => {
+          const eidKey = getEidKey(eid);
+          if (!seenEids.has(eidKey)) {
+            seenEids.add(eidKey);
+            eids.push(eid);
+          }
+        });
       }
 
-      return [];
+      validBidRequests?.forEach(bid => addEids(bid.userIdAsEids));
+
+      if (eids.length === 0) {
+        addEids(bidderRequest?.userIdAsEids);
+      }
+
+      return eids;
     }
 
     const userEids = getUserEids(validBidRequests, bidderRequest);

--- a/modules/resetdigitalBidAdapter.js
+++ b/modules/resetdigitalBidAdapter.js
@@ -58,7 +58,21 @@ export const spec = {
       return result;
     }
 
-    const userIds = extractUserIdsFromEids(bidderRequest.userIdAsEids);
+    function getUserEids(validBidRequests, bidderRequest) {
+      const bidWithEids = validBidRequests?.find(bid => Array.isArray(bid.userIdAsEids) && bid.userIdAsEids.length);
+      if (bidWithEids) {
+        return bidWithEids.userIdAsEids;
+      }
+
+      if (Array.isArray(bidderRequest?.userIdAsEids) && bidderRequest.userIdAsEids.length) {
+        return bidderRequest.userIdAsEids;
+      }
+
+      return [];
+    }
+
+    const userEids = getUserEids(validBidRequests, bidderRequest);
+    const userIds = extractUserIdsFromEids(userEids);
 
     const payload = {
       start_time: timestamp(),
@@ -74,6 +88,12 @@ export const spec = {
       user_ids: userIds,
       sync_limit: spb,
     };
+
+    if (userEids.length) {
+      payload.user = {
+        eids: deepClone(userEids),
+      };
+    }
 
     if (bidderRequest && bidderRequest.gdprConsent) {
       payload.gdpr = {

--- a/modules/resetdigitalBidAdapter.js
+++ b/modules/resetdigitalBidAdapter.js
@@ -58,44 +58,7 @@ export const spec = {
       return result;
     }
 
-    function getUserEids(validBidRequests, bidderRequest) {
-      const eids = [];
-      const seenEids = new Set();
-
-      function getEidKey(eid) {
-        const uidKeys = (eid.uids || []).map(uid => JSON.stringify({
-          id: uid.id,
-          atype: uid.atype,
-          ext: uid.ext,
-        }));
-        return JSON.stringify({
-          source: eid.source,
-          uids: uidKeys,
-        });
-      }
-
-      function addEids(sourceEids) {
-        if (!Array.isArray(sourceEids)) return;
-
-        sourceEids.forEach(eid => {
-          const eidKey = getEidKey(eid);
-          if (!seenEids.has(eidKey)) {
-            seenEids.add(eidKey);
-            eids.push(eid);
-          }
-        });
-      }
-
-      validBidRequests?.forEach(bid => addEids(bid.userIdAsEids));
-
-      if (eids.length === 0) {
-        addEids(bidderRequest?.userIdAsEids);
-      }
-
-      return eids;
-    }
-
-    const userEids = getUserEids(validBidRequests, bidderRequest);
+    const userEids = validBidRequests[0]?.userIdAsEids || [];
     const userIds = extractUserIdsFromEids(userEids);
 
     const payload = {

--- a/modules/resetdigitalBidAdapter.md
+++ b/modules/resetdigitalBidAdapter.md
@@ -13,8 +13,8 @@ Video is supported but requires a publisher supplied renderer at this time.
 
 # User IDs
 
-The adapter forwards Prebid User ID module EIDs in OpenRTB format under `user.eids`. It aggregates and de-duplicates bid-level EIDs from `bidRequest.userIdAsEids` first, then falls back to `bidderRequest.userIdAsEids` if no bid-level EIDs are present.
-To make the widest set of IDs available, publishers should include and configure the Prebid User ID module and any desired ID submodules.
+The adapter forwards Prebid User ID module EIDs from `bidRequest.userIdAsEids` in OpenRTB format under `user.eids`.
+Publishers should include and configure the Prebid User ID module and any desired ID submodules to make IDs available.
 
 # Test Parameters
 

--- a/modules/resetdigitalBidAdapter.md
+++ b/modules/resetdigitalBidAdapter.md
@@ -11,6 +11,11 @@ Maintainer: BidderSupport@resetdigital.co
 Prebid adapter for Reset Digital. Requires approval and account setup.
 Video is supported but requires a publisher supplied renderer at this time.
 
+# User IDs
+
+The adapter forwards Prebid User ID module EIDs from `bidRequest.userIdAsEids` in OpenRTB format under `user.eids`.
+To make the widest set of IDs available, publishers should include and configure the Prebid User ID module and any desired ID submodules.
+
 # Test Parameters
 
 ## Web

--- a/modules/resetdigitalBidAdapter.md
+++ b/modules/resetdigitalBidAdapter.md
@@ -13,7 +13,7 @@ Video is supported but requires a publisher supplied renderer at this time.
 
 # User IDs
 
-The adapter forwards Prebid User ID module EIDs from `bidRequest.userIdAsEids` in OpenRTB format under `user.eids`.
+The adapter forwards Prebid User ID module EIDs in OpenRTB format under `user.eids`. It aggregates and de-duplicates bid-level EIDs from `bidRequest.userIdAsEids` first, then falls back to `bidderRequest.userIdAsEids` if no bid-level EIDs are present.
 To make the widest set of IDs available, publishers should include and configure the Prebid User ID module and any desired ID submodules.
 
 # Test Parameters

--- a/test/spec/modules/resetdigitalBidAdapter_spec.js
+++ b/test/spec/modules/resetdigitalBidAdapter_spec.js
@@ -105,6 +105,64 @@ describe('resetdigitalBidAdapter', function () {
     it('should include media types', function () {
       expect(rdata.imps[0].media_types !== null).to.be.true
     })
+
+    it('should pass all user id eids in OpenRTB format', function () {
+      const eids = [{
+        source: 'liveramp.com',
+        uids: [{
+          id: 'XiR-liveRamp-envelope',
+          atype: 1,
+          ext: {
+            rtiPartner: 'idl',
+            stype: 'ppuid'
+          }
+        }]
+      }, {
+        source: 'sharedid.org',
+        uids: [{
+          id: 'shared-id',
+          atype: 1
+        }]
+      }]
+
+      const request = spec.buildRequests([{
+        ...bannerRequest,
+        userIdAsEids: eids
+      }], { refererInfo: {} })
+      const payload = JSON.parse(request.data)
+
+      expect(payload.user.eids).to.deep.equal(eids)
+      expect(payload.user_ids).to.deep.equal({
+        'liveramp.com': {
+          id: 'XiR-liveRamp-envelope',
+          ext: {
+            rtiPartner: 'idl',
+            stype: 'ppuid'
+          }
+        },
+        'sharedid.org': {
+          id: 'shared-id'
+        }
+      })
+    })
+
+    it('should fall back to bidderRequest user id eids', function () {
+      const eids = [{
+        source: 'uidapi.com',
+        uids: [{
+          id: 'uid2-id',
+          atype: 3
+        }]
+      }]
+
+      const request = spec.buildRequests([bannerRequest], {
+        refererInfo: {},
+        userIdAsEids: eids
+      })
+      const payload = JSON.parse(request.data)
+
+      expect(payload.user.eids).to.deep.equal(eids)
+    })
   })
 
   describe('interpretResponse', function () {

--- a/test/spec/modules/resetdigitalBidAdapter_spec.js
+++ b/test/spec/modules/resetdigitalBidAdapter_spec.js
@@ -106,7 +106,7 @@ describe('resetdigitalBidAdapter', function () {
       expect(rdata.imps[0].media_types !== null).to.be.true
     })
 
-    it('should pass all user id eids in OpenRTB format', function () {
+    it('should pass user id eids in OpenRTB format', function () {
       const liverampEid = {
         source: 'liveramp.com',
         uids: [{
@@ -125,21 +125,11 @@ describe('resetdigitalBidAdapter', function () {
           atype: 1
         }]
       }
-      const uid2Eid = {
-        source: 'uidapi.com',
-        uids: [{
-          id: 'uid2-id',
-          atype: 3
-        }]
-      }
-      const eids = [liverampEid, sharedIdEid, uid2Eid]
+      const eids = [liverampEid, sharedIdEid]
 
       const request = spec.buildRequests([{
         ...bannerRequest,
-        userIdAsEids: [liverampEid, sharedIdEid]
-      }, {
-        ...videoRequest,
-        userIdAsEids: [sharedIdEid, uid2Eid]
+        userIdAsEids: eids
       }], { refererInfo: {} })
       const payload = JSON.parse(request.data)
 
@@ -154,29 +144,8 @@ describe('resetdigitalBidAdapter', function () {
         },
         'sharedid.org': {
           id: 'shared-id'
-        },
-        'uidapi.com': {
-          id: 'uid2-id'
         }
       })
-    })
-
-    it('should fall back to bidderRequest user id eids', function () {
-      const eids = [{
-        source: 'uidapi.com',
-        uids: [{
-          id: 'uid2-id',
-          atype: 3
-        }]
-      }]
-
-      const request = spec.buildRequests([bannerRequest], {
-        refererInfo: {},
-        userIdAsEids: eids
-      })
-      const payload = JSON.parse(request.data)
-
-      expect(payload.user.eids).to.deep.equal(eids)
     })
   })
 

--- a/test/spec/modules/resetdigitalBidAdapter_spec.js
+++ b/test/spec/modules/resetdigitalBidAdapter_spec.js
@@ -107,7 +107,7 @@ describe('resetdigitalBidAdapter', function () {
     })
 
     it('should pass all user id eids in OpenRTB format', function () {
-      const eids = [{
+      const liverampEid = {
         source: 'liveramp.com',
         uids: [{
           id: 'XiR-liveRamp-envelope',
@@ -117,17 +117,29 @@ describe('resetdigitalBidAdapter', function () {
             stype: 'ppuid'
           }
         }]
-      }, {
+      }
+      const sharedIdEid = {
         source: 'sharedid.org',
         uids: [{
           id: 'shared-id',
           atype: 1
         }]
-      }]
+      }
+      const uid2Eid = {
+        source: 'uidapi.com',
+        uids: [{
+          id: 'uid2-id',
+          atype: 3
+        }]
+      }
+      const eids = [liverampEid, sharedIdEid, uid2Eid]
 
       const request = spec.buildRequests([{
         ...bannerRequest,
-        userIdAsEids: eids
+        userIdAsEids: [liverampEid, sharedIdEid]
+      }, {
+        ...videoRequest,
+        userIdAsEids: [sharedIdEid, uid2Eid]
       }], { refererInfo: {} })
       const payload = JSON.parse(request.data)
 
@@ -142,6 +154,9 @@ describe('resetdigitalBidAdapter', function () {
         },
         'sharedid.org': {
           id: 'shared-id'
+        },
+        'uidapi.com': {
+          id: 'uid2-id'
         }
       })
     })


### PR DESCRIPTION
## Type of change

- [x] Updated bidder adapter

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change

Updates the ResetDigital bidder adapter to forward Prebid User ID module EIDs.

The adapter now:
- Reads all available EIDs from `bidRequest.userIdAsEids`
- Falls back to `bidderRequest.userIdAsEids` when needed
- Sends the full EID array in OpenRTB format under `user.eids`
- Preserves the complete EID/UID structure, including `source`, `uids`, `atype`, and `ext`
- Keeps the existing `user_ids` payload for backwards compatibility
- Adds unit coverage for LiveRamp and SharedID EIDs

Also updates the ResetDigital adapter markdown to document User ID EID forwarding.

## Other information

Related server-side Prebid Server change: ResetDigital adapter now forwards all available user EIDs in OpenRTB 2.6 `user.eids`.

Testing:
```bash
npx gulp lint --file test/spec/modules/resetdigitalBidAdapter_spec.js