### PR TITLE
Tests: fix dxkulture banner validation case

### DIFF
--- a/test/spec/modules/dxkultureBidAdapter_spec.js
+++ b/test/spec/modules/dxkultureBidAdapter_spec.js
@@ -270,14 +270,21 @@ describe('dxkultureBidAdapter', function() {
   });
 
   context('banner validation', function () {
-    let bidderRequest;
-
-    beforeEach(function() {
-      bidderRequest = getBannerRequest();
-    });
-
     it('returns true when banner sizes are defined', function () {
-      expect(spec.isBidRequestValid(bidderRequest.bids[0])).to.be.true;
+      const bid = {
+        bidder: 'dxkulture',
+        mediaTypes: {
+          banner: {
+            sizes: [[250, 300]]
+          }
+        },
+        params: {
+          placementId: 'placementId',
+          publisherId: 'publisherId',
+        }
+      };
+
+      expect(spec.isBidRequestValid(bid)).to.be.true;
     });
 
     it('returns false when banner sizes are invalid', function () {


### PR DESCRIPTION
### Motivation
- Address a review comment pointing out a missing argument in the dxkulture banner validation test and make the test robust against enabling `no-unused-vars` linting. 

### Description
- Restore an explicit valid banner `bid` fixture and pass it to `spec.isBidRequestValid` in `test/spec/modules/dxkultureBidAdapter_spec.js`.
- Remove the now-unneeded shared `bidderRequest` setup from the `banner validation` context so the test does not reference an external variable.
- Change is limited to the `dxkulture` spec file to keep the test self-contained and lint-friendly.

### Testing
- Ran `npx eslint test/spec/modules/dxkultureBidAdapter_spec.js --cache --cache-strategy content` which completed successfully.
- Ran `npx gulp test --nolint --file test/spec/modules/dxkultureBidAdapter_spec.js` and the spec file tests passed (all tests in the file completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3bac526650832bb421241cb44483d4)