### PR TITLE
Vuukle Bid Adapter: ortbConverter rewrite; add video + native; new endpoint

### DIFF
--- a/modules/vuukleBidAdapter.d.ts
+++ b/modules/vuukleBidAdapter.d.ts
@@ -1,0 +1,20 @@
+export interface VuukleBidderParams {
+  /**
+   * Your Vuukle seller ID, as listed in https://vuukle.com/sellers.json. Required.
+   */
+  sid: string;
+  /**
+   * Optional named placement / tag ID. Falls back to the ad unit code when omitted.
+   */
+  placementId?: string;
+  /**
+   * Optional static hard floor in USD. The priceFloors module is preferred when configured.
+   */
+  bidfloor?: number;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    vuukle: VuukleBidderParams;
+  }
+}

--- a/modules/vuukleBidAdapter.js
+++ b/modules/vuukleBidAdapter.js
@@ -1,98 +1,162 @@
-import { parseSizesInput, deepAccess } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import { BANNER } from '../src/mediaTypes.js';
-import { config } from '../src/config.js';
+import { BANNER, VIDEO, NATIVE } from '../src/mediaTypes.js';
+import { ortbConverter } from '../libraries/ortbConverter/converter.js';
+import { Renderer } from '../src/Renderer.js';
+import { deepAccess, deepSetValue, logError, logWarn } from '../src/utils.js';
+
+/**
+ * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
+ * @typedef {import('./vuukleBidAdapter.d.ts').VuukleBidderParams} VuukleBidderParams
+ * @typedef {BidRequest & { params: VuukleBidderParams }} VuukleBidRequest
+ */
 
 const BIDDER_CODE = 'vuukle';
