### PR TITLE
Fix/strengthen unit tests for ablida adapter and dynamicTimeout plugin

### DIFF
--- a/test/spec/libraries/pubmaticUtils/plugins/dynamicTimeout_spec.js
+++ b/test/spec/libraries/pubmaticUtils/plugins/dynamicTimeout_spec.js
@@ -110,12 +110,13 @@ describe('DynamicTimeout Plugin', () => {
 
   describe('processBidRequest', () => {
     let logInfoStub;
+    let getGlobalStub;
     let calculateTimeoutModifierStub;
     let shouldThrottleStub;
 
     beforeEach(() => {
       logInfoStub = sandbox.stub(utils, 'logInfo');
-      sandbox.stub(prebidGlobal, 'getGlobal').returns({
+      getGlobalStub = sandbox.stub(prebidGlobal, 'getGlobal').returns({
         getConfig: sandbox.stub().returns(800),
         adUnits: [{ code: 'test-div' }]
       });

--- a/test/spec/modules/ablidaBidAdapter_spec.js
+++ b/test/spec/modules/ablidaBidAdapter_spec.js
@@ -136,11 +136,17 @@ describe('ablidaBidAdapter', function () {
     });
 
     it('Should not trigger pixel if bid does not contain nurl', function() {
+      spec.onBidWon({});
+
       expect(utils.triggerPixel.callCount).to.equal(0);
     });
 
     it('Should trigger pixel if bid nurl', function() {
-      expect(utils.triggerPixel.callCount).to.equal(1);
+      const nurl = 'https://bidder.ablida.net/win';
+
+      spec.onBidWon({ nurl });
+
+      expect(utils.triggerPixel.calledOnceWithExactly(nurl)).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
### Motivation
- Ensure tests actually exercise `onBidWon` behavior and make the `prebidGlobal.getGlobal` stub accessible so the test setup is less fragile.

### Description
- In `ablidaBidAdapter_spec.js` explicitly call `spec.onBidWon({})` in the no-nurl test and call `spec.onBidWon({ nurl })` in the nurl test, and replace the loose call-count assertion with `utils.triggerPixel.calledOnceWithExactly(nurl)`.
- In `dynamicTimeout_spec.js` introduce `getGlobalStub` and assign the `prebidGlobal.getGlobal` stub to it so the stub can be referenced in tests.

### Testing
- Ran the unit test suite with `npm test` and the updated specs executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39b605d0c4832ba3db5c8c64f147e0)