### PR TITLE
Generic Analytics Adapter: fix constructor invocation handling

### DIFF
--- a/libraries/analyticsAdapter/AnalyticsAdapter.ts
+++ b/libraries/analyticsAdapter/AnalyticsAdapter.ts
@@ -85,6 +85,10 @@ export default function AnalyticsAdapter<PROVIDER extends AnalyticsProvider>({ u
   global?: string;
   handler?: any;
 }) {
+  if (!new.target) {
+    return new (AnalyticsAdapter as any)({ url, analyticsType, global, handler });
+  }
+
   const queue = [];
   let handlers;
   let enabled = false;

--- a/libraries/analyticsAdapter/AnalyticsAdapter.ts
+++ b/libraries/analyticsAdapter/AnalyticsAdapter.ts
@@ -79,15 +79,41 @@ export type AnalyticsConfig<P extends AnalyticsProvider> = (
       options?: P extends keyof AnalyticsProviderConfig ? AnalyticsProviderConfig[P] : Record<string, unknown>
     };
 
-export default function AnalyticsAdapter<PROVIDER extends AnalyticsProvider>({ url, analyticsType, global, handler }: {
+type AnalyticsAdapterOptions = {
   analyticsType?: AnalyticsType;
   url?: string;
   global?: string;
   handler?: any;
-}) {
+};
+
+type AnalyticsEvent = {
+  eventType: keyof events.Events;
+  args: events.Events[keyof events.Events][0];
+  labels?: Record<string, unknown>;
+  callback?: any;
+};
+
+export type AnalyticsAdapterInstance<PROVIDER extends AnalyticsProvider = AnalyticsProvider> = {
+  track: (arg: AnalyticsEvent) => void;
+  enqueue: (arg: AnalyticsEvent) => void;
+  enableAnalytics: (config?: AnalyticsConfig<PROVIDER>) => void;
+  disableAnalytics: () => void;
+  getAdapterType: () => AnalyticsType | undefined;
+  getGlobal: () => string | undefined;
+  getHandler: () => any;
+  getUrl: () => string | undefined;
+  enabled: boolean;
+  _oldEnable?: (config?: AnalyticsConfig<PROVIDER>) => void;
+};
+
+type AnalyticsAdapterConstructor = new <PROVIDER extends AnalyticsProvider>(options: AnalyticsAdapterOptions) => AnalyticsAdapterInstance<PROVIDER>;
+
+export default function AnalyticsAdapter<PROVIDER extends AnalyticsProvider>(options: AnalyticsAdapterOptions): AnalyticsAdapterInstance<PROVIDER> {
   if (!new.target) {
-    return new (AnalyticsAdapter as any)({ url, analyticsType, global, handler });
+    return new (AnalyticsAdapter as unknown as AnalyticsAdapterConstructor)<PROVIDER>(options);
   }
+
+  const { url, analyticsType, global, handler } = options;
 
   const queue = [];
   let handlers;
@@ -147,7 +173,7 @@ export default function AnalyticsAdapter<PROVIDER extends AnalyticsProvider>({ u
     enabled: {
       get: () => enabled
     }
-  });
+  }) as AnalyticsAdapterInstance<PROVIDER>;
 
   function _track(arg) {
     const { eventType, args } = arg;

--- a/modules/genericAnalyticsAdapter.ts
+++ b/modules/genericAnalyticsAdapter.ts
@@ -1,4 +1,4 @@
-import AnalyticsAdapter, { type DefaultOptions } from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
+import AnalyticsAdapter, { type AnalyticsAdapterInstance, type DefaultOptions } from '../libraries/analyticsAdapter/AnalyticsAdapter.js';
 import { prefixLog, isPlainObject } from '../src/utils.js';
 import { type Events, has as hasEvent } from '../src/events.js';
 import adapterManager from '../src/adapterManager.js';
@@ -91,9 +91,15 @@ const TYPES = {
 
 const MAX_CALL_DEPTH = 20;
 
-export function GenericAnalytics() {
+type GenericAnalyticsAdapter = AnalyticsAdapterInstance<'generic'> & {
+  gvlid: (config) => number | undefined;
+};
+
+type GenericAnalyticsConstructor = new () => GenericAnalyticsAdapter;
+
+export function GenericAnalytics(): GenericAnalyticsAdapter {
   if (!new.target) {
-    return new (GenericAnalytics as any)();
+    return new (GenericAnalytics as unknown as GenericAnalyticsConstructor)();
   }
 
   const parent = AnalyticsAdapter<'generic'>({ analyticsType: 'endpoint' });

--- a/modules/genericAnalyticsAdapter.ts
+++ b/modules/genericAnalyticsAdapter.ts
@@ -92,6 +92,10 @@ const TYPES = {
 const MAX_CALL_DEPTH = 20;
 
 export function GenericAnalytics() {
+  if (!new.target) {
+    return new (GenericAnalytics as any)();
+  }
+
   const parent = AnalyticsAdapter<'generic'>({ analyticsType: 'endpoint' });
   const { logError, logWarn } = prefixLog('Generic analytics:');
   let batch = [];


### PR DESCRIPTION
### Motivation
- A code-scanning warning flagged inconsistent constructor invocation for analytics adapter factories when callers invoked them without `new`, so normalize behavior to avoid runtime inconsistencies.
- Ensure both the generic adapter factory and the shared `AnalyticsAdapter` behave the same when called as functions or constructed, preserving backwards-compatible usage patterns.

### Description
- Added a `new.target` guard to `libraries/analyticsAdapter/AnalyticsAdapter.ts` so calls like `AnalyticsAdapter(...)` are normalized to a constructor invocation via `return new (AnalyticsAdapter as any)(...)`.
- Added the same `new.target` guard to `modules/genericAnalyticsAdapter.ts` so `GenericAnalytics()` and `new GenericAnalytics()` behave consistently via `return new (GenericAnalytics as any)()`.
- The `as any` casts were used to satisfy TypeScript when invoking the factory with `new` in this fallback path.

### Testing
- Ran `npx eslint libraries/analyticsAdapter/AnalyticsAdapter.ts modules/genericAnalyticsAdapter.ts --cache --cache-strategy content` and it passed.
- Ran `npx gulp test --nolint --file test/spec/AnalyticsAdapter_spec.js` and the spec suite completed successfully (all tests passed).
- Ran `npx gulp test --nolint --file test/spec/modules/genericAnalyticsAdapter_spec.js` and the spec suite completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2ab69a2014832b8cc41be56512db87)