### PR TITLE
Build: replace through2 with native Node.js streams

### DIFF
--- a/gulpHelpers.js
+++ b/gulpHelpers.js
@@ -3,7 +3,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const argv = require('yargs').argv;
 const MANIFEST = 'package.json';
-const through = require('through2');
+const { Transform } = require('node:stream');
 const _ = require('lodash');
 const PluginError = require('plugin-error');
 const execaCmd = require('execa');
@@ -166,10 +166,13 @@ module.exports = {
 
   nameModules: function(externalModules) {
     var modules = this.getModules(externalModules);
-    return through.obj(function(file, enc, done) {
-      file.named = modules[file.path] ? modules[file.path] : 'prebid';
-      this.push(file);
-      done();
+    return new Transform({
+      objectMode: true,
+      transform(file, enc, done) {
+        file.named = modules[file.path] ? modules[file.path] : 'prebid';
+        this.push(file);
+        done();
+      }
     })
   },
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,7 +17,7 @@ const execaTask = helpers.execaTask;
 var concat = require('gulp-concat');
 var replace = require('gulp-replace');
 const execaCmd = require('execa');
-var through = require('through2');
+const { Transform, PassThrough } = require('node:stream');
 var fs = require('fs');
 var jsEscape = require('gulp-js-escape');
 const path = require('path');
@@ -179,11 +179,14 @@ function nodeBundle(modules, dev = false) {
       .on('error', (err) => {
         reject(err);
       })
-      .pipe(through.obj(function (file, enc, done) {
-        if (file.path.endsWith('.js')) {
-          resolve(file.contents.toString(enc));
+      .pipe(new Transform({
+        objectMode: true,
+        transform(file, enc, done) {
+          if (file.path.endsWith('.js')) {
+            resolve(file.contents.toString(enc));
+          }
+          done();
         }
-        done();
       }));
   });
 }
@@ -211,7 +214,7 @@ function wrapWithHeaderAndFooter(dev, modules, sourcemaps = false) {
   // NOTE: gulp-header, gulp-footer & gulp-wrap do not play nice with source maps.
   // gulp-concat does; for that reason we are prepending and appending the source stream with "fake" header & footer files.
   return function wrap(stream) {
-    const wrapped = through.obj();
+    const wrapped = new PassThrough({ objectMode: true });
     const placeholder = '$$PREBID_SOURCE$$';
     const tpl = _.template(fs.readFileSync('./bundle-template.txt'))({
       prebid,
@@ -241,7 +244,7 @@ function wrapWithHeaderAndFooter(dev, modules, sourcemaps = false) {
 }
 
 function disclosureSummary(modules, summaryFileName) {
-  const stream = through.obj();
+  const stream = new PassThrough({ objectMode: true });
   import('./libraries/storageDisclosure/summary.mjs').then(({getStorageDisclosureSummary}) => {
     const summary = getStorageDisclosureSummary(modules, (moduleName) => {
       const metadataPath = `./metadata/modules/${moduleName}.json`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,6 @@
         "puppeteer": "^24.10.0",
         "resolve-from": "^5.0.0",
         "sinon": "^22.0.0",
-        "through2": "^4.0.2",
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.26.1",
         "url": "^0.11.0",
@@ -19002,27 +19001,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/through2": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "3"
-      }
-    },
-    "node_modules/through2/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/time-stamp": {
       "version": "1.1.0",
       "dev": true,
@@ -33309,24 +33287,6 @@
     "through": {
       "version": "2.3.8",
       "dev": true
-    },
-    "through2": {
-      "version": "4.0.2",
-      "dev": true,
-      "requires": {
-        "readable-stream": "3"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.2",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
     },
     "time-stamp": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "puppeteer": "^24.10.0",
     "resolve-from": "^5.0.0",
     "sinon": "^22.0.0",
-    "through2": "^4.0.2",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.26.1",
     "url": "^0.11.0",


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
replace through2 with native Node.js streams, reducing supply chain by 2 packages.

## Other information
through2 was added in 2017 (PR #1570) to collect webpack output from a gulp stream into a Promise. At the time it was the idiomatic way to create object-mode transform streams; since Node 12 the native stream. Transform and stream.PassThrough with objectMode: true are full equivalents with no behavioral difference.

  Changes in gulpHelpers.js:
  - require('through2') → const { Transform } = require('node:stream')
  - through.obj(fn) → new Transform({ objectMode: true, transform(file, enc, done) {...} })

  Changes in gulpfile.js:
  - require('through2') → const { Transform, PassThrough } = require('node:stream')
  - through.obj(fn) → new Transform({ objectMode: true, transform(file, enc, done) {...} })
  - through.obj() → new PassThrough({ objectMode: true }) (2 places)

  Package removed via npm uninstall through2.

  No behavior change expected. Verified with npx gulp build.
