### PR TITLE
Uniquest Bid Adapters: send im_uid from Intimatemerger EID

### DIFF
--- a/libraries/uniquestUtils/uniquestUtils.js
+++ b/libraries/uniquestUtils/uniquestUtils.js
@@ -1,3 +1,11 @@
+import { deepAccess } from '../../src/utils.js';
+
+export function getImuid(request) {
+  const eids = request.userIdAsEids || deepAccess(request, 'ortb2.user.ext.eids') || [];
+  const imuidEid = eids.find(eid => eid.source === 'intimatemerger.com');
+  return deepAccess(imuidEid, 'uids.0.id');
+}
+
 export function interpretResponse (serverResponse) {
   const response = serverResponse.body;
 

--- a/libraries/uniquestUtils/uniquestUtils.js
+++ b/libraries/uniquestUtils/uniquestUtils.js
@@ -1,9 +1,21 @@
-import { deepAccess } from '../../src/utils.js';
+import { deepAccess, getBidIdParameter } from '../../src/utils.js';
+import { tryAppendQueryString } from '../urlUtils/urlUtils.js';
 
-export function getImuid(request) {
-  const eids = request.userIdAsEids || deepAccess(request, 'ortb2.user.ext.eids') || [];
+export function buildQueryString(request, bidderRequest, paramKey) {
+  const eids = (request.userIdAsEids?.length ? request.userIdAsEids : deepAccess(request, 'ortb2.user.ext.eids')) || [];
   const imuidEid = eids.find(eid => eid.source === 'intimatemerger.com');
-  return deepAccess(imuidEid, 'uids.0.id');
+  const imuid = deepAccess(imuidEid, 'uids.0.id');
+  const widths = request.sizes.map(size => size[0]).join(',');
+  const heights = request.sizes.map(size => size[1]).join(',');
+
+  let queryString = '';
+  queryString = tryAppendQueryString(queryString, 'bid', request.bidId);
+  queryString = tryAppendQueryString(queryString, paramKey, getBidIdParameter(paramKey, request.params));
+  queryString = tryAppendQueryString(queryString, 'widths', widths);
+  queryString = tryAppendQueryString(queryString, 'heights', heights);
+  queryString = tryAppendQueryString(queryString, 'timeout', bidderRequest.timeout);
+  queryString = tryAppendQueryString(queryString, 'im_uid', imuid);
+  return queryString;
 }
 
 export function interpretResponse (serverResponse) {

--- a/modules/uniquestBidAdapter.js
+++ b/modules/uniquestBidAdapter.js
@@ -1,8 +1,6 @@
-import { getBidIdParameter } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
-import { tryAppendQueryString } from '../libraries/urlUtils/urlUtils.js';
-import { interpretResponse, getImuid } from '../libraries/uniquestUtils/uniquestUtils.js';
+import { interpretResponse, buildQueryString } from '../libraries/uniquestUtils/uniquestUtils.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory').Bid} Bid
@@ -35,33 +33,11 @@ export const spec = {
    * @return ServerRequest Info describing the request to the server.
    */
   buildRequests: function (validBidRequests, bidderRequest) {
-    const bidRequests = [];
-
-    for (let i = 0; i < validBidRequests.length; i++) {
-      let queryString = '';
-      const request = validBidRequests[i];
-
-      const bid = request.bidId;
-      const sid = getBidIdParameter('sid', request.params);
-      const widths = request.sizes.map(size => size[0]).join(',');
-      const heights = request.sizes.map(size => size[1]).join(',');
-      const timeout = bidderRequest.timeout;
-      const imuid = getImuid(request);
-
-      queryString = tryAppendQueryString(queryString, 'bid', bid);
-      queryString = tryAppendQueryString(queryString, 'sid', sid);
-      queryString = tryAppendQueryString(queryString, 'widths', widths);
-      queryString = tryAppendQueryString(queryString, 'heights', heights);
-      queryString = tryAppendQueryString(queryString, 'timeout', timeout);
-      queryString = tryAppendQueryString(queryString, 'im_uid', imuid);
-
-      bidRequests.push({
-        method: 'GET',
-        url: ENDPOINT,
-        data: queryString,
-      });
-    }
-    return bidRequests;
+    return validBidRequests.map(request => ({
+      method: 'GET',
+      url: ENDPOINT,
+      data: buildQueryString(request, bidderRequest, 'sid'),
+    }));
   },
   interpretResponse: interpretResponse,
 };

--- a/modules/uniquestBidAdapter.js
+++ b/modules/uniquestBidAdapter.js
@@ -1,8 +1,8 @@
-import { getBidIdParameter, deepAccess } from '../src/utils.js';
+import { getBidIdParameter } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
 import { tryAppendQueryString } from '../libraries/urlUtils/urlUtils.js';
-import { interpretResponse } from '../libraries/uniquestUtils/uniquestUtils.js';
+import { interpretResponse, getImuid } from '../libraries/uniquestUtils/uniquestUtils.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory').Bid} Bid
@@ -46,9 +46,7 @@ export const spec = {
       const widths = request.sizes.map(size => size[0]).join(',');
       const heights = request.sizes.map(size => size[1]).join(',');
       const timeout = bidderRequest.timeout;
-      const eids = deepAccess(request, 'ortb2.user.ext.eids') || [];
-      const imuidEid = eids.find(eid => eid.source === 'intimatemerger.com');
-      const imuid = deepAccess(imuidEid, 'uids.0.id');
+      const imuid = getImuid(request);
 
       queryString = tryAppendQueryString(queryString, 'bid', bid);
       queryString = tryAppendQueryString(queryString, 'sid', sid);

--- a/modules/uniquestBidAdapter.js
+++ b/modules/uniquestBidAdapter.js
@@ -1,4 +1,4 @@
-import { getBidIdParameter } from '../src/utils.js';
+import { getBidIdParameter, deepAccess } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
 import { tryAppendQueryString } from '../libraries/urlUtils/urlUtils.js';
@@ -46,12 +46,16 @@ export const spec = {
       const widths = request.sizes.map(size => size[0]).join(',');
       const heights = request.sizes.map(size => size[1]).join(',');
       const timeout = bidderRequest.timeout;
+      const eids = deepAccess(request, 'ortb2.user.ext.eids') || [];
+      const imuidEid = eids.find(eid => eid.source === 'intimatemerger.com');
+      const imuid = deepAccess(imuidEid, 'uids.0.id');
 
       queryString = tryAppendQueryString(queryString, 'bid', bid);
       queryString = tryAppendQueryString(queryString, 'sid', sid);
       queryString = tryAppendQueryString(queryString, 'widths', widths);
       queryString = tryAppendQueryString(queryString, 'heights', heights);
       queryString = tryAppendQueryString(queryString, 'timeout', timeout);
+      queryString = tryAppendQueryString(queryString, 'im_uid', imuid);
 
       bidRequests.push({
         method: 'GET',

--- a/modules/uniquest_widgetBidAdapter.js
+++ b/modules/uniquest_widgetBidAdapter.js
@@ -1,4 +1,4 @@
-import { getBidIdParameter } from '../src/utils.js';
+import { getBidIdParameter, deepAccess } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
 import { tryAppendQueryString } from '../libraries/urlUtils/urlUtils.js';
@@ -46,12 +46,16 @@ export const spec = {
       const widths = request.sizes.map(size => size[0]).join(',');
       const heights = request.sizes.map(size => size[1]).join(',');
       const timeout = bidderRequest.timeout;
+      const eids = deepAccess(request, 'ortb2.user.ext.eids') || [];
+      const imuidEid = eids.find(eid => eid.source === 'intimatemerger.com');
+      const imuid = deepAccess(imuidEid, 'uids.0.id');
 
       queryString = tryAppendQueryString(queryString, 'bid', bid);
       queryString = tryAppendQueryString(queryString, 'wid', wid);
       queryString = tryAppendQueryString(queryString, 'widths', widths);
       queryString = tryAppendQueryString(queryString, 'heights', heights);
       queryString = tryAppendQueryString(queryString, 'timeout', timeout);
+      queryString = tryAppendQueryString(queryString, 'im_uid', imuid);
 
       bidRequests.push({
         method: 'GET',

--- a/modules/uniquest_widgetBidAdapter.js
+++ b/modules/uniquest_widgetBidAdapter.js
@@ -1,8 +1,6 @@
-import { getBidIdParameter } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
-import { tryAppendQueryString } from '../libraries/urlUtils/urlUtils.js';
-import { interpretResponse, getImuid } from '../libraries/uniquestUtils/uniquestUtils.js';
+import { interpretResponse, buildQueryString } from '../libraries/uniquestUtils/uniquestUtils.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory').Bid} Bid
@@ -35,33 +33,11 @@ export const spec = {
    * @return ServerRequest Info describing the request to the server.
    */
   buildRequests: function (validBidRequests, bidderRequest) {
-    const bidRequests = [];
-
-    for (let i = 0; i < validBidRequests.length; i++) {
-      let queryString = '';
-      const request = validBidRequests[i];
-
-      const bid = request.bidId;
-      const wid = getBidIdParameter('wid', request.params);
-      const widths = request.sizes.map(size => size[0]).join(',');
-      const heights = request.sizes.map(size => size[1]).join(',');
-      const timeout = bidderRequest.timeout;
-      const imuid = getImuid(request);
-
-      queryString = tryAppendQueryString(queryString, 'bid', bid);
-      queryString = tryAppendQueryString(queryString, 'wid', wid);
-      queryString = tryAppendQueryString(queryString, 'widths', widths);
-      queryString = tryAppendQueryString(queryString, 'heights', heights);
-      queryString = tryAppendQueryString(queryString, 'timeout', timeout);
-      queryString = tryAppendQueryString(queryString, 'im_uid', imuid);
-
-      bidRequests.push({
-        method: 'GET',
-        url: ENDPOINT,
-        data: queryString,
-      });
-    }
-    return bidRequests;
+    return validBidRequests.map(request => ({
+      method: 'GET',
+      url: ENDPOINT,
+      data: buildQueryString(request, bidderRequest, 'wid'),
+    }));
   },
   interpretResponse: interpretResponse,
 };

--- a/modules/uniquest_widgetBidAdapter.js
+++ b/modules/uniquest_widgetBidAdapter.js
@@ -1,8 +1,8 @@
-import { getBidIdParameter, deepAccess } from '../src/utils.js';
+import { getBidIdParameter } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
 import { tryAppendQueryString } from '../libraries/urlUtils/urlUtils.js';
-import { interpretResponse } from '../libraries/uniquestUtils/uniquestUtils.js';
+import { interpretResponse, getImuid } from '../libraries/uniquestUtils/uniquestUtils.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory').Bid} Bid
@@ -46,9 +46,7 @@ export const spec = {
       const widths = request.sizes.map(size => size[0]).join(',');
       const heights = request.sizes.map(size => size[1]).join(',');
       const timeout = bidderRequest.timeout;
-      const eids = deepAccess(request, 'ortb2.user.ext.eids') || [];
-      const imuidEid = eids.find(eid => eid.source === 'intimatemerger.com');
-      const imuid = deepAccess(imuidEid, 'uids.0.id');
+      const imuid = getImuid(request);
 
       queryString = tryAppendQueryString(queryString, 'bid', bid);
       queryString = tryAppendQueryString(queryString, 'wid', wid);

--- a/test/spec/modules/uniquestBidAdapter_spec.js
+++ b/test/spec/modules/uniquestBidAdapter_spec.js
@@ -87,6 +87,25 @@ describe('UniquestAdapter', function () {
       expect(requests[0].data).to.include('im_uid=test_imuid_123');
     });
 
+    it('includes im_uid from ortb2 when userIdAsEids is an empty array', function () {
+      const bidsWithEid = [{
+        ...bids[0],
+        userIdAsEids: [],
+        ortb2: {
+          user: {
+            ext: {
+              eids: [{
+                source: 'intimatemerger.com',
+                uids: [{ id: 'test_imuid_123' }],
+              }],
+            },
+          },
+        },
+      }];
+      const requests = spec.buildRequests(bidsWithEid, bidderRequest);
+      expect(requests[0].data).to.include('im_uid=test_imuid_123');
+    });
+
     it('does not include im_uid in query string when imuid EID is absent', function () {
       const requests = spec.buildRequests(bids, bidderRequest);
       expect(requests[0].data).to.not.include('im_uid');

--- a/test/spec/modules/uniquestBidAdapter_spec.js
+++ b/test/spec/modules/uniquestBidAdapter_spec.js
@@ -56,6 +56,29 @@ describe('UniquestAdapter', function () {
       expect(requests[0].method).to.equal('GET');
       expect(requests[0].data).to.equal('bid=259d7a594535852&sid=sid_0001&widths=300%2C300%2C320&heights=300%2C250%2C100&timeout=1500&');
     });
+
+    it('includes im_uid in query string when imuid EID is present', function () {
+      const bidsWithEid = [{
+        ...bids[0],
+        ortb2: {
+          user: {
+            ext: {
+              eids: [{
+                source: 'intimatemerger.com',
+                uids: [{ id: 'test_imuid_123' }],
+              }],
+            },
+          },
+        },
+      }];
+      const requests = spec.buildRequests(bidsWithEid, bidderRequest);
+      expect(requests[0].data).to.include('im_uid=test_imuid_123');
+    });
+
+    it('does not include im_uid in query string when imuid EID is absent', function () {
+      const requests = spec.buildRequests(bids, bidderRequest);
+      expect(requests[0].data).to.not.include('im_uid');
+    });
   });
 
   describe('interpretResponse', function() {

--- a/test/spec/modules/uniquestBidAdapter_spec.js
+++ b/test/spec/modules/uniquestBidAdapter_spec.js
@@ -57,7 +57,19 @@ describe('UniquestAdapter', function () {
       expect(requests[0].data).to.equal('bid=259d7a594535852&sid=sid_0001&widths=300%2C300%2C320&heights=300%2C250%2C100&timeout=1500&');
     });
 
-    it('includes im_uid in query string when imuid EID is present', function () {
+    it('includes im_uid in query string when imuid EID is present via userIdAsEids', function () {
+      const bidsWithEid = [{
+        ...bids[0],
+        userIdAsEids: [{
+          source: 'intimatemerger.com',
+          uids: [{ id: 'test_imuid_123' }],
+        }],
+      }];
+      const requests = spec.buildRequests(bidsWithEid, bidderRequest);
+      expect(requests[0].data).to.include('im_uid=test_imuid_123');
+    });
+
+    it('includes im_uid in query string when imuid EID is present via ortb2 fallback', function () {
       const bidsWithEid = [{
         ...bids[0],
         ortb2: {

--- a/test/spec/modules/uniquest_widgetBidAdapter_spec.js
+++ b/test/spec/modules/uniquest_widgetBidAdapter_spec.js
@@ -85,6 +85,25 @@ describe('uniquest_widgetBidAdapter', function () {
       expect(requests[0].data).to.include('im_uid=test_imuid_123');
     });
 
+    it('includes im_uid from ortb2 when userIdAsEids is an empty array', function () {
+      const bidsWithEid = [{
+        ...bids[0],
+        userIdAsEids: [],
+        ortb2: {
+          user: {
+            ext: {
+              eids: [{
+                source: 'intimatemerger.com',
+                uids: [{ id: 'test_imuid_123' }],
+              }],
+            },
+          },
+        },
+      }];
+      const requests = spec.buildRequests(bidsWithEid, bidderRequest);
+      expect(requests[0].data).to.include('im_uid=test_imuid_123');
+    });
+
     it('does not include im_uid in query string when imuid EID is absent', function () {
       const requests = spec.buildRequests(bids, bidderRequest);
       expect(requests[0].data).to.not.include('im_uid');

--- a/test/spec/modules/uniquest_widgetBidAdapter_spec.js
+++ b/test/spec/modules/uniquest_widgetBidAdapter_spec.js
@@ -55,7 +55,19 @@ describe('uniquest_widgetBidAdapter', function () {
       expect(requests[0].data).to.equal('bid=359d7a594535852&wid=wid_0001&widths=1&heights=1&timeout=1500&');
     });
 
-    it('includes im_uid in query string when imuid EID is present', function () {
+    it('includes im_uid in query string when imuid EID is present via userIdAsEids', function () {
+      const bidsWithEid = [{
+        ...bids[0],
+        userIdAsEids: [{
+          source: 'intimatemerger.com',
+          uids: [{ id: 'test_imuid_123' }],
+        }],
+      }];
+      const requests = spec.buildRequests(bidsWithEid, bidderRequest);
+      expect(requests[0].data).to.include('im_uid=test_imuid_123');
+    });
+
+    it('includes im_uid in query string when imuid EID is present via ortb2 fallback', function () {
       const bidsWithEid = [{
         ...bids[0],
         ortb2: {

--- a/test/spec/modules/uniquest_widgetBidAdapter_spec.js
+++ b/test/spec/modules/uniquest_widgetBidAdapter_spec.js
@@ -54,6 +54,29 @@ describe('uniquest_widgetBidAdapter', function () {
       expect(requests[0].method).to.equal('GET');
       expect(requests[0].data).to.equal('bid=359d7a594535852&wid=wid_0001&widths=1&heights=1&timeout=1500&');
     });
+
+    it('includes im_uid in query string when imuid EID is present', function () {
+      const bidsWithEid = [{
+        ...bids[0],
+        ortb2: {
+          user: {
+            ext: {
+              eids: [{
+                source: 'intimatemerger.com',
+                uids: [{ id: 'test_imuid_123' }],
+              }],
+            },
+          },
+        },
+      }];
+      const requests = spec.buildRequests(bidsWithEid, bidderRequest);
+      expect(requests[0].data).to.include('im_uid=test_imuid_123');
+    });
+
+    it('does not include im_uid in query string when imuid EID is absent', function () {
+      const requests = spec.buildRequests(bids, bidderRequest);
+      expect(requests[0].data).to.not.include('im_uid');
+    });
   });
 
   describe('interpretResponse', function() {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->

Adds support for sending `im_uid` (Intimatemerger user ID) to the Uniquest bid servers.

Both `uniquestBidAdapter` and `uniquest_widgetBidAdapter` now read the IntimateMarger EID from
`ortb2.user.ext.eids` (source: `intimatemerger.com`) and append `im_uid` as a query parameter
in the bid request when available.

`gulp lint` passed with no output.

`gulp test` passed: 22,241 tests completed across 8 chunks, 7 skipped, 0 failed.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->

- Related adapters: `modules/uniquestBidAdapter.js`, `modules/uniquest_widgetBidAdapter.js`
- Tests added in `test/spec/modules/uniquestBidAdapter_spec.js` and `test/spec/modules/uniquest_widgetBidAdapter_spec.js`