### PR TITLE
tests(dxtechBidAdapter): add shared videoBidRequest fixture and update video validation tests

### DIFF
--- a/test/spec/modules/dxtechBidAdapter_spec.js
+++ b/test/spec/modules/dxtechBidAdapter_spec.js
@@ -192,6 +192,47 @@ const getBidderResponse = () => {
 };
 
 describe('dxtechBidAdapter', function() {
+  let videoBidRequest;
+
+  beforeEach(function () {
+    videoBidRequest = {
+      mediaTypes: {
+        video: {
+          context: 'instream',
+          playerSize: [[640, 480]],
+        }
+      },
+      bidder: 'dxtech',
+      sizes: [640, 480],
+      bidId: '30b3efwfwe1e',
+      adUnitCode: 'video1',
+      params: {
+        video: {
+          playerWidth: 640,
+          playerHeight: 480,
+          mimes: ['video/mp4', 'application/javascript'],
+          protocols: [2, 5],
+          api: [2],
+          position: 1,
+          delivery: [2],
+          sid: 134,
+          rewarded: 1,
+          placement: 1,
+          plcmt: 1,
+          hp: 1,
+          inventoryid: 123
+        },
+        site: {
+          id: 1,
+          page: 'https://test.com',
+          referrer: 'http://test.com'
+        },
+        publisherId: 'km123',
+        bidfloor: 0
+      }
+    };
+  });
+
   describe('isBidRequestValid', function() {
     let bidderRequest;
 
@@ -293,7 +334,6 @@ describe('dxtechBidAdapter', function() {
     });
 
     it('returns true when video request includes required params', function () {
-      const videoBidRequest = getVideoRequest().bids[0];
       videoBidRequest.params.placementId = 'placementId';
       expect(spec.isBidRequestValid(videoBidRequest)).to.be.true;
     });


### PR DESCRIPTION
### Motivation

- Provide a consistent, reusable video bid fixture for the adapter spec to simplify and standardize video validation tests.

### Description

- Add a top-level `videoBidRequest` test fixture initialized in `beforeEach` with comprehensive `video`, `site`, and `params` fields in `test/spec/modules/dxtechBidAdapter_spec.js`.
- Update video validation tests to use the shared `videoBidRequest` fixture instead of calling `getVideoRequest().bids[0]` inline.
- Refactor test setup to centralize video test data and reduce duplication in the spec file.

### Testing

- Ran the adapter unit specs via the project's test runner (`npm test` / Karma) focusing on `dxtechBidAdapter_spec.js` and the spec suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3bac2fb240832bade24f3925d479e6)