### PR TITLE
Automatad Analytics Adapter: clean fake timer warnings

### DIFF
--- a/test/spec/modules/automatadAnalyticsAdapter_spec.js
+++ b/test/spec/modules/automatadAnalyticsAdapter_spec.js
@@ -319,7 +319,7 @@ describe('Automatad Analytics Adapter', () => {
       exports.retryCount = 0;
       exports.__atmtdAnalyticsQueue.length = 0;
 
-      clock = sandbox.useFakeTimers();
+      clock = sandbox.useFakeTimers({ shouldClearNativeTimers: true });
 
       sandbox.spy(exports.__atmtdAnalyticsQueue, 'push');
     });
@@ -406,7 +406,7 @@ describe('Automatad Analytics Adapter', () => {
       sandbox.spy(exports, 'prettyLog');
       sandbox.spy(exports, 'processEvents');
 
-      clock = sandbox.useFakeTimers();
+      clock = sandbox.useFakeTimers({ shouldClearNativeTimers: true });
       exports.__atmtdAnalyticsQueue.length = 0;
     });
     afterEach(() => {


### PR DESCRIPTION
### Motivation
- Prevent Sinon fake-timer native-timer cleanup warnings that appeared while running the Automatad analytics adapter unit tests where timers created before installing the fake clock are cleared.

### Description
- Replace `sandbox.useFakeTimers()` with `sandbox.useFakeTimers({ shouldClearNativeTimers: true })` in `test/spec/modules/automatadAnalyticsAdapter_spec.js` (the two setup blocks that prepare fake timers for the queue tests).

### Testing
- Ran `npx eslint test/spec/modules/automatadAnalyticsAdapter_spec.js --cache --cache-strategy content` and `npx gulp test --nolint --file test/spec/modules/automatadAnalyticsAdapter_spec.js`, and the spec chunk completed successfully with the tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a303e0e2a04832bba0c5b192bcc84ea)