### PR TITLE
Various Modules: add explicit semicolons

### DIFF
--- a/modules/advRedAnalyticsAdapter.js
+++ b/modules/advRedAnalyticsAdapter.js
@@ -1,26 +1,26 @@
-import { generateUUID, logInfo } from '../src/utils.js'
-import { ajaxBuilder } from '../src/ajax.js'
-import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js'
-import adapterManager from '../src/adapterManager.js'
-import { EVENTS } from '../src/constants.js'
+import { generateUUID, logInfo } from '../src/utils.js';
+import { ajaxBuilder } from '../src/ajax.js';
+import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
+import adapterManager from '../src/adapterManager.js';
+import { EVENTS } from '../src/constants.js';
 import { getRefererInfo } from '../src/refererDetection.js';
 
 /**
  * advRedAnalyticsAdapter.js - analytics adapter for AdvRed
  */
-const DEFAULT_EVENT_URL = 'https://api.adv.red/api/event'
+const DEFAULT_EVENT_URL = 'https://api.adv.red/api/event';
 
-const ajax = ajaxBuilder(10000)
-let pwId
-let initOptions
-let flushInterval
-let queue = []
+const ajax = ajaxBuilder(10000);
+let pwId;
+let initOptions;
+let flushInterval;
+let queue = [];
 
 const advRedAnalytics = Object.assign(adapter({ url: DEFAULT_EVENT_URL, analyticsType: 'endpoint' }), {
   track({ eventType, args }) {
-    handleEvent(eventType, args)
+    handleEvent(eventType, args);
   }
-})
+});
 
 function sendEvents() {
   if (queue.length > 0) {
@@ -29,10 +29,10 @@ function sendEvents() {
       publisherId: initOptions.publisherId,
       events: queue,
       pageUrl: getRefererInfo().page
-    }
-    queue = []
+    };
+    queue = [];
 
-    const url = initOptions.url ? initOptions.url : DEFAULT_EVENT_URL
+    const url = initOptions.url ? initOptions.url : DEFAULT_EVENT_URL;
     ajax(
       url,
       () => logInfo('AdvRed Analytics sent ' + queue.length + ' events'),
@@ -42,157 +42,157 @@ function sendEvents() {
         contentType: 'application/json',
         withCredentials: true
       }
-    )
+    );
   }
 }
 
 function convertAdUnit(adUnit) {
-  if (!adUnit) return adUnit
+  if (!adUnit) return adUnit;
 
-  const shortAdUnit = {}
-  shortAdUnit.code = adUnit.code
-  shortAdUnit.sizes = adUnit.sizes
-  return shortAdUnit
+  const shortAdUnit = {};
+  shortAdUnit.code = adUnit.code;
+  shortAdUnit.sizes = adUnit.sizes;
+  return shortAdUnit;
 }
 
 function convertBid(bid) {
-  if (!bid) return bid
+  if (!bid) return bid;
 
-  const shortBid = {}
-  shortBid.adUnitCode = bid.adUnitCode
-  shortBid.bidder = bid.bidder
-  shortBid.cpm = bid.cpm
-  shortBid.currency = bid.currency
-  shortBid.mediaTypes = bid.mediaTypes
-  shortBid.sizes = bid.sizes
-  shortBid.serverResponseTimeMs = bid.serverResponseTimeMs
-  return shortBid
+  const shortBid = {};
+  shortBid.adUnitCode = bid.adUnitCode;
+  shortBid.bidder = bid.bidder;
+  shortBid.cpm = bid.cpm;
+  shortBid.currency = bid.currency;
+  shortBid.mediaTypes = bid.mediaTypes;
+  shortBid.sizes = bid.sizes;
+  shortBid.serverResponseTimeMs = bid.serverResponseTimeMs;
+  return shortBid;
 }
 
 function convertAuctionInit(origEvent) {
-  const shortEvent = {}
-  shortEvent.auctionId = origEvent.auctionId
-  shortEvent.timeout = origEvent.timeout
-  shortEvent.adUnits = origEvent.adUnits && origEvent.adUnits.map(convertAdUnit)
-  return shortEvent
+  const shortEvent = {};
+  shortEvent.auctionId = origEvent.auctionId;
+  shortEvent.timeout = origEvent.timeout;
+  shortEvent.adUnits = origEvent.adUnits && origEvent.adUnits.map(convertAdUnit);
+  return shortEvent;
 }
 
 function convertBidRequested(origEvent) {
-  const shortEvent = {}
-  shortEvent.bidderCode = origEvent.bidderCode
-  shortEvent.bids = origEvent.bids && origEvent.bids.map(convertBid)
-  shortEvent.timeout = origEvent.timeout
-  return shortEvent
+  const shortEvent = {};
+  shortEvent.bidderCode = origEvent.bidderCode;
+  shortEvent.bids = origEvent.bids && origEvent.bids.map(convertBid);
+  shortEvent.timeout = origEvent.timeout;
+  return shortEvent;
 }
 
 function convertBidTimeout(origEvent) {
-  const shortEvent = {}
-  shortEvent.bids = origEvent && origEvent.map ? origEvent.map(convertBid) : origEvent
-  return shortEvent
+  const shortEvent = {};
+  shortEvent.bids = origEvent && origEvent.map ? origEvent.map(convertBid) : origEvent;
+  return shortEvent;
 }
 
 function convertBidderError(origEvent) {
-  const shortEvent = {}
-  shortEvent.bids = origEvent.bidderRequest && origEvent.bidderRequest.bids && origEvent.bidderRequest.bids.map(convertBid)
-  return shortEvent
+  const shortEvent = {};
+  shortEvent.bids = origEvent.bidderRequest && origEvent.bidderRequest.bids && origEvent.bidderRequest.bids.map(convertBid);
+  return shortEvent;
 }
 
 function convertAuctionEnd(origEvent) {
-  const shortEvent = {}
-  shortEvent.adUnitCodes = origEvent.adUnitCodes
-  shortEvent.bidsReceived = origEvent.bidsReceived && origEvent.bidsReceived.map(convertBid)
-  shortEvent.noBids = origEvent.noBids && origEvent.noBids.map(convertBid)
-  return shortEvent
+  const shortEvent = {};
+  shortEvent.adUnitCodes = origEvent.adUnitCodes;
+  shortEvent.bidsReceived = origEvent.bidsReceived && origEvent.bidsReceived.map(convertBid);
+  shortEvent.noBids = origEvent.noBids && origEvent.noBids.map(convertBid);
+  return shortEvent;
 }
 
 function convertBidWon(origEvent) {
-  const shortEvent = {}
-  shortEvent.adUnitCode = origEvent.adUnitCode
-  shortEvent.bidderCode = origEvent.bidderCode
-  shortEvent.mediaType = origEvent.mediaType
-  shortEvent.netRevenue = origEvent.netRevenue
-  shortEvent.cpm = origEvent.cpm
-  shortEvent.size = origEvent.size
-  shortEvent.currency = origEvent.currency
-  return shortEvent
+  const shortEvent = {};
+  shortEvent.adUnitCode = origEvent.adUnitCode;
+  shortEvent.bidderCode = origEvent.bidderCode;
+  shortEvent.mediaType = origEvent.mediaType;
+  shortEvent.netRevenue = origEvent.netRevenue;
+  shortEvent.cpm = origEvent.cpm;
+  shortEvent.size = origEvent.size;
+  shortEvent.currency = origEvent.currency;
+  return shortEvent;
 }
 
 function handleEvent(eventType, origEvent) {
   try {
-    origEvent = origEvent ? JSON.parse(JSON.stringify(origEvent)) : {}
+    origEvent = origEvent ? JSON.parse(JSON.stringify(origEvent)) : {};
   } catch (e) {
   }
 
-  let shortEvent
+  let shortEvent;
   switch (eventType) {
     case EVENTS.AUCTION_INIT: {
-      shortEvent = convertAuctionInit(origEvent)
-      break
+      shortEvent = convertAuctionInit(origEvent);
+      break;
     }
     case EVENTS.BID_REQUESTED: {
-      shortEvent = convertBidRequested(origEvent)
-      break
+      shortEvent = convertBidRequested(origEvent);
+      break;
     }
     case EVENTS.BID_TIMEOUT: {
-      shortEvent = convertBidTimeout(origEvent)
-      break
+      shortEvent = convertBidTimeout(origEvent);
+      break;
     }
     case EVENTS.BIDDER_ERROR: {
-      shortEvent = convertBidderError(origEvent)
-      break
+      shortEvent = convertBidderError(origEvent);
+      break;
     }
     case EVENTS.AUCTION_END: {
-      shortEvent = convertAuctionEnd(origEvent)
-      break
+      shortEvent = convertAuctionEnd(origEvent);
+      break;
     }
     case EVENTS.BID_WON: {
-      shortEvent = convertBidWon(origEvent)
-      break
+      shortEvent = convertBidWon(origEvent);
+      break;
     }
     default:
-      return
+      return;
   }
 
-  shortEvent.eventType = eventType
-  shortEvent.auctionId = origEvent.auctionId
-  shortEvent.timestamp = origEvent.timestamp || Date.now()
+  shortEvent.eventType = eventType;
+  shortEvent.auctionId = origEvent.auctionId;
+  shortEvent.timestamp = origEvent.timestamp || Date.now();
 
-  sendEvent(shortEvent)
+  sendEvent(shortEvent);
 }
 
 function sendEvent(event) {
-  queue.push(event)
+  queue.push(event);
 
   if (event.eventType === EVENTS.AUCTION_END) {
-    sendEvents()
+    sendEvents();
   }
 }
 
-advRedAnalytics.originEnableAnalytics = advRedAnalytics.enableAnalytics
+advRedAnalytics.originEnableAnalytics = advRedAnalytics.enableAnalytics;
 advRedAnalytics.enableAnalytics = function (config) {
-  initOptions = config.options || {}
-  pwId = generateUUID()
-  flushInterval = setInterval(sendEvents, 1000)
+  initOptions = config.options || {};
+  pwId = generateUUID();
+  flushInterval = setInterval(sendEvents, 1000);
 
-  advRedAnalytics.originEnableAnalytics(config)
-}
+  advRedAnalytics.originEnableAnalytics(config);
+};
 
-advRedAnalytics.originDisableAnalytics = advRedAnalytics.disableAnalytics
+advRedAnalytics.originDisableAnalytics = advRedAnalytics.disableAnalytics;
 advRedAnalytics.disableAnalytics = function () {
-  clearInterval(flushInterval)
-  sendEvents()
-  advRedAnalytics.originDisableAnalytics()
-}
+  clearInterval(flushInterval);
+  sendEvents();
+  advRedAnalytics.originDisableAnalytics();
+};
 
 adapterManager.registerAnalyticsAdapter({
   adapter: advRedAnalytics,
   code: 'advRed'
-})
+});
 
 advRedAnalytics.getOptions = function () {
-  return initOptions
-}
+  return initOptions;
+};
 
-advRedAnalytics.sendEvents = sendEvents
+advRedAnalytics.sendEvents = sendEvents;
 
-export default advRedAnalytics
+export default advRedAnalytics;

--- a/modules/afpBidAdapter.js
+++ b/modules/afpBidAdapter.js
@@ -2,23 +2,23 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { Renderer } from '../src/Renderer.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 
-export const IS_DEV = location.hostname === 'localhost'
-export const BIDDER_CODE = 'afp'
-export const SSP_ENDPOINT = 'https://ssp.afp.ai/api/prebid'
-export const REQUEST_METHOD = 'POST'
+export const IS_DEV = location.hostname === 'localhost';
+export const BIDDER_CODE = 'afp';
+export const SSP_ENDPOINT = 'https://ssp.afp.ai/api/prebid';
+export const REQUEST_METHOD = 'POST';
 // TODO: test code should be kept in tests
-export const TEST_PAGE_URL = 'https://rtbinsight.ru/smiert-bolshikh-dannykh-kto-na-novienkogo/'
-const SDK_PATH = 'https://cdn.afp.ai/ssp/sdk.js?auto_initialization=false&deploy_to_parent_window=true'
-const TTL = 60
-export const IN_IMAGE_BANNER_TYPE = 'In-image'
-export const IN_IMAGE_MAX_BANNER_TYPE = 'In-image Max'
-export const IN_CONTENT_BANNER_TYPE = 'In-content Banner'
-export const IN_CONTENT_VIDEO_TYPE = 'In-content Video'
-export const OUT_CONTENT_VIDEO_TYPE = 'Out-content Video'
-export const IN_CONTENT_STORY_TYPE = 'In-content Stories'
-export const ACTION_SCROLLER_TYPE = 'Action Scroller'
-export const ACTION_SCROLLER_LIGHT_TYPE = 'Action Scroller Light'
-export const JUST_BANNER_TYPE = 'Just Banner'
+export const TEST_PAGE_URL = 'https://rtbinsight.ru/smiert-bolshikh-dannykh-kto-na-novienkogo/';
+const SDK_PATH = 'https://cdn.afp.ai/ssp/sdk.js?auto_initialization=false&deploy_to_parent_window=true';
+const TTL = 60;
+export const IN_IMAGE_BANNER_TYPE = 'In-image';
+export const IN_IMAGE_MAX_BANNER_TYPE = 'In-image Max';
+export const IN_CONTENT_BANNER_TYPE = 'In-content Banner';
+export const IN_CONTENT_VIDEO_TYPE = 'In-content Video';
+export const OUT_CONTENT_VIDEO_TYPE = 'Out-content Video';
+export const IN_CONTENT_STORY_TYPE = 'In-content Stories';
+export const ACTION_SCROLLER_TYPE = 'Action Scroller';
+export const ACTION_SCROLLER_LIGHT_TYPE = 'Action Scroller Light';
+export const JUST_BANNER_TYPE = 'Just Banner';
 
 export const mediaTypeByPlaceType = {
   [IN_IMAGE_BANNER_TYPE]: BANNER,
@@ -30,7 +30,7 @@ export const mediaTypeByPlaceType = {
   [JUST_BANNER_TYPE]: BANNER,
   [IN_CONTENT_VIDEO_TYPE]: VIDEO,
   [OUT_CONTENT_VIDEO_TYPE]: VIDEO,
-}
+};
 
 const wrapAd = (dataToCreatePlace) => {
   return `<!DOCTYPE html>
@@ -45,54 +45,54 @@ const wrapAd = (dataToCreatePlace) => {
             window.afp.createPlaceByData(JSON.parse(decodeURIComponent("${encodeURIComponent(JSON.stringify(dataToCreatePlace))}")))
         </script>
     </body>
-  </html>`
-}
+  </html>`;
+};
 
-const bidRequestMap = {}
+const bidRequestMap = {};
 
 const createRenderer = (bid, dataToCreatePlace) => {
   const renderer = new Renderer({
     targetId: bid.adUnitCode,
     url: SDK_PATH,
     callback() {
-      renderer.loaded = true
-      window.afp.createPlaceByData(dataToCreatePlace)
+      renderer.loaded = true;
+      window.afp.createPlaceByData(dataToCreatePlace);
     }
-  })
+  });
 
-  return renderer
-}
+  return renderer;
+};
 
 export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: [BANNER, VIDEO],
   isBidRequestValid({ mediaTypes, params }) {
     if (typeof params !== 'object' || typeof mediaTypes !== 'object') {
-      return false
+      return false;
     }
 
-    const { placeId, placeType, imageUrl, imageWidth, imageHeight } = params
-    const media = mediaTypes[mediaTypeByPlaceType[placeType]]
+    const { placeId, placeType, imageUrl, imageWidth, imageHeight } = params;
+    const media = mediaTypes[mediaTypeByPlaceType[placeType]];
 
     if (placeId && media) {
       if (mediaTypeByPlaceType[placeType] === VIDEO) {
         if (!media.playerSize) {
-          return false
+          return false;
         }
       } else if (mediaTypeByPlaceType[placeType] === BANNER) {
         if (!media.sizes) {
-          return false
+          return false;
         }
       }
       if ([IN_IMAGE_BANNER_TYPE, IN_IMAGE_MAX_BANNER_TYPE].includes(placeType)) {
         if (imageUrl && imageWidth && imageHeight) {
-          return true
+          return true;
         }
       } else {
-        return true
+        return true;
       }
     }
-    return false
+    return false;
   },
   buildRequests(validBidRequests, { refererInfo, gdprConsent }) {
     const payload = {
@@ -103,24 +103,24 @@ export const spec = {
           bidId, ortb2Imp, sizes, params: {
             placeId, placeType, imageUrl, imageWidth, imageHeight
           }
-        } = validBidRequest
-        bidRequestMap[bidId] = validBidRequest
+        } = validBidRequest;
+        bidRequestMap[bidId] = validBidRequest;
         const bidRequest = {
           bidId,
           transactionId: ortb2Imp?.ext?.tid,
           sizes,
           placeId,
-        }
+        };
         if ([IN_IMAGE_BANNER_TYPE, IN_IMAGE_MAX_BANNER_TYPE].includes(placeType)) {
           Object.assign(bidRequest, {
             imageUrl,
             imageWidth: Math.floor(imageWidth),
             imageHeight: Math.floor(imageHeight),
-          })
+          });
         }
-        return bidRequest
+        return bidRequest;
       })
-    }
+    };
 
     return {
       method: REQUEST_METHOD,
@@ -129,11 +129,11 @@ export const spec = {
       options: {
         contentType: 'application/json'
       }
-    }
+    };
   },
   interpretResponse(serverResponse) {
-    let bids = serverResponse.body && serverResponse.body.bids
-    bids = Array.isArray(bids) ? bids : []
+    let bids = serverResponse.body && serverResponse.body.bids;
+    bids = Array.isArray(bids) ? bids : [];
 
     return bids.map(({ bidId, cpm, width, height, creativeId, currency, netRevenue, adSettings, placeSettings }, index) => {
       const bid = {
@@ -148,21 +148,21 @@ export const spec = {
           mediaType: mediaTypeByPlaceType[placeSettings.placeType],
         },
         ttl: TTL
-      }
+      };
 
-      const bidRequest = bidRequestMap[bidId]
-      const placeContainer = bidRequest.params.placeContainer
-      const dataToCreatePlace = { adSettings, placeSettings, placeContainer, isPrebid: true }
+      const bidRequest = bidRequestMap[bidId];
+      const placeContainer = bidRequest.params.placeContainer;
+      const dataToCreatePlace = { adSettings, placeSettings, placeContainer, isPrebid: true };
 
       if (mediaTypeByPlaceType[placeSettings.placeType] === BANNER) {
-        bid.ad = wrapAd(dataToCreatePlace)
+        bid.ad = wrapAd(dataToCreatePlace);
       } else if (mediaTypeByPlaceType[placeSettings.placeType] === VIDEO) {
-        bid.vastXml = adSettings.content
-        bid.renderer = createRenderer(bid, dataToCreatePlace)
+        bid.vastXml = adSettings.content;
+        bid.renderer = createRenderer(bid, dataToCreatePlace);
       }
-      return bid
-    })
+      return bid;
+    });
   }
-}
+};
 
 registerBidder(spec);

--- a/modules/asteriobidAnalyticsAdapter.js
+++ b/modules/asteriobidAnalyticsAdapter.js
@@ -1,83 +1,83 @@
-import { generateUUID, getParameterByName, logError, logInfo, parseUrl, deepClone, hasNonSerializableProperty } from '../src/utils.js'
-import { ajaxBuilder } from '../src/ajax.js'
-import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js'
-import adapterManager from '../src/adapterManager.js'
-import { getStorageManager } from '../src/storageManager.js'
-import { EVENTS } from '../src/constants.js'
-import { MODULE_TYPE_ANALYTICS } from '../src/activities/modules.js'
+import { generateUUID, getParameterByName, logError, logInfo, parseUrl, deepClone, hasNonSerializableProperty } from '../src/utils.js';
+import { ajaxBuilder } from '../src/ajax.js';
+import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
+import adapterManager from '../src/adapterManager.js';
+import { getStorageManager } from '../src/storageManager.js';
+import { EVENTS } from '../src/constants.js';
+import { MODULE_TYPE_ANALYTICS } from '../src/activities/modules.js';
 import { getRefererInfo } from '../src/refererDetection.js';
-import { collectUtmTagData, trimAdUnit, trimBid, trimBidderRequest } from '../libraries/asteriobidUtils/asteriobidUtils.js'
+import { collectUtmTagData, trimAdUnit, trimBid, trimBidderRequest } from '../libraries/asteriobidUtils/asteriobidUtils.js';
 
 /**
  * asteriobidAnalyticsAdapter.js - analytics adapter for AsterioBid
  */
-export const storage = getStorageManager({ moduleType: MODULE_TYPE_ANALYTICS, moduleName: 'asteriobid' })
-const DEFAULT_EVENT_URL = 'https://endpt.asteriobid.com/endpoint'
-const analyticsType = 'endpoint'
-const analyticsName = 'AsterioBid Analytics'
-const _VERSION = 1
+export const storage = getStorageManager({ moduleType: MODULE_TYPE_ANALYTICS, moduleName: 'asteriobid' });
+const DEFAULT_EVENT_URL = 'https://endpt.asteriobid.com/endpoint';
+const analyticsType = 'endpoint';
+const analyticsName = 'AsterioBid Analytics';
+const _VERSION = 1;
 
-const ajax = ajaxBuilder(20000)
-let initOptions
-const auctionStarts = {}
-const auctionTimeouts = {}
-let sampling
-let pageViewId
-let flushInterval
-let eventQueue = []
-let asteriobidAnalyticsEnabled = false
+const ajax = ajaxBuilder(20000);
+let initOptions;
+const auctionStarts = {};
+const auctionTimeouts = {};
+let sampling;
+let pageViewId;
+let flushInterval;
+let eventQueue = [];
+let asteriobidAnalyticsEnabled = false;
 
 const asteriobidAnalytics = Object.assign(adapter({ url: DEFAULT_EVENT_URL, analyticsType }), {
   track({ eventType, args }) {
-    handleEvent(eventType, args)
+    handleEvent(eventType, args);
   }
-})
+});
 
-asteriobidAnalytics.originEnableAnalytics = asteriobidAnalytics.enableAnalytics
+asteriobidAnalytics.originEnableAnalytics = asteriobidAnalytics.enableAnalytics;
 asteriobidAnalytics.enableAnalytics = function (config) {
-  initOptions = config.options || {}
+  initOptions = config.options || {};
 
-  pageViewId = initOptions.pageViewId || generateUUID()
-  sampling = initOptions.sampling || 1
+  pageViewId = initOptions.pageViewId || generateUUID();
+  sampling = initOptions.sampling || 1;
 
   if (Math.floor(Math.random() * sampling) === 0) {
-    asteriobidAnalyticsEnabled = true
-    flushInterval = setInterval(flush, 1000)
+    asteriobidAnalyticsEnabled = true;
+    flushInterval = setInterval(flush, 1000);
   } else {
-    logInfo(`${analyticsName} isn't enabled because of sampling`)
+    logInfo(`${analyticsName} isn't enabled because of sampling`);
   }
 
-  asteriobidAnalytics.originEnableAnalytics(config)
-}
+  asteriobidAnalytics.originEnableAnalytics(config);
+};
 
-asteriobidAnalytics.originDisableAnalytics = asteriobidAnalytics.disableAnalytics
+asteriobidAnalytics.originDisableAnalytics = asteriobidAnalytics.disableAnalytics;
 asteriobidAnalytics.disableAnalytics = function () {
   if (!asteriobidAnalyticsEnabled) {
-    return
+    return;
   }
-  flush()
-  clearInterval(flushInterval)
-  asteriobidAnalytics.originDisableAnalytics()
-}
+  flush();
+  clearInterval(flushInterval);
+  asteriobidAnalytics.originDisableAnalytics();
+};
 
 function collectPageInfo() {
   const pageInfo = {
     domain: window.location.hostname,
-  }
+  };
   if (document.referrer) {
-    pageInfo.referrerDomain = parseUrl(document.referrer).hostname
+    pageInfo.referrerDomain = parseUrl(document.referrer).hostname;
   }
 
-  const refererInfo = getRefererInfo()
-  pageInfo.page = refererInfo.page
-  pageInfo.ref = refererInfo.ref
+  const refererInfo = getRefererInfo();
+  pageInfo.page = refererInfo.page;
+  pageInfo.ref = refererInfo.ref;
 
-  return pageInfo
+  return pageInfo;
 }
 
 function flush() {
   if (!asteriobidAnalyticsEnabled) {
-    return
+    return;
   }
 
   if (eventQueue.length > 0) {
@@ -89,14 +89,14 @@ function flush() {
       utmTags: collectUtmTagData(storage, getParameterByName, logError, analyticsName),
       pageInfo: collectPageInfo(),
       sampling: sampling
-    }
-    eventQueue = []
+    };
+    eventQueue = [];
 
     if ('version' in initOptions) {
-      data.version = initOptions.version
+      data.version = initOptions.version;
     }
     if ('tcf_compliant' in initOptions) {
-      data.tcf_compliant = initOptions.tcf_compliant
+      data.tcf_compliant = initOptions.tcf_compliant;
     }
     if ('adUnitDict' in initOptions) {
       data.adUnitDict = initOptions.adUnitDict;
@@ -105,7 +105,7 @@ function flush() {
       data.customParam = initOptions.customParam;
     }
 
-    const url = initOptions.url ? initOptions.url : DEFAULT_EVENT_URL
+    const url = initOptions.url ? initOptions.url : DEFAULT_EVENT_URL;
     ajax(
       url,
       () => logInfo(`${analyticsName} sent events batch`),
@@ -115,151 +115,151 @@ function flush() {
         method: 'POST',
         withCredentials: true
       }
-    )
+    );
   }
 }
 
 function handleEvent(eventType, eventArgs) {
   if (!asteriobidAnalyticsEnabled) {
-    return
+    return;
   }
 
   if (eventArgs) {
-    eventArgs = hasNonSerializableProperty(eventArgs) ? eventArgs : deepClone(eventArgs)
+    eventArgs = hasNonSerializableProperty(eventArgs) ? eventArgs : deepClone(eventArgs);
   } else {
-    eventArgs = {}
+    eventArgs = {};
   }
 
-  const pmEvent = {}
-  pmEvent.timestamp = eventArgs.timestamp || Date.now()
-  pmEvent.eventType = eventType
+  const pmEvent = {};
+  pmEvent.timestamp = eventArgs.timestamp || Date.now();
+  pmEvent.eventType = eventType;
 
   switch (eventType) {
     case EVENTS.AUCTION_INIT: {
-      pmEvent.auctionId = eventArgs.auctionId
-      pmEvent.timeout = eventArgs.timeout
-      pmEvent.adUnits = eventArgs.adUnits && eventArgs.adUnits.map(trimAdUnit)
-      pmEvent.bidderRequests = eventArgs.bidderRequests && eventArgs.bidderRequests.map(trimBidderRequest)
-      auctionStarts[pmEvent.auctionId] = pmEvent.timestamp
-      auctionTimeouts[pmEvent.auctionId] = pmEvent.timeout
-      break
+      pmEvent.auctionId = eventArgs.auctionId;
+      pmEvent.timeout = eventArgs.timeout;
+      pmEvent.adUnits = eventArgs.adUnits && eventArgs.adUnits.map(trimAdUnit);
+      pmEvent.bidderRequests = eventArgs.bidderRequests && eventArgs.bidderRequests.map(trimBidderRequest);
+      auctionStarts[pmEvent.auctionId] = pmEvent.timestamp;
+      auctionTimeouts[pmEvent.auctionId] = pmEvent.timeout;
+      break;
     }
     case EVENTS.AUCTION_END: {
-      pmEvent.auctionId = eventArgs.auctionId
-      pmEvent.end = eventArgs.end
-      pmEvent.start = eventArgs.start
-      pmEvent.adUnitCodes = eventArgs.adUnitCodes
-      pmEvent.bidsReceived = eventArgs.bidsReceived && eventArgs.bidsReceived.map(trimBid)
-      pmEvent.start = auctionStarts[pmEvent.auctionId]
-      pmEvent.end = Date.now()
-      break
+      pmEvent.auctionId = eventArgs.auctionId;
+      pmEvent.end = eventArgs.end;
+      pmEvent.start = eventArgs.start;
+      pmEvent.adUnitCodes = eventArgs.adUnitCodes;
+      pmEvent.bidsReceived = eventArgs.bidsReceived && eventArgs.bidsReceived.map(trimBid);
+      pmEvent.start = auctionStarts[pmEvent.auctionId];
+      pmEvent.end = Date.now();
+      break;
     }
     case EVENTS.BID_ADJUSTMENT: {
-      break
+      break;
     }
     case EVENTS.BID_TIMEOUT: {
-      pmEvent.bidders = eventArgs && eventArgs.map ? eventArgs.map(trimBid) : eventArgs
-      pmEvent.duration = auctionTimeouts[pmEvent.auctionId]
-      break
+      pmEvent.bidders = eventArgs && eventArgs.map ? eventArgs.map(trimBid) : eventArgs;
+      pmEvent.duration = auctionTimeouts[pmEvent.auctionId];
+      break;
     }
     case EVENTS.BID_REQUESTED: {
-      pmEvent.auctionId = eventArgs.auctionId
-      pmEvent.bidderCode = eventArgs.bidderCode
-      pmEvent.doneCbCallCount = eventArgs.doneCbCallCount
-      pmEvent.start = eventArgs.start
-      pmEvent.bidderRequestId = eventArgs.bidderRequestId
-      pmEvent.bids = eventArgs.bids && eventArgs.bids.map(trimBid)
-      pmEvent.auctionStart = eventArgs.auctionStart
-      pmEvent.timeout = eventArgs.timeout
-      break
+      pmEvent.auctionId = eventArgs.auctionId;
+      pmEvent.bidderCode = eventArgs.bidderCode;
+      pmEvent.doneCbCallCount = eventArgs.doneCbCallCount;
+      pmEvent.start = eventArgs.start;
+      pmEvent.bidderRequestId = eventArgs.bidderRequestId;
+      pmEvent.bids = eventArgs.bids && eventArgs.bids.map(trimBid);
+      pmEvent.auctionStart = eventArgs.auctionStart;
+      pmEvent.timeout = eventArgs.timeout;
+      break;
     }
     case EVENTS.BID_RESPONSE: {
-      pmEvent.bidderCode = eventArgs.bidderCode
-      pmEvent.width = eventArgs.width
-      pmEvent.height = eventArgs.height
-      pmEvent.adId = eventArgs.adId
-      pmEvent.mediaType = eventArgs.mediaType
-      pmEvent.cpm = eventArgs.cpm
-      pmEvent.currency = eventArgs.currency
-      pmEvent.requestId = eventArgs.requestId
-      pmEvent.adUnitCode = eventArgs.adUnitCode
-      pmEvent.auctionId = eventArgs.auctionId
-      pmEvent.timeToRespond = eventArgs.timeToRespond
-      pmEvent.requestTimestamp = eventArgs.requestTimestamp
-      pmEvent.responseTimestamp = eventArgs.responseTimestamp
-      pmEvent.netRevenue = eventArgs.netRevenue
-      pmEvent.size = eventArgs.size
-      pmEvent.adserverTargeting = eventArgs.adserverTargeting
-      break
+      pmEvent.bidderCode = eventArgs.bidderCode;
+      pmEvent.width = eventArgs.width;
+      pmEvent.height = eventArgs.height;
+      pmEvent.adId = eventArgs.adId;
+      pmEvent.mediaType = eventArgs.mediaType;
+      pmEvent.cpm = eventArgs.cpm;
+      pmEvent.currency = eventArgs.currency;
+      pmEvent.requestId = eventArgs.requestId;
+      pmEvent.adUnitCode = eventArgs.adUnitCode;
+      pmEvent.auctionId = eventArgs.auctionId;
+      pmEvent.timeToRespond = eventArgs.timeToRespond;
+      pmEvent.requestTimestamp = eventArgs.requestTimestamp;
+      pmEvent.responseTimestamp = eventArgs.responseTimestamp;
+      pmEvent.netRevenue = eventArgs.netRevenue;
+      pmEvent.size = eventArgs.size;
+      pmEvent.adserverTargeting = eventArgs.adserverTargeting;
+      break;
     }
     case EVENTS.BID_WON: {
-      pmEvent.auctionId = eventArgs.auctionId
-      pmEvent.adId = eventArgs.adId
-      pmEvent.adserverTargeting = eventArgs.adserverTargeting
-      pmEvent.adUnitCode = eventArgs.adUnitCode
-      pmEvent.bidderCode = eventArgs.bidderCode
-      pmEvent.height = eventArgs.height
-      pmEvent.mediaType = eventArgs.mediaType
-      pmEvent.netRevenue = eventArgs.netRevenue
-      pmEvent.cpm = eventArgs.cpm
-      pmEvent.requestTimestamp = eventArgs.requestTimestamp
-      pmEvent.responseTimestamp = eventArgs.responseTimestamp
-      pmEvent.size = eventArgs.size
-      pmEvent.width = eventArgs.width
-      pmEvent.currency = eventArgs.currency
-      pmEvent.bidder = eventArgs.bidder
-      break
+      pmEvent.auctionId = eventArgs.auctionId;
+      pmEvent.adId = eventArgs.adId;
+      pmEvent.adserverTargeting = eventArgs.adserverTargeting;
+      pmEvent.adUnitCode = eventArgs.adUnitCode;
+      pmEvent.bidderCode = eventArgs.bidderCode;
+      pmEvent.height = eventArgs.height;
+      pmEvent.mediaType = eventArgs.mediaType;
+      pmEvent.netRevenue = eventArgs.netRevenue;
+      pmEvent.cpm = eventArgs.cpm;
+      pmEvent.requestTimestamp = eventArgs.requestTimestamp;
+      pmEvent.responseTimestamp = eventArgs.responseTimestamp;
+      pmEvent.size = eventArgs.size;
+      pmEvent.width = eventArgs.width;
+      pmEvent.currency = eventArgs.currency;
+      pmEvent.bidder = eventArgs.bidder;
+      break;
     }
     case EVENTS.BIDDER_DONE: {
-      pmEvent.auctionId = eventArgs.auctionId
-      pmEvent.auctionStart = eventArgs.auctionStart
-      pmEvent.bidderCode = eventArgs.bidderCode
-      pmEvent.bidderRequestId = eventArgs.bidderRequestId
-      pmEvent.bids = eventArgs.bids && eventArgs.bids.map(trimBid)
-      pmEvent.doneCbCallCount = eventArgs.doneCbCallCount
-      pmEvent.start = eventArgs.start
-      pmEvent.timeout = eventArgs.timeout
-      pmEvent.tid = eventArgs.tid
-      pmEvent.src = eventArgs.src
-      break
+      pmEvent.auctionId = eventArgs.auctionId;
+      pmEvent.auctionStart = eventArgs.auctionStart;
+      pmEvent.bidderCode = eventArgs.bidderCode;
+      pmEvent.bidderRequestId = eventArgs.bidderRequestId;
+      pmEvent.bids = eventArgs.bids && eventArgs.bids.map(trimBid);
+      pmEvent.doneCbCallCount = eventArgs.doneCbCallCount;
+      pmEvent.start = eventArgs.start;
+      pmEvent.timeout = eventArgs.timeout;
+      pmEvent.tid = eventArgs.tid;
+      pmEvent.src = eventArgs.src;
+      break;
     }
     case EVENTS.SET_TARGETING: {
-      break
+      break;
     }
     case EVENTS.REQUEST_BIDS: {
-      break
+      break;
     }
     case EVENTS.AD_RENDER_FAILED: {
-      pmEvent.bid = eventArgs.bid
-      pmEvent.message = eventArgs.message
-      pmEvent.reason = eventArgs.reason
-      break
+      pmEvent.bid = eventArgs.bid;
+      pmEvent.message = eventArgs.message;
+      pmEvent.reason = eventArgs.reason;
+      break;
     }
     default:
-      return
+      return;
   }
 
-  sendEvent(pmEvent)
+  sendEvent(pmEvent);
 }
 
 function sendEvent(event) {
-  eventQueue.push(event)
-  logInfo(`${analyticsName} Event ${event.eventType}:`, event)
+  eventQueue.push(event);
+  logInfo(`${analyticsName} Event ${event.eventType}:`, event);
 
   if (event.eventType === EVENTS.AUCTION_END) {
-    flush()
+    flush();
   }
 }
 
 adapterManager.registerAnalyticsAdapter({
   adapter: asteriobidAnalytics,
   code: 'asteriobid'
-})
+});
 
 asteriobidAnalytics.getOptions = function () {
-  return initOptions
-}
+  return initOptions;
+};
 
