### PR TITLE
Equativ Bid Adapter: skip invalid bid requests and address review comments

### DIFF
--- a/libraries/equativUtils/equativUtils.js
+++ b/libraries/equativUtils/equativUtils.js
@@ -67,7 +67,7 @@ export function getBidFloor(bid, currency, mediaType) {
  */
 function getFloor(bid, mediaType, width, height, currency) {
   return bid.getFloor?.({ currency, mediaType, size: [width, height] })
-    .floor || bid.params.bidfloor || -1;
+    .floor || bid.params?.bidfloor || -1;
 }
 
 /**

--- a/modules/equativBidAdapter.js
+++ b/modules/equativBidAdapter.js
@@ -92,20 +92,25 @@ export const spec = {
     const requests = [];
 
     bidRequests.forEach(bid => {
+      if (!isValid(bid)) {
+        logWarn(`${LOG_PREFIX} Skipping bid: invalid media types.`, bid.bidId);
+        return;
+      }
+
       const data = converter.toORTB({ bidRequests: [bid], bidderRequest });
 
       if (!data) {
-        logWarn(`${LOG_PREFIX} Skipping bid: converter returned empty data.`, bid);
+        logWarn(`${LOG_PREFIX} Skipping bid: converter returned empty data.`, bid.bidId);
         return;
       }
 
       if (!data.id) {
-        logWarn(`${LOG_PREFIX} Skipping bid: request is missing required id field.`, bid);
+        logWarn(`${LOG_PREFIX} Skipping bid: request is missing required id field.`, bid.bidId);
         return;
       }
 
       if (!data.imp?.length) {
-        logWarn(`${LOG_PREFIX} Skipping bid: no valid impressions after processing.`, bid);
+        logWarn(`${LOG_PREFIX} Skipping bid: no valid impressions after processing.`, bid.bidId);
         return;
       }
 
@@ -210,7 +215,7 @@ export const converter = ortbConverter({
 
   imp(buildImp, bidRequest, context) {
     const imp = buildImp(bidRequest, context);
-    const { siteId, pageId, formatId } = bidRequest.params;
+    const { siteId, pageId, formatId } = bidRequest.params || {};
 
     delete imp.dt;
 
@@ -238,8 +243,12 @@ export const converter = ortbConverter({
 
     let req = buildRequest(splitImps, bidderRequest, context);
 
+    if (!splitImps?.length) {
+      return req;
+    }
+
     let env = ['ortb2.site.publisher', 'ortb2.app.publisher', 'ortb2.dooh.publisher'].find(propPath => deepAccess(bid, propPath)) || 'ortb2.site.publisher';
-    networkId = deepAccess(bid, env + '.id') || bid.params.networkId;
+    networkId = deepAccess(bid, env + '.id') || deepAccess(bid, 'params.networkId');
     deepSetValue(req, env.replace('ortb2.', '') + '.id', networkId);
 
     [
@@ -250,7 +259,7 @@ export const converter = ortbConverter({
       if (deepAccess(bid, path)) {
         props.forEach(prop => {
           if (!deepAccess(bid, `${path}.${prop}`)) {
-            logWarn(`${LOG_PREFIX} Property "${path}.${prop}" is missing from request. Request will proceed, but the use of "${prop}" is strongly encouraged.`, bid);
+            logWarn(`${LOG_PREFIX} Property "${path}.${prop}" is missing from request. Request will proceed, but the use of "${prop}" is strongly encouraged.`, bid.bidId);
           }
         });
       }

--- a/modules/equativBidAdapter.js
+++ b/modules/equativBidAdapter.js
@@ -93,6 +93,22 @@ export const spec = {
 
     bidRequests.forEach(bid => {
       const data = converter.toORTB({ bidRequests: [bid], bidderRequest });
+
+      if (!data) {
+        logWarn(`${LOG_PREFIX} Skipping bid: converter returned empty data.`, bid);
+        return;
+      }
+
+      if (!data.id) {
+        logWarn(`${LOG_PREFIX} Skipping bid: request is missing required id field.`, bid);
+        return;
+      }
+
+      if (!data.imp?.length) {
+        logWarn(`${LOG_PREFIX} Skipping bid: no valid impressions after processing.`, bid);
+        return;
+      }
+
       requests.push({
         data,
         method: 'POST',

--- a/test/spec/modules/equativBidAdapter_spec.js
+++ b/test/spec/modules/equativBidAdapter_spec.js
@@ -311,7 +311,7 @@ describe('Equativ bid adapter tests', () => {
           }
         }
       }];
-      bidRequests[0].params = {};
+      delete bidRequests[0].params;
       const bidderRequest = { ...DEFAULT_BANNER_BIDDER_REQUEST, bids: bidRequests };
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.data.site.publisher.id).to.equal(98);
@@ -342,7 +342,7 @@ describe('Equativ bid adapter tests', () => {
           }
         }
       }];
-      bidRequests[0].params = {};
+      delete bidRequests[0].params;
       const bidderRequest = { ...DEFAULT_BANNER_BIDDER_REQUEST, bids: bidRequests };
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.data.app.publisher.id).to.equal(27);
@@ -373,7 +373,7 @@ describe('Equativ bid adapter tests', () => {
           }
         }
       }];
-      bidRequests[0].params = {};
+      delete bidRequests[0].params;
       const bidderRequest = { ...DEFAULT_BANNER_BIDDER_REQUEST, bids: bidRequests };
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.data.dooh.publisher.id).to.equal(35);
@@ -619,26 +619,26 @@ describe('Equativ bid adapter tests', () => {
       }
     });
 
-    it('should warn about missing required properties for video requests', () => {
-      if (FEATURES.VIDEO) {
-        // ASSEMBLE
-        const missingRequiredVideoRequest = DEFAULT_VIDEO_BID_REQUESTS[0];
+    it('should warn about missing required properties for video requests', function() {
+      if (!FEATURES.VIDEO) this.skip();
 
-        // removing required properties
-        delete missingRequiredVideoRequest.mediaTypes.video.mimes;
-        delete missingRequiredVideoRequest.mediaTypes.video.placement;
+      // ASSEMBLE
+      const missingRequiredVideoRequest = utils.deepClone(DEFAULT_VIDEO_BID_REQUESTS[0]);
 
-        const bidRequests = [missingRequiredVideoRequest];
-        const bidderRequest = { ...DEFAULT_VIDEO_BIDDER_REQUEST, bids: bidRequests };
+      // removing required properties
+      delete missingRequiredVideoRequest.mediaTypes.video.mimes;
+      delete missingRequiredVideoRequest.mediaTypes.video.placement;
 
-        // ACT
-        spec.buildRequests(bidRequests, bidderRequest);
+      const bidRequests = [missingRequiredVideoRequest];
+      const bidderRequest = { ...DEFAULT_VIDEO_BIDDER_REQUEST, bids: bidRequests };
 
-        // ASSERT
-        expect(utils.logWarn.callCount).to.equal(2);
-        expect(utils.logWarn.getCall(0).args[0]).to.satisfy(arg => arg.includes('"mediaTypes.video.mimes" is missing'));
-        expect(utils.logWarn.getCall(1).args[0]).to.satisfy(arg => arg.includes('"mediaTypes.video.placement" is missing'));
-      }
+      // ACT
+      spec.buildRequests(bidRequests, bidderRequest);
+
+      // ASSERT
+      expect(utils.logWarn.callCount).to.equal(2);
+      expect(utils.logWarn.getCall(0).args[0]).to.satisfy(arg => arg.includes('"mediaTypes.video.mimes" is missing'));
+      expect(utils.logWarn.getCall(1).args[0]).to.satisfy(arg => arg.includes('"mediaTypes.video.placement" is missing'));
     });
 
     it('should not send a video request when it has an empty body and no other impressions with any media types are defined', () => {
@@ -743,14 +743,12 @@ describe('Equativ bid adapter tests', () => {
         spec.buildRequests(bidRequests, bidderRequest);
 
         // ASSERT
-        // 4 warnings from the request itself + 1 from the adapter guard (no valid impressions,
-        // since the native processor skips imps with no assets)
-        expect(utils.logWarn.callCount).to.equal(5);
+        // 1 warning from the library (no assets) + 1 from the adapter guard (no valid impressions).
+        // Property warnings (privacy, plcmttype, eventtrackers) are skipped because the early
+        // return in the request customizer fires before reaching them when splitImps is empty.
+        expect(utils.logWarn.callCount).to.equal(2);
         expect(utils.logWarn.getCall(0).args[0]).to.satisfy(arg => arg.includes('no assets were specified'));
-        expect(utils.logWarn.getCall(1).args[0]).to.satisfy(arg => arg.includes('"mediaTypes.native.ortb.privacy" is missing'));
-        expect(utils.logWarn.getCall(2).args[0]).to.satisfy(arg => arg.includes('"mediaTypes.native.ortb.plcmttype" is missing'));
-        expect(utils.logWarn.getCall(3).args[0]).to.satisfy(arg => arg.includes('"mediaTypes.native.ortb.eventtrackers" is missing'));
-        expect(utils.logWarn.getCall(4).args[0]).to.satisfy(arg => arg.includes('no valid impressions'));
+        expect(utils.logWarn.getCall(1).args[0]).to.satisfy(arg => arg.includes('no valid impressions'));
       }
     });
 
@@ -938,9 +936,25 @@ describe('Equativ bid adapter tests', () => {
       });
     });
 
+    it('should skip invalid bid and log warning when mixed with valid bids', () => {
+      // ASSEMBLE - one valid bid and one with empty video (invalid)
+      const mixedBidRequests = [
+        DEFAULT_BANNER_BID_REQUESTS[0],
+        { ...DEFAULT_BANNER_BID_REQUESTS[0], bidId: 'invalid-bid', mediaTypes: { video: {} } }
+      ];
+
+      // ACT
+      const requests = spec.buildRequests(mixedBidRequests, { ...DEFAULT_BANNER_BIDDER_REQUEST, bids: mixedBidRequests });
+
+      // ASSERT - only the valid bid produces a request; the invalid one is warned about
+      expect(requests).to.have.lengthOf(1);
+      expect(utils.logWarn.calledOnce).to.equal(true);
+      expect(utils.logWarn.args[0][0]).to.satisfy(arg => arg.includes('invalid media types'));
+    });
+
     it('should skip bid and log warning when converter returns null data', () => {
       // ASSEMBLE
-      const toORTBStub = sinon.stub(converter, 'toORTB').returns(null);
+      sandBox.stub(converter, 'toORTB').returns(null);
 
       // ACT
       const requests = spec.buildRequests(DEFAULT_BANNER_BID_REQUESTS, DEFAULT_BANNER_BIDDER_REQUEST);
@@ -949,13 +963,11 @@ describe('Equativ bid adapter tests', () => {
       expect(requests).to.be.an('array').that.is.empty;
       expect(utils.logWarn.calledOnce).to.equal(true);
       expect(utils.logWarn.args[0][0]).to.satisfy(arg => arg.includes('empty data'));
-
-      toORTBStub.restore();
     });
 
     it('should skip bid and log warning when request id is missing', () => {
       // ASSEMBLE
-      const toORTBStub = sinon.stub(converter, 'toORTB').returns({ imp: [{ id: 'abc' }] });
+      sandBox.stub(converter, 'toORTB').returns({ imp: [{ id: 'abc' }] });
 
       // ACT
       const requests = spec.buildRequests(DEFAULT_BANNER_BID_REQUESTS, DEFAULT_BANNER_BIDDER_REQUEST);
@@ -964,13 +976,11 @@ describe('Equativ bid adapter tests', () => {
       expect(requests).to.be.an('array').that.is.empty;
       expect(utils.logWarn.calledOnce).to.equal(true);
       expect(utils.logWarn.args[0][0]).to.satisfy(arg => arg.includes('missing required id'));
-
-      toORTBStub.restore();
     });
 
     it('should skip bid and log warning when request id is empty string', () => {
       // ASSEMBLE
-      const toORTBStub = sinon.stub(converter, 'toORTB').returns({ id: '', imp: [{ id: 'abc' }] });
+      sandBox.stub(converter, 'toORTB').returns({ id: '', imp: [{ id: 'abc' }] });
 
       // ACT
       const requests = spec.buildRequests(DEFAULT_BANNER_BID_REQUESTS, DEFAULT_BANNER_BIDDER_REQUEST);
@@ -979,13 +989,11 @@ describe('Equativ bid adapter tests', () => {
       expect(requests).to.be.an('array').that.is.empty;
       expect(utils.logWarn.calledOnce).to.equal(true);
       expect(utils.logWarn.args[0][0]).to.satisfy(arg => arg.includes('missing required id'));
-
-      toORTBStub.restore();
     });
 
     it('should skip bid and log warning when imp array is empty', () => {
       // ASSEMBLE
-      const toORTBStub = sinon.stub(converter, 'toORTB').returns({ id: 'req-id-123', imp: [] });
+      sandBox.stub(converter, 'toORTB').returns({ id: 'req-id-123', imp: [] });
 
       // ACT
       const requests = spec.buildRequests(DEFAULT_BANNER_BID_REQUESTS, DEFAULT_BANNER_BIDDER_REQUEST);
@@ -994,13 +1002,11 @@ describe('Equativ bid adapter tests', () => {
       expect(requests).to.be.an('array').that.is.empty;
       expect(utils.logWarn.calledOnce).to.equal(true);
       expect(utils.logWarn.args[0][0]).to.satisfy(arg => arg.includes('no valid impressions'));
-
-      toORTBStub.restore();
     });
 
     it('should skip bid and log warning when imp array is absent', () => {
       // ASSEMBLE
-      const toORTBStub = sinon.stub(converter, 'toORTB').returns({ id: 'req-id-123' });
+      sandBox.stub(converter, 'toORTB').returns({ id: 'req-id-123' });
 
       // ACT
       const requests = spec.buildRequests(DEFAULT_BANNER_BID_REQUESTS, DEFAULT_BANNER_BIDDER_REQUEST);
@@ -1009,8 +1015,6 @@ describe('Equativ bid adapter tests', () => {
       expect(requests).to.be.an('array').that.is.empty;
       expect(utils.logWarn.calledOnce).to.equal(true);
       expect(utils.logWarn.args[0][0]).to.satisfy(arg => arg.includes('no valid impressions'));
-
-      toORTBStub.restore();
     });
   });
 

--- a/test/spec/modules/equativBidAdapter_spec.js
+++ b/test/spec/modules/equativBidAdapter_spec.js
@@ -311,7 +311,7 @@ describe('Equativ bid adapter tests', () => {
           }
         }
       }];
-      delete bidRequests[0].params;
+      bidRequests[0].params = {};
       const bidderRequest = { ...DEFAULT_BANNER_BIDDER_REQUEST, bids: bidRequests };
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.data.site.publisher.id).to.equal(98);
@@ -342,7 +342,7 @@ describe('Equativ bid adapter tests', () => {
           }
         }
       }];
-      delete bidRequests[0].params;
+      bidRequests[0].params = {};
       const bidderRequest = { ...DEFAULT_BANNER_BIDDER_REQUEST, bids: bidRequests };
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.data.app.publisher.id).to.equal(27);
@@ -373,7 +373,7 @@ describe('Equativ bid adapter tests', () => {
           }
         }
       }];
-      delete bidRequests[0].params;
+      bidRequests[0].params = {};
       const bidderRequest = { ...DEFAULT_BANNER_BIDDER_REQUEST, bids: bidRequests };
       const request = spec.buildRequests(bidRequests, bidderRequest)[0];
       expect(request.data.dooh.publisher.id).to.equal(35);
@@ -620,23 +620,25 @@ describe('Equativ bid adapter tests', () => {
     });
 
     it('should warn about missing required properties for video requests', () => {
-      // ASSEMBLE
-      const missingRequiredVideoRequest = DEFAULT_VIDEO_BID_REQUESTS[0];
+      if (FEATURES.VIDEO) {
+        // ASSEMBLE
+        const missingRequiredVideoRequest = DEFAULT_VIDEO_BID_REQUESTS[0];
 
-      // removing required properties
-      delete missingRequiredVideoRequest.mediaTypes.video.mimes;
-      delete missingRequiredVideoRequest.mediaTypes.video.placement;
+        // removing required properties
+        delete missingRequiredVideoRequest.mediaTypes.video.mimes;
+        delete missingRequiredVideoRequest.mediaTypes.video.placement;
 
-      const bidRequests = [missingRequiredVideoRequest];
-      const bidderRequest = { ...DEFAULT_VIDEO_BIDDER_REQUEST, bids: bidRequests };
+        const bidRequests = [missingRequiredVideoRequest];
+        const bidderRequest = { ...DEFAULT_VIDEO_BIDDER_REQUEST, bids: bidRequests };
 
-      // ACT
-      spec.buildRequests(bidRequests, bidderRequest);
+        // ACT
+        spec.buildRequests(bidRequests, bidderRequest);
 
-      // ASSERT
-      expect(utils.logWarn.callCount).to.equal(2);
-      expect(utils.logWarn.getCall(0).args[0]).to.satisfy(arg => arg.includes('"mediaTypes.video.mimes" is missing'));
-      expect(utils.logWarn.getCall(1).args[0]).to.satisfy(arg => arg.includes('"mediaTypes.video.placement" is missing'));
+        // ASSERT
+        expect(utils.logWarn.callCount).to.equal(2);
+        expect(utils.logWarn.getCall(0).args[0]).to.satisfy(arg => arg.includes('"mediaTypes.video.mimes" is missing'));
+        expect(utils.logWarn.getCall(1).args[0]).to.satisfy(arg => arg.includes('"mediaTypes.video.placement" is missing'));
+      }
     });
 
     it('should not send a video request when it has an empty body and no other impressions with any media types are defined', () => {
@@ -741,11 +743,14 @@ describe('Equativ bid adapter tests', () => {
         spec.buildRequests(bidRequests, bidderRequest);
 
         // ASSERT
-        expect(utils.logWarn.callCount).to.equal(4); // the first message, regarding missing assets, is supplied by the ortbConverter library
+        // 4 warnings from the request itself + 1 from the adapter guard (no valid impressions,
+        // since the native processor skips imps with no assets)
+        expect(utils.logWarn.callCount).to.equal(5);
         expect(utils.logWarn.getCall(0).args[0]).to.satisfy(arg => arg.includes('no assets were specified'));
         expect(utils.logWarn.getCall(1).args[0]).to.satisfy(arg => arg.includes('"mediaTypes.native.ortb.privacy" is missing'));
         expect(utils.logWarn.getCall(2).args[0]).to.satisfy(arg => arg.includes('"mediaTypes.native.ortb.plcmttype" is missing'));
         expect(utils.logWarn.getCall(3).args[0]).to.satisfy(arg => arg.includes('"mediaTypes.native.ortb.eventtrackers" is missing'));
+        expect(utils.logWarn.getCall(4).args[0]).to.satisfy(arg => arg.includes('no valid impressions'));
       }
     });
 
@@ -931,6 +936,81 @@ describe('Equativ bid adapter tests', () => {
         loss: 0,
         price: cpm
       });
+    });
+
+    it('should skip bid and log warning when converter returns null data', () => {
+      // ASSEMBLE
+      const toORTBStub = sinon.stub(converter, 'toORTB').returns(null);
+
+      // ACT
+      const requests = spec.buildRequests(DEFAULT_BANNER_BID_REQUESTS, DEFAULT_BANNER_BIDDER_REQUEST);
+
+      // ASSERT
+      expect(requests).to.be.an('array').that.is.empty;
+      expect(utils.logWarn.calledOnce).to.equal(true);
+      expect(utils.logWarn.args[0][0]).to.satisfy(arg => arg.includes('empty data'));
+
+      toORTBStub.restore();
+    });
+
+    it('should skip bid and log warning when request id is missing', () => {
+      // ASSEMBLE
+      const toORTBStub = sinon.stub(converter, 'toORTB').returns({ imp: [{ id: 'abc' }] });
+
+      // ACT
+      const requests = spec.buildRequests(DEFAULT_BANNER_BID_REQUESTS, DEFAULT_BANNER_BIDDER_REQUEST);
+
+      // ASSERT
+      expect(requests).to.be.an('array').that.is.empty;
+      expect(utils.logWarn.calledOnce).to.equal(true);
+      expect(utils.logWarn.args[0][0]).to.satisfy(arg => arg.includes('missing required id'));
+
+      toORTBStub.restore();
+    });
+
+    it('should skip bid and log warning when request id is empty string', () => {
+      // ASSEMBLE
+      const toORTBStub = sinon.stub(converter, 'toORTB').returns({ id: '', imp: [{ id: 'abc' }] });
+
+      // ACT
+      const requests = spec.buildRequests(DEFAULT_BANNER_BID_REQUESTS, DEFAULT_BANNER_BIDDER_REQUEST);
+
+      // ASSERT
+      expect(requests).to.be.an('array').that.is.empty;
+      expect(utils.logWarn.calledOnce).to.equal(true);
+      expect(utils.logWarn.args[0][0]).to.satisfy(arg => arg.includes('missing required id'));
+
+      toORTBStub.restore();
+    });
+
+    it('should skip bid and log warning when imp array is empty', () => {
+      // ASSEMBLE
+      const toORTBStub = sinon.stub(converter, 'toORTB').returns({ id: 'req-id-123', imp: [] });
+
+      // ACT
+      const requests = spec.buildRequests(DEFAULT_BANNER_BID_REQUESTS, DEFAULT_BANNER_BIDDER_REQUEST);
+
+      // ASSERT
+      expect(requests).to.be.an('array').that.is.empty;
+      expect(utils.logWarn.calledOnce).to.equal(true);
+      expect(utils.logWarn.args[0][0]).to.satisfy(arg => arg.includes('no valid impressions'));
+
+      toORTBStub.restore();
+    });
+
+    it('should skip bid and log warning when imp array is absent', () => {
+      // ASSEMBLE
+      const toORTBStub = sinon.stub(converter, 'toORTB').returns({ id: 'req-id-123' });
+
+      // ACT
+      const requests = spec.buildRequests(DEFAULT_BANNER_BID_REQUESTS, DEFAULT_BANNER_BIDDER_REQUEST);
+
+      // ASSERT
+      expect(requests).to.be.an('array').that.is.empty;
+      expect(utils.logWarn.calledOnce).to.equal(true);
+      expect(utils.logWarn.args[0][0]).to.satisfy(arg => arg.includes('no valid impressions'));
+
+      toORTBStub.restore();
     });
   });
 


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Updated bidder adapter

## Description of change

This PR builds on #15125 and addresses the review comments raised there.

### Original fix (from #15125)

Root causes of ~2,200 invalid model errors and ~50 null body errors per 24h in SSB:
- `imp[]` could be empty when all impressions were filtered by `prepareSplitImps`
- The request `id` field could be absent if `bidderRequest.auctionId` was missing
- The POST body could be null if `converter.toORTB` returned nothing

Fix: three guards in `buildRequests` after `converter.toORTB`:
1. Skip bid if data is null/undefined
2. Skip bid if `data.id` is falsy
3. Skip bid if `data.imp` is empty

### Review comment fixes (addressing feedback on #15125)

- **Log `bid.bidId`** instead of full bid object in warnings to avoid exposing sensitive metadata
- **Move per-bid `isValid` check before `converter.toORTB`** to prevent side effects (`networkId`, `feedbackArray`) on bids that will be skipped
- **Early return in `request` customizer when `splitImps` is empty** — ensures `networkId` and `updateFeedbackData` are not called for bids producing no impressions
- **Guard `bidRequest.params` destructure with `|| {}`** for bids where params is undefined
- **Fix video properties test**: use `this.skip()` when `FEATURES.VIDEO` is off; deep-clone shared fixture to avoid mutation
- **Replace manual stub cleanup** with `sandBox.stub()` for guaranteed cleanup in `afterEach`
- **Add test** for mixed valid/invalid bid scenario

## Other information

61 unit tests passing. No user-facing API changes. No docs PR required.