### PR TITLE
adQuery Bid Adapter: pass qid to user sync URL (10.29.x legacy)

### DIFF
--- a/modules/adqueryBidAdapter.js
+++ b/modules/adqueryBidAdapter.js
@@ -42,11 +42,14 @@ export const spec = {
    */
   isBidRequestValid: (bid) => {
     const video = bid.mediaTypes && bid.mediaTypes.video;
-    if (video && ['instream', 'outstream'].includes(video.context)) {
-      return !!(video.playerSize);
+    if (video) {
+      if (['instream', 'outstream'].includes(video.context)) {
+        return !!(video.playerSize);
+      }
+      return false;
     }
 
-    return !!(bid && bid.params && bid.params.placementId && bid.mediaTypes.banner.sizes);
+    return !!(bid && bid.params && bid.params.placementId && bid.mediaTypes.banner && bid.mediaTypes.banner.sizes);
   },
 
   /**

--- a/modules/adqueryBidAdapter.js
+++ b/modules/adqueryBidAdapter.js
@@ -9,6 +9,7 @@ import {
   deepSetValue,
   deepAccess
 } from '../src/utils.js';
+import { hasPurpose1Consent } from '../src/utils/gdpr.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -41,14 +42,11 @@ export const spec = {
    */
   isBidRequestValid: (bid) => {
     const video = bid.mediaTypes && bid.mediaTypes.video;
-    if (video) {
-      if (['instream', 'outstream'].includes(video.context)) {
-        return !!(video.playerSize);
-      }
-      return false;
+    if (video && ['instream', 'outstream'].includes(video.context)) {
+      return !!(video.playerSize);
     }
 
-    return !!(bid && bid.params && bid.params.placementId && bid.mediaTypes.banner.sizes)
+    return !!(bid && bid.params && bid.params.placementId && bid.mediaTypes.banner.sizes);
   },
 
   /**
@@ -189,15 +187,15 @@ export const spec = {
     logInfo('onBidWon', bid);
 
     if (bid.nurl) {
-      triggerPixel(bid.nurl)
-      return
+      triggerPixel(bid.nurl);
+      return;
     }
 
-    const copyOfBid = { ...bid }
+    const copyOfBid = { ...bid };
 
     const uuidMatch = copyOfBid.ad && typeof copyOfBid.ad === 'string' ? copyOfBid.ad.match(/data-uuid="([^"]*)"/) : null;
     copyOfBid.uuid = uuidMatch ? uuidMatch[1] : null;
-    delete copyOfBid.ad
+    delete copyOfBid.ad;
     const shortBidString = JSON.stringify(copyOfBid);
     const encodedBuf = window.btoa(shortBidString);
 
@@ -249,10 +247,20 @@ export const spec = {
    */
   getUserSyncs: (syncOptions, serverResponses, gdprConsent, uspConsent) => {
     logMessage('getUserSyncs', syncOptions, serverResponses, gdprConsent, uspConsent);
+    if (!gdprConsent?.gdprApplies || !hasPurpose1Consent(gdprConsent)) {
+      logMessage('no gdpr or purpose1 consent, no syncs');
+      return [];
+    }
+    const qid = Array.isArray(serverResponses) ? serverResponses.map(r => deepAccess(r, 'body.data.qid')).find(Boolean) : null;
+    if (!qid) {
+      logMessage('no qid found in server responses');
+      return [];
+    }
     const syncData = {
       'gdpr': gdprConsent && gdprConsent.gdprApplies ? 1 : 0,
       'gdpr_consent': gdprConsent && gdprConsent.consentString ? gdprConsent.consentString : '',
-      'ccpa_consent': uspConsent && uspConsent.uspConsent ? uspConsent.uspConsent : '',
+      'ccpa_consent': uspConsent || '',
+      'qid': qid,
     };
 
     const syncUrlObject = {
@@ -306,20 +314,22 @@ function buildRequest(bid, bidderRequest, isVideo = false) {
   }
 
   if (isVideo) {
-    let baseRequest = bid.ortb2
+    let baseRequest = bid.ortb2;
     let videoRequest = {
       ...baseRequest,
       imp: [{
         id: bid.bidId,
         video: bid.ortb2Imp?.video || {},
       }]
-    }
+    };
 
     deepSetValue(videoRequest, 'site.ext.bidder', bid.params);
-    videoRequest.id = bid.bidId
+    videoRequest.id = bid.bidId;
 
-    if (bidderRequest?.gdprConsent?.consentString) {
+    if (bidderRequest?.gdprConsent?.gdprApplies != null) {
       deepSetValue(videoRequest, 'regs.ext.gdpr', bidderRequest.gdprConsent.gdprApplies ? 1 : 0);
+    }
+    if (bidderRequest?.gdprConsent?.consentString) {
       deepSetValue(videoRequest, 'user.consent', bidderRequest.gdprConsent.consentString);
     }
     if (bidderRequest?.uspConsent) {
@@ -327,7 +337,7 @@ function buildRequest(bid, bidderRequest, isVideo = false) {
     }
 
     let currency = bid?.ortb2?.ext?.prebid?.adServerCurrency || "PLN";
-    videoRequest.cur = [currency]
+    videoRequest.cur = [currency];
 
     let floorInfo;
     if (typeof bid.getFloor === 'function') {
@@ -341,11 +351,11 @@ function buildRequest(bid, bidderRequest, isVideo = false) {
     const bidfloorcur = floorInfo?.currency;
 
     if (bidfloor && bidfloorcur) {
-      videoRequest.imp[0].video.bidfloor = bidfloor
-      videoRequest.imp[0].video.bidfloorcur = bidfloorcur
+      videoRequest.imp[0].video.bidfloor = bidfloor;
+      videoRequest.imp[0].video.bidfloorcur = bidfloorcur;
     }
 
-    return videoRequest
+    return videoRequest;
   }
 
   return {

--- a/test/spec/modules/adqueryBidAdapter_spec.js
+++ b/test/spec/modules/adqueryBidAdapter_spec.js
@@ -1,10 +1,9 @@
-import { expect } from 'chai'
-import { spec } from 'modules/adqueryBidAdapter.js'
-import { newBidder } from 'src/adapters/bidderFactory.js'
+import { expect } from 'chai';
+import { spec } from 'modules/adqueryBidAdapter.js';
+
 import * as utils from '../../../src/utils.js';
 
 describe('adqueryBidAdapter', function () {
-  const adapter = newBidder(spec)
   const bidRequest = {
     bidder: 'adquery',
     params: {
@@ -16,7 +15,7 @@ describe('adqueryBidAdapter', function () {
         sizes: [[300, 250]],
       }
     }
-  }
+  };
 
   const expectedResponse = {
     'body': {
@@ -53,23 +52,23 @@ describe('adqueryBidAdapter', function () {
           }
         }
     }
-  }
+  };
   describe('codes', function () {
     it('should return a bidder code of adquery', function () {
-      expect(spec.code).to.equal('adquery')
-    })
-  })
+      expect(spec.code).to.equal('adquery');
+    });
+  });
 
   describe('isBidRequestValid', function () {
-    const inValidBid = Object.assign({}, bidRequest)
-    delete inValidBid.params
+    const inValidBid = Object.assign({}, bidRequest);
+    delete inValidBid.params;
     it('should return true if all params present', function () {
-      expect(spec.isBidRequestValid(bidRequest)).to.equal(true)
-    })
+      expect(spec.isBidRequestValid(bidRequest)).to.equal(true);
+    });
 
     it('should return false if any parameter missing', function () {
-      expect(spec.isBidRequestValid(inValidBid)).to.be.false
-    })
+      expect(spec.isBidRequestValid(inValidBid)).to.be.false;
+    });
 
     it('should return false when sizes for banner are not specified', () => {
       const bid = utils.deepClone(bidRequest);
@@ -449,55 +448,55 @@ describe('adqueryBidAdapter', function () {
         }
       )).to.equal(true);
     });
-  })
+  });
 
   describe('buildRequests', function () {
-    const req = spec.buildRequests([bidRequest], { refererInfo: { } })[0]
+    const req = spec.buildRequests([bidRequest], { refererInfo: { } })[0];
 
     it('should return request object', function () {
-      expect(req).to.not.be.null
-    })
+      expect(req).to.not.be.null;
+    });
 
     it('should build request data', function () {
-      expect(req.data).to.not.be.null
-    })
+      expect(req.data).to.not.be.null;
+    });
 
     it('should include one request', function () {
-      expect(req.data.data).to.not.be.null
-    })
+      expect(req.data.data).to.not.be.null;
+    });
 
     it('should include placementCode', function () {
-      expect(req.data.placementCode).not.be.null
-    })
+      expect(req.data.placementCode).not.be.null;
+    });
 
     it('should include qid', function () {
-      expect(req.data.qid).not.be.null
-    })
+      expect(req.data.qid).not.be.null;
+    });
 
     it('should include type', function () {
-      expect(req.data.type !== null).not.be.null
-    })
+      expect(req.data.type !== null).not.be.null;
+    });
 
     it('should include all publisher params', function () {
-      expect(req.data.type !== null && req.data.placementCode !== null).to.be.true
-    })
+      expect(req.data.type !== null && req.data.placementCode !== null).to.be.true;
+    });
 
     it('should include bidder', function () {
-      expect(req.data.bidder !== null).to.be.true
-    })
+      expect(req.data.bidder !== null).to.be.true;
+    });
 
     it('should include sizes', function () {
-      expect(req.data.sizes).not.be.null
-    })
+      expect(req.data.sizes).not.be.null;
+    });
 
     it('should include version', function () {
-      expect(req.data.v).not.be.null
-      expect(req.data.v).equal('$prebid.version$')
-    })
+      expect(req.data.v).not.be.null;
+      expect(req.data.v).equal('$prebid.version$');
+    });
 
     it('should include referrer', function () {
-      expect(req.data.bidPageUrl).not.be.null
-    })
+      expect(req.data.bidPageUrl).not.be.null;
+    });
 
     const req_video = spec.buildRequests([
       {
@@ -686,15 +685,15 @@ describe('adqueryBidAdapter', function () {
           }
         }
       }
-    ], { refererInfo: {} })[0]
+    ], { refererInfo: {} })[0];
 
     it('should include video', function () {
-      expect(req_video.data.bidPageUrl).not.be.null
-    })
+      expect(req_video.data.bidPageUrl).not.be.null;
+    });
 
     it('url must be auction2', function () {
-      expect(req_video.url).eq('https://bidder.adquery.io/openrtb2/auction2')
-    })
+      expect(req_video.url).eq('https://bidder.adquery.io/openrtb2/auction2');
+    });
 
     it('url must be auction2 for instream', function () {
       const req_video_instream = spec.buildRequests([
@@ -710,65 +709,65 @@ describe('adqueryBidAdapter', function () {
             placementId: 'd30f79cf7fef47bd7a5611719f936539bec0d2e9'
           }
         }
-      ], { refererInfo: {} })[0]
-      expect(req_video_instream.url).eq('https://bidder.adquery.io/openrtb2/auction2')
-    })
+      ], { refererInfo: {} })[0];
+      expect(req_video_instream.url).eq('https://bidder.adquery.io/openrtb2/auction2');
+    });
 
     it('data must have id key', function () {
       expect(req_video.data.id).not.be.null;
-    })
+    });
 
     it('data must have cur key', function () {
       expect(req_video.data.cur).not.be.null;
-    })
+    });
 
     it('data must have video key', function () {
       expect(req_video.data.imp[0].video).not.be.null;
-    })
+    });
 
     it('data must have video h property', function () {
       expect(req_video.data.imp[0].video.h).not.be.null;
-    })
+    });
 
     it('data must have video w property', function () {
       expect(req_video.data.imp[0].video.w).not.be.null;
-    })
+    });
 
     it('data must have video protocols property', function () {
       expect(req_video.data.imp[0].video.protocols).not.be.null;
-    })
+    });
 
     it('data must have video mimes property', function () {
       expect(req_video.data.imp[0].video.mimes).not.be.null;
-    })
+    });
 
     it('data must have video bidfloor property', function () {
       expect(req_video.data.imp[0].video.bidfloor).not.exist;
-    })
+    });
 
     it('data must have video bidfloorcur property', function () {
       expect(req_video.data.imp[0].video.bidfloorcur).not.exist;
-    })
+    });
 
     it('data must have bidder placementCode', function () {
       expect(req_video.data.site.ext.bidder.placementId).eq('d30f79cf7fef47bd7a5611719f936539bec0d2e9');
-    })
+    });
 
     it('data must have user key', function () {
       expect(req_video.data.user).not.be.null;
-    })
+    });
 
     it('data must have device.ua key', function () {
       expect(req_video.data.device.ua).not.be.null;
-    })
+    });
 
     it('data must have site.page key', function () {
       expect(req_video.data.site.page).not.be.null;
-    })
+    });
 
     it('data must have site.domain key', function () {
       expect(req_video.data.site.domain).not.be.null;
-    })
+    });
 
     const req_video_for_floor = spec.buildRequests([
       {
@@ -960,15 +959,15 @@ describe('adqueryBidAdapter', function () {
           }
         }
       }
-    ], { refererInfo: {} })[0]
+    ], { refererInfo: {} })[0];
 
     it('data with floor must have video bidfloor property', function () {
       expect(req_video_for_floor.data.imp[0].video.bidfloor).eq(1.13);
-    })
+    });
 
     it('data with floor must have video bidfloorcur property', function () {
       expect(req_video_for_floor.data.imp[0].video.bidfloorcur).eq("USD");
-    })
+    });
 
     describe('GDPR and USP consent in banner requests', function () {
       it('should set gdpr=1 and gdpr_consent when gdprApplies is true', function () {
@@ -1074,17 +1073,17 @@ describe('adqueryBidAdapter', function () {
         expect(req.data.bidQid).to.match(/^qd_/);
       });
     });
-  })
+  });
 
   describe('interpretResponse', function () {
     it('should get the correct bid response', function () {
-      const result = spec.interpretResponse(expectedResponse)
-      expect(result).to.be.an('array')
-    })
+      const result = spec.interpretResponse(expectedResponse);
+      expect(result).to.be.an('array');
+    });
 
     it('validate response params', function() {
       const newResponse = spec.interpretResponse(expectedResponse, bidRequest);
-      expect(newResponse[0].requestId).to.be.equal(1)
+      expect(newResponse[0].requestId).to.be.equal(1);
     });
     it('handles empty bid response', function () {
       const response = {
@@ -1092,7 +1091,7 @@ describe('adqueryBidAdapter', function () {
       };
       const result = spec.interpretResponse(response);
       expect(result.length).to.equal(0);
-    })
+    });
 
     it('validate video response params, seatbid', function () {
       const newResponse = spec.interpretResponse({
@@ -1122,7 +1121,7 @@ describe('adqueryBidAdapter', function () {
           }
         }
       }, bidRequest);
-      expect(newResponse[0].requestId).to.be.equal("48169c9f-f033-48fa-878d-a319273e5c15")
+      expect(newResponse[0].requestId).to.be.equal("48169c9f-f033-48fa-878d-a319273e5c15");
     });
 
     it('validate video response params, seatbid: nurl, vastXml', function () {
@@ -1153,8 +1152,8 @@ describe('adqueryBidAdapter', function () {
           }
         }
       }, bidRequest);
