### PR TITLE
Magnite analytics: Fix for Useless conditional

### DIFF
--- a/modules/magniteAnalyticsAdapter.js
+++ b/modules/magniteAnalyticsAdapter.js
@@ -336,7 +336,8 @@ const getTopLevelDetails = () => {
   // Add DM wrapper details
   if (rubiConf.wrapperName) {
     let rule = rubiConf.rule_name;
-    if (cookieless) {
+    const isCookieless = !!(rubiConf.cookieless || deepAccess(cache, 'sessionData.cookieless'));
+    if (isCookieless) {
       rule = rule ? rule.concat('_cookieless') : 'cookieless';
     }
     payload.wrapper = {

--- a/modules/magniteAnalyticsAdapter.js
+++ b/modules/magniteAnalyticsAdapter.js
@@ -53,7 +53,6 @@ let pageReferer;
 let auctionIndex = 0; // count of auctions on page
 let accountId;
 let endpoint;
-let cookieless;
 
 const prebidGlobal = getGlobal();
 const {

--- a/modules/magniteAnalyticsAdapter.js
+++ b/modules/magniteAnalyticsAdapter.js
@@ -704,7 +704,6 @@ magniteAdapter.disableAnalytics = function () {
   magniteAdapter._oldEnable = enableMgniAnalytics;
   endpoint = undefined;
   accountId = undefined;
-  cookieless = undefined;
   auctionIndex = 0;
   resetConfs();
   getHook('callPrebidCache').getHooks({ hook: callPrebidCacheHook }).remove();


### PR DESCRIPTION
To fix this without changing intended functionality, replace the direct `if (cookieless)` check with a computed boolean derived from existing runtime state (`rubiConf` and/or session data), so the condition reflects actual cookieless mode rather than a stale variable.

Best targeted change in `modules/magniteAnalyticsAdapter.js` (inside `getTopLevelDetails`, around lines 337–341):

- Introduce a local `isCookieless` boolean immediately before the conditional.
- Compute it from known config/session flags (using optional access patterns already used in file, e.g., `deepAccess`).
- Use `if (isCookieless)` instead of `if (cookieless)`.

This keeps behavior identical when cookieless is truly enabled, and removes the always-false condition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

@robertrmartinez see https://github.com/prebid/Prebid.js/security/quality/rules/js%2Ftrivial-conditional