### PR TITLE
Core: send Content-Encoding gzip header on compressed bid requests

### DIFF
--- a/src/adapters/bidderFactory.ts
+++ b/src/adapters/bidderFactory.ts
@@ -542,7 +542,7 @@ export const processBidderRequests = hook('async', function<B extends BidderCode
         break;
       case 'POST':
         const enableGZipCompression = request.options?.endpointCompression;
-        const callAjax = ({ url, payload }) => {
+        const callAjax = ({ url, payload, customHeaders }: { url: string, payload: any, customHeaders?: Record<string, string> }) => {
           ajax(
             url,
             {
@@ -553,7 +553,8 @@ export const processBidderRequests = hook('async', function<B extends BidderCode
             getOptions({
               method: 'POST',
               contentType: 'text/plain',
-              withCredentials: true
+              withCredentials: true,
+              ...(customHeaders ? { customHeaders: { ...request.options?.customHeaders, ...customHeaders } } : {})
             })
           );
         };
@@ -568,7 +569,7 @@ export const processBidderRequests = hook('async', function<B extends BidderCode
             if (!url.searchParams.has('gzip')) {
               url.searchParams.set('gzip', '1');
             }
-            callAjax({ url: url.href, payload: compressedPayload });
+            callAjax({ url: url.href, payload: compressedPayload, customHeaders: { 'Content-Encoding': 'gzip' } });
           });
         } else {
           callAjax({ url: request.url, payload: typeof request.data === 'string' ? request.data : JSON.stringify(request.data) });

--- a/src/adapters/bidderFactory.ts
+++ b/src/adapters/bidderFactory.ts
@@ -515,13 +515,17 @@ export const processBidderRequests = hook('async', function<B extends BidderCode
 
     function getOptions(defaults) {
       const ro = request.options;
+      // capture headers injected by the caller (e.g. Content-Encoding for gzip) before `ro` is merged,
+      // so they survive and take precedence over any bidder-provided customHeaders.
+      const injectedHeaders = defaults.customHeaders;
       return Object.assign(defaults, ro, {
         browsingTopics: ro?.hasOwnProperty('browsingTopics') && !ro.browsingTopics
           ? false
           : (bidderSettings.get(spec.code, 'topicsHeader') ?? true) && isActivityAllowed(ACTIVITY_TRANSMIT_UFPD, activityParams(MODULE_TYPE_BIDDER, spec.code)),
         suppressTopicsEnrollmentWarning: ro?.hasOwnProperty('suppressTopicsEnrollmentWarning')
           ? ro.suppressTopicsEnrollmentWarning
-          : !debugMode
+          : !debugMode,
+        ...((injectedHeaders || ro?.customHeaders) ? { customHeaders: { ...ro?.customHeaders, ...injectedHeaders } } : {})
       });
     }
 
@@ -554,7 +558,7 @@ export const processBidderRequests = hook('async', function<B extends BidderCode
               method: 'POST',
               contentType: 'text/plain',
               withCredentials: true,
-              ...(customHeaders ? { customHeaders: { ...request.options?.customHeaders, ...customHeaders } } : {})
+              ...(customHeaders ? { customHeaders } : {})
             })
           );
         };

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -1803,6 +1803,7 @@ describe('bidderFactory', () => {
     let url;
     let data;
     let endpointCompression;
+    let requestCustomHeaders;
 
     before(() => {
       origBS = getGlobal().bidderSettings;
@@ -1835,6 +1836,7 @@ describe('bidderFactory', () => {
       url = 'https://test.url.com';
       data = { arg: 'value' };
       endpointCompression = true;
+      requestCustomHeaders = undefined;
     });
 
     afterEach(() => {
@@ -1850,7 +1852,8 @@ describe('bidderFactory', () => {
           url: url,
           data: data,
           options: {
-            endpointCompression
+            endpointCompression,
+            ...(requestCustomHeaders ? { customHeaders: requestCustomHeaders } : {})
           }
         });
         bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, () => {
@@ -1882,6 +1885,22 @@ describe('bidderFactory', () => {
       await runRequest();
       expect(ajaxStub.calledOnce).to.be.true;
       expect(ajaxStub.firstCall.args[3].customHeaders).to.be.undefined; // No Content-Encoding header on uncompressed requests
+    });
+
+    it('should preserve the Content-Encoding header alongside bidder-provided customHeaders on compressed requests', async function () {
+      const compressedPayload = 'compressedData';
+      isGzipSupportedStub.returns(true);
+      gzipStub.resolves(compressedPayload);
+      getParameterByNameStub.withArgs(DEBUG_MODE).returns('false');
+      debugTurnedOnStub.returns(false);
+      requestCustomHeaders = { 'X-Custom': 'foo' };
+
+      await runRequest();
+      expect(ajaxStub.calledOnce).to.be.true;
+      expect(ajaxStub.firstCall.args[3].customHeaders).to.deep.equal({
+        'X-Custom': 'foo',
+        'Content-Encoding': 'gzip'
+      });
     });
 
     it('should send the request normally if gzip is not supported', async () => {

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -1872,6 +1872,16 @@ describe('bidderFactory', () => {
       expect(ajaxStub.calledOnce).to.be.true;
       expect(ajaxStub.firstCall.args[0]).to.include('gzip=1'); // Ensure the URL has gzip=1
       expect(ajaxStub.firstCall.args[2]).to.equal(compressedPayload); // Ensure compressed data is sent
+      expect(ajaxStub.firstCall.args[3].customHeaders).to.deep.include({ 'Content-Encoding': 'gzip' }); // Ensure Content-Encoding header is set
+    });
+
+    it('should not set a Content-Encoding header when sending uncompressed data', async () => {
+      isGzipSupportedStub.returns(false);
+      getParameterByNameStub.withArgs(DEBUG_MODE).returns('false');
+      debugTurnedOnStub.returns(false);
+      await runRequest();
+      expect(ajaxStub.calledOnce).to.be.true;
+      expect(ajaxStub.firstCall.args[3].customHeaders).to.be.undefined; // No Content-Encoding header on uncompressed requests
     });
 
     it('should send the request normally if gzip is not supported', async () => {


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description of change

TTD server fails to parse the compressed request body without `Content-Encoding` header.

The compressed POST branch in processBidderRequests sets the `gzip=1` query param but did not set a `Content-Encoding` header, which the server needs to detect and parse the gzip-compressed request body. Add the header on the compressed path, merging it with any bidder-provided customHeaders, and leave the uncompressed path unchanged.
