### PR TITLE
Mediasquare: Fix for Comparison between inconvertible types

### DIFF
--- a/modules/mediasquareBidAdapter.js
+++ b/modules/mediasquareBidAdapter.js
@@ -166,8 +166,13 @@ export const spec = {
    * @return {UserSync[]} The user syncs which should be dropped.
    */
   getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent) {
-    if (typeof serverResponses === 'object' && serverResponses !== null && serverResponses !== undefined && serverResponses.length > 0 && serverResponses[0].hasOwnProperty('body') &&
-        serverResponses[0].body.hasOwnProperty('cookies') && typeof serverResponses[0].body.cookies === 'object') {
+    if (Array.isArray(serverResponses) &&
+        serverResponses.length > 0 &&
+        serverResponses[0] &&
+        serverResponses[0].body &&
+        typeof serverResponses[0].body === 'object' &&
+        serverResponses[0].body.hasOwnProperty('cookies') &&
+        typeof serverResponses[0].body.cookies === 'object') {
       return serverResponses[0].body.cookies;
     } else {
       return [];


### PR DESCRIPTION
General fix: replace weak/redundant type checks with precise structural checks that match how the variable is used.

Best fix here: in `modules/mediasquareBidAdapter.js`, update `getUserSyncs` so it validates `serverResponses` as an array, then safely reads `serverResponses[0].body.cookies` using truthy/object checks. Remove `serverResponses !== undefined` and `typeof serverResponses === 'object'` checks, since they are either redundant or too generic. This preserves behavior (return cookies array/object when present, otherwise `[]`) while avoiding the flagged undefined comparison.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._