-      expect(newResponse[0].nurl).to.be.equal("https://bidder.adquery.io/openrtb2/uuid/nurl/d")
-      expect(newResponse[0].vastXml).to.be.equal("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VAST version=\"2.0\"><\/VAST>\n")
+      expect(newResponse[0].nurl).to.be.equal("https://bidder.adquery.io/openrtb2/uuid/nurl/d");
+      expect(newResponse[0].vastXml).to.be.equal("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<VAST version=\"2.0\"><\/VAST>\n");
     });
 
     it('should not include referrer field in banner bid response', function () {
@@ -1162,66 +1161,86 @@ describe('adqueryBidAdapter', function () {
       const bannerBid = result[result.length - 1];
       expect(bannerBid.referrer).to.be.undefined;
     });
-  })
+  });
 
   describe('getUserSyncs', function () {
+    const gdprConsentWithPurpose1 = {
+      consentString: 'ALL',
+      gdprApplies: true,
+      vendorData: { purpose: { consents: { 1: true } } }
+    };
+    const serverResponsesWithQid = [{ body: { data: { qid: 'test-qid-value' } } }];
+
     it('should return iframe sync', function () {
       const sync = spec.getUserSyncs(
         {
           iframeEnabled: true,
           pixelEnabled: true,
         },
-        {},
-        {
-          consentString: 'ALL',
-          gdprApplies: true,
-        },
+        serverResponsesWithQid,
+        gdprConsentWithPurpose1,
         {}
-      )
-      expect(sync.length).to.equal(1)
-      expect(sync[0].type === 'iframe')
-      expect(typeof sync[0].url === 'string')
-    })
+      );
+      expect(sync.length).to.equal(1);
+      expect(sync[0].type === 'iframe');
+      expect(typeof sync[0].url === 'string');
+    });
     it('should return image sync', function () {
       const sync = spec.getUserSyncs(
         {
           iframeEnabled: false,
           pixelEnabled: true,
         },
-        {},
-        {
-          consentString: 'ALL',
-          gdprApplies: true,
-        },
+        serverResponsesWithQid,
+        gdprConsentWithPurpose1,
         {}
-      )
-      expect(sync.length).to.equal(1)
-      expect(sync[0].type === 'image')
-      expect(typeof sync[0].url === 'string')
-    })
+      );
+      expect(sync.length).to.equal(1);
+      expect(sync[0].type === 'image');
+      expect(typeof sync[0].url === 'string');
+    });
 
     it('Should return array of objects with proper sync config , include GDPR', function() {
-      const syncData = spec.getUserSyncs({}, {}, {
-        consentString: 'ALL',
-        gdprApplies: true,
-      }, {});
+      const syncData = spec.getUserSyncs({}, serverResponsesWithQid, gdprConsentWithPurpose1, {});
       expect(syncData).to.be.an('array').which.is.not.empty;
-      expect(syncData[0]).to.be.an('object')
-      expect(syncData[0].type).to.be.a('string')
-      expect(syncData[0].type).to.equal('image')
+      expect(syncData[0]).to.be.an('object');
+      expect(syncData[0].type).to.be.a('string');
+      expect(syncData[0].type).to.equal('image');
     });
 
