### PR TITLE
Maintenance: fix missing semicolons

### DIFF
--- a/modules/rediadsBidAdapter.js
+++ b/modules/rediadsBidAdapter.js
@@ -45,11 +45,11 @@ export const spec = {
   supportedMediaTypes: [NATIVE, BANNER, VIDEO],
   isBidRequestValid: function (bid) {
     let isValid = false;
-    const accountID = bid?.params?.account_id
+    const accountID = bid?.params?.account_id;
     if (accountID && typeof accountID === 'string') {
       isValid = true;
     } else {
-      logError(`${LOG_PREFIX} account_id is missing from params or is not of type "string"`)
+      logError(`${LOG_PREFIX} account_id is missing from params or is not of type "string"`);
     }
     return isValid;
   },
@@ -81,7 +81,7 @@ export const spec = {
 
       if (testBidsRequested) {
         deepSetValue(data, 'test', 1);
-        logWarn(`${LOG_PREFIX} test bids are enabled as rediads-test-bids is present in page URL hash.`)
+        logWarn(`${LOG_PREFIX} test bids are enabled as rediads-test-bids is present in page URL hash.`);
       }
 
       // handle impression/bid level requirements
@@ -92,7 +92,7 @@ export const spec = {
         }
       });
     } catch (err) {
-      logError(`${LOG_PREFIX} encountered an error while building bid requests :: ${err}`)
+      logError(`${LOG_PREFIX} encountered an error while building bid requests :: ${err}`);
     }
 
     return [
@@ -109,9 +109,9 @@ export const spec = {
       bids = converter.fromORTB({
         response: response.body,
         request: request.data,
-      }).bids
+      }).bids;
     } catch (err) {
-      logError(`${LOG_PREFIX} encountered an error while processing bid responses :: ${err}`)
+      logError(`${LOG_PREFIX} encountered an error while processing bid responses :: ${err}`);
     }
     return bids;
   },

--- a/modules/relevantdigitalBidAdapter.js
+++ b/modules/relevantdigitalBidAdapter.js
@@ -56,7 +56,7 @@ const getBidderConfig = (bids) => {
     }
   }
   return cfg;
-}
+};
 
 const converter = ortbConverter({
   context: {

--- a/modules/retailspotBidAdapter.js
+++ b/modules/retailspotBidAdapter.js
@@ -111,7 +111,7 @@ function getSize(bid) {
   if (Array.isArray(bid.params?.size)) {
     inputSize = bid.params.size;
     if (!Array.isArray(inputSize[0])) {
-      inputSize = [inputSize]
+      inputSize = [inputSize];
     }
   }
 

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -543,7 +543,7 @@ export const spec = {
 
     // If the bid request contains a 'mobile' property under 'ortb2.site', add it to 'data' as 'p_site.mobile'.
     if (typeof bidRequest?.ortb2?.site?.mobile === 'number') {
-      data['p_site.mobile'] = bidRequest.ortb2.site.mobile
+      data['p_site.mobile'] = bidRequest.ortb2.site.mobile;
     }
 
     // loop through userIds and add to request
@@ -940,7 +940,7 @@ function applyFPD(bidRequest, mediaType, data) {
             }, '');
           }
         }
-      ])
+      ]);
     }
 
     // only send one of pbadslot or dfp adunit code (prefer pbadslot)
@@ -975,7 +975,7 @@ function applyFPD(bidRequest, mediaType, data) {
           data.m_ch_platform = platform?.brand;
           data.m_ch_platform_ver = platform?.version?.join?.('.');
         }
