### PR TITLE
RelevateHealth & RIVR Adapters: address test review comments

### DIFF
--- a/test/spec/modules/relevatehealthBidAdapter_spec.js
+++ b/test/spec/modules/relevatehealthBidAdapter_spec.js
@@ -109,6 +109,8 @@ describe('relevatehealth adapter', function() {
     it('Immutable bid request validate', function() {
       const _Request = utils.deepClone(request);
 
+      spec.buildRequests(request);
+
       expect(request).to.deep.equal(_Request);
     });
     it('Validate bidder connection', function() {

--- a/test/spec/modules/rivrAnalyticsAdapter_spec.js
+++ b/test/spec/modules/rivrAnalyticsAdapter_spec.js
@@ -33,7 +33,6 @@ describe('RIVR Analytics adapter', () => {
   });
 
   beforeEach(() => {
-    rivraddonsTrackPbjsEventStub = sandbox.stub(window.rivraddon.analytics, 'trackPbjsEvent');
     timer = sandbox.useFakeTimers(0);
     ajaxStub = sandbox.stub(ajax, 'ajax');
     sandbox.stub(events, 'getEvents').returns([]);
@@ -54,10 +53,6 @@ describe('RIVR Analytics adapter', () => {
 
   afterEach(() => {
     analyticsAdapter.disableAnalytics();
-    rivraddonsTrackPbjsEventStub.restore();
-    if (window.rivraddon.analytics.getContext.restore) {
-      window.rivraddon.analytics.getContext.restore();
-    }
     events.getEvents.restore();
     ajaxStub.restore();
     timer.restore();
@@ -80,16 +75,22 @@ describe('RIVR Analytics adapter', () => {
   });
 
   it('Firing an event when rivraddon context is not defined it should do nothing', () => {
-    sandbox.stub(window.rivraddon.analytics, 'getContext').returns(undefined);
+    const rivraddonsGetContextStub = sandbox.stub(window.rivraddon.analytics, 'getContext').returns(undefined);
+    rivraddonsTrackPbjsEventStub = sandbox.stub(window.rivraddon.analytics, 'trackPbjsEvent');
 
     expect(rivraddonsTrackPbjsEventStub.callCount).to.be.equal(0);
 
     events.emit(EVENTS.AUCTION_INIT, { auctionId: EMITTED_AUCTION_ID, config: {}, timeout: 3000 });
 
     expect(rivraddonsTrackPbjsEventStub.callCount).to.be.equal(0);
+
+    rivraddonsGetContextStub.restore();
+    rivraddonsTrackPbjsEventStub.restore();
   });
 
   it('Firing AUCTION_INIT should call rivraddon trackPbjsEvent passing the parameters', () => {
+    rivraddonsTrackPbjsEventStub = sandbox.stub(window.rivraddon.analytics, 'trackPbjsEvent');
+
     expect(rivraddonsTrackPbjsEventStub.callCount).to.be.equal(0);
 
     events.emit(EVENTS.AUCTION_INIT, { auctionId: EMITTED_AUCTION_ID, config: {}, timeout: 3000 });
@@ -99,6 +100,8 @@ describe('RIVR Analytics adapter', () => {
     const firstArgument = rivraddonsTrackPbjsEventStub.getCall(0).args[0];
     expect(firstArgument.eventType).to.be.equal(EVENTS.AUCTION_INIT);
     expect(firstArgument.args.auctionId).to.be.equal(EMITTED_AUCTION_ID);
+
+    rivraddonsTrackPbjsEventStub.restore();
   });
 
   const BANNER_AD_UNITS_MOCK = [


### PR DESCRIPTION
### Motivation
- Fix unresolved review comments that caused an immutability spec to stop exercising the adapter and left RIVR event stubs applied globally, which reduced test isolation and could mask regressions.

### Description
- In `test/spec/modules/relevatehealthBidAdapter_spec.js` call `spec.buildRequests(request)` before asserting the original `request` remains unchanged so the immutability test actually exercises the code under test.
- In `test/spec/modules/rivrAnalyticsAdapter_spec.js` stop pre-stubbing `trackPbjsEvent` in `beforeEach` and instead stub `getContext`/`trackPbjsEvent` inside the event-specific specs and restore them inside those specs, and remove unnecessary global restores from `afterEach`.
- Adjusted test setup/teardown so per-test stubs do not interfere with other assertions and shared cleanup only handles globally-applied resources.

### Testing
- Ran `npx eslint test/spec/modules/relevatehealthBidAdapter_spec.js test/spec/modules/rivrAnalyticsAdapter_spec.js --cache --cache-strategy content` and it completed successfully.
- Ran `npx gulp test --nolint --file test/spec/modules/relevatehealthBidAdapter_spec.js` and the spec passed.
- Ran `npx gulp test --nolint --file test/spec/modules/rivrAnalyticsAdapter_spec.js` and the spec passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b491e2228832b979b7487692a1d10)