### PR TITLE
bidResponseFilter: fix attr enforcement incorrectly expecting a single attribute in meta.attr

### DIFF
--- a/modules/bidResponseFilter/index.js
+++ b/modules/bidResponseFilter/index.js
@@ -71,7 +71,7 @@ export function addBidResponseHook(next, adUnitCode, bid, reject, index = auctio
   } else if ((advConfig.enforce && badv.some(domain => advertiserDomains.includes(domain))) ||
     (advConfig.blockUnknown && !advertiserDomains.length)) {
     reject(BID_ADV_DOMAINS_REJECTION_REASON);
-  } else if ((attrConfig.enforce && (attrConfig.blockUnknown && !Array.isArray(metaAttr)) || metaAttr.find(attr => battr.includes(attr)))) {
+  } else if ((attrConfig.enforce && ((attrConfig.blockUnknown && !Array.isArray(metaAttr) || metaAttr.length === 0) || metaAttr.find(attr => battr.includes(attr))))) {
     reject(BID_ATTR_REJECTION_REASON);
   } else if ((mediaTypesConfig.enforce && (!allowedMediaTypes.includes(metaMediaType) || rejectIbvBannerOnMultiFormat)) ||
     (mediaTypesConfig.blockUnknown && !metaMediaType)) {

--- a/modules/bidResponseFilter/index.js
+++ b/modules/bidResponseFilter/index.js
@@ -71,7 +71,12 @@ export function addBidResponseHook(next, adUnitCode, bid, reject, index = auctio
   } else if ((advConfig.enforce && badv.some(domain => advertiserDomains.includes(domain))) ||
     (advConfig.blockUnknown && !advertiserDomains.length)) {
     reject(BID_ADV_DOMAINS_REJECTION_REASON);
-  } else if ((attrConfig.enforce && ((attrConfig.blockUnknown && !Array.isArray(metaAttr) || metaAttr.length === 0) || metaAttr.find(attr => battr.includes(attr))))) {
+  } else if (
+    attrConfig.enforce && (
+      (attrConfig.blockUnknown && (!Array.isArray(metaAttr) || metaAttr.length === 0)) ||
+      (Array.isArray(metaAttr) && metaAttr.find(attr => battr.includes(attr)))
+    )
+  ) {
     reject(BID_ATTR_REJECTION_REASON);
   } else if ((mediaTypesConfig.enforce && (!allowedMediaTypes.includes(metaMediaType) || rejectIbvBannerOnMultiFormat)) ||
     (mediaTypesConfig.blockUnknown && !metaMediaType)) {

--- a/modules/bidResponseFilter/index.js
+++ b/modules/bidResponseFilter/index.js
@@ -71,8 +71,7 @@ export function addBidResponseHook(next, adUnitCode, bid, reject, index = auctio
   } else if ((advConfig.enforce && badv.some(domain => advertiserDomains.includes(domain))) ||
     (advConfig.blockUnknown && !advertiserDomains.length)) {
     reject(BID_ADV_DOMAINS_REJECTION_REASON);
-  } else if ((attrConfig.enforce && battr.includes(metaAttr)) ||
-    (attrConfig.blockUnknown && !metaAttr)) {
+  } else if ((attrConfig.enforce && (attrConfig.blockUnknown && !Array.isArray(metaAttr)) || metaAttr.find(attr => battr.includes(attr)))) {
     reject(BID_ATTR_REJECTION_REASON);
   } else if ((mediaTypesConfig.enforce && (!allowedMediaTypes.includes(metaMediaType) || rejectIbvBannerOnMultiFormat)) ||
     (mediaTypesConfig.blockUnknown && !metaMediaType)) {

--- a/modules/bidResponseFilter/index.js
+++ b/modules/bidResponseFilter/index.js
@@ -42,7 +42,7 @@ export function addBidResponseHook(next, adUnitCode, bid, reject, index = auctio
 
   const catConfig = { enforce: true, blockUnknown: true, ...(moduleConfig?.cat || {}) };
   const advConfig = { enforce: true, blockUnknown: true, ...(moduleConfig?.adv || {}) };
-  const attrConfig = { enforce: true, blockUnknown: true, ...(moduleConfig?.attr || {}) };
+  const attrConfig = { enforce: true, blockUnknown: false, ...(moduleConfig?.attr || {}) };
   const mediaTypesConfig = {
     enforce: true,
     blockUnknown: true,

--- a/test/spec/modules/bidResponseFilter_spec.js
+++ b/test/spec/modules/bidResponseFilter_spec.js
@@ -276,7 +276,6 @@ describe('bidResponseFilter', () => {
         sinon.assert.called(call);
       });
     });
-
   });
 
   it('should omit the validation if the flag is set to false', () => {

--- a/test/spec/modules/bidResponseFilter_spec.js
+++ b/test/spec/modules/bidResponseFilter_spec.js
@@ -68,7 +68,7 @@ describe('bidResponseFilter', () => {
       meta: {
         advertiserDomains: ['domain1.com', 'domain2.com'],
         primaryCatId: 'EXAMPLE-CAT-ID',
-        attr: 'attr',
+        attr: ['attr'],
         mediaType: 'banner',
         cattax: 1
       }
@@ -86,7 +86,7 @@ describe('bidResponseFilter', () => {
       meta: {
         advertiserDomains: ['domain1.com', 'domain2.com'],
         primaryCatId: 'BANNED_CAT1',
-        attr: 'attr',
+        attr: ['attr'],
         cattax: 1
       }
     };
@@ -106,7 +106,7 @@ describe('bidResponseFilter', () => {
         meta: {
           advertiserDomains: ['domain1.com'],
           primaryCatId: 'BANNED_CAT1',
-          attr: 1,
+          attr: [1],
           mediaType: 'banner',
           cattax: 1
         }
@@ -131,7 +131,7 @@ describe('bidResponseFilter', () => {
         meta: {
           advertiserDomains: ['domain1.com'],
           primaryCatId: 'ALLOWED_CAT',
-          attr: 1,
+          attr: [1],
           mediaType: 'banner',
           cattax: 1
         }
@@ -156,7 +156,7 @@ describe('bidResponseFilter', () => {
         meta: {
           advertiserDomains: ['domain1.com'],
           primaryCatId: 'ALLOWED_CAT',
-          attr: 1,
+          attr: [1],
           mediaType: 'banner',
           cattax: 2
         }
@@ -181,7 +181,7 @@ describe('bidResponseFilter', () => {
         meta: {
           advertiserDomains: ['domain1.com'],
           primaryCatId: 'BANNED_CAT1',
-          attr: 1,
+          attr: [1],
           mediaType: 'banner',
           cattax: 2
         }
@@ -208,7 +208,7 @@ describe('bidResponseFilter', () => {
       meta: {
         advertiserDomains: ['domain1.com', 'domain2.com'],
         primaryCatId: 'VALID_CAT',
-        attr: 'attr',
+        attr: ['attr'],
         cattax: 1
       }
     };
@@ -227,7 +227,7 @@ describe('bidResponseFilter', () => {
       meta: {
         advertiserDomains: ['validdomain1.com', 'validdomain2.com'],
         primaryCatId: 'VALID_CAT',
-        attr: 'BANNED_ATTR',
+        attr: ['BANNED_ATTR', 'OTHER_ATTR'],
         cattax: 1
       },
       mediaType: 'video'
@@ -239,7 +239,7 @@ describe('bidResponseFilter', () => {
     mockAuctionIndex.getBidRequest = () => ({
       ortb2Imp: {
         video: {
-          battr: 'BANNED_ATTR'
+          battr: ['BANNED_ATTR']
         }
       }
     });
@@ -254,7 +254,7 @@ describe('bidResponseFilter', () => {
       meta: {
         advertiserDomains: ['validdomain1.com', 'validdomain2.com'],
         primaryCatId: 'BANNED_CAT1',
-        attr: 'valid_attr',
+        attr: ['valid_attr'],
         mediaType: 'banner',
         cattax: 1
       }
@@ -284,7 +284,7 @@ describe('bidResponseFilter', () => {
       meta: {
         advertiserDomains: ['validdomain1.com', 'validdomain2.com'],
         primaryCatId: undefined,
-        attr: 'valid_attr',
+        attr: ['valid_attr'],
         mediaType: 'banner',
         cattax: 1
       }
@@ -315,7 +315,7 @@ describe('bidResponseFilter', () => {
       meta: {
         advertiserDomains: ['validdomain1.com', 'validdomain2.com'],
         primaryCatId: 'VALID_CAT',
-        attr: 6,
+        attr: [6],
         mediaType: 'audio',
         cattax: 1
       },
@@ -343,7 +343,7 @@ describe('bidResponseFilter', () => {
       meta: {
         advertiserDomains: ['validdomain1.com'],
         primaryCatId: 'VALID_CAT',
-        attr: 6,
+        attr: [6],
         mediaType: 'banner',
         cattax: 1
       },
@@ -376,7 +376,7 @@ describe('bidResponseFilter', () => {
       meta: {
         advertiserDomains: ['validdomain1.com'],
         primaryCatId: 'VALID_CAT',
-        attr: 6,
+        attr: [6],
         mediaType: 'banner',
         cattax: 1
       },

--- a/test/spec/modules/bidResponseFilter_spec.js
+++ b/test/spec/modules/bidResponseFilter_spec.js
@@ -220,32 +220,38 @@ describe('bidResponseFilter', () => {
     sinon.assert.calledWith(rejection, BID_ADV_DOMAINS_REJECTION_REASON);
   });
 
-  it('should reject the bid after failed ortb2 attr rule validation', () => {
-    const reject = sinon.stub();
-    const call = sinon.stub();
-    const bid = {
-      meta: {
-        advertiserDomains: ['validdomain1.com', 'validdomain2.com'],
-        primaryCatId: 'VALID_CAT',
-        attr: ['BANNED_ATTR', 'OTHER_ATTR'],
-        cattax: 1
-      },
-      mediaType: 'video'
-    };
-    mockAuctionIndex.getOrtb2 = () => ({
-      badv: ['domain2.com'], bcat: ['BANNED_CAT1', 'BANNED_CAT2']
-    });
+  Object.entries({
+    'banned': ['BANNED_ATTR', 'OTHER_ATTR'],
+    'invalid': 'attr',
+    'unknown': []
+  }).forEach(([t, attr]) => {
+    it('should reject the bid after failed ortb2 attr rule validation', () => {
+      const reject = sinon.stub();
+      const call = sinon.stub();
+      const bid = {
+        meta: {
+          advertiserDomains: ['validdomain1.com', 'validdomain2.com'],
+          primaryCatId: 'VALID_CAT',
+          attr,
+          cattax: 1
+        },
+        mediaType: 'video'
+      };
+      mockAuctionIndex.getOrtb2 = () => ({
+        badv: ['domain2.com'], bcat: ['BANNED_CAT1', 'BANNED_CAT2']
+      });
 
-    mockAuctionIndex.getBidRequest = () => ({
-      ortb2Imp: {
-        video: {
-          battr: ['BANNED_ATTR']
+      mockAuctionIndex.getBidRequest = () => ({
+        ortb2Imp: {
+          video: {
+            battr: ['BANNED_ATTR']
+          }
         }
-      }
-    });
+      });
 
-    addBidResponseHook(call, 'adcode', bid, reject, mockAuctionIndex);
-    sinon.assert.calledWith(reject, BID_ATTR_REJECTION_REASON);
+      addBidResponseHook(call, 'adcode', bid, reject, mockAuctionIndex);
+      sinon.assert.calledWith(reject, BID_ATTR_REJECTION_REASON);
+    });
   });
 
   it('should omit the validation if the flag is set to false', () => {

--- a/test/spec/modules/bidResponseFilter_spec.js
+++ b/test/spec/modules/bidResponseFilter_spec.js
@@ -220,38 +220,63 @@ describe('bidResponseFilter', () => {
     sinon.assert.calledWith(rejection, BID_ADV_DOMAINS_REJECTION_REASON);
   });
 
-  Object.entries({
-    'banned': ['BANNED_ATTR', 'OTHER_ATTR'],
-    'invalid': 'attr',
-    'unknown': []
-  }).forEach(([t, attr]) => {
-    it('should reject the bid after failed ortb2 attr rule validation', () => {
-      const reject = sinon.stub();
-      const call = sinon.stub();
-      const bid = {
+  describe('attr validation', () => {
+    let reject, call;
+
+    function makeBid(attr) {
+      return {
         meta: {
           advertiserDomains: ['validdomain1.com', 'validdomain2.com'],
           primaryCatId: 'VALID_CAT',
           attr,
-          cattax: 1
+          cattax: 1,
+          mediaType: 'video',
         },
         mediaType: 'video'
       };
+    }
+
+    beforeEach(() => {
       mockAuctionIndex.getOrtb2 = () => ({
         badv: ['domain2.com'], bcat: ['BANNED_CAT1', 'BANNED_CAT2']
       });
 
       mockAuctionIndex.getBidRequest = () => ({
+        mediaTypes: {
+          video: {}
+        },
         ortb2Imp: {
           video: {
             battr: ['BANNED_ATTR']
           }
         }
       });
-
-      addBidResponseHook(call, 'adcode', bid, reject, mockAuctionIndex);
-      sinon.assert.calledWith(reject, BID_ATTR_REJECTION_REASON);
+      reject = sinon.stub();
+      call = sinon.stub();
     });
+    Object.entries({
+      'banned': ['BANNED_ATTR', 'OTHER_ATTR'],
+      'invalid': 'attr',
+      'unknown': []
+    }).forEach(([t, attr]) => {
+      it(`should reject the bid when its attr is ${t}`, () => {
+        addBidResponseHook(call, 'adcode', makeBid(attr), reject, mockAuctionIndex);
+        sinon.assert.calledWith(reject, BID_ATTR_REJECTION_REASON);
+        sinon.assert.notCalled(call);
+      });
+    });
+    Object.entries({
+      'missing': null,
+      'empty': []
+    }).forEach(([t, attr]) => {
+      it(`it should not reject when its attr is ${t}, but blockUnknown is false`, () => {
+        config.setConfig({ [MODULE_NAME]: { attr: { enforce: true, blockUnknown: false } } });
+        addBidResponseHook(call, 'adcode', makeBid(attr), reject, mockAuctionIndex);
+        sinon.assert.notCalled(reject);
+        sinon.assert.called(call);
+      });
+    });
+
   });
 
   it('should omit the validation if the flag is set to false', () => {

--- a/test/spec/modules/bidResponseFilter_spec.js
+++ b/test/spec/modules/bidResponseFilter_spec.js
@@ -254,21 +254,24 @@ describe('bidResponseFilter', () => {
       reject = sinon.stub();
       call = sinon.stub();
     });
+
+    it(`should reject the bid when its attr is banned`, () => {
+      addBidResponseHook(call, 'adcode', makeBid(['BANNED_ATTR', 'OTHER_ATTR']), reject, mockAuctionIndex);
+      sinon.assert.calledWith(reject, BID_ATTR_REJECTION_REASON);
+      sinon.assert.notCalled(call);
+    });
+
     Object.entries({
-      'banned': ['BANNED_ATTR', 'OTHER_ATTR'],
+      'missing': null,
+      'empty': [],
       'invalid': 'attr',
-      'unknown': []
     }).forEach(([t, attr]) => {
-      it(`should reject the bid when its attr is ${t}`, () => {
+      it(`should reject when attr is ${t}, and blockUnknown is set`, () => {
+        config.setConfig({ [MODULE_NAME]: { attr: { enforce: true, blockUnknown: true } } });
         addBidResponseHook(call, 'adcode', makeBid(attr), reject, mockAuctionIndex);
         sinon.assert.calledWith(reject, BID_ATTR_REJECTION_REASON);
         sinon.assert.notCalled(call);
       });
-    });
-    Object.entries({
-      'missing': null,
-      'empty': []
-    }).forEach(([t, attr]) => {
       it(`it should not reject when its attr is ${t}, but blockUnknown is false`, () => {
         config.setConfig({ [MODULE_NAME]: { attr: { enforce: true, blockUnknown: false } } });
         addBidResponseHook(call, 'adcode', makeBid(attr), reject, mockAuctionIndex);


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change

Fixes https://github.com/prebid/Prebid.js/issues/15230

Also flips the default for `attr.blockUnknown` to false, since it's not obvious that every bid should have attributes.
