### PR TITLE
Reconciliation RTD Provider: restore spec coverage

### DIFF
--- a/test/spec/modules/reconciliationRtdProvider_spec.js
+++ b/test/spec/modules/reconciliationRtdProvider_spec.js
@@ -111,8 +111,9 @@ describe('Reconciliation Real time data submodule', function () {
       it('should return null if there is an error in frames chain', function() {
         const topWin = {};
         const iframe1Win = mockFrameWin(topWin, null); // break chain
+        const iframe2Win = mockFrameWin(topWin, iframe1Win);
 
-        expect(getTopIFrameWin(iframe1Win, topWin)).to.be.null;
+        expect(getTopIFrameWin(iframe2Win, topWin)).to.be.null;
       });
 
       it('should get the topmost iframe', function () {
@@ -145,6 +146,7 @@ describe('Reconciliation Real time data submodule', function () {
         adSlotElement.id = 'reconciliationAd';
         document.body.appendChild(adSlotElement);
         document.body.appendChild(adSlotIframe); // iframe is not in ad slot
+        makeSlot({ code: '/reconciliationAdunit', divId: adSlotElement.id });
 
         expect(getSlotByWin(adSlotIframe.contentWindow)).to.be.null;
       });


### PR DESCRIPTION
### Motivation
- Restore unit-test coverage for the Reconciliation RTD provider by fixing two test cases so they exercise the intended error and non-matching slot scenarios.

### Description
- Update `test/spec/modules/reconciliationRtdProvider_spec.js` to add a nested iframe (`iframe2Win`) in the frames-chain error test and to call `makeSlot(...)` in the negative `getSlotByWin` case so the spec covers a present-but-nonmatching GPT slot.

### Testing
- Ran `npx eslint test/spec/modules/reconciliationRtdProvider_spec.js --cache --cache-strategy content` which completed without errors.
- Ran `npx gulp test --nolint --file test/spec/modules/reconciliationRtdProvider_spec.js` which completed successfully and reported the spec tests as passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b3832f7c8832b8b8ae06dc30c2e57)