### PR TITLE
Tests: address remaining adapter review comments

### DIFF
--- a/test/spec/modules/invibesBidAdapter_spec.js
+++ b/test/spec/modules/invibesBidAdapter_spec.js
@@ -1394,40 +1394,52 @@ describe('invibesBidAdapter:', function () {
 
     context('in multiposition context, with conflicting ads', function() {
       it('registers the second ad when no conflict', function() {
+        var firstResponse = buildResponse('12345', 1, [1], 123);
         var secondResponse = buildResponse('abcde', 2, [2], 456);
 
+        var firstResult = spec.interpretResponse({ body: firstResponse }, { bidRequests });
         var secondResult = spec.interpretResponse({ body: secondResponse }, { bidRequests });
+        expect(firstResult[0].creativeId).to.equal(123);
         expect(secondResult[0].creativeId).to.equal(456);
       });
 
       it('registers the second ad when no conflict - empty arrays', function() {
+        var firstResponse = buildResponse('12345', 1, [], 123);
         var secondResponse = buildResponse('abcde', 2, [], 456);
 
+        var firstResult = spec.interpretResponse({ body: firstResponse }, { bidRequests });
         var secondResult = spec.interpretResponse({ body: secondResponse }, { bidRequests });
+        expect(firstResult[0].creativeId).to.equal(123);
         expect(secondResult[0].creativeId).to.equal(456);
       });
 
       it('doesnt register the second ad when it is blacklisted by the first', function() {
-        spec.interpretResponse({ body: buildResponse('12345', 1, [2], 123) }, { bidRequests });
+        var firstResponse = buildResponse('12345', 1, [2], 123);
         var secondResponse = buildResponse('abcde', 2, [], 456);
 
+        var firstResult = spec.interpretResponse({ body: firstResponse }, { bidRequests });
         var secondResult = spec.interpretResponse({ body: secondResponse }, { bidRequests });
+        expect(firstResult[0].creativeId).to.equal(123);
         expect(secondResult).to.be.empty;
       });
 
       it('doesnt register the second ad when it is blacklisting the first', function() {
-        spec.interpretResponse({ body: buildResponse('12345', 1, [], 123) }, { bidRequests });
+        var firstResponse = buildResponse('12345', 1, [], 123);
         var secondResponse = buildResponse('abcde', 2, [1], 456);
 
+        var firstResult = spec.interpretResponse({ body: firstResponse }, { bidRequests });
         var secondResult = spec.interpretResponse({ body: secondResponse }, { bidRequests });
+        expect(firstResult[0].creativeId).to.equal(123);
         expect(secondResult).to.be.empty;
       });
 
       it('doesnt register the second ad when it has same ids as the first', function() {
-        spec.interpretResponse({ body: buildResponse('12345', 1, [], 123) }, { bidRequests });
+        var firstResponse = buildResponse('12345', 1, [1], 123);
         var secondResponse = buildResponse('abcde', 1, [1], 456);
 
+        var firstResult = spec.interpretResponse({ body: firstResponse }, { bidRequests });
         var secondResult = spec.interpretResponse({ body: secondResponse }, { bidRequests });
+        expect(firstResult[0].creativeId).to.equal(123);
         expect(secondResult).to.be.empty;
       });
     });

--- a/test/spec/modules/reconciliationRtdProvider_spec.js
+++ b/test/spec/modules/reconciliationRtdProvider_spec.js
@@ -113,6 +113,7 @@ describe('Reconciliation Real time data submodule', function () {
         const iframe1Win = mockFrameWin(topWin, null); // break chain
         const iframe2Win = mockFrameWin(topWin, iframe1Win);
 
+        expect(getTopIFrameWin(iframe1Win, topWin)).to.be.null;
         expect(getTopIFrameWin(iframe2Win, topWin)).to.be.null;
       });
 

--- a/test/spec/modules/seedingAllianceAdapter_spec.js
+++ b/test/spec/modules/seedingAllianceAdapter_spec.js
@@ -329,7 +329,8 @@ describe('SeedingAlliance adapter', function () {
 
       delete badResponse.body;
 
-      assert.equal(result.length, 0);
+      const result1 = spec.interpretResponse(badResponse, bidNativeRequest);
+      assert.equal(result1.length, 0);
     });
 
     it('should return the correct params', function () {


### PR DESCRIPTION
### Motivation
- Resolve unresolved review comments that removed or altered assertions in adapter and RTD provider specs so tests validate the production code paths they intend to cover.
- Ensure multiposition and conflict-handling logic is exercised in `invibes` tests and that empty/absent-body handling is correctly re-tested in `seedingAlliance` specs.
- Improve coverage for iframe traversal edge-cases in the Reconciliation RTD provider spec so both direct and nested broken chains are asserted.

### Description
- Restored the initial `interpretResponse` setup and assertions in `test/spec/modules/invibesBidAdapter_spec.js` before exercising the second-response conflict checks.
- Updated `test/spec/modules/seedingAllianceAdapter_spec.js` to call `spec.interpretResponse` again after deleting `badResponse.body` and assert on the new `result1`.
- Expanded `test/spec/modules/reconciliationRtdProvider_spec.js` to assert `getTopIFrameWin` returns `null` for both the directly broken iframe and the nested iframe chain.

### Testing
- Ran lint across the affected specs with `npx eslint test/spec/modules/... --cache --cache-strategy content` and resolved an unused-variable lint finding so the lint run completed cleanly.
- Executed per-file test runs with `npx gulp test --nolint --file` for `test/spec/modules/seedingAllianceAdapter_spec.js`, `invibesBidAdapter_spec.js`, `reconciliationRtdProvider_spec.js`, `nodalsAiRtdProvider_spec.js`, and `nobidBidAdapter_spec.js`, and observed each targeted spec run complete successfully (see individual summaries in the rollout logs).
- End-to-end local test runs showed the updated specs completed without failures (per-spec summaries: `seedingAlliance` 32 tests, `invibes` 87 tests, `reconciliationRtdProvider` 12 tests, `nodalsAiRtdProvider` 55 tests, `nobidBidAdapter` 46 tests as recorded in the test output).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b4a063b9c832b8578eb5057737be4)