### PR TITLE
Tighten isGzipCompressionSupported test by instantiating CompressionStream

### DIFF
--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -1293,6 +1293,7 @@ describe('Utils', function () {
             if (typeof window.CompressionStream === 'undefined') {
               cachedResult = false;
             } else {
+              (() => new window.CompressionStream('gzip'))();
               cachedResult = true;
             }
           } catch (error) {


### PR DESCRIPTION
### Motivation
- Ensure the test verifies that `window.CompressionStream` is not only defined but can be constructed, reflecting real runtime behavior.

### Description
- Updated `test/spec/utils_spec.js` to call `(() => new window.CompressionStream('gzip'))();` inside the mocked `isGzipCompressionSupported` implementation to force instantiation and catch constructor failures.

### Testing
- Ran the unit tests with `npm test` covering `test/spec/utils_spec.js`, and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3ba8517a88832b871eb994dddcf24a)