### PR TITLE
Core: restore isolated sandbox for user sync iframes

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -479,7 +479,7 @@ export function insertHtmlIntoIframe(htmlCode) {
  * @param  {Number} [timeout] an optional timeout in milliseconds for the iframe to load before calling `done`
  */
 export function insertUserSyncIframe(url, done, timeout) {
-  const iframeHtml = internal.createTrackPixelIframeHtml(url, false, 'allow-scripts allow-same-origin');
+  const iframeHtml = internal.createTrackPixelIframeHtml(url, false, 'allow-scripts');
   const div = document.createElement('div');
   div.innerHTML = iframeHtml;
   const iframe = div.firstChild;

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -604,6 +604,29 @@ describe('Utils', function () {
     });
   });
 
+  describe('insertUserSyncIframe', function () {
+    let sandbox;
+
+    beforeEach(function () {
+      sandbox = sinon.createSandbox();
+      sandbox.stub(utils.internal, 'createTrackPixelIframeHtml').returns('<iframe></iframe>');
+      sandbox.stub(utils.internal, 'insertElement');
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    it('should create sandboxed sync iframe without same-origin', function () {
+      utils.insertUserSyncIframe('https://example.com/sync');
+      expect(utils.internal.createTrackPixelIframeHtml.calledOnceWithExactly(
+        'https://example.com/sync',
+        false,
+        'allow-scripts'
+      )).to.equal(true);
+    });
+  });
+
   describe('polyfill test', function () {
     it('should not add polyfill to array', function() {
       var arr = ['hello', 'world'];


### PR DESCRIPTION
### Motivation
- A recent change added `allow-same-origin` to user-sync iframes which removed the opaque-origin isolation and allowed bidder-controlled sync URLs to gain same-origin privileges.
- Restore the original isolated sandbox behavior to prevent potential same-origin script execution or access to publisher-origin data.

### Description
- Removed `allow-same-origin` from the iframe sandbox in `insertUserSyncIframe` by calling `createTrackPixelIframeHtml(url, false, 'allow-scripts')` in `src/utils.js`.
- Added a focused unit test in `test/spec/utils_spec.js` that asserts `insertUserSyncIframe` calls `createTrackPixelIframeHtml` with `'allow-scripts'` only.

### Testing
- Ran `npx eslint --cache --cache-strategy content src/utils.js test/spec/utils_spec.js` which completed successfully.
- Ran `npx gulp test --nolint --file test/spec/utils_spec.js` and the targeted run completed (summary: `175 tests completed`).
- Ran `npx gulp lint --files 'src/utils.js,test/spec/utils_spec.js'` which finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ebf969fdf8832bb2b9b69edb7a8cfb)