### PR TITLE
Adspirit Bid Adapter: fix viewport dimensions

### DIFF
--- a/modules/adspiritBidAdapter.js
+++ b/modules/adspiritBidAdapter.js
@@ -6,6 +6,14 @@ const { getWinDimensions } = utils;
 const RTB_URL = '/rtb/getbid.php?rtbprovider=prebid';
 const SCRIPT_URL = '/adasync.min.js';
 
+function getViewportWidth(win) {
+  return win.innerWidth || win.document?.documentElement?.clientWidth || win.document?.body?.clientWidth || 0;
+}
+
+function getViewportHeight(win) {
+  return win.innerHeight || win.document?.documentElement?.clientHeight || win.document?.body?.clientHeight || 0;
+}
+
 export const spec = {
 
   code: 'adspirit',
@@ -26,6 +34,8 @@ export const spec = {
     const requests = [];
     const prebidVersion = getGlobal().version;
     const win = getWinDimensions();
+    const viewportWidth = getViewportWidth(win);
+    const viewportHeight = getViewportHeight(win);
 
     for (let i = 0; i < validBidRequests.length; i++) {
       const bidRequest = validBidRequests[i];
@@ -39,8 +49,8 @@ export const spec = {
         '&ref=' + encodeURIComponent(bidderRequest.refererInfo.topmostLocation) +
         '&scx=' + (win.screen?.width || 0) +
         '&scy=' + (win.screen?.height || 0) +
-        '&wcx=' + win.innerWidth +
-        '&wcy=' + win.innerHeight +
+        '&wcx=' + viewportWidth +
+        '&wcy=' + viewportHeight +
         '&async=' + bidRequest.adspiritConId +
         '&t=' + Math.round(Math.random() * 100000);
 
@@ -106,8 +116,8 @@ export const spec = {
         device: {
           ua: navigator.userAgent,
           language: (navigator.language || '').split('-')[0],
-          w: win.innerWidth,
-          h: win.innerHeight,
+          w: viewportWidth,
+          h: viewportHeight,
           geo: {
             lat: bidderRequest?.geo?.lat || 0,
             lon: bidderRequest?.geo?.lon || 0,

--- a/test/spec/modules/adspiritBidAdapter_spec.js
+++ b/test/spec/modules/adspiritBidAdapter_spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { spec } from 'modules/adspiritBidAdapter.js';
-import 'src/utils.js';
+import { internal, resetWinDimensions } from 'src/utils.js';
 
 describe('Adspirit Bidder Spec', function () {
   // isBidRequestValid ---case
@@ -48,28 +48,42 @@ describe('Adspirit Bidder Spec', function () {
   });
   // Test cases for buildRequests
   describe('Adspirit Bidder Spec', function () {
-    let originalInnerWidth;
-    let originalInnerHeight;
-    let originalClientWidth;
-    let originalClientHeight;
+    let sandbox;
+
+    function mockWindow({ innerWidth, innerHeight, clientWidth, clientHeight }) {
+      return {
+        innerWidth,
+        innerHeight,
+        screen: {
+          width: 1920,
+          height: 1080
+        },
+        document: {
+          documentElement: {
+            clientWidth,
+            clientHeight
+          },
+          body: {}
+        }
+      };
+    }
 
     beforeEach(() => {
-      originalInnerWidth = window.innerWidth;
-      originalInnerHeight = window.innerHeight;
-      originalClientWidth = document.documentElement.clientWidth;
-      originalClientHeight = document.documentElement.clientHeight;
-
-      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 1024 });
-      Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: 768 });
-      Object.defineProperty(document.documentElement, 'clientWidth', { writable: true, configurable: true, value: 800 });
-      Object.defineProperty(document.documentElement, 'clientHeight', { writable: true, configurable: true, value: 600 });
+      sandbox = sinon.createSandbox();
+      const win = mockWindow({
+        innerWidth: 1024,
+        innerHeight: 768,
+        clientWidth: 800,
+        clientHeight: 600
+      });
+      sandbox.stub(internal, 'getWindowTop').returns(win);
+      sandbox.stub(internal, 'getWindowSelf').returns(win);
+      resetWinDimensions();
     });
 
     afterEach(() => {
-      Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: originalInnerWidth });
-      Object.defineProperty(window, 'innerHeight', { writable: true, configurable: true, value: originalInnerHeight });
-      Object.defineProperty(document.documentElement, 'clientWidth', { writable: true, configurable: true, value: originalClientWidth });
-      Object.defineProperty(document.documentElement, 'clientHeight', { writable: true, configurable: true, value: originalClientHeight });
+      sandbox.restore();
+      resetWinDimensions();
     });
 
     it('should correctly capture window and document dimensions in payload', function () {
@@ -95,8 +109,13 @@ describe('Adspirit Bidder Spec', function () {
     });
 
     it('should correctly fall back to document dimensions if window dimensions are not available', function () {
-      delete global.window.innerWidth;
-      delete global.window.innerHeight;
+      const win = mockWindow({
+        clientWidth: 800,
+        clientHeight: 600
+      });
+      internal.getWindowTop.returns(win);
+      internal.getWindowSelf.returns(win);
+      resetWinDimensions();
       const bidRequest = [
         {
           bidId: '26c1ee0038ac11',


### PR DESCRIPTION
### Motivation
- Adspirit unit tests were failing because viewport dimensions used `win.innerWidth`/`win.innerHeight` directly while the test environment uses a cached window-dimensions source, causing the adapter to read stale/undefined values.

### Description
- Add `getViewportWidth` and `getViewportHeight` helpers and use them instead of direct `win.innerWidth`/`win.innerHeight` accesses for both the request URL (`&wcx`/`&wcy`) and the OpenRTB `device` payload.
- Continue to source the base window from the existing `getWinDimensions()` cache so behavior is consistent with other utilities.
- Update `test/spec/modules/adspiritBidAdapter_spec.js` to stub `internal.getWindowTop` and `internal.getWindowSelf`, call `resetWinDimensions()` around assertions, and use a `mockWindow` helper with a Sinon sandbox so the tests observe deterministic viewport values.

### Testing
- Linted the changed files with `npx eslint modules/adspiritBidAdapter.js test/spec/modules/adspiritBidAdapter_spec.js --cache --cache-strategy content` which completed with no reported errors.
- Ran the adapter spec with `npx gulp test --nolint --file test/spec/modules/adspiritBidAdapter_spec.js` and all tests passed (20 tests completed), resolving the previous failures for viewport assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b1c333c24832b8e2789bbd610b859)