### PR TITLE
Consent Management USP: fix spec lint error

### DIFF
--- a/test/spec/modules/consentManagementUsp_spec.js
+++ b/test/spec/modules/consentManagementUsp_spec.js
@@ -311,7 +311,6 @@ describe('consentManagement', function () {
 
     describe('USPAPI workflow for iframed page', function () {
       let ifr = null;
-      let stringifyResponse = false;
       let mockApi, replySent;
 
       beforeEach(function () {
@@ -355,14 +354,11 @@ describe('consentManagement', function () {
         }
       }
 
-      // Run tests with JSON response and String response
-      // from CMP window postMessage listener.
-      testIFramedPage('with/JSON response', false);
-      // testIFramedPage('with/String response', true);
+      // Run tests with JSON response from CMP window postMessage listener.
+      testIFramedPage('with/JSON response');
 
-      function testIFramedPage(testName, messageFormatString) {
+      function testIFramedPage(testName) {
         it(`should return the consent string from a postmessage + addEventListener response - ${testName}`, (done) => {
-          stringifyResponse = messageFormatString;
           mockApi.callsFake((cmd) => {
             if (cmd === 'getUSPData') {
               return { uspString: '1YY' };


### PR DESCRIPTION
Unused var in master is a setup for a commented out test on cmps returning a different response type

### Motivation
- Remove an unused variable and obsolete test plumbing in the USP consent iframe spec to resolve an `eslint` `no-unused-vars` failure in `test/spec/modules/consentManagementUsp_spec.js`.
