### PR TITLE
Ablida Adapter: fix chunk 1 test failures

### DIFF
--- a/modules/ablidaBidAdapter.js
+++ b/modules/ablidaBidAdapter.js
@@ -1,4 +1,4 @@
-import { triggerPixel } from '../src/utils.js';
+import * as utils from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
@@ -90,7 +90,7 @@ export const spec = {
   },
   onBidWon: function (bid) {
     if (!bid['nurl']) { return; }
-    triggerPixel(bid['nurl']);
+    utils.triggerPixel(bid['nurl']);
   }
 };
 

--- a/test/spec/libraries/pubmaticUtils/plugins/dynamicTimeout_spec.js
+++ b/test/spec/libraries/pubmaticUtils/plugins/dynamicTimeout_spec.js
@@ -110,12 +110,13 @@ describe('DynamicTimeout Plugin', () => {
 
   describe('processBidRequest', () => {
     let logInfoStub;
+    let getGlobalStub;
     let calculateTimeoutModifierStub;
     let shouldThrottleStub;
 
     beforeEach(() => {
       logInfoStub = sandbox.stub(utils, 'logInfo');
-      sandbox.stub(prebidGlobal, 'getGlobal').returns({
+      getGlobalStub = sandbox.stub(prebidGlobal, 'getGlobal').returns({
         getConfig: sandbox.stub().returns(800),
         adUnits: [{ code: 'test-div' }]
       });

--- a/test/spec/modules/ablidaBidAdapter_spec.js
+++ b/test/spec/modules/ablidaBidAdapter_spec.js
@@ -136,11 +136,17 @@ describe('ablidaBidAdapter', function () {
     });
 
     it('Should not trigger pixel if bid does not contain nurl', function() {
+      spec.onBidWon({});
+
       expect(utils.triggerPixel.callCount).to.equal(0);
     });
 
     it('Should trigger pixel if bid nurl', function() {
-      expect(utils.triggerPixel.callCount).to.equal(1);
+      const nurl = 'https://bidder.ablida.net/win';
+
+      spec.onBidWon({ nurl });
+
+      expect(utils.triggerPixel.calledOnceWithExactly(nurl)).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
### Motivation
- Address failing unit tests in chunk 1 caused by an undeclared `getGlobalStub` reference in the `DynamicTimeout` spec.  
- Ensure the Ablida adapter's win-notification is observable by the Sinon stub used in tests.  
- Make the Ablida `onBidWon` tests actually exercise the code path so assertions validate behavior.

### Description
- In `test/spec/libraries/pubmaticUtils/plugins/dynamicTimeout_spec.js` declare and assign `getGlobalStub` to the `prebidGlobal.getGlobal` stub so tests that override its return value no longer throw.  
- In `modules/ablidaBidAdapter.js` change the import to `import * as utils from '../src/utils.js'` and call `utils.triggerPixel(...)` inside `onBidWon` so the test stub can intercept the call.  
- In `test/spec/modules/ablidaBidAdapter_spec.js` invoke `spec.onBidWon` for both missing and present `nurl` cases and assert the `utils.triggerPixel` stub is called (or not) with the expected URL.

### Testing
- Ran lint for the changed files with `npx eslint ... --cache --cache-strategy content` and it completed successfully.  
- Executed the affected spec chunk with `npx gulp test --nolint --file test/spec/libraries/pubmaticUtils/plugins/dynamicTimeout_spec.js` and it passed.  
- Executed the Ablida spec with `npx gulp test --nolint --file test/spec/modules/ablidaBidAdapter_spec.js` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39b605d0c4832ba3db5c8c64f147e0)