### PR TITLE
Analytics: Fix for Inconsistent use of 'new'

### DIFF
--- a/libraries/analyticsAdapter/AnalyticsAdapter.ts
+++ b/libraries/analyticsAdapter/AnalyticsAdapter.ts
@@ -85,6 +85,9 @@ export default function AnalyticsAdapter<PROVIDER extends AnalyticsProvider>({ u
   global?: string;
   handler?: any;
 }) {
+  if (!new.target) {
+    return new AnalyticsAdapter<PROVIDER>({ url, analyticsType, global, handler });
+  }
   const queue = [];
   let handlers;
   let enabled = false;


### PR DESCRIPTION
To fix this without breaking existing callers, make `AnalyticsAdapter` consistently constructor-oriented while remaining backward-compatible with plain calls:

- Update the function body to detect non-constructor invocation and immediately re-invoke itself with `new`.
- Add a `new.target` guard at the top of `AnalyticsAdapter`.
- Keep the existing implementation unchanged after that guard.

This approach avoids changing external call sites (which we are not allowed to edit here), preserves functionality, and resolves mixed invocation semantics by normalizing both call styles to constructor behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._