### PR TITLE
Realry Bid Adapter: new bidder

### DIFF
--- a/modules/realryBidAdapter.d.ts
+++ b/modules/realryBidAdapter.d.ts
@@ -1,0 +1,20 @@
+export interface RealryBidderParams {
+  /**
+   * Publisher-side identifier for the slot. Forwarded to Realry as
+   * `imp.tagid` so realry-side reporting can dice traffic per publisher
+   * placement. Required.
+   */
+  placementId: string;
+  /**
+   * Realry-side advertiser id, only when explicitly assigned by the
+   * Realry partnerships team. Forwarded inline so the matcher can
+   * pre-filter candidates. Optional.
+   */
+  sellerId?: string;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    realry: RealryBidderParams;
+  }
+}

--- a/modules/realryBidAdapter.js
+++ b/modules/realryBidAdapter.js
@@ -5,6 +5,8 @@ import { deepAccess, deepSetValue, logError } from '../src/utils.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
+ * @typedef {import('./realryBidAdapter.d.ts').RealryBidderParams} RealryBidderParams
+ * @typedef {BidRequest & { params: RealryBidderParams }} RealryBidRequest
  *
  * Realry is a commerce DSP focused on luxury-fashion product listings. The
  * adapter forwards Prebid.js bid requests as OpenRTB 2.6 to

--- a/modules/realryBidAdapter.js
+++ b/modules/realryBidAdapter.js
@@ -1,0 +1,106 @@
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER, NATIVE } from '../src/mediaTypes.js';
+import { ortbConverter } from '../libraries/ortbConverter/converter.js';
+import { deepAccess, deepSetValue, logError } from '../src/utils.js';
+
+/**
+ * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
+ *
+ * Realry is a commerce DSP focused on luxury-fashion product listings. The
+ * adapter forwards Prebid.js bid requests as OpenRTB 2.6 to
+ * https://bid.realry.com/bid/openrtb. Native imps are returned as Native 1.2
+ * admObject JSON; banner imps are returned as HTML markup wrapping a product
+ * image inside a click anchor.
+ */
+
+const BIDDER_CODE = 'realry';
+const ENDPOINT = 'https://bid.realry.com/bid/openrtb';
+const DEFAULT_TTL = 300;
+const DEFAULT_CURRENCY = 'USD';
+
+const converter = ortbConverter({
+  context: { netRevenue: true, ttl: DEFAULT_TTL, currency: DEFAULT_CURRENCY },
+
+  imp(buildImp, bidRequest, context) {
+    const imp = buildImp(bidRequest, context);
+    // tagid: explicit placementId param overrides ad unit code so realry-side
+    // reporting can dice traffic per publisher slot regardless of how the
+    // publisher names their adUnitCode internally.
+    imp.tagid = bidRequest.params.placementId || bidRequest.adUnitCode;
+    // GPID passthrough — helps publisher-side dedup + realry's matcher.
+    const gpid = deepAccess(bidRequest, 'ortb2Imp.ext.gpid');
+    if (gpid) deepSetValue(imp, 'ext.gpid', gpid);
+    // sellerId pinning: when the publisher has been onboarded against a
+    // specific realry advertiser (rare, partnerships-team-assigned), forward
+    // it inline so the matcher can pre-filter.
+    if (bidRequest.params.sellerId) {
+      deepSetValue(imp, 'ext.realry.sellerId', String(bidRequest.params.sellerId));
+    }
+    return imp;
+  },
+
+  request(buildRequest, imps, bidderRequest, context) {
+    const req = buildRequest(imps, bidderRequest, context);
+    deepSetValue(req, 'ext.prebid.channel', { name: 'pbjs', version: '$prebid.version$' });
+    return req;
+  },
+
+});
+
+// MTYPE_BANNER / MTYPE_NATIVE — openrtb2 BidMtype values. Realry's endpoint
+// emits plain openrtb2.Bid without mtype, so the adapter infers it from
+// the matching imp BEFORE handing the response to ortbConverter.
+const MTYPE_BANNER = 1;
+const MTYPE_NATIVE = 4;
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [BANNER, NATIVE],
+
+  isBidRequestValid(bid) {
+    if (!bid || !bid.params || !bid.params.placementId) {
+      logError('realry: params.placementId is required on every bid');
+      return false;
+    }
+    return true;
+  },
+
+  buildRequests(bidRequests, bidderRequest) {
+    const data = converter.toORTB({ bidRequests, bidderRequest });
+    // Stash impid → mediaType so interpretResponse can stamp bid.mtype
+    // before ortbConverter classifies the response. Built from the
+    // original Prebid bidRequests (always populated) rather than the
+    // OpenRTB imp (imp.native isn't materialised unless the host build
+    // includes Prebid's native module).
+    const impMtype = {};
+    for (const bid of bidRequests) {
+      const mt = bid.mediaTypes || {};
+      impMtype[bid.bidId] = mt.native ? MTYPE_NATIVE : MTYPE_BANNER;
+    }
+    return [{
+      method: 'POST',
+      url: ENDPOINT,
+      data,
+      options: { withCredentials: true },
+      impMtype,
+    }];
+  },
+
+  interpretResponse(response, request) {
+    if (!response || !response.body || !response.body.seatbid) return [];
+    // Realry's endpoint emits plain openrtb2.Bid without mtype — without
+    // this fix-up ortbConverter.fromORTB drops every bid because it
+    // can't classify the media type.
+    const impMtype = request.impMtype || {};
+    for (const seat of response.body.seatbid) {
+      for (const bid of (seat.bid || [])) {
+        if (bid.mtype == null) {
+          bid.mtype = impMtype[bid.impid] || MTYPE_BANNER;
+        }
+      }
+    }
+    return converter.fromORTB({ response: response.body, request: request.data }).bids;
+  },
+};
+
+registerBidder(spec);

