### PR TITLE
Tests: fix chunk3 strict-mode specs

### DIFF
--- a/test/spec/modules/browsiRtdProvider_spec.js
+++ b/test/spec/modules/browsiRtdProvider_spec.js
@@ -66,7 +66,7 @@ describe('browsi Real time data sub module', function () {
   });
 
   it('should return correct macro values', function () {
-    mockGpt.makeSlot({ code: '/123/abc', divId: 'browsiAd_1' });
+    const slot = mockGpt.makeSlot({ code: '/123/abc', divId: 'browsiAd_1' });
 
     slot.setTargeting('test', ['test', 'value']);
     // slot getTargeting doesn't act like GPT so we can't expect real value

--- a/test/spec/modules/chromeAiRtdProvider_spec.js
+++ b/test/spec/modules/chromeAiRtdProvider_spec.js
@@ -78,10 +78,6 @@ describe('Chrome AI RTD Provider', function () {
       addEventListener: sandbox.stub()
     };
 
-    // Reset mock availability to default values
-    mockLanguageDetectorAvailability = 'available';
-    mockSummarizerAvailability = 'available';
-
     // Mock global Chrome AI API constructors and their methods
     // LanguageDetector
     const MockLanguageDetectorFn = function () { /* This constructor body isn't called by the module */ };

--- a/test/spec/modules/condorxBidAdapter_spec.js
+++ b/test/spec/modules/condorxBidAdapter_spec.js
@@ -453,23 +453,6 @@ describe('CondorX Bid Adapter Tests', function () {
           config: '{"css":".__condorx_banner_title{display:block!important;}"}'
         },
       };
-
-      ortbResponseData = {
-        id: 'response-123',
-        seatbid: [{
-          bid: [{
-            id: 'bid-123',
-            impid: 'condorx121212',
-            price: 0.5,
-            adm: '<div>Test Banner Ad</div>',
-            w: 300,
-            h: 250,
-            crid: '12345',
-            adomain: ['condorx.test']
-          }]
-        }],
-        cur: 'USD'
-      };
     });
 
     it('should return an empty array for missing response', function () {

--- a/test/spec/modules/confiantRtdProvider_spec.js
+++ b/test/spec/modules/confiantRtdProvider_spec.js
@@ -37,7 +37,7 @@ describe('Confiant RTD module', function () {
 
   describe('Module initialization', function() {
     beforeEach(function() {
-      insertElementStub = sinon.stub(utils, 'insertElement');
+      sinon.stub(utils, 'insertElement');
     });
     afterEach(function() {
       utils.insertElement.restore();
@@ -92,7 +92,7 @@ describe('Confiant RTD module', function () {
 
     beforeEach(function () {
       submoduleStub = sinon.stub(hook, 'submodule');
-      insertElementStub = sinon.stub(utils, 'insertElement');
+      sinon.stub(utils, 'insertElement');
     });
     afterEach(function () {
       utils.insertElement.restore();

--- a/test/spec/modules/connatixBidAdapter_spec.js
+++ b/test/spec/modules/connatixBidAdapter_spec.js
@@ -348,6 +348,7 @@ describe('connatixBidAdapter', function () {
     });
 
     it('call event if bidder is connatix', () => {
+      spec.onTimeout([{ bidder: 'connatix', timeout: 500 }]);
       expect(ajaxStub.calledOnce).to.equal(true);
 
       const data = ajaxStub.firstCall.args[0];
@@ -356,6 +357,7 @@ describe('connatixBidAdapter', function () {
     });
 
     it('timeout event is not triggered if bidder is not connatix', () => {
+      spec.onTimeout([{ bidder: 'other', timeout: 500 }]);
       expect(ajaxStub.notCalled).to.equal(true);
     });
   });

--- a/test/spec/modules/consentManagementGpp_spec.js
+++ b/test/spec/modules/consentManagementGpp_spec.js
@@ -407,7 +407,6 @@ describe('consentManagementGpp', function () {
 
     describe('error checks:', function () {
       beforeEach(function () {
-        didHookReturn = false;
         sinon.stub(utils, 'logWarn');
         sinon.stub(utils, 'logError');
       });

--- a/test/spec/modules/contxtfulRtdProvider_spec.js
+++ b/test/spec/modules/contxtfulRtdProvider_spec.js
@@ -96,7 +96,7 @@ describe('contxtfulRtdProvider', function () {
     RX_CONNECTOR_MOCK.rxApiBuilder.resetHistory();
     RX_CONNECTOR_MOCK.rxApiBuilder.callsFake((_config) => new Promise((resolve, reject) => resolve(RX_API_MOCK)));
 
-    eventsEmitSpy = sandbox.spy(events, ['emit']);
+    sandbox.spy(events, ['emit']);
 
     sandbox.stub(utils, 'generateUUID').returns(SM);
 

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -151,7 +151,7 @@ describe('The Criteo bidding adapter', function () {
       getCookieStub = sandbox.stub(storage, 'getCookie');
       setCookieStub = sandbox.stub(storage, 'setCookie');
       getDataFromLocalStorageStub = sandbox.stub(storage, 'getDataFromLocalStorage');
-      setDataInLocalStorageStub = sandbox.stub(storage, 'setDataInLocalStorage');
+      sandbox.stub(storage, 'setDataInLocalStorage');
       removeDataFromLocalStorageStub = sandbox.stub(storage, 'removeDataFromLocalStorage');
 
       triggerPixelStub = sandbox.stub(utils, 'triggerPixel');

--- a/test/spec/modules/dataController_spec.js
+++ b/test/spec/modules/dataController_spec.js
@@ -4,9 +4,7 @@ import { filterBidData, init } from 'modules/dataControllerModule/index.js';
 import { startAuction } from 'src/prebid.js';
 
 describe('data controller', function () {
-  beforeEach(function () {
-    spyFn = sinon.spy();
-  });
+  let result; // eslint-disable-line no-unused-vars
 
   afterEach(function () {
     config.resetConfig();

--- a/test/spec/modules/dochaseBidAdapter_spec.js
+++ b/test/spec/modules/dochaseBidAdapter_spec.js
@@ -4,7 +4,7 @@ import * as utils from '../../../src/utils.js';
 
 describe('dochase adapter', function () {
   let bannerRequest, nativeRequest;
-  let bannerResponse, nativeResponse, invalidBannerResponse;
+  let bannerResponse, nativeResponse, invalidBannerResponse, invalidNativeResponse; // eslint-disable-line no-unused-vars
 
   beforeEach(function () {
     bannerRequest = [

--- a/test/spec/modules/dxkultureBidAdapter_spec.js
+++ b/test/spec/modules/dxkultureBidAdapter_spec.js
@@ -583,7 +583,7 @@ describe('dxkultureBidAdapter', function() {
     let bidderResponse;
     beforeEach(function() {
       const bidderRequest = getVideoRequest();
-      bidRequest = spec.buildRequests(bidderRequest.bids, bidderRequest);
+      spec.buildRequests(bidderRequest.bids, bidderRequest);
       bidderResponse = getBidderResponse();
     });
 

--- a/test/spec/modules/dxtechBidAdapter_spec.js
+++ b/test/spec/modules/dxtechBidAdapter_spec.js
@@ -192,6 +192,7 @@ const getBidderResponse = () => {
 };
 
 describe('dxtechBidAdapter', function() {
+  let videoBidRequest; // eslint-disable-line no-unused-vars
   beforeEach(function () {
     videoBidRequest = {
       mediaTypes: {

--- a/test/spec/modules/ehealthcaresolutionsBidAdapter_spec.js
+++ b/test/spec/modules/ehealthcaresolutionsBidAdapter_spec.js
@@ -4,7 +4,7 @@ import * as utils from '../../../src/utils.js';
 
 describe('ehealthcaresolutions adapter', function () {
   let bannerRequest, nativeRequest;
-  let bannerResponse, nativeResponse, invalidBannerResponse;
+  let bannerResponse, nativeResponse, invalidBannerResponse, invalidNativeResponse; // eslint-disable-line no-unused-vars
 
   beforeEach(function () {
     bannerRequest = [

--- a/test/spec/modules/eplanningBidAdapter_spec.js
+++ b/test/spec/modules/eplanningBidAdapter_spec.js
@@ -1114,6 +1114,7 @@ describe('E-Planning Adapter', function () {
     let getLocalStorageSpy;
     let setDataInLocalStorageSpy;
     let hasLocalStorageStub;
+    let respuesta;
     let clock;
     let element;
 
@@ -1134,7 +1135,7 @@ describe('E-Planning Adapter', function () {
         };
       };
 
-      intersectionObserverStub = sandbox.stub(window, 'IntersectionObserver').callsFake(fakeIntersectionObserver);
+      sandbox.stub(window, 'IntersectionObserver').callsFake(fakeIntersectionObserver);
     }
     function createElement(id) {
       element = document.createElement('div');
@@ -1266,7 +1267,6 @@ describe('E-Planning Adapter', function () {
     });
 
     context('when element is fully in view', function() {
-      let respuesta;
       beforeEach(function () {
         createElementVisible();
         setIntersectionObserverMock({ [ADUNIT_CODE_VIEW]: { 'ratio': 1, 'isIntersecting': true, 'width': 200, 'height': 200 } });
@@ -1304,7 +1304,6 @@ describe('E-Planning Adapter', function () {
     });
 
     context('when element is out of view', function() {
-      let respuesta;
       beforeEach(function () {
         createElementOutOfView();
         setIntersectionObserverMock({ [ADUNIT_CODE_VIEW]: { 'ratio': 0, 'isIntersecting': false, 'width': 200, 'height': 200 } });
@@ -1407,7 +1406,6 @@ describe('E-Planning Adapter', function () {
       });
     });
     context('when there are multiple adunit', function() {
-      let respuesta;
       beforeEach(function () {
         [ADUNIT_CODE_VIEW, ADUNIT_CODE_VIEW2, ADUNIT_CODE_VIEW3].forEach(ac => {
           storage.setDataInLocalStorage('pbsr_' + ac, 5);
@@ -1481,10 +1479,16 @@ describe('E-Planning Adapter', function () {
   });
   describe('Send eids', function() {
     let sandbox;
+    let addedGetUserIds;
     beforeEach(() => {
       sandbox = sinon.createSandbox();
+      const global = getGlobal();
+      addedGetUserIds = !global.getUserIds;
+      if (addedGetUserIds) {
+        global.getUserIds = () => {};
+      }
       // TODO: bid adapters should look at request data, not call getGlobal().getUserIds
-      sandbox.stub(getGlobal(), 'getUserIds').callsFake(() => ({
+      sandbox.stub(global, 'getUserIds').callsFake(() => ({
         pubcid: 'c29cb2ae-769d-42f6-891a-f53cadee823d',
         tdid: 'D6885E90-2A7A-4E0F-87CB-7734ED1B99A3',
         id5id: { uid: 'ID5-ZHMOL_IfFSt7_lVYX8rBZc6GH3XMWyPQOBUfr4bm0g!', ext: { linkType: 1 } }
@@ -1493,6 +1497,9 @@ describe('E-Planning Adapter', function () {
 
     afterEach(() => {
       sandbox.restore();
+      if (addedGetUserIds) {
+        delete getGlobal().getUserIds;
+      }
     });
 
     it('should add eids to the request', function() {


### PR DESCRIPTION
### Motivation
- Fix multiple failing tests in the chunk3 bundle caused by undeclared or unused test setup state and strict-mode issues when specs are bundled by Karma.

### Description
- Scoped the mocked GPT slot in the Browsi macro test by assigning `const slot = mockGpt.makeSlot(...)` to avoid a ReferenceError. 
- Removed or inlined stale/unused test setup variables (Chrome AI availability, CondorX/Confiant/Contxtful/Criteo setup stubs) and declared or annotated test-scoped variables to prevent strict-mode/no-unused-vars failures across specs. 
- Adjusted Connatix timeout tests to explicitly invoke `spec.onTimeout(...)` before asserting `triggerEvent` behavior to avoid relying on implicit global state. 
- Fixed E-Planning viewability and eids tests by declaring shared `respuesta` state, stubbing `IntersectionObserver` without leaking a global holder, and adding a temporary `getUserIds` when the global is absent so the spec can stub it safely.

### Testing
- Ran ESLint on the modified specs with `npx eslint test/spec/modules/{browsiRtdProvider,chromeAiRtdProvider,condorxBidAdapter,confiantRtdProvider,connatixBidAdapter,consentManagementGpp,contxtfulRtdProvider,criteoBidAdapter,dataController,dochaseBidAdapter,dxkultureBidAdapter,dxtechBidAdapter,ehealthcaresolutionsBidAdapter,eplanningBidAdapter}_spec.js --cache --cache-strategy content` and the lint run completed successfully. 
- Ran the targeted Karma/Gulp suite with `npx gulp test --nolint --file <each modified spec file>` and verified the targeted specs completed successfully (all targeted tests passed; final run reported 520 tests completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39adc36860832bad0124493f9d7eda)