### PR TITLE
OneTag Bid Adapter: report bid timeouts

### DIFF
--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -5,6 +5,7 @@ import { INSTREAM, OUTSTREAM } from '../src/video.js';
 import { Renderer } from '../src/Renderer.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { ajax } from '../src/ajax.js';
 import { deepClone, logError, deepAccess, getWinDimensions } from '../src/utils.js';
 import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
 import { toOrtbNativeRequest } from '../src/native.js';
@@ -14,10 +15,12 @@ import { getAdUnitElement } from '../src/utils/adUnits.js';
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
  * @typedef {import('../src/adapters/bidderFactory.js').validBidRequests} validBidRequests
+ * @typedef {BidRequest & { timeout: number }} TimedOutBid A bid request that exceeded the auction timeout.
  */
 
 const ENDPOINT = 'https://onetag-sys.com/prebid-request';
 const USER_SYNC_ENDPOINT = 'https://onetag-sys.com/usync/';
+const TIMEOUT_ENDPOINT = 'https://onetag-sys.com/ptimeout';
 const BIDDER_CODE = 'onetag';
 const GVLID = 241;
 const NATIVE_SUFFIX = 'Ad';
@@ -501,6 +504,27 @@ export function isSchainValid(schain) {
   return isValid;
 }
 
+/**
+ * Notifies the OneTag server that one or more of our bids timed out.
+ * @param {Array<TimedOutBid>} timeoutData One entry per timed-out bid.
+ */
+function onTimeout(timeoutData) {
+  if (!Array.isArray(timeoutData) || timeoutData.length === 0) {
+    return;
+  }
+  const onetagTimeouts = timeoutData.filter(bid => bid && bid.bidder === BIDDER_CODE);
+  if (onetagTimeouts.length === 0) {
+    return;
+  }
+  // text/plain avoids a CORS preflight (OPTIONS) on this low-priority call.
+  spec.ajaxCall(TIMEOUT_ENDPOINT, null, JSON.stringify(onetagTimeouts), {
+    method: 'POST',
+    contentType: 'text/plain',
+    keepalive: true,
+    withCredentials: false
+  });
+}
+
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
@@ -508,7 +532,10 @@ export const spec = {
   isBidRequestValid: isBidRequestValid,
   buildRequests: buildRequests,
   interpretResponse: interpretResponse,
-  getUserSyncs: getUserSyncs
+  getUserSyncs: getUserSyncs,
+  onTimeout: onTimeout,
+  // Thin wrapper around `ajax` so it can be stubbed in unit tests.
+  ajaxCall: ajax
 
 };
 