-asteriobidAnalytics.flush = flush
+asteriobidAnalytics.flush = flush;
 
-export default asteriobidAnalytics
+export default asteriobidAnalytics;

--- a/modules/automatadAnalyticsAdapter.js
+++ b/modules/automatadAnalyticsAdapter.js
@@ -7,62 +7,62 @@ import {
 import { EVENTS } from '../src/constants.js';
 import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
 import adapterManager from '../src/adapterManager.js';
-import { config } from '../src/config.js'
-import { MODULE_TYPE_ANALYTICS } from '../src/activities/modules.js'
-import { getStorageManager } from '../src/storageManager.js'
+import { config } from '../src/config.js';
+import { MODULE_TYPE_ANALYTICS } from '../src/activities/modules.js';
+import { getStorageManager } from '../src/storageManager.js';
 
 /** Prebid Event Handlers */
 
-const ADAPTER_CODE = 'automatadAnalytics'
-export const storage = getStorageManager({ moduleType: MODULE_TYPE_ANALYTICS, moduleName: ADAPTER_CODE })
+const ADAPTER_CODE = 'automatadAnalytics';
+export const storage = getStorageManager({ moduleType: MODULE_TYPE_ANALYTICS, moduleName: ADAPTER_CODE });
 const trialCountMilsMapping = [1500, 3000, 5000, 10000];
 
 var isLoggingEnabled; var queuePointer = 0; var retryCount = 0; var timer = null; var __atmtdAnalyticsQueue = []; var qBeingUsed; var qTraversalComplete;
 
 const prettyLog = (level, text, isGroup = false, cb = () => {}) => {
   if (self.isLoggingEnabled === undefined) {
-    let loggingFlag = false
+    let loggingFlag = false;
     try {
       if (storage.hasLocalStorage()) {
-        loggingFlag = !!storage.getDataFromLocalStorage('__aggLoggingEnabled')
+        loggingFlag = !!storage.getDataFromLocalStorage('__aggLoggingEnabled');
       }
     } catch (e) {}
     if (loggingFlag) {
-      self.isLoggingEnabled = true
+      self.isLoggingEnabled = true;
     } else {
-      const queryParams = new URLSearchParams(new URL(window.location.href).search)
-      self.isLoggingEnabled = queryParams.has('aggLoggingEnabled')
+      const queryParams = new URLSearchParams(new URL(window.location.href).search);
+      self.isLoggingEnabled = queryParams.has('aggLoggingEnabled');
     }
   }
 
   if (self.isLoggingEnabled) {
     if (isGroup) {
-      logInfo(`ATD Analytics Adapter: ${level.toUpperCase()}: ${text} --- Group Start ---`)
+      logInfo(`ATD Analytics Adapter: ${level.toUpperCase()}: ${text} --- Group Start ---`);
       try {
         cb();
       } catch (error) {
-        logError(`ATD Analytics Adapter: ERROR: ${'Error during cb function in prettyLog'}`)
+        logError(`ATD Analytics Adapter: ERROR: ${'Error during cb function in prettyLog'}`);
       }
-      logInfo(`ATD Analytics Adapter: ${level.toUpperCase()}: ${text} --- Group End ---`)
+      logInfo(`ATD Analytics Adapter: ${level.toUpperCase()}: ${text} --- Group End ---`);
     } else {
-      logInfo(`ATD Analytics Adapter: ${level.toUpperCase()}: ${text}`)
+      logInfo(`ATD Analytics Adapter: ${level.toUpperCase()}: ${text}`);
     }
   }
-}
+};
 
 const processEvents = () => {
   if (self.retryCount === trialCountMilsMapping.length) {
-    self.prettyLog('error', `Aggregator still hasn't loaded. Processing que stopped`, trialCountMilsMapping, self.retryCount)
+    self.prettyLog('error', `Aggregator still hasn't loaded. Processing que stopped`, trialCountMilsMapping, self.retryCount);
     return;
   }
 
-  self.prettyLog('status', `Que has been inactive for a while. Adapter starting to process que now... Trial Count = ${self.retryCount + 1}`)
+  self.prettyLog('status', `Que has been inactive for a while. Adapter starting to process que now... Trial Count = ${self.retryCount + 1}`);
 
-  let shouldTryAgain = false
+  let shouldTryAgain = false;
 
   while (self.queuePointer < self.__atmtdAnalyticsQueue.length) {
-    const eventType = self.__atmtdAnalyticsQueue[self.queuePointer][0]
-    const args = self.__atmtdAnalyticsQueue[self.queuePointer][1]
+    const eventType = self.__atmtdAnalyticsQueue[self.queuePointer][0];
+    const args = self.__atmtdAnalyticsQueue[self.queuePointer][1];
 
     try {
       switch (eventType) {
@@ -70,7 +70,7 @@ const processEvents = () => {
           if (window.atmtdAnalytics && window.atmtdAnalytics.auctionInitHandler) {
             window.atmtdAnalytics.auctionInitHandler(args);
           } else {
-            shouldTryAgain = true
+            shouldTryAgain = true;
           }
           break;
         case EVENTS.BID_REQUESTED:
@@ -117,14 +117,14 @@ const processEvents = () => {
           if (window.atmtdAnalytics && window.atmtdAnalytics.slotRenderEndedGPTHandler) {
             window.atmtdAnalytics.slotRenderEndedGPTHandler(args);
           } else {
-            shouldTryAgain = true
+            shouldTryAgain = true;
           }
           break;
         case 'impressionViewable':
           if (window.atmtdAnalytics && window.atmtdAnalytics.impressionViewableHandler) {
             window.atmtdAnalytics.impressionViewableHandler(args);
           } else {
-            shouldTryAgain = true
+            shouldTryAgain = true;
           }
           break;
       }
@@ -132,50 +132,50 @@ const processEvents = () => {
       if (shouldTryAgain) break;
     } catch (error) {
       self.prettyLog('error', `Unhandled Error while processing ${eventType} of ${self.queuePointer}th index in the que. Will not be retrying this raw event ...`, true, () => {
-        logError(`The error is `, error)
-      })
+        logError(`The error is `, error);
+      });
     }
 
-    self.queuePointer = self.queuePointer + 1
+    self.queuePointer = self.queuePointer + 1;
   }
 
   if (shouldTryAgain) {
     if (trialCountMilsMapping[self.retryCount]) self.prettyLog('warn', `Adapter failed to process event as aggregator has not loaded. Retrying in ${trialCountMilsMapping[self.retryCount]}ms ...`);
-    setTimeout(self.processEvents, trialCountMilsMapping[self.retryCount])
-    self.retryCount = self.retryCount + 1
+    setTimeout(self.processEvents, trialCountMilsMapping[self.retryCount]);
+    self.retryCount = self.retryCount + 1;
   } else {
-    self.qBeingUsed = false
-    self.qTraversalComplete = true
+    self.qBeingUsed = false;
+    self.qTraversalComplete = true;
   }
-}
+};
 
 const addGPTHandlers = () => {
-  const googletag = window.googletag || {}
-  googletag.cmd = googletag.cmd || []
+  const googletag = window.googletag || {};
+  googletag.cmd = googletag.cmd || [];
   googletag.cmd.push(() => {
     googletag.pubads().addEventListener('slotRenderEnded', (event) => {
       if (window.atmtdAnalytics && window.atmtdAnalytics.slotRenderEndedGPTHandler && !self.qBeingUsed) {
-        window.atmtdAnalytics.slotRenderEndedGPTHandler(event)
+        window.atmtdAnalytics.slotRenderEndedGPTHandler(event);
         return;
       }
-      self.__atmtdAnalyticsQueue.push(['slotRenderEnded', event])
-      self.prettyLog(`warn`, `Aggregator not initialised at auctionInit, exiting slotRenderEnded handler and pushing to que instead`)
-    })
+      self.__atmtdAnalyticsQueue.push(['slotRenderEnded', event]);
+      self.prettyLog(`warn`, `Aggregator not initialised at auctionInit, exiting slotRenderEnded handler and pushing to que instead`);
+    });
 
     googletag.pubads().addEventListener('impressionViewable', (event) => {
       if (window.atmtdAnalytics && window.atmtdAnalytics.impressionViewableHandler && !self.qBeingUsed) {
-        window.atmtdAnalytics.impressionViewableHandler(event)
+        window.atmtdAnalytics.impressionViewableHandler(event);
         return;
       }
-      self.__atmtdAnalyticsQueue.push(['impressionViewable', event])
-      self.prettyLog(`warn`, `Aggregator not initialised at auctionInit, exiting impressionViewable handler and pushing to que instead`)
-    })
-  })
-}
+      self.__atmtdAnalyticsQueue.push(['impressionViewable', event]);
+      self.prettyLog(`warn`, `Aggregator not initialised at auctionInit, exiting impressionViewable handler and pushing to que instead`);
+    });
+  });
+};
 
 const initializeQueue = () => {
   self.__atmtdAnalyticsQueue.push = (args) => {
-    self.qBeingUsed = true
+    self.qBeingUsed = true;
     Array.prototype.push.apply(self.__atmtdAnalyticsQueue, [args]);
     if (timer) {
       clearTimeout(timer);
@@ -183,17 +183,17 @@ const initializeQueue = () => {
     }
 
     if (args[0] === EVENTS.AUCTION_INIT) {
-      const timeout = parseInt(config.getConfig('bidderTimeout')) + 1500
+      const timeout = parseInt(config.getConfig('bidderTimeout')) + 1500;
       timer = setTimeout(() => {
-        self.processEvents()
+        self.processEvents();
       }, timeout);
     } else {
       timer = setTimeout(() => {
-        self.processEvents()
+        self.processEvents();
       }, 1500);
     }
   };
-}
+};
 
 // ANALYTICS ADAPTER
 
@@ -205,7 +205,7 @@ const atmtdAdapter = Object.assign({}, baseAdapter, {
   },
 
   track({ eventType, args }) {
-    const shouldNotPushToQueue = !self.qBeingUsed
+    const shouldNotPushToQueue = !self.qBeingUsed;
     switch (eventType) {
       case EVENTS.AUCTION_INIT:
         if (window.atmtdAnalytics && window.atmtdAnalytics.auctionInitHandler && shouldNotPushToQueue) {
@@ -213,7 +213,7 @@ const atmtdAdapter = Object.assign({}, baseAdapter, {
           window.atmtdAnalytics.auctionInitHandler(args);
         } else {
           self.prettyLog('warn', 'Aggregator not loaded, initialising auction through que ...');
-          self.__atmtdAnalyticsQueue.push([eventType, args])
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
         }
         break;
       case EVENTS.BID_REQUESTED:
@@ -221,7 +221,7 @@ const atmtdAdapter = Object.assign({}, baseAdapter, {
           window.atmtdAnalytics.bidRequestedHandler(args);
         } else {
           self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
-          self.__atmtdAnalyticsQueue.push([eventType, args])
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
         }
         break;
       case EVENTS.BID_REJECTED:
@@ -229,7 +229,7 @@ const atmtdAdapter = Object.assign({}, baseAdapter, {
           window.atmtdAnalytics.bidRejectedHandler(args);
         } else {
           self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
-          self.__atmtdAnalyticsQueue.push([eventType, args])
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
         }
         break;
       case EVENTS.BID_RESPONSE:
@@ -237,7 +237,7 @@ const atmtdAdapter = Object.assign({}, baseAdapter, {
           window.atmtdAnalytics.bidResponseHandler(args);
         } else {
           self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
-          self.__atmtdAnalyticsQueue.push([eventType, args])
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
         }
         break;
       case EVENTS.BIDDER_DONE:
@@ -245,7 +245,7 @@ const atmtdAdapter = Object.assign({}, baseAdapter, {
           window.atmtdAnalytics.bidderDoneHandler(args);
         } else {
           self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
-          self.__atmtdAnalyticsQueue.push([eventType, args])
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
         }
         break;
       case EVENTS.BID_WON:
@@ -253,7 +253,7 @@ const atmtdAdapter = Object.assign({}, baseAdapter, {
           window.atmtdAnalytics.bidWonHandler(args);
         } else {
           self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
-          self.__atmtdAnalyticsQueue.push([eventType, args])
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
         }
         break;
       case EVENTS.NO_BID:
@@ -261,7 +261,7 @@ const atmtdAdapter = Object.assign({}, baseAdapter, {
           window.atmtdAnalytics.noBidHandler(args);
         } else {
           self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
-          self.__atmtdAnalyticsQueue.push([eventType, args])
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
         }
         break;
       case EVENTS.AUCTION_DEBUG:
@@ -269,7 +269,7 @@ const atmtdAdapter = Object.assign({}, baseAdapter, {
           window.atmtdAnalytics.auctionDebugHandler(args);
         } else {
           self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
-          self.__atmtdAnalyticsQueue.push([eventType, args])
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
         }
         break;
       case EVENTS.BID_TIMEOUT:
@@ -277,14 +277,14 @@ const atmtdAdapter = Object.assign({}, baseAdapter, {
           window.atmtdAnalytics.bidderTimeoutHandler(args);
         } else {
           self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
-          self.__atmtdAnalyticsQueue.push([eventType, args])
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
         }
         break;
     }
   }
 });
 
-atmtdAdapter.originEnableAnalytics = atmtdAdapter.enableAnalytics
+atmtdAdapter.originEnableAnalytics = atmtdAdapter.enableAnalytics;
 
 atmtdAdapter.enableAnalytics = function (configuration) {
   if ((configuration === undefined && typeof configuration !== 'object') || configuration.options === undefined) {
@@ -292,25 +292,25 @@ atmtdAdapter.enableAnalytics = function (configuration) {
     return;
   }
 
-  const conf = configuration.options
+  const conf = configuration.options;
 
   if (conf === undefined || typeof conf !== 'object' || conf.siteID === undefined || conf.publisherID === undefined) {
     logError('A valid publisher ID and siteID must be passed to the Atmtd Analytics Adapter.');
     return;
   }
 
-  self.initializeQueue()
-  self.addGPTHandlers()
+  self.initializeQueue();
+  self.addGPTHandlers();
 
   window.__atmtdSDKConfig = {
     publisherID: conf.publisherID,
     siteID: conf.siteID,
     collectDebugMessages: conf.logDebug ? conf.logDebug : false
-  }
+  };
 
-  logMessage(`Automatad Analytics Adapter enabled with sdk config`, window.__atmtdSDKConfig)
+  logMessage(`Automatad Analytics Adapter enabled with sdk config`, window.__atmtdSDKConfig);
 
-  atmtdAdapter.originEnableAnalytics(configuration)
+  atmtdAdapter.originEnableAnalytics(configuration);
 };
 
 /// /////////// ADAPTER REGISTRATION /////////////
@@ -331,12 +331,12 @@ export var self = {
   isLoggingEnabled,
   qBeingUsed,
   qTraversalComplete
-}
+};
 
 window.__atmtdAnalyticsGlobalObject = {
   q: self.__atmtdAnalyticsQueue,
   qBeingUsed: self.qBeingUsed,
   qTraversalComplete: self.qTraversalComplete
-}
+};
 
 export default atmtdAdapter;

--- a/modules/byDataAnalyticsAdapter.js
+++ b/modules/byDataAnalyticsAdapter.js
@@ -13,28 +13,28 @@ import { getViewportSize } from '../libraries/viewport/viewport.js';
 import { getOsBrowserInfo } from '../libraries/userAgentUtils/detailed.js';
 import { getTimeZone } from '../libraries/timezone/timezone.js';
 
-const versionCode = '4.4.1'
-const secretKey = 'bydata@123456'
-const { NO_BID, BID_TIMEOUT, AUCTION_END, AUCTION_INIT, BID_WON } = EVENTS
-const DEFAULT_EVENT_URL = 'https://pbjs-stream.bydata.com/topics/prebid'
-const analyticsType = 'endpoint'
-const isBydata = isKeyInUrl('bydata_debug')
-const adunitsMap = {}
+const versionCode = '4.4.1';
+const secretKey = 'bydata@123456';
+const { NO_BID, BID_TIMEOUT, AUCTION_END, AUCTION_INIT, BID_WON } = EVENTS;
+const DEFAULT_EVENT_URL = 'https://pbjs-stream.bydata.com/topics/prebid';
+const analyticsType = 'endpoint';
+const isBydata = isKeyInUrl('bydata_debug');
+const adunitsMap = {};
 const MODULE_CODE = 'bydata';
 const storage = getStorageManager({ moduleType: MODULE_TYPE_ANALYTICS, moduleName: MODULE_CODE });
 
-let initOptions = {}
-var payload = {}
-var winPayload = {}
-var isDataSend = window.asc_data || false
-var bdNbTo = { 'to': [], 'nb': [] }
+let initOptions = {};
+var payload = {};
+var winPayload = {};
+var isDataSend = window.asc_data || false;
+var bdNbTo = { 'to': [], 'nb': [] };
 
 /* method used for testing parameters */
 function isKeyInUrl(name) {
   const queryString = window.location.search;
   const urlParams = new URLSearchParams(queryString);
-  const param = urlParams.get(name)
-  return param
+  const param = urlParams.get(name);
+  return param;
 }
 
 /* return ad unit full path wrt custom ad unit code */
@@ -50,31 +50,31 @@ function getAdunitName(code) {
 function onAuctionStart(t) {
   /* map of ad unit code - ad unit full path */
   t.adUnits && t.adUnits.length && t.adUnits.forEach((adu) => {
-    const { code, adunit } = adu
-    adunitsMap[code] = adunit
+    const { code, adunit } = adu;
+    adunitsMap[code] = adunit;
   });
 }
 
 /* EVENT: bid timeout */
 function onBidTimeout(t) {
   if (payload['visitor_data'] && t && t.length > 0) {
-    bdNbTo['to'] = t
+    bdNbTo['to'] = t;
   }
 }
 
 /* EVENT: no bid */
 function onNoBidData(t) {
   if (payload['visitor_data'] && t) {
-    bdNbTo['nb'].push(t)
+    bdNbTo['nb'].push(t);
   }
 }
 
 /* EVENT: bid won */
 function onBidWon(t) {
-  const { isCorrectOption } = initOptions
+  const { isCorrectOption } = initOptions;
   if (isCorrectOption && (isDataSend || isBydata)) {
-    ascAdapter.getBidWonData(t)
-    ascAdapter.sendPayload(winPayload)
+    ascAdapter.getBidWonData(t);
+    ascAdapter.sendPayload(winPayload);
   }
 }
 
@@ -141,31 +141,31 @@ ascAdapter.initConfig = function (config) {
 };
 
 ascAdapter.getBidWonData = function(t) {
-  const { auctionId, adUnitCode, size, requestId, bidder, timeToRespond, currency, mediaType, cpm } = t
-  const aun = getAdunitName(adUnitCode)
-  winPayload['aid'] = auctionId
+  const { auctionId, adUnitCode, size, requestId, bidder, timeToRespond, currency, mediaType, cpm } = t;
+  const aun = getAdunitName(adUnitCode);
+  winPayload['aid'] = auctionId;
   winPayload['as'] = '';
   winPayload['auctionData'] = [];
-  var data = {}
-  data['au'] = aun
-  data['auc'] = adUnitCode
-  data['aus'] = size
-  data['bid'] = requestId
-  data['bidadv'] = bidder
-  data['br_pb_mg'] = cpm
-  data['br_tr'] = timeToRespond
-  data['bradv'] = bidder
-  data['brid'] = requestId
-  data['brs'] = size
-  data['cur'] = currency
-  data['inb'] = 0
-  data['ito'] = 0
-  data['ipwb'] = 1
-  data['iwb'] = 1
-  data['mt'] = mediaType
-  winPayload['auctionData'].push(data)
-  return winPayload
-}
+  var data = {};
+  data['au'] = aun;
+  data['auc'] = adUnitCode;
+  data['aus'] = size;
+  data['bid'] = requestId;
+  data['bidadv'] = bidder;
+  data['br_pb_mg'] = cpm;
+  data['br_tr'] = timeToRespond;
+  data['bradv'] = bidder;
+  data['brid'] = requestId;
+  data['brs'] = size;
+  data['cur'] = currency;
+  data['inb'] = 0;
+  data['ito'] = 0;
+  data['ipwb'] = 1;
+  data['iwb'] = 1;
+  data['mt'] = mediaType;
+  winPayload['auctionData'].push(data);
+  return winPayload;
+};
 
 ascAdapter.getVisitorData = function (data = {}) {
   var ua = data.uid ? data : {};
@@ -241,7 +241,7 @@ ascAdapter.getVisitorData = function (data = {}) {
   payload['visitor_data'] = signedToken;
   winPayload['visitor_data'] = signedToken;
   return signedToken;
-}
+};
 
 ascAdapter.dataProcess = function (t) {
   if (isBydata) { payload['bydata_debug'] = 'true'; }
@@ -262,7 +262,7 @@ ascAdapter.dataProcess = function (t) {
       var mt = bid.mediaTypes.banner ? 'display' : 'video';
       data['mediaTypes'].push(mt);
       pObj['bids'].push(data);
-    })
+    });
     bidderRequestsData.push(pObj);
   });
   t.bidsReceived && t.bidsReceived.forEach(bid => {
@@ -274,7 +274,7 @@ ascAdapter.dataProcess = function (t) {
     bdsArray.forEach(bid => {
       const { adUnitCode, sizes, bidder, bidId, mediaTypes } = bid;
       sizes.forEach(size => {
-        var sstr = size[0] + 'x' + size[1]
+        var sstr = size[0] + 'x' + size[1];
         payload['auctionData'].push({ au: getAdunitName(adUnitCode), auc: adUnitCode, aus: sstr, mt: mediaTypes[0], bidadv: bidder, bid: bidId, inb: 0, ito: 0, ipwb: 0, iwb: 0 });
       });
     });
@@ -297,7 +297,7 @@ ascAdapter.dataProcess = function (t) {
         rwData['ipwb'] = 1;
       }
     });
-  })
+  });
 
   var winningBids = auctionManager.getAllWinningBids();
   winningBids && winningBids.length > 0 && winningBids.forEach(wBid => {
@@ -306,7 +306,7 @@ ascAdapter.dataProcess = function (t) {
         rwData['iwb'] = 1;
       }
     });
-  })
+  });
 
   payload['auctionData'] && payload['auctionData'].length > 0 && payload['auctionData'].forEach(u => {
     bdNbTo['to'].forEach(i => {
@@ -314,16 +314,16 @@ ascAdapter.dataProcess = function (t) {
     });
     bdNbTo['nb'].forEach(i => {
       if (u.bidadv === i.bidder && u.bid === i.bidId) { u.inb = 1; }
-    })
+    });
   });
   return payload;
-}
+};
 
 ascAdapter.sendPayload = function (data) {
   var obj = { 'records': [{ 'value': data }] };
   const strJSON = JSON.stringify(obj);
   sendDataOnKf(strJSON);
-}
+};
 
 function sendDataOnKf(dataObj) {
   ajax(DEFAULT_EVENT_URL, {

--- a/modules/ccxBidAdapter.js
+++ b/modules/ccxBidAdapter.js
@@ -2,109 +2,109 @@ import { _each, deepAccess, isArray, isEmpty, logWarn } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { getStorageManager } from '../src/storageManager.js';
 
-const BIDDER_CODE = 'ccx'
+const BIDDER_CODE = 'ccx';
 const storage = getStorageManager({ bidderCode: BIDDER_CODE });
-const BID_URL = 'https://delivery.clickonometrics.pl/ortb/prebid/bid'
-const SUPPORTED_VIDEO_PROTOCOLS = [2, 3, 5, 6]
-const SUPPORTED_VIDEO_MIMES = ['video/mp4', 'video/x-flv']
-const SUPPORTED_VIDEO_PLAYBACK_METHODS = [1, 2, 3, 4]
+const BID_URL = 'https://delivery.clickonometrics.pl/ortb/prebid/bid';
+const SUPPORTED_VIDEO_PROTOCOLS = [2, 3, 5, 6];
+const SUPPORTED_VIDEO_MIMES = ['video/mp4', 'video/x-flv'];
+const SUPPORTED_VIDEO_PLAYBACK_METHODS = [1, 2, 3, 4];
 
 function _getDeviceObj () {
-  const device = {}
-  device.w = screen.width
-  device.y = screen.height
-  device.ua = navigator.userAgent
-  return device
+  const device = {};
+  device.w = screen.width;
+  device.y = screen.height;
+  device.ua = navigator.userAgent;
+  return device;
 }
 
 function _getSiteObj (bidderRequest) {
-  const site = {}
-  let url = bidderRequest?.refererInfo?.page || ''
+  const site = {};
+  let url = bidderRequest?.refererInfo?.page || '';
   if (url.length > 0) {
-    url = url.split('?')[0]
+    url = url.split('?')[0];
   }
-  site.page = url
+  site.page = url;
 
-  return site
+  return site;
 }
 
 function _validateSizes (sizeObj, type) {
   if (!isArray(sizeObj) || typeof sizeObj[0] === 'undefined') {
-    return false
+    return false;
   }
 
   if (type === 'video' && (!isArray(sizeObj[0]) || sizeObj[0].length !== 2)) {
-    return false
+    return false;
   }
 
-  let result = true
+  let result = true;
 
   if (type === 'banner') {
     _each(sizeObj, function (size) {
       if (!isArray(size) || (size.length !== 2)) {
-        result = false
+        result = false;
       }
-    })
-    return result
+    });
+    return result;
   }
 
   if (type === 'old') {
     if (!isArray(sizeObj[0]) && sizeObj.length !== 2) {
-      result = false
+      result = false;
     } else if (isArray(sizeObj[0])) {
       _each(sizeObj, function (size) {
         if (!isArray(size) || (size.length !== 2)) {
-          result = false
+          result = false;
         }
-      })
+      });
     }
     return result;
   }
 
-  return true
+  return true;
 }
 
 function _buildBid (bid, bidderRequest) {
-  const placement = {}
-  placement.id = bid.bidId
-  placement.secure = 1
+  const placement = {};
+  placement.id = bid.bidId;
+  placement.secure = 1;
 
-  const sizes = deepAccess(bid, 'mediaTypes.banner.sizes') || deepAccess(bid, 'mediaTypes.video.playerSize') || deepAccess(bid, 'sizes')
+  const sizes = deepAccess(bid, 'mediaTypes.banner.sizes') || deepAccess(bid, 'mediaTypes.video.playerSize') || deepAccess(bid, 'sizes');
 
   if (deepAccess(bid, 'mediaTypes.banner') || deepAccess(bid, 'mediaType') === 'banner' || (!deepAccess(bid, 'mediaTypes.video') && !deepAccess(bid, 'mediaType'))) {
-    placement.banner = { 'format': [] }
+    placement.banner = { 'format': [] };
     if (isArray(sizes[0])) {
       _each(sizes, function (size) {
-        placement.banner.format.push({ 'w': size[0], 'h': size[1] })
-      })
+        placement.banner.format.push({ 'w': size[0], 'h': size[1] });
+      });
     } else {
-      placement.banner.format.push({ 'w': sizes[0], 'h': sizes[1] })
+      placement.banner.format.push({ 'w': sizes[0], 'h': sizes[1] });
     }
   } else if (deepAccess(bid, 'mediaTypes.video') || deepAccess(bid, 'mediaType') === 'video') {
-    placement.video = {}
+    placement.video = {};
 
     if (typeof sizes !== 'undefined') {
       if (isArray(sizes[0])) {
-        placement.video.w = sizes[0][0]
-        placement.video.h = sizes[0][1]
+        placement.video.w = sizes[0][0];
+        placement.video.h = sizes[0][1];
       } else {
-        placement.video.w = sizes[0]
-        placement.video.h = sizes[1]
+        placement.video.w = sizes[0];
+        placement.video.h = sizes[1];
       }
     }
 
-    placement.video.protocols = deepAccess(bid, 'mediaTypes.video.protocols') || deepAccess(bid, 'params.video.protocols') || SUPPORTED_VIDEO_PROTOCOLS
-    placement.video.mimes = deepAccess(bid, 'mediaTypes.video.mimes') || deepAccess(bid, 'params.video.mimes') || SUPPORTED_VIDEO_MIMES
-    placement.video.playbackmethod = deepAccess(bid, 'mediaTypes.video.playbackmethod') || deepAccess(bid, 'params.video.playbackmethod') || SUPPORTED_VIDEO_PLAYBACK_METHODS
-    placement.video.skip = deepAccess(bid, 'mediaTypes.video.skip') || deepAccess(bid, 'params.video.skip') || 0
+    placement.video.protocols = deepAccess(bid, 'mediaTypes.video.protocols') || deepAccess(bid, 'params.video.protocols') || SUPPORTED_VIDEO_PROTOCOLS;
+    placement.video.mimes = deepAccess(bid, 'mediaTypes.video.mimes') || deepAccess(bid, 'params.video.mimes') || SUPPORTED_VIDEO_MIMES;
+    placement.video.playbackmethod = deepAccess(bid, 'mediaTypes.video.playbackmethod') || deepAccess(bid, 'params.video.playbackmethod') || SUPPORTED_VIDEO_PLAYBACK_METHODS;
+    placement.video.skip = deepAccess(bid, 'mediaTypes.video.skip') || deepAccess(bid, 'params.video.skip') || 0;
     if (placement.video.skip === 1 && (deepAccess(bid, 'mediaTypes.video.skipafter') || deepAccess(bid, 'params.video.skipafter'))) {
-      placement.video.skipafter = deepAccess(bid, 'mediaTypes.video.skipafter') || deepAccess(bid, 'params.video.skipafter')
+      placement.video.skipafter = deepAccess(bid, 'mediaTypes.video.skipafter') || deepAccess(bid, 'params.video.skipafter');
     }
   }
 