-    it('should not include qid in sync URL even when window.qid is set', function () {
-      const originalQid = window.qid;
-      window.qid = 'test-qid-value';
-      try {
-        const sync = spec.getUserSyncs({ pixelEnabled: true }, {}, {}, {});
-        expect(sync[0].url).to.not.include('qid');
-      } finally {
-        window.qid = originalQid;
-      }
+    it('should return empty array when Purpose 1 consent is missing', function () {
+      const gdprConsent = { gdprApplies: true, vendorData: { purpose: { consents: { 1: false } } } };
+      const sync = spec.getUserSyncs({ pixelEnabled: true }, serverResponsesWithQid, gdprConsent, {});
+      expect(sync).to.be.an('array').that.is.empty;
     });
-  })
+
+    it('should return empty array when GDPR does not apply', function () {
+      const sync = spec.getUserSyncs({ pixelEnabled: true }, serverResponsesWithQid, { gdprApplies: false }, {});
+      expect(sync).to.be.an('array').that.is.empty;
+    });
+
+    it('should return empty array when qid is not present in serverResponses', function () {
+      const sync = spec.getUserSyncs({ pixelEnabled: true }, [{ body: { data: {} } }], gdprConsentWithPurpose1, {});
+      expect(sync).to.be.an('array').that.is.empty;
+    });
+
+    it('should include ccpa_consent in sync URL when uspConsent provided', function () {
+      const sync = spec.getUserSyncs({ pixelEnabled: true }, serverResponsesWithQid, gdprConsentWithPurpose1, '1YNN');
+      expect(sync[0].url).to.include('ccpa_consent=1YNN');
+    });
+
+    it('should include qid in sync URL when present in serverResponses', function () {
+      const serverResponses = [{ body: { data: { qid: 'test-qid-value' } } }];
+      const sync = spec.getUserSyncs({ pixelEnabled: true }, serverResponses, gdprConsentWithPurpose1, {});
+      expect(sync[0].url).to.include('qid=test-qid-value');
+    });
+
+    it('should find qid from any response, not just the first', function () {
+      const serverResponses = [{ body: '' }, { body: '' }, { body: { data: { qid: 'test-qid-value' } } }];
+      const sync = spec.getUserSyncs({ pixelEnabled: true }, serverResponses, gdprConsentWithPurpose1, {});
+      expect(sync[0].url).to.include('qid=test-qid-value');
+    });
+  });
 
   describe('test onBidWon function', function () {
     beforeEach(function() {
@@ -1235,12 +1254,12 @@ describe('adqueryBidAdapter', function () {
     });
     it('should return nothing', function () {
       var response = spec.onBidWon({});
-      expect(response).to.be.an('undefined')
+      expect(response).to.be.an('undefined');
       expect(utils.triggerPixel.called).to.equal(true);
     });
     it('should use nurl if exists', function () {
       var response = spec.onBidWon({ nurl: "https://example.com/test-nurl" });
-      expect(response).to.be.an('undefined')
+      expect(response).to.be.an('undefined');
       expect(utils.triggerPixel.calledWith("https://example.com/test-nurl")).to.equal(true);
     });
     it('should extract uuid from ad string and remove ad from payload', function () {
@@ -1275,7 +1294,7 @@ describe('adqueryBidAdapter', function () {
       expect(decodedBid.uuid).to.be.null;
       expect(decodedBid.ad).to.be.undefined;
     });
-  })
+  });
 
   describe('onTimeout', function () {
     const timeoutData = [{
@@ -1287,10 +1306,10 @@ describe('adqueryBidAdapter', function () {
     });
     it('should include timeoutData', function () {
       expect(spec.onTimeout(timeoutData)).to.be.undefined;
-    })
+    });
   });
 
   it(`onSetTargeting is present and type function`, function () {
-    expect(spec.onSetTargeting).to.exist.and.to.be.a('function')
+    expect(spec.onSetTargeting).to.exist.and.to.be.a('function');
   });
-})
+});


### PR DESCRIPTION
Type of change

  - [x] Feature
  - [x] Updated bidder adapter

  Description of change

  Passes qid (query ID) from the bid server response (body.data.qid) to the user sync URL as a query parameter. This allows adQuery's sync endpoint to identify the user server-side during synchronization.

  Additionally, syncs are skipped when no qid is present in any server response, and GDPR Purpose 1 consent is verified before syncing.

