### PR TITLE
Core: declare terser webpack plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
         "puppeteer": "^24.10.0",
         "resolve-from": "^5.0.0",
         "sinon": "^22.0.0",
+        "terser-webpack-plugin": "^5.6.1",
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.26.1",
         "url": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "puppeteer": "^24.10.0",
     "resolve-from": "^5.0.0",
     "sinon": "^22.0.0",
+    "terser-webpack-plugin": "^5.6.1",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.26.1",
     "url": "^0.11.0",


### PR DESCRIPTION

- Top-level `webpack.conf.js` requires `terser-webpack-plugin` but it was not declared in the root `devDependencies`, causing builds to rely on a transitive install; this fixes #15255.

This seems to only be a problem for build scripts that deleted package lock
