### PR TITLE
Maintenance: fix chunk 2 adapter specs

### DIFF
--- a/test/spec/modules/adkernelBidAdapter_spec.js
+++ b/test/spec/modules/adkernelBidAdapter_spec.js
@@ -375,7 +375,7 @@ describe('Adkernel adapter', function () {
     let bidRequest, bidRequests;
 
     before(function () {
-      [_, bidRequests] = buildRequest([bid1_zone1]);
+      [, bidRequests] = buildRequest([bid1_zone1]);
       bidRequest = bidRequests[0];
     });
 
@@ -498,7 +498,7 @@ describe('Adkernel adapter', function () {
   describe('video request building', function () {
     let bidRequests;
     before(function () {
-      [_, bidRequests] = buildRequest([bid_video]);
+      [, bidRequests] = buildRequest([bid_video]);
     });
 
     it('should have video object', function () {
@@ -725,7 +725,7 @@ describe('Adkernel adapter', function () {
   describe('native support', () => {
     let bidRequests;
     before(function () {
-      [_, bidRequests] = buildRequest([bid_native]);
+      [, bidRequests] = buildRequest([bid_native]);
     });
 
     it('native request building', () => {

--- a/test/spec/modules/adlaneRtdProvider_spec.js
+++ b/test/spec/modules/adlaneRtdProvider_spec.js
@@ -196,6 +196,12 @@ describe('adlane Module', () => {
 
   describe('adlaneSubmodule', () => {
     it('should init with AdlCmp present', () => {
+      sandbox.stub(utils, 'getWindowTop').returns({
+        AdlCmp: {
+          getAgeVerification: () => ({ status: 'accepted' })
+        }
+      });
+
       expect(adlaneSubmodule.init()).to.be.true;
     });
 

--- a/test/spec/modules/aniviewBidAdapter_spec.js
+++ b/test/spec/modules/aniviewBidAdapter_spec.js
@@ -87,7 +87,7 @@ const MOCK = {
           currency: CURRENCY,
           floor: FLOOR_PRICE,
         },
-        getFloor: _ => ({
+        getFloor: () => ({
           currency: CURRENCY,
           floor: FLOOR_PRICE,
         }),
@@ -183,7 +183,7 @@ describe('Aniview Bid Adapter', function () {
     });
 
     it('should return expected request object', function () {
-      spec.buildRequests(videoBidRequest.bids, videoBidRequest);
+      const bidRequest = spec.buildRequests(videoBidRequest.bids, videoBidRequest);
 
       expect(bidRequest).to.exist.and.to.be.a('array').and.to.have.lengthOf(2);
 
@@ -198,7 +198,7 @@ describe('Aniview Bid Adapter', function () {
     });
 
     it('should have floor data inside imp', function () {
-      spec.buildRequests(videoBidRequest.bids, videoBidRequest);
+      const bidRequest = spec.buildRequests(videoBidRequest.bids, videoBidRequest);
       const imp = bidRequest[1].data.imp[0];
 
       expect(imp.bidfloor).equal(FLOOR_PRICE);
@@ -206,7 +206,7 @@ describe('Aniview Bid Adapter', function () {
     });
 
     it('should have replacements in request', function () {
-      spec.buildRequests(videoBidRequest.bids, videoBidRequest);
+      const bidRequest = spec.buildRequests(videoBidRequest.bids, videoBidRequest);
       const { replacements } = bidRequest[1].data.ext.aniview;
 
       expect(replacements.AV_CDIM1).equal(REPLACEMENT_1);
@@ -215,7 +215,7 @@ describe('Aniview Bid Adapter', function () {
     it('should not have floor data in imp if getFloor returns empty object', function () {
       videoBidRequest.bids[1].getFloor = () => ({});
 
-      spec.buildRequests(videoBidRequest.bids, videoBidRequest);
+      const bidRequest = spec.buildRequests(videoBidRequest.bids, videoBidRequest);
       const imp = bidRequest[1].data.imp[0];
 
       expect(imp.bidfloor).not.exist;
@@ -240,7 +240,7 @@ describe('Aniview Bid Adapter', function () {
       const DEV_ENDPOINT = 'https://dev.aniview.com/sspRTB2';
       videoBidRequest.bids[0].params.dev = { endpoint: DEV_ENDPOINT };
 
-      spec.buildRequests(videoBidRequest.bids, videoBidRequest);
+      const bidRequest = spec.buildRequests(videoBidRequest.bids, videoBidRequest);
 
       expect(bidRequest[0].url).to.equal(DEV_ENDPOINT);
     });


### PR DESCRIPTION
### Motivation
- Fix failing tests in chunk 2 caused by test-suite mistakes (undefined placeholder binding, unused placeholder param, and missing fixture stub) so CI chunk completes reliably.

### Description
- Replace assignments that used an undefined `_` placeholder in destructuring with an empty slot, e.g. change `[_, bidRequests] = buildRequest(...)` to `[, bidRequests] = buildRequest(...)` in `test/spec/modules/adkernelBidAdapter_spec.js`.
- Replace the underscore parameter used in a floor provider with a proper zero-arg function, changing `getFloor: _ => ({ ... })` to `getFloor: () => ({ ... })` in `test/spec/modules/aniviewBidAdapter_spec.js`.
- Capture `spec.buildRequests(...)` return values into local `const bidRequest` variables in `test/spec/modules/aniviewBidAdapter_spec.js` instead of relying on a global `bidRequest` binding.
- Make the adlane RTD init test exercise the AdlCmp-present path by stubbing `utils.getWindowTop()` to return an `AdlCmp` object with `getAgeVerification()` in `test/spec/modules/adlaneRtdProvider_spec.js`.

### Testing
- Ran lint on the modified specs with `npx eslint test/spec/modules/adkernelBidAdapter_spec.js test/spec/modules/adlaneRtdProvider_spec.js test/spec/modules/aniviewBidAdapter_spec.js --cache --cache-strategy content` and it completed without errors.
- Ran focused test runs with `npx gulp test --nolint --file test/spec/modules/adkernelBidAdapter_spec.js`, `npx gulp test --nolint --file test/spec/modules/adlaneRtdProvider_spec.js`, and `npx gulp test --nolint --file test/spec/modules/aniviewBidAdapter_spec.js`, and the spec chunks completed successfully (tests in each file ran and passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39ad95e0a8832bb727583a4ae18f0a)