--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -516,14 +516,20 @@ function onTimeout(timeoutData) {
   if (onetagTimeouts.length === 0) {
     return;
   }
-  // text/plain avoids a CORS preflight (OPTIONS) on this low-priority call.
-  spec.ajaxCall(TIMEOUT_ENDPOINT, null, JSON.stringify(onetagTimeouts), {
+  dep.ajax(TIMEOUT_ENDPOINT, null, JSON.stringify(onetagTimeouts), {
     method: 'POST',
     contentType: 'text/plain',
     keepalive: true,
     withCredentials: false
   });
 }
+
+// Container for the external dependencies used internally by the adapter.
+// Kept separate from `spec` (the interface exposed to Prebid) so these
+// dependencies can be stubbed in unit tests through a mutable reference.
+export const dep = {
+  ajax
+};
 
 export const spec = {
   code: BIDDER_CODE,
@@ -533,10 +539,7 @@ export const spec = {
   buildRequests: buildRequests,
   interpretResponse: interpretResponse,
   getUserSyncs: getUserSyncs,
-  onTimeout: onTimeout,
-  // Thin wrapper around `ajax` so it can be stubbed in unit tests.
-  ajaxCall: ajax
-
+  onTimeout: onTimeout
 };
 
 registerBidder(spec);

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -1019,6 +1019,60 @@ describe('onetag', function () {
       expect(isSchainValid(validSchain)).to.be.true;
     });
   });
+  describe('onTimeout', function () {
+    const TIMEOUT_ENDPOINT = 'https://onetag-sys.com/ptimeout';
+    let ajaxStub;
+    beforeEach(function () {
+      ajaxStub = sinon.stub(spec, 'ajaxCall');
+    });
+    afterEach(function () {
+      ajaxStub.restore();
+    });
+    function createTimeoutData(bidder = 'onetag') {
+      return {
+        bidder,
+        params: [{ pubId: '386276e072' }],
+        adUnitCode: 'banner-0',
+        auctionId: 'f8c64531-ee71-46c1-b2dc-8b4a124be6e8',
+        bidId: 'c860a979-6665-4bbd-80bb-78de34fafd11',
+        timeout: 1
+      };
+    }
+    it('Should expose an onTimeout function', function () {
+      expect(spec.onTimeout).to.exist.and.to.be.a('function');
+    });
+    it('Should POST the timed-out onetag bids to the ptimeout endpoint', function () {
+      const timeoutData = [createTimeoutData('onetag')];
+      spec.onTimeout(timeoutData);
+      expect(ajaxStub.calledOnce).to.be.true;
+      const [url, callback, data, options] = ajaxStub.firstCall.args;
+      expect(url).to.equal(TIMEOUT_ENDPOINT);
+      expect(callback).to.equal(null);
+      expect(JSON.parse(data)).to.deep.equal(timeoutData);
+      expect(options.method).to.equal('POST');
+      expect(options.contentType).to.equal('text/plain');
+      expect(options.keepalive).to.be.true;
+      expect(options.withCredentials).to.be.false;
+    });
+    it('Should only forward bids belonging to onetag', function () {
+      const onetagBid = createTimeoutData('onetag');
+      spec.onTimeout([createTimeoutData('otherBidder'), onetagBid]);
+      expect(ajaxStub.calledOnce).to.be.true;
+      const sent = JSON.parse(ajaxStub.firstCall.args[2]);
+      expect(sent).to.have.lengthOf(1);
+      expect(sent[0].bidder).to.equal('onetag');
+    });
+    it('Should not call ajax when no onetag bid timed out', function () {
+      spec.onTimeout([createTimeoutData('otherBidder')]);
+      expect(ajaxStub.notCalled).to.be.true;
+    });
+    it('Should not call ajax when timeoutData is empty or not an array', function () {
+      spec.onTimeout([]);
+      spec.onTimeout(undefined);
+      spec.onTimeout(null);
+      expect(ajaxStub.notCalled).to.be.true;
+    });
+  });
 });
 
 function getBannerVideoNativeResponse() {

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -1,4 +1,4 @@
-import { spec, isValid, hasTypeVideo, isSchainValid, hasTypeNative } from 'modules/onetagBidAdapter.js';
+import { spec, dep, isValid, hasTypeVideo, isSchainValid, hasTypeNative } from 'modules/onetagBidAdapter.js';
 import { expect } from 'chai';
 import { BANNER, VIDEO, NATIVE } from 'src/mediaTypes.js';
 import { INSTREAM, OUTSTREAM } from 'src/video.js';
@@ -1023,7 +1023,7 @@ describe('onetag', function () {
     const TIMEOUT_ENDPOINT = 'https://onetag-sys.com/ptimeout';
     let ajaxStub;
     beforeEach(function () {
-      ajaxStub = sinon.stub(spec, 'ajaxCall');
+      ajaxStub = sinon.stub(dep, 'ajax');
     });
     afterEach(function () {
       ajaxStub.restore();


### PR DESCRIPTION
## Type of change

- [x] Updated bidder adapter

## Description of change

Adds an `onTimeout` handler to the OneTag bid adapter. When one or more OneTag
bids exceed the auction timeout, the adapter notifies OneTag's server with a
`POST` to `https://onetag-sys.com/ptimeout`, sending the timed-out bid data as
the request body.

Details:
- Only OneTag's own timed-out bids are reported (filtered by
  `bidder === 'onetag'`); it no-ops when there is nothing to report.
- The request uses `contentType: 'text/plain'` (a CORS-safelisted content type)
  so the browser issues no CORS preflight; the endpoint parses the JSON body
  regardless of the declared content type. Sent with `keepalive: true` and
  `withCredentials: false`.
- Small refactoring: the `ajax` dependency is moved into an exported `dep`
  container so it can be stubbed in unit tests, keeping `spec` (the Prebid
  interface) unchanged apart from the new `onTimeout` entry.

Tests: added coverage for `onTimeout` in
`test/spec/modules/onetagBidAdapter_spec.js` — early returns for empty /
foreign-bidder input, and assertions on the endpoint, method, body and options.
The adapter spec passes locally
(`gulp test-only --file test/spec/modules/onetagBidAdapter_spec.js`).

## Other information

No new bidder parameters and no user-facing API changes, so no companion
prebid.github.io docs PR is required.
