### PR TITLE
Fwssp bid adapter: Fix for Useless conditional

### DIFF
--- a/modules/fwsspBidAdapter.js
+++ b/modules/fwsspBidAdapter.js
@@ -541,10 +541,6 @@ function getSdkVersionFromBidRequest(bidRequest) {
  * @returns {number} Returns 1 if versionA is greater, -1 if versionB is greater, 0 if equal
  */
 function compareVersions(versionA, versionB) {
-  if (!versionA || !versionB) {
-    return 0;
-  }
-
   const normalize = (v) => v.split('.').map(Number);
 
   const partsA = normalize(versionA);


### PR DESCRIPTION
To fix this, remove the always-false guard from `compareVersions` and keep input validation at the caller level (`getSDKVersion` already does this with `if (!paramVersion) return DEFAULT;` and a `try/catch` fallback).  
This avoids dead-code warnings without changing functional behavior for existing call paths.

Best single change:
- In `modules/fwsspBidAdapter.js`, inside `compareVersions`, delete the block:
  - `if (!versionA || !versionB) { return 0; }`

No imports or new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._