### PR TITLE
AdPlayerPro Adapter: fix provider spec player setup

### DIFF
--- a/test/spec/modules/videoModule/submodules/adplayerproVideoProvider_spec.js
+++ b/test/spec/modules/videoModule/submodules/adplayerproVideoProvider_spec.js
@@ -89,13 +89,14 @@ describe('AdPlayerProProvider', function () {
   let config;
   let callbackStorage;
   let utilsMock;
+  let player;
 
   beforeEach(() => {
     addDiv();
     config = { divId: 'test', playerConfig: { placementId: 'testId' } };
     callbackStorage = callbackStorageFactory();
     utilsMock = getUtilsMock();
-    getPlayerMock();
+    player = getPlayerMock();
   });
 
   afterEach(() => {


### PR DESCRIPTION
### Motivation
- Tests in the AdPlayerPro provider spec were failing with `ReferenceError: player is not defined` because the per-test `player` mock was not declared or assigned in the spec scope.

### Description
- Declare a scoped `player` variable and assign `player = getPlayerMock()` in `beforeEach` in `test/spec/modules/videoModule/submodules/adplayerproVideoProvider_spec.js` so each test gets a proper player mock and no longer references an undefined variable.

### Testing
- Ran `npx eslint --cache --cache-strategy content test/spec/modules/videoModule/submodules/adplayerproVideoProvider_spec.js` which passed, and ran `npx gulp test --nolint --file test/spec/modules/videoModule/submodules/adplayerproVideoProvider_spec.js` which completed successfully with 28 tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39ae7dd36c832b840eb94680a0557e)