### PR TITLE
Modules: add missing semicolons

### DIFF
--- a/modules/adnuntiusBidAdapter.js
+++ b/modules/adnuntiusBidAdapter.js
@@ -313,13 +313,13 @@ export const spec = {
 
   buildRequests: function (validBidRequests, bidderRequest) {
     const queryParamsAndValues = [];
-    queryParamsAndValues.push('tzo=' + new Date().getTimezoneOffset())
-    queryParamsAndValues.push('format=prebid')
+    queryParamsAndValues.push('tzo=' + new Date().getTimezoneOffset());
+    queryParamsAndValues.push('format=prebid');
     const gdprApplies = deepAccess(bidderRequest, 'gdprConsent.gdprApplies');
     const consentString = deepAccess(bidderRequest, 'gdprConsent.consentString');
     queryParamsAndValues.push('pbv=' + getGlobal().version);
     if (gdprApplies !== undefined) {
-      const flag = gdprApplies ? '1' : '0'
+      const flag = gdprApplies ? '1' : '0';
       queryParamsAndValues.push('consentString=' + consentString);
       queryParamsAndValues.push('gdpr=' + flag);
     }
@@ -415,7 +415,7 @@ export const spec = {
                 'methods': [1]
               }
             ];
-            adUnit.nativeRequest = { ortb: nativeOrtb }
+            adUnit.nativeRequest = { ortb: nativeOrtb };
           } else {
             adUnit.nativeRequest = { ortb: mediaTypeData.ortb };
           }
@@ -477,7 +477,7 @@ export const spec = {
       if (advertiserDomains.length === 0) {
         const destinationUrls = ad.destinationUrls || {};
         for (const value of Object.values(destinationUrls)) {
-          advertiserDomains.push(value.split('/')[2])
+          advertiserDomains.push(value.split('/')[2]);
         }
       }
       const adResponse = {

--- a/modules/adverxoBidAdapter.js
+++ b/modules/adverxoBidAdapter.js
@@ -353,6 +353,6 @@ export const spec = {
 
     return result;
   }
-}
+};
 
 registerBidder(spec);

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -278,7 +278,7 @@ export const spec = {
     const ortb2 = deepClone(bidderRequest && bidderRequest.ortb2);
 
     const anAuctionKeywords = deepClone(config.getConfig('appnexusAuctionKeywords')) || {};
-    const auctionKeywords = getANKeywordParam(ortb2, anAuctionKeywords)
+    const auctionKeywords = getANKeywordParam(ortb2, anAuctionKeywords);
     if (auctionKeywords.length > 0) {
       payload.keywords = auctionKeywords;
     }
@@ -323,12 +323,12 @@ export const spec = {
       payload.privacy = {
         gpp: bidderRequest.gppConsent.gppString,
         gpp_sid: bidderRequest.gppConsent.applicableSections
-      }
+      };
     } else if (bidderRequest?.ortb2?.regs?.gpp) {
       payload.privacy = {
         gpp: bidderRequest.ortb2.regs.gpp,
         gpp_sid: bidderRequest.ortb2.regs.gpp_sid
-      }
+      };
     }
 
     if (bidderRequest && bidderRequest.refererInfo) {

--- a/modules/axisBidAdapter.js
+++ b/modules/axisBidAdapter.js
@@ -76,6 +76,6 @@ export const spec = {
       url: syncUrl
     }];
   }
-}
+};
 
 registerBidder(spec);

