### PR TITLE
Tests: Fix for Missing space in string concatenation

### DIFF
--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -2901,7 +2901,7 @@ describe('adapterManager tests', function () {
       });
 
       it('should not surpress client side bids if testServerOnly is true in one config, ' +
-      ',bidderControl resolves to server in another config' +
+      'bidderControl resolves to server in another config ' +
       'and there are no bid with bidSource at the adUnit Level', () => {
         const testConfig1 = utils.deepClone(getServerTestingConfig(CONFIG));
         const testConfig2 = utils.deepClone(CONFIG2);


### PR DESCRIPTION
The fix is to correct the concatenated test-description literals so spacing/punctuation is natural when joined.  
Best minimal fix: in `test/spec/unit/core/adapterManager_spec.js` around lines 2903–2905, update the second string fragment to include a leading space and remove the stray comma at the beginning. This preserves functionality while fixing the wording only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._