### PR TITLE
Modules: fix semicolon style issues

### DIFF
--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -43,7 +43,7 @@ const VIDEO_CUSTOM_PARAMS = {
   'minbitrate': DATA_TYPES.NUMBER,
   'maxbitrate': DATA_TYPES.NUMBER,
   'skip': DATA_TYPES.NUMBER
-}
+};
 
 var hostDomain;
 
@@ -330,7 +330,7 @@ function buildOneRequest(validBidRequests, bidderRequest) {
 
     banner.api = api;
 
-    const formatArr = bannerMediaType.sizes.map(size => ({ w: size[0], h: size[1] }))
+    const formatArr = bannerMediaType.sizes.map(size => ({ w: size[0], h: size[1] }));
     banner.format = Object.assign({}, formatArr);
 
     imp.banner = banner;

--- a/modules/teadsBidAdapter.js
+++ b/modules/teadsBidAdapter.js
@@ -101,7 +101,7 @@ export const spec = {
       const isValidConsentString = typeof gpp.gppString === 'string';
       const validateApplicableSections =
         Array.isArray(gpp.applicableSections) &&
-        gpp.applicableSections.every((section) => typeof (section) === 'number')
+        gpp.applicableSections.every((section) => typeof (section) === 'number');
       payload.gpp = {
         consentString: isValidConsentString ? gpp.gppString : '',
         applicableSectionIds: validateApplicableSections ? gpp.applicableSections : [],

--- a/modules/theAdxBidAdapter.js
+++ b/modules/theAdxBidAdapter.js
@@ -532,7 +532,7 @@ const generatePayload = (bidRequest, bidderRequest) => {
 };
 
 function getEids(bidRequest) {
-  const eids = {}
+  const eids = {};
 
   const uId2 = deepAccess(bidRequest, 'userId.uid2.id');
   if (uId2) {

--- a/modules/topicsFpdModule.js
+++ b/modules/topicsFpdModule.js
@@ -31,7 +31,7 @@ const TAXONOMIES = {
   '2': 601,
   '3': 602,
   '4': 603
-}
+};
 
 function partitionBy(field, items) {
   return items.reduce((partitions, item) => {

--- a/modules/tpmnBidAdapter.js
+++ b/modules/tpmnBidAdapter.js
@@ -40,7 +40,7 @@ export const spec = {
       utils.triggerPixel(bid.burl);
     }
   }
-}
+};
 
 function isBidRequestValid(bid) {
   return (isValidInventoryId(bid) && (isValidBannerRequest(bid) || isValidVideoRequest(bid)));

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -170,10 +170,10 @@ function getImpression(bidRequest) {
   }
 
   const secure = utils.deepAccess(bidRequest, 'ortb2Imp.secure');
-  impression.secure = isNumber(secure) ? secure : 1
+  impression.secure = isNumber(secure) ? secure : 1;
 
   const { video: _, ...ortb2ImpWithoutVideo } = bidRequest.ortb2Imp; // if enabled, video is already assigned above
-  utils.mergeDeep(impression, ortb2ImpWithoutVideo)
+  utils.mergeDeep(impression, ortb2ImpWithoutVideo);
 
   return impression;
 }
@@ -395,7 +395,7 @@ export const spec = {
       regs: getRegs(bidderRequest),
       source: getSource(validBidRequests, bidderRequest),
       ext: getExt(firstPartyData)
-    }
+    };
 
     if (firstPartyData && firstPartyData.bcat) {
       topLevel.bcat = firstPartyData.bcat;

--- a/modules/underdogmediaBidAdapter.js
+++ b/modules/underdogmediaBidAdapter.js
@@ -23,7 +23,7 @@ const NON_MEASURABLE = -1;
 const PRODUCT = {
   standard: 1,
   sticky: 2
-}
+};
 
 let USER_SYNCED = false;
 

--- a/modules/unicornBidAdapter.js
+++ b/modules/unicornBidAdapter.js
@@ -117,7 +117,7 @@ const initializeEids = (bidRequest) => {
   }
 
   return eids;
-}
+};
 
 const interpretResponse = (serverResponse, request) => {
   logInfo('[UNICORN] interpretResponse.serverResponse:', serverResponse);

--- a/modules/uniquestBidAdapter.js
+++ b/modules/uniquestBidAdapter.js
@@ -45,7 +45,7 @@ export const spec = {
       const sid = getBidIdParameter('sid', request.params);
       const widths = request.sizes.map(size => size[0]).join(',');
       const heights = request.sizes.map(size => size[1]).join(',');
-      const timeout = bidderRequest.timeout
+      const timeout = bidderRequest.timeout;
 
       queryString = tryAppendQueryString(queryString, 'bid', bid);
       queryString = tryAppendQueryString(queryString, 'sid', sid);

--- a/modules/uniquest_widgetBidAdapter.js
+++ b/modules/uniquest_widgetBidAdapter.js
@@ -45,7 +45,7 @@ export const spec = {
       const wid = getBidIdParameter('wid', request.params);
       const widths = request.sizes.map(size => size[0]).join(',');
       const heights = request.sizes.map(size => size[1]).join(',');
-      const timeout = bidderRequest.timeout
+      const timeout = bidderRequest.timeout;
 
       queryString = tryAppendQueryString(queryString, 'bid', bid);
       queryString = tryAppendQueryString(queryString, 'wid', wid);

--- a/modules/userId/eids.js
+++ b/modules/userId/eids.js
@@ -73,7 +73,7 @@ export function createEidsArray(bidRequestUserId, eidConfigs = EID_CONFIG) {
           eids = [eids];
         }
         eids.forEach(eid => {
-          eid.uids = eid.uids.filter(({ id }) => isStr(id))
+          eid.uids = eid.uids.filter(({ id }) => isStr(id));
         })
         eids = eids.filter(({ uids }) => uids?.length > 0);
       } catch (e) {

--- a/modules/viantBidAdapter.js
+++ b/modules/viantBidAdapter.js
@@ -114,7 +114,7 @@ function createRequest(bidRequests, bidderRequest, mediaType) {
     method: 'POST',
     url: ENDPOINT,
     data: data
-  }
+  };
 }
 
 function isVideoBid(bid) {

--- a/modules/videojsVideoProvider.js
+++ b/modules/videojsVideoProvider.js
@@ -64,7 +64,7 @@ export function VideojsProvider(providerConfig, vjs_, adState_, timeState_, call
 
   function init() {
     if (!vjs) {
-      triggerSetupFailure(-1, setupFailMessage + ': Videojs not present')
+      triggerSetupFailure(-1, setupFailMessage + ': Videojs not present');
       return;
     }
 
@@ -114,7 +114,7 @@ export function VideojsProvider(providerConfig, vjs_, adState_, timeState_, call
     const supportedMediaTypes = Object.values(VIDEO_MIME_TYPE).filter(
       // Follows w3 spec https://www.w3.org/TR/2011/WD-html5-20110113/video.html#dom-navigator-canplaytype
       type => player.canPlayType(type) !== ''
-    )
+    );
 
     // IMA supports vpaid unless its expliclty turned off
     // TODO: needs a reference to the imaOptions used at setup to determine if vpaid can be used
@@ -636,13 +636,13 @@ export const utils = {
       case AD_REQUEST:
         return 'ads-request';
       case AD_LOADED:
-        return 'loaded'
+        return 'loaded';
       case AD_STARTED:
         return 'start';
       case AD_IMPRESSION:
         return 'impression';
       case AD_PLAY:
-        return 'resume'
+        return 'resume';
       case AD_PAUSE:
         return PAUSE;
       case AD_TIME:

--- a/modules/vrtcalBidAdapter.js
+++ b/modules/vrtcalBidAdapter.js
@@ -159,7 +159,7 @@ export const spec = {
     const usPrivacy = `&us_privacy=${encodeURIComponent(uspConsent)}`;
     const gpp = gppConsent.gppString ? gppConsent.gppString : '';
     const gppSid = Array.isArray(gppConsent.applicableSections) ? gppConsent.applicableSections.join(',') : '';
-    let vrtcalSyncURL = ''
+    let vrtcalSyncURL = '';
 
     if (syncOptions.iframeEnabled) {
       vrtcalSyncURL = `${VRTCAL_USER_SYNC_URL_IFRAME}${usPrivacy}${gdprFlag}${gdprString}&gpp=${gpp}&gpp_sid=${gppSid}&surl=`;

--- a/modules/winrBidAdapter.js
+++ b/modules/winrBidAdapter.js
@@ -455,7 +455,7 @@ function bidToTag(bid) {
   if (bid.params.externalImpId) {
     tag.external_imp_id = bid.params.externalImpId;
   }
-  tag.keywords = getANKeywordParam(bid.ortb2, bid.params.keywords)
+  tag.keywords = getANKeywordParam(bid.ortb2, bid.params.keywords);
 
   const gpid = deepAccess(bid, 'ortb2Imp.ext.gpid');
   if (gpid) {

--- a/modules/yaleoBidAdapter.ts
+++ b/modules/yaleoBidAdapter.ts
@@ -57,7 +57,7 @@ const buildRequests: BidderSpec<typeof BIDDER_CODE>['buildRequests'] = (validBid
     method: 'POST',
     data: ortbRequest,
   };
-}
+};
 
 const interpretResponse: BidderSpec<typeof BIDDER_CODE>['interpretResponse'] = (serverResponse, bidderRequest) => {
   const response = converter.fromORTB({

--- a/modules/yieldlabBidAdapter.js
+++ b/modules/yieldlabBidAdapter.js
@@ -205,7 +205,7 @@ export const spec = {
           },
         };
 
-        const dsa = getDigitalServicesActObjectFromMatchedBid(matchedBid)
+        const dsa = getDigitalServicesActObjectFromMatchedBid(matchedBid);
         if (dsa !== undefined) {
           bidResponse.meta = { ...bidResponse.meta, dsa: dsa };
         }

--- a/modules/zeta_global_sspBidAdapter.js
+++ b/modules/zeta_global_sspBidAdapter.js
@@ -44,7 +44,7 @@ const VIDEO_CUSTOM_PARAMS = {
   'minbitrate': DATA_TYPES.NUMBER,
   'maxbitrate': DATA_TYPES.NUMBER,
   'skip': DATA_TYPES.NUMBER
-}
+};
 
 export const spec = {
   code: BIDDER_CODE,
@@ -195,7 +195,7 @@ export const spec = {
         ext: {
           schain: schain
         }
-      }
+      };
     }
 
     if (bidderRequest?.timeout) {
@@ -324,12 +324,12 @@ function buildBanner(request) {
       w: sizes[0][0],
       h: sizes[0][1],
       format: format
-    }
+    };
   } else {
     return {
       w: sizes[0][0],
       h: sizes[0][1]
-    }
+    };
   }
 }
 


### PR DESCRIPTION
### Motivation
- CodeQL flagged numerous automated semicolon insertion (ASI) warnings across multiple modules; the intent is to remove ASI reliance and make statement termination explicit. 
- The changes are stylistic only and aim to improve static-analysis noise without affecting runtime behavior. 

### Description
- Added explicit semicolons to close object literals, arrow-return expressions, variable declarations, and statement terminators in 18 modules (examples: `tappxBidAdapter.js`, `teadsBidAdapter.js`, `ttdBidAdapter.js`, `videojsVideoProvider.js`, `zeta_global_sspBidAdapter.js`).
- Normalized nearby terminators where an expression or block previously relied on ASI (e.g., `const formatArr = ...;`, closing `};` for object literals, and trailing semicolons after returned objects/expressions).
- No functional or API changes were made; only punctuation/style fixes to eliminate ASI warnings from static analysis.

### Testing
- Ran lint on the modified files with `npx eslint --cache --cache-strategy content <files>` and the lint step completed successfully. 
- Executed unit tests for the affected specs via `npx gulp test --nolint --file <spec_file.js>` for the changed modules, and the test run completed with the test chunks finishing and no failing tests reported. 
- This is a style-only change so full integration or docs updates were not required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a296e973494832bb1e765abdb4dc8eb)