### PR TITLE
Core: fix: guard renderer lookup when bid has no ad unit

### DIFF
--- a/src/auction.ts
+++ b/src/auction.ts
@@ -771,8 +771,8 @@ export function getPreparedBidForAuction(bid: Partial<Bid>, { index = auctionMan
 
   // a publisher-defined renderer can be used to render bids
   const bidRequest = index.getBidRequest(bid);
-  const bidRenderer = bidRequest?.renderer || adUnit.renderer;
-  const bidSafeRenderer = bidRequest?.safeRenderer || adUnit.safeRenderer;
+  const bidRenderer = bidRequest?.renderer || adUnit?.renderer;
+  const bidSafeRenderer = bidRequest?.safeRenderer || adUnit?.safeRenderer;
 
   // a publisher can also define a renderer for a mediaType
   const bidObjectMediaType = bid.mediaType;

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -1245,6 +1245,29 @@ describe('auctionmanager.js', function () {
             expect(getBid().renderer.renderNow).to.be.true;
           });
         });
+
+        // Regression: a bid can be accepted when its ad unit is no longer
+        // resolvable (e.g. the originating auction has expired out of the
+        // auctionManager TTL collection, or the bid carries an adUnitId that
+        // matches no held ad unit). getPreparedBidForAuction must not throw
+        // while reading the publisher-defined renderer off the (missing) ad unit.
+        it('does not throw when the bid has no matching ad unit', () => {
+          const index = {
+            getAdUnit: () => undefined,
+            getBidRequest: () => undefined,
+            getMediaTypes: () => undefined,
+          };
+          const bid = {
+            cpm: 1.0,
+            bidderCode: BIDDER_CODE,
+            mediaType: 'banner',
+          };
+          let prepared;
+          expect(() => {
+            prepared = auctionModule.getPreparedBidForAuction(bid, { index });
+          }).to.not.throw();
+          expect(prepared.renderer).to.not.exist;
+        });
       });
 
       it('installs publisher-defined backup renderers on bids', function () {


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description of change

Add optional chaining, consistent with the adjacent adUnit?.ortb2Imp / adUnit?.element / adUnit?.ttlBuffer guards, plus a regression test.

## Context

`getPreparedBidForAuction` dereferenced `adUnit.renderer/adUnit.safeRenderer` without optional chaining, while `index.getAdUnit(bid)` can legitimately return `undefined` (e.g. the originating auction has expired out of the auctionManager TTL collection, or the bid carries an adUnitId matching no held ad unit). This threw an unhandled
"TypeError: undefined is not an object (evaluating 'i.renderer')" while accepting the bid, before any rendering, so no `adRenderFailed` event fired.