### PR TITLE
GH Actions: use node 24 versions and replace github-app-token usage

### DIFF
--- a/.github/actions/combine-coverage/action.yml
+++ b/.github/actions/combine-coverage/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - name: Restore from cache
       id: restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: ${{ runner.temp }}/coverage.info
         key: ${{ inputs.cache-key }}
@@ -30,7 +30,7 @@ runs:
         find build/coverage/chunks  -name 'lcov.info' -printf ' -a %p' | xargs lcov -o ${{ runner.temp }}/coverage.info
     - name: Save to cache
       if: ${{ steps.restore.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: ${{ runner.temp }}/coverage.info
         key: ${{ inputs.cache-key }}

--- a/.github/actions/install-deb/action.yml
+++ b/.github/actions/install-deb/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - name: Restore deb
       id: deb-restore
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: "${{ runner.temp }}/${{ inputs.name }}"
         key: ${{ inputs.url }}
@@ -25,7 +25,7 @@ runs:
         wget --no-verbose "${{ inputs.url }}" -O "${{ runner.temp }}/${{ inputs.name }}"
     - name: Cache deb
       if: ${{ steps.deb-restore.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: "${{ runner.temp }}/${{ inputs.name }}"
         key: ${{ inputs.url }}

--- a/.github/actions/load/action.yml
+++ b/.github/actions/load/action.yml
@@ -11,7 +11,7 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version-file: '.nvmrc'
-    - uses: actions/github-script@v8
+    - uses: actions/github-script@v9
       id: platform
       with:
         result-encoding: string

--- a/.github/actions/npm-ci/action.yml
+++ b/.github/actions/npm-ci/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - name: Restore dependencies
       id: restore-modules
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: "node_modules"
         key: node_modules-${{ hashFiles('package-lock.json') }}
@@ -17,7 +17,7 @@ runs:
         npm ci
     - name: Cache dependencies
       if: ${{ steps.restore-modules.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: "node_modules"
         key: node_modules-${{ hashFiles('package-lock.json') }}

--- a/.github/actions/save/action.yml
+++ b/.github/actions/save/action.yml
@@ -15,7 +15,7 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/github-script@v8
+    - uses: actions/github-script@v9
       id: platform
       with:
         script: |
@@ -34,7 +34,7 @@ runs:
         target="$(basename "$wdir")"
         tar ${{ fromJSON(steps.platform.outputs.result).platform == 'win32' && '--force-local' || '' }} -C "$parent" -cf "${{ runner.temp }}/${{ fromJSON(steps.platform.outputs.result).name }}.tar" "$target"
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         path: '${{ runner.temp }}/${{ fromJSON(steps.platform.outputs.result).name }}.tar'
         name: ${{ fromJSON(steps.platform.outputs.result).name }}

--- a/.github/actions/unzip-artifact/action.yml
+++ b/.github/actions/unzip-artifact/action.yml
@@ -16,7 +16,7 @@ runs:
       run: sleep 10
     - name: 'Download artifact'
       id: download
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       with:
         result-encoding: string
         script: |

--- a/.github/workflows/issue_tracker.yml
+++ b/.github/workflows/issue_tracker.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        uses: actions/create-github-app-token@v3
         with:
-          app_id: ${{ secrets.ISSUE_APP_ID }}
-          private_key: ${{ secrets.ISSUE_APP_PEM }}
+          app-id: ${{ secrets.ISSUE_APP_ID }}
+          private-key: ${{ secrets.ISSUE_APP_PEM }}
 
       - name: Get project data
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,7 +137,7 @@ jobs:
     steps:
       - name: Restore from cache
         id: restore
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ runner.temp }}/coverage.info
           key: coverage-${{ needs.checkout.outputs.base-commit }}


### PR DESCRIPTION
### Motivation
- Modernize composite actions and workflows by upgrading referenced GitHub Action versions for node24 runners
- Replace an external `tibdex/github-app-token` usage with the maintained `actions/create-github-app-token` action and adapt its input names.

