### PR TITLE
AutomatadAnalyticsAdapter: Capture Video Events

### DIFF
--- a/modules/automatadAnalyticsAdapter.js
+++ b/modules/automatadAnalyticsAdapter.js
@@ -131,56 +131,78 @@ const processEvents = () => {
         case 'videoAuctionAdLoadAttempt':
           if (window.atmtdAnalytics && window.atmtdAnalytics.videoAuctionAdLoadAttemptHandler) {
             window.atmtdAnalytics.videoAuctionAdLoadAttemptHandler(args);
+          } else if (!window.atmtdAnalytics) {
+            shouldTryAgain = true;
           }
           break;
         case 'videoAuctionAdLoadQueued':
           if (window.atmtdAnalytics && window.atmtdAnalytics.videoAuctionAdLoadQueuedHandler) {
             window.atmtdAnalytics.videoAuctionAdLoadQueuedHandler(args);
+          } else if (!window.atmtdAnalytics) {
+            shouldTryAgain = true;
           }
           break;
         case 'videoAuctionAdLoadAbort':
           if (window.atmtdAnalytics && window.atmtdAnalytics.videoAuctionAdLoadAbortHandler) {
             window.atmtdAnalytics.videoAuctionAdLoadAbortHandler(args);
+          } else if (!window.atmtdAnalytics) {
+            shouldTryAgain = true;
           }
           break;
         case 'videoBidImpression':
           if (window.atmtdAnalytics && window.atmtdAnalytics.videoBidImpressionHandler) {
             window.atmtdAnalytics.videoBidImpressionHandler(args);
+          } else if (!window.atmtdAnalytics) {
+            shouldTryAgain = true;
           }
           break;
         case 'videoBidError':
           if (window.atmtdAnalytics && window.atmtdAnalytics.videoBidErrorHandler) {
             window.atmtdAnalytics.videoBidErrorHandler(args);
+          } else if (!window.atmtdAnalytics) {
+            shouldTryAgain = true;
           }
           break;
         case 'videoAdLoaded':
           if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdLoadedHandler) {
             window.atmtdAnalytics.videoAdLoadedHandler(args);
+          } else if (!window.atmtdAnalytics) {
+            shouldTryAgain = true;
           }
           break;
         case 'videoAdStarted':
           if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdStartedHandler) {
             window.atmtdAnalytics.videoAdStartedHandler(args);
+          } else if (!window.atmtdAnalytics) {
+            shouldTryAgain = true;
           }
           break;
         case 'videoAdImpression':
           if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdImpressionHandler) {
             window.atmtdAnalytics.videoAdImpressionHandler(args);
+          } else if (!window.atmtdAnalytics) {
+            shouldTryAgain = true;
           }
           break;
         case 'videoAdSkipped':
           if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdSkippedHandler) {
             window.atmtdAnalytics.videoAdSkippedHandler(args);
+          } else if (!window.atmtdAnalytics) {
+            shouldTryAgain = true;
           }
           break;
         case 'videoAdError':
           if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdErrorHandler) {
             window.atmtdAnalytics.videoAdErrorHandler(args);
+          } else if (!window.atmtdAnalytics) {
+            shouldTryAgain = true;
           }
           break;
         case 'videoAdComplete':
           if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdCompleteHandler) {
             window.atmtdAnalytics.videoAdCompleteHandler(args);
+          } else if (!window.atmtdAnalytics) {
+            shouldTryAgain = true;
           }
           break;
         case 'slotRenderEnded':

--- a/modules/automatadAnalyticsAdapter.js
+++ b/modules/automatadAnalyticsAdapter.js
@@ -10,6 +10,21 @@ import adapterManager from '../src/adapterManager.js';
 import { config } from '../src/config.js';
 import { MODULE_TYPE_ANALYTICS } from '../src/activities/modules.js';
 import { getStorageManager } from '../src/storageManager.js';
+import * as events from '../src/events.js';
+import { getExternalVideoEventName } from '../libraries/video/shared/helpers.js';
+import {
+  AD_LOADED,
+  AD_STARTED,
+  AD_IMPRESSION,
+  AD_SKIPPED,
+  AD_ERROR,
+  AD_COMPLETE,
+  AUCTION_AD_LOAD_ATTEMPT,
+  AUCTION_AD_LOAD_QUEUED,
+  AUCTION_AD_LOAD_ABORT,
+  BID_IMPRESSION,
+  BID_ERROR
+} from '../libraries/video/constants/events.js';
 
 /** Prebid Event Handlers */
 
@@ -113,6 +128,61 @@ const processEvents = () => {
             window.atmtdAnalytics.auctionDebugHandler(args);
           }
           break;
+        case 'videoAuctionAdLoadAttempt':
+          if (window.atmtdAnalytics && window.atmtdAnalytics.videoAuctionAdLoadAttemptHandler) {
+            window.atmtdAnalytics.videoAuctionAdLoadAttemptHandler(args);
+          }
+          break;
+        case 'videoAuctionAdLoadQueued':
+          if (window.atmtdAnalytics && window.atmtdAnalytics.videoAuctionAdLoadQueuedHandler) {
+            window.atmtdAnalytics.videoAuctionAdLoadQueuedHandler(args);
+          }
+          break;
+        case 'videoAuctionAdLoadAbort':
+          if (window.atmtdAnalytics && window.atmtdAnalytics.videoAuctionAdLoadAbortHandler) {
+            window.atmtdAnalytics.videoAuctionAdLoadAbortHandler(args);
+          }
+          break;
+        case 'videoBidImpression':
+          if (window.atmtdAnalytics && window.atmtdAnalytics.videoBidImpressionHandler) {
+            window.atmtdAnalytics.videoBidImpressionHandler(args);
+          }
+          break;
+        case 'videoBidError':
+          if (window.atmtdAnalytics && window.atmtdAnalytics.videoBidErrorHandler) {
+            window.atmtdAnalytics.videoBidErrorHandler(args);
+          }
+          break;
+        case 'videoAdLoaded':
+          if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdLoadedHandler) {
+            window.atmtdAnalytics.videoAdLoadedHandler(args);
+          }
+          break;
+        case 'videoAdStarted':
+          if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdStartedHandler) {
+            window.atmtdAnalytics.videoAdStartedHandler(args);
+          }
+          break;
+        case 'videoAdImpression':
+          if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdImpressionHandler) {
+            window.atmtdAnalytics.videoAdImpressionHandler(args);
+          }
+          break;
+        case 'videoAdSkipped':
+          if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdSkippedHandler) {
+            window.atmtdAnalytics.videoAdSkippedHandler(args);
+          }
+          break;
+        case 'videoAdError':
+          if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdErrorHandler) {
+            window.atmtdAnalytics.videoAdErrorHandler(args);
+          }
+          break;
+        case 'videoAdComplete':
+          if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdCompleteHandler) {
+            window.atmtdAnalytics.videoAdCompleteHandler(args);
+          }
+          break;
         case 'slotRenderEnded':
           if (window.atmtdAnalytics && window.atmtdAnalytics.slotRenderEndedGPTHandler) {
             window.atmtdAnalytics.slotRenderEndedGPTHandler(args);
@@ -173,6 +243,40 @@ const addGPTHandlers = () => {
   });
 };
 