-const URL = 'https://pb.vuukle.com/adapter';
-const TIME_TO_LIVE = 360;
-const VENDOR_ID = 1004;
+const GVLID = 1004;
+const ENDPOINT = 'https://rtb.vuukle.com/openrtb2/web';
+const SYNC_URL = 'https://rtb.vuukle.com/cookie-sync';
+const DEFAULT_TTL = 300;
+// Hosted outstream renderer (Vuukle-served). Publishers may override by
+// supplying their own renderer on the ad unit.
+const OUTSTREAM_RENDERER_URL = 'https://rtb.vuukle.com/static/outstream.js';
+
+const converter = ortbConverter({
+  context: { netRevenue: true, ttl: DEFAULT_TTL, currency: 'USD' },
+
+  imp(buildImp, bidRequest, context) {
+    const imp = buildImp(bidRequest, context);
+    // tagid: explicit placement, else the ad unit code.
+    imp.tagid = bidRequest.params.placementId || bidRequest.adUnitCode;
+    // GPID passthrough (helps DSP targeting / dedup).
+    const gpid = deepAccess(bidRequest, 'ortb2Imp.ext.gpid');
+    if (gpid) deepSetValue(imp, 'ext.gpid', gpid);
+    // priceFloors (getFloor) is wired by ortbConverter automatically; if it
+    // didn't set a floor, fall back to the static params.bidfloor (USD).
+    if (imp.bidfloor == null && bidRequest.params.bidfloor != null) {
+      const f = parseFloat(bidRequest.params.bidfloor);
+      if (!isNaN(f)) {
+        imp.bidfloor = f;
+        imp.bidfloorcur = imp.bidfloorcur || 'USD';
+      }
+    }
+    return imp;
+  },
+
+  request(buildRequest, imps, bidderRequest, context) {
+    const req = buildRequest(imps, bidderRequest, context);
+    // sellers.json seller_id is our universal publisher key — set it as the
+    // oRTB site.publisher.id so demand can verify the supply chain.
+    const sid = context.bidRequests && context.bidRequests[0] && context.bidRequests[0].params.sid;
+    if (sid) deepSetValue(req, 'site.publisher.id', String(sid));
+    deepSetValue(req, 'ext.prebid.channel', { name: 'pbjs', version: '$prebid.version$' });
+    // ortbConverter already populates: imp.banner/imp.video, sizes, floors,
+    // user.eids, source.schain, regs (gdpr/usp/gpp/coppa), site/device/user
+    // first-party data from ortb2 — so we keep this thin on purpose.
+    return req;
+  },
+
+  bidResponse(buildBidResponse, bid, context) {
+    const bidResponse = buildBidResponse(bid, context);
+    const req = context.bidRequest;
+    // Attach our outstream renderer only for outstream video when the
+    // publisher hasn't supplied their own.
+    if (
+      bidResponse.mediaType === VIDEO &&
+      deepAccess(req, 'mediaTypes.video.context') === 'outstream' &&
+      !deepAccess(req, 'renderer') &&
+      !deepAccess(req, 'mediaTypes.video.renderer')
+    ) {
+      const rUrl = deepAccess(bid, 'ext.renderer_url') || deepAccess(bid, 'ext.prebid.cache.vastXml.renderer') || OUTSTREAM_RENDERER_URL;
+      bidResponse.renderer = createRenderer(bidResponse, rUrl);
+    }
+    return bidResponse;
+  },
+});
+
+function createRenderer(bid, rendererUrl) {
+  const renderer = Renderer.install({
+    id: bid.requestId,
+    url: rendererUrl || OUTSTREAM_RENDERER_URL,
+    adUnitCode: bid.adUnitCode,
+  });
+  try {
+    renderer.setRender((b) => {
+      b.renderer.push(() => {
+        if (window.vuukleOutstream && typeof window.vuukleOutstream.render === 'function') {
+          window.vuukleOutstream.render({
+            adUnitCode: b.adUnitCode,
+            vastXml: b.vastXml,
+            vastUrl: b.vastUrl,
+            width: b.width,
+            height: b.height,
+          });
+        } else {
+          logWarn('vuukle: outstream renderer not loaded');
+        }
+      });
+    });
+  } catch (e) {
+    logWarn('vuukle: failed to set renderer', e);
+  }
+  return renderer;
+}
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: VENDOR_ID,
-  supportedMediaTypes: [BANNER],
+  gvlid: GVLID,
+  supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 
-  isBidRequestValid: function(bid) {
-    return true
-  },
-
-  buildRequests: function(bidRequests, bidderRequest) {
-    bidderRequest = bidderRequest || {};
-    const requests = bidRequests.map(function (bid) {
-      const parseSized = parseSizesInput(bid.sizes);
-      const arrSize = parseSized[0].split('x');
-      const params = {
-        url: encodeURIComponent(window.location.href),
-        sizes: JSON.stringify(parseSized),
-        width: arrSize[0],
-        height: arrSize[1],
-        params: JSON.stringify(bid.params),
-        rnd: Math.random(),
-        bidId: bid.bidId,
-        source: 'pbjs',
-        schain: JSON.stringify(bid?.ortb2?.source?.ext?.schain),
-        requestId: bid.bidderRequestId,
-        tmax: bidderRequest.timeout,
-        gdpr: (bidderRequest.gdprConsent && bidderRequest.gdprConsent.gdprApplies) ? 1 : 0,
-        consentGiven: vuukleGetConsentGiven(bidderRequest.gdprConsent),
-        version: '$prebid.version$',
-        v: 2,
-      };
-
-      if (bidderRequest.uspConsent) {
-        params.uspConsent = bidderRequest.uspConsent;
-      }
-
-      if (config.getConfig('coppa') === true) {
-        params.coppa = 1;
-      }
-
-      if (bidderRequest.gdprConsent && bidderRequest.gdprConsent.consentString) {
-        params.consent = bidderRequest.gdprConsent.consentString;
-      }
-
-      return {
-        method: 'GET',
-        url: URL,
-        data: params,
-        options: { withCredentials: false }
-      }
-    });
-
-    return requests;
-  },
-
-  interpretResponse: function(serverResponse, bidRequest) {
-    if (!serverResponse || !serverResponse.body || !serverResponse.body.ad) {
-      return [];
+  isBidRequestValid(bid) {
+    if (!bid || !bid.params || !bid.params.sid) {
+      logError('vuukle: params.sid (your sellers.json seller_id) is required');
+      return false;
     }
-
-    const res = serverResponse.body;
-    const bidResponse = {
-      requestId: bidRequest.data.bidId,
-      cpm: res.cpm,
-      width: res.width,
-      height: res.height,
-      creativeId: res.creative_id,
-      currency: res.currency || 'USD',
-      netRevenue: true,
-      ttl: TIME_TO_LIVE,
-      ad: res.ad,
-      meta: {
-        advertiserDomains: Array.isArray(res.adomain) ? res.adomain : []
+    const video = deepAccess(bid, 'mediaTypes.video');
+    if (video) {
+      if (!Array.isArray(video.mimes) || video.mimes.length === 0) {
+        logError('vuukle: mediaTypes.video.mimes is required for video');
+        return false;
       }
-    };
-
-    return [bidResponse];
+      if (!video.playerSize && !bid.sizes) {
+        logError('vuukle: video playerSize is required');
+        return false;
+      }
+    }
+    return true;
   },
-}
-registerBidder(spec);
 
-function vuukleGetConsentGiven(gdprConsent) {
-  let consentGiven = 0;
-  if (typeof gdprConsent !== 'undefined') {
-    consentGiven = deepAccess(gdprConsent, `vendorData.vendor.consents.${VENDOR_ID}`) ? 1 : 0;
-  }
-  return consentGiven;
-}
+  buildRequests(bidRequests, bidderRequest) {
+    const data = converter.toORTB({ bidRequests, bidderRequest });
+    return [{
+      method: 'POST',
+      url: ENDPOINT,
+      data,
+      options: { withCredentials: true },
+    }];
+  },
+
+  interpretResponse(response, request) {
+    if (!response || !response.body || !response.body.seatbid) return [];
+    return converter.fromORTB({ response: response.body, request: request.data }).bids;
+  },
+
+  getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) {
+    if (!syncOptions.iframeEnabled && !syncOptions.pixelEnabled) return [];
+    const params = [];
+    if (gdprConsent) {
+      params.push('gdpr=' + (gdprConsent.gdprApplies ? 1 : 0));
+      params.push('gdpr_consent=' + encodeURIComponent(gdprConsent.consentString || ''));
+    }
+    if (uspConsent) params.push('us_privacy=' + encodeURIComponent(uspConsent));
+    if (gppConsent && gppConsent.gppString) {
+      params.push('gpp=' + encodeURIComponent(gppConsent.gppString));
+      params.push('gpp_sid=' + encodeURIComponent((gppConsent.applicableSections || []).join(',')));
+    }
+    const qs = params.length ? ('?' + params.join('&')) : '';
+    if (syncOptions.iframeEnabled) {
+      return [{ type: 'iframe', url: SYNC_URL + '/iframe' + qs }];
+    }
+    return [{ type: 'image', url: SYNC_URL + '/pixel' + qs }];
+  },
+};
+
+registerBidder(spec);

