### PR TITLE
Examples: Fix for Variable not declared before use

### DIFF
--- a/integrationExamples/gpt/amp/remote.html
+++ b/integrationExamples/gpt/amp/remote.html
@@ -26,6 +26,8 @@ document.write('<script'+' src="'+encodeURI(u)+'"><'+'/script>');
 
 <script>
     // The Prebid global must match Prebid.js setting. This example file is not preprocessed so below we refer to global as `pbjs`.
+    var pbjs = pbjs || {};
+    pbjs.que = pbjs.que || [];
     var $$PREBID_GLOBAL$$ = pbjs;
     var prebidSrc = 'https://publisher.com:9999/build/dev/prebid.js';
     var adUnits;
@@ -40,8 +42,6 @@ document.write('<script'+' src="'+encodeURI(u)+'"><'+'/script>');
         target.insertBefore(pbs, target.firstChild);
     })();
 
-    var pbjs = pbjs || {};
-    pbjs.que = pbjs.que || [];
 
     var date = new Date().getTime();
 


### PR DESCRIPTION
To fix this, declare and initialize `pbjs` before it is first used, then assign the global alias variable.

Best minimal fix in `integrationExamples/gpt/amp/remote.html`:
1. Move `var pbjs = pbjs || {};` and `pbjs.que = pbjs.que || [];` above line 29 usage.
2. Keep `var $$PREBID_GLOBAL$$ = pbjs;` after that initialization.
3. Remove the duplicated later initialization block (current lines 43–44) to avoid redundancy.

This preserves behavior while satisfying the rule and ensuring `pbjs` is always defined before aliasing.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._