### PR TITLE
Cadent Aperture MX Bid Adapter: migrate endpoints to ssp.cadent.com

### DIFF
--- a/modules/cadent_aperture_mxBidAdapter.js
+++ b/modules/cadent_aperture_mxBidAdapter.js
@@ -15,8 +15,8 @@ import { parseDomain } from '../src/refererDetection.js';
 import { getDNT } from '../libraries/dnt/index.js';
 
 const BIDDER_CODE = 'cadent_aperture_mx';
-const ENDPOINT = 'hb.emxdgt.com';
-const RENDERER_URL = 'https://js.brealtime.com/outstream/1.30.0/bundle.js';
+const ENDPOINT = 'hb-pub.ssp.cadent.com';
+const RENDERER_URL = 'https://js.ssp.cadent.com/outstream/1.30.0/bundle.js';
 const ADAPTER_VERSION = '1.5.1';
 const DEFAULT_CUR = 'USD';
 const ALIASES = [
@@ -281,7 +281,8 @@ export const spec = {
       // adding gpid support
       const gpid =
         deepAccess(bid, 'ortb2Imp.ext.gpid') ||
-        deepAccess(bid, 'ortb2Imp.ext.data.adserver.adslot');
+        deepAccess(bid, 'ortb2Imp.ext.data.adserver.adslot') ||
+        deepAccess(bid, 'ortb2Imp.ext.data.pbadslot');
 
       if (gpid) {
         data.ext = { gpid: gpid.toString() };
@@ -374,7 +375,7 @@ export const spec = {
     const syncs = [];
     const consentParams = [];
     if (syncOptions.iframeEnabled) {
-      let url = 'https://biddr.brealtime.com/check.html';
+      let url = 'https://js.ssp.cadent.com/check.html';
       if (gdprConsent && typeof gdprConsent.consentString === 'string') {
         // add 'gdpr' only if 'gdprApplies' is defined
         if (typeof gdprConsent.gdprApplies === 'boolean') {

--- a/test/spec/modules/cadent_aperture_mxBidAdapter_spec.js
+++ b/test/spec/modules/cadent_aperture_mxBidAdapter_spec.js
@@ -440,7 +440,7 @@ describe('cadent_aperture_mx Adapter', function () {
       it('should add gpid to request if present in ext.data.pbadslot', () => {
         const gpid = '/12345/my-gpt-tag-0';
         const bid = utils.deepClone(bidderRequest.bids[0]);
-        bid.ortb2Imp = { ext: { data: {}, gpid } };
+        bid.ortb2Imp = { ext: { data: { pbadslot: gpid } } };
         let requestWithGPID = spec.buildRequests([bid], bidderRequest);
         requestWithGPID = JSON.parse(requestWithGPID.data);
         expect(requestWithGPID.imp[0].ext.gpid).to.exist.and.equal(gpid);
@@ -751,7 +751,7 @@ describe('cadent_aperture_mx Adapter', function () {
       const ad0 = result[0];
       const ad1 = result[1];
       expect(ad0.renderer).to.exist.and.to.be.a('object');
-      expect(ad0.renderer.url).to.equal('https://js.brealtime.com/outstream/1.30.0/bundle.js');
+      expect(ad0.renderer.url).to.equal('https://js.ssp.cadent.com/outstream/1.30.0/bundle.js');
       expect(ad0.renderer.id).to.equal('987654321cba');
       expect(ad1.renderer).to.equal(undefined);
     });
@@ -794,7 +794,7 @@ describe('cadent_aperture_mx Adapter', function () {
       expect(syncs).to.not.be.an('undefined');
       expect(syncs).to.have.lengthOf(1);
       expect(syncs[0].type).to.equal('iframe');
-      expect(syncs[0].url).to.equal('https://biddr.brealtime.com/check.html');
+      expect(syncs[0].url).to.equal('https://js.ssp.cadent.com/check.html');
     });
 
     it('should pass gdpr params', function () {
@@ -805,7 +805,7 @@ describe('cadent_aperture_mx Adapter', function () {
       expect(syncs).to.have.lengthOf(1);
       expect(syncs[0].type).to.equal('iframe');
       expect(syncs[0].url).to.contains('gdpr=0');
-      expect(syncs[0].url).to.equal('https://biddr.brealtime.com/check.html?gdpr=0&gdpr_consent=test');
+      expect(syncs[0].url).to.equal('https://js.ssp.cadent.com/check.html?gdpr=0&gdpr_consent=test');
     });
 
     it('should pass us_privacy string', function () {
@@ -832,7 +832,7 @@ describe('cadent_aperture_mx Adapter', function () {
       expect(syncs[0].type).to.equal('iframe');
       expect(syncs[0].url).to.contains('gdpr=1');
       expect(syncs[0].url).to.contains('usp=test');
-      expect(syncs[0].url).to.equal('https://biddr.brealtime.com/check.html?gdpr=1&gdpr_consent=test&usp=test');
+      expect(syncs[0].url).to.equal('https://js.ssp.cadent.com/check.html?gdpr=1&gdpr_consent=test&usp=test');
     });
 
     it('should pass gpp string and section id', function() {
@@ -865,7 +865,7 @@ describe('cadent_aperture_mx Adapter', function () {
       expect(syncs[0].url).to.contains('gdpr=1');
       expect(syncs[0].url).to.contains('usp=test');
       expect(syncs[0].url).to.contains('gpp=abcdefgs');
-      expect(syncs[0].url).to.equal('https://biddr.brealtime.com/check.html?gdpr=1&gdpr_consent=test&usp=test&gpp=abcdefgs&gpp_sid=1,2,4');
+      expect(syncs[0].url).to.equal('https://js.ssp.cadent.com/check.html?gdpr=1&gdpr_consent=test&usp=test&gpp=abcdefgs&gpp_sid=1,2,4');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Migrate bid endpoint from `hb.emxdgt.com` to `hb-pub.ssp.cadent.com`
- Migrate user sync iframe from `https://biddr.brealtime.com/check.html` to `https://js.ssp.cadent.com/check.html`
- Migrate outstream renderer from `https://js.brealtime.com/outstream/1.30.0/bundle.js` to `https://js.ssp.cadent.com/outstream/1.30.0/bundle.js`
- Update unit test expectations for renderer URL and user sync URLs (including GDPR/USP/GPP variants)
- Add `pbadslot` as a GPID fallback source and fix the corresponding unit test setup

## Test plan
- [x] `gulp test --nolint --file test/spec/modules/cadent_aperture_mxBidAdapter_spec.js` (46 tests passing)