### PR TITLE
Tests: restore removed spec actions

### DIFF
--- a/test/spec/modules/admaticBidAdapter_spec.js
+++ b/test/spec/modules/admaticBidAdapter_spec.js
@@ -712,11 +712,11 @@ describe('admaticBidAdapter', () => {
     });
 
     it('should properly build a video request with several player sizes with floors', function () {
-
+      spec.buildRequests(validRequest, bidderRequest);
     });
 
     it('should properly build a native request with floors', function () {
-
+      spec.buildRequests(validRequest, bidderRequest);
     });
   });
 

--- a/test/spec/modules/adtrueBidAdapter_spec.js
+++ b/test/spec/modules/adtrueBidAdapter_spec.js
@@ -261,6 +261,10 @@ describe('AdTrueBidAdapter', function () {
       it('buildRequests function should not modify original bidRequests object', function () {
         const originalBidRequests = utils.deepClone(bidRequests);
 
+        spec.buildRequests(bidRequests, {
+          auctionId: 'new-auction-id'
+        });
+
         expect(bidRequests).to.deep.equal(originalBidRequests);
       });
 

--- a/test/spec/modules/contxtfulRtdProvider_spec.js
+++ b/test/spec/modules/contxtfulRtdProvider_spec.js
@@ -321,6 +321,7 @@ describe('contxtfulRtdProvider', function () {
         window.dispatchEvent(RX_CONNECTOR_IS_READY_EVENT);
 
         setTimeout(() => {
+          contxtfulSubmodule.getTargetingData(adUnits, config);
           expect(RX_API_MOCK.receptivity.callCount).to.be.equal(0);
           done();
         }, TIMEOUT);

--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -315,6 +315,8 @@ describe('The Criteo bidding adapter', function () {
         origin: 'https://gum.criteo.com'
       });
 
+      spec.getUserSyncs(syncOptionsIframeEnabled, undefined, undefined, undefined);
+
       window.dispatchEvent(event);
       setTimeout(() => {
         expect(triggerPixelStub.calledTwice).to.be.true;
@@ -2456,6 +2458,40 @@ describe('The Criteo bidding adapter', function () {
 
   describe('when pubtag prebid adapter is not available', function () {
     it('should not warn if sendId is provided on required fields for native bidRequest', async () => {
+      const bidderRequest = {};
+      const bidRequests = [{
+        bidder: 'criteo',
+        adUnitCode: 'bid-123',
+        mediaTypes: {
+          native: {}
+        },
+        nativeOrtbRequest: {
+          assets: [{
+            required: 1,
+            id: 1,
+            img: {
+              type: 3,
+              wmin: 100,
+              hmin: 100,
+            }
+          }]
+        },
+        nativeParams: {
+          image: { sendId: true },
+          icon: { sendId: true },
+          clickUrl: { sendId: true },
+          displayUrl: { sendId: true },
+          privacyLink: { sendId: true },
+          privacyIcon: { sendId: true },
+        },
+        params: {
+          zoneId: 123,
+          publisherSubId: '123'
+        },
+      }];
+
+      spec.buildRequests(bidRequests, await addFPDToBidderRequest(bidderRequest));
+
       expect(logWarnStub.withArgs('Criteo: all native assets containing URL should be sent as placeholders with sendId(icon, image, clickUrl, displayUrl, privacyLink, privacyIcon)').notCalled).to.be.true;
     });
 


### PR DESCRIPTION
### Motivation
- Several recent cleanups removed bare calls in unit specs that produced necessary side effects or exercised code paths, making tests fragile or ineffective; this change restores those actions to ensure the specs validate behavior rather than only checking static state.

### Description
- In `test/spec/modules/adtrueBidAdapter_spec.js` restore a `spec.buildRequests(...)` call in the immutability test so the test actually exercises `buildRequests` before asserting the original object is unchanged.
- In `test/spec/modules/admaticBidAdapter_spec.js` add bare `spec.buildRequests(validRequest, bidderRequest)` calls to the video and native floor tests so the floor code paths are executed.
- In `test/spec/modules/criteoBidAdapter_spec.js` call `spec.getUserSyncs(...)` before dispatching the iframe `MessageEvent` so the message handler is registered, and add a `spec.buildRequests(...)` call with `sendId` placeholders for the native no-warning case.
- In `test/spec/modules/contxtfulRtdProvider_spec.js` invoke `contxtfulSubmodule.getTargetingData(...)` before asserting the RX API was not called to ensure the test checks the runtime behavior.

### Testing
- Ran `npx eslint test/spec/modules/adtrueBidAdapter_spec.js test/spec/modules/admaticBidAdapter_spec.js test/spec/modules/criteoBidAdapter_spec.js test/spec/modules/contxtfulRtdProvider_spec.js --cache --cache-strategy content`, which completed successfully with no lint failures for the changed files.
- Ran `npx gulp test --nolint --file test/spec/modules/adtrueBidAdapter_spec.js --file test/spec/modules/admaticBidAdapter_spec.js --file test/spec/modules/criteoBidAdapter_spec.js --file test/spec/modules/contxtfulRtdProvider_spec.js`, which executed the chunked specs and passed (tests completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a4c45f92c832bbafef331d5a39618)