### PR TITLE
Core: fix chunk 8 unit specs

### DIFF
--- a/test/spec/modules/zeotapIdPlusIdSystem_spec.js
+++ b/test/spec/modules/zeotapIdPlusIdSystem_spec.js
@@ -56,11 +56,14 @@ describe('Zeotap ID System', function() {
     });
 
     it('should check if cookies are enabled', function() {
+      zeotapIdPlusSubmodule.getId();
+
       expect(cookiesAreEnabledStub.calledOnce).to.be.true;
     });
 
     it('should call getCookie if cookies are enabled', function() {
       cookiesAreEnabledStub.returns(true);
+      zeotapIdPlusSubmodule.getId();
 
       expect(cookiesAreEnabledStub.calledOnce).to.be.true;
       expect(getCookieStub.calledOnce).to.be.true;
@@ -70,6 +73,7 @@ describe('Zeotap ID System', function() {
     it('should check for localStorage if cookies are disabled', function() {
       cookiesAreEnabledStub.returns(false);
       localStorageIsEnabledStub.returns(true);
+      zeotapIdPlusSubmodule.getId();
 
       expect(cookiesAreEnabledStub.calledOnce).to.be.true;
       expect(getCookieStub.called).to.be.false;

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -2485,6 +2485,8 @@ describe('adapterManager tests', function () {
       it('setting to `random` uses shuffled order of adUnits', function () {
         config.setConfig({ bidderSequence: 'random' });
 
+        makeBidRequests();
+
         sinon.assert.calledOnce(utils.shuffle);
       });
     });

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -44,9 +44,11 @@ before(() => {
 const wrappedCallback = config.callbackWithBidder(CODE);
 
 describe('bidderFactory', () => {
+  let doneStub;
   let onTimelyResponseStub;
 
   beforeEach(() => {
+    doneStub = sinon.stub();
     onTimelyResponseStub = sinon.stub();
   });
 
@@ -66,7 +68,6 @@ describe('bidderFactory', () => {
 
       addBidResponseStub = sinon.stub();
       addBidResponseStub.reject = sinon.stub();
-      sinon.stub();
     });
 
     describe('when the ajax response is irrelevant', function () {
@@ -1240,7 +1241,6 @@ describe('bidderFactory', () => {
 
       addBidResponseStub = sinon.stub();
       addBidResponseStub.reject = sinon.stub();
-      sinon.stub();
       ajaxStub = sinon.stub(ajax, 'ajax').callsFake(function(url, callbacks) {
         const fakeResponse = sinon.stub();
         fakeResponse.returns('headerContent');


### PR DESCRIPTION
### Motivation
- Several unit tests in chunk 8 were failing because assertions ran before invoking the code under test or because a shared stub was undefined. 
- The failures affected the Zeotap ID System storage-method tests, the `setBidderSequence` shuffle assertion in `adapterManager`, and `doneStub` usage in `bidderFactory` specs. 

### Description
- Updated `test/spec/modules/zeotapIdPlusIdSystem_spec.js` to invoke `zeotapIdPlusSubmodule.getId()` before asserting storage-method stubs so the storage access paths are exercised. 
- Updated `test/spec/unit/core/adapterManager_spec.js` to call the local `makeBidRequests()` helper before asserting that `utils.shuffle` was called when `config.setConfig({ bidderSequence: 'random' })`. 
- Restored a shared `doneStub` in `test/spec/unit/core/bidderFactory_spec.js` `beforeEach` and removed a stray no-op `sinon.stub()` so code paths that expect `doneStub` have a defined callback. 

### Testing
- Ran lint on the changed specs with `npx eslint <files> --cache --cache-strategy content` and the lint step completed without blocking the change. 
- Ran the focused test chunk with `npx gulp test --nolint --file test/spec/modules/zeotapIdPlusIdSystem_spec.js --file test/spec/unit/core/adapterManager_spec.js --file test/spec/unit/core/bidderFactory_spec.js` and the run completed successfully with the test bundle compiling and the test run completing (222 tests completed) and the affected specs passing. 
- No additional changes to production code were required and only the three spec files listed were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a426621c8832b8b9776586b55a8a8)