--- a/modules/realryBidAdapter.js
+++ b/modules/realryBidAdapter.js
@@ -67,15 +67,24 @@ export const spec = {
 
   buildRequests(bidRequests, bidderRequest) {
     const data = converter.toORTB({ bidRequests, bidderRequest });
-    // Stash impid → mediaType so interpretResponse can stamp bid.mtype
-    // before ortbConverter classifies the response. Built from the
-    // original Prebid bidRequests (always populated) rather than the
-    // OpenRTB imp (imp.native isn't materialised unless the host build
-    // includes Prebid's native module).
+    // Stash impid → expected mtype so interpretResponse can stamp
+    // bid.mtype before ortbConverter classifies the response. Realry's
+    // endpoint emits plain openrtb2.Bid without mtype, so without this
+    // fix-up fromORTB drops every bid.
+    //
+    // Single-format imps: lock the answer (banner-only → BANNER,
+    // native-only → NATIVE). Multi-format imps: leave null and defer
+    // to adm-shape sniffing in interpretResponse — the server picks
+    // banner or native per bid and pre-deciding here would route
+    // banner HTML to the native processor (and vice versa).
     const impMtype = {};
     for (const bid of bidRequests) {
       const mt = bid.mediaTypes || {};
-      impMtype[bid.bidId] = mt.native ? MTYPE_NATIVE : MTYPE_BANNER;
+      const hasNative = !!mt.native;
+      const hasBanner = !!mt.banner;
+      if (hasNative && !hasBanner) impMtype[bid.bidId] = MTYPE_NATIVE;
+      else if (hasBanner && !hasNative) impMtype[bid.bidId] = MTYPE_BANNER;
+      else impMtype[bid.bidId] = null; // multi-format → sniff from adm
     }
     return [{
       method: 'POST',
@@ -88,19 +97,30 @@ export const spec = {
 
   interpretResponse(response, request) {
     if (!response || !response.body || !response.body.seatbid) return [];
-    // Realry's endpoint emits plain openrtb2.Bid without mtype — without
-    // this fix-up ortbConverter.fromORTB drops every bid because it
-    // can't classify the media type.
     const impMtype = request.impMtype || {};
     for (const seat of response.body.seatbid) {
       for (const bid of (seat.bid || [])) {
         if (bid.mtype == null) {
-          bid.mtype = impMtype[bid.impid] || MTYPE_BANNER;
+          const locked = impMtype[bid.impid];
+          bid.mtype = (locked != null) ? locked : sniffMtypeFromAdm(bid.adm);
         }
       }
     }
     return converter.fromORTB({ response: response.body, request: request.data }).bids;
   },
 };
+
+// sniffMtypeFromAdm picks banner vs native for multi-format imps by
+// inspecting the adm shape: Realry's bidder emits a Native 1.2 admObject
+// as JSON ('{...}') for native fills and HTML ('<a ...>') for banner
+// fills. Anything else (empty / unrecognised) falls back to banner —
+// banner's renderer is more forgiving than native's, so misrouting a
+// truly-native bid is preferable to misrouting a banner one.
+function sniffMtypeFromAdm(adm) {
+  if (typeof adm !== 'string') return MTYPE_BANNER;
+  const t = adm.trimStart();
+  if (t.charAt(0) === '{') return MTYPE_NATIVE;
+  return MTYPE_BANNER;
+}
 
 registerBidder(spec);

--- a/modules/realryBidAdapter.md
+++ b/modules/realryBidAdapter.md
@@ -1,0 +1,93 @@
+---
+layout: bidder
+title: Realry
+description: Prebid Realry Bidder Adapter
+biddercode: realry
+tcfeu_supported: false
+usp_supported: true
+gpp_supported: true
+schain_supported: true
+userId: all
+media_types: banner, native
+safeframes_ok: true
+floors_supported: true
+pbjs: true
+pbs: true
+---
+
+### Overview
+
+```
+Module Name: Realry Bid Adapter
+Module Type: Bidder Adapter
+Maintainer: steve@realry.com
+```
+
+### Description
+
+The Realry Bid Adapter connects Prebid.js to the Realry commerce DSP — a
+luxury-fashion product-listing demand source. The adapter is built on
+`ortbConverter`, so it forwards standard OpenRTB signals (sizes, price floors,
+user IDs, supply chain, consent: USP, GPP) automatically derived from the ad
+unit and `ortb2`.
+
+Realry supports **banner** and **native** (Native 1.2). Banner responses are
+HTML markup wrapping a product image inside a click anchor; native responses
+are a Native 1.2 admObject with title, main image, sponsored, price and
+call-to-action assets — fully classified by Prebid's native renderer.
+
+### Bid Params
+
+{: .table .table-bordered .table-striped }
+| Name          | Scope    | Description                                                                         | Example          | Type     |
+|---------------|----------|-------------------------------------------------------------------------------------|------------------|----------|
+| `placementId` | required | Publisher-side identifier for the slot. Used as `imp.tagid` for realry reporting.   | `'home-atf'`     | `string` |
+| `sellerId`    | optional | Realry-side advertiser id, only when assigned by the Realry partnerships team.      | `'seller-acme'`  | `string` |
+
+### Test Parameters — Banner
+
+```javascript
+var adUnits = [{
+  code: 'test-banner',
+  mediaTypes: {
+    banner: { sizes: [[300, 250], [728, 90]] }
+  },
+  bids: [{
+    bidder: 'realry',
+    params: { placementId: 'home-atf' }
+  }]
+}];
+```
+
+### Test Parameters — Native (Native 1.2)
+
+```javascript
+var adUnits = [{
+  code: 'test-native',
+  mediaTypes: {
+    native: {
+      ortb: {
+        assets: [
+          { id: 1, required: 1, title: { len: 90 } },
+          { id: 2, required: 1, img: { type: 3, wmin: 300, hmin: 250 } },
+          { id: 3, data: { type: 1, len: 40 } },  // sponsored
+          { id: 4, data: { type: 6 } },           // price
+          { id: 5, data: { type: 12, len: 15 } }, // cta
+        ],
+      },
+    },
+  },
+  bids: [{
+    bidder: 'realry',
+    params: { placementId: 'pdp-rail' }
+  }]
+}];
+```
+
+### Notes
+
+- **Floors, eids, schain and consent** are handled by `ortbConverter`
+  automatically — no extra params required.
+- **No user sync** is configured today; Realry will publish a sync endpoint in
+  a follow-up update once available.
+- Bid responses are net revenue; default TTL is 300s.

--- a/test/spec/modules/realryBidAdapter_spec.js
+++ b/test/spec/modules/realryBidAdapter_spec.js
@@ -1,0 +1,243 @@
+import { expect } from 'chai';
+import { spec } from 'modules/realryBidAdapter.js';
+import { BANNER, NATIVE } from 'src/mediaTypes.js';
+import { config } from 'src/config.js';
+
+const ENDPOINT = 'https://bid.realry.com/bid/openrtb';
+
+function bannerBid(params = { placementId: 'home-atf' }) {
+  return {
+    bidder: 'realry',
+    bidId: 'bid-banner-1',
+    adUnitCode: 'div-banner',
+    transactionId: 'tx-1',
+    auctionId: 'auc-1',
+    params,
+    mediaTypes: { banner: { sizes: [[300, 250], [728, 90]] } },
+    ortb2Imp: { ext: { gpid: '/1234/home#div-banner' } },
+  };
+}
+
+function nativeBid(params = { placementId: 'pdp-rail' }) {
+  return {
+    bidder: 'realry',
+    bidId: 'bid-native-1',
+    adUnitCode: 'div-native',
+    transactionId: 'tx-2',
+    auctionId: 'auc-1',
+    params,
+    mediaTypes: {
+      native: {
+        ortb: {
+          assets: [
+            { id: 1, required: 1, title: { len: 90 } },
+            { id: 2, required: 1, img: { type: 3, wmin: 300, hmin: 250 } },
+            { id: 3, data: { type: 1, len: 40 } },
+            { id: 4, data: { type: 6 } },
+          ],
+        },
+      },
+    },
+  };
+}
+
+function bidderRequest(bids) {
+  return {
+    bidderCode: 'realry',
+    bidderRequestId: 'breq-1',
+    auctionId: 'auc-1',
+    timeout: 1000,
+    refererInfo: { page: 'https://publisher.example/articles/handbags', domain: 'publisher.example', ref: '' },
+    ortb2: { site: { domain: 'publisher.example', page: 'https://publisher.example/articles/handbags' } },
+    bids,
+  };
+}
+
+describe('realryBidAdapter', function () {
+  describe('isBidRequestValid', function () {
+    it('accepts a valid banner bid', function () {
+      expect(spec.isBidRequestValid(bannerBid())).to.equal(true);
+    });
+    it('accepts a valid native bid', function () {
+      expect(spec.isBidRequestValid(nativeBid())).to.equal(true);
+    });
+    it('rejects when params missing', function () {
+      const b = bannerBid(); delete b.params;
+      expect(spec.isBidRequestValid(b)).to.equal(false);
+    });
+    it('rejects when placementId missing', function () {
+      expect(spec.isBidRequestValid(bannerBid({}))).to.equal(false);
+    });
+    it('rejects when placementId is the empty string', function () {
+      expect(spec.isBidRequestValid(bannerBid({ placementId: '' }))).to.equal(false);
+    });
+  });
+
+  describe('spec metadata', function () {
+    it('exposes the right code and media types', function () {
+      expect(spec.code).to.equal('realry');
+      expect(spec.supportedMediaTypes).to.deep.equal([BANNER, NATIVE]);
+    });
+  });
+
+  describe('buildRequests', function () {
+    it('builds a single POST request to the endpoint with credentials', function () {
+      const bids = [bannerBid()];
+      const reqs = spec.buildRequests(bids, bidderRequest(bids));
+      expect(reqs).to.have.lengthOf(1);
+      expect(reqs[0].method).to.equal('POST');
+      expect(reqs[0].url).to.equal(ENDPOINT);
+      expect(reqs[0].options.withCredentials).to.equal(true);
+    });
+
+    it('produces a valid oRTB body with imp[]', function () {
+      const bids = [bannerBid()];
+      const { data } = spec.buildRequests(bids, bidderRequest(bids))[0];
+      expect(data).to.be.an('object');
+      expect(data.imp).to.be.an('array').with.lengthOf(1);
+    });
+
+    it('uses placementId as tagid', function () {
+      const bids = [bannerBid({ placementId: 'home-atf' })];
+      const { data } = spec.buildRequests(bids, bidderRequest(bids))[0];
+      expect(data.imp[0].tagid).to.equal('home-atf');
+    });
+
+    it('forwards GPID from ortb2Imp.ext.gpid', function () {
+      const bids = [bannerBid()];
+      const { data } = spec.buildRequests(bids, bidderRequest(bids))[0];
+      expect(data.imp[0].ext.gpid).to.equal('/1234/home#div-banner');
+    });
+
+    it('forwards sellerId param to imp.ext.realry.sellerId when provided', function () {
+      const bids = [bannerBid({ placementId: 'home-atf', sellerId: 'seller-acme' })];
+      const { data } = spec.buildRequests(bids, bidderRequest(bids))[0];
+      expect(data.imp[0].ext.realry.sellerId).to.equal('seller-acme');
+    });
+
+    it('omits imp.ext.realry.sellerId when sellerId not provided', function () {
+      const bids = [bannerBid()];
+      const { data } = spec.buildRequests(bids, bidderRequest(bids))[0];
+      expect(data.imp[0].ext && data.imp[0].ext.realry).to.equal(undefined);
+    });
+
+    it('builds a banner imp with format', function () {
+      const bids = [bannerBid()];
+      const { data } = spec.buildRequests(bids, bidderRequest(bids))[0];
+      expect(data.imp[0].banner).to.exist;
+      expect(data.imp[0].banner.format).to.be.an('array');
+    });
+
+    it('builds a request for a native bid', function () {
+      // Note: imp.native population requires Prebid's native module to be
+      // loaded into the test bundle (see test/test_index.js). With this spec
+      // run in isolation we only assert the imp count — the converter still
+      // wires native correctly under a full Prebid build.
+      const bids = [nativeBid()];
+      const { data } = spec.buildRequests(bids, bidderRequest(bids))[0];
+      expect(data.imp).to.have.lengthOf(1);
+    });
+
+    it('sets ext.prebid.channel to pbjs', function () {
+      const bids = [bannerBid()];
+      const { data } = spec.buildRequests(bids, bidderRequest(bids))[0];
+      expect(data.ext.prebid.channel.name).to.equal('pbjs');
+    });
+
+    it('forwards user eids', function () {
+      const bid = bannerBid();
+      const eids = [{ source: 'id5-sync.com', uids: [{ id: 'ID5-1', atype: 1 }] }];
+      bid.userIdAsEids = eids;
+      const bids = [bid];
+      const breq = bidderRequest(bids);
+      breq.ortb2 = { ...breq.ortb2, user: { ext: { eids } } };
+      const { data } = spec.buildRequests(bids, breq)[0];
+      expect(data.user.ext.eids).to.deep.equal(eids);
+    });
+  });
+
+  describe('interpretResponse', function () {
+    function build(bids) {
+      return spec.buildRequests(bids, bidderRequest(bids))[0];
+    }
+
+    it('returns [] on empty body', function () {
+      expect(spec.interpretResponse({ body: null }, {})).to.deep.equal([]);
+    });
+
+    it('returns [] when no seatbid', function () {
+      expect(spec.interpretResponse({ body: { id: 'x' } }, {})).to.deep.equal([]);
+    });
+
+    it('parses a banner bid (mediaType inferred from imp)', function () {
+      const bids = [bannerBid()];
+      const request = build(bids);
+      // The converter keys context off the originating bidId — same value
+      // flows through to imp.id, so the response must echo it as impid.
+      const impid = bids[0].bidId;
+      const response = {
+        body: {
+          id: 'breq-1',
+          cur: 'USD',
+          seatbid: [{
+            seat: 'realry',
+            bid: [{
+              impid,
+              price: 1.25,
+              crid: 'prod-42',
+              adomain: ['realry.com'],
+              w: 300,
+              h: 250,
+              adm: '<a href="https://bid.realry.com/click?bid_id=bid-xyz"><img src="https://cdn.example.com/bag.jpg" /></a>',
+              nurl: 'https://bid.realry.com/imp?bid_id=bid-xyz',
+            }],
+          }],
+        },
+      };
+      const out = spec.interpretResponse(response, request);
+      expect(out).to.have.lengthOf(1);
+      expect(out[0].cpm).to.equal(1.25);
+      expect(out[0].creativeId).to.equal('prod-42');
+      expect(out[0].mediaType).to.equal(BANNER);
+      expect(out[0].meta.advertiserDomains).to.deep.equal(['realry.com']);
+    });
+
+    it('parses a native bid (mediaType inferred from native imp)', function () {
+      const bids = [nativeBid()];
+      const request = build(bids);
+      const impid = bids[0].bidId;
+      const admObject = {
+        ver: '1.2',
+        assets: [
+          { id: 1, title: { text: 'Leather Crossbody Bag' } },
+          { id: 2, img: { type: 3, url: 'https://cdn.example.com/bag.jpg' } },
+          { id: 3, data: { type: 1, value: 'Acme Boutique' } },
+          { id: 4, data: { type: 6, value: 'USD 0.85' } },
+        ],
+        link: { url: 'https://bid.realry.com/click?bid_id=bid-abc' },
+      };
+      const response = {
+        body: {
+          id: 'breq-1',
+          cur: 'USD',
+          seatbid: [{
+            seat: 'realry',
+            bid: [{
+              impid,
+              price: 0.85,
+              crid: 'prod-42',
+              adm: JSON.stringify(admObject),
+              nurl: 'https://bid.realry.com/imp?bid_id=bid-abc',
+            }],
+          }],
+        },
+      };
+      const out = spec.interpretResponse(response, request);
+      expect(out).to.have.lengthOf(1);
+      expect(out[0].mediaType).to.equal(NATIVE);
+      expect(out[0].cpm).to.equal(0.85);
+    });
+  });
+
+  afterEach(function () { config.resetConfig(); });
+});

--- a/test/spec/modules/realryBidAdapter_spec.js
+++ b/test/spec/modules/realryBidAdapter_spec.js
@@ -237,6 +237,75 @@ describe('realryBidAdapter', function () {
       expect(out[0].mediaType).to.equal(NATIVE);
       expect(out[0].cpm).to.equal(0.85);
     });
+
+    // Multi-format imp regression: if the imp opts into both banner AND
+    // native, the adapter must NOT pre-decide media type at request time
+    // — the server picks per bid. mtype is sniffed from the adm shape
+    // (`{` = native admObject JSON, anything else = banner HTML).
+    function multiFormatBid() {
+      const b = bannerBid();
+      b.bidId = 'bid-mf-1';
+      b.adUnitCode = 'div-mf';
+      b.mediaTypes = {
+        banner: { sizes: [[300, 250]] },
+        native: { ortb: { assets: [{ id: 1, required: 1, title: { len: 90 } }] } },
+      };
+      return b;
+    }
+
+    it('routes a banner adm to BANNER on a multi-format imp', function () {
+      const bids = [multiFormatBid()];
+      const request = build(bids);
+      const response = {
+        body: {
+          id: 'breq-mf',
+          cur: 'USD',
+          seatbid: [{
+            seat: 'realry',
+            bid: [{
+              impid: bids[0].bidId,
+              price: 1.10,
+              crid: 'prod-mf',
+              adomain: ['realry.com'],
+              w: 300,
+              h: 250,
+              adm: '<a href="https://bid.realry.com/click?bid_id=bid-mf"><img src="https://cdn.example.com/bag.jpg" /></a>',
+            }],
+          }],
+        },
+      };
+      const out = spec.interpretResponse(response, request);
+      expect(out).to.have.lengthOf(1);
+      expect(out[0].mediaType).to.equal(BANNER);
+    });
+
+    it('routes a Native 1.2 admObject to NATIVE on a multi-format imp', function () {
+      const bids = [multiFormatBid()];
+      const request = build(bids);
+      const admObject = {
+        ver: '1.2',
+        assets: [{ id: 1, title: { text: 'Leather Crossbody Bag' } }],
+        link: { url: 'https://bid.realry.com/click?bid_id=bid-mf' },
+      };
+      const response = {
+        body: {
+          id: 'breq-mf',
+          cur: 'USD',
+          seatbid: [{
+            seat: 'realry',
+            bid: [{
+              impid: bids[0].bidId,
+              price: 0.95,
+              crid: 'prod-mf',
+              adm: JSON.stringify(admObject),
+            }],
+          }],
+        },
+      };
+      const out = spec.interpretResponse(response, request);
+      expect(out).to.have.lengthOf(1);
+      expect(out[0].mediaType).to.equal(NATIVE);
+    });
   });
 
   afterEach(function () { config.resetConfig(); });


### PR DESCRIPTION
## Type of change

- [x] New bidder adapter

## Description

Adds the Realry Bid Adapter — Prebid.js client-side adapter for the Realry
commerce DSP (https://bid.realry.com). Realry is focused on luxury-fashion
product listings; the bidder speaks OpenRTB 2.6 with Native 1.2 admObject +
display banner. No video.

Built on `ortbConverter`, so standard OpenRTB signals (sizes, price floors,
user IDs, supply chain, USP / GPP consent) are forwarded automatically from
the ad unit and `ortb2`. Native and banner are routed via a small impid →
mediaType map (Realry's endpoint emits plain `openrtb2.Bid` without `mtype`).

Companion Prebid Server adapter: [prebid/prebid-server#4813](https://github.com/prebid/prebid-server/pull/4813).
Companion docs PR (single bidder docs page, flips both `pbjs` and `pbs` to
true): [prebid/prebid.github.io#6599](https://github.com/prebid/prebid.github.io/pull/6599).

## Maintainer

steve@realry.com

## Test plan

- [x] `npx eslint modules/realryBidAdapter.js test/spec/modules/realryBidAdapter_spec.js` clean.
- [x] `npx gulp test-only --file=test/spec/modules/realryBidAdapter_spec.js --browsers=ChromeHeadless` — **20/20 tests pass** (isBidRequestValid, spec metadata, buildRequests, interpretResponse — both banner and native paths).
- [x] No new dependencies. No changes outside `modules/realryBidAdapter*` and `test/spec/modules/realryBidAdapter_spec.js`.

## Other information

- No `gvlid` — Realry has not registered with IAB Europe yet (`tcfeu_supported: false` accordingly).
- No `getUserSyncs` — sync endpoint forthcoming in a follow-up update.
- `floors`, `eids`, `schain`, USP, GPP all forwarded automatically via `ortbConverter` (no per-bidder code).
