### PR TITLE
CI: error catching in wait-for-browserstack GitHub Action

### DIFF
--- a/.github/actions/wait-for-browserstack/action.yml
+++ b/.github/actions/wait-for-browserstack/action.yml
@@ -5,23 +5,50 @@ inputs:
     description: Number of sessions needed to continue
     default: "6"
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - shell: bash
       run: |
-        while            
-          status=$(curl -u "${BROWSERSTACK_USERNAME}:${BROWSERSTACK_ACCESS_KEY}" \
-            -X GET "https://api-cloud.browserstack.com/automate/plan.json" 2> /dev/null);
-          running=$(jq '.parallel_sessions_running' <<< $status)
-          max_running=$(jq '.parallel_sessions_max_allowed' <<< $status)
-          queued=$(jq '.queued_sessions' <<< $status)
-          max_queued=$(jq '.queued_sessions_max_allowed' <<< $status)
-          spare=$(( ${max_running} + ${max_queued} - ${running} - ${queued} ))
-          required=${{ inputs.sessions }}
-          echo "Browserstack status: ${running} sessions running, ${queued} queued, ${spare} free"
-          (( ${required} > ${spare} ))
-        do
+        required=${{ inputs.sessions }}
+        failures=0
+
+        while true; do
+          if ! status=$(curl --fail --silent --show-error -u "${BROWSERSTACK_USERNAME}:${BROWSERSTACK_ACCESS_KEY}" \
+            -X GET "https://api-cloud.browserstack.com/automate/plan.json"); then
+            failures=$((failures + 1))
+            if (( failures >= 5 )); then
+              echo "BrowserStack plan request failed ${failures} times; giving up"
+              exit 1
+            fi
+          elif ! jq -e 'type == "object"' <<< "$status" > /dev/null; then
+            failures=$((failures + 1))
+            echo "BrowserStack plan response was not JSON object: ${status:0:200}"
+            if (( failures >= 5 )); then
+              echo "BrowserStack returned an invalid plan response ${failures} times; giving up"
+              exit 1
+            fi
+          elif ! jq -e '
+            [.parallel_sessions_running, .parallel_sessions_max_allowed, .queued_sessions, .queued_sessions_max_allowed]
+            | all(type == "number")
+          ' <<< "$status" > /dev/null; then
+            echo "BrowserStack plan response did not include the expected numeric session fields"
+            jq . <<< "$status"
+            exit 1
+          else
+            failures=0
+            running=$(jq -r '.parallel_sessions_running' <<< "$status")
+            max_running=$(jq -r '.parallel_sessions_max_allowed' <<< "$status")
+            queued=$(jq -r '.queued_sessions' <<< "$status")
+            max_queued=$(jq -r '.queued_sessions_max_allowed' <<< "$status")
+            spare=$(( max_running + max_queued - running - queued ))
+            echo "BrowserStack status: ${running} sessions running, ${queued} queued, ${spare} free"
+
+            if (( required <= spare )); then
+              break
+            fi
+          fi
+
           delay=$(( 60 + $(shuf -i 1-60 -n 1) ))
           echo "Waiting for ${required} sessions to free up, checking again in ${delay}s"
-          sleep $delay
+          sleep "$delay"
         done


### PR DESCRIPTION
### Motivation
- Make the `wait-for-browserstack` composite action more resilient to transient network and API errors and to unexpected API responses.
- Validate and parse the BrowserStack plan JSON more strictly to avoid silent failures and incorrect session calculations.

designed to fix the jq -l errors seen here

<img width="1395" height="700" alt="image" src="https://github.com/user-attachments/assets/e37c9554-492c-4401-84af-a8d2fad126bb" />
https://github.com/prebid/Prebid.js/actions/runs/27968438100/job/82769076162