### PR TITLE
ESLint Plugin: handle no-redundant fact invalidation

### DIFF
--- a/plugins/eslint/noRedundantValidatedCondition.js
+++ b/plugins/eslint/noRedundantValidatedCondition.js
@@ -1,4 +1,6 @@
 const SCOPE_NODES = new Set([
+  'BlockStatement',
+  'CatchClause',
   'FunctionDeclaration',
   'FunctionExpression',
   'ArrowFunctionExpression',
@@ -35,6 +37,45 @@ function collectFalsyImpliedTruthyIdentifiers(node, names = new Set()) {
   return names;
 }
 
+function collectPatternIdentifiers(node, names) {
+  node = unwrap(node);
+  if (!node) return;
+  if (node.type === 'Identifier') {
+    names.add(node.name);
+  } else if (node.type === 'RestElement') {
+    collectPatternIdentifiers(node.argument, names);
+  } else if (node.type === 'AssignmentPattern') {
+    collectPatternIdentifiers(node.left, names);
+  } else if (node.type === 'ArrayPattern') {
+    node.elements.forEach(element => collectPatternIdentifiers(element, names));
+  } else if (node.type === 'ObjectPattern') {
+    node.properties.forEach((property) => {
+      if (property.type === 'Property') collectPatternIdentifiers(property.value, names);
+      else collectPatternIdentifiers(property.argument, names);
+    });
+  }
+}
+
+function collectInvalidatedIdentifiers(node, names = new Set()) {
+  node = unwrap(node);
+  if (!node || typeof node.type !== 'string' || SCOPE_NODES.has(node.type)) return names;
+
+  if (node.type === 'AssignmentExpression') {
+    collectPatternIdentifiers(node.left, names);
+  } else if (node.type === 'UpdateExpression') {
+    collectPatternIdentifiers(node.argument, names);
+  } else if (node.type === 'VariableDeclarator') {
+    collectPatternIdentifiers(node.id, names);
+  }
+
+  for (const key of collectInvalidatedIdentifiers.visitorKeys[node.type] || []) {
+    const child = node[key];
+    if (Array.isArray(child)) child.forEach(child => collectInvalidatedIdentifiers(child, names));
+    else collectInvalidatedIdentifiers(child, names);
+  }
+  return names;
+}
+
 module.exports = {
   meta: {
     type: 'problem',
@@ -45,6 +86,7 @@ module.exports = {
   },
   create(context) {
     const sourceCode = context.sourceCode || context.getSourceCode();
+    collectInvalidatedIdentifiers.visitorKeys = sourceCode.visitorKeys;
 
     function inspect(node, knownTruthy) {
       node = unwrap(node);
@@ -66,6 +108,7 @@ module.exports = {
       const knownTruthy = new Set();
 
       for (const statement of statements) {
+        collectInvalidatedIdentifiers(statement).forEach(name => knownTruthy.delete(name));
         inspect(statement, knownTruthy);
 
         if (statement.type === 'IfStatement' && exits(statement.consequent) && statement.alternate == null) {

--- a/plugins/eslint/test/noRedundantValidatedCondition.test.js
+++ b/plugins/eslint/test/noRedundantValidatedCondition.test.js
@@ -1,0 +1,51 @@
+const {RuleTester} = require('eslint');
+const rule = require('../noRedundantValidatedCondition.js');
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'script'
+  }
+});
+
+ruleTester.run('no-redundant-validated-condition', rule, {
+  valid: [
+    `
+      function example(foo, bar, maybeNull) {
+        if (!foo) return;
+        foo = maybeNull();
+        if (foo && bar) bar();
+      }
+    `,
+    `
+      function example(foo, bar, maybeNull) {
+        if (!foo) return;
+        {
+          let foo = maybeNull();
+          if (foo && bar) bar();
+        }
+      }
+    `,
+    `
+      function example(foo, bar) {
+        if (!foo) return;
+        try {
+          bar();
+        } catch (foo) {
+          if (foo && bar) bar();
+        }
+      }
+    `
+  ],
+  invalid: [
+    {
+      code: `
+        function example(foo, bar) {
+          if (!foo) return;
+          if (foo && bar) bar();
+        }
+      `,
+      errors: [{message: "Redundant conditional: 'foo' is already known to be truthy."}]
+    }
+  ]
+});


### PR DESCRIPTION
### Motivation
- The custom `no-redundant-validated-condition` rule could report redundant conditionals when an identifier previously validated by an early guard was reassigned, updated, redeclared, or shadowed inside block/catch scopes.

### Description
- Stop truthy-fact propagation at `BlockStatement` and `CatchClause` boundaries by extending the scope node set in `plugins/eslint/noRedundantValidatedCondition.js`.
- Add `collectPatternIdentifiers` and `collectInvalidatedIdentifiers` to discover identifiers invalidated by `AssignmentExpression`, `UpdateExpression`, and `VariableDeclarator` and wire `sourceCode.visitorKeys` for traversal.
- Clear matching known-truthy facts before inspecting each statement so stale facts are not used to report redundant conditionals.
- Add `plugins/eslint/test/noRedundantValidatedCondition.test.js` with RuleTester cases covering reassignment invalidation, block-scoped shadowing, catch-parameter shadowing, and the original redundant-condition report.

### Testing
- Ran the RuleTester file with `node plugins/eslint/test/noRedundantValidatedCondition.test.js`, and the tests passed.
- Running `npx eslint plugins/eslint/noRedundantValidatedCondition.js plugins/eslint/test/noRedundantValidatedCondition.test.js` emitted ignored-file warnings because the `plugins/eslint` path is excluded by the repo ESLint config.
- Running `npx eslint --no-ignore plugins/eslint/noRedundantValidatedCondition.js plugins/eslint/test/noRedundantValidatedCondition.test.js` surfaced repository style rule errors unrelated to the plugin logic, so the RuleTester run is the targeted verification for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b1bad9904832ba645d6edd27bdcc1)