### PR TITLE
Stackup RTD Module: disclose sessionStorage cache keys and fix ortb2 data block merge collapse

### DIFF
--- a/metadata/disclosures/modules/stackupRtdProvider.json
+++ b/metadata/disclosures/modules/stackupRtdProvider.json
@@ -1,0 +1,16 @@
+{
+  "disclosures": [
+    {
+      "identifier": "stackup:enrich:v1:*",
+      "type": "web",
+      "domains": ["*"],
+      "purposes": [1, 4]
+    }
+  ],
+  "domains": [
+    {
+      "domain": "*",
+      "use": "Cached ORTB enrichment for the current article is stored in sessionStorage"
+    }
+  ]
+}

--- a/modules/stackupRtdProvider.md
+++ b/modules/stackupRtdProvider.md
@@ -10,10 +10,12 @@ Maintainers: anton@stackup-ai.com, chen@stackup-ai.com, nicolas@stackup-ai.com
 
 The Stack Up RTD module enriches Prebid.js bid requests with contextual and audience segments derived from the content of the current page. Before the auction fires, the module calls the Stack Up enrichment API (or reads from a `sessionStorage` cache on revisit) and merges the response into the global `ortb2` fragments:
 
-- **`site.content.data`** — Content segments (`segtax 502`) such as topics, brand-safety and emotion signals attached to the article, plus publisher first-party signals (`segtax 600`).
+- **`site.content.data`** — Content segments (`segtax 502`, or `segtax 7` for IAB Content Taxonomy 3.0) such as topics, brand-safety and emotion signals attached to the article, plus publisher first-party signals (`segtax 600`).
 - **`user.data`** — Audience segments inferred from contextual signals: IAB Audience (`segtax 4`) and legacy Stack Up Audience Taxonomy 1.0 (`segtax 501`).
 
-Only blocks carrying a recognised taxonomy (`segtax` 4, 501, 502 or 600) are merged; blocks with any other taxonomy are ignored rather than rejected, so an unexpected `segtax` never discards the rest of the enrichment. Multiple blocks sharing a provider `name` are kept as distinct entries — they are de-duplicated by `name` + `segtax` + `dimension`, not by `name` alone.
+Only blocks carrying a recognised taxonomy (`segtax` 4, 7, 501, 502 or 600) are merged; blocks with any other taxonomy are ignored rather than rejected, so an unexpected `segtax` never discards the rest of the enrichment. Multiple blocks sharing a provider `name` are kept as distinct entries — they are de-duplicated by `name` + `segtax` + `dimension`, not by `name` alone.
+
+When the API returns an IAB Content Taxonomy 3.0 (`segtax 7`) block, its category ids are also mirrored into the standard `site.content.cat`/`site.content.cattax` and `site.pagecat`/`site.cattax` fields, so buyers reading either the flat category fields or `content.data[]` see the same signal. By default the mirror never overwrites a value the publisher already set — see `params.overwritePublisherCategories` below.
 
 Every bidder that participates in the auction receives these segments in its `ortb2` object. No cookies, fingerprints, or user identifiers are transmitted to the Stack Up API — only a URL path and publisher domain.
 
@@ -80,6 +82,7 @@ pbjs.setConfig({
 | `params.cache.storage`    |  optional   | String  | Cache backend: `'session'` for browser sessionStorage or `'memory'` for in-process cache                                    |                    `'session'`                    |
 | `params.debug`            |  optional   | Boolean | Enable verbose `[stackupRtd]` console logging                                                                               |                      `false`                      |
 | `params.debugDomain`      |  optional   | String  | Override the domain sent to the API when `debug: true`                                                                      |                    page domain                    |
+| `params.overwritePublisherCategories` | optional | Boolean | Let StackUp's IAB Content Taxonomy 3.0 classification overwrite a publisher-supplied `content.cat`/`site.pagecat`/`cattax` instead of deferring to it | `false` |
 
 ## Consent
 
@@ -129,6 +132,8 @@ After a successful enrichment the following fields are merged into the global `o
     "content": {
       "id": "<articleId>",
       "title": "<article title>",
+      "cat": ["<CT3.0 id>"],
+      "cattax": 7,
       "data": [
         {
           "name": "data.stackup-ai.com",
@@ -142,6 +147,11 @@ After a successful enrichment the following fields are merged into the global `o
           ]
         },
         {
+          "name": "data.stackup-ai.com",
+          "ext": { "segtax": 7 },
+          "segment": [{ "id": "<CT3.0 id>", "name": "<CT3.0 name>" }]
+        },
+        {
           "name": "<publisher-domain>",
           "ext": { "segtax": 600 },
           "segment": [
@@ -153,7 +163,9 @@ After a successful enrichment the following fields are merged into the global `o
         "brand_safety": {},
         "emotion": {}
       }
-    }
+    },
+    "pagecat": ["<CT3.0 id>"],
+    "cattax": 7
   },
   "user": {
     "data": [
@@ -178,7 +190,9 @@ After a successful enrichment the following fields are merged into the global `o
 }
 ```
 
-`site.content.data` carries content segments (`segtax 502`) and publisher first-party signals (`segtax 600`); `user.data` carries audience segments (`segtax 4` IAB Audience and `segtax 501` legacy Stack Up). Blocks with an unrecognised `segtax` are filtered out rather than rejecting the whole response. `site.content.ext.brand_safety` and `site.content.ext.emotion` are optional fields populated when the API returns them. Existing publisher values in `ext` are preserved — the module only fills fields that are absent.
+`site.content.data` carries content segments (`segtax 502` and `segtax 7` IAB Content Taxonomy 3.0) and publisher first-party signals (`segtax 600`); `user.data` carries audience segments (`segtax 4` IAB Audience and `segtax 501` legacy Stack Up). Blocks with an unrecognised `segtax` are filtered out rather than rejecting the whole response. `site.content.ext.brand_safety` and `site.content.ext.emotion` are optional fields populated when the API returns them. Existing publisher values in `ext` are preserved — the module only fills fields that are absent.
+
+When a `segtax 7` block is present, its ids are also copied into `site.content.cat`/`site.content.cattax` and `site.pagecat`/`site.cattax`. This mirror only fills those fields if the publisher hasn't already set them (or set `params.overwritePublisherCategories: true`) — it never invents or maps ids itself, only relays what the enrichment API already classified.
 
 ## Integration Example
 

--- a/modules/stackupRtdProvider.md
+++ b/modules/stackupRtdProvider.md
@@ -10,8 +10,10 @@ Maintainers: anton@stackup-ai.com, chen@stackup-ai.com, nicolas@stackup-ai.com
 
 The Stack Up RTD module enriches Prebid.js bid requests with contextual and audience segments derived from the content of the current page. Before the auction fires, the module calls the Stack Up enrichment API (or reads from a `sessionStorage` cache on revisit) and merges the response into the global `ortb2` fragments:
 
-- **`site.content.data`** — Stack Up Content Taxonomy 1.0 segments (segtax 502), such as topics, brand-safety signals and emotion signals attached to the article.
-- **`user.data`** — Stack Up Audience Taxonomy 1.0 segments (segtax 501) inferred from contextual signals.
+- **`site.content.data`** — Content segments (`segtax 502`) such as topics, brand-safety and emotion signals attached to the article, plus publisher first-party signals (`segtax 600`).
+- **`user.data`** — Audience segments inferred from contextual signals: IAB Audience (`segtax 4`) and legacy Stack Up Audience Taxonomy 1.0 (`segtax 501`).
+
+Only blocks carrying a recognised taxonomy (`segtax` 4, 501, 502 or 600) are merged; blocks with any other taxonomy are ignored rather than rejected, so an unexpected `segtax` never discards the rest of the enrichment. Multiple blocks sharing a provider `name` are kept as distinct entries — they are de-duplicated by `name` + `segtax` + `dimension`, not by `name` alone.
 
 Every bidder that participates in the auction receives these segments in its `ortb2` object. No cookies, fingerprints, or user identifiers are transmitted to the Stack Up API — only a URL path and publisher domain.
 
@@ -138,6 +140,13 @@ After a successful enrichment the following fields are merged into the global `o
               "ext": { "confidence": 0.95 }
             }
           ]
