### PR TITLE
Tercept Anlytics Adapter: Add video support and other bug fixes

### DIFF
--- a/modules/terceptAnalyticsAdapter.js
+++ b/modules/terceptAnalyticsAdapter.js
@@ -10,7 +10,7 @@ import { EVENTS } from '../src/constants.js';
 
 const emptyUrl = '';
 const analyticsType = 'endpoint';
-const terceptAnalyticsVersion = 'v2.1.0';
+const terceptAnalyticsVersion = 'v2.2.0';
 const defaultHostName = 'b-s.tercept.com';
 const defaultPathName = '/prebid-analytics';
 const DEFAULT_ANALYTICS_BATCH_TIMEOUT = 0;
@@ -35,6 +35,7 @@ function flush(auctionId, useBeacon = false) {
   });
   send({ auctionInit: auction.auctionInit, bids: auction.bids }, useBeacon);
   pendingAuctions.delete(auctionId);
+  adUnitMap.delete(auctionId);
 }
 
 // flush remaining auctions via sendBeacon on page exit
@@ -114,6 +115,10 @@ var terceptAnalyticsAdapter = Object.assign(adapter(
             timeToRespond: args.timeToRespond,
             requestTimestamp: args.requestTimestamp,
             responseTimestamp: args.responseTimestamp,
+            vastUrl: args.vastUrl || null,
+            vastImpUrl: args.vastImpUrl || null,
+            playerWidth: args.playerWidth || null,
+            playerHeight: args.playerHeight || null,
             ...winFields
           }
         });
