### PR TITLE
Yahoo Ads Bid Adapter: remove custom header and use text/plain content type

### DIFF
--- a/modules/yahooAdsBidAdapter.js
+++ b/modules/yahooAdsBidAdapter.js
@@ -12,7 +12,7 @@ const BIDDER_ALIASES = [
   { code: 'yahoossp', gvlid: GVLID },
   { code: 'yahooAdvertising', gvlid: GVLID }
 ];
-const ADAPTER_VERSION = '2.1.0';
+const ADAPTER_VERSION = '2.2.0';
 const PREBID_VERSION = '$prebid.version$';
 const DEFAULT_BID_TTL = 300;
 const TEST_MODE_DCN = '8a969516017a7a396ec539d97f540011';
@@ -716,10 +716,7 @@ export const spec = {
     };
 
     const requestOptions = {
-      contentType: 'application/json',
-      customHeaders: {
-        'x-openrtb-version': '2.6'
-      }
+      contentType: 'text/plain'
     };
 
     requestOptions.withCredentials = hasPurpose1Consent(bidderRequest.gdprConsent);

--- a/test/spec/modules/yahooAdsBidAdapter_spec.js
+++ b/test/spec/modules/yahooAdsBidAdapter_spec.js
@@ -13,7 +13,7 @@ const DEFAULT_AD_UNIT_CODE = '/19968336/header-bid-tag-1';
 const DEFAULT_AD_UNIT_TYPE = 'banner';
 const DEFAULT_PARAMS_BID_OVERRIDE = {};
 const DEFAULT_VIDEO_CONTEXT = 'instream';
-const ADAPTER_VERSION = '2.1.0';
+const ADAPTER_VERSION = '2.2.0';
 const DEFAULT_BIDDER_CODE = 'yahooAds';
 const VALID_BIDDER_CODES = [DEFAULT_BIDDER_CODE, 'yahoossp', 'yahooAdvertising'];
 const PREBID_VERSION = '$prebid.version$';
@@ -1043,16 +1043,13 @@ describe('Yahoo Advertising Bid Adapter:', () => {
   });
 
   describe('Request Headers validation:', () => {
-    it('should return request objects with the relevant custom headers and content type declaration', () => {
+    it('should return request objects with the relevant content type declaration', () => {
       const { validBidRequests, bidderRequest } = generateBuildRequestMock({});
       bidderRequest.gdprConsent.gdprApplies = false;
       const options = spec.buildRequests(validBidRequests, bidderRequest)[0].options;
       expect(options).to.deep.equal(
         {
-          contentType: 'application/json',
-          customHeaders: {
-            'x-openrtb-version': '2.6'
-          },
+          contentType: 'text/plain',
           withCredentials: true
         });
     });
@@ -1850,11 +1847,11 @@ describe('Yahoo Advertising Bid Adapter:', () => {
   });
 
   describe('OpenRTB 2.6 compliance:', () => {
-    it('should use application/json content type and send x-openrtb-version header', () => {
+    it('should use text/plain content type and not send custom headers', () => {
       const { validBidRequests, bidderRequest } = generateBuildRequestMock({});
       const request = spec.buildRequests(validBidRequests, bidderRequest)[0];
-      expect(request.options.contentType).to.equal('application/json');
-      expect(request.options.customHeaders['x-openrtb-version']).to.equal('2.6');
+      expect(request.options.contentType).to.equal('text/plain');
+      expect(request.options.customHeaders).to.be.undefined;
     });
 
     it('should place us_privacy at regs top-level AND keep in regs.ext for backward compat', () => {


### PR DESCRIPTION
This change updates the request options in the Yahoo Ads bid adapter:

- Removed the `customHeaders` block (`x-openrtb-version: '2.6'`) from `buildRequests`.
- Changed `contentType` from `application/json` to `text/plain`.
- Bumped `ADAPTER_VERSION` from `2.1.0` to `2.2.0`.


## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Using `application/json` causes the browser to treat the bid request as a
non-simple CORS request, triggering a preflight `OPTIONS` call that adds
latency to every auction. Sending the payload as `text/plain` (and dropping the
custom header, which also forces a preflight) keeps the request "simple" and
avoids the extra round trip, in line with the Prebid module rules that
discourage `application/json` calls.

### Files changed
- `modules/yahooAdsBidAdapter.js` — request options + adapter version bump.
- `test/spec/modules/yahooAdsBidAdapter_spec.js` — updated header/content-type
  assertions and `ADAPTER_VERSION` constant.
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
Related https://github.com/prebid/Prebid.js/issues/12948#issuecomment-2770413560
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
