### PR TITLE
Add opt-out tests for EUID/UID2 and exercise buildRequests in Mediaeyes immutability test

### DIFF
--- a/test/spec/modules/euidIdSystem_spec.js
+++ b/test/spec/modules/euidIdSystem_spec.js
@@ -22,6 +22,7 @@ const refreshedToken = 'refreshed-advertising-token';
 const auctionDelayMs = 10;
 
 const makeEuidIdentityContainer = (token) => ({ euid: { id: token } });
+const makeEuidOptoutContainer = () => ({ euid: { optout: true } });
 
 const useLocalStorage = true;
 
@@ -186,6 +187,11 @@ describe('EUID module', function() {
           atype: 3
         }]
       });
+    });
+
+    it('does not create an eid for optout values', function() {
+      const newEids = createEidsArray(makeEuidOptoutContainer());
+      expect(newEids.length).to.equal(0);
     });
   });
 });

--- a/test/spec/modules/mediaeyesBidAdapter_spec.js
+++ b/test/spec/modules/mediaeyesBidAdapter_spec.js
@@ -109,6 +109,8 @@ describe('mediaeyes adapter', function () {
     it('Immutable bid request validate', function () {
       const _Request = utils.deepClone(request);
 
+      spec.buildRequests(request);
+
       expect(request).to.deep.equal(_Request);
     });
   });

--- a/test/spec/modules/uid2IdSystem_spec.js
+++ b/test/spec/modules/uid2IdSystem_spec.js
@@ -32,6 +32,7 @@ const newServerCookieConfigParams = { uid2Cookie: publisherCookieName };
 const cstgConfigParams = { serverPublicKey: 'UID2-X-L-24B8a/eLYBmRkXA9yPgRZt+ouKbXewG2OPs23+ov3JC8mtYJBCx6AxGwJ4MlwUcguebhdDp2CvzsCgS9ogwwGA==', subscriptionId: 'subscription-id' };
 
 const makeUid2IdentityContainer = (token) => ({ uid2: { id: token } });
+const makeUid2OptoutContainer = () => ({ uid2: { optout: true } });
 
 let useLocalStorage = false;
 const makePrebidConfig = (params = null, extraSettings = {}, debug = false) => ({
@@ -688,6 +689,11 @@ describe(`UID2 module`, function () {
           }
         }]
       });
+    });
+
+    it('does not create an eid for optout values', function() {
+      const newEids = createEidsArray(makeUid2OptoutContainer());
+      expect(newEids.length).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
### Motivation

- Ensure that `createEidsArray` does not emit an eid when the identity container signals an opt-out value for both EUID and UID2 flows.
- Make the Mediaeyes adapter immutability test actually exercise the code path by calling `spec.buildRequests` so the original request object is validated for no mutation.

### Description

- Added `makeEuidOptoutContainer` and `makeUid2OptoutContainer` helpers and new tests asserting `createEidsArray` returns no eids for opt-out containers in `test/spec/modules/euidIdSystem_spec.js` and `test/spec/modules/uid2IdSystem_spec.js`.
- Updated `test/spec/modules/mediaeyesBidAdapter_spec.js` to call `spec.buildRequests(request)` inside the "Immutable bid request validate" test so the request immutability assertion is meaningful.
- Minor test scaffolding adjustments and whitespace alignment in the modified spec files.

### Testing

- Ran unit specs for the modified files: `euidIdSystem_spec`, `uid2IdSystem_spec`, and `mediaeyesBidAdapter_spec` using the existing Mocha/Chai test runner, and all updated tests passed successfully.
- No new integration or end-to-end tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b1ed0e8e8832bb219ff324d8c7166)