### PR TITLE
Rubicon Bid Adapter: encode gdpr consent for userSync iframe

### DIFF
--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -765,6 +765,9 @@ export const spec = {
     if (syncOptions.iframeEnabled) {
       // data is only assigned if params are available to pass to syncEndpoint
       let params = getUserSyncParams(gdprConsent, uspConsent, gppConsent);
+      if (typeof params.gdpr_consent === 'string') {
+        params.gdpr_consent = encodeURIComponent(params.gdpr_consent);
+      }
       params = Object.keys(params).length ? `?${formatQS(params)}` : '';
 
       return {

--- a/test/spec/modules/rubiconBidAdapter_spec.js
+++ b/test/spec/modules/rubiconBidAdapter_spec.js
@@ -4467,6 +4467,14 @@ describe('the rubicon adapter', function () {
       });
     });
 
+    it('should encode gdpr consent string for iframe url', function () {
+      expect(spec.getUserSyncs({ iframeEnabled: true }, {}, {
+        consentString: 'foo" onload="alert(1)'
+      })).to.deep.equal({
+        type: 'iframe', url: `${emilyUrl}?gdpr_consent=foo%22%20onload%3D%22alert(1)`
+      });
+    });
+
     it('should pass no params if gdpr consentString is not defined', function () {
       expect(spec.getUserSyncs({ iframeEnabled: true }, {}, {})).to.deep.equal({
         type: 'iframe', url: `${emilyUrl}`


### PR DESCRIPTION
### Motivation
- A GDPR consent string was being appended raw to the Rubicon user-sync iframe URL which could contain quotes or HTML metacharacters and enable a DOM XSS when the URL is inserted via `createTrackPixelIframeHtml(..., encodeUri=false)` and `div.innerHTML`.
- The change aims to close that DOM XSS vector by ensuring the consent string is URI-encoded before being serialized into the sync URL.

### Description
- In `modules/rubiconBidAdapter.js` the `getUserSyncs` path now URI-encodes `params.gdpr_consent` with `encodeURIComponent` when it is a string before calling `formatQS`.
- Added a unit test in `test/spec/modules/rubiconBidAdapter_spec.js` that asserts a malicious-looking consent string (including a quote and an `onload` payload) is encoded in the produced iframe URL.
- Preserved existing behavior for non-string or undefined consent values and only encode the `gdpr_consent` value when it is a string.

### Testing
- Ran `npx eslint modules/rubiconBidAdapter.js test/spec/modules/rubiconBidAdapter_spec.js --cache --cache-strategy content` and it completed without errors.
- Ran `npx gulp test --nolint --file test/spec/modules/rubiconBidAdapter_spec.js` and the spec run completed successfully (unit tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ebcb31eb20832b89a2eee0aec86ca4)