### PR TITLE
Tests: address review feedback for Criteo, PubMatic, DeepIntent

### DIFF
--- a/test/spec/modules/criteoBidAdapter_spec.js
+++ b/test/spec/modules/criteoBidAdapter_spec.js
@@ -346,6 +346,8 @@ describe('The Criteo bidding adapter', function () {
         origin: 'https://gum.criteo.com'
       });
 
+      spec.getUserSyncs(syncOptionsIframeEnabled, undefined, undefined, undefined);
+
       window.dispatchEvent(event);
       setTimeout(() => {
         expect(setCookieStub.calledWith('cto_bundle', 'bundle', sinon.match.string, null, '.com')).to.be.true;

--- a/test/spec/modules/deepintentBidAdapter_spec.js
+++ b/test/spec/modules/deepintentBidAdapter_spec.js
@@ -204,6 +204,8 @@ describe('Deepintent adapter', function () {
     it('unmutaable bid request check', function () {
       const oRequest = utils.deepClone(request);
 
+      spec.buildRequests(request);
+
       expect(request).to.deep.equal(oRequest);
     });
     it('bidder connection check', function () {

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -1897,6 +1897,7 @@ describe('addViewabilityToImp', () => {
   });
 
   it('should set viewability amount to "na" if not measurable (e.g., in iframe)', () => {
+    sandbox.stub(utils, 'inIframe').returns(true);
     addViewabilityToImp(imp, { adUnitCode: 'Div1' }, { w: 300, h: 250 });
     expect(imp.ext).to.have.property('viewability');
     expect(imp.ext.viewability.amount).to.equal('na');


### PR DESCRIPTION
### Motivation
- Restore test behaviors that were broken by prior cleanup so the specs exercise the intended code paths and cover edge branches.
- Ensure the Criteo cookie-sync listener is registered before dispatching the GUM `message` event so the iframe-based path is tested.
- Ensure PubMatic and DeepIntent specs explicitly cover the non-measurable viewability branch and the immutability check respectively.

### Description
- In `test/spec/modules/criteoBidAdapter_spec.js` re-added a call to `spec.getUserSyncs(syncOptionsIframeEnabled, ...)` before dispatching the `MessageEvent` so the GUM listener is registered.
- In `test/spec/modules/pubmaticBidAdapter_spec.js` stubbed `utils.inIframe` with `sandbox.stub(utils, 'inIframe').returns(true)` to force the non-measurable (`"na"`) viewability branch.
- In `test/spec/modules/deepintentBidAdapter_spec.js` invoked `spec.buildRequests(request)` in the immutability test so the test validates that building requests does not mutate the original `request` object.

### Testing
- Ran linter on the changed specs with `npx eslint --cache --cache-strategy content test/spec/modules/criteoBidAdapter_spec.js test/spec/modules/pubmaticBidAdapter_spec.js test/spec/modules/deepintentBidAdapter_spec.js` and it passed.
- Ran the affected unit tests with `npx gulp test --nolint --file test/spec/modules/criteoBidAdapter_spec.js --file test/spec/modules/pubmaticBidAdapter_spec.js --file test/spec/modules/deepintentBidAdapter_spec.js` and the test chunk completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b288ff230832b976a5e891cbf80c7)