### PR TITLE
tests: tighten adapter specs, add invalid-response checks, and clean up unused-var declarations

### DIFF
--- a/test/spec/modules/dataController_spec.js
+++ b/test/spec/modules/dataController_spec.js
@@ -4,7 +4,7 @@ import { filterBidData, init } from 'modules/dataControllerModule/index.js';
 import { startAuction } from 'src/prebid.js';
 
 describe('data controller', function () {
-  let result; // eslint-disable-line no-unused-vars
+  let result;
 
   afterEach(function () {
     config.resetConfig();
@@ -91,6 +91,7 @@ describe('data controller', function () {
       };
       config.setConfig(dataControllerConfiguration);
       filterBidData(callbackFn, req);
+      expect(result).to.equal(req);
       expect(req.adUnits[0].bids[0].userIdAsEids).that.is.empty;
       expect(req.adUnits[0].bids[0].userId).that.is.empty;
       expect(req.ortb2Fragments.bidder.ix.user.ext.eids).that.is.empty;

--- a/test/spec/modules/dochaseBidAdapter_spec.js
+++ b/test/spec/modules/dochaseBidAdapter_spec.js
@@ -4,7 +4,7 @@ import * as utils from '../../../src/utils.js';
 
 describe('dochase adapter', function () {
   let bannerRequest, nativeRequest;
-  let bannerResponse, nativeResponse, invalidBannerResponse, invalidNativeResponse; // eslint-disable-line no-unused-vars
+  let bannerResponse, nativeResponse, invalidBannerResponse, invalidNativeResponse;
 
   beforeEach(function () {
     bannerRequest = [
@@ -270,6 +270,12 @@ describe('dochase adapter', function () {
     });
   });
   describe('Validate native response ', function () {
+    it('Validate bid response : invalid bid response', function () {
+      const bRequest = spec.buildRequests(nativeRequest);
+      const response = spec.interpretResponse(invalidNativeResponse, bRequest);
+      expect(response).to.be.an('array').that.is.empty;
+    });
+
     it('Validate bid response : valid bid response', function () {
       const _Request = spec.buildRequests(nativeRequest);
       const bResponse = spec.interpretResponse(nativeResponse, _Request);

--- a/test/spec/modules/dxtechBidAdapter_spec.js
+++ b/test/spec/modules/dxtechBidAdapter_spec.js
@@ -192,46 +192,6 @@ const getBidderResponse = () => {
 };
 
 describe('dxtechBidAdapter', function() {
-  let videoBidRequest; // eslint-disable-line no-unused-vars
-  beforeEach(function () {
-    videoBidRequest = {
-      mediaTypes: {
-        video: {
-          context: 'instream',
-          playerSize: [[640, 480]],
-        }
-      },
-      bidder: 'dxtech',
-      sizes: [640, 480],
-      bidId: '30b3efwfwe1e',
-      adUnitCode: 'video1',
-      params: {
-        video: {
-          playerWidth: 640,
-          playerHeight: 480,
-          mimes: ['video/mp4', 'application/javascript'],
-          protocols: [2, 5],
-          api: [2],
-          position: 1,
-          delivery: [2],
-          sid: 134,
-          rewarded: 1,
-          placement: 1,
-          plcmt: 1,
-          hp: 1,
-          inventoryid: 123
-        },
-        site: {
-          id: 1,
-          page: 'https://test.com',
-          referrer: 'http://test.com'
-        },
-        publisherId: 'km123',
-        bidfloor: 0
-      }
-    };
-  });
-
   describe('isBidRequestValid', function() {
     let bidderRequest;
 
@@ -330,6 +290,12 @@ describe('dxtechBidAdapter', function() {
           publisherId: 'publisherId',
         }
       };
+    });
+
+    it('returns true when video request includes required params', function () {
+      const videoBidRequest = getVideoRequest().bids[0];
+      videoBidRequest.params.placementId = 'placementId';
+      expect(spec.isBidRequestValid(videoBidRequest)).to.be.true;
     });
 
     it('should return true (skip validations) when e2etest = true', function () {

--- a/test/spec/modules/ehealthcaresolutionsBidAdapter_spec.js
+++ b/test/spec/modules/ehealthcaresolutionsBidAdapter_spec.js
@@ -4,7 +4,7 @@ import * as utils from '../../../src/utils.js';
 
 describe('ehealthcaresolutions adapter', function () {
   let bannerRequest, nativeRequest;
-  let bannerResponse, nativeResponse, invalidBannerResponse, invalidNativeResponse; // eslint-disable-line no-unused-vars
+  let bannerResponse, nativeResponse, invalidBannerResponse, invalidNativeResponse;
 
   beforeEach(function () {
     bannerRequest = [
@@ -270,6 +270,12 @@ describe('ehealthcaresolutions adapter', function () {
     });
   });
   describe('Validate native response ', function () {
+    it('Validate bid response : invalid bid response', function () {
+      const bRequest = spec.buildRequests(nativeRequest);
+      const response = spec.interpretResponse(invalidNativeResponse, bRequest);
+      expect(response).to.be.an('array').that.is.empty;
+    });
+
     it('Validate bid response : valid bid response', function () {
       const _Request = spec.buildRequests(nativeRequest);
       const bResponse = spec.interpretResponse(nativeResponse, _Request);


### PR DESCRIPTION
### Motivation
- Improve test coverage by asserting behavior on invalid bid responses and video validation paths.
- Ensure the data controller callback returns the expected request object in SDA filtering tests.
- Remove unnecessary `eslint-disable` comments and explicitly declare previously-unused variables to satisfy linters.

### Description
- Added an explicit assertion `expect(result).to.equal(req)` to `test/spec/modules/dataController_spec.js` to verify the callback result.
- Added invalid-response tests to `dochaseBidAdapter_spec.js` and `ehealthcaresolutionsBidAdapter_spec.js` that confirm `spec.interpretResponse` returns an empty array for invalid native responses.
- Added a video validation test in `dxtechBidAdapter_spec.js` to assert `spec.isBidRequestValid` returns true when required video params are present and removed the now-unused `videoBidRequest` setup.
- Replaced several `// eslint-disable-line no-unused-vars` occurrences by declaring the variables to address linter warnings in multiple spec files.

### Testing
- Ran the updated unit spec files including `dataController_spec`, `dochaseBidAdapter_spec`, `ehealthcaresolutionsBidAdapter_spec`, and `dxtechBidAdapter_spec` under the test runner, and all modified tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a489f5890832bbd1195e1ad569f51)