### PR TITLE
Test Lint: fix chunk 8 test stubs

### DIFF
--- a/test/spec/unit/core/targeting_spec.js
+++ b/test/spec/unit/core/targeting_spec.js
@@ -308,6 +308,9 @@ describe('targeting tests', function () {
   });
 
   describe('getAllTargeting', function () {
+    let amBidsReceivedStub;
+    let amGetAdUnitsStub;
+    let bidExpiryStub;
     let logWarnStub;
     let logErrorStub;
     let bidsReceived;
@@ -315,13 +318,13 @@ describe('targeting tests', function () {
     beforeEach(function () {
       bidsReceived = [bid1, bid2, bid3].map(deepClone);
 
-      sandbox.stub(auctionManager, 'getBidsReceived').callsFake(function() {
+      amBidsReceivedStub = sandbox.stub(auctionManager, 'getBidsReceived').callsFake(function() {
         return bidsReceived;
       });
-      sandbox.stub(auctionManager, 'getAdUnitCodes').callsFake(function() {
+      amGetAdUnitsStub = sandbox.stub(auctionManager, 'getAdUnitCodes').callsFake(function() {
         return ['/123456/header-bid-tag-0'];
       });
-      sandbox.stub(bidFilters, 'isBidNotExpired').returns(true);
+      bidExpiryStub = sandbox.stub(bidFilters, 'isBidNotExpired').returns(true);
       logWarnStub = sinon.stub(utils, 'logWarn');
       logErrorStub = sinon.stub(utils, 'logError');
     });

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -42,7 +42,7 @@ require('modules/appnexusBidAdapter');
 var config = require('test/fixtures/config.json');
 
 var adUnits = getAdUnits();
-getAdUnits().map(unit => unit.code);
+var adUnitCodes = getAdUnits().map(unit => unit.code);
 var bidsBackHandler = function() {};
 const timeout = 2000;
 const auctionId = generateUUID();
@@ -635,6 +635,7 @@ describe('Unit: Prebid Module', function () {
           }
         }]
       }];
+      const adUnitCodes = ['div-gpt-ad-1460505748561-0'];
       auction = auctionManagerInstance.createAuction({ adUnits, adUnitCodes });
       indexStub = sinon.stub(auctionManager, 'index');
       indexStub.get(() => auctionManagerInstance.index);
@@ -3100,6 +3101,7 @@ describe('Unit: Prebid Module', function () {
 
     describe('part-3', function () {
       const auctionManagerInstance = newAuctionManager();
+      let auctionManagerStub;
       const adUnits1 = getAdUnits().filter((adUnit) => {
         return adUnit.code === '/19968336/header-bid-tag1';
       });
@@ -3149,7 +3151,7 @@ describe('Unit: Prebid Module', function () {
 
       beforeEach(function() {
         spyCallBids = sinon.spy(adapterManager, 'callBids');
-        sinon.stub(auctionManager, 'createAuction');
+        auctionManagerStub = sinon.stub(auctionManager, 'createAuction');
         auctionsStarted = Promise.all(
           [auction1, auction2].map((au, i) => new Promise((resolve) => {
             auctionManagerStub.onCall(i).callsFake(() => {
@@ -4068,9 +4070,10 @@ describe('Unit: Prebid Module', function () {
   });
 
   describe('getAllPrebidWinningBids', function () {
+    let auctionManagerStub;
     let logWarnSpy;
     beforeEach(function () {
-      sinon.stub(auctionManager, 'getBidsReceived');
+      auctionManagerStub = sinon.stub(auctionManager, 'getBidsReceived');
       logWarnSpy = sandbox.spy(utils, 'logWarn');
     });
 


### PR DESCRIPTION
### Motivation
- Fix failing tests in chunk 8 caused by recent test cleanup that removed some local bindings and stub references used by setup/teardown in unit tests. 
- Restore captured stub variables so `afterEach`/`after` handlers can properly restore them and avoid ReferenceErrors and wrapping conflicts.

### Description
- Restored the shared `adUnitCodes` binding used by `resetAuction` in `test/spec/unit/pbjs_api_spec.js` by replacing the previous dropped expression with `var adUnitCodes = getAdUnits().map(unit => unit.code);`.
- Reintroduced local `adUnitCodes` where a test case expects a local list and restored `auctionManager` stub captures used in setup/teardown in `test/spec/unit/pbjs_api_spec.js`.
- Captured the targeting-related stubs (`getBidsReceived`, `getAdUnitCodes`, and `isBidNotExpired`) into variables in `test/spec/unit/core/targeting_spec.js` so they can be `restore()`d in `afterEach`.
- Committed changes with message `Test Lint: fix chunk 8 test stubs` and kept edits confined to test files only.

### Testing
- Ran linter on the modified files with `npx eslint test/spec/unit/pbjs_api_spec.js test/spec/unit/core/targeting_spec.js --cache --cache-strategy content` and it passed.
- Ran the affected test chunk with `TEST_CHUNK=8 npx gulp test --nolint` and observed the chunk complete successfully.
- Ran the full test task with `npx gulp test --nolint` and observed the test suite complete without the previous chunk 8 failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a4ab04480832b97320910a1369d1e)