### PR TITLE
Brid bid adapter: remove unused sizes logic

### DIFF
--- a/modules/bridBidAdapter.js
+++ b/modules/bridBidAdapter.js
@@ -38,8 +38,6 @@ export const spec = {
     _each(bidRequests, function(bid) {
       const placementId = bid.params.placementId;
       const bidId = bid.bidId;
-      let sizes = bid.sizes;
-      if (sizes && !Array.isArray(sizes[0])) sizes = [sizes];
 
       const site = getSiteObj();
 


### PR DESCRIPTION
Remove the unused local variable assignment in `buildRequests` in `modules/bridBidAdapter.js`.

This appears to be a bug; alternative is to use sizes in the request construction

Cc @grajzer 