### PR TITLE
CI: do not run code-path-changes workflow on forks

### DIFF
--- a/.github/workflows/code-path-changes.yml
+++ b/.github/workflows/code-path-changes.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   notify:
+    if: github.repository_owner == 'prebid'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
- in this [comment](https://github.com/prebid/Prebid.js/issues/15118#issuecomment-4721940928) @dgirardi mentions 'The "Notify code path changes" workflow is expected to fail on forks.' - can we just skip workflows on forks which are not expected to run successfully?

## Other information
- relates #15118 
