### PR TITLE
Tests: fix chunk 6 failures

### DIFF
--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -1537,7 +1537,7 @@ describe('S2S Adapter', function () {
                 const origConvertCurrency = getGlobal().convertCurrency;
                 beforeEach(() => {
                   if (conversionFn) {
-                    sinon.stub().callsFake(conversionFn);
+                    getGlobal().convertCurrency = sinon.stub().callsFake(conversionFn);
                   } else {
                     delete getGlobal().convertCurrency;
                   }

--- a/test/spec/modules/pubxBidAdapter_spec.js
+++ b/test/spec/modules/pubxBidAdapter_spec.js
@@ -91,7 +91,7 @@ describe('pubxAdapter', function () {
     });
 
     afterEach(function () {
-      documentStubMeta.restore();
+      sandbox.restore();
     });
 
     let kwString = '';
@@ -126,6 +126,8 @@ describe('pubxAdapter', function () {
       if (titleText.length > 30) {
         titleText = titleText.substr(0, 30);
       }
+
+      sandbox.stub(document, 'title').value('title1title2title3title4title5title');
 
       const syncs = spec.getUserSyncs({ iframeEnabled: true });
       expect(syncs[0].url).to.include(`pt=${encodeURIComponent(titleText)}`);

--- a/test/spec/modules/r2b2BidAdapter_spec.js
+++ b/test/spec/modules/r2b2BidAdapter_spec.js
@@ -354,6 +354,7 @@ describe('R2B2 adapter', function () {
     });
 
     it('should set up internal variables', function () {
+      spec.buildRequests(bids, bidderRequest);
       const bid1Id = bids[0].bidId;
       const bid2Id = bids[1].bidId;
       expect(r2b2.placementsToSync).to.be.an('array').that.has.lengthOf(2);

--- a/test/spec/modules/rivrAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rivrAnalyticsAdapter_spec.js
@@ -33,9 +33,10 @@ describe('RIVR Analytics adapter', () => {
   });
 
   beforeEach(() => {
+    rivraddonsTrackPbjsEventStub = sandbox.stub(window.rivraddon.analytics, 'trackPbjsEvent');
     timer = sandbox.useFakeTimers(0);
     ajaxStub = sandbox.stub(ajax, 'ajax');
-    sinon.stub(events, 'getEvents').returns([]);
+    sandbox.stub(events, 'getEvents').returns([]);
 
     adapterManager.registerAnalyticsAdapter({
       code: 'rivr',
@@ -53,6 +54,10 @@ describe('RIVR Analytics adapter', () => {
 
   afterEach(() => {
     analyticsAdapter.disableAnalytics();
+    rivraddonsTrackPbjsEventStub.restore();
+    if (window.rivraddon.analytics.getContext.restore) {
+      window.rivraddon.analytics.getContext.restore();
+    }
     events.getEvents.restore();
     ajaxStub.restore();
     timer.restore();
@@ -75,21 +80,16 @@ describe('RIVR Analytics adapter', () => {
   });
 
   it('Firing an event when rivraddon context is not defined it should do nothing', () => {
-    rivraddonsTrackPbjsEventStub = sandbox.stub(window.rivraddon.analytics, 'trackPbjsEvent');
+    sandbox.stub(window.rivraddon.analytics, 'getContext').returns(undefined);
 
     expect(rivraddonsTrackPbjsEventStub.callCount).to.be.equal(0);
 
     events.emit(EVENTS.AUCTION_INIT, { auctionId: EMITTED_AUCTION_ID, config: {}, timeout: 3000 });
 
     expect(rivraddonsTrackPbjsEventStub.callCount).to.be.equal(0);
-
-    window.rivraddon.analytics.getContext.restore();
-    window.rivraddon.analytics.trackPbjsEvent.restore();
   });
 
   it('Firing AUCTION_INIT should call rivraddon trackPbjsEvent passing the parameters', () => {
-    rivraddonsTrackPbjsEventStub = sandbox.stub(window.rivraddon.analytics, 'trackPbjsEvent');
-
     expect(rivraddonsTrackPbjsEventStub.callCount).to.be.equal(0);
 
     events.emit(EVENTS.AUCTION_INIT, { auctionId: EMITTED_AUCTION_ID, config: {}, timeout: 3000 });
@@ -99,8 +99,6 @@ describe('RIVR Analytics adapter', () => {
     const firstArgument = rivraddonsTrackPbjsEventStub.getCall(0).args[0];
     expect(firstArgument.eventType).to.be.equal(EVENTS.AUCTION_INIT);
     expect(firstArgument.args.auctionId).to.be.equal(EMITTED_AUCTION_ID);
-
-    window.rivraddon.analytics.trackPbjsEvent.restore();
   });
 
   const BANNER_AD_UNITS_MOCK = [


### PR DESCRIPTION
### Motivation
- Stabilize a failing test chunk by fixing incorrect or leaking test stubs and ensuring test setup exercises the code paths under test.

### Description
- Install the stubbed currency conversion on `getGlobal().convertCurrency` in `test/spec/modules/prebidServerBidAdapter_spec.js` so currency-conversion scenarios are invoked as intended.
- Make the PubX user-sync title spec deterministic by stubbing `document.title` via the test `sandbox` and restoring sandbox state in `test/spec/modules/pubxBidAdapter_spec.js`.
- Ensure R2B2 internal state is populated before assertions by calling `spec.buildRequests(bids, bidderRequest)` in `test/spec/modules/r2b2BidAdapter_spec.js`.
- Isolate RIVR analytics tests in `test/spec/modules/rivrAnalyticsAdapter_spec.js` by stubbing `trackPbjsEvent` in `beforeEach`, using `sandbox.stub(events, 'getEvents')`, restoring the `trackPbjsEvent` stub and `getContext` when applicable, and testing the undefined-context path explicitly.

### Testing
- Ran lint on modified specs with `npx eslint <files> --cache --cache-strategy content` and it passed for the changed files.
- Ran the affected specs with `npx gulp test --nolint --file test/spec/modules/prebidServerBidAdapter_spec.js --file test/spec/modules/pubxBidAdapter_spec.js --file test/spec/modules/r2b2BidAdapter_spec.js --file test/spec/modules/rivrAnalyticsAdapter_spec.js` and the chunk passed.
- Ran `npx gulp test --nolint --file test/spec/modules/rivrAnalyticsAdapter_spec.js` during iterative fixes and it passed after the adjustments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39ae22769c832b9d3d2c41fcc3360d)