-      ])
+      ]);
     }
   } else {
     if (Object.keys(impExt).length) {

--- a/modules/rules/index.ts
+++ b/modules/rules/index.ts
@@ -170,7 +170,7 @@ function getGlobalRandom(auctionId: string, auctionIndex: AuctionIndex = auction
   return globalRandomStore.get(auction);
 }
 
-const unregisterFunctions: Array<() => void> = []
+const unregisterFunctions: Array<() => void> = [];
 
 let moduleConfig: ShapingRulesConfig = {
   endpoint: {
@@ -412,7 +412,7 @@ export function registerActivities() {
             }
           }
           return false;
-        }
+        };
 
         const results = [];
         let modelGroups = auctionConfigStore.get(auctionId) || [];

--- a/modules/schain.ts
+++ b/modules/schain.ts
@@ -32,7 +32,7 @@ export function applySchainConfig(ortb2Fragments) {
     if (!ortb2Fragments?.global?.source?.schain) {
       applySchainToPath(ortb2Fragments, 'global.source', globalSchainConfig.config);
     } else {
-      logWarn('Disregarding global schain config as schain is already provided in FPD')
+      logWarn('Disregarding global schain config as schain is already provided in FPD');
     }
   }
 

--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -38,7 +38,7 @@ const deviceConnection = {
   UNKNOWN: 'unknown',
 };
 
-export const BIDFLOOR_CURRENCY = 'USD'
+export const BIDFLOOR_CURRENCY = 'USD';
 
 function getBidFloor(bidRequest) {
   let floorInfo = {};

--- a/modules/semantiqRtdProvider.js
+++ b/modules/semantiqRtdProvider.js
@@ -106,7 +106,7 @@ const getKeywords = (params) => new Promise((resolve, reject) => {
     error(error) {
       reject(error);
     }
-  }
+  };
 
   ajax(requestUrl, callbacks);
 });
@@ -243,7 +243,7 @@ const getBidRequestData = (
       onDone();
     }
   }, timeout);
-}
+};
 
 /** @type {RtdSubmodule} */
 export const semantiqRtdSubmodule = {

--- a/modules/smartytechBidAdapter.js
+++ b/modules/smartytechBidAdapter.js
@@ -157,7 +157,7 @@ export const spec = {
         oneRequest.coppa = coppa;
       }
 
-      return oneRequest
+      return oneRequest;
     });
 
     const smartytechRequestUrl = buildUrl({

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -103,7 +103,7 @@ export const spec = {
 
     if (fpd) {
       delete fpd.experianRtidData; // Omit the experian data since we already pass this through a dedicated query param
-      delete fpd.experianRtidKey
+      delete fpd.experianRtidKey;
       payload.fpd = JSON.stringify(fpd);
     }
 

--- a/modules/startioBidAdapter.js
+++ b/modules/startioBidAdapter.js
@@ -64,7 +64,7 @@ const converter = ortbConverter({
       if (request.imp[0].hasOwnProperty(mediaType)) {
         request.imp[0][mediaType].battr ??= ortb?.[mediaType]?.battr || bidParams?.battr;
       }
-    })
+    });
 
     return request;
   },

--- a/modules/storageControl.ts
+++ b/modules/storageControl.ts
@@ -150,7 +150,7 @@ declare module '../src/config' {
 
 config.getConfig('storageControl', (cfg) => {
   enforcement = cfg?.storageControl?.enforcement ?? ENFORCE_STRICT;
-})
+});
 
 export function dynamicDisclosureCollector() {
   const disclosures = {};

--- a/modules/stvBidAdapter.js
+++ b/modules/stvBidAdapter.js
@@ -107,7 +107,7 @@ export const spec = {
             payload.pfilter[VIDEO_ORTB_PARAMS[key]] = videoParams[key];
           });
       }
