### PR TITLE
Fluct Bid Adapter: send autoplay capability as a signal

### DIFF
--- a/modules/fluctBidAdapter.js
+++ b/modules/fluctBidAdapter.js
@@ -1,6 +1,7 @@
 import { _each, deepAccess, deepSetValue, isEmpty, isFn, isPlainObject } from '../src/utils.js';
 import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { isAutoplayEnabled } from '../libraries/autoplayDetection/autoplay.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -241,6 +242,10 @@ export const spec = {
 
       const pos = deepAccess(request, 'mediaTypes.banner.pos') ?? deepAccess(request, 'ortb2Imp.ext.data.pos');
       if (pos != null) data.pos = pos;
+
+      // Forward the device autoplay capability as a raw signal so the bidder can
+      // avoid autoplay-dependent (e.g. video) inventory when autoplay is blocked.
+      data.autoplay = isAutoplayEnabled() ? 1 : 0;
 
       const ortb2Device = bidderRequest.ortb2?.device;
       if (ortb2Device) {

--- a/test/spec/modules/fluctBidAdapter_spec.js
+++ b/test/spec/modules/fluctBidAdapter_spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { spec } from 'modules/fluctBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
 import { config } from 'src/config';
+import * as autoplay from 'libraries/autoplayDetection/autoplay.js';
 
 describe('fluctAdapter', function () {
   const adapter = newBidder(spec);
@@ -950,6 +951,20 @@ describe('fluctAdapter', function () {
     it('does not include data.user.ext when ortb2.user.ext.data is absent', function () {
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.data.user.ext).to.eql(undefined);
+    });
+
+    describe('autoplay signal', function () {
+      it('sends data.autoplay = 1 when autoplay is enabled', function () {
+        sb.stub(autoplay, 'isAutoplayEnabled').returns(true);
+        const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+        expect(request.data.autoplay).to.equal(1);
+      });
+
+      it('sends data.autoplay = 0 when autoplay is disabled', function () {
+        sb.stub(autoplay, 'isAutoplayEnabled').returns(false);
+        const request = spec.buildRequests(bidRequests, bidderRequest)[0];
+        expect(request.data.autoplay).to.equal(0);
+      });
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter

## Description of change
The Fluct adapter now reports the device autoplay capability as a signal on
every bid request: `data.autoplay` is set to `1` when autoplay is available and
`0` otherwise, using Prebid's shared `libraries/autoplayDetection/autoplay.js`
(`isAutoplayEnabled()`). This mirrors how other adapters (e.g. missena, cwire)
expose autoplay capability.

The adapter does not transform the request based on this signal — the bidder
server decides how to use it (e.g. to avoid returning autoplay-dependent video
inventory when autoplay is blocked).

No bidder parameters, media types, or support flags change, so no documentation
update is required.

## Other information
