### PR TITLE
Bid response filter: Fix for Useless assignment to property in tests

### DIFF
--- a/test/spec/modules/bidResponseFilter_spec.js
+++ b/test/spec/modules/bidResponseFilter_spec.js
@@ -326,15 +326,6 @@ describe('bidResponseFilter', () => {
     });
 
     mockAuctionIndex.getBidRequest = () => ({
-      ortb2Imp: {
-        banner: {
-        },
-        video: {
-        },
-      }
-    })
-
-    mockAuctionIndex.getBidRequest = () => ({
       mediaTypes: {
         banner: {},
       },


### PR DESCRIPTION
The fix is to eliminate the overwritten assignment and keep a single `mockAuctionIndex.getBidRequest` definition in that test case.

Best fix without changing intended functionality: in `test/spec/modules/bidResponseFilter_spec.js`, inside `it('should reject bid for meta.mediaType not present on adunit', ...)`, remove the first `getBidRequest` assignment block (the one returning only `ortb2Imp` with `banner` and `video`) and keep the second assignment (the one returning `mediaTypes: { banner: {} }, ortb2Imp: {}`), since that is the effective value currently used at runtime. This preserves existing behavior while removing dead code and satisfying CodeQL.

No imports, new methods, or new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._