### PR TITLE
Floxis Bid Adapter: first-party fallback id (user.ext.floxisId)

### DIFF
--- a/modules/floxisBidAdapter.js
+++ b/modules/floxisBidAdapter.js
@@ -1,7 +1,8 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
-import { triggerPixel, politeTriggerPixel, mergeDeep, replaceAuctionPrice } from '../src/utils.js';
+import { triggerPixel, politeTriggerPixel, mergeDeep, replaceAuctionPrice, generateUUID } from '../src/utils.js';
+import { getStorageManager } from '../src/storageManager.js';
 
 const BIDDER_CODE = 'floxis';
 const GVLID = 1609;
@@ -11,6 +12,12 @@ const DEFAULT_NET_REVENUE = true;
 const DEFAULT_REGION = 'us-e';
 const DEFAULT_PARTNER = BIDDER_CODE;
 const SYNC_PATH = '/sync';
+const FLOXIS_ID_KEY = 'flx_uid';
+const FLOXIS_ID_COOKIE_EXP = 2592000000; // 30 days
+const UUID_LENGTH = 36;
+
+export const storage = getStorageManager({ bidderCode: BIDDER_CODE });
+
 // Server-echo user-sync: the /pbjs response carries seat + region in this header (on bid and no-bid
 // alike), so getUserSyncs derives sync targets from serverResponses statelessly — no module state that
 // could leak across concurrent auctions. Absent header (older backend) => no sync, a safe no-op.
@@ -88,6 +95,40 @@ function normalizeBidParams(params = {}) {
   };
 }
 
+function isValidFloxisId(id) {
+  return typeof id === 'string' && id.length === UUID_LENGTH;
+}
+
+// Neither store available => null, not a freshly minted id we can't persist (would defeat stability).
+function getOrCreateFloxisId() {
+  if (typeof window === 'undefined') return null;
+  try {
+    const localOk = storage.localStorageIsEnabled();
+    const cookieOk = storage.cookiesAreEnabled();
+    if (!localOk && !cookieOk) return null;
+
+    let id = localOk ? storage.getDataFromLocalStorage(FLOXIS_ID_KEY) : null;
+    if (!isValidFloxisId(id) && cookieOk) {
+      id = storage.getCookie(FLOXIS_ID_KEY);
+    }
+    if (!isValidFloxisId(id)) {
+      id = generateUUID();
+    }
+
+    if (localOk) {
+      storage.setDataInLocalStorage(FLOXIS_ID_KEY, id);
+    }
+    if (cookieOk) {
+      const expires = new Date(Date.now() + FLOXIS_ID_COOKIE_EXP).toUTCString();
+      storage.setCookie(FLOXIS_ID_KEY, id, expires);
+    }
+
+    return id;
+  } catch (e) {
+    return null;
+  }
+}
+
 // Parse the server-echoed sync header (`seat=<seat>&region=<label>`) into a sync target. Returns null
 // for an absent or malformed header so a response without it simply contributes no sync.
 function parseSyncHeader(headerValue) {
@@ -151,6 +192,12 @@ const CONVERTER = ortbConverter({
         }
       }
     });
