### PR TITLE
Modules: fix semicolon style issues

### DIFF
--- a/modules/defineMediaBidAdapter.js
+++ b/modules/defineMediaBidAdapter.js
@@ -12,7 +12,7 @@
 import { logInfo, logError, logWarn } from "../src/utils.js";
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
-import { ortbConverter } from '../libraries/ortbConverter/converter.js'
+import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { ajax } from '../src/ajax.js';
 
 // Bidder identification and compliance constants
@@ -152,7 +152,7 @@ export const spec = {
         url: endpointUrl,
         data: ortbRequest,
         converter: dynamicConverter // Attach converter for response processing
-      }
+      };
     });
   },
 

--- a/modules/digitalMatterBidAdapter.js
+++ b/modules/digitalMatterBidAdapter.js
@@ -39,7 +39,7 @@ export const spec = {
     const device = getDevice(common.device);
     const schain = getByKey(validBidRequests, 'ortb2.source.ext.schain');
     const eids = getByKey(validBidRequests, 'userIdAsEids');
-    const currency = config.getConfig('currency')
+    const currency = config.getConfig('currency');
     const cur = currency && [currency];
 
     const imp = validBidRequests.map((bid, id) => {

--- a/modules/discoveryBidAdapter.js
+++ b/modules/discoveryBidAdapter.js
@@ -236,7 +236,7 @@ export const buildUTMTagData = (url) => {
   UTMValue = JSON.parse(storage.getCookie(UTM_KEY) || '{}');
   Object.assign(UTMValue, UTMParams);
   storage.setCookie(UTM_KEY, JSON.stringify(UTMValue), getCookieTimeToUTCString());
-}
+};
 
 /**
  * get rtb qequest params
@@ -288,7 +288,7 @@ function getParam(validBidRequests, bidderRequest) {
       device: {
         nbw: getConnectionDownLink(),
       }
-    }
+    };
   } catch (error) {}
   try {
     buildUTMTagData(page);

--- a/modules/displayioBidAdapter.js
+++ b/modules/displayioBidAdapter.js
@@ -137,7 +137,7 @@ function getPayload (bid, bidderRequest) {
         connection_type: connection?.effectiveType || '',
       }
     }
-  }
+  };
 }
 
 function newRenderer(bid) {

--- a/modules/dspxBidAdapter.js
+++ b/modules/dspxBidAdapter.js
@@ -212,7 +212,7 @@ function outstreamRender(bid) {
       logError('[DSPx][outstreamRender] Error: slot not found');
     }
   } catch (err) {
-    logError('[DSPx][outstreamRender] Error:' + err.message)
+    logError('[DSPx][outstreamRender] Error:' + err.message);
   }
 }
 

--- a/modules/dynamicAdBoostRtdProvider.js
+++ b/modules/dynamicAdBoostRtdProvider.js
@@ -78,7 +78,7 @@ function getBidRequestData(reqBidsConfigObj, callback) {
 const markViewed = (entry, observer) => {
   return () => {
     observer.unobserve(entry.target);
-  }
+  };
 }
 
 // Callback function when an observed element becomes visible

--- a/modules/enrichmentLiftMeasurement/index.js
+++ b/modules/enrichmentLiftMeasurement/index.js
@@ -37,7 +37,7 @@ export function init(storageManager = getStorageManager({ moduleType: MODULE_TYP
       modules = internals.getCalculatedSubmodules();
       storeTestConfig(testRun, modules, storeSplits, storageManager);
     } else {
-      modules = testConfig.modules
+      modules = testConfig.modules;
     }
   }
 
@@ -127,7 +127,7 @@ export function storeTestConfig(testRun, modules, storeSplits, storageManager) {
 
 export const internals = {
   getCalculatedSubmodules
-}
+};
 
 GDPR_GVLIDS.register(MODULE_TYPE, MODULE_NAME, VENDORLESS_GVLID);
 

--- a/modules/eskimiBidAdapter.js
+++ b/modules/eskimiBidAdapter.js
@@ -69,7 +69,7 @@ export const spec = {
   onBidderError: function ({ error, bidderRequest }) {
     logInfo('Error: ', error, bidderRequest);
   },
-}
+};
 
 registerBidder(spec);
 

--- a/modules/exadsBidAdapter.js
+++ b/modules/exadsBidAdapter.js
@@ -70,7 +70,7 @@ function handleReqORTB2Dot4(validBidRequest, endpointUrl, bidderRequest) {
   if (gdprConsent && gdprConsent.gdprApplies) {
     bidRequestData.user['ext'] = {
       consent: gdprConsent.consentString
-    }
+    };
   }
 
   if (validBidRequest.params.dsa && (
@@ -85,7 +85,7 @@ function handleReqORTB2Dot4(validBidRequest, endpointUrl, bidderRequest) {
           'datatopub': validBidRequest.params.dsa.datatopub
         }
       }
-    }
+    };
   }
 
   const impData = imps.get(validBidRequest.params.impressionId);

--- a/modules/fintezaAnalyticsAdapter.js
+++ b/modules/fintezaAnalyticsAdapter.js
@@ -71,7 +71,7 @@ function initFirstVisit() {
 
   try {
     // TODO: commented out because of rule violations
-    cookies = {} // parseCookies(document.cookie);
+    cookies = {}; // parseCookies(document.cookie);
   } catch (a) {
     cookies = {};
   }
@@ -176,7 +176,7 @@ function initSession() {
 
   try {
     // TODO: commented out because of rule violations
-    cookies = {} // parseCookies(document.cookie);
+    cookies = {}; // parseCookies(document.cookie);
   } catch (a) {
     cookies = {};
   }

--- a/modules/flippBidAdapter.js
+++ b/modules/flippBidAdapter.js
@@ -91,7 +91,7 @@ const getAdTypes = (creativeType) => {
     return DTX_TYPES;
   }
   return AD_TYPES;
-}
+};
 
 export const spec = {
   code: BIDDER_CODE,
@@ -196,5 +196,5 @@ export const spec = {
    * @return {UserSync[]} The user syncs which should be dropped.
    */
   getUserSyncs: (syncOptions, serverResponses) => [],
-}
+};
 registerBidder(spec);