-  placement.ext = { 'pid': bid.params.placementId }
+  placement.ext = { 'pid': bid.params.placementId };
 
-  return placement
+  return placement;
 }
 
 function _buildResponse (bid, currency, ttl) {
@@ -117,7 +117,7 @@ function _buildResponse (bid, currency, ttl) {
     netRevenue: false,
     ttl: ttl,
     currency: currency
-  }
+  };
 
   resp.meta = {};
   if (bid.adomain && bid.adomain.length > 0) {
@@ -125,16 +125,16 @@ function _buildResponse (bid, currency, ttl) {
   }
 
   if (bid.ext.type === 'video') {
-    resp.vastXml = bid.adm
+    resp.vastXml = bid.adm;
   } else {
-    resp.ad = bid.adm
+    resp.ad = bid.adm;
   }
 
   if (deepAccess(bid, 'dealid')) {
-    resp.dealId = bid.dealid
+    resp.dealId = bid.dealid;
   }
 
-  return resp
+  return resp;
 }
 
 export const spec = {
@@ -143,41 +143,41 @@ export const spec = {
 
   isBidRequestValid: function (bid) {
     if (!deepAccess(bid, 'params.placementId')) {
-      logWarn('placementId param is required.')
-      return false
+      logWarn('placementId param is required.');
+      return false;
     }
     if (deepAccess(bid, 'mediaTypes.banner.sizes')) {
-      const isValid = _validateSizes(bid.mediaTypes.banner.sizes, 'banner')
+      const isValid = _validateSizes(bid.mediaTypes.banner.sizes, 'banner');
       if (!isValid) {
-        logWarn('Bid sizes are invalid.')
+        logWarn('Bid sizes are invalid.');
       }
-      return isValid
+      return isValid;
     } else if (deepAccess(bid, 'mediaTypes.video.playerSize')) {
-      const isValid = _validateSizes(bid.mediaTypes.video.playerSize, 'video')
+      const isValid = _validateSizes(bid.mediaTypes.video.playerSize, 'video');
       if (!isValid) {
-        logWarn('Bid sizes are invalid.')
+        logWarn('Bid sizes are invalid.');
       }
-      return isValid
+      return isValid;
     } else if (deepAccess(bid, 'sizes')) {
-      const isValid = _validateSizes(bid.sizes, 'old')
+      const isValid = _validateSizes(bid.sizes, 'old');
       if (!isValid) {
-        logWarn('Bid sizes are invalid.')
+        logWarn('Bid sizes are invalid.');
       }
-      return isValid
+      return isValid;
     } else {
-      logWarn('Bid sizes are required.')
-      return false
+      logWarn('Bid sizes are required.');
+      return false;
     }
   },
   buildRequests: function (validBidRequests, bidderRequest) {
     // check if validBidRequests is not empty
     if (validBidRequests.length > 0) {
-      const requestBody = {}
-      requestBody.imp = []
-      requestBody.site = _getSiteObj(bidderRequest)
-      requestBody.device = _getDeviceObj()
+      const requestBody = {};
+      requestBody.imp = [];
+      requestBody.site = _getSiteObj(bidderRequest);
+      requestBody.device = _getDeviceObj();
       requestBody.id = bidderRequest.bidderRequestId;
-      requestBody.ext = { 'ce': (storage.cookiesAreEnabled() ? 1 : 0) }
+      requestBody.ext = { 'ce': (storage.cookiesAreEnabled() ? 1 : 0) };
 
       // Attaching GDPR Consent Params
       if (bidderRequest && bidderRequest.gdprConsent) {
@@ -195,32 +195,32 @@ export const spec = {
       }
 
       _each(validBidRequests, function (bid) {
-        requestBody.imp.push(_buildBid(bid, bidderRequest))
-      })
+        requestBody.imp.push(_buildBid(bid, bidderRequest));
+      });
       // Return the server request
       return {
         'method': 'POST',
         'url': BID_URL,
         'data': JSON.stringify(requestBody)
-      }
+      };
     }
   },
   interpretResponse: function (serverResponse, request) {
-    const bidResponses = []
+    const bidResponses = [];
 
     // response is not empty (HTTP 204)
     if (!isEmpty(serverResponse.body)) {
       _each(serverResponse.body.seatbid, function (seatbid) {
         _each(seatbid.bid, function (bid) {
-          bidResponses.push(_buildResponse(bid, serverResponse.body.cur, serverResponse.body.ext.ttl))
-        })
-      })
+          bidResponses.push(_buildResponse(bid, serverResponse.body.cur, serverResponse.body.ext.ttl));
+        });
+      });
     }
 
-    return bidResponses
+    return bidResponses;
   },
   getUserSyncs: function (syncOptions, serverResponses) {
-    const syncs = []
+    const syncs = [];
 
     if (deepAccess(serverResponses[0], 'body.ext.usersync') && !isEmpty(serverResponses[0].body.ext.usersync)) {
       _each(serverResponses[0].body.ext.usersync, function (match) {
@@ -228,12 +228,12 @@ export const spec = {
           syncs.push({
             type: match.type,
             url: match.url
-          })
+          });
         }
-      })
+      });
     }
 
-    return syncs
+    return syncs;
   }
-}
-registerBidder(spec)
+};
+registerBidder(spec);

--- a/modules/intentIqIdSystem.js
+++ b/modules/intentIqIdSystem.js
@@ -97,7 +97,7 @@ function appendFirstPartyData(url, firstPartyData, partnerData) {
   url += firstPartyData.pid ? '&pid=' + encodeURIComponent(firstPartyData.pid) : '';
   url += firstPartyData.pcid ? '&iiqidtype=2&iiqpcid=' + encodeURIComponent(firstPartyData.pcid) : '';
   url += firstPartyData.pcidDate ? '&iiqpciddate=' + encodeURIComponent(firstPartyData.pcidDate) : '';
-  return url
+  return url;
 }
 
 function verifyIdType(value) {
@@ -127,14 +127,14 @@ function appendCMPData(url, cmpData) {
   } else {
     url += '&gdpr=0';
   }
-  return url
+  return url;
 }
 
 function appendCounters(url) {
   url += '&jaesc=' + encodeURIComponent(callCount);
   url += '&jafc=' + encodeURIComponent(failCount);
   url += '&jaensc=' + encodeURIComponent(noDataCount);
-  return url
+  return url;
 }
 
 /**
@@ -164,11 +164,11 @@ function addMetaData(url, data) {
 
 export function initializeGlobalIIQ(partnerId) {
   if (!globalName || !window[globalName]) {
-    globalName = `iiq_identity_${partnerId}`
-    window[globalName] = {}
-    return true
+    globalName = `iiq_identity_${partnerId}`;
+    window[globalName] = {};
+    return true;
   }
-  return false
+  return false;
 }
 
 export function createPixelUrl(firstPartyData, clientHints, configParams, partnerData, cmpData) {
@@ -199,15 +199,15 @@ export function createPixelUrl(firstPartyData, clientHints, configParams, partne
 
 function sendSyncRequest(allowedStorage, url, partner, firstPartyData, newUser) {
   const lastSyncDate = Number(readData(SYNC_KEY(partner) || '', allowedStorage)) || false;
-  const lastSyncElapsedTime = Date.now() - lastSyncDate
+  const lastSyncElapsedTime = Date.now() - lastSyncDate;
 
   if (firstPartyData.isOptedOut) {
-    const needToDoSync = (Date.now() - (firstPartyData?.date || firstPartyData?.sCal || Date.now())) > SYNC_REFRESH_MILL
+    const needToDoSync = (Date.now() - (firstPartyData?.date || firstPartyData?.sCal || Date.now())) > SYNC_REFRESH_MILL;
     if (newUser || needToDoSync) {
       ajax(url, () => {
       }, undefined, { method: 'GET', withCredentials: true });
       if (firstPartyData?.date) {
-        firstPartyData.date = Date.now()
+        firstPartyData.date = Date.now();
         storeData(FIRST_PARTY_KEY_FINAL, JSON.stringify(firstPartyData), allowedStorage, firstPartyData);
       }
     }
@@ -322,16 +322,16 @@ export const intentIqIdSubmodule = {
         if (data?.eids?.length === 1 && typeof data.eids[0] === 'string') data = data.eids[0];
         configParams.callback(data);
       }
-      updateGlobalObj()
-    }
+      updateGlobalObj();
+    };
 
     if (typeof configParams.partner !== 'number') {
       logError('User ID - intentIqId submodule requires a valid partner to be defined');
-      firePartnerCallback()
+      firePartnerCallback();
       return;
     }
 
-    initializeGlobalIIQ(configParams.partner)
+    initializeGlobalIIQ(configParams.partner);
 
     let decryptedData, callbackTimeoutID;
     let callbackFired = false;
@@ -412,7 +412,7 @@ export const intentIqIdSubmodule = {
           logError('CH fetch failed', err);
           if (clientHints !== '') {
             clientHints = '';
-            removeDataByKey(CLIENT_HINTS_KEY, allowedStorage)
+            removeDataByKey(CLIENT_HINTS_KEY, allowedStorage);
           }
           return '';
         });
@@ -425,7 +425,7 @@ export const intentIqIdSubmodule = {
       });
     } else {
       clientHints = '';
-      removeDataByKey(CLIENT_HINTS_KEY, allowedStorage)
+      removeDataByKey(CLIENT_HINTS_KEY, allowedStorage);
     }
 
     function waitOnCH(timeoutMs) {
@@ -450,16 +450,16 @@ export const intentIqIdSubmodule = {
 
     function updateGlobalObj() {
       if (globalName) {
-        window[globalName].partnerData = partnerData
-        window[globalName].firstPartyData = firstPartyData
-        window[globalName].clientHints = clientHints
-        window[globalName].actualABGroup = actualABGroup
-        window[globalName].abPercentage = getEffectiveAbPercentage(configParams.abPercentage)
-        window[globalName].userProvidedAbPercentage = configParams.abPercentage
+        window[globalName].partnerData = partnerData;
+        window[globalName].firstPartyData = firstPartyData;
+        window[globalName].clientHints = clientHints;
+        window[globalName].actualABGroup = actualABGroup;
+        window[globalName].abPercentage = getEffectiveAbPercentage(configParams.abPercentage);
+        window[globalName].userProvidedAbPercentage = configParams.abPercentage;
       }
     }
 
-    const pdLength = Object.keys(partnerData).length
+    const pdLength = Object.keys(partnerData).length;
     const hasPartnerData = pdLength && pdLength > 1; // in OptOut case we keep one property inside
 
     if ((!isCMPStringTheSame(firstPartyData, cmpData)) ||
@@ -480,11 +480,11 @@ export const intentIqIdSubmodule = {
 
     if (firstPartyData.isOptedOut) {
       partnerData.data = runtimeEids = { eids: [] };
-      firePartnerCallback()
+      firePartnerCallback();
     }
 
     if (runtimeEids?.eids?.length) {
-      firePartnerCallback()
+      firePartnerCallback();
     }
 
     function buildAndSendPixel(ch) {
@@ -499,7 +499,7 @@ export const intentIqIdSubmodule = {
 
       if (chSupported) {
         if (clientHints) {
-          buildAndSendPixel(clientHints)
+          buildAndSendPixel(clientHints);
         } else {
           waitOnCH(chTimeout)
             .then(ch => buildAndSendPixel(ch || ''));
@@ -516,7 +516,7 @@ export const intentIqIdSubmodule = {
       return { id: runtimeEids.eids };
     }
 
-    updateGlobalObj() // update global object before server request, to make sure analytical adapter will have it even if the server is "not in time"
+    updateGlobalObj(); // update global object before server request, to make sure analytical adapter will have it even if the server is "not in time"
 
     // use protocol relative urls for http or https
     let url = `${getIiqServerAddress(configParams)}/profiles_engine/ProfilesEngineServlet?at=39&mi=10&dpi=${configParams.partner}&pt=17&dpn=1`;
@@ -535,19 +535,19 @@ export const intentIqIdSubmodule = {
       url += '&testPercentage=' + encodeURIComponent(getEffectiveAbPercentage(configParams.abPercentage));
     }
     url = handleAdditionalParams(currentBrowserLowerCase, url, 1, additionalParams);
-    url = appendSPData(url, partnerData)
+    url = appendSPData(url, partnerData);
     url += '&source=' + PREBID;
-    url += '&ABTestingConfigurationSource=' + configParams.ABTestingConfigurationSource
-    url += '&abtg=' + encodeURIComponent(actualABGroup)
+    url += '&ABTestingConfigurationSource=' + configParams.ABTestingConfigurationSource;
+    url += '&abtg=' + encodeURIComponent(actualABGroup);
 
     // Add vrref and fui to the URL
     url = appendVrrefAndFui(url, configParams.domainName);
 
     const storeFirstPartyData = () => {
-      partnerData.eidl = runtimeEids?.eids?.length || -1
+      partnerData.eidl = runtimeEids?.eids?.length || -1;
       storeData(FIRST_PARTY_KEY_FINAL, JSON.stringify(firstPartyData), allowedStorage, firstPartyData);
       storeData(PARTNER_DATA_KEY, JSON.stringify(partnerData), allowedStorage, firstPartyData);
-    }
+    };
 
     const resp = function (callback) {
       const callbacks = {
@@ -562,11 +562,11 @@ export const intentIqIdSubmodule = {
             firstPartyData.sCal = Date.now();
             const defineEmptyDataAndFireCallback = () => {
               respJson.data = partnerData.data = runtimeEids = { eids: [] };
-              storeFirstPartyData()
-              firePartnerCallback()
-              callback(runtimeEids)
-            }
-            if (callbackTimeoutID) clearTimeout(callbackTimeoutID)
+              storeFirstPartyData();
+              firePartnerCallback();
+              callback(runtimeEids);
+            };
+            if (callbackTimeoutID) clearTimeout(callbackTimeoutID);
             if ('cttl' in respJson) {
               partnerData.cttl = respJson.cttl;
             } else partnerData.cttl = HOURS_72;
@@ -593,7 +593,7 @@ export const intentIqIdSubmodule = {
                 storeData(PARTNER_DATA_KEY, JSON.stringify(partnerData), allowedStorage, firstPartyData);
                 firePartnerCallback();
                 callback(runtimeEids);
-                return
+                return;
               }
             }
             if ('pid' in respJson) {
@@ -604,8 +604,8 @@ export const intentIqIdSubmodule = {
             }
             if ('ls' in respJson) {
               if (respJson.ls === false) {
-                defineEmptyDataAndFireCallback()
-                return
+                defineEmptyDataAndFireCallback();
+                return;
               }
               // If data is empty, means we should save as INVALID_ID
               if (respJson.data === '') {
@@ -613,7 +613,7 @@ export const intentIqIdSubmodule = {
               } else {
                 // If data is a single string, assume it is an id with source intentiq.com
                 if (respJson.data && typeof respJson.data === 'string') {
-                  respJson.data = { eids: [respJson.data] }
+                  respJson.data = { eids: [respJson.data] };
                 }
               }
               partnerData.data = respJson.data;
@@ -642,24 +642,24 @@ export const intentIqIdSubmodule = {
               // GAM prediction reporting
               partnerData.gpr = respJson.gpr;
             } else {
-              delete partnerData.gpr // remove prediction flag in case server doesn't provide it
+              delete partnerData.gpr; // remove prediction flag in case server doesn't provide it
             }
 
             if (respJson.data?.eids) {
-              runtimeEids = respJson.data
+              runtimeEids = respJson.data;
               callback(respJson.data.eids);
-              firePartnerCallback()
+              firePartnerCallback();
               const encryptedData = encryptData(JSON.stringify(respJson.data));
               partnerData.data = encryptedData;
             } else {
               callback(runtimeEids);
-              firePartnerCallback()
+              firePartnerCallback();
             }
             updateCountersAndStore(runtimeEids, allowedStorage, partnerData);
             storeFirstPartyData();
           } else {
             callback(runtimeEids);
-            firePartnerCallback()
+            firePartnerCallback();
           }
         },
         error: error => {
@@ -679,7 +679,7 @@ export const intentIqIdSubmodule = {
       const sendAjax = uh => {
         if (uh) url += '&uh=' + encodeURIComponent(uh);
         ajax(url, callbacks, undefined, { method: 'GET', withCredentials: true });
-      }
+      };
 
       if (chSupported) {
         if (clientHints) {
@@ -690,7 +690,7 @@ export const intentIqIdSubmodule = {
           waitOnCH(chTimeout).then(ch => {
             // Send with received CH or without it
             sendAjax(ch || '');
-          })
+          });
         }
       } else {
         // CH not supported: send without uh
@@ -700,7 +700,7 @@ export const intentIqIdSubmodule = {
     const respObj = { callback: resp };
 
     if (runtimeEids?.eids?.length) respObj.id = runtimeEids.eids;
-    return respObj
+    return respObj;
   },
   eids: {
     'intentIqId': {
@@ -711,15 +711,15 @@ export const intentIqIdSubmodule = {
       },
       getValue: function (data) {
         if (data?.uids?.length) {
-          return data.uids[0].id
+          return data.uids[0].id;
         }
-        return null
+        return null;
       },
       getUidExt: function (data) {
         if (data?.uids?.length) {
           return data.uids[0].ext;
         }
-        return null
+        return null;
       }
     },
   }

--- a/modules/justpremiumBidAdapter.js
+++ b/modules/justpremiumBidAdapter.js
@@ -1,10 +1,10 @@
-import { registerBidder } from '../src/adapters/bidderFactory.js'
+import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { deepAccess, getWinDimensions } from '../src/utils.js';
 
-const BIDDER_CODE = 'justpremium'
-const GVLID = 62
-const ENDPOINT_URL = 'https://pre.ads.justpremium.com/v/2.0/t/xhr'
-const JP_ADAPTER_VERSION = '1.8.3'
+const BIDDER_CODE = 'justpremium';
+const GVLID = 62;
+const ENDPOINT_URL = 'https://pre.ads.justpremium.com/v/2.0/t/xhr';
+const JP_ADAPTER_VERSION = '1.8.3';
 
 export const spec = {
   code: BIDDER_CODE,
@@ -12,20 +12,20 @@ export const spec = {
   time: 60000,
 
   isBidRequestValid: (bid) => {
-    return !!(bid && bid.params && bid.params.zone)
+    return !!(bid && bid.params && bid.params.zone);
   },
 
   buildRequests: (validBidRequests, bidderRequest) => {
-    const c = preparePubCond(validBidRequests)
+    const c = preparePubCond(validBidRequests);
     const {
       screen
     } = getWinDimensions();
-    const ggExt = getGumGumParams()
+    const ggExt = getGumGumParams();
     const payload = {
       zone: validBidRequests.map(b => {
-        return parseInt(b.params.zone)
+        return parseInt(b.params.zone);
       }).filter((value, index, self) => {
-        return self.indexOf(value) === index
+        return self.indexOf(value) === index;
       }),
       // TODO: is 'page' the right value here?
       referer: bidderRequest.refererInfo.page,
@@ -37,60 +37,60 @@ export const spec = {
       id: validBidRequests[0].params.zone,
       sizes: {},
       ggExt: ggExt
-    }
+    };
     validBidRequests.forEach(b => {
-      const zone = b.params.zone
-      const sizes = payload.sizes
-      sizes[zone] = sizes[zone] || []
-      sizes[zone].push.apply(sizes[zone], b.mediaTypes && b.mediaTypes.banner && b.mediaTypes.banner.sizes)
-    })
+      const zone = b.params.zone;
+      const sizes = payload.sizes;
+      sizes[zone] = sizes[zone] || [];
+      sizes[zone].push.apply(sizes[zone], b.mediaTypes && b.mediaTypes.banner && b.mediaTypes.banner.sizes);
+    });
 
     if (deepAccess(validBidRequests[0], 'userId.pubcid')) {
-      payload.pubcid = deepAccess(validBidRequests[0], 'userId.pubcid')
+      payload.pubcid = deepAccess(validBidRequests[0], 'userId.pubcid');
     } else if (deepAccess(validBidRequests[0], 'crumbs.pubcid')) {
-      payload.pubcid = deepAccess(validBidRequests[0], 'crumbs.pubcid')
+      payload.pubcid = deepAccess(validBidRequests[0], 'crumbs.pubcid');
     }
 
-    payload.uids = validBidRequests[0].userId
+    payload.uids = validBidRequests[0].userId;
 
     if (bidderRequest && bidderRequest.gdprConsent) {
       payload.gdpr_consent = {
         consent_string: bidderRequest.gdprConsent.consentString,
         consent_required: (typeof bidderRequest.gdprConsent.gdprApplies === 'boolean') ? bidderRequest.gdprConsent.gdprApplies : true
-      }
+      };
     }
 
     if (bidderRequest && bidderRequest.uspConsent) {
-      payload.us_privacy = bidderRequest.uspConsent
+      payload.us_privacy = bidderRequest.uspConsent;
     }
 
     payload.version = {
       prebid: '$prebid.version$',
       jp_adapter: JP_ADAPTER_VERSION
-    }
+    };
 
     const schain = validBidRequests[0]?.ortb2?.source?.ext?.schain;
     if (schain) {
       payload.schain = schain;
     }
 
-    const payloadString = JSON.stringify(payload)
+    const payloadString = JSON.stringify(payload);
 
     return {
       method: 'POST',
       url: ENDPOINT_URL + '?i=' + (+new Date()),
       data: payloadString,
       bids: validBidRequests
-    }
+    };
   },
 
   interpretResponse: (serverResponse, bidRequests) => {
-    const body = serverResponse.body
-    const bidResponses = []
+    const body = serverResponse.body;
+    const bidResponses = [];
     bidRequests.bids.forEach(adUnit => {
-      const bid = findBid(adUnit.params, body.bid)
+      const bid = findBid(adUnit.params, body.bid);
       if (bid) {
-        const size = (adUnit.mediaTypes && adUnit.mediaTypes.banner && adUnit.mediaTypes.banner.sizes && adUnit.mediaTypes.banner.sizes.length && adUnit.mediaTypes.banner.sizes[0]) || []
+        const size = (adUnit.mediaTypes && adUnit.mediaTypes.banner && adUnit.mediaTypes.banner.sizes && adUnit.mediaTypes.banner.sizes.length && adUnit.mediaTypes.banner.sizes[0]) || [];
         const bidResponse = {
           requestId: adUnit.bidId,
           creativeId: bid.id,
@@ -105,163 +105,163 @@ export const spec = {
           meta: {
             advertiserDomains: bid.adomain && bid.adomain.length > 0 ? bid.adomain : []
           }
-        }
+        };
         if (bid.ext && bid.ext.pg) {
           bidResponse.adserverTargeting = {
             'hb_deal_justpremium': 'jp_pg'
-          }
+          };
         }
-        bidResponses.push(bidResponse)
+        bidResponses.push(bidResponse);
       }
-    })
-    return bidResponses
+    });
+    return bidResponses;
   },
 
   getUserSyncs: (syncOptions, serverResponses, gdprConsent, uspConsent) => {
     let url = 'https://pre.ads.justpremium.com/v/1.0/t/sync' + '?_c=' + 'a' + Math.random().toString(36).substring(7) + Date.now();
-    let pixels = []
+    let pixels = [];
 
     if (gdprConsent && (typeof gdprConsent.gdprApplies === 'boolean') && gdprConsent.gdprApplies && gdprConsent.consentString) {
-      url = url + '&consentString=' + encodeURIComponent(gdprConsent.consentString)
+      url = url + '&consentString=' + encodeURIComponent(gdprConsent.consentString);
     }
     if (uspConsent) {
-      url = url + '&usPrivacy=' + encodeURIComponent(uspConsent)
+      url = url + '&usPrivacy=' + encodeURIComponent(uspConsent);
     }
     if (syncOptions.iframeEnabled) {
       pixels.push({
         type: 'iframe',
         url: url
-      })
+      });
     }
     if (syncOptions.pixelEnabled && serverResponses.length !== 0) {
       const pxsFromResponse = serverResponses.map(res => res?.body?.pxs).reduce((acc, cur) => acc.concat(cur), []).filter((obj) => obj !== undefined);
       pixels = [...pixels, ...pxsFromResponse];
     }
-    return pixels
+    return pixels;
   },
-}
+};
 
 function findBid (params, bids) {
-  const tagId = params.zone
+  const tagId = params.zone;
   if (bids[tagId]) {
-    let len = bids[tagId].length
+    let len = bids[tagId].length;
     while (len--) {
       if (passCond(params, bids[tagId][len])) {
-        return bids[tagId].splice(len, 1).pop()
+        return bids[tagId].splice(len, 1).pop();
       }
     }
   }
 
-  return false
+  return false;
 }
 
 function passCond (params, bid) {
-  const format = bid.format
+  const format = bid.format;
 
   if (params.allow && params.allow.length) {
-    return params.allow.indexOf(format) > -1
+    return params.allow.indexOf(format) > -1;
   }
 
   if (params.exclude && params.exclude.length) {
-    return params.exclude.indexOf(format) < 0
+    return params.exclude.indexOf(format) < 0;
   }
 
-  return true
+  return true;
 }
 
 function preparePubCond (bids) {
-  const cond = {}
-  const count = {}
+  const cond = {};
+  const count = {};
 
   bids.forEach((bid) => {
-    const params = bid.params
-    const zone = params.zone
+    const params = bid.params;
+    const zone = params.zone;
 
     if (cond[zone] === 1) {
-      return
+      return;
     }
 
-    const allow = params.allow || params.formats || []
-    const exclude = params.exclude || []
+    const allow = params.allow || params.formats || [];
+    const exclude = params.exclude || [];
 
     if (allow.length === 0 && exclude.length === 0) {
-      cond[params.zone] = 1
-      return cond[params.zone]
+      cond[params.zone] = 1;
+      return cond[params.zone];
     }
 
-    cond[zone] = cond[zone] || [[], {}]
-    cond[zone][0] = arrayUnique(cond[zone][0].concat(allow))
+    cond[zone] = cond[zone] || [[], {}];
+    cond[zone][0] = arrayUnique(cond[zone][0].concat(allow));
     exclude.forEach((e) => {
       if (!cond[zone][1][e]) {
-        cond[zone][1][e] = 1
+        cond[zone][1][e] = 1;
       } else {
-        cond[zone][1][e]++
+        cond[zone][1][e]++;
       }
-    })
+    });
 
-    count[zone] = count[zone] || 0
+    count[zone] = count[zone] || 0;
     if (exclude.length) {
-      count[zone]++
+      count[zone]++;
     }
-  })
+  });
 
   Object.keys(count).forEach((zone) => {
-    if (cond[zone] === 1) return
+    if (cond[zone] === 1) return;
 
-    const exclude = []
+    const exclude = [];
     Object.keys(cond[zone][1]).forEach((format) => {
       if (cond[zone][1][format] === count[zone]) {
-        exclude.push(format)
+        exclude.push(format);
       }
-    })
-    cond[zone][1] = exclude
-  })
+    });
+    cond[zone][1] = exclude;
+  });
 
   Object.keys(cond).forEach((zone) => {
     if (cond[zone] !== 1 && cond[zone][1].length) {
       cond[zone][0].forEach((r) => {
-        const idx = cond[zone][1].indexOf(r)
+        const idx = cond[zone][1].indexOf(r);
         if (idx > -1) {
-          cond[zone][1].splice(idx, 1)
+          cond[zone][1].splice(idx, 1);
         }
-      })
-      cond[zone][0].length = 0
+      });
+      cond[zone][0].length = 0;
     }
 
     if (cond[zone] !== 1 && !cond[zone][0].length && !cond[zone][1].length) {
-      cond[zone] = 1
+      cond[zone] = 1;
     }
-  })
+  });
 
-  return cond
+  return cond;
 }
 
 function arrayUnique (array) {
-  const a = array.concat()
+  const a = array.concat();
   for (let i = 0; i < a.length; ++i) {
     for (let j = i + 1; j < a.length; ++j) {
       if (a[i] === a[j]) {
-        a.splice(j--, 1)
+        a.splice(j--, 1);
       }
     }
   }
 
-  return a
+  return a;
 }
 
 function getGumGumParams () {
-  if (!window.top) return null
+  if (!window.top) return null;
 
-  const urlParams = new URLSearchParams(window.top.location.search)
+  const urlParams = new URLSearchParams(window.top.location.search);
   const ggParams = {
     'ggAdbuyid': urlParams.get('gg_adbuyid'),
     'ggDealid': urlParams.get('gg_dealid'),
     'ggEadbuyid': urlParams.get('gg_eadbuyid')
-  }
+  };
 
-  const checkIfEmpty = (obj) => Object.keys(obj).length === 0 ? null : obj
-  const removeNullEntries = (obj) => Object.fromEntries(Object.entries(obj).filter(([_, v]) => v != null))
-  return checkIfEmpty(removeNullEntries(ggParams))
+  const checkIfEmpty = (obj) => Object.keys(obj).length === 0 ? null : obj;
+  const removeNullEntries = (obj) => Object.fromEntries(Object.entries(obj).filter(([_, v]) => v != null));
+  return checkIfEmpty(removeNullEntries(ggParams));
 }
 
-registerBidder(spec)
+registerBidder(spec);

--- a/modules/magniteAnalyticsAdapter.js
+++ b/modules/magniteAnalyticsAdapter.js
@@ -46,7 +46,7 @@ const pbsErrorMap = {
   3: 'connect-error',
   4: 'request-error',
   999: 'generic-error'
-}
+};
 
 let browser;
 let pageReferer;
@@ -84,7 +84,7 @@ const resetConfs = () => {
     elementIdMap: {},
     sessionData: {},
     bidsCachedClientSide: new WeakSet()
-  }
+  };
   rubiConf = {
     pvid: generateUUID().slice(0, 8),
     analyticsEventDelay: 500,
@@ -95,14 +95,14 @@ const resetConfs = () => {
       vendors: [],
       waitForAuction: true
     }
-  }
-}
+  };
+};
 resetConfs();
 
 config.getConfig('rubicon', config => {
   mergeDeep(rubiConf, config.rubicon);
   if (deepAccess(config, 'rubicon.updatePageView') === true) {
-    rubiConf.pvid = generateUUID().slice(0, 8)
+    rubiConf.pvid = generateUUID().slice(0, 8);
   }
 });
 
@@ -114,14 +114,14 @@ config.getConfig('s2sConfig', ({ s2sConfig }) => {
 
 const adUnitIsOnlyInstream = adUnit => {
   return adUnit.mediaTypes && Object.keys(adUnit.mediaTypes).length === 1 && deepAccess(adUnit, 'mediaTypes.video.context') === 'instream';
-}
+};
 
 const sendPendingEvents = () => {
   cache.pendingEvents.trigger = `batched-${Object.keys(cache.pendingEvents).sort().join('-')}`;
   sendEvent(cache.pendingEvents);
   cache.pendingEvents = {};
   cache.eventPending = false;
-}
+};
 
 const addEventToQueue = (event, auctionId, eventName) => {
   // If it's auction has not left yet, add it there
@@ -141,13 +141,13 @@ const addEventToQueue = (event, auctionId, eventName) => {
     event.trigger = `solo-${eventName}`;
     sendEvent(event);
   }
-}
+};
 
 const sendEvent = payload => {
   const event = {
     ...getTopLevelDetails(),
     ...payload
-  }
+  };
   if (window.pbjs?.rp?.eventDispatcher) {
     const analyticsEvent = new CustomEvent('beforeSendingMagniteAnalytics', { detail: event });
     window.pbjs.rp.eventDispatcher.dispatchEvent(analyticsEvent);
@@ -160,7 +160,7 @@ const sendEvent = payload => {
       contentType: 'application/json'
     }
   );
-}
+};
 
 const sendAuctionEvent = (auctionId, trigger) => {
   const auctionCache = cache.auctions[auctionId];
@@ -172,7 +172,7 @@ const sendAuctionEvent = (auctionId, trigger) => {
     ...(auctionCache.pendingEvents || {}), // if any pending events were attached
     trigger
   });
-}
+};
 
 const formatAuction = auction => {
   const auctionEvent = deepClone(auction);
@@ -199,7 +199,7 @@ const formatAuction = auction => {
     return adUnit;
   });
   return auctionEvent;
-}
+};
 
 const isBillingEventValid = event => {
   // vendor is whitelisted
@@ -208,7 +208,7 @@ const isBillingEventValid = event => {
   const isNotDuplicate = typeof deepAccess(cache.billing, `${event.vendor}.${event.billingId}`) !== 'boolean';
   // billingId is defined and a string
   return typeof event.billingId === 'string' && isWhitelistedVendor && isNotDuplicate;
-}
+};
 
 const formatBillingEvent = event => {
   const billingEvent = deepClone(event);
@@ -218,7 +218,7 @@ const formatBillingEvent = event => {
   // mark as sent
   deepSetValue(cache.billing, `${event.vendor}.${event.billingId}`, true);
   return billingEvent;
-}
+};
 
 const getBidPrice = bid => {
   // get the cpm from bidResponse
@@ -250,11 +250,11 @@ const getBidPrice = bid => {
     bid.ogPrice = cpm;
     return 0;
   }
-}
+};
 
 export const parseBidResponse = (bid, previousBidResponse) => {
   // The current bidResponse for this matching requestId/bidRequestId
-  const responsePrice = getBidPrice(bid)
+  const responsePrice = getBidPrice(bid);
   // we need to compare it with the previous one (if there was one) log highest only
   // THIS WILL CHANGE WITH ALLOWING MULTIBID BETTER
   if (previousBidResponse && previousBidResponse.bidPriceUSD > responsePrice) {
@@ -277,7 +277,7 @@ export const parseBidResponse = (bid, previousBidResponse) => {
     'adomains', () => {
       const adomains = deepAccess(bid, 'meta.advertiserDomains');
       const validAdomains = Array.isArray(adomains) && adomains.filter(domain => typeof domain === 'string');
-      return validAdomains && validAdomains.length > 0 ? validAdomains.slice(0, 10) : undefined
+      return validAdomains && validAdomains.length > 0 ? validAdomains.slice(0, 10) : undefined;
     },
     'networkId', () => {
       const networkId = deepAccess(bid, 'meta.networkId');
@@ -289,7 +289,7 @@ export const parseBidResponse = (bid, previousBidResponse) => {
     'ogPrice',
     'rejectionReason'
   ]);
-}
+};
 
 const addFloorData = floorData => {
   if (floorData.location === 'noData') {
@@ -313,7 +313,7 @@ const addFloorData = floorData => {
       'floorProvider as provider'
     ]);
   }
-}
+};
 
 const getTopLevelDetails = () => {
   const payload = {
@@ -327,7 +327,7 @@ const getTopLevelDetails = () => {
       eventTime: Date.now(),
       prebidLoaded: magniteAdapter.MODULE_INITIALIZED_TIME
     }
-  }
+  };
 
   if (browser) {
     deepSetValue(payload, rubiConf.pbaBrowserLocation || 'client.browser', browser);
@@ -343,7 +343,7 @@ const getTopLevelDetails = () => {
       name: rubiConf.wrapperName,
       family: rubiConf.wrapperFamily,
       rule
-    }
+    };
   }
 
   if (cache.sessionData) {
@@ -362,7 +362,7 @@ const getTopLevelDetails = () => {
     }
   }
   return payload;
-}
+};
 
 export const getHostNameFromReferer = referer => {
   try {
@@ -371,7 +371,7 @@ export const getHostNameFromReferer = referer => {
     logError(`${MODULE_NAME}: Unable to parse hostname from supplied url: `, referer, e);
     magniteAdapter.referrerHostname = '';
   }
-  return magniteAdapter.referrerHostname
+  return magniteAdapter.referrerHostname;
 };
 
 const getRpaCookie = () => {
@@ -384,7 +384,7 @@ const getRpaCookie = () => {
     }
   }
   return {};
-}
+};
 
 const setRpaCookie = (decodedCookie) => {
   try {
@@ -392,7 +392,7 @@ const setRpaCookie = (decodedCookie) => {
   } catch (e) {
     logError(`${MODULE_NAME}: Unable to encode ${COOKIE_NAME} value: `, e);
   }
-}
+};
 
 const updateRpaCookie = () => {
   const currentTime = Date.now();
@@ -406,17 +406,17 @@ const updateRpaCookie = () => {
       id: generateUUID(),
       start: currentTime,
       expires: currentTime + END_EXPIRE_TIME, // six hours later,
-    }
+    };
   }
   // possible that decodedRpaCookie is undefined, and if it is, we probably are blocked by storage or some other exception
   if (Object.keys(decodedRpaCookie).length) {
     decodedRpaCookie.lastSeen = currentTime;
     decodedRpaCookie.fpkvs = { ...decodedRpaCookie.fpkvs, ...getFpkvs() };
     decodedRpaCookie.pvid = rubiConf.pvid;
-    setRpaCookie(decodedRpaCookie)
+    setRpaCookie(decodedRpaCookie);
   }
   return decodedRpaCookie;
-}
+};
 
 /*
   Filters and converts URL Params into an object and returns only KVs that match the 'utm_KEY' format
@@ -436,7 +436,7 @@ const getUtmParams = () => {
     }
     return accum;
   }, {});
-}
+};
 
 const getFpkvs = () => {
   rubiConf.fpkvs = Object.assign((rubiConf.fpkvs || {}), getUtmParams());
@@ -447,7 +447,7 @@ const getFpkvs = () => {
   });
 
   return rubiConf.fpkvs;
-}
+};
 
 /*
   Checks the alias registry for any entries of the rubicon bid adapter.
@@ -456,14 +456,14 @@ const getFpkvs = () => {
 const setRubiconAliases = (aliasRegistry) => {
   const otherAliases = Object.keys(aliasRegistry).filter(alias => aliasRegistry[alias] === 'rubicon');
   rubiconAliases.push(...otherAliases);
-}
+};
 
 const sizeToDimensions = size => {
   return {
     width: size.w || size[0],
     height: size.h || size[1]
   };
-}
+};
 
 const findMatchingAdUnitFromAuctions = (matchesFunction, returnFirstMatch) => {
   // finding matching adUnit / auction
@@ -508,14 +508,14 @@ const getRenderingIds = bidWonData => {
     // does adUnit match our bidWon and gam id's are present
     const gamHasRendered = deepAccess(cache, `auctions.${auction.auctionId}.gamRenders.${adUnit.transactionId}`);
     return adUnit.adUnitCode === bidWonData.adUnitCode && gamHasRendered;
-  }
+  };
   const { adUnit, auction } = findMatchingAdUnitFromAuctions(matchingFunction, false);
   // If no match was found, we will use the actual bid won auction id
   return {
     renderTransactionId: (adUnit && adUnit.transactionId) || bidWonData.transactionId,
     renderAuctionId: (auction && auction.auctionId) || bidWonData.auctionId
-  }
-}
+  };
+};
 
 const formatBidWon = bidWonData => {
   // get transaction and auction id of where this "rendered"
@@ -547,10 +547,10 @@ const formatBidWon = bidWonData => {
     mediaTypes: adUnit.mediaTypes,
     adUnitCode: adUnit.adUnitCode,
     isCachedBid: isCachedBid || undefined // only send if it is true (save some space)
-  }
+  };
   delete bidWon.pbsBidId; // if pbsBidId is there delete it (no need to pass it)
   return bidWon;
-}
+};
 
 const formatGamEvent = (slotEvent, adUnit, auction) => {
   const gamEvent = pick(slotEvent, [
@@ -565,7 +565,7 @@ const formatGamEvent = (slotEvent, adUnit, auction) => {
   gamEvent.auctionId = auction.auctionId;
   gamEvent.transactionId = adUnit.transactionId;
   return gamEvent;
-}
+};
 
 const subscribeToGamSlots = () => {
   window.googletag.pubads().addEventListener('slotRenderEnded', event => {
@@ -581,7 +581,7 @@ const subscribeToGamSlots = () => {
       // next it has to have NOT already been counted as gam rendered
       const gamHasRendered = deepAccess(cache, `auctions.${auction.auctionId}.gamRenders.${adUnit.transactionId}`);
       return matchesSlot && !gamHasRendered;
-    }
+    };
     const { adUnit, auction } = findMatchingAdUnitFromAuctions(matchingFunction, true);
 
     const slotName = `${event.slot.getAdUnitPath()} - ${event.slot.getSlotElementId()}`;
@@ -625,7 +625,7 @@ const subscribeToGamSlots = () => {
       }
     }
   });
-}
+};
 
 /**
  * Lazy parsing of UA to determine browser
@@ -647,7 +647,7 @@ export const detectBrowserFromUa = userAgent => {
     return 'Safari';
   }
   return 'OTHER';
-}
+};
 
 const magniteAdapter = adapter({ analyticsType: 'endpoint' });
 
@@ -694,7 +694,7 @@ export function callPrebidCacheHook(fn, auctionInstance, bidResponse, afterBidAd
 const handleBidWon = args => {
   const bidWon = formatBidWon(args);
   addEventToQueue({ bidsWon: [bidWon] }, bidWon.renderAuctionId, 'bidWon');
-}
+};
 
 magniteAdapter.enableAnalytics = enableMgniAnalytics;
 
@@ -773,7 +773,7 @@ const handleBidResponse = (args, bidStatus) => {
   if (pbsBidId && !cache.bidsCachedClientSide.has(args)) {
     bid.pbsBidId = pbsBidId;
   }
-}
+};
 
 const getLatencies = (args, auctionStart) => {
   try {
@@ -783,16 +783,16 @@ const getLatencies = (args, auctionStart) => {
       total: parseInt(metrics[`adapter.${src}.total`]),
       // If it is array, get slowest
       net: parseInt(Array.isArray(metrics[`adapter.${src}.net`]) ? metrics[`adapter.${src}.net`][metrics[`adapter.${src}.net`].length - 1] : metrics[`adapter.${src}.net`])
-    }
+    };
   } catch (error) {
     // default to old way if not able to get better ones
     const latency = Date.now() - auctionStart;
     return {
       total: latency,
       net: latency
-    }
+    };
   }
-}
+};
 
 magniteAdapter.track = ({ eventType, args }) => {
   switch (eventType) {
@@ -842,7 +842,7 @@ magniteAdapter.track = ({ eventType, args }) => {
 
       // User ID Data included in auction
       const userIds = Object.keys(deepAccess(args, 'bidderRequests.0.bids.0.userId', {})).map(id => {
-        return { provider: id, hasId: true }
+        return { provider: id, hasId: true };
       });
       if (userIds.length) {
         auctionData.user = { ids: userIds };
@@ -889,7 +889,7 @@ magniteAdapter.track = ({ eventType, args }) => {
         auction: auctionData,
         gamRenders,
         pendingEvents: {}
-      }
+      };
       break;
     case BID_REQUESTED:
       args.bids.forEach(bid => {
@@ -938,7 +938,7 @@ magniteAdapter.track = ({ eventType, args }) => {
           cachedBid.error = {
             code: pbsErrorMap[serverError.code] || pbsErrorMap[999],
             description: serverError.message
-          }
+          };
         }
 
         // set client latency if not done yet
@@ -1019,18 +1019,18 @@ const handlePbsAnalytics = function (args) {
   if (atag) {
     handleAtagEvent(atag, auctionId);
   }
-}
+};
 
 const handleAtagEvent = function (atag, auctionId) {
-  const tags = findTimeoutOptimization(atag)
+  const tags = findTimeoutOptimization(atag);
   tags.forEach(tag => {
     tag.activities.forEach(activity => {
       if (activity.name === 'optimize-tmax' && activity.status === 'success') {
-        setAnalyticsTagData(activity.results[0]?.values, deepAccess(cache, `auctions.${auctionId}.auction`))
+        setAnalyticsTagData(activity.results[0]?.values, deepAccess(cache, `auctions.${auctionId}.auction`));
       }
-    })
+    });
   });
-}
+};
 const handleNonBidEvent = function(seatnonbid, auctionId) {
   const auction = deepAccess(cache, `auctions.${auctionId}.auction`);
   // if no auction just bail
@@ -1067,21 +1067,21 @@ const findTimeoutOptimization = (atag) => {
     if (tag.module === 'mgni-timeout-optimization') {
       timeoutOpt = tag.analyticstags;
     }
-  })
+  });
   return timeoutOpt;
-}
+};
 const setAnalyticsTagData = (values, auction) => {
   const data = {
     name: values.scenario,
     rule: values.rule,
     value: values.tmax
-  }
+  };
 
   const experiments = deepAccess(auction, 'experiments') || [];
   experiments.push(data);
 
   deepSetValue(auction, 'experiments', experiments);
-}
+};
 
 const statusMap = {
   0: {

--- a/modules/malltvAnalyticsAdapter.js
+++ b/modules/malltvAnalyticsAdapter.js
@@ -1,25 +1,25 @@
-import { ajax } from '../src/ajax.js'
-import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js'
-import { EVENTS } from '../src/constants.js'
-import adapterManager from '../src/adapterManager.js'
-import { getGlobal } from '../src/prebidGlobal.js'
-import { logInfo, logError, deepClone } from '../src/utils.js'
+import { ajax } from '../src/ajax.js';
+import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
+import { EVENTS } from '../src/constants.js';
+import adapterManager from '../src/adapterManager.js';
+import { getGlobal } from '../src/prebidGlobal.js';
+import { logInfo, logError, deepClone } from '../src/utils.js';
 
-const analyticsType = 'endpoint'
-export const ANALYTICS_VERSION = '1.0.0'
-export const DEFAULT_SERVER = 'https://central.mall.tv/analytics'
+const analyticsType = 'endpoint';
+export const ANALYTICS_VERSION = '1.0.0';
+export const DEFAULT_SERVER = 'https://central.mall.tv/analytics';
 
 const {
   AUCTION_END,
   BID_TIMEOUT
-} = EVENTS
+} = EVENTS;
 
 export const BIDDER_STATUS = {
   BID: 1,
   NO_BID: 2,
   BID_WON: 3,
   TIMEOUT: 4
-}
+};
 
 export const getCpmInEur = function (bid) {
   if (bid.currency !== 'EUR' && typeof bid.getCpmInNewCurrency === 'function') {
@@ -27,18 +27,18 @@ export const getCpmInEur = function (bid) {
   }
 
   return bid.cpm;
-}
+};
 
-const analyticsOptions = {}
+const analyticsOptions = {};
 
 export const parseBidderCode = function (bid) {
-  const bidderCode = bid.bidderCode || bid.bidder
-  return bidderCode.toLowerCase()
-}
+  const bidderCode = bid.bidderCode || bid.bidder;
+  return bidderCode.toLowerCase();
+};
 
 export const parseAdUnitCode = function (bidResponse) {
-  return bidResponse.adUnitCode.toLowerCase()
-}
+  return bidResponse.adUnitCode.toLowerCase();
+};
 
 export const malltvAnalyticsAdapter = Object.assign(adapter({ DEFAULT_SERVER, analyticsType }), {
 
@@ -51,70 +51,70 @@ export const malltvAnalyticsAdapter = Object.assign(adapter({ DEFAULT_SERVER, an
      * Optional option: server
      * @type {boolean}
      */
