### PR TITLE
Core: add RuleTester unit tests for no-implicit-operand-conversion

### DIFF
--- a/test/build-logic/eslint_spec.mjs
+++ b/test/build-logic/eslint_spec.mjs
@@ -1,0 +1,65 @@
+import { RuleTester } from 'eslint';
+import { describe, it } from 'mocha';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const prebid = require('../../plugins/eslint/index.js');
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+describe('prebid/no-implicit-operand-conversion', () => {
+  ruleTester.run('no-implicit-operand-conversion', prebid.rules['no-implicit-operand-conversion'], {
+    valid: [
+      'const isReady = Boolean(value); if (isReady < 1) {}',
+      'if (value < 1) {}',
+      'if (!value === true) {}',
+      'const value = 1; const label = `${value}`;',
+      'const value = getValue(); const label = `${value}`;',
+      'const value = undefined; const label = `${String(value)}`;',
+      'function getLabel() {}; const label = `${getLabel()}`;',
+      'const getLabel = () => {}; const label = `${getLabel()}`;'
+    ],
+    invalid: [
+      {
+        code: 'if (!value < 1) {}',
+        errors: [{ message: 'Do not compare a negated value; compare the original operand explicitly instead.' }]
+      },
+      {
+        code: 'if (value >= !limit) {}',
+        errors: [{ message: 'Do not compare a negated value; compare the original operand explicitly instead.' }]
+      },
+      {
+        code: 'const value = undefined; const label = `${value}`;',
+        errors: [{ message: 'Avoid interpolating values that require implicit string conversion.' }]
+      },
+      {
+        code: 'let value; const label = `${value}`;',
+        errors: [{ message: 'Avoid interpolating values that require implicit string conversion.' }]
+      },
+      {
+        code: 'function getLabel() {}; const label = `${getLabel}`;',
+        errors: [{ message: 'Avoid interpolating values that require implicit string conversion.' }]
+      },
+      {
+        code: 'const getLabel = () => {}; const label = `${getLabel}`;',
+        errors: [{ message: 'Avoid interpolating values that require implicit string conversion.' }]
+      },
+      {
+        code: 'const getLabel = function() {}; const label = `${getLabel}`;',
+        errors: [{ message: 'Avoid interpolating values that require implicit string conversion.' }]
+      },
+      {
+        code: 'const label = `${undefined}`;',
+        errors: [{ message: 'Avoid interpolating values that require implicit string conversion.' }]
+      }
+    ]
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide automated RuleTester coverage for the new `prebid/no-implicit-operand-conversion` ESLint rule to prevent regressions and document expected behavior. 

### Description
- Add `test/build-logic/eslint_spec.mjs` which loads the local plugin via `require('../../plugins/eslint/index.js')` and instantiates an `eslint` `RuleTester` configured for modern ECMAScript. 
- Cover allowed cases including explicit conversions and ordinary comparisons and disallowed cases including negated operands in comparisons and implicit template interpolation of `undefined`/function references. 
- Wire `RuleTester.describe`/`RuleTester.it` to `mocha` so the spec runs under the existing test tooling.

### Testing
- Ran `npx mocha ./test/build-logic/eslint_spec.mjs` which passed (16 tests passing). 
- Ran `npx eslint test/build-logic/eslint_spec.mjs --cache --cache-strategy content` which produced no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b1fd9572c832bacdf0ea9275e28f2)