### PR TITLE
Tests: address adapter review comments

### DIFF
--- a/test/spec/modules/smaatoBidAdapter_spec.js
+++ b/test/spec/modules/smaatoBidAdapter_spec.js
@@ -1227,10 +1227,6 @@ describe('smaatoBidAdapterTest', () => {
       });
     });
 
-    describe('ad pod', () => {
-
-    });
-
     it('uses correct TTL when expire header exists', () => {
       const clock = sinon.useFakeTimers();
       clock.tick(2000);

--- a/test/spec/modules/tapnativeBidAdapter_spec.js
+++ b/test/spec/modules/tapnativeBidAdapter_spec.js
@@ -144,6 +144,7 @@ describe('tapnative adapter', function () {
   describe('Validate Banner Request', function () {
     it('Immutable bid request validate', function () {
       const _Request = utils.deepClone(bannerRequest);
+      spec.buildRequests(bannerRequest);
 
       expect(bannerRequest).to.deep.equal(_Request);
     });
@@ -211,6 +212,7 @@ describe('tapnative adapter', function () {
   describe('Validate Native Request', function () {
     it('Immutable bid request validate', function () {
       const _Request = utils.deepClone(nativeRequest);
+      spec.buildRequests(nativeRequest);
 
       expect(nativeRequest).to.deep.equal(_Request);
     });

--- a/test/spec/modules/temedyaBidAdapter_spec.js
+++ b/test/spec/modules/temedyaBidAdapter_spec.js
@@ -87,12 +87,14 @@ describe('temedya adapter', function() {
 
     it('buildRequests function should not modify original bidRequests object', function () {
       const originalBidRequests = utils.deepClone(bidRequests);
+      spec.buildRequests(bidRequests);
 
       expect(bidRequests).to.deep.equal(originalBidRequests);
     });
 
     it('buildRequests function should not modify original nativeBidRequests object', function () {
       const originalBidRequests = utils.deepClone(nativeBidRequests);
+      spec.buildRequests(nativeBidRequests);
 
       expect(nativeBidRequests).to.deep.equal(originalBidRequests);
     });


### PR DESCRIPTION
### Motivation
- Fix unresolved review comments that left immutability tests vacuous for TapNative and Temedya and remove an empty/unsupported Smaato `describe` block.
- Ensure adapter test fixtures are exercised by `buildRequests` so future mutations in `spec.buildRequests` are detected.
- Keep test suite behavior consistent with adapter review feedback.

### Description
- Removed the empty `describe('ad pod')` block from `test/spec/modules/smaatoBidAdapter_spec.js`.
- Restored calls to `spec.buildRequests(...)` in `test/spec/modules/tapnativeBidAdapter_spec.js` to exercise banner and native immutability checks before assertions.
- Restored calls to `spec.buildRequests(...)` in `test/spec/modules/temedyaBidAdapter_spec.js` to exercise bidRequests and nativeBidRequests immutability checks before assertions.

### Testing
- Ran `npm ci` which completed successfully to install dependencies.
- Ran `npx eslint test/spec/modules/smaatoBidAdapter_spec.js test/spec/modules/tapnativeBidAdapter_spec.js test/spec/modules/temedyaBidAdapter_spec.js --cache --cache-strategy content` and the lint pass succeeded after edits.
- Ran `npx gulp test --nolint --file test/spec/modules/smaatoBidAdapter_spec.js`, `npx gulp test --nolint --file test/spec/modules/tapnativeBidAdapter_spec.js`, and `npx gulp test --nolint --file test/spec/modules/temedyaBidAdapter_spec.js` and all targeted test chunks completed successfully (Smaato: 67 tests, TapNative: 19 tests, Temedya: 7 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b4976a8e4832b92936ce24526f350)