-    analyticsOptions.options = deepClone(config.options)
+    analyticsOptions.options = deepClone(config.options);
     if (typeof config.options.propertyId !== 'string' || config.options.propertyId.length < 1) {
-      logError('"options.propertyId" is required.')
-      return false
+      logError('"options.propertyId" is required.');
+      return false;
     }
 
-    analyticsOptions.propertyId = config.options.propertyId
-    analyticsOptions.server = config.options.server || DEFAULT_SERVER
+    analyticsOptions.propertyId = config.options.propertyId;
+    analyticsOptions.server = config.options.server || DEFAULT_SERVER;
 
-    return true
+    return true;
   },
   track({ eventType, args }) {
     switch (eventType) {
       case BID_TIMEOUT:
-        this.handleBidTimeout(args)
-        break
+        this.handleBidTimeout(args);
+        break;
       case AUCTION_END:
-        this.handleAuctionEnd(args)
-        break
+        this.handleAuctionEnd(args);
+        break;
     }
   },
   handleBidTimeout(timeoutBids) {
     timeoutBids.forEach((bid) => {
-      const cachedAuction = this.getCachedAuction(bid.auctionId)
-      cachedAuction.timeoutBids.push(bid)
-    })
+      const cachedAuction = this.getCachedAuction(bid.auctionId);
+      cachedAuction.timeoutBids.push(bid);
+    });
   },
   handleAuctionEnd(auctionEndArgs) {
-    const cachedAuction = this.getCachedAuction(auctionEndArgs.auctionId)
-    const highestCpmBids = getGlobal().getHighestCpmBids()
+    const cachedAuction = this.getCachedAuction(auctionEndArgs.auctionId);
+    const highestCpmBids = getGlobal().getHighestCpmBids();
     this.sendEventMessage('end',
       this.createBidMessage(auctionEndArgs, highestCpmBids, cachedAuction.timeoutBids)
-    )
+    );
   },
   createBidMessage(auctionEndArgs, winningBids, timeoutBids) {
-    const { auctionId, timestamp, timeout, auctionEnd, adUnitCodes, bidsReceived, noBids } = auctionEndArgs
-    const message = this.createCommonMessage(auctionId)
+    const { auctionId, timestamp, timeout, auctionEnd, adUnitCodes, bidsReceived, noBids } = auctionEndArgs;
+    const message = this.createCommonMessage(auctionId);
 
-    message.auctionElapsed = (auctionEnd - timestamp)
-    message.timeout = timeout
+    message.auctionElapsed = (auctionEnd - timestamp);
+    message.timeout = timeout;
 
     adUnitCodes.forEach((adUnitCode) => {
-      message.adUnits[adUnitCode] = {}
-    })
+      message.adUnits[adUnitCode] = {};
+    });
 
     // We handled noBids first because when currency conversion is enabled, a bid with a foreign currency
     // will be set to NO_BID initially, and then set to BID after the currency rate json file is fully loaded.
     // In this situation, the bid exists in both noBids and bids arrays.
-    noBids.forEach(bid => this.addBidResponseToMessage(message, bid, BIDDER_STATUS.NO_BID))
+    noBids.forEach(bid => this.addBidResponseToMessage(message, bid, BIDDER_STATUS.NO_BID));
 
     // This array may contain some timeout bids (responses come back after auction timeout)
-    bidsReceived.forEach(bid => this.addBidResponseToMessage(message, bid, BIDDER_STATUS.BID))
+    bidsReceived.forEach(bid => this.addBidResponseToMessage(message, bid, BIDDER_STATUS.BID));
 
     // We handle timeout after bids since it's possible that a bid has a response, but the response comes back
     // after auction end. In this case, the bid exists in both bidsReceived and timeoutBids arrays.
-    timeoutBids.forEach(bid => this.addBidResponseToMessage(message, bid, BIDDER_STATUS.TIMEOUT))
+    timeoutBids.forEach(bid => this.addBidResponseToMessage(message, bid, BIDDER_STATUS.TIMEOUT));
 
     // mark the winning bids with prebidWon = true
     winningBids.forEach(bid => {
-      const adUnitCode = parseAdUnitCode(bid)
-      const bidder = parseBidderCode(bid)
-      message.adUnits[adUnitCode][bidder].prebidWon = true
-    })
-    return message
+      const adUnitCode = parseAdUnitCode(bid);
+      const bidder = parseBidderCode(bid);
+      message.adUnits[adUnitCode][bidder].prebidWon = true;
+    });
+    return message;
   },
   createCommonMessage(auctionId) {
     return {
@@ -124,21 +124,21 @@ export const malltvAnalyticsAdapter = Object.assign(adapter({ DEFAULT_SERVER, an
       referrer: window.location.href,
       prebidVersion: '$prebid.version$',
       adUnits: {},
-    }
+    };
   },
   addBidResponseToMessage(message, bid, status) {
-    const adUnitCode = parseAdUnitCode(bid)
-    message.adUnits[adUnitCode] = message.adUnits[adUnitCode] || {}
-    const bidder = parseBidderCode(bid)
-    const bidResponse = this.serializeBidResponse(bid, status)
-    message.adUnits[adUnitCode][bidder] = bidResponse
+    const adUnitCode = parseAdUnitCode(bid);
+    message.adUnits[adUnitCode] = message.adUnits[adUnitCode] || {};
+    const bidder = parseBidderCode(bid);
+    const bidResponse = this.serializeBidResponse(bid, status);
+    message.adUnits[adUnitCode][bidder] = bidResponse;
   },
   serializeBidResponse(bid, status) {
     const result = {
       prebidWon: (status === BIDDER_STATUS.BID_WON),
       isTimeout: (status === BIDDER_STATUS.TIMEOUT),
       status: status,
-    }
+    };
     if (status === BIDDER_STATUS.BID || status === BIDDER_STATUS.BID_WON) {
       Object.assign(result, {
         time: bid.timeToRespond,
@@ -148,39 +148,39 @@ export const malltvAnalyticsAdapter = Object.assign(adapter({ DEFAULT_SERVER, an
         cpmEur: getCpmInEur(bid),
         originalCurrency: bid.originalCurrency || bid.currency,
         vastUrl: bid.vastUrl
-      })
+      });
     }
-    return result
+    return result;
   },
   sendEventMessage(endPoint, data) {
-    logInfo(`AJAX: ${endPoint}: ` + JSON.stringify(data))
+    logInfo(`AJAX: ${endPoint}: ` + JSON.stringify(data));
 
     ajax(`${analyticsOptions.server}/${endPoint}`, null, JSON.stringify(data), {
       contentType: 'application/json'
-    })
+    });
   },
   getCachedAuction(auctionId) {
     this.cachedAuctions[auctionId] = this.cachedAuctions[auctionId] || {
       timeoutBids: [],
-    }
-    return this.cachedAuctions[auctionId]
+    };
+    return this.cachedAuctions[auctionId];
   },
   getAnalyticsOptions() {
-    return analyticsOptions
+    return analyticsOptions;
   },
-})
+});
 
 // save the base class function
-malltvAnalyticsAdapter.originEnableAnalytics = malltvAnalyticsAdapter.enableAnalytics
+malltvAnalyticsAdapter.originEnableAnalytics = malltvAnalyticsAdapter.enableAnalytics;
 
 // override enableAnalytics so we can get access to the config passed in from the page
 malltvAnalyticsAdapter.enableAnalytics = function (config) {
   if (this.initConfig(config)) {
-    malltvAnalyticsAdapter.originEnableAnalytics(config) // call the base class function
+    malltvAnalyticsAdapter.originEnableAnalytics(config); // call the base class function
   }
-}
+};
 
 adapterManager.registerAnalyticsAdapter({
   adapter: malltvAnalyticsAdapter,
   code: 'malltv'
-})
+});

--- a/modules/mediaConsortiumBidAdapter.js
+++ b/modules/mediaConsortiumBidAdapter.js
@@ -1,36 +1,36 @@
-import { BANNER, VIDEO } from '../src/mediaTypes.js'
-import { registerBidder } from '../src/adapters/bidderFactory.js'
+import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
 import {
   generateUUID, isPlainObject, isArray, isStr,
   isFn,
   logInfo,
   logWarn,
   logError, deepClone
-} from '../src/utils.js'
-import { Renderer } from '../src/Renderer.js'
-import { OUTSTREAM } from '../src/video.js'
-import { config } from '../src/config.js'
-import { getStorageManager } from '../src/storageManager.js'
+} from '../src/utils.js';
+import { Renderer } from '../src/Renderer.js';
+import { OUTSTREAM } from '../src/video.js';
+import { config } from '../src/config.js';
+import { getStorageManager } from '../src/storageManager.js';
 
-const BIDDER_CODE = 'mediaConsortium'
+const BIDDER_CODE = 'mediaConsortium';
 
-const PROFILE_API_USAGE_CONFIG_KEY = 'useProfileApi'
-const ONE_PLUS_X_ID_USAGE_CONFIG_KEY = 'readOnePlusXId'
+const PROFILE_API_USAGE_CONFIG_KEY = 'useProfileApi';
+const ONE_PLUS_X_ID_USAGE_CONFIG_KEY = 'readOnePlusXId';
 
-const SYNC_ENDPOINT = 'https://relay.hubvisor.io/v1/sync/big'
-const AUCTION_ENDPOINT = 'https://relay.hubvisor.io/v1/auction/big'
+const SYNC_ENDPOINT = 'https://relay.hubvisor.io/v1/sync/big';
+const AUCTION_ENDPOINT = 'https://relay.hubvisor.io/v1/auction/big';
 
-const OUTSTREAM_RENDERER_URL = 'https://cdn.hubvisor.io/big/player.js'
+const OUTSTREAM_RENDERER_URL = 'https://cdn.hubvisor.io/big/player.js';
 
-export const OPTIMIZATIONS_STORAGE_KEY = 'media_consortium_optimizations'
+export const OPTIMIZATIONS_STORAGE_KEY = 'media_consortium_optimizations';
 
 const SYNC_TYPES = {
   image: 'image',
   redirect: 'image',
   iframe: 'iframe'
-}
+};
 
-const storageManager = getStorageManager({ bidderCode: BIDDER_CODE })
+const storageManager = getStorageManager({ bidderCode: BIDDER_CODE });
 
 export const spec = {
   version: '0.0.1',
@@ -38,51 +38,51 @@ export const spec = {
   gvlid: 1112,
   supportedMediaTypes: [BANNER, VIDEO],
   isBidRequestValid(bid) {
-    return true
+    return true;
   },
   buildRequests(bidRequests, bidderRequest) {
-    const useProfileApi = config.getConfig(PROFILE_API_USAGE_CONFIG_KEY) ?? false
-    const readOnePlusXId = config.getConfig(ONE_PLUS_X_ID_USAGE_CONFIG_KEY) ?? false
+    const useProfileApi = config.getConfig(PROFILE_API_USAGE_CONFIG_KEY) ?? false;
+    const readOnePlusXId = config.getConfig(ONE_PLUS_X_ID_USAGE_CONFIG_KEY) ?? false;
 
     const {
       auctionId,
       bids,
       gdprConsent: { gdprApplies = false, consentString } = {},
       ortb2: { device, site }
-    } = bidderRequest
+    } = bidderRequest;
 
-    const currentTimestamp = Date.now()
-    const optimizations = getOptimizationsFromLocalStorage()
+    const currentTimestamp = Date.now();
+    const optimizations = getOptimizationsFromLocalStorage();
 
     const impressions = bids.reduce((acc, bidRequest) => {
-      const { bidId, adUnitCode, mediaTypes } = bidRequest
-      const optimization = optimizations[adUnitCode]
+      const { bidId, adUnitCode, mediaTypes } = bidRequest;
+      const optimization = optimizations[adUnitCode];
 
       if (optimization) {
-        const { expiresAt, isEnabled } = optimization
+        const { expiresAt, isEnabled } = optimization;
 
         if (expiresAt >= currentTimestamp && !isEnabled) {
-          return acc
+          return acc;
         }
       }
 
-      const finalizedMediatypes = deepClone(mediaTypes)
+      const finalizedMediatypes = deepClone(mediaTypes);
 
       if (mediaTypes.video && mediaTypes.video.context !== OUTSTREAM) {
-        logWarn(`Filtering video request for adUnitCode ${adUnitCode} because context is not ${OUTSTREAM}`)
+        logWarn(`Filtering video request for adUnitCode ${adUnitCode} because context is not ${OUTSTREAM}`);
 
         if (Object.keys(finalizedMediatypes).length > 1) {
-          delete finalizedMediatypes.video
+          delete finalizedMediatypes.video;
         } else {
-          return acc
+          return acc;
         }
       }
 
-      return acc.concat({ id: bidId, adUnitCode, mediaTypes: finalizedMediatypes })
-    }, [])
+      return acc.concat({ id: bidId, adUnitCode, mediaTypes: finalizedMediatypes });
+    }, []);
 
     if (!impressions.length) {
-      return
+      return;
     }
 
     const request = {
@@ -103,23 +103,23 @@ export const spec = {
       options: {
         useProfileApi
       }
-    }
+    };
 
     if (readOnePlusXId) {
-      const fpId = getFpIdFromLocalStorage()
+      const fpId = getFpIdFromLocalStorage();
 
       if (fpId) {
-        request.user.ids['1plusX'] = fpId
+        request.user.ids['1plusX'] = fpId;
       }
     }
 
     const syncData = {
       gdpr: gdprApplies,
       ad_unit_codes: impressions.map(({ adUnitCode }) => adUnitCode).join(',')
-    }
+    };
 
     if (consentString) {
-      syncData.gdpr_consent = consentString
+      syncData.gdpr_consent = consentString;
     }
 
     return [
@@ -134,26 +134,26 @@ export const spec = {
         data: request,
         internal: { bidRequests: bidRequests.reduce((acc, bidRequest) => ({ ...acc, [bidRequest.bidId]: bidRequest }), {}) }
       }
-    ]
+    ];
   },
   interpretResponse(serverResponse, params) {
-    if (!isValidResponse(serverResponse)) return []
+    if (!isValidResponse(serverResponse)) return [];
 
-    const { body: { bids, optimizations } } = serverResponse
+    const { body: { bids, optimizations } } = serverResponse;
 
     if (optimizations && isArray(optimizations)) {
-      const currentTimestamp = Date.now()
+      const currentTimestamp = Date.now();
 
       const optimizationsToStore = optimizations.reduce((acc, optimization) => {
-        const { adUnitCode, isEnabled, ttl } = optimization
+        const { adUnitCode, isEnabled, ttl } = optimization;
 
         return {
           ...acc,
           [adUnitCode]: { isEnabled, expiresAt: currentTimestamp + ttl }
-        }
-      }, getOptimizationsFromLocalStorage())
+        };
+      }, getOptimizationsFromLocalStorage());
 
-      storageManager.setDataInLocalStorage(OPTIMIZATIONS_STORAGE_KEY, JSON.stringify(optimizationsToStore))
+      storageManager.setDataInLocalStorage(OPTIMIZATIONS_STORAGE_KEY, JSON.stringify(optimizationsToStore));
     }
 
     return bids.map((bid) => {
@@ -172,7 +172,7 @@ export const spec = {
           }
         },
         ttl = 360
-      } = bid
+      } = bid;
 
       const formattedBid = {
         requestId: impressionId,
@@ -187,71 +187,71 @@ export const spec = {
         height,
         ad: markup,
         adUrl: null
-      }
+      };
 
       if (mediaType === VIDEO) {
-        const { data: { impressions: impressionRequests }, internal: { bidRequests } } = params
-        const impressionRequest = impressionRequests.find(({ id }) => id === impressionId)
-        const bidRequest = bidRequests[impressionId]
+        const { data: { impressions: impressionRequests }, internal: { bidRequests } } = params;
+        const impressionRequest = impressionRequests.find(({ id }) => id === impressionId);
+        const bidRequest = bidRequests[impressionId];
 
-        formattedBid.vastXml = markup
+        formattedBid.vastXml = markup;
 
         if (impressionRequest && bidRequest) {
-          const { adUnitCode } = impressionRequest
-          const localPlayerConfiguration = bidRequest.params?.video || {}
+          const { adUnitCode } = impressionRequest;
+          const localPlayerConfiguration = bidRequest.params?.video || {};
 
-          formattedBid.renderer = makeOutstreamRenderer(bidId, adUnitCode, localPlayerConfiguration, rendering.video?.player)
+          formattedBid.renderer = makeOutstreamRenderer(bidId, adUnitCode, localPlayerConfiguration, rendering.video?.player);
         } else {
-          logError(`Could not find adUnitCode or bidRequest matching the impressionId ${impressionId} to setup the renderer`)
+          logError(`Could not find adUnitCode or bidRequest matching the impressionId ${impressionId} to setup the renderer`);
         }
       }
 
-      return formattedBid
-    })
+      return formattedBid;
+    });
   },
   getUserSyncs(syncOptions, serverResponses) {
     if (serverResponses.length !== 2) {
-      return
+      return;
     }
 
-    const [sync] = serverResponses
+    const [sync] = serverResponses;
 
     return sync.body?.bidders?.reduce((acc, { type, url }) => {
-      const syncType = SYNC_TYPES[type]
+      const syncType = SYNC_TYPES[type];
 
       if (!syncType || !url) {
-        return acc
+        return acc;
       }
 
-      return acc.concat({ type: syncType, url })
-    }, [])
+      return acc.concat({ type: syncType, url });
+    }, []);
   }
-}
+};
 
-registerBidder(spec)
+registerBidder(spec);
 
 export function getOptimizationsFromLocalStorage() {
   try {
-    const storedOptimizations = storageManager.getDataFromLocalStorage(OPTIMIZATIONS_STORAGE_KEY)
+    const storedOptimizations = storageManager.getDataFromLocalStorage(OPTIMIZATIONS_STORAGE_KEY);
 
-    return storedOptimizations ? JSON.parse(storedOptimizations) : {}
+    return storedOptimizations ? JSON.parse(storedOptimizations) : {};
   } catch (err) {
-    return {}
+    return {};
   }
 }
 
 function getFpIdFromLocalStorage() {
   try {
-    return storageManager.getDataFromLocalStorage('ope_fpid')
+    return storageManager.getDataFromLocalStorage('ope_fpid');
   } catch (err) {
-    return null
+    return null;
   }
 }
 
 function isValidResponse(response) {
   return isPlainObject(response) &&
     isPlainObject(response.body) &&
-    isArray(response.body.bids)
+    isArray(response.body.bids);
 }
 
 function makeOutstreamRenderer(bidId, adUnitCode, localPlayerConfiguration = {}, remotePlayerConfiguration = {}) {
@@ -264,24 +264,24 @@ function makeOutstreamRenderer(bidId, adUnitCode, localPlayerConfiguration = {},
       ...remotePlayerConfiguration,
       ...localPlayerConfiguration
     },
-  })
+  });
 
-  renderer.setRender(render)
+  renderer.setRender(render);
 
