### PR TITLE
CI: bump WDIO Mocha framework

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@wdio/browserstack-service": "^9.19.1",
         "@wdio/cli": "^9.19.1",
         "@wdio/local-runner": "^9.15.0",
-        "@wdio/mocha-framework": "^9.12.6",
+        "@wdio/mocha-framework": "^9.28.0",
         "@wdio/spec-reporter": "^8.43.0",
         "assert": "^2.0.0",
         "babel-loader": "^8.4.1",
@@ -6227,15 +6227,17 @@
       }
     },
     "node_modules/@wdio/mocha-framework": {
-      "version": "9.12.6",
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-9.28.0.tgz",
+      "integrity": "sha512-UdkgigdyxJu0Rpx2ZRSNuB8u8B5nmLBeRjn5JHYTXBp8Ubi+wgFR1+EdLg8k2z+CtuYe3bNHBw7vPpBYuQMLZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.11.28",
-        "@wdio/logger": "9.4.4",
-        "@wdio/types": "9.12.6",
-        "@wdio/utils": "9.12.6",
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.28.0",
+        "@wdio/utils": "9.28.0",
         "mocha": "^10.3.0"
       },
       "engines": {
@@ -6243,25 +6245,17 @@
       }
     },
     "node_modules/@wdio/mocha-framework/node_modules/@wdio/logger": {
-      "version": "9.4.4",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
+      "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.1.2",
         "loglevel": "^1.6.0",
         "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
         "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/@wdio/types": {
-      "version": "9.12.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "^20.1.0"
       },
       "engines": {
         "node": ">=18.20.0"
@@ -6301,7 +6295,9 @@
       }
     },
     "node_modules/@wdio/mocha-framework/node_modules/chalk": {
-      "version": "5.4.1",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7041,45 +7037,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@wdio/utils": {
-      "version": "9.12.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@puppeteer/browsers": "^2.2.0",
-        "@wdio/logger": "9.4.4",
-        "@wdio/types": "9.12.6",
-        "decamelize": "^6.0.0",
-        "deepmerge-ts": "^7.0.3",
-        "edgedriver": "^6.1.1",
-        "geckodriver": "^5.0.0",
-        "get-port": "^7.0.0",
-        "import-meta-resolve": "^4.0.0",
-        "locate-app": "^2.2.24",
-        "safaridriver": "^1.0.0",
-        "split2": "^4.2.0",
-        "wait-port": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/utils/node_modules/@wdio/logger": {
-      "version": "9.4.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.1.2",
-        "loglevel": "^1.6.0",
-        "loglevel-plugin-prefix": "^0.8.4",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18.20.0"
-      }
-    },
-    "node_modules/@wdio/utils/node_modules/@wdio/types": {
-      "version": "9.12.6",
+    "node_modules/@wdio/types": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.28.0.tgz",
+      "integrity": "sha512-75JPq39gifkPNqOSn5C4/A5ZSyXwF+dGr5jfsCubFN9Lk9dKBXfjdbWueSQNpJg0jmE6dVrbT7+9mnDNnO0HdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7089,8 +7050,63 @@
         "node": ">=18.20.0"
       }
     },
+    "node_modules/@wdio/utils": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.28.0.tgz",
+      "integrity": "sha512-VDqUaXpR8oOZSs26dy06Y2LhmA8bldsXDHeZ36n8SfW+Bq0miG0RRxou7aqx7sifVbbsuxrbBPXvmK+40uAIbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@puppeteer/browsers": "^2.2.0",
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.28.0",
+        "decamelize": "^6.0.0",
+        "deepmerge-ts": "^7.0.3",
+        "edgedriver": "^6.1.2",
+        "geckodriver": "^6.1.0",
+        "get-port": "^7.0.0",
+        "import-meta-resolve": "^4.0.0",
+        "locate-app": "^2.2.24",
+        "mitt": "^3.0.1",
+        "safaridriver": "^1.0.0",
+        "split2": "^4.2.0",
+        "wait-port": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/utils/node_modules/@wdio/logger": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
+      "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.1.2",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "safe-regex2": "^5.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "node_modules/@wdio/utils/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/@wdio/utils/node_modules/chalk": {
-      "version": "5.4.1",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7098,6 +7114,42 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@wdio/utils/node_modules/geckodriver": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-6.1.0.tgz",
+      "integrity": "sha512-ZRXLa4ZaYTTgUO4Eefw+RsQCleugU2QLb1ME7qTYxxuRj51yAhfnXaItXNs5/vUzfIaDHuZ+YnSF005hfp07nQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/logger": "^9.18.0",
+        "@zip.js/zip.js": "^2.8.11",
+        "decamelize": "^6.0.1",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "modern-tar": "^0.7.2"
+      },
+      "bin": {
+        "geckodriver": "bin/geckodriver.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@wdio/utils/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -26794,32 +26846,30 @@
       }
     },
     "@wdio/mocha-framework": {
-      "version": "9.12.6",
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@wdio/mocha-framework/-/mocha-framework-9.28.0.tgz",
+      "integrity": "sha512-UdkgigdyxJu0Rpx2ZRSNuB8u8B5nmLBeRjn5JHYTXBp8Ubi+wgFR1+EdLg8k2z+CtuYe3bNHBw7vPpBYuQMLZw==",
       "dev": true,
       "requires": {
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.11.28",
-        "@wdio/logger": "9.4.4",
-        "@wdio/types": "9.12.6",
-        "@wdio/utils": "9.12.6",
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.28.0",
+        "@wdio/utils": "9.28.0",
         "mocha": "^10.3.0"
       },
       "dependencies": {
         "@wdio/logger": {
-          "version": "9.4.4",
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
+          "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
           "dev": true,
           "requires": {
             "chalk": "^5.1.2",
             "loglevel": "^1.6.0",
             "loglevel-plugin-prefix": "^0.8.4",
+            "safe-regex2": "^5.0.0",
             "strip-ansi": "^7.1.0"
-          }
-        },
-        "@wdio/types": {
-          "version": "9.12.6",
-          "dev": true,
-          "requires": {
-            "@types/node": "^20.1.0"
           }
         },
         "ansi-styles": {
@@ -26847,7 +26897,9 @@
           }
         },
         "chalk": {
-          "version": "5.4.1",
+          "version": "5.6.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+          "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
           "dev": true
         },
         "cliui": {
@@ -27342,45 +27394,85 @@
         }
       }
     },
