### PR TITLE
Iiq Adapter: superfluous trailing argument

### DIFF
--- a/modules/intentIqIdSystem.js
+++ b/modules/intentIqIdSystem.js
@@ -174,7 +174,7 @@ export function initializeGlobalIIQ(partnerId) {
 export function createPixelUrl(firstPartyData, clientHints, configParams, partnerData, cmpData) {
   const browser = detectBrowser();
 
-  let url = iiqPixelServerAddress(configParams, cmpData.gdprString);
+  let url = iiqPixelServerAddress(configParams);
   url += '/profiles_engine/ProfilesEngineServlet?at=20&mi=10&secure=1';
   url += '&dpi=' + configParams.partner;
   url = appendFirstPartyData(url, firstPartyData, partnerData);


### PR DESCRIPTION
Remove the extra trailing argument from the `iiqPixelServerAddress` call in `modules/intentIqIdSystem.js` so the invocation matches the function’s intended arity.

Best fix (without changing behavior): update line 177 in `createPixelUrl(...)` from:
- `iiqPixelServerAddress(configParams, cmpData.gdprString)`
to:
- `iiqPixelServerAddress(configParams)`

No imports, new methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._