### PR TITLE
Tests: Fix for Property access on null or undefined

### DIFF
--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -2457,8 +2457,7 @@ describe('Unit: Prebid Module', function () {
 
         var requestObj = {
           bidsBackHandler: function bidsBackHandlerCallback() {
-            var test;
-            return test.test;
+            throw new Error('test callback failure');
           }
         };
 


### PR DESCRIPTION
Use an explicit throw in the callback instead of dereferencing an undefined variable.

Best fix (no functional change): in `test/spec/unit/pbjs_api_spec.js`, inside the test `should not propagate exceptions from bidsBackHandler`, replace:

- `var test;`
- `return test.test;`

with a direct `throw new Error(...)` (or equivalent guaranteed throw).  
This preserves the exact behavior under test (callback throws), avoids null/undefined property access, and satisfies CodeQL.

No imports or new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._