### PR TITLE
Improve unit tests: non-mutation checks, nobid refreshLimit handling, and UID2 test logging

### DIFF
--- a/test/spec/modules/condorxBidAdapter_spec.js
+++ b/test/spec/modules/condorxBidAdapter_spec.js
@@ -388,11 +388,15 @@ describe('CondorX Bid Adapter Tests', function () {
     it('should not mutate the original bid object', function () {
       const originalBidRequests = utils.deepClone(basicBidRequests);
 
+      adapterSpec.buildRequests(basicBidRequests);
+
       expect(basicBidRequests).to.deep.equal(originalBidRequests);
     });
 
     it('should maintain the integrity of the native bid object', function () {
       const originalBidRequests = utils.deepClone(nativeBidData);
+
+      adapterSpec.buildRequests(nativeBidData);
 
       expect(nativeBidData).to.deep.equal(originalBidRequests);
     });

--- a/test/spec/modules/nobidBidAdapter_spec.js
+++ b/test/spec/modules/nobidBidAdapter_spec.js
@@ -796,7 +796,10 @@ describe('Nobid Adapter', function () {
     const REFRESH_LIMIT = 3;
 
     it('should refreshLimit be respected', function () {
-      nobid.refreshLimit = REFRESH_LIMIT;
+      const response = { rlimit: REFRESH_LIMIT };
+
+      spec.interpretResponse({ body: response }, { bidderRequest: { bids: [] } });
+
       expect(nobid.refreshLimit).to.equal(REFRESH_LIMIT);
     });
   });

--- a/test/spec/modules/uid2IdSystem_spec.js
+++ b/test/spec/modules/uid2IdSystem_spec.js
@@ -15,7 +15,7 @@ import { createEidsArray } from '../../../modules/userId/eids.js';
 const expect = require('chai').expect;
 
 const clearTimersAfterEachTest = true;
-const debugOutput = () => {};
+const debugTimerOutput = false;
 
 const moduleCookieName = '__uid2_advertising_token';
 const publisherCookieName = '__UID2_SERVER_COOKIE';
@@ -103,6 +103,13 @@ const testCookieAndLocalStorage = (description, test, only = false) => {
 
 describe(`UID2 module`, function () {
   let suiteSandbox; let testSandbox; let timerSpy; let fullTestTitle; let restoreSubtleToUndefined = false;
+  const getFullTestTitle = (test) => `${test.parent.title ? getFullTestTitle(test.parent) + ' | ' : ''}${test.title}`;
+  const debugOutput = (message) => {
+    if (debugTimerOutput) {
+      utils.logMessage(`${fullTestTitle}: ${message}`);
+    }
+  };
+
   before(function () {
     timerSpy = configureTimerInterceptors(debugOutput);
     hook.ready();
@@ -150,8 +157,6 @@ describe(`UID2 module`, function () {
       await act(false);
     });
   };
-
-  const getFullTestTitle = (test) => `${test.parent.title ? getFullTestTitle(test.parent) + ' | ' : ''}${test.title}`;
 
   beforeEach(function () {
     fullTestTitle = getFullTestTitle(this.test.ctx.currentTest);


### PR DESCRIPTION
### Motivation

- Ensure bid request builders do not mutate original input objects by exercising `buildRequests` in relevant specs. 
- Verify the `refreshLimit` is set via the adapter `interpretResponse` path instead of being assigned directly. 
- Make UID2 timer debug output conditional and centralize full test title generation for clearer timer logs. 

### Description

- Updated `test/spec/modules/condorxBidAdapter_spec.js` to call `adapterSpec.buildRequests(...)` in non-mutation tests so the assertions verify the original objects remain unchanged. 
- Modified `test/spec/modules/nobidBidAdapter_spec.js` to create a response object (`{ rlimit: REFRESH_LIMIT }`) and call `spec.interpretResponse(...)` to exercise the code path that sets `nobid.refreshLimit` instead of setting it directly. 
- Refactored `test/spec/modules/uid2IdSystem_spec.js` by introducing a `debugTimerOutput` flag and a `debugOutput` wrapper that logs only when debugging is enabled, and moved/added `getFullTestTitle` so the timer interceptor receives a proper title string. 

### Testing

- Ran the updated unit specs for the modified modules (`condorxBidAdapter_spec`, `nobidBidAdapter_spec`, and `uid2IdSystem_spec`) as part of the test suite. All affected tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a531366fc832bbcf2a9352a9d04ac)