### PR TITLE
Reconciliation RTD Provider: cover broken frame chain

### DIFF
--- a/test/spec/modules/reconciliationRtdProvider_spec.js
+++ b/test/spec/modules/reconciliationRtdProvider_spec.js
@@ -113,6 +113,7 @@ describe('Reconciliation Real time data submodule', function () {
         const iframe1Win = mockFrameWin(topWin, null); // break chain
         const iframe2Win = mockFrameWin(topWin, iframe1Win);
 
+        expect(getTopIFrameWin(iframe1Win, topWin)).to.be.null;
         expect(getTopIFrameWin(iframe2Win, topWin)).to.be.null;
       });
 


### PR DESCRIPTION
### Motivation
- Restore the originally-intended test coverage for the broken iframe parent chain and close the unresolved review comment in `test/spec/modules/reconciliationRtdProvider_spec.js`.

### Description
- Add an assertion to `test/spec/modules/reconciliationRtdProvider_spec.js` to verify `getTopIFrameWin(iframe1Win, topWin)` returns `null` when the parent chain is broken, while keeping the existing nested-frame assertion.

### Testing
- Ran `npx eslint test/spec/modules/reconciliationRtdProvider_spec.js --cache --cache-strategy content` with no lint output and `npx gulp test --nolint --file test/spec/modules/reconciliationRtdProvider_spec.js` which completed successfully (12 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b4a742800832b89b4c28f53b075b0)