### PR TITLE
tests(liveIntentAnalyticsAdapter): fix failing test when using custom pbjs variable

### DIFF
--- a/test/spec/modules/liveIntentAnalyticsAdapter_spec.js
+++ b/test/spec/modules/liveIntentAnalyticsAdapter_spec.js
@@ -10,6 +10,7 @@ import { BID_WON_EVENT, AUCTION_INIT_EVENT, BID_WON_EVENT_UNDEFINED, AUCTION_INI
 const utils = require('src/utils');
 const refererDetection = require('src/refererDetection');
 const instanceId = '77abbc81-c1f1-41cd-8f25-f7149244c800';
+const iid = encodeURIComponent(getGlobalVarName());
 const url = 'https://www.test.com'
 let sandbox;
 let clock;
@@ -78,11 +79,11 @@ describe('LiveIntent Analytics Adapter ', () => {
 
     events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT);
     expect(server.requests.length).to.equal(1);
-    expect(server.requests[0].url).to.equal(`https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${getGlobalVarName()}&liip=y&aun=2&asz=300x250%2C728x90%2C300x250`);
+    expect(server.requests[0].url).to.equal(`https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${iid}&liip=y&aun=2&asz=300x250%2C728x90%2C300x250`);
 
     events.emit(EVENTS.BID_WON, BID_WON_EVENT);
     expect(server.requests.length).to.equal(2);
-    expect(server.requests[1].url).to.equal(`https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=${getGlobalVarName()}&sts=1739971147744&rts=1739971147806&liip=y&asz=728x90`);
+    expect(server.requests[1].url).to.equal(`https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=${iid}&sts=1739971147744&rts=1739971147806&liip=y&asz=728x90`);
   });
 
   it('request is computed and sent correctly when sampling is 1 and liModule is enabled', () => {
@@ -91,11 +92,11 @@ describe('LiveIntent Analytics Adapter ', () => {
 
     events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT);
     expect(server.requests.length).to.equal(1);
-    expect(server.requests[0].url).to.equal(`https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${getGlobalVarName()}&me=y&liip=y&aun=2&asz=300x250%2C728x90%2C300x250`)
+    expect(server.requests[0].url).to.equal(`https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${iid}&me=y&liip=y&aun=2&asz=300x250%2C728x90%2C300x250`)
 
     events.emit(EVENTS.BID_WON, BID_WON_EVENT);
     expect(server.requests.length).to.equal(2);
-    expect(server.requests[1].url).to.equal(`https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=${getGlobalVarName()}&sts=1739971147744&rts=1739971147806&me=y&liip=y&asz=728x90`);
+    expect(server.requests[1].url).to.equal(`https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=${iid}&sts=1739971147744&rts=1739971147806&me=y&liip=y&asz=728x90`);
   });
 
   it('request is computed and sent correctly when sampling is 1 and liModule is disabled', () => {
@@ -104,11 +105,11 @@ describe('LiveIntent Analytics Adapter ', () => {
 
     events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT);
     expect(server.requests.length).to.equal(1);
-    expect(server.requests[0].url).to.equal(`https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${getGlobalVarName()}&me=n&liip=y&aun=2&asz=300x250%2C728x90%2C300x250`)
+    expect(server.requests[0].url).to.equal(`https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${iid}&me=n&liip=y&aun=2&asz=300x250%2C728x90%2C300x250`)
 
     events.emit(EVENTS.BID_WON, BID_WON_EVENT);
     expect(server.requests.length).to.equal(2);
-    expect(server.requests[1].url).to.equal(`https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=${getGlobalVarName()}&sts=1739971147744&rts=1739971147806&me=n&liip=y&asz=728x90`);
+    expect(server.requests[1].url).to.equal(`https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=${iid}&sts=1739971147744&rts=1739971147806&me=n&liip=y&asz=728x90`);
   });
 
   it('request is computed and sent correctly when sampling is 1 and should forward the correct liTreatmentRate', () => {
@@ -117,11 +118,11 @@ describe('LiveIntent Analytics Adapter ', () => {
 
     events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT);
     expect(server.requests.length).to.equal(1);
-    expect(server.requests[0].url).to.equal(`https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${getGlobalVarName()}&tr=0.95&liip=y&aun=2&asz=300x250%2C728x90%2C300x250`)
+    expect(server.requests[0].url).to.equal(`https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${iid}&tr=0.95&liip=y&aun=2&asz=300x250%2C728x90%2C300x250`)
 
     events.emit(EVENTS.BID_WON, BID_WON_EVENT);
     expect(server.requests.length).to.equal(2);
-    expect(server.requests[1].url).to.equal(`https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=${getGlobalVarName()}&sts=1739971147744&rts=1739971147806&tr=0.95&liip=y&asz=728x90`);
+    expect(server.requests[1].url).to.equal(`https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=${iid}&sts=1739971147744&rts=1739971147806&tr=0.95&liip=y&asz=728x90`);
   });
 
   it('not send any events on auction init if disabled in settings', () => {
@@ -138,7 +139,7 @@ describe('LiveIntent Analytics Adapter ', () => {
     events.emit(EVENTS.BID_WON, BID_WON_EVENT_UNDEFINED);
 
     expect(server.requests.length).to.equal(2);
-    expect(server.requests[1].url).to.equal(`https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${getGlobalVarName()}&liip=y&asz=728x90`);
+    expect(server.requests[1].url).to.equal(`https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${iid}&liip=y&asz=728x90`);
   });
 
   it('liip should be n if there is no source or provider in userIdAsEids have the value liveintent.com', () => {
@@ -146,7 +147,7 @@ describe('LiveIntent Analytics Adapter ', () => {
 
     events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT_NOT_LI);
     expect(server.requests.length).to.equal(1);
-    expect(server.requests[0].url).to.equal(`https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${getGlobalVarName()}&liip=n&aun=2&asz=300x250%2C728x90`);
+    expect(server.requests[0].url).to.equal(`https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${iid}&liip=n&aun=2&asz=300x250%2C728x90`);
   });
 
   it('no request is computed when sampling is 0', () => {

--- a/test/spec/modules/liveIntentAnalyticsAdapter_spec.js
+++ b/test/spec/modules/liveIntentAnalyticsAdapter_spec.js
@@ -2,6 +2,7 @@ import liAnalytics from 'modules/liveIntentAnalyticsAdapter';
 import { expect } from 'chai';
 import { server } from 'test/mocks/xhr.js';
 import { auctionManager } from 'src/auctionManager.js';
+import { getGlobalVarName } from 'src/buildOptions.js';
 import { EVENTS } from 'src/constants.js';
 import { config } from 'src/config.js';
 import { BID_WON_EVENT, AUCTION_INIT_EVENT, BID_WON_EVENT_UNDEFINED, AUCTION_INIT_EVENT_NOT_LI } from '../../fixtures/liveIntentAuctionEvents.js';
@@ -77,11 +78,11 @@ describe('LiveIntent Analytics Adapter ', () => {
 
     events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT);
     expect(server.requests.length).to.equal(1);
-    expect(server.requests[0].url).to.equal('https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=pbjs&liip=y&aun=2&asz=300x250%2C728x90%2C300x250');
+    expect(server.requests[0].url).to.equal(`https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${getGlobalVarName()}&liip=y&aun=2&asz=300x250%2C728x90%2C300x250`);
 
     events.emit(EVENTS.BID_WON, BID_WON_EVENT);
     expect(server.requests.length).to.equal(2);
-    expect(server.requests[1].url).to.equal('https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=pbjs&sts=1739971147744&rts=1739971147806&liip=y&asz=728x90');
+    expect(server.requests[1].url).to.equal(`https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=${getGlobalVarName()}&sts=1739971147744&rts=1739971147806&liip=y&asz=728x90`);
   });
 
   it('request is computed and sent correctly when sampling is 1 and liModule is enabled', () => {
@@ -90,11 +91,11 @@ describe('LiveIntent Analytics Adapter ', () => {
 
     events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT);
     expect(server.requests.length).to.equal(1);
-    expect(server.requests[0].url).to.equal('https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=pbjs&me=y&liip=y&aun=2&asz=300x250%2C728x90%2C300x250')
+    expect(server.requests[0].url).to.equal(`https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${getGlobalVarName()}&me=y&liip=y&aun=2&asz=300x250%2C728x90%2C300x250`)
 
     events.emit(EVENTS.BID_WON, BID_WON_EVENT);
     expect(server.requests.length).to.equal(2);
-    expect(server.requests[1].url).to.equal('https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=pbjs&sts=1739971147744&rts=1739971147806&me=y&liip=y&asz=728x90');
+    expect(server.requests[1].url).to.equal(`https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=${getGlobalVarName()}&sts=1739971147744&rts=1739971147806&me=y&liip=y&asz=728x90`);
   });
 
   it('request is computed and sent correctly when sampling is 1 and liModule is disabled', () => {
@@ -103,11 +104,11 @@ describe('LiveIntent Analytics Adapter ', () => {
 
     events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT);
     expect(server.requests.length).to.equal(1);
-    expect(server.requests[0].url).to.equal('https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=pbjs&me=n&liip=y&aun=2&asz=300x250%2C728x90%2C300x250')
+    expect(server.requests[0].url).to.equal(`https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${getGlobalVarName()}&me=n&liip=y&aun=2&asz=300x250%2C728x90%2C300x250`)
 
     events.emit(EVENTS.BID_WON, BID_WON_EVENT);
     expect(server.requests.length).to.equal(2);
-    expect(server.requests[1].url).to.equal('https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=pbjs&sts=1739971147744&rts=1739971147806&me=n&liip=y&asz=728x90');
+    expect(server.requests[1].url).to.equal(`https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=${getGlobalVarName()}&sts=1739971147744&rts=1739971147806&me=n&liip=y&asz=728x90`);
   });
 
   it('request is computed and sent correctly when sampling is 1 and should forward the correct liTreatmentRate', () => {
@@ -116,11 +117,11 @@ describe('LiveIntent Analytics Adapter ', () => {
 
     events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT);
     expect(server.requests.length).to.equal(1);
-    expect(server.requests[0].url).to.equal('https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=pbjs&tr=0.95&liip=y&aun=2&asz=300x250%2C728x90%2C300x250')
+    expect(server.requests[0].url).to.equal(`https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${getGlobalVarName()}&tr=0.95&liip=y&aun=2&asz=300x250%2C728x90%2C300x250`)
 
     events.emit(EVENTS.BID_WON, BID_WON_EVENT);
     expect(server.requests.length).to.equal(2);
-    expect(server.requests[1].url).to.equal('https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=pbjs&sts=1739971147744&rts=1739971147806&tr=0.95&liip=y&asz=728x90');
+    expect(server.requests[1].url).to.equal(`https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&auc=test-div2&auid=afc6bc6a-3082-4940-b37f-d22e1b026e48&cpm=1.5&c=USD&b=appnexus&bc=appnexus&pid=a123&iid=${getGlobalVarName()}&sts=1739971147744&rts=1739971147806&tr=0.95&liip=y&asz=728x90`);
   });
 
   it('not send any events on auction init if disabled in settings', () => {
@@ -137,7 +138,7 @@ describe('LiveIntent Analytics Adapter ', () => {
     events.emit(EVENTS.BID_WON, BID_WON_EVENT_UNDEFINED);
 
     expect(server.requests.length).to.equal(2);
-    expect(server.requests[1].url).to.equal('https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=pbjs&liip=y&asz=728x90');
+    expect(server.requests[1].url).to.equal(`https://wba.liadm.com/analytic-events/bid-won?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${getGlobalVarName()}&liip=y&asz=728x90`);
   });
 
   it('liip should be n if there is no source or provider in userIdAsEids have the value liveintent.com', () => {
@@ -145,7 +146,7 @@ describe('LiveIntent Analytics Adapter ', () => {
 
     events.emit(EVENTS.AUCTION_INIT, AUCTION_INIT_EVENT_NOT_LI);
     expect(server.requests.length).to.equal(1);
-    expect(server.requests[0].url).to.equal('https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=pbjs&liip=n&aun=2&asz=300x250%2C728x90');
+    expect(server.requests[0].url).to.equal(`https://wba.liadm.com/analytic-events/auction-init?id=77abbc81-c1f1-41cd-8f25-f7149244c800&aid=87b4a93d-19ae-432a-96f0-8c2d4cc1c539&u=https%3A%2F%2Fwww.test.com&ats=1739969798557&pid=a123&iid=${getGlobalVarName()}&liip=n&aun=2&asz=300x250%2C728x90`);
   });
 
   it('no request is computed when sampling is 0', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [x] Other

## Description of change
- `liveIntentAnalyticsAdapter` test fails when using a custom prebid.js variable as the test was hardcoding 'pbjs' in its expected value

## Steps to reproduce
- change `globalVarName` in `package.json`
- run `npx gulp test --file test/spec/modules/liveIntentAnalyticsAdapter_spec.js`

## Other information
- prebid.js 11.15.0
- relates #15020