### PR TITLE
Maintenance: add semicolons for CodeQL ASI findings

### DIFF
--- a/.github/workflows/scripts/getPRProperties.js
+++ b/.github/workflows/scripts/getPRProperties.js
@@ -147,7 +147,7 @@ async function getPRProperties({github, context, prNo, reviewerTeam, engTeam, au
     prebidReviewers,
     prebidEngineers,
     review,
-  }
+  };
   data.review.requires = reviewRequirements(data);
   data.review.ok = data.draft || satisfiesReviewRequirements(data.review);
   return data;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -509,8 +509,8 @@ gulp.task('build-bundle-verbose', gulp.series(precompile(), makeWebpackPkg(makeV
 
 // public tasks (dependencies are needed for each task since they can be ran on their own)
 gulp.task('update-browserslist', execaTask('npx update-browserslist-db@latest'));
-gulp.task('test-build-logic', execaTask('npx mocha ./test/build-logic'))
-gulp.task('test-only-nobuild', gulp.series(testTaskMaker({coverage: argv.coverage ?? true})))
+gulp.task('test-build-logic', execaTask('npx mocha ./test/build-logic'));
+gulp.task('test-only-nobuild', gulp.series(testTaskMaker({coverage: argv.coverage ?? true})));
 gulp.task('test-only', gulp.series('test-build-logic', 'precompile', test));
 
 gulp.task('test-all-features-disabled-nobuild', testTaskMaker({disableFeatures: helpers.getTestDisableFeatures(), oneBrowser: 'chrome', watch: false}));
@@ -523,8 +523,8 @@ gulp.task('test-coverage', gulp.series(clean, precompile(), testCoverage));
 gulp.task('update-codeql', function (done) {
   import('./fingerprintApis.mjs').then(({updateQueries}) => {
     updateQueries().then(() => done(), done);
-  })
-})
+  });
+});
 
 // npm will by default use .gitignore, so create an .npmignore that is a copy of it except it includes "dist"
 gulp.task('setup-npmignore', execaTask("sed 's/^\\/\\?dist\\/\\?$//g;w .npmignore' .gitignore", {quiet: true}));
@@ -532,7 +532,7 @@ gulp.task('build', gulp.series(clean, 'build-bundle-prod', setupDist));
 // build for release - in addition to 'build', run tasks that update the codebase to be included in a release commit
 gulp.task('build-release', gulp.series('update-codeql', 'build', updateCreativeExample, 'update-browserslist'));
 // prepare NPM release - 'build' to generate files in dist/; 'setup-npmignore' to make sure 'dist' is published in NPM
-gulp.task('prepare-release', gulp.series('build', 'setup-npmignore'))
+gulp.task('prepare-release', gulp.series('build', 'setup-npmignore'));
 gulp.task('build-postbid', gulp.series(escapePostbidConfig, buildPostbid));
 
 gulp.task('serve', gulp.series(clean, lint, precompile(), gulp.parallel('build-bundle-dev-no-precomp', watch, test)));
@@ -546,7 +546,7 @@ gulp.task('default', gulp.series('build'));
 
 gulp.task('e2e-test-only', gulp.series(requireNodeVersion(16), () => runWebdriver({file: argv.file})));
 gulp.task('e2e-test', gulp.series(requireNodeVersion(16), clean, 'build-bundle-prod', e2eTestTaskMaker()));
-gulp.task('e2e-test-nobuild', gulp.series(requireNodeVersion(16), e2eTestTaskMaker()))
+gulp.task('e2e-test-nobuild', gulp.series(requireNodeVersion(16), e2eTestTaskMaker()));
 
 // other tasks
 gulp.task(bundleToStdout);
@@ -561,16 +561,16 @@ gulp.task('extract-metadata', function (done) {
   const server = startLocalServer();
   import('./metadata/extractMetadata.mjs').then(({default: extract}) => {
     extract().then(metadata => {
-      fs.writeFileSync('./metadata/modules.json', JSON.stringify(metadata, null, 2))
+      fs.writeFileSync('./metadata/modules.json', JSON.stringify(metadata, null, 2));
     }).finally(() => {
-      server.close()
+      server.close();
     }).then(() => done(), done);
   });
-})
+});
 gulp.task('compile-metadata', function (done) {
   import('./metadata/compileMetadata.mjs').then(({default: compile}) => {
     compile(argv.fetch ?? true).then(() => done(), done);
-  })
-})
+  });
+});
 gulp.task('update-metadata', gulp.series('build', 'extract-metadata', 'compile-metadata'));
 module.exports = nodeBundle;

--- a/integrationExamples/gpt/neuwoRtdProvider_example.html
+++ b/integrationExamples/gpt/neuwoRtdProvider_example.html
@@ -183,8 +183,8 @@
                             }
                         ]
                     }
-                })
-            })
+                });
+            });
 
             // Request Bids
             pbjs.que.push(function () {
@@ -192,7 +192,7 @@
                 pbjs.requestBids({
                     bidsBackHandler: initAdserver,
                 });
-            })
+            });
             // Timeout
             setTimeout(function () {
                 initAdserver();
@@ -417,7 +417,7 @@ pbjs.onEvent("bidRequested", function(bidRequest) {
                 };
                 console.log("Neuwo data stored in global \"neuwoData\" variable:", neuwoData);
 
-                updateDisplayElements(neuwoSiteData, neuwoUserData, ortb25Fields)
+                updateDisplayElements(neuwoSiteData, neuwoUserData, ortb25Fields);
             } else {
                 console.warn("No ortb2 data found in bidRequest. This may indicate the RTD module has not enriched the bid request yet.");
             }

--- a/integrationExamples/gpt/precisonativeExample.html
+++ b/integrationExamples/gpt/precisonativeExample.html
@@ -133,7 +133,7 @@
 
         function renderOne(winningBid) {
             if (winningBid && winningBid.adId) {
-                let options = winningBid.adm
+                let options = winningBid.adm;
                 console.log("Here 123");
                 var div = document.getElementById(winningBid.adUnitCode);
                 if (div) {

--- a/integrationExamples/gpt/x-domain/safeRenderer.js
+++ b/integrationExamples/gpt/x-domain/safeRenderer.js
@@ -69,7 +69,7 @@ window.pbRenderInFrame = function ({ mediaType, config, ...renderingData }) {
         mediaType,
         config,
         renderingData
-      })
+      });
     
     }
 

--- a/karmaRunner.js
+++ b/karmaRunner.js
@@ -62,7 +62,7 @@ process.on('message', function (options) {
       chunks.push([options.file]);
     } else {
       const chunkNum = process.env['TEST_CHUNKS'] ?? 1;
-      const pat = process.env['TEST_PAT'] ?? '*_spec.js'
+      const pat = process.env['TEST_PAT'] ?? '*_spec.js';
       const tests = glob.sync('test/**/' + pat).sort();
       const chunkLen = chunkNum === 'MAX' ? 0 : Math.floor(tests.length / Number(chunkNum));
       chunks.push([]);

--- a/modules/smartxBidAdapter.js
+++ b/modules/smartxBidAdapter.js
@@ -446,7 +446,7 @@ function createOutstreamConfig(bid) {
 
   try {
     // eslint-disable-next-line
-    outstreamplayer.connect(divID).setup(playerConfig, playerListener)
+    outstreamplayer.connect(divID).setup(playerConfig, playerListener);
   } catch (e) {
     logError('[SMARTX][renderer] Error caught: ' + e);
   }


### PR DESCRIPTION
mops up the remaining after the lint change