### PR TITLE
Floxis Bid Adapter: read user-sync from response body (ext.sync), header fallback

### DIFF
--- a/modules/floxisBidAdapter.js
+++ b/modules/floxisBidAdapter.js
@@ -249,13 +249,12 @@ export const spec = {
       if (!target) return;
       const { seat, region } = target;
       const host = getSyncHost(region);
-      const key = `${seat}|${region}`;
-      if (!host || seen[key]) return;
-      seen[key] = true;
-      syncs.push({
-        type: pixelType,
-        url: `${host}${SYNC_PATH}?seat=${encodeURIComponent(seat)}${consentSuffix}`
-      });
+      if (!host) return;
+      // Dedupe on the final URL so a header sync collapses with a same-URL body.ext.sync entry in a mixed rollout.
+      const url = `${host}${SYNC_PATH}?seat=${encodeURIComponent(seat)}${consentSuffix}`;
+      if (seen[url]) return;
+      seen[url] = true;
+      syncs.push({ type: pixelType, url });
     });
     return syncs;
   },

--- a/modules/floxisBidAdapter.js
+++ b/modules/floxisBidAdapter.js
@@ -229,6 +229,16 @@ export const spec = {
     const seen = {};
     const syncs = [];
     serverResponses.forEach((serverResponse) => {
+      // body.ext.sync is primary; serverResponse.headers is not a real Headers object in every Prebid build.
+      const bodySyncs = serverResponse?.body?.ext?.sync;
+      if (Array.isArray(bodySyncs) && bodySyncs.length) {
+        const entry = bodySyncs.find((e) => e && typeof e.url === 'string' && e.url);
+        if (entry && !seen[entry.url]) {
+          seen[entry.url] = true;
+          syncs.push({ type: pixelType, url: entry.url });
+        }
+        return;
+      }
       const target = parseSyncHeader(serverResponse?.headers?.get?.(SYNC_HEADER));
       if (!target) return;
       const { seat, region } = target;

--- a/modules/floxisBidAdapter.js
+++ b/modules/floxisBidAdapter.js
@@ -224,6 +224,9 @@ export const spec = {
     if (!syncOptions.iframeEnabled && !syncOptions.pixelEnabled) return [];
     if (!serverResponses || !serverResponses.length) return [];
     const pixelType = syncOptions.iframeEnabled ? 'iframe' : 'image';
+    // Only honor a body sync whose type is enabled here — core userSync drops a disabled-type sync.
+    const isEnabledSync = (e) => e && typeof e.url === 'string' && e.url &&
+      ((e.type === 'iframe' && syncOptions.iframeEnabled) || (e.type === 'image' && syncOptions.pixelEnabled));
     const query = buildConsentQuery(gdprConsent, uspConsent, gppConsent);
     const consentSuffix = query.length ? '&' + query.join('&') : '';
     const seen = {};
@@ -232,13 +235,15 @@ export const spec = {
       // body.ext.sync is primary; serverResponse.headers is not a real Headers object in every Prebid build.
       const bodySyncs = serverResponse?.body?.ext?.sync;
       if (Array.isArray(bodySyncs) && bodySyncs.length) {
-        const entry = bodySyncs.find((e) => e && typeof e.url === 'string' && e.url && e.type === pixelType) ||
-          bodySyncs.find((e) => e && typeof e.url === 'string' && e.url);
-        if (entry && !seen[entry.url]) {
-          seen[entry.url] = true;
-          syncs.push({ type: entry.type, url: entry.url });
+        const entry = bodySyncs.find((e) => isEnabledSync(e) && e.type === pixelType) || bodySyncs.find(isEnabledSync);
+        if (entry) {
+          if (!seen[entry.url]) {
+            seen[entry.url] = true;
+            syncs.push({ type: entry.type, url: entry.url });
+          }
+          return;
         }
-        return;
+        // body carried no entry of an enabled sync type — fall through to the header path below
       }
       const target = parseSyncHeader(serverResponse?.headers?.get?.(SYNC_HEADER));
       if (!target) return;

--- a/modules/floxisBidAdapter.js
+++ b/modules/floxisBidAdapter.js
@@ -232,10 +232,11 @@ export const spec = {
       // body.ext.sync is primary; serverResponse.headers is not a real Headers object in every Prebid build.
       const bodySyncs = serverResponse?.body?.ext?.sync;
       if (Array.isArray(bodySyncs) && bodySyncs.length) {
-        const entry = bodySyncs.find((e) => e && typeof e.url === 'string' && e.url);
+        const entry = bodySyncs.find((e) => e && typeof e.url === 'string' && e.url && e.type === pixelType) ||
+          bodySyncs.find((e) => e && typeof e.url === 'string' && e.url);
         if (entry && !seen[entry.url]) {
           seen[entry.url] = true;
-          syncs.push({ type: pixelType, url: entry.url });
+          syncs.push({ type: entry.type, url: entry.url });
         }
         return;
       }

--- a/test/spec/modules/floxisBidAdapter_spec.js
+++ b/test/spec/modules/floxisBidAdapter_spec.js
@@ -756,6 +756,44 @@ describe('floxisBidAdapter', function () {
       const syncs = spec.getUserSyncs({ iframeEnabled: true }, responses);
       expect(syncs).to.have.lengthOf(1);
     });
+
+    describe('body.ext.sync (primary channel)', function () {
+      const BODY_URL = 'https://px-us-e.floxis.tech/sync?seat=aBfL&gdpr=1';
+      function bodySync(url, type) { return { type, url }; }
+      function bodyResponse(syncArray, headerValue = null) {
+        return { body: { id: 'r', seatbid: [], ext: { sync: syncArray } }, headers: { get: (n) => (n === 'x-floxis-sync' && headerValue ? headerValue : null) } };
+      }
+
+      it('should emit the server-baked sync URL from body.ext.sync with no header present', function () {
+        const syncs = spec.getUserSyncs({ iframeEnabled: true }, [bodyResponse([bodySync(BODY_URL, 'iframe'), bodySync(BODY_URL, 'image')])]);
+        expect(syncs).to.have.lengthOf(1);
+        expect(syncs[0].type).to.equal('iframe');
+        expect(syncs[0].url).to.equal(BODY_URL);
+      });
+
+      it('should use image type from the body channel when only pixels are enabled', function () {
+        const syncs = spec.getUserSyncs({ iframeEnabled: false, pixelEnabled: true }, [bodyResponse([bodySync(BODY_URL, 'iframe'), bodySync(BODY_URL, 'image')])]);
+        expect(syncs[0].type).to.equal('image');
+        expect(syncs[0].url).to.equal(BODY_URL);
+      });
+
+      it('should prefer the body channel over the header when both are present', function () {
+        const syncs = spec.getUserSyncs({ iframeEnabled: true }, [bodyResponse([bodySync(BODY_URL, 'iframe')], 'seat=Gmtb&region=us-e')]);
+        expect(syncs).to.have.lengthOf(1);
+        expect(syncs[0].url).to.equal(BODY_URL);
+      });
+
+      it('should fall back to the header when body.ext.sync is an empty array', function () {
+        const syncs = spec.getUserSyncs({ iframeEnabled: true }, [bodyResponse([], 'seat=Gmtb&region=us-e')]);
+        expect(syncs).to.have.lengthOf(1);
+        expect(syncs[0].url).to.equal('https://px-us-e.floxis.tech/sync?seat=Gmtb');
+      });
+
+      it('should dedupe identical body sync URLs across responses', function () {
+        const syncs = spec.getUserSyncs({ iframeEnabled: true }, [bodyResponse([bodySync(BODY_URL, 'iframe')]), bodyResponse([bodySync(BODY_URL, 'iframe')])]);
+        expect(syncs).to.have.lengthOf(1);
+      });
+    });
   });
 
   describe('onBidBillable', function () {

--- a/test/spec/modules/floxisBidAdapter_spec.js
+++ b/test/spec/modules/floxisBidAdapter_spec.js
@@ -759,6 +759,8 @@ describe('floxisBidAdapter', function () {
 
     describe('body.ext.sync (primary channel)', function () {
       const BODY_URL = 'https://px-us-e.floxis.tech/sync?seat=aBfL&gdpr=1';
+      const IFRAME_URL = 'https://px-us-e.floxis.tech/sync?seat=aBfL&type=iframe';
+      const IMAGE_URL = 'https://px-us-e.floxis.tech/sync?seat=aBfL&type=image';
       function bodySync(url, type) { return { type, url }; }
       function bodyResponse(syncArray, headerValue = null) {
         return { body: { id: 'r', seatbid: [], ext: { sync: syncArray } }, headers: { get: (n) => (n === 'x-floxis-sync' && headerValue ? headerValue : null) } };
@@ -775,6 +777,33 @@ describe('floxisBidAdapter', function () {
         const syncs = spec.getUserSyncs({ iframeEnabled: false, pixelEnabled: true }, [bodyResponse([bodySync(BODY_URL, 'iframe'), bodySync(BODY_URL, 'image')])]);
         expect(syncs[0].type).to.equal('image');
         expect(syncs[0].url).to.equal(BODY_URL);
+      });
+
+      it('should select the iframe entry by enabled type when iframe and image urls differ', function () {
+        const syncs = spec.getUserSyncs({ iframeEnabled: true }, [bodyResponse([bodySync(IFRAME_URL, 'iframe'), bodySync(IMAGE_URL, 'image')])]);
+        expect(syncs).to.have.lengthOf(1);
+        expect(syncs[0].type).to.equal('iframe');
+        expect(syncs[0].url).to.equal(IFRAME_URL);
+      });
+
+      it('should select the image entry by enabled type when only pixels are enabled and urls differ', function () {
+        const syncs = spec.getUserSyncs({ iframeEnabled: false, pixelEnabled: true }, [bodyResponse([bodySync(IFRAME_URL, 'iframe'), bodySync(IMAGE_URL, 'image')])]);
+        expect(syncs).to.have.lengthOf(1);
+        expect(syncs[0].type).to.equal('image');
+        expect(syncs[0].url).to.equal(IMAGE_URL);
+      });
+
+      it('should pick the correct entry by type regardless of array order', function () {
+        const syncs = spec.getUserSyncs({ iframeEnabled: false, pixelEnabled: true }, [bodyResponse([bodySync(IMAGE_URL, 'image'), bodySync(IFRAME_URL, 'iframe')])]);
+        expect(syncs[0].type).to.equal('image');
+        expect(syncs[0].url).to.equal(IMAGE_URL);
+      });
+
+      it('should fall back to the only available entry when its type does not match the enabled mode', function () {
+        const syncs = spec.getUserSyncs({ iframeEnabled: true }, [bodyResponse([bodySync(IMAGE_URL, 'image')])]);
+        expect(syncs).to.have.lengthOf(1);
+        expect(syncs[0].type).to.equal('image');
+        expect(syncs[0].url).to.equal(IMAGE_URL);
       });
 
       it('should prefer the body channel over the header when both are present', function () {

--- a/test/spec/modules/floxisBidAdapter_spec.js
+++ b/test/spec/modules/floxisBidAdapter_spec.js
@@ -827,6 +827,25 @@ describe('floxisBidAdapter', function () {
         const syncs = spec.getUserSyncs({ iframeEnabled: true }, [bodyResponse([bodySync(BODY_URL, 'iframe')]), bodyResponse([bodySync(BODY_URL, 'iframe')])]);
         expect(syncs).to.have.lengthOf(1);
       });
+
+      it('should dedupe a body sync against a header sync that resolves to the same URL', function () {
+        const SHARED_URL = 'https://px-us-e.floxis.tech/sync?seat=Gmtb';
+        const syncs = spec.getUserSyncs({ iframeEnabled: true }, [
+          bodyResponse([bodySync(SHARED_URL, 'iframe')]),
+          bodyResponse([], 'seat=Gmtb&region=us-e')
+        ]);
+        expect(syncs).to.have.lengthOf(1);
+        expect(syncs[0].url).to.equal(SHARED_URL);
+      });
+
+      it('should dedupe a header sync against a body sync regardless of response order', function () {
+        const SHARED_URL = 'https://px-us-e.floxis.tech/sync?seat=Gmtb';
+        const syncs = spec.getUserSyncs({ iframeEnabled: true }, [
+          bodyResponse([], 'seat=Gmtb&region=us-e'),
+          bodyResponse([bodySync(SHARED_URL, 'iframe')])
+        ]);
+        expect(syncs).to.have.lengthOf(1);
+      });
     });
   });
 

--- a/test/spec/modules/floxisBidAdapter_spec.js
+++ b/test/spec/modules/floxisBidAdapter_spec.js
@@ -799,11 +799,16 @@ describe('floxisBidAdapter', function () {
         expect(syncs[0].url).to.equal(IMAGE_URL);
       });
 
-      it('should fall back to the only available entry when its type does not match the enabled mode', function () {
-        const syncs = spec.getUserSyncs({ iframeEnabled: true }, [bodyResponse([bodySync(IMAGE_URL, 'image')])]);
+      it('should ignore a disabled-type body entry and fall through to the header', function () {
+        const syncs = spec.getUserSyncs({ iframeEnabled: true }, [bodyResponse([bodySync(IMAGE_URL, 'image')], 'seat=Gmtb&region=us-e')]);
         expect(syncs).to.have.lengthOf(1);
-        expect(syncs[0].type).to.equal('image');
-        expect(syncs[0].url).to.equal(IMAGE_URL);
+        expect(syncs[0].type).to.equal('iframe');
+        expect(syncs[0].url).to.equal('https://px-us-e.floxis.tech/sync?seat=Gmtb');
+      });
+
+      it('should emit no sync when the body carries only a disabled-type entry and no header', function () {
+        const syncs = spec.getUserSyncs({ iframeEnabled: true }, [bodyResponse([bodySync(IMAGE_URL, 'image')])]);
+        expect(syncs).to.have.lengthOf(0);
       });
 
       it('should prefer the body channel over the header when both are present', function () {


### PR DESCRIPTION
## Type of change

Maintenance / improvement — no new feature, no breaking change.

## Description

Adds `body.ext.sync` as the **primary** user-sync channel for the Floxis bid adapter, keeping the existing `x-floxis-sync` response header as a fallback.

**Why:** `serverResponse.headers` is not a real `Headers` object in every Prebid.js build and transport layer. The header-only approach is fragile in some publisher wrappers. `body.ext.sync` (the conventional OpenRTB `ext.sync` pattern, used by adapters such as insticatorBidAdapter) is the reliable channel.

**What the server emits:** The Floxis server now includes `body.ext.sync` on both bid and no-bid responses alongside the existing header. Adapter change: if `body.ext.sync` is a non-empty array, use the first entry with a valid URL and skip the header; if `body.ext.sync` is absent or empty, fall through to the header as before.

## Backward compatibility

- Existing header path is unchanged.
- Existing tests (which use `body: ''`) still pass — `''.ext` is `undefined`, so the body branch is never entered.
- Publishers not yet receiving `body.ext.sync` from the server continue to sync via the header.

## Tests

Added a `describe('body.ext.sync (primary channel)')` block covering:
- Body URL emitted with no header present
- `pixelType` respects `iframeEnabled`/`pixelEnabled` options
- Body takes priority when both body and header are present
- Falls back to header when `body.ext.sync` is an empty array
- Deduplication of identical body sync URLs across multiple responses

All existing `getUserSyncs` tests continue to pass (header path unchanged).

## Checklist

- [x] `npx eslint modules/floxisBidAdapter.js` passes (no output)
- [x] Spec tests added for new code paths
- [x] Backward-compatible: header fallback preserved