--- a/modules/vuukleBidAdapter.md
+++ b/modules/vuukleBidAdapter.md
@@ -1,26 +1,92 @@
-# Overview
+---
+layout: bidder
+title: Vuukle
+description: Prebid Vuukle Bidder Adapter
+biddercode: vuukle
+tcfeu_supported: true
+usp_supported: true
+gpp_supported: true
+schain_supported: true
+userId: all
+media_types: banner, video, native
+gvl_id: 1004
+safeframes_ok: true
+floors_supported: true
+pbjs: true
+pbs: false
+---
+
+### Overview
+
 ```
 Module Name: Vuukle Bid Adapter
 Module Type: Bidder Adapter
 Maintainer: support@vuukle.com
 ```
 
-# Description
-Module that connects to Vuukle's server for bids.
-Currently module supports only banner mediaType.
+### Description
 
-# Test Parameters
+The Vuukle Bid Adapter connects Prebid.js to the Vuukle SSP for **banner**, **native** and
+**video** (instream and outstream) demand. It is built on Prebid's
+`ortbConverter`, so it automatically forwards standard OpenRTB signals — sizes,
+price floors (priceFloors module), user IDs (`eids`), supply chain (`schain`),
+and consent (TCF EU, US Privacy, GPP, COPPA, DSA) — derived from the ad unit and
+`ortb2`. For outstream video, the adapter installs a Vuukle-hosted renderer
+unless the publisher supplies their own.
+
+### Bid Params
+
+{: .table .table-bordered .table-striped }
+| Name          | Scope    | Description                                                                 | Example                | Type     |
+|---------------|----------|-----------------------------------------------------------------------------|------------------------|----------|
+| `sid`         | required | Your Vuukle seller ID, as listed in [vuukle.com/sellers.json](https://vuukle.com/sellers.json). | `'vuukle-12345'`       | `string` |
+| `placementId` | optional | A named placement/tag ID. Falls back to the ad unit code if omitted.        | `'homepage-atf'`       | `string` |
+| `bidfloor`    | optional | Hard floor (USD). The priceFloors module is preferred when configured.      | `1.50`                 | `number` |
+
+**Required:** `sid` is required on every request. For **video**, `mediaTypes.video` must include `context`, `playerSize`, and `mimes`.
+
+### Test Parameters — Banner
+
+```javascript
+var adUnits = [{
+  code: 'test-banner',
+  mediaTypes: {
+    banner: { sizes: [[300, 250], [728, 90]] }
+  },
+  bids: [{
+    bidder: 'vuukle',
+    params: { sid: 'vuukle-test' }
+  }]
+}];
 ```
-    var adUnits = [{
-        code: '/test/div',
-        mediaTypes: {
-            banner: {
-                sizes: [[300, 250]]
-            }
-        },
-        bids: [{
-            bidder: 'vuukle',
-            params: {}
-        }]
-    }];
+
+### Test Parameters — Video (outstream)
+
+```javascript
+var adUnits = [{
+  code: 'test-video',
+  mediaTypes: {
+    video: {
+      context: 'outstream',
+      playerSize: [640, 480],
+      mimes: ['video/mp4'],
+      protocols: [2, 3, 5, 6],
+      api: [2],
+      plcmt: 4
+    }
+  },
+  bids: [{
+    bidder: 'vuukle',
+    params: { sid: 'vuukle-test' }
+  }]
+}];
 ```
+
+### Notes
+
+- **First-party data, floors, eids, schain and consent** are handled by
+  `ortbConverter` automatically from the ad unit and `ortb2` — no extra params
+  required.
+- **User sync**: the adapter supports both iframe and image (pixel) syncs,
+  gated by the publisher's `userSync` configuration and forwarded consent.
+- Bid responses are net revenue; default TTL is 300s.

--- a/test/spec/modules/vuukleBidAdapter_spec.js
+++ b/test/spec/modules/vuukleBidAdapter_spec.js
@@ -1,148 +1,289 @@
 import { expect } from 'chai';
 import { spec } from 'modules/vuukleBidAdapter.js';
-import { config } from '../../../src/config.js';
+import { BANNER, VIDEO, NATIVE } from 'src/mediaTypes.js';
+import { config } from 'src/config.js';
 
-describe('vuukleBidAdapterTests', function() {
-  const bidRequestData = {
-    bids: [
-      {
-        bidId: 'testbid',
-        bidder: 'vuukle',
-        params: {
-          test: 1
-        },
-        sizes: [[300, 250]]
-      }
-    ]
+const ENDPOINT = 'https://rtb.vuukle.com/openrtb2/web';
+
+function bannerBid(params = { sid: 'vuukle-test' }) {
+  return {
+    bidder: 'vuukle',
+    bidId: 'bid-banner-1',
+    adUnitCode: 'div-banner',
+    transactionId: 'tx-1',
+    auctionId: 'auc-1',
+    params,
+    mediaTypes: { banner: { sizes: [[300, 250], [728, 90]] } },
+    ortb2Imp: { ext: { gpid: '/1234/home#div-banner' } },
   };
-  let request = [];
+}
 
-  it('validate_pub_params', function() {
-    expect(
-      spec.isBidRequestValid({
-        bidder: 'vuukle',
-        params: {
-          test: 1
-        }
-      })
-    ).to.equal(true);
+function videoBid(context = 'outstream', params = { sid: 'vuukle-test' }) {
+  return {
+    bidder: 'vuukle',
+    bidId: 'bid-video-1',
+    adUnitCode: 'div-video',
+    transactionId: 'tx-2',
+    auctionId: 'auc-1',
+    params,
+    mediaTypes: {
+      video: {
+        context,
+        playerSize: [[640, 480]],
+        mimes: ['video/mp4'],
+        protocols: [2, 3, 5, 6],
+        api: [2],
+        plcmt: context === 'instream' ? 1 : 4,
+      },
+    },
+  };
+}
+
+function nativeBid(params = { sid: 'vuukle-test' }) {
+  return {
+    bidder: 'vuukle',
+    bidId: 'bid-native-1',
+    adUnitCode: 'div-native',
+    transactionId: 'tx-3',
+    auctionId: 'auc-1',
+    params,
+    mediaTypes: {
+      native: {
+        ortb: {
+          assets: [
+            { id: 1, required: 1, title: { len: 80 } },
+            { id: 2, required: 1, img: { type: 3, w: 300, h: 250 } },
+          ],
+        },
+      },
+    },
+  };
+}
+
+function bidderRequest(bids) {
+  return {
+    bidderCode: 'vuukle',
+    bidderRequestId: 'breq-1',
+    auctionId: 'auc-1',
+    timeout: 1000,
+    refererInfo: { page: 'https://example.com/article', domain: 'example.com', ref: '' },
+    ortb2: { site: { domain: 'example.com', page: 'https://example.com/article' } },
+    bids,
+  };
+}
+
+describe('vuukleBidAdapter', function () {
+  describe('isBidRequestValid', function () {
+    it('accepts a valid banner bid', function () {
+      expect(spec.isBidRequestValid(bannerBid())).to.equal(true);
+    });
+    it('rejects when params missing', function () {
+      const b = bannerBid(); delete b.params;
+      expect(spec.isBidRequestValid(b)).to.equal(false);
+    });
+    it('rejects when sid missing', function () {
+      expect(spec.isBidRequestValid(bannerBid({}))).to.equal(false);
+    });
+    it('accepts a valid video bid', function () {
+      expect(spec.isBidRequestValid(videoBid())).to.equal(true);
+    });
+    it('rejects video without mimes', function () {
+      const b = videoBid(); b.mediaTypes.video.mimes = [];
+      expect(spec.isBidRequestValid(b)).to.equal(false);
+    });
+    it('rejects video without playerSize', function () {
+      const b = videoBid(); delete b.mediaTypes.video.playerSize; delete b.sizes;
+      expect(spec.isBidRequestValid(b)).to.equal(false);
+    });
+    it('accepts a valid native bid', function () {
+      expect(spec.isBidRequestValid(nativeBid())).to.equal(true);
+    });
   });
 
-  it('validate_generated_params', function() {
-    request = spec.buildRequests(bidRequestData.bids);
-    const req_data = request[0].data;
-
-    expect(req_data.bidId).to.equal('testbid');
+  describe('spec metadata', function () {
+    it('has the right code, gvlid and media types', function () {
+      expect(spec.code).to.equal('vuukle');
+      expect(spec.gvlid).to.equal(1004);
+      expect(spec.supportedMediaTypes).to.include.members([BANNER, VIDEO, NATIVE]);
+    });
   });
 
-  it('validate_generated_params_tmax', function() {
-    request = spec.buildRequests(bidRequestData.bids, { timeout: 1234 });
-    const req_data = request[0].data;
+  describe('buildRequests', function () {
+    it('builds a single POST request to the endpoint with credentials', function () {
+      const bids = [bannerBid()];
+      const reqs = spec.buildRequests(bids, bidderRequest(bids));
+      expect(reqs).to.have.lengthOf(1);
+      expect(reqs[0].method).to.equal('POST');
+      expect(reqs[0].url).to.equal(ENDPOINT);
+      expect(reqs[0].options.withCredentials).to.equal(true);
+    });
 
-    expect(req_data.tmax).to.equal(1234);
+    it('produces a valid oRTB body with imp + site.publisher.id = sid', function () {
+      const bids = [bannerBid({ sid: 'vuukle-abc' })];
+      const { data } = spec.buildRequests(bids, bidderRequest(bids))[0];
+      expect(data).to.be.an('object');
+      expect(data.imp).to.be.an('array').with.lengthOf(1);
+      expect(data.site.publisher.id).to.equal('vuukle-abc');
+    });
+
+    it('sets a banner imp with format and tagid from adUnitCode', function () {
+      const bids = [bannerBid()];
+      const { data } = spec.buildRequests(bids, bidderRequest(bids))[0];
+      expect(data.imp[0].banner).to.exist;
+      expect(data.imp[0].banner.format).to.be.an('array');
+      expect(data.imp[0].tagid).to.equal('div-banner');
+      expect(data.imp[0].ext.gpid).to.equal('/1234/home#div-banner');
+    });
+
+    it('uses placementId as tagid when provided', function () {
+      const bids = [bannerBid({ sid: 'vuukle-test', placementId: 'home-atf' })];
+      const { data } = spec.buildRequests(bids, bidderRequest(bids))[0];
+      expect(data.imp[0].tagid).to.equal('home-atf');
+    });
+
+    it('forwards params.bidfloor to imp.bidfloor', function () {
+      const bids = [bannerBid({ sid: 'vuukle-test', bidfloor: 1.75 })];
+      const { data } = spec.buildRequests(bids, bidderRequest(bids))[0];
+      expect(data.imp[0].bidfloor).to.equal(1.75);
+      expect(data.imp[0].bidfloorcur).to.equal('USD');
+    });
+
+    it('builds a request for a video bid', function () {
+      const bids = [videoBid('instream')];
+      const { data } = spec.buildRequests(bids, bidderRequest(bids))[0];
+      expect(data.imp).to.have.lengthOf(1);
+    });
+
+    it('builds a request for a native bid', function () {
+      const bids = [nativeBid()];
+      const { data } = spec.buildRequests(bids, bidderRequest(bids))[0];
+      expect(data.imp).to.have.lengthOf(1);
+    });
+
+    it('forwards user eids', function () {
+      const bid = bannerBid();
+      const eids = [{ source: 'id5.io', uids: [{ id: 'ID5-1', atype: 1 }] }];
+      bid.userIdAsEids = eids;
+      const bids = [bid];
+      const breq = bidderRequest(bids);
+      breq.ortb2 = { ...breq.ortb2, user: { ext: { eids } } };
+      const { data } = spec.buildRequests(bids, breq)[0];
+      expect(data.user.ext.eids).to.deep.equal(eids);
+    });
+
+    it('forwards supply chain (schain)', function () {
+      const schain = { complete: 1, ver: '1.0', nodes: [{ asi: 'vuukle.com', sid: 'vuukle-test', hp: 1 }] };
+      const bids = [bannerBid()];
+      const breq = bidderRequest(bids);
+      breq.ortb2 = { ...breq.ortb2, source: { ext: { schain } } };
+      const { data } = spec.buildRequests(bids, breq)[0];
+      const sc = (data.source && (data.source.schain || (data.source.ext && data.source.ext.schain)));
+      expect(sc).to.deep.equal(schain);
+    });
   });
 
-  it('validate_response_params', function() {
-    const serverResponse = {
-      body: {
-        'cpm': 0.01,
-        'width': 300,
-        'height': 250,
-        'creative_id': '12345',
-        'ad': 'test ad',
-        'adomain': ['example.com']
-      }
-    };
-
-    request = spec.buildRequests(bidRequestData.bids);
-    const bids = spec.interpretResponse(serverResponse, request[0]);
-    expect(bids).to.have.lengthOf(1);
-
-    const bid = bids[0];
-    expect(bid.ad).to.equal('test ad');
-    expect(bid.cpm).to.equal(0.01);
-    expect(bid.width).to.equal(300);
-    expect(bid.height).to.equal(250);
-    expect(bid.creativeId).to.equal('12345');
-    expect(bid.meta.advertiserDomains).to.deep.equal(['example.com']);
-  });
-
-  describe('consent handling', function() {
-    const bidderRequest = {
-      gdprConsent: {
-        consentString: 'COvFyGBOvFyGBAbAAAENAPCAAOAAAAAAAAAAAEEUACCKAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw',
-        gdprApplies: 1,
-        vendorData: {
-          vendor: {
-            consents: {
-              1004: 1
-            }
-          }
-        }
-      }
+  describe('interpretResponse', function () {
+    function build(bids) {
+      return spec.buildRequests(bids, bidderRequest(bids))[0];
     }
 
-    it('must handle consent 1/1', function() {
-      request = spec.buildRequests(bidRequestData.bids, bidderRequest);
-      const req_data = request[0].data;
+    it('returns [] on empty body', function () {
+      expect(spec.interpretResponse({ body: null }, {})).to.deep.equal([]);
+    });
 
-      expect(req_data.gdpr).to.equal(1);
-      expect(req_data.consentGiven).to.equal(1);
-      expect(req_data.consent).to.equal('COvFyGBOvFyGBAbAAAENAPCAAOAAAAAAAAAAAEEUACCKAAA.IFoEUQQgAIQwgIwQABAEAAAAOIAACAIAAAAQAIAgEAACEAAAAAgAQBAAAAAAAGBAAgAAAAAAAFAAECAAAgAAQARAEQAAAAAJAAIAAgAAAYQEAAAQmAgBC3ZAYzUw');
-    })
+    it('returns [] when no seatbid', function () {
+      expect(spec.interpretResponse({ body: { id: 'x' } }, {})).to.deep.equal([]);
+    });
 
-    it('must handle consent 0/1', function() {
-      bidderRequest.gdprConsent.gdprApplies = 0;
-      request = spec.buildRequests(bidRequestData.bids, bidderRequest);
-      const req_data = request[0].data;
+    it('parses a banner bid', function () {
+      const bids = [bannerBid()];
+      const request = build(bids);
+      const response = {
+        body: {
+          id: 'breq-1',
+          cur: 'USD',
+          seatbid: [{
+            seat: 'pubmatic',
+            bid: [{
+              impid: 'bid-banner-1',
+              price: 3.21,
+              crid: 'cr-9',
+              adomain: ['acme.com'],
+              w: 300,
+              h: 250,
+              adm: '<div>ad</div>',
+              mtype: 1
+            }]
+          }]
+        }
+      };
+      const out = spec.interpretResponse(response, request);
+      expect(out).to.have.lengthOf(1);
+      expect(out[0].cpm).to.equal(3.21);
+      expect(out[0].creativeId).to.equal('cr-9');
+      expect(out[0].width).to.equal(300);
+      expect(out[0].height).to.equal(250);
+      expect(out[0].mediaType).to.equal(BANNER);
+      expect(out[0].meta.advertiserDomains).to.deep.equal(['acme.com']);
+    });
 
-      expect(req_data.gdpr).to.equal(0);
-      expect(req_data.consentGiven).to.equal(1);
-    })
+    it('parses an outstream video bid and attaches a renderer', function () {
+      const bids = [videoBid('outstream')];
+      const request = build(bids);
+      const response = {
+        body: {
+          id: 'breq-1',
+          cur: 'USD',
+          seatbid: [{
+            seat: 'unruly',
+            bid: [{
+              impid: 'bid-video-1',
+              price: 8.5,
+              crid: 'v-1',
+              adomain: ['brand.com'],
+              w: 640,
+              h: 480,
+              adm: '<VAST version="4.2"></VAST>',
+              mtype: 2
+            }]
+          }]
+        }
+      };
+      const out = spec.interpretResponse(response, request);
+      expect(out).to.have.lengthOf(1);
+      expect(out[0].mediaType).to.equal(VIDEO);
+      expect(out[0].renderer).to.exist;
+    });
+  });
 
-    it('must handle consent 0/0', function() {
-      bidderRequest.gdprConsent.gdprApplies = 0;
-      bidderRequest.gdprConsent.vendorData = undefined;
-      request = spec.buildRequests(bidRequestData.bids, bidderRequest);
-      const req_data = request[0].data;
+  describe('getUserSyncs', function () {
+    it('returns [] when neither iframe nor pixel is enabled', function () {
+      expect(spec.getUserSyncs({ iframeEnabled: false, pixelEnabled: false }, [])).to.deep.equal([]);
+    });
+    it('returns an iframe sync when iframe is enabled', function () {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true, pixelEnabled: true }, []);
+      expect(syncs).to.have.lengthOf(1);
+      expect(syncs[0].type).to.equal('iframe');
+    });
+    it('returns a pixel sync when only pixel is enabled', function () {
+      const syncs = spec.getUserSyncs({ iframeEnabled: false, pixelEnabled: true }, []);
+      expect(syncs[0].type).to.equal('image');
+    });
+    it('forwards consent params (gdpr, usp, gpp)', function () {
+      const syncs = spec.getUserSyncs(
+        { iframeEnabled: true },
+        [],
+        { gdprApplies: true, consentString: 'CONSENT' },
+        '1YNN',
+        { gppString: 'GPP', applicableSections: [7, 8] },
+      );
+      expect(syncs[0].url).to.contain('gdpr=1');
+      expect(syncs[0].url).to.contain('gdpr_consent=CONSENT');
+      expect(syncs[0].url).to.contain('us_privacy=1YNN');
+      expect(syncs[0].url).to.contain('gpp=GPP');
+      expect(syncs[0].url).to.contain('gpp_sid=7%2C8');
+    });
+  });
 
-      expect(req_data.gdpr).to.equal(0);
-      expect(req_data.consentGiven).to.equal(0);
-    })
-
-    it('must handle consent undef', function() {
-      request = spec.buildRequests(bidRequestData.bids, {});
-      const req_data = request[0].data;
-
-      expect(req_data.gdpr).to.equal(0);
-      expect(req_data.consentGiven).to.equal(0);
-    })
-  })
-
-  it('must handle usp consent', function() {
-    request = spec.buildRequests(bidRequestData.bids, { uspConsent: '1YNN' });
-    const req_data = request[0].data;
-
-    expect(req_data.uspConsent).to.equal('1YNN');
-  })
-
-  it('must handle undefined usp consent', function() {
-    request = spec.buildRequests(bidRequestData.bids, {});
-    const req_data = request[0].data;
-
-    expect(req_data.uspConsent).to.equal(undefined);
-  })
-
-  it('must handle coppa flag', function() {
-    sinon.stub(config, 'getConfig')
-      .withArgs('coppa')
-      .returns(true);
-
-    request = spec.buildRequests(bidRequestData.bids);
-    const req_data = request[0].data;
-
-    expect(req_data.coppa).to.equal(1);
-
-    config.getConfig.restore();
-  })
+  afterEach(function () { config.resetConfig(); });
 });


### PR DESCRIPTION
Modernizes the Vuukle Bid Adapter.

## Type of change
- [x] Refactoring (no functional changes to existing behavior beyond the rewrite)
- [x] New feature / enhancement

## Description of change
- Rewritten on `ortbConverter` (replaces the legacy hand-rolled GET implementation).
- Adds **video** (instream + outstream, with an outstream renderer) and **native** media types — previously banner-only.
- New OpenRTB endpoint: `https://rtb.vuukle.com/openrtb2/web` (POST, CORS-enabled).
- Required bid param is `sid` (the publisher's sellers.json seller_id, set as `site.publisher.id`).
- Forwards price floors (priceFloors module), user `eids`, `schain`, and consent (TCF EU / US Privacy / GPP / COPPA / DSA) via ortbConverter.
- iframe + pixel user-sync with consent passthrough.
- Maintainer updated to `support@vuukle.com` (Vuukle company ownership; transfer coordinated with Prebid).

- contact email of the adapter's maintainer: support@vuukle.com
- [x] test parameters for validating bids are in the .md file
- Bidder code: `vuukle`
- GVL ID: 1004

## Other information
Unit tests included (`test/spec/modules/vuukleBidAdapter_spec.js`). `gulp lint` and `gulp test --file test/spec/modules/vuukleBidAdapter_spec.js` pass locally (incl. the all-features-disabled bundle).
