### PR TITLE
Medianet analytics: Fix for Implicit operand conversion

### DIFF
--- a/modules/medianetAnalyticsAdapter.js
+++ b/modules/medianetAnalyticsAdapter.js
@@ -497,7 +497,8 @@ function getDfpCurrencyInfo(bidResponse) {
   let dfpbd = deepAccess(adserverTargeting, `${TARGETING_KEYS.PRICE_BUCKET}`);
   if (!dfpbd) {
     const priceGranularityKey = getPriceByGranularity(bidResponse);
-    dfpbd = bidResponse[priceGranularityKey] || bidResponse.cpm;
+    const priceGranularityValue = typeof priceGranularityKey === 'string' ? bidResponse[priceGranularityKey] : undefined;
+    dfpbd = priceGranularityValue || bidResponse.cpm;
   }
   if (currency !== 'USD' && dfpbd) {
     dfpbd = convertCurrency(dfpbd, currency, 'USD');


### PR DESCRIPTION
The safest fix is to avoid using a non-string as an object key.  
Specifically in `modules/medianetAnalyticsAdapter.js` around lines 499–500, compute `priceGranularityKey`, then only use `bidResponse[priceGranularityKey]` if the key is a string. Otherwise, fall back to `bidResponse.cpm` (same existing behavior intent).

This preserves functionality while removing implicit conversion and making intent explicit. No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._