+    if (!req.user?.ext?.floxisId) {
+      const floxisId = getOrCreateFloxisId();
+      if (floxisId) {
+        mergeDeep(req, { user: { ext: { floxisId } } });
+      }
+    }
     return req;
   },
   bidResponse(buildBidResponse, bid, context) {

--- a/modules/floxisBidAdapter.js
+++ b/modules/floxisBidAdapter.js
@@ -99,7 +99,8 @@ function isValidFloxisId(id) {
   return typeof id === 'string' && id.length === UUID_LENGTH;
 }
 
-// Neither store available => null, not a freshly minted id we can't persist (would defeat stability).
+// Never returns an id that didn't persist (no store, or storageControl denying the key while the
+// keyless enablement checks pass) — an unpersisted id would rotate every auction, worse than none.
 function getOrCreateFloxisId() {
   if (typeof window === 'undefined') return null;
   try {
@@ -111,7 +112,8 @@ function getOrCreateFloxisId() {
     if (!isValidFloxisId(id) && cookieOk) {
       id = storage.getCookie(FLOXIS_ID_KEY);
     }
-    if (!isValidFloxisId(id)) {
+    const minted = !isValidFloxisId(id);
+    if (minted) {
       id = generateUUID();
     }
 
@@ -123,6 +125,11 @@ function getOrCreateFloxisId() {
       storage.setCookie(FLOXIS_ID_KEY, id, expires);
     }
 
+    if (minted &&
+        storage.getDataFromLocalStorage(FLOXIS_ID_KEY) !== id &&
+        storage.getCookie(FLOXIS_ID_KEY) !== id) {
+      return null;
+    }
     return id;
   } catch (e) {
     return null;

--- a/modules/floxisBidAdapter.js
+++ b/modules/floxisBidAdapter.js
@@ -1,7 +1,7 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
-import { triggerPixel, politeTriggerPixel, mergeDeep, deepSetValue, replaceAuctionPrice, generateUUID } from '../src/utils.js';
+import { triggerPixel, politeTriggerPixel, mergeDeep, replaceAuctionPrice, generateUUID } from '../src/utils.js';
 import { getStorageManager } from '../src/storageManager.js';
 
 const BIDDER_CODE = 'floxis';
@@ -211,7 +211,8 @@ const CONVERTER = ortbConverter({
     if (!req.user?.ext?.floxisId) {
       const floxisId = context.resolveFloxisId();
       if (floxisId) {
-        deepSetValue(req, 'user.ext.floxisId', floxisId);
+        // mergeDeep, not deepSetValue: it repairs a non-object user/user.ext, which publisher ortb2 can supply
+        mergeDeep(req, { user: { ext: { floxisId } } });
       }
     }
     return req;

--- a/modules/floxisBidAdapter.js
+++ b/modules/floxisBidAdapter.js
@@ -1,7 +1,7 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
-import { triggerPixel, politeTriggerPixel, mergeDeep, replaceAuctionPrice, generateUUID } from '../src/utils.js';
+import { triggerPixel, politeTriggerPixel, mergeDeep, deepSetValue, replaceAuctionPrice, generateUUID } from '../src/utils.js';
 import { getStorageManager } from '../src/storageManager.js';
 
 const BIDDER_CODE = 'floxis';
@@ -99,9 +99,7 @@ function isValidFloxisId(id) {
   return typeof id === 'string' && id.length === UUID_LENGTH;
 }
 
-// Never returns an id that didn't persist (no store, or storageControl denying the key while the
-// keyless enablement checks pass) — an unpersisted id would rotate every auction, worse than none.
-function getOrCreateFloxisId() {
+function getOrCreatePersistedFloxisId() {
   try {
     const localOk = storage.localStorageIsEnabled();
     const cookieOk = storage.cookiesAreEnabled();
@@ -135,14 +133,13 @@ function getOrCreateFloxisId() {
   }
 }
 
-// request() runs once per seat|region|partner group; memoize to one storage round-trip per auction.
 function createFloxisIdResolver() {
   let resolved = false;
   let id = null;
   return () => {
     if (!resolved) {
       resolved = true;
-      id = getOrCreateFloxisId();
+      id = getOrCreatePersistedFloxisId();
     }
     return id;
   };
@@ -212,9 +209,9 @@ const CONVERTER = ortbConverter({
       }
     });
     if (!req.user?.ext?.floxisId) {
-      const floxisId = context.resolveFloxisId?.();
+      const floxisId = context.resolveFloxisId();
       if (floxisId) {
-        mergeDeep(req, { user: { ext: { floxisId } } });
+        deepSetValue(req, 'user.ext.floxisId', floxisId);
       }
     }
     return req;
@@ -244,10 +241,7 @@ export const spec = {
 
   buildRequests(validBidRequests = [], bidderRequest = {}) {
     if (!validBidRequests.length) return [];
-    const filteredBidRequests = validBidRequests.filter((bidRequest) => spec.isBidRequestValid(bidRequest));
-    if (!filteredBidRequests.length) return [];
-
-    const bidRequestsByParams = filteredBidRequests.reduce((groups, bidRequest) => {
+    const bidRequestsByParams = validBidRequests.reduce((groups, bidRequest) => {
       const { seat, region, partner } = normalizeBidParams(bidRequest.params);
       const key = `${seat}|${region}|${partner}`;
       groups[key] = groups[key] || [];

--- a/modules/floxisBidAdapter.js
+++ b/modules/floxisBidAdapter.js
@@ -102,7 +102,6 @@ function isValidFloxisId(id) {
 // Never returns an id that didn't persist (no store, or storageControl denying the key while the
 // keyless enablement checks pass) — an unpersisted id would rotate every auction, worse than none.
 function getOrCreateFloxisId() {
-  if (typeof window === 'undefined') return null;
   try {
     const localOk = storage.localStorageIsEnabled();
     const cookieOk = storage.cookiesAreEnabled();
@@ -134,6 +133,19 @@ function getOrCreateFloxisId() {
   } catch (e) {
     return null;
   }
+}
+
+// request() runs once per seat|region|partner group; memoize to one storage round-trip per auction.
+function createFloxisIdResolver() {
+  let resolved = false;
+  let id = null;
+  return () => {
+    if (!resolved) {
+      resolved = true;
+      id = getOrCreateFloxisId();
+    }
+    return id;
+  };
 }
 
 // Parse the server-echoed sync header (`seat=<seat>&region=<label>`) into a sync target. Returns null
@@ -200,7 +212,7 @@ const CONVERTER = ortbConverter({
       }
     });
     if (!req.user?.ext?.floxisId) {
-      const floxisId = getOrCreateFloxisId();
+      const floxisId = context.resolveFloxisId?.();
       if (floxisId) {
         mergeDeep(req, { user: { ext: { floxisId } } });
       }
@@ -252,6 +264,7 @@ export const spec = {
     }, {});
 
     const groups = Object.values(bidRequestsByParams);
+    const resolveFloxisId = createFloxisIdResolver();
 
     return groups.map((groupedBidRequests) => {
       const { seat, region, partner } = groupedBidRequests[0].params;
@@ -260,7 +273,7 @@ export const spec = {
       return {
         method: 'POST',
         url,
-        data: CONVERTER.toORTB({ bidRequests: groupedBidRequests, bidderRequest }),
+        data: CONVERTER.toORTB({ bidRequests: groupedBidRequests, bidderRequest, context: { resolveFloxisId } }),
         options: {
           withCredentials: true,
           contentType: 'text/plain'

--- a/modules/floxisBidAdapter.md
+++ b/modules/floxisBidAdapter.md
@@ -15,6 +15,7 @@ The Floxis Bid Adapter enables integration with the Floxis programmatic advertis
 - OpenRTB 2.x compliant
 - Privacy signal forwarding (GDPR/TCF, USP, GPP, COPPA) via Prebid.js core
 - User identity (User ID / `eids`) and supply chain (`schain`) passthrough
+- First-party fallback id for cookieless browsers (`user.ext.floxisId`)
 - Prebid.js Floors Module support (plus a static `bidFloor` param fallback)
 - User sync (iframe and pixel cookie matching)
 
@@ -28,6 +29,22 @@ The Floxis Bid Adapter supports the Prebid.js [Floors Module](https://docs.prebi
 
 ## User Identity & Supply Chain
 `user.ext.eids` from the Prebid [User ID module](https://docs.prebid.org/dev-docs/modules/userId.html) and `source.ext.schain` (set via `pbjs.setConfig({ schain })` or `ortb2`) are forwarded automatically through first-party-data passthrough — no adapter-specific configuration is required.
+
+## First-Party Fallback Id
+Floxis's primary identity signal, the `__fxId` cookie set on `.floxis.tech`, is a third-party cookie relative to the publisher and is blocked by Safari, Firefox and other ITP/ETP browsers. To keep an identity-of-last-resort in those browsers, the adapter mints a random v4 UUID **in the publisher's own page context** (first-party) and places it at `user.ext.floxisId` in the OpenRTB request.
+
+- **Storage & scope**: the id is persisted via `localStorage` (preferred) and a cookie, both scoped to the *publisher's own origin* — it is per-publisher, not cross-site, and is never shared between different sites running the adapter. Cookie lifetime is ~30 days; the id is regenerated if the stored value is not a well-formed 36-character UUID.
+- **Priority on the backend**: the client id is a fallback only. Floxis's backend applies `processedCookieUserId (the __fxId cookie) .orElse(clientFloxisId) .orElse(existing user.id)` — when the `__fxId` cookie is present (e.g. Chrome/Edge), behavior is unchanged and the client id is ignored.
+- **Consent**: storage access goes through Prebid.js core's `storageManager`, gated by the standard `deviceAccess` config and GDPR purpose-1 consent under Floxis's registered `gvlid` (1609) — the adapter adds no bespoke consent logic. If storage access is disallowed, no id is generated or sent, and the auction is unaffected.
+- **Publisher opt-in required**: since Prebid.js 7.x, bidder-level storage access is denied by default and must be explicitly granted per bidder — without it, no `floxisId` is ever generated (a safe no-op, not an error). Enable it via:
+```js
+// https://docs.prebid.org/dev-docs/publisher-api-reference/bidderSettings.html
+pbjs.bidderSettings = {
+    floxis: {
+        storageAllowed: true
+    }
+}
+```
 
 ## Privacy
 GDPR/TCF, US Privacy, GPP and COPPA signals are handled by Prebid.js core and automatically included in the OpenRTB request; consent strings are also appended to user-sync calls. Floxis is registered with IAB Europe TCF as Vendor ID **1609**, declared via the adapter's `gvlid`.
@@ -109,4 +126,4 @@ pbjs.setConfig({
 The adapter reports client-observed auction timeouts and bidder transport errors to Floxis as cookieless operational telemetry. Each beacon is a `keepalive` fetch sent with credentials omitted (no cookies) and scheduled off the auction's critical path, so it carries only the seat, region, event type, and relevant operational dimensions (HTTP status, timeout flag, duration, auction ID, publisher domain) — no user or device identifier is included. Consent signals are forwarded as opaque pass-through parameters where available. Each beacon fires at most once per distinct seat+region pair per event, and telemetry failures are silently suppressed so they never affect the auction lifecycle.
 
 ## Testing
-Unit tests are provided in `test/spec/modules/floxisBidAdapter_spec.js` and cover validation, request building (params, host-label safety, floors, FPD/consent passthrough), response interpretation and meta mapping, user syncs, billing notifications, and error/timeout telemetry callbacks.
+Unit tests are provided in `test/spec/modules/floxisBidAdapter_spec.js` and cover validation, request building (params, host-label safety, floors, FPD/consent passthrough, first-party fallback id), response interpretation and meta mapping, user syncs, billing notifications, and error/timeout telemetry callbacks.

--- a/test/spec/modules/floxisBidAdapter_spec.js
+++ b/test/spec/modules/floxisBidAdapter_spec.js
@@ -417,8 +417,14 @@ describe('floxisBidAdapter', function () {
         cookiesAreEnabledStub = sinon.stub(storage, 'cookiesAreEnabled');
         getDataFromLocalStorageStub = sinon.stub(storage, 'getDataFromLocalStorage');
         getCookieStub = sinon.stub(storage, 'getCookie');
-        setDataInLocalStorageStub = sinon.stub(storage, 'setDataInLocalStorage');
-        setCookieStub = sinon.stub(storage, 'setCookie');
+        // Writes persist to the paired get stub (withArgs overrides blanket returns) so the
+        // adapter's read-back sees them, like a real store; strict-mode tests override these.
+        setDataInLocalStorageStub = sinon.stub(storage, 'setDataInLocalStorage').callsFake(function (key, value) {
+          getDataFromLocalStorageStub.withArgs(key).returns(value);
+        });
+        setCookieStub = sinon.stub(storage, 'setCookie').callsFake(function (key, value) {
+          getCookieStub.withArgs(key).returns(value);
+        });
         generateUUIDStub = sinon.stub(utils, 'generateUUID').returns(STUBBED_UUID);
       });
 
@@ -494,6 +500,20 @@ describe('floxisBidAdapter', function () {
         expect(data.user?.ext?.floxisId).to.be.undefined;
         expect(setDataInLocalStorageStub.called).to.be.false;
         expect(setCookieStub.called).to.be.false;
+      });
+
+      it('sends no id when key-specific access is denied but enablement checks pass (storageControl strict mode)', function () {
+        localStorageIsEnabledStub.returns(true);
+        cookiesAreEnabledStub.returns(true);
+        getDataFromLocalStorageStub.returns(null);
+        getCookieStub.returns(null);
+        setDataInLocalStorageStub.callsFake(function () {});
+        setCookieStub.callsFake(function () {});
+
+        const data = spec.buildRequests([validBannerBid], floxisIdBidderRequest)[0].data;
+
+        expect(data.user?.ext?.floxisId).to.be.undefined;
+        expect(generateUUIDStub.calledOnce).to.be.true;
       });
 
       it('sends no id and does not throw when a storage accessor throws', function () {

--- a/test/spec/modules/floxisBidAdapter_spec.js
+++ b/test/spec/modules/floxisBidAdapter_spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { spec } from 'modules/floxisBidAdapter.js';
+import { spec, storage } from 'modules/floxisBidAdapter.js';
 import { BANNER, NATIVE, VIDEO } from 'src/mediaTypes.js';
 import * as utils from 'src/utils.js';
 
@@ -384,6 +384,144 @@ describe('floxisBidAdapter', function () {
       it('should default cur to USD', function () {
         const data = spec.buildRequests([validBannerBid], bidderRequest)[0].data;
         expect(data.cur).to.deep.equal(['USD']);
+      });
+    });
+
+    describe('First-party fallback id (user.ext.floxisId)', function () {
+      const STUBBED_UUID = '11111111-1111-4111-8111-111111111111';
+      const STORED_UUID = '22222222-2222-4222-8222-222222222222';
+      // ortb2.id avoids the core request processor's own generateUUID() call for req.id, so the stub's call count reflects only the floxisId logic.
+      const floxisIdBidderRequest = { ...bidderRequest, ortb2: { id: 'fixed-request-id' } };
+      let localStorageIsEnabledStub, cookiesAreEnabledStub;
+      let getDataFromLocalStorageStub, getCookieStub;
+      let setDataInLocalStorageStub, setCookieStub;
+      let generateUUIDStub;
+
+      beforeEach(function () {
+        localStorageIsEnabledStub = sinon.stub(storage, 'localStorageIsEnabled');
+        cookiesAreEnabledStub = sinon.stub(storage, 'cookiesAreEnabled');
+        getDataFromLocalStorageStub = sinon.stub(storage, 'getDataFromLocalStorage');
+        getCookieStub = sinon.stub(storage, 'getCookie');
+        setDataInLocalStorageStub = sinon.stub(storage, 'setDataInLocalStorage');
+        setCookieStub = sinon.stub(storage, 'setCookie');
+        generateUUIDStub = sinon.stub(utils, 'generateUUID').returns(STUBBED_UUID);
+      });
+
+      afterEach(function () {
+        localStorageIsEnabledStub.restore();
+        cookiesAreEnabledStub.restore();
+        getDataFromLocalStorageStub.restore();
+        getCookieStub.restore();
+        setDataInLocalStorageStub.restore();
+        setCookieStub.restore();
+        generateUUIDStub.restore();
+      });
+
+      it('mints and persists a new id when none is stored', function () {
+        localStorageIsEnabledStub.returns(true);
+        cookiesAreEnabledStub.returns(true);
+        getDataFromLocalStorageStub.returns(null);
+        getCookieStub.returns(null);
+
+        const data = spec.buildRequests([validBannerBid], floxisIdBidderRequest)[0].data;
+
+        expect(data.user.ext.floxisId).to.equal(STUBBED_UUID);
+        expect(generateUUIDStub.calledOnce).to.be.true;
+        expect(setDataInLocalStorageStub.calledWith('flx_uid', STUBBED_UUID)).to.be.true;
+        expect(setCookieStub.calledWith('flx_uid', STUBBED_UUID)).to.be.true;
+      });
+
+      it('reuses a valid stored id without regenerating it', function () {
+        localStorageIsEnabledStub.returns(true);
+        cookiesAreEnabledStub.returns(true);
+        getDataFromLocalStorageStub.returns(STORED_UUID);
+
+        const data = spec.buildRequests([validBannerBid], floxisIdBidderRequest)[0].data;
+
+        expect(data.user.ext.floxisId).to.equal(STORED_UUID);
+        expect(generateUUIDStub.called).to.be.false;
+      });
+
+      it('falls back to the cookie when localStorage has no stored value', function () {
+        localStorageIsEnabledStub.returns(true);
+        cookiesAreEnabledStub.returns(true);
+        getDataFromLocalStorageStub.returns(null);
+        getCookieStub.returns(STORED_UUID);
+
+        const data = spec.buildRequests([validBannerBid], floxisIdBidderRequest)[0].data;
+
+        expect(data.user.ext.floxisId).to.equal(STORED_UUID);
+        expect(generateUUIDStub.called).to.be.false;
+      });
+
+      it('regenerates the id when the stored value is a malformed UUID', function () {
+        localStorageIsEnabledStub.returns(true);
+        cookiesAreEnabledStub.returns(true);
+        getDataFromLocalStorageStub.returns('not-a-uuid');
+        getCookieStub.returns('also-not-a-uuid');
+
+        const data = spec.buildRequests([validBannerBid], floxisIdBidderRequest)[0].data;
+
+        expect(data.user.ext.floxisId).to.equal(STUBBED_UUID);
+        expect(generateUUIDStub.calledOnce).to.be.true;
+        expect(setDataInLocalStorageStub.calledWith('flx_uid', STUBBED_UUID)).to.be.true;
+      });
+
+      it('sends no id and does not throw when storage is disallowed', function () {
+        localStorageIsEnabledStub.returns(false);
+        cookiesAreEnabledStub.returns(false);
+
+        let data;
+        expect(function () {
+          data = spec.buildRequests([validBannerBid], floxisIdBidderRequest)[0].data;
+        }).to.not.throw();
+
+        expect(data.user?.ext?.floxisId).to.be.undefined;
+        expect(setDataInLocalStorageStub.called).to.be.false;
+        expect(setCookieStub.called).to.be.false;
+      });
+
+      it('sends no id and does not throw when a storage accessor throws', function () {
+        localStorageIsEnabledStub.returns(true);
+        cookiesAreEnabledStub.returns(true);
+        getDataFromLocalStorageStub.throws(new Error('storage access error'));
+
+        let data;
+        expect(function () {
+          data = spec.buildRequests([validBannerBid], floxisIdBidderRequest)[0].data;
+        }).to.not.throw();
+
+        expect(data.user?.ext?.floxisId).to.be.undefined;
+      });
+
+      it('does not clobber other user.ext fields set via ortb2 FPD', function () {
+        localStorageIsEnabledStub.returns(true);
+        cookiesAreEnabledStub.returns(true);
+        getDataFromLocalStorageStub.returns(null);
+        getCookieStub.returns(null);
+
+        const ortb2BidderRequest = {
+          ...floxisIdBidderRequest,
+          ortb2: { ...floxisIdBidderRequest.ortb2, user: { ext: { consent: 'consent-string-123' } } }
+        };
+        const data = spec.buildRequests([validBannerBid], ortb2BidderRequest)[0].data;
+
+        expect(data.user.ext.consent).to.equal('consent-string-123');
+        expect(data.user.ext.floxisId).to.equal(STUBBED_UUID);
+      });
+
+      it('does not overwrite an existing user.ext.floxisId', function () {
+        localStorageIsEnabledStub.returns(true);
+        cookiesAreEnabledStub.returns(true);
+
+        const ortb2BidderRequest = {
+          ...floxisIdBidderRequest,
+          ortb2: { ...floxisIdBidderRequest.ortb2, user: { ext: { floxisId: STORED_UUID } } }
+        };
+        const data = spec.buildRequests([validBannerBid], ortb2BidderRequest)[0].data;
+
+        expect(data.user.ext.floxisId).to.equal(STORED_UUID);
+        expect(generateUUIDStub.called).to.be.false;
       });
     });
   });

--- a/test/spec/modules/floxisBidAdapter_spec.js
+++ b/test/spec/modules/floxisBidAdapter_spec.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { spec, storage } from 'modules/floxisBidAdapter.js';
 import { BANNER, NATIVE, VIDEO } from 'src/mediaTypes.js';
 import * as utils from 'src/utils.js';
+import 'modules/priceFloors.js';
 
 describe('floxisBidAdapter', function () {
   const DEFAULT_PARAMS = { seat: 'Gmtb', region: 'us-e', partner: 'floxis' };
@@ -318,6 +319,20 @@ describe('floxisBidAdapter', function () {
         const requests = spec.buildRequests([bidStaticFloor], bidderRequest);
         const imp = requests[0].data.imp[0];
         expect(imp.bidfloor).to.equal(1.75);
+        expect(imp.bidfloorcur).to.equal('USD');
+      });
+
+      it('should set bidfloor from getFloor and default bidfloorcur when currency is absent', function () {
+        // no currency field: priceFloors' tryGetFloor skips it, so the adapter fallback fires
+        const bidNoCurrencyFloor = {
+          ...validBannerBid,
+          getFloor: function () {
+            return { floor: 1.5 };
+          }
+        };
+        const requests = spec.buildRequests([bidNoCurrencyFloor], bidderRequest);
+        const imp = requests[0].data.imp[0];
+        expect(imp.bidfloor).to.equal(1.5);
         expect(imp.bidfloorcur).to.equal('USD');
       });
     });

--- a/test/spec/modules/floxisBidAdapter_spec.js
+++ b/test/spec/modules/floxisBidAdapter_spec.js
@@ -323,7 +323,6 @@ describe('floxisBidAdapter', function () {
       });
 
       it('should set bidfloor from getFloor and default bidfloorcur when currency is absent', function () {
-        // no currency field: priceFloors' tryGetFloor skips it, so the adapter fallback fires
         const bidNoCurrencyFloor = {
           ...validBannerBid,
           getFloor: function () {
@@ -405,7 +404,7 @@ describe('floxisBidAdapter', function () {
     describe('First-party fallback id (user.ext.floxisId)', function () {
       const STUBBED_UUID = '11111111-1111-4111-8111-111111111111';
       const STORED_UUID = '22222222-2222-4222-8222-222222222222';
-      // ortb2.id avoids the core request processor's own generateUUID() call for req.id, so the stub's call count reflects only the floxisId logic.
+      // fixed ortb2.id keeps core's own generateUUID out of the stub's call count
       const floxisIdBidderRequest = { ...bidderRequest, ortb2: { id: 'fixed-request-id' } };
       let localStorageIsEnabledStub, cookiesAreEnabledStub;
       let getDataFromLocalStorageStub, getCookieStub;
@@ -417,8 +416,7 @@ describe('floxisBidAdapter', function () {
         cookiesAreEnabledStub = sinon.stub(storage, 'cookiesAreEnabled');
         getDataFromLocalStorageStub = sinon.stub(storage, 'getDataFromLocalStorage');
         getCookieStub = sinon.stub(storage, 'getCookie');
-        // Writes persist to the paired get stub (withArgs overrides blanket returns) so the
-        // adapter's read-back sees them, like a real store; strict-mode tests override these.
+        // writes feed the paired get stub so the adapter's read-back behaves like a real store
         setDataInLocalStorageStub = sinon.stub(storage, 'setDataInLocalStorage').callsFake(function (key, value) {
           getDataFromLocalStorageStub.withArgs(key).returns(value);
         });
@@ -576,7 +574,6 @@ describe('floxisBidAdapter', function () {
         requests.forEach(function (request) {
           expect(request.data.user.ext.floxisId).to.equal(STUBBED_UUID);
         });
-        // One storage round-trip for the whole auction — the per-group call site read and rewrote once per group.
         expect(localStorageIsEnabledStub.calledOnce).to.be.true;
         expect(setDataInLocalStorageStub.calledOnce).to.be.true;
         expect(setCookieStub.calledOnce).to.be.true;

--- a/test/spec/modules/floxisBidAdapter_spec.js
+++ b/test/spec/modules/floxisBidAdapter_spec.js
@@ -558,6 +558,29 @@ describe('floxisBidAdapter', function () {
         expect(data.user.ext.floxisId).to.equal(STORED_UUID);
         expect(generateUUIDStub.called).to.be.false;
       });
+
+      it('resolves the id once per auction, not once per seat group', function () {
+        localStorageIsEnabledStub.returns(true);
+        cookiesAreEnabledStub.returns(true);
+        getDataFromLocalStorageStub.returns(null);
+        getCookieStub.returns(null);
+
+        const secondGroupBid = {
+          ...validBannerBid,
+          bidId: 'bid-3',
+          params: { seat: 'Seat2', region: 'eu-w', partner: 'mypartner' }
+        };
+        const requests = spec.buildRequests([validBannerBid, secondGroupBid], floxisIdBidderRequest);
+
+        expect(requests).to.have.lengthOf(2);
+        requests.forEach(function (request) {
+          expect(request.data.user.ext.floxisId).to.equal(STUBBED_UUID);
+        });
+        // One storage round-trip for the whole auction — the per-group call site read and rewrote once per group.
+        expect(localStorageIsEnabledStub.calledOnce).to.be.true;
+        expect(setDataInLocalStorageStub.calledOnce).to.be.true;
+        expect(setCookieStub.calledOnce).to.be.true;
+      });
     });
   });
 

--- a/test/spec/modules/floxisBidAdapter_spec.js
+++ b/test/spec/modules/floxisBidAdapter_spec.js
@@ -557,6 +557,37 @@ describe('floxisBidAdapter', function () {
         expect(generateUUIDStub.called).to.be.false;
       });
 
+      it('still sets the id when publisher ortb2 supplies a non-object user', function () {
+        localStorageIsEnabledStub.returns(true);
+        cookiesAreEnabledStub.returns(true);
+        getDataFromLocalStorageStub.returns(null);
+        getCookieStub.returns(null);
+
+        [null, [], 'nope'].forEach(function (badUser) {
+          const bidderRequestWithBadUser = {
+            ...floxisIdBidderRequest,
+            ortb2: { ...floxisIdBidderRequest.ortb2, user: badUser }
+          };
+          const data = spec.buildRequests([validBannerBid], bidderRequestWithBadUser)[0].data;
+          expect(data.user.ext.floxisId).to.equal(STUBBED_UUID);
+        });
+      });
+
+      it('still sets the id when publisher ortb2 supplies a non-object user.ext', function () {
+        localStorageIsEnabledStub.returns(true);
+        cookiesAreEnabledStub.returns(true);
+        getDataFromLocalStorageStub.returns(null);
+        getCookieStub.returns(null);
+
+        const bidderRequestWithBadUserExt = {
+          ...floxisIdBidderRequest,
+          ortb2: { ...floxisIdBidderRequest.ortb2, user: { ext: null } }
+        };
+        const data = spec.buildRequests([validBannerBid], bidderRequestWithBadUserExt)[0].data;
+
+        expect(data.user.ext.floxisId).to.equal(STUBBED_UUID);
+      });
+
       it('resolves the id once per auction, not once per seat group', function () {
         localStorageIsEnabledStub.returns(true);
         cookiesAreEnabledStub.returns(true);


### PR DESCRIPTION
## Summary

Adds a first-party UUID fallback identity to the Floxis Bid Adapter, sent as `user.ext.floxisId` in the OpenRTB request.

**Why:** Floxis's primary identity signal (`__fxId`) is a third-party cookie on `.floxis.tech`. In Safari, Firefox, and other ITP/ETP environments it is blocked. This change mints a stable UUID in the publisher's own page context (first-party) so there is an identity-of-last-resort for cookieless browsers.

## What it does

- Generates a random v4 UUID via Prebid's `generateUUID()` utility on the first auction on a given publisher's site.
- Persists the id via `storageManager` (localStorage preferred, cookie fallback) scoped to the **publisher's own origin** — it is per-publisher, not cross-site.
- Cookie lifetime: ~30 days (`flx_uid` key). The id is refreshed on malformed or missing stored values.
- Places the id at `user.ext.floxisId` via `mergeDeep` — additive, never overwrites an existing `user.ext.floxisId` supplied via `ortb2` FPD or the User ID module.
- On the backend, this value is consumed only as a fallback after the processed `__fxId` cookie (`processedCookieUserId.orElse(clientFloxisId).orElse(user.id)`), so existing Chrome/Edge behavior is unchanged.

## Storage & consent

- Storage access goes through Prebid's `storageManager`, gated by `deviceAccess` config and GDPR purpose-1 consent under Floxis's registered `gvlid` (**1609**). No bespoke consent logic is added.
- Storage access is denied by default in Prebid.js 7+. Publishers must explicitly opt in via `bidderSettings`:

```js
pbjs.bidderSettings = {
  floxis: { storageAllowed: true }
};
```

When storage is disallowed (or throws), no id is generated, no storage is written, and the auction is unaffected — a safe no-op.

## Testing

All 118 adapter unit tests pass (`gulp test-only --file test/spec/modules/floxisBidAdapter_spec.js --nolint` on Node 24.14.1). The 8 new tests cover: mint + persist new id, reuse stored id, cookie fallback when localStorage empty, regenerate on malformed stored value, no-op when storage disallowed, no-op on storage accessor throw, FPD field preservation (`user.ext` fields from `ortb2` are not clobbered), and no-overwrite of a pre-set `user.ext.floxisId`.

## Files changed

- `modules/floxisBidAdapter.js` — `getOrCreateFloxisId()` helper + `buildRequest` hook
- `modules/floxisBidAdapter.md` — First-Party Fallback Id section added
- `test/spec/modules/floxisBidAdapter_spec.js` — 8 new unit tests

## Why not a userId (sharedId) module?

We considered the userId framework first. Three reasons the adapter-side fallback is the right shape here:

- **Works without the userId module in the build.** The id must function on publisher pages that don't ship `userId`/`sharedId` — this adapter is deployed to long-tail publishers whose wrappers we don't control. `user.ext.eids` from the userId module (including sharedId) is still forwarded via FPD passthrough and is preferred when present.
- **It is a bidder-scoped fallback, not a general-purpose id.** Floxis's primary identity is the `__fxId` cookie on `.floxis.tech`; the backend applies `__fxId → client floxisId → existing user.id`, so this id only matters in ITP/ETP browsers where the third-party cookie is blocked. Placing it at `user.ext.floxisId` (not `user.id`/eids) keeps it from colliding with or masquerading as publisher-declared identity.
- **Strictly first-party and consent-gated.** The id is minted per publisher origin, never shared cross-site, goes through `storageManager` (purpose-1 under GVL 1609), requires the explicit `bidderSettings.floxis.storageAllowed` opt-in, and is disclosed at https://floxis.tech/vendor-storage.json (embedded in `metadata/modules/floxisBidAdapter.json`). An id that fails to persist is never sent.

## Docs PR

prebid/prebid.github.io#6650 — documents the `flx_uid` storage use + `storageAllowed` opt-in on the bidder page (stacks on the already-approved prebid/prebid.github.io#6596, which sets `gvl_id: 1609` and `pbs: true`).

