### PR TITLE
TTD Bid Adapter: configurable endpointCompression support

### DIFF
--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -21,6 +21,7 @@ const BIDDER_CODE_LONG = 'thetradedesk';
 const BIDDER_ENDPOINT = 'https://direct.adsrvr.org/bid/bidder/';
 const USER_SYNC_ENDPOINT = 'https://match.adsrvr.org';
 const TTL = 360;
+const DEFAULT_GZIP_ENABLED = false;
 
 const MEDIA_TYPE = {
   BANNER: 1,
@@ -36,6 +37,28 @@ function getExt(firstPartyData) {
   return {
     ttdprebid: ext
   };
+}
+
+function getGzipSetting() {
+  try {
+    const gzipSetting = utils.deepAccess(config.getBidderConfig(), `${BIDDER_CODE}.gzipEnabled`);
+
+    if (gzipSetting !== undefined) {
+      const gzipValue = String(gzipSetting).toLowerCase().trim();
+      if (gzipValue === 'true' || gzipValue === 'false') {
+        const parsedValue = gzipValue === 'true';
+        utils.logInfo('TTD: Using bidder-specific gzipEnabled setting:', parsedValue);
+        return parsedValue;
+      }
+
+      utils.logWarn('TTD: Invalid gzipEnabled value in bidder config:', gzipSetting);
+    }
+  } catch (e) {
+    utils.logWarn('TTD: Error accessing bidder config:', e);
+  }
+
+  utils.logInfo('TTD: Using default gzipEnabled setting:', DEFAULT_GZIP_ENABLED);
+  return DEFAULT_GZIP_ENABLED;
 }
 
 function getRegs(bidderRequest) {
@@ -428,6 +451,7 @@ export const spec = {
       data: topLevel,
       options: {
         withCredentials: true,
+        endpointCompression: getGzipSetting()
       }
     };
 

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -39,9 +39,13 @@ function getExt(firstPartyData) {
   };
 }
 
-function getGzipSetting() {
+function getGzipSetting(bidderCode) {
   try {
-    const gzipSetting = utils.deepAccess(config.getBidderConfig(), `${BIDDER_CODE}.gzipEnabled`);
+    const bidderConfig = config.getBidderConfig();
+    // Honor config set against the active bidder code (e.g. the `thetradedesk`
+    // alias), falling back to the canonical `ttd` code.
+    const gzipSetting = utils.deepAccess(bidderConfig, `${bidderCode}.gzipEnabled`) ??
+      utils.deepAccess(bidderConfig, `${BIDDER_CODE}.gzipEnabled`);
 
     if (gzipSetting !== undefined) {
       const gzipValue = String(gzipSetting).toLowerCase().trim();
@@ -451,7 +455,7 @@ export const spec = {
       data: topLevel,
       options: {
         withCredentials: true,
-        endpointCompression: getGzipSetting()
+        endpointCompression: getGzipSetting(bidderRequest.bidderCode)
       }
     };
 

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -1,6 +1,7 @@
 import * as utils from '../src/utils.js';
 import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { DEBUG_MODE } from '../src/constants.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { isNumber } from '../src/utils.js';
 import { getConnectionType } from '../libraries/connectionInfo/connectionUtils.js';
@@ -63,6 +64,12 @@ function getGzipSetting(bidderCode) {
 
   utils.logInfo('TTD: Using default gzipEnabled setting:', DEFAULT_GZIP_ENABLED);
   return DEFAULT_GZIP_ENABLED;
+}
+
+// Mirrors the debug-mode check in core's bidderFactory: when debug mode is on, core skips
+// GZIP compression, so the adapter must not advertise a `Content-Encoding: gzip` header.
+function isDebugMode() {
+  return utils.getParameterByName(DEBUG_MODE).toUpperCase() === 'TRUE' || utils.debugTurnedOn();
 }
 
 function getRegs(bidderRequest) {
@@ -449,13 +456,19 @@ export const spec = {
 
     const url = selectEndpoint(bidderRequest.bids[0].params) + bidderRequest.bids[0].params.supplySourceId;
 
+    const gzipEnabled = getGzipSetting(bidderRequest.bidderCode);
+    // Core skips compression in debug mode, so only advertise the gzip encoding when the body
+    // will actually be compressed — otherwise the endpoint receives a mismatched header.
+    const sendGzipHeader = gzipEnabled && !isDebugMode();
+
     const serverRequest = {
       method: 'POST',
       url: url,
       data: topLevel,
       options: {
         withCredentials: true,
-        endpointCompression: getGzipSetting(bidderRequest.bidderCode)
+        endpointCompression: gzipEnabled,
+        ...(sendGzipHeader ? { customHeaders: { 'Content-Encoding': 'gzip' } } : {})
       }
     };
 

--- a/modules/ttdBidAdapter.md
+++ b/modules/ttdBidAdapter.md
@@ -12,6 +12,26 @@ Module that connects to The Trade Desk's demand sources to fetch bids.
 
 The Trade Desk bid adapter supports Banner and Video.
 
+# Configuration
+
+## Endpoint compression (GZIP)
+
+GZIP compression of the outgoing bid request is **disabled by default**. Publishers can opt in
+via bidder-specific configuration:
+
+```js
+pbjs.setBidderConfig({
+    bidders: ['ttd'],
+    config: {
+        gzipEnabled: true
+    }
+});
+```
+
+`gzipEnabled` accepts a boolean (`true`/`false`) or the equivalent string. Any other/invalid value
+falls back to the default (disabled). Compression is automatically skipped when Prebid debug mode is
+enabled or when the browser does not support GZIP.
+
 # Test Parameters
 
 ```js

--- a/modules/ttdBidAdapter.md
+++ b/modules/ttdBidAdapter.md
@@ -32,6 +32,10 @@ pbjs.setBidderConfig({
 falls back to the default (disabled). Compression is automatically skipped when Prebid debug mode is
 enabled or when the browser does not support GZIP.
 
+When enabled, the adapter sends a `Content-Encoding: gzip` request header alongside the compressed
+payload so the endpoint knows to decompress the body. The header is omitted in Prebid debug mode,
+where core skips compression, so the header always matches the actual payload encoding.
+
 # Test Parameters
 
 ```js

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -756,6 +756,91 @@ describe('ttdBidAdapter', function () {
     });
   });
 
+  describe('buildRequests-endpointCompression', function () {
+    const baseBannerBidRequests = [{
+      'bidder': 'ttd',
+      'params': {
+        'supplySourceId': 'supplier',
+        'publisherId': '13144370',
+        'placementId': '1gaa015'
+      },
+      'mediaTypes': {
+        'banner': {
+          'sizes': [[300, 250]]
+        }
+      },
+      'ortb2Imp': {
+        'ext': {
+          'tid': '8651474f-58b1-4368-b812-84f8c937a099',
+        }
+      },
+      'sizes': [[300, 250]],
+      'bidId': '243310435309b5',
+      'bidderRequestId': '18084284054531',
+      'auctionId': 'e7b34fa3-8654-424e-8c49-03e509e53d8c',
+      'src': 'client',
+      'bidRequestsCount': 1
+    }];
+
+    const baseBidderRequest = {
+      'bidderCode': 'ttd',
+      ortb2: {
+        source: {
+          tid: 'e7b34fa3-8654-424e-8c49-03e509e53d8c',
+        }
+      },
+      'bidderRequestId': '18084284054531',
+      'auctionStart': 1540945362095,
+      'timeout': 3000,
+      'refererInfo': {
+        'page': 'https://www.example.com/test',
+        'ref': 'https://referer.com'
+      },
+    };
+
+    let sandbox;
+    let bidderConfigStub;
+
+    beforeEach(function () {
+      sandbox = sinon.createSandbox();
+      bidderConfigStub = sandbox.stub(config, 'getBidderConfig');
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    it('should default endpointCompression to false when no bidder config is set', function () {
+      bidderConfigStub.returns({});
+      const request = testBuildRequests(baseBannerBidRequests, baseBidderRequest);
+      expect(request.options.endpointCompression).to.be.false;
+    });
+
+    it('should interpret correctly gzip configuration given as a boolean', function () {
+      bidderConfigStub.returns({ ttd: { gzipEnabled: false } });
+      const request = testBuildRequests(baseBannerBidRequests, baseBidderRequest);
+      expect(request.options.endpointCompression).to.be.false;
+    });
+
+    it('should interpret correctly gzip configuration given as a string', function () {
+      bidderConfigStub.returns({ ttd: { gzipEnabled: 'false' } });
+      const request = testBuildRequests(baseBannerBidRequests, baseBidderRequest);
+      expect(request.options.endpointCompression).to.be.false;
+    });
+
+    it('should enable endpointCompression when gzipEnabled is true', function () {
+      bidderConfigStub.returns({ ttd: { gzipEnabled: true } });
+      const request = testBuildRequests(baseBannerBidRequests, baseBidderRequest);
+      expect(request.options.endpointCompression).to.be.true;
+    });
+
+    it('should default to false when it receives an invalid configuration', function () {
+      bidderConfigStub.returns({ ttd: { gzipEnabled: 'randomString' } });
+      const request = testBuildRequests(baseBannerBidRequests, baseBidderRequest);
+      expect(request.options.endpointCompression).to.be.false;
+    });
+  });
+
   describe('buildRequests-banner-multiple', function () {
     const baseBannerMultipleBidRequests = [{
       'bidder': 'ttd',

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -839,6 +839,22 @@ describe('ttdBidAdapter', function () {
       const request = testBuildRequests(baseBannerBidRequests, baseBidderRequest);
       expect(request.options.endpointCompression).to.be.false;
     });
+
+    it('should honor config set against the active alias bidder code', function () {
+      bidderConfigStub.returns({ thetradedesk: { gzipEnabled: true } });
+      const aliasBidRequests = baseBannerBidRequests.map(bid => ({ ...bid, bidder: 'thetradedesk' }));
+      const aliasBidderRequest = { ...baseBidderRequest, bidderCode: 'thetradedesk' };
+      const request = testBuildRequests(aliasBidRequests, aliasBidderRequest);
+      expect(request.options.endpointCompression).to.be.true;
+    });
+
+    it('should fall back to the canonical ttd config when on an alias without its own config', function () {
+      bidderConfigStub.returns({ ttd: { gzipEnabled: true } });
+      const aliasBidRequests = baseBannerBidRequests.map(bid => ({ ...bid, bidder: 'thetradedesk' }));
+      const aliasBidderRequest = { ...baseBidderRequest, bidderCode: 'thetradedesk' };
+      const request = testBuildRequests(aliasBidRequests, aliasBidderRequest);
+      expect(request.options.endpointCompression).to.be.true;
+    });
   });
 
   describe('buildRequests-banner-multiple', function () {

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -808,12 +808,34 @@ describe('ttdBidAdapter', function () {
 
     afterEach(function () {
       sandbox.restore();
+      config.setConfig({ debug: false });
     });
 
     it('should default endpointCompression to false when no bidder config is set', function () {
       bidderConfigStub.returns({});
       const request = testBuildRequests(baseBannerBidRequests, baseBidderRequest);
       expect(request.options.endpointCompression).to.be.false;
+    });
+
+    it('should not add a Content-Encoding header when gzip is disabled', function () {
+      bidderConfigStub.returns({});
+      const request = testBuildRequests(baseBannerBidRequests, baseBidderRequest);
+      expect(request.options.customHeaders).to.be.undefined;
+    });
+
+    it('should add a Content-Encoding: gzip header when gzip is enabled', function () {
+      bidderConfigStub.returns({ ttd: { gzipEnabled: true } });
+      const request = testBuildRequests(baseBannerBidRequests, baseBidderRequest);
+      expect(request.options.customHeaders).to.deep.equal({ 'Content-Encoding': 'gzip' });
+    });
+
+    it('should not add a Content-Encoding header in debug mode even when gzip is enabled', function () {
+      bidderConfigStub.returns({ ttd: { gzipEnabled: true } });
+      config.setConfig({ debug: true });
+      const request = testBuildRequests(baseBannerBidRequests, baseBidderRequest);
+      // gzip stays requested (core decides), but the header is dropped since core skips compression
+      expect(request.options.endpointCompression).to.be.true;
+      expect(request.options.customHeaders).to.be.undefined;
     });
 
     it('should interpret correctly gzip configuration given as a boolean', function () {
@@ -846,6 +868,7 @@ describe('ttdBidAdapter', function () {
       const aliasBidderRequest = { ...baseBidderRequest, bidderCode: 'thetradedesk' };
       const request = testBuildRequests(aliasBidRequests, aliasBidderRequest);
       expect(request.options.endpointCompression).to.be.true;
+      expect(request.options.customHeaders).to.deep.equal({ 'Content-Encoding': 'gzip' });
     });
 
     it('should fall back to the canonical ttd config when on an alias without its own config', function () {
@@ -854,6 +877,7 @@ describe('ttdBidAdapter', function () {
       const aliasBidderRequest = { ...baseBidderRequest, bidderCode: 'thetradedesk' };
       const request = testBuildRequests(aliasBidRequests, aliasBidderRequest);
       expect(request.options.endpointCompression).to.be.true;
+      expect(request.options.customHeaders).to.deep.equal({ 'Content-Encoding': 'gzip' });
     });
   });
 


### PR DESCRIPTION
## Type of change

- [x] Updated bidder adapter  

## Description of change

Add opt-in GZIP compression of the outgoing bid request via a `ttd.gzipEnabled` bidder config, mirroring the Criteo adapter. Defaults to disabled; accepts a boolean or string and falls back to the default on invalid values. Core `bidderFactory` already honors `options.endpointCompression`.
Set 'Content-encoding: gzip' header for TTD bid request only
