### PR TITLE
Linting: prevent redundant conditionals

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -114,6 +114,8 @@ module.exports = [
       '@stylistic/comma-dangle': 'off',
       '@stylistic/semi': ['error', 'always'],
       'no-undef': 2,
+      'no-constant-binary-expression': 'error',
+      'prebid/no-redundant-validated-condition': 'error',
       'no-console': 'error',
       'space-before-function-paren': 'off',
       '@stylistic/space-before-function-paren': 'off',

--- a/modules/abtshieldIdSystem.js
+++ b/modules/abtshieldIdSystem.js
@@ -76,7 +76,7 @@ export const abtshieldIdSubmodule = {
       logError(`${MODULE_NAME}: storage.refreshInSeconds must be >= ${MIN_REFRESH_SECONDS} seconds.`);
       return undefined;
     }
-    const params = (config && config.params) || {};
+    const params = config.params || {};
     const sid = typeof params.sid === 'string' ? params.sid.trim() : '';
     if (!sid) {
       logError(`${MODULE_NAME}: params.sid is required. Obtain a service ID at abtshield.com and set params: { sid: '<your-sid>' }.`);

--- a/modules/cwireBidAdapter.js
+++ b/modules/cwireBidAdapter.js
@@ -318,7 +318,7 @@ export const spec = {
       logInfo("GDPR purpose 1 consent was given, adding user-syncs");
       const type = syncOptions.pixelEnabled
         ? "image"
-        : null ?? syncOptions.iframeEnabled
+        : syncOptions.iframeEnabled
           ? "iframe"
           : null;
       if (type) {

--- a/modules/insticatorBidAdapter.js
+++ b/modules/insticatorBidAdapter.js
@@ -368,7 +368,7 @@ function extractSchain(bids, requestId) {
 
   const schain = bids[0]?.ortb2?.source?.ext?.schain;
   if (!schain) return;
-  if (schain && schain.nodes && schain.nodes.length && schain.nodes[0]) {
+  if (schain.nodes && schain.nodes.length && schain.nodes[0]) {
     schain.nodes[0].rid = requestId;
   }
 

--- a/modules/jwplayerRtdProvider.js
+++ b/modules/jwplayerRtdProvider.js
@@ -54,7 +54,7 @@ export const jwplayerSubmodule = {
 
 config.getConfig('realTimeData', ({ realTimeData }) => {
   const providers = realTimeData.dataProviders;
-  const jwplayerProvider = providers && ((providers) || []).find(pr => pr.name && pr.name.toLowerCase() === SUBMODULE_NAME);
+  const jwplayerProvider = providers && providers.find(pr => pr.name && pr.name.toLowerCase() === SUBMODULE_NAME);
   const params = jwplayerProvider && jwplayerProvider.params;
   if (!params) {
     return;

--- a/modules/magniteAnalyticsAdapter.js
+++ b/modules/magniteAnalyticsAdapter.js
@@ -53,7 +53,6 @@ let pageReferer;
 let auctionIndex = 0; // count of auctions on page
 let accountId;
 let endpoint;
-let cookieless;
 
 const prebidGlobal = getGlobal();
 const {
@@ -336,7 +335,8 @@ const getTopLevelDetails = () => {
   // Add DM wrapper details
   if (rubiConf.wrapperName) {
     let rule = rubiConf.rule_name;
-    if (cookieless) {
+    const isCookieless = !!(rubiConf.cookieless || deepAccess(cache, 'sessionData.cookieless'));
+    if (isCookieless) {
       rule = rule ? rule.concat('_cookieless') : 'cookieless';
     }
     payload.wrapper = {
@@ -704,7 +704,6 @@ magniteAdapter.disableAnalytics = function () {
   magniteAdapter._oldEnable = enableMgniAnalytics;
   endpoint = undefined;
   accountId = undefined;
-  cookieless = undefined;
   auctionIndex = 0;
   resetConfs();
   getHook('callPrebidCache').getHooks({ hook: callPrebidCacheHook }).remove();

--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -617,7 +617,7 @@ function getSua() {
   return {
     browsers: brands,
     mobile: Number(!!mobile),
-    platform: (platform && { brand: platform }) || undefined,
+    platform: { brand: platform },
   };
 }
 

--- a/modules/optidigitalBidAdapter.js
+++ b/modules/optidigitalBidAdapter.js
@@ -81,7 +81,7 @@ export const spec = {
     }
 
     const gdpr = deepAccess(bidderRequest, 'gdprConsent');
-    if (bidderRequest && gdpr) {
+    if (gdpr) {
       const isConsentString = typeof gdpr.consentString === 'string';
       const isGdprApplies = typeof gdpr.gdprApplies === 'boolean';
       payload.gdpr = {
@@ -92,7 +92,7 @@ export const spec = {
         payload.gdpr.addtlConsent = gdpr.addtlConsent;
       }
     }
-    if (bidderRequest && !gdpr) {
+    if (!gdpr) {
       payload.gdpr = {
         consent: '',
         required: false
@@ -115,7 +115,7 @@ export const spec = {
       payload.testMode = true;
     }
 
-    if (bidderRequest && bidderRequest.uspConsent) {
+    if (bidderRequest.uspConsent) {
       payload.us_privacy = bidderRequest.uspConsent;
     }
 

--- a/modules/pubmaticAnalyticsAdapter.js
+++ b/modules/pubmaticAnalyticsAdapter.js
@@ -270,7 +270,7 @@ function getRootLevelDetails(auctionCache, auctionId) {
     tgid: getTgId(),
     s2sls: s2sBidders,
     dm: DISPLAY_MANAGER,
-    dmv: '$prebid.version$' || '-1'
+    dmv: '$prebid.version$'
   };
 }
 

--- a/modules/pubxaiRtdProvider.js
+++ b/modules/pubxaiRtdProvider.js
@@ -86,7 +86,7 @@ export const getUrl = (provider) => {
   if (!endpoint) {
     return null; // Indicate that no endpoint is provided
   }
-  return `${endpoint || FLOORS_END_POINT}?pubxId=${pubxId}&page=${window.location.href}`;
+  return `${endpoint}?pubxId=${pubxId}&page=${window.location.href}`;
 };
 
 export const fetchFloorRules = async (provider) => {

--- a/modules/reconciliationRtdProvider.js
+++ b/modules/reconciliationRtdProvider.js
@@ -153,12 +153,9 @@ function getSlotByCode(code) {
   if (!slots || !slots.length) {
     return null;
   }
-  return (
-    ((
-      slots) || []).find(
-      (s) => s.getSlotElementId() === code || s.getAdUnitPath() === code
-    ) || null
-  );
+  return slots.find(
+    (s) => s.getSlotElementId() === code || s.getAdUnitPath() === code
+  ) || null;
 }
 
 /**
@@ -174,7 +171,7 @@ export function getSlotByWin(win) {
   }
 
   return (
-    ((slots) || []).find((s) => {
+    slots.find((s) => {
       const slotElement = document.getElementById(s.getSlotElementId());
 
       if (slotElement) {

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -298,7 +298,7 @@ export const spec = {
     let filteredRequests;
 
     filteredRequests = bidRequests.filter(req => {
-      const mediaTypes = bidType(req) || [];
+      const mediaTypes = bidType(req);
       const { length } = mediaTypes;
       const { bidonmultiformat, video } = req.params || {};
 
@@ -327,7 +327,7 @@ export const spec = {
     }
 
     const bannerBidRequests = bidRequests.filter((req) => {
-      const mediaTypes = bidType(req) || [];
+      const mediaTypes = bidType(req);
       const { bidonmultiformat, video } = req.params || {};
       return (
         // Send to fastlane if: it must include BANNER and...
@@ -336,10 +336,8 @@ export const spec = {
           (mediaTypes.length === 1) ||
           // if bidonmultiformat is true
           bidonmultiformat ||
-          // if bidonmultiformat is false and there's no video parameter
-          (!bidonmultiformat && !video) ||
-          // if there's video parameter, but there's no video mediatype
-          (!bidonmultiformat && video && !mediaTypes.includes(VIDEO))
+          // if there's no video parameter, or there's video parameter but no video mediaType
+          !video || !mediaTypes.includes(VIDEO)
         )
       );
     });

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -507,7 +507,7 @@ function loadOrCreateFirstPartyData() {
   if (!firstPartyData || !firstPartyData.pcid) {
     var firstPartyId = generateGUID();
     firstPartyData = { pcid: firstPartyId, pcidDate: Date.now() };
-  } else if (firstPartyData && !firstPartyData.pcidDate) {
+  } else if (!firstPartyData.pcidDate) {
     firstPartyData.pcidDate = Date.now();
   }
   storeData(FIRST_PARTY_KEY, JSON.stringify(firstPartyData));

--- a/modules/topicsFpdModule.js
+++ b/modules/topicsFpdModule.js
@@ -233,7 +233,7 @@ export function loadTopicsForBidders(doc = document) {
         ifrm.src = ''.concat(iframeURL, '?bidder=').concat(bidder);
         ifrm.style.display = 'none';
         setLoadedIframeURL(new URL(iframeURL).origin);
-        iframeURL && doc.documentElement.appendChild(ifrm);
+        doc.documentElement.appendChild(ifrm);
       }
 
       if (bidder && fetchUrl) {

--- a/plugins/eslint/index.js
+++ b/plugins/eslint/index.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const { flagErrors } = require('./validateImports.js');
 const { checkDeclarationFilename } = require('./filename.js');
+const noRedundantValidatedCondition = require('./noRedundantValidatedCondition.js');
 
 module.exports = {
   rules: {
@@ -18,6 +19,7 @@ module.exports = {
         };
       }
     },
+    'no-redundant-validated-condition': noRedundantValidatedCondition,
     'validate-imports': {
       meta: {
         docs: {

--- a/plugins/eslint/noRedundantValidatedCondition.js
+++ b/plugins/eslint/noRedundantValidatedCondition.js
@@ -1,0 +1,71 @@
+function exits(node) {
+  if (!node) return false;
+  if (['ReturnStatement', 'ThrowStatement', 'ContinueStatement', 'BreakStatement'].includes(node.type)) return true;
+  if (node.type === 'BlockStatement') return node.body.some(exits);
+  return false;
+}
+
+function collectNegatedIdentifiers(node, names = new Set()) {
+  if (!node) return names;
+  if (node.type === 'UnaryExpression' && node.operator === '!' && node.argument.type === 'Identifier') {
+    names.add(node.argument.name);
+  } else if (node.type === 'LogicalExpression') {
+    collectNegatedIdentifiers(node.left, names);
+    collectNegatedIdentifiers(node.right, names);
+  }
+  return names;
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow redundant conditionals on identifiers already validated by an exiting guard'
+    },
+    schema: []
+  },
+  create(context) {
+    function checkStatements(statements) {
+      const knownTruthy = new Set();
+
+      for (const statement of statements) {
+        if (statement.type === 'IfStatement' && exits(statement.consequent) && statement.alternate == null) {
+          collectNegatedIdentifiers(statement.test).forEach(name => knownTruthy.add(name));
+        }
+
+        if (statement.type === 'BlockStatement') {
+          checkStatements(statement.body);
+        } else if (statement.type === 'IfStatement') {
+          if (statement.consequent?.type === 'BlockStatement') checkStatements(statement.consequent.body);
+          if (statement.alternate?.type === 'BlockStatement') checkStatements(statement.alternate.body);
+        }
+
+        const sourceCode = context.sourceCode || context.getSourceCode();
+        const inspect = (node) => {
+          if (!node || typeof node.type !== 'string') return;
+          if (node.type === 'LogicalExpression' && node.left.type === 'Identifier' && knownTruthy.has(node.left.name)) {
+            context.report({
+              node: node.left,
+              message: `Redundant conditional: '${node.left.name}' is already known to be truthy.`
+            });
+          }
+          for (const key of sourceCode.visitorKeys[node.type] || []) {
+            const child = node[key];
+            if (Array.isArray(child)) child.forEach(inspect);
+            else inspect(child);
+          }
+        };
+        inspect(statement);
+      }
+    }
+
+    return {
+      Program(node) {
+        checkStatements(node.body);
+      },
+      BlockStatement(node) {
+        checkStatements(node.body);
+      }
+    };
+  }
+};

--- a/plugins/eslint/noRedundantValidatedCondition.js
+++ b/plugins/eslint/noRedundantValidatedCondition.js
@@ -1,3 +1,11 @@
+const SCOPE_NODES = new Set([
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'ArrowFunctionExpression',
+  'ClassDeclaration',
+  'ClassExpression'
+]);
+
 function exits(node) {
   if (!node) return false;
   if (['ReturnStatement', 'ThrowStatement', 'ContinueStatement', 'BreakStatement'].includes(node.type)) return true;
@@ -5,13 +13,24 @@ function exits(node) {
   return false;
 }
 
-function collectNegatedIdentifiers(node, names = new Set()) {
+function unwrap(node) {
+  while (node && (node.type === 'ParenthesizedExpression' || node.type === 'ChainExpression')) {
+    node = node.expression;
+  }
+  return node;
+}
+
+function collectFalsyImpliedTruthyIdentifiers(node, names = new Set()) {
+  node = unwrap(node);
   if (!node) return names;
-  if (node.type === 'UnaryExpression' && node.operator === '!' && node.argument.type === 'Identifier') {
-    names.add(node.argument.name);
-  } else if (node.type === 'LogicalExpression') {
-    collectNegatedIdentifiers(node.left, names);
-    collectNegatedIdentifiers(node.right, names);
+  if (node.type === 'UnaryExpression' && node.operator === '!') {
+    const argument = unwrap(node.argument);
+    if (argument?.type === 'Identifier') {
+      names.add(argument.name);
+    }
+  } else if (node.type === 'LogicalExpression' && node.operator === '||') {
+    collectFalsyImpliedTruthyIdentifiers(node.left, names);
+    collectFalsyImpliedTruthyIdentifiers(node.right, names);
   }
   return names;
 }
@@ -25,12 +44,32 @@ module.exports = {
     schema: []
   },
   create(context) {
+    const sourceCode = context.sourceCode || context.getSourceCode();
+
+    function inspect(node, knownTruthy) {
+      node = unwrap(node);
+      if (!node || typeof node.type !== 'string' || SCOPE_NODES.has(node.type)) return;
+      if (node.type === 'LogicalExpression' && node.left.type === 'Identifier' && knownTruthy.has(node.left.name)) {
+        context.report({
+          node: node.left,
+          message: `Redundant conditional: '${node.left.name}' is already known to be truthy.`
+        });
+      }
+      for (const key of sourceCode.visitorKeys[node.type] || []) {
+        const child = node[key];
+        if (Array.isArray(child)) child.forEach(child => inspect(child, knownTruthy));
+        else inspect(child, knownTruthy);
+      }
+    }
+
     function checkStatements(statements) {
       const knownTruthy = new Set();
 
       for (const statement of statements) {
+        inspect(statement, knownTruthy);
+
         if (statement.type === 'IfStatement' && exits(statement.consequent) && statement.alternate == null) {
-          collectNegatedIdentifiers(statement.test).forEach(name => knownTruthy.add(name));
+          collectFalsyImpliedTruthyIdentifiers(statement.test).forEach(name => knownTruthy.add(name));
         }
 
         if (statement.type === 'BlockStatement') {
@@ -39,23 +78,12 @@ module.exports = {
           if (statement.consequent?.type === 'BlockStatement') checkStatements(statement.consequent.body);
           if (statement.alternate?.type === 'BlockStatement') checkStatements(statement.alternate.body);
         }
+      }
+    }
 
-        const sourceCode = context.sourceCode || context.getSourceCode();
-        const inspect = (node) => {
-          if (!node || typeof node.type !== 'string') return;
-          if (node.type === 'LogicalExpression' && node.left.type === 'Identifier' && knownTruthy.has(node.left.name)) {
-            context.report({
-              node: node.left,
-              message: `Redundant conditional: '${node.left.name}' is already known to be truthy.`
-            });
-          }
-          for (const key of sourceCode.visitorKeys[node.type] || []) {
-            const child = node[key];
-            if (Array.isArray(child)) child.forEach(inspect);
-            else inspect(child);
-          }
-        };
-        inspect(statement);
+    function checkFunction(node) {
+      if (node.body?.type === 'BlockStatement') {
+        checkStatements(node.body.body);
       }
     }
 
@@ -63,9 +91,9 @@ module.exports = {
       Program(node) {
         checkStatements(node.body);
       },
-      BlockStatement(node) {
-        checkStatements(node.body);
-      }
+      FunctionDeclaration: checkFunction,
+      FunctionExpression: checkFunction,
+      ArrowFunctionExpression: checkFunction
     };
   }
 };

--- a/plugins/eslint/noRedundantValidatedCondition.js
+++ b/plugins/eslint/noRedundantValidatedCondition.js
@@ -1,5 +1,4 @@
 const SCOPE_NODES = new Set([
-  'BlockStatement',
   'CatchClause',
   'FunctionDeclaration',
   'FunctionExpression',
@@ -56,22 +55,49 @@ function collectPatternIdentifiers(node, names) {
   }
 }
 
-function collectInvalidatedIdentifiers(node, names = new Set()) {
+function collectBlockScopedIdentifiers(statements) {
+  const names = new Set();
+  statements.forEach((statement) => {
+    if (statement.type === 'VariableDeclaration' && statement.kind !== 'var') {
+      statement.declarations.forEach(declarator => collectPatternIdentifiers(declarator.id, names));
+    } else if (statement.type === 'FunctionDeclaration' || statement.type === 'ClassDeclaration') {
+      if (statement.id) names.add(statement.id.name);
+    }
+  });
+  return names;
+}
+
+function collectInvalidatedIdentifiers(node, names = new Set(), shadowed = new Set()) {
   node = unwrap(node);
   if (!node || typeof node.type !== 'string' || SCOPE_NODES.has(node.type)) return names;
 
+  if (node.type === 'BlockStatement') {
+    const blockShadowed = new Set([...shadowed, ...collectBlockScopedIdentifiers(node.body)]);
+    node.body.forEach(statement => collectInvalidatedIdentifiers(statement, names, blockShadowed));
+    return names;
+  }
+
   if (node.type === 'AssignmentExpression') {
-    collectPatternIdentifiers(node.left, names);
+    const assigned = new Set();
+    collectPatternIdentifiers(node.left, assigned);
+    assigned.forEach((name) => {
+      if (!shadowed.has(name)) names.add(name);
+    });
   } else if (node.type === 'UpdateExpression') {
-    collectPatternIdentifiers(node.argument, names);
+    const assigned = new Set();
+    collectPatternIdentifiers(node.argument, assigned);
+    assigned.forEach((name) => {
+      if (!shadowed.has(name)) names.add(name);
+    });
   } else if (node.type === 'VariableDeclarator') {
-    collectPatternIdentifiers(node.id, names);
+    if (node.init) collectInvalidatedIdentifiers(node.init, names, shadowed);
+    return names;
   }
 
   for (const key of collectInvalidatedIdentifiers.visitorKeys[node.type] || []) {
     const child = node[key];
-    if (Array.isArray(child)) child.forEach(child => collectInvalidatedIdentifiers(child, names));
-    else collectInvalidatedIdentifiers(child, names);
+    if (Array.isArray(child)) child.forEach(child => collectInvalidatedIdentifiers(child, names, shadowed));
+    else collectInvalidatedIdentifiers(child, names, shadowed);
   }
   return names;
 }
@@ -88,10 +114,15 @@ module.exports = {
     const sourceCode = context.sourceCode || context.getSourceCode();
     collectInvalidatedIdentifiers.visitorKeys = sourceCode.visitorKeys;
 
-    function inspect(node, knownTruthy) {
+    function inspect(node, knownTruthy, shadowed = new Set()) {
       node = unwrap(node);
       if (!node || typeof node.type !== 'string' || SCOPE_NODES.has(node.type)) return;
-      if (node.type === 'LogicalExpression' && node.left.type === 'Identifier' && knownTruthy.has(node.left.name)) {
+      if (node.type === 'BlockStatement') {
+        const blockShadowed = new Set([...shadowed, ...collectBlockScopedIdentifiers(node.body)]);
+        node.body.forEach(statement => inspect(statement, knownTruthy, blockShadowed));
+        return;
+      }
+      if (node.type === 'LogicalExpression' && node.left.type === 'Identifier' && knownTruthy.has(node.left.name) && !shadowed.has(node.left.name)) {
         context.report({
           node: node.left,
           message: `Redundant conditional: '${node.left.name}' is already known to be truthy.`
@@ -99,8 +130,8 @@ module.exports = {
       }
       for (const key of sourceCode.visitorKeys[node.type] || []) {
         const child = node[key];
-        if (Array.isArray(child)) child.forEach(child => inspect(child, knownTruthy));
-        else inspect(child, knownTruthy);
+        if (Array.isArray(child)) child.forEach(child => inspect(child, knownTruthy, shadowed));
+        else inspect(child, knownTruthy, shadowed);
       }
     }
 

--- a/plugins/eslint/noRedundantValidatedCondition.js
+++ b/plugins/eslint/noRedundantValidatedCondition.js
@@ -1,4 +1,6 @@
 const SCOPE_NODES = new Set([
+  'BlockStatement',
+  'CatchClause',
   'FunctionDeclaration',
   'FunctionExpression',
   'ArrowFunctionExpression',
@@ -35,6 +37,45 @@ function collectFalsyImpliedTruthyIdentifiers(node, names = new Set()) {
   return names;
 }
 
+function collectPatternIdentifiers(node, names) {
+  node = unwrap(node);
+  if (!node) return;
+  if (node.type === 'Identifier') {
+    names.add(node.name);
+  } else if (node.type === 'RestElement') {
+    collectPatternIdentifiers(node.argument, names);
+  } else if (node.type === 'AssignmentPattern') {
+    collectPatternIdentifiers(node.left, names);
+  } else if (node.type === 'ArrayPattern') {
+    node.elements.forEach(element => collectPatternIdentifiers(element, names));
+  } else if (node.type === 'ObjectPattern') {
+    node.properties.forEach((property) => {
+      if (property.type === 'Property') collectPatternIdentifiers(property.value, names);
+      else collectPatternIdentifiers(property.argument, names);
+    });
+  }
+}
+
+function collectInvalidatedIdentifiers(node, names = new Set()) {
+  node = unwrap(node);
+  if (!node || typeof node.type !== 'string' || SCOPE_NODES.has(node.type)) return names;
+
+  if (node.type === 'AssignmentExpression') {
+    collectPatternIdentifiers(node.left, names);
+  } else if (node.type === 'UpdateExpression') {
+    collectPatternIdentifiers(node.argument, names);
+  } else if (node.type === 'VariableDeclarator') {
+    collectPatternIdentifiers(node.id, names);
+  }
+
+  for (const key of collectInvalidatedIdentifiers.visitorKeys[node.type] || []) {
+    const child = node[key];
+    if (Array.isArray(child)) child.forEach(child => collectInvalidatedIdentifiers(child, names));
+    else collectInvalidatedIdentifiers(child, names);
+  }
+  return names;
+}
+
 module.exports = {
   meta: {
     type: 'problem',
@@ -45,6 +86,7 @@ module.exports = {
   },
   create(context) {
     const sourceCode = context.sourceCode || context.getSourceCode();
+    collectInvalidatedIdentifiers.visitorKeys = sourceCode.visitorKeys;
 
     function inspect(node, knownTruthy) {
       node = unwrap(node);
@@ -66,6 +108,7 @@ module.exports = {
       const knownTruthy = new Set();
 
       for (const statement of statements) {
+        collectInvalidatedIdentifiers(statement).forEach(name => knownTruthy.delete(name));
         inspect(statement, knownTruthy);
 
         if (statement.type === 'IfStatement' && exits(statement.consequent) && statement.alternate == null) {

--- a/plugins/eslint/test/noRedundantValidatedCondition.test.js
+++ b/plugins/eslint/test/noRedundantValidatedCondition.test.js
@@ -35,6 +35,15 @@ ruleTester.run('no-redundant-validated-condition', rule, {
           if (foo && bar) bar();
         }
       }
+    `,
+    `
+      function example(foo, bar, maybeNull, cond) {
+        if (!foo) return;
+        if (cond) {
+          foo = maybeNull();
+        }
+        if (foo && bar) bar();
+      }
     `
   ],
   invalid: [

--- a/plugins/eslint/test/noRedundantValidatedCondition.test.js
+++ b/plugins/eslint/test/noRedundantValidatedCondition.test.js
@@ -1,0 +1,51 @@
+const {RuleTester} = require('eslint');
+const rule = require('../noRedundantValidatedCondition.js');
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'script'
+  }
+});
+
+ruleTester.run('no-redundant-validated-condition', rule, {
+  valid: [
+    `
+      function example(foo, bar, maybeNull) {
+        if (!foo) return;
+        foo = maybeNull();
+        if (foo && bar) bar();
+      }
+    `,
+    `
+      function example(foo, bar, maybeNull) {
+        if (!foo) return;
+        {
+          let foo = maybeNull();
+          if (foo && bar) bar();
+        }
+      }
+    `,
+    `
+      function example(foo, bar) {
+        if (!foo) return;
+        try {
+          bar();
+        } catch (foo) {
+          if (foo && bar) bar();
+        }
+      }
+    `
+  ],
+  invalid: [
+    {
+      code: `
+        function example(foo, bar) {
+          if (!foo) return;
+          if (foo && bar) bar();
+        }
+      `,
+      errors: [{message: "Redundant conditional: 'foo' is already known to be truthy."}]
+    }
+  ]
+});

--- a/test/spec/modules/consentManagementUsp_spec.js
+++ b/test/spec/modules/consentManagementUsp_spec.js
@@ -348,7 +348,7 @@ describe('consentManagement', function () {
                   success: true
                 }
               };
-              event.source.postMessage(stringifyResponse ? JSON.stringify(response) : response, '*');
+              event.source.postMessage(response, '*');
               replySent.resolve();
             }
           }

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -302,7 +302,7 @@ describe('onetag', function () {
       });
       it('Should return false when native.ortb if defined but it isn\'t an object', function () {
         const nativeBid = createNativeBid();
-        nativeBid.mediaTypes.native.ortb = 30 || 'string';
+        nativeBid.mediaTypes.native.ortb = 30;
         expect(spec.isBidRequestValid(nativeBid)).to.be.false;
       });
       it('Should return false when native.ortb.assets is not an array', function () {

--- a/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
+++ b/test/spec/modules/pubmaticAnalyticsAdapter_spec.js
@@ -1603,7 +1603,7 @@ describe('pubmatic analytics adapter', function () {
       // Verify display manager
       expect(data.rd.dm).to.equal(DISPLAY_MANAGER);
       // Verify display manager version using global Prebid version
-      expect(data.rd.dmv).to.equal('$prebid.version$' || '-1');
+      expect(data.rd.dmv).to.equal('$prebid.version$');
     });
   });
 });

--- a/test/spec/unit/secureCreatives_spec.js
+++ b/test/spec/unit/secureCreatives_spec.js
@@ -117,7 +117,7 @@ describe('secureCreatives', () => {
         stubEmit
       ].forEach(s => s.resetHistory());
 
-      if (others && others.length > 0) { others.forEach(s => s.resetHistory()); }
+      if (others.length > 0) { others.forEach(s => s.resetHistory()); }
     }
 
     before(function() {


### PR DESCRIPTION
### Motivation
- Reduce noisy/incorrect conditionals flagged by CodeQL by adding a lint rule to detect redundant checks that follow an exiting guard. 
- Replace always-true/always-false fallbacks with simpler, clearer expressions to avoid confusion and potential bugs.

### Description
- Enable ESLint's `no-constant-binary-expression` rule and add a custom rule `prebid/no-redundant-validated-condition` in `eslint.config.js` to catch redundant conditionals. 
- Add a new custom rule implementation at `plugins/eslint/noRedundantValidatedCondition.js` and register it in `plugins/eslint/index.js`.