### PR TITLE
Onetag: Fix for Comparison between inconvertible types in tests 

### DIFF
--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -574,7 +574,7 @@ describe('onetag', function () {
             expect(priceFloor.currency).to.be.a('string');
             expect(priceFloor.floor).to.be.a('number');
             expect(priceFloor.size).to.satisfy(function (size) {
-              if (typeof size !== 'object' && size !== null && typeof size !== 'undefined') {
+              if (typeof size !== 'object' && typeof size !== 'undefined') {
                 return false;
               }
               if (size !== null) {


### PR DESCRIPTION
The best fix is to rewrite the type guard for `size` so it explicitly allows only `object`, `null`, or `undefined`, without contradictory checks.  
In `test/spec/modules/onetagBidAdapter_spec.js` around line 577, replace:

- `if (typeof size !== 'object' && size !== null && typeof size !== 'undefined') { ... }`

with:

- `if (typeof size !== 'object' && typeof size !== 'undefined') { ... }`

This preserves existing functionality:
- `null` remains accepted (because `typeof null === 'object'`)
- `undefined` remains accepted
- non-object defined primitives are still rejected

No imports, new methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._