### PR TITLE
JJTech Bid Adapter: new banner bid adapter

### DIFF
--- a/modules/jjtechBidAdapter.md
+++ b/modules/jjtechBidAdapter.md
@@ -1,0 +1,40 @@
+# JJTech Bid Adapter
+
+# Overview
+
+```
+Module name: JJTech Bid Adapter
+Module Type: Bidder Adapter
+Maintainer: bhavin@jambojar-tech.com
+```
+
+# Description
+
+Module that connects publishers to JJTech's (Jambojar Technologies) demand sources
+over OpenRTB 2.6. Supports the banner media type.
+
+Publishers need a JJTech account and a `placementId` per ad unit. Contact
+bhavin@jambojar-tech.com to get set up.
+
+# Test parameters
+
+```js
+const adUnits = [
+  {
+    code: 'test-div-1',
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250], [728, 90]],
+      },
+    },
+    bids: [
+      {
+        bidder: 'jjtech',
+        params: {
+          placementId: 'test-placement-1',
+        },
+      },
+    ],
+  },
+];
+```

--- a/modules/jjtechBidAdapter.ts
+++ b/modules/jjtechBidAdapter.ts
@@ -1,0 +1,57 @@
+import { ortbConverter } from '../libraries/ortbConverter/converter.js';
+import { BidderSpec, registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER } from '../src/mediaTypes.js';
+
+interface JJTechBidParams {
+  /**
+   * JJTech placement ID, assigned by JJTech during publisher onboarding.
+   */
+  placementId: string;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    [BIDDER_CODE]: JJTechBidParams;
+  }
+}
+
+const BIDDER_CODE = 'jjtech';
+const ENDPOINT_URL = 'https://prebid-server.jambojar.com/openrtb2/auction';
+const DEFAULT_TTL = 300;
+const DEFAULT_CURRENCY = 'USD';
+
+const converter = ortbConverter<typeof BIDDER_CODE>({
+  context: {
+    netRevenue: true,
+    ttl: DEFAULT_TTL,
+    currency: DEFAULT_CURRENCY,
+  },
+});
+
+const isBidRequestValid: BidderSpec<typeof BIDDER_CODE>['isBidRequestValid'] = (bid) => {
+  return false;
+};
+
+const buildRequests: BidderSpec<typeof BIDDER_CODE>['buildRequests'] = (validBidRequests, bidderRequest) => {
+  const data = converter.toORTB({ bidRequests: validBidRequests, bidderRequest });
+  return {
+    method: 'POST',
+    url: ENDPOINT_URL,
+    data,
+  };
+};
+
+const interpretResponse: BidderSpec<typeof BIDDER_CODE>['interpretResponse'] = (serverResponse, request) => {
+  return converter.fromORTB({ response: serverResponse.body, request: request.data });
+};
+
+export const spec: BidderSpec<typeof BIDDER_CODE> = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [BANNER],
+  isBidRequestValid,
+  buildRequests,
+  interpretResponse,
+  getUserSyncs: () => [],
+};
+
+registerBidder(spec);

