### PR TITLE
fluct Bid Adapter: remove CORS preflight by switching to text/plain

### DIFF
--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -113,20 +113,14 @@ export const spec = {
     const serverRequests = [];
     const page = bidderRequest.refererInfo.page;
     const wrapperName = config.getConfig('fluct')?.wrapperName;
-    const customHeaders = {
-      'x-fluct-app': 'prebid/fluctBidAdapter',
-      'x-fluct-version': VERSION,
-      'x-openrtb-version': 2.5,
-    };
-    if (wrapperName) {
-      customHeaders['x-fluct-prebid-wrapper'] = wrapperName;
-    }
 
     _each(validBidRequests, (request) => {
       const impExt = request.ortb2Imp?.ext;
       const data = {};
 
       data.page = page;
+      data.adapterVersion = VERSION;
+      if (wrapperName) data.wrapperName = wrapperName;
 
       const ortb2Site = bidderRequest.ortb2?.site;
       if (ortb2Site) {
@@ -277,9 +271,7 @@ export const spec = {
         method: 'POST',
         url: END_POINT + '?' + searchParams.toString(),
         options: {
-          contentType: 'application/json',
           withCredentials: true,
-          customHeaders,
         },
         data: data
       });

--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -10,7 +10,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 
 const BIDDER_CODE = 'fluct';
 const END_POINT = 'https://hb.adingo.jp/prebid/';
-const VERSION = '1.7';
+const VERSION = '1.8';
 const NET_REVENUE = true;
 const TTL = 300;
 const DEFAULT_CURRENCY = 'JPY';

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -192,16 +192,31 @@ describe('fluctAdapter', function () {
       expect(request.data.regs).to.eql(undefined);
     });
 
-    it('does not include x-fluct-prebid-wrapper header by default', function () {
+    it('does not include wrapperName in data by default', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
-      expect(request.options.customHeaders['x-fluct-prebid-wrapper']).to.be.undefined;
+      expect(request.data.wrapperName).to.be.undefined;
     });
 
-    it('includes x-fluct-prebid-wrapper header when fluct.wrapperName is configured', function () {
+    it('includes wrapperName in data when fluct.wrapperName is configured', function () {
       sb.stub(config, 'getConfig').withArgs('fluct').returns({ wrapperName: 'boost' });
 
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
-      expect(request.options.customHeaders['x-fluct-prebid-wrapper']).to.equal('boost');
+      expect(request.data.wrapperName).to.equal('boost');
+    });
+
+    it('includes adapterVersion in data', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.data.adapterVersion).to.be.a('string').and.not.empty;
+    });
+
+    it('does not set application/json content type', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.options.contentType).to.be.undefined;
+    });
+
+    it('does not include custom headers', function () {
+      const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+      expect(request.options.customHeaders).to.be.undefined;
     });
 
     it('includes filtered user.eids if any exists', function () {


### PR DESCRIPTION
## Type of issue

Enhancement / feature — existing bid adapter update

## Description

The fluct bid adapter currently sends `Content-Type: application/json` with several custom headers (`x-fluct-app`, `x-fluct-version`, `x-openrtb-version`, `x-fluct-prebid-wrapper`). This combination triggers a CORS preflight OPTIONS request before every bid request, adding ~400ms of latency.

This PR removes the CORS preflight by:

- Dropping `Content-Type: application/json` → default `text/plain` (CORS simple request, no preflight)
- Removing all custom headers (custom headers always trigger preflight)
- Moving the former header data into the request body:
  - `adapterVersion` (was `x-fluct-version`)
  - `wrapperName` (was `x-fluct-prebid-wrapper`, set only when `config.getConfig('fluct').wrapperName` is configured)

The fluct server has been updated to accept `text/plain` and read `adapterVersion` / `wrapperName` from the request body.

## Steps to reproduce

1. Open DevTools Network tab with fluct bid adapter configured
2. Observe OPTIONS preflight before every POST to `https://hb.adingo.jp/prebid/`

## Expected results

Only a single POST per auction — no OPTIONS preflight.

## Actual results (before this PR)

Two requests per auction: OPTIONS (~400ms) + POST.

## Platform details

- Adapter: `modules/fluctBidAdapter.js` (VERSION 1.7)
- Tests: `test/spec/modules/fluctBidAdapter_spec.js`

```
gulp test --nolint --file test/spec/modules/fluctBidAdapter_spec.js
✔ 68 tests completed
```

## Other information

Follows up on reviewer feedback from #14957 ([@patmmccann](https://github.com/prebid/Prebid.js/pull/14957#discussion_r2127690000)):
> you should stop sending all these extra headers, they make your bid request take an extra 400ms by causing a preflight cors request, you also need to switch to text/plain

🤖 Generated with [Claude Code](https://claude.com/claude-code)