### PR TITLE
Utils: allow politeTriggerPixel without creds & Floxis Bid Adapter: add onTimeout/onBidderError telemetry callbacks

### DIFF
--- a/modules/floxisBidAdapter.js
+++ b/modules/floxisBidAdapter.js
@@ -1,7 +1,7 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
-import { triggerPixel, mergeDeep, replaceAuctionPrice } from '../src/utils.js';
+import { triggerPixel, politeTriggerPixel, mergeDeep, replaceAuctionPrice } from '../src/utils.js';
 
 const BIDDER_CODE = 'floxis';
 const DEFAULT_BID_TTL = 300;
@@ -39,6 +39,23 @@ function getEndpointUrl(seat, region, partner) {
 // the partner subdomain used for bidding. The trackers /sync endpoint resolves seat -> supply partner.
 function getSyncHost(region) {
   return isValidHostLabel(region) ? `https://px-${region}.floxis.tech` : null;
+}
+
+// Telemetry event host is pinned to px-us-e regardless of bid region. Only us-e is provisioned;
+// a beacon to an unprovisioned host would lose the very signal meant to catch misconfiguration.
+// SHIPPING-INTENT: switch to region-derived host (getSyncHost(region)) when px-eu and px-apac are provisioned.
+const TELEMETRY_HOST = 'https://px-us-e.floxis.tech';
+const TELEMETRY_PATH = '/event';
+
+// Assemble an event-beacon URL. consentSuffix is a pre-built '&k=v&...' string (may be empty).
+// extras is a plain object of optional dimension key→value pairs; falsy values are omitted.
+function buildEventUrl(eventType, { seat, region }, extras, consentSuffix) {
+  const base = `${TELEMETRY_HOST}${TELEMETRY_PATH}?event=${encodeURIComponent(eventType)}&seat=${encodeURIComponent(seat)}&region=${encodeURIComponent(region)}`;
+  const extraParams = Object.entries(extras)
+    .filter(([, v]) => v != null && v !== '')
+    .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
+    .join('&');
+  return base + (extraParams ? '&' + extraParams : '') + consentSuffix;
 }
 
 // IAB consent query params for the trackers /sync endpoint.
@@ -231,6 +248,64 @@ export const spec = {
     if (bid.burl) {
       triggerPixel(replaceAuctionPrice(bid.burl, bid.originalCpm || bid.cpm));
     }
+  },
+
+  onTimeout(timeoutData) {
+    // Report client-observed auction timeouts as cookieless operational telemetry.
+    // One beacon per distinct (seat, region); no consent exposed in timeout entries.
+    try {
+      if (!Array.isArray(timeoutData)) return;
+      const seen = {};
+      timeoutData.forEach((entry) => {
+        const { seat, region } = normalizeBidParams(entry.params);
+        if (!seat) return;
+        const key = `${seat}|${region}`;
+        if (seen[key]) return;
+        seen[key] = true;
+        const extras = {
+          ...(entry.timeout != null ? { duration: entry.timeout } : {}),
+          ...(entry.auctionId != null ? { auctionId: entry.auctionId } : {})
+        };
+        // 'omit' keeps this beacon cookieless — the px-us-e sync cookie never rides along.
+        politeTriggerPixel(buildEventUrl('timeout', { seat, region }, extras, ''), 'omit');
+      });
+    } catch (e) { }
+  },
+
+  onBidderError({ error, bidderRequest }) {
+    // Report client-observed bidder transport errors as cookieless operational telemetry.
+    // One beacon per distinct (seat, region); status/timedout are constant across the call.
+    try {
+      const bids = bidderRequest?.bids;
+      if (!Array.isArray(bids)) return;
+      const status = error?.status != null ? error.status : undefined;
+      const timedout = error?.timedOut ? 1 : 0;
+      const auctionId = bidderRequest?.auctionId;
+      // domain (not page): refererInfo.page carries the location query string, which can hold
+      // identifiers — the domain is enough to know which publisher errored and keeps the beacon identifier-free.
+      const puburl = bidderRequest?.refererInfo?.domain;
+      const consentQuery = buildConsentQuery(
+        bidderRequest?.gdprConsent,
+        bidderRequest?.uspConsent,
+        bidderRequest?.gppConsent
+      );
+      const consentSuffix = consentQuery.length ? '&' + consentQuery.join('&') : '';
+      const seen = {};
+      bids.forEach((bid) => {
+        const { seat, region } = normalizeBidParams(bid.params);
+        if (!seat) return;
+        const key = `${seat}|${region}`;
+        if (seen[key]) return;
+        seen[key] = true;
+        const extras = {
+          ...(status != null ? { status } : {}),
+          timedout,
+          ...(auctionId != null ? { auctionId } : {}),
+          ...(puburl ? { puburl } : {})
+        };
+        politeTriggerPixel(buildEventUrl('bidder-error', { seat, region }, extras, consentSuffix), 'omit');
+      });
+    } catch (e) { }
   }
 };
 

