### PR TITLE
CI: pin macos e2e github runner version

### DIFF
--- a/.github/actions/wait-for-browserstack/action.yml
+++ b/.github/actions/wait-for-browserstack/action.yml
@@ -11,11 +11,12 @@ runs:
       run: |
         while            
           status=$(curl -u "${BROWSERSTACK_USERNAME}:${BROWSERSTACK_ACCESS_KEY}" \
-            -X GET "https://api-cloud.browserstack.com/automate/plan.json" 2> /dev/null);
-          running=$(jq '.parallel_sessions_running' <<< $status)
-          max_running=$(jq '.parallel_sessions_max_allowed' <<< $status)
-          queued=$(jq '.queued_sessions' <<< $status)
-          max_queued=$(jq '.queued_sessions_max_allowed' <<< $status)
+            -X GET "https://api-cloud.browserstack.com/automate/plan.json" 2> /dev/null)
+          echo "Response: $status"
+          running=$(jq -e '.parallel_sessions_running' <<< $status || echo "0")
+          max_running=$(jq -e '.parallel_sessions_max_allowed' <<< $status || echo "-1")
+          queued=$(jq -e '.queued_sessions' <<< $status || echo "0")
+          max_queued=$(jq -e '.queued_sessions_max_allowed' <<< $status || echo "0")
           spare=$(( ${max_running} + ${max_queued} - ${running} - ${queued} ))
           required=${{ inputs.sessions }}
           echo "Browserstack status: ${running} sessions running, ${queued} queued, ${spare} free"

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -123,7 +123,7 @@ jobs:
       test-cmd: npx gulp e2e-test-nobuild --local
       chunks: 1
       runs-on: ${{ matrix.browser.runsOn || 'ubuntu-latest' }}
-      install-safari: ${{ matrix.browser.runsOn == 'macos-latest' }}
+      install-safari: ${{ matrix.browser.wdioName == 'safari technology preview' }}
       run-npm-install: ${{ matrix.browser.runsOn == 'windows-latest' }}
       browserstack: false
 

--- a/.github/workflows/browser_testing.json
+++ b/.github/workflows/browser_testing.json
@@ -18,7 +18,7 @@
   },
   "SafariNative": {
     "wdioName": "safari technology preview",
-    "runsOn": "macos-latest",
+    "runsOn": "macos-26",
     "bsName": "safari"
   },
   "FirefoxHeadless": {

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -134,8 +134,14 @@ jobs:
 
       - name: Install safari
         if: ${{ inputs.install-safari }}
+        shell: bash
         run: |
-          brew install --cask safari-technology-preview
+          brew update
+          brew install --cask safari-technology-preview || {
+            brew update-reset
+            brew update
+            brew install --cask safari-technology-preview
+          }
           defaults write com.apple.Safari IncludeDevelopMenu YES
           defaults write com.apple.Safari AllowRemoteAutomation 1
           sudo safaridriver --enable

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -134,14 +134,8 @@ jobs:
 
       - name: Install safari
         if: ${{ inputs.install-safari }}
-        shell: bash
         run: |
-          brew update
-          brew install --cask safari-technology-preview || {
-            brew update-reset
-            brew update
-            brew install --cask safari-technology-preview
-          }
+          brew install --cask safari-technology-preview
           defaults write com.apple.Safari IncludeDevelopMenu YES
           defaults write com.apple.Safari AllowRemoteAutomation 1
           sudo safaridriver --enable


### PR DESCRIPTION
### Motivation

- Improve reliability of the `Install safari` step in the test GitHub Actions workflow by pinning the github runner