### PR TITLE
Silverpush bid adapter: Fix for Use of returnless function

### DIFF
--- a/modules/silverpushBidAdapter.js
+++ b/modules/silverpushBidAdapter.js
@@ -226,8 +226,6 @@ function buildVideoOutstreamResponse(bidResponse, context) {
     });
 
     bidResponse.renderer.setRender(() => _renderer(bidResponse));
-
-    bidResponse.renderer.render(bidResponse);
   }
 
   return { ...bidResponse };

--- a/modules/silverpushBidAdapter.js
+++ b/modules/silverpushBidAdapter.js
@@ -225,7 +225,7 @@ function buildVideoOutstreamResponse(bidResponse, context) {
       url: bidResponse.rendererUrl
     });
 
-    bidResponse.renderer.setRender(_renderer(bidResponse));
+    bidResponse.renderer.setRender(() => _renderer(bidResponse));
 
     bidResponse.renderer.render(bidResponse);
   }

--- a/test/spec/modules/silverpushBidAdapter_spec.js
+++ b/test/spec/modules/silverpushBidAdapter_spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import * as utils from 'src/utils';
 import { newBidder } from 'src/adapters/bidderFactory.js';
+import { Renderer } from 'src/Renderer.js';
 import { REQUEST_URL, SP_OUTSTREAM_PLAYER_URL, CONVERTER, spec } from '../../../modules/silverpushBidAdapter.js';
 
 const bannerBid = {
@@ -357,6 +358,31 @@ describe('Silverpush Adapter', function () {
         expect(bids[0].seatBidId).to.equal('soCWeklh');
         expect(bids[0].width).to.equal(1024);
         expect(bids[0].height).to.equal(768);
+      });
+
+      it('should defer outstream rendering until the renderer is executed', () => {
+        const response = utils.deepClone(videoResponse);
+        const outstreamBid = utils.deepClone(videoBid);
+        outstreamBid.mediaTypes.video.context = 'outstream';
+
+        const fakeRenderer = {
+          url: SP_OUTSTREAM_PLAYER_URL,
+          setRender: sinon.spy(),
+          render: sinon.spy()
+        };
+        const installStub = sinon.stub(Renderer, 'install').returns(fakeRenderer);
+
+        try {
+          const requests = spec.buildRequests([outstreamBid], bidderRequest);
+          const bids = spec.interpretResponse({ body: response }, requests[0]);
+
+          expect(installStub.calledOnce).to.equal(true);
+          expect(fakeRenderer.setRender.calledOnce).to.equal(true);
+          expect(fakeRenderer.render.called).to.equal(false);
+          expect(bids[0].renderer).to.equal(fakeRenderer);
+        } finally {
+          installStub.restore();
+        }
       });
     }
   });


### PR DESCRIPTION
The safest fix is to pass a function reference (or wrapper callback) to `setRender` instead of invoking `_renderer` immediately.

Best single change (without altering existing behavior outside this callsite):
- In `modules/silverpushBidAdapter.js`, line 228 region inside `buildVideoOutstreamResponse`, replace:
  - `bidResponse.renderer.setRender(_renderer(bidResponse));`
- With:
  - `bidResponse.renderer.setRender(() => _renderer(bidResponse));`

Why this is best:
- It avoids relying on `_renderer` to return a value.
- It preserves current intent: when renderer executes, `_renderer(bidResponse)` is called with the same `bidResponse`.
- It avoids changing `_renderer` implementation (not shown), keeping scope minimal and safe.

No imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._