-      if (Object.keys(payload.pfilter).length === 0) { delete payload.pfilter }
+      if (Object.keys(payload.pfilter).length === 0) { delete payload.pfilter; }
 
       if (bidderRequest && bidderRequest.gdprConsent) {
         payload.gdpr_consent = bidderRequest.gdprConsent.consentString;

--- a/modules/taboolaBidAdapter.js
+++ b/modules/taboolaBidAdapter.js
@@ -97,7 +97,7 @@ export const userData = {
   getFromTRC() {
     return window.TRC ? window.TRC.user_id : 0;
   }
-}
+};
 
 export const internal = {
   getPageUrl: (refererInfo = {}) => {
@@ -106,7 +106,7 @@ export const internal = {
   getReferrer: (refererInfo = {}) => {
     return refererInfo?.ref || getWindowSelf().document.referrer;
   }
-}
+};
 
 export function detectBot() {
   try {
@@ -375,7 +375,7 @@ function fillTaboolaReqData(bidderRequest, bidRequest, data, context) {
     data.user = {
       buyeruid: 0,
       ext: {}
-    }
+    };
   }
   if (extractedUserId && extractedUserId !== 0) {
     deepSetValue(data, 'user.buyeruid', extractedUserId);
@@ -383,7 +383,7 @@ function fillTaboolaReqData(bidderRequest, bidRequest, data, context) {
   if (data.regs?.ext === undefined || data.regs?.ext === null) {
     data.regs = {
       ext: {}
-    }
+    };
   }
   deepSetValue(data, 'regs.coppa', 0);
   if (gdprConsent.gdprApplies) {

--- a/modules/targetVideoAdServerVideo.js
+++ b/modules/targetVideoAdServerVideo.js
@@ -29,7 +29,7 @@ export function buildVideoUrl(options) {
     page_url: '[page_url]',
     cachebuster: '[timestamp]',
     gdpr_consent: '[consent]',
-  }
+  };
 
   const adUnit = options.adUnit;
   const bid = options.bid || targeting.getWinningBids(adUnit.code)[0];

--- a/modules/targetVideoBidAdapter.js
+++ b/modules/targetVideoBidAdapter.js
@@ -73,7 +73,7 @@ export const spec = {
               device: deepAccess(bidderRequest, 'ortb2.device'),
               user: { ext: {} },
               imp: []
-            }
+            };
 
             const gpid = deepAccess(bid, 'ortb2Imp.ext.gpid');
             const tid = deepAccess(bid, 'ortb2Imp.ext.tid');
@@ -87,7 +87,7 @@ export const spec = {
                 tid,
               },
               video: getDefinedParams(video, VIDEO_PARAMS)
-            }
+            };
 
             const bidFloor = typeof floor === 'string' ? Number(floor.trim())
               : typeof floor === 'number' ? floor
@@ -184,7 +184,7 @@ export const spec = {
             }
 
             if (bidderRequest && bidderRequest.uspConsent) {
-              payload.us_privacy = bidderRequest.uspConsent
+              payload.us_privacy = bidderRequest.uspConsent;
             }
 
             return formatRequest({ payload, url: BANNER_ENDPOINT_URL, bidderRequest });


### PR DESCRIPTION
### Motivation
- Address CodeQL warnings about automatic semicolon insertion (ASI) by making statement termination explicit across multiple modules to improve consistency and avoid potential runtime pitfalls.
- Keep behavior identical while satisfying linting and static analysis checks.

### Description
- Added missing semicolons and closed block delimiters at CodeQL-reported ASI sites across adapter and core modules, including `modules/rediadsBidAdapter.js`, `modules/relevantdigitalBidAdapter.js`, `modules/retailspotBidAdapter.js`, `modules/rubiconBidAdapter.js`, `modules/rules/index.ts`, `modules/schain.ts`, `modules/seedtagBidAdapter.js`, `modules/semantiqRtdProvider.js`, `modules/smartytechBidAdapter.js`, `modules/sonobiBidAdapter.js`, `modules/startioBidAdapter.js`, `modules/storageControl.ts`, `modules/stvBidAdapter.js`, `modules/taboolaBidAdapter.js`, `modules/targetVideoAdServerVideo.js`, and `modules/targetVideoBidAdapter.js`.
- Changes are limited to adding semicolons or closing delimiters where required and do not alter program logic or API behavior.

### Testing
- Ran ESLint against the modified files with `npx eslint <files> --cache --cache-strategy content` and observed no new lint failures.
- Executed the affected unit tests via `npx gulp test --nolint --file <spec_file.js>` for the listed specs; the test run completed successfully with the test summary showing all specified tests passing (summary: 582 tests completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a296e764e70832bba14ce6afda1a1e3)