### PR TITLE
Admatic Bid Adapter: restore video floor test; LemmaDigital Bid Adapter: restore immutability call

### DIFF
--- a/test/spec/modules/admaticBidAdapter_spec.js
+++ b/test/spec/modules/admaticBidAdapter_spec.js
@@ -710,14 +710,10 @@ describe('admaticBidAdapter', () => {
       });
     });
 
-    it('should properly build a video request with several player sizes with floors', function () {
-      const [{ getFloor, ...requestWithoutFloor }] = validRequest;
-      const videoRequest = [{ ...structuredClone(requestWithoutFloor), getFloor }];
-      videoRequest[0].mediaTypes.video.playerSize = [[300, 250], [728, 90]];
-      const request = spec.buildRequests(videoRequest, bidderRequest);
+    it('should properly build a video request with floors', function () {
+      const request = spec.buildRequests(validRequest, bidderRequest);
       expect(request.data.imp[0].floors.video).to.deep.equal({
-        '300x250': { 'currency': 'USD', 'floor': 1 },
-        '728x90': { 'currency': 'USD', 'floor': 1 }
+        '336x280': { 'currency': 'USD', 'floor': 1 }
       });
     });
 

--- a/test/spec/modules/lemmaDigitalBidAdapter_spec.js
+++ b/test/spec/modules/lemmaDigitalBidAdapter_spec.js
@@ -205,6 +205,8 @@ describe('lemmaDigitalBidAdapter', function () {
       it('buildRequests function should not modify original bidRequests object', function () {
         const originalBidRequests = utils.deepClone(bidRequests);
 
+        spec.buildRequests(bidRequests);
+
         expect(bidRequests).to.deep.equal(originalBidRequests);
       });
       it('bidRequest imp array check empty', function () {


### PR DESCRIPTION
### Motivation
- Address unresolved review feedback on PR #15161 by restoring intended test coverage for Admatic video floors and ensuring the LemmaDigital immutability test actually exercises `spec.buildRequests` before asserting no mutation.

### Description
- Updated `test/spec/modules/admaticBidAdapter_spec.js` to use the shared `validRequest` fixture for the video-floor assertion and adjusted the expected video floor key to `336x280` so the test exercises the existing fixture.
- Restored the call to `spec.buildRequests(bidRequests)` inside `test/spec/modules/lemmaDigitalBidAdapter_spec.js` before verifying `bidRequests` remains unchanged to validate immutability.
- Small test-only changes committed to the branch for PR review and to address the code comments.

### Testing
- Ran `npx eslint test/spec/modules/admaticBidAdapter_spec.js test/spec/modules/lemmaDigitalBidAdapter_spec.js --cache --cache-strategy content`, which passed without errors.
- Attempted to run `npx gulp test --nolint --file test/spec/modules/admaticBidAdapter_spec.js`, but it could not run due to a missing local dependency (`fancy-log`) referenced by `gulpfile.js` so unit tests were not executed.
- Attempted `npx gulp test --nolint --file test/spec/modules/lemmaDigitalBidAdapter_spec.js` with the same `fancy-log` missing error, so full spec execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b363c8510832b8a9d9eed50d1c9bd)