### PR TITLE
Anonymised RTd: implemented eid injection

### DIFF
--- a/integrationExamples/gpt/anonymised_segments_example.html
+++ b/integrationExamples/gpt/anonymised_segments_example.html
@@ -52,7 +52,8 @@
               realTimeData: {
                 dataProviders: [
                   {
-                    name: "anonymised",                    
+                    name: "anonymised",
+                    waitForIt: true,
                     params: {
                       cohortStorageKey: "cohort_ids",
                       bidders: ['smartadserver', 'appnexus'],

--- a/modules/anonymisedRtdProvider.js
+++ b/modules/anonymisedRtdProvider.js
@@ -18,6 +18,8 @@ export function createRtdProvider(moduleName) {
   const SUBMODULE_NAME = moduleName;
   const GVLID = 1116;
   const MARKETING_TAG_URL = 'https://static.anonymised.io/light/loader.js';
+  const SIGNAL_LIFT_GROUP_KEY = 'anon-sl-group-session';
+  const ANONYMISED_SOURCE = 'anonymised.io';
 
   const storage = getStorageManager({ moduleType: MODULE_TYPE_RTD, moduleName: SUBMODULE_NAME });
   /**
@@ -43,6 +45,31 @@ export function createRtdProvider(moduleName) {
       logError(`${SUBMODULE_NAME}RtdProvider: failed to parse json:`, data);
       return null;
     }
+  }
+  /**
+   * Retrieve the current user's CUID from localStorage via the Prebid storage
+   * manager. The OIDC key is composed as:
+   * "oidc.user:" + OIDC_AUTHORITY + ":" + window.location.origin
+   * @return {string|undefined}
+   */
+  function getCUID() {
+    const oidcKey = `oidc.user:https://account.anonymised.io/login:${window.location.origin}`;
+    try {
+      const record = storage.getDataFromLocalStorage(oidcKey);
+      return record ? JSON.parse(record)?.profile?.cuid : undefined;
+    } catch (e) {
+      logWarn(`${SUBMODULE_NAME}RtdProvider: failed to parse CUID from localStorage`);
+      return undefined;
+    }
+  }
+  /**
+   * Return the SignalLift holdout/treatment group for the current user.
+   * Reads from sessionStorage via the Prebid storage manager.
+   * Defaults to 't' (treatment) when the key is absent.
+   * @return {'t'|'h'}
+   */
+  function getSignalLiftGroup() {
+    return storage.getDataFromSessionStorage(SIGNAL_LIFT_GROUP_KEY) ?? 't';
   }
   /**
    * Load the Anonymised Marketing Tag script
@@ -87,47 +114,63 @@ export function createRtdProvider(moduleName) {
       const cohortStorageKey = config.params.cohortStorageKey;
       const bidders = config.params.bidders;
 
-      if (cohortStorageKey !== 'cohort_ids') {
-        logError(`${SUBMODULE_NAME}RtdProvider: 'cohortStorageKey' should be 'cohort_ids'`)
-        return;
-      }
+      if (cohortStorageKey === 'cohort_ids') {
+        const jsonData = storage.getDataFromLocalStorage(cohortStorageKey);
+        const segments = jsonData && tryParse(jsonData);
 
-      const jsonData = storage.getDataFromLocalStorage(cohortStorageKey);
-      if (!jsonData) {
-        return;
-      }
+        if (segments) {
+          const udSegment = {
+            name: ANONYMISED_SOURCE,
+            ext: {
+              segtax: config.params.segtax
+            },
+            segment: segments.map(x => ({ id: x }))
+          }
 
-      const segments = tryParse(jsonData);
-
-      if (segments) {
-        const udSegment = {
-          name: 'anonymised.io',
-          ext: {
-            segtax: config.params.segtax
-          },
-          segment: segments.map(x => ({ id: x }))
-        }
-
-        logMessage(`${SUBMODULE_NAME}RtdProvider: user.data.segment: `, udSegment);
-        const data = {
-          rtd: {
-            ortb2: {
-              user: {
-                data: [
-                  udSegment
-                ]
+          logMessage(`${SUBMODULE_NAME}RtdProvider: user.data.segment: `, udSegment);
+          const data = {
+            rtd: {
+              ortb2: {
+                user: {
+                  data: [
+                    udSegment
+                  ]
+                }
               }
             }
+          };
+
+          if (bidders?.includes('appnexus')) {
+            data.rtd.ortb2.user.keywords = segments.map(x => `perid=${x}`).join(',');
           }
-        };
 
-        if (bidders?.includes('appnexus')) {
-          data.rtd.ortb2.user.keywords = segments.map(x => `perid=${x}`).join(',');
+          addRealTimeData(reqBidsConfigObj.ortb2Fragments?.global, data.rtd);
         }
-
-        addRealTimeData(reqBidsConfigObj.ortb2Fragments?.global, data.rtd);
+      } else if (cohortStorageKey) {
+        logError(`${SUBMODULE_NAME}RtdProvider: 'cohortStorageKey' should be 'cohort_ids'`);
       }
     }
+
+    if (getSignalLiftGroup() !== 'h') {
+      const cuid = getCUID();
+      const existingEids = reqBidsConfigObj.ortb2Fragments?.global?.user?.ext?.eids;
+      const alreadyPresent = existingEids?.some(eid => eid.source === ANONYMISED_SOURCE);
+      if (cuid && !alreadyPresent) {
+        logMessage(`${SUBMODULE_NAME}RtdProvider: injecting CUID as user EID`);
+        mergeDeep(reqBidsConfigObj.ortb2Fragments?.global, {
+          user: {
+            ext: {
+              eids: [{
+                source: ANONYMISED_SOURCE,
+                uids: [{ id: cuid, atype: 1, ext: { stype: 'ppuid' } }]
+              }]
+            }
+          }
+        });
+      }
+    }
+
+    onDone();
   }
   /**
    * Module init

--- a/modules/anonymisedRtdProvider.js
+++ b/modules/anonymisedRtdProvider.js
@@ -157,7 +157,9 @@ export function createRtdProvider(moduleName) {
       const alreadyPresent = existingEids?.some(eid => eid.source === ANONYMISED_SOURCE);
       if (cuid && !alreadyPresent) {
         logMessage(`${SUBMODULE_NAME}RtdProvider: injecting CUID as user EID`);
-        mergeDeep(reqBidsConfigObj.ortb2Fragments?.global, {
+        reqBidsConfigObj.ortb2Fragments = reqBidsConfigObj.ortb2Fragments || {};
+        reqBidsConfigObj.ortb2Fragments.global = reqBidsConfigObj.ortb2Fragments.global || {};
+        mergeDeep(reqBidsConfigObj.ortb2Fragments.global, {
           user: {
             ext: {
               eids: [{

--- a/modules/anonymisedRtdProvider.js
+++ b/modules/anonymisedRtdProvider.js
@@ -69,7 +69,7 @@ export function createRtdProvider(moduleName) {
    * @return {'t'|'h'}
    */
   function getSignalLiftGroup() {
-    return storage.getDataFromSessionStorage(SIGNAL_LIFT_GROUP_KEY) ?? 't';
+    return storage.getDataFromSessionStorage(SIGNAL_LIFT_GROUP_KEY) === 'h' ? 'h' : 't';
   }
   /**
    * Load the Anonymised Marketing Tag script

--- a/modules/anonymisedRtdProvider.js
+++ b/modules/anonymisedRtdProvider.js
@@ -7,7 +7,7 @@
  */
 import { getStorageManager } from '../src/storageManager.js';
 import { submodule } from '../src/hook.js';
-import { isPlainObject, mergeDeep, logMessage, logWarn, logError } from '../src/utils.js';
+import { isPlainObject, mergeDeep, logMessage, logWarn, logError, getWindowLocation } from '../src/utils.js';
 import { MODULE_TYPE_RTD } from '../src/activities/modules.js';
 import { loadExternalScript } from '../src/adloader.js';
 /**
@@ -53,7 +53,9 @@ export function createRtdProvider(moduleName) {
    * @return {string|undefined}
    */
   function getCUID() {
-    const oidcKey = `oidc.user:https://account.anonymised.io/login:${window.location.origin}`;
+    const origin = getWindowLocation()?.origin;
+    if (!origin) return undefined;
+    const oidcKey = `oidc.user:https://account.anonymised.io/login:${origin}`;
     try {
       const record = storage.getDataFromLocalStorage(oidcKey);
       return record ? JSON.parse(record)?.profile?.cuid : undefined;

--- a/modules/anonymisedRtdProvider.md
+++ b/modules/anonymisedRtdProvider.md
@@ -3,6 +3,8 @@
 Anonymised is a data anonymization technology for privacy-preserving advertising. Publishers and advertisers are able to target and retarget custom audience segments covering 100% of consented audiences.
 Anonymised’s Real-time Data Provider automatically obtains segment IDs from the Anonymised on-domain script (via localStorage) and passes them to the bid-stream.
 
+It also injects the authenticated user’s CUID (Customer User ID) as a publisher-provided ID (`user.ext.eids`) into each bid request, equivalent to what the `pubProvidedId` user ID module provides. Users in the SignalLift holdout group are excluded from PPID injection to preserve measurement integrity. `waitForIt: true` is required so the auction waits for PPID injection before sending bids.
+
 ### Integration
 
  - Build the anonymisedRtd module into the Prebid.js package with:

--- a/test/spec/modules/anonymisedRtdProvider_spec.js
+++ b/test/spec/modules/anonymisedRtdProvider_spec.js
@@ -359,4 +359,71 @@ describe('anonymisedRtdProvider', function() {
       expect(getRealTimeData(testReqBidsConfigObj, onDone, cmoduleConfig)).to.equal(undefined)
     });
   });
+
+  describe('CUID EID injection', function() {
+    const OIDC_KEY = `oidc.user:https://account.anonymised.io/login:${window.location.origin}`;
+    let getDataFromSessionStorageStub;
+
+    beforeEach(function() {
+      getDataFromSessionStorageStub = sinon.stub(storage, 'getDataFromSessionStorage').returns(null);
+    });
+
+    afterEach(function() {
+      getDataFromSessionStorageStub.restore();
+    });
+
+    it('injects CUID as user EID when OIDC user record is present', function() {
+      getDataFromLocalStorageStub.withArgs(OIDC_KEY).returns(JSON.stringify({ profile: { cuid: 'test-cuid-123' } }));
+
+      const bidConfig = { ortb2Fragments: { global: {} } };
+      getRealTimeData(bidConfig, () => {}, { params: {} }, {});
+
+      expect(bidConfig.ortb2Fragments.global.user.ext.eids).to.deep.equal([{
+        source: 'anonymised.io',
+        uids: [{ id: 'test-cuid-123', atype: 1, ext: { stype: 'ppuid' } }]
+      }]);
+    });
+
+    it('does not inject EID when OIDC user record is absent', function() {
+      getDataFromLocalStorageStub.withArgs(OIDC_KEY).returns(null);
+
+      const bidConfig = { ortb2Fragments: { global: {} } };
+      getRealTimeData(bidConfig, () => {}, { params: {} }, {});
+
+      expect(bidConfig.ortb2Fragments.global.user).to.be.undefined;
+    });
+
+    it('does not inject EID when user record has no cuid', function() {
+      getDataFromLocalStorageStub.withArgs(OIDC_KEY).returns(JSON.stringify({ profile: { name: 'Test User' } }));
+
+      const bidConfig = { ortb2Fragments: { global: {} } };
+      getRealTimeData(bidConfig, () => {}, { params: {} }, {});
+
+      expect(bidConfig.ortb2Fragments.global.user).to.be.undefined;
+    });
+
+    it('does not inject EID when SignalLift group is holdout', function() {
+      getDataFromLocalStorageStub.withArgs(OIDC_KEY).returns(JSON.stringify({ profile: { cuid: 'test-cuid-123' } }));
+      getDataFromSessionStorageStub.withArgs('anon-sl-group-session').returns('h');
+
+      const bidConfig = { ortb2Fragments: { global: {} } };
+      getRealTimeData(bidConfig, () => {}, { params: {} }, {});
+
+      expect(bidConfig.ortb2Fragments.global.user?.ext?.eids).to.be.undefined;
+    });
+
+    it('injects CUID alongside cohort segments', function() {
+      getDataFromLocalStorageStub.withArgs('cohort_ids').returns(JSON.stringify(['SEG001']));
+      getDataFromLocalStorageStub.withArgs(OIDC_KEY).returns(JSON.stringify({ profile: { cuid: 'cuid-with-cohort' } }));
+
+      const bidConfig = { ortb2Fragments: { global: {} } };
+      getRealTimeData(bidConfig, () => {}, { params: { cohortStorageKey: 'cohort_ids', segtax: 503 } }, {});
+
+      expect(bidConfig.ortb2Fragments.global.user.data).to.have.length(1);
+      expect(bidConfig.ortb2Fragments.global.user.ext.eids).to.deep.equal([{
+        source: 'anonymised.io',
+        uids: [{ id: 'cuid-with-cohort', atype: 1, ext: { stype: 'ppuid' } }]
+      }]);
+    });
+  });
 });

--- a/test/spec/modules/anonymisedRtdProvider_spec.js
+++ b/test/spec/modules/anonymisedRtdProvider_spec.js
@@ -412,6 +412,20 @@ describe('anonymisedRtdProvider', function() {
       expect(bidConfig.ortb2Fragments.global.user?.ext?.eids).to.be.undefined;
     });
 
+    it('does not inject duplicate EID when anonymised.io entry already exists in user.ext.eids', function() {
+      const existingEid = {
+        source: 'anonymised.io',
+        uids: [{ id: 'existing-cuid', atype: 1, ext: { stype: 'ppuid' } }]
+      };
+      getDataFromLocalStorageStub.withArgs(OIDC_KEY).returns(JSON.stringify({ profile: { cuid: 'new-cuid' } }));
+
+      const bidConfig = { ortb2Fragments: { global: { user: { ext: { eids: [existingEid] } } } } };
+      getRealTimeData(bidConfig, () => {}, { params: {} }, {});
+
+      expect(bidConfig.ortb2Fragments.global.user.ext.eids).to.have.length(1);
+      expect(bidConfig.ortb2Fragments.global.user.ext.eids[0]).to.deep.equal(existingEid);
+    });
+
     it('injects CUID alongside cohort segments', function() {
       getDataFromLocalStorageStub.withArgs('cohort_ids').returns(JSON.stringify(['SEG001']));
       getDataFromLocalStorageStub.withArgs(OIDC_KEY).returns(JSON.stringify({ profile: { cuid: 'cuid-with-cohort' } }));


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
**Anonymised RTD Provider: inject authenticated user CUID as publisher-provided ID (PPID)**
**Summary**
- The RTD module now reads the authenticated user's CUID from localStorage and injects it as a publisher-provided extended ID into each bid request via `user.ext.eids`
- The SignalLift holdout/treatment group is checked before injection — users in the holdout group ('`h`') are excluded, matching Anonymised's measurement requirements
- Injection is skipped if a source: "anonymised.io" entry already exists in `user.ext.eids`, preventing duplicates when the EID has been set upstream
- `getBidRequestData` now always calls `onDone() `— required because `waitForIt: true `must be set in the publisher's RTD config to gate the auction until the EID is available
- The segment injection logic (`cohortStorageKey / cohort_ids`) was restructured to eliminate early returns that previously skipped both EID injection and `onDone()` when cohort data was absent; an authenticated user with no cohort segments now still receives the PPID

**Note on responsibility**
PPID injection is conventionally the responsibility of the `pubProvidedId` user ID submodule. This change moves that responsibility into the RTD module to eliminate a timing race: when `pubProvidedId` is configured externally with an eidsFunction that reads from `window._anonymised_tag`, the function is called before the Anonymised tag script has loaded, causing a runtime crash. By reading directly from localStorage (via the Prebid storage manager, keyed at oidc.user:https://account.anonymised.io/login:{origin}) inside `getBidRequestData`, the injection happens at the correct point in the auction lifecycle with no dependency on the tag's load state. The resulting user.ext.eids entry is equivalent to what `pubProvidedId` would produce.

Publisher config change required
Publishers must add `waitForIt: true `to the RTD provider config:

`realTimeData: {
  dataProviders: [{
    name: 'anonymised',
    waitForIt: true,   // required — gates the auction until PPID is injected
    params: { ... }
  }]
}`

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
