### PR TITLE
Unruly Adapter: validate outstream renderer URL

### DIFF
--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -23,6 +23,17 @@ function notifyRenderer(bidResponseBid) {
   parent.window.unruly['native'].prebid.uq.push(['render', bidResponseBid]);
 }
 
+const UNRULY_RENDERER_HOST_PATTERN = /(^|\.)unrulymedia\.com$/;
+
+const isValidRendererUrl = (url) => {
+  try {
+    const parsedUrl = new URL(url);
+    return parsedUrl.protocol === 'https:' && UNRULY_RENDERER_HOST_PATTERN.test(parsedUrl.hostname);
+  } catch (e) {
+    return false;
+  }
+};
+
 const addBidFloorInfo = (validBid) => {
   Object.keys(validBid.mediaTypes).forEach((key) => {
     let floor;
@@ -144,6 +155,10 @@ const handleOutStreamBid = (bid) => {
   }
   if (!hasSiteId) {
     logError(new Error('UnrulyBidAdapter: Missing renderer siteId.'));
+    return;
+  }
+  if (!isValidRendererUrl(deepAccess(bid, 'ext.renderer.url'))) {
+    logError(new Error('UnrulyBidAdapter: Invalid renderer URL.'));
     return;
   }
 

--- a/test/spec/modules/unrulyBidAdapter_spec.js
+++ b/test/spec/modules/unrulyBidAdapter_spec.js
@@ -726,7 +726,7 @@ describe('UnrulyAdapter', function () {
 
       const mockReturnedBid = createOutStreamExchangeBid({ adUnitCode: 'video1', requestId: 'mockBidId' });
       const mockRenderer = {
-        url: 'value: mockRendererURL',
+        url: 'https://video.unrulymedia.com/native/prebid-loader.js',
         config: {
           siteId: 123456,
           targetingUUID: 'xxx-yyy-zzz'
@@ -794,6 +794,22 @@ describe('UnrulyAdapter', function () {
 
       expect(siteIdErrorCall.args.length).to.equal(1);
       expect(siteIdErrorCall.args[0].message).to.equal('UnrulyBidAdapter: Missing renderer siteId.');
+    });
+
+    it('should return [] and log if renderer URL is invalid', function () {
+      sinon.assert.notCalled(utils.logError);
+      expect(Renderer.install.called).to.be.false;
+
+      const mockReturnedBid = createOutStreamExchangeBid({ adUnitCode: 'video1', requestId: 'mockBidId' });
+      mockReturnedBid.ext.renderer.url = 'https://attacker.example/malicious-renderer.js';
+      const mockServerResponse = createExchangeResponse(mockReturnedBid);
+
+      expect(adapter.interpretResponse(mockServerResponse)).to.deep.equal([]);
+      sinon.assert.notCalled(Renderer.install);
+
+      const logErrorCalls = utils.logError.getCalls();
+      expect(logErrorCalls.length).to.equal(1);
+      expect(logErrorCalls[0].args[0].message).to.equal('UnrulyBidAdapter: Invalid renderer URL.');
     });
 
     it('bid is placed on the bid queue when render is called', function () {


### PR DESCRIPTION
### Motivation
- The Unruly outstream flow accepted bidder-provided `ext.renderer.url` and passed it directly to `Renderer.install`, allowing attacker-controlled script loading; this change closes that RCE/external script injection vector.

### Description
- Added `UNRULY_RENDERER_HOST_PATTERN` and `isValidRendererUrl()` to `modules/unrulyBidAdapter.js` to validate renderer URLs.
- Enforced validation in `handleOutStreamBid` to require `https:` and hostnames ending with `unrulymedia.com`, and to log and reject bids with invalid renderer URLs instead of calling `Renderer.install`.
- Updated unit tests in `test/spec/modules/unrulyBidAdapter_spec.js` by adding a test that asserts invalid renderer URLs are rejected and by switching a renderer fixture to a valid `https://video.unrulymedia.com` URL so renderer-init tests remain correct.

### Testing
- Ran lint for the changed files with `npx eslint --cache --cache-strategy content modules/unrulyBidAdapter.js test/spec/modules/unrulyBidAdapter_spec.js` which completed successfully.
- Ran `npx gulp lint --files modules/unrulyBidAdapter.js,test/spec/modules/unrulyBidAdapter_spec.js` which completed successfully.
- Ran the focused unit test with `npx gulp test --nolint --file test/spec/modules/unrulyBidAdapter_spec.js` and the suite for that file passed (tests completed after the change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ebd38d9084832b86c4457cfe5029eb)