### PR TITLE
Tests: clean stale review comments

### DIFF
--- a/test/spec/modules/adagioBidAdapter_spec.js
+++ b/test/spec/modules/adagioBidAdapter_spec.js
@@ -70,8 +70,6 @@ describe('Adagio bid adapter', () => {
   let utilsMock;
   let sandbox;
 
-  // safeFrame implementation
-
   beforeEach(() => {
     window.ADAGIO = {};
     window.ADAGIO.adUnits = {};

--- a/test/spec/modules/contxtfulBidAdapter_spec.js
+++ b/test/spec/modules/contxtfulBidAdapter_spec.js
@@ -357,8 +357,6 @@ describe('contxtful bid adapter', function () {
         testObj.textNode = document.createTextNode('test'); // Text -> Node
       }
 
-      // Add objects that should be caught by duck typing (constructor name patterns)
-
       // Mock HTMLCanvasElement (constructor name contains 'HTML' and 'Canvas')
       function HTMLCanvasElement() {}
       const mockCanvas = Object.create(HTMLCanvasElement.prototype);

--- a/test/spec/modules/symitriDapRtdProvider_spec.js
+++ b/test/spec/modules/symitriDapRtdProvider_spec.js
@@ -607,7 +607,6 @@ describe('symitriDapRtdProvider', function() {
 
   describe('Symitri-DAP-SS-ID test', function () {
     it('Symitri-DAP-SS-ID present in response header', function () {
-      // in seconds
       dapUtils.dapRefreshToken(ortb2, sampleConfig, false, onDone);
       const request = server.requests[0];
       request.requestHeaders['Content-Type'].should.equal('application/json');
@@ -619,7 +618,6 @@ describe('symitriDapRtdProvider', function() {
     });
 
     it('Test if Symitri-DAP-SS-ID is present in request header', function () {
-      // in seconds
       storage.setDataInLocalStorage(DAP_SS_ID, JSON.stringify('Test_SSID_Spec'));
       dapUtils.dapRefreshToken(ortb2, sampleConfig, false, onDone);
       const request = server.requests[0];

--- a/test/spec/modules/wurflRtdProvider_spec.js
+++ b/test/spec/modules/wurflRtdProvider_spec.js
@@ -2355,8 +2355,6 @@ describe('wurflRtdProvider', function () {
           getHighestCpmBids: () => []
         });
 
-        // Import the WurflLCEDevice to stub it
-
         const callback = () => {
           const device = reqBidsConfigObj.ortb2Fragments.global.device;
 


### PR DESCRIPTION
### Motivation
- Remove stale review-comment leftovers in several spec files to clean up noise and avoid confusion during reviews.
- Keep test behavior and assertions unchanged while removing obsolete comments that no longer match the surrounding code.

### Description
- Deleted obsolete/stale comment lines in `test/spec/modules/adagioBidAdapter_spec.js`, `test/spec/modules/contxtfulBidAdapter_spec.js`, `test/spec/modules/symitriDapRtdProvider_spec.js`, and `test/spec/modules/wurflRtdProvider_spec.js`.
- Preserved all mocks, stubs, and test assertions so tests exercise the same logic as before.
- Committed the tidy-up with the message `Tests: clean stale review comments`.

### Testing
- Ran `npx eslint` against the modified files (`test/spec/modules/*`) and it completed without new lint errors.
- Ran `npx gulp test --nolint --file <spec_file.js>` for the four changed specs and the test run completed successfully (259 tests completed across the invoked chunks, all green).
- The local `gulp` test pipeline finished without failures after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3b4dd13f9c832b9941e49083705b74)