-  return renderer
+  return renderer;
 }
 
 function render(bid) {
-  const config = bid.renderer.getConfig()
+  const config = bid.renderer.getConfig();
 
   bid.renderer.push(() => {
-    const { impressionId, vastXml, vastUrl, width: targetWidth, height: targetHeight } = bid
-    const { selector } = config
+    const { impressionId, vastXml, vastUrl, width: targetWidth, height: targetHeight } = bid;
+    const { selector } = config;
 
-    const container = getContainer(selector)
+    const container = getContainer(selector);
 
     if (!window.HbvPlayer) {
-      return logError("Failed to load player!")
+      return logError("Failed to load player!");
     }
 
     window.HbvPlayer.playOutstream(container, {
@@ -294,45 +294,45 @@ function render(bid) {
       onEvent: (event) => {
         switch (event) {
           case 'impression':
-            logInfo(`Video impression for ad unit ${impressionId}`)
-            break
+            logInfo(`Video impression for ad unit ${impressionId}`);
+            break;
           case 'error':
-            logWarn(`Error while playing video for ad unit ${impressionId}`)
-            break
+            logWarn(`Error while playing video for ad unit ${impressionId}`);
+            break;
         }
       },
-    })
-  })
+    });
+  });
 }
 
 function formatSelector(adUnitCode) {
-  return window.CSS ? `#${window.CSS.escape(adUnitCode)}` : `#${adUnitCode}`
+  return window.CSS ? `#${window.CSS.escape(adUnitCode)}` : `#${adUnitCode}`;
 }
 
 function getContainer(containerOrSelector) {
   if (isStr(containerOrSelector)) {
-    const container = document.querySelector(containerOrSelector)
+    const container = document.querySelector(containerOrSelector);
 
     if (container) {
-      return container
+      return container;
     }
 
-    logError(`Player container not found for selector ${containerOrSelector}`)
+    logError(`Player container not found for selector ${containerOrSelector}`);
 
-    return undefined
+    return undefined;
   }
 
   if (isFn(containerOrSelector)) {
-    const container = containerOrSelector()
+    const container = containerOrSelector();
 
     if (container) {
-      return container
+      return container;
     }
 
-    logError("Player container not found for selector function")
+    logError("Player container not found for selector function");
 
-    return undefined
+    return undefined;
   }
 
-  return containerOrSelector
+  return containerOrSelector;
 }

--- a/modules/nativoBidAdapter.js
+++ b/modules/nativoBidAdapter.js
@@ -1,8 +1,8 @@
-import { deepAccess, isEmpty } from '../src/utils.js'
-import { registerBidder } from '../src/adapters/bidderFactory.js'
-import { BANNER, VIDEO, NATIVE } from '../src/mediaTypes.js'
-import { getGlobal } from '../src/prebidGlobal.js'
-import { ortbConverter } from '../libraries/ortbConverter/converter.js'
+import { deepAccess, isEmpty } from '../src/utils.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER, VIDEO, NATIVE } from '../src/mediaTypes.js';
+import { getGlobal } from '../src/prebidGlobal.js';
+import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 
 const converter = ortbConverter({
   context: {
@@ -11,34 +11,34 @@ const converter = ortbConverter({
     ttl: 30, // default bidResponse.ttl (when not specified in ORTB response.seatbid[].bid[].exp)
   },
   imp(buildImp, bidRequest, context) {
-    const imp = buildImp(bidRequest, context)
-    imp.tagid = bidRequest.adUnitCode
-    if (imp.ext) imp.ext.placementId = bidRequest.params.placementId
+    const imp = buildImp(bidRequest, context);
+    imp.tagid = bidRequest.adUnitCode;
+    if (imp.ext) imp.ext.placementId = bidRequest.params.placementId;
 
-    return imp
+    return imp;
   },
-})
+});
 
-const BIDDER_CODE = 'nativo'
-const BIDDER_ENDPOINT = 'https://exchange.postrelease.com/prebid'
+const BIDDER_CODE = 'nativo';
+const BIDDER_ENDPOINT = 'https://exchange.postrelease.com/prebid';
 
-const GVLID = 263
+const GVLID = 263;
 
-const TIME_TO_LIVE = 360
+const TIME_TO_LIVE = 360;
 
-const SUPPORTED_AD_TYPES = [BANNER, VIDEO, NATIVE]
-const FLOOR_PRICE_CURRENCY = 'USD'
-const PRICE_FLOOR_WILDCARD = '*'
+const SUPPORTED_AD_TYPES = [BANNER, VIDEO, NATIVE];
+const FLOOR_PRICE_CURRENCY = 'USD';
+const PRICE_FLOOR_WILDCARD = '*';
 
-const localPbjsRef = getGlobal()
+const localPbjsRef = getGlobal();
 
 function getMediaType(accessObj) {
   if (deepAccess(accessObj, 'mediaTypes.video')) {
-    return VIDEO
+    return VIDEO;
   } else if (deepAccess(accessObj, 'mediaTypes.native')) {
-    return NATIVE
+    return NATIVE;
   } else {
-    return BANNER
+    return BANNER;
   }
 }
 
@@ -47,8 +47,8 @@ function getMediaType(accessObj) {
  * @returns {Object} - Map of bid data that can be referenced by multiple keys
  */
 export function BidDataMap() {
-  const referenceMap = {}
-  const bids = []
+  const referenceMap = {};
+  const bids = [];
 
   /**
    * Add a refence to the index by key value
@@ -57,7 +57,7 @@ export function BidDataMap() {
    */
   function addKeyReference(key, index) {
     if (!referenceMap.hasOwnProperty(key)) {
-      referenceMap[key] = index
+      referenceMap[key] = index;
     }
   }
 
@@ -67,17 +67,17 @@ export function BidDataMap() {
    * @param {(Array|string)} keys - Keys to reference the index value
    */
   function addBidData(bid, keys) {
-    const index = bids.length
-    bids.push(bid)
+    const index = bids.length;
+    bids.push(bid);
 
     if (Array.isArray(keys)) {
       keys.forEach((key) => {
-        addKeyReference(String(key), index)
-      })
-      return
+        addKeyReference(String(key), index);
+      });
+      return;
     }
 
-    addKeyReference(String(keys), index)
+    addKeyReference(String(keys), index);
   }
 
   /**
@@ -86,9 +86,9 @@ export function BidDataMap() {
    * @returns {Object} - The bid data
    */
   function getBidData(key) {
-    const stringKey = String(key)
+    const stringKey = String(key);
     if (referenceMap.hasOwnProperty(stringKey)) {
-      return bids[referenceMap[stringKey]]
+      return bids[referenceMap[stringKey]];
     }
   }
 
@@ -96,17 +96,17 @@ export function BidDataMap() {
   return {
     addBidData,
     getBidData,
-  }
+  };
 }
 
-const bidRequestMap = {}
-const adUnitsRequested = {}
-const extData = {}
+const bidRequestMap = {};
+const adUnitsRequested = {};
+const extData = {};
 
 // Filtering
-const adsToFilter = new Set()
-const advertisersToFilter = new Set()
-const campaignsToFilter = new Set()
+const adsToFilter = new Set();
+const advertisersToFilter = new Set();
+const campaignsToFilter = new Set();
 
 // Prebid adapter referrence doc: https://docs.prebid.org/dev-docs/bidder-adaptor.html
 
@@ -114,11 +114,11 @@ const campaignsToFilter = new Set()
 const validParameter = {
   url: (value) => typeof value === 'string',
   placementId: (value) => {
-    const isString = typeof value === 'string'
-    const isNumber = typeof value === 'number'
-    return isString || isNumber
+    const isString = typeof value === 'string';
+    const isNumber = typeof value === 'number';
+    return isString || isNumber;
   },
-}
+};
 
 export const spec = {
   code: BIDDER_CODE,
@@ -134,21 +134,21 @@ export const spec = {
    */
   isBidRequestValid: function (bid) {
     // We don't need any specific parameters to make a bid request
-    if (!bid.params) return true
+    if (!bid.params) return true;
 
     // Check if any supplied parameters are invalid
     const hasInvalidParameters = Object.keys(bid.params).some((key) => {
-      const value = bid.params[key]
-      const validityCheck = validParameter[key]
+      const value = bid.params[key];
+      const validityCheck = validParameter[key];
 
       // We don't have a test for this so it's not a parameter we care about
-      if (!validityCheck) return false
+      if (!validityCheck) return false;
 
       // Return if the check is not passed
-      return !validityCheck(value)
-    })
+      return !validityCheck(value);
+    });
 
-    return !hasInvalidParameters
+    return !hasInvalidParameters;
   },
 
   /**
@@ -164,52 +164,52 @@ export const spec = {
     const openRTBData = converter.toORTB({
       bidRequests: validBidRequests,
       bidderRequest,
-    })
-    const openRTBDataString = JSON.stringify(openRTBData)
+    });
+    const openRTBDataString = JSON.stringify(openRTBData);
 
-    const requestData = new RequestData()
-    requestData.addBidRequestDataSource(new UserEIDs())
+    const requestData = new RequestData();
+    requestData.addBidRequestDataSource(new UserEIDs());
 
     // Parse values from bid requests
-    const placementIds = new Set()
-    const bidDataMap = BidDataMap()
-    const placementSizes = { length: 0 }
-    const floorPriceData = {}
-    let placementId, pageUrl
+    const placementIds = new Set();
+    const bidDataMap = BidDataMap();
+    const placementSizes = { length: 0 };
+    const floorPriceData = {};
+    let placementId, pageUrl;
     validBidRequests.forEach((bidRequest) => {
       pageUrl =
         getPageUrlFromBidRequest(bidRequest) ||
-        bidderRequest.refererInfo.location
+        bidderRequest.refererInfo.location;
 
-      placementId = deepAccess(bidRequest, 'params.placementId')
+      placementId = deepAccess(bidRequest, 'params.placementId');
 
-      const bidDataKeys = [bidRequest.adUnitCode]
+      const bidDataKeys = [bidRequest.adUnitCode];
 
       if (placementId && !placementIds.has(placementId)) {
-        placementIds.add(placementId)
-        bidDataKeys.push(placementId)
+        placementIds.add(placementId);
+        bidDataKeys.push(placementId);
 
-        placementSizes[placementId] = bidRequest.sizes
-        placementSizes.length++
+        placementSizes[placementId] = bidRequest.sizes;
+        placementSizes.length++;
       }
 
       const bidData = {
         bidId: bidRequest.bidId,
         size: getLargestSize(bidRequest.sizes),
-      }
-      bidDataMap.addBidData(bidData, bidDataKeys)
+      };
+      bidDataMap.addBidData(bidData, bidDataKeys);
 
-      const bidRequestFloorPriceData = parseFloorPriceData(bidRequest)
+      const bidRequestFloorPriceData = parseFloorPriceData(bidRequest);
       if (bidRequestFloorPriceData) {
-        floorPriceData[bidRequest.adUnitCode] = bidRequestFloorPriceData
+        floorPriceData[bidRequest.adUnitCode] = bidRequestFloorPriceData;
       }
 
-      requestData.processBidRequestData(bidRequest, bidderRequest)
-    })
-    bidRequestMap[bidderRequest.bidderRequestId] = bidDataMap
+      requestData.processBidRequestData(bidRequest, bidderRequest);
+    });
+    bidRequestMap[bidderRequest.bidderRequestId] = bidDataMap;
 
     // Build adUnit data
-    const adUnitData = buildAdUnitData(validBidRequests)
+    const adUnitData = buildAdUnitData(validBidRequests);
 
     // Build basic required QS Params
     const params = [
@@ -235,14 +235,14 @@ export const spec = {
         key: 'ntv_url',
         value: encodeURIComponent(pageUrl),
       },
-    ]
+    ];
 
     // Floor pricing
     if (Object.keys(floorPriceData).length) {
       params.unshift({
         key: 'ntv_ppf',
         value: btoa(JSON.stringify(floorPriceData)),
-      })
+      });
     }
 
     // Add filtering
@@ -250,21 +250,21 @@ export const spec = {
       params.unshift({
         key: 'ntv_atf',
         value: Array.from(adsToFilter).join(','),
-      })
+      });
     }
 
     if (advertisersToFilter.size > 0) {
       params.unshift({
         key: 'ntv_avtf',
         value: Array.from(advertisersToFilter).join(','),
-      })
+      });
     }
 
     if (campaignsToFilter.size > 0) {
       params.unshift({
         key: 'ntv_ctf',
         value: Array.from(campaignsToFilter).join(','),
-      })
+      });
     }
 
     // Placement Sizes
@@ -272,16 +272,16 @@ export const spec = {
       params.unshift({
         key: 'ntv_pas',
         value: btoa(JSON.stringify(placementSizes)),
-      })
+      });
     }
 
     // Add placement IDs
     if (placementIds.size > 0) {
       // Convert Set to Array (IE 11 Safe)
-      const placements = []
-      placementIds.forEach((value) => placements.push(value))
+      const placements = [];
+      placementIds.forEach((value) => placements.push(value));
       // Append to query string parameters
-      params.unshift({ key: 'ntv_ptd', value: placements.join(',') })
+      params.unshift({ key: 'ntv_ptd', value: placements.join(',') });
     }
 
     // Add GDPR params
@@ -290,7 +290,7 @@ export const spec = {
       params.unshift({
         key: 'ntv_gdpr_consent',
         value: bidderRequest.gdprConsent.consentString,
-      })
+      });
     }
 
     // Add GPP params
@@ -298,29 +298,29 @@ export const spec = {
       params.unshift({
         key: 'ntv_gpp_consent',
         value: bidderRequest.gppConsent.gppString,
-      })
+      });
     }
 
     // Add USP params
     if (bidderRequest.uspConsent) {
       // Put on the beginning of the qs param array
-      params.unshift({ key: 'us_privacy', value: bidderRequest.uspConsent })
+      params.unshift({ key: 'us_privacy', value: bidderRequest.uspConsent });
     }
 
     const qsParamStrings = [
       requestData.getRequestDataQueryString(),
       arrayToQS(params),
-    ]
-    const requestUrl = buildRequestUrl(BIDDER_ENDPOINT, qsParamStrings)
+    ];
+    const requestUrl = buildRequestUrl(BIDDER_ENDPOINT, qsParamStrings);
 
     const serverRequest = {
       method: 'POST',
       url: requestUrl,
       data: openRTBDataString,
       bidderRequest: bidderRequest,
-    }
+    };
 
-    return serverRequest
+    return serverRequest;
   },
 
   /**
@@ -334,22 +334,22 @@ export const spec = {
    */
   interpretResponse: function (response, request) {
     // If the bid response was empty, return []
-    if (!response || !response.body || isEmpty(response.body)) return []
+    if (!response || !response.body || isEmpty(response.body)) return [];
 
     try {
       const body =
         typeof response.body === 'string'
           ? JSON.parse(response.body)
-          : response.body
+          : response.body;
 
-      const bidResponses = []
-      const seatbids = body.seatbid
+      const bidResponses = [];
+      const seatbids = body.seatbid;
 
       // Step through and grab pertinent data
-      let bidResponse, adUnit
+      let bidResponse, adUnit;
       seatbids.forEach((seatbid, i) => {
         seatbid.bid.forEach((bid) => {
-          adUnit = this.getAdUnitData(body.id, bid)
+          adUnit = this.getAdUnitData(body.id, bid);
 
           bidResponse = {
             requestId: adUnit.bidId,
@@ -366,28 +366,28 @@ export const spec = {
               advertiserDomains: bid.adomain,
             },
             mediaType: getMediaType(request.bidderRequest.bids[i]),
-          }
+          };
 
-          if (bid.ext) extData[bid.id] = bid.ext
+          if (bid.ext) extData[bid.id] = bid.ext;
           if (bidResponse.mediaType === VIDEO) {
-            bidResponse.vastUrl = bid.adm
+            bidResponse.vastUrl = bid.adm;
           }
           if (bidResponse.mediaType === NATIVE) {
             bidResponse.native = {
               ortb: JSON.parse(bidResponse.ad),
-            }
+            };
           }
-          bidResponses.push(bidResponse)
-        })
-      })
+          bidResponses.push(bidResponse);
+        });
+      });
 
       // Don't need the map anymore as it was unique for one request/response
-      delete bidRequestMap[body.id]
+      delete bidRequestMap[body.id];
 
-      return bidResponses
+      return bidResponses;
     } catch (error) {
       // If there is an error, return []
-      return []
+      return [];
     }
   },
 
@@ -408,19 +408,19 @@ export const spec = {
     uspConsent
   ) {
     // Generate consent qs string
-    let params = ''
+    let params = '';
     // GDPR
     if (gdprConsent) {
       params = appendQSParamString(
         params,
         'gdpr',
         gdprConsent.gdprApplies ? 1 : 0
-      )
+      );
       params = appendQSParamString(
         params,
         'gdpr_consent',
         encodeURIComponent(gdprConsent.consentString || '')
-      )
+      );
     }
     // CCPA
     if (uspConsent) {
@@ -428,34 +428,34 @@ export const spec = {
         params,
         'us_privacy',
         encodeURIComponent(uspConsent.uspConsent)
-      )
+      );
     }
 
     // Get sync urls from the respnse and inject cinbsent params
     const types = {
       iframe: syncOptions.iframeEnabled,
       image: syncOptions.pixelEnabled,
-    }
-    const syncs = []
+    };
+    const syncs = [];
 
-    let body
+    let body;
     serverResponses.forEach((response) => {
       // If the bid response was empty, return []
       if (!response || !response.body || isEmpty(response.body)) {
-        return syncs
+        return syncs;
       }
 
       try {
         body =
           typeof response.body === 'string'
             ? JSON.parse(response.body)
-            : response.body
+            : response.body;
       } catch (err) {
-        return
+        return;
       }
 
       // Make sure we have valid content
-      if (!body || !body.seatbid || body.seatbid.length === 0) return
+      if (!body || !body.seatbid || body.seatbid.length === 0) return;
 
       body.seatbid.forEach((seatbid) => {
         // Grab the syncs for each seatbid
@@ -466,15 +466,15 @@ export const spec = {
                 syncs.push({
                   type: sync.type,
                   url: sync.url.replace('{GDPR_params}', params),
-                })
+                });
               }
             }
-          })
+          });
         }
-      })
-    })
+      });
+    });
 
-    return syncs
+    return syncs;
   },
 
   /**
@@ -482,13 +482,13 @@ export const spec = {
    * @param {Object} bid - The bid that won the auction
    */
   onBidWon: function (bid) {
-    const ext = extData[bid.dealId]
+    const ext = extData[bid.dealId];
 
-    if (!ext) return
+    if (!ext) return;
 
-    appendFilterData(adsToFilter, ext.adsToFilter)
-    appendFilterData(advertisersToFilter, ext.advertisersToFilter)
-    appendFilterData(campaignsToFilter, ext.campaignsToFilter)
+    appendFilterData(adsToFilter, ext.adsToFilter);
+    appendFilterData(advertisersToFilter, ext.advertisersToFilter);
+    appendFilterData(campaignsToFilter, ext.campaignsToFilter);
   },
 
   /**
@@ -498,109 +498,109 @@ export const spec = {
    * @returns {String} - The bidId value associated with the corresponding placementId
    */
   getAdUnitData: function (bidderRequestId, bid) {
-    const bidDataMap = bidRequestMap[bidderRequestId]
+    const bidDataMap = bidRequestMap[bidderRequestId];
 
-    const placementId = bid.impid
-    const adUnitCode = deepAccess(bid, 'ext.ad_unit_id')
+    const placementId = bid.impid;
+    const adUnitCode = deepAccess(bid, 'ext.ad_unit_id');
 
     return (
       bidDataMap.getBidData(adUnitCode) || bidDataMap.getBidData(placementId)
-    )
+    );
   },
-}
-registerBidder(spec)
+};
+registerBidder(spec);
 
 // Utils
 export class RequestData {
   constructor() {
-    this.bidRequestDataSources = []
+    this.bidRequestDataSources = [];
   }
 
   addBidRequestDataSource(bidRequestDataSource) {
-    if (!(bidRequestDataSource instanceof BidRequestDataSource)) return
+    if (!(bidRequestDataSource instanceof BidRequestDataSource)) return;
 
-    this.bidRequestDataSources.push(bidRequestDataSource)
+    this.bidRequestDataSources.push(bidRequestDataSource);
   }
 
   processBidRequestData(bidRequest, bidderRequest) {
     for (const bidRequestDataSource of this.bidRequestDataSources) {
-      bidRequestDataSource.processBidRequestData(bidRequest, bidderRequest)
+      bidRequestDataSource.processBidRequestData(bidRequest, bidderRequest);
     }
   }
 
   getRequestDataQueryString() {
-    if (this.bidRequestDataSources.length === 0) return
+    if (this.bidRequestDataSources.length === 0) return;
 
     const queryParams = this.bidRequestDataSources
       .map((dataSource) => dataSource.getRequestQueryString())
-      .filter((queryString) => queryString !== '')
-    return queryParams.join('&')
+      .filter((queryString) => queryString !== '');
+    return queryParams.join('&');
   }
 }
 
 export class BidRequestDataSource {
   constructor() {
-    this.type = 'BidRequestDataSource'
+    this.type = 'BidRequestDataSource';
   }
 
   processBidRequestData(bidRequest, bidderRequest) {}
   getRequestQueryString() {
-    return ''
+    return '';
   }
 }
 
 export class UserEIDs extends BidRequestDataSource {
   constructor() {
-    super()
-    this.type = 'UserEIDs'
-    this.qsParam = new QueryStringParam('ntv_pb_eid')
-    this.eids = []
+    super();
+    this.type = 'UserEIDs';
+    this.qsParam = new QueryStringParam('ntv_pb_eid');
+    this.eids = [];
   }
 
   processBidRequestData(bidRequest, bidderRequest) {
-    if (bidRequest.userIdAsEids === undefined || this.eids.length > 0) return
-    this.eids = bidRequest.userIdAsEids
+    if (bidRequest.userIdAsEids === undefined || this.eids.length > 0) return;
+    this.eids = bidRequest.userIdAsEids;
   }
 
   getRequestQueryString() {
-    if (this.eids.length === 0) return ''
+    if (this.eids.length === 0) return '';
 
-    const encodedValueArray = encodeToBase64(this.eids)
-    this.qsParam.value = encodedValueArray
-    return this.qsParam.toString()
+    const encodedValueArray = encodeToBase64(this.eids);
+    this.qsParam.value = encodedValueArray;
+    return this.qsParam.toString();
   }
 }
 
 export class QueryStringParam {
   constructor(key, value) {
-    this.key = key
-    this.value = value
+    this.key = key;
+    this.value = value;
   }
 }
 
 QueryStringParam.prototype.toString = function () {
-  return `${this.key}=${this.value}`
-}
+  return `${this.key}=${this.value}`;
+};
 
 export function encodeToBase64(value) {
   try {
-    return btoa(JSON.stringify(value))
+    return btoa(JSON.stringify(value));
   } catch (err) {}
 }
 
 export function parseFloorPriceData(bidRequest) {
-  if (typeof bidRequest.getFloor !== 'function') return
+  if (typeof bidRequest.getFloor !== 'function') return;
 
   // Setup price floor data per bid request
-  const bidRequestFloorPriceData = {}
-  const bidMediaTypes = bidRequest.mediaTypes
-  const sizeOptions = new Set()
+  const bidRequestFloorPriceData = {};
+  const bidMediaTypes = bidRequest.mediaTypes;
+  const sizeOptions = new Set();
   // Step through meach media type so we can get floor data for each media type per bid request
   Object.keys(bidMediaTypes).forEach((mediaType) => {
     // Setup price floor data per media type
-    const mediaTypeData = bidMediaTypes[mediaType]
-    const mediaTypeFloorPriceData = {}
-    const mediaTypeSizes = mediaTypeData.sizes || mediaTypeData.playerSize || []
+    const mediaTypeData = bidMediaTypes[mediaType];
+    const mediaTypeFloorPriceData = {};
+    const mediaTypeSizes = mediaTypeData.sizes || mediaTypeData.playerSize || [];
     // Step through each size of the media type so we can get floor data for each size per media type
     mediaTypeSizes.forEach((size) => {
       // Get floor price data per the getFloor method and respective media type / size combination
@@ -608,29 +608,29 @@ export function parseFloorPriceData(bidRequest) {
         currency: FLOOR_PRICE_CURRENCY,
         mediaType,
         size,
-      })
+      });
       // Save the data and track the sizes
-      mediaTypeFloorPriceData[sizeToString(size)] = priceFloorData?.floor
-      sizeOptions.add(size)
-    })
-    bidRequestFloorPriceData[mediaType] = mediaTypeFloorPriceData
+      mediaTypeFloorPriceData[sizeToString(size)] = priceFloorData?.floor;
+      sizeOptions.add(size);
+    });
+    bidRequestFloorPriceData[mediaType] = mediaTypeFloorPriceData;
 
     // Get floor price of current media type with a wildcard size
-    const sizeWildcardFloor = getSizeWildcardPrice(bidRequest, mediaType)
+    const sizeWildcardFloor = getSizeWildcardPrice(bidRequest, mediaType);
     // Save the wildcard floor price if it was retrieved successfully
     if (sizeWildcardFloor?.floor > 0) {
-      mediaTypeFloorPriceData['*'] = sizeWildcardFloor.floor
+      mediaTypeFloorPriceData['*'] = sizeWildcardFloor.floor;
     }
-  })
+  });
 
   // Get floor price for wildcard media type using all of the sizes present in the previous media types
   const mediaWildCardPrices = getMediaWildcardPrices(bidRequest, [
     PRICE_FLOOR_WILDCARD,
     ...Array.from(sizeOptions),
-  ])
-  bidRequestFloorPriceData['*'] = mediaWildCardPrices
+  ]);
+  bidRequestFloorPriceData['*'] = mediaWildCardPrices;
 
-  return bidRequestFloorPriceData
+  return bidRequestFloorPriceData;
 }
 
 /**
@@ -644,7 +644,7 @@ export function getSizeWildcardPrice(bidRequest, mediaType) {
     currency: FLOOR_PRICE_CURRENCY,
     mediaType,
     size: PRICE_FLOOR_WILDCARD,
-  })
+  });
 }
 
 /**
@@ -657,26 +657,26 @@ export function getMediaWildcardPrices(
   bidRequest,
   sizes = [PRICE_FLOOR_WILDCARD]
 ) {
-  const sizePrices = {}
+  const sizePrices = {};
   sizes.forEach((size) => {
     // MODIFY the bid request's mediaTypes property (so we can get the wildcard media type value)
-    const temp = bidRequest.mediaTypes
-    bidRequest.mediaTypes = { PRICE_FLOOR_WILDCARD: temp.sizes }
+    const temp = bidRequest.mediaTypes;
+    bidRequest.mediaTypes = { PRICE_FLOOR_WILDCARD: temp.sizes };
     // Get price floor data
     const priceFloorData = bidRequest.getFloor({
       currency: FLOOR_PRICE_CURRENCY,
       mediaType: PRICE_FLOOR_WILDCARD,
       size,
-    })
+    });
     // RESTORE initial property value
-    bidRequest.mediaTypes = temp
+    bidRequest.mediaTypes = temp;
 
     // Only save valid floor price data
     const key =
-      size !== PRICE_FLOOR_WILDCARD ? sizeToString(size) : PRICE_FLOOR_WILDCARD
-    sizePrices[key] = priceFloorData.floor
-  })
-  return sizePrices
+      size !== PRICE_FLOOR_WILDCARD ? sizeToString(size) : PRICE_FLOOR_WILDCARD;
+    sizePrices[key] = priceFloorData.floor;
+  });
+  return sizePrices;
 }
 
 /**
@@ -685,8 +685,8 @@ export function getMediaWildcardPrices(
  * @returns {String} - Formated size string
  */
 export function sizeToString(size) {
-  if (!Array.isArray(size) || size.length < 2) return ''
-  return `${size[0]}x${size[1]}`
+  if (!Array.isArray(size) || size.length < 2) return '';
+  return `${size[0]}x${size[1]}`;
 }
 
 /**
@@ -700,13 +700,13 @@ function buildAdUnitData(requests) {
     adUnitsRequested[request.adUnitCode] =
       adUnitsRequested[request.adUnitCode] !== undefined
         ? adUnitsRequested[request.adUnitCode] + 1
-        : 0
+        : 0;
     // Return a new object with only the data we need
     return {
       adUnitCode: request.adUnitCode,
       mediaTypes: request.mediaTypes,
-    }
-  })
+    };
+  });
 }
 
 /**
@@ -717,7 +717,7 @@ function buildAdUnitData(requests) {
  * @returns
  */
 function appendQSParamString(str, key, value) {
-  return str + `${str.length ? '&' : ''}${key}=${value}`
+  return str + `${str.length ? '&' : ''}${key}=${value}`;
 }
 
 /**
@@ -727,8 +727,8 @@ function appendQSParamString(str, key, value) {
  */
 function arrayToQS(arr) {
   return arr.reduce((value, obj) => {
-    return appendQSParamString(value, obj.key, obj.value)
-  }, '')
+    return appendQSParamString(value, obj.key, obj.value);
+  }, '');
 }
 
 /**
@@ -737,16 +737,16 @@ function arrayToQS(arr) {
  * @returns Size array with the largest area
  */
 function getLargestSize(sizes, method = area) {
-  if (!sizes || sizes.length === 0) return []
-  if (sizes.length === 1) return sizes[0]
+  if (!sizes || sizes.length === 0) return [];
+  if (sizes.length === 1) return sizes[0];
 
   return sizes.reduce((prev, current) => {
     if (method(current) > method(prev)) {
-      return current
+      return current;
     } else {
-      return prev
+      return prev;
     }
-  })
+  });
 }
 
 /**
@@ -754,21 +754,21 @@ function getLargestSize(sizes, method = area) {
  */
 export function buildRequestUrl(baseUrl, qsParamStringArray = []) {
   if (qsParamStringArray.length === 0 || !Array.isArray(qsParamStringArray)) {
-    return baseUrl
+    return baseUrl;
   }
 
   const nonEmptyQSParamStrings = qsParamStringArray.filter(
     (qsParamString) => qsParamString.trim() !== ''
-  )
+  );
 
-  if (nonEmptyQSParamStrings.length === 0) return baseUrl
+  if (nonEmptyQSParamStrings.length === 0) return baseUrl;
 
-  let requestUrl = `${baseUrl}?${nonEmptyQSParamStrings[0]}`
+  let requestUrl = `${baseUrl}?${nonEmptyQSParamStrings[0]}`;
   for (let i = 1; i < nonEmptyQSParamStrings.length; i++) {
-    requestUrl += `&${nonEmptyQSParamStrings[i]}`
+    requestUrl += `&${nonEmptyQSParamStrings[i]}`;
   }
 
-  return requestUrl
+  return requestUrl;
 }
 
 /**
@@ -776,7 +776,7 @@ export function buildRequestUrl(baseUrl, qsParamStringArray = []) {
  * @param {Array} size - [width, height]
  * @returns The calculated area
  */
-const area = (size) => size[0] * size[1]
+const area = (size) => size[0] * size[1];
 
 /**
  * Save any filter data from winning bid requests for subsequent requests
@@ -785,40 +785,40 @@ const area = (size) => size[0] * size[1]
  */
 function appendFilterData(filter, filterData) {
   if (filterData && Array.isArray(filterData) && filterData.length) {
-    filterData.forEach((ad) => filter.add(ad))
+    filterData.forEach((ad) => filter.add(ad));
   }
 }
 
 export function getPageUrlFromBidRequest(bidRequest) {
-  let paramPageUrl = deepAccess(bidRequest, 'params.url')
+  let paramPageUrl = deepAccess(bidRequest, 'params.url');
 
-  if (paramPageUrl === undefined) return
+  if (paramPageUrl === undefined) return;
 
-  if (hasProtocol(paramPageUrl)) return paramPageUrl
+  if (hasProtocol(paramPageUrl)) return paramPageUrl;
 
-  paramPageUrl = addProtocol(paramPageUrl)
+  paramPageUrl = addProtocol(paramPageUrl);
 
   try {
-    const url = new URL(paramPageUrl)
-    return url.href
+    const url = new URL(paramPageUrl);
+    return url.href;
   } catch (err) {}
 }
 
 export function hasProtocol(url) {
-  const protocolRegexp = /^http[s]?:/
-  return protocolRegexp.test(url)
+  const protocolRegexp = /^http[s]?:/;
+  return protocolRegexp.test(url);
 }
 
 export function addProtocol(url) {
   if (hasProtocol(url)) {
-    return url
+    return url;
   }
 
-  let protocolPrefix = 'https:'
+  let protocolPrefix = 'https:';
 
   if (url.indexOf('//') !== 0) {
-    protocolPrefix += '//'
+    protocolPrefix += '//';
   }
 
-  return `${protocolPrefix}${url}`
+  return `${protocolPrefix}${url}`;
 }

--- a/modules/ooloAnalyticsAdapter.js
+++ b/modules/ooloAnalyticsAdapter.js
@@ -1,12 +1,12 @@
 import { _each, deepClone, pick, deepSetValue, logError, logInfo } from '../src/utils.js';
 import { getOrigin } from '../libraries/getOrigin/index.js';
