### PR TITLE
Silverpush Bid Adapter: avoid eager outstream render

### DIFF
--- a/modules/silverpushBidAdapter.js
+++ b/modules/silverpushBidAdapter.js
@@ -226,8 +226,6 @@ function buildVideoOutstreamResponse(bidResponse, context) {
     });
 
     bidResponse.renderer.setRender(() => _renderer(bidResponse));
-
-    bidResponse.renderer.render(bidResponse);
   }
 
   return { ...bidResponse };

--- a/test/spec/modules/silverpushBidAdapter_spec.js
+++ b/test/spec/modules/silverpushBidAdapter_spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import * as utils from 'src/utils';
 import { newBidder } from 'src/adapters/bidderFactory.js';
+import { Renderer } from 'src/Renderer.js';
 import { REQUEST_URL, SP_OUTSTREAM_PLAYER_URL, CONVERTER, spec } from '../../../modules/silverpushBidAdapter.js';
 
 const bannerBid = {
@@ -357,6 +358,31 @@ describe('Silverpush Adapter', function () {
         expect(bids[0].seatBidId).to.equal('soCWeklh');
         expect(bids[0].width).to.equal(1024);
         expect(bids[0].height).to.equal(768);
+      });
+
+      it('should defer outstream rendering until the renderer is executed', () => {
+        const response = utils.deepClone(videoResponse);
+        const outstreamBid = utils.deepClone(videoBid);
+        outstreamBid.mediaTypes.video.context = 'outstream';
+
+        const fakeRenderer = {
+          url: SP_OUTSTREAM_PLAYER_URL,
+          setRender: sinon.spy(),
+          render: sinon.spy()
+        };
+        const installStub = sinon.stub(Renderer, 'install').returns(fakeRenderer);
+
+        try {
+          const requests = spec.buildRequests([outstreamBid], bidderRequest);
+          const bids = spec.interpretResponse({ body: response }, requests[0]);
+
+          expect(installStub.calledOnce).to.equal(true);
+          expect(fakeRenderer.setRender.calledOnce).to.equal(true);
+          expect(fakeRenderer.render.called).to.equal(false);
+          expect(bids[0].renderer).to.equal(fakeRenderer);
+        } finally {
+          installStub.restore();
+        }
       });
     }
   });


### PR DESCRIPTION
### Motivation
- Prevent a double render for Silverpush outstream video bids by stopping interpretation from invoking the renderer immediately, ensuring render only happens when Prebid executes the renderer.

### Description
- Remove the eager `bidResponse.renderer.render(bidResponse)` call from `buildVideoOutstreamResponse` so the adapter only installs the renderer and sets its render callback via `setRender`.
- Add a regression unit test that stubs `Renderer.install`, verifies `setRender` is called during interpretation, and asserts `render` is not invoked; import `Renderer` in the spec to enable the stub.

### Testing
- Ran lint on the changed files with `npx eslint modules/silverpushBidAdapter.js test/spec/modules/silverpushBidAdapter_spec.js --cache --cache-strategy content` which passed with no lint output.
- Ran the focused test with `npx gulp test --nolint --file test/spec/modules/silverpushBidAdapter_spec.js` and the affected spec completed successfully (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a291fa5b768832ba2701faf6c21194c)