### PR TITLE
adtelligent Bid Adapter: remove deprecated aliases

### DIFF
--- a/metadata/modules.json
+++ b/metadata/modules.json
@@ -892,42 +892,7 @@
     },
     {
       "componentType": "bidder",
-      "componentName": "streamkey",
-      "aliasOf": "adtelligent",
-      "gvlid": null,
-      "disclosureURL": null
-    },
-    {
-      "componentType": "bidder",
-      "componentName": "janet",
-      "aliasOf": "adtelligent",
-      "gvlid": null,
-      "disclosureURL": null
-    },
-    {
-      "componentType": "bidder",
-      "componentName": "ocm",
-      "aliasOf": "adtelligent",
-      "gvlid": 1148,
-      "disclosureURL": null
-    },
-    {
-      "componentType": "bidder",
-      "componentName": "9dotsmedia",
-      "aliasOf": "adtelligent",
-      "gvlid": null,
-      "disclosureURL": null
-    },
-    {
-      "componentType": "bidder",
       "componentName": "indicue",
-      "aliasOf": "adtelligent",
-      "gvlid": null,
-      "disclosureURL": null
-    },
-    {
-      "componentType": "bidder",
-      "componentName": "stellormedia",
       "aliasOf": "adtelligent",
       "gvlid": null,
       "disclosureURL": null

--- a/metadata/modules/adtelligentBidAdapter.json
+++ b/metadata/modules/adtelligentBidAdapter.json
@@ -51,42 +51,7 @@
     },
     {
       "componentType": "bidder",
-      "componentName": "streamkey",
-      "aliasOf": "adtelligent",
-      "gvlid": null,
-      "disclosureURL": null
-    },
-    {
-      "componentType": "bidder",
-      "componentName": "janet",
-      "aliasOf": "adtelligent",
-      "gvlid": null,
-      "disclosureURL": null
-    },
-    {
-      "componentType": "bidder",
-      "componentName": "ocm",
-      "aliasOf": "adtelligent",
-      "gvlid": 1148,
-      "disclosureURL": "https://orangeclickmedia.com/device_storage_disclosure.json"
-    },
-    {
-      "componentType": "bidder",
-      "componentName": "9dotsmedia",
-      "aliasOf": "adtelligent",
-      "gvlid": null,
-      "disclosureURL": null
-    },
-    {
-      "componentType": "bidder",
       "componentName": "indicue",
-      "aliasOf": "adtelligent",
-      "gvlid": null,
-      "disclosureURL": null
-    },
-    {
-      "componentType": "bidder",
-      "componentName": "stellormedia",
       "aliasOf": "adtelligent",
       "gvlid": null,
       "disclosureURL": null

--- a/modules/adtelligentBidAdapter.js
+++ b/modules/adtelligentBidAdapter.js
@@ -25,12 +25,7 @@ const HOST_GETTERS = {
       return 'ghb' + subdomainSuffixes[num++ % subdomainSuffixes.length] + '.adtelligent.com';
     }
   }()),
-  streamkey: () => 'ghb.hb.streamkey.net',
-  janet: () => 'ghb.bidder.jmgads.com',
-  ocm: () => 'ghb.cenarius.orangeclickmedia.com',
-  '9dotsmedia': () => 'ghb.platform.audiodots.com',
   indicue: () => 'ghb.console.indicue.com',
-  stellormedia: () => 'ghb.ads.stellormedia.com'
 }
 const getUri = function (bidderCode) {
   const bidderWithoutSuffix = bidderCode.split('_')[0];
@@ -47,12 +42,7 @@ export const spec = {
   code: BIDDER_CODE,
   gvlid: 410,
   aliases: [
-    'streamkey',
-    'janet',
-    { code: 'ocm', gvlid: 1148 },
-    '9dotsmedia',
     'indicue',
-    'stellormedia'
   ],
   supportedMediaTypes,
   isBidRequestValid,

--- a/test/spec/modules/adtelligentBidAdapter_spec.js
+++ b/test/spec/modules/adtelligentBidAdapter_spec.js
@@ -11,13 +11,7 @@ const EXPECTED_ENDPOINTS = [
   'https://ghb.adtelligent.com/v2/auction/'
 ];
 const aliasEP = {
-  'janet_publisherSuffix': 'https://ghb.bidder.jmgads.com/v2/auction/',
-  'streamkey': 'https://ghb.hb.streamkey.net/v2/auction/',
-  'janet': 'https://ghb.bidder.jmgads.com/v2/auction/',
-  'ocm': 'https://ghb.cenarius.orangeclickmedia.com/v2/auction/',
-  '9dotsmedia': 'https://ghb.platform.audiodots.com/v2/auction/',
   'indicue': 'https://ghb.console.indicue.com/v2/auction/',
-  'stellormedia': 'https://ghb.ads.stellormedia.com/v2/auction/',
 };
 
 const DEFAULT_ADATPER_REQ = { bidderCode: 'adtelligent', ortb2: { source: { ext: { schain: { ver: 1 } } } } };


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter  

## Description of change

  Removes deprecated aliases from the adtelligent bid adapter that are no longer
  supported:
  - streamkey
  - janet
  - ocm
  - 9dotsmedia
  - stellormedia
