### PR TITLE
Tests: fix lint failures from extra arguments

### DIFF
--- a/test/spec/modules/bliinkBidAdapter_spec.js
+++ b/test/spec/modules/bliinkBidAdapter_spec.js
@@ -579,7 +579,7 @@ const testsBuildBid = [
   {
     title: 'input data respect the output model for video',
     args: {
-      fn: buildBid(getConfigVideoBid('video'), getConfigCreativeVideo()),
+      fn: buildBid(getConfigVideoBid(), getConfigCreativeVideo()),
     },
     want: {
       requestId: getConfigBid('video').bidId,
@@ -602,7 +602,7 @@ const testsBuildBid = [
     args: {
       fn: buildBid(
         {
-          ...getConfigVideoBid('video'),
+          ...getConfigVideoBid(),
           creative: {
             video: {
               content: '<VAST></VAST>',

--- a/test/spec/modules/euidIdSystem_spec.js
+++ b/test/spec/modules/euidIdSystem_spec.js
@@ -165,7 +165,7 @@ describe('EUID module', function() {
       apiHelpers.respondAfterDelay(1, server);
 
       const bid = await runAuction();
-      expectOptout(bid, optoutToken);
+      expectOptout(bid);
     });
   }
 

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -2964,7 +2964,7 @@ describe('S2S Adapter', function () {
       adapter.callBids(await addFpdEnrichmentsToS2SRequest({
         ...s2sBidRequest,
         ortb2Fragments
-      }, bidRequests, cfg), bidRequests, addBidResponse, done, ajax);
+      }, bidRequests), bidRequests, addBidResponse, done, ajax);
       const parsedRequestBody = JSON.parse(server.requests[0].requestBody);
       // eslint-disable-next-line no-console
       console.log(parsedRequestBody);


### PR DESCRIPTION
### Motivation
- Fix lint failures caused by tests passing unsupported extra arguments to helper functions, which broke CI linting.

### Description
- Remove the unsupported `cfg` argument passed to `addFpdEnrichmentsToS2SRequest` in `test/spec/modules/prebidServerBidAdapter_spec.js` so the call matches the helper signature.
- Update the EUID opt-out assertion in `test/spec/modules/euidIdSystem_spec.js` to call `expectOptout` with only the `bid` argument.
- Update Bliink video bid tests in `test/spec/modules/bliinkBidAdapter_spec.js` to call `getConfigVideoBid()` without the unsupported `'video'` argument and adjust spread usage accordingly.
- Files changed: `test/spec/modules/prebidServerBidAdapter_spec.js`, `test/spec/modules/euidIdSystem_spec.js`, `test/spec/modules/bliinkBidAdapter_spec.js`.

### Testing
- Ran ESLint on the modified files with `npx eslint test/spec/modules/prebidServerBidAdapter_spec.js test/spec/modules/euidIdSystem_spec.js test/spec/modules/bliinkBidAdapter_spec.js --cache --cache-strategy content` and it passed.
- Ran the targeted test specs with `npx gulp test --nolint --file <spec_file.js>` for `prebidServerBidAdapter_spec.js`, `euidIdSystem_spec.js`, and `bliinkBidAdapter_spec.js`, and each task completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3a5c73c418832b9fab40a4d03404c6)