### PR TITLE
Tests: address IntentIQ and Finative review comments

### DIFF
--- a/test/spec/modules/finativeBidAdapter_spec.js
+++ b/test/spec/modules/finativeBidAdapter_spec.js
@@ -141,7 +141,8 @@ describe('Finative adapter', function () {
 
       delete badResponse.body;
 
-      assert.equal(result.length, 0);
+      const resultWithoutBody = spec.interpretResponse(badResponse, bidRequest);
+      assert.equal(resultWithoutBody.length, 0);
     });
 
     it('should return the correct params', function () {

--- a/test/spec/modules/intentIqIdSystem_spec.js
+++ b/test/spec/modules/intentIqIdSystem_spec.js
@@ -890,6 +890,7 @@ describe('IntentIQ tests', function () {
       localStorage.setItem(FIRST_PARTY_KEY, JSON.stringify(FPD));
       localStorage.setItem(partnerDataKey, JSON.stringify(strippedPartnerData));
 
+      intentIqIdSubmodule.getId(defaultConfigParams);
       await waitForClientHints();
 
       expect(server.requests.length).to.equal(0);


### PR DESCRIPTION
### Motivation
- Fix two vacuous/regression tests left by earlier edits so they actually exercise the production paths for IntentIQ and Finative.
- Ensure the test-suite will catch regressions where `interpretResponse` or `getId` behave incorrectly when `body` is missing or when an opted-out IntentIQ user would trigger a server call.

### Description
- In `test/spec/modules/finativeBidAdapter_spec.js` call `spec.interpretResponse` again after `delete badResponse.body` and assert the empty result to exercise the body-less response path.
- In `test/spec/modules/intentIqIdSystem_spec.js` restore invoking `intentIqIdSubmodule.getId(defaultConfigParams)` in the opt-out regression so the production path is executed before asserting no XHR is made.
- Minor test-only edits; no production code or documentation changes were made.

### Testing
- Ran `npx eslint test/spec/modules/finativeBidAdapter_spec.js test/spec/modules/intentIqIdSystem_spec.js --cache --cache-strategy content` with no lint errors.
- Ran `npx gulp test --nolint --file test/spec/modules/finativeBidAdapter_spec.js` and the spec chunk completed successfully.
- Ran `npx gulp test --nolint --file test/spec/modules/intentIqIdSystem_spec.js` and the spec chunk completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3ba7cc7e38832b907607afec0ec9ed)