### PR TITLE
Maintenance: remove redundant defensive guards

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -113,10 +113,7 @@ function buildRequests(validBidRequests, bidderRequest) {
   // Add user data object if available
   krakenParams.user.data = deepAccess(firstBidRequest, REQUEST_KEYS.USER_DATA) || [];
 
-  const reqCount = getRequestCount();
-  if (reqCount !== null && reqCount !== undefined) {
-    krakenParams.requestCount = reqCount;
-  }
+  krakenParams.requestCount = getRequestCount();
 
   // Add currency if not USD
   if ((currency !== null && currency !== undefined) && currency !== CURRENCY.US_DOLLAR) {

--- a/modules/topicsFpdModule.js
+++ b/modules/topicsFpdModule.js
@@ -132,7 +132,7 @@ export function getCachedTopics() {
   const topics = config.getConfig('userSync.topics');
   const bidderList = topics?.bidders || [];
   const storedSegments = new Map(safeJSONParse(coreStorage.getDataFromLocalStorage(topicStorageName)));
-  storedSegments && storedSegments.forEach((value, cachedBidder) => {
+  storedSegments.forEach((value, cachedBidder) => {
     // Check bidder exist in config for cached bidder data and then only retrieve the cached data
     const bidderConfigObj = bidderList.find(({ bidder }) => cachedBidder === bidder);
     if (bidderConfigObj && isActivityAllowed(ACTIVITY_ENRICH_UFPD, activityParams(MODULE_TYPE_BIDDER, cachedBidder))) {
@@ -226,7 +226,7 @@ export function loadTopicsForBidders(doc = document) {
   if (topics) {
     listenMessagesFromTopicIframe();
     const randomBidders = getRandomAllowedConfigs(topics.bidders || [], topics.maxTopicCaller || 1);
-    randomBidders && randomBidders.forEach(({ bidder, iframeURL, fetchUrl, fetchRate }) => {
+    randomBidders.forEach(({ bidder, iframeURL, fetchUrl, fetchRate }) => {
       if (bidder && iframeURL) {
         const ifrm = doc.createElement('iframe');
         ifrm.name = 'ifrm_'.concat(bidder);


### PR DESCRIPTION
### Motivation
- Simplify code by removing unnecessary null/undefined and truthiness checks that guard against values which are always present or properly typed.
- Reduce code noise and potential confusion caused by redundant defensive checks in Kargo adapter and Topics FPD module.

### Description
- Assign `krakenParams.requestCount` directly from `getRequestCount()` in `modules/kargoBidAdapter.js` instead of performing an extra nullish check. 
- Remove redundant truthiness guard before iterating `Map` returned from `coreStorage` in `modules/topicsFpdModule.js` and iterate it directly with `forEach`.
- Remove redundant truthiness guard before iterating the `randomBidders` array in `modules/topicsFpdModule.js` and call `forEach` directly.

### Testing
- Ran lint on the modified files with `npx eslint modules/kargoBidAdapter.js modules/topicsFpdModule.js --cache --cache-strategy content` which completed successfully.
- Ran unit tests for the Kargo adapter with `npx gulp test --nolint --file test/spec/modules/kargoBidAdapter_spec.js` which completed successfully (82 tests completed).
- Ran unit tests for the Topics FPD module with `npx gulp test --nolint --file test/spec/modules/topicsFpdModule_spec.js` which completed successfully (32 tests completed) but the test run emitted an existing unhandled rejection message (`TypeError: response.json is not a function`) that appears unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2d4359efb8832bb76a90fdbed6811b)