### PR TITLE
Core: update browserslist target

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ For instructions on writing tests for Prebid.js, see [Testing Prebid.js](https:/
 
 ### Supported Browsers
 
-Prebid.js is supported on IE11 and modern browsers until 5.x. 6.x+ transpiles to target >0.25%; not dead; not Opera Mini; not IE11.
+Prebid.js is supported on IE11 and modern browsers until 5.x. 6.x+ transpiles to target >0.25%; not ios_saf 11.
 
 ### Governance
 Review our governance model [here](https://github.com/prebid/Prebid.js/tree/master/governance.md).

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ For instructions on writing tests for Prebid.js, see [Testing Prebid.js](https:/
 
 ### Supported Browsers
 
-Prebid.js is supported on IE11 and modern browsers until 5.x. 6.x+ transpiles to target >0.25%; not ios_saf 11.
+Prebid.js is supported on IE11 and modern browsers until 5.x. 6.x+ transpiles to target >0.25%; not dead. 11.21+ removes not dead and adds not ios_saf 11.
 
 ### Governance
 Review our governance model [here](https://github.com/prebid/Prebid.js/tree/master/governance.md).

--- a/package.json
+++ b/package.json
@@ -36,9 +36,7 @@
   ],
   "browserslist": [
     "> 0.25%",
-    "not IE 11",
-    "not dead",
-    "not op_mini all"
+    "not ios_saf 11"
   ],
   "keywords": [
     "advertising",


### PR DESCRIPTION
### Motivation
- Reimplement PR #14985 to update the project's Browserslist to `> 0.25%` while explicitly excluding `ios_saf 11` (see https://github.com/prebid/Prebid.js/pull/14985).

### Description
- Replace the `browserslist` entry in `package.json` with `["> 0.25%","not ios_saf 11"]` (file: `package.json`, lines ~37-40) and commit the change.

### Testing
- Ran `git diff --check` with no issues, `npx eslint package.json --cache --cache-strategy content` which completed but reported `package.json` is ignored, and a verification `node -e "..."` plus `npx browserslist` which resolved the configured targets; checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3bc00f5bb8832baa973620b2326ad0)