### PR TITLE
Core: handle lexical arguments in lint rule

### DIFF
--- a/plugins/eslint/noExtraFunctionArgs.js
+++ b/plugins/eslint/noExtraFunctionArgs.js
@@ -32,7 +32,7 @@ function referencesArguments(functionNode) {
     if (!node || found) {
       return;
     }
-    if (node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression') {
+    if (node.type === 'FunctionExpression' || node.type === 'FunctionDeclaration') {
       return;
     }
     if (node.type === 'Identifier' && node.name === 'arguments') {

--- a/plugins/eslint/noExtraFunctionArgs_test.js
+++ b/plugins/eslint/noExtraFunctionArgs_test.js
@@ -1,0 +1,48 @@
+const { RuleTester } = require('eslint');
+const rule = require('./noExtraFunctionArgs.js');
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module'
+  }
+});
+
+ruleTester.run('no-extra-function-args', rule, {
+  valid: [
+    {
+      code: `
+        function makeReader(value) {
+          const read = () => arguments[0] || value;
+          return read;
+        }
+        makeReader('one', 'two');
+      `
+    },
+    {
+      code: `
+        function makeReader(value) {
+          function read() {
+            return arguments[0];
+          }
+          return read;
+        }
+        makeReader('one');
+      `
+    }
+  ],
+  invalid: [
+    {
+      code: `
+        function makeReader(value) {
+          function read() {
+            return arguments[0];
+          }
+          return read;
+        }
+        makeReader('one', 'two');
+      `,
+      errors: [{ message: "Function 'makeReader' expects at most 1 argument, but 2 were provided." }]
+    }
+  ]
+});


### PR DESCRIPTION
### Motivation
- Fix the ESLint rule that incorrectly treated `arguments` inside nested arrow functions as local, causing false positives for extra function arguments.
- Provide a regression test that exercises lexical `arguments` in nested arrow functions and nested function declarations to prevent regressions.

### Description
- Change `referencesArguments` in `plugins/eslint/noExtraFunctionArgs.js` to skip nested non-arrow functions (`FunctionExpression`/`FunctionDeclaration`) but allow traversal into arrow functions so lexical `arguments` are detected correctly.
- Add a RuleTester regression at `plugins/eslint/noExtraFunctionArgs_test.js` covering the nested-arrow lexical `arguments` case and a nested function declaration invalid-case.
- Keep the existing argument-count enforcement logic in `getMaxArgs` unchanged, but make its `referencesArguments` check more accurate for modern JS patterns.

### Testing
- Ran the RuleTester directly with `node plugins/eslint/noExtraFunctionArgs_test.js` and it passed. 
- Ran lint on the rule and test with `npx eslint plugins/eslint/noExtraFunctionArgs.js plugins/eslint/noExtraFunctionArgs_test.js --cache --cache-strategy content --no-warn-ignored` and it passed. 
- Attempted to run the Karma/webpack browser test with `npx gulp test --nolint --file test/spec/plugins/noExtraFunctionArgs_spec.js` which errored due to Node-only ESLint dependencies (e.g. `node:fs/promises`) not resolving in the browser webpack bundle, so the browser-suite run failed for environmental reasons.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b207bfbd0832bb7e3631013009a6a)