### PR TITLE
UID2 module: adjust test timing for stability

### DIFF
--- a/test/mocks/xhr.js
+++ b/test/mocks/xhr.js
@@ -106,6 +106,7 @@ function mockFetchServer() {
         // tests expect respond() to run everything immediately,
         // so make body available syncronously
         resp.text = () => GreedyPromise.resolve(body || '');
+        resp.json = () => resp.text().then(text => JSON.parse(text));
         Object.assign(mockReq.fetch, {
           response: resp,
           responseBody: body || ''

--- a/test/spec/modules/uid2IdSystem_helpers.js
+++ b/test/spec/modules/uid2IdSystem_helpers.js
@@ -31,6 +31,12 @@ export const runAuction = async () => {
   });
 };
 
+const waitForPromiseTurns = async (turns = 5) => {
+  while (turns-- > 0) {
+    await Promise.resolve();
+  }
+};
+
 export const apiHelpers = {
   makeTokenResponse: (token, shouldRefresh = false, expired = false, refreshExpired = false) => ({
     advertising_token: token,
@@ -40,9 +46,13 @@ export const apiHelpers = {
     refresh_expires: refreshExpired ? Date.now() - 1000 : Date.now() + 24 * 60 * 60 * 1000, // 24 hours
     refresh_response_key: 'wR5t6HKMfJ2r4J7fEGX9Gw==', // Fake data
   }),
-  respondAfterDelay: (delay, srv = server) => new Promise((resolve) => setTimeout(() => {
+  respondAfterDelay: (delay, srv = server) => new Promise((resolve) => setTimeout(async () => {
     srv.respond();
-    setTimeout(() => resolve());
+    // The UID2 refresh path chains several native promises after ajax success
+    // (WebCrypto import/decrypt, then storage writes). Resolve only after those
+    // promise turns have had a chance to run so Safari does not assert early.
+    await waitForPromiseTurns();
+    resolve();
   }, delay)),
 };
 


### PR DESCRIPTION
### Motivation
- Provide a working `json()` implementation on mocked `Response` objects so tests that call `Response.json()` behave like real fetch responses.
- Avoid intermittent test failures (notably on Safari) by letting chained native promise microtasks (e.g. WebCrypto operations and storage writes) run after simulated AJAX responses.

attempt to fix https://github.com/prebid/Prebid.js/actions/runs/27584817881/job/81553573672 test failures in safari chunk 7
