### PR TITLE
Tests: fix superfluous test arguments

### DIFF
--- a/test/spec/ortbConverter/native_spec.js
+++ b/test/spec/ortbConverter/native_spec.js
@@ -85,18 +85,18 @@ describe('ortb -> ortb native response', () => {
         const bidResponse = {
           mediaType: NATIVE
         };
-        fillNativeResponse(bidResponse, bid, {});
+        fillNativeResponse(bidResponse, bid);
         expect(bidResponse.native).to.eql({ ortb: MOCK_NATIVE_RESPONSE });
       });
     });
     it('should throw if response has no assets', () => {
-      expect(() => fillNativeResponse({ mediaType: NATIVE }, { adm: { ...MOCK_NATIVE_RESPONSE, assets: null } }, {})).to.throw;
+      expect(() => fillNativeResponse({ mediaType: NATIVE }, { adm: { ...MOCK_NATIVE_RESPONSE, assets: null } })).to.throw;
     });
     it('should do nothing if bidResponse.mediaType is not NATIVE', () => {
       const bidResponse = {
         mediaType: BANNER
       };
-      fillNativeResponse(bidResponse, { adm: MOCK_NATIVE_RESPONSE }, {});
+      fillNativeResponse(bidResponse, { adm: MOCK_NATIVE_RESPONSE });
       expect(bidResponse).to.eql({
         mediaType: BANNER
       });

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -3119,7 +3119,7 @@ describe('adapterManager tests', function () {
       });
 
       it('should remove bids that have bidder not present in s2sConfig', () => {
-        s2sBidders = new Set('A', 'B');
+        s2sBidders = new Set(['A', 'B']);
         const s2sConfig = {};
         expect(filterBids(['A', 'C', 'D'].map((code) => ({ bidder: code })), s2sConfig)).to.eql([{ bidder: 'A' }]);
         sinon.assert.calledWith(getS2SBidders, sinon.match.same(s2sConfig));


### PR DESCRIPTION
New linting rule didn't catch everything because it is scoped to local functions, not imported ones or functions like Set