### PR TITLE
Tests: fix duplicate regex character classes

### DIFF
--- a/test/spec/modules/33acrossAnalyticsAdapter_spec.js
+++ b/test/spec/modules/33acrossAnalyticsAdapter_spec.js
@@ -698,7 +698,7 @@ function getLocalAssert() {
   function isValidAnalyticsReport(report) {
     assert.containsAllKeys(report, ['analyticsVersion', 'pid', 'src', 'pbjsVersion', 'auctions']);
     if ('usPrivacy' in report) {
-      assert.match(report.usPrivacy, /[0|1][Y|N|-]{3}/);
+      assert.match(report.usPrivacy, /[01][YN-]{3}/);
     }
     if ('gdpr' in report) {
       assert.oneOf(report.gdpr, [0, 1]);

--- a/test/spec/userSync_spec.js
+++ b/test/spec/userSync_spec.js
@@ -230,9 +230,9 @@ describe('user sync', function () {
     userSync.registerSync('image', 'testBidder', 'http://example.com/3');
     userSync.syncUsers();
     expect(triggerPixelStub.getCall(0)).to.not.be.null;
-    expect(triggerPixelStub.getCall(0).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|2]/);
+    expect(triggerPixelStub.getCall(0).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[12]/);
     expect(triggerPixelStub.getCall(1)).to.not.be.null;
-    expect(triggerPixelStub.getCall(1).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|2]/);
+    expect(triggerPixelStub.getCall(1).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[12]/);
     expect(triggerPixelStub.getCall(2)).to.be.null;
   });
 
@@ -243,11 +243,11 @@ describe('user sync', function () {
     userSync.registerSync('image', 'testBidder', 'http://example.com/3');
     userSync.syncUsers();
     expect(triggerPixelStub.getCall(0)).to.not.be.null;
-    expect(triggerPixelStub.getCall(0).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|2|3]/);
+    expect(triggerPixelStub.getCall(0).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[123]/);
     expect(triggerPixelStub.getCall(1)).to.not.be.null;
-    expect(triggerPixelStub.getCall(1).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|2|3]/);
+    expect(triggerPixelStub.getCall(1).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[123]/);
     expect(triggerPixelStub.getCall(2)).to.not.be.null;
-    expect(triggerPixelStub.getCall(2).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[1|2|3]/);
+    expect(triggerPixelStub.getCall(2).args[0]).to.exist.and.to.match(/^http:\/\/example\.com\/[123]/);
   });
 
   it('should balance out bidder requests', function () {


### PR DESCRIPTION
### Motivation
- Fix CodeQL duplicate-character-class findings by removing redundant `|` characters inside character classes in test regexes.
- Ensure the test expectations continue to match the same intended values while satisfying static-analysis rules.

### Description
- Replace `/[0|1][Y|N|-]{3}/` with `/[01][YN-]{3}/` in `test/spec/modules/33acrossAnalyticsAdapter_spec.js` to validate `usPrivacy` correctly without duplicate characters.
- Replace `/[1|2]/` with `/[12]/` and `/[1|2|3]/` with `/[123]/` in `test/spec/userSync_spec.js` so URL-suffix matching uses proper character classes.
- Commit the two modified test files to remove the duplicate-character-class patterns without changing test semantics.

### Testing
- Ran `npx eslint 'test/spec/modules/33acrossAnalyticsAdapter_spec.js' 'test/spec/userSync_spec.js' --cache --cache-strategy content` which passed.
- Ran `npx gulp test --nolint --file test/spec/modules/33acrossAnalyticsAdapter_spec.js` which completed successfully with `40 tests completed`.
- Ran `npx gulp test --nolint --file test/spec/userSync_spec.js` which completed successfully with `35 tests completed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2d43159b40832b9c8519e628bf6076)