### PR TITLE
PubMatic Adapter: fix missing playerSize warning test

### DIFF
--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -636,8 +636,12 @@ describe('PubMatic adapter', () => {
 
           it('should log a warning if playerSize is missing', () => {
             delete videoBidderRequest.bids[0].mediaTypes.video.playerSize;
+            const request = spec.buildRequests(validBidRequests, videoBidderRequest);
+            const { imp } = request?.data;
 
+            expect(imp).to.be.an('array');
             sinon.assert.called(utils.logWarn);
+            expect(imp[0].video).to.be.undefined;
           });
 
           it('should log a warning if plcmt is missing', () => {


### PR DESCRIPTION
### Motivation
- Fix a failing unit test that asserted `utils.logWarn` was called when `mediaTypes.video.playerSize` was removed but did not exercise the request-formation path that emits the warning.

### Description
- Update `test/spec/modules/pubmaticBidAdapter_spec.js` to call `spec.buildRequests(validBidRequests, videoBidderRequest)` after deleting `playerSize` and assert the returned `imp` is an array, that `utils.logWarn` was called, and that `imp[0].video` is `undefined`.

### Testing
- Ran `npx eslint --cache --cache-strategy content test/spec/modules/pubmaticBidAdapter_spec.js` which completed successfully, and ran `npx gulp test --nolint --file test/spec/modules/pubmaticBidAdapter_spec.js` which passed the spec suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a42ffd00c832b8ffa23f84bd86dec)