### PR TITLE
Onetag Bid Adapter: add category and creative attribute meta fields in interpretResponse

### DIFF
--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -177,7 +177,11 @@ function interpretResponse(serverResponse, bidderRequest) {
       mediaType: (bid.mediaType === NATIVE + NATIVE_SUFFIX) ? NATIVE : bid.mediaType,
       meta: {
         mediaType: bid.mediaType,
-        advertiserDomains: bid.adomain
+        advertiserDomains: bid.adomain,
+        primaryCatId: bid.primaryCatId,
+        secondaryCatIds: bid.secondaryCatIds,
+        attr: bid.attr,
+        cattax: bid.cattax
       },
       ttl: bid.ttl || 300
     };

--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -295,7 +295,7 @@ function getPageInfo(bidderRequest) {
     timing: getTiming(),
     version: {
       prebid: '$prebid.version$',
-      adapter: '1.1.7'
+      adapter: '1.1.8'
     }
   };
 }

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -874,6 +874,39 @@ describe('onetag', function () {
       expect(bannerBid.meta.attr).to.be.undefined;
       expect(bannerBid.meta.cattax).to.be.undefined;
     });
+    it('Returns meta fields independently when only some are present in server response', function () {
+      const partialResponse = getBannerVideoNativeResponse();
+      delete partialResponse.body.bids[0].secondaryCatIds;
+      delete partialResponse.body.bids[0].attr;
+      const interpretedResponse = spec.interpretResponse(partialResponse, request);
+      const bannerBid = interpretedResponse.find(bid => bid.meta.mediaType === BANNER);
+      expect(bannerBid.meta.primaryCatId).to.equal('IAB-1');
+      expect(bannerBid.meta.cattax).to.equal(1);
+      expect(bannerBid.meta.secondaryCatIds).to.be.undefined;
+      expect(bannerBid.meta.attr).to.be.undefined;
+    });
+    it('Returns meta.secondaryCatIds as empty array when server response has empty array', function () {
+      const responseWithEmptySecondary = getBannerVideoNativeResponse();
+      responseWithEmptySecondary.body.bids[0].secondaryCatIds = [];
+      const interpretedResponse = spec.interpretResponse(responseWithEmptySecondary, request);
+      const bannerBid = interpretedResponse.find(bid => bid.meta.mediaType === BANNER);
+      expect(bannerBid.meta.secondaryCatIds).to.deep.equal([]);
+    });
+    it('Returns meta category and attr fields as undefined for video and native bids when absent from server response', function () {
+      const interpretedResponse = spec.interpretResponse(response, request);
+      const videoBids = interpretedResponse.filter(bid => bid.meta.mediaType === VIDEO);
+      const nativeBid = interpretedResponse.find(bid => bid.meta.mediaType === NATIVE || bid.meta.mediaType === NATIVE + NATIVE_SUFFIX);
+      videoBids.forEach(bid => {
+        expect(bid.meta.primaryCatId).to.be.undefined;
+        expect(bid.meta.secondaryCatIds).to.be.undefined;
+        expect(bid.meta.attr).to.be.undefined;
+        expect(bid.meta.cattax).to.be.undefined;
+      });
+      expect(nativeBid.meta.primaryCatId).to.be.undefined;
+      expect(nativeBid.meta.secondaryCatIds).to.be.undefined;
+      expect(nativeBid.meta.attr).to.be.undefined;
+      expect(nativeBid.meta.cattax).to.be.undefined;
+    });
   });
   describe('getUserSyncs', function () {
     const sync_endpoint = 'https://onetag-sys.com/usync/';

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -853,6 +853,27 @@ describe('onetag', function () {
       const bannerBid = interpretedResponse.find(bid => bid.requestId === 'banner');
       expect(bannerBid.dealId).to.be.undefined;
     });
+    it('Returns meta category and attr fields when present in server response', function () {
+      const interpretedResponse = spec.interpretResponse(response, request);
+      const bannerBid = interpretedResponse.find(bid => bid.meta.mediaType === BANNER);
+      expect(bannerBid.meta.primaryCatId).to.equal('IAB-1');
+      expect(bannerBid.meta.secondaryCatIds).to.deep.equal(['IAB-2', 'IAB-3']);
+      expect(bannerBid.meta.attr).to.equal(1);
+      expect(bannerBid.meta.cattax).to.equal(1);
+    });
+    it('Returns meta category and attr fields as undefined when absent from server response', function () {
+      const responseWithoutMeta = getBannerVideoNativeResponse();
+      delete responseWithoutMeta.body.bids[0].primaryCatId;
+      delete responseWithoutMeta.body.bids[0].secondaryCatIds;
+      delete responseWithoutMeta.body.bids[0].attr;
+      delete responseWithoutMeta.body.bids[0].cattax;
+      const interpretedResponse = spec.interpretResponse(responseWithoutMeta, request);
+      const bannerBid = interpretedResponse.find(bid => bid.meta.mediaType === BANNER);
+      expect(bannerBid.meta.primaryCatId).to.be.undefined;
+      expect(bannerBid.meta.secondaryCatIds).to.be.undefined;
+      expect(bannerBid.meta.attr).to.be.undefined;
+      expect(bannerBid.meta.cattax).to.be.undefined;
+    });
   });
   describe('getUserSyncs', function () {
     const sync_endpoint = 'https://onetag-sys.com/usync/';
@@ -982,7 +1003,11 @@ function getBannerVideoNativeResponse() {
           currency: 'USD',
           requestId: 'banner',
           mediaType: BANNER,
-          adomain: []
+          adomain: [],
+          primaryCatId: 'IAB-1',
+          secondaryCatIds: ['IAB-2', 'IAB-3'],
+          attr: 1,
+          cattax: 1
         },
         {
           cpm: 13,


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter
- [x] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This change enriches the `meta` object returned by `interpretResponse` with the
standard taxonomy/creative-attribute fields:

- `primaryCatId` — primary category id (ORTB `bid.cat[0]`)
- `secondaryCatIds` — remaining category ids (ORTB `bid.cat.slice(1)`)
- `attr` — creative attribute (ORTB `bid.attr`)
- `cattax` — category taxonomy

Field names match the core `BidMeta` interface (`src/bidfactory.ts`) and the
fields consumed by the `bidResponseFilter` module, so they integrate with
category, attribute and `cattax` enforcement out of the box.

The Onetag server does not currently populate these fields, so the values are
`undefined` for now and the change has no observable effect on existing
behaviour. It is shipped ahead of the server-side change so publishers have time
to adopt the updated adapter before the fields are enabled server-side.

`attr` is forwarded as a single integer to stay compatible with the
`bidResponseFilter` module, which matches `meta.attr` as a scalar (same
array-vs-scalar mismatch already addressed for `primaryCatId` in #13218).

Five unit tests added to cover: all fields present, all absent, a partial mix,
an empty `secondaryCatIds` array, and the video/native bid cases.

## Other information
No documentation changes required. Related: #13218.
