### PR TITLE
Core: restore API spec initialization

### DIFF
--- a/test/spec/aliasBidder_spec.js
+++ b/test/spec/aliasBidder_spec.js
@@ -1,3 +1,4 @@
+import '../../src/prebid.js';
 import { pbjsTestOnly } from 'test/helpers/pbjs-test-only.js';
 import { getGlobal } from '../../src/prebidGlobal.js';
 

--- a/test/spec/api_spec.js
+++ b/test/spec/api_spec.js
@@ -1,4 +1,5 @@
 var assert = require('chai').assert;
+require('../../src/prebid.js');
 const { getGlobalVarName } = require('../../src/buildOptions.js');
 const { getGlobal } = require('../../src/prebidGlobal.js');
 


### PR DESCRIPTION
### Motivation
- Ensure the Prebid public API is initialized when API-related specs run in isolation so tests that assert or use public methods see the expected global state.

### Description
- Add a side-effect require of `src/prebid.js` to `test/spec/api_spec.js` so the public API hooks are registered before assertions.
- Add a side-effect import of `src/prebid.js` to `test/spec/aliasBidder_spec.js` so `addAdUnits` and `aliasBidder` are available when the spec runs in isolation.

### Testing
- Ran lint on the modified specs with `npx eslint test/spec/api_spec.js test/spec/aliasBidder_spec.js --cache --cache-strategy content`, which passed.
- Attempted to run the isolated spec tests with `npx gulp test --nolint --file <spec>`, but the commands failed due to a missing local dependency (`fancy-log`) required by the repo `gulpfile.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b1c6e39a8832ba49f6dc198ee5976)