--- a/modules/jjtechBidAdapter.ts
+++ b/modules/jjtechBidAdapter.ts
@@ -1,6 +1,7 @@
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { BidderSpec, registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
+import { deepSetValue } from '../src/utils.js';
 
 interface JJTechBidParams {
   /**
@@ -25,6 +26,11 @@ const converter = ortbConverter<typeof BIDDER_CODE>({
     netRevenue: true,
     ttl: DEFAULT_TTL,
     currency: DEFAULT_CURRENCY,
+  },
+  imp(buildImp, bidRequest, context) {
+    const imp = buildImp(bidRequest, context);
+    deepSetValue(imp, 'ext.jjtech.placementId', bidRequest.params.placementId);
+    return imp;
   },
 });
 

--- a/modules/jjtechBidAdapter.ts
+++ b/modules/jjtechBidAdapter.ts
@@ -29,7 +29,7 @@ const converter = ortbConverter<typeof BIDDER_CODE>({
 });
 
 const isBidRequestValid: BidderSpec<typeof BIDDER_CODE>['isBidRequestValid'] = (bid) => {
-  return false;
+  return typeof bid?.params?.placementId === 'string' && bid.params.placementId.length > 0;
 };
 
 const buildRequests: BidderSpec<typeof BIDDER_CODE>['buildRequests'] = (validBidRequests, bidderRequest) => {

--- a/modules/jjtechBidAdapter.ts
+++ b/modules/jjtechBidAdapter.ts
@@ -26,6 +26,7 @@ const converter = ortbConverter<typeof BIDDER_CODE>({
     netRevenue: true,
     ttl: DEFAULT_TTL,
     currency: DEFAULT_CURRENCY,
+    mediaType: BANNER,
   },
   imp(buildImp, bidRequest, context) {
     const imp = buildImp(bidRequest, context);

--- a/modules/jjtechBidAdapter.ts
+++ b/modules/jjtechBidAdapter.ts
@@ -17,7 +17,7 @@ declare module '../src/adUnits' {
 }
 
 const BIDDER_CODE = 'jjtech';
-const ENDPOINT_URL = 'https://prebid-server.jambojar.com/openrtb2/auction';
+const ENDPOINT_URL = 'https://prebid-server.jambojar-tech.com/openrtb2/auction';
 const DEFAULT_TTL = 300;
 const DEFAULT_CURRENCY = 'USD';
 
@@ -29,7 +29,7 @@ const converter = ortbConverter<typeof BIDDER_CODE>({
   },
   imp(buildImp, bidRequest, context) {
     const imp = buildImp(bidRequest, context);
-    deepSetValue(imp, 'ext.jjtech.placementId', bidRequest.params.placementId);
+    deepSetValue(imp, 'ext.prebid.storedrequest.id', bidRequest.params.placementId);
     return imp;
   },
 });

--- a/test/spec/modules/jjtechBidAdapter_spec.js
+++ b/test/spec/modules/jjtechBidAdapter_spec.js
@@ -126,6 +126,16 @@ describe('JJTech bid adapter', () => {
       const request = spec.buildRequests([bid], bidderRequest);
       expect(request.data.regs.coppa).to.equal(1);
     });
+
+    it('sends only a banner imp for mixed banner+video ad units', () => {
+      bid.mediaTypes = {
+        banner: { sizes: [[300, 250]] },
+        video: { context: 'outstream', playerSize: [[640, 480]], mimes: ['video/mp4'] },
+      };
+      const request = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.imp[0].banner).to.exist;
+      expect(request.data.imp[0].video).to.not.exist;
+    });
   });
 
   describe('interpretResponse', () => {

--- a/test/spec/modules/jjtechBidAdapter_spec.js
+++ b/test/spec/modules/jjtechBidAdapter_spec.js
@@ -199,4 +199,10 @@ describe('JJTech bid adapter', () => {
       expect(bids).to.have.lengthOf(0);
     });
   });
+
+  describe('getUserSyncs', () => {
+    it('registers no user syncs', () => {
+      expect(spec.getUserSyncs({ iframeEnabled: true, pixelEnabled: true }, [])).to.deep.equal([]);
+    });
+  });
 });

--- a/test/spec/modules/jjtechBidAdapter_spec.js
+++ b/test/spec/modules/jjtechBidAdapter_spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { spec } from '../../../modules/jjtechBidAdapter.ts';
+import { deepClone } from '../../../src/utils.js';
 
 const ENDPOINT_URL = 'https://prebid-server.jambojar.com/openrtb2/auction';
 
@@ -22,6 +23,43 @@ describe('JJTech bid adapter', () => {
       expect(spec).to.have.property('buildRequests').that.is.a('function');
       expect(spec).to.have.property('interpretResponse').that.is.a('function');
       expect(spec).to.have.property('getUserSyncs').that.is.a('function');
+    });
+  });
+
+  describe('isBidRequestValid', () => {
+    let bid;
+
+    beforeEach(() => {
+      bid = deepClone(bidRequestBase);
+    });
+
+    it('returns true when placementId is a non-empty string', () => {
+      expect(spec.isBidRequestValid(bid)).to.be.true;
+    });
+
+    it('returns false when params is missing', () => {
+      delete bid.params;
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+    });
+
+    it('returns false when placementId is missing', () => {
+      bid.params = {};
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+    });
+
+    it('returns false when placementId is an empty string', () => {
+      bid.params = { placementId: '' };
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+    });
+
+    it('returns false when placementId is a number', () => {
+      bid.params = { placementId: 12345 };
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+    });
+
+    it('returns false when placementId is null', () => {
+      bid.params = { placementId: null };
+      expect(spec.isBidRequestValid(bid)).to.be.false;
     });
   });
 });

--- a/test/spec/modules/jjtechBidAdapter_spec.js
+++ b/test/spec/modules/jjtechBidAdapter_spec.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import { spec } from '../../../modules/jjtechBidAdapter.ts';
+
+const ENDPOINT_URL = 'https://prebid-server.jambojar.com/openrtb2/auction';
+
+const bidRequestBase = {
+  adUnitCode: 'banner-ad-unit-code',
+  auctionId: 'auction-id',
+  bidId: 'bid-id-1',
+  bidder: 'jjtech',
+  bidderRequestId: 'bidder-request-id',
+  mediaTypes: { banner: { sizes: [[300, 250]] } },
+  params: { placementId: 'test-placement-1' },
+};
+
+describe('JJTech bid adapter', () => {
+  describe('spec', () => {
+    it('has the required properties', () => {
+      expect(spec).to.have.property('code', 'jjtech');
+      expect(spec).to.have.property('supportedMediaTypes').that.includes('banner');
+      expect(spec).to.have.property('isBidRequestValid').that.is.a('function');
+      expect(spec).to.have.property('buildRequests').that.is.a('function');
+      expect(spec).to.have.property('interpretResponse').that.is.a('function');
+      expect(spec).to.have.property('getUserSyncs').that.is.a('function');
+    });
+  });
+});

--- a/test/spec/modules/jjtechBidAdapter_spec.js
+++ b/test/spec/modules/jjtechBidAdapter_spec.js
@@ -172,7 +172,7 @@ describe('JJTech bid adapter', () => {
 
     it('maps an ORTB banner bid to a Prebid bid', () => {
       const result = spec.interpretResponse(serverResponse, request);
-      const bids = result.bids || result;
+      const bids = result.bids;
       expect(bids).to.have.lengthOf(1);
       expect(bids[0].requestId).to.equal('bid-id-1');
       expect(bids[0].cpm).to.equal(1.25);
@@ -189,13 +189,13 @@ describe('JJTech bid adapter', () => {
 
     it('returns no bids for an empty response body', () => {
       const result = spec.interpretResponse({ body: null }, request);
-      const bids = result.bids || result;
+      const bids = result.bids;
       expect(bids).to.have.lengthOf(0);
     });
 
     it('returns no bids when seatbid is missing', () => {
       const result = spec.interpretResponse({ body: { id: 'response-id' } }, request);
-      const bids = result.bids || result;
+      const bids = result.bids;
       expect(bids).to.have.lengthOf(0);
     });
   });

--- a/test/spec/modules/jjtechBidAdapter_spec.js
+++ b/test/spec/modules/jjtechBidAdapter_spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { spec } from '../../../modules/jjtechBidAdapter.ts';
 import { deepClone } from '../../../src/utils.js';
 
-const ENDPOINT_URL = 'https://prebid-server.jambojar.com/openrtb2/auction';
+const ENDPOINT_URL = 'https://prebid-server.jambojar-tech.com/openrtb2/auction';
 
 const bidRequestBase = {
   adUnitCode: 'banner-ad-unit-code',
@@ -94,7 +94,7 @@ describe('JJTech bid adapter', () => {
       expect(request.data.site.page).to.equal('https://example.com/article');
     });
 
-    it('puts placementId on each imp at ext.jjtech.placementId', () => {
+    it('puts placementId on each imp at ext.prebid.storedrequest.id', () => {
       const secondBid = deepClone(bidRequestBase);
       secondBid.bidId = 'bid-id-2';
       secondBid.adUnitCode = 'banner-ad-unit-code-2';
@@ -103,8 +103,8 @@ describe('JJTech bid adapter', () => {
 
       const request = spec.buildRequests([bid, secondBid], bidderRequest);
       expect(request.data.imp).to.have.lengthOf(2);
-      expect(request.data.imp[0].ext.jjtech.placementId).to.equal('test-placement-1');
-      expect(request.data.imp[1].ext.jjtech.placementId).to.equal('test-placement-2');
+      expect(request.data.imp[0].ext.prebid.storedrequest.id).to.equal('test-placement-1');
+      expect(request.data.imp[1].ext.prebid.storedrequest.id).to.equal('test-placement-2');
     });
 
     it('forwards the US privacy string', () => {

--- a/test/spec/modules/jjtechBidAdapter_spec.js
+++ b/test/spec/modules/jjtechBidAdapter_spec.js
@@ -62,4 +62,69 @@ describe('JJTech bid adapter', () => {
       expect(spec.isBidRequestValid(bid)).to.be.false;
     });
   });
+
+  describe('buildRequests', () => {
+    let bid;
+    let bidderRequest;
+
+    beforeEach(() => {
+      bid = deepClone(bidRequestBase);
+      bidderRequest = {
+        bidderCode: 'jjtech',
+        auctionId: bid.auctionId,
+        bidderRequestId: bid.bidderRequestId,
+        bids: [bid],
+        ortb2: {
+          site: { page: 'https://example.com/article' },
+        },
+      };
+    });
+
+    it('sends a single POST to the JJTech endpoint', () => {
+      const request = spec.buildRequests([bid], bidderRequest);
+      expect(request.method).to.equal('POST');
+      expect(request.url).to.equal(ENDPOINT_URL);
+    });
+
+    it('builds an ORTB request with one banner imp per bid', () => {
+      const request = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.imp).to.have.lengthOf(1);
+      expect(request.data.imp[0].id).to.equal('bid-id-1');
+      expect(request.data.imp[0].banner.format).to.deep.equal([{ w: 300, h: 250 }]);
+      expect(request.data.site.page).to.equal('https://example.com/article');
+    });
+
+    it('puts placementId on each imp at ext.jjtech.placementId', () => {
+      const secondBid = deepClone(bidRequestBase);
+      secondBid.bidId = 'bid-id-2';
+      secondBid.adUnitCode = 'banner-ad-unit-code-2';
+      secondBid.params = { placementId: 'test-placement-2' };
+      bidderRequest.bids = [bid, secondBid];
+
+      const request = spec.buildRequests([bid, secondBid], bidderRequest);
+      expect(request.data.imp).to.have.lengthOf(2);
+      expect(request.data.imp[0].ext.jjtech.placementId).to.equal('test-placement-1');
+      expect(request.data.imp[1].ext.jjtech.placementId).to.equal('test-placement-2');
+    });
+
+    it('forwards the US privacy string', () => {
+      bidderRequest.ortb2.regs = { ext: { us_privacy: '1YNN' } };
+      const request = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.regs.ext.us_privacy).to.equal('1YNN');
+    });
+
+    it('forwards GDPR consent when present', () => {
+      bidderRequest.ortb2.regs = { ext: { gdpr: 1 } };
+      bidderRequest.ortb2.user = { ext: { consent: 'CONSENT-STRING' } };
+      const request = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.regs.ext.gdpr).to.equal(1);
+      expect(request.data.user.ext.consent).to.equal('CONSENT-STRING');
+    });
+
+    it('forwards the COPPA flag from config', () => {
+      bidderRequest.ortb2.regs = { coppa: 1 };
+      const request = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.regs.coppa).to.equal(1);
+    });
+  });
 });

--- a/test/spec/modules/jjtechBidAdapter_spec.js
+++ b/test/spec/modules/jjtechBidAdapter_spec.js
@@ -127,4 +127,76 @@ describe('JJTech bid adapter', () => {
       expect(request.data.regs.coppa).to.equal(1);
     });
   });
+
+  describe('interpretResponse', () => {
+    let bid;
+    let bidderRequest;
+    let request;
+
+    const serverResponse = {
+      body: {
+        id: 'response-id',
+        cur: 'USD',
+        seatbid: [
+          {
+            seat: 'jjtech',
+            bid: [
+              {
+                id: 'seatbid-bid-id',
+                impid: 'bid-id-1',
+                price: 1.25,
+                adm: '<div>jjtech-ad</div>',
+                adomain: ['advertiser.com'],
+                crid: 'creative-id-1',
+                w: 300,
+                h: 250,
+                mtype: 1,
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    beforeEach(() => {
+      bid = deepClone(bidRequestBase);
+      bidderRequest = {
+        bidderCode: 'jjtech',
+        auctionId: bid.auctionId,
+        bidderRequestId: bid.bidderRequestId,
+        bids: [bid],
+        ortb2: {},
+      };
+      request = spec.buildRequests([bid], bidderRequest);
+    });
+
+    it('maps an ORTB banner bid to a Prebid bid', () => {
+      const result = spec.interpretResponse(serverResponse, request);
+      const bids = result.bids || result;
+      expect(bids).to.have.lengthOf(1);
+      expect(bids[0].requestId).to.equal('bid-id-1');
+      expect(bids[0].cpm).to.equal(1.25);
+      expect(bids[0].width).to.equal(300);
+      expect(bids[0].height).to.equal(250);
+      expect(bids[0].ad).to.equal('<div>jjtech-ad</div>');
+      expect(bids[0].creativeId).to.equal('creative-id-1');
+      expect(bids[0].currency).to.equal('USD');
+      expect(bids[0].netRevenue).to.equal(true);
+      expect(bids[0].ttl).to.equal(300);
+      expect(bids[0].mediaType).to.equal('banner');
+      expect(bids[0].meta.advertiserDomains).to.deep.equal(['advertiser.com']);
+    });
+
+    it('returns no bids for an empty response body', () => {
+      const result = spec.interpretResponse({ body: null }, request);
+      const bids = result.bids || result;
+      expect(bids).to.have.lengthOf(0);
+    });
+
+    it('returns no bids when seatbid is missing', () => {
+      const result = spec.interpretResponse({ body: { id: 'response-id' } }, request);
+      const bids = result.bids || result;
+      expect(bids).to.have.lengthOf(0);
+    });
+  });
 });


### PR DESCRIPTION
## Type of change

- [x] New bidder adapter

## Description of change

New bid adapter for JJTech (Jambojar Technologies) — an independent supply-side platform. Banner media type, OpenRTB 2.6 over a single endpoint (`https://prebid-server.jambojar-tech.com/openrtb2/auction`), built on the `ortbConverter` library. TypeScript module with typed public params.

The endpoint is JJTech's Prebid Server deployment; the adapter passes the publisher's `placementId` as `imp.ext.prebid.storedrequest.id` (standard PBS stored-imp lookup), so all demand configuration stays server-side.

- contact email of the adapter's maintainer: bhavin@jambojar-tech.com
- [x] official adapter submitted by the bidder
- Link to the docs PR: https://github.com/prebid/prebid.github.io/pull/6652

## Test parameters for validating bids

```js
const adUnits = [{
  code: 'test-div-1',
  mediaTypes: { banner: { sizes: [[300, 250], [728, 90]] } },
  bids: [{ bidder: 'jjtech', params: { placementId: 'test-placement-1' } }]
}];
```

## Checklist

- [x] `gulp lint` passes with no errors on the new files
- [x] Full `gulp test` suite passes locally (15,917 tests, 0 failures); the adapter has 17 unit tests with 100% line/branch/function coverage (>80% required)
- [x] Adapter docs file `modules/jjtechBidAdapter.md` included with maintainer contact and working test params

## Other information

Release label suggestion: `feature` / `minor` (new module).
