### PR TITLE
Ferio Bid Adapter: add featuretv client-side alias

### DIFF
--- a/libraries/ferioUtils/bidderUtils.ts
+++ b/libraries/ferioUtils/bidderUtils.ts
@@ -11,6 +11,7 @@ import {
 import {
   isPlainObject,
   logError,
+  logWarn,
   sizesToSizeTuples,
 } from "../../src/utils.js";
 import type {
@@ -57,6 +58,14 @@ type FerioAdapterRequest = AdapterRequest & {
   };
 };
 
+export type FerioAliasOptions = {
+  code: BidderCode;
+  endpoint?: string;
+  gvlid?: number;
+  paramBidderCode?: BidderCode;
+  skipPbsAliasing?: boolean;
+};
+
 export type FerioBidderSpecOptions<
   Code extends BidderCode = typeof DEFAULT_PARAM_BIDDER_CODE
 > = {
@@ -64,6 +73,7 @@ export type FerioBidderSpecOptions<
   endpoint: string;
   paramBidderCode?: BidderCode;
   requiredParams?: readonly RequiredParam[];
+  aliases?: readonly FerioAliasOptions[];
 };
 
 type GdprConsent = null | undefined | ConsentDataForKey<typeof CONSENT_GDPR>;
@@ -159,7 +169,9 @@ function isBidRequestValid<B extends BidderCode>(
   return true;
 }
 
-function isSupportedMediaType(value: unknown): value is SupportedFerioMediaType {
+function isSupportedMediaType(
+  value: unknown
+): value is SupportedFerioMediaType {
   return supportedMediaTypes.includes(value as SupportedFerioMediaType);
 }
 
@@ -167,7 +179,9 @@ function isFerioResponseMType(value: unknown): value is FerioResponseMType {
   return ORTB_RESPONSE_MEDIA_TYPES.includes(value as FerioResponseMType);
 }
 
-function getBidPrebidMediaType(bid: ORTBBid): SupportedFerioMediaType | undefined {
+function getBidPrebidMediaType(
+  bid: ORTBBid
+): SupportedFerioMediaType | undefined {
   const prebidExt = bid.ext?.prebid;
   if (!isRecord(prebidExt)) {
     return;
@@ -213,7 +227,11 @@ function parseAdm(adm: unknown): unknown {
 }
 
 function isNativeAdmWrapper(value: unknown): value is NativeAdmWrapper {
-  if (!isRecord(value) || Array.isArray(value.assets) || !isRecord(value.native)) {
+  if (
+    !isRecord(value) ||
+    Array.isArray(value.assets) ||
+    !isRecord(value.native)
+  ) {
     return false;
   }
 
@@ -262,7 +280,10 @@ function getContextAdapterCode(context: {
 }
 
 function createFerioConverter<B extends BidderCode>(
-  paramBidderCode: BidderCode
+  getParamBidderCode: (
+    bidRequest: BidRequest<B>,
+    context: { bidderRequest?: unknown }
+  ) => BidderCode
 ) {
   return ortbConverter<B>({
     context: {
@@ -272,6 +293,7 @@ function createFerioConverter<B extends BidderCode>(
     },
     processors: pbsExtensions,
     imp(buildImp, bidRequest, context) {
+      const paramBidderCode = getParamBidderCode(bidRequest, context);
       return buildImp(
         { ...bidRequest, bidder: paramBidderCode } as BidRequest<B>,
         context
@@ -313,6 +335,10 @@ function normalizeEndpoint(endpoint?: string): string | undefined {
   }
 
   const normalizedEndpoint = endpoint.trim().replace(/\/+$/, "");
+  if (!isHttpsUrl(normalizedEndpoint)) {
+    return;
+  }
+
   return /\/bid$/.test(normalizedEndpoint)
     ? normalizedEndpoint
     : `${normalizedEndpoint}/bid`;
@@ -320,6 +346,16 @@ function normalizeEndpoint(endpoint?: string): string | undefined {
 
 function getEndpointBase(endpoint?: string): string | undefined {
   return endpoint?.replace(/\/bid$/, "");
+}
+
+function getMappedCodeValue<T>(
+  valuesByCode: Record<BidderCode, T | undefined>,
+  bidderCode: BidderCode,
+  fallback: T | undefined
+): T | undefined {
+  return Object.prototype.hasOwnProperty.call(valuesByCode, bidderCode)
+    ? valuesByCode[bidderCode]
+    : fallback;
 }
 
 function appendQueryParams(url: string, params: ConsentParam[]): string {
@@ -417,9 +453,7 @@ function getUserSyncs(
 
 export function createFerioBidderSpec<
   Code extends BidderCode = typeof DEFAULT_PARAM_BIDDER_CODE
->(
-  options: FerioBidderSpecOptions<Code>
-): BidderSpec<Code> {
+>(options: FerioBidderSpecOptions<Code>): BidderSpec<Code> {
   const code = getNonEmptyString(
     options.code,
     DEFAULT_PARAM_BIDDER_CODE
@@ -429,12 +463,65 @@ export function createFerioBidderSpec<
     : [];
   const endpoint = normalizeEndpoint(options.endpoint);
   const syncBase = getEndpointBase(endpoint);
-  const converter = createFerioConverter<Code>(
-    getNonEmptyString(options.paramBidderCode, code)
+  const aliases: FerioAliasOptions[] = [];
+  (options.aliases ?? []).forEach((alias) => {
+    if (!isRecord(alias) || !isNonEmptyString(alias.code)) {
+      return;
+    }
+    if (
+      alias.code === code ||
+      aliases.some((seen) => seen.code === alias.code)
+    ) {
+      logError(
+        `ferioUtils: ignoring alias with duplicate code "${alias.code}"`
+      );
+      return;
+    }
+    aliases.push(alias);
+  });
+  const endpointByCode: Record<BidderCode, string | undefined> = {
+    [code]: endpoint,
+  };
+  const syncBaseByCode: Record<BidderCode, string | undefined> = {
+    [code]: syncBase,
+  };
+  const paramBidderCodeByCode: Record<BidderCode, BidderCode> = {
+    [code]: getNonEmptyString(options.paramBidderCode, code),
+  };
+  aliases.forEach((alias) => {
+    const hasAliasEndpoint = isNonEmptyString(alias.endpoint);
+    const normalizedAliasEndpoint = normalizeEndpoint(alias.endpoint);
+    if (!normalizedAliasEndpoint && hasAliasEndpoint) {
+      logWarn(
+        `ferioUtils: invalid alias endpoint for "${alias.code}", skipping alias requests`
+      );
+    }
+    const aliasEndpoint = hasAliasEndpoint ? normalizedAliasEndpoint : endpoint;
+    endpointByCode[alias.code] = aliasEndpoint;
+    syncBaseByCode[alias.code] = getEndpointBase(aliasEndpoint);
+    paramBidderCodeByCode[alias.code] = getNonEmptyString(
+      alias.paramBidderCode,
+      alias.code
+    );
+  });
+  const specAliases = aliases.map(
+    ({ code: aliasCode, gvlid, skipPbsAliasing }) => ({
+      code: aliasCode,
+      gvlid,
+      skipPbsAliasing,
+    })
   );
+  const converter = createFerioConverter<Code>((bidRequest, context) => {
+    const requestCode = getNonEmptyString(
+      bidRequest.bidder,
+      getContextAdapterCode(context) ?? code
+    );
+    return paramBidderCodeByCode[requestCode] ?? paramBidderCodeByCode[code];
+  });
 
   return {
     code,
+    ...(specAliases.length ? { aliases: specAliases } : {}),
     supportedMediaTypes,
     isBidRequestValid(bid) {
       return isBidRequestValid(bid, requiredParams);
@@ -448,7 +535,13 @@ export function createFerioBidderSpec<
       if (!validBidRequests.length) {
         return [];
       }
-      if (!endpoint) {
+      const requestCode = getNonEmptyString(bidderRequest.bidderCode, code);
+      const requestEndpoint = getMappedCodeValue(
+        endpointByCode,
+        requestCode,
+        endpoint
+      );
+      if (!requestEndpoint) {
         logError("ferioUtils: missing endpoint option");
         return [];
       }
@@ -456,8 +549,11 @@ export function createFerioBidderSpec<
       return [
         {
           method: "POST",
-          url: endpoint,
-          data: converter.toORTB({ bidRequests: validBidRequests, bidderRequest }),
+          url: requestEndpoint,
+          data: converter.toORTB({
+            bidRequests: validBidRequests,
+            bidderRequest,
+          }),
           options: {
             contentType: "text/plain",
             withCredentials: true,
@@ -485,9 +581,18 @@ export function createFerioBidderSpec<
         return [];
       }
     },
-    getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) {
+    getUserSyncs(
+      syncOptions,
+      serverResponses,
+      gdprConsent,
+      uspConsent,
+      gppConsent
+    ) {
+      const syncCode = isRecord(this)
+        ? getNonEmptyString(this.code, code)
+        : code;
       return getUserSyncs(
-        syncBase,
+        getMappedCodeValue(syncBaseByCode, syncCode, syncBase),
         syncOptions,
         gdprConsent,
         uspConsent,

--- a/modules/ferioBidAdapter.md
+++ b/modules/ferioBidAdapter.md
@@ -23,10 +23,10 @@ Ferio bid adapter supports banner, video, and native ads.
 
 | Alias       | Company   | Maintainer         | Endpoint domain |
 | ----------- | --------- | ------------------ | --------------- |
-| `featuretv` | FeatureTV | prebid@ferio.cloud | featuretv.bid   |
+| `myfeature` | MyFeature | prebid@ferio.cloud | featuretv.bid   |
 
 Client-side aliases take the same bid params as `ferio` and request bids from
-their own endpoint domain. The `featuretv` alias is not configured as a Prebid
+their own endpoint domain. The `myfeature` alias is not configured as a Prebid
 Server/S2S alias. User syncs for aliases only run when the publisher enables
 `userSync.aliasSyncEnabled` via `pbjs.setConfig`.
 
@@ -41,9 +41,9 @@ var adUnits = [
     },
     bids: [
       {
-        bidder: "featuretv",
+        bidder: "myfeature",
         params: {
-          tenantId: "featuretv-pbjs",
+          tenantId: "myfeature-pbjs",
           publisherId: "pub22yCUTGq6An3d",
           adUnitId: "59a8d685-ed01-4b10-9f50-fe9ad0c9c0c1",
         },

--- a/modules/ferioBidAdapter.md
+++ b/modules/ferioBidAdapter.md
@@ -19,6 +19,40 @@ Ferio bid adapter supports banner, video, and native ads.
 | `adUnitId`    | required | String | Ad unit ID on the Ferio platform.   |
 | `tenantId`    | required | String | Tenant ID on the Ferio platform.    |
 
+# Aliases
+
+| Alias       | Company   | Maintainer         | Endpoint domain |
+| ----------- | --------- | ------------------ | --------------- |
+| `featuretv` | FeatureTV | prebid@ferio.cloud | featuretv.bid   |
+
+Client-side aliases take the same bid params as `ferio` and request bids from
+their own endpoint domain. The `featuretv` alias is not configured as a Prebid
+Server/S2S alias. User syncs for aliases only run when the publisher enables
+`userSync.aliasSyncEnabled` via `pbjs.setConfig`.
+
+```javascript
+var adUnits = [
+  {
+    code: "banner-div",
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]],
+      },
+    },
+    bids: [
+      {
+        bidder: "featuretv",
+        params: {
+          tenantId: "featuretv-pbjs",
+          publisherId: "pub22yCUTGq6An3d",
+          adUnitId: "59a8d685-ed01-4b10-9f50-fe9ad0c9c0c1",
+        },
+      },
+    ],
+  },
+];
+```
+
 # Test Parameters
 
 ```javascript
@@ -34,7 +68,7 @@ var adUnits = [
       {
         bidder: "ferio",
         params: {
-          tenantId: "anyclip-pbjs",
+          tenantId: "client-pbjs",
           publisherId: "pub22yCUTGq6An3d",
           adUnitId: "59a8d685-ed01-4b10-9f50-fe9ad0c9c0c1",
         },
@@ -55,7 +89,7 @@ var adUnits = [
       {
         bidder: "ferio",
         params: {
-          tenantId: "anyclip-pbjs",
+          tenantId: "client-pbjs",
           publisherId: "pub22yCUTGq6An3d",
           adUnitId: "59a8d685-ed01-4b10-9f50-fe9ad0c9c0c1",
         },
@@ -93,7 +127,7 @@ var adUnits = [
       {
         bidder: "ferio",
         params: {
-          tenantId: "anyclip-pbjs",
+          tenantId: "client-pbjs",
           publisherId: "pub22yCUTGq6An3d",
           adUnitId: "59a8d685-ed01-4b10-9f50-fe9ad0c9c0c1",
         },

--- a/modules/ferioBidAdapter.ts
+++ b/modules/ferioBidAdapter.ts
@@ -6,6 +6,8 @@ import { createFerioBidderSpec } from "../libraries/ferioUtils/bidderUtils.js";
 
 const BIDDER_CODE = "ferio";
 const FERIO_ENDPOINT = "https://ferio.bid/pbjs/bid";
+const FEATURETV_BIDDER_CODE = "featuretv";
+const FEATURETV_ENDPOINT = "https://featuretv.bid/prebid";
 
 export interface FerioBidParams {
   publisherId: string;
@@ -16,6 +18,7 @@ export interface FerioBidParams {
 declare module "../src/adUnits" {
   interface BidderParams {
     [BIDDER_CODE]: FerioBidParams;
+    [FEATURETV_BIDDER_CODE]: FerioBidParams;
   }
 }
 
@@ -23,6 +26,13 @@ export const spec: BidderSpec<typeof BIDDER_CODE> = createFerioBidderSpec({
   code: BIDDER_CODE,
   endpoint: FERIO_ENDPOINT,
   requiredParams: ["tenantId"],
+  aliases: [
+    {
+      code: FEATURETV_BIDDER_CODE,
+      endpoint: FEATURETV_ENDPOINT,
+      skipPbsAliasing: true,
+    },
+  ],
 });
 
 registerBidder(spec);

--- a/modules/ferioBidAdapter.ts
+++ b/modules/ferioBidAdapter.ts
@@ -6,8 +6,8 @@ import { createFerioBidderSpec } from "../libraries/ferioUtils/bidderUtils.js";
 
 const BIDDER_CODE = "ferio";
 const FERIO_ENDPOINT = "https://ferio.bid/pbjs/bid";
-const FEATURETV_BIDDER_CODE = "featuretv";
-const FEATURETV_ENDPOINT = "https://featuretv.bid/prebid";
+const MYFEATURE_BIDDER_CODE = "myfeature";
+const MYFEATURE_ENDPOINT = "https://featuretv.bid/prebid";
 
 export interface FerioBidParams {
   publisherId: string;
@@ -18,7 +18,7 @@ export interface FerioBidParams {
 declare module "../src/adUnits" {
   interface BidderParams {
     [BIDDER_CODE]: FerioBidParams;
-    [FEATURETV_BIDDER_CODE]: FerioBidParams;
+    [MYFEATURE_BIDDER_CODE]: FerioBidParams;
   }
 }
 
@@ -28,8 +28,8 @@ export const spec: BidderSpec<typeof BIDDER_CODE> = createFerioBidderSpec({
   requiredParams: ["tenantId"],
   aliases: [
     {
-      code: FEATURETV_BIDDER_CODE,
-      endpoint: FEATURETV_ENDPOINT,
+      code: MYFEATURE_BIDDER_CODE,
+      endpoint: MYFEATURE_ENDPOINT,
       skipPbsAliasing: true,
     },
   ],

--- a/test/spec/modules/ferioBidAdapter_spec.js
+++ b/test/spec/modules/ferioBidAdapter_spec.js
@@ -11,6 +11,16 @@ const ALIAS_CODE = "clientABidder";
 const ALIAS_PARAM_BIDDER_CODE = "ferioflow";
 const FERIO_BID_URL = "https://ferio.bid/pbjs/bid";
 const ALIAS_BID_URL = "https://bidder.ferio.cloud/prebid/bid";
+const FEATURETV_CODE = "featuretv";
+const FEATURETV_BID_URL = "https://featuretv.bid/prebid/bid";
+const FERIO_ALIASES = [
+  {
+    code: FEATURETV_CODE,
+    bidUrl: FEATURETV_BID_URL,
+    syncBaseUrl: "https://featuretv.bid/prebid",
+    skipPbsAliasing: true,
+  },
+];
 
 function bidRequest(overrides = {}) {
   return {
@@ -186,6 +196,224 @@ describe("ferioBidAdapter", function () {
           })
         )
       ).to.equal(true);
+    });
+  });
+
+  describe("aliases", function () {
+    it("registers aliases without leaking endpoint config", function () {
+      expect(spec.aliases).to.have.lengthOf(FERIO_ALIASES.length);
+      FERIO_ALIASES.forEach(({ code, skipPbsAliasing }) => {
+        const alias = spec.aliases.find((alias) => alias.code === code);
+
+        expect(alias).to.exist;
+        expect(alias.skipPbsAliasing).to.equal(skipPbsAliasing);
+        expect(alias).to.not.have.property("endpoint");
+      });
+    });
+
+    it("routes alias bid requests to the alias endpoint", function () {
+      FERIO_ALIASES.forEach(({ code, bidUrl }) => {
+        const aliasBid = bidRequest({ bidder: code });
+        const request = buildRequest([aliasBid], {
+          bidderCode: code,
+          bids: [aliasBid],
+        });
+        const imp = getImp(request, "bid-1");
+
+        expect(request.url).to.equal(bidUrl);
+        expect(imp.ext.prebid.bidder[code]).to.deep.equal({
+          publisherId: "pub-123",
+          adUnitId: "ad-unit-456",
+          tenantId: "tenant-123",
+        });
+        expect(imp.ext.prebid.bidder).to.not.have.property(BIDDER_CODE);
+      });
+
+      const primaryRequest = buildRequest([bidRequest()]);
+      expect(primaryRequest.url).to.equal(FERIO_BID_URL);
+    });
+
+    it("lets embedded aliases override the bidder params key", function () {
+      const aliasSpec = createFerioBidderSpec({
+        endpoint: FERIO_BID_URL,
+        aliases: [
+          {
+            code: ALIAS_CODE,
+            endpoint: ALIAS_BID_URL,
+            paramBidderCode: ALIAS_PARAM_BIDDER_CODE,
+          },
+        ],
+      });
+      const aliasBid = bidRequest({ bidder: ALIAS_CODE });
+      const request = buildRequest(
+        [aliasBid],
+        { bidderCode: ALIAS_CODE, bids: [aliasBid] },
+        aliasSpec
+      );
+      const imp = getImp(request, "bid-1");
+
+      expect(request.url).to.equal(ALIAS_BID_URL);
+      expect(imp.ext.prebid.bidder[ALIAS_PARAM_BIDDER_CODE]).to.deep.equal({
+        publisherId: "pub-123",
+        adUnitId: "ad-unit-456",
+        tenantId: "tenant-123",
+      });
+      expect(imp.ext.prebid.bidder).to.not.have.property(ALIAS_CODE);
+      expect(imp.ext.prebid.bidder).to.not.have.property(BIDDER_CODE);
+    });
+
+    it("attributes alias responses to the alias bidder code", function () {
+      FERIO_ALIASES.forEach(({ code }) => {
+        const aliasBid = bidRequest({ bidder: code });
+        const request = buildRequest([aliasBid], {
+          bidderCode: code,
+          bids: [aliasBid],
+        });
+
+        const bids = spec.interpretResponse(
+          serverResponse([
+            {
+              id: "seat-banner",
+              impid: "bid-1",
+              price: 1.1,
+              adm: "<div>ad</div>",
+              crid: "creative-banner",
+              w: 300,
+              h: 250,
+              mtype: 1,
+            },
+          ]),
+          request
+        );
+
+        expect(bids).to.have.lengthOf(1);
+        expect(bids[0]).to.deep.include({
+          requestId: "bid-1",
+          bidderCode: code,
+          adapterCode: code,
+          mediaType: BANNER,
+        });
+      });
+    });
+
+    it("falls back to the primary endpoint for alias and unknown codes without one", function () {
+      const aliasSpec = createFerioBidderSpec({
+        endpoint: FERIO_BID_URL,
+        aliases: [{ code: ALIAS_CODE }],
+      });
+      const aliasBid = bidRequest({ bidder: ALIAS_CODE });
+
+      const aliasRequest = aliasSpec.buildRequests(
+        [aliasBid],
+        bidderRequest({ bidderCode: ALIAS_CODE, bids: [aliasBid] })
+      )[0];
+      expect(aliasRequest.url).to.equal(FERIO_BID_URL);
+
+      const unknownRequest = aliasSpec.buildRequests(
+        [aliasBid],
+        bidderRequest({ bidderCode: "unregisteredAlias", bids: [aliasBid] })
+      )[0];
+      expect(unknownRequest.url).to.equal(FERIO_BID_URL);
+    });
+
+    it("ignores aliases that duplicate the primary or another alias code", function () {
+      const guardedSpec = createFerioBidderSpec({
+        endpoint: FERIO_BID_URL,
+        aliases: [
+          { code: BIDDER_CODE, endpoint: "https://hijack.example/bid" },
+          { code: ALIAS_CODE, endpoint: ALIAS_BID_URL },
+          { code: ALIAS_CODE, endpoint: "https://hijack.example/bid" },
+        ],
+      });
+
+      expect(guardedSpec.aliases).to.have.lengthOf(1);
+      expect(guardedSpec.aliases[0].code).to.equal(ALIAS_CODE);
+
+      const primaryRequest = buildRequest([bidRequest()], {}, guardedSpec);
+      expect(primaryRequest.url).to.equal(FERIO_BID_URL);
+
+      const aliasBid = bidRequest({ bidder: ALIAS_CODE });
+      const aliasRequest = buildRequest(
+        [aliasBid],
+        { bidderCode: ALIAS_CODE },
+        guardedSpec
+      );
+      expect(aliasRequest.url).to.equal(ALIAS_BID_URL);
+    });
+
+    it("builds no alias requests or syncs when an explicit alias endpoint is not https", function () {
+      ["javascript:alert(1)", "http://insecure.ferio.cloud/bid"].forEach(
+        (aliasEndpoint) => {
+          const aliasSpec = createFerioBidderSpec({
+            endpoint: FERIO_BID_URL,
+            aliases: [{ code: ALIAS_CODE, endpoint: aliasEndpoint }],
+          });
+          const aliasBid = bidRequest({ bidder: ALIAS_CODE });
+
+          const aliasRequests = aliasSpec.buildRequests(
+            [aliasBid],
+            bidderRequest({ bidderCode: ALIAS_CODE, bids: [aliasBid] })
+          );
+          expect(aliasRequests).to.deep.equal([]);
+
+          const syncs = aliasSpec.getUserSyncs.call(
+            { ...aliasSpec, code: ALIAS_CODE },
+            { pixelEnabled: true },
+            []
+          );
+          expect(syncs).to.deep.equal([]);
+        }
+      );
+    });
+
+    it("builds no requests when the primary endpoint is not a valid https URL", function () {
+      const invalidSpec = createFerioBidderSpec({ endpoint: "not a url" });
+
+      expect(
+        invalidSpec.buildRequests([bidRequest()], bidderRequest())
+      ).to.deep.equal([]);
+    });
+
+    it("derives alias user sync URLs from the alias endpoint", function () {
+      FERIO_ALIASES.forEach(({ code, syncBaseUrl }) => {
+        const syncs = spec.getUserSyncs.call(
+          { ...spec, code },
+          {
+            iframeEnabled: true,
+            pixelEnabled: true,
+          },
+          []
+        );
+
+        expect(syncs).to.deep.equal([
+          {
+            type: "image",
+            url: `${syncBaseUrl}/sync?us_privacy=&gdpr=0&gdpr_consent=`,
+          },
+          {
+            type: "iframe",
+            url: `${syncBaseUrl}/cli/iframe.html?us_privacy=&gdpr=0&gdpr_consent=`,
+          },
+        ]);
+      });
+    });
+
+    it("falls back to the primary sync base when called without a spec context", function () {
+      const { getUserSyncs } = spec;
+      const syncs = getUserSyncs(
+        {
+          iframeEnabled: false,
+          pixelEnabled: true,
+        },
+        []
+      );
+
+      expect(syncs).to.deep.equal([
+        {
+          type: "image",
+          url: "https://ferio.bid/pbjs/sync?us_privacy=&gdpr=0&gdpr_consent=",
+        },
+      ]);
     });
   });
 

--- a/test/spec/modules/ferioBidAdapter_spec.js
+++ b/test/spec/modules/ferioBidAdapter_spec.js
@@ -11,12 +11,12 @@ const ALIAS_CODE = "clientABidder";
 const ALIAS_PARAM_BIDDER_CODE = "ferioflow";
 const FERIO_BID_URL = "https://ferio.bid/pbjs/bid";
 const ALIAS_BID_URL = "https://bidder.ferio.cloud/prebid/bid";
-const FEATURETV_CODE = "featuretv";
-const FEATURETV_BID_URL = "https://featuretv.bid/prebid/bid";
+const MYFEATURE_CODE = "myfeature";
+const MYFEATURE_BID_URL = "https://featuretv.bid/prebid/bid";
 const FERIO_ALIASES = [
   {
-    code: FEATURETV_CODE,
-    bidUrl: FEATURETV_BID_URL,
+    code: MYFEATURE_CODE,
+    bidUrl: MYFEATURE_BID_URL,
     syncBaseUrl: "https://featuretv.bid/prebid",
     skipPbsAliasing: true,
   },


### PR DESCRIPTION
## Type of change

- [x] Feature
- [x] Updated bidder adapter

## Description of change

Adds `featuretv` as a client-side alias for the Ferio bid adapter. The alias uses the same bid params as `ferio`, routes requests to the FeatureTV endpoint, and is marked with `skipPbsAliasing` so it is not configured as a Prebid Server alias.

Extends the shared Ferio bidder utility to support per-alias endpoint, params-key, sync-base, and alias metadata configuration.

## Other information

- Docs PR including `featuretv` bidder page on prebid.github.io: https://github.com/prebid/prebid.github.io/pull/6568