+        },
+        {
+          "name": "<publisher-domain>",
+          "ext": { "segtax": 600 },
+          "segment": [
+            { "id": "cpm_tier", "name": "cpm_tier", "value": "Mid-range" }
+          ]
         }
       ],
       "ext": {
@@ -158,13 +167,18 @@ After a successful enrichment the following fields are merged into the global `o
             "ext": { "confidence": 0.87 }
           }
         ]
+      },
+      {
+        "name": "data.stackup-ai.com",
+        "ext": { "segtax": 4 },
+        "segment": [{ "id": "IAB-1", "name": "Automotive" }]
       }
     ]
   }
 }
 ```
 
-`site.content.ext.brand_safety` and `site.content.ext.emotion` are optional fields populated when the API returns them. Existing publisher values in `ext` are preserved — the module only fills fields that are absent.
+`site.content.data` carries content segments (`segtax 502`) and publisher first-party signals (`segtax 600`); `user.data` carries audience segments (`segtax 4` IAB Audience and `segtax 501` legacy Stack Up). Blocks with an unrecognised `segtax` are filtered out rather than rejecting the whole response. `site.content.ext.brand_safety` and `site.content.ext.emotion` are optional fields populated when the API returns them. Existing publisher values in `ext` are preserved — the module only fills fields that are absent.
 
 ## Integration Example
 

--- a/modules/stackupRtdProvider.md
+++ b/modules/stackupRtdProvider.md
@@ -13,7 +13,7 @@ The Stack Up RTD module enriches Prebid.js bid requests with contextual and audi
 - **`site.content.data`** — Content segments (`segtax 502`, or `segtax 7` for IAB Content Taxonomy 3.0) such as topics, brand-safety and emotion signals attached to the article, plus publisher first-party signals (`segtax 600`).
 - **`user.data`** — Audience segments inferred from contextual signals: IAB Audience (`segtax 4`) and legacy Stack Up Audience Taxonomy 1.0 (`segtax 501`).
 
-Only blocks carrying a recognised taxonomy (`segtax` 4, 7, 501, 502 or 600) are merged; blocks with any other taxonomy are ignored rather than rejected, so an unexpected `segtax` never discards the rest of the enrichment. Multiple blocks sharing a provider `name` are kept as distinct entries — they are de-duplicated by `name` + `segtax` + `dimension`, not by `name` alone.
+Any block with a valid shape (string `name`, a numeric `segtax`, and well-formed `segment[]` entries) is merged regardless of its taxonomy — StackUp can introduce new taxonomies from the backend alone, without a client update. A malformed block causes the whole enrichment response to be rejected. Multiple blocks sharing a provider `name` are kept as distinct entries — they are de-duplicated by `name` + `segtax` + `dimension`, not by `name` alone.
 
 When the API returns an IAB Content Taxonomy 3.0 (`segtax 7`) block, its category ids are also mirrored into the standard `site.content.cat`/`site.content.cattax` and `site.pagecat`/`site.cattax` fields, so buyers reading either the flat category fields or `content.data[]` see the same signal. By default the mirror never overwrites a value the publisher already set — see `params.overwritePublisherCategories` below.
 

--- a/modules/stackupRtdProvider.md
+++ b/modules/stackupRtdProvider.md
@@ -190,7 +190,7 @@ After a successful enrichment the following fields are merged into the global `o
 }
 ```
 
-`site.content.data` carries content segments (`segtax 502` and `segtax 7` IAB Content Taxonomy 3.0) and publisher first-party signals (`segtax 600`); `user.data` carries audience segments (`segtax 4` IAB Audience and `segtax 501` legacy Stack Up). Blocks with an unrecognised `segtax` are filtered out rather than rejecting the whole response. `site.content.ext.brand_safety` and `site.content.ext.emotion` are optional fields populated when the API returns them. Existing publisher values in `ext` are preserved — the module only fills fields that are absent.
+`site.content.data` carries content segments (`segtax 502` and `segtax 7` IAB Content Taxonomy 3.0) and publisher first-party signals (`segtax 600`); `user.data` carries audience segments (`segtax 4` IAB Audience and `segtax 501` legacy Stack Up). A block with any other, vendor-defined `segtax` is still merged as long as it is shape-valid — only a malformed block (not an unrecognised taxonomy) causes the whole response to be rejected. `site.content.ext.brand_safety` and `site.content.ext.emotion` are optional fields populated when the API returns them. Existing publisher values in `ext` are preserved — the module only fills fields that are absent.
 
 When a `segtax 7` block is present, its ids are also copied into `site.content.cat`/`site.content.cattax` and `site.pagecat`/`site.cattax`. This mirror only fills those fields if the publisher hasn't already set them (or set `params.overwritePublisherCategories: true`) — it never invents or maps ids itself, only relays what the enrichment API already classified.
 

--- a/modules/stackupRtdProvider.ts
+++ b/modules/stackupRtdProvider.ts
@@ -42,10 +42,15 @@ const MAX_SNAPSHOTS = 10;
 // any other taxonomy are ignored (filtered out) rather than rejected, so an
 // unexpected segtax never discards the whole enrichment payload.
 //   4   = IAB Audience Taxonomy
+//   7   = IAB Content Taxonomy 3.0
 //   501 = StackUP Audience Taxonomy 1.0 (legacy audience signals)
 //   502 = StackUP Content Taxonomy 1.0
 //   600 = StackUP Publisher FPD (private)
-const ALLOWED_SEGTAX = new Set<number>([4, 501, 502, 600]);
+const ALLOWED_SEGTAX = new Set<number>([4, 7, 501, 502, 600]);
+
+// segtax value used to mirror IAB Content Taxonomy 3.0 segment ids into the
+// standard content.cat[]/site.pagecat[] fields (see mergeSiteContent/mergeSitePagecat).
+const CT3_SEGTAX = 7;
 
 export const storage = getStorageManager({
   moduleType: MODULE_TYPE_RTD,
@@ -95,6 +100,10 @@ export interface StackupRtdParams {
   };
   debug?: boolean;
   debugDomain?: string; // overrides the domain sent to the API when debug: true
+  // default: false — the CT3.0 category mirror (content.cat/content.cattax,
+  // site.pagecat/site.cattax) never overwrites a value the publisher already
+  // set. Set true to let StackUp's classification take priority instead.
+  overwritePublisherCategories?: boolean;
 }
 
 declare module "./rtdModule/spec.ts" {
@@ -111,9 +120,10 @@ type EmotionBlock = unknown; // TODO: define properly when we have real data
 // types/stackup.ts — shared between RTD and analytics modules
 
 // segtax values StackUP emits across content, audience and publisher-FPD blocks.
-// Content segments use segtax 502; IAB Audience segments use segtax 4; legacy
-// StackUp audience signals remain segtax 501; publisher FPD uses private segtax 600.
-export type StackupSegtax = 4 | 501 | 502 | 600;
+// Content segments use segtax 502 or 7 (IAB Content Taxonomy 3.0); IAB Audience
+// segments use segtax 4; legacy StackUp audience signals remain segtax 501;
+// publisher FPD uses private segtax 600.
+export type StackupSegtax = 4 | 7 | 501 | 502 | 600;
 
 export interface EnrichmentSnapshot {
   articleId: string;
@@ -584,11 +594,13 @@ function getBidRequestData(
     release();
   }, effectiveTimeout);
 
+  const allowCategoryOverwrite = config.params?.overwritePublisherCategories === true;
+
   const onReady = () => {
     clearTimeout(timeoutId);
     if (state.enrichment) {
       try {
-        mergeIntoOrtb2(reqBidsConfigObj, state.enrichment);
+        mergeIntoOrtb2(reqBidsConfigObj, state.enrichment, allowCategoryOverwrite);
         // Stash snapshot keyed by auctionId so analytics adapter can retrieve it
         if (reqBidsConfigObj.auctionId) {
           storeSnapshot(reqBidsConfigObj.auctionId, state.enrichment);
@@ -624,17 +636,23 @@ function storeSnapshot(auctionId: string, snapshot: EnrichmentSnapshot): void {
 
 function mergeIntoOrtb2(
   reqBidsConfigObj: StartAuctionOptions,
-  enrichment: EnrichmentSnapshot
+  enrichment: EnrichmentSnapshot,
+  allowCategoryOverwrite: boolean
 ): void {
   const global = reqBidsConfigObj.ortb2Fragments?.global ?? {};
   reqBidsConfigObj.ortb2Fragments = reqBidsConfigObj.ortb2Fragments ?? {};
   reqBidsConfigObj.ortb2Fragments.global = global;
 
-  mergeSiteContent(global, enrichment.site.content);
+  mergeSiteContent(global, enrichment.site.content, allowCategoryOverwrite);
   mergeUserData(global, enrichment.user.data);
+  mergeSitePagecat(global, allowCategoryOverwrite);
 }
 
-function mergeSiteContent(global: any, ours: any): void {
+function mergeSiteContent(
+  global: any,
+  ours: any,
+  allowCategoryOverwrite: boolean
+): void {
   global.site = global.site ?? {};
   global.site.content = global.site.content ?? { data: [] };
   const target = global.site.content;
@@ -666,6 +684,48 @@ function mergeSiteContent(global: any, ours: any): void {
   if (!target.ext.emotion && ours.ext?.emotion) {
     target.ext.emotion = ours.ext.emotion;
   }
+
+  // Mirror IAB Content Taxonomy 3.0 (segtax 7) segment ids into the standard
+  // content.cat[]/content.cattax field so buyers reading either content.data[]
+  // or content.cat[] see the same signal. Never invents or maps ids — only
+  // copies what the API already returned. By default (allowCategoryOverwrite
+  // false) this is skipped entirely if the publisher already declared
+  // content.cat, or declared a cattax that isn't CT3.0, so it never conflates
+  // taxonomies or clobbers publisher-set FPD unless explicitly opted in via
+  // params.overwritePublisherCategories.
+  const ct3Ids = collectSegtaxIds(target.data, CT3_SEGTAX);
+  const catIsFree = allowCategoryOverwrite || !(isArray(target.cat) && target.cat.length);
+  const cattaxIsFree =
+    allowCategoryOverwrite || !target.cattax || target.cattax === CT3_SEGTAX;
+  if (ct3Ids.length && catIsFree && cattaxIsFree) {
+    target.cattax = CT3_SEGTAX;
+    target.cat = ct3Ids;
+  }
+}
+
+// Mirrors IAB Content Taxonomy 3.0 (segtax 7) segment ids already merged into
+// site.content.data into the standard site.pagecat[]/site.cattax field, with
+// the same publisher-wins guards as the content.cat mirror above.
+function mergeSitePagecat(global: any, allowCategoryOverwrite: boolean): void {
+  const ct3Ids = collectSegtaxIds(global.site?.content?.data, CT3_SEGTAX);
+  if (!ct3Ids.length) return;
+  global.site = global.site ?? {};
+  if (
+    !allowCategoryOverwrite &&
+    isArray(global.site.pagecat) &&
+    global.site.pagecat.length
+  ) {
+    return;
+  }
+  if (
+    !allowCategoryOverwrite &&
+    global.site.cattax &&
+    global.site.cattax !== CT3_SEGTAX
+  ) {
+    return;
+  }
+  global.site.cattax = CT3_SEGTAX;
+  global.site.pagecat = ct3Ids;
 }
 
 function mergeUserData(global: any, ours: any[]): void {
@@ -702,6 +762,18 @@ function blockKey(block: any): string {
   const segtax = block?.ext?.segtax ?? "";
   const dimension = block?.ext?.stackup?.dimension ?? "";
   return `${name}|${segtax}|${dimension}`;
+}
+
+// Collects deduped segment ids from data blocks tagged with the given segtax.
+// Used to mirror already backend-classified categories into flat cat/pagecat
+// fields — never computes or guesses an id itself.
+function collectSegtaxIds(blocks: any[] | undefined, segtax: number): string[] {
+  const ids = new Set<string>();
+  for (const block of blocks ?? []) {
+    if (block?.ext?.segtax !== segtax) continue;
+    for (const seg of block.segment ?? []) ids.add(seg.id);
+  }
+  return Array.from(ids);
 }
 
 function dedupeSegments(block: any): any {

--- a/modules/stackupRtdProvider.ts
+++ b/modules/stackupRtdProvider.ts
@@ -197,6 +197,7 @@ function getCacheConfig(): {
 
 export const subModuleObj: RtdProviderSpec<"stackupRtd"> = {
   name: MODULE_NAME as "stackupRtd",
+  disclosureURL: "local://modules/stackupRtdProvider.json",
   init,
   getBidRequestData,
 };

--- a/modules/stackupRtdProvider.ts
+++ b/modules/stackupRtdProvider.ts
@@ -38,6 +38,15 @@ const CACHE_SCHEMA_VERSION = 1;
 // any analytics adapter to read a snapshot before it is evicted.
 const MAX_SNAPSHOTS = 10;
 
+// segtax values this module recognises and merges into ortb2. Blocks carrying
+// any other taxonomy are ignored (filtered out) rather than rejected, so an
+// unexpected segtax never discards the whole enrichment payload.
+//   4   = IAB Audience Taxonomy
+//   501 = StackUP Audience Taxonomy 1.0 (legacy audience signals)
+//   502 = StackUP Content Taxonomy 1.0
+//   600 = StackUP Publisher FPD (private)
+const ALLOWED_SEGTAX = new Set<number>([4, 501, 502, 600]);
+
 export const storage = getStorageManager({
   moduleType: MODULE_TYPE_RTD,
   moduleName: MODULE_NAME,
@@ -101,6 +110,11 @@ type EmotionBlock = unknown; // TODO: define properly when we have real data
 
 // types/stackup.ts — shared between RTD and analytics modules
 
+// segtax values StackUP emits across content, audience and publisher-FPD blocks.
+// Content segments use segtax 502; IAB Audience segments use segtax 4; legacy
+// StackUp audience signals remain segtax 501; publisher FPD uses private segtax 600.
+export type StackupSegtax = 4 | 501 | 502 | 600;
+
 export interface EnrichmentSnapshot {
   articleId: string;
   fetchedAt: number; // unix ms when enrichment landed
@@ -125,8 +139,12 @@ export interface Ortb2ContentSegment {
   id?: string;
   name: string; // provider domain: 'data.stackup-ai.com'
   ext: {
-    segtax: 502; // StackUP Content Taxonomy 1.0
-    stackup?: { taxonomy_version: string; source_tier?: string };
+    segtax: StackupSegtax; // typically 502 (content) or 600 (publisher FPD)
+    stackup?: {
+      taxonomy_version: string;
+      source_tier?: string;
+      dimension?: string;
+    };
   };
   segment: Array<{
     id: string;
@@ -140,7 +158,7 @@ export interface Ortb2UserSegment {
   id?: string;
   name: string; // provider domain: 'data.stackup-ai.com'
   ext: {
-    segtax: 501; // StackUP Audience Taxonomy 1.0 — one block per dimension
+    segtax: StackupSegtax; // typically 501 (legacy audience) or 4 (IAB Audience)
     stackup?: { dimension: string; taxonomy_version: string };
   };
   segment: Array<{
@@ -348,9 +366,10 @@ function fetchEnrichment(
           content: {
             ...data.site.content,
             id: data.site.content.id ?? articleId,
+            data: filterAllowedSegtax(data.site.content.data),
           },
         },
-        user: { data: data.user?.data ?? [] },
+        user: { data: filterAllowedSegtax(data.user?.data ?? []) },
       };
       setCachedEnrichment(articleId, snapshot);
       return snapshot;
@@ -362,12 +381,12 @@ function isValidEnrichment(data: any): data is RawEnrichmentResponse {
   if (!data.site?.content) return false;
   if (!isArray(data.site.content.data)) return false;
 
-  // Validate every segment in site.content.data.
-  // segtax 502 = StackUP Content Taxonomy 1.0 — the only value emitted by the
-  // StackUP worker and returned by the /v1/enrich-ortb-rtd endpoint.
+  // Validate the recognised segments in site.content.data. Blocks whose taxonomy
+  // is not in ALLOWED_SEGTAX are ignored here and filtered out before merge, so a
+  // single unrecognised segtax never rejects the whole enrichment payload.
   for (const block of data.site.content.data) {
+    if (!ALLOWED_SEGTAX.has(block?.ext?.segtax)) continue;
     if (!isStr(block.name)) return false;
-    if (block.ext?.segtax !== 502) return false;
     if (!isArray(block.segment)) return false;
     for (const seg of block.segment) {
       if (!isStr(seg.id)) return false;
@@ -663,6 +682,14 @@ function mergeUserData(global: any, ours: any[]): void {
       global.user.data.push(dedupeSegments(ourBlock));
     }
   }
+}
+
+// Keep only blocks whose taxonomy this module recognises (ALLOWED_SEGTAX).
+// Applied before merge so unrecognised taxonomies never reach ortb2.
+function filterAllowedSegtax<T extends { ext?: { segtax?: number } }>(
+  blocks: T[]
+): T[] {
+  return blocks.filter((b) => ALLOWED_SEGTAX.has(b?.ext?.segtax as number));
 }
 
 // Identity key for an ORTB data block. StackUP delivers several blocks under a

--- a/modules/stackupRtdProvider.ts
+++ b/modules/stackupRtdProvider.ts
@@ -623,11 +623,14 @@ function mergeSiteContent(global: any, ours: any): void {
   target.id = target.id ?? ours.id;
   target.title = target.title ?? ours.title;
 
-  // Array merge by provider name
+  // Array merge by block identity (name + segtax + dimension).
+  // StackUP emits multiple blocks under the same provider `name`
+  // (e.g. several segtax:501 user dimensions all named data.stackup-ai.com),
+  // so keying on `name` alone would overwrite sibling dimensions.
   target.data = target.data ?? [];
   for (const ourBlock of ours.data) {
     const existingIdx = target.data.findIndex(
-      (b: any) => b.name === ourBlock.name
+      (b: any) => blockKey(b) === blockKey(ourBlock)
     );
     if (existingIdx >= 0) {
       target.data[existingIdx] = dedupeSegments(ourBlock);
@@ -652,7 +655,7 @@ function mergeUserData(global: any, ours: any[]): void {
 
   for (const ourBlock of ours) {
     const existingIdx = global.user.data.findIndex(
-      (b: any) => b.name === ourBlock.name
+      (b: any) => blockKey(b) === blockKey(ourBlock)
     );
     if (existingIdx >= 0) {
       global.user.data[existingIdx] = dedupeSegments(ourBlock);
@@ -660,6 +663,18 @@ function mergeUserData(global: any, ours: any[]): void {
       global.user.data.push(dedupeSegments(ourBlock));
     }
   }
+}
+
+// Identity key for an ORTB data block. StackUP delivers several blocks under a
+// single provider `name`, distinguished only by taxonomy (`ext.segtax`) and,
+// for user data, `ext.stackup.dimension` (profile, purchase_intent, ...).
+// Merging/de-duping on `name` alone collapses these siblings, so the key
+// combines all three.
+function blockKey(block: any): string {
+  const name = block?.name ?? "";
+  const segtax = block?.ext?.segtax ?? "";
+  const dimension = block?.ext?.stackup?.dimension ?? "";
+  return `${name}|${segtax}|${dimension}`;
 }
 
 function dedupeSegments(block: any): any {

--- a/modules/stackupRtdProvider.ts
+++ b/modules/stackupRtdProvider.ts
@@ -395,8 +395,11 @@ function isValidEnrichment(data: any): data is RawEnrichmentResponse {
   // Validate every block's shape regardless of segtax — any taxonomy the
   // backend emits is accepted here (see StackupSegtax); only the CT3.0
   // mirror into content.cat/site.pagecat is gated to a specific segtax.
+  // segtax must be a positive integer — the registry is 1-based, so 0,
+  // negatives, NaN and non-integers are never valid taxonomy ids.
   for (const block of data.site.content.data) {
-    if (!isNumber(block?.ext?.segtax)) return false;
+    const segtax = block?.ext?.segtax;
+    if (!isNumber(segtax) || segtax <= 0 || segtax % 1 !== 0) return false;
     if (!isStr(block.name)) return false;
     if (!isArray(block.segment)) return false;
     for (const seg of block.segment) {
@@ -720,13 +723,16 @@ function mergeSitePagecat(
   const ct3Ids = collectSegtaxIds(ours.data, CT3_SEGTAX);
   if (!ct3Ids.length) return;
   global.site = global.site ?? {};
-  if (
-    !allowCategoryOverwrite &&
-    isArray(global.site.pagecat) &&
-    global.site.pagecat.length
-  ) {
-    return;
-  }
+
+  // site.cattax applies to cat[], sectioncat[], and pagecat[] together
+  // (defaulting to 1, IAB Content Category Taxonomy 1.0, when omitted), so
+  // a publisher-set site.cat/site.sectioncat with no explicit cattax must
+  // block this mirror too, or setting cattax here would silently reinterpret
+  // those untouched fields' ids as CT3.0.
+  const hasPublisherCategories = ["cat", "sectioncat", "pagecat"].some(
+    (field) => isArray(global.site[field]) && global.site[field].length
+  );
+  if (!allowCategoryOverwrite && hasPublisherCategories) return;
   if (
     !allowCategoryOverwrite &&
     global.site.cattax &&

--- a/modules/stackupRtdProvider.ts
+++ b/modules/stackupRtdProvider.ts
@@ -38,18 +38,21 @@ const CACHE_SCHEMA_VERSION = 1;
 // any analytics adapter to read a snapshot before it is evicted.
 const MAX_SNAPSHOTS = 10;
 
-// segtax values this module recognises and merges into ortb2. Blocks carrying
-// any other taxonomy are ignored (filtered out) rather than rejected, so an
-// unexpected segtax never discards the whole enrichment payload.
+// segtax values StackUP currently emits (informational — any well-formed
+// segtax block is accepted and merged into ortb2, see isValidEnrichment, so
+// the backend can introduce new taxonomies without a client-side change).
 //   4   = IAB Audience Taxonomy
 //   7   = IAB Content Taxonomy 3.0
 //   501 = StackUP Audience Taxonomy 1.0 (legacy audience signals)
 //   502 = StackUP Content Taxonomy 1.0
 //   600 = StackUP Publisher FPD (private)
-const ALLOWED_SEGTAX = new Set<number>([4, 7, 501, 502, 600]);
 
 // segtax value used to mirror IAB Content Taxonomy 3.0 segment ids into the
 // standard content.cat[]/site.pagecat[] fields (see mergeSiteContent/mergeSitePagecat).
+// Unlike passthrough above, this stays hardcoded: cattax only has a small,
+// spec-registered set of legal content-taxonomy values, so which segtax may
+// be mirrored into content.cat/site.pagecat is a spec constant, not something
+// the backend can change unilaterally.
 const CT3_SEGTAX = 7;
 
 export const storage = getStorageManager({
@@ -119,11 +122,9 @@ type EmotionBlock = unknown; // TODO: define properly when we have real data
 
 // types/stackup.ts — shared between RTD and analytics modules
 
-// segtax values StackUP emits across content, audience and publisher-FPD blocks.
-// Content segments use segtax 502 or 7 (IAB Content Taxonomy 3.0); IAB Audience
-// segments use segtax 4; legacy StackUp audience signals remain segtax 501;
-// publisher FPD uses private segtax 600.
-export type StackupSegtax = 4 | 7 | 501 | 502 | 600;
+// Any numeric segtax is accepted — StackUP may introduce new taxonomies on
+// the backend without a corresponding client-side change (see isValidEnrichment).
+export type StackupSegtax = number;
 
 export interface EnrichmentSnapshot {
   articleId: string;
@@ -376,10 +377,10 @@ function fetchEnrichment(
           content: {
             ...data.site.content,
             id: data.site.content.id ?? articleId,
-            data: filterAllowedSegtax(data.site.content.data),
+            data: data.site.content.data,
           },
         },
-        user: { data: filterAllowedSegtax(data.user?.data ?? []) },
+        user: { data: data.user?.data ?? [] },
       };
       setCachedEnrichment(articleId, snapshot);
       return snapshot;
@@ -391,11 +392,11 @@ function isValidEnrichment(data: any): data is RawEnrichmentResponse {
   if (!data.site?.content) return false;
   if (!isArray(data.site.content.data)) return false;
 
-  // Validate the recognised segments in site.content.data. Blocks whose taxonomy
-  // is not in ALLOWED_SEGTAX are ignored here and filtered out before merge, so a
-  // single unrecognised segtax never rejects the whole enrichment payload.
+  // Validate every block's shape regardless of segtax — any taxonomy the
+  // backend emits is accepted here (see StackupSegtax); only the CT3.0
+  // mirror into content.cat/site.pagecat is gated to a specific segtax.
   for (const block of data.site.content.data) {
-    if (!ALLOWED_SEGTAX.has(block?.ext?.segtax)) continue;
+    if (!isNumber(block?.ext?.segtax)) return false;
     if (!isStr(block.name)) return false;
     if (!isArray(block.segment)) return false;
     for (const seg of block.segment) {
@@ -742,14 +743,6 @@ function mergeUserData(global: any, ours: any[]): void {
       global.user.data.push(dedupeSegments(ourBlock));
     }
   }
-}
-
-// Keep only blocks whose taxonomy this module recognises (ALLOWED_SEGTAX).
-// Applied before merge so unrecognised taxonomies never reach ortb2.
-function filterAllowedSegtax<T extends { ext?: { segtax?: number } }>(
-  blocks: T[]
-): T[] {
-  return blocks.filter((b) => ALLOWED_SEGTAX.has(b?.ext?.segtax as number));
 }
 
 // Identity key for an ORTB data block. StackUP delivers several blocks under a

--- a/modules/stackupRtdProvider.ts
+++ b/modules/stackupRtdProvider.ts
@@ -646,7 +646,7 @@ function mergeIntoOrtb2(
 
   mergeSiteContent(global, enrichment.site.content, allowCategoryOverwrite);
   mergeUserData(global, enrichment.user.data);
-  mergeSitePagecat(global, allowCategoryOverwrite);
+  mergeSitePagecat(global, enrichment.site.content, allowCategoryOverwrite);
 }
 
 function mergeSiteContent(
@@ -688,13 +688,16 @@ function mergeSiteContent(
 
   // Mirror IAB Content Taxonomy 3.0 (segtax 7) segment ids into the standard
   // content.cat[]/content.cattax field so buyers reading either content.data[]
-  // or content.cat[] see the same signal. Never invents or maps ids — only
-  // copies what the API already returned. By default (allowCategoryOverwrite
-  // false) this is skipped entirely if the publisher already declared
-  // content.cat, or declared a cattax that isn't CT3.0, so it never conflates
-  // taxonomies or clobbers publisher-set FPD unless explicitly opted in via
-  // params.overwritePublisherCategories.
-  const ct3Ids = collectSegtaxIds(target.data, CT3_SEGTAX);
+  // or content.cat[] see the same signal. Collected from `ours.data` (the
+  // enrichment's own blocks) rather than the merged `target.data` — the
+  // latter may also contain an unrelated provider's segtax:7 block already
+  // set by the publisher, which must never be blended into StackUp's mirror.
+  // Never invents or maps ids — only copies what the API already returned.
+  // By default (allowCategoryOverwrite false) this is skipped entirely if the
+  // publisher already declared content.cat, or declared a cattax that isn't
+  // CT3.0, so it never conflates taxonomies or clobbers publisher-set FPD
+  // unless explicitly opted in via params.overwritePublisherCategories.
+  const ct3Ids = collectSegtaxIds(ours.data, CT3_SEGTAX);
   const catIsFree = allowCategoryOverwrite || !(isArray(target.cat) && target.cat.length);
   const cattaxIsFree =
     allowCategoryOverwrite || !target.cattax || target.cattax === CT3_SEGTAX;
@@ -704,11 +707,17 @@ function mergeSiteContent(
   }
 }
 
-// Mirrors IAB Content Taxonomy 3.0 (segtax 7) segment ids already merged into
-// site.content.data into the standard site.pagecat[]/site.cattax field, with
-// the same publisher-wins guards as the content.cat mirror above.
-function mergeSitePagecat(global: any, allowCategoryOverwrite: boolean): void {
-  const ct3Ids = collectSegtaxIds(global.site?.content?.data, CT3_SEGTAX);
+// Mirrors IAB Content Taxonomy 3.0 (segtax 7) segment ids from the
+// enrichment's own content blocks into the standard site.pagecat[]/site.cattax
+// field, with the same publisher-wins guards as the content.cat mirror above.
+// Sourced from `ours` (StackUP's own blocks), not the merged site.content.data,
+// so an unrelated provider's pre-existing segtax:7 block is never mixed in.
+function mergeSitePagecat(
+  global: any,
+  ours: any,
+  allowCategoryOverwrite: boolean
+): void {
+  const ct3Ids = collectSegtaxIds(ours.data, CT3_SEGTAX);
   if (!ct3Ids.length) return;
   global.site = global.site ?? {};
   if (

--- a/test/spec/modules/stackupRtdProvider_spec.js
+++ b/test/spec/modules/stackupRtdProvider_spec.js
@@ -21,6 +21,11 @@ const VALID_CONFIG = {
   },
 };
 
+const OVERWRITE_CATEGORIES_CONFIG = {
+  ...VALID_CONFIG,
+  params: { ...VALID_CONFIG.params, overwritePublisherCategories: true },
+};
+
 // Minimal valid API response matching RawEnrichmentResponse schema
 const VALID_API_RESPONSE = {
   site: {
@@ -56,6 +61,29 @@ const VALID_API_RESPONSE = {
       },
     ],
   },
+};
+
+// Variant of VALID_API_RESPONSE carrying an additional segtax:7 (IAB Content
+// Taxonomy 3.0) block, used to exercise the content.cat/site.pagecat mirror.
+const CT3_API_RESPONSE = {
+  site: {
+    content: {
+      id: "test-article-001",
+      title: "Test Article Title",
+      data: [
+        ...VALID_API_RESPONSE.site.content.data,
+        {
+          name: "data.stackup-ai.com",
+          ext: { segtax: 7 },
+          segment: [
+            { id: "483", name: "Sports" },
+            { id: "533", name: "Soccer" },
+          ],
+        },
+      ],
+    },
+  },
+  user: { data: [] },
 };
 
 function respond200(body) {
@@ -642,7 +670,7 @@ describe("StackUp RTD Provider", function () {
     it("should accept publisher-FPD blocks (segtax 600)", async function () {
       const resp = JSON.parse(JSON.stringify(VALID_API_RESPONSE));
       resp.site.content.data.push({
-        name: "phonearena.com",
+        name: "publisher.example.com",
         ext: { segtax: 600, stackup: { dimension: "publisher_intelligence" } },
         segment: [{ id: "cpm_tier", name: "cpm_tier", value: "Mid-range" }],
       });
@@ -804,6 +832,118 @@ describe("StackUp RTD Provider", function () {
       const segs = req.ortb2Fragments.global.site.content.data[0].segment;
       expect(segs).to.have.length(1);
       expect(segs[0].ext.confidence).to.equal(0.95);
+    });
+  });
+
+  // ── 9b. content.cat / site.pagecat mirroring (segtax 7) ───────────────────
+
+  describe("CT3.0 (segtax 7) cat/pagecat mirroring", function () {
+    beforeEach(async function () {
+      subModuleObj.init(VALID_CONFIG, {});
+      respond200(CT3_API_RESPONSE);
+      await flushMicrotasks();
+    });
+
+    it("should accept and merge a segtax:7 content block", function () {
+      const req = { ortb2Fragments: { global: {} } };
+      subModuleObj.getBidRequestData(req, sinon.spy(), VALID_CONFIG);
+      const data = req.ortb2Fragments.global.site.content.data;
+      const ct3Block = data.find((b) => b.ext.segtax === 7);
+      expect(ct3Block).to.not.be.undefined;
+      expect(ct3Block.segment.map((s) => s.id)).to.have.members([
+        "483",
+        "533",
+      ]);
+    });
+
+    it("should mirror segtax:7 ids into content.cat and set content.cattax to 7", function () {
+      const req = { ortb2Fragments: { global: {} } };
+      subModuleObj.getBidRequestData(req, sinon.spy(), VALID_CONFIG);
+      const content = req.ortb2Fragments.global.site.content;
+      expect(content.cattax).to.equal(7);
+      expect(content.cat).to.have.members(["483", "533"]);
+    });
+
+    it("should not overwrite a publisher-supplied content.cat", function () {
+      const req = {
+        ortb2Fragments: {
+          global: {
+            site: { content: { data: [], cat: ["999"], cattax: 6 } },
+          },
+        },
+      };
+      subModuleObj.getBidRequestData(req, sinon.spy(), VALID_CONFIG);
+      const content = req.ortb2Fragments.global.site.content;
+      expect(content.cat).to.deep.equal(["999"]);
+      expect(content.cattax).to.equal(6);
+    });
+
+    it("should mirror segtax:7 ids into site.pagecat and set site.cattax to 7", function () {
+      const req = { ortb2Fragments: { global: {} } };
+      subModuleObj.getBidRequestData(req, sinon.spy(), VALID_CONFIG);
+      const site = req.ortb2Fragments.global.site;
+      expect(site.cattax).to.equal(7);
+      expect(site.pagecat).to.have.members(["483", "533"]);
+    });
+
+    it("should not overwrite a publisher-supplied site.pagecat", function () {
+      const req = {
+        ortb2Fragments: {
+          global: { site: { pagecat: ["999"], cattax: 6 } },
+        },
+      };
+      subModuleObj.getBidRequestData(req, sinon.spy(), VALID_CONFIG);
+      const site = req.ortb2Fragments.global.site;
+      expect(site.pagecat).to.deep.equal(["999"]);
+      expect(site.cattax).to.equal(6);
+    });
+
+    it("should overwrite a publisher-supplied content.cat when params.overwritePublisherCategories is true", function () {
+      const req = {
+        ortb2Fragments: {
+          global: {
+            site: { content: { data: [], cat: ["999"], cattax: 6 } },
+          },
+        },
+      };
+      subModuleObj.getBidRequestData(
+        req,
+        sinon.spy(),
+        OVERWRITE_CATEGORIES_CONFIG
+      );
+      const content = req.ortb2Fragments.global.site.content;
+      expect(content.cattax).to.equal(7);
+      expect(content.cat).to.have.members(["483", "533"]);
+    });
+
+    it("should overwrite a publisher-supplied site.pagecat when params.overwritePublisherCategories is true", function () {
+      const req = {
+        ortb2Fragments: {
+          global: { site: { pagecat: ["999"], cattax: 6 } },
+        },
+      };
+      subModuleObj.getBidRequestData(
+        req,
+        sinon.spy(),
+        OVERWRITE_CATEGORIES_CONFIG
+      );
+      const site = req.ortb2Fragments.global.site;
+      expect(site.cattax).to.equal(7);
+      expect(site.pagecat).to.have.members(["483", "533"]);
+    });
+
+    it("should not mirror a segtax:502 block into content.cat or site.pagecat", async function () {
+      _resetStateForTesting();
+      subModuleObj.init(VALID_CONFIG, {});
+      respond200(VALID_API_RESPONSE); // segtax 502 only, no segtax 7
+      await flushMicrotasks();
+
+      const req = { ortb2Fragments: { global: {} } };
+      subModuleObj.getBidRequestData(req, sinon.spy(), VALID_CONFIG);
+      expect(req.ortb2Fragments.global.site.content.cat).to.be.undefined;
+      expect(req.ortb2Fragments.global.site.content.cattax).to.be.undefined;
+      expect(req.ortb2Fragments.global.site.pagecat).to.be.undefined;
+      expect(req.ortb2Fragments.global.site.cattax).to.be.undefined;
     });
   });
 

--- a/test/spec/modules/stackupRtdProvider_spec.js
+++ b/test/spec/modules/stackupRtdProvider_spec.js
@@ -624,11 +624,32 @@ describe("StackUp RTD Provider", function () {
       expect(req.ortb2Fragments.global.site).to.be.undefined;
     });
 
-    it("should reject content segments with segtax !== 502", async function () {
-      const bad = JSON.parse(JSON.stringify(VALID_API_RESPONSE));
-      bad.site.content.data[0].ext.segtax = 999;
-      const req = await runAndGetReq(bad);
-      expect(req.ortb2Fragments.global.site).to.be.undefined;
+    it("should drop content blocks with an unrecognised segtax", async function () {
+      const resp = JSON.parse(JSON.stringify(VALID_API_RESPONSE));
+      // Foreign taxonomy block alongside the valid segtax:502 block — the
+      // foreign block must be filtered out without discarding the whole payload.
+      resp.site.content.data.push({
+        name: "foreign.example.com",
+        ext: { segtax: 999 },
+        segment: [{ id: "x", name: "Foreign" }],
+      });
+      const req = await runAndGetReq(resp);
+      const data = req.ortb2Fragments.global.site.content.data;
+      expect(data).to.have.length(1);
+      expect(data[0].ext.segtax).to.equal(502);
+    });
+
+    it("should accept publisher-FPD blocks (segtax 600)", async function () {
+      const resp = JSON.parse(JSON.stringify(VALID_API_RESPONSE));
+      resp.site.content.data.push({
+        name: "phonearena.com",
+        ext: { segtax: 600, stackup: { dimension: "publisher_intelligence" } },
+        segment: [{ id: "cpm_tier", name: "cpm_tier", value: "Mid-range" }],
+      });
+      const req = await runAndGetReq(resp);
+      const data = req.ortb2Fragments.global.site.content.data;
+      expect(data).to.have.length(2);
+      expect(data.map((b) => b.ext.segtax)).to.include(600);
     });
 
     it("should reject content segments where segment is not an array", async function () {

--- a/test/spec/modules/stackupRtdProvider_spec.js
+++ b/test/spec/modules/stackupRtdProvider_spec.js
@@ -675,6 +675,27 @@ describe("StackUp RTD Provider", function () {
       expect(req.ortb2Fragments.global.site).to.be.undefined;
     });
 
+    it("should reject a content segment with segtax 0", async function () {
+      const bad = JSON.parse(JSON.stringify(VALID_API_RESPONSE));
+      bad.site.content.data[0].ext.segtax = 0;
+      const req = await runAndGetReq(bad);
+      expect(req.ortb2Fragments.global.site).to.be.undefined;
+    });
+
+    it("should reject a content segment with a negative segtax", async function () {
+      const bad = JSON.parse(JSON.stringify(VALID_API_RESPONSE));
+      bad.site.content.data[0].ext.segtax = -1;
+      const req = await runAndGetReq(bad);
+      expect(req.ortb2Fragments.global.site).to.be.undefined;
+    });
+
+    it("should reject a content segment with a non-integer segtax", async function () {
+      const bad = JSON.parse(JSON.stringify(VALID_API_RESPONSE));
+      bad.site.content.data[0].ext.segtax = 502.5;
+      const req = await runAndGetReq(bad);
+      expect(req.ortb2Fragments.global.site).to.be.undefined;
+    });
+
     it("should accept publisher-FPD blocks (segtax 600)", async function () {
       const resp = JSON.parse(JSON.stringify(VALID_API_RESPONSE));
       resp.site.content.data.push({
@@ -1000,6 +1021,47 @@ describe("StackUp RTD Provider", function () {
       const site = req.ortb2Fragments.global.site;
       expect(content.cat).to.deep.equal(["483", "533"]);
       expect(site.pagecat).to.deep.equal(["483", "533"]);
+    });
+
+    it("should not set site.cattax/pagecat when the publisher already set site.cat with no explicit cattax", function () {
+      const req = {
+        ortb2Fragments: {
+          global: { site: { cat: ["1"] } },
+        },
+      };
+      subModuleObj.getBidRequestData(req, sinon.spy(), VALID_CONFIG);
+      const site = req.ortb2Fragments.global.site;
+      expect(site.cattax).to.be.undefined;
+      expect(site.pagecat).to.be.undefined;
+      expect(site.cat).to.deep.equal(["1"]);
+    });
+
+    it("should not set site.cattax/pagecat when the publisher already set site.sectioncat with no explicit cattax", function () {
+      const req = {
+        ortb2Fragments: {
+          global: { site: { sectioncat: ["2"] } },
+        },
+      };
+      subModuleObj.getBidRequestData(req, sinon.spy(), VALID_CONFIG);
+      const site = req.ortb2Fragments.global.site;
+      expect(site.cattax).to.be.undefined;
+      expect(site.pagecat).to.be.undefined;
+    });
+
+    it("should mirror into site.pagecat/cattax despite a pre-existing site.cat when overwritePublisherCategories is true", function () {
+      const req = {
+        ortb2Fragments: {
+          global: { site: { cat: ["1"] } },
+        },
+      };
+      subModuleObj.getBidRequestData(
+        req,
+        sinon.spy(),
+        OVERWRITE_CATEGORIES_CONFIG
+      );
+      const site = req.ortb2Fragments.global.site;
+      expect(site.cattax).to.equal(7);
+      expect(site.pagecat).to.have.members(["483", "533"]);
     });
 
     it("should not mirror a segtax:502 block into content.cat or site.pagecat", async function () {

--- a/test/spec/modules/stackupRtdProvider_spec.js
+++ b/test/spec/modules/stackupRtdProvider_spec.js
@@ -940,6 +940,68 @@ describe("StackUp RTD Provider", function () {
       expect(site.pagecat).to.have.members(["483", "533"]);
     });
 
+    it("should exclude a publisher's own pre-existing segtax:7 block from the content.cat/site.pagecat mirror", function () {
+      const req = {
+        ortb2Fragments: {
+          global: {
+            site: {
+              content: {
+                data: [
+                  {
+                    name: "other-ct-vendor.com",
+                    ext: { segtax: 7 },
+                    segment: [{ id: "999", name: "OtherVendorCategory" }],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      };
+      subModuleObj.getBidRequestData(req, sinon.spy(), VALID_CONFIG);
+      const content = req.ortb2Fragments.global.site.content;
+      const site = req.ortb2Fragments.global.site;
+      expect(content.cat).to.have.members(["483", "533"]);
+      expect(content.cat).to.not.include("999");
+      expect(site.pagecat).to.have.members(["483", "533"]);
+      expect(site.pagecat).to.not.include("999");
+      // the other vendor's block itself is preserved, just not mirrored
+      expect(content.data.map((b) => b.name)).to.include("other-ct-vendor.com");
+    });
+
+    it("should give StackUp's ids exclusive priority (not a union) when overwritePublisherCategories is true", function () {
+      const req = {
+        ortb2Fragments: {
+          global: {
+            site: {
+              content: {
+                data: [
+                  {
+                    name: "other-ct-vendor.com",
+                    ext: { segtax: 7 },
+                    segment: [{ id: "999", name: "OtherVendorCategory" }],
+                  },
+                ],
+                cat: ["999"],
+                cattax: 7,
+              },
+              pagecat: ["999"],
+              cattax: 7,
+            },
+          },
+        },
+      };
+      subModuleObj.getBidRequestData(
+        req,
+        sinon.spy(),
+        OVERWRITE_CATEGORIES_CONFIG
+      );
+      const content = req.ortb2Fragments.global.site.content;
+      const site = req.ortb2Fragments.global.site;
+      expect(content.cat).to.deep.equal(["483", "533"]);
+      expect(site.pagecat).to.deep.equal(["483", "533"]);
+    });
+
     it("should not mirror a segtax:502 block into content.cat or site.pagecat", async function () {
       _resetStateForTesting();
       subModuleObj.init(VALID_CONFIG, {});

--- a/test/spec/modules/stackupRtdProvider_spec.js
+++ b/test/spec/modules/stackupRtdProvider_spec.js
@@ -652,10 +652,11 @@ describe("StackUp RTD Provider", function () {
       expect(req.ortb2Fragments.global.site).to.be.undefined;
     });
 
-    it("should drop content blocks with an unrecognised segtax", async function () {
+    it("should accept and merge a content block with any well-formed segtax", async function () {
       const resp = JSON.parse(JSON.stringify(VALID_API_RESPONSE));
-      // Foreign taxonomy block alongside the valid segtax:502 block — the
-      // foreign block must be filtered out without discarding the whole payload.
+      // A taxonomy this module has no special handling for — still passed
+      // through as-is provided the block itself is shape-valid, so the
+      // backend can introduce new taxonomies without a client-side change.
       resp.site.content.data.push({
         name: "foreign.example.com",
         ext: { segtax: 999 },
@@ -663,8 +664,15 @@ describe("StackUp RTD Provider", function () {
       });
       const req = await runAndGetReq(resp);
       const data = req.ortb2Fragments.global.site.content.data;
-      expect(data).to.have.length(1);
-      expect(data[0].ext.segtax).to.equal(502);
+      expect(data).to.have.length(2);
+      expect(data.map((b) => b.ext.segtax)).to.include(999);
+    });
+
+    it("should reject content segments with a missing or non-numeric segtax", async function () {
+      const bad = JSON.parse(JSON.stringify(VALID_API_RESPONSE));
+      delete bad.site.content.data[0].ext.segtax;
+      const req = await runAndGetReq(bad);
+      expect(req.ortb2Fragments.global.site).to.be.undefined;
     });
 
     it("should accept publisher-FPD blocks (segtax 600)", async function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

The module caches ORTB enrichment in sessionStorage under the key
pattern `stackup:enrich:v1:*`. Without a device storage disclosure,
storageControl denies `accessDevice` in strict mode, disabling the
cache and logging warnings on every read/write.

This PR:
- adds `disclosureURL: "local://modules/stackupRtdProvider.json"` to the
  RTD submodule object
- adds the local disclosure file listing the `stackup:enrich:v1:*` web
  storage identifier (TCF purposes 1 and 4)

Runtime enforcement (modules/storageControl.ts) reads module metadata,
so the disclosure must be declared statically; the runtime
discloseStorageUse() call only feeds the reporting API.

 Metadata regen is expected as part of the build.


This PR also fixes a merge bug in how enrichment blocks are folded into
the global ortb2 object. Site content and user data blocks were being
de-duplicated by their provider name alone. Because Stack Up delivers
several blocks under a single provider name — one per taxonomy and, for
user data, one per audience dimension such as profile, purchase intent,
interests, and industry — keying on name alone caused each block to
overwrite the previous one. The result was that only the last block in
each array survived, silently discarding every earlier dimension.

The merge now identifies blocks by the combination of provider name,
segment taxonomy, and audience dimension, so sibling blocks that share a
name are kept as distinct entries. All contextual and audience segments
returned by the API are now preserved in the bid request instead of
collapsing to a single block.

It also swaps the strict [segtax: 502] -only check for an allowlist (4, 501, 502, 600); blocks with an unrecognised taxonomy are now skipped instead of rejecting the whole response.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
