### PR TITLE
Floxis Bid Adapter: require only seat, ungate partner/region, add user sync

### DIFF
--- a/modules/floxisBidAdapter.js
+++ b/modules/floxisBidAdapter.js
@@ -1,7 +1,7 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
-import { triggerPixel, mergeDeep } from '../src/utils.js';
+import { triggerPixel, mergeDeep, replaceAuctionPrice } from '../src/utils.js';
 
 const BIDDER_CODE = 'floxis';
 const DEFAULT_BID_TTL = 300;
@@ -41,8 +41,12 @@ function getSyncHost(region) {
 function buildConsentQuery(gdprConsent, uspConsent, gppConsent) {
   const query = [];
   if (gdprConsent) {
-    query.push('gdpr=' + (gdprConsent.gdprApplies & 1));
-    query.push('gdpr_consent=' + encodeURIComponent(gdprConsent.consentString || ''));
+    if (typeof gdprConsent.gdprApplies === 'boolean') {
+      query.push('gdpr=' + Number(gdprConsent.gdprApplies));
+    }
+    if (gdprConsent.consentString) {
+      query.push('gdpr_consent=' + encodeURIComponent(gdprConsent.consentString));
+    }
   }
   if (uspConsent) {
     query.push('us_privacy=' + encodeURIComponent(uspConsent));
@@ -69,33 +73,45 @@ const CONVERTER = ortbConverter({
   context: {
     netRevenue: DEFAULT_NET_REVENUE,
     ttl: DEFAULT_BID_TTL,
-    currency: DEFAULT_CURRENCY
+    currency: DEFAULT_CURRENCY,
+    nativeRequest: { eventtrackers: [{ event: 1, methods: [1, 2] }] }
   },
   imp(buildImp, bidRequest, context) {
     const imp = buildImp(bidRequest, context);
     imp.secure = bidRequest.ortb2Imp?.secure ?? 1;
 
-    let floorInfo;
-    if (typeof bidRequest.getFloor === 'function') {
-      try {
-        floorInfo = bidRequest.getFloor({
-          currency: DEFAULT_CURRENCY,
-          mediaType: '*',
-          size: '*'
-        });
-      } catch (e) { }
-    }
-    const floor = floorInfo?.floor;
-    const floorCur = floorInfo?.currency || DEFAULT_CURRENCY;
-    if (typeof floor === 'number' && !isNaN(floor)) {
-      imp.bidfloor = floor;
-      imp.bidfloorcur = floorCur;
+    // The priceFloors processor already sets imp.bidfloor when the module is active; only fill a
+    // floor here when it left none — from getFloor (ignoring 0, which would clobber an FPD floor)
+    // or a static params.bidFloor fallback for bundles without the floors module.
+    if (!imp.bidfloor) {
+      let floor;
+      let floorCur = DEFAULT_CURRENCY;
+      if (typeof bidRequest.getFloor === 'function') {
+        try {
+          const floorInfo = bidRequest.getFloor({ currency: DEFAULT_CURRENCY, mediaType: '*', size: '*' });
+          if (floorInfo && typeof floorInfo.floor === 'number' && floorInfo.floor > 0) {
+            floor = floorInfo.floor;
+            floorCur = floorInfo.currency || DEFAULT_CURRENCY;
+          }
+        } catch (e) { }
+      }
+      if (floor === undefined && bidRequest.params?.bidFloor > 0) {
+        floor = parseFloat(bidRequest.params.bidFloor);
+        floorCur = bidRequest.params.bidFloorCur || DEFAULT_CURRENCY;
+      }
+      if (floor !== undefined) {
+        imp.bidfloor = floor;
+        imp.bidfloorcur = floorCur;
+      }
     }
 
     return imp;
   },
   request(buildRequest, imps, bidderRequest, context) {
     const req = buildRequest(imps, bidderRequest, context);
+    if (!req.cur) {
+      req.cur = [DEFAULT_CURRENCY];
+    }
     mergeDeep(req, {
       at: 1,
       ext: {
@@ -106,6 +122,17 @@ const CONVERTER = ortbConverter({
       }
     });
     return req;
+  },
+  bidResponse(buildBidResponse, bid, context) {
+    const bidResponse = buildBidResponse(bid, context);
+    const ext = bid.ext || {};
+    bidResponse.meta = bidResponse.meta || {};
+    if (ext.dspid != null) bidResponse.meta.networkId = ext.dspid;
+    if (ext.advertiser_name) bidResponse.meta.advertiserName = ext.advertiser_name;
+    if (ext.agency_name) bidResponse.meta.agencyName = ext.agency_name;
+    if (ext.agency_id) bidResponse.meta.agencyId = ext.agency_id;
+    if (bidResponse.mediaType) bidResponse.meta.mediaType = bidResponse.mediaType;
+    return bidResponse;
   }
 });
 
@@ -194,12 +221,11 @@ export const spec = {
     return syncs;
   },
 
-  onBidWon(bid) {
+  onBidBillable(bid) {
+    // Fire the DSP billing notice on billing (which respects bidViewability's deferral), substituting
+    // the cleared price into the ${AUCTION_PRICE} macro. originalCpm is pre-currency-conversion.
     if (bid.burl) {
-      triggerPixel(bid.burl);
-    }
-    if (bid.nurl) {
-      triggerPixel(bid.nurl);
+      triggerPixel(replaceAuctionPrice(bid.burl, bid.originalCpm || bid.cpm));
     }
   }
 };

--- a/modules/floxisBidAdapter.js
+++ b/modules/floxisBidAdapter.js
@@ -9,29 +9,61 @@ const DEFAULT_CURRENCY = 'USD';
 const DEFAULT_NET_REVENUE = true;
 const DEFAULT_REGION = 'us-e';
 const DEFAULT_PARTNER = BIDDER_CODE;
-const PARTNER_REGION_WHITELIST = {
-  [DEFAULT_PARTNER]: [DEFAULT_REGION],
-};
+const SYNC_PATH = '/sync';
 
-function isAllowedPartnerRegion(partner, region) {
-  return PARTNER_REGION_WHITELIST[partner]?.includes(region) || false;
+// partner/region are interpolated into the request host, so they must be valid DNS labels —
+// otherwise a value with URL delimiters (e.g. 'evil.com/x?') would change the request origin.
+const HOST_LABEL_REGEX = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/i;
+function isValidHostLabel(label) {
+  return typeof label === 'string' && HOST_LABEL_REGEX.test(label);
+}
+
+// Bidding host: the supply partner's regional subdomain (floxis itself has no partner prefix).
+function getBidHost(region, partner) {
+  if (!isValidHostLabel(region) || !isValidHostLabel(partner)) return null;
+  return partner === BIDDER_CODE
+    ? `${region}.floxis.tech`
+    : `${partner}-${region}.floxis.tech`;
 }
 
 function getEndpointUrl(seat, region, partner) {
-  if (!isAllowedPartnerRegion(partner, region)) return null;
-  const host = partner === BIDDER_CODE
-    ? `${region}.floxis.tech`
-    : `${partner}-${region}.floxis.tech`;
-  return `https://${host}/pbjs?seat=${encodeURIComponent(seat)}`;
+  const host = getBidHost(region, partner);
+  return host ? `https://${host}/pbjs?seat=${encodeURIComponent(seat)}` : null;
+}
+
+// Cookie-sync host is Floxis-operated and region-scoped (px-<region>.floxis.tech), independent of
+// the partner subdomain used for bidding. The trackers /sync endpoint resolves seat -> supply partner.
+function getSyncHost(region) {
+  return isValidHostLabel(region) ? `https://px-${region}.floxis.tech` : null;
+}
+
+// IAB consent query params for the trackers /sync endpoint.
+function buildConsentQuery(gdprConsent, uspConsent, gppConsent) {
+  const query = [];
+  if (gdprConsent) {
+    query.push('gdpr=' + (gdprConsent.gdprApplies & 1));
+    query.push('gdpr_consent=' + encodeURIComponent(gdprConsent.consentString || ''));
+  }
+  if (uspConsent) {
+    query.push('us_privacy=' + encodeURIComponent(uspConsent));
+  }
+  if (gppConsent?.gppString && gppConsent?.applicableSections?.length) {
+    query.push('gpp=' + encodeURIComponent(gppConsent.gppString));
+    query.push('gpp_sid=' + encodeURIComponent(gppConsent.applicableSections.join(',')));
+  }
+  return query;
 }
 
 function normalizeBidParams(params = {}) {
   return {
     seat: params.seat,
-    region: params.region ?? DEFAULT_REGION,
-    partner: params.partner ?? DEFAULT_PARTNER
+    region: params.region || DEFAULT_REGION,
+    partner: params.partner || DEFAULT_PARTNER
   };
 }
+
+// Seat/region pairs from the latest buildRequests, consumed by getUserSyncs (which is not given params).
+let syncTargets = [];
 
 const CONVERTER = ortbConverter({
   context: {
@@ -82,15 +114,12 @@ export const spec = {
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 
   isBidRequestValid(bid) {
-    const params = bid?.params;
-    if (!params) return false;
-    const { seat, region, partner } = normalizeBidParams(params);
-    if (typeof seat !== 'string' || !seat.length) return false;
-    if (!isAllowedPartnerRegion(partner, region)) return false;
-    return true;
+    const seat = bid?.params?.seat;
+    return typeof seat === 'string' && seat.length > 0;
   },
 
   buildRequests(validBidRequests = [], bidderRequest = {}) {
+    syncTargets = [];
     if (!validBidRequests.length) return [];
     const filteredBidRequests = validBidRequests.filter((bidRequest) => spec.isBidRequestValid(bidRequest));
     if (!filteredBidRequests.length) return [];
@@ -111,7 +140,15 @@ export const spec = {
       return groups;
     }, {});
 
-    return Object.values(bidRequestsByParams).map((groupedBidRequests) => {
+    const groups = Object.values(bidRequestsByParams);
+    syncTargets = groups
+      .map((groupedBidRequests) => {
+        const { seat, region } = groupedBidRequests[0].params;
+        return { seat, region };
+      })
+      .filter((target) => isValidHostLabel(target.region));
+
+    return groups.map((groupedBidRequests) => {
       const { seat, region, partner } = groupedBidRequests[0].params;
       const url = getEndpointUrl(seat, region, partner);
       if (!url) return null;
@@ -132,8 +169,29 @@ export const spec = {
     return CONVERTER.fromORTB({ request: request.data, response: response.body })?.bids || [];
   },
 
-  getUserSyncs() {
-    return [];
+  getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) {
+    if (!syncOptions.iframeEnabled && !syncOptions.pixelEnabled) return [];
+    // Empty serverResponses => this adapter did not bid in this auction, so buildRequests was not
+    // called and syncTargets would be stale from a prior auction. Consume the targets either way.
+    const targets = syncTargets;
+    syncTargets = [];
+    if (!serverResponses || !serverResponses.length || !targets.length) return [];
+    const pixelType = syncOptions.iframeEnabled ? 'iframe' : 'image';
+    const query = buildConsentQuery(gdprConsent, uspConsent, gppConsent);
+    const consentSuffix = query.length ? '&' + query.join('&') : '';
+    const seen = {};
+    const syncs = [];
+    targets.forEach(({ seat, region }) => {
+      const host = getSyncHost(region);
+      const key = `${seat}|${region}`;
+      if (!host || seen[key]) return;
+      seen[key] = true;
+      syncs.push({
+        type: pixelType,
+        url: `${host}${SYNC_PATH}?seat=${encodeURIComponent(seat)}${consentSuffix}`
+      });
+    });
+    return syncs;
   },
 
   onBidWon(bid) {

--- a/modules/floxisBidAdapter.js
+++ b/modules/floxisBidAdapter.js
@@ -10,6 +10,10 @@ const DEFAULT_NET_REVENUE = true;
 const DEFAULT_REGION = 'us-e';
 const DEFAULT_PARTNER = BIDDER_CODE;
 const SYNC_PATH = '/sync';
+// Server-echo user-sync: the /pbjs response carries seat + region in this header (on bid and no-bid
+// alike), so getUserSyncs derives sync targets from serverResponses statelessly — no module state that
+// could leak across concurrent auctions. Absent header (older backend) => no sync, a safe no-op.
+const SYNC_HEADER = 'x-floxis-sync';
 
 // partner/region are interpolated into the request host, so they must be valid DNS labels —
 // otherwise a value with URL delimiters (e.g. 'evil.com/x?') would change the request origin.
@@ -66,8 +70,16 @@ function normalizeBidParams(params = {}) {
   };
 }
 
-// Seat/region pairs from the latest buildRequests, consumed by getUserSyncs (which is not given params).
-let syncTargets = [];
+// Parse the server-echoed sync header (`seat=<seat>&region=<label>`) into a sync target. Returns null
+// for an absent or malformed header so a response without it simply contributes no sync.
+function parseSyncHeader(headerValue) {
+  if (typeof headerValue !== 'string' || !headerValue) return null;
+  const params = new URLSearchParams(headerValue);
+  const seat = params.get('seat');
+  const region = params.get('region');
+  if (!seat || !isValidHostLabel(region)) return null;
+  return { seat, region };
+}
 
 const CONVERTER = ortbConverter({
   context: {
@@ -146,7 +158,6 @@ export const spec = {
   },
 
   buildRequests(validBidRequests = [], bidderRequest = {}) {
-    syncTargets = [];
     if (!validBidRequests.length) return [];
     const filteredBidRequests = validBidRequests.filter((bidRequest) => spec.isBidRequestValid(bidRequest));
     if (!filteredBidRequests.length) return [];
@@ -168,12 +179,6 @@ export const spec = {
     }, {});
 
     const groups = Object.values(bidRequestsByParams);
-    syncTargets = groups
-      .map((groupedBidRequests) => {
-        const { seat, region } = groupedBidRequests[0].params;
-        return { seat, region };
-      })
-      .filter((target) => isValidHostLabel(target.region));
 
     return groups.map((groupedBidRequests) => {
       const { seat, region, partner } = groupedBidRequests[0].params;
@@ -198,17 +203,16 @@ export const spec = {
 
   getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) {
     if (!syncOptions.iframeEnabled && !syncOptions.pixelEnabled) return [];
-    // Empty serverResponses => this adapter did not bid in this auction, so buildRequests was not
-    // called and syncTargets would be stale from a prior auction. Consume the targets either way.
-    const targets = syncTargets;
-    syncTargets = [];
-    if (!serverResponses || !serverResponses.length || !targets.length) return [];
+    if (!serverResponses || !serverResponses.length) return [];
     const pixelType = syncOptions.iframeEnabled ? 'iframe' : 'image';
     const query = buildConsentQuery(gdprConsent, uspConsent, gppConsent);
     const consentSuffix = query.length ? '&' + query.join('&') : '';
     const seen = {};
     const syncs = [];
-    targets.forEach(({ seat, region }) => {
+    serverResponses.forEach((serverResponse) => {
+      const target = parseSyncHeader(serverResponse?.headers?.get?.(SYNC_HEADER));
+      if (!target) return;
+      const { seat, region } = target;
       const host = getSyncHost(region);
       const key = `${seat}|${region}`;
       if (!host || seen[key]) return;

--- a/modules/floxisBidAdapter.md
+++ b/modules/floxisBidAdapter.md
@@ -15,6 +15,7 @@ The Floxis Bid Adapter enables integration with the Floxis programmatic advertis
 - OpenRTB 2.x compliant
 - Privacy regulation compliance (GDPR, USP, GPP, COPPA)
 - Prebid.js Floors Module support
+- User sync (iframe and pixel cookie matching)
 
 ## Supported Media Types
 - Banner
@@ -36,9 +37,7 @@ pbjs.addAdUnits([
     bids: [{
       bidder: 'floxis',
       params: {
-        seat: 'testSeat',
-        region: 'us-e',
-        partner: 'floxis'
+        seat: 'testSeat'
       }
     }]
   }
@@ -52,8 +51,22 @@ pbjs.addAdUnits([
 | Name | Scope | Description | Example | Type |
 | --- | --- | --- | --- | --- |
 | `seat` | required | Seat identifier | `'testSeat'` | `string` |
-| `region` | required | Region identifier for routing | `'us-e'` | `string` |
-| `partner` | required | Partner identifier | `'floxis'` | `string` |
+| `region` | optional | Region identifier for routing (defaults to `us-e`) | `'us-e'` | `string` |
+| `partner` | optional | Partner identifier (defaults to `floxis`) | `'floxis'` | `string` |
+
+Only `seat` is required. `region` and `partner` are optional and accepted as-is — any value routes to the matching `[<partner>-]<region>.floxis.tech` endpoint.
+
+## User Sync
+The adapter registers cookie syncs to the Floxis trackers endpoint (`px-<region>.floxis.tech/sync`), which sets the Floxis DMP id and chains to the seat's demand-partner syncs. Both iframe and pixel syncs are supported; the type emitted follows your `userSync` configuration. Enable it for the adapter, e.g.:
+```javascript
+pbjs.setConfig({
+  userSync: {
+    filterSettings: {
+      iframe: { bidders: ['floxis'], filter: 'include' }
+    }
+  }
+});
+```
 
 ## Testing
-Unit tests are provided in `test/spec/modules/floxisBidAdapter_spec.js` and cover validation, request building, response interpretation, and bid-won notifications.
+Unit tests are provided in `test/spec/modules/floxisBidAdapter_spec.js` and cover validation, request building, response interpretation, user syncs, and bid-won notifications.

--- a/modules/floxisBidAdapter.md
+++ b/modules/floxisBidAdapter.md
@@ -8,38 +8,73 @@ Maintainer: admin@floxis.tech
 
 # Description
 
-The Floxis Bid Adapter enables integration with the Floxis programmatic advertising platform via Prebid.js. It supports banner, video (instream and outstream), and native formats.
+The Floxis Bid Adapter enables integration with the Floxis programmatic advertising platform via Prebid.js. It supports banner, video, and native formats.
 
 **Key Features:**
 - Banner, Video and Native ad support
 - OpenRTB 2.x compliant
-- Privacy regulation compliance (GDPR, USP, GPP, COPPA)
-- Prebid.js Floors Module support
+- Privacy signal forwarding (GDPR/TCF, USP, GPP, COPPA) via Prebid.js core
+- User identity (User ID / `eids`) and supply chain (`schain`) passthrough
+- Prebid.js Floors Module support (plus a static `bidFloor` param fallback)
 - User sync (iframe and pixel cookie matching)
 
 ## Supported Media Types
 - Banner
-- Video
+- Video (instream; outstream requires a publisher-supplied `mediaTypes.video.renderer`)
 - Native
 
 ## Floors Module Support
-The Floxis Bid Adapter supports the Prebid.js [Floors Module](https://docs.prebid.org/dev-docs/modules/floors.html). Floor values are automatically included in the OpenRTB request as `imp.bidfloor` and `imp.bidfloorcur`.
+The Floxis Bid Adapter supports the Prebid.js [Floors Module](https://docs.prebid.org/dev-docs/modules/floors.html). Floor values are automatically included in the OpenRTB request as `imp.bidfloor` and `imp.bidfloorcur`. When the Floors module is not in the build, a static `params.bidFloor` (with optional `params.bidFloorCur`) is used as a fallback.
+
+## User Identity & Supply Chain
+`user.ext.eids` from the Prebid [User ID module](https://docs.prebid.org/dev-docs/modules/userId.html) and `source.ext.schain` (set via `pbjs.setConfig({ schain })` or `ortb2`) are forwarded automatically through first-party-data passthrough — no adapter-specific configuration is required.
 
 ## Privacy
-Privacy fields (GDPR, USP, GPP, COPPA) are handled by Prebid.js core and automatically included in the OpenRTB request.
+GDPR/TCF, US Privacy, GPP and COPPA signals are handled by Prebid.js core and automatically included in the OpenRTB request; consent strings are also appended to user-sync calls. Note: a Floxis IAB Europe GVL (Global Vendor List) ID registration is in progress — until it is assigned and added to the adapter, Floxis is not yet an independently listed TCF vendor.
 
 ## Example Usage
+
+Banner:
 ```javascript
 pbjs.addAdUnits([
   {
-    code: 'adunit-1',
+    code: 'adunit-banner',
     mediaTypes: { banner: { sizes: [[300, 250]] } },
-    bids: [{
-      bidder: 'floxis',
-      params: {
-        seat: 'testSeat'
+    bids: [{ bidder: 'floxis', params: { seat: 'testSeat' } }]
+  }
+]);
+```
+
+Video (instream):
+```javascript
+pbjs.addAdUnits([
+  {
+    code: 'adunit-video',
+    mediaTypes: {
+      video: {
+        context: 'instream',
+        playerSize: [[640, 480]],
+        mimes: ['video/mp4'],
+        protocols: [2, 3, 5, 6]
       }
-    }]
+    },
+    bids: [{ bidder: 'floxis', params: { seat: 'testSeat' } }]
+  }
+]);
+```
+
+Native:
+```javascript
+pbjs.addAdUnits([
+  {
+    code: 'adunit-native',
+    mediaTypes: {
+      native: {
+        title: { required: true, len: 80 },
+        image: { required: true, sizes: [300, 250] }
+      }
+    },
+    bids: [{ bidder: 'floxis', params: { seat: 'testSeat' } }]
   }
 ]);
 ```
@@ -53,8 +88,10 @@ pbjs.addAdUnits([
 | `seat` | required | Seat identifier | `'testSeat'` | `string` |
 | `region` | optional | Region identifier for routing (defaults to `us-e`) | `'us-e'` | `string` |
 | `partner` | optional | Partner identifier (defaults to `floxis`) | `'floxis'` | `string` |
+| `bidFloor` | optional | Static bid floor (CPM) used only when the Floors module is absent | `0.5` | `number` |
+| `bidFloorCur` | optional | Currency for `bidFloor` (defaults to `USD`) | `'USD'` | `string` |
 
-Only `seat` is required. `region` and `partner` are optional and accepted as-is — any value routes to the matching `[<partner>-]<region>.floxis.tech` endpoint.
+Only `seat` is required. `region` and `partner` are optional and accepted as-is (validated as DNS host labels) — any value routes to the matching `[<partner>-]<region>.floxis.tech` endpoint.
 
 ## User Sync
 The adapter registers cookie syncs to the Floxis trackers endpoint (`px-<region>.floxis.tech/sync`), which sets the Floxis DMP id and chains to the seat's demand-partner syncs. Both iframe and pixel syncs are supported; the type emitted follows your `userSync` configuration. Enable it for the adapter, e.g.:
@@ -69,4 +106,4 @@ pbjs.setConfig({
 ```
 
 ## Testing
-Unit tests are provided in `test/spec/modules/floxisBidAdapter_spec.js` and cover validation, request building, response interpretation, user syncs, and bid-won notifications.
+Unit tests are provided in `test/spec/modules/floxisBidAdapter_spec.js` and cover validation, request building (params, host-label safety, floors, FPD/consent passthrough), response interpretation and meta mapping, user syncs, and billing notifications.

--- a/test/spec/modules/floxisBidAdapter_spec.js
+++ b/test/spec/modules/floxisBidAdapter_spec.js
@@ -298,6 +298,28 @@ describe('floxisBidAdapter', function () {
         const imp = requests[0].data.imp[0];
         expect(imp.bidfloor).to.be.undefined;
       });
+
+      it('should not set bidfloor when getFloor returns 0', function () {
+        const bidZeroFloor = {
+          ...validBannerBid,
+          getFloor: function () {
+            return { floor: 0, currency: 'USD' };
+          }
+        };
+        const requests = spec.buildRequests([bidZeroFloor], bidderRequest);
+        expect(requests[0].data.imp[0].bidfloor).to.be.undefined;
+      });
+
+      it('should fall back to params.bidFloor when getFloor is absent', function () {
+        const bidStaticFloor = {
+          ...validBannerBid,
+          params: { ...DEFAULT_PARAMS, bidFloor: 1.75, bidFloorCur: 'USD' }
+        };
+        const requests = spec.buildRequests([bidStaticFloor], bidderRequest);
+        const imp = requests[0].data.imp[0];
+        expect(imp.bidfloor).to.equal(1.75);
+        expect(imp.bidfloorcur).to.equal('USD');
+      });
     });
 
     describe('ortb2 passthrough', function () {
@@ -325,6 +347,43 @@ describe('floxisBidAdapter', function () {
         const requests = spec.buildRequests([validBannerBid], uspBidderRequest);
         const data = requests[0].data;
         expect(data.regs.ext.us_privacy).to.equal('1YNN');
+      });
+
+      it('should forward COPPA from ortb2.regs', function () {
+        const coppaReq = { ...bidderRequest, ortb2: { regs: { coppa: 1 } } };
+        const data = spec.buildRequests([validBannerBid], coppaReq)[0].data;
+        expect(data.regs.coppa).to.equal(1);
+      });
+
+      it('should forward GPP from ortb2.regs', function () {
+        const gppReq = { ...bidderRequest, ortb2: { regs: { gpp: 'DBACNYA~xxx', gpp_sid: [7] } } };
+        const data = spec.buildRequests([validBannerBid], gppReq)[0].data;
+        expect(data.regs.gpp).to.equal('DBACNYA~xxx');
+        expect(data.regs.gpp_sid).to.deep.equal([7]);
+      });
+
+      it('should forward user.ext.eids', function () {
+        const eids = [{ source: 'id5-sync.com', uids: [{ id: 'ID5-x', atype: 1 }] }];
+        const eidsReq = { ...bidderRequest, ortb2: { user: { ext: { eids } } } };
+        const data = spec.buildRequests([validBannerBid], eidsReq)[0].data;
+        expect(data.user.ext.eids).to.deep.equal(eids);
+      });
+
+      it('should forward source.ext.schain', function () {
+        const schain = { ver: '1.0', complete: 1, nodes: [{ asi: 'floxis.tech', sid: '1', hp: 1 }] };
+        const schainReq = { ...bidderRequest, ortb2: { source: { ext: { schain } } } };
+        const data = spec.buildRequests([validBannerBid], schainReq)[0].data;
+        expect(data.source.ext.schain).to.deep.equal(schain);
+      });
+
+      it('should pass tmax from the bidder request timeout', function () {
+        const data = spec.buildRequests([validBannerBid], bidderRequest)[0].data;
+        expect(data.tmax).to.equal(3000);
+      });
+
+      it('should default cur to USD', function () {
+        const data = spec.buildRequests([validBannerBid], bidderRequest)[0].data;
+        expect(data.cur).to.deep.equal(['USD']);
       });
     });
   });
@@ -666,11 +725,18 @@ describe('floxisBidAdapter', function () {
       expect(url).to.include('gpp_sid=7%2C8');
     });
 
-    it('should set gdpr=0 when gdpr does not apply (consent param still present, empty)', function () {
+    it('should set gdpr=0 when gdprApplies is false and omit empty consent', function () {
       spec.buildRequests([validBannerBid], syncBidderRequest);
       const syncs = spec.getUserSyncs({ iframeEnabled: true }, RESPONSES, { gdprApplies: false, consentString: '' });
       expect(syncs[0].url).to.include('gdpr=0');
-      expect(syncs[0].url).to.include('gdpr_consent=');
+      expect(syncs[0].url).to.not.include('gdpr_consent=');
+    });
+
+    it('should omit the gdpr param entirely when gdprApplies is not a boolean', function () {
+      spec.buildRequests([validBannerBid], syncBidderRequest);
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, RESPONSES, { consentString: 'TC123' });
+      expect(syncs[0].url).to.not.match(/[?&]gdpr=/);
+      expect(syncs[0].url).to.include('gdpr_consent=TC123');
     });
 
     it('should emit one sync per distinct seat', function () {
@@ -697,7 +763,7 @@ describe('floxisBidAdapter', function () {
     });
   });
 
-  describe('onBidWon', function () {
+  describe('onBidBillable', function () {
     let triggerPixelStub;
 
     beforeEach(function () {
@@ -708,27 +774,54 @@ describe('floxisBidAdapter', function () {
       triggerPixelStub.restore();
     });
 
-    it('should fire burl pixel', function () {
-      spec.onBidWon({ burl: 'https://example.com/burl' });
-      expect(triggerPixelStub.calledWith('https://example.com/burl')).to.be.true;
+    it('should fire the burl pixel with the AUCTION_PRICE macro substituted', function () {
+      spec.onBidBillable({ burl: 'https://example.com/burl?p=${AUCTION_PRICE}', cpm: 1.23, originalCpm: 1.23 });
+      expect(triggerPixelStub.calledWith('https://example.com/burl?p=1.23')).to.be.true;
     });
 
-    it('should fire nurl pixel', function () {
-      spec.onBidWon({ nurl: 'https://example.com/nurl' });
-      expect(triggerPixelStub.calledWith('https://example.com/nurl')).to.be.true;
+    it('should prefer originalCpm over cpm for the macro', function () {
+      spec.onBidBillable({ burl: 'https://example.com/burl?p=${AUCTION_PRICE}', cpm: 0.9, originalCpm: 1.5 });
+      expect(triggerPixelStub.calledWith('https://example.com/burl?p=1.5')).to.be.true;
     });
 
-    it('should fire both burl and nurl pixels', function () {
-      spec.onBidWon({
-        burl: 'https://example.com/burl',
-        nurl: 'https://example.com/nurl'
-      });
-      expect(triggerPixelStub.callCount).to.equal(2);
-    });
-
-    it('should not fire pixels when no urls present', function () {
-      spec.onBidWon({});
+    it('should not fire a pixel when burl is absent', function () {
+      spec.onBidBillable({ cpm: 1.0 });
       expect(triggerPixelStub.called).to.be.false;
+    });
+  });
+
+  describe('bid response meta', function () {
+    function responseWithExt(ext) {
+      const request = spec.buildRequests([validBannerBid], { bidderCode: 'floxis', auctionId: 'a-meta' })[0];
+      const serverResponse = {
+        body: {
+          seatbid: [{
+            bid: [{
+              impid: validBannerBid.bidId, price: 1.0, w: 300, h: 250, crid: 'c1', adm: '<div>ad</div>', mtype: 1, ext
+            }]
+          }]
+        }
+      };
+      return spec.interpretResponse(serverResponse, request);
+    }
+
+    it('should map DSP ext fields into bid.meta', function () {
+      const bids = responseWithExt({ dspid: 42, advertiser_name: 'AdvCo', agency_name: 'AgCo', agency_id: 'ag-7' });
+      expect(bids[0].meta.networkId).to.equal(42);
+      expect(bids[0].meta.advertiserName).to.equal('AdvCo');
+      expect(bids[0].meta.agencyName).to.equal('AgCo');
+      expect(bids[0].meta.agencyId).to.equal('ag-7');
+    });
+
+    it('should mirror the resolved mediaType into bid.meta', function () {
+      const bids = responseWithExt({});
+      expect(bids[0].meta.mediaType).to.equal(BANNER);
+    });
+
+    it('should leave meta DSP fields unset when ext is absent', function () {
+      const bids = responseWithExt(undefined);
+      expect(bids[0].meta.networkId).to.be.undefined;
+      expect(bids[0].meta.advertiserName).to.be.undefined;
     });
   });
 });

--- a/test/spec/modules/floxisBidAdapter_spec.js
+++ b/test/spec/modules/floxisBidAdapter_spec.js
@@ -71,9 +71,9 @@ describe('floxisBidAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
 
-    it('should return false when region is empty string', function () {
+    it('should return true when region is empty string (default region applies)', function () {
       const bid = { ...validBannerBid, params: { seat: 'Gmtb', region: '' } };
-      expect(spec.isBidRequestValid(bid)).to.be.false;
+      expect(spec.isBidRequestValid(bid)).to.be.true;
     });
 
     it('should return true when partner is missing (default partner applies)', function () {
@@ -81,9 +81,9 @@ describe('floxisBidAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.be.true;
     });
 
-    it('should return false when partner is empty string', function () {
+    it('should return true when partner is empty string (default partner applies)', function () {
       const bid = { ...validBannerBid, params: { seat: 'Gmtb', region: 'us-e', partner: '' } };
-      expect(spec.isBidRequestValid(bid)).to.be.false;
+      expect(spec.isBidRequestValid(bid)).to.be.true;
     });
 
     it('should return false when params is missing', function () {
@@ -96,14 +96,14 @@ describe('floxisBidAdapter', function () {
       expect(spec.isBidRequestValid(bid)).to.be.false;
     });
 
-    it('should return false when region is not in whitelist', function () {
+    it('should return true for any region (no gating)', function () {
       const bid = { ...validBannerBid, params: { ...DEFAULT_PARAMS, region: 'eu-w' } };
-      expect(spec.isBidRequestValid(bid)).to.be.false;
+      expect(spec.isBidRequestValid(bid)).to.be.true;
     });
 
-    it('should return false when partner is not in whitelist', function () {
+    it('should return true for any partner (no gating)', function () {
       const bid = { ...validBannerBid, params: { ...DEFAULT_PARAMS, partner: 'mypartner' } };
-      expect(spec.isBidRequestValid(bid)).to.be.false;
+      expect(spec.isBidRequestValid(bid)).to.be.true;
     });
 
     it('should return true with default partner', function () {
@@ -136,12 +136,31 @@ describe('floxisBidAdapter', function () {
       expect(requests[0].url).to.equal('https://us-e.floxis.tech/pbjs?seat=Gmtb');
     });
 
-    it('should return no requests for non-whitelisted partner', function () {
+    it('should build a request to a custom partner+region host (no gating)', function () {
       const bidWithPartner = {
         ...validBannerBid,
-        params: { ...DEFAULT_PARAMS, partner: 'mypartner' }
+        params: { seat: 'Gmtb', region: 'apac-sin', partner: 'mypartner' }
       };
       const requests = spec.buildRequests([bidWithPartner], bidderRequest);
+      expect(requests).to.have.lengthOf(1);
+      expect(requests[0].url).to.equal('https://mypartner-apac-sin.floxis.tech/pbjs?seat=Gmtb');
+    });
+
+    it('should not build a request when partner is not a valid host label', function () {
+      const bidWithBadPartner = {
+        ...validBannerBid,
+        params: { seat: 'Gmtb', partner: 'evil.com/path?x=' }
+      };
+      const requests = spec.buildRequests([bidWithBadPartner], bidderRequest);
+      expect(requests).to.be.an('array').that.is.empty;
+    });
+
+    it('should not build a request when region is not a valid host label', function () {
+      const bidWithBadRegion = {
+        ...validBannerBid,
+        params: { seat: 'Gmtb', region: 'evil.com/' }
+      };
+      const requests = spec.buildRequests([bidWithBadRegion], bidderRequest);
       expect(requests).to.be.an('array').that.is.empty;
     });
 
@@ -226,8 +245,8 @@ describe('floxisBidAdapter', function () {
       expect(requests[1].data.imp).to.have.lengthOf(1);
     });
 
-    it('should ignore non-whitelisted bids in mixed request arrays', function () {
-      const invalidBid = {
+    it('should build separate requests for distinct partner/region groups', function () {
+      const customBid = {
         ...validVideoBid,
         params: {
           seat: 'Seat2',
@@ -236,10 +255,11 @@ describe('floxisBidAdapter', function () {
         }
       };
 
-      const requests = spec.buildRequests([validBannerBid, invalidBid], bidderRequest);
-      expect(requests).to.have.lengthOf(1);
-      expect(requests[0].url).to.equal('https://us-e.floxis.tech/pbjs?seat=Gmtb');
-      expect(requests[0].data.imp).to.have.lengthOf(1);
+      const requests = spec.buildRequests([validBannerBid, customBid], bidderRequest);
+      expect(requests).to.have.lengthOf(2);
+      const urls = requests.map((r) => r.url);
+      expect(urls).to.include('https://us-e.floxis.tech/pbjs?seat=Gmtb');
+      expect(urls).to.include('https://mypartner-eu-w.floxis.tech/pbjs?seat=Seat2');
     });
 
     it('should set withCredentials option', function () {
@@ -458,9 +478,222 @@ describe('floxisBidAdapter', function () {
     });
   });
 
+  // Floxis now emits OpenRTB 2.6 bid.mtype for Prebid.js supply (banner=1, video=2, native=4).
+  // The ortbConverter's setResponseMediaType requires it: without mtype it cannot resolve the
+  // media type and drops the bid (bids:[]). These tests assert each media type round-trips to
+  // exactly one Prebid bid with the correct mediaType and intact cpm/burl, plus the control that
+  // a banner response WITHOUT mtype is dropped. Audio (OpenRTB mtype=3) is N/A: the Floxis adapter
+  // declares supportedMediaTypes [BANNER, VIDEO, NATIVE] only, so no audio handling is forced.
+  describe('mtype media-type resolution (ortbConverter end-to-end)', function () {
+    const BURL = 'https://us-e.floxis.tech/wn?p=${AUCTION_PRICE}';
+
+    it('resolves a banner mtype=1 response to exactly one BANNER bid with cpm/burl intact', function () {
+      const request = spec.buildRequests([validBannerBid], { bidderCode: 'floxis', auctionId: 'a-banner' })[0];
+      const serverResponse = {
+        body: {
+          seatbid: [{
+            bid: [{
+              impid: validBannerBid.bidId,
+              price: 1.23,
+              w: 300,
+              h: 250,
+              crid: 'creative-banner',
+              adm: '<div>banner</div>',
+              burl: BURL,
+              mtype: 1
+            }]
+          }]
+        }
+      };
+      const bids = spec.interpretResponse(serverResponse, request);
+      expect(bids).to.be.an('array').with.lengthOf(1);
+      expect(bids[0].mediaType).to.equal(BANNER);
+      expect(bids[0].cpm).to.equal(1.23);
+      expect(bids[0].ad).to.equal('<div>banner</div>');
+      expect(bids[0].burl).to.equal(BURL);
+    });
+
+    if (FEATURES.VIDEO) {
+      it('resolves a video mtype=2 response to exactly one VIDEO bid with cpm/burl intact', function () {
+        const request = spec.buildRequests([validVideoBid], { bidderCode: 'floxis', auctionId: 'a-video' })[0];
+        const serverResponse = {
+          body: {
+            seatbid: [{
+              bid: [{
+                impid: validVideoBid.bidId,
+                price: 5.5,
+                w: 640,
+                h: 480,
+                crid: 'creative-video',
+                adm: '<VAST></VAST>',
+                burl: BURL,
+                mtype: 2
+              }]
+            }]
+          }
+        };
+        const bids = spec.interpretResponse(serverResponse, request);
+        expect(bids).to.be.an('array').with.lengthOf(1);
+        expect(bids[0].mediaType).to.equal(VIDEO);
+        expect(bids[0].cpm).to.equal(5.5);
+        expect(bids[0].vastXml).to.equal('<VAST></VAST>');
+        expect(bids[0].burl).to.equal(BURL);
+      });
+    }
+
+    if (FEATURES.NATIVE) {
+      it('resolves a native mtype=4 response to exactly one NATIVE bid with cpm/burl intact', function () {
+        const request = spec.buildRequests([validNativeBid], { bidderCode: 'floxis', auctionId: 'a-native' })[0];
+        const nativeAdm = JSON.stringify({
+          ver: '1.2',
+          link: { url: 'https://example.com/click' },
+          assets: [
+            { id: 1, title: { text: 'Native Title' } },
+            { id: 2, img: { url: 'https://example.com/img.png', w: 150, h: 50 } }
+          ]
+        });
+        const serverResponse = {
+          body: {
+            seatbid: [{
+              bid: [{
+                impid: validNativeBid.bidId,
+                price: 2.75,
+                crid: 'creative-native',
+                adm: nativeAdm,
+                burl: BURL,
+                mtype: 4
+              }]
+            }]
+          }
+        };
+        const bids = spec.interpretResponse(serverResponse, request);
+        expect(bids).to.be.an('array').with.lengthOf(1);
+        expect(bids[0].mediaType).to.equal(NATIVE);
+        expect(bids[0].cpm).to.equal(2.75);
+        expect(bids[0].burl).to.equal(BURL);
+      });
+    }
+
+    it('drops a banner response that omits mtype (the original ortbConverter drop bug)', function () {
+      const request = spec.buildRequests([validBannerBid], { bidderCode: 'floxis', auctionId: 'a-nomtype' })[0];
+      const serverResponse = {
+        body: {
+          seatbid: [{
+            bid: [{
+              impid: validBannerBid.bidId,
+              price: 1.23,
+              w: 300,
+              h: 250,
+              crid: 'creative-banner',
+              adm: '<div>banner</div>'
+              // no mtype -> setResponseMediaType cannot resolve -> bid dropped
+            }]
+          }]
+        }
+      };
+      const bids = spec.interpretResponse(serverResponse, request);
+      expect(bids).to.be.an('array').that.is.empty;
+    });
+
+    it('does not advertise an audio media type (audio is N/A for Prebid.js)', function () {
+      expect(spec.supportedMediaTypes).to.not.include('audio');
+    });
+  });
+
   describe('getUserSyncs', function () {
-    it('should return empty array', function () {
-      expect(spec.getUserSyncs()).to.be.an('array').that.is.empty;
+    const syncBidderRequest = { bidderCode: 'floxis', auctionId: 'auction-sync' };
+    const RESPONSES = [{ body: {} }];
+
+    it('should return empty array when no sync method is enabled', function () {
+      spec.buildRequests([validBannerBid], syncBidderRequest);
+      expect(spec.getUserSyncs({ iframeEnabled: false, pixelEnabled: false }, RESPONSES)).to.be.an('array').that.is.empty;
+    });
+
+    it('should return empty array when no requests were built', function () {
+      spec.buildRequests([], syncBidderRequest);
+      expect(spec.getUserSyncs({ iframeEnabled: true }, RESPONSES)).to.be.an('array').that.is.empty;
+    });
+
+    it('should return empty array when the adapter did not respond this auction (no serverResponses)', function () {
+      spec.buildRequests([validBannerBid], syncBidderRequest);
+      expect(spec.getUserSyncs({ iframeEnabled: true }, [])).to.be.an('array').that.is.empty;
+    });
+
+    it('should not reuse stale sync targets on a later auction without buildRequests', function () {
+      spec.buildRequests([validBannerBid], syncBidderRequest);
+      // first auction consumes the targets
+      expect(spec.getUserSyncs({ iframeEnabled: true }, RESPONSES)).to.have.lengthOf(1);
+      // a later auction where buildRequests was never called must not re-register them
+      expect(spec.getUserSyncs({ iframeEnabled: true }, RESPONSES)).to.be.an('array').that.is.empty;
+    });
+
+    it('should emit an iframe sync to the region trackers host for the seat', function () {
+      spec.buildRequests([validBannerBid], syncBidderRequest);
+      const syncs = spec.getUserSyncs({ iframeEnabled: true, pixelEnabled: true }, RESPONSES);
+      expect(syncs).to.have.lengthOf(1);
+      expect(syncs[0].type).to.equal('iframe');
+      expect(syncs[0].url).to.equal('https://px-us-e.floxis.tech/sync?seat=Gmtb');
+    });
+
+    it('should emit an image sync when only pixels are enabled', function () {
+      spec.buildRequests([validBannerBid], syncBidderRequest);
+      const syncs = spec.getUserSyncs({ iframeEnabled: false, pixelEnabled: true }, RESPONSES);
+      expect(syncs[0].type).to.equal('image');
+    });
+
+    it('should use the custom partner region for the sync host', function () {
+      const customBid = { ...validBannerBid, params: { seat: 'Gmtb', region: 'apac-sin', partner: 'mypartner' } };
+      spec.buildRequests([customBid], syncBidderRequest);
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, RESPONSES);
+      expect(syncs[0].url).to.equal('https://px-apac-sin.floxis.tech/sync?seat=Gmtb');
+    });
+
+    it('should append gdpr, us_privacy and gpp consent params', function () {
+      spec.buildRequests([validBannerBid], syncBidderRequest);
+      const syncs = spec.getUserSyncs(
+        { iframeEnabled: true },
+        RESPONSES,
+        { gdprApplies: true, consentString: 'CONSENT123' },
+        '1YNN',
+        { gppString: 'GPPSTR', applicableSections: [7, 8] }
+      );
+      const url = syncs[0].url;
+      expect(url).to.include('seat=Gmtb');
+      expect(url).to.include('gdpr=1');
+      expect(url).to.include('gdpr_consent=CONSENT123');
+      expect(url).to.include('us_privacy=1YNN');
+      expect(url).to.include('gpp=GPPSTR');
+      expect(url).to.include('gpp_sid=7%2C8');
+    });
+
+    it('should set gdpr=0 when gdpr does not apply (consent param still present, empty)', function () {
+      spec.buildRequests([validBannerBid], syncBidderRequest);
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, RESPONSES, { gdprApplies: false, consentString: '' });
+      expect(syncs[0].url).to.include('gdpr=0');
+      expect(syncs[0].url).to.include('gdpr_consent=');
+    });
+
+    it('should emit one sync per distinct seat', function () {
+      const secondBid = { ...validBannerBid, bidId: 'bid-9', params: { ...DEFAULT_PARAMS, seat: 'Seat2' } };
+      spec.buildRequests([validBannerBid, secondBid], syncBidderRequest);
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, RESPONSES);
+      expect(syncs).to.have.lengthOf(2);
+      const urls = syncs.map((s) => s.url);
+      expect(urls).to.include('https://px-us-e.floxis.tech/sync?seat=Gmtb');
+      expect(urls).to.include('https://px-us-e.floxis.tech/sync?seat=Seat2');
+    });
+
+    it('should dedupe syncs that share a seat and region across partners', function () {
+      const bidA = { ...validBannerBid, bidId: 'a', params: { seat: 'Gmtb', region: 'us-e', partner: 'floxis' } };
+      const bidB = {
+        ...validBannerBid,
+        bidId: 'b',
+        adUnitCode: 'adunit-2',
+        params: { seat: 'Gmtb', region: 'us-e', partner: 'other' }
+      };
+      spec.buildRequests([bidA, bidB], syncBidderRequest);
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, RESPONSES);
+      expect(syncs).to.have.lengthOf(1);
     });
   });
 

--- a/test/spec/modules/floxisBidAdapter_spec.js
+++ b/test/spec/modules/floxisBidAdapter_spec.js
@@ -660,34 +660,43 @@ describe('floxisBidAdapter', function () {
   });
 
   describe('getUserSyncs', function () {
-    const syncBidderRequest = { bidderCode: 'floxis', auctionId: 'auction-sync' };
-    const RESPONSES = [{ body: {} }];
+    // Server-echo: the /pbjs response carries seat + region in the x-floxis-sync header (on bid and
+    // no-bid alike). getUserSyncs reads it off serverResponses — no module state. A no-bid is a 204 with
+    // an empty body, so these fixtures carry only the header (body is irrelevant to sync derivation).
+    function syncResponse(headerValue, body = '') {
+      return {
+        body,
+        headers: { get: (name) => (name === 'x-floxis-sync' ? headerValue : null) }
+      };
+    }
+    const RESPONSES = [syncResponse('seat=Gmtb&region=us-e')];
 
     it('should return empty array when no sync method is enabled', function () {
-      spec.buildRequests([validBannerBid], syncBidderRequest);
       expect(spec.getUserSyncs({ iframeEnabled: false, pixelEnabled: false }, RESPONSES)).to.be.an('array').that.is.empty;
     });
 
-    it('should return empty array when no requests were built', function () {
-      spec.buildRequests([], syncBidderRequest);
-      expect(spec.getUserSyncs({ iframeEnabled: true }, RESPONSES)).to.be.an('array').that.is.empty;
-    });
-
     it('should return empty array when the adapter did not respond this auction (no serverResponses)', function () {
-      spec.buildRequests([validBannerBid], syncBidderRequest);
       expect(spec.getUserSyncs({ iframeEnabled: true }, [])).to.be.an('array').that.is.empty;
     });
 
-    it('should not reuse stale sync targets on a later auction without buildRequests', function () {
-      spec.buildRequests([validBannerBid], syncBidderRequest);
-      // first auction consumes the targets
-      expect(spec.getUserSyncs({ iframeEnabled: true }, RESPONSES)).to.have.lengthOf(1);
-      // a later auction where buildRequests was never called must not re-register them
-      expect(spec.getUserSyncs({ iframeEnabled: true }, RESPONSES)).to.be.an('array').that.is.empty;
+    it('should sync on a no-bid response (empty body) as long as the sync header is present', function () {
+      const noBid = syncResponse('seat=Gmtb&region=us-e', '');
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, [noBid]);
+      expect(syncs).to.have.lengthOf(1);
+      expect(syncs[0].url).to.equal('https://px-us-e.floxis.tech/sync?seat=Gmtb');
+    });
+
+    it('should be a no-op when the response carries no sync header (older backend)', function () {
+      const noHeader = { body: '', headers: { get: () => null } };
+      expect(spec.getUserSyncs({ iframeEnabled: true }, [noHeader])).to.be.an('array').that.is.empty;
+    });
+
+    it('should ignore a malformed sync header that lacks a valid region', function () {
+      const malformed = syncResponse('seat=Gmtb&region=evil.com/x');
+      expect(spec.getUserSyncs({ iframeEnabled: true }, [malformed])).to.be.an('array').that.is.empty;
     });
 
     it('should emit an iframe sync to the region trackers host for the seat', function () {
-      spec.buildRequests([validBannerBid], syncBidderRequest);
       const syncs = spec.getUserSyncs({ iframeEnabled: true, pixelEnabled: true }, RESPONSES);
       expect(syncs).to.have.lengthOf(1);
       expect(syncs[0].type).to.equal('iframe');
@@ -695,20 +704,16 @@ describe('floxisBidAdapter', function () {
     });
 
     it('should emit an image sync when only pixels are enabled', function () {
-      spec.buildRequests([validBannerBid], syncBidderRequest);
       const syncs = spec.getUserSyncs({ iframeEnabled: false, pixelEnabled: true }, RESPONSES);
       expect(syncs[0].type).to.equal('image');
     });
 
-    it('should use the custom partner region for the sync host', function () {
-      const customBid = { ...validBannerBid, params: { seat: 'Gmtb', region: 'apac-sin', partner: 'mypartner' } };
-      spec.buildRequests([customBid], syncBidderRequest);
-      const syncs = spec.getUserSyncs({ iframeEnabled: true }, RESPONSES);
+    it('should use the echoed custom region for the sync host', function () {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, [syncResponse('seat=Gmtb&region=apac-sin')]);
       expect(syncs[0].url).to.equal('https://px-apac-sin.floxis.tech/sync?seat=Gmtb');
     });
 
     it('should append gdpr, us_privacy and gpp consent params', function () {
-      spec.buildRequests([validBannerBid], syncBidderRequest);
       const syncs = spec.getUserSyncs(
         { iframeEnabled: true },
         RESPONSES,
@@ -726,39 +731,29 @@ describe('floxisBidAdapter', function () {
     });
 
     it('should set gdpr=0 when gdprApplies is false and omit empty consent', function () {
-      spec.buildRequests([validBannerBid], syncBidderRequest);
       const syncs = spec.getUserSyncs({ iframeEnabled: true }, RESPONSES, { gdprApplies: false, consentString: '' });
       expect(syncs[0].url).to.include('gdpr=0');
       expect(syncs[0].url).to.not.include('gdpr_consent=');
     });
 
     it('should omit the gdpr param entirely when gdprApplies is not a boolean', function () {
-      spec.buildRequests([validBannerBid], syncBidderRequest);
       const syncs = spec.getUserSyncs({ iframeEnabled: true }, RESPONSES, { consentString: 'TC123' });
       expect(syncs[0].url).to.not.match(/[?&]gdpr=/);
       expect(syncs[0].url).to.include('gdpr_consent=TC123');
     });
 
-    it('should emit one sync per distinct seat', function () {
-      const secondBid = { ...validBannerBid, bidId: 'bid-9', params: { ...DEFAULT_PARAMS, seat: 'Seat2' } };
-      spec.buildRequests([validBannerBid, secondBid], syncBidderRequest);
-      const syncs = spec.getUserSyncs({ iframeEnabled: true }, RESPONSES);
+    it('should emit one sync per distinct seat across responses', function () {
+      const responses = [syncResponse('seat=Gmtb&region=us-e'), syncResponse('seat=Seat2&region=us-e')];
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, responses);
       expect(syncs).to.have.lengthOf(2);
       const urls = syncs.map((s) => s.url);
       expect(urls).to.include('https://px-us-e.floxis.tech/sync?seat=Gmtb');
       expect(urls).to.include('https://px-us-e.floxis.tech/sync?seat=Seat2');
     });
 
-    it('should dedupe syncs that share a seat and region across partners', function () {
-      const bidA = { ...validBannerBid, bidId: 'a', params: { seat: 'Gmtb', region: 'us-e', partner: 'floxis' } };
-      const bidB = {
-        ...validBannerBid,
-        bidId: 'b',
-        adUnitCode: 'adunit-2',
-        params: { seat: 'Gmtb', region: 'us-e', partner: 'other' }
-      };
-      spec.buildRequests([bidA, bidB], syncBidderRequest);
-      const syncs = spec.getUserSyncs({ iframeEnabled: true }, RESPONSES);
+    it('should dedupe syncs that share a seat and region across responses', function () {
+      const responses = [syncResponse('seat=Gmtb&region=us-e'), syncResponse('seat=Gmtb&region=us-e')];
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, responses);
       expect(syncs).to.have.lengthOf(1);
     });
   });


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [x] Feature

## Description of change

Improvements to the **Floxis** bid adapter:

- **Only `seat` is required.** `partner` and `region` are now optional and accepted as-is (no whitelist). They default to `floxis` / `us-e`; empty strings fall back to those defaults. Requests route to `[<partner>-]<region>.floxis.tech`. Both values are validated as DNS host labels before being interpolated into the host, so a value containing URL delimiters cannot change the request origin — an invalid label simply builds no request (and no sync).

- **Adds `getUserSyncs` (iframe + pixel).** Cookie syncs go to the region-scoped Floxis trackers host (`px-<region>.floxis.tech/sync?seat=...`) with GDPR / US Privacy / GPP consent parameters appended. Because Floxis is multi-tenant, a sync is keyed by the endpoint `seat` (resolved to the supply partner server-side) rather than a single fixed vendor id.

  The sync target is **derived statelessly from the server response**, not from module-level state: the Floxis `/pbjs` endpoint echoes the `seat` + `region` in an `x-floxis-sync` response header (on both bid and no-bid responses), and `getUserSyncs` reads it from `serverResponses[].headers`. This keeps syncs strictly per-auction — an auction in which the adapter did not bid contributes no sync — and works on the common no-bid `204` without forcing a response body.

### Notes

- `isBidRequestValid` only checks for a non-empty `seat` string.
- `getUserSyncs` honors `syncOptions.iframeEnabled` / `pixelEnabled` and appends `gdpr`, `gdpr_consent`, `us_privacy`, `gpp`, `gpp_sid` when present.
- A Floxis IAB Europe GVL (Global Vendor List) ID registration is in progress; until it is assigned and added to the adapter, Floxis is not yet listed as an independent TCF vendor (also noted in `modules/floxisBidAdapter.md`).
- Unit tests in `test/spec/modules/floxisBidAdapter_spec.js` cover validation, request building (optional/ungated params and host-label rejection), response interpretation and bid meta, user syncs (including the response-header channel and host-label safety), and bid-won / billable notifications.

## Other information

Maintainer: admin@floxis.tech
Docs updated in `modules/floxisBidAdapter.md`.
