### PR TITLE
Maintenance: remove unused plugin and gulpfile variables

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,7 +34,7 @@ const INTEG_SERVER_PORT = 4444;
 const { spawn, fork } = require('child_process');
 const TerserPlugin = require('terser-webpack-plugin');
 
-const {precompile, babelPrecomp} = require('./gulp.precompilation.js');
+const {precompile} = require('./gulp.precompilation.js');
 
 const TEST_CHUNKS = 8;
 
@@ -352,7 +352,7 @@ function e2eTestTaskMaker() {
     const integ = startIntegServer();
     startLocalServer();
     runWebdriver({})
-      .then(stdout => {
+      .then(() => {
         // kill fake server
         integ.kill('SIGINT');
         done();

--- a/plugins/gvlPurposes.js
+++ b/plugins/gvlPurposes.js
@@ -4,14 +4,12 @@ const {
   getModuleName,
   getMetadata
 } = require('./utils.js');
-const { types: t } = require('@babel/core');
-
 function getPurposes(filename) {
   const metadata = getMetadata(getModuleName(filename));
   return Object.keys(metadata?.purposes ?? {}).length > 0 ? metadata.purposes : null;
 }
 
-module.exports = function (api, options) {
+module.exports = function (api) {
   return {
     visitor: {
       Program(path, state) {

--- a/plugins/pbjsGlobals.js
+++ b/plugins/pbjsGlobals.js
@@ -1,12 +1,11 @@
 let t = require('@babel/core').types;
 let prebid = require('../package.json');
-const path = require('path');
 const {buildOptions} = require('./buildOptions.js');
 const FEATURES_GLOBAL = 'FEATURES';
 const {getModuleName, relPath, getFreeName} = require('./utils.js');
 
 module.exports = function(api, options) {
-  const {features, distUrlBase, skipCalls} = buildOptions(options);
+  const {features, skipCalls} = buildOptions(options);
 
   let replace = {
     '$prebid.version$': prebid.version,
@@ -21,7 +20,7 @@ module.exports = function(api, options) {
     '$$REPO_AND_VERSION$$'
   ];
 
-  function translateToJs(path, state) {
+  function translateToJs(path) {
     const source = path.node.source?.value;
     if (source) {
       if (source.endsWith('.d.ts')) {
@@ -52,7 +51,7 @@ module.exports = function(api, options) {
       },
       ImportDeclaration: translateToJs,
       ExportDeclaration: translateToJs,
-      StringLiteral(path, state) {
+      StringLiteral(path) {
         Object.keys(replace).forEach(name => {
           if (path.node.value.includes(name)) {
             checkMacroAllowed(name);
@@ -63,7 +62,7 @@ module.exports = function(api, options) {
           }
         });
       },
-      TemplateLiteral(path, state) {
+      TemplateLiteral(path) {
         path.traverse({
           TemplateElement(path) {
             Object.keys(replace).forEach(name => {
@@ -80,7 +79,7 @@ module.exports = function(api, options) {
           }
         });
       },
-      Identifier(path, state) {
+      Identifier(path) {
         Object.keys(replace).forEach(name => {
           if (path.node.name === name) {
             checkMacroAllowed(name);


### PR DESCRIPTION
### Motivation
- Clean up remaining unused variables and parameters flagged by linting in the gulpfile and two Babel plugin files to reduce spurious `no-unused-vars` warnings and keep code clearer.
