### PR TITLE
Core: Drop Retained Data

### DIFF
--- a/libraries/analyticsAdapter/AnalyticsAdapter.ts
+++ b/libraries/analyticsAdapter/AnalyticsAdapter.ts
@@ -1,6 +1,6 @@
 import { EVENTS } from '../../src/constants.js';
 import { noCredsAjax as ajax } from '../../src/ajax.js';
-import { logError, logMessage } from '../../src/utils.js';
+import { deepClone, logError, logMessage } from '../../src/utils.js';
 import * as events from '../../src/events.js';
 import { config } from '../../src/config.js';
 
@@ -34,6 +34,41 @@ const combineLabels = () => Object.values(labels).reduce((acc, curr) => ({ ...ac
 
 export const DEFAULT_INCLUDE_EVENTS = Object.values(EVENTS)
   .filter(ev => ev !== EVENTS.AUCTION_DEBUG);
+
+const AUCTION_PAYLOAD_FIELDS = ['adUnits', 'bidderRequests', 'noBids', 'bidsReceived'];
+const BID_PAYLOAD_FIELDS = [
+  'ortb2',
+  'ortb2Imp',
+  'userId',
+  'userIdAsEids',
+  'params',
+  'mediaTypes',
+  'rtd',
+  'floorData',
+  'getFloor',
+  'labelAll'
+];
+
+function isBidPayload(args) {
+  return (args.bidId || args.requestId || args.bidderRequestId) &&
+    (args.bidder || args.bidderCode || args.adUnitCode) &&
+    BID_PAYLOAD_FIELDS.some(field => args[field] != null);
+}
+
+function snapshotAnalyticsArgs(args) {
+  if (args == null || typeof args !== 'object' || Array.isArray(args)) {
+    return args;
+  }
+
+  let snapshot;
+  AUCTION_PAYLOAD_FIELDS.forEach((field) => {
+    if (Array.isArray(args[field])) {
+      snapshot ??= { ...args };
+      snapshot[field] = deepClone(args[field]);
+    }
+  });
+  return snapshot ?? (isBidPayload(args) ? deepClone(args) : args);
+}
 
 let debounceDelay = 100;
 
@@ -193,17 +228,18 @@ export default function AnalyticsAdapter<PROVIDER extends AnalyticsProvider>(opt
   }
 
   function _enqueue({ eventType, args, sequence }) {
+    const queuedArgs = snapshotAnalyticsArgs(args);
     queue.push(() => {
-      if (Object.keys(allLabels || []).length > 0) {
-        args = {
-          [LABELS_KEY]: allLabels,
-          ...args,
-        };
-      }
+      const eventArgs = Object.keys(allLabels || []).length > 0
+        ? {
+            [LABELS_KEY]: allLabels,
+            ...queuedArgs,
+          }
+        : queuedArgs;
       if (lastTrackedEvent == null || sequence > lastTrackedEvent) {
         lastTrackedEvent = sequence;
       }
-      this.track({ eventType, labels: allLabels, args });
+      this.track({ eventType, labels: allLabels, args: eventArgs });
     });
     emptyQueue();
   }

--- a/modules/consentManagementUsp.ts
+++ b/modules/consentManagementUsp.ts
@@ -49,6 +49,7 @@ declare module '../src/consentHandler' {
 
 let consentData;
 let enabled = false;
+let deletionRequestRegistered = false;
 
 // consent APIs
 const uspCallMap = {
@@ -115,12 +116,16 @@ function lookupUspConsent({ onSuccess, onError }) {
     callback: callbackHandler.consentDataCallback
   });
 
-  cmp({
-    command: 'registerDeletion',
-    callback: (res, success) => (success == null || success) && adapterManager.callDataDeletionRequest(res)
-  }).catch(e => {
-    logError('Error invoking CMP `registerDeletion`:', e);
-  });
+  if (!deletionRequestRegistered) {
+    deletionRequestRegistered = true;
+    cmp({
+      command: 'registerDeletion',
+      callback: (res, success) => (success == null || success) && adapterManager.callDataDeletionRequest(res)
+    }).catch(e => {
+      deletionRequestRegistered = false;
+      logError('Error invoking CMP `registerDeletion`:', e);
+    });
+  }
 }
 
 /**
@@ -227,6 +232,7 @@ export function resetConsentData() {
   consentTimeout = undefined;
   uspDataHandler.reset();
   enabled = false;
+  deletionRequestRegistered = false;
 }
 
 /**

--- a/src/adapterManager.ts
+++ b/src/adapterManager.ts
@@ -339,6 +339,15 @@ type PBSAdUnit = Omit<AdUnit, 'bids'> & {
   bids: PBSAdUnitBid[];
 };
 
+function dropS2SBidUserIds(adUnit: PBSAdUnit) {
+  adUnit.bids.forEach((bid: any) => {
+    delete bid.userId;
+  });
+  if (adUnit.s2sBid) {
+    delete (adUnit.s2sBid as any).userId;
+  }
+}
+
 function getAdUnitCopyForPrebidServer(adUnits: AdUnit[], s2sConfig) {
   let adUnitsCopy = deepClone(adUnits) as PBSAdUnit[];
   let hasModuleBids = false;
@@ -360,6 +369,7 @@ function getAdUnitCopyForPrebidServer(adUnits: AdUnit[], s2sConfig) {
         bid.bid_id = getUniqueIdentifierStr();
         return bid;
       });
+    dropS2SBidUserIds(adUnit);
   });
   adUnitsCopy = adUnitsCopy.filter(adUnit => {
     if (s2sConfig.filterBidderlessCalls) {

--- a/src/adapters/bidderFactory.ts
+++ b/src/adapters/bidderFactory.ts
@@ -197,7 +197,7 @@ export function registerBidder<B extends BidderCode>(spec: BidderSpec<B>) {
   }
 }
 
-export const guardTids: any = memoize(({ bidderCode }) => {
+export const guardTids: any = ({ bidderCode }) => {
   const tidsAllowed = isActivityAllowed(ACTIVITY_TRANSMIT_TID, activityParams(MODULE_TYPE_BIDDER, bidderCode));
   function get(target, prop, receiver) {
     if (TIDS.hasOwnProperty(prop)) {
@@ -225,6 +225,7 @@ export const guardTids: any = memoize(({ bidderCode }) => {
    */
   return {
     bidRequest,
+    clear: () => bidRequest.clear(),
     bidderRequest: (br) => privateAccessProxy(br, {
       get(target, prop, receiver) {
         if (prop === 'bids') return br.bids.map(bidRequest);
@@ -232,7 +233,7 @@ export const guardTids: any = memoize(({ bidderCode }) => {
       }
     })
   };
-});
+};
 
 declare module '../events' {
   interface Events {
@@ -276,8 +277,6 @@ export function newBidder<B extends BidderCode>(spec: BidderSpec<B>) {
       if (!Array.isArray(bidderRequest.bids)) {
         return;
       }
-      const tidGuard = guardTids(bidderRequest);
-
       const adUnitCodesHandled = {};
       function addBidWithCode(adUnitCode: string, bid: Bid, responseMediaType = null) {
         const metrics = useMetrics(bid.metrics);
@@ -302,7 +301,14 @@ export function newBidder<B extends BidderCode>(spec: BidderSpec<B>) {
       }
 
       const validBidRequests = adapterMetrics(bidderRequest)
-        .measureTime('validate', () => bidderRequest.bids.filter((br) => filterAndWarn(tidGuard.bidRequest(br))));
+        .measureTime('validate', () => {
+          const tidGuard = guardTids(bidderRequest);
+          try {
+            return bidderRequest.bids.filter((br) => filterAndWarn(tidGuard.bidRequest(br)));
+          } finally {
+            tidGuard.clear();
+          }
+        });
 
       if (validBidRequests.length === 0) {
         afterAllResponses();
@@ -391,6 +397,19 @@ const RESPONSE_PROPS = [
   'paapi',
 ];
 
+function buildRequestsWithTidsGuard<B extends BidderCode>(
+  spec: BidderSpec<B>,
+  bids: BidRequest<B>[],
+  bidderRequest: ClientBidderRequest<B>
+) {
+  const tidGuard = guardTids(bidderRequest);
+  try {
+    return spec.buildRequests(bids.map(tidGuard.bidRequest), tidGuard.bidderRequest(bidderRequest));
+  } finally {
+    tidGuard.clear();
+  }
+}
+
 /**
  * Run a set of bid requests - that entails converting them to HTTP requests, sending
  * them over the network, and parsing the responses.
@@ -431,8 +450,7 @@ export const processBidderRequests = hook('async', function<B extends BidderCode
   }) {
   const metrics = adapterMetrics(bidderRequest);
   onCompletion = metrics.startTiming('total').stopBefore(onCompletion);
-  const tidGuard = guardTids(bidderRequest);
-  let requests = metrics.measureTime('buildRequests', () => spec.buildRequests(bids.map(tidGuard.bidRequest), tidGuard.bidderRequest(bidderRequest))) as AdapterRequest[];
+  let requests = metrics.measureTime('buildRequests', () => buildRequestsWithTidsGuard(spec, bids, bidderRequest)) as AdapterRequest[];
   if (!Array.isArray(requests)) {
     requests = [requests];
   }

--- a/src/auction.ts
+++ b/src/auction.ts
@@ -224,6 +224,84 @@ export function newAuction({ adUnits, adUnitCodes, callback, cbTimeout, labels, 
   function addNoBid(noBid) { _noBids = _noBids.concat(noBid); }
   function addNonBids(seatnonbids) { _nonBids = _nonBids.concat(seatnonbids); }
 
+  const BID_IDENTITY_FIELDS_TO_DROP = ['ortb2', 'userId', 'userIdAsEids', 'ortb2Imp'];
+  const AD_UNIT_BID_IDENTITY_FIELDS_TO_DROP = BID_IDENTITY_FIELDS_TO_DROP.filter(field => field !== 'ortb2Imp');
+  const BID_REQUEST_FIELDS_TO_DROP = [
+    ...BID_IDENTITY_FIELDS_TO_DROP,
+    'params',
+    'mediaTypes',
+    'rtd',
+    'floorData',
+    'getFloor',
+    'labelAll'
+  ];
+  const BID_RESPONSE_FIELDS_TO_DROP = BID_REQUEST_FIELDS_TO_DROP.filter(field => field !== 'floorData');
+  const BIDDER_REQUEST_FIELDS_TO_DROP = ['ortb2', 'ortb2Imp', 'adUnitsS2SCopy', 'pbsExt', 'refererInfo'];
+
+  function dropFields(target, fields) {
+    fields.forEach(field => {
+      delete target?.[field];
+    });
+  }
+
+  function getRetainedMediaTypes(mediaTypes) {
+    const video = mediaTypes?.[VIDEO];
+    if (!video?.renderer) return;
+
+    return {
+      [VIDEO]: {
+        context: video.context,
+        renderer: video.renderer,
+        useCacheKey: video.useCacheKey
+      }
+    };
+  }
+
+  function dropRetainedBidRequestFields(bid) {
+    const retainedMediaTypes = getRetainedMediaTypes(bid?.mediaTypes);
+    dropFields(bid, BID_REQUEST_FIELDS_TO_DROP);
+    if (retainedMediaTypes) {
+      bid.mediaTypes = retainedMediaTypes;
+    }
+  }
+
+  function dropRetainedBidderRequestFields(bidderRequest) {
+    dropFields(bidderRequest, BIDDER_REQUEST_FIELDS_TO_DROP);
+    bidderRequest?.bids?.forEach(dropRetainedBidRequestFields);
+  }
+
+  function dropRetainedBidResponseFields(bid) {
+    dropFields(bid, BID_RESPONSE_FIELDS_TO_DROP);
+  }
+
+  function dropRetainedAdUnitBidIdentityFields(bid) {
+    dropFields(bid, AD_UNIT_BID_IDENTITY_FIELDS_TO_DROP);
+  }
+
+  function dropRetainedAdUnitFields(adUnit) {
+    adUnit?.bids?.forEach(dropRetainedAdUnitBidIdentityFields);
+  }
+
+  function dropRetainedUserExtEids(userExt) {
+    delete userExt?.eids;
+    delete userExt?.data?.eids;
+  }
+
+  function dropRetainedFpdEids() {
+    dropRetainedUserExtEids(ortb2Fragments?.global?.user?.ext);
+    Object.values(ortb2Fragments?.bidder ?? {}).forEach((bidderFpd: any) => {
+      dropRetainedUserExtEids(bidderFpd?.user?.ext);
+    });
+  }
+
+  function dropRetainedRequestFields() {
+    _adUnits.forEach(dropRetainedAdUnitFields);
+    _bidderRequests.forEach(dropRetainedBidderRequestFields);
+    _noBids.forEach(dropRetainedBidRequestFields);
+    _bidsReceived.toArray().forEach(dropRetainedBidResponseFields);
+    dropRetainedFpdEids();
+  }
+
   function getProperties() {
     return {
       auctionId: _auctionId,
@@ -284,15 +362,19 @@ export function newAuction({ adUnits, adUnitCodes, callback, cbTimeout, labels, 
         } catch (e) {
           logError('Error executing bidsBackHandler', null, e);
         } finally {
-          // Calling timed out bidders
-          if (timedOutRequests.length) {
-            adapterManager.callTimedOutBidders(adUnits, timedOutRequests, _timeout);
-          }
-          // Only automatically sync if the publisher has not chosen to "enableOverride"
-          const userSyncConfig = config.getConfig('userSync') ?? {} as any;
-          if (!userSyncConfig.enableOverride) {
-            // Delay the auto sync by the config delay
-            syncUsers(userSyncConfig.syncDelay);
+          try {
+            // Calling timed out bidders
+            if (timedOutRequests.length) {
+              adapterManager.callTimedOutBidders(adUnits, timedOutRequests, _timeout);
+            }
+            // Only automatically sync if the publisher has not chosen to "enableOverride"
+            const userSyncConfig = config.getConfig('userSync') ?? {} as any;
+            if (!userSyncConfig.enableOverride) {
+              // Delay the auto sync by the config delay
+              syncUsers(userSyncConfig.syncDelay);
+            }
+          } finally {
+            dropRetainedRequestFields();
           }
         }
       });

--- a/src/storageManager.ts
+++ b/src/storageManager.ts
@@ -1,4 +1,4 @@
-import { checkCookieSupport, hasDeviceAccess, logError, memoize, timestamp } from './utils.js';
+import { checkCookieSupport, hasDeviceAccess, logError } from './utils.js';
 import { bidderSettings } from './bidderSettings.js';
 import { MODULE_TYPE_BIDDER, MODULE_TYPE_PREBID, type ModuleType } from './activities/modules.js';
 import { isActivityAllowed, registerActivityControl } from './activities/rules.js';
@@ -291,9 +291,11 @@ export function getCoreStorageManager(moduleName) {
 
 export const canSetCookie = (() => {
   const testStorageMgr = getCoreStorageManager('storage');
+  const cache = new Map();
+  const DEFAULT_DOMAIN = '__default__';
 
-  return memoize(function (domain?, storageMgr = testStorageMgr) {
-    const expirationDate = new Date(timestamp() + 10 * 1000).toUTCString();
+  function checkCanSetCookie(domain?, storageMgr = testStorageMgr) {
+    const expirationDate = new Date(Date.now() + 10 * 1000).toUTCString();
     const cookieName = `_rdc${Date.now()}`;
     const cookieValue = 'writeable';
 
@@ -318,7 +320,19 @@ export const canSetCookie = (() => {
     } else {
       return false;
     }
-  });
+  }
+
+  const canSet = function (domain?, storageMgr = testStorageMgr) {
+    const cacheKey = storageMgr === testStorageMgr ? domain ?? DEFAULT_DOMAIN : undefined;
+    if (cacheKey && cache.get(cacheKey) === true) return true;
+
+    const result = checkCanSetCookie(domain, storageMgr);
+    if (cacheKey && result === true) cache.set(cacheKey, true);
+    return result;
+  };
+
+  canSet.clear = cache.clear.bind(cache);
+  return canSet;
 })();
 
 /**

--- a/test/spec/AnalyticsAdapter_spec.js
+++ b/test/spec/AnalyticsAdapter_spec.js
@@ -12,6 +12,7 @@ import { config } from 'src/config.js';
 
 const BID_WON = EVENTS.BID_WON;
 const NO_BID = EVENTS.NO_BID;
+const BID_RESPONSE = EVENTS.BID_RESPONSE;
 
 const AnalyticsAdapter = require('libraries/analyticsAdapter/AnalyticsAdapter.js').default;
 const adapterConfig = {
@@ -291,7 +292,9 @@ describe('Analytics asynchronous event tracking', () => {
   });
 
   afterEach(() => {
+    adapter.disableAnalytics();
     clock.restore();
+    clearEvents();
   });
 
   it('does not call track as long as events are coming', () => {
@@ -306,5 +309,71 @@ describe('Analytics asynchronous event tracking', () => {
     sinon.assert.calledTwice(adapter.track);
     sinon.assert.calledWith(adapter.track.firstCall, sinon.match({ eventType: BID_WON, args: { i: 0 } }));
     sinon.assert.calledWith(adapter.track.secondCall, sinon.match({ eventType: BID_WON, args: { i: 1 } }));
+  });
+
+  it('snapshots mutable auction fields before the debounce flush', () => {
+    const metrics = { getMetrics: sinon.stub() };
+    const args = {
+      auctionId: 'auction-1',
+      metrics,
+      bidderRequests: [{
+        bids: [{
+          userId: { id5id: { uid: 'id5' } },
+          params: { placementId: '123' }
+        }],
+        ortb2: { user: { ext: { eids: [{ source: 'id5-sync.com' }] } } }
+      }],
+      adUnits: [{
+        bids: [{ userIdAsEids: [{ source: 'id5-sync.com' }] }]
+      }]
+    };
+
+    events.emit(EVENTS.AUCTION_INIT, args);
+    delete args.bidderRequests[0].bids[0].userId;
+    delete args.bidderRequests[0].bids[0].params;
+    delete args.bidderRequests[0].ortb2;
+    delete args.adUnits[0].bids[0].userIdAsEids;
+
+    clock.tick(100);
+
+    sinon.assert.calledOnce(adapter.track);
+    const queuedArgs = adapter.track.firstCall.args[0].args;
+    expect(queuedArgs.metrics).to.equal(metrics);
+    expect(queuedArgs.bidderRequests[0].bids[0].userId).to.eql({ id5id: { uid: 'id5' } });
+    expect(queuedArgs.bidderRequests[0].bids[0].params).to.eql({ placementId: '123' });
+    expect(queuedArgs.bidderRequests[0].ortb2.user.ext.eids).to.eql([{ source: 'id5-sync.com' }]);
+    expect(queuedArgs.adUnits[0].bids[0].userIdAsEids).to.eql([{ source: 'id5-sync.com' }]);
+  });
+
+  [BID_RESPONSE, NO_BID].forEach(eventType => {
+    it(`snapshots mutable ${eventType} payloads before the debounce flush`, () => {
+      const args = {
+        requestId: 'bid-id',
+        bidder: 'bidder',
+        adUnitCode: 'ad-unit',
+        userId: { id5id: { uid: 'id5' } },
+        userIdAsEids: [{ source: 'id5-sync.com' }],
+        ortb2Imp: { ext: { gpid: 'gpid' } },
+        params: { placementId: '123' },
+        mediaTypes: { banner: { sizes: [[300, 250]] } }
+      };
+
+      events.emit(eventType, args);
+      delete args.userId;
+      delete args.userIdAsEids;
+      delete args.ortb2Imp;
+      delete args.params;
+      delete args.mediaTypes;
+
+      clock.tick(100);
+
+      sinon.assert.calledOnce(adapter.track);
+      const queuedArgs = adapter.track.firstCall.args[0].args;
+      expect(queuedArgs.userId).to.eql({ id5id: { uid: 'id5' } });
+      expect(queuedArgs.userIdAsEids).to.eql([{ source: 'id5-sync.com' }]);
+      expect(queuedArgs.ortb2Imp).to.eql({ ext: { gpid: 'gpid' } });
+      expect(queuedArgs.params).to.eql({ placementId: '123' });
+      expect(queuedArgs.mediaTypes).to.eql({ banner: { sizes: [[300, 250]] } });
+    });
   });
 });

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -846,6 +846,260 @@ describe('auctionmanager.js', function () {
       expect(auction.getNonBids()[0]).to.equal('test');
     });
 
+    it('drops request-only data from retained bid request state after auction callbacks finish', async () => {
+      const identityData = {
+        ortb2: { user: { ext: { eids: [{ source: 'id5', uids: [{ id: 'uid', ext: { provider: 'id5' } }] }] } } },
+        userId: { id5id: { uid: 'uid' } },
+        userIdAsEids: [{ source: 'id5', uids: [{ id: 'uid' }] }]
+      };
+      const mediaTypes = { banner: { sizes: [[300, 250]] } };
+      const requestOnlyData = {
+        params: { placementId: 'placement-id' },
+        mediaTypes,
+        ortb2Imp: { ext: { gpid: 'gpid' } },
+        rtd: { provider: 'provider' },
+        floorData: { floorMin: 1 },
+        getFloor: () => ({ floor: 1 }),
+        labelAll: ['label']
+      };
+      const ortb2Fragments = {
+        global: {
+          user: {
+            ext: {
+              eids: [{ source: 'global-id', uids: [{ id: 'global-uid' }] }],
+              data: { eids: [{ source: 'global-data-id', uids: [{ id: 'global-data-uid' }] }] }
+            }
+          }
+        },
+        bidder: {
+          [BIDDER_CODE]: {
+            user: {
+              ext: {
+                eids: [{ source: 'bidder-id', uids: [{ id: 'bidder-uid' }] }],
+                data: { eids: [{ source: 'bidder-data-id', uids: [{ id: 'bidder-data-uid' }] }] }
+              }
+            }
+          }
+        }
+      };
+      const adUnitBid = adUnits[0].bids[0];
+      Object.assign(adUnitBid, requestOnlyData, identityData);
+      let sawIdentityOnAuctionEnd = false;
+
+      stubMakeBidRequests.callsFake((_adUnits, _auctionStart, auctionId) => [{
+        bidderCode: BIDDER_CODE,
+        bidderRequestId: 'bidder-request-id',
+        auctionId,
+        ...identityData,
+        bids: [{
+          bidder: BIDDER_CODE,
+          adUnitCode: ADUNIT_CODE,
+          transactionId: ADUNIT_CODE,
+          adUnitId: ADUNIT_CODE,
+          sizes: [[300, 250]],
+          bidId: 'bid-id',
+          bidderRequestId: 'bidder-request-id',
+          auctionId,
+          ...requestOnlyData,
+          ...identityData
+        }]
+      }]);
+
+      const onAuctionEnd = ({ bidderRequests, adUnits }) => {
+        sawIdentityOnAuctionEnd = !!bidderRequests[0].ortb2 &&
+          !!bidderRequests[0].bids[0].ortb2 &&
+          !!bidderRequests[0].bids[0].userId &&
+          !!bidderRequests[0].bids[0].userIdAsEids &&
+          !!adUnits[0].bids[0].ortb2 &&
+          !!adUnits[0].bids[0].userId &&
+          !!adUnits[0].bids[0].userIdAsEids &&
+          !!ortb2Fragments.global.user.ext.eids &&
+          !!ortb2Fragments.global.user.ext.data.eids &&
+          !!ortb2Fragments.bidder[BIDDER_CODE].user.ext.eids &&
+          !!ortb2Fragments.bidder[BIDDER_CODE].user.ext.data.eids;
+      };
+      events.on(EVENTS.AUCTION_END, onAuctionEnd);
+
+      const auction = auctionManager.createAuction({ adUnits, ortb2Fragments });
+      auction.callBids();
+      try {
+        await auction.end;
+      } finally {
+        events.off(EVENTS.AUCTION_END, onAuctionEnd);
+      }
+
+      const retainedBidderRequest = auction.getBidRequests()[0];
+      const retainedBidRequest = retainedBidderRequest.bids[0];
+      const noBid = auction.getNoBids()[0];
+
+      expect(sawIdentityOnAuctionEnd).to.equal(true);
+      expect(retainedBidderRequest.ortb2).to.equal(undefined);
+      expect(retainedBidRequest.ortb2).to.equal(undefined);
+      expect(retainedBidRequest.userId).to.equal(undefined);
+      expect(retainedBidRequest.userIdAsEids).to.equal(undefined);
+      expect(retainedBidRequest.params).to.equal(undefined);
+      expect(retainedBidRequest.mediaTypes).to.equal(undefined);
+      expect(retainedBidRequest.ortb2Imp).to.equal(undefined);
+      expect(retainedBidRequest.rtd).to.equal(undefined);
+      expect(retainedBidRequest.floorData).to.equal(undefined);
+      expect(retainedBidRequest.getFloor).to.equal(undefined);
+      expect(retainedBidRequest.labelAll).to.equal(undefined);
+      expect(noBid).to.equal(retainedBidRequest);
+      expect(retainedBidRequest.timeToRespond).to.be.a('number');
+      expect(adUnitBid.ortb2).to.equal(undefined);
+      expect(adUnitBid.userId).to.equal(undefined);
+      expect(adUnitBid.userIdAsEids).to.equal(undefined);
+      expect(adUnitBid.ortb2Imp).to.deep.equal(requestOnlyData.ortb2Imp);
+      expect(adUnitBid.params).to.deep.equal(requestOnlyData.params);
+      expect(adUnitBid.mediaTypes).to.equal(mediaTypes);
+      expect(ortb2Fragments.global.user.ext.eids).to.equal(undefined);
+      expect(ortb2Fragments.global.user.ext.data.eids).to.equal(undefined);
+      expect(ortb2Fragments.bidder[BIDDER_CODE].user.ext.eids).to.equal(undefined);
+      expect(ortb2Fragments.bidder[BIDDER_CODE].user.ext.data.eids).to.equal(undefined);
+    });
+
+    it('drops request-only data from retained bid responses after auction callbacks finish but keeps bidWon analytics fields', async () => {
+      const mediaTypes = { banner: { sizes: [[300, 250]] } };
+      const requestOnlyData = {
+        ortb2: { user: { ext: { eids: [{ source: 'id5', uids: [{ id: 'uid' }] }] } } },
+        userId: { id5id: { uid: 'uid' } },
+        userIdAsEids: [{ source: 'id5', uids: [{ id: 'uid' }] }],
+        ortb2Imp: { ext: { gpid: 'gpid' } },
+        params: { placementId: 'placement-id' },
+        mediaTypes,
+        rtd: { provider: 'provider' },
+        floorData: { floorMin: 1 },
+        getFloor: () => ({ floor: 1 }),
+        labelAll: ['label']
+      };
+      let sawRequestOnlyDataOnBidResponse = false;
+
+      stubMakeBidRequests.callsFake((_adUnits, _auctionStart, auctionId) => [{
+        bidderCode: BIDDER_CODE,
+        bidderRequestId: 'bidder-request-id',
+        auctionId,
+        bids: [{
+          bidder: BIDDER_CODE,
+          adUnitCode: ADUNIT_CODE,
+          transactionId: ADUNIT_CODE,
+          adUnitId: ADUNIT_CODE,
+          sizes: [[300, 250]],
+          bidId: 'bid-id',
+          bidderRequestId: 'bidder-request-id',
+          auctionId,
+          mediaTypes
+        }]
+      }]);
+      bids = [{
+        ...mockBid(),
+        requestId: 'bid-id',
+        ...requestOnlyData
+      }];
+
+      const onBidResponse = (bid) => {
+        sawRequestOnlyDataOnBidResponse = !!bid.ortb2 &&
+          !!bid.userId &&
+          !!bid.userIdAsEids &&
+          !!bid.params &&
+          !!bid.mediaTypes &&
+          !!bid.ortb2Imp;
+      };
+      events.on(EVENTS.BID_RESPONSE, onBidResponse);
+
+      const auction = auctionManager.createAuction({ adUnits });
+      indexAuctions.push(auction);
+      auction.callBids();
+      try {
+        await auction.end;
+      } finally {
+        events.off(EVENTS.BID_RESPONSE, onBidResponse);
+      }
+
+      const retainedBidResponse = auction.getBidsReceived()[0];
+
+      expect(sawRequestOnlyDataOnBidResponse).to.equal(true);
+      expect(retainedBidResponse.ortb2).to.equal(undefined);
+      expect(retainedBidResponse.userId).to.equal(undefined);
+      expect(retainedBidResponse.userIdAsEids).to.equal(undefined);
+      expect(retainedBidResponse.params).to.equal(undefined);
+      expect(retainedBidResponse.mediaTypes).to.equal(undefined);
+      expect(retainedBidResponse.ortb2Imp).to.equal(undefined);
+      expect(retainedBidResponse.rtd).to.equal(undefined);
+      expect(retainedBidResponse.floorData).to.deep.equal(requestOnlyData.floorData);
+      expect(retainedBidResponse.getFloor).to.equal(undefined);
+      expect(retainedBidResponse.labelAll).to.equal(undefined);
+      expect(retainedBidResponse.ad).to.equal('creative');
+      expect(retainedBidResponse.adserverTargeting).to.be.an('object');
+    });
+
+    it('keeps retained outstream renderer metadata for late video bids after auction callbacks finish', async () => {
+      const renderer = {
+        url: 'video-renderer.js',
+        render: sinon.spy()
+      };
+      let addLateBid;
+
+      stubMakeBidRequests.callsFake((_adUnits, _auctionStart, auctionId) => [{
+        bidderCode: BIDDER_CODE,
+        bidderRequestId: 'bidder-request-id',
+        auctionId,
+        bids: [{
+          bidder: BIDDER_CODE,
+          adUnitCode: ADUNIT_CODE,
+          transactionId: ADUNIT_CODE,
+          adUnitId: ADUNIT_CODE,
+          sizes: [[300, 250]],
+          bidId: 'late-video-bid-id',
+          bidderRequestId: 'bidder-request-id',
+          auctionId,
+          mediaTypes: {
+            banner: { sizes: [[300, 250]] },
+            video: {
+              context: 'outstream',
+              renderer,
+              playerSize: [300, 250]
+            }
+          }
+        }]
+      }]);
+      stubCallAdapters.callsFake((au, reqs, addBid, done) => {
+        addLateBid = addBid;
+        reqs.forEach(r => done.apply(r));
+      });
+
+      const auction = auctionManager.createAuction({ adUnits });
+      indexAuctions.push(auction);
+      auction.callBids();
+      await auction.end;
+
+      const retainedBidRequest = auction.getBidRequests()[0].bids[0];
+      expect(retainedBidRequest.mediaTypes).to.deep.equal({
+        video: {
+          context: 'outstream',
+          renderer,
+          useCacheKey: undefined
+        }
+      });
+
+      const lateBid = {
+        ...mockBid(),
+        ...createBid({
+          bidder: retainedBidRequest.bidder,
+          bidId: retainedBidRequest.bidId,
+          transactionId: retainedBidRequest.transactionId,
+          adUnitId: retainedBidRequest.adUnitId,
+          auctionId: retainedBidRequest.auctionId
+        }),
+        mediaType: 'video',
+        vastUrl: 'https://example.com/vast.xml'
+      };
+
+      addLateBid(ADUNIT_CODE, lateBid);
+
+      const retainedBidResponse = auction.getBidsReceived().find((bid) => bid.requestId === 'late-video-bid-id');
+      expect(retainedBidResponse.renderer.url).to.equal(renderer.url);
+    });
+
     it('resolves .requestsDone', async () => {
       const auction = auctionManager.createAuction({ adUnits });
       stubCallAdapters.resetHistory();
@@ -1521,8 +1775,6 @@ describe('auctionmanager.js', function () {
           const timedOutBids = bidTimeoutCall.args[1];
           assert.equal(timedOutBids.length, 1);
           assert.equal(timedOutBids[0].bidder, BIDDER_CODE1);
-          // Check that additional properties are available
-          assert.equal(timedOutBids[0].params[0].placementId, 'id');
 
           const auctionEndCall = eventsEmitSpy.withArgs(EVENTS.AUCTION_END).getCalls()[0];
           const auctionProps = auctionEndCall.args[1];

--- a/test/spec/modules/consentManagementUsp_spec.js
+++ b/test/spec/modules/consentManagementUsp_spec.js
@@ -506,6 +506,25 @@ describe('consentManagement', function () {
         sinon.assert.calledOnce(adapterManager.callDataDeletionRequest);
       });
 
+      it('registers deletion request event listener only once across consent lookups', () => {
+        let listener;
+        const uspapiStub = sandbox.stub(window, '__uspapi').callsFake((cmd, _, cb) => {
+          if (cmd === 'registerDeletion') {
+            listener = cb;
+          } else if (cmd === 'getUSPData') {
+            cb({ uspString: 'string' }, true);
+          }
+        });
+
+        setConsentConfig(goodConfig);
+        requestBidsHook(() => {}, {});
+        requestBidsHook(() => {}, {});
+
+        expect(uspapiStub.getCalls().filter(call => call.args[0] === 'registerDeletion')).to.have.length(1);
+        listener();
+        sinon.assert.calledOnce(adapterManager.callDataDeletionRequest);
+      });
+
       it('does not fail if CMP does not support registerDeletion', () => {
         sandbox.stub(window, '__uspapi').callsFake((cmd, _, cb) => {
           if (cmd === 'registerDeletion') {

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -722,6 +722,35 @@ describe('adapterManager tests', function () {
       sinon.assert.calledOnce(prebidServerAdapterMock.callBids);
     });
 
+    it('removes raw userId from retained S2S ad unit bid copies', function () {
+      const adUnits = utils.deepClone(getAdUnits()).map(adUnit => {
+        adUnit.bids = adUnit.bids.filter(bid => bid.bidder === 'appnexus');
+        adUnit.bids.forEach(bid => {
+          bid.userId = {
+            id5id: { uid: 'id5', ext: { provider: 'id5' } },
+            gpid: { uid: 'gpid', ext: { provider: 'gpid' } }
+          };
+        });
+        return adUnit;
+      });
+      const ortb2Fragments = {
+        global: {
+          user: {
+            ext: {
+              eids: [{ source: 'id5-sync.com', uids: [{ id: 'id5' }] }]
+            }
+          }
+        },
+        bidder: {}
+      };
+
+      const requests = adapterManager.makeBidRequests(adUnits, 1111, 2222, 1000, [], ortb2Fragments);
+
+      expect(requests[0].adUnitsS2SCopy[0].bids[0].userId).to.equal(undefined);
+      expect(requests[0].bids[0].userId).to.equal(undefined);
+      expect(ortb2Fragments.global.user.ext.eids).to.have.length(1);
+    });
+
     // Enable this test when prebidServer adapter is made 1.0 compliant
     it('invokes callBids with only s2s bids', function () {
       const adUnits = getAdUnits();

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -1,4 +1,4 @@
-import { isValid, newBidder, registerBidder } from 'src/adapters/bidderFactory.js';
+import { guardTids, isValid, newBidder, registerBidder } from 'src/adapters/bidderFactory.js';
 import adapterManager from 'src/adapterManager.js';
 import * as ajax from 'src/ajax.js';
 import { expect } from 'chai';
@@ -390,6 +390,32 @@ describe('bidderFactory', () => {
         expect(spec.isBidRequestValid.calledTwice).to.equal(true);
         expect(spec.buildRequests.calledOnce).to.equal(true);
         expect(spec.buildRequests.firstCall.args[0]).to.deep.equal([MOCK_BIDS_REQUEST.bids[0]]);
+      });
+
+      it('can clear cached guarded bid request proxies', () => {
+        const tidGuard = guardTids({ bidderCode: 'mockBidder' });
+        const bidRequest = {
+          adUnitCode: 'mockAU',
+          bidId: 'bid',
+          auctionId: 'aid',
+          ortb2: {
+            source: {
+              tid: 'bidder-tid'
+            }
+          }
+        };
+        const firstProxy = tidGuard.bidRequest(bidRequest);
+
+        expect(tidGuard.bidRequest(bidRequest)).to.equal(firstProxy);
+
+        tidGuard.clear();
+
+        const secondProxy = tidGuard.bidRequest(bidRequest);
+        expect(secondProxy).to.not.equal(firstProxy);
+        expect(secondProxy.auctionId).to.equal('bidder-tid');
+        expect(guardTids({ bidderCode: 'mockBidder' })).to.not.equal(tidGuard);
+
+        tidGuard.clear();
       });
 
       it('should make no server requests if the spec doesn\'t return any', function () {

--- a/test/spec/unit/core/storageManager_spec.js
+++ b/test/spec/unit/core/storageManager_spec.js
@@ -350,6 +350,13 @@ describe('canSetCookie', () => {
     expect(canSetCookie()).to.be.false;
   });
 
+  it('should not cache false results', () => {
+    allow = false;
+    expect(canSetCookie()).to.be.false;
+    allow = true;
+    expect(canSetCookie()).to.be.true;
+  });
+
   it('should cache results', () => {
     expect(canSetCookie()).to.be.true;
     allow = false;


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

These changes reduce long-lived object retention after auctions complete. They are mostly memory-retention fixes, not new behavior.

The main change is in `src/auction.ts`: after auction callbacks finish, Prebid no longer keeps request-only data like `ortb2`, `userId`, `userIdAsEids`, `params`, `mediaTypes`, RTD data, floor helpers, and FPD EIDs on retained auction objects. Those objects can be large and can include identity data, and auctions stay reachable for later APIs, analytics, and bid lookup. Cleanup happens after `AUCTION_END` and bid callbacks, so consumers still see the full event payload while retained state becomes smaller afterward.

Related cleanup:
- `libraries/analyticsAdapter/AnalyticsAdapter.ts`: snapshots mutable auction and bid event payloads before debounce flushes, so cleanup does not remove fields analytics legitimately received at event time.
- `src/adapters/bidderFactory.ts`: clears TID guard proxy caches after validation and `buildRequests`.
- `src/adapterManager.ts`: strips raw `userId` from S2S ad-unit copies while preserving ORTB EIDs as the transport shape.
- `modules/consentManagementUsp.ts`: avoids duplicate USP deletion listener registration across consent lookups.
- `src/storageManager.ts`: only caches successful `canSetCookie` checks, so temporary denied/failed checks do not poison future calls.

## Other information

No docs PR needed; this does not change user-facing APIs.