+const VIDEO_EVENTS = [
+  AUCTION_AD_LOAD_ATTEMPT,
+  AUCTION_AD_LOAD_QUEUED,
+  AUCTION_AD_LOAD_ABORT,
+  BID_IMPRESSION,
+  BID_ERROR,
+  AD_LOADED,
+  AD_STARTED,
+  AD_IMPRESSION,
+  AD_SKIPPED,
+  AD_ERROR,
+  AD_COMPLETE
+].map(getExternalVideoEventName);
+
+var registeredVideoHandlers = [];
+
+const removeVideoHandlers = () => {
+  registeredVideoHandlers.forEach(([eventType, handler]) => events.off(eventType, handler));
+  registeredVideoHandlers = [];
+};
+
+const addVideoHandlers = () => {
+  self.removeVideoHandlers();
+  VIDEO_EVENTS.forEach((eventType) => {
+    if (events.has(eventType)) {
+      const handler = (args) => atmtdAdapter.track({ eventType, args });
+      events.on(eventType, handler);
+      registeredVideoHandlers.push([eventType, handler]);
+    } else {
+      self.prettyLog('warn', `Video event ${eventType} is not registered, skipping listener. Is the video module included?`);
+    }
+  });
+};
+
 const initializeQueue = () => {
   self.__atmtdAnalyticsQueue.push = (args) => {
     self.qBeingUsed = true;
@@ -201,6 +305,7 @@ const baseAdapter = adapter({ analyticsType: 'bundle' });
 const atmtdAdapter = Object.assign({}, baseAdapter, {
 
   disableAnalytics() {
+    self.removeVideoHandlers();
     baseAdapter.disableAnalytics.apply(this, arguments);
   },
 
@@ -280,6 +385,94 @@ const atmtdAdapter = Object.assign({}, baseAdapter, {
           self.__atmtdAnalyticsQueue.push([eventType, args]);
         }
         break;
+      case 'videoAuctionAdLoadAttempt':
+        if (window.atmtdAnalytics && window.atmtdAnalytics.videoAuctionAdLoadAttemptHandler && shouldNotPushToQueue) {
+          window.atmtdAnalytics.videoAuctionAdLoadAttemptHandler(args);
+        } else if (!window.atmtdAnalytics || window.atmtdAnalytics.videoAuctionAdLoadAttemptHandler) {
+          self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
+        }
+        break;
+      case 'videoAuctionAdLoadQueued':
+        if (window.atmtdAnalytics && window.atmtdAnalytics.videoAuctionAdLoadQueuedHandler && shouldNotPushToQueue) {
+          window.atmtdAnalytics.videoAuctionAdLoadQueuedHandler(args);
+        } else if (!window.atmtdAnalytics || window.atmtdAnalytics.videoAuctionAdLoadQueuedHandler) {
+          self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
+        }
+        break;
+      case 'videoAuctionAdLoadAbort':
+        if (window.atmtdAnalytics && window.atmtdAnalytics.videoAuctionAdLoadAbortHandler && shouldNotPushToQueue) {
+          window.atmtdAnalytics.videoAuctionAdLoadAbortHandler(args);
+        } else if (!window.atmtdAnalytics || window.atmtdAnalytics.videoAuctionAdLoadAbortHandler) {
+          self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
+        }
+        break;
+      case 'videoBidImpression':
+        if (window.atmtdAnalytics && window.atmtdAnalytics.videoBidImpressionHandler && shouldNotPushToQueue) {
+          window.atmtdAnalytics.videoBidImpressionHandler(args);
+        } else if (!window.atmtdAnalytics || window.atmtdAnalytics.videoBidImpressionHandler) {
+          self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
+        }
+        break;
+      case 'videoBidError':
+        if (window.atmtdAnalytics && window.atmtdAnalytics.videoBidErrorHandler && shouldNotPushToQueue) {
+          window.atmtdAnalytics.videoBidErrorHandler(args);
+        } else if (!window.atmtdAnalytics || window.atmtdAnalytics.videoBidErrorHandler) {
+          self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
+        }
+        break;
+      case 'videoAdLoaded':
+        if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdLoadedHandler && shouldNotPushToQueue) {
+          window.atmtdAnalytics.videoAdLoadedHandler(args);
+        } else if (!window.atmtdAnalytics || window.atmtdAnalytics.videoAdLoadedHandler) {
+          self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
+        }
+        break;
+      case 'videoAdStarted':
+        if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdStartedHandler && shouldNotPushToQueue) {
+          window.atmtdAnalytics.videoAdStartedHandler(args);
+        } else if (!window.atmtdAnalytics || window.atmtdAnalytics.videoAdStartedHandler) {
+          self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
+        }
+        break;
+      case 'videoAdImpression':
+        if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdImpressionHandler && shouldNotPushToQueue) {
+          window.atmtdAnalytics.videoAdImpressionHandler(args);
+        } else if (!window.atmtdAnalytics || window.atmtdAnalytics.videoAdImpressionHandler) {
+          self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
+        }
+        break;
+      case 'videoAdSkipped':
+        if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdSkippedHandler && shouldNotPushToQueue) {
+          window.atmtdAnalytics.videoAdSkippedHandler(args);
+        } else if (!window.atmtdAnalytics || window.atmtdAnalytics.videoAdSkippedHandler) {
+          self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
+        }
+        break;
+      case 'videoAdError':
+        if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdErrorHandler && shouldNotPushToQueue) {
+          window.atmtdAnalytics.videoAdErrorHandler(args);
+        } else if (!window.atmtdAnalytics || window.atmtdAnalytics.videoAdErrorHandler) {
+          self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
+        }
+        break;
+      case 'videoAdComplete':
+        if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdCompleteHandler && shouldNotPushToQueue) {
+          window.atmtdAnalytics.videoAdCompleteHandler(args);
+        } else if (!window.atmtdAnalytics || window.atmtdAnalytics.videoAdCompleteHandler) {
+          self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
+        }
+        break;
     }
   }
 });