--- a/modules/beopBidAdapter.js
+++ b/modules/beopBidAdapter.js
@@ -130,7 +130,7 @@ export const spec = {
       method: 'POST',
       url: ENDPOINT_URL,
       data: payloadString
-    }
+    };
   },
   interpretResponse: function(serverResponse, request) {
     if (serverResponse && serverResponse.body && isArray(serverResponse.body.bids) && serverResponse.body.bids.length > 0) {

--- a/modules/bidglassBidAdapter.js
+++ b/modules/bidglassBidAdapter.js
@@ -140,7 +140,7 @@ export const spec = {
         contentType: 'text/plain',
         withCredentials: false
       }
-    }
+    };
   },
 
   /**

--- a/modules/bidmaticBidAdapter.js
+++ b/modules/bidmaticBidAdapter.js
@@ -154,7 +154,7 @@ export function remapBidRequest(bidRequests, adapterRequest) {
   bidRequestBody.USP = deepAccess(adapterRequest, 'uspConsent');
   bidRequestBody.Coppa = deepAccess(adapterRequest, 'ortb2.regs.coppa') ? 1 : 0;
   bidRequestBody.AgeVerification = deepAccess(adapterRequest, 'ortb2.regs.ext.age_verification');
-  bidRequestBody.GPP = adapterRequest.gppConsent ? adapterRequest.gppConsent.gppString : adapterRequest.ortb2?.regs?.gpp
+  bidRequestBody.GPP = adapterRequest.gppConsent ? adapterRequest.gppConsent.gppString : adapterRequest.ortb2?.regs?.gpp;
   bidRequestBody.GPPSid = adapterRequest.gppConsent ? adapterRequest.gppConsent.applicableSections?.toString() : adapterRequest.ortb2?.regs?.gpp_sid;
   bidRequestBody.Schain = deepAccess(bidRequests[0], 'schain');
   bidRequestBody.UserEids = deepAccess(bidRequests[0], 'userIdAsEids');

--- a/modules/bidtheatreBidAdapter.js
+++ b/modules/bidtheatreBidAdapter.js
@@ -112,6 +112,6 @@ export const spec = {
   onSetTargeting: function(bid) {},
   // onBidderError: function({ error, bidderRequest }) {},
   onAdRenderSucceeded: function(bid) {}
-}
+};
 
 registerBidder(spec);

--- a/modules/browsiRtdProvider.js
+++ b/modules/browsiRtdProvider.js
@@ -145,7 +145,7 @@ export function addBrowsiTag(data) {
   script.setAttribute('prebidbpt', 'true');
   script.setAttribute('id', 'browsi-tag');
   script.setAttribute('src', data.u);
-  script.prebidData = deepClone(typeof data === 'string' ? Object(data) : data)
+  script.prebidData = deepClone(typeof data === 'string' ? Object(data) : data);
   script.brwRandom = RANDOM;
   Object.assign(script.prebidData, { pvid: PVID || data.pvid, t: TIMESTAMP, apik: API_KEY });
   if (_moduleParams.keyName) {
@@ -279,7 +279,7 @@ function getPredictionsFromServer(url) {
             addBrowsiTag(data);
           } catch (err) {
             logError('unable to parse data');
-            setBrowsiData({})
+            setBrowsiData({});
           }
         } else if (req.status === 204) {
           // unrecognized site key

--- a/modules/cadent_aperture_mxBidAdapter.js
+++ b/modules/cadent_aperture_mxBidAdapter.js
@@ -281,7 +281,7 @@ export const spec = {
       // adding gpid support
       const gpid =
         deepAccess(bid, 'ortb2Imp.ext.gpid') ||
-        deepAccess(bid, 'ortb2Imp.ext.data.adserver.adslot')
+        deepAccess(bid, 'ortb2Imp.ext.data.adserver.adslot');
 
       if (gpid) {
         data.ext = { gpid: gpid.toString() };

--- a/modules/carodaBidAdapter.js
+++ b/modules/carodaBidAdapter.js
@@ -157,7 +157,7 @@ function getORTBCommon (bidderRequest) {
   const commonFpd = bidderRequest.ortb2 || {};
   const { user } = commonFpd;
   if (typeof getConfig('app') === 'object') {
-    app = getConfig('app') || {}
+    app = getConfig('app') || {};
     if (commonFpd.app) {
       mergeDeep(app, commonFpd.app);
     }

--- a/modules/connectadBidAdapter.js
+++ b/modules/connectadBidAdapter.js
@@ -107,9 +107,9 @@ export const spec = {
       deepSetValue(data, 'user.ext.eids', validBidRequests[0].userIdAsEids);
     }
 
-    const tid = deepAccess(bidderRequest, 'ortb2.source.tid')
+    const tid = deepAccess(bidderRequest, 'ortb2.source.tid');
     if (tid) {
-      deepSetValue(data, 'source.tid', tid)
+      deepSetValue(data, 'source.tid', tid);
     }
     data.tmax = bidderRequest.timeout;
 
@@ -178,10 +178,10 @@ export const spec = {
           bid.netRevenue = true;
 
           if (decision.dsa) {
-            bid.meta = Object.assign({}, bid.meta, { dsa: decision.dsa })
+            bid.meta = Object.assign({}, bid.meta, { dsa: decision.dsa });
           }
           if (decision.category) {
-            bid.meta = Object.assign({}, bid.meta, { primaryCatId: decision.category })
+            bid.meta = Object.assign({}, bid.meta, { primaryCatId: decision.category });
           }
 
           bidResponses.push(bid);

--- a/modules/craftBidAdapter.js
+++ b/modules/craftBidAdapter.js
@@ -62,7 +62,7 @@ export const spec = {
         payload.referrer_detection = refererinfo;
       }
       if (bidRequest.userId) {
-        payload.userId = bidRequest.userId
+        payload.userId = bidRequest.userId;
       }
     }
     const request = formatRequest(payload, bidderRequest);

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -28,7 +28,7 @@ export const storage = getStorageManager({ bidderCode: BIDDER_CODE });
 const LOG_PREFIX = 'Criteo: ';
 const TRANSLATOR = ortb25Translator();
 
-const PUBLISHER_TAG_OUTSTREAM_SRC = 'https://static.criteo.net/js/ld/publishertag.renderer.js'
+const PUBLISHER_TAG_OUTSTREAM_SRC = 'https://static.criteo.net/js/ld/publishertag.renderer.js';
 const OPTOUT_COOKIE_NAME = 'cto_optout';
 const BUNDLE_COOKIE_NAME = 'cto_bundle';
 const GUID_RETENTION_TIME_HOUR = 24 * 30 * 13; // 13 months

--- a/modules/dailymotionBidAdapter.js
+++ b/modules/dailymotionBidAdapter.js
@@ -59,7 +59,7 @@ function getVideoMetadata(bidRequest, bidderRequest) {
     ? deepAccess(bidderRequest, 'ortb2.site')
     : deepAccess(bidderRequest, 'ortb2.app');
   // Content object is either from Object: Site or Object: App
-  const contentObj = deepAccess(siteOrAppObj, 'content')
+  const contentObj = deepAccess(siteOrAppObj, 'content');
 
   const contentCattax = deepAccess(contentObj, 'cattax', 0);
   const isContentCattaxV1 = contentCattax === 1;

--- a/modules/dasBidAdapter.js
+++ b/modules/dasBidAdapter.js
@@ -53,7 +53,7 @@ function parseNativeResponse(ad) {
     nativeResponse.privacyLink = dsaurl;
   }
 
-  return nativeResponse
+  return nativeResponse;
 }
 
 function getGdeScriptUrl(adDataFields) {


### PR DESCRIPTION
### Motivation
- Address CodeQL warnings about Automated Semicolon Insertion (ASI) by making statement terminations explicit in several modules. 
- Improve consistency and avoid style-related static-analysis noise without changing runtime behavior. 
- Keep changes scoped to formatting-only edits so adapters/RTD logic remains unchanged.

### Description
- Added missing semicolons to flagged statements such as query param `push` calls, ternary `const` assignments, object-return literals, `return` statements, and `script.prebidData` assignments across multiple modules. 
- Fixed a few module/spec/object closures by ensuring exported spec objects and return objects end with a semicolon. 
- Files updated include: `modules/adnuntiusBidAdapter.js`, `modules/adverxoBidAdapter.js`, `modules/appnexusBidAdapter.js`, `modules/axisBidAdapter.js`, `modules/beopBidAdapter.js`, `modules/bidglassBidAdapter.js`, `modules/bidmaticBidAdapter.js`, `modules/bidtheatreBidAdapter.js`, `modules/browsiRtdProvider.js`, `modules/cadent_aperture_mxBidAdapter.js`, `modules/carodaBidAdapter.js`, `modules/connectadBidAdapter.js`, `modules/craftBidAdapter.js`, `modules/criteoBidAdapter.js`, `modules/dailymotionBidAdapter.js`, and `modules/dasBidAdapter.js`. 
- Changes are stylistic only; no functional code paths were modified.

### Testing
- Ran lint on the touched files with `npx eslint <files> --cache --cache-strategy content`, which completed without reported lint failures. 
- Ran targeted unit tests with `TEST_PAT='{...}_spec.js' npx gulp test --nolint` covering the updated adapter/RTD specs, and the targeted test chunks completed successfully. 
- All automated checks executed for this PR passed for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a296dfd6b88832b8ba489b2902775d8)