### PR TITLE
Connectid: Fix for Template syntax in string literal

### DIFF
--- a/test/spec/modules/connectIdSystem_spec.js
+++ b/test/spec/modules/connectIdSystem_spec.js
@@ -980,7 +980,7 @@ describe('Yahoo ConnectID Submodule', () => {
       }
     }];
     VALID_API_RESPONSES.forEach(responseData => {
-      it('should return a newly constructed object with the connect ID for a payload with ${responseData.key} key(s)', () => {
+      it(`should return a newly constructed object with the connect ID for a payload with ${responseData.key} key(s)`, () => {
         expect(connectIdSubmodule.decode(responseData.payload)).to.deep.equal(
           { connectId: responseData.expected }
         );


### PR DESCRIPTION
Use a template literal (backticks) for the `it(...)` description on line 983 so `${responseData.key}` is interpolated as intended.

Best fix without changing functionality:
- In `test/spec/modules/connectIdSystem_spec.js`, inside `VALID_API_RESPONSES.forEach(...)`, replace:
  - `'should return a newly constructed object with the connect ID for a payload with ${responseData.key} key(s)'`
  with:
  - `` `should return a newly constructed object with the connect ID for a payload with ${responseData.key} key(s)` ``

No imports, new methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._