### PR TITLE
vidoomyBidAdapter: forward ortb2Imp.ext.gpid to endpoint

### DIFF
--- a/modules/vidoomyBidAdapter.js
+++ b/modules/vidoomyBidAdapter.js
@@ -150,6 +150,7 @@ const buildRequests = (validBidRequests, bidderRequest) => {
       id: bid.params.id,
       adtype: adType,
       auc: bid.adUnitCode,
+      gpid: deepAccess(bid, 'ortb2Imp.ext.gpid') || '',
       w: widths,
       h: heights,
       pos: parseInt(bid.params.position) || 1,

--- a/test/spec/modules/vidoomyBidAdapter_spec.js
+++ b/test/spec/modules/vidoomyBidAdapter_spec.js
@@ -165,6 +165,18 @@ describe('vidoomyBidAdapter', function() {
       expect('' + request[1].data.multiBidsSupport).to.equal('1');
     });
 
+    it('should default gpid to empty string when ortb2Imp.ext.gpid is absent', function () {
+      expect(request[0].data.gpid).to.equal('');
+      expect(request[1].data.gpid).to.equal('');
+    });
+
+    it('should send gpid from ortb2Imp.ext.gpid when present', function () {
+      const gpid = 'example.com/vidoomyad/12345';
+      const bidRequest = { ...bidRequests[0], ortb2Imp: { ext: { gpid } } };
+      const req = spec.buildRequests([bidRequest], bidderRequest)[0];
+      expect(req.data.gpid).to.equal(gpid);
+    });
+
     it('should send schain parameter in serialized form', function () {
       const serializedForm = '1.0,1!exchange1.com,1234%21abcd,1,bid-request-1,publisher%2C%20Inc.,publisher.com!exchange2.com,abcd,1,,,!exchange2.com,abcd,1,bid-request-2,intermediary,intermediary.com';
       expect(request[0].data).to.include.any.keys('schain');


### PR DESCRIPTION
 ## Type of change

  - [x] Updated bidder adapter

  ## Description of change

  Forward the Global Placement ID to the Vidoomy endpoint.

  The adapter now reads the standard first-party `ortb2Imp.ext.gpid` field and
  sends it as a `gpid` query parameter on the bid request. This lets buyers/DSPs
  optimize per placement, which a missing/random placement id prevents.

  - Reads from `ortb2Imp.ext.gpid` (set by the publisher/page), consistent with
    Prebid's first-party impression data conventions.
  - Falls back to an empty string when no GPID is present, so existing behavior
    is unchanged for requests without one.
  - No new bid parameter is introduced, so no bidder-docs change is required.

  Unit tests added in `test/spec/modules/vidoomyBidAdapter_spec.js` covering both
  the present and absent cases.

  ## Other information

  Single, self-contained change to the Vidoomy adapter. Lint and unit tests pass locally
  (`npx eslint`, `gulp test-only --file test/spec/modules/vidoomyBidAdapter_spec.js`).