@@ -301,6 +494,7 @@ atmtdAdapter.enableAnalytics = function (configuration) {
 
   self.initializeQueue();
   self.addGPTHandlers();
+  self.addVideoHandlers();
 
   window.__atmtdSDKConfig = {
     publisherID: conf.publisherID,
@@ -325,6 +519,8 @@ export var self = {
   processEvents,
   initializeQueue,
   addGPTHandlers,
+  addVideoHandlers,
+  removeVideoHandlers,
   prettyLog,
   queuePointer,
   retryCount,

--- a/modules/automatadAnalyticsAdapter.js
+++ b/modules/automatadAnalyticsAdapter.js
@@ -286,20 +286,23 @@ const removeVideoHandlers = () => {
   registeredVideoHandlers = [];
 };
 
-const addVideoHandlers = () => {
+const addVideoHandlers = (configuration = {}) => {
   self.removeVideoHandlers();
-  const videoEventSet = new Set(VIDEO_EVENTS);
+  const { includeEvents, excludeEvents = [] } = configuration;
+  // if includeEvents is set, only those that appear in the whitelist.
+  const trackedVideoEvents = VIDEO_EVENTS
+    .filter((ev) => includeEvents == null || includeEvents.includes(ev))
+    .filter((ev) => !excludeEvents.includes(ev));
+  const videoEventSet = new Set(trackedVideoEvents);
 
   // Replay video events that fired before these listeners were attached.
-  // Base AnalyticsAdapter only replays core EVENTS, so dynamically registered
-  // video names would otherwise be silently dropped on late enableAnalytics.
   events.getEvents().forEach((event) => {
     if (event && videoEventSet.has(event.eventType)) {
       atmtdAdapter.track({ eventType: event.eventType, args: event.args });
     }
   });
 
-  VIDEO_EVENTS.forEach((eventType) => {
+  trackedVideoEvents.forEach((eventType) => {
     if (events.has(eventType)) {
       const handler = (args) => atmtdAdapter.track({ eventType, args });
       events.on(eventType, handler);
@@ -527,7 +530,7 @@ atmtdAdapter.enableAnalytics = function (configuration) {
 
   self.initializeQueue();
   self.addGPTHandlers();
-  self.addVideoHandlers();
+  self.addVideoHandlers(configuration);
 
   window.__atmtdSDKConfig = {
     publisherID: conf.publisherID,

--- a/modules/automatadAnalyticsAdapter.js
+++ b/modules/automatadAnalyticsAdapter.js
@@ -288,6 +288,17 @@ const removeVideoHandlers = () => {
 
 const addVideoHandlers = () => {
   self.removeVideoHandlers();
+  const videoEventSet = new Set(VIDEO_EVENTS);
+
+  // Replay video events that fired before these listeners were attached.
+  // Base AnalyticsAdapter only replays core EVENTS, so dynamically registered
+  // video names would otherwise be silently dropped on late enableAnalytics.
+  events.getEvents().forEach((event) => {
+    if (event && videoEventSet.has(event.eventType)) {
+      atmtdAdapter.track({ eventType: event.eventType, args: event.args });
+    }
+  });
+
   VIDEO_EVENTS.forEach((eventType) => {
     if (events.has(eventType)) {
       const handler = (args) => atmtdAdapter.track({ eventType, args });

--- a/modules/automatadAnalyticsAdapter.js
+++ b/modules/automatadAnalyticsAdapter.js
@@ -16,6 +16,7 @@ import {
   AD_LOADED,
   AD_STARTED,
   AD_IMPRESSION,
+  AD_TIME,
   AD_SKIPPED,
   AD_ERROR,
   AD_COMPLETE,
@@ -205,6 +206,13 @@ const processEvents = () => {
             shouldTryAgain = true;
           }
           break;
+        case AD_QUARTILE_EVENT:
+          if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdQuartileHandler) {
+            window.atmtdAnalytics.videoAdQuartileHandler(args);
+          } else if (!window.atmtdAnalytics) {
+            shouldTryAgain = true;
+          }
+          break;
         case 'slotRenderEnded':
           if (window.atmtdAnalytics && window.atmtdAnalytics.slotRenderEndedGPTHandler) {
             window.atmtdAnalytics.slotRenderEndedGPTHandler(args);
@@ -279,11 +287,72 @@ const VIDEO_EVENTS = [
   AD_COMPLETE
 ].map(getExternalVideoEventName);
 
+const AD_TIME_EVENT = getExternalVideoEventName(AD_TIME);
+const AD_QUARTILE_EVENT = 'videoAdQuartile';
+const QUARTILES = [
+  { name: 'firstQuartile', threshold: 0.25 },
+  { name: 'midpoint', threshold: 0.5 },
+  { name: 'thirdQuartile', threshold: 0.75 }
+];
 var registeredVideoHandlers = [];
+var quartileStateByAd = new Map();
+
+const getAdKey = (args) => {
+  return (args && (args.adId || args.vastAdId || args.adTagUrl)) || 'default';
+};
+
+const resetQuartileState = (args) => {
+  if (args) {
+    quartileStateByAd.delete(getAdKey(args));
+  } else {
+    quartileStateByAd.clear();
+  }
+};
+
+// Sample high-frequency adTime ticks into quartile events (25/50/75).
+// Most ticks return null and are dropped, at most one emit per quartile per ad.
+const sampleAdTimeToQuartile = (args) => {
+  const time = args && args.time;
+  const duration = args && args.duration;
+  if (!(duration > 0) || !(time >= 0)) {
+    return null;
+  }
+
+  const progress = time / duration;
+  const adKey = getAdKey(args);
+  let fired = quartileStateByAd.get(adKey);
+  if (!fired) {
+    fired = new Set();
+    quartileStateByAd.set(adKey, fired);
+  }
+
+  for (let i = 0; i < QUARTILES.length; i++) {
+    const { name, threshold } = QUARTILES[i];
+    if (progress >= threshold && !fired.has(name)) {
+      fired.add(name);
+      return Object.assign({}, args, {
+        quartile: name,
+        progress,
+        type: AD_QUARTILE_EVENT
+      });
+    }
+  }
+  return null;
+};
+
+const shouldTrackQuartiles = (includeEvents, excludeEvents = []) => {
+  if (excludeEvents.includes(AD_QUARTILE_EVENT) || excludeEvents.includes(AD_TIME_EVENT)) {
+    return false;
+  }
+  return includeEvents == null ||
+    includeEvents.includes(AD_QUARTILE_EVENT) ||
+    includeEvents.includes(AD_TIME_EVENT);
+};
 
 const removeVideoHandlers = () => {
   registeredVideoHandlers.forEach(([eventType, handler]) => events.off(eventType, handler));
   registeredVideoHandlers = [];
+  resetQuartileState();
 };
 
 const addVideoHandlers = (configuration = {}) => {
@@ -311,6 +380,22 @@ const addVideoHandlers = (configuration = {}) => {
       self.prettyLog('warn', `Video event ${eventType} is not registered, skipping listener. Is the video module included?`);
     }
   });
+
+  // Listen to adTime only to derive quartiles
+  if (shouldTrackQuartiles(includeEvents, excludeEvents)) {
+    if (events.has(AD_TIME_EVENT)) {
+      const adTimeHandler = (args) => {
+        const quartileArgs = sampleAdTimeToQuartile(args);
+        if (quartileArgs) {
+          atmtdAdapter.track({ eventType: AD_QUARTILE_EVENT, args: quartileArgs });
+        }
+      };
+      events.on(AD_TIME_EVENT, adTimeHandler);
+      registeredVideoHandlers.push([AD_TIME_EVENT, adTimeHandler]);
+    } else {
+      self.prettyLog('warn', `Video event ${AD_TIME_EVENT} is not registered, skipping quartile sampling. Is the video module included?`);
+    }
+  }
 };
 
 const initializeQueue = () => {
@@ -470,6 +555,7 @@ const atmtdAdapter = Object.assign({}, baseAdapter, {
         }
         break;
       case 'videoAdStarted':
+        resetQuartileState(args);
         if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdStartedHandler && shouldNotPushToQueue) {
           window.atmtdAnalytics.videoAdStartedHandler(args);
         } else if (!window.atmtdAnalytics || window.atmtdAnalytics.videoAdStartedHandler) {
@@ -492,6 +578,7 @@ const atmtdAdapter = Object.assign({}, baseAdapter, {
           self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
           self.__atmtdAnalyticsQueue.push([eventType, args]);
         }
+        resetQuartileState(args);
         break;
       case 'videoAdError':
         if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdErrorHandler && shouldNotPushToQueue) {
@@ -500,11 +587,21 @@ const atmtdAdapter = Object.assign({}, baseAdapter, {
           self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
           self.__atmtdAnalyticsQueue.push([eventType, args]);
         }
+        resetQuartileState(args);
         break;
       case 'videoAdComplete':
         if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdCompleteHandler && shouldNotPushToQueue) {
           window.atmtdAnalytics.videoAdCompleteHandler(args);
         } else if (!window.atmtdAnalytics || window.atmtdAnalytics.videoAdCompleteHandler) {
+          self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
+          self.__atmtdAnalyticsQueue.push([eventType, args]);
+        }
+        resetQuartileState(args);
+        break;
+      case AD_QUARTILE_EVENT:
+        if (window.atmtdAnalytics && window.atmtdAnalytics.videoAdQuartileHandler && shouldNotPushToQueue) {
+          window.atmtdAnalytics.videoAdQuartileHandler(args);
+        } else if (!window.atmtdAnalytics || window.atmtdAnalytics.videoAdQuartileHandler) {
           self.prettyLog('warn', `Aggregator not loaded, pushing ${eventType} to que instead ...`);
           self.__atmtdAnalyticsQueue.push([eventType, args]);
         }
@@ -558,6 +655,8 @@ export var self = {
   addVideoHandlers,
   removeVideoHandlers,
   prettyLog,
+  sampleAdTimeToQuartile,
+  resetQuartileState,
   queuePointer,
   retryCount,
   isLoggingEnabled,

--- a/test/spec/modules/automatadAnalyticsAdapter_spec.js
+++ b/test/spec/modules/automatadAnalyticsAdapter_spec.js
@@ -15,8 +15,33 @@ const obj = {
   auctionDebugHandler: (args) => {},
   bidderTimeoutHandler: (args) => {},
   bidRequestedHandler: (args) => {},
-  bidRejectedHandler: (args) => {}
+  bidRejectedHandler: (args) => {},
+  videoAuctionAdLoadAttemptHandler: (args) => {},
+  videoAuctionAdLoadQueuedHandler: (args) => {},
+  videoAuctionAdLoadAbortHandler: (args) => {},
+  videoBidImpressionHandler: (args) => {},
+  videoBidErrorHandler: (args) => {},
+  videoAdLoadedHandler: (args) => {},
+  videoAdStartedHandler: (args) => {},
+  videoAdImpressionHandler: (args) => {},
+  videoAdSkippedHandler: (args) => {},
+  videoAdErrorHandler: (args) => {},
+  videoAdCompleteHandler: (args) => {}
 };
+
+const VIDEO_EVENTS = [
+  ['videoAuctionAdLoadAttempt', 'videoAuctionAdLoadAttemptHandler'],
+  ['videoAuctionAdLoadQueued', 'videoAuctionAdLoadQueuedHandler'],
+  ['videoAuctionAdLoadAbort', 'videoAuctionAdLoadAbortHandler'],
+  ['videoBidImpression', 'videoBidImpressionHandler'],
+  ['videoBidError', 'videoBidErrorHandler'],
+  ['videoAdLoaded', 'videoAdLoadedHandler'],
+  ['videoAdStarted', 'videoAdStartedHandler'],
+  ['videoAdImpression', 'videoAdImpressionHandler'],
+  ['videoAdSkipped', 'videoAdSkippedHandler'],
+  ['videoAdError', 'videoAdErrorHandler'],
+  ['videoAdComplete', 'videoAdCompleteHandler']
+];
 
 const {
   AUCTION_DEBUG,
@@ -108,6 +133,7 @@ describe('Automatad Analytics Adapter', () => {
     it('Should successfully configure the adapter and set global log debug messages flag to true', () => {
       sandbox.stub(exports, 'initializeQueue').callsFake(() => {});
       sandbox.stub(exports, 'addGPTHandlers').callsFake(() => {});
+      sandbox.stub(exports, 'addVideoHandlers').callsFake(() => {});
       const config = {
         provider: 'atmtdAnalyticsAdapter',
         options: {
@@ -121,6 +147,7 @@ describe('Automatad Analytics Adapter', () => {
       expect(utils.logError.called).to.equal(false);
       expect(exports.initializeQueue.called).to.equal(true);
       expect(exports.addGPTHandlers.called).to.equal(true);
+      expect(exports.addVideoHandlers.called).to.equal(true);
       expect(utils.logMessage.called).to.equal(true);
       spec.disableAnalytics();
     });
@@ -196,6 +223,13 @@ describe('Automatad Analytics Adapter', () => {
     it('Should call the auctionDebugHandler when the auctionDebug event is fired', () => {
       events.emit(AUCTION_DEBUG, { type: AUCTION_DEBUG });
       expect(global.window.atmtdAnalytics.auctionDebugHandler.called).to.equal(true);
+    });
+
+    VIDEO_EVENTS.forEach(([eventType, handler]) => {
+      it(`Should call the ${handler} when the ${eventType} event is tracked`, () => {
+        spec.track({ eventType, args: { type: eventType } });
+        expect(global.window.atmtdAnalytics[handler].called).to.equal(true);
+      });
     });
   });
 
@@ -301,6 +335,17 @@ describe('Automatad Analytics Adapter', () => {
       expect(exports.__atmtdAnalyticsQueue[0]).to.have.lengthOf(2);
       expect(exports.__atmtdAnalyticsQueue[0][0]).to.equal(BID_TIMEOUT);
       expect(exports.__atmtdAnalyticsQueue[0][1].type).to.equal(BID_TIMEOUT);
+    });
+
+    VIDEO_EVENTS.forEach(([eventType]) => {
+      it(`Should push to the que when the ${eventType} event is tracked`, () => {
+        spec.track({ eventType, args: { type: eventType } });
+        expect(exports.__atmtdAnalyticsQueue.push.called).to.equal(true);
+        expect(exports.__atmtdAnalyticsQueue).to.be.an('array').to.have.lengthOf(1);
+        expect(exports.__atmtdAnalyticsQueue[0]).to.have.lengthOf(2);
+        expect(exports.__atmtdAnalyticsQueue[0][0]).to.equal(eventType);
+        expect(exports.__atmtdAnalyticsQueue[0][1].type).to.equal(eventType);
+      });
     });
   });
 
@@ -534,7 +579,18 @@ describe('Automatad Analytics Adapter', () => {
         impressionViewableHandler: (args) => {},
         slotRenderEndedGPTHandler: (args) => {},
         bidRequestedHandler: (args) => {},
-        bidRejectedHandler: (args) => {}
+        bidRejectedHandler: (args) => {},
+        videoAuctionAdLoadAttemptHandler: (args) => {},
+        videoAuctionAdLoadQueuedHandler: (args) => {},
+        videoAuctionAdLoadAbortHandler: (args) => {},
+        videoBidImpressionHandler: (args) => {},
+        videoBidErrorHandler: (args) => {},
+        videoAdLoadedHandler: (args) => {},
+        videoAdStartedHandler: (args) => {},
+        videoAdImpressionHandler: (args) => {},
+        videoAdSkippedHandler: (args) => {},
+        videoAdErrorHandler: (args) => {},
+        videoAdCompleteHandler: (args) => {}
       };
 
       global.window.atmtdAnalytics = obj;
@@ -555,7 +611,8 @@ describe('Automatad Analytics Adapter', () => {
         [AUCTION_DEBUG, { type: AUCTION_DEBUG }],
         [BID_TIMEOUT, { type: BID_TIMEOUT }],
         ['slotRenderEnded', { type: 'slotRenderEnded' }],
-        ['impressionViewable', { type: 'impressionViewable' }]
+        ['impressionViewable', { type: 'impressionViewable' }],
+        ...VIDEO_EVENTS.map(([eventType]) => [eventType, { type: eventType }])
       ];
     });
     afterEach(() => {
@@ -583,6 +640,96 @@ describe('Automatad Analytics Adapter', () => {
       expect(global.window.atmtdAnalytics.bidderDoneHandler.calledOnce).to.equal(true);
       expect(global.window.atmtdAnalytics.slotRenderEndedGPTHandler.calledOnce).to.equal(true);
       expect(global.window.atmtdAnalytics.impressionViewableHandler.calledOnce).to.equal(true);
+      VIDEO_EVENTS.forEach(([, handler]) => {
+        expect(global.window.atmtdAnalytics[handler].calledOnce).to.equal(true);
+      });
+    });
+  });
+
+  describe('Behaviour of the adapter when a video handler is not implemented but the SDK is loaded', () => {
+    before(() => {
+      spec.enableAnalytics(CONFIG_WITH_DEBUG);
+    });
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      sandbox.stub(events, 'getEvents').returns([]);
+      sandbox.stub(utils, 'logMessage');
+      sandbox.stub(utils, 'logError');
+
+      global.window.atmtdAnalytics = {
+        auctionInitHandler: (args) => {},
+        bidResponseHandler: (args) => {},
+        bidderDoneHandler: (args) => {},
+        bidWonHandler: (args) => {},
+        noBidHandler: (args) => {},
+        auctionDebugHandler: (args) => {},
+        bidderTimeoutHandler: (args) => {},
+        bidRequestedHandler: (args) => {},
+        bidRejectedHandler: (args) => {}
+      };
+      exports.qBeingUsed = false;
+      exports.__atmtdAnalyticsQueue.length = 0;
+      sandbox.stub(exports.__atmtdAnalyticsQueue, 'push').callsFake((args) => {
+        Array.prototype.push.apply(exports.__atmtdAnalyticsQueue, [args]);
+      });
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+    after(() => {
+      global.window.atmtdAnalytics = undefined;
+      spec.disableAnalytics();
+    });
+
+    VIDEO_EVENTS.forEach(([eventType]) => {
+      it(`Should drop the ${eventType} event without queueing when its handler is not implemented`, () => {
+        spec.track({ eventType, args: { type: eventType } });
+        expect(exports.__atmtdAnalyticsQueue.push.called).to.equal(false);
+        expect(exports.__atmtdAnalyticsQueue).to.be.an('array').to.have.lengthOf(0);
+      });
+    });
+  });
+
+  describe('Behaviour of the adapter when video events are emitted on the event bus', () => {
+    let videoObj;
+    before(() => {
+      events.addEvents(VIDEO_EVENTS.map(([eventType]) => eventType));
+      sandbox = sinon.createSandbox();
+      sandbox.stub(events, 'getEvents').returns([]);
+      sandbox.stub(utils, 'logMessage');
+      sandbox.stub(utils, 'logError');
+      videoObj = {};
+      VIDEO_EVENTS.forEach(([, handler]) => { videoObj[handler] = (args) => {}; });
+
+      spec.enableAnalytics(CONFIG_WITH_DEBUG);
+      global.window.atmtdAnalytics = videoObj;
+      exports.qBeingUsed = false;
+      exports.qTraversalComplete = undefined;
+      Object.keys(videoObj).forEach((fn) => sandbox.spy(global.window.atmtdAnalytics, fn));
+    });
+    afterEach(() => {
+      Object.keys(videoObj).forEach((handler) => global.window.atmtdAnalytics[handler].resetHistory());
+    });
+    after(() => {
+      global.window.atmtdAnalytics = undefined;
+      spec.disableAnalytics();
+      sandbox.restore();
+      exports.qBeingUsed = false;
+      exports.qTraversalComplete = undefined;
+    });
+
+    VIDEO_EVENTS.forEach(([eventType, handler]) => {
+      it(`Should call the ${handler} when the ${eventType} event is emitted`, () => {
+        events.emit(eventType, { type: eventType });
+        expect(global.window.atmtdAnalytics[handler].calledOnce).to.equal(true);
+      });
+    });
+
+    it('Should remove the video event listeners on disableAnalytics', () => {
+      spec.disableAnalytics();
+      events.emit('videoAdStarted', { type: 'videoAdStarted' });
+      expect(global.window.atmtdAnalytics.videoAdStartedHandler.called).to.equal(false);
+      spec.enableAnalytics(CONFIG_WITH_DEBUG);
     });
   });
 

--- a/test/spec/modules/automatadAnalyticsAdapter_spec.js
+++ b/test/spec/modules/automatadAnalyticsAdapter_spec.js
@@ -556,6 +556,80 @@ describe('Automatad Analytics Adapter', () => {
       expect(exports.queuePointer).to.equal(0);
       expect(exports.processEvents.callCount).to.equal(5);
     });
+
+    it('Should retry processing videoAdStarted in certain intervals', () => {
+      expect(exports.queuePointer).to.equal(0);
+      expect(exports.retryCount).to.equal(0);
+      const que = [['videoAdStarted', { type: 'videoAdStarted' }]];
+      exports.__atmtdAnalyticsQueue.push(que[0]);
+      exports.processEvents();
+      expect(exports.prettyLog.getCall(0).args[0]).to.equal('status');
+      expect(exports.prettyLog.getCall(0).args[1]).to.equal(`Que has been inactive for a while. Adapter starting to process que now... Trial Count = 1`);
+      expect(exports.prettyLog.getCall(1).args[0]).to.equal('warn');
+      expect(exports.prettyLog.getCall(1).args[1]).to.equal(`Adapter failed to process event as aggregator has not loaded. Retrying in 1500ms ...`);
+      clock.tick(1510);
+      expect(exports.prettyLog.getCall(2).args[0]).to.equal('status');
+      expect(exports.prettyLog.getCall(2).args[1]).to.equal(`Que has been inactive for a while. Adapter starting to process que now... Trial Count = 2`);
+      expect(exports.prettyLog.getCall(3).args[0]).to.equal('warn');
+      expect(exports.prettyLog.getCall(3).args[1]).to.equal(`Adapter failed to process event as aggregator has not loaded. Retrying in 3000ms ...`);
+      clock.tick(3010);
+      expect(exports.prettyLog.getCall(4).args[0]).to.equal('status');
+      expect(exports.prettyLog.getCall(4).args[1]).to.equal(`Que has been inactive for a while. Adapter starting to process que now... Trial Count = 3`);
+      expect(exports.prettyLog.getCall(5).args[0]).to.equal('warn');
+      expect(exports.prettyLog.getCall(5).args[1]).to.equal(`Adapter failed to process event as aggregator has not loaded. Retrying in 5000ms ...`);
+      clock.tick(5010);
+      expect(exports.prettyLog.getCall(6).args[0]).to.equal('status');
+      expect(exports.prettyLog.getCall(6).args[1]).to.equal(`Que has been inactive for a while. Adapter starting to process que now... Trial Count = 4`);
+      expect(exports.prettyLog.getCall(7).args[0]).to.equal('warn');
+      expect(exports.prettyLog.getCall(7).args[1]).to.equal(`Adapter failed to process event as aggregator has not loaded. Retrying in 10000ms ...`);
+      clock.tick(10010);
+      expect(exports.prettyLog.getCall(8).args[0]).to.equal('error');
+      expect(exports.prettyLog.getCall(8).args[1]).to.equal(`Aggregator still hasn't loaded. Processing que stopped`);
+      expect(exports.queuePointer).to.equal(0);
+      expect(exports.processEvents.callCount).to.equal(5);
+    });
+  });
+
+  describe('Process Events from Que when SDK is loaded without video handlers', () => {
+    before(() => {
+      spec.enableAnalytics({
+        provider: 'atmtdAnalyticsAdapter',
+        options: {
+          publisherID: '230',
+          siteID: '421'
+        }
+      });
+      global.window.atmtdAnalytics = {
+        auctionInitHandler: (args) => {}
+      };
+      exports.retryCount = 0;
+      exports.queuePointer = 0;
+      exports.__atmtdAnalyticsQueue = [
+        ['videoAdStarted', { type: 'videoAdStarted' }]
+      ];
+    });
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      sandbox.stub(events, 'getEvents').returns([]);
+      sandbox.spy(exports, 'prettyLog');
+      sandbox.spy(exports, 'processEvents');
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+    after(() => {
+      global.window.atmtdAnalytics = undefined;
+      spec.disableAnalytics();
+    });
+
+    it('Should skip unimplemented video events without retrying', () => {
+      exports.processEvents();
+      expect(exports.retryCount).to.equal(0);
+      expect(exports.processEvents.callCount).to.equal(1);
+      expect(exports.queuePointer).to.equal(exports.__atmtdAnalyticsQueue.length);
+      expect(exports.qBeingUsed).to.equal(false);
+      expect(exports.qTraversalComplete).to.equal(true);
+    });
   });
 
   describe('Process Events from Que when SDK has loaded', () => {

--- a/test/spec/modules/automatadAnalyticsAdapter_spec.js
+++ b/test/spec/modules/automatadAnalyticsAdapter_spec.js
@@ -807,6 +807,48 @@ describe('Automatad Analytics Adapter', () => {
     });
   });
 
+  describe('Behaviour of the adapter when video events fire before enableAnalytics', () => {
+    let videoObj;
+    before(() => {
+      events.addEvents(VIDEO_EVENTS.map(([eventType]) => eventType));
+    });
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      sandbox.stub(utils, 'logMessage');
+      sandbox.stub(utils, 'logError');
+      videoObj = {};
+      VIDEO_EVENTS.forEach(([, handler]) => { videoObj[handler] = sandbox.spy(); });
+      global.window.atmtdAnalytics = videoObj;
+      exports.qBeingUsed = false;
+      exports.__atmtdAnalyticsQueue.length = 0;
+    });
+    afterEach(() => {
+      global.window.atmtdAnalytics = undefined;
+      spec.disableAnalytics();
+      sandbox.restore();
+      exports.qBeingUsed = false;
+    });
+
+    it('Should replay matching video event history when adding video handlers', () => {
+      const pastEvents = VIDEO_EVENTS.map(([eventType], index) => ({
+        eventType,
+        args: { type: eventType, id: index },
+        sequence: index
+      }));
+      sandbox.stub(events, 'getEvents').returns([
+        { eventType: AUCTION_INIT, args: { type: AUCTION_INIT }, sequence: 0 },
+        ...pastEvents
+      ]);
+
+      spec.enableAnalytics(CONFIG_WITH_DEBUG);
+
+      VIDEO_EVENTS.forEach(([eventType, handler]) => {
+        expect(global.window.atmtdAnalytics[handler].calledOnce).to.equal(true);
+        expect(global.window.atmtdAnalytics[handler].firstCall.args[0].type).to.equal(eventType);
+      });
+    });
+  });
+
   describe('Prettylog fn tests', () => {
     beforeEach(() => {
       sandbox = sinon.createSandbox();

--- a/test/spec/modules/automatadAnalyticsAdapter_spec.js
+++ b/test/spec/modules/automatadAnalyticsAdapter_spec.js
@@ -26,7 +26,8 @@ const obj = {
   videoAdImpressionHandler: (args) => {},
   videoAdSkippedHandler: (args) => {},
   videoAdErrorHandler: (args) => {},
-  videoAdCompleteHandler: (args) => {}
+  videoAdCompleteHandler: (args) => {},
+  videoAdQuartileHandler: (args) => {}
 };
 
 const VIDEO_EVENTS = [
@@ -68,7 +69,9 @@ const CONFIG_WITH_VIDEO = {
   ...CONFIG_WITH_DEBUG,
   includeEvents: [
     ...CONFIG_WITH_DEBUG.includeEvents,
-    ...VIDEO_EVENTS.map(([eventType]) => eventType)
+    ...VIDEO_EVENTS.map(([eventType]) => eventType),
+    'videoAdQuartile',
+    'videoAdTime'
   ]
 };
 
@@ -672,7 +675,8 @@ describe('Automatad Analytics Adapter', () => {
         videoAdImpressionHandler: (args) => {},
         videoAdSkippedHandler: (args) => {},
         videoAdErrorHandler: (args) => {},
-        videoAdCompleteHandler: (args) => {}
+        videoAdCompleteHandler: (args) => {},
+        videoAdQuartileHandler: (args) => {}
       };
 
       global.window.atmtdAnalytics = obj;
@@ -860,7 +864,7 @@ describe('Automatad Analytics Adapter', () => {
   describe('Behaviour of the adapter when includeEvents or excludeEvents filter video events', () => {
     let videoObj;
     before(() => {
-      events.addEvents(VIDEO_EVENTS.map(([eventType]) => eventType));
+      events.addEvents([...VIDEO_EVENTS.map(([eventType]) => eventType), 'videoAdTime']);
     });
     beforeEach(() => {
       sandbox = sinon.createSandbox();
@@ -869,6 +873,7 @@ describe('Automatad Analytics Adapter', () => {
       sandbox.stub(utils, 'logError');
       videoObj = {};
       VIDEO_EVENTS.forEach(([, handler]) => { videoObj[handler] = sandbox.spy(); });
+      videoObj.videoAdQuartileHandler = sandbox.spy();
       global.window.atmtdAnalytics = videoObj;
       exports.qBeingUsed = false;
     });
@@ -938,6 +943,7 @@ describe('Automatad Analytics Adapter', () => {
       ]);
       videoObj = {};
       VIDEO_EVENTS.forEach(([, handler]) => { videoObj[handler] = sandbox.spy(); });
+      videoObj.videoAdQuartileHandler = sandbox.spy();
       global.window.atmtdAnalytics = videoObj;
       exports.qBeingUsed = false;
 
@@ -948,6 +954,146 @@ describe('Automatad Analytics Adapter', () => {
 
       expect(global.window.atmtdAnalytics.videoAdErrorHandler.called).to.equal(false);
       expect(global.window.atmtdAnalytics.videoAdStartedHandler.calledOnce).to.equal(true);
+    });
+  });
+
+  describe('Behaviour of adTime quartile sampling', () => {
+    let videoObj;
+    before(() => {
+      events.addEvents([...VIDEO_EVENTS.map(([eventType]) => eventType), 'videoAdTime']);
+    });
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      sandbox.stub(events, 'getEvents').returns([]);
+      sandbox.stub(utils, 'logMessage');
+      sandbox.stub(utils, 'logError');
+      videoObj = {};
+      VIDEO_EVENTS.forEach(([, handler]) => { videoObj[handler] = sandbox.spy(); });
+      videoObj.videoAdQuartileHandler = sandbox.spy();
+      global.window.atmtdAnalytics = videoObj;
+      exports.qBeingUsed = false;
+      exports.queuePointer = 0;
+      exports.retryCount = 0;
+      exports.resetQuartileState();
+    });
+    afterEach(() => {
+      global.window.atmtdAnalytics = undefined;
+      spec.disableAnalytics();
+      sandbox.restore();
+      exports.qBeingUsed = false;
+      exports.queuePointer = 0;
+      exports.retryCount = 0;
+      exports.resetQuartileState();
+    });
+
+    it('Should sample adTime into first/mid/third quartile events and drop other ticks', () => {
+      spec.enableAnalytics(CONFIG_WITH_VIDEO);
+      const ad = { adId: 'ad-1', duration: 40 };
+
+      events.emit('videoAdTime', { ...ad, time: 5 });
+      events.emit('videoAdTime', { ...ad, time: 10 });
+      events.emit('videoAdTime', { ...ad, time: 10.5 });
+      events.emit('videoAdTime', { ...ad, time: 20 });
+      events.emit('videoAdTime', { ...ad, time: 21 });
+      events.emit('videoAdTime', { ...ad, time: 30 });
+      events.emit('videoAdTime', { ...ad, time: 35 });
+
+      expect(global.window.atmtdAnalytics.videoAdQuartileHandler.callCount).to.equal(3);
+      expect(global.window.atmtdAnalytics.videoAdQuartileHandler.getCall(0).args[0].quartile).to.equal('firstQuartile');
+      expect(global.window.atmtdAnalytics.videoAdQuartileHandler.getCall(1).args[0].quartile).to.equal('midpoint');
+      expect(global.window.atmtdAnalytics.videoAdQuartileHandler.getCall(2).args[0].quartile).to.equal('thirdQuartile');
+      expect(exports.__atmtdAnalyticsQueue).to.have.lengthOf(0);
+    });
+
+    it('Should not re-fire the same quartile for the same ad', () => {
+      spec.enableAnalytics(CONFIG_WITH_VIDEO);
+      const ad = { adId: 'ad-2', duration: 20, time: 5 };
+
+      events.emit('videoAdTime', ad);
+      events.emit('videoAdTime', ad);
+      events.emit('videoAdTime', ad);
+
+      expect(global.window.atmtdAnalytics.videoAdQuartileHandler.calledOnce).to.equal(true);
+      expect(global.window.atmtdAnalytics.videoAdQuartileHandler.firstCall.args[0].quartile).to.equal('firstQuartile');
+    });
+
+    it('Should reset quartile state on videoAdStarted so the next ad can fire quartiles', () => {
+      spec.enableAnalytics(CONFIG_WITH_VIDEO);
+      const ad = { adId: 'ad-3', duration: 20 };
+
+      events.emit('videoAdTime', { ...ad, time: 5 });
+      expect(global.window.atmtdAnalytics.videoAdQuartileHandler.calledOnce).to.equal(true);
+
+      events.emit('videoAdStarted', ad);
+      events.emit('videoAdTime', { ...ad, time: 5 });
+      expect(global.window.atmtdAnalytics.videoAdQuartileHandler.callCount).to.equal(2);
+    });
+
+    it('Should not listen for adTime when videoAdQuartile is excluded', () => {
+      spec.enableAnalytics({
+        ...CONFIG_WITH_VIDEO,
+        excludeEvents: ['videoAdQuartile']
+      });
+
+      events.emit('videoAdTime', { adId: 'ad-4', time: 10, duration: 20 });
+      expect(global.window.atmtdAnalytics.videoAdQuartileHandler.called).to.equal(false);
+    });
+
+    it('Should drop videoAdQuartile without queueing when its handler is not implemented', () => {
+      delete global.window.atmtdAnalytics.videoAdQuartileHandler;
+      spec.enableAnalytics(CONFIG_WITH_VIDEO);
+      exports.__atmtdAnalyticsQueue.length = 0;
+      sandbox.stub(exports.__atmtdAnalyticsQueue, 'push').callsFake((args) => {
+        Array.prototype.push.apply(exports.__atmtdAnalyticsQueue, [args]);
+      });
+
+      events.emit('videoAdTime', { adId: 'ad-5', time: 10, duration: 20 });
+
+      expect(exports.__atmtdAnalyticsQueue.push.called).to.equal(false);
+      expect(exports.__atmtdAnalyticsQueue).to.have.lengthOf(0);
+    });
+
+    it('Should queue videoAdQuartile when aggregator is not loaded', () => {
+      global.window.atmtdAnalytics = undefined;
+      spec.enableAnalytics(CONFIG_WITH_VIDEO);
+      exports.__atmtdAnalyticsQueue.length = 0;
+      sandbox.stub(exports.__atmtdAnalyticsQueue, 'push').callsFake((args) => {
+        Array.prototype.push.apply(exports.__atmtdAnalyticsQueue, [args]);
+      });
+
+      events.emit('videoAdTime', { adId: 'ad-6', time: 10, duration: 20 });
+
+      expect(exports.__atmtdAnalyticsQueue.push.calledOnce).to.equal(true);
+      expect(exports.__atmtdAnalyticsQueue.push.firstCall.args[0][0]).to.equal('videoAdQuartile');
+      expect(exports.__atmtdAnalyticsQueue.push.firstCall.args[0][1].quartile).to.equal('firstQuartile');
+    });
+
+    it('Should not re-queue the same quartile while processEvents retries videoAdStarted', () => {
+      clock = sandbox.useFakeTimers({ shouldClearNativeTimers: true });
+      global.window.atmtdAnalytics = undefined;
+      spec.enableAnalytics(CONFIG_WITH_VIDEO);
+      exports.queuePointer = 0;
+      exports.retryCount = 0;
+      exports.__atmtdAnalyticsQueue.length = 0;
+      exports.resetQuartileState();
+      sandbox.stub(exports.__atmtdAnalyticsQueue, 'push').callsFake((args) => {
+        Array.prototype.push.apply(exports.__atmtdAnalyticsQueue, [args]);
+      });
+
+      const ad = { adId: 'ad-retry', duration: 20 };
+      const quartileEntries = () => exports.__atmtdAnalyticsQueue.filter((entry) => entry[0] === 'videoAdQuartile');
+
+      events.emit('videoAdStarted', ad);
+      events.emit('videoAdTime', { ...ad, time: 5 });
+      expect(quartileEntries()).to.have.lengthOf(1);
+
+      // Retry path: aggregator still missing, videoAdStarted stays at queue head.
+      exports.processEvents();
+      events.emit('videoAdTime', { ...ad, time: 5 });
+      events.emit('videoAdTime', { ...ad, time: 6 });
+
+      expect(quartileEntries()).to.have.lengthOf(1);
+      expect(exports.__atmtdAnalyticsQueue.some((entry) => entry[0] === 'videoAdTime')).to.equal(false);
     });
   });
 

--- a/test/spec/modules/automatadAnalyticsAdapter_spec.js
+++ b/test/spec/modules/automatadAnalyticsAdapter_spec.js
@@ -64,6 +64,14 @@ const CONFIG_WITH_DEBUG = {
   includeEvents: [AUCTION_DEBUG, AUCTION_INIT, BIDDER_DONE, BID_RESPONSE, BID_TIMEOUT, NO_BID, BID_WON, BID_REQUESTED, BID_REJECTED]
 };
 
+const CONFIG_WITH_VIDEO = {
+  ...CONFIG_WITH_DEBUG,
+  includeEvents: [
+    ...CONFIG_WITH_DEBUG.includeEvents,
+    ...VIDEO_EVENTS.map(([eventType]) => eventType)
+  ]
+};
+
 describe('Automatad Analytics Adapter', () => {
   var sandbox, clock;
 
@@ -775,7 +783,7 @@ describe('Automatad Analytics Adapter', () => {
       videoObj = {};
       VIDEO_EVENTS.forEach(([, handler]) => { videoObj[handler] = (args) => {}; });
 
-      spec.enableAnalytics(CONFIG_WITH_DEBUG);
+      spec.enableAnalytics(CONFIG_WITH_VIDEO);
       global.window.atmtdAnalytics = videoObj;
       exports.qBeingUsed = false;
       exports.qTraversalComplete = undefined;
@@ -803,7 +811,7 @@ describe('Automatad Analytics Adapter', () => {
       spec.disableAnalytics();
       events.emit('videoAdStarted', { type: 'videoAdStarted' });
       expect(global.window.atmtdAnalytics.videoAdStartedHandler.called).to.equal(false);
-      spec.enableAnalytics(CONFIG_WITH_DEBUG);
+      spec.enableAnalytics(CONFIG_WITH_VIDEO);
     });
   });
 
@@ -840,12 +848,106 @@ describe('Automatad Analytics Adapter', () => {
         ...pastEvents
       ]);
 
-      spec.enableAnalytics(CONFIG_WITH_DEBUG);
+      spec.enableAnalytics(CONFIG_WITH_VIDEO);
 
       VIDEO_EVENTS.forEach(([eventType, handler]) => {
         expect(global.window.atmtdAnalytics[handler].calledOnce).to.equal(true);
         expect(global.window.atmtdAnalytics[handler].firstCall.args[0].type).to.equal(eventType);
       });
+    });
+  });
+
+  describe('Behaviour of the adapter when includeEvents or excludeEvents filter video events', () => {
+    let videoObj;
+    before(() => {
+      events.addEvents(VIDEO_EVENTS.map(([eventType]) => eventType));
+    });
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      sandbox.stub(events, 'getEvents').returns([]);
+      sandbox.stub(utils, 'logMessage');
+      sandbox.stub(utils, 'logError');
+      videoObj = {};
+      VIDEO_EVENTS.forEach(([, handler]) => { videoObj[handler] = sandbox.spy(); });
+      global.window.atmtdAnalytics = videoObj;
+      exports.qBeingUsed = false;
+    });
+    afterEach(() => {
+      global.window.atmtdAnalytics = undefined;
+      spec.disableAnalytics();
+      sandbox.restore();
+      exports.qBeingUsed = false;
+    });
+
+    it('Should not register excluded video events', () => {
+      spec.enableAnalytics({
+        ...CONFIG_WITH_VIDEO,
+        excludeEvents: ['videoAdError']
+      });
+
+      events.emit('videoAdError', { type: 'videoAdError' });
+      events.emit('videoAdStarted', { type: 'videoAdStarted' });
+
+      expect(global.window.atmtdAnalytics.videoAdErrorHandler.called).to.equal(false);
+      expect(global.window.atmtdAnalytics.videoAdStartedHandler.calledOnce).to.equal(true);
+    });
+
+    it('Should only register video events present in includeEvents', () => {
+      spec.enableAnalytics({
+        provider: 'atmtdAnalyticsAdapter',
+        options: {
+          publisherID: '230',
+          siteID: '421'
+        },
+        includeEvents: ['videoAdImpression', AUCTION_INIT]
+      });
+
+      events.emit('videoAdImpression', { type: 'videoAdImpression' });
+      events.emit('videoAdError', { type: 'videoAdError' });
+      events.emit('videoAdStarted', { type: 'videoAdStarted' });
+
+      expect(global.window.atmtdAnalytics.videoAdImpressionHandler.calledOnce).to.equal(true);
+      expect(global.window.atmtdAnalytics.videoAdErrorHandler.called).to.equal(false);
+      expect(global.window.atmtdAnalytics.videoAdStartedHandler.called).to.equal(false);
+    });
+
+    it('Should register all video events when includeEvents is omitted', () => {
+      spec.enableAnalytics({
+        provider: 'atmtdAnalyticsAdapter',
+        options: {
+          publisherID: '230',
+          siteID: '421'
+        }
+      });
+
+      events.emit('videoAdError', { type: 'videoAdError' });
+      events.emit('videoAdStarted', { type: 'videoAdStarted' });
+
+      expect(global.window.atmtdAnalytics.videoAdErrorHandler.calledOnce).to.equal(true);
+      expect(global.window.atmtdAnalytics.videoAdStartedHandler.calledOnce).to.equal(true);
+    });
+
+    it('Should not replay excluded video events from event history', () => {
+      sandbox.restore();
+      sandbox = sinon.createSandbox();
+      sandbox.stub(utils, 'logMessage');
+      sandbox.stub(utils, 'logError');
+      sandbox.stub(events, 'getEvents').returns([
+        { eventType: 'videoAdError', args: { type: 'videoAdError' }, sequence: 1 },
+        { eventType: 'videoAdStarted', args: { type: 'videoAdStarted' }, sequence: 2 }
+      ]);
+      videoObj = {};
+      VIDEO_EVENTS.forEach(([, handler]) => { videoObj[handler] = sandbox.spy(); });
+      global.window.atmtdAnalytics = videoObj;
+      exports.qBeingUsed = false;
+
+      spec.enableAnalytics({
+        ...CONFIG_WITH_VIDEO,
+        excludeEvents: ['videoAdError']
+      });
+
+      expect(global.window.atmtdAnalytics.videoAdErrorHandler.called).to.equal(false);
+      expect(global.window.atmtdAnalytics.videoAdStartedHandler.calledOnce).to.equal(true);
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
The following prebid video events are now captured from the AutomatadAnalyticsAdapter:
- videoAuctionAdLoadAttempt
- videoAuctionAdLoadQueued
- videoAuctionAdLoadAbort
- videoBidImpression
- videoBidError
- videoAdLoaded
- videoAdStarted
- videoAdImpression
- videoAdSkipped
- videoAdError
- videoAdComplete

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
