### PR TITLE
CI: fix failing safari e2e tests

### DIFF
--- a/.github/actions/wait-for-browserstack/action.yml
+++ b/.github/actions/wait-for-browserstack/action.yml
@@ -11,11 +11,12 @@ runs:
       run: |
         while            
           status=$(curl -u "${BROWSERSTACK_USERNAME}:${BROWSERSTACK_ACCESS_KEY}" \
-            -X GET "https://api-cloud.browserstack.com/automate/plan.json" 2> /dev/null);
-          running=$(jq '.parallel_sessions_running' <<< $status)
-          max_running=$(jq '.parallel_sessions_max_allowed' <<< $status)
-          queued=$(jq '.queued_sessions' <<< $status)
-          max_queued=$(jq '.queued_sessions_max_allowed' <<< $status)
+            -X GET "https://api-cloud.browserstack.com/automate/plan.json" 2> /dev/null)
+          echo "Response: $status"
+          running=$(jq -e '.parallel_sessions_running' <<< $status || echo "0")
+          max_running=$(jq -e '.parallel_sessions_max_allowed' <<< $status || echo "-1")
+          queued=$(jq -e '.queued_sessions' <<< $status || echo "0")
+          max_queued=$(jq -e '.queued_sessions_max_allowed' <<< $status || echo "0")
           spare=$(( ${max_running} + ${max_queued} - ${running} - ${queued} ))
           required=${{ inputs.sessions }}
           echo "Browserstack status: ${running} sessions running, ${queued} queued, ${spare} free"

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -127,6 +127,22 @@ jobs:
       run-npm-install: ${{ matrix.browser.runsOn == 'windows-latest' }}
       browserstack: false
 
+  browserstack-e2e-tests:
+    needs: [setup, build]
+    if: ${{ !inputs.coverage-only }}
+    name: "Browserstack E2E tests"
+    uses:
+      ./.github/workflows/run-tests.yml
+    with:
+      built-key: ${{ needs.build.outputs.built-key }}
+      test-cmd: npx gulp e2e-test-nobuild
+      chunks: 1
+      browserstack: true
+      browserstack-sessions: 1
+    secrets:
+      BROWSERSTACK_USER_NAME: ${{ secrets.BROWSERSTACK_USER_NAME }}
+      BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+
   unit-tests:
     needs: [setup, build]
     name: "Unit (browser: ${{ matrix.browser.name }} ${{ matrix.browser.version }})"
@@ -159,3 +175,4 @@ jobs:
     secrets:
       BROWSERSTACK_USER_NAME: ${{ secrets.BROWSERSTACK_USER_NAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -159,20 +159,3 @@ jobs:
       test-cmd: npx gulp test-only-nobuild --browsers ${{ matrix.browser.name }} ${{ matrix.browser.coverage && '--coverage' || '--no-coverage' }}
       chunks: 8
       runs-on: ${{ matrix.browser.runsOn || 'ubuntu-latest' }}
-
-  browserstack-tests:
-    needs: setup
-    if: ${{ needs.setup.outputs.bstack-key }}
-    name: "Browserstack tests"
-    uses:
-      ./.github/workflows/run-tests.yml
-    with:
-      built-key: ${{ needs.setup.outputs.bstack-key }}
-      test-cmd: npx gulp test-only-nobuild --browserstack --no-coverage
-      chunks: 8
-      browserstack: true
-      browserstack-sessions: ${{ fromJSON(needs.setup.outputs.bstack-sessions) }}
-    secrets:
-      BROWSERSTACK_USER_NAME: ${{ secrets.BROWSERSTACK_USER_NAME }}
-      BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-

--- a/.github/workflows/browser_testing.json
+++ b/.github/workflows/browser_testing.json
@@ -17,7 +17,6 @@
     "runsOn": "windows-latest"
   },
   "SafariNative": {
-    "wdioName": "safari technology preview",
     "runsOn": "macos-latest",
     "bsName": "safari"
   },

--- a/browsers-e2e.json
+++ b/browsers-e2e.json
@@ -1,0 +1,10 @@
+{
+  "bs_safari_latest_mac": {
+    "base": "BrowserStack",
+    "os_version": "Tahoe",
+    "browser": "safari",
+    "browser_version": "latest",
+    "device": null,
+    "os": "OS X"
+  }
+}

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -2,12 +2,7 @@ const shared = require('./wdio.shared.conf.js');
 const process = require('process');
 
 const browsers = Object.fromEntries(
-  Object.entries(require('./browsers.json'))
-    .filter(([k, v]) => {
-      // run only on latest; exclude Safari
-      // (Webdriver's `browser.url(...)` times out on Safari if the page loads a video; does it wait for playback to complete?)
-      return v.browser_version === 'latest' && v.browser !== 'safari'
-    })
+  Object.entries(require('./browsers-e2e.json'))
 );
 
 function getCapabilities() {

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -36,7 +36,15 @@ exports.config = {
   ...shared.config,
   services: [
     ['browserstack', {
-      browserstackLocal: true
+      browserstackLocal: true,
+      testReporting: true,
+      testReportingOptions: {
+        projectName: "Prebid.js",
+        buildName: process.env.BROWSERSTACK_BUILD_NAME
+      },
+      opts: {
+        localIdentifier: process.env.BROWSERSTACK_LOCAL_IDENTIFIER,
+      }
     }]
   ],
   user: process.env.BROWSERSTACK_USERNAME,


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] CI related changes

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
