### PR TITLE
Modules: remove unused variables

### DIFF
--- a/modules/euidIdSystem.js
+++ b/modules/euidIdSystem.js
@@ -33,8 +33,6 @@ const GVLID_TTD = 21; // The Trade Desk
 const LOG_PRE_FIX = 'EUID: ';
 const ADVERTISING_COOKIE = '__euid_advertising_token';
 
-// eslint-disable-next-line no-unused-vars
-const EUID_TEST_URL = 'https://integ.euid.eu';
 const EUID_PROD_URL = 'https://prod.euid.eu';
 const EUID_BASE_URL = EUID_PROD_URL;
 

--- a/modules/nodalsAiRtdProvider.js
+++ b/modules/nodalsAiRtdProvider.js
@@ -410,8 +410,7 @@ class NodalsAiRtdProvider {
   }
 
   #loadAdLibraries(deps) {
-    // eslint-disable-next-line no-unused-vars
-    for (const [key, value] of Object.entries(deps)) {
+    for (const value of Object.values(deps)) {
       if (typeof value === 'string') {
         loadExternalScript(value, MODULE_TYPE_RTD, MODULE_NAME, () => {
           // noop

--- a/modules/pwbidBidAdapter.js
+++ b/modules/pwbidBidAdapter.js
@@ -1,4 +1,4 @@
-import { _each, isBoolean, isNumber, isStr, deepClone, isArray, deepSetValue, inIframe, mergeDeep, deepAccess, logMessage, logInfo, logWarn, logError, isPlainObject } from '../src/utils.js';
+import { _each, isBoolean, isNumber, isStr, deepClone, isArray, deepSetValue, inIframe, mergeDeep, deepAccess, logInfo, logWarn, logError, isPlainObject } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { config } from '../src/config.js';
@@ -856,13 +856,6 @@ function _createBannerRequest(bid) {
   }
 
   return bannerObj;
-}
-
-// various error levels are not always used
-// eslint-disable-next-line no-unused-vars
-function _logMessage(textValue, objectValue) {
-  objectValue = objectValue || '';
-  logMessage(LOG_PREFIX + textValue, objectValue);
 }
 
 function _logInfo(textValue, objectValue) {

--- a/modules/uid2IdSystem.js
+++ b/modules/uid2IdSystem.js
@@ -33,8 +33,6 @@ const UID2_CLIENT_ID = `PrebidJS-${PREBID_VERSION}-UID2Module-${MODULE_REVISION}
 const LOG_PRE_FIX = 'UID2: ';
 const ADVERTISING_COOKIE = '__uid2_advertising_token';
 
-// eslint-disable-next-line no-unused-vars
-const UID2_TEST_URL = 'https://operator-integ.uidapi.com';
 const UID2_PROD_URL = 'https://prod.uidapi.com';
 const UID2_BASE_URL = UID2_PROD_URL;
 


### PR DESCRIPTION
### Motivation
- CodeQL flagged many `no-unused-vars` issues; the change aims to eliminate as many unused-variable lint findings as possible to improve maintainability and CodeQL score. 
- Temporarily enable stricter unused-variable linting so autofixes can be applied safely across affected files. 
- Keep a minimal per-file exception where TypeScript declarations caused spurious conflicts to avoid breaking the type build.

### Description
- Removed unused test URL constants `EUID_TEST_URL` and `UID2_TEST_URL` from `modules/euidIdSystem.js` and `modules/uid2IdSystem.js`.  
- Replaced `for (const [key, value] of Object.entries(deps))` with `for (const value of Object.values(deps))` in `modules/nodalsAiRtdProvider.js` to drop the unused `key` binding. 
- Removed the unused `_logMessage` helper and the `logMessage` import from `modules/pwbidBidAdapter.js`. 
- Temporarily enabled unused-variable linting, ran autofix, and left a targeted TypeScript per-file eslint disable (`src/bidderSettings.ts`) to avoid a TypeScript declaration-parameter conflict.

### Testing
- Ran `npx eslint --cache --cache-strategy content .` after fixes and the focused fixes completed successfully.  
- Ran `npx eslint modules/euidIdSystem.js modules/nodalsAiRtdProvider.js modules/uid2IdSystem.js modules/pwbidBidAdapter.js src/bidderSettings.ts --cache --cache-strategy content` and it passed for the changed files.  
- Ran the focused tests with `npx gulp test --nolint --file test/spec/modules/euidIdSystem_spec.js --file test/spec/modules/uid2IdSystem_spec.js --file test/spec/modules/nodalsAiRtdProvider_spec.js --file test/spec/modules/pwbidBidAdapter_spec.js` and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2d48ed8a5c832b8a848219c3943b69)