### PR TITLE
Adlane RTD Provider: address review comments

### DIFF
--- a/test/spec/modules/adlaneRtdProvider_spec.js
+++ b/test/spec/modules/adlaneRtdProvider_spec.js
@@ -161,6 +161,7 @@ describe('adlane Module', () => {
           })
       };
 
+      sandbox.stub(utils, 'cleanObj').callsFake((o) => o);
       const logInfoStub = sandbox.stub(utils, 'logInfo');
       const result = getAgeVerification(win, storage);
 
@@ -211,6 +212,7 @@ describe('adlane Module', () => {
         getDataFromLocalStorage: () => JSON.stringify({ status: 'accepted' })
       };
       sandbox.stub(storageManager, 'getStorageManager').returns(storage);
+      sandbox.stub(utils, 'getWindowTop').returns({});
 
       expect(adlaneSubmodule.init()).to.be.true;
     });
@@ -221,6 +223,7 @@ describe('adlane Module', () => {
         getDataFromLocalStorage: () => null
       };
       sandbox.stub(storageManager, 'getStorageManager').returns(storage);
+      sandbox.stub(utils, 'getWindowTop').returns({});
       const logStub = sandbox.stub(utils, 'logWarn');
 
       expect(adlaneSubmodule.init()).to.be.false;
@@ -235,6 +238,7 @@ describe('adlane Module', () => {
           getAgeVerification: () => ageVerification
         }
       });
+      sandbox.stub(utils, 'cleanObj').callsFake((o) => o);
       const setStub = sandbox.stub(utils, 'mergeDeep');
       const reqBidsConfigObj = { ortb2Fragments: { global: {} } };
 


### PR DESCRIPTION
### Motivation
- Respond to PR review feedback by removing unused stub assignments and restoring the minimal stubs required for stable Adlane RTD provider tests. 

### Description
- Added `sandbox.stub(utils, 'cleanObj').callsFake((o) => o)` where tests depend on identity-cleaning behavior to keep assertions stable. 
- Added `sandbox.stub(utils, 'getWindowTop').returns({})` in localStorage-init and init-failure tests to avoid unused stub assignments while preserving intended test setup. 
- Changes are limited to `test/spec/modules/adlaneRtdProvider_spec.js` and only affect test scaffolding.

### Testing
- Ran `npx eslint test/spec/modules/adlaneRtdProvider_spec.js --cache --cache-strategy content` and it passed. 
- Ran `npx gulp test --nolint --file test/spec/modules/adlaneRtdProvider_spec.js` and the spec passed (18 tests completed) along with build-logic checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b4b10a2b0832b9f4aae4baa8abb22)