+    "@wdio/types": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-9.28.0.tgz",
+      "integrity": "sha512-75JPq39gifkPNqOSn5C4/A5ZSyXwF+dGr5jfsCubFN9Lk9dKBXfjdbWueSQNpJg0jmE6dVrbT7+9mnDNnO0HdQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "^20.1.0"
+      }
+    },
     "@wdio/utils": {
-      "version": "9.12.6",
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-9.28.0.tgz",
+      "integrity": "sha512-VDqUaXpR8oOZSs26dy06Y2LhmA8bldsXDHeZ36n8SfW+Bq0miG0RRxou7aqx7sifVbbsuxrbBPXvmK+40uAIbQ==",
       "dev": true,
       "requires": {
         "@puppeteer/browsers": "^2.2.0",
-        "@wdio/logger": "9.4.4",
-        "@wdio/types": "9.12.6",
+        "@wdio/logger": "9.18.0",
+        "@wdio/types": "9.28.0",
         "decamelize": "^6.0.0",
         "deepmerge-ts": "^7.0.3",
-        "edgedriver": "^6.1.1",
-        "geckodriver": "^5.0.0",
+        "edgedriver": "^6.1.2",
+        "geckodriver": "^6.1.0",
         "get-port": "^7.0.0",
         "import-meta-resolve": "^4.0.0",
         "locate-app": "^2.2.24",
+        "mitt": "^3.0.1",
         "safaridriver": "^1.0.0",
         "split2": "^4.2.0",
         "wait-port": "^1.1.0"
       },
       "dependencies": {
         "@wdio/logger": {
-          "version": "9.4.4",
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-9.18.0.tgz",
+          "integrity": "sha512-HdzDrRs+ywAqbXGKqe1i/bLtCv47plz4TvsHFH3j729OooT5VH38ctFn5aLXgECmiAKDkmH/A6kOq2Zh5DIxww==",
           "dev": true,
           "requires": {
             "chalk": "^5.1.2",
             "loglevel": "^1.6.0",
             "loglevel-plugin-prefix": "^0.8.4",
+            "safe-regex2": "^5.0.0",
             "strip-ansi": "^7.1.0"
           }
         },
-        "@wdio/types": {
-          "version": "9.12.6",
-          "dev": true,
-          "requires": {
-            "@types/node": "^20.1.0"
-          }
+        "agent-base": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+          "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+          "dev": true
         },
         "chalk": {
-          "version": "5.4.1",
+          "version": "5.6.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+          "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
           "dev": true
+        },
+        "geckodriver": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/geckodriver/-/geckodriver-6.1.0.tgz",
+          "integrity": "sha512-ZRXLa4ZaYTTgUO4Eefw+RsQCleugU2QLb1ME7qTYxxuRj51yAhfnXaItXNs5/vUzfIaDHuZ+YnSF005hfp07nQ==",
+          "dev": true,
+          "requires": {
+            "@wdio/logger": "^9.18.0",
+            "@zip.js/zip.js": "^2.8.11",
+            "decamelize": "^6.0.1",
+            "http-proxy-agent": "^7.0.2",
+            "https-proxy-agent": "^7.0.6",
+            "modern-tar": "^0.7.2"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+          "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^7.1.2",
+            "debug": "4"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@wdio/browserstack-service": "^9.19.1",
     "@wdio/cli": "^9.19.1",
     "@wdio/local-runner": "^9.15.0",
-    "@wdio/mocha-framework": "^9.12.6",
+    "@wdio/mocha-framework": "^9.28.0",
     "@wdio/spec-reporter": "^8.43.0",
     "assert": "^2.0.0",
     "babel-loader": "^8.4.1",


### PR DESCRIPTION
### Motivation
- Update the WebdriverIO Mocha test framework dev dependency to `@wdio/mocha-framework@^9.28.0` to pick up bug fixes and compatible transitive WDIO packages for e2e/browser tooling.