--- a/modules/floxisBidAdapter.md
+++ b/modules/floxisBidAdapter.md
@@ -3,7 +3,7 @@
 ```
 Module Name: Floxis Bidder Adapter
 Module Type: Bidder Adapter
-Maintainer: admin@floxis.tech
+Maintainer: prebid@floxis.tech
 ```
 
 # Description
@@ -105,5 +105,8 @@ pbjs.setConfig({
 });
 ```
 
+## Error & Timeout Telemetry
+The adapter reports client-observed auction timeouts and bidder transport errors to Floxis as cookieless operational telemetry. Each beacon is a `keepalive` fetch sent with credentials omitted (no cookies) and scheduled off the auction's critical path, so it carries only the seat, region, event type, and relevant operational dimensions (HTTP status, timeout flag, duration, auction ID, publisher domain) — no user or device identifier is included. Consent signals are forwarded as opaque pass-through parameters where available. Each beacon fires at most once per distinct seat+region pair per event, and telemetry failures are silently suppressed so they never affect the auction lifecycle.
+
 ## Testing
-Unit tests are provided in `test/spec/modules/floxisBidAdapter_spec.js` and cover validation, request building (params, host-label safety, floors, FPD/consent passthrough), response interpretation and meta mapping, user syncs, and billing notifications.
+Unit tests are provided in `test/spec/modules/floxisBidAdapter_spec.js` and cover validation, request building (params, host-label safety, floors, FPD/consent passthrough), response interpretation and meta mapping, user syncs, billing notifications, and error/timeout telemetry callbacks.

--- a/src/utils.js
+++ b/src/utils.js
@@ -356,27 +356,28 @@ export function waitForElementToLoad(element, timeout) {
 }
 
 /**
- * Inserts an image pixel with the specified `url` for cookie sync
- * @param {string} url URL string of the image pixel to load
- * @param  {function} [done] an optional exit callback, used when this usersync pixel is added during an async process
- * @param  {Number} [timeout] an optional timeout in milliseconds for the image to load before calling `done`
+ * Fires a fire-and-forget request for `url` on the background task queue (a keepalive fetch, falling
+ * back to an image pixel) for cookie sync and similar best-effort pixels.
+ * @param {string} url URL string to request
+ * @param {string} [credentials='include'] fetch credentials mode (e.g. `'include'`, `'omit'`); pass
+ *   `'omit'` for a cookieless request — the image fallback (which cannot omit cookies) is then skipped.
  */
 
-export function politeTriggerPixel(url) {
+export function politeTriggerPixel(url, credentials = 'include') {
   const triggerSync = () => {
     if (window.fetch && window.Request) {
       try {
         const request = new Request(url, {
           method: 'GET',
           mode: 'no-cors',
-          credentials: 'include',
+          credentials,
           keepalive: true
         });
-        window.fetch(request).catch(() => triggerPixel(url));
+        window.fetch(request).catch(() => { if (credentials !== 'omit') triggerPixel(url); });
         return;
       } catch (e) {}
     }
-    triggerPixel(url);
+    if (credentials !== 'omit') triggerPixel(url);
   };
 
   runBackgroundTask(triggerSync);

--- a/test/spec/modules/floxisBidAdapter_spec.js
+++ b/test/spec/modules/floxisBidAdapter_spec.js
@@ -785,6 +785,216 @@ describe('floxisBidAdapter', function () {
     });
   });
 
+  describe('onTimeout', function () {
+    let politeStub;
+
+    beforeEach(function () {
+      // Telemetry beacons route through politeTriggerPixel(url, 'omit'); stub it to capture the call.
+      politeStub = sinon.stub(utils, 'politeTriggerPixel');
+    });
+
+    afterEach(function () {
+      politeStub.restore();
+    });
+
+    const beaconUrl = (i = 0) => politeStub.getCall(i).args[0];
+
+    it('should fire a timeout event beacon to the pinned us-e host', function () {
+      spec.onTimeout([{ params: { seat: 'Gmtb', region: 'us-e' }, timeout: 2000, auctionId: 'a1' }]);
+      expect(politeStub.calledOnce).to.be.true;
+      const url = beaconUrl();
+      expect(url).to.include('https://px-us-e.floxis.tech/event');
+      expect(url).to.include('event=timeout');
+      expect(url).to.include('seat=Gmtb');
+      expect(url).to.include('region=us-e');
+      expect(url).to.include('duration=2000');
+      expect(url).to.include('auctionId=a1');
+    });
+
+    it('should send the beacon cookieless via politeTriggerPixel (credentials omitted)', function () {
+      spec.onTimeout([{ params: { seat: 'Gmtb', region: 'us-e' }, timeout: 2000, auctionId: 'a1' }]);
+      expect(politeStub.calledOnce).to.be.true;
+      expect(politeStub.firstCall.args[1]).to.equal('omit'); // no Floxis sync cookie rides along
+    });
+
+    it('should beacon to px-us-e even when region is eu (host is NOT region-derived)', function () {
+      spec.onTimeout([{ params: { seat: 'Gmtb', region: 'eu' }, timeout: 1500, auctionId: 'a2' }]);
+      const url = beaconUrl();
+      expect(url).to.include('https://px-us-e.floxis.tech/event');
+      expect(url).to.include('region=eu');
+      expect(url).not.to.include('px-eu');
+    });
+
+    it('should deduplicate beacons for the same seat+region across entries', function () {
+      spec.onTimeout([
+        { params: { seat: 'Gmtb', region: 'us-e' }, timeout: 2000, auctionId: 'a1' },
+        { params: { seat: 'Gmtb', region: 'us-e' }, timeout: 2000, auctionId: 'a1' }
+      ]);
+      expect(politeStub.callCount).to.equal(1);
+    });
+
+    it('should emit one beacon per distinct seat+region pair', function () {
+      spec.onTimeout([
+        { params: { seat: 'Gmtb', region: 'us-e' }, timeout: 1000, auctionId: 'a1' },
+        { params: { seat: 'Seat2', region: 'us-e' }, timeout: 1000, auctionId: 'a1' }
+      ]);
+      expect(politeStub.callCount).to.equal(2);
+    });
+
+    it('should not throw on an empty array', function () {
+      expect(() => spec.onTimeout([])).not.to.throw();
+      expect(politeStub.called).to.be.false;
+    });
+
+    it('should not throw when called with a non-array', function () {
+      expect(() => spec.onTimeout(null)).not.to.throw();
+      expect(() => spec.onTimeout(undefined)).not.to.throw();
+    });
+
+    it('should skip entries with missing params', function () {
+      expect(() => spec.onTimeout([{ timeout: 2000, auctionId: 'a1' }])).not.to.throw();
+      expect(politeStub.called).to.be.false;
+    });
+
+    it('should skip entries with no seat', function () {
+      spec.onTimeout([{ params: { region: 'us-e' }, timeout: 2000 }]);
+      expect(politeStub.called).to.be.false;
+    });
+
+    it('should default region to us-e when region is absent from params', function () {
+      spec.onTimeout([{ params: { seat: 'Gmtb' }, timeout: 500 }]);
+      expect(politeStub.calledOnce).to.be.true;
+      const url = beaconUrl();
+      expect(url).to.include('region=us-e');
+    });
+  });
+
+  describe('onBidderError', function () {
+    let politeStub;
+
+    beforeEach(function () {
+      politeStub = sinon.stub(utils, 'politeTriggerPixel');
+    });
+
+    afterEach(function () {
+      politeStub.restore();
+    });
+
+    const beaconUrl = (i = 0) => politeStub.getCall(i).args[0];
+
+    const makeBidderRequest = (overrides = {}) => ({
+      auctionId: 'a1',
+      bids: [{ params: { seat: 'Gmtb', region: 'us-e' } }],
+      refererInfo: { page: 'https://pub.example.com/page?q=secret', domain: 'pub.example.com' },
+      ...overrides
+    });
+
+    it('should fire a bidder-error beacon to the pinned us-e host', function () {
+      spec.onBidderError({ error: { status: 500, timedOut: false }, bidderRequest: makeBidderRequest() });
+      expect(politeStub.calledOnce).to.be.true;
+      const url = beaconUrl();
+      expect(url).to.include('https://px-us-e.floxis.tech/event');
+      expect(url).to.include('event=bidder-error');
+      expect(url).to.include('seat=Gmtb');
+      expect(url).to.include('region=us-e');
+      expect(url).to.include('status=500');
+      expect(url).to.include('timedout=0');
+      expect(url).to.include('auctionId=a1');
+    });
+
+    it('should send the beacon cookieless via politeTriggerPixel (credentials omitted)', function () {
+      spec.onBidderError({ error: { status: 500, timedOut: false }, bidderRequest: makeBidderRequest() });
+      expect(politeStub.calledOnce).to.be.true;
+      expect(politeStub.firstCall.args[1]).to.equal('omit');
+    });
+
+    it('should beacon to px-us-e even when region is eu (host is NOT region-derived)', function () {
+      spec.onBidderError({
+        error: { status: 503, timedOut: false },
+        bidderRequest: makeBidderRequest({ bids: [{ params: { seat: 'Gmtb', region: 'eu' } }] })
+      });
+      const url = beaconUrl();
+      expect(url).to.include('https://px-us-e.floxis.tech/event');
+      expect(url).to.include('region=eu');
+      expect(url).not.to.include('px-eu');
+    });
+
+    it('should set timedout=1 when error.timedOut is true', function () {
+      spec.onBidderError({ error: { timedOut: true }, bidderRequest: makeBidderRequest() });
+      const url = beaconUrl();
+      expect(url).to.include('timedout=1');
+    });
+
+    it('should omit status when error.status is absent', function () {
+      spec.onBidderError({ error: { timedOut: false }, bidderRequest: makeBidderRequest() });
+      const url = beaconUrl();
+      expect(url).not.to.match(/[?&]status=/);
+    });
+
+    it('should include puburl as the publisher domain (no query string identifiers)', function () {
+      spec.onBidderError({ error: { status: 500, timedOut: false }, bidderRequest: makeBidderRequest() });
+      const url = beaconUrl();
+      expect(url).to.include('puburl=pub.example.com');
+      expect(url).not.to.include('secret'); // the page query string never leaves the browser
+    });
+
+    it('should deduplicate beacons for the same seat+region across bids', function () {
+      spec.onBidderError({
+        error: { status: 503, timedOut: false },
+        bidderRequest: {
+          auctionId: 'a1',
+          bids: [
+            { params: { seat: 'Gmtb', region: 'us-e' } },
+            { params: { seat: 'Gmtb', region: 'us-e' } }
+          ]
+        }
+      });
+      expect(politeStub.callCount).to.equal(1);
+    });
+
+    it('should emit one beacon per distinct seat+region pair', function () {
+      spec.onBidderError({
+        error: { status: 503, timedOut: false },
+        bidderRequest: {
+          auctionId: 'a1',
+          bids: [
+            { params: { seat: 'Gmtb', region: 'us-e' } },
+            { params: { seat: 'Seat2', region: 'us-e' } }
+          ]
+        }
+      });
+      expect(politeStub.callCount).to.equal(2);
+    });
+
+    it('should not throw when bidderRequest is missing', function () {
+      expect(() => spec.onBidderError({ error: { status: 500 } })).not.to.throw();
+      expect(politeStub.called).to.be.false;
+    });
+
+    it('should not throw when bidderRequest.bids is empty', function () {
+      expect(() => spec.onBidderError({ error: {}, bidderRequest: { bids: [] } })).not.to.throw();
+      expect(politeStub.called).to.be.false;
+    });
+
+    it('should skip bids with no seat', function () {
+      spec.onBidderError({ error: {}, bidderRequest: { bids: [{ params: { region: 'us-e' } }] } });
+      expect(politeStub.called).to.be.false;
+    });
+
+    it('should append consent params when bidderRequest carries them', function () {
+      const bidderRequest = {
+        ...makeBidderRequest(),
+        gdprConsent: { gdprApplies: true, consentString: 'CONSENT123' },
+        uspConsent: '1YNN'
+      };
+      spec.onBidderError({ error: { status: 500, timedOut: false }, bidderRequest });
+      const url = beaconUrl();
+      expect(url).to.include('gdpr=1');
+      expect(url).to.include('gdpr_consent=CONSENT123');
+      expect(url).to.include('us_privacy=1YNN');
+    });
+  });
+
   describe('bid response meta', function () {
     function responseWithExt(ext) {
       const request = spec.buildRequests([validBannerBid], { bidderCode: 'floxis', auctionId: 'a-meta' })[0];

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -1530,6 +1530,46 @@ describe('polite sync helpers', () => {
     });
   });
 
+  it('omits credentials when requested for politeTriggerPixel', () => {
+    utils.politeTriggerPixel('http://example.com/pixel', 'omit');
+    expect(window.fetch.calledOnce).to.equal(true);
+    expect(window.fetch.getCall(0).args[0].opts).to.include({
+      method: 'GET',
+      mode: 'no-cors',
+      credentials: 'omit',
+      keepalive: true
+    });
+  });
+
+  it('skips the image fallback for an omit beacon when the keepalive fetch fails', async () => {
+    window.fetch = sinon.stub().callsFake(() => Promise.reject(new Error('network')));
+    const imageSpy = sinon.spy(window, 'Image');
+    utils.politeTriggerPixel('http://example.com/pixel', 'omit');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const fellBack = imageSpy.called;
+    imageSpy.restore();
+    expect(fellBack).to.equal(false); // no <img> => the cookieless guarantee holds even on fetch failure
+  });
+
+  it('falls back to an image pixel for the default include beacon when the keepalive fetch fails', async () => {
+    window.fetch = sinon.stub().callsFake(() => Promise.reject(new Error('network')));
+    const imageSpy = sinon.spy(window, 'Image');
+    utils.politeTriggerPixel('http://example.com/pixel');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const fellBack = imageSpy.called;
+    imageSpy.restore();
+    expect(fellBack).to.equal(true); // default behavior preserved byte-for-byte
+  });
+
+  it('skips the image fallback for an omit beacon when Request is unavailable', () => {
+    window.Request = undefined;
+    const imageSpy = sinon.spy(window, 'Image');
+    utils.politeTriggerPixel('http://example.com/pixel', 'omit');
+    const fellBack = imageSpy.called;
+    imageSpy.restore();
+    expect(fellBack).to.equal(false);
+  });
+
   it('does not attempt fetch when Request is unavailable', () => {
     window.Request = undefined;
     utils.politeTriggerPixel('http://example.com/pixel');


### PR DESCRIPTION
## Type of change

- [x] Feature

## Description of change

Adds `onTimeout` and `onBidderError` telemetry callbacks to the **Floxis** bid adapter (introduced in #14983).

Each callback fires a fire-and-forget beacon to the Floxis trackers `/event` endpoint, reporting client-observed auction timeouts and bidder transport errors (DNS / TLS / HTTP) — failures that happen on the publisher page before the exchange ever sees the request.

- The beacon carries only operational dimensions: `event` (`timeout` | `bidder-error`), `seat`, `region`, the publisher **domain** (not the page URL — no query-string identifiers leave the browser), and (for errors) HTTP `status` / `timedout`, plus the client-observed `duration` for timeouts. **No user or device identifier is sent.** It is sent through the core `politeTriggerPixel(url, 'omit')` helper — a background-scheduled `keepalive` fetch with `credentials: 'omit'`, so no cookies ride along. Being cookieless and identifier-free, it is the ad-tech equivalent of a server access log and is not consent-gated; the existing IAB consent params are still forwarded as opaque values for forward-compatibility.
- A single beacon is emitted per distinct `(seat, region)` in the event (deduped like `getUserSyncs`), wrapped in `try/catch` so a telemetry failure can never disrupt the auction lifecycle.

### Notes

- **All network egress goes through core `utils`** — there is no `fetch` / `Request` / `XMLHttpRequest` / `sendBeacon` in the module. `politeTriggerPixel` gained an optional `credentials` param (defaults to `'include'`, so its existing `userSync` caller is byte-identical). `'omit'` is required for genuine cookielessness here: `sendBeacon` and `<img>` are always credentialed, so a `keepalive` fetch with `credentials: 'omit'` is the only cookieless egress — and when omitting, the image fallback is deliberately skipped (an image would re-attach the first-party cookie).
- The telemetry host is pinned to the provisioned `px-us-e.floxis.tech` edge (it is not derived from the `region` param), so a misconfigured `region` cannot send the beacon to an unprovisioned host — a unit test asserts that a non-`us-e` region still beacons to `px-us-e`.
- Reuses the adapter's existing helpers (`buildConsentQuery`, `normalizeBidParams`, host-label validation); no new module-level state.
- Unit tests cover both callbacks (correct `/event` URL + dimensions, dedup, host pinning, `credentials: 'omit'`, domain-only `puburl`, no-throw on malformed input) and the new `politeTriggerPixel` param in `test/spec/utils_spec.js` (the `'omit'` path skips the cookie-bearing image fallback on both fetch-failure and no-`Request`; the default `'include'` path is unchanged).

## Other information

Maintainer: prebid@floxis.tech
Docs updated in `modules/floxisBidAdapter.md`.

Follow-up to #14983. (A separate one-line follow-up — #15011, draft — will declare `gvlid: 1609` once the vendor ID is live in the IAB Europe GVL, published Thursday 17:00 CET.)