-import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js'
-import adapterManager from '../src/adapterManager.js'
-import { EVENTS } from '../src/constants.js'
-import { ajax } from '../src/ajax.js'
-import { config } from '../src/config.js'
+import adapter from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
+import adapterManager from '../src/adapterManager.js';
+import { EVENTS } from '../src/constants.js';
+import { ajax } from '../src/ajax.js';
+import { config } from '../src/config.js';
 
-const baseUrl = 'https://pbdata.oolo.io/'
+const baseUrl = 'https://pbdata.oolo.io/';
 const ENDPOINTS = {
   CONFIG: 'https://config-pbdata.oolo.io',
   PAGE_DATA: baseUrl + 'page',
@@ -15,15 +15,15 @@ const ENDPOINTS = {
   AD_RENDER_FAILED: baseUrl + 'adRenderFailedData',
   RAW: baseUrl + 'raw',
   HBCONFIG: baseUrl + 'hbconfig',
-}
+};
 
-const pbModuleVersion = '1.0.0'
-const prebidVersion = '$prebid.version$'
-const analyticsType = 'endpoint'
-const ADAPTER_CODE = 'oolo'
-const AUCTION_END_SEND_TIMEOUT = 1500
+const pbModuleVersion = '1.0.0';
+const prebidVersion = '$prebid.version$';
+const analyticsType = 'endpoint';
+const ADAPTER_CODE = 'oolo';
+const AUCTION_END_SEND_TIMEOUT = 1500;
 // TODO: consider using the Prebid-generated page view ID instead of generating a custom one
-export const PAGEVIEW_ID = +generatePageViewId()
+export const PAGEVIEW_ID = +generatePageViewId();
 
 const {
   AUCTION_INIT,
@@ -34,13 +34,13 @@ const {
   BID_WON,
   BID_TIMEOUT,
   AD_RENDER_FAILED
-} = EVENTS
+} = EVENTS;
 
 const SERVER_EVENTS = {
   AUCTION: 'auction',
   WON: 'bidWon',
   AD_RENDER_FAILED: 'adRenderFailed'
-}
+};
 
 const SERVER_BID_STATUS = {
   NO_BID: 'noBid',
@@ -48,23 +48,23 @@ const SERVER_BID_STATUS = {
   BID_RECEIVED: 'bidReceived',
   BID_TIMEDOUT: 'bidTimedOut',
   BID_WON: 'bidWon'
-}
+};
 
-let auctions = {}
-let initOptions = {}
-const eventsQueue = []
+let auctions = {};
+let initOptions = {};
+const eventsQueue = [];
 
 const onAuctionInit = (args) => {
-  const { auctionId, adUnits, timestamp } = args
+  const { auctionId, adUnits, timestamp } = args;
 
   const auction = auctions[auctionId] = {
     ...args,
     adUnits: {},
     auctionStart: timestamp,
     _sentToServer: false
-  }
+  };
 
-  handleCustomFields(auction, AUCTION_INIT, args)
+  handleCustomFields(auction, AUCTION_INIT, args);
 
   _each(adUnits, adUnit => {
     auction.adUnits[adUnit.code] = {
@@ -72,19 +72,19 @@ const onAuctionInit = (args) => {
       auctionId,
       adunid: adUnit.code,
       bids: {},
-    }
-  })
-}
+    };
+  });
+};
 
 const onBidRequested = (args) => {
-  const { auctionId, bids, start, timeout } = args
-  const _start = start || Date.now()
-  const auction = auctions[auctionId]
-  const auctionAdUnits = auction.adUnits
+  const { auctionId, bids, start, timeout } = args;
+  const _start = start || Date.now();
+  const auction = auctions[auctionId];
+  const auctionAdUnits = auction.adUnits;
 
   bids.forEach(bid => {
-    const { adUnitCode } = bid
-    const bidId = parseBidId(bid)
+    const { adUnitCode } = bid;
+    const bidId = parseBidId(bid);
 
     auctionAdUnits[adUnitCode].bids[bidId] = {
       ...bid,
@@ -92,206 +92,206 @@ const onBidRequested = (args) => {
       start: _start,
       rs: _start - auction.auctionStart,
       bidStatus: SERVER_BID_STATUS.BID_REQUESTED,
-    }
-  })
-}
+    };
+  });
+};
 
 const onBidResponse = (args) => {
-  const { auctionId, adUnitCode } = args
-  const auction = auctions[auctionId]
-  const bidId = parseBidId(args)
-  const bid = auction.adUnits[adUnitCode].bids[bidId]
+  const { auctionId, adUnitCode } = args;
+  const auction = auctions[auctionId];
+  const bidId = parseBidId(args);
+  const bid = auction.adUnits[adUnitCode].bids[bidId];
 
   Object.assign(bid, args, {
     bidStatus: SERVER_BID_STATUS.BID_RECEIVED,
     end: args.responseTimestamp,
     re: args.responseTimestamp - auction.auctionStart
-  })
-}
+  });
+};
 
 const onNoBid = (args) => {
-  const { auctionId, adUnitCode } = args
-  const bidId = parseBidId(args)
-  const end = Date.now()
-  const auction = auctions[auctionId]
-  const bid = auction.adUnits[adUnitCode].bids[bidId]
+  const { auctionId, adUnitCode } = args;
+  const bidId = parseBidId(args);
+  const end = Date.now();
+  const auction = auctions[auctionId];
+  const bid = auction.adUnits[adUnitCode].bids[bidId];
 
   Object.assign(bid, args, {
     bidStatus: SERVER_BID_STATUS.NO_BID,
     end,
     re: end - auction.auctionStart
-  })
-}
+  });
+};
 
 const onBidWon = (args) => {
-  const { auctionId, adUnitCode } = args
-  const bidId = parseBidId(args)
-  const bid = auctions[auctionId].adUnits[adUnitCode].bids[bidId]
+  const { auctionId, adUnitCode } = args;
+  const bidId = parseBidId(args);
+  const bid = auctions[auctionId].adUnits[adUnitCode].bids[bidId];
 
   Object.assign(bid, args, {
     bidStatus: SERVER_BID_STATUS.BID_WON,
     isW: true,
     isH: true
-  })
+  });
 
   if (auctions[auctionId]._sentToServer) {
     const payload = {
       auctionId,
       adunid: adUnitCode,
       bid: mapBid(bid, BID_WON)
-    }
+    };
 
-    sendEvent(SERVER_EVENTS.WON, payload)
+    sendEvent(SERVER_EVENTS.WON, payload);
   }
-}
+};
 
 const onBidTimeout = (args) => {
   _each(args, bid => {
-    const { auctionId, adUnitCode } = bid
-    const bidId = parseBidId(bid)
-    const bidCache = auctions[auctionId].adUnits[adUnitCode].bids[bidId]
+    const { auctionId, adUnitCode } = bid;
+    const bidId = parseBidId(bid);
+    const bidCache = auctions[auctionId].adUnits[adUnitCode].bids[bidId];
 
     Object.assign(bidCache, bid, {
       bidStatus: SERVER_BID_STATUS.BID_TIMEDOUT,
-    })
-  })
-}
+    });
+  });
+};
 
 const onAuctionEnd = (args) => {
-  const { auctionId, adUnits, ...restAuctionEnd } = args
+  const { auctionId, adUnits, ...restAuctionEnd } = args;
 
   Object.assign(auctions[auctionId], restAuctionEnd, {
     auctionEnd: args.auctionEnd || Date.now()
-  })
+  });
 
   // wait for bidWon before sending to server
   setTimeout(() => {
-    auctions[auctionId]._sentToServer = true
-    const finalAuctionData = buildAuctionData(auctions[auctionId])
+    auctions[auctionId]._sentToServer = true;
+    const finalAuctionData = buildAuctionData(auctions[auctionId]);
 
-    sendEvent(SERVER_EVENTS.AUCTION, finalAuctionData)
-  }, initOptions.serverConfig.BID_WON_TIMEOUT || AUCTION_END_SEND_TIMEOUT)
-}
+    sendEvent(SERVER_EVENTS.AUCTION, finalAuctionData);
+  }, initOptions.serverConfig.BID_WON_TIMEOUT || AUCTION_END_SEND_TIMEOUT);
+};
 
 const onAdRenderFailed = (args) => {
-  const data = deepClone(args)
-  data.timestamp = Date.now()
+  const data = deepClone(args);
+  data.timestamp = Date.now();
 
   if (data.bid) {
-    data.bid = mapBid(data.bid, AD_RENDER_FAILED)
+    data.bid = mapBid(data.bid, AD_RENDER_FAILED);
   }
 
-  sendEvent(SERVER_EVENTS.AD_RENDER_FAILED, data)
-}
+  sendEvent(SERVER_EVENTS.AD_RENDER_FAILED, data);
+};
 
 var ooloAdapter = Object.assign(
   adapter({ analyticsType }), {
     track({ eventType, args }) {
       // wait for server configuration before processing the events
       if (typeof initOptions.serverConfig !== 'undefined' && eventsQueue.length === 0) {
-        handleEvent(eventType, args)
+        handleEvent(eventType, args);
       } else {
-        eventsQueue.push({ eventType, args })
+        eventsQueue.push({ eventType, args });
       }
     }
   }
-)
+);
 
 function handleEvent(eventType, args) {
   try {
-    const { sendRaw } = initOptions.serverConfig.events[eventType]
+    const { sendRaw } = initOptions.serverConfig.events[eventType];
     if (sendRaw) {
-      sendEvent(eventType, args, true)
+      sendEvent(eventType, args, true);
     }
   } catch (e) { }
 
   switch (eventType) {
     case AUCTION_INIT:
-      onAuctionInit(args)
-      break
+      onAuctionInit(args);
+      break;
     case BID_REQUESTED:
-      onBidRequested(args)
-      break
+      onBidRequested(args);
+      break;
     case NO_BID:
-      onNoBid(args)
-      break
+      onNoBid(args);
+      break;
     case BID_RESPONSE:
-      onBidResponse(args)
-      break
+      onBidResponse(args);
+      break;
     case BID_WON:
-      onBidWon(args)
-      break
+      onBidWon(args);
+      break;
     case BID_TIMEOUT:
-      onBidTimeout(args)
-      break
+      onBidTimeout(args);
+      break;
     case AUCTION_END:
-      onAuctionEnd(args)
-      break
+      onAuctionEnd(args);
+      break;
     case AD_RENDER_FAILED:
-      onAdRenderFailed(args)
-      break
+      onAdRenderFailed(args);
+      break;
   }
 }
 
 function sendEvent(eventType, args, isRaw) {
-  const data = deepClone(args)
+  const data = deepClone(args);
 
   Object.assign(data, buildCommonDataProperties(), {
     eventType
-  })
+  });
 
   if (isRaw) {
-    let rawEndpoint
+    let rawEndpoint;
     try {
-      const { endpoint, omitRawFields } = initOptions.serverConfig.events[eventType]
-      rawEndpoint = endpoint
-      handleCustomRawFields(data, omitRawFields)
+      const { endpoint, omitRawFields } = initOptions.serverConfig.events[eventType];
+      rawEndpoint = endpoint;
+      handleCustomRawFields(data, omitRawFields);
     } catch (e) { }
-    ajaxCall(rawEndpoint || ENDPOINTS.RAW, () => { }, JSON.stringify(data))
+    ajaxCall(rawEndpoint || ENDPOINTS.RAW, () => { }, JSON.stringify(data));
   } else {
-    let endpoint
+    let endpoint;
     if (eventType === SERVER_EVENTS.AD_RENDER_FAILED) {
-      endpoint = ENDPOINTS.AD_RENDER_FAILED
+      endpoint = ENDPOINTS.AD_RENDER_FAILED;
     } else if (eventType === SERVER_EVENTS.WON) {
-      endpoint = ENDPOINTS.BID_WON
+      endpoint = ENDPOINTS.BID_WON;
     } else {
-      endpoint = ENDPOINTS.AUCTION
+      endpoint = ENDPOINTS.AUCTION;
     }
 
-    ajaxCall(endpoint, () => { }, JSON.stringify(data))
+    ajaxCall(endpoint, () => { }, JSON.stringify(data));
   }
 }
 
 function checkEventsQueue() {
   while (eventsQueue.length) {
-    const event = eventsQueue.shift()
-    handleEvent(event.eventType, event.args)
+    const event = eventsQueue.shift();
+    handleEvent(event.eventType, event.args);
   }
 }
 
 function buildAuctionData(auction) {
-  const auctionData = deepClone(auction)
-  const keysToRemove = ['adUnitCodes', 'auctionStatus', 'bidderRequests', 'bidsReceived', 'noBids', 'winningBids', 'timestamp', 'config']
+  const auctionData = deepClone(auction);
+  const keysToRemove = ['adUnitCodes', 'auctionStatus', 'bidderRequests', 'bidsReceived', 'noBids', 'winningBids', 'timestamp', 'config'];
 
   keysToRemove.forEach(key => {
-    delete auctionData[key]
-  })
+    delete auctionData[key];
+  });
 
-  handleCustomFields(auctionData, AUCTION_END, auction)
+  handleCustomFields(auctionData, AUCTION_END, auction);
 
   // turn bids object into array of objects
   Object.keys(auctionData.adUnits).forEach(adUnit => {
-    const adUnitObj = auctionData.adUnits[adUnit]
-    adUnitObj.bids = Object.keys(adUnitObj.bids).map(key => mapBid(adUnitObj.bids[key]))
-    delete adUnitObj['adUnitCode']
-    delete adUnitObj['code']
-    delete adUnitObj['transactionId']
-  })
+    const adUnitObj = auctionData.adUnits[adUnit];
+    adUnitObj.bids = Object.keys(adUnitObj.bids).map(key => mapBid(adUnitObj.bids[key]));
+    delete adUnitObj['adUnitCode'];
+    delete adUnitObj['code'];
+    delete adUnitObj['transactionId'];
+  });
 
   // turn adUnits objects into array of adUnits
-  auctionData.adUnits = Object.keys(auctionData.adUnits).map(key => auctionData.adUnits[key])
+  auctionData.adUnits = Object.keys(auctionData.adUnits).map(key => auctionData.adUnits[key]);
 
-  return auctionData
+  return auctionData;
 }
 
 function buildCommonDataProperties() {
@@ -299,15 +299,15 @@ function buildCommonDataProperties() {
     pvid: PAGEVIEW_ID,
     pid: initOptions.pid,
     pbModuleVersion
-  }
+  };
 }
 
 function buildLogMessage(message) {
-  return `oolo: ${message}`
+  return `oolo: ${message}`;
 }
 
 function parseBidId(bid) {
-  return bid.bidId || bid.requestId
+  return bid.bidId || bid.requestId;
 }
 
 function mapBid({
@@ -342,39 +342,39 @@ function mapBid({
     h: height,
     ttr: timeToRespond,
     ...rest,
-  }
+  };
 
-  delete bidObj['bidRequestsCount']
-  delete bidObj['bidderRequestId']
-  delete bidObj['bidderRequestsCount']
-  delete bidObj['bidderWinsCount']
-  delete bidObj['schain']
-  delete bidObj['refererInfo']
-  delete bidObj['status']
-  delete bidObj['adUrl']
-  delete bidObj['ad']
-  delete bidObj['usesGenericKeys']
-  delete bidObj['requestTimestamp']
+  delete bidObj['bidRequestsCount'];
+  delete bidObj['bidderRequestId'];
+  delete bidObj['bidderRequestsCount'];
+  delete bidObj['bidderWinsCount'];
+  delete bidObj['schain'];
+  delete bidObj['refererInfo'];
+  delete bidObj['status'];
+  delete bidObj['adUrl'];
+  delete bidObj['ad'];
+  delete bidObj['usesGenericKeys'];
+  delete bidObj['requestTimestamp'];
 
   try {
-    handleCustomFields(bidObj, eventType || BID_RESPONSE, rest)
+    handleCustomFields(bidObj, eventType || BID_RESPONSE, rest);
   } catch (e) { }
 
-  return bidObj
+  return bidObj;
 }
 
 function handleCustomFields(obj, eventType, args) {
   try {
-    const { pickFields, omitFields } = initOptions.serverConfig.events[eventType]
+    const { pickFields, omitFields } = initOptions.serverConfig.events[eventType];
 
     if (pickFields && obj && args) {
-      Object.assign(obj, pick(args, pickFields))
+      Object.assign(obj, pick(args, pickFields));
     }
 
     if (omitFields && obj && args) {
       omitFields.forEach(field => {
-        deepSetValue(obj, field, undefined)
-      })
+        deepSetValue(obj, field, undefined);
+      });
     }
   } catch (e) { }
 }
@@ -383,33 +383,33 @@ function handleCustomRawFields(obj, omitRawFields) {
   try {
     if (omitRawFields && obj) {
       omitRawFields.forEach(field => {
-        deepSetValue(obj, field, undefined)
-      })
+        deepSetValue(obj, field, undefined);
+      });
     }
   } catch (e) { }
 }
 
 function getServerConfig() {
-  const defaultConfig = { events: {} }
+  const defaultConfig = { events: {} };
 
   ajaxCall(
     ENDPOINTS.CONFIG + '?pid=' + initOptions.pid,
     {
       success: function (data) {
         try {
-          initOptions.serverConfig = JSON.parse(data) || defaultConfig
+          initOptions.serverConfig = JSON.parse(data) || defaultConfig;
         } catch (e) {
-          initOptions.serverConfig = defaultConfig
+          initOptions.serverConfig = defaultConfig;
         }
-        checkEventsQueue()
+        checkEventsQueue();
       },
       error: function () {
-        initOptions.serverConfig = defaultConfig
-        checkEventsQueue()
+        initOptions.serverConfig = defaultConfig;
+        checkEventsQueue();
       }
     },
     null
-  )
+  );
 }
 
 function sendPage() {
@@ -423,16 +423,16 @@ function sendPage() {
       origin: getOrigin(),
       referrer: getTopWindowReferrer(),
       pbVersion: prebidVersion,
-    }
+    };
 
-    Object.assign(payload, buildCommonDataProperties(), getPagePerformance())
-    ajaxCall(ENDPOINTS.PAGE_DATA, () => { }, JSON.stringify(payload))
-  }, 0)
+    Object.assign(payload, buildCommonDataProperties(), getPagePerformance());
+    ajaxCall(ENDPOINTS.PAGE_DATA, () => { }, JSON.stringify(payload));
+  }, 0);
 }
 
 function sendHbConfigData() {
-  const conf = {}
-  const pbjsConfig = config.getConfig()
+  const conf = {};
+  const pbjsConfig = config.getConfig();
   // Check if pbjsConfig.userSync exists and has userIds property
   if (pbjsConfig.userSync && pbjsConfig.userSync.userIds) {
     // Delete the userIds property
@@ -441,45 +441,45 @@ function sendHbConfigData() {
 
   Object.keys(pbjsConfig).forEach(key => {
     if (key[0] !== '_') {
-      conf[key] = pbjsConfig[key]
+      conf[key] = pbjsConfig[key];
     }
-  })
+  });
 
-  ajaxCall(ENDPOINTS.HBCONFIG, () => { }, JSON.stringify(conf))
+  ajaxCall(ENDPOINTS.HBCONFIG, () => { }, JSON.stringify(conf));
 }
 
 function getPagePerformance() {
-  let timing
+  let timing;
 
   try {
-    timing = window.top.performance.timing
+    timing = window.top.performance.timing;
   } catch (e) { }
 
   if (!timing) {
-    return
+    return;
   }
 
-  const { navigationStart, domContentLoadedEventEnd, loadEventEnd } = timing
-  const domContentLoadTime = domContentLoadedEventEnd - navigationStart
-  const pageLoadTime = loadEventEnd - navigationStart
+  const { navigationStart, domContentLoadedEventEnd, loadEventEnd } = timing;
+  const domContentLoadTime = domContentLoadedEventEnd - navigationStart;
+  const pageLoadTime = loadEventEnd - navigationStart;
 
   return {
     domContentLoadTime,
     pageLoadTime,
-  }
+  };
 }
 
 function getTopWindowReferrer() {
   try {
-    return window.top.document.referrer
+    return window.top.document.referrer;
   } catch (e) {
-    return ''
+    return '';
   }
 }
 
 function generatePageViewId(min = 10000, max = 90000) {
-  var randomNumber = Math.floor((Math.random() * max) + min)
-  var currentdate = new Date()
+  var randomNumber = Math.floor((Math.random() * max) + min);
+  var currentdate = new Date();
   var currentTime = {
     getDate: currentdate.getDate(),
     getMonth: currentdate.getMonth(),
@@ -488,7 +488,7 @@ function generatePageViewId(min = 10000, max = 90000) {
     getMinutes: currentdate.getMinutes(),
     getSeconds: currentdate.getSeconds(),
     getMilliseconds: currentdate.getMilliseconds()
-  }
+  };
   return ((currentTime.getDate <= 9) ? '0' + (currentTime.getDate) : (currentTime.getDate)) + '' +
     (currentTime.getMonth + 1 <= 9 ? '0' + (currentTime.getMonth + 1) : (currentTime.getMonth + 1)) + '' +
     currentTime.getFullYear % 100 + '' +
@@ -496,58 +496,58 @@ function generatePageViewId(min = 10000, max = 90000) {
     (currentTime.getMinutes <= 9 ? '0' + currentTime.getMinutes : currentTime.getMinutes) + '' +
     (currentTime.getSeconds <= 9 ? '0' + currentTime.getSeconds : currentTime.getSeconds) + '' +
     (currentTime.getMilliseconds % 100 <= 9 ? '0' + (currentTime.getMilliseconds % 100) : (currentTime.getMilliseconds % 100)) + '' +
-    (randomNumber)
+    (randomNumber);
 }
 
 function ajaxCall(endpoint, callback, data, options = {}) {
   if (data) {
-    options.contentType = 'application/json'
+    options.contentType = 'application/json';
   }
 
-  return ajax(endpoint, callback, data, options)
+  return ajax(endpoint, callback, data, options);
 }
 
-ooloAdapter.originEnableAnalytics = ooloAdapter.enableAnalytics
+ooloAdapter.originEnableAnalytics = ooloAdapter.enableAnalytics;
 ooloAdapter.enableAnalytics = function (config) {
-  ooloAdapter.originEnableAnalytics(config)
-  initOptions = config ? config.options : {}
+  ooloAdapter.originEnableAnalytics(config);
+  initOptions = config ? config.options : {};
 
   if (!initOptions.pid) {
-    logError(buildLogMessage('enableAnalytics missing config object with "pid"'))
-    return
+    logError(buildLogMessage('enableAnalytics missing config object with "pid"'));
+    return;
   }
 
-  getServerConfig()
-  sendHbConfigData()
+  getServerConfig();
+  sendHbConfigData();
 
   if (document.readyState === 'complete') {
-    sendPage()
+    sendPage();
   } else {
-    window.addEventListener('load', sendPage)
+    window.addEventListener('load', sendPage);
   }
 
-  logInfo(buildLogMessage('enabled analytics adapter'), config)
+  logInfo(buildLogMessage('enabled analytics adapter'), config);
   ooloAdapter.enableAnalytics = function () {
-    logInfo(buildLogMessage('Analytics adapter already enabled..'))
-  }
-}
+    logInfo(buildLogMessage('Analytics adapter already enabled..'));
+  };
+};
 
-ooloAdapter.originDisableAnalytics = ooloAdapter.disableAnalytics
+ooloAdapter.originDisableAnalytics = ooloAdapter.disableAnalytics;
 ooloAdapter.disableAnalytics = function () {
-  auctions = {}
-  initOptions = {}
-  ooloAdapter.originDisableAnalytics()
-}
+  auctions = {};
+  initOptions = {};
+  ooloAdapter.originDisableAnalytics();
+};
 
 adapterManager.registerAnalyticsAdapter({
   adapter: ooloAdapter,
   code: ADAPTER_CODE
-})
+});
 
 // export for testing
 export {
   buildAuctionData,
   generatePageViewId
-}
+};
 
-export default ooloAdapter
+export default ooloAdapter;

--- a/modules/permutiveIdentityManagerIdSystem.js
+++ b/modules/permutiveIdentityManagerIdSystem.js
@@ -1,8 +1,8 @@
-import { MODULE_TYPE_UID } from '../src/activities/modules.js'
-import { submodule } from '../src/hook.js'
-import { getStorageManager } from '../src/storageManager.js'
-import { deepAccess, prefixLog, safeJSONParse } from '../src/utils.js'
-import { hasPurposeConsent } from '../libraries/permutiveUtils/index.js'
+import { MODULE_TYPE_UID } from '../src/activities/modules.js';
+import { submodule } from '../src/hook.js';
+import { getStorageManager } from '../src/storageManager.js';
+import { deepAccess, prefixLog, safeJSONParse } from '../src/utils.js';
+import { hasPurposeConsent } from '../libraries/permutiveUtils/index.js';
 import { VENDORLESS_GVLID } from "../src/consentHandler.js";
 /**
  * @typedef {import('../modules/userId/index.js').Submodule} Submodule
@@ -11,35 +11,35 @@ import { VENDORLESS_GVLID } from "../src/consentHandler.js";
  * @typedef {import('../modules/userId/index.js').IdResponse} IdResponse
  */
 
-const MODULE_NAME = 'permutiveIdentityManagerId'
-const PERMUTIVE_ID_DATA_STORAGE_KEY = 'permutive-prebid-id'
+const MODULE_NAME = 'permutiveIdentityManagerId';
+const PERMUTIVE_ID_DATA_STORAGE_KEY = 'permutive-prebid-id';
 
-const ID5_DOMAIN = 'id5-sync.com'
-const LIVERAMP_DOMAIN = 'liveramp.com'
-const UID_DOMAIN = 'uidapi.com'
-const GOOGLE_DOMAIN = 'google.com'
+const ID5_DOMAIN = 'id5-sync.com';
+const LIVERAMP_DOMAIN = 'liveramp.com';
+const UID_DOMAIN = 'uidapi.com';
+const GOOGLE_DOMAIN = 'google.com';
 
-const PRIMARY_IDS = ['id5id', 'idl_env', 'uid2', 'pairId']
+const PRIMARY_IDS = ['id5id', 'idl_env', 'uid2', 'pairId'];
 
-export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME })
+export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME });
 
-const logger = prefixLog('[PermutiveID]')
+const logger = prefixLog('[PermutiveID]');
 
 const readFromSdkLocalStorage = () => {
-  const data = safeJSONParse(storage.getDataFromLocalStorage(PERMUTIVE_ID_DATA_STORAGE_KEY))
-  const id = {}
+  const data = safeJSONParse(storage.getDataFromLocalStorage(PERMUTIVE_ID_DATA_STORAGE_KEY));
+  const id = {};
   if (data && typeof data === 'object' && 'providers' in data && typeof data.providers === 'object') {
-    const now = Date.now()
+    const now = Date.now();
     for (const [idName, value] of Object.entries(data.providers)) {
       if (PRIMARY_IDS.includes(idName) && value.userId) {
         if (!value.expiryTime || value.expiryTime > now) {
-          id[idName] = value.userId
+          id[idName] = value.userId;
         }
       }
     }
   }
-  return id
-}
+  return id;
+};
 
 /**
  * Catch and log errors
@@ -47,9 +47,9 @@ const readFromSdkLocalStorage = () => {
  */
 function makeSafe (fn) {
   try {
-    return fn()
+    return fn();
   } catch (e) {
-    logger.logError(e)
+    logger.logError(e);
   }
 }
 
@@ -57,24 +57,24 @@ const waitAndRetrieveFromSdk = (timeoutMs) =>
   new Promise(
     resolve => {
       const fallback = setTimeout(() => {
-        logger.logInfo('timeout expired waiting for SDK - attempting read from local storage again')
-        resolve(readFromSdkLocalStorage())
-      }, timeoutMs)
+        logger.logInfo('timeout expired waiting for SDK - attempting read from local storage again');
+        resolve(readFromSdkLocalStorage());
+      }, timeoutMs);
       return window?.permutive?.ready(() => makeSafe(() => {
-        logger.logInfo('Permutive SDK is ready')
-        const onReady = makeSafe(() => window.permutive.addons.identity_manager.prebid.onReady)
+        logger.logInfo('Permutive SDK is ready');
+        const onReady = makeSafe(() => window.permutive.addons.identity_manager.prebid.onReady);
         if (typeof onReady === 'function') {
           onReady((ids) => {
-            logger.logInfo('Permutive SDK has provided ids')
-            resolve(ids)
-            clearTimeout(fallback)
-          })
+            logger.logInfo('Permutive SDK has provided ids');
+            resolve(ids);
+            clearTimeout(fallback);
+          });
         } else {
-          logger.logError('Permutive SDK initialised but identity manager prebid api not present')
+          logger.logError('Permutive SDK initialised but identity manager prebid api not present');
         }
-      }))
+      }));
     }
