### PR TITLE
Nobid Bid Adapter: restore review test coverage

### DIFF
--- a/test/spec/modules/nobidBidAdapter_spec.js
+++ b/test/spec/modules/nobidBidAdapter_spec.js
@@ -333,33 +333,32 @@ describe('Nobid Adapter', function () {
   describe('isVideoBidRequestValid', function () {
     const SITE_ID = 2;
     const REFERER = 'https://www.examplereferer.com';
-    const bidRequests = [
-      {
-        bidder: 'nobid',
-        params: {
-          siteId: SITE_ID,
-          video: {
-            skippable: true,
-            playback_methods: ['auto_play_sound_off'],
-            position: 'atf',
-            mimes: ['video/x-flv', 'video/mp4', 'video/x-ms-wmv', 'application/x-shockwave-flash', 'application/javascript'],
-            minduration: 1,
-            maxduration: 30,
-            frameworks: [1, 2, 3, 4, 5, 6]
-          }
-        },
-        adUnitCode: 'adunit-code',
-        bidId: '30b31c1838de1e',
-        bidderRequestId: '22edbae2733bf6',
-        auctionId: '1d1a030790a475',
-        mediaTypes: {
-          video: {
-            playerSize: [640, 480],
-            context: 'instream'
-          }
+    const bid = {
+      bidder: 'nobid',
+      params: {
+        siteId: SITE_ID,
+        video: {
+          skippable: true,
+          playback_methods: ['auto_play_sound_off'],
+          position: 'atf',
+          mimes: ['video/x-flv', 'video/mp4', 'video/x-ms-wmv', 'application/x-shockwave-flash', 'application/javascript'],
+          minduration: 1,
+          maxduration: 30,
+          frameworks: [1, 2, 3, 4, 5, 6]
+        }
+      },
+      adUnitCode: 'adunit-code',
+      bidId: '30b31c1838de1e',
+      bidderRequestId: '22edbae2733bf6',
+      auctionId: '1d1a030790a475',
+      mediaTypes: {
+        video: {
+          playerSize: [640, 480],
+          context: 'instream'
         }
       }
-    ];
+    };
+    const bidRequests = [bid];
 
     const bidderRequest = {
       refererInfo: { page: REFERER }
@@ -793,12 +792,42 @@ describe('Nobid Adapter', function () {
   });
 
   describe('interpretResponseWithRefreshLimit', function () {
+    const CREATIVE_ID_300x250 = 'CREATIVE-100';
+    const ADUNIT_300x250 = 'ADUNIT-1';
+    const ADMARKUP_300x250 = 'ADMARKUP-300x250';
+    const PRICE_300x250 = 0.51;
+    const REQUEST_ID = '3db3773286ee59';
+    const DEAL_ID = 'deal123';
     const REFRESH_LIMIT = 3;
+    const response = {
+      country: 'US',
+      ip: '68.83.15.75',
+      device: 'COMPUTER',
+      site: 2,
+      rlimit: REFRESH_LIMIT,
+      bids: [
+        {
+          id: 1,
+          bdrid: 101,
+          divid: ADUNIT_300x250,
+          dealid: DEAL_ID,
+          creativeid: CREATIVE_ID_300x250,
+          size: { 'w': 300, 'h': 250 },
+          adm: ADMARKUP_300x250,
+          price: '' + PRICE_300x250
+        }
+      ]
+    };
 
     it('should refreshLimit be respected', function () {
-      const response = { rlimit: REFRESH_LIMIT };
+      const bidderRequest = {
+        bids: [{
+          bidId: REQUEST_ID,
+          adUnitCode: ADUNIT_300x250
+        }]
+      };
 
-      spec.interpretResponse({ body: response }, { bidderRequest: { bids: [] } });
+      spec.interpretResponse({ body: response }, { bidderRequest: bidderRequest });
 
       expect(nobid.refreshLimit).to.equal(REFRESH_LIMIT);
     });


### PR DESCRIPTION
### Motivation
- Restore test logic that was removed during review cleanup which weakened coverage by removing setup and exercised code paths for the Nobid adapter.  
- Ensure the refresh-limit behavior is exercised via `spec.interpretResponse` so regressions in copying `response.rlimit` to `window.nobid.refreshLimit` are caught.

### Description
- Reintroduced a reusable video `bid` fixture and replaced the previous inline `bidRequests` array with `const bidRequests = [bid];` to avoid unused-variable lint noise while keeping the setup available.  
- Restored the full refresh-limit `response` fixture including `rlimit` and `bids`, and changed the test to call `spec.interpretResponse({ body: response }, { bidderRequest })` before asserting `nobid.refreshLimit`.  
- Changes were applied to `test/spec/modules/nobidBidAdapter_spec.js` to reinstate the removed assertions and exercise the intended production paths under test.

### Testing
- Ran `npx eslint test/spec/modules/nobidBidAdapter_spec.js --cache --cache-strategy content` and it passed with no lint errors.  
- Ran `npx gulp test --nolint --file test/spec/modules/nobidBidAdapter_spec.js` and the targeted spec ran successfully.  
- Karma reported the spec run completed with all tests passing (46 tests completed) in both feature-disabled and normal runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3bac3d2810832b841dc5ba351b0a27)