### PR TITLE
Maintenance: fix chunk 4 module tests

### DIFF
--- a/test/spec/modules/gamoshiBidAdapter_spec.js
+++ b/test/spec/modules/gamoshiBidAdapter_spec.js
@@ -83,37 +83,6 @@ describe('GamoshiAdapter', () => {
       refererInfo: { referer: 'http://examplereferer.com' }
     };
 
-    bannerRequestWithEids = {
-      'adUnitCode': 'adunit-code',
-      'auctionId': 'auction-id-12345',
-      'mediaTypes': {
-        banner: {}
-      },
-      'params': {
-        'supplyPartnerId': supplyPartnerId
-      },
-      userIdAsEids: [
-        {
-          source: '1.test.org',
-          uids: [{
-            id: '11111',
-            atype: 1,
-          }]
-        },
-        {
-          source: '2.test.org',
-          uids: [{
-            id: '11111',
-            atype: 1,
-          }]
-        }
-      ],
-      'sizes': [[300, 250], [300, 600]],
-      'transactionId': '1d1a030790a475',
-      'bidId': 'request-id-12345',
-      refererInfo: { referer: 'http://examplereferer.com' }
-    };
-
     videoBidRequest = {
       'adUnitCode': 'adunit-code',
       'auctionId': 'auction-id-12345',

--- a/test/spec/modules/goadserverBidAdapter_spec.js
+++ b/test/spec/modules/goadserverBidAdapter_spec.js
@@ -398,10 +398,6 @@ describe('goadserverBidAdapter', function () {
   });
 
   describe('onBidWon', function () {
-    beforeEach(function () {
-      triggerPixelStub = sinon.stub();
-    });
-
     it('does not throw on a bid without nurl', function () {
       expect(() => spec.onBidWon({})).to.not.throw();
     });

--- a/test/spec/modules/impactifyBidAdapter_spec.js
+++ b/test/spec/modules/impactifyBidAdapter_spec.js
@@ -27,8 +27,8 @@ describe('ImpactifyAdapter', function () {
     };
     sinon.stub(document.body, 'appendChild');
     sandbox = sinon.createSandbox();
-    getLocalStorageStub = sandbox.stub(STORAGE, 'getDataFromLocalStorage');
-    localStorageIsEnabledStub = sandbox.stub(STORAGE, 'localStorageIsEnabled');
+    sandbox.stub(STORAGE, 'getDataFromLocalStorage');
+    sandbox.stub(STORAGE, 'localStorageIsEnabled');
   });
 
   afterEach(function () {

--- a/test/spec/modules/intentIqIdSystem_spec.js
+++ b/test/spec/modules/intentIqIdSystem_spec.js
@@ -1141,9 +1141,7 @@ describe('IntentIQ tests', function () {
           partnerClientId,
           browserBlackList: 'Chrome',
           iiqPixelServerAddress: syncTestAPILink,
-          callback: () => {
-            wasCallbackCalled = true;
-          }
+          callback: () => {}
         }
       };
 

--- a/test/spec/modules/invibesBidAdapter_spec.js
+++ b/test/spec/modules/invibesBidAdapter_spec.js
@@ -1356,6 +1356,7 @@ describe('invibesBidAdapter:', function () {
       });
 
       it('does not make multiple bids', function () {
+        spec.interpretResponse({ body: response }, { bidRequests });
         const secondResult = spec.interpretResponse({ body: response }, { bidRequests });
         expect(secondResult).to.be.empty;
       });
@@ -1407,6 +1408,7 @@ describe('invibesBidAdapter:', function () {
       });
 
       it('doesnt register the second ad when it is blacklisted by the first', function() {
+        spec.interpretResponse({ body: buildResponse('12345', 1, [2], 123) }, { bidRequests });
         var secondResponse = buildResponse('abcde', 2, [], 456);
 
         var secondResult = spec.interpretResponse({ body: secondResponse }, { bidRequests });
@@ -1414,6 +1416,7 @@ describe('invibesBidAdapter:', function () {
       });
 
       it('doesnt register the second ad when it is blacklisting the first', function() {
+        spec.interpretResponse({ body: buildResponse('12345', 1, [], 123) }, { bidRequests });
         var secondResponse = buildResponse('abcde', 2, [1], 456);
 
         var secondResult = spec.interpretResponse({ body: secondResponse }, { bidRequests });
@@ -1421,6 +1424,7 @@ describe('invibesBidAdapter:', function () {
       });
 
       it('doesnt register the second ad when it has same ids as the first', function() {
+        spec.interpretResponse({ body: buildResponse('12345', 1, [], 123) }, { bidRequests });
         var secondResponse = buildResponse('abcde', 1, [1], 456);
 
         var secondResult = spec.interpretResponse({ body: secondResponse }, { bidRequests });

--- a/test/spec/modules/jwplayerRtdProvider_spec.js
+++ b/test/spec/modules/jwplayerRtdProvider_spec.js
@@ -370,8 +370,6 @@ describe('jwplayerRtdProvider', function() {
     let clock;
 
     beforeEach(function () {
-      bidRequestSpy = sinon.spy();
-
       clock = sinon.useFakeTimers();
     });
 


### PR DESCRIPTION
### Motivation
- Prevent ReferenceError/TypeError failures observed when running chunked tests by removing stale undeclared test variables and making tests self-contained so they can run in isolation.
- Remove ordering dependencies in tests that assumed state persisted across unrelated spec files to stabilize chunked CI runs.

### Description
- Removed an unused `bannerRequestWithEids` fixture from `test/spec/modules/gamoshiBidAdapter_spec.js` to avoid an undeclared reference in chunked runs.
- Eliminated an unused `triggerPixelStub` declaration from `test/spec/modules/goadserverBidAdapter_spec.js` and let the adapter tests rely on local stubs where required.
- Replaced assignments to undeclared storage stub variables in `test/spec/modules/impactifyBidAdapter_spec.js` with sandbox stubs to avoid leaking Sinon state across hooks.
- Replaced a test-local `wasCallbackCalled` assignment in `test/spec/modules/intentIqIdSystem_spec.js` with a noop callback to prevent a missing-variable error when tests are executed by chunk.
- Seeded prior bid state at the start of each relevant test in `test/spec/modules/invibesBidAdapter_spec.js` so multiposition/blacklist/conflict assertions no longer depend on test ordering.
- Removed an unused `bidRequestSpy` declaration from `test/spec/modules/jwplayerRtdProvider_spec.js` and ensured fake-timer usage remains local to each test.

### Testing
- Ran lint on the modified specs with `npx eslint 'test/spec/modules/gamoshiBidAdapter_spec.js' 'test/spec/modules/goadserverBidAdapter_spec.js' 'test/spec/modules/impactifyBidAdapter_spec.js' 'test/spec/modules/intentIqIdSystem_spec.js' 'test/spec/modules/invibesBidAdapter_spec.js' 'test/spec/modules/jwplayerRtdProvider_spec.js' --cache --cache-strategy content` which completed successfully after fixes.
- Ran the focused test chunk with `npx gulp test --nolint --file test/spec/modules/gamoshiBidAdapter_spec.js --file test/spec/modules/goadserverBidAdapter_spec.js --file test/spec/modules/impactifyBidAdapter_spec.js --file test/spec/modules/intentIqIdSystem_spec.js --file test/spec/modules/invibesBidAdapter_spec.js --file test/spec/modules/jwplayerRtdProvider_spec.js` and the suite completed successfully (396 tests completed for the chunked run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39ade2c9dc832b9e8f05ad68b0998b)