### PR TITLE
APS Bid Adapter: map bidder metadata

### DIFF
--- a/modules/apsBidAdapter.js
+++ b/modules/apsBidAdapter.js
@@ -199,6 +199,13 @@ export const converter = ortbConverter({
     }
 
     const bidResponse = buildBidResponse(bid, context);
+    bidResponse.meta = bidResponse.meta || {};
+    if (bid.ext?.bidder) {
+      bidResponse.meta.networkId = bid.ext.bidder;
+    }
+    if (context.seatbid?.seat) {
+      bidResponse.meta.seat = context.seatbid.seat;
+    }
     if (bidResponse.mediaType === VIDEO) {
       bidResponse.vastUrl = vastUrl;
     }

--- a/test/spec/modules/apsBidAdapter_spec.js
+++ b/test/spec/modules/apsBidAdapter_spec.js
@@ -465,8 +465,12 @@ describe('apsBidAdapter', () => {
                   w: 300,
                   h: 250,
                   exp: 3600,
+                  ext: {
+                    bidder: '911',
+                  },
                 },
               ],
+              seat: '10432',
             },
           ],
         },
@@ -492,6 +496,13 @@ describe('apsBidAdapter', () => {
 
       expect(result).to.be.an('array');
       expect(result.length).to.equal(1);
+    });
+
+    it('should fill networkId and seat metadata from APS response fields', () => {
+      const result = spec.interpretResponse(response, request);
+
+      expect(result[0].meta.networkId).to.equal('911');
+      expect(result[0].meta.seat).to.equal('10432');
     });
 
     it('should include accountID in creative script', () => {


### PR DESCRIPTION
### Motivation
- APS server responses now include the bidder ID at `seatbid[].bid[].ext.bidder` and the seat at `seatbid[].seat`, and the adapter should surface those values on the Prebid bid object as `meta.networkId` and `meta.seat`.

### Description
- Copy `bid.ext.bidder` into `bidResponse.meta.networkId` and `context.seatbid.seat` into `bidResponse.meta.seat` in `modules/apsBidAdapter.js` so ORTB-to-Prebid mapping preserves the new APS fields.
- Update the adapter unit test `test/spec/modules/apsBidAdapter_spec.js` to include `ext.bidder` and `seat` in the response fixture and add assertions that verify `meta.networkId` and `meta.seat` are populated.

### Testing
- Ran `npx eslint modules/apsBidAdapter.js test/spec/modules/apsBidAdapter_spec.js --cache --cache-strategy content` and it passed.
- Ran `npx gulp test --nolint --file test/spec/modules/apsBidAdapter_spec.js` and the spec passed (Karma output: `✔ 98 tests completed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1f1c99c4f8832ba6fdcffee12f9d48)