### PR TITLE
Floxis Bid Adapter: declare IAB Europe TCF GVL Vendor ID 1609

### DIFF
--- a/modules/floxisBidAdapter.js
+++ b/modules/floxisBidAdapter.js
@@ -4,6 +4,7 @@ import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { triggerPixel, mergeDeep, replaceAuctionPrice } from '../src/utils.js';
 
 const BIDDER_CODE = 'floxis';
+const GVLID = 1609;
 const DEFAULT_BID_TTL = 300;
 const DEFAULT_CURRENCY = 'USD';
 const DEFAULT_NET_REVENUE = true;
@@ -150,6 +151,7 @@ const CONVERTER = ortbConverter({
 
 export const spec = {
   code: BIDDER_CODE,
+  gvlid: GVLID,
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 
   isBidRequestValid(bid) {

--- a/modules/floxisBidAdapter.md
+++ b/modules/floxisBidAdapter.md
@@ -30,7 +30,7 @@ The Floxis Bid Adapter supports the Prebid.js [Floors Module](https://docs.prebi
 `user.ext.eids` from the Prebid [User ID module](https://docs.prebid.org/dev-docs/modules/userId.html) and `source.ext.schain` (set via `pbjs.setConfig({ schain })` or `ortb2`) are forwarded automatically through first-party-data passthrough — no adapter-specific configuration is required.
 
 ## Privacy
-GDPR/TCF, US Privacy, GPP and COPPA signals are handled by Prebid.js core and automatically included in the OpenRTB request; consent strings are also appended to user-sync calls. Note: a Floxis IAB Europe GVL (Global Vendor List) ID registration is in progress — until it is assigned and added to the adapter, Floxis is not yet an independently listed TCF vendor.
+GDPR/TCF, US Privacy, GPP and COPPA signals are handled by Prebid.js core and automatically included in the OpenRTB request; consent strings are also appended to user-sync calls. Floxis is registered with IAB Europe TCF as Vendor ID **1609**, declared via the adapter's `gvlid`.
 
 ## Example Usage
 


### PR DESCRIPTION
## Type of change

- [x] Feature

## Description of change

Declares the Floxis adapter's IAB Europe TCF Global Vendor List (GVL) Vendor ID via `spec.gvlid`:

```js
const GVLID = 1609;
// ...
export const spec = {
  code: BIDDER_CODE,
  gvlid: GVLID,
  // ...
};
```

Floxis has been approved as a registered IAB Europe TCF vendor (**Vendor ID 1609**). Declaring `gvlid` lets Prebid.js core apply TCF consent enforcement to the adapter correctly.

### ⚠️ Do not merge until 1609 is live in the GVL

At the time of opening, vendor **1609** is not yet in the published vendor list — `https://vendor-list.consensu.org/v3/vendor-list.json` is at version 162 (max vendor id 1608). IAB Europe has confirmed in writing that it will publish **1609 on Thursday, 2026-06-11 at 17:00 CET**.

This PR is kept as a **draft** until then. Once `vendor-list.json` contains 1609, it will be verified and marked ready for review.

## Other information

Maintainer: prebid@floxis.tech

Split out of #15008 (error/timeout telemetry) per maintainer review, to keep the telemetry change unblocked while the GVL entry publishes. Follow-up to #14983.
