### PR TITLE
Azerion example: Fix for Duplicate HTML element attributes

### DIFF
--- a/integrationExamples/gpt/azerionedgeRtdProvider_example.html
+++ b/integrationExamples/gpt/azerionedgeRtdProvider_example.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <meta name="keywords" content="football basketball rugby tenis" />
-    <script async src="../../build/dev/prebid.js" async></script>
+    <script async src="../../build/dev/prebid.js"></script>
     <script
       async
       src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"


### PR DESCRIPTION
To fix this, remove the duplicated `async` attribute from the script tag on line 4, keeping only one `async` attribute.

Best fix (no functional change):
- File: `integrationExamples/gpt/azerionedgeRtdProvider_example.html`
- Region: the first `<script>` tag in `<head>` (current line 4).
- Change: replace `<script async src="../../build/dev/prebid.js" async></script>` with `<script async src="../../build/dev/prebid.js"></script>`.

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._