### PR TITLE
NodalsAI: automated Fix for linting exception

### DIFF
--- a/modules/nodalsAiRtdProvider.js
+++ b/modules/nodalsAiRtdProvider.js
@@ -410,8 +410,7 @@ class NodalsAiRtdProvider {
   }
 
   #loadAdLibraries(deps) {
-    // eslint-disable-next-line no-unused-vars
-    for (const [key, value] of Object.entries(deps)) {
+    for (const value of Object.values(deps)) {
       if (typeof value === 'string') {
         loadExternalScript(value, MODULE_TYPE_RTD, MODULE_NAME, () => {
           // noop


### PR DESCRIPTION
The best fix is to stop binding the unused `key` variable while keeping behavior unchanged.

In `modules/nodalsAiRtdProvider.js`, inside `#loadAdLibraries(deps)`, replace the `Object.entries` destructuring loop with iteration over `Object.values(deps)` since only dependency URLs (`value`) are needed. This removes the unused variable cleanly and allows removal of the eslint suppression comment for `no-unused-vars`.

No new methods/imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._