### PR TITLE
Examples: Fix for Call to eval-like DOM function

### DIFF
--- a/integrationExamples/gpt/amp/remote.html
+++ b/integrationExamples/gpt/amp/remote.html
@@ -18,7 +18,9 @@
 var v = location.search.substr(1);
 if (!(/^\d+(-canary)?$/.test(v))) return;
 var u = 'https://3p.ampproject.net/'+encodeURIComponent(v)+'/f.js';
-document.write('<script'+' src="'+encodeURI(u)+'"><'+'/script>');
+var s = document.createElement('script');
+s.src = u;
+(document.head || document.documentElement).appendChild(s);
 })();
 </script>
 


### PR DESCRIPTION
Use DOM APIs to create and append a `<script>` element instead of writing script markup as a string.

Best fix (no functional change):
- In `integrationExamples/gpt/amp/remote.html`, inside the first `<script>` block (around lines 17–22), keep the existing validation and URL construction.
- Replace the `document.write(...)` line with:
  - `var s = document.createElement('script');`
  - `s.src = u;` (no need to `encodeURI` again; `u` is already constructed safely)
  - append to `document.head` if available, otherwise `document.documentElement`.
- This preserves behavior (loading the same remote script) while removing the eval-like sink.

No new imports or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._