### PR TITLE
CI: Move Safari testing back to GH runners

### DIFF
--- a/.github/workflows/browser_testing.json
+++ b/.github/workflows/browser_testing.json
@@ -18,7 +18,8 @@
   },
   "SafariNative": {
     "wdioName": "safari technology preview",
-    "runsOn": "macos-latest"
+    "runsOn": "macos-latest",
+    "bsName": "safari"
   },
   "FirefoxHeadless": {
     "wdioName": "firefox",

--- a/browsers.json
+++ b/browsers.json
@@ -33,7 +33,7 @@
   },
   "bs_safari_latest_mac": {
     "base": "BrowserStack",
-    "os_version": "Sonoma",
+    "os_version": "latest",
     "browser": "safari",
     "browser_version": "latest",
     "device": null,

--- a/browsers.json
+++ b/browsers.json
@@ -33,7 +33,7 @@
   },
   "bs_safari_latest_mac": {
     "base": "BrowserStack",
-    "os_version": "latest",
+    "os_version": "Tahoe",
     "browser": "safari",
     "browser_version": "latest",
     "device": null,

--- a/test/spec/libraries/greedy/greedyPromise_spec.js
+++ b/test/spec/libraries/greedy/greedyPromise_spec.js
@@ -201,13 +201,11 @@ describe('greedySetTimeout', () => {
       const handle = greedySetTimeout(() => {
         cbRan = true;
       }, 5);
+      clearTimeout(handle);
       setTimeout(() => {
-        clearTimeout(handle);
-        setTimeout(() => {
-          expect(cbRan).to.be.false;
-          done();
-        }, 10);
-      }, 0);
+        expect(cbRan).to.be.false;
+        done();
+      }, 10);
     });
   });
 });


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] CI related changes

## Description of change

Since #14946 safari tests have been been running on Sonoma. Move testing back onto GH runners and fix a test that fails on safari latest.

