### PR TITLE
Fix tests: restore spies/stubs and make random bidder-sequence test deterministic

### DIFF
--- a/test/spec/modules/zeotapIdPlusIdSystem_spec.js
+++ b/test/spec/modules/zeotapIdPlusIdSystem_spec.js
@@ -26,6 +26,10 @@ describe('Zeotap ID System', function() {
       getStorageManagerSpy = sinon.spy(storageManager, 'getStorageManager');
     });
 
+    afterEach(function() {
+      getStorageManagerSpy.restore();
+    });
+
     it('when a stored Zeotap ID exists it is added to bids', function() {
       getStorage();
       expect(getStorageManagerSpy.calledOnce).to.be.true;

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -2434,13 +2434,15 @@ describe('adapterManager tests', function () {
     })
 
     describe('setBidderSequence', function () {
+      let randomStub;
+
       beforeEach(function () {
-        sinon.spy(utils, 'shuffle');
+        randomStub = sinon.stub(Math, 'random').returns(0);
       });
 
       afterEach(function () {
         config.resetConfig();
-        utils.shuffle.restore();
+        randomStub.restore();
       });
 
       it('setting to `random` uses shuffled order of adUnits', function () {
@@ -2452,7 +2454,7 @@ describe('adapterManager tests', function () {
           function callback() {},
           []
         );
-        sinon.assert.calledOnce(utils.shuffle);
+        expect(bidRequests.map(bidRequest => bidRequest.bidderCode)).to.deep.equal(['rubicon', 'appnexus']);
       });
     });
 


### PR DESCRIPTION
### Motivation

- Prevent sinon spies/stubs from leaking between tests by ensuring they are restored after each test.
- Make the `random` bidder sequence test deterministic and robust by controlling randomness instead of spying on `utils.shuffle`.

### Description

- Added an `afterEach` that restores the `getStorageManager` spy in `test/spec/modules/zeotapIdPlusIdSystem_spec.js` by calling `getStorageManagerSpy.restore()`.
- Replaced spying on `utils.shuffle` with a stub of `Math.random` that returns a fixed value in `test/spec/unit/core/adapterManager_spec.js` and updated the corresponding `afterEach` to restore `Math.random`.
- Updated the `random` bidder-sequence test assertion to validate the produced `bidRequests` order (`['rubicon', 'appnexus']`) instead of asserting a call to `utils.shuffle`.

### Testing

- Ran unit tests for the modified specs including `adapterManager` and `zeotapIdPlusIdSystem`, and they completed successfully.
- The `setBidderSequence` test now deterministically verifies order when `bidderSequence` is set to `random` and passes.
- Restores for spies/stubs were exercised by the test suite and did not cause teardown issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a39d0d38b04832b85f6219fdf990187)