-  )
+  );
 
 /** @type {Submodule} */
 export const permutiveIdentityManagerIdSubmodule = {
@@ -95,19 +95,19 @@ export const permutiveIdentityManagerIdSubmodule = {
    * @returns {(Object|undefined)}
    */
   decode(value, config) {
-    const storedPairId = value['pairId']
-    let pairId
+    const storedPairId = value['pairId'];
+    let pairId;
     try {
       if (storedPairId !== undefined) {
-        const decoded = safeJSONParse(atob(storedPairId))
+        const decoded = safeJSONParse(atob(storedPairId));
         if (Array.isArray(decoded)) {
-          pairId = decoded
+          pairId = decoded;
         }
       }
     } catch (e) {
-      logger.logInfo('Error parsing pairId')
+      logger.logInfo('Error parsing pairId');
     }
-    return pairId === undefined ? value : { ...value, pairId }
+    return pairId === undefined ? value : { ...value, pairId };
   },
 
   /**
@@ -119,22 +119,22 @@ export const permutiveIdentityManagerIdSubmodule = {
    * @returns {IdResponse|undefined}
    */
   getId(submoduleConfig, consentData, cacheIdObj) {
-    const enforceVendorConsent = deepAccess(submoduleConfig, 'params.enforceVendorConsent')
+    const enforceVendorConsent = deepAccess(submoduleConfig, 'params.enforceVendorConsent');
     if (!hasPurposeConsent(consentData, [1], enforceVendorConsent)) {
-      logger.logInfo('GDPR purpose 1 consent not satisfied for Permutive Identity Manager')
-      return
+      logger.logInfo('GDPR purpose 1 consent not satisfied for Permutive Identity Manager');
+      return;
     }
 
-    const id = readFromSdkLocalStorage()
+    const id = readFromSdkLocalStorage();
     if (Object.entries(id).length > 0) {
-      logger.logInfo('found id in sdk storage')
-      return { id }
+      logger.logInfo('found id in sdk storage');
+      return { id };
     } else if ('params' in submoduleConfig && submoduleConfig.params.ajaxTimeout) {
-      logger.logInfo('failed to find id in sdk storage - waiting for sdk')
+      logger.logInfo('failed to find id in sdk storage - waiting for sdk');
       // Is ajaxTimeout an appropriate timeout to use here?
-      return { callback: (done) => waitAndRetrieveFromSdk(submoduleConfig.params.ajaxTimeout).then(done) }
+      return { callback: (done) => waitAndRetrieveFromSdk(submoduleConfig.params.ajaxTimeout).then(done) };
     } else {
-      logger.logInfo('failed to find id in sdk storage and no wait time specified')
+      logger.logInfo('failed to find id in sdk storage and no wait time specified');
     }
   },
 
@@ -143,13 +143,13 @@ export const permutiveIdentityManagerIdSubmodule = {
   eids: {
     'id5id': {
       getValue: function (data) {
-        return data.uid
+        return data.uid;
       },
       source: ID5_DOMAIN,
       atype: 1,
       getUidExt: function (data) {
         if (data.ext) {
-          return data.ext
+          return data.ext;
         }
       }
     },
@@ -161,11 +161,11 @@ export const permutiveIdentityManagerIdSubmodule = {
       source: UID_DOMAIN,
       atype: 3,
       getValue: function(data) {
-        return data.id
+        return data.id;
       },
       getUidExt: function(data) {
         if (data.ext) {
-          return data.ext
+          return data.ext;
         }
       }
     },
@@ -174,6 +174,6 @@ export const permutiveIdentityManagerIdSubmodule = {
       atype: 571187
     }
   }
-}
+};
 
-submodule('userId', permutiveIdentityManagerIdSubmodule)
+submodule('userId', permutiveIdentityManagerIdSubmodule);

--- a/modules/permutiveRtdProvider.js
+++ b/modules/permutiveRtdProvider.js
@@ -22,30 +22,30 @@ import { MODULE_TYPE_RTD } from '../src/activities/modules.js';
  * @typedef {import('./permutiveRtdProvider.d.ts').PermutiveTransformationConfig} PermutiveTransformationConfig
  */
 
-const MODULE_NAME = 'permutive'
+const MODULE_NAME = 'permutive';
 
-const logger = prefixLog('[PermutiveRTD]')
+const logger = prefixLog('[PermutiveRTD]');
 
-export const PERMUTIVE_SUBMODULE_CONFIG_KEY = 'permutive-prebid-rtd'
-export const PERMUTIVE_STANDARD_KEYWORD = 'p_standard'
-export const PERMUTIVE_CUSTOM_COHORTS_KEYWORD = 'permutive'
-export const PERMUTIVE_STANDARD_AUD_KEYWORD = 'p_standard_aud'
+export const PERMUTIVE_SUBMODULE_CONFIG_KEY = 'permutive-prebid-rtd';
+export const PERMUTIVE_STANDARD_KEYWORD = 'p_standard';
+export const PERMUTIVE_CUSTOM_COHORTS_KEYWORD = 'permutive';
+export const PERMUTIVE_STANDARD_AUD_KEYWORD = 'p_standard_aud';
 
-export const storage = getStorageManager({ moduleType: MODULE_TYPE_RTD, moduleName: MODULE_NAME })
+export const storage = getStorageManager({ moduleType: MODULE_TYPE_RTD, moduleName: MODULE_NAME });
 
 function init(moduleConfig, userConsent) {
-  readPermutiveModuleConfigFromCache()
+  readPermutiveModuleConfigFromCache();
 
-  const enforceVendorConsent = deepAccess(moduleConfig, 'params.enforceVendorConsent')
+  const enforceVendorConsent = deepAccess(moduleConfig, 'params.enforceVendorConsent');
 
-  return hasPurposeConsent(userConsent, [1], enforceVendorConsent)
+  return hasPurposeConsent(userConsent, [1], enforceVendorConsent);
 }
 
 function liftIntoParams(params) {
-  return isPlainObject(params) ? { params } : {}
+  return isPlainObject(params) ? { params } : {};
 }
 
-let cachedPermutiveModuleConfig = {}
+let cachedPermutiveModuleConfig = {};
 
 /**
  * Access the submodules RTD params that are cached to LocalStorage by the Permutive SDK. This lets the RTD submodule
@@ -53,9 +53,9 @@ let cachedPermutiveModuleConfig = {}
  * not initialised before this submodule is initialised.
  */
 function readPermutiveModuleConfigFromCache() {
-  const params = safeJSONParse(storage.getDataFromLocalStorage(PERMUTIVE_SUBMODULE_CONFIG_KEY))
-  cachedPermutiveModuleConfig = liftIntoParams(params)
-  return cachedPermutiveModuleConfig
+  const params = safeJSONParse(storage.getDataFromLocalStorage(PERMUTIVE_SUBMODULE_CONFIG_KEY));
+  cachedPermutiveModuleConfig = liftIntoParams(params);
+  return cachedPermutiveModuleConfig;
 }
 
 /**
@@ -65,9 +65,9 @@ function readPermutiveModuleConfigFromCache() {
  */
 function getParamsFromPermutive() {
   try {
-    return liftIntoParams(window.permutive.addons.prebid.getPermutiveRtdConfig())
+    return liftIntoParams(window.permutive.addons.prebid.getPermutiveRtdConfig());
   } catch (e) {
-    return null
+    return null;
   }
 }
 
@@ -86,7 +86,7 @@ function getParamsFromPermutive() {
  */
 export function getModuleConfig(customModuleConfig) {
   // Use the params from Permutive if available, otherwise fallback to the cached value set by Permutive.
-  const permutiveModuleConfig = getParamsFromPermutive() || cachedPermutiveModuleConfig
+  const permutiveModuleConfig = getParamsFromPermutive() || cachedPermutiveModuleConfig;
 
   return mergeDeep({
     waitForIt: false,
@@ -100,7 +100,7 @@ export function getModuleConfig(customModuleConfig) {
   },
   permutiveModuleConfig,
   customModuleConfig,
-  )
+  );
 }
 
 /**
@@ -110,37 +110,37 @@ export function getModuleConfig(customModuleConfig) {
  * @param {Object} segmentData - Segment data grouped by bidder or type
  */
 export function setBidderRtb (bidderOrtb2, moduleConfig, segmentData) {
-  const acBidders = deepAccess(moduleConfig, 'params.acBidders')
-  const maxSegs = deepAccess(moduleConfig, 'params.maxSegs')
-  const transformationConfigs = deepAccess(moduleConfig, 'params.transformations') || []
-  const biddersConfig = deepAccess(moduleConfig, 'params.bidders') || {}
+  const acBidders = deepAccess(moduleConfig, 'params.acBidders');
+  const maxSegs = deepAccess(moduleConfig, 'params.maxSegs');
+  const transformationConfigs = deepAccess(moduleConfig, 'params.transformations') || [];
+  const biddersConfig = deepAccess(moduleConfig, 'params.bidders') || {};
 
-  const ssps = segmentData?.ssp?.ssps ?? []
-  const sspCohorts = segmentData?.ssp?.cohorts ?? []
-  const topics = segmentData?.topics ?? {}
+  const ssps = segmentData?.ssp?.ssps ?? [];
+  const sspCohorts = segmentData?.ssp?.cohorts ?? [];
+  const topics = segmentData?.topics ?? {};
 
-  const bidders = new Set([...acBidders, ...ssps, ...Object.keys(biddersConfig)])
+  const bidders = new Set([...acBidders, ...ssps, ...Object.keys(biddersConfig)]);
   bidders.forEach(function (bidder) {
     const bidderConfig = biddersConfig[bidder] || {};
-    const currConfig = { ortb2: bidderOrtb2[bidder] || {} }
+    const currConfig = { ortb2: bidderOrtb2[bidder] || {} };
 
-    let cohorts = []
+    let cohorts = [];
 
-    const isAcBidder = acBidders.indexOf(bidder) > -1
+    const isAcBidder = acBidders.indexOf(bidder) > -1;
     if (isAcBidder) {
-      cohorts = segmentData.ac
+      cohorts = segmentData.ac;
     }
 
-    const isSspBidder = ssps.indexOf(bidder) > -1
+    const isSspBidder = ssps.indexOf(bidder) > -1;
     if (isSspBidder) {
-      cohorts = [...new Set([...cohorts, ...sspCohorts])].slice(0, maxSegs)
+      cohorts = [...new Set([...cohorts, ...sspCohorts])].slice(0, maxSegs);
     }
 
-    const customCohortsData = getCustomCohortsData(bidderConfig, bidder, segmentData, maxSegs)
+    const customCohortsData = getCustomCohortsData(bidderConfig, bidder, segmentData, maxSegs);
 
-    const nextConfig = updateOrtbConfig(bidder, currConfig, cohorts, sspCohorts, topics, transformationConfigs, customCohortsData)
-    bidderOrtb2[bidder] = nextConfig.ortb2
-  })
+    const nextConfig = updateOrtbConfig(bidder, currConfig, cohorts, sspCohorts, topics, transformationConfigs, customCohortsData);
+    bidderOrtb2[bidder] = nextConfig.ortb2;
+  });
 }
 
 /**
@@ -152,11 +152,11 @@ export function setBidderRtb (bidderOrtb2, moduleConfig, segmentData) {
  * @return {string[]} Custom cohort IDs
  */
 function getCustomCohortsData (bidderCfg, bidder, segmentData, maxSegs) {
-  const customCohorts = bidderCfg?.customCohorts
+  const customCohorts = bidderCfg?.customCohorts;
   if (customCohorts?.source === 'ls' && customCohorts?.key) {
-    return makeSafe(() => readSegments(customCohorts.key, []).map(String).slice(0, maxSegs)) || []
+    return makeSafe(() => readSegments(customCohorts.key, []).map(String).slice(0, maxSegs)) || [];
   }
-  return deepAccess(segmentData, bidder) || []
+  return deepAccess(segmentData, bidder) || [];
 }
 
 /**
@@ -172,28 +172,28 @@ function getCustomCohortsData (bidderCfg, bidder, segmentData, maxSegs) {
  * @return {Object} Merged ortb2 object
  */
 function updateOrtbConfig(bidder, currConfig, segmentIDs, sspSegmentIDs, topics, transformationConfigs, customCohortsData) {
-  logger.logInfo(`Current ortb2 config`, { bidder, config: currConfig })
+  logger.logInfo(`Current ortb2 config`, { bidder, config: currConfig });
 
-  const name = 'permutive.com'
+  const name = 'permutive.com';
 
   const permutiveUserData = {
     name,
     segment: segmentIDs.map(segmentId => ({ id: segmentId })),
-  }
+  };
 
   const transformedUserData = transformationConfigs
     .filter(({ id }) => ortb2UserDataTransformations.hasOwnProperty(id))
-    .map(({ id, config }) => ortb2UserDataTransformations[id](permutiveUserData, config))
+    .map(({ id, config }) => ortb2UserDataTransformations[id](permutiveUserData, config));
 
   const customCohortsUserData = {
     name: PERMUTIVE_CUSTOM_COHORTS_KEYWORD,
     segment: customCohortsData.map(cohortID => ({ id: cohortID })),
-  }
+  };
 
-  const ortbConfig = mergeDeep({}, currConfig)
-  const currentUserData = deepAccess(ortbConfig, 'ortb2.user.data') || []
+  const ortbConfig = mergeDeep({}, currConfig);
+  const currentUserData = deepAccess(ortbConfig, 'ortb2.user.data') || [];
 
-  const topicsUserData = []
+  const topicsUserData = [];
   for (const [k, value] of Object.entries(topics)) {
     topicsUserData.push({
       name,
@@ -201,62 +201,62 @@ function updateOrtbConfig(bidder, currConfig, segmentIDs, sspSegmentIDs, topics,
         segtax: Number(k)
       },
       segment: value.map(topic => ({ id: topic.toString() })),
-    })
+    });
   }
 
   const updatedUserData = currentUserData
     .filter(el => el.name !== permutiveUserData.name && el.name !== customCohortsUserData.name)
     .concat(permutiveUserData, transformedUserData, customCohortsUserData)
-    .concat(topicsUserData)
+    .concat(topicsUserData);
 
-  logger.logInfo(`Updating ortb2.user.data`, { bidder, user_data: updatedUserData })
-  deepSetValue(ortbConfig, 'ortb2.user.data', updatedUserData)
+  logger.logInfo(`Updating ortb2.user.data`, { bidder, user_data: updatedUserData });
+  deepSetValue(ortbConfig, 'ortb2.user.data', updatedUserData);
 
   // Set ortb2.user.keywords
-  const currentKeywords = deepAccess(ortbConfig, 'ortb2.user.keywords')
+  const currentKeywords = deepAccess(ortbConfig, 'ortb2.user.keywords');
   const keywordGroups = {
     [PERMUTIVE_STANDARD_KEYWORD]: segmentIDs,
     [PERMUTIVE_STANDARD_AUD_KEYWORD]: sspSegmentIDs,
     [PERMUTIVE_CUSTOM_COHORTS_KEYWORD]: customCohortsData,
-  }
+  };
 
   // Transform groups of key-values into a single array of strings
   // i.e { permutive: ['1', '2'], p_standard: ['3', '4'] } => ['permutive=1', 'permutive=2', 'p_standard=3',' p_standard=4']
   const transformedKeywordGroups = Object.entries(keywordGroups)
-    .flatMap(([keyword, ids]) => ids.map(id => `${keyword}=${id}`))
+    .flatMap(([keyword, ids]) => ids.map(id => `${keyword}=${id}`));
 
   const keywords = Array.from(new Set([
     ...(currentKeywords || '').split(',').map(kv => kv.trim()),
     ...transformedKeywordGroups
   ]))
     .filter(Boolean)
-    .join(',')
+    .join(',');
 
   logger.logInfo(`Updating ortb2.user.keywords`, {
     bidder,
     keywords,
-  })
-  deepSetValue(ortbConfig, 'ortb2.user.keywords', keywords)
+  });
+  deepSetValue(ortbConfig, 'ortb2.user.keywords', keywords);
 
   // Set user extensions
   if (segmentIDs.length > 0) {
-    deepSetValue(ortbConfig, `ortb2.user.ext.data.${PERMUTIVE_STANDARD_KEYWORD}`, segmentIDs)
-    logger.logInfo(`Extending ortb2.user.ext.data with "${PERMUTIVE_STANDARD_KEYWORD}"`, segmentIDs)
+    deepSetValue(ortbConfig, `ortb2.user.ext.data.${PERMUTIVE_STANDARD_KEYWORD}`, segmentIDs);
+    logger.logInfo(`Extending ortb2.user.ext.data with "${PERMUTIVE_STANDARD_KEYWORD}"`, segmentIDs);
   }
 
   if (customCohortsData.length > 0) {
-    deepSetValue(ortbConfig, `ortb2.user.ext.data.${PERMUTIVE_CUSTOM_COHORTS_KEYWORD}`, customCohortsData.map(String))
-    logger.logInfo(`Extending ortb2.user.ext.data with "${PERMUTIVE_CUSTOM_COHORTS_KEYWORD}"`, customCohortsData)
+    deepSetValue(ortbConfig, `ortb2.user.ext.data.${PERMUTIVE_CUSTOM_COHORTS_KEYWORD}`, customCohortsData.map(String));
+    logger.logInfo(`Extending ortb2.user.ext.data with "${PERMUTIVE_CUSTOM_COHORTS_KEYWORD}"`, customCohortsData);
   }
 
   // Set site extensions
   if (segmentIDs.length > 0) {
-    deepSetValue(ortbConfig, `ortb2.site.ext.permutive.${PERMUTIVE_STANDARD_KEYWORD}`, segmentIDs)
-    logger.logInfo(`Extending ortb2.site.ext.permutive with "${PERMUTIVE_STANDARD_KEYWORD}"`, segmentIDs)
+    deepSetValue(ortbConfig, `ortb2.site.ext.permutive.${PERMUTIVE_STANDARD_KEYWORD}`, segmentIDs);
+    logger.logInfo(`Extending ortb2.site.ext.permutive with "${PERMUTIVE_STANDARD_KEYWORD}"`, segmentIDs);
   }
 
-  logger.logInfo(`Updated ortb2 config`, { bidder, config: ortbConfig })
-  return ortbConfig
+  logger.logInfo(`Updated ortb2 config`, { bidder, config: ortbConfig });
+  return ortbConfig;
 }
 
 /**
@@ -266,32 +266,32 @@ function updateOrtbConfig(bidder, currConfig, segmentIDs, sspSegmentIDs, topics,
  * @param {Object} segmentData - Segment object
  */
 function setSegments (reqBidsConfigObj, moduleConfig, segmentData) {
-  const adUnits = (reqBidsConfigObj && reqBidsConfigObj.adUnits) || getGlobal().adUnits
-  const utils = { deepSetValue, deepAccess, isFn, mergeDeep }
+  const adUnits = (reqBidsConfigObj && reqBidsConfigObj.adUnits) || getGlobal().adUnits;
+  const utils = { deepSetValue, deepAccess, isFn, mergeDeep };
   const aliasMap = {
     appnexusAst: 'appnexus'
-  }
+  };
 
   if (!adUnits) {
-    return
+    return;
   }
 
   adUnits.forEach(adUnit => {
     adUnit.bids.forEach(bid => {
-      let { bidder } = bid
+      let { bidder } = bid;
       if (typeof aliasMap[bidder] !== 'undefined') {
-        bidder = aliasMap[bidder]
+        bidder = aliasMap[bidder];
       }
-      const acEnabled = isAcEnabled(moduleConfig, bidder)
-      const customFn = getCustomBidderFn(moduleConfig, bidder)
+      const acEnabled = isAcEnabled(moduleConfig, bidder);
+      const customFn = getCustomBidderFn(moduleConfig, bidder);
 
       if (customFn) {
         // For backwards compatibility we pass an identity function to any custom bidder function set by a publisher
-        const bidIdentity = (bid) => bid
-        customFn(bid, segmentData, acEnabled, utils, bidIdentity)
+        const bidIdentity = (bid) => bid;
+        customFn(bid, segmentData, acEnabled, utils, bidIdentity);
       }
-    })
-  })
+    });
+  });
 }
 
 /**
@@ -300,19 +300,19 @@ function setSegments (reqBidsConfigObj, moduleConfig, segmentData) {
  */
 function makeSafe (fn) {
   try {
-    return fn()
+    return fn();
   } catch (e) {
-    logError(e)
+    logError(e);
   }
 }
 
 function getCustomBidderFn (moduleConfig, bidder) {
-  const overwriteFn = deepAccess(moduleConfig, `params.overwrites.${bidder}`)
+  const overwriteFn = deepAccess(moduleConfig, `params.overwrites.${bidder}`);
 
   if (overwriteFn && isFn(overwriteFn)) {
-    return overwriteFn
+    return overwriteFn;
   } else {
-    return null
+    return null;
   }
 }
 
@@ -323,8 +323,8 @@ function getCustomBidderFn (moduleConfig, bidder) {
  * @return {boolean}
  */
 export function isAcEnabled (moduleConfig, bidder) {
-  const acBidders = deepAccess(moduleConfig, 'params.acBidders') || []
-  return acBidders.includes(bidder)
+  const acBidders = deepAccess(moduleConfig, 'params.acBidders') || [];
+  return acBidders.includes(bidder);
 }
 
 /**
@@ -332,7 +332,7 @@ export function isAcEnabled (moduleConfig, bidder) {
  * @return {boolean}
  */
 export function isPermutiveOnPage () {
-  return typeof window.permutive !== 'undefined' && typeof window.permutive.ready === 'function'
+  return typeof window.permutive !== 'undefined' && typeof window.permutive.ready === 'function';
 }
 
 /**
@@ -409,18 +409,18 @@ export function getSegments(maxSegs) {
   for (const bidder in segments) {
     if (bidder === 'ssp') {
       if (segments[bidder].cohorts && Array.isArray(segments[bidder].cohorts)) {
-        segments[bidder].cohorts = segments[bidder].cohorts.slice(0, maxSegs)
+        segments[bidder].cohorts = segments[bidder].cohorts.slice(0, maxSegs);
       }
     } else if (bidder === 'topics') {
       for (const taxonomy in segments[bidder]) {
-        segments[bidder][taxonomy] = segments[bidder][taxonomy].slice(0, maxSegs)
+        segments[bidder][taxonomy] = segments[bidder][taxonomy].slice(0, maxSegs);
       }
     } else {
-      segments[bidder] = segments[bidder].slice(0, maxSegs)
+      segments[bidder] = segments[bidder].slice(0, maxSegs);
     }
   }
 
-  logger.logInfo(`Read segments`, segments)
+  logger.logInfo(`Read segments`, segments);
   return segments;
 }
 
@@ -434,13 +434,13 @@ export function getSegments(maxSegs) {
  */
 function readSegments (key, defaultValue) {
   try {
-    return JSON.parse(storage.getDataFromLocalStorage(key)) || defaultValue
+    return JSON.parse(storage.getDataFromLocalStorage(key)) || defaultValue;
   } catch (e) {
-    return defaultValue
+    return defaultValue;
   }
 }
 
-const unknownIabSegmentId = '_unknown_'
+const unknownIabSegmentId = '_unknown_';
 
 /**
  * Functions to apply to ORT2B2 `user.data` objects.
@@ -456,7 +456,7 @@ const ortb2UserDataTransformations = {
       .map(segment => ({ id: iabSegmentId(segment.id, config.iabIds) }))
       .filter(segment => segment.id !== unknownIabSegmentId)
   })
-}
+};
 
 /**
  * Transform a Permutive segment ID into an IAB audience taxonomy ID.
@@ -465,7 +465,7 @@ const ortb2UserDataTransformations = {
  * @return {string} IAB audience taxonomy ID associated with the Permutive segment ID
  */
 function iabSegmentId(permutiveSegmentId, iabIds) {
-  return iabIds[permutiveSegmentId] || unknownIabSegmentId
+  return iabIds[permutiveSegmentId] || unknownIabSegmentId;
 }
 
 /**
@@ -475,21 +475,21 @@ function iabSegmentId(permutiveSegmentId, iabIds) {
  * @param moduleConfig - Publisher provided config
  */
 export function readAndSetCohorts(reqBidsConfigObj, moduleConfig) {
-  const segmentData = getSegments(deepAccess(moduleConfig, 'params.maxSegs'))
+  const segmentData = getSegments(deepAccess(moduleConfig, 'params.maxSegs'));
 
   makeSafe(function () {
     // Legacy route with custom parameters
     // ACK policy violation, in process of removing
-    setSegments(reqBidsConfigObj, moduleConfig, segmentData)
+    setSegments(reqBidsConfigObj, moduleConfig, segmentData);
   });
 
   makeSafe(function () {
     // Route for bidders supporting ORTB2
-    setBidderRtb(reqBidsConfigObj.ortb2Fragments?.bidder, moduleConfig, segmentData)
-  })
+    setBidderRtb(reqBidsConfigObj.ortb2Fragments?.bidder, moduleConfig, segmentData);
+  });
 }
 
-let permutiveSDKInRealTime = false
+let permutiveSDKInRealTime = false;
 
 /** @type {RtdSubmodule} */
 export const permutiveSubmodule = {
@@ -498,30 +498,30 @@ export const permutiveSubmodule = {
   gvlid: VENDORLESS_GVLID,
   getBidRequestData: function (reqBidsConfigObj, callback, customModuleConfig) {
     const completeBidRequestData = () => {
-      logger.logInfo(`Request data updated`)
-      callback()
-    }
+      logger.logInfo(`Request data updated`);
+      callback();
+    };
 
-    const moduleConfig = getModuleConfig(customModuleConfig)
+    const moduleConfig = getModuleConfig(customModuleConfig);
 
-    readAndSetCohorts(reqBidsConfigObj, moduleConfig)
+    readAndSetCohorts(reqBidsConfigObj, moduleConfig);
 
     makeSafe(function () {
       if (permutiveSDKInRealTime || !(moduleConfig.waitForIt && isPermutiveOnPage())) {
-        return completeBidRequestData()
+        return completeBidRequestData();
       }
 
       window.permutive.ready(function () {
-        logger.logInfo(`SDK is realtime, updating cohorts`)
-        permutiveSDKInRealTime = true
-        readAndSetCohorts(reqBidsConfigObj, getModuleConfig(customModuleConfig))
-        completeBidRequestData()
-      }, 'realtime')
+        logger.logInfo(`SDK is realtime, updating cohorts`);
+        permutiveSDKInRealTime = true;
+        readAndSetCohorts(reqBidsConfigObj, getModuleConfig(customModuleConfig));
+        completeBidRequestData();
+      }, 'realtime');
 
-      logger.logInfo(`Registered cohort update when SDK is realtime`)
-    })
+      logger.logInfo(`Registered cohort update when SDK is realtime`);
+    });
   },
   init: init
-}
+};
 
-submodule('realTimeData', permutiveSubmodule)
+submodule('realTimeData', permutiveSubmodule);

--- a/modules/r2b2AnalyticsAdapter.js
+++ b/modules/r2b2AnalyticsAdapter.js
@@ -13,7 +13,7 @@ export const dep = {
 
 const ADAPTER_VERSION = '1.1.0';
 const ADAPTER_CODE = 'r2b2';
-const MODULE_NAME = 'R2B2 Analytics'
+const MODULE_NAME = 'R2B2 Analytics';
 const GVLID = 1235;
 const analyticsType = 'endpoint';
 
@@ -123,12 +123,12 @@ function processEvent (event) {
   // console.log('process event:', event);
   // console.log(JSON.stringify(event));
   if (!event) {
-    return
+    return;
   }
   eventBuffer.push(event);
   if (flushTimer) {
     clearTimeout(flushTimer);
-    flushTimer = null
+    flushTimer = null;
   }
   if (eventBuffer.length >= BATCH_SIZE) {
     flushEvents();
@@ -143,7 +143,7 @@ function processErrorParams(params) {
       return JSON.stringify(params);
     } catch (e) { /* do nothing */ }
   }
-  return null
+  return null;
 }
 function reportError (message, params) {
   errors++;
@@ -172,7 +172,7 @@ function reportEvents (events) {
       `&u=${encodeURIComponent(REPORTED_URL)}`;
     const headers = {
       contentType: 'application/x-www-form-urlencoded'
-    }
+    };
     data = data.replace(/&/g, '%26');
     dep.ajax(url, null, data, headers);
   } catch (e) {
@@ -189,7 +189,7 @@ function getStandardTargeting (obj) {
       sz: obj.hb_size || '',
       pb: obj.hb_pb || '',
       fmt: obj.hb_format || ''
-    }
+    };
   }
 }
 function getEventTimestamps (eventName, auctionId) {
@@ -197,7 +197,7 @@ function getEventTimestamps (eventName, auctionId) {
     t: Date.now() - START_TIME
   };
   if (!auctionId || !auctionsData[auctionId]) {
-    return timestamps
+    return timestamps;
   }
   const auctionData = auctionsData[auctionId];
 
@@ -209,7 +209,7 @@ function getEventTimestamps (eventName, auctionId) {
   if (eventName === EVENT_MAP[EVENTS.AUCTION_INIT] && auctionCount > 1) {
     timestamps.tprev = auctionsData[previousAuction].start - START_TIME;
   }
-  return timestamps
+  return timestamps;
 }
 
 function createEvent (name, data, auctionId) {
@@ -218,10 +218,10 @@ function createEvent (name, data, auctionId) {
       event: name,
       auctionId: !!auctionId
     });
-    return null
+    return null;
   }
   if (auctionsData[auctionId] && auctionsData[auctionId].empty) {
-    return null
+    return null;
   }
 
   data = data || {};
