### PR TITLE
Sovrn Adapter: encode user sync query params

### DIFF
--- a/modules/sovrnBidAdapter.js
+++ b/modules/sovrnBidAdapter.js
@@ -267,7 +267,7 @@ export const spec = {
             params.push(['informer', iidArr[0]]);
             tracks.push({
               type: 'iframe',
-              url: 'https://ce.lijit.com/beacon?' + params.map(p => p.join('=')).join('&')
+              url: 'https://ce.lijit.com/beacon?' + params.map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`).join('&')
             });
           }
         }

--- a/test/spec/modules/sovrnBidAdapter_spec.js
+++ b/test/spec/modules/sovrnBidAdapter_spec.js
@@ -1078,7 +1078,7 @@ describe('sovrnBidAdapter', function() {
       }
       const expectedReturnStatement = {
         type: 'iframe',
-        url: `https://ce.lijit.com/beacon?gdpr_consent=${gdprConsent.consentString}&informer=13487408`,
+        url: `https://ce.lijit.com/beacon?gdpr_consent=${encodeURIComponent(gdprConsent.consentString)}&informer=13487408`,
       }
 
       const returnStatement = spec.getUserSyncs(syncOptions, serverResponse, gdprConsent, '', null)
@@ -1105,7 +1105,7 @@ describe('sovrnBidAdapter', function() {
       }
       const expectedReturnStatement = {
         type: 'iframe',
-        url: `https://ce.lijit.com/beacon?gpp=${gppConsent.gppString}&gpp_sid=${gppConsent.applicableSections}&informer=13487408`,
+        url: `https://ce.lijit.com/beacon?gpp=${encodeURIComponent(gppConsent.gppString)}&gpp_sid=${encodeURIComponent(gppConsent.applicableSections)}&informer=13487408`,
       }
 
       const returnStatement = spec.getUserSyncs(syncOptions, serverResponse, null, '', gppConsent)
@@ -1126,7 +1126,7 @@ describe('sovrnBidAdapter', function() {
 
       const expectedReturnStatement = {
         type: 'iframe',
-        url: `https://ce.lijit.com/beacon?gdpr_consent=${gdprConsent.consentString}&us_privacy=${uspString}&gpp=${gppConsent.gppString}&gpp_sid=${gppConsent.applicableSections}&informer=13487408`,
+        url: `https://ce.lijit.com/beacon?gdpr_consent=${encodeURIComponent(gdprConsent.consentString)}&us_privacy=${uspString}&gpp=${encodeURIComponent(gppConsent.gppString)}&gpp_sid=${encodeURIComponent(gppConsent.applicableSections)}&informer=13487408`,
       }
 
       const returnStatement = spec.getUserSyncs(syncOptions, serverResponse, gdprConsent, uspString, gppConsent)
@@ -1177,6 +1177,23 @@ describe('sovrnBidAdapter', function() {
         { type: 'image', url: 'http://idprovider3.com' },
         { type: 'image', url: 'http://idprovider4.com' }
       ])
+    })
+
+    it('should encode informer value in iframe URL', function() {
+      const maliciousResponse = [{
+        body: {
+          ext: {
+            iid: '1234" onload="alert(1)'
+          }
+        }
+      }]
+
+      const returnStatement = spec.getUserSyncs(syncOptions, maliciousResponse)
+
+      expect(returnStatement[0]).to.deep.equal({
+        type: 'iframe',
+        url: `https://ce.lijit.com/beacon?informer=${encodeURIComponent('1234" onload="alert(1)')}`,
+      })
     })
   })
 


### PR DESCRIPTION
### Motivation

- Close a DOM XSS vector where `getUserSyncs` concatenated an untrusted `iid` into an iframe sync URL that is later inserted via `innerHTML`, allowing attribute breakout and script execution. 
- Ensure user-sync query parameters (including consent strings and the `informer`/`iid` value) are safely encoded before being placed in the URL.

### Description

- Encode all user-sync query parameter keys and values with `encodeURIComponent` when constructing the Sovrn iframe URL in `modules/sovrnBidAdapter.js`. (changed URL builder to `params.map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`).) 
- Update `test/spec/modules/sovrnBidAdapter_spec.js` expectations to reflect encoded consent and gpp values, and add a regression test that verifies a malicious `iid` (e.g. containing quotes and `onload`) is percent-encoded rather than injected raw. 
- Files modified: `modules/sovrnBidAdapter.js` and `test/spec/modules/sovrnBidAdapter_spec.js`.

### Testing

- Ran lint for the changed files with `npx eslint --cache --cache-strategy content modules/sovrnBidAdapter.js test/spec/modules/sovrnBidAdapter_spec.js` and it completed without errors. 
- Ran the focused unit tests with `npx gulp test --nolint --file test/spec/modules/sovrnBidAdapter_spec.js` and the spec run completed successfully (test bundle built and the suite ran; all tests passed for the changed spec).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ebb0de7e18832bad78b627dfe14a2d)