### PR TITLE
Kargo Bid Adapter: fix test helper arguments

### DIFF
--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -1026,7 +1026,7 @@ describe('kargo adapter tests', function() {
       it('retrieves CRB from localStorage and cookies', function() {
         setCrb('valid', 'valid');
 
-        const payload = getPayloadFromTestBids(testBids, bidderRequest);
+        const payload = getPayloadFromTestBids(testBids);
 
         expect(payload.rawCRB).to.equal(crbValues.valid);
         expect(payload.rawCRBLocalStorage).to.equal(crbValues.validLs);
@@ -1040,7 +1040,7 @@ describe('kargo adapter tests', function() {
       it('retrieves CRB from localStorage if cookie is missing', function() {
         setCrb(false, 'valid');
 
-        const payload = getPayloadFromTestBids(testBids, bidderRequest);
+        const payload = getPayloadFromTestBids(testBids);
 
         expect(payload.rawCRB).to.be.undefined;
         expect(payload.rawCRBLocalStorage).to.equal(crbValues.validLs);
@@ -1054,7 +1054,7 @@ describe('kargo adapter tests', function() {
       it('retrieves CRB from cookies if localstorage is missing', function() {
         setCrb('valid', false);
 
-        const payload = getPayloadFromTestBids(testBids, bidderRequest);
+        const payload = getPayloadFromTestBids(testBids);
 
         expect(payload.rawCRB).to.equal(crbValues.valid);
         expect(payload.rawCRBLocalStorage).to.be.undefined;
@@ -1071,7 +1071,7 @@ describe('kargo adapter tests', function() {
         sandbox.stub(STORAGE, 'getDataFromLocalStorage').throws();
         setCrb('valid', 'invalid');
 
-        const payload = getPayloadFromTestBids(testBids, bidderRequest);
+        const payload = getPayloadFromTestBids(testBids);
 
         expect(payload.rawCRB).to.equal(crbValues.valid);
         expect(payload.rawCRBLocalStorage).to.be.undefined;
@@ -1083,7 +1083,7 @@ describe('kargo adapter tests', function() {
       });
 
       it('does not fail if CRB is missing', function() {
-        const payload = getPayloadFromTestBids(testBids, bidderRequest);
+        const payload = getPayloadFromTestBids(testBids);
 
         expect(payload.rawCRB).to.be.undefined;
         expect(payload.rawCRBLocalStorage).to.be.undefined;
@@ -1097,7 +1097,7 @@ describe('kargo adapter tests', function() {
       it('fails gracefully if the CRB is invalid base 64 cookie', function() {
         setCrb('invalidB64', false);
 
-        const payload = getPayloadFromTestBids(testBids, bidderRequest);
+        const payload = getPayloadFromTestBids(testBids);
 
         expect(payload.rawCRB).to.equal(crbValues.invalidB64);
         expect(payload.rawCRBLocalStorage).to.be.undefined;
@@ -1111,7 +1111,7 @@ describe('kargo adapter tests', function() {
       it('fails gracefully if the CRB is invalid base 64 localStorage', function() {
         setCrb(false, 'invalidB64');
 
-        const payload = getPayloadFromTestBids(testBids, bidderRequest);
+        const payload = getPayloadFromTestBids(testBids);
 
         expect(payload.rawCRB).to.be.undefined;
         expect(payload.rawCRBLocalStorage).to.equal(crbValues.invalidB64Ls);
@@ -1134,7 +1134,7 @@ describe('kargo adapter tests', function() {
       ].forEach(config => {
         it(`uses ${config[2]} if the cookie is ${config[0]} and localStorage is ${config[1]}`, function() {
           setCrb(config[0], config[1]);
-          const payload = getPayloadFromTestBids(testBids, bidderRequest);
+          const payload = getPayloadFromTestBids(testBids);
 
           expect(payload.rawCRB).to.equal(crbValues[config[0]]);
           expect(payload.rawCRBLocalStorage).to.equal(crbValues[`${config[1]}Ls`]);
@@ -1162,21 +1162,21 @@ describe('kargo adapter tests', function() {
 
       it('uses the tdID from cerberus to populate the tdID field', function() {
         setCrb('valid', 'valid');
-        const payload = getPayloadFromTestBids(testBids, bidderRequest);
+        const payload = getPayloadFromTestBids(testBids);
 
         expect(payload.user.tdID).to.equal('test-tdid-cerberus-localstorage');
       });
 
       it('uses the lexId from cerberus to populate the kargoID field', function() {
         setCrb('valid', 'valid');
-        const payload = getPayloadFromTestBids(testBids, bidderRequest);
+        const payload = getPayloadFromTestBids(testBids);
 
         expect(payload.user.kargoID).to.equal('test-lexid-cerberus-localstorage');
       });
 
       it('uses the clientId from cerberus to populate the clientID field', function() {
         setCrb('valid', 'valid');
-        const payload = getPayloadFromTestBids(testBids, bidderRequest);
+        const payload = getPayloadFromTestBids(testBids);
 
         expect(payload.user.clientID).to.equal('test-clientid-cerberus-localstorage');
       });
@@ -1184,12 +1184,12 @@ describe('kargo adapter tests', function() {
       it('uses the optOut from cerberus to populate the clientID field', function() {
         setCrb('valid', 'valid');
         let payload;
-        payload = getPayloadFromTestBids(testBids, bidderRequest);
+        payload = getPayloadFromTestBids(testBids);
 
         expect(payload.user.optOut).to.equal(false);
 
         setLocalStorageValue('krg_crb', buildCrbValue(false, true, true, true, true, true));
-        payload = getPayloadFromTestBids(testBids, bidderRequest);
+        payload = getPayloadFromTestBids(testBids);
 
         expect(payload.user.optOut).to.equal(true);
       });


### PR DESCRIPTION
### Motivation
- Tests were passing an unused trailing `bidderRequest` argument to the `getPayloadFromTestBids` helper, which doesn't accept it and triggered superfluous-argument findings from static analysis. 

### Description
- Remove the obsolete `bidderRequest` argument from all `getPayloadFromTestBids` calls in `test/spec/modules/kargoBidAdapter_spec.js` so calls match the helper signature `getPayloadFromTestBids(testBids)`.
- Changes are limited to the Cerberus-related test blocks in `kargoBidAdapter_spec.js` (around lines ~1029-1192). 
- No production code or API behavior was modified; this is a test-only cleanup.

### Testing
- Ran `npx eslint test/spec/modules/kargoBidAdapter_spec.js --cache --cache-strategy content` and the lint check completed with no errors.
- Ran `npx gulp test --nolint --file test/spec/modules/kargoBidAdapter_spec.js` and the spec run completed successfully with `82 tests completed` in both all-features-disabled and default test chunks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2d43aab570832b943bba0d14a24e89)