### PR TITLE
Yahoo & Adtrgtme Adapters: avoid reassigned bid request fixtures

### DIFF
--- a/test/spec/modules/adtrgtmeBidAdapter_spec.js
+++ b/test/spec/modules/adtrgtmeBidAdapter_spec.js
@@ -492,9 +492,9 @@ describe('Adtrgtme Bid Adapter:', () => {
     });
 
     it('should return a single request object for single request mode', () => {
-      let { bidRequest, validBR, bidderRequest } = createRequestMock({});
+      const { bidRequest, bidderRequest } = createRequestMock({});
       const { bidRequest: mock } = createRequestMock({ bidId: '6heos7ks8z0j', zid: '98876543210', adUnitCode: 'bidder-code' });
-      validBR = [bidRequest, mock];
+      const validBR = [bidRequest, mock];
       bidderRequest.bids = validBR;
 
       config.setConfig({

--- a/test/spec/modules/yahooAdsBidAdapter_spec.js
+++ b/test/spec/modules/yahooAdsBidAdapter_spec.js
@@ -995,12 +995,12 @@ describe('Yahoo Advertising Bid Adapter:', () => {
     });
 
     it('should return a single request object for single request mode', () => {
-      let { bidRequest, validBidRequests, bidderRequest } = generateBuildRequestMock({});
+      const { bidRequest, bidderRequest } = generateBuildRequestMock({});
       const BID_ID_2 = '84ab50xxxxx';
       const BID_POS_2 = 'footer';
       const AD_UNIT_CODE_2 = 'test-ad-unit-code-123';
       const { bidRequest: bidRequest2 } = generateBuildRequestMock({ bidId: BID_ID_2, pos: BID_POS_2, adUnitCode: AD_UNIT_CODE_2 });
-      validBidRequests = [bidRequest, bidRequest2];
+      const validBidRequests = [bidRequest, bidRequest2];
       bidderRequest.bids = validBidRequests;
 
       config.setConfig({
@@ -1398,10 +1398,10 @@ describe('Yahoo Advertising Bid Adapter:', () => {
       const BID_POS_3 = 'hero';
       const AD_UNIT_CODE_3 = 'video-ad-unit';
 
-      let { bidRequest, validBidRequests, bidderRequest } = generateBuildRequestMock({}); // banner
+      const { bidRequest, bidderRequest } = generateBuildRequestMock({}); // banner
       const { bidRequest: bidRequest2 } = generateBuildRequestMock({ bidId: BID_ID_2, pos: BID_POS_2, adUnitCode: AD_UNIT_CODE_2 }); // banner
       const { bidRequest: bidRequest3 } = generateBuildRequestMock({ bidId: BID_ID_3, pos: BID_POS_3, adUnitCode: AD_UNIT_CODE_3, adUnitType: 'video' }); // video (should be filtered)
-      validBidRequests = [bidRequest, bidRequest2, bidRequest3];
+      const validBidRequests = [bidRequest, bidRequest2, bidRequest3];
       bidderRequest.bids = validBidRequests;
 
       const reqs = spec.buildRequests(validBidRequests, bidderRequest);
@@ -1430,10 +1430,10 @@ describe('Yahoo Advertising Bid Adapter:', () => {
       const BID_POS_3 = 'hero';
       const AD_UNIT_CODE_3 = 'video-ad-unit';
 
-      let { bidRequest, validBidRequests, bidderRequest } = generateBuildRequestMock({ adUnitType: 'video' }); // video
+      const { bidRequest, bidderRequest } = generateBuildRequestMock({ adUnitType: 'video' }); // video
       const { bidRequest: bidRequest2 } = generateBuildRequestMock({ bidId: BID_ID_2, pos: BID_POS_2, adUnitCode: AD_UNIT_CODE_2, adUnitType: 'video' }); // video
       const { bidRequest: bidRequest3 } = generateBuildRequestMock({ bidId: BID_ID_3, pos: BID_POS_3, adUnitCode: AD_UNIT_CODE_3 }); // banner (should be filtered)
-      validBidRequests = [bidRequest, bidRequest2, bidRequest3];
+      const validBidRequests = [bidRequest, bidRequest2, bidRequest3];
       bidderRequest.bids = validBidRequests;
 
       const reqs = spec.buildRequests(validBidRequests, bidderRequest);
@@ -1473,10 +1473,10 @@ describe('Yahoo Advertising Bid Adapter:', () => {
       const BID_POS_3 = 'hero';
       const AD_UNIT_CODE_3 = 'native-ad-unit';
 
-      let { bidRequest, validBidRequests, bidderRequest } = generateBuildRequestMock({ adUnitType: 'banner' }); // banner
+      const { bidRequest, bidderRequest } = generateBuildRequestMock({ adUnitType: 'banner' }); // banner
       const { bidRequest: bidRequest2 } = generateBuildRequestMock({ bidId: BID_ID_2, pos: BID_POS_2, adUnitCode: AD_UNIT_CODE_2, adUnitType: 'video' }); // video
       const { bidRequest: bidRequest3 } = generateBuildRequestMock({ bidId: BID_ID_3, pos: BID_POS_3, adUnitCode: AD_UNIT_CODE_3, adUnitType: 'native' }); // native (should be filtered)
-      validBidRequests = [bidRequest, bidRequest2, bidRequest3];
+      const validBidRequests = [bidRequest, bidRequest2, bidRequest3];
       bidderRequest.bids = validBidRequests;
 
       const reqs = spec.buildRequests(validBidRequests, bidderRequest);


### PR DESCRIPTION
### Motivation
- Prevent tests from reassigning helper-returned fixtures by overwriting `validBidRequests`/`validBR`, which can be confusing and error-prone.
- Make multi-bid test fixtures explicit and immutable to improve clarity and reduce accidental scope/assignment bugs in adapter specs.

### Description
- Updated `test/spec/modules/yahooAdsBidAdapter_spec.js` to stop destructuring `validBidRequests` from `generateBuildRequestMock` and then overwriting it, by declaring the multi-bid fixture as `const validBidRequests = [...]` and keeping the original helper return values separate.
- Updated `test/spec/modules/adtrgtmeBidAdapter_spec.js` to stop overwriting the helper-returned `validBR` by declaring the combined fixture as `const validBR = [...]` while preserving the original destructured values.
- Changes are limited to test files: `test/spec/modules/yahooAdsBidAdapter_spec.js` and `test/spec/modules/adtrgtmeBidAdapter_spec.js` and only adjust how multi-bid fixtures are created.

### Testing
- Ran `npx eslint test/spec/modules/yahooAdsBidAdapter_spec.js test/spec/modules/adtrgtmeBidAdapter_spec.js --cache --cache-strategy content` with no lint errors.
- Ran `npx gulp test --nolint --file test/spec/modules/yahooAdsBidAdapter_spec.js` and the spec chunk completed successfully with `277 tests completed`.
- Ran `npx gulp test --nolint --file test/spec/modules/adtrgtmeBidAdapter_spec.js` and the spec chunk completed successfully with `91 tests completed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3cf30d20a0832b9bcc2e401fb0e501)