### PR TITLE
Tcf control module: fix TypeError: Cannot read properties of undefined (reading 'gdpr') for non-GDPR countries in 11.21

### DIFF
--- a/modules/tcfControl.ts
+++ b/modules/tcfControl.ts
@@ -501,7 +501,7 @@ export function setEnforcementConfig(config) {
   }
   rules = Object.fromEntries((rules as any || []).map(r => [r.purpose, r])) as any;
   strictStorageEnforcement = !!deepAccess(config, STRICT_STORAGE_ENFORCEMENT);
-  defaultPurposeDeclaration = Object.assign({}, NO_PURPOSE_DECLARATION, config.gdpr?.defaultLegalBasis ?? DEFAULT_PURPOSE_DECLARATION);
+  defaultPurposeDeclaration = Object.assign({}, NO_PURPOSE_DECLARATION, config?.gdpr?.defaultLegalBasis ?? DEFAULT_PURPOSE_DECLARATION);
 
   Object.entries(CONFIGURABLE_RULES).forEach(([name, opts]) => {
     ACTIVE_RULES[opts.type][opts.id] = rules[name] ?? opts.default;

--- a/test/spec/modules/tcfControl_spec.js
+++ b/test/spec/modules/tcfControl_spec.js
@@ -1348,6 +1348,20 @@ describe('gdpr enforcement', function () {
       expect(ACTIVE_RULES.purpose[1]).to.deep.equal(rules[0]);
       expect(ACTIVE_RULES.purpose[2]).to.deep.equal(rules[1]);
     });
+
+    Object.entries({
+      'undefined': undefined,
+      'null': null,
+    }).forEach(([t, cfg]) => {
+      it(`should not throw when config is ${t} (e.g. for non-GDPR countries)`, function () {
+        expect(() => setEnforcementConfig(cfg)).to.not.throw();
+      });
+
+      it(`should fall back to the default purpose declaration when config is ${t}`, function () {
+        setEnforcementConfig(cfg);
+        expect(getPurposeDeclarations(null)).to.eql(DEFAULT_PURPOSE_DECLARATION);
+      });
+    });
   });
 
   describe('TCF2FinalResults', function() {


### PR DESCRIPTION
When upgrading to prebid version: 11.21.0, noticed this error, only for non-GDPR countries.

This is happening because of the missing nil check on config at Prebid.js/modules/tcfControl.ts
`defaultPurposeDeclaration = Object.assign({}, NO_PURPOSE_DECLARATION, config.gdpr?.defaultLegalBasis ?? DEFAULT_PURPOSE_DECLARATION);`

<img width="1464" height="151" alt="616656159-56102225-3a94-423e-9e2a-609bebd012ef" src="https://github.com/user-attachments/assets/affea841-2dd5-461b-bd7f-d8144ea08712" />

Introduced in PR: https://github.com/prebid/Prebid.js/pull/14988
Resolves: [Issue 15307](https://github.com/prebid/Prebid.js/issues/15307)