### PR TITLE
Bydata Analytics Adapter: update auction payload tracking

### DIFF
--- a/modules/byDataAnalyticsAdapter.js
+++ b/modules/byDataAnalyticsAdapter.js
@@ -11,12 +11,11 @@ import { ajax } from '../src/ajax.js';
 import { MODULE_TYPE_ANALYTICS } from '../src/activities/modules.js';
 import { getViewportSize } from '../libraries/viewport/viewport.js';
 import { getOsBrowserInfo } from '../libraries/userAgentUtils/detailed.js';
-import { getTimeZone } from '../libraries/timezone/timezone.js';
 
-const versionCode = '4.4.1';
+const versionCode = '4.5.0';
 const secretKey = 'bydata@123456';
 const { NO_BID, BID_TIMEOUT, AUCTION_END, AUCTION_INIT, BID_WON } = EVENTS;
-const DEFAULT_EVENT_URL = 'https://pbjs-stream.bydata.com/topics/prebid';
+const DEFAULT_EVENT_URL = 'https://telemetry.bydata.com/topics/prebid';
 const analyticsType = 'endpoint';
 const isBydata = isKeyInUrl('bydata_debug');
 const adunitsMap = {};
@@ -25,9 +24,16 @@ const storage = getStorageManager({ moduleType: MODULE_TYPE_ANALYTICS, moduleNam
 
 let initOptions = {};
 var payload = {};
-var winPayload = {};
-var isDataSend = window.asc_data || false;
-var bdNbTo = { 'to': [], 'nb': [] };
+var isDataSend = false;
+var bdNbTo = {};
+
+function normalizeSize(size) {
+  if (!size) return '';
+  if (Array.isArray(size)) return size[0] + 'x' + size[1];
+  if (typeof size === 'string') return size;
+  if (size.width && size.height) return size.width + 'x' + size.height;
+  return '';
+}
 
 /* method used for testing parameters */
 function isKeyInUrl(name) {
@@ -49,6 +55,10 @@ function getAdunitName(code) {
 /* EVENT: auction init */
 function onAuctionStart(t) {
   /* map of ad unit code - ad unit full path */
+  if (!t || !t.auctionId) return;
+  // init per-auction storage
+  bdNbTo[t.auctionId] = { to: [], nb: [] };
+
   t.adUnits && t.adUnits.length && t.adUnits.forEach((adu) => {
     const { code, adunit } = adu;
     adunitsMap[code] = adunit;
@@ -57,25 +67,35 @@ function onAuctionStart(t) {
 
 /* EVENT: bid timeout */
 function onBidTimeout(t) {
-  if (payload['visitor_data'] && t && t.length > 0) {
-    bdNbTo['to'] = t;
-  }
+  if (!payload['visitor_data'] || !t || !t.length) return;
+  t.forEach(timeout => {
+    const { auctionId } = timeout;
+    if (!bdNbTo[auctionId]) bdNbTo[auctionId] = { to: [], nb: [] };
+    bdNbTo[auctionId].to.push(timeout);
+  });
 }
 
 /* EVENT: no bid */
 function onNoBidData(t) {
-  if (payload['visitor_data'] && t) {
-    bdNbTo['nb'].push(t);
-  }
+  if (!payload['visitor_data'] || !t) return;
+  const { auctionId } = t;
+  if (!bdNbTo[auctionId]) bdNbTo[auctionId] = { to: [], nb: [] };
+  bdNbTo[auctionId].nb.push(t);
 }
 
 /* EVENT: bid won */
 function onBidWon(t) {
   const { isCorrectOption } = initOptions;
-  if (isCorrectOption && (isDataSend || isBydata)) {
-    ascAdapter.getBidWonData(t);
-    ascAdapter.sendPayload(winPayload);
-  }
+  if (!(isCorrectOption && (isDataSend || isBydata))) return;
+
+  // initialize per-auction wins storage if not present
+  if (!payload._wins) payload._wins = {};
+  if (!payload._wins[t.auctionId]) payload._wins[t.auctionId] = [];
+  payload._wins[t.auctionId].push({
+    requestId: t.requestId,
+    size: normalizeSize(t.size),
+    auctionId: t.auctionId
+  });
 }
 
 /* EVENT: auction end */
@@ -85,8 +105,16 @@ function onAuctionEnd(t) {
     if (isCorrectOption && (isDataSend || isBydata)) {
       ascAdapter.dataProcess(t);
       ascAdapter.sendPayload(payload);
+
+      // cleanup this auction only
+      if (payload._wins && payload._wins[t.auctionId]) {
+        delete payload._wins[t.auctionId];
+      }
+      if (bdNbTo[t.auctionId]) {
+        delete bdNbTo[t.auctionId];
+      }
     }
-  }, 500);
+  }, 1500);
 }
 
 const ascAdapter = Object.assign(adapter({ url: DEFAULT_EVENT_URL, analyticsType: analyticsType }), {
@@ -126,7 +154,7 @@ ascAdapter.enableAnalytics = function (config) {
 ascAdapter.initConfig = function (config) {
   let isCorrectOption = true;
   initOptions = {};
-  var rndNum = Math.floor(Math.random() * 10000 + 1);
+
   initOptions.options = deepClone(config.options);
   initOptions.clientId = initOptions.options.clientId || null;
   initOptions.logFrequency = initOptions.options.logFrequency;
@@ -134,37 +162,19 @@ ascAdapter.initConfig = function (config) {
     _logError('"options.clientId" should not empty!!');
     isCorrectOption = false;
   }
-  if (rndNum <= initOptions.logFrequency) { window.asc_data = isDataSend = true; }
+
+  // FIXED  (single source of truth)
+  const existingFlag = window.asc_data;
+  if (typeof existingFlag === 'boolean') {
+    isDataSend = existingFlag;
+  } else {
+    const rndNum = Math.floor(Math.random() * 10000 + 1);
+    isDataSend = rndNum <= initOptions.logFrequency;
+    window.asc_data = isDataSend; // persist for session
+  }
   initOptions.isCorrectOption = isCorrectOption;
   this.initOptions = initOptions;
   return isCorrectOption;
-};
-
-ascAdapter.getBidWonData = function(t) {
-  const { auctionId, adUnitCode, size, requestId, bidder, timeToRespond, currency, mediaType, cpm } = t;
-  const aun = getAdunitName(adUnitCode);
-  winPayload['aid'] = auctionId;
-  winPayload['as'] = '';
-  winPayload['auctionData'] = [];
-  var data = {};
-  data['au'] = aun;
-  data['auc'] = adUnitCode;
-  data['aus'] = size;
-  data['bid'] = requestId;
-  data['bidadv'] = bidder;
-  data['br_pb_mg'] = cpm;
-  data['br_tr'] = timeToRespond;
-  data['bradv'] = bidder;
-  data['brid'] = requestId;
-  data['brs'] = size;
-  data['cur'] = currency;
-  data['inb'] = 0;
-  data['ito'] = 0;
-  data['ipwb'] = 1;
-  data['iwb'] = 1;
-  data['mt'] = mediaType;
-  winPayload['auctionData'].push(data);
-  return winPayload;
 };
 
 ascAdapter.getVisitorData = function (data = {}) {
@@ -235,93 +245,143 @@ ascAdapter.getVisitorData = function (data = {}) {
     ua["brv"] = info.browser.version;
     ua['ss'] = screenSize;
     ua['de'] = deviceType;
-    ua['tz'] = getTimeZone();
+    ua['tz'] = window.Intl.DateTimeFormat().resolvedOptions().timeZone;
   }
   var signedToken = getJWToken(ua);
   payload['visitor_data'] = signedToken;
-  winPayload['visitor_data'] = signedToken;
+  // winPayload['visitor_data'] = signedToken;
   return signedToken;
 };
 
 ascAdapter.dataProcess = function (t) {
-  if (isBydata) { payload['bydata_debug'] = 'true'; }
-  _logInfo('fulldata - ', t);
-  payload['aid'] = t.auctionId;
+  if (!t || !t.auctionId) return payload;
+  const auctionId = t.auctionId;
+
+  if (isBydata) payload['bydata_debug'] = 'true';
+
+  payload['aid'] = auctionId;
   payload['as'] = t.timestamp;
   payload['auctionData'] = [];
-  var bidderRequestsData = []; var bidsReceivedData = [];
+
+  const timeoutData = bdNbTo[auctionId] || { to: [], nb: [] };
+
+  // Build request map
+  let requestMap = [];
+
   t.bidderRequests && t.bidderRequests.forEach(bidReq => {
-    var pObj = {}; pObj['bids'] = [];
     bidReq.bids.forEach(bid => {
-      var data = {};
-      data['adUnitCode'] = bid.adUnitCode;
-      data['sizes'] = bid.sizes;
-      data['bidder'] = bid.bidder;
-      data['bidId'] = bid.bidId;
-      data['mediaTypes'] = [];
-      var mt = bid.mediaTypes.banner ? 'display' : 'video';
-      data['mediaTypes'].push(mt);
-      pObj['bids'].push(data);
-    });
-    bidderRequestsData.push(pObj);
-  });
-  t.bidsReceived && t.bidsReceived.forEach(bid => {
-    const { requestId, bidder, width, height, cpm, currency, timeToRespond, adUnitCode } = bid;
-    bidsReceivedData.push({ requestId, bidder, width, height, cpm, currency, timeToRespond, adUnitCode });
-  });
-  bidderRequestsData.length > 0 && bidderRequestsData.forEach(bdObj => {
-    var bdsArray = bdObj['bids'];
-    bdsArray.forEach(bid => {
-      const { adUnitCode, sizes, bidder, bidId, mediaTypes } = bid;
-      sizes.forEach(size => {
-        var sstr = size[0] + 'x' + size[1];
-        payload['auctionData'].push({ au: getAdunitName(adUnitCode), auc: adUnitCode, aus: sstr, mt: mediaTypes[0], bidadv: bidder, bid: bidId, inb: 0, ito: 0, ipwb: 0, iwb: 0 });
+      const sizeList = bid.sizes || [];
+
+      sizeList.forEach(size => {
+        requestMap.push({
+          au: getAdunitName(bid.adUnitCode),
+          auc: bid.adUnitCode,
+          aus: normalizeSize(size),
+          mt: bid.mediaTypes?.banner ? 'display' : 'video',
+          bidadv: bid.bidder,
+          bid: bid.bidId,
+          inb: 0,
+          ito: 0,
+          ipwb: 0,
+          iwb: 0
+        });
       });
     });
   });
 
-  bidsReceivedData.length > 0 && bidsReceivedData.forEach(bdRecived => {
-    const { requestId, bidder, width, height, cpm, currency, timeToRespond } = bdRecived;
-    payload["auctionData"].forEach(rwData => {
-      if (rwData["bid"] === requestId && rwData["aus"] === width + "x" + height) {
-        rwData["brid"] = requestId; rwData["bradv"] = bidder; rwData["br_pb_mg"] = cpm;
-        rwData["cur"] = currency; rwData["br_tr"] = timeToRespond; rwData["brs"] = width + "x" + height;
+  payload['auctionData'] = requestMap;
+
+  //  Map bidsReceived (FILTER BY AUCTION)
+  const bidsReceived = (t.bidsReceived || []).filter(b => b.auctionId === auctionId);
+
+  bidsReceived.forEach(bid => {
+    const size = normalizeSize([bid.width, bid.height]);
+
+    payload['auctionData'].forEach(row => {
+      if (row.bid === bid.requestId && row.aus === size) {
+        row.brid = bid.requestId;
+        row.ipwb = 1;
+        row.bradv = bid.bidder;
+        row.br_pb_mg = bid.cpm;
+        row.cur = bid.currency;
+        row.br_tr = bid.timeToRespond;
+        row.brs = size;
       }
     });
   });
 
-  var prebidWinningBids = auctionManager.getBidsReceived().filter(bid => bid.status === BID_STATUS.BID_TARGETING_SET);
-  prebidWinningBids && prebidWinningBids.length > 0 && prebidWinningBids.forEach(pbbid => {
-    payload['auctionData'] && payload['auctionData'].forEach(rwData => {
-      if (rwData['bid'] === pbbid.requestId && rwData['brs'] === pbbid.size) {
-        rwData['ipwb'] = 1;
+  // Prebid targeting wins
+  const targetingWins = auctionManager.getBidsReceived()
+    .filter(b => b.auctionId === auctionId && b.status === BID_STATUS.BID_TARGETING_SET);
+
+  targetingWins.forEach(bid => {
+    const size = normalizeSize(bid.size);
+
+    payload['auctionData'].forEach(row => {
+      if (row.bid === bid.requestId && row.aus === size) {
+        row.ipwb = 1;
       }
     });
   });
 
-  var winningBids = auctionManager.getAllWinningBids();
-  winningBids && winningBids.length > 0 && winningBids.forEach(wBid => {
-    payload['auctionData'] && payload['auctionData'].forEach(rwData => {
-      if (rwData['bid'] === wBid.requestId && rwData['brs'] === wBid.size) {
-        rwData['iwb'] = 1;
+  // Actual wins (FILTERED) - this will include prebid wins + any direct integrations
+  const winningBids = auctionManager.getAllWinningBids()
+    .filter(b => b.auctionId === auctionId);
+
+  winningBids.forEach(bid => {
+    const size = normalizeSize(bid.size);
+
+    payload['auctionData'].forEach(row => {
+      if (row.bid === bid.requestId && row.aus === size) {
+        row.iwb = 1; row.ipwb = 1;
       }
     });
   });
 
-  payload['auctionData'] && payload['auctionData'].length > 0 && payload['auctionData'].forEach(u => {
-    bdNbTo['to'].forEach(i => {
-      if (u.bid === i.bidId) u.ito = 1;
+  // Handle any wins recorded via onBidWon (for direct integrations or if auctionManager misses any)
+  if (payload._wins && payload._wins[auctionId]) {
+    payload._wins[auctionId].forEach(w => {
+      payload['auctionData'].forEach(row => {
+        if (row.bid === w.requestId && row.aus === w.size) {
+          row.iwb = 1; row.ipwb = 1;
+        }
+      });
     });
-    bdNbTo['nb'].forEach(i => {
-      if (u.bidadv === i.bidder && u.bid === i.bidId) { u.inb = 1; }
+  }
+
+  // Timeout + NoBid
+  payload['auctionData'].forEach(row => {
+    timeoutData.to.forEach(t => {
+      if (row.bid === t.bidId) row.ito = 1;
+    });
+
+    timeoutData.nb.forEach(n => {
+      if (row.bid === n.bidId && row.bidadv === n.bidder) {
+        row.inb = 1;
+      }
     });
   });
   return payload;
 };
 
 ascAdapter.sendPayload = function (data) {
+  // remove internal helper state
+  if (data._wins) {
+    delete data._wins;
+  }
+
+  if (window.sType !== undefined && window.sType !== null && window.sType !== '') {
+    data.auctionData.forEach(item => {
+      if (item.bidadv && !item.bidadv.endsWith(`_${window.sType}`)) {
+        item.bidadv = `${item.bidadv}_${window.sType}`;
+      }
+    });
+  }
+
+  _logInfo('payload: ', JSON.stringify(data));
+
   var obj = { 'records': [{ 'value': data }] };
-  const strJSON = JSON.stringify(obj);
+  let strJSON = JSON.stringify(obj);
   sendDataOnKf(strJSON);
 };
 

--- a/modules/byDataAnalyticsAdapter.js
+++ b/modules/byDataAnalyticsAdapter.js
@@ -11,6 +11,7 @@ import { ajax } from '../src/ajax.js';
 import { MODULE_TYPE_ANALYTICS } from '../src/activities/modules.js';
 import { getViewportSize } from '../libraries/viewport/viewport.js';
 import { getOsBrowserInfo } from '../libraries/userAgentUtils/detailed.js';
+import { getTimeZone } from '../libraries/timezone/timezone.js';
 
 const versionCode = '4.5.0';
 const secretKey = 'bydata@123456';
@@ -26,6 +27,7 @@ let initOptions = {};
 var payload = {};
 var isDataSend = false;
 var bdNbTo = {};
+var sentAuctions = {};
 
 function normalizeSize(size) {
   if (!size) return '';
@@ -88,6 +90,11 @@ function onBidWon(t) {
   const { isCorrectOption } = initOptions;
   if (!(isCorrectOption && (isDataSend || isBydata))) return;
 
+  if (sentAuctions[t.auctionId]) {
+    ascAdapter.sendPayload(ascAdapter.getBidWonData(t));
+    return;
+  }
+
   // initialize per-auction wins storage if not present
   if (!payload._wins) payload._wins = {};
   if (!payload._wins[t.auctionId]) payload._wins[t.auctionId] = [];
@@ -105,6 +112,7 @@ function onAuctionEnd(t) {
     if (isCorrectOption && (isDataSend || isBydata)) {
       ascAdapter.dataProcess(t);
       ascAdapter.sendPayload(payload);
+      sentAuctions[t.auctionId] = true;
 
       // cleanup this auction only
       if (payload._wins && payload._wins[t.auctionId]) {
@@ -172,9 +180,40 @@ ascAdapter.initConfig = function (config) {
     isDataSend = rndNum <= initOptions.logFrequency;
     window.asc_data = isDataSend; // persist for session
   }
+  sentAuctions = {};
   initOptions.isCorrectOption = isCorrectOption;
   this.initOptions = initOptions;
   return isCorrectOption;
+};
+
+ascAdapter.getBidWonData = function(t) {
+  const { auctionId, adUnitCode, size, requestId, bidder, timeToRespond, currency, mediaType, cpm } = t;
+  const aun = getAdunitName(adUnitCode);
+  const bidWonPayload = {
+    visitor_data: payload['visitor_data'],
+    aid: auctionId,
+    as: '',
+    auctionData: []
+  };
+  var data = {};
+  data['au'] = aun;
+  data['auc'] = adUnitCode;
+  data['aus'] = normalizeSize(size);
+  data['bid'] = requestId;
+  data['bidadv'] = bidder;
+  data['br_pb_mg'] = cpm;
+  data['br_tr'] = timeToRespond;
+  data['bradv'] = bidder;
+  data['brid'] = requestId;
+  data['brs'] = normalizeSize(size);
+  data['cur'] = currency;
+  data['inb'] = 0;
+  data['ito'] = 0;
+  data['ipwb'] = 1;
+  data['iwb'] = 1;
+  data['mt'] = mediaType;
+  bidWonPayload['auctionData'].push(data);
+  return bidWonPayload;
 };
 
 ascAdapter.getVisitorData = function (data = {}) {
@@ -245,7 +284,7 @@ ascAdapter.getVisitorData = function (data = {}) {
     ua["brv"] = info.browser.version;
     ua['ss'] = screenSize;
     ua['de'] = deviceType;
-    ua['tz'] = window.Intl.DateTimeFormat().resolvedOptions().timeZone;
+    ua['tz'] = getTimeZone();
   }
   var signedToken = getJWToken(ua);
   payload['visitor_data'] = signedToken;
@@ -300,7 +339,6 @@ ascAdapter.dataProcess = function (t) {
     payload['auctionData'].forEach(row => {
       if (row.bid === bid.requestId && row.aus === size) {
         row.brid = bid.requestId;
-        row.ipwb = 1;
         row.bradv = bid.bidder;
         row.br_pb_mg = bid.cpm;
         row.cur = bid.currency;
@@ -365,22 +403,23 @@ ascAdapter.dataProcess = function (t) {
 };
 
 ascAdapter.sendPayload = function (data) {
-  // remove internal helper state
-  if (data._wins) {
-    delete data._wins;
-  }
+  const payloadToSend = {
+    ...data,
+    auctionData: (data.auctionData || []).map(item => ({ ...item }))
+  };
+  delete payloadToSend._wins;
 
   if (window.sType !== undefined && window.sType !== null && window.sType !== '') {
-    data.auctionData.forEach(item => {
+    payloadToSend.auctionData.forEach(item => {
       if (item.bidadv && !item.bidadv.endsWith(`_${window.sType}`)) {
         item.bidadv = `${item.bidadv}_${window.sType}`;
       }
     });
   }
 
-  _logInfo('payload: ', JSON.stringify(data));
+  _logInfo('payload: ', JSON.stringify(payloadToSend));
 
-  var obj = { 'records': [{ 'value': data }] };
+  var obj = { 'records': [{ 'value': payloadToSend }] };
   let strJSON = JSON.stringify(obj);
   sendDataOnKf(strJSON);
 };

--- a/test/spec/modules/byDataAnalyticsAdapter_spec.js
+++ b/test/spec/modules/byDataAnalyticsAdapter_spec.js
@@ -6,6 +6,7 @@ const adapterManager = require('src/adapterManager').default;
 const events = require('src/events');
 const auctionId = 'b70ef967-5c5b-4602-831e-f2cf16e59af2';
 const bidWonAuctionId = 'c80ef967-5c5b-4602-831e-f2cf16e59af3';
+const bidResponseAuctionId = 'd90ef967-5c5b-4602-831e-f2cf16e59af4';
 const initOptions = {
   clientId: 'asc00000',
   logFrequency: 1,
@@ -108,6 +109,40 @@ const bidWonAuctionEndArgs = {
         mediaTypes: { banner: { sizes: [[300, 250], [250, 250]] } },
         sizes: [[300, 250], [250, 250]],
         transactionId: 'd8ee3914-1ee0-4ce6-9126-748d5692189d'
+      }
+    ]
+  }]
+};
+const bidResponseAuctionEndArgs = {
+  ...auctionEndArgs,
+  auctionId: bidResponseAuctionId,
+  bidsReceived: [{
+    auctionId: bidResponseAuctionId,
+    requestId: '34480e9832f2d2d',
+    bidder: 'appnexus',
+    width: 300,
+    height: 250,
+    cpm: 0.50,
+    currency: 'USD',
+    timeToRespond: 114,
+    adUnitCode: 'div-gpt-ad-mrec1'
+  }],
+  bidderRequests: [{
+    auctionId: bidResponseAuctionId,
+    auctionStart: 1627973484504,
+    bidderCode: 'appnexus',
+    bidderRequestId: '33b87b6c20d3638',
+    bids: [
+      {
+        adUnitCode: 'div-gpt-ad-mrec1',
+        auctionId: bidResponseAuctionId,
+        bidId: '34480e9832f2d2d',
+        bidder: 'appnexus',
+        bidderRequestId: '33b87b6c20d3638',
+        src: 'client',
+        mediaTypes: { banner: { sizes: [[300, 250], [250, 250]] } },
+        sizes: [[300, 250], [250, 250]],
+        transactionId: 'e8ee3914-1ee0-4ce6-9126-748d5692190e'
       }
     ]
   }]
@@ -220,6 +255,20 @@ describe('byData Analytics Adapter ', () => {
       delete newAuData._wins;
       newAuData['visitor_data'] = userToken;
       expect(newAuData).to.deep.equal(expectedBidWonDataArgs);
+    });
+
+    it('does not mark every received bid as a prebid winner ', function () {
+      var newAuData = ascAdapter.dataProcess(bidResponseAuctionEndArgs);
+      expect(newAuData.auctionData[0]).to.include({
+        brid: '34480e9832f2d2d',
+        bradv: 'appnexus',
+        br_pb_mg: 0.50,
+        cur: 'USD',
+        br_tr: 114,
+        brs: '300x250',
+        ipwb: 0,
+        iwb: 0
+      });
     });
   });
 });

--- a/test/spec/modules/byDataAnalyticsAdapter_spec.js
+++ b/test/spec/modules/byDataAnalyticsAdapter_spec.js
@@ -5,6 +5,7 @@ import { EVENTS } from 'src/constants.js';
 const adapterManager = require('src/adapterManager').default;
 const events = require('src/events');
 const auctionId = 'b70ef967-5c5b-4602-831e-f2cf16e59af2';
+const bidWonAuctionId = 'c80ef967-5c5b-4602-831e-f2cf16e59af3';
 const initOptions = {
   clientId: 'asc00000',
   logFrequency: 1,
@@ -42,10 +43,10 @@ const noBidArgs = {
   transactionId: 'c8ee3914-1ee0-4ce6-9126-748d5692188c'
 };
 const bidWonArgs = {
-  auctionId,
+  auctionId: bidWonAuctionId,
   adUnitCode: 'div-gpt-ad-mrec1',
   size: '300x250',
-  requestId: '15c86b6c10d3746',
+  requestId: '24480e9832f2d2c',
   bidder: 'appnexus',
   timeToRespond: 114,
   currency: 'USD',
@@ -87,6 +88,30 @@ const auctionEndArgs = {
     ]
   }]
 };
+const bidWonAuctionEndArgs = {
+  ...auctionEndArgs,
+  auctionId: bidWonAuctionId,
+  bidsReceived: [],
+  bidderRequests: [{
+    auctionId: bidWonAuctionId,
+    auctionStart: 1627973484504,
+    bidderCode: 'appnexus',
+    bidderRequestId: '23b87b6c20d3637',
+    bids: [
+      {
+        adUnitCode: 'div-gpt-ad-mrec1',
+        auctionId: bidWonAuctionId,
+        bidId: '24480e9832f2d2c',
+        bidder: 'appnexus',
+        bidderRequestId: '23b87b6c20d3637',
+        src: 'client',
+        mediaTypes: { banner: { sizes: [[300, 250], [250, 250]] } },
+        sizes: [[300, 250], [250, 250]],
+        transactionId: 'd8ee3914-1ee0-4ce6-9126-748d5692189d'
+      }
+    ]
+  }]
+};
 const expectedDataArgs = {
   visitor_data: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiIyNzFhOC0yYjg2LWY0YTQtZjU5YmMiLCJjaWQiOiJhc2MwMDAwMCIsInBpZCI6Ind3dy5sZXRzcnVuLmNvbSIsIm9zIjoiTWFjaW50b3NoIiwib3N2IjoxMC4xNTcsImJyIjoiQ2hyb21lIiwiYnJ2IjoxMDMsInNzIjp7IndpZHRoIjoxNzkyLCJoZWlnaHQiOjExMjB9LCJkZSI6IkRlc2t0b3AiLCJ0eiI6IkFzaWEvQ2FsY3V0dGEifQ.Oj3qnh--t06XO-foVmrMJCGqFfOBed09A-f7LZX5rtfBf4w1_RNRZ4F3on4TMPLonSa7GgzbcEfJS9G_amnleQ',
   aid: auctionId,
@@ -115,35 +140,41 @@ const expectedDataArgs = {
     mt: 'display',
   }]
 };
-const expectedBidWonArgs = {
-  visitor_data: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiIyNzFhOC0yYjg2LWY0YTQtZjU5YmMiLCJjaWQiOiJhc2MwMDAwMCIsInBpZCI6Ind3dy5sZXRzcnVuLmNvbSIsIm9zIjoiTWFjaW50b3NoIiwib3N2IjoxMC4xNTcsImJyIjoiQ2hyb21lIiwiYnJ2IjoxMDMsInNzIjp7IndpZHRoIjoxNzkyLCJoZWlnaHQiOjExMjB9LCJkZSI6IkRlc2t0b3AiLCJ0eiI6IkFzaWEvQ2FsY3V0dGEifQ.Oj3qnh--t06XO-foVmrMJCGqFfOBed09A-f7LZX5rtfBf4w1_RNRZ4F3on4TMPLonSa7GgzbcEfJS9G_amnleQ',
-  aid: auctionId,
-  as: '',
+const expectedBidWonDataArgs = {
+  ...expectedDataArgs,
+  aid: bidWonAuctionId,
   auctionData: [{
     au: 'div-gpt-ad-mrec1',
     auc: 'div-gpt-ad-mrec1',
     aus: '300x250',
-    bid: '15c86b6c10d3746',
     bidadv: 'appnexus',
-    br_pb_mg: 0.50,
-    br_tr: 114,
-    bradv: 'appnexus',
-    brid: '15c86b6c10d3746',
-    brs: '300x250',
-    cur: 'USD',
+    bid: '24480e9832f2d2c',
     inb: 0,
     ito: 0,
     ipwb: 1,
     iwb: 1,
+    mt: 'display',
+  }, {
+    au: 'div-gpt-ad-mrec1',
+    auc: 'div-gpt-ad-mrec1',
+    aus: '250x250',
+    bidadv: 'appnexus',
+    bid: '24480e9832f2d2c',
+    inb: 0,
+    ito: 0,
+    ipwb: 0,
+    iwb: 0,
     mt: 'display',
   }]
 };
 
 describe('byData Analytics Adapter ', () => {
   beforeEach(() => {
+    window.asc_data = true;
     sinon.stub(events, 'getEvents').returns([]);
   });
   afterEach(() => {
+    delete window.asc_data;
     events.getEvents.restore();
   });
 
@@ -156,8 +187,6 @@ describe('byData Analytics Adapter ', () => {
       ascAdapter.track.restore();
     });
     it('should init with correct options', function () {
-      ascAdapter.enableAnalytics(initOptions);
-      // Step 1: Initialize adapter
       adapterManager.enableAnalytics({
         provider: 'bydata',
         options: initOptions
@@ -169,8 +198,7 @@ describe('byData Analytics Adapter ', () => {
 
   describe('track-events', function () {
     before(() => {
-      ascAdapter.enableAnalytics(initOptions);
-      // Step 1: Initialize adapter
+      window.asc_data = true;
       adapterManager.enableAnalytics({
         provider: 'bydata',
         options: initOptions
@@ -179,14 +207,19 @@ describe('byData Analytics Adapter ', () => {
     it('sends and formatted auction data ', function () {
       events.emit(EVENTS.BID_TIMEOUT, bidTimeoutArgs);
       events.emit(EVENTS.NO_BID, noBidArgs);
-      events.emit(EVENTS.BID_WON, bidWonArgs);
       var userToken = ascAdapter.getVisitorData(userData);
       var newAuData = ascAdapter.dataProcess(auctionEndArgs);
-      var newBwData = ascAdapter.getBidWonData(bidWonArgs);
       newAuData['visitor_data'] = userToken;
-      newBwData['visitor_data'] = userToken;
       expect(newAuData).to.deep.equal(expectedDataArgs);
-      expect(newBwData).to.deep.equal(expectedBidWonArgs);
+    });
+
+    it('marks bid won data on auction payload ', function () {
+      events.emit(EVENTS.BID_WON, bidWonArgs);
+      var userToken = ascAdapter.getVisitorData(userData);
+      var newAuData = ascAdapter.dataProcess(bidWonAuctionEndArgs);
+      delete newAuData._wins;
+      newAuData['visitor_data'] = userToken;
+      expect(newAuData).to.deep.equal(expectedBidWonDataArgs);
     });
   });
 });


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter
- [ ] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Updates the Bydata Analytics Adapter to improve auction-level analytics payload tracking.

This change:
- updates the adapter version to `4.5.0`
- sends analytics data to the new Bydata telemetry endpoint
- tracks timeout, no-bid, and bid-won data per auction instead of using shared global state
- merges `BID_WON` information into the auction payload instead of sending a separate bid-won payload
- normalizes bid sizes before matching request, response, timeout, and win records
- adds support for optional bidder suffixing through `window.sType`
- updates unit tests for the new auction payload behavior

Validation completed:
- `npx eslint 'modules/byDataAnalyticsAdapter.js' 'test/spec/modules/byDataAnalyticsAdapter_spec.js' --cache --cache-strategy content`
- `npx gulp build --modules=byDataAnalyticsAdapter`
- `npx gulp test --file test/spec/modules/byDataAnalyticsAdapter_spec.js --nolint`

## Other information
This PR updates only the Bydata Analytics Adapter and its unit tests.

No user-facing Prebid API or documentation changes are expected.