### PR TITLE
Cadent Aperture MX Bid Adapter: migrate endpoints to ssp.cadent.com

### DIFF
--- a/modules/cadent_aperture_mxBidAdapter.js
+++ b/modules/cadent_aperture_mxBidAdapter.js
@@ -15,8 +15,8 @@ import { parseDomain } from '../src/refererDetection.js';
 import { getDNT } from '../libraries/dnt/index.js';
 
 const BIDDER_CODE = 'cadent_aperture_mx';
-const ENDPOINT = 'hb.emxdgt.com';
-const RENDERER_URL = 'https://js.brealtime.com/outstream/1.30.0/bundle.js';
+const ENDPOINT = 'hb-pub.ssp.cadent.com';
+const RENDERER_URL = 'https://js.ssp.cadent.com/outstream/1.30.0/bundle.js';
 const ADAPTER_VERSION = '1.5.1';
 const DEFAULT_CUR = 'USD';
 const ALIASES = [
@@ -374,7 +374,7 @@ export const spec = {
     const syncs = [];
     const consentParams = [];
     if (syncOptions.iframeEnabled) {
-      let url = 'https://biddr.brealtime.com/check.html';
+      let url = 'https://js.ssp.cadent.com/check.html';
       if (gdprConsent && typeof gdprConsent.consentString === 'string') {
         // add 'gdpr' only if 'gdprApplies' is defined
         if (typeof gdprConsent.gdprApplies === 'boolean') {

--- a/test/spec/modules/cadent_aperture_mxBidAdapter_spec.js
+++ b/test/spec/modules/cadent_aperture_mxBidAdapter_spec.js
@@ -751,7 +751,7 @@ describe('cadent_aperture_mx Adapter', function () {
       const ad0 = result[0];
       const ad1 = result[1];
       expect(ad0.renderer).to.exist.and.to.be.a('object');
-      expect(ad0.renderer.url).to.equal('https://js.brealtime.com/outstream/1.30.0/bundle.js');
+      expect(ad0.renderer.url).to.equal('https://js.ssp.cadent.com/outstream/1.30.0/bundle.js');
       expect(ad0.renderer.id).to.equal('987654321cba');
       expect(ad1.renderer).to.equal(undefined);
     });
@@ -794,7 +794,7 @@ describe('cadent_aperture_mx Adapter', function () {
       expect(syncs).to.not.be.an('undefined');
       expect(syncs).to.have.lengthOf(1);
       expect(syncs[0].type).to.equal('iframe');
-      expect(syncs[0].url).to.equal('https://biddr.brealtime.com/check.html');
+      expect(syncs[0].url).to.equal('https://js.ssp.cadent.com/check.html');
     });
 
     it('should pass gdpr params', function () {
@@ -805,7 +805,7 @@ describe('cadent_aperture_mx Adapter', function () {
       expect(syncs).to.have.lengthOf(1);
       expect(syncs[0].type).to.equal('iframe');
       expect(syncs[0].url).to.contains('gdpr=0');
-      expect(syncs[0].url).to.equal('https://biddr.brealtime.com/check.html?gdpr=0&gdpr_consent=test');
+      expect(syncs[0].url).to.equal('https://js.ssp.cadent.com/check.html?gdpr=0&gdpr_consent=test');
     });
 
     it('should pass us_privacy string', function () {
@@ -832,7 +832,7 @@ describe('cadent_aperture_mx Adapter', function () {
       expect(syncs[0].type).to.equal('iframe');
       expect(syncs[0].url).to.contains('gdpr=1');
       expect(syncs[0].url).to.contains('usp=test');
-      expect(syncs[0].url).to.equal('https://biddr.brealtime.com/check.html?gdpr=1&gdpr_consent=test&usp=test');
+      expect(syncs[0].url).to.equal('https://js.ssp.cadent.com/check.html?gdpr=1&gdpr_consent=test&usp=test');
     });
 
     it('should pass gpp string and section id', function() {
@@ -865,7 +865,7 @@ describe('cadent_aperture_mx Adapter', function () {
       expect(syncs[0].url).to.contains('gdpr=1');
       expect(syncs[0].url).to.contains('usp=test');
       expect(syncs[0].url).to.contains('gpp=abcdefgs');
-      expect(syncs[0].url).to.equal('https://biddr.brealtime.com/check.html?gdpr=1&gdpr_consent=test&usp=test&gpp=abcdefgs&gpp_sid=1,2,4');
+      expect(syncs[0].url).to.equal('https://js.ssp.cadent.com/check.html?gdpr=1&gdpr_consent=test&usp=test&gpp=abcdefgs&gpp_sid=1,2,4');
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Updates the Cadent Aperture MX bid adapter to use Cadent SSP infrastructure endpoints, replacing legacy `emxdgt.com` and `brealtime.com` domains.

### URL changes

| Purpose | Old | New |
|---------|-----|-----|
| Bid endpoint | `hb.emxdgt.com` | `hb-pub.ssp.cadent.com` |
| Outstream renderer | `https://js.brealtime.com/outstream/1.30.0/bundle.js` | `https://js.ssp.cadent.com/outstream/1.30.0/bundle.js` |
| User sync (iframe) | `https://biddr.brealtime.com/check.html` | `https://js.ssp.cadent.com/check.html` |

### Files changed
- `modules/cadent_aperture_mxBidAdapter.js` — endpoint, renderer, and user sync URLs
- `test/spec/modules/cadent_aperture_mxBidAdapter_spec.js` — updated expectations for renderer and sync URLs (including GDPR, USP, and GPP query params)

No changes to bidder parameters, aliases, or adapter behavior beyond the domain migration.

### Testing
- [x] `npx eslint 'modules/cadent_aperture_mxBidAdapter.js' 'test/spec/modules/cadent_aperture_mxBidAdapter_spec.js' --cache --cache-strategy content`
- [x] `npx gulp test --nolint --file test/spec/modules/cadent_aperture_mxBidAdapter_spec.js`

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
- Maintainer: contactaperturemx@cadent.tv
- Docs PR: Not required — bidder parameter documentation is unchanged; docs do not reference the old endpoint URLs
- Prebid Server: will be updated in the near future, continues to work as-is for the time being