### PR TITLE
Jixieid submodule: Fixes for Useless conditionals

### DIFF
--- a/modules/jixieIdSystem.js
+++ b/modules/jixieIdSystem.js
@@ -68,7 +68,7 @@ function buildIdCallUrl(params, gdprConsent) {
   const url = parseUrl(params.idendpoint || TRACKER_EP_FROM_IDMODULE);
 
   if (gdprConsent) {
-    url.search.gdpr_consent = gdprConsent && gdprConsent.gdprApplies ? gdprConsent.consentString : '';
+    url.search.gdpr_consent = gdprConsent.gdprApplies ? gdprConsent.consentString : '';
   }
   if (params) {
     if (params.accountid) { url.search.accountid = params.accountid; }

--- a/modules/jixieIdSystem.js
+++ b/modules/jixieIdSystem.js
@@ -110,7 +110,7 @@ function shouldCallSrv(logstr) {
   if (!(tsStr.length === 13 && ts && ts >= (now - ONE_YEAR_IN_MS) && ts <= (now + ONE_YEAR_IN_MS))) {
     ts = undefined;
   }
-  return (ts === undefined || (ts && now > ts));
+  return (ts === undefined || now > ts);
 }
 
 /** @type {Submodule} */


### PR DESCRIPTION
General fix: remove redundant boolean checks that are already guaranteed by an enclosing condition.

Best fix here: in `modules/jixieIdSystem.js`, inside `buildIdCallUrl`, update line 71 to stop re-checking `gdprConsent` and only test `gdprConsent.gdprApplies` (safe because of the surrounding `if (gdprConsent)` on line 70). This preserves existing behavior exactly while resolving the CodeQL warning.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._