--- a/modules/fwsspBidAdapter.js
+++ b/modules/fwsspBidAdapter.js
@@ -208,7 +208,7 @@ export const spec = {
         keyValues._fw_is_lat = lmt;
       }
 
-      PRIVACY_VALUES = {}
+      PRIVACY_VALUES = {};
       if (keyValues._fw_coppa != null) {
         PRIVACY_VALUES._fw_coppa = keyValues._fw_coppa;
       }

--- a/modules/gamoshiBidAdapter.js
+++ b/modules/gamoshiBidAdapter.js
@@ -279,7 +279,7 @@ function imp(buildImp, bidRequest, context) {
     logWarn('Gamoshi: Failed to build imp for bid request:', bidRequest);
     return null;
   }
-  let isVideo = bidRequest.mediaTypes.mediaType === VIDEO
+  let isVideo = bidRequest.mediaTypes.mediaType === VIDEO;
   if (isVideo) {
     if (!imp.video) {
       imp.video = {};

--- a/modules/genericAnalyticsAdapter.ts
+++ b/modules/genericAnalyticsAdapter.ts
@@ -100,7 +100,7 @@ export function GenericAnalytics() {
 
   function optionsAreValid(options) {
     if (!options.url && !options.handler) {
-      logError('options must specify either `url` or `handler`')
+      logError('options must specify either `url` or `handler`');
       return false;
     }
     if (options.hasOwnProperty('method') && !['GET', 'POST'].includes(options.method)) {

--- a/modules/gptPreAuction.ts
+++ b/modules/gptPreAuction.ts
@@ -101,7 +101,7 @@ const sanitizeSlotPath = (path) => {
   }
 
   return path;
-}
+};
 
 const defaultPreAuction = (adUnit, adServerAdSlot, adUnitPath) => {
   // confirm that GPT is set up
@@ -122,7 +122,7 @@ const defaultPreAuction = (adUnit, adServerAdSlot, adUnitPath) => {
 
   // else the adunit code must be div id. append it.
   return `${adServerAdSlot}#${adUnit.code}`;
-}
+};
 
 export const makeBidRequestsHook = (fn, adUnits, ...args) => {
   const adUnitPaths = appendGptSlots(adUnits);
@@ -145,7 +145,7 @@ export const makeBidRequestsHook = (fn, adUnits, ...args) => {
     } else if (useDefaultPreAuction) {
       result = defaultPreAuction(adUnit, adserverSlot, adUnitPaths?.[adUnit.code]);
     } else {
-      logWarn('Neither customPreAuction, defaultPreAuction and gpid were specified')
+      logWarn('Neither customPreAuction, defaultPreAuction and gpid were specified');
     }
     if (result) {
       context.gpid = result;
@@ -200,7 +200,7 @@ const handleSetGptConfig = moduleConfig => {
   if (_currentConfig.enabled) {
     if (!hooksAdded) {
       getHook('makeBidRequests').before(makeBidRequestsHook);
-      getHook('targetingDone').after(setPpsConfigFromTargetingSet)
+      getHook('targetingDone').after(setPpsConfigFromTargetingSet);
       hooksAdded = true;
     }
   } else {

--- a/modules/greenbidsAnalyticsAdapter.js
+++ b/modules/greenbidsAnalyticsAdapter.js
@@ -50,7 +50,7 @@ export const isSampled = function(greenbidsId, samplingRate, exploratorySampling
   if (isPrimarySampled) return true;
   const isExtraSampled = hashInt >= (1 - throttledSamplingRate) * (0xFFFF + 1);
   return isExtraSampled;
-}
+};
 
 export const greenbidsAnalyticsAdapter = Object.assign(adapter({ ANALYTICS_SERVER, analyticsType }), {
 
@@ -93,7 +93,7 @@ export const greenbidsAnalyticsAdapter = Object.assign(adapter({ ANALYTICS_SERVE
       this.exploratorySamplingSplit = analyticsOptions.options.exploratorySamplingSplit;
     }
 
-    analyticsOptions.pbuid = config.options.pbuid
+    analyticsOptions.pbuid = config.options.pbuid;
     analyticsOptions.server = ANALYTICS_SERVER;
 
     return true;

--- a/modules/gridBidAdapter.js
+++ b/modules/gridBidAdapter.js
@@ -26,7 +26,7 @@ import { getBidFromResponse } from '../libraries/processResponse/index.js';
 
 const BIDDER_CODE = 'grid';
 const ENDPOINT_URL = 'https://grid.bidswitch.net/hbjson';
-const USP_DELETE_DATA_HANDLER = 'https://media.grid.bidswitch.net/uspapi_delete_c2s'
+const USP_DELETE_DATA_HANDLER = 'https://media.grid.bidswitch.net/uspapi_delete_c2s';
 
 const SYNC_URL = 'https://x.bidswitch.net/sync?ssp=themediagrid';
 const TIME_TO_LIVE = 360;

--- a/modules/growthCodeAnalyticsAdapter.js
+++ b/modules/growthCodeAnalyticsAdapter.js
@@ -94,7 +94,7 @@ const growthCodeAnalyticsAdapter = Object.assign(adapter({ url: url, analyticsTy
       }
 
       case EVENTS.NO_BID: {
-        data = eventData
+        data = eventData;
         break;
       }
 

--- a/modules/gumgumBidAdapter.js
+++ b/modules/gumgumBidAdapter.js
@@ -39,7 +39,7 @@ function _getBrowserParams(topWindowUrl, mosttopLocation) {
   let topWindow;
   let topScreen;
   let topUrl;
-  let mosttopURL
+  let mosttopURL;
   let ggad;
   let ggdeal;
   let ns;
@@ -112,7 +112,7 @@ function _getBrowserParams(topWindowUrl, mosttopLocation) {
 }
 
 function getWrapperCode(wrapper, data) {
-  return wrapper.replace('AD_JSON', window.btoa(JSON.stringify(data)))
+  return wrapper.replace('AD_JSON', window.btoa(JSON.stringify(data)));
 }
 
 /**
@@ -132,7 +132,7 @@ function _serializeSupplyChainObj(schainObj) {
     serializedSchain += `${encodeURIComponent(node['rid'] || '')},`;
     serializedSchain += `${encodeURIComponent(node['name'] || '')},`;
     serializedSchain += `${encodeURIComponent(node['domain'] || '')}`;
-  })
+  });
 
   return serializedSchain;
 }


### PR DESCRIPTION
### Motivation
- Address CodeQL/ASI findings by making statement termination explicit across multiple modules to match the repository's predominant semicolon style.
- Reduce noisy automated warnings and ensure consistent formatting in adapters, analytics, and helper modules.

### Description
- Added explicit semicolons and terminated object/function literals where CodeQL reported Automated Semicolon Insertion issues (examples: `modules/defineMediaBidAdapter.js`, `modules/gptPreAuction.ts`, `modules/gumgumBidAdapter.js`).
- Normalized similar statement terminators in a set of adapter and analytics modules so the files consistently use explicit semicolons rather than relying on ASI.
- No behavioral logic was changed; only statement terminators and small syntactic fixes were applied to preserve runtime semantics.
- Changes are committed under a single change set (commit `46d3355`).

### Testing
- Ran `npx eslint --cache --cache-strategy content <affected files>` and the lint check completed without new errors for the modified files.
- Ran `npx gulp precompile` which completed successfully and generated creative renderer assets.
- Ran the unit tests for the impacted modules with `TEST_CHUNKS=1 TEST_PAT='{defineMediaBidAdapter,digitalMatterBidAdapter,displayioBidAdapter,discoveryBidAdapter,dspxBidAdapter,dynamicAdBoostRtdProvider,enrichmentLiftMeasurement,eskimiBidAdapter,exadsBidAdapter,fintezaAnalyticsAdapter,flippBidAdapter,fwsspBidAdapter,genericAnalyticsAdapter,gamoshiBidAdapter,gptPreAuction,greenbidsAnalyticsAdapter,growthCodeAnalyticsAdapter,gridBidAdapter,gumgumBidAdapter}_spec.js' npx gulp test-only-nobuild --nolint` and the test run completed successfully (summary: 472 tests completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a296e2462ac832b9ab5317e7bc003f4)