@@ -231,7 +231,7 @@ function createEvent (name, data, auctionId) {
     e: name,
     d: data,
     t: getEventTimestamps(name, auctionId)
-  }
+  };
 }
 
 function createAuctionData (auction, empty) {
@@ -257,11 +257,11 @@ function handleAuctionInit (args) {
     u: bidderRequests.reduce((result, bidderRequest) => {
       bidderRequest.bids.forEach((bid) => {
         if (!result[bid.adUnitCode]) {
-          result[bid.adUnitCode] = []
+          result[bid.adUnitCode] = [];
         }
-        result[bid.adUnitCode].push(bid.bidder)
+        result[bid.adUnitCode].push(bid.bidder);
       });
-      return result
+      return result;
     }, {})
   };
   const event = createEvent(EVENT_MAP[EVENTS.AUCTION_INIT], data, auctionId);
@@ -273,11 +273,11 @@ function handleBidRequested (args) {
     b: args.bidderCode,
     u: args.bids.reduce((result, bid) => {
       if (!result[bid.adUnitCode]) {
-        result[bid.adUnitCode] = 1
+        result[bid.adUnitCode] = 1;
       } else {
-        result[bid.adUnitCode]++
+        result[bid.adUnitCode]++;
       }
-      return result
+      return result;
     }, {})
   };
   const event = createEvent(EVENT_MAP[EVENTS.BID_REQUESTED], data, args.auctionId);
@@ -289,20 +289,20 @@ function handleBidTimeout (args) {
   if (auctionId) {
     const bidders = args.reduce((result, bid) => {
       if (!result[bid.bidder]) {
-        result[bid.bidder] = {}
+        result[bid.bidder] = {};
       }
       const bidderData = result[bid.bidder];
       if (!bidderData[bid.adUnitCode]) {
-        bidderData[bid.adUnitCode] = 1
+        bidderData[bid.adUnitCode] = 1;
       } else {
-        bidderData[bid.adUnitCode]++
+        bidderData[bid.adUnitCode]++;
       }
-      return result
+      return result;
     }, {});
 
     const data = {
       b: bidders,
-    }
+    };
     const event = createEvent(EVENT_MAP[EVENTS.BID_TIMEOUT], data, auctionId);
     processEvent(event);
   }
@@ -367,16 +367,16 @@ function getAuctionUnitsData (auctionObject) {
     data[adUnitCode] = data[adUnitCode] || {};
     data[adUnitCode][key] = data[adUnitCode][key] || {};
     data[adUnitCode][key][bidder] = (data[adUnitCode][key][bidder] || 0) + 1;
-    return data
+    return data;
   };
   unitsData = bidsReceived.reduce((data, bid) => {
     if (!bid.cpm) return data;
-    return _unitsDataBidReducer(data, bid, 'b')
+    return _unitsDataBidReducer(data, bid, 'b');
   }, unitsData);
   unitsData = bidsRejected.reduce((data, bid) => {
-    return _unitsDataBidReducer(data, bid, 'rj')
+    return _unitsDataBidReducer(data, bid, 'rj');
   }, unitsData);
-  return unitsData
+  return unitsData;
 }
 function handleEmptyAuction(auction) {
   const auctionId = auction.auctionId;
@@ -388,7 +388,7 @@ function handleAuctionEnd (args) {
   // console.log('auction end:', arguments);
   if (!args.bidderRequests.length) {
     handleEmptyAuction(args);
-    return
+    return;
   }
   auctionsData[args.auctionId].end = args.auctionEnd;
   let winningBids = getGlobal().getHighestCpmBids() || [];
@@ -405,7 +405,7 @@ function handleAuctionEnd (args) {
         c: bid.currency,
         sz: bid.size,
         bi: bid.requestId,
-      })
+      });
     }
   });
   const data = {
@@ -417,7 +417,7 @@ function handleAuctionEnd (args) {
     rjc: args.bidsRejected.length,
     brc: args.bidderRequests.reduce((count, bidderRequest) => {
       const c = bidderRequest.bids.length || 0;
-      return count + c
+      return count + c;
     }, 0)
   };
   const event = createEvent(EVENT_MAP[EVENTS.AUCTION_END], data, args.auctionId);
@@ -448,7 +448,7 @@ function handleSetTargeting (args) {
   Object.keys(args).forEach((unit) => {
     if (Object.keys(args[unit]).length) {
       if (!adId) {
-        adId = args[unit].hb_adid
+        adId = args[unit].hb_adid;
       }
       filteredTargetings[unit] = getStandardTargeting(args[unit]);
     }
@@ -457,7 +457,7 @@ function handleSetTargeting (args) {
     const auctionId = bidsData[adId].auctionId;
     const data = {
       u: filteredTargetings
-    }
+    };
     const event = createEvent(EVENT_MAP[EVENTS.SET_TARGETING], data, auctionId);
     processEvent(event);
   }
@@ -520,36 +520,36 @@ function handleBidViewable (args) {
 const baseAdapter = adapter({ analyticsType });
 const r2b2Analytics = Object.assign({}, baseAdapter, {
   getUrl() {
-    return `${DEFAULT_PROTOCOL}://${LOG_SERVER}/${DEFAULT_EVENT_PATH}`
+    return `${DEFAULT_PROTOCOL}://${LOG_SERVER}/${DEFAULT_EVENT_PATH}`;
   },
   getErrorUrl() {
-    return `${DEFAULT_PROTOCOL}://${LOG_SERVER}/${DEFAULT_ERROR_PATH}`
+    return `${DEFAULT_PROTOCOL}://${LOG_SERVER}/${DEFAULT_ERROR_PATH}`;
   },
   enableAnalytics(conf = {}) {
     if (isPlainObject(conf.options)) {
       const { domain, configId, configVer, server } = conf.options;
       if (!domain || !isStr(domain)) {
         logWarn(`${MODULE_NAME}: Mandatory parameter 'domain' not configured, analytics disabled`);
-        return
+        return;
       }
-      WEBSITE = domain
+      WEBSITE = domain;
       if (server) {
         if (isStr(server)) {
-          LOG_SERVER = server
+          LOG_SERVER = server;
         } else {
           logWarn(`options.server must be a string`);
         }
       }
       if (configId) {
         if (isNumber(configId)) {
-          CONFIG_ID = configId
+          CONFIG_ID = configId;
         } else {
           logWarn(`options.configId must be a number`);
         }
       }
       if (configVer) {
         if (isNumber(configVer)) {
-          CONFIG_VERSION = configVer
+          CONFIG_VERSION = configVer;
         } else {
           logWarn(`options.configVer must be a number`);
         }
@@ -566,50 +566,50 @@ const r2b2Analytics = Object.assign({}, baseAdapter, {
       }
       switch (eventType) {
         case EVENTS.NO_BID:
-          handleNoBid(args)
+          handleNoBid(args);
           break;
         case EVENTS.AUCTION_INIT:
-          handleAuctionInit(args)
+          handleAuctionInit(args);
           break;
         case EVENTS.BID_REQUESTED:
-          handleBidRequested(args)
+          handleBidRequested(args);
           break;
         case EVENTS.BID_TIMEOUT:
-          handleBidTimeout(args)
+          handleBidTimeout(args);
           break;
         case EVENTS.BID_RESPONSE:
-          handleBidResponse(args)
+          handleBidResponse(args);
           break;
         case EVENTS.BID_REJECTED:
-          handleBidRejected(args)
+          handleBidRejected(args);
           break;
         case EVENTS.BIDDER_DONE:
-          handleBidderDone(args)
+          handleBidderDone(args);
           break;
         case EVENTS.AUCTION_END:
-          handleAuctionEnd(args)
+          handleAuctionEnd(args);
           break;
         case EVENTS.BID_WON:
-          handleBidWon(args)
+          handleBidWon(args);
           break;
         case EVENTS.SET_TARGETING:
-          handleSetTargeting(args)
+          handleSetTargeting(args);
           break;
         case EVENTS.STALE_RENDER:
-          handleStaleRender(args)
+          handleStaleRender(args);
           break;
         case EVENTS.AD_RENDER_SUCCEEDED:
-          handleRenderSuccess(args)
+          handleRenderSuccess(args);
           break;
         case EVENTS.AD_RENDER_FAILED:
-          handleRenderFailed(args)
+          handleRenderFailed(args);
           break;
         case EVENTS.BID_VIEWABLE:
-          handleBidViewable(args)
+          handleBidViewable(args);
           break;
       }
     } catch (e) {
-      reportError(`${eventType} - ${e.message}`)
+      reportError(`${eventType} - ${e.message}`);
     }
   }
 });

--- a/modules/sovrnBidAdapter.js
+++ b/modules/sovrnBidAdapter.js
@@ -10,11 +10,11 @@ import {
   getBidIdParameter,
   mergeDeep
 } from '../src/utils.js';
-import { registerBidder } from '../src/adapters/bidderFactory.js'
+import { registerBidder } from '../src/adapters/bidderFactory.js';
 import {
   BANNER,
   VIDEO
-} from '../src/mediaTypes.js'
+} from '../src/mediaTypes.js';
 import { COMMON_ORTB_VIDEO_PARAMS } from '../libraries/deepintentUtils/index.js';
 
 /**
@@ -27,13 +27,13 @@ const ORTB_VIDEO_PARAMS = {
   'plcmt': (value) => isInteger(value) && value >= 1 && value <= 4,
   'delivery': (value) => Array.isArray(value) && value.every(v => v >= 1 && v <= 3),
   'pos': (value) => isInteger(value) && value >= 1 && value <= 7,
-}
+};
 
 const REQUIRED_VIDEO_PARAMS = {
   mimes: ORTB_VIDEO_PARAMS.mimes,
   maxduration: ORTB_VIDEO_PARAMS.maxduration,
   protocols: ORTB_VIDEO_PARAMS.protocols
-}
+};
 
 export const spec = {
   code: 'sovrn',
@@ -47,7 +47,7 @@ export const spec = {
    * @return boolean for whether or not a bid is valid
    */
   isBidRequestValid: function (bid) {
-    const video = bid?.mediaTypes?.video
+    const video = bid?.mediaTypes?.video;
     return !!(
       bid.params.tagid &&
       !isNaN(parseFloat(bid.params.tagid)) &&
@@ -57,7 +57,7 @@ export const spec = {
             .every(key => REQUIRED_VIDEO_PARAMS[key](video[key]))
         )
       )
-    )
+    );
   },
 
   /**
@@ -80,30 +80,30 @@ export const spec = {
           eids.forEach(function (id) {
             if (id.uids && id.uids[0]) {
               if (id.source === 'criteo.com') {
-                criteoId = id.uids[0].id
+                criteoId = id.uids[0].id;
               }
             }
-          })
+          });
         }
 
         const bidSchain = bid?.ortb2?.source?.ext?.schain;
         if (bidSchain) {
-          schain = schain || bidSchain
+          schain = schain || bidSchain;
         }
-        iv = iv || getBidIdParameter('iv', bid.params)
+        iv = iv || getBidIdParameter('iv', bid.params);
 
         const imp = {
           adunitcode: bid.adUnitCode,
           id: bid.bidId,
           tagid: String(getBidIdParameter('tagid', bid.params)),
           bidfloor: _getBidFloors(bid)
-        }
+        };
 
         if (deepAccess(bid, 'mediaTypes.banner')) {
-          let bidSizes = deepAccess(bid, 'mediaTypes.banner.sizes') || bid.sizes
-          bidSizes = (isArray(bidSizes) && isArray(bidSizes[0])) ? bidSizes : [bidSizes]
-          bidSizes = bidSizes.filter(size => isArray(size))
-          const processedSizes = bidSizes.map(size => ({ w: parseInt(size[0], 10), h: parseInt(size[1], 10) }))
+          let bidSizes = deepAccess(bid, 'mediaTypes.banner.sizes') || bid.sizes;
+          bidSizes = (isArray(bidSizes) && isArray(bidSizes[0])) ? bidSizes : [bidSizes];
+          bidSizes = bidSizes.filter(size => isArray(size));
+          const processedSizes = bidSizes.map(size => ({ w: parseInt(size[0], 10), h: parseInt(size[1], 10) }));
 
           imp.banner = {
             format: processedSizes,
@@ -115,21 +115,21 @@ export const spec = {
           imp.video = _buildVideoRequestObj(bid);
         }
 
-        imp.ext = getBidIdParameter('ext', bid.ortb2Imp) || undefined
+        imp.ext = getBidIdParameter('ext', bid.ortb2Imp) || undefined;
 
-        const segmentsString = getBidIdParameter('segments', bid.params)
+        const segmentsString = getBidIdParameter('segments', bid.params);
         if (segmentsString) {
-          imp.ext = imp.ext || {}
-          imp.ext.deals = segmentsString.split(',').map(deal => deal.trim())
+          imp.ext = imp.ext || {};
+          imp.ext.deals = segmentsString.split(',').map(deal => deal.trim());
         }
-        sovrnImps.push(imp)
-      })
+        sovrnImps.push(imp);
+      });
 
       const fpd = bidderRequest.ortb2 || {};
 
-      const site = fpd.site || {}
-      site.page = bidderRequest.refererInfo.page
-      site.domain = bidderRequest.refererInfo.domain
+      const site = fpd.site || {};
+      site.page = bidderRequest.refererInfo.page;
+      site.domain = bidderRequest.refererInfo.domain;
 
       const tmax = deepAccess(bidderRequest, 'timeout');
 
@@ -139,7 +139,7 @@ export const spec = {
         site: site,
         user: fpd.user || {},
         tmax: tmax
-      }
+      };
 
       if (schain) {
         sovrnBidReq.source = {
@@ -149,9 +149,9 @@ export const spec = {
         };
       }
 
-      const tid = deepAccess(bidderRequest, 'ortb2.source.tid')
+      const tid = deepAccess(bidderRequest, 'ortb2.source.tid');
       if (tid) {
-        deepSetValue(sovrnBidReq, 'source.tid', tid)
+        deepSetValue(sovrnBidReq, 'source.tid', tid);
       }
 
       const coppa = deepAccess(bidderRequest, 'ortb2.regs.coppa');
@@ -166,7 +166,7 @@ export const spec = {
 
       if (bidderRequest.gdprConsent) {
         deepSetValue(sovrnBidReq, 'regs.ext.gdpr', +bidderRequest.gdprConsent.gdprApplies);
-        deepSetValue(sovrnBidReq, 'user.ext.consent', bidderRequest.gdprConsent.consentString)
+        deepSetValue(sovrnBidReq, 'user.ext.consent', bidderRequest.gdprConsent.consentString);
       }
       if (bidderRequest.uspConsent) {
         deepSetValue(sovrnBidReq, 'regs.ext.us_privacy', bidderRequest.uspConsent);
@@ -183,9 +183,9 @@ export const spec = {
       }
 
       if (eids) {
-        deepSetValue(sovrnBidReq, 'user.ext.eids', eids)
+        deepSetValue(sovrnBidReq, 'user.ext.eids', eids);
         if (criteoId) {
-          deepSetValue(sovrnBidReq, 'user.ext.prebid_criteoid', criteoId)
+          deepSetValue(sovrnBidReq, 'user.ext.prebid_criteoid', criteoId);
         }
       }
 
@@ -197,7 +197,7 @@ export const spec = {
         url: url,
         data: JSON.stringify(sovrnBidReq),
         options: { contentType: 'text/plain' }
-      }
+      };
     } catch (e) {
       logError('Could not build bidrequest, error deatils:', e);
     }
@@ -209,7 +209,7 @@ export const spec = {
    * @return {Bid[]} An array of formatted bids.
    */
   interpretResponse: function({ body: { id, seatbid } }) {
-    if (!id || !seatbid || !Array.isArray(seatbid)) return []
+    if (!id || !seatbid || !Array.isArray(seatbid)) return [];
 
     try {
       return seatbid
@@ -227,26 +227,26 @@ export const spec = {
             mediaType: Number(sovrnBid.mtype) === 2 ? VIDEO : BANNER,
             ttl: sovrnBid.ext?.ttl || 90,
             meta: { advertiserDomains: sovrnBid && sovrnBid.adomain ? sovrnBid.adomain : [] }
-          }
+          };
 
           if (Number(sovrnBid.mtype) === 2) {
-            bid.vastXml = decodeURIComponent(sovrnBid.adm)
+            bid.vastXml = decodeURIComponent(sovrnBid.adm);
           } else {
-            bid.ad = sovrnBid.nurl ? decodeURIComponent(`${sovrnBid.adm}<img src="${sovrnBid.nurl}">`) : decodeURIComponent(sovrnBid.adm)
+            bid.ad = sovrnBid.nurl ? decodeURIComponent(`${sovrnBid.adm}<img src="${sovrnBid.nurl}">`) : decodeURIComponent(sovrnBid.adm);
           }
 
-          return bid
+          return bid;
         }))
-        .flat()
+        .flat();
     } catch (e) {
-      logError('Could not interpret bidresponse, error details:', e)
-      return e
+      logError('Could not interpret bidresponse, error details:', e);
+      return e;
     }
   },
 
   getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) {
     try {
-      const tracks = []
+      const tracks = [];
       if (serverResponses && serverResponses.length !== 0) {
         if (syncOptions.iframeEnabled) {
           const iidArr = serverResponses.filter(resp => deepAccess(resp, 'body.ext.iid'))
@@ -260,7 +260,7 @@ export const spec = {
           }
           if (gppConsent) {
             params.push(['gpp', gppConsent.gppString]);
-            params.push(['gpp_sid', gppConsent.applicableSections])
+            params.push(['gpp_sid', gppConsent.applicableSections]);
           }
 
           if (iidArr[0]) {
@@ -276,31 +276,31 @@ export const spec = {
           serverResponses.filter(resp => deepAccess(resp, 'body.ext.sync.pixels'))
             .reduce((acc, resp) => acc.concat(resp.body.ext.sync.pixels), [])
             .map(pixel => pixel.url)
-            .forEach(url => tracks.push({ type: 'image', url }))
+            .forEach(url => tracks.push({ type: 'image', url }));
         }
       }
-      return tracks
+      return tracks;
     } catch (e) {
-      return []
+      return [];
     }
   },
-}
+};
 
 function _buildVideoRequestObj(bid) {
-  const videoObj = {}
-  const bidSizes = deepAccess(bid, 'sizes')
-  const videoAdUnitParams = deepAccess(bid, 'mediaTypes.video', {})
-  const videoBidderParams = deepAccess(bid, 'params.video', {})
-  const computedParams = {}
+  const videoObj = {};
+  const bidSizes = deepAccess(bid, 'sizes');
+  const videoAdUnitParams = deepAccess(bid, 'mediaTypes.video', {});
+  const videoBidderParams = deepAccess(bid, 'params.video', {});
+  const computedParams = {};
 
   if (bidSizes) {
-    const sizes = (Array.isArray(bidSizes[0])) ? bidSizes[0] : bidSizes
-    computedParams.w = sizes[0]
-    computedParams.h = sizes[1]
+    const sizes = (Array.isArray(bidSizes[0])) ? bidSizes[0] : bidSizes;
+    computedParams.w = sizes[0];
+    computedParams.h = sizes[1];
   } else if (Array.isArray(videoAdUnitParams.playerSize)) {
-    const sizes = (Array.isArray(videoAdUnitParams.playerSize[0])) ? videoAdUnitParams.playerSize[0] : videoAdUnitParams.playerSize
-    computedParams.w = sizes[0]
-    computedParams.h = sizes[1]
+    const sizes = (Array.isArray(videoAdUnitParams.playerSize[0])) ? videoAdUnitParams.playerSize[0] : videoAdUnitParams.playerSize;
+    computedParams.w = sizes[0];
+    computedParams.h = sizes[1];
   }
 
   const videoParams = {
@@ -312,13 +312,13 @@ function _buildVideoRequestObj(bid) {
   Object.keys(ORTB_VIDEO_PARAMS).forEach(paramName => {
     if (videoParams.hasOwnProperty(paramName)) {
       if (ORTB_VIDEO_PARAMS[paramName](videoParams[paramName])) {
-        videoObj[paramName] = videoParams[paramName]
+        videoObj[paramName] = videoParams[paramName];
       } else {
         logWarn(`The OpenRTB video param ${paramName} has been skipped due to misformating. Please refer to OpenRTB 2.5 spec.`);
       }
     }
-  })
-  return videoObj
+  });
+  return videoObj;
 }
 
 function _getBidFloors(bid) {
@@ -326,13 +326,13 @@ function _getBidFloors(bid) {
     currency: 'USD',
     mediaType: bid.mediaTypes && bid.mediaTypes.banner ? 'banner' : 'video',
     size: '*'
-  }) : {}
-  const floorModuleValue = parseFloat(floorInfo?.floor)
+  }) : {};
+  const floorModuleValue = parseFloat(floorInfo?.floor);
   if (!isNaN(floorModuleValue)) {
-    return floorModuleValue
+    return floorModuleValue;
   }
-  const paramValue = parseFloat(getBidIdParameter('bidfloor', bid.params))
-  return !isNaN(paramValue) ? paramValue : undefined
+  const paramValue = parseFloat(getBidIdParameter('bidfloor', bid.params));
+  return !isNaN(paramValue) ? paramValue : undefined;
 }
 
-registerBidder(spec)
+registerBidder(spec);

--- a/modules/userId/index.ts
+++ b/modules/userId/index.ts
@@ -72,7 +72,7 @@ export const PBJS_USER_ID_OPTOUT_NAME = '_pbjs_id_optout';
 export const coreStorage = getCoreStorageManager('userId');
 export const dep = {
   isAllowed: isActivityAllowed
-}
+};
 
 declare module '../../src/userSync' {
   interface UserSyncConfig {
@@ -142,11 +142,11 @@ const uidMetrics = (() => {
       metrics = newMetrics();
     }
     return metrics;
-  }
+  };
 })();
 
 function submoduleMetrics(moduleName) {
-  return uidMetrics().fork().renameWith(n => [`userId.mod.${n}`, `userId.mods.${moduleName}.${n}`])
+  return uidMetrics().fork().renameWith(n => [`userId.mod.${n}`, `userId.mods.${moduleName}.${n}`]);
 }
 
 export function setSubmoduleRegistry(submodules) {
@@ -160,7 +160,7 @@ function cookieSetter(submodule, storageMgr?) {
   const name = submodule.config.storage.name;
   return function setCookie(suffix, value, expiration) {
     storageMgr.setCookie(name + (suffix || ''), value, expiration, 'Lax', domainOverride);
-  }
+  };
 }
 
 function setValueInCookie(submodule, valueStr, expiresStr) {
@@ -220,7 +220,7 @@ function deleteValueFromCookie(submodule) {
     } catch (e) {
       logError(e);
     }
-  })
+  });
 }
 
 export const HTML5_SUFFIXES = ['', '_last', '_exp', '_cst'];
@@ -251,7 +251,7 @@ export function deleteStoredValue(submodule) {
 }
 
 function getValueFromCookie(submodule, storedKey) {
-  return submodule.storageMgr.getCookie(storedKey)
+  return submodule.storageMgr.getCookie(storedKey);
 }
 
 function getValueFromLocalStorage(submodule, storedKey) {
@@ -334,14 +334,14 @@ function getIds(priorityMap): Partial<UserId> {
     Object.entries(priorityMap)
       .map(([key, getActiveModule]: [string, any]) => [key, getActiveModule()?.idObj?.[key]])
       .filter(([_, value]) => value != null)
-  )
+  );
 }
 
 function getPrimaryIds(submodule) {
   if (submodule.primaryIds) return submodule.primaryIds;
   const ids = Object.keys(submodule.eids ?? {});
   if (ids.length > 1) {
-    throw new Error(`ID submodule ${submodule.name} can provide multiple IDs, but does not specify 'primaryIds'`)
+    throw new Error(`ID submodule ${submodule.name} can provide multiple IDs, but does not specify 'primaryIds'`);
   }
   return ids;
 }
@@ -357,13 +357,13 @@ function orderByPriority(items, getKeys, getIdMod) {
     const module = getIdMod(item);
     const primaryIds = getPrimaryIds(module);
     getKeys(item).forEach(key => {
-      const keyItems = tally[key] = tally[key] ?? []
+      const keyItems = tally[key] = tally[key] ?? [];
       const keyPriority = idPriority[key]?.indexOf(module.name) ?? (primaryIds.includes(key) ? 0 : -1);
       const pos = keyItems.findIndex(([priority]) => priority < keyPriority);
-      keyItems.splice(pos === -1 ? keyItems.length : pos, 0, [keyPriority, item])
-    })
-  })
-  return Object.fromEntries(Object.entries(tally).map(([key, items]: [string, any]) => [key, items.map(([_, item]) => item)]))
+      keyItems.splice(pos === -1 ? keyItems.length : pos, 0, [keyPriority, item]);
+    });
+  });
+  return Object.fromEntries(Object.entries(tally).map(([key, items]: [string, any]) => [key, items.map(([_, item]) => item)]));
 }
 
 function mkPriorityMaps() {
@@ -384,13 +384,13 @@ function mkPriorityMaps() {
       map.submodules = [];
       update();
     }
-  }
+  };
   function update() {
     const modulesById = orderByPriority(
       map.submodules,
       (submod) => Object.keys(submod.idObj ?? {}),
       (submod) => submod.submodule,
-    )
+    );
     const global: any = {};
     const bidder: any = {};
 
@@ -412,7 +412,7 @@ function mkPriorityMaps() {
               // do not keep looking for alternative IDs in other (lower priority) modules; the ID will be provided only
               // to the bidders this module is configured for.
               const listModules = (modules) => modules.map(mod => mod.module.submodule.name).join(', ');
-              logWarn(`userID modules ${listModules(modules)} provide the same ID ('${key}'); ${module.submodule.name} is the preferred source, but it's configured only for some bidders, unlike ${listModules(modules.filter(mod => mod.bidders == null))}. Other bidders will not see the "${key}" ID.`)
+              logWarn(`userID modules ${listModules(modules)} provide the same ID ('${key}'); ${module.submodule.name} is the preferred source, but it's configured only for some bidders, unlike ${listModules(modules.filter(mod => mod.bidders == null))}. Other bidders will not see the "${key}" ID.`);
               return null;
             } else if (bidders == null) {
               // value != null, allowed = false, useGlobals = false, bidders == null:
@@ -424,7 +424,7 @@ function mkPriorityMaps() {
           }
         }
         return null;
-      }
+      };
     }
 
     Object.entries(modulesById)
@@ -442,15 +442,15 @@ function mkPriorityMaps() {
           return {
             module,
             bidders
-          }
-        })
+          };
+        });
         if (!allNonGlobal) {
           global[key] = activeModuleGetter(key, true, modules.map(({ bidders, module }) => ({ allowed: bidders == null, bidders, module })));
         }
         bidderFilters.forEach(bidderCode => {
           bidder[bidderCode] = bidder[bidderCode] ?? {};
           bidder[bidderCode][key] = activeModuleGetter(key, false, modules.map(({ bidders, module }) => ({ allowed: bidders?.includes(bidderCode), bidders, module })));
-        })
+        });
       });
     const combined = Object.values(bidder).concat([global]).reduce((combo, map) => Object.assign(combo, map), {});
     Object.assign(map, { global, bidder, combined });
@@ -474,7 +474,7 @@ export function enrichEids(ortb2Fragments) {
         (bidderFpd[bidder]?.user?.ext?.eids ?? []).concat(bidderEids)
       );
     }
-  })
+  });
   return ortb2Fragments;
 }
 
@@ -485,7 +485,7 @@ declare module '../../src/adapterManager' {
 }
 
 export function addIdData({ ortb2Fragments }) {
-  ortb2Fragments = ortb2Fragments ?? { global: {}, bidder: {} }
+  ortb2Fragments = ortb2Fragments ?? { global: {}, bidder: {} };
   enrichEids(ortb2Fragments);
 }
 
@@ -506,7 +506,7 @@ function idSystemInitializer({ mkDelay = delay } = {}) {
     }
     cancel = defer();
     return PbPromise.race([promise, cancel.promise])
-      .finally(initMetrics.startTiming('userId.total'))
+      .finally(initMetrics.startTiming('userId.total'));
   }
 
   // grab a reference to global vars so that the promise chains remain isolated;
@@ -521,11 +521,11 @@ function idSystemInitializer({ mkDelay = delay } = {}) {
       if (initModules === initializedSubmodules && allModules === submodules) {
         return fn(...args);
       }
-    }
+    };
   }
 
   function timeConsent() {
-    return allConsent.promise.finally(initMetrics.startTiming('userId.init.consent'))
+    return allConsent.promise.finally(initMetrics.startTiming('userId.init.consent'));
   }
 
   let done = cancelAndTry(
@@ -635,8 +635,8 @@ function aliasEidsHook(next, bidderRequests) {
           return bidderRequest.ortb2.user?.ext?.eids ?? [];
         }
       })
-    )
-  })
+    );
+  });
   next(bidderRequests);
 }
 
@@ -682,7 +682,7 @@ function addedStartAuctionHook() {
  * Simple use case will be passing these UserIds to A9 wrapper solution
  */
 function getUserIds() {
-  return getIds(initializedSubmodules.combined)
+  return getIds(initializedSubmodules.combined);
 }
 
 /**
@@ -690,7 +690,7 @@ function getUserIds() {
  * Simple use case will be passing these UserIds to A9 wrapper solution
  */
 function getUserIdsAsEids(): EID[] {
-  return getEids(initializedSubmodules.combined)
+  return getEids(initializedSubmodules.combined);
 }
 
 /**
@@ -725,7 +725,7 @@ function getEncryptedEidsForSource(source, encrypt, customFunction) {
     }
     logInfo(`${MODULE_NAME} - Fetching encrypted eids: ${eidsSignals[source]}`);
     return eidsSignals[source];
-  })
+  });
 }
 
 function encryptSignals(signals, version = 1) {
@@ -759,8 +759,8 @@ function registerSignalSources() {
             collectorFunction: () => getEncryptedEidsForSource(src, encrypt, customFunc)
           });
         });
-      })
-    }, registerDelay)
+      });
+    }, registerDelay);
   } else {
     logWarn(`${MODULE_NAME} - ESP : encryptedSignalSources config not defined under userSync Object`);
   }
@@ -779,10 +779,10 @@ function retryOnCancel(initParams?) {
         // there's a pending refresh - because GreedyPromise runs this synchronously, we are now in the middle
         // of canceling the previous init, before the refresh logic has had a chance to run.
         // Use a "normal" Promise to clear the stack and let it complete (or this will just recurse infinitely)
-        return Promise.resolve().then(getUserIdsAsync)
+        return Promise.resolve().then(getUserIdsAsync);
       } else {
-        logError('Error initializing userId', e)
-        return PbPromise.reject(e)
+        logError('Error initializing userId', e);
+        return PbPromise.reject(e);
       }
     }
   );
@@ -960,12 +960,12 @@ function initSubmodules(priorityMaps, submodules, forceRefresh = false) {
           logError(`Error in userID module '${submodule.submodule.name}':`, e);
         }
         return carry;
-      })
+      });
     }, []);
     priorityMaps.refresh(initialized);
     updatePPID(priorityMaps);
     return initialized;
-  })
+  });
 }
 
 function getConfiguredStorageTypes(config) {
@@ -985,7 +985,7 @@ function hasValidStorageTypes(config) {
  */
 export function getValidSubmoduleConfigs(configRegistry) {
   function err(msg, ...args) {
-    logWarn(`Invalid userSync.userId config: ${msg}`, ...args)
+    logWarn(`Invalid userSync.userId config: ${msg}`, ...args);
   }
   if (!Array.isArray(configRegistry)) {
     if (configRegistry != null) {
@@ -1000,12 +1000,12 @@ export function getValidSubmoduleConfigs(configRegistry) {
       if (!config.storage.name || !config.storage.type) {
         return err('must specify "storage.name" and "storage.type"', config);
       } else if (!hasValidStorageTypes(config)) {
-        return err('invalid "storage.type"', config)
+        return err('invalid "storage.type"', config);
       }
       ['expires', 'refreshInSeconds'].forEach(param => {
         let value = config.storage[param];
         if (value != null && typeof value !== 'number') {
-          value = Number(value)
+          value = Number(value);
           if (isNaN(value)) {
             err(`storage.${param} must be a number and will be ignored`, config);
             delete config.storage[param];
@@ -1016,7 +1016,7 @@ export function getValidSubmoduleConfigs(configRegistry) {
       });
     }
     return true;
-  })
+  });
 }
 
 const ALL_STORAGE_TYPES = new Set([LOCAL_STORAGE, COOKIE]);
@@ -1032,7 +1032,7 @@ function canUseCookies(submodule) {
   if (!submodule.storageMgr.cookiesAreEnabled()) {
     return false;
   }
-  return true
+  return true;
 }
 
 const STORAGE_PURPOSES = [1, 2, 3, 4, 7];
@@ -1052,8 +1052,8 @@ function populateEnabledStorageTypes(submodule: SubmoduleContainer<UserIdProvide
             type: 'web',
             identifier: submodule.config.storage.name + suffix,
             purposes: STORAGE_PURPOSES
-          })
-        })
+          });
+        });
         return canUseLocalStorage(submodule);
       case COOKIE:
         COOKIE_SUFFIXES.forEach(suffix => {
@@ -1063,8 +1063,8 @@ function populateEnabledStorageTypes(submodule: SubmoduleContainer<UserIdProvide
             purposes: STORAGE_PURPOSES,
             maxAgeSeconds: (submodule.config.storage.expires ?? 0) * 24 * 60 * 60,
             cookieRefresh: true
-          })
-        })
+          });
+        });
         return canUseCookies(submodule);
     }
 
@@ -1084,7 +1084,7 @@ function updateEIDConfig(submodules) {
       (mod) => Object.keys(mod.eids || {}),
       (mod) => mod
     )
-  ).forEach(([key, submodules]) => EID_CONFIG.set(key, submodules[0].eids[key]))
+  ).forEach(([key, submodules]) => EID_CONFIG.set(key, submodules[0].eids[key]));
 }
 
 export function generateSubmoduleContainers(options, configs, prevSubmodules = submodules, registry = submoduleRegistry) {
@@ -1153,7 +1153,7 @@ function updateSubmodules(options = {}) {
 
   if (submodules.length) {
     if (!addedStartAuctionHook()) {
-      startAuction.before(startAuctionHook, 100) // use higher priority than dataController / rtd
+      startAuction.before(startAuctionHook, 100); // use higher priority than dataController / rtd
       adapterManager.callDataDeletionRequest.before(requestDataDeletion);
       coreGetPPID.after((next) => next(getPPID()));
     }
@@ -1169,7 +1169,7 @@ function updateIdPriority(idPriorityConfig, submodules) {
     const result = {};
     const aliasToName = new Map(submodules.map(s => s.aliasName ? [s.aliasName, s.name] : []));
     Object.keys(idPriorityConfig).forEach(key => {
-      const priority = isArray(idPriorityConfig[key]) ? [...idPriorityConfig[key]].reverse() : []
+      const priority = isArray(idPriorityConfig[key]) ? [...idPriorityConfig[key]].reverse() : [];
       result[key] = priority.map(s => aliasToName.has(s) ? aliasToName.get(s) : s);
     });
     idPriority = result;
@@ -1177,11 +1177,11 @@ function updateIdPriority(idPriorityConfig, submodules) {
     idPriority = {};
   }
   initializedSubmodules.refresh();
-  updateEIDConfig(submodules)
+  updateEIDConfig(submodules);
 }
 
 export function requestDataDeletion(next, ...args) {
-  logInfo('UserID: received data deletion request; deleting all stored IDs...')
+  logInfo('UserID: received data deletion request; deleting all stored IDs...');
   submodules.forEach(submodule => {
     if (typeof submodule.submodule.onDataDeletionRequest === 'function') {
       try {
@@ -1191,7 +1191,7 @@ export function requestDataDeletion(next, ...args) {
       }
     }
     deleteStoredValue(submodule);
-  })
+  });
   next.apply(this, args);
 }
 
@@ -1202,7 +1202,7 @@ export function attachIdSystem(submodule: IdProviderSpec<UserIdProvider>) {
   submodule.findRootDomain = findRootDomain;
   if (!(submoduleRegistry || []).find(i => i.name === submodule.name)) {
     submoduleRegistry.push(submodule);
-    GDPR_GVLIDS.register(MODULE_TYPE_UID, submodule.name, submodule.gvlid)
+    GDPR_GVLIDS.register(MODULE_TYPE_UID, submodule.name, submodule.gvlid);
     updateSubmodules();
     // TODO: a test case wants this to work even if called after init (the setConfig({userId}))
     // so we trigger a refresh. But is that even possible outside of tests?
@@ -1247,8 +1247,8 @@ const enforceStorageTypeRule = (userIdsConfig, enforceStorageType) => {
         logWarn(reason);
       }
     }
-  }
-}
+  };
+};
 
 /**
  * test browser support for storage config types (local storage or cookie), initializes submodules but consentManagement is required,
@@ -1263,12 +1263,12 @@ export function init(config, { mkDelay = delay } = {}) {
   initIdSystem = idSystemInitializer({ mkDelay });
   allConsent.onChange(() => {
     initIdSystem({ refresh: true });
-  })
+  });
   if (configListener != null) {
     configListener();
   }
   submoduleRegistry = [];
-  let unregisterEnforceStorageTypeRule: () => void
+  let unregisterEnforceStorageTypeRule: () => void;
 
   // listen for config userSyncs to be set
   configListener = config.getConfig('userSync', conf => {
@@ -1279,7 +1279,7 @@ export function init(config, { mkDelay = delay } = {}) {
       if (userSync.userIds) {
         const { autoRefresh = false, retainConfig = true, enforceStorageType } = userSync;
         configRegistry = userSync.userIds;
-        syncDelay = isNumber(userSync.syncDelay) ? userSync.syncDelay : USERSYNC_DEFAULT_CONFIG.syncDelay
+        syncDelay = isNumber(userSync.syncDelay) ? userSync.syncDelay : USERSYNC_DEFAULT_CONFIG.syncDelay;
         auctionDelay = isNumber(userSync.auctionDelay) ? userSync.auctionDelay : USERSYNC_DEFAULT_CONFIG.auctionDelay;
         updateSubmodules({ retainConfig, autoRefresh });
         unregisterEnforceStorageTypeRule?.();
@@ -1307,7 +1307,7 @@ export function init(config, { mkDelay = delay } = {}) {
 }
 
 export function resetUserIds() {
-  config.setConfig({ userSync: {} })
+  config.setConfig({ userSync: {} });
   init(config);
 }
 


### PR DESCRIPTION
See https://github.com/prebid/Prebid.js/security/quality/rules/js%2Fautomatic-semicolon-insertion


### Motivation
- Reduce CodeQL "implied semicolon" / ESLint `semi` noise by making semicolons explicit across high-volume module files.
- Keep changes purely stylistic so runtime behavior remains unchanged.

### Description
- Added explicit semicolons and minor stylistic formatting to eight modules: `modules/advRedAnalyticsAdapter.js`, `modules/asteriobidAnalyticsAdapter.js`, `modules/ccxBidAdapter.js`, `modules/justpremiumBidAdapter.js`, `modules/mediaConsortiumBidAdapter.js`, `modules/nativoBidAdapter.js`, `modules/ooloAnalyticsAdapter.js`, and `modules/permutiveRtdProvider.js`.
- Applied consistent line-end semicolons, fixed a few trailing-comma/empty-line cases and small formatting to satisfy the `semi:[error,always]` rule while preserving original logic.
- No functional or API changes were made; data flow and behavior are unchanged.

### Testing
- Ran ESLint semi check on changed modules with `npx eslint --rule 'semi:[error,always]' --format json <files>` and verified zero remaining `semi` findings for the modified files.
- Ran `npx eslint <files> --cache --cache-strategy content` to validate general linting and `git diff --check` to ensure no whitespace/errors; both succeeded.
- Executed unit-spec subsets with `npx gulp test --nolint --file <spec_file.js>` for the affected modules' specs (examples: `test/spec/modules/nativoBidAdapter_spec.js`, `ooloAnalyticsAdapter_spec.js`, `asteriobidAnalyticsAdapter_spec.js`, `permutiveCombined_spec.js`, `advRedAnalyticsAdapter_spec.js`, `mediaConsortiumBidAdapter_spec.js`, `justpremiumBidAdapter_spec.js`, `ccxBidAdapter_spec.js`) and the runs completed successfully.
- Attempted `npx gulp update-codeql` and local CodeQL pack compile but the update/compile failed in this environment due to network/fetch and certificate issues, so autogenerated CodeQL query changes were not produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a29113588d4832baad9e2a5b340c0f5)