@@ -169,6 +174,15 @@ function mapBidRequests(params) {
   const arr = [];
   if (typeof params.bids !== 'undefined' && params.bids.length) {
     params.bids.forEach(function (bid) {
+      const mediaType = bid.mediaTypes?.video ? 'video'
+        : bid.mediaTypes?.banner ? 'banner'
+        : bid.mediaTypes?.native ? 'native'
+        : null;
+      const sizes = bid.mediaTypes?.banner?.sizes
+        ? parseSizesInput(bid.mediaTypes.banner.sizes).toString()
+        : bid.mediaTypes?.video?.playerSize
+          ? parseSizesInput(bid.mediaTypes.video.playerSize).toString()
+          : '';
       arr.push({
         bidderCode: bid.bidder,
         bidId: bid.bidId,
@@ -176,7 +190,9 @@ function mapBidRequests(params) {
         requestId: bid.bidderRequestId,
         auctionId: bid.auctionId,
         transactionId: bid.transactionId,
-        sizes: parseSizesInput(bid.mediaTypes.banner.sizes).toString(),
+        mediaType,
+        sizes,
+        videoContext: bid.mediaTypes?.video?.context || null,
         renderStatus: 1,
         requestTimestamp: params.auctionStart
       });
@@ -242,6 +258,10 @@ function mapBidResponse(bidResponse, status) {
     adId: bidResponse.adId,
     adserverTargeting: bidResponse.adserverTargeting,
     videoCacheKey: bidResponse.videoCacheKey,
+    vastUrl: bidResponse.vastUrl || null,
+    vastImpUrl: bidResponse.vastImpUrl || null,
+    playerWidth: bidResponse.playerWidth || null,
+    playerHeight: bidResponse.playerHeight || null,
     meta: bidResponse.meta || {}
   };
 }

--- a/modules/terceptAnalyticsAdapter.js
+++ b/modules/terceptAnalyticsAdapter.js
@@ -90,9 +90,9 @@ var terceptAnalyticsAdapter = Object.assign(adapter(
         const winFields = {
           renderStatus: 4,
           renderedSize: args.size,
-          host: window.location.hostname,
-          path: window.location.pathname,
-          search: window.location.search,
+          host: getWindowLocation().hostname,
+          path: getWindowLocation().pathname,
+          search: getWindowLocation().search,
           adserverAdSlot,
           pbAdSlot
         };
@@ -126,9 +126,9 @@ var terceptAnalyticsAdapter = Object.assign(adapter(
           renderStatus: 7,
           renderTimestamp: Date.now(),
           renderedSize: bid.size,
-          host: window.location.hostname,
-          path: window.location.pathname,
-          search: window.location.search,
+          host: getWindowLocation().hostname,
+          path: getWindowLocation().pathname,
+          search: getWindowLocation().search,
           adserverAdSlot,
           pbAdSlot
         });
@@ -138,9 +138,9 @@ var terceptAnalyticsAdapter = Object.assign(adapter(
           renderStatus: 8,
           reason: args.reason,
           message: args.message,
-          host: window.location.hostname,
-          path: window.location.pathname,
-          search: window.location.search
+          host: getWindowLocation().hostname,
+          path: getWindowLocation().pathname,
+          search: getWindowLocation().search
         });
       } else if (eventType === EVENTS.BIDDER_ERROR) {
         const { bidderRequest, error } = args;
@@ -268,7 +268,7 @@ function send(data, useBeacon = false) {
   const location = getWindowLocation();
   if (data.auctionInit) {
     Object.assign(data.auctionInit, {
-      host: location.host,
+      host: location.hostname,
       path: location.pathname,
       search: location.search
     });

--- a/modules/terceptAnalyticsAdapter.js
+++ b/modules/terceptAnalyticsAdapter.js
@@ -114,8 +114,6 @@ var terceptAnalyticsAdapter = Object.assign(adapter(
             timeToRespond: args.timeToRespond,
             requestTimestamp: args.requestTimestamp,
             responseTimestamp: args.responseTimestamp,
-            vastUrl: args.vastUrl || null,
-            vastImpUrl: args.vastImpUrl || null,
             playerWidth: args.playerWidth || null,
             playerHeight: args.playerHeight || null,
             ...winFields
@@ -260,8 +258,6 @@ function mapBidResponse(bidResponse, status) {
     adId: bidResponse.adId,
     adserverTargeting: bidResponse.adserverTargeting,
     videoCacheKey: bidResponse.videoCacheKey,
-    vastUrl: bidResponse.vastUrl || null,
-    vastImpUrl: bidResponse.vastImpUrl || null,
     playerWidth: bidResponse.playerWidth || null,
     playerHeight: bidResponse.playerHeight || null,
     meta: bidResponse.meta || {}

--- a/modules/terceptAnalyticsAdapter.js
+++ b/modules/terceptAnalyticsAdapter.js
@@ -114,8 +114,8 @@ var terceptAnalyticsAdapter = Object.assign(adapter(
             timeToRespond: args.timeToRespond,
             requestTimestamp: args.requestTimestamp,
             responseTimestamp: args.responseTimestamp,
-            playerWidth: args.playerWidth || null,
-            playerHeight: args.playerHeight || null,
+            playerWidth: args.playerWidth ?? null,
+            playerHeight: args.playerHeight ?? null,
             ...winFields
           }
         });
@@ -258,8 +258,8 @@ function mapBidResponse(bidResponse, status) {
     adId: bidResponse.adId,
     adserverTargeting: bidResponse.adserverTargeting,
     videoCacheKey: bidResponse.videoCacheKey,
-    playerWidth: bidResponse.playerWidth || null,
-    playerHeight: bidResponse.playerHeight || null,
+    playerWidth: bidResponse.playerWidth ?? null,
+    playerHeight: bidResponse.playerHeight ?? null,
     meta: bidResponse.meta || {}
   };
 }

--- a/modules/terceptAnalyticsAdapter.js
+++ b/modules/terceptAnalyticsAdapter.js
@@ -10,7 +10,7 @@ import { EVENTS } from '../src/constants.js';
 
 const emptyUrl = '';
 const analyticsType = 'endpoint';
-const terceptAnalyticsVersion = 'v2.2.0';
+const terceptAnalyticsVersion = 'v2.3.0';
 const defaultHostName = 'b-s.tercept.com';
 const defaultPathName = '/prebid-analytics';
 const DEFAULT_ANALYTICS_BATCH_TIMEOUT = 0;
@@ -35,7 +35,6 @@ function flush(auctionId, useBeacon = false) {
   });
   send({ auctionInit: auction.auctionInit, bids: auction.bids }, useBeacon);
   pendingAuctions.delete(auctionId);
-  adUnitMap.delete(auctionId);
 }
 
 // flush remaining auctions via sendBeacon on page exit
@@ -167,16 +166,19 @@ function updateBid(auctionId, bidId, fields) {
   const auction = pendingAuctions.get(auctionId);
   if (!auction) return;
   const bid = auction.bids.find(b => b.bidId === bidId);
-  if (bid) Object.assign(bid, fields);
+  if (!bid) return;
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== undefined) bid[key] = value;
+  }
 }
 
 function mapBidRequests(params) {
   const arr = [];
   if (typeof params.bids !== 'undefined' && params.bids.length) {
     params.bids.forEach(function (bid) {
-      const mediaType = bid.mediaTypes?.video ? 'video'
-        : bid.mediaTypes?.banner ? 'banner'
-        : bid.mediaTypes?.native ? 'native'
+      const mediaTypeKeys = Object.keys(bid.mediaTypes || {});
+      const mediaType = mediaTypeKeys.length === 1
+        ? (bid.mediaTypes.video ? 'video' : bid.mediaTypes.banner ? 'banner' : 'native')
         : null;
       const sizes = bid.mediaTypes?.banner?.sizes
         ? parseSizesInput(bid.mediaTypes.banner.sizes).toString()

--- a/test/spec/modules/terceptAnalyticsAdapter_spec.js
+++ b/test/spec/modules/terceptAnalyticsAdapter_spec.js
@@ -135,6 +135,63 @@ describe('tercept analytics adapter', function () {
     cpm: 0.5
   };
 
+  const videoAdUnit = {
+    code: AD_UNIT_CODE,
+    mediaTypes: { video: { context: 'instream', playerSize: [[640, 480]] } },
+    bids: [{ bidder: 'appnexus', params: { placementId: 13144370 } }],
+    ortb2Imp: adUnit.ortb2Imp
+  };
+
+  const videoBidRequested = {
+    bidderCode: 'appnexus',
+    auctionId: AUCTION_ID,
+    bidderRequestId: BIDDER_REQUEST_ID,
+    bids: [{
+      bidder: 'appnexus',
+      mediaTypes: { video: { context: 'instream', playerSize: [[640, 480]] } },
+      adUnitCode: AD_UNIT_CODE,
+      transactionId: '6d275806-1943-4f3e-9cd5-624cbd05ad98',
+      bidId: BID_ID,
+      bidderRequestId: BIDDER_REQUEST_ID,
+      auctionId: AUCTION_ID
+    }],
+    auctionStart: 1576823893836,
+    timeout: 1000
+  };
+
+  const videoBidResponse = {
+    ...bidResponse,
+    mediaType: 'video',
+    width: 640,
+    height: 480,
+    playerWidth: 640,
+    playerHeight: 480,
+    vastUrl: 'https://vast.example.com/ad',
+    vastImpUrl: 'https://vast.example.com/imp',
+    videoCacheKey: 'vc-key-123'
+  };
+
+  const videoBidWon = {
+    ...bidWon,
+    mediaType: 'video',
+    size: '640x480',
+    playerWidth: 640,
+    playerHeight: 480,
+    vastUrl: 'https://vast.example.com/ad',
+    vastImpUrl: 'https://vast.example.com/imp'
+  };
+
+  const multiFormatBidRequested = {
+    ...bidRequested,
+    bids: [{
+      ...bidRequested.bids[0],
+      mediaTypes: {
+        banner: { sizes: [[300, 250]] },
+        video: { context: 'outstream', playerSize: [[300, 250]] }
+      }
+    }]
+  };
+
   function emitFullAuction(id = AUCTION_ID) {
     const init = id === AUCTION_ID ? auctionInit : { ...auctionInit, auctionId: id };
     const req = id === AUCTION_ID ? bidRequested : {
@@ -256,6 +313,8 @@ describe('tercept analytics adapter', function () {
       expect(bids[0].sizes).to.equal('300x250,300x600');
       expect(bids[0].bidderCode).to.equal('appnexus');
       expect(bids[0].requestId).to.equal(BIDDER_REQUEST_ID);
+      expect(bids[0].mediaType).to.equal('banner');
+      expect(bids[0].videoContext).to.be.null;
     });
   });
 
@@ -286,6 +345,17 @@ describe('tercept analytics adapter', function () {
       const { bids } = JSON.parse(server.requests[0].requestBody);
       expect(bids[0].renderStatus).to.equal(3);
     });
+
+    it('preserves mediaType set at request time — timeout event must not overwrite it with undefined', function () {
+      events.emit(EVENTS.AUCTION_INIT, { ...auctionInit, adUnits: [videoAdUnit] });
+      events.emit(EVENTS.BID_REQUESTED, videoBidRequested);
+      events.emit(EVENTS.BID_TIMEOUT, [{ auctionId: AUCTION_ID, bidId: BID_ID, adUnitCode: AD_UNIT_CODE }]);
+      events.emit(EVENTS.AUCTION_END, auctionEnd);
+      clock.tick(0);
+      const { bids } = JSON.parse(server.requests[0].requestBody);
+      expect(bids[0].renderStatus).to.equal(3);
+      expect(bids[0].mediaType).to.equal('video');
+    });
   });
 
   // ─── NO_BID ───────────────────────────────────────────────────────────────
@@ -299,6 +369,17 @@ describe('tercept analytics adapter', function () {
       clock.tick(0);
       const { bids } = JSON.parse(server.requests[0].requestBody);
       expect(bids[0].renderStatus).to.equal(5);
+    });
+
+    it('preserves mediaType set at request time — no_bid event must not overwrite it with undefined', function () {
+      events.emit(EVENTS.AUCTION_INIT, { ...auctionInit, adUnits: [videoAdUnit] });
+      events.emit(EVENTS.BID_REQUESTED, videoBidRequested);
+      events.emit(EVENTS.NO_BID, { auctionId: AUCTION_ID, bidId: BID_ID, adUnitCode: AD_UNIT_CODE, bidder: 'appnexus' });
+      events.emit(EVENTS.AUCTION_END, auctionEnd);
+      clock.tick(0);
+      const { bids } = JSON.parse(server.requests[0].requestBody);
+      expect(bids[0].renderStatus).to.equal(5);
+      expect(bids[0].mediaType).to.equal('video');
     });
   });
 
@@ -357,6 +438,15 @@ describe('tercept analytics adapter', function () {
       const { bidWon: bw } = JSON.parse(server.requests[1].requestBody);
       expect(bw.renderStatus).to.equal(4);
       expect(bw.bidId).to.equal(BID_ID);
+    });
+
+    it('late BID_WON beacon still resolves adserverAdSlot after batch has flushed', function () {
+      emitFullAuction();
+      clock.tick(0); // batch flushed — pendingAuctions cleared, adUnitMap must survive
+      events.emit(EVENTS.BID_WON, bidWon);
+      const { bidWon: bw } = JSON.parse(server.requests[1].requestBody);
+      expect(bw.adserverAdSlot).to.equal('/1234567/homepage-banner');
+      expect(bw.pbAdSlot).to.equal('homepage-banner-pbadslot');
     });
   });
 
@@ -675,6 +765,75 @@ describe('tercept analytics adapter', function () {
       const p2 = JSON.parse(server.requests[3].requestBody);
       expect(p1.auctionInit.auctionId).to.equal(id1);
       expect(p2.auctionInit.auctionId).to.equal(id2);
+    });
+  });
+
+  // ─── Video media type ─────────────────────────────────────────────────────
+
+  describe('video media type', function () {
+    it('captures mediaType, videoContext and playerSize-based sizes for a video-only bid', function () {
+      events.emit(EVENTS.AUCTION_INIT, { ...auctionInit, adUnits: [videoAdUnit] });
+      events.emit(EVENTS.BID_REQUESTED, videoBidRequested);
+      events.emit(EVENTS.AUCTION_END, auctionEnd);
+      clock.tick(0);
+      const { bids } = JSON.parse(server.requests[0].requestBody);
+      expect(bids[0].mediaType).to.equal('video');
+      expect(bids[0].videoContext).to.equal('instream');
+      expect(bids[0].sizes).to.equal('640x480');
+    });
+
+    it('does not throw when there is no banner mediaType on the ad unit', function () {
+      expect(() => {
+        events.emit(EVENTS.AUCTION_INIT, { ...auctionInit, adUnits: [videoAdUnit] });
+        events.emit(EVENTS.BID_REQUESTED, videoBidRequested);
+        events.emit(EVENTS.AUCTION_END, auctionEnd);
+      }).not.to.throw();
+    });
+
+    it('captures vastUrl, vastImpUrl, playerWidth and playerHeight from bid response', function () {
+      events.emit(EVENTS.AUCTION_INIT, { ...auctionInit, adUnits: [videoAdUnit] });
+      events.emit(EVENTS.BID_REQUESTED, videoBidRequested);
+      events.emit(EVENTS.BID_RESPONSE, videoBidResponse);
+      events.emit(EVENTS.AUCTION_END, auctionEnd);
+      clock.tick(0);
+      const { bids } = JSON.parse(server.requests[0].requestBody);
+      expect(bids[0].vastUrl).to.equal('https://vast.example.com/ad');
+      expect(bids[0].vastImpUrl).to.equal('https://vast.example.com/imp');
+      expect(bids[0].playerWidth).to.equal(640);
+      expect(bids[0].playerHeight).to.equal(480);
+      expect(bids[0].mediaType).to.equal('video');
+    });
+
+    it('captures video fields in the BID_WON beacon', function () {
+      events.emit(EVENTS.AUCTION_INIT, { ...auctionInit, adUnits: [videoAdUnit] });
+      events.emit(EVENTS.BID_REQUESTED, videoBidRequested);
+      events.emit(EVENTS.AUCTION_END, auctionEnd);
+      events.emit(EVENTS.BID_WON, videoBidWon);
+      const { bidWon: bw } = JSON.parse(server.requests[0].requestBody);
+      expect(bw.vastUrl).to.equal('https://vast.example.com/ad');
+      expect(bw.vastImpUrl).to.equal('https://vast.example.com/imp');
+      expect(bw.playerWidth).to.equal(640);
+      expect(bw.playerHeight).to.equal(480);
+      expect(bw.mediaType).to.equal('video');
+    });
+
+    it('sets mediaType null for multi-format ad units at request time', function () {
+      events.emit(EVENTS.AUCTION_INIT, auctionInit);
+      events.emit(EVENTS.BID_REQUESTED, multiFormatBidRequested);
+      events.emit(EVENTS.AUCTION_END, auctionEnd);
+      clock.tick(0);
+      const { bids } = JSON.parse(server.requests[0].requestBody);
+      expect(bids[0].mediaType).to.be.null;
+    });
+
+    it('multi-format bid gets correct mediaType from the bid response', function () {
+      events.emit(EVENTS.AUCTION_INIT, auctionInit);
+      events.emit(EVENTS.BID_REQUESTED, multiFormatBidRequested);
+      events.emit(EVENTS.BID_RESPONSE, bidResponse); // mediaType: 'banner'
+      events.emit(EVENTS.AUCTION_END, auctionEnd);
+      clock.tick(0);
+      const { bids } = JSON.parse(server.requests[0].requestBody);
+      expect(bids[0].mediaType).to.equal('banner');
     });
   });
 

--- a/test/spec/modules/terceptAnalyticsAdapter_spec.js
+++ b/test/spec/modules/terceptAnalyticsAdapter_spec.js
@@ -424,6 +424,15 @@ describe('tercept analytics adapter', function () {
       expect(bids[0].adserverAdSlot).to.equal('/1234567/homepage-banner');
     });
 
+    it('host in win beacon matches host in auctionInit — same property, no port discrepancy', function () {
+      emitFullAuction();
+      events.emit(EVENTS.BID_WON, bidWon);
+      clock.tick(0);
+      const beacon = JSON.parse(server.requests[0].requestBody);
+      const batch = JSON.parse(server.requests[1].requestBody);
+      expect(beacon.bidWon.host).to.equal(batch.auctionInit.host);
+    });
+
     it('sends win beacon even after the batch timer has already flushed the auction', function () {
       emitFullAuction();
       clock.tick(0); // batch fires, auction deleted from pendingAuctions

--- a/test/spec/modules/terceptAnalyticsAdapter_spec.js
+++ b/test/spec/modules/terceptAnalyticsAdapter_spec.js
@@ -166,8 +166,6 @@ describe('tercept analytics adapter', function () {
     height: 480,
     playerWidth: 640,
     playerHeight: 480,
-    vastUrl: 'https://vast.example.com/ad',
-    vastImpUrl: 'https://vast.example.com/imp',
     videoCacheKey: 'vc-key-123'
   };
 
@@ -176,9 +174,7 @@ describe('tercept analytics adapter', function () {
     mediaType: 'video',
     size: '640x480',
     playerWidth: 640,
-    playerHeight: 480,
-    vastUrl: 'https://vast.example.com/ad',
-    vastImpUrl: 'https://vast.example.com/imp'
+    playerHeight: 480
   };
 
   const multiFormatBidRequested = {
@@ -790,28 +786,24 @@ describe('tercept analytics adapter', function () {
       }).not.to.throw();
     });
 
-    it('captures vastUrl, vastImpUrl, playerWidth and playerHeight from bid response', function () {
+    it('captures playerWidth and playerHeight from bid response', function () {
       events.emit(EVENTS.AUCTION_INIT, { ...auctionInit, adUnits: [videoAdUnit] });
       events.emit(EVENTS.BID_REQUESTED, videoBidRequested);
       events.emit(EVENTS.BID_RESPONSE, videoBidResponse);
       events.emit(EVENTS.AUCTION_END, auctionEnd);
       clock.tick(0);
       const { bids } = JSON.parse(server.requests[0].requestBody);
-      expect(bids[0].vastUrl).to.equal('https://vast.example.com/ad');
-      expect(bids[0].vastImpUrl).to.equal('https://vast.example.com/imp');
       expect(bids[0].playerWidth).to.equal(640);
       expect(bids[0].playerHeight).to.equal(480);
       expect(bids[0].mediaType).to.equal('video');
     });
 
-    it('captures video fields in the BID_WON beacon', function () {
+    it('captures playerWidth, playerHeight and mediaType in the BID_WON beacon', function () {
       events.emit(EVENTS.AUCTION_INIT, { ...auctionInit, adUnits: [videoAdUnit] });
       events.emit(EVENTS.BID_REQUESTED, videoBidRequested);
       events.emit(EVENTS.AUCTION_END, auctionEnd);
       events.emit(EVENTS.BID_WON, videoBidWon);
       const { bidWon: bw } = JSON.parse(server.requests[0].requestBody);
-      expect(bw.vastUrl).to.equal('https://vast.example.com/ad');
-      expect(bw.vastImpUrl).to.equal('https://vast.example.com/imp');
       expect(bw.playerWidth).to.equal(640);
       expect(bw.playerHeight).to.equal(480);
       expect(bw.mediaType).to.equal('video');


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Updated bidder adapter
- [x] Updated analytics adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

The adapter hardcoded `bid.mediaTypes.banner.sizes` in `mapBidRequests`, throwing a TypeError for video-only ad units and silently dropping all bids in that auction from the analytics payload. Several follow-on issues were also found and fixed.

- Fixed `mapBidRequests` to detect media type from `bid.mediaTypes` and derive sizes from `playerSize` for video-only ad units instead of always reading `banner.sizes`
- Added `mediaType` (banner / video / native) and `videoContext` (instream / outstream) to bid request mapping so timed-out and no-bid events carry the correct media type
- Added `playerWidth`, and `playerHeight` to bid responses and the `bidWon` beacon
- Fixed `updateBid` to skip `undefined` values so timeout and no_bid events do not overwrite `mediaType` and other fields set at BID_REQUESTED time
- Fixed late BID_WON beacons losing `adserverAdSlot` and `pbAdSlot` for lazy-loaded ads by retaining `adUnitMap` entries until `disableAnalytics` rather than deleting them on auction flush
- Fixed multi-format ad units (banner + video) incorrectly getting `mediaType: 'video'` at request time; `mediaType` is now set to `null` for multi-format bids and filled in by the bid response
- Fixed a memory leak where `adUnitMap` entries were never removed in SPA environments

## Other information