### PR TITLE
Admatic Adapter: reuse floor fixtures in tests

### DIFF
--- a/test/spec/modules/admaticBidAdapter_spec.js
+++ b/test/spec/modules/admaticBidAdapter_spec.js
@@ -26,6 +26,10 @@ describe('admaticBidAdapter', () => {
       'native': {
       },
       'video': {
+        'playerSize': [
+          336,
+          280
+        ]
       }
     },
     getFloor: inputParams => {
@@ -141,7 +145,7 @@ describe('admaticBidAdapter', () => {
       {
         'size': [
           {
-            'w': 338,
+            'w': 336,
             'h': 280
           }
         ],
@@ -712,16 +716,12 @@ describe('admaticBidAdapter', () => {
 
     it('should properly build a video request with floors', function () {
       const request = spec.buildRequests(validRequest, bidderRequest);
-      expect(request.data.imp[0].floors.video).to.deep.equal({
-        '336x280': { 'currency': 'USD', 'floor': 1 }
-      });
+      expect(request.data.imp[0].floors.video).to.deep.equal(validRequest[0].imp[1].floors.video);
     });
 
     it('should properly build a native request with floors', function () {
       const request = spec.buildRequests(validRequest, bidderRequest);
-      expect(request.data.imp[0].floors.native).to.deep.equal({
-        '*': { 'currency': 'USD', 'floor': 1 }
-      });
+      expect(request.data.imp[0].floors.native).to.deep.equal(validRequest[0].imp[2].floors.native);
     });
   });
 


### PR DESCRIPTION
### Motivation
- Restore and reuse the larger shared `validRequest` fixture so video/native floor handling is exercised and to address review comments about over-deletion in the tests.

### Description
- Add `playerSize` to the shared `validRequest.mediaTypes.video` fixture so the adapter’s video floor path is exercised.
- Fix the video impression width from `338` to `336` to match the floor key used in the fixture.
- Replace duplicated inline expected floor objects with assertions that compare against the shared `validRequest` fixture (use `validRequest[0].imp[1].floors.video` and `validRequest[0].imp[2].floors.native`).

### Testing
- Ran `npx eslint test/spec/modules/admaticBidAdapter_spec.js --cache --cache-strategy content` and it passed.
- Ran the focused unit test `npx gulp test --nolint --file test/spec/modules/admaticBidAdapter_spec.js` and the spec passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b3821b5f8832bb928f10715f7c847)