### PR TITLE
OCM Bid Adapter: add bidder adapter, docs and tests

### DIFF
--- a/modules/ocmBidAdapter.d.ts
+++ b/modules/ocmBidAdapter.d.ts
@@ -1,0 +1,28 @@
+/**
+ * OCM bidder-specific parameters, supplied on each ad unit's `bids[].params`. These are the adapter's
+ * public interface; everything else (sizes, video/native config, consent, first-party data) is read
+ * from standard ad-unit / ORTB2 fields by the ORTB converter rather than from params.
+ */
+export interface OcmBidParams {
+  /**
+   * OCM-issued publisher ID. Used as the Prebid Server `account` and set as `site`/`app`
+   * `publisher.id` on the ORTB request. Required.
+   */
+  publisherId: string;
+  /**
+   * OCM placement ID; mapped to the PBS stored-request id (`imp.ext.prebid.storedrequest.id`).
+   * Required.
+   */
+  placementId: string;
+  /**
+   * Optional overrides deep-merged into the OCM outstream video player config at render time (an
+   * alternative to `mediaTypes.video.renderer.options`).
+   */
+  rendererConfig?: Record<string, unknown>;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    ocm: OcmBidParams;
+  }
+}

--- a/modules/ocmBidAdapter.js
+++ b/modules/ocmBidAdapter.js
@@ -438,16 +438,30 @@ function isOutstreamVideo(bidRequest) {
 }
 
 /**
- * Determines whether the OCM renderer should be installed on a bid. It is skipped when the publisher
- * supplied their own renderer (at the ad unit or mediaTypes.video level) that is not flagged
- * backupOnly, so the publisher's renderer wins. Prebid core enforces the same precedence at render
- * time (isRendererPreferredFromAdUnit in src/Renderer.js); this just avoids installing a redundant one.
+ * Determines whether a renderer object counts as a publisher-supplied renderer. This mirrors Prebid
+ * core's isRendererPreferredFromAdUnit (src/Renderer.js), which only prefers an ad-unit/mediaType
+ * renderer that defines BOTH `url` and `render`. In particular, the documented OCM override shape
+ * `mediaTypes.video.renderer.options` (an options-only holder with no `url`/`render`) is NOT a
+ * publisher renderer, so it must not suppress the OCM renderer.
+ * @param {Object} [renderer] - A candidate renderer (ad unit or mediaTypes.video level)
+ * @returns {boolean} True if it is a real publisher renderer that should take precedence
+ */
+function isPublisherRenderer(renderer) {
+  return !!(renderer && renderer.url && renderer.render && renderer.backupOnly !== true);
+}
+
+/**
+ * Determines whether the OCM renderer should be installed on a bid. It is skipped only when the
+ * publisher supplied their own real renderer (at the ad unit or mediaTypes.video level) that is not
+ * flagged backupOnly, so the publisher's renderer wins. An options-only renderer holder (the
+ * documented `mediaTypes.video.renderer.options` override) does not count and still gets the OCM
+ * renderer, matching the precedence Prebid core enforces at render time (isRendererPreferredFromAdUnit).
  * @param {BidRequest} bidRequest - The originating bid request
  * @returns {boolean} True if the OCM renderer should be installed
  */
 function shouldAttachRenderer(bidRequest) {
-  const publisherRenderer = bidRequest?.renderer || deepAccess(bidRequest, 'mediaTypes.video.renderer');
-  return !publisherRenderer || publisherRenderer.backupOnly === true;
+  return !(isPublisherRenderer(bidRequest?.renderer) ||
+    isPublisherRenderer(deepAccess(bidRequest, 'mediaTypes.video.renderer')));
 }
 
 /**

--- a/modules/ocmBidAdapter.js
+++ b/modules/ocmBidAdapter.js
@@ -68,16 +68,10 @@ const converter = ortbConverter({
  */
 
 /**
- * OCM bidder-specific parameters, supplied on each ad unit's `bids[].params`. These are the adapter's
- * public interface; everything else (sizes, video/native config, consent, first-party data) is read
- * from standard ad-unit / ORTB2 fields by the ORTB converter rather than from params.
- * @typedef {Object} OcmBidParams
- * @property {string} publisherId - OCM-issued publisher ID. Used as the Prebid Server `account` and set
- *   as `site`/`app` `publisher.id` on the ORTB request. Required.
- * @property {string} placementId - OCM placement ID; mapped to the PBS stored-request id
- *   (`imp.ext.prebid.storedrequest.id`). Required.
- * @property {Object} [rendererConfig] - Optional overrides deep-merged into the OCM outstream video
- *   player config at render time (an alternative to `mediaTypes.video.renderer.options`).
+ * OCM bidder-specific parameters (the adapter's public interface). The type is declared in the
+ * co-located ocmBidAdapter.d.ts, which also augments the global `BidderParams` map so `adUnit.bids[]`
+ * with `bidder: 'ocm'` are typed. Importing it here pulls the declaration into the TS program.
+ * @typedef {import('./ocmBidAdapter.d.ts').OcmBidParams} OcmBidParams
  */
 
 const ENDPOINT = 'https://pbam.orangeclickmedia.com/openrtb2/auction';
@@ -101,14 +95,6 @@ const GVLID = 1148;
 // video is deliberately left to the publisher's own player / ad server, so no renderer is attached
 // for it. The same player is used as a custom renderer in the OCM prebid wrapper (dsg-core).
 const RENDERER_URL = 'https://cdn.orangeclickmedia.com/tech/libs/ocm-player.js';
-
-// Publisher id captured during buildRequests and used as the fallback cookie_sync `account` in
-// getUserSyncs, which does not receive bid params. This is a last resort: getUserSyncs prefers an
-// account echoed by PBS in the auction response (which is correlated with the responses actually
-// being synced). The fallback is a single mutable scalar, so on a page running several OCM
-// auctions the most recent buildRequests wins — it therefore assumes a single OCM publisher per
-// page. See getUserSyncs.
-let syncAccount = null;
 
 /**
  * Checks if the bid request includes video media type
@@ -315,10 +301,6 @@ function addOrtbPublisherData(data, bidRequests) {
  * @returns {ServerRequest} Server request object with url, method, and data
  */
 function buildRequests(bidRequests, bidderRequest) {
-  // getUserSyncs has no access to bid params, so capture the publisher id here for reuse as the
-  // cookie_sync `account`.
-  syncAccount = bidRequests?.[0]?.params?.publisherId || null;
-
   const ortbRequest = converter.toORTB({ bidderRequest, bidRequests });
 
   return {
@@ -359,7 +341,9 @@ function interpretResponse(response, request) {
  * seats) — i.e. the bidders PBS actually invoked for the stored request — because the client has no
  * visibility into the stored request's contents.
  *
- * @param {Object} syncOptions - Allowed sync types (only iframe applies here; the loader is an HTML page)
+ * @param {Object} syncOptions - Allowed sync types. The loader itself is delivered as an iframe, and
+ *   the enabled types (iframeEnabled/pixelEnabled) are forwarded to it so it only drops syncs of a type
+ *   the publisher permitted.
  * @param {Array} serverResponses - Auction responses; source of the participating bidder list
  * @param {Object} gdprConsent - GDPR consent data (gdprApplies, consentString)
  * @param {string} uspConsent - US privacy (CCPA) consent string
@@ -367,8 +351,10 @@ function interpretResponse(response, request) {
  * @returns {Array<{type: string, url: string}>} A single iframe sync to the loader, or empty if disabled / no bidders
  */
 function getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) {
-  // The loader is an HTML page, so only iframe syncing applies here. The per-bidder pixels the
-  // loader itself drops still honour both image (redirect) and iframe sync types.
+  // The loader is an HTML page, so it can only be delivered as an iframe sync; if iframe syncing is
+  // disabled there is nothing to return. The sync types the loader is then allowed to actually drop
+  // (iframe vs image/redirect) are constrained by the `filter` it is passed below, derived from
+  // syncOptions, so a disabled sync type never fires from inside the loader iframe.
   if (!syncOptions.iframeEnabled) {
     return [];
   }
@@ -387,16 +373,30 @@ function getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent, gpp
     return [];
   }
 
+  // Forward the sync policy Prebid authorised so the loader can constrain its PBS /cookie_sync POST
+  // (filterSettings + coopSync) instead of dropping whatever PBS returns into the hidden iframe.
+  // Without this, image/redirect syncs (when only iframe is enabled) or cooperatively-synced bidders
+  // the publisher never authorised would still fire from inside the loader iframe. iframe is always
+  // allowed at this point (we returned early otherwise); image is allowed only when pixelEnabled.
+  const filter = syncOptions.pixelEnabled ? 'iframe,image' : 'iframe';
+
   const params = [
     `bidders=${encodeURIComponent([...bidders].slice(0, MAX_SYNC_COUNT).join(','))}`,
-    `limit=${MAX_SYNC_COUNT}`
+    `limit=${MAX_SYNC_COUNT}`,
+    `filter=${encodeURIComponent(filter)}`,
+    // Prebid only authorised syncing the bidders that participated in this auction, so disable PBS
+    // cooperative syncing (which would sync additional, unrequested bidders).
+    'coopSync=0'
   ];
 
-  // Prefer an account echoed by PBS in the auction response (correlated with these responses); fall
-  // back to the publisherId captured at request time (single-publisher-per-page assumption).
+  // The cookie_sync `account` is taken solely from the account PBS echoes in the auction response
+  // (ext.account), which is scoped to exactly these responses. Deriving it per-auction here — rather
+  // than from a shared module-level value captured in buildRequests — is what keeps overlapping OCM
+  // auctions (or multiple pbjs instances) from leaking one auction's publisher account into another's
+  // sync. OCM's PBS echoes ext.account for this purpose.
   const account = (serverResponses || [])
     .map((response) => response?.body?.ext?.account)
-    .find(Boolean) || syncAccount;
+    .find(Boolean);
   if (account) {
     params.push(`account=${encodeURIComponent(account)}`);
   }

--- a/modules/ocmBidAdapter.js
+++ b/modules/ocmBidAdapter.js
@@ -1,0 +1,680 @@
+import { BANNER, VIDEO, NATIVE } from '../src/mediaTypes.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { Renderer } from '../src/Renderer.js';
+import { toOrtbNativeRequest } from '../src/native.js';
+import { ortbConverter } from '../libraries/ortbConverter/converter.js';
+import { pbsExtensions } from '../libraries/pbsExtensions/pbsExtensions.js';
+import { deepSetValue, deepAccess, mergeDeep, getUniqueIdentifierStr, logMessage, logWarn, logError } from '../src/utils.js';
+import { EVENT_TYPE_IMPRESSION, TRACKER_METHOD_IMG } from '../src/eventTrackers.js';
+
+const converter = ortbConverter({
+  context: {
+    netRevenue: true,
+    ttl: 300
+  },
+  processors: pbsExtensions,
+  request(buildRequest, imps, bidderRequest, context) {
+    const request = buildRequest(imps, bidderRequest, context);
+
+    // Add publisherId to site or app
+    addOrtbPublisherData(request, context.bidRequests || []);
+
+    return request;
+  },
+  imp(buildImp, bidRequest, context) {
+    if (bidRequest?.params?.placementId) {
+      bidRequest.ortb2Imp = bidRequest.ortb2Imp || {};
+      bidRequest.ortb2Imp.ext = bidRequest.ortb2Imp.ext || {};
+      bidRequest.ortb2Imp.ext.prebid = bidRequest.ortb2Imp.ext.prebid || {};
+      bidRequest.ortb2Imp.ext.prebid.storedrequest = bidRequest.ortb2Imp.ext.prebid.storedrequest || {};
+      bidRequest.ortb2Imp.ext.prebid.storedrequest.id = bidRequest.params.placementId;
+    }
+
+    const imp = buildImp(bidRequest, context);
+
+    // The pbsExtensions params processor sets imp.ext.prebid.bidder.ocm = bid.params, which makes
+    // PBS try to call a server-side bidder named "ocm" with those params instead of resolving demand
+    // from the stored request — that is what breaks the OCM setup. Remove only that field; the rest
+    // of imp.ext.prebid (storedrequest, the price-floors floorMin set by setImpExtPrebidFloors, and
+    // adunitcode) is valid for PBS and passes through. imp.bidfloor / imp.bidfloorcur live at the imp
+    // root, are populated by the price-floors module, and are untouched here.
+    if (imp?.ext?.prebid?.bidder) {
+      delete imp.ext.prebid.bidder;
+    }
+
+    return imp;
+  },
+  bidResponse(buildBidResponse, bid, context) {
+    const bidResponse = buildBidResponse(bid, context);
+
+    // Attach the OCM outstream video renderer here rather than in interpretResponse: the converter
+    // exposes context.bidRequest (the original Prebid bid request, matched to this bid by imp id),
+    // which is the only place the video context (outstream vs instream) is known. interpretResponse
+    // only receives the ServerRequest, so it cannot tell which bids are outstream.
+    maybeAttachOutstreamRenderer(bidResponse, context.bidRequest);
+
+    // Register the impression event URL PBS returns at bid.ext.prebid.events.imp as an ORTB event
+    // tracker so Prebid core fires it at billing time. The matching win URL is registered upstream by
+    // the shared pbsExtensions processor (addEventTrackers). See addPbsEventTrackers.
+    addPbsEventTrackers(bidResponse, bid);
+
+    return bidResponse;
+  }
+});
+
+/**
+ * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
+ * @typedef {import('../src/adapters/bidderFactory.js').ServerRequest} ServerRequest
+ */
+
+/**
+ * OCM bidder-specific parameters, supplied on each ad unit's `bids[].params`. These are the adapter's
+ * public interface; everything else (sizes, video/native config, consent, first-party data) is read
+ * from standard ad-unit / ORTB2 fields by the ORTB converter rather than from params.
+ * @typedef {Object} OcmBidParams
+ * @property {string} publisherId - OCM-issued publisher ID. Used as the Prebid Server `account` and set
+ *   as `site`/`app` `publisher.id` on the ORTB request. Required.
+ * @property {string} placementId - OCM placement ID; mapped to the PBS stored-request id
+ *   (`imp.ext.prebid.storedrequest.id`). Required.
+ * @property {Object} [rendererConfig] - Optional overrides deep-merged into the OCM outstream video
+ *   player config at render time (an alternative to `mediaTypes.video.renderer.options`).
+ */
+
+const ENDPOINT = 'https://pbam.orangeclickmedia.com/openrtb2/auction';
+
+// getUserSyncs can only emit GET descriptors, but PBS /cookie_sync is POST-only. Syncing is
+// therefore routed through a GET-renderable loader page (hosted on the OCM origin) that POSTs to
+// /cookie_sync and drops the per-bidder sync pixels it returns. See ocmBidAdapter.md and the
+// reference loader in tasks/cookie_sync.html.
+const USER_SYNC_LOADER = 'https://pbam.orangeclickmedia.com/static/cookie_sync.html';
+
+// Maximum number of bidders forwarded to a single cookie_sync (mirrors the cookie_sync `limit`).
+const MAX_SYNC_COUNT = 10;
+
+const BIDDER_CODE = 'ocm';
+
+const GVLID = 1148;
+
+// Outstream video renderer. OCM outstream bids are rendered client-side by the OCM Video Player;
+// Prebid's Renderer lazily loads this script (via loadExternalScript) the first time such a bid
+// renders, and it exposes the global `window.OcmPlayer(containerId, config, callback)`. Instream
+// video is deliberately left to the publisher's own player / ad server, so no renderer is attached
+// for it. The same player is used as a custom renderer in the OCM prebid wrapper (dsg-core).
+const RENDERER_URL = 'https://cdn.orangeclickmedia.com/tech/libs/ocm-player.js';
+
+// Publisher id captured during buildRequests and used as the fallback cookie_sync `account` in
+// getUserSyncs, which does not receive bid params. This is a last resort: getUserSyncs prefers an
+// account echoed by PBS in the auction response (which is correlated with the responses actually
+// being synced). The fallback is a single mutable scalar, so on a page running several OCM
+// auctions the most recent buildRequests wins — it therefore assumes a single OCM publisher per
+// page. See getUserSyncs.
+let syncAccount = null;
+
+/**
+ * Checks if the bid request includes video media type
+ * @param {BidRequest} bid - The bid request object to check
+ * @returns {boolean} True if video media type is present, false otherwise
+ */
+function hasTypeVideo(bid) {
+  return typeof bid.mediaTypes !== 'undefined' && typeof bid.mediaTypes.video !== 'undefined';
+}
+
+/**
+ * Determines if the native request uses ORTB (OpenRTB) format
+ * @param {BidRequest} bidRequest - The bid request to check
+ * @returns {boolean} True if using ORTB native format, false otherwise
+ */
+function isNativeOrtbVersion(bidRequest) {
+  return bidRequest.mediaTypes.native.ortb && typeof bidRequest.mediaTypes.native.ortb === 'object';
+}
+
+/**
+ * Validates a native asset object according to ORTB native spec
+ * Checks for required fields: id, content (title/img/data/video), and type-specific requirements
+ * @param {Object} asset - The native asset to validate
+ * @returns {boolean} True if the asset is valid, false otherwise
+ */
+function isValidAsset(asset) {
+  // Asset must have a valid integer ID
+  if (!asset.hasOwnProperty('id') || !Number.isInteger(asset.id)) {
+    return false;
+  }
+
+  // Asset must contain at least one content type
+  const hasValidContent = asset.title || asset.img || asset.data || asset.video;
+  if (!hasValidContent) {
+    return false;
+  }
+
+  // Title assets must have a valid length
+  if (asset.title && (!asset.title.len || !Number.isInteger(asset.title.len))) {
+    return false;
+  }
+
+  // Data assets must have a valid type
+  if (asset.data && (!asset.data.type || !Number.isInteger(asset.data.type))) {
+    return false;
+  }
+
+  // Video assets must have required fields: mimes, duration constraints, and protocols.
+  // Duration bounds are checked with Number.isInteger so a legitimate minduration/maxduration of 0
+  // is not mistakenly rejected as falsy.
+  if (asset.video && (!asset.video.mimes || !Number.isInteger(asset.video.minduration) || !Number.isInteger(asset.video.maxduration) || !asset.video.protocols)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Validates a native event tracker object according to ORTB native spec
+ * Checks for required event type and tracking methods
+ * @param {Object} et - The event tracker to validate
+ * @returns {boolean} True if the event tracker is valid, false otherwise
+ */
+function isValidEventTracker(et) {
+  // Event tracker must have a valid event type (integer) and at least one method
+  if (!et.event || !Number.isInteger(et.event) || !Array.isArray(et.methods) || et.methods.length === 0) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Validates a bid request for a specific media type
+ * @param {string} type - The media type to validate (BANNER, VIDEO, or NATIVE)
+ * @param {BidRequest} bid - The bid request to validate
+ * @returns {boolean} True if the bid is valid for the specified media type, false otherwise
+ */
+function isValid(type, bid) {
+  // Banner bids must declare at least one size
+  if (type === BANNER) {
+    return hasBannerSizes(bid);
+  }
+
+  // Video bids must have a valid context (outstream/instream) and at least one player size
+  if (type === VIDEO && hasTypeVideo(bid)) {
+    const context = bid.mediaTypes.video.context;
+    if (context === 'outstream' || context === 'instream') {
+      return hasVideoSize(bid);
+    }
+  }
+
+  // Native bids must have valid assets and optionally valid event trackers
+  if (type === NATIVE) {
+    // Read mediaTypes.native defensively: isValid(NATIVE, ...) is evaluated for every bid (see
+    // isBidRequestValid), including banner/video bids or malformed bids with no mediaTypes at all, so
+    // the presence check must not assume mediaTypes exists (mirrors hasBannerSizes / hasTypeVideo).
+    const native = bid?.mediaTypes?.native;
+    if (typeof native !== 'object' || native === null) {
+      return false;
+    }
+
+    // Handle legacy native params by converting to ORTB format
+    if (!isNativeOrtbVersion(bid)) {
+      if (bid.nativeParams === undefined) return false;
+      const ortbConversion = toOrtbNativeRequest(bid.nativeParams);
+      return ortbConversion && ortbConversion.assets &&
+        Array.isArray(ortbConversion.assets) && ortbConversion.assets.length > 0 &&
+        ortbConversion.assets.every(asset => isValidAsset(asset));
+    }
+
+    // Validate ORTB native format
+    let isValidAssets = false;
+    let isValidEventTrackers;
+
+    const assets = bid.mediaTypes.native?.ortb?.assets;
+    const eventTrackers = bid.mediaTypes.native?.ortb?.eventtrackers;
+
+    // At least one valid asset is required
+    if (assets && Array.isArray(assets) && assets.length > 0 && assets.every(asset => isValidAsset(asset))) {
+      isValidAssets = true;
+    }
+
+    // Event trackers are optional, but if present must be valid
+    if (eventTrackers && Array.isArray(eventTrackers) && eventTrackers.length > 0) {
+      isValidEventTrackers = eventTrackers.every(eventTracker => isValidEventTracker(eventTracker));
+    } else {
+      isValidEventTrackers = true;
+    }
+    return isValidAssets && isValidEventTrackers;
+  }
+
+  return false;
+}
+
+/**
+ * Determines whether a bid declares at least one banner size.
+ * Reads mediaTypes.banner.sizes — the shape Prebid core normalizes ad-unit sizes into. The actual
+ * ORTB sizes are built by ortbConverter; this is only a presence check for validation, so no size
+ * objects are allocated here.
+ * @param {BidRequest} bid - The bid request object
+ * @returns {boolean} True if at least one banner size is present, false otherwise
+ */
+function hasBannerSizes(bid) {
+  const sizes = bid?.mediaTypes?.banner?.sizes;
+  return Array.isArray(sizes) && sizes.length > 0;
+}
+
+/**
+ * Determines whether a video bid declares at least one player size.
+ * @param {BidRequest} bid - The bid request object with video media type
+ * @returns {boolean} True if at least one player size is present, false otherwise
+ */
+function hasVideoSize(bid) {
+  const playerSize = bid?.mediaTypes?.video?.playerSize;
+  return Array.isArray(playerSize) && playerSize.length > 0;
+}
+
+/**
+ * Determines whether or not the given bid request is valid.
+ * Validates required parameters (publisherId, placementId) and media type specifications.
+ * @param {BidRequest} bid - The bid request object to validate
+ * @returns {boolean} True if this is a valid bid with all required params and at least one valid media type, false otherwise
+ */
+function isBidRequestValid(bid) {
+  if (!bid?.params) {
+    return false;
+  }
+
+  /** @type {OcmBidParams} */
+  const params = bid.params;
+  // publisherId and placementId are both required and must be strings
+  if (typeof params.publisherId !== 'string' || typeof params.placementId !== 'string') {
+    return false;
+  }
+
+  // Bid must be valid for at least one supported media type
+  return isValid(BANNER, bid) || isValid(VIDEO, bid) || isValid(NATIVE, bid);
+}
+
+/**
+ * Adds publisher identification data to the OpenRTB request
+ * Merges publisherId from bid params into the site or app publisher object
+ * @param {Object} data - The OpenRTB request data object
+ * @param {Array<BidRequest>} bidRequests - Array of bid requests containing publisher params
+ * @returns {void}
+ */
+function addOrtbPublisherData(data, bidRequests) {
+  const params = bidRequests[0]?.params || {};
+  const key = data.app ? 'app' : 'site';
+
+  // Set the publisher id unconditionally so it is attached even when the converter/FPD
+  // did not pre-seed a publisher object (deepSetValue creates the intermediate objects).
+  if (params.publisherId) {
+    deepSetValue(data, `${key}.publisher.id`, params.publisherId);
+  }
+}
+
+/**
+ * Constructs server requests from the list of valid bid requests.
+ * Builds OpenRTB-formatted requests to send to the OCM bid server.
+ * @param {Array<BidRequest>} bidRequests - Array of valid bid requests
+ * @param {Object} bidderRequest - Additional data for the bidder request (referer, GDPR consent, etc.)
+ * @returns {ServerRequest} Server request object with url, method, and data
+ */
+function buildRequests(bidRequests, bidderRequest) {
+  // getUserSyncs has no access to bid params, so capture the publisher id here for reuse as the
+  // cookie_sync `account`.
+  syncAccount = bidRequests?.[0]?.params?.publisherId || null;
+
+  const ortbRequest = converter.toORTB({ bidderRequest, bidRequests });
+
+  return {
+    method: 'POST',
+    url: ENDPOINT,
+    data: ortbRequest,
+  };
+}
+
+/**
+ * Parses the server response and converts it into bid response objects.
+ * Interprets OpenRTB bid responses and maps them to Prebid bid objects.
+ * @param {Object} response - The server's response object
+ * @param {Object} request - The original bidder request for reference
+ * @returns {Array} Array of bid response objects
+ */
+function interpretResponse(response, request) {
+  // Return the bids array (not the converter's wrapper object): bidderFactory only treats a wrapper
+  // as a BidderAuctionResponse when its keys are limited to bids/paapi, so returning the array is
+  // the robust, conventional contract. Every bid is attributed to OCM — PBS resolves demand from
+  // real server-side seats, and Prebid would otherwise drop those bids as alternate bidder codes.
+  const { bids = [] } = converter.fromORTB({ request: request.data, response: response.body });
+  bids.forEach((bid) => {
+    bid.bidderCode = BIDDER_CODE;
+  });
+  return bids;
+}
+
+/**
+ * Registers user syncs (cookie syncing) for OCM's Prebid Server.
+ *
+ * Because `getUserSyncs` can only return GET descriptors while PBS `/cookie_sync` is POST-only, the
+ * sync is routed through a GET-renderable loader page (USER_SYNC_LOADER) hosted on the OCM origin.
+ * This adapter hands the loader the participating bidder list and consent signals; the loader then
+ * POSTs to `/cookie_sync` (with credentials) and drops the per-bidder sync pixels it returns.
+ *
+ * The bidder list comes from the auction response (`ext.responsetimemillis` keys, plus any seatbid
+ * seats) — i.e. the bidders PBS actually invoked for the stored request — because the client has no
+ * visibility into the stored request's contents.
+ *
+ * @param {Object} syncOptions - Allowed sync types (only iframe applies here; the loader is an HTML page)
+ * @param {Array} serverResponses - Auction responses; source of the participating bidder list
+ * @param {Object} gdprConsent - GDPR consent data (gdprApplies, consentString)
+ * @param {string} uspConsent - US privacy (CCPA) consent string
+ * @param {Object} gppConsent - GPP consent data (gppString, applicableSections)
+ * @returns {Array<{type: string, url: string}>} A single iframe sync to the loader, or empty if disabled / no bidders
+ */
+function getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) {
+  // The loader is an HTML page, so only iframe syncing applies here. The per-bidder pixels the
+  // loader itself drops still honour both image (redirect) and iframe sync types.
+  if (!syncOptions.iframeEnabled) {
+    return [];
+  }
+
+  // PBS reports the bidders it invoked for the stored request in the auction response.
+  const bidders = new Set();
+  (serverResponses || []).forEach((response) => {
+    const body = response?.body;
+    Object.keys(body?.ext?.responsetimemillis || {}).forEach((bidder) => bidders.add(bidder));
+    (body?.seatbid || []).forEach((seatbid) => {
+      if (seatbid?.seat) bidders.add(seatbid.seat);
+    });
+  });
+
+  if (bidders.size === 0) {
+    return [];
+  }
+
+  const params = [
+    `bidders=${encodeURIComponent([...bidders].slice(0, MAX_SYNC_COUNT).join(','))}`,
+    `limit=${MAX_SYNC_COUNT}`
+  ];
+
+  // Prefer an account echoed by PBS in the auction response (correlated with these responses); fall
+  // back to the publisherId captured at request time (single-publisher-per-page assumption).
+  const account = (serverResponses || [])
+    .map((response) => response?.body?.ext?.account)
+    .find(Boolean) || syncAccount;
+  if (account) {
+    params.push(`account=${encodeURIComponent(account)}`);
+  }
+
+  if (gdprConsent) {
+    if (gdprConsent.gdprApplies !== undefined) {
+      params.push(`gdpr=${gdprConsent.gdprApplies ? 1 : 0}`);
+    }
+    if (gdprConsent.consentString) {
+      params.push(`gdpr_consent=${encodeURIComponent(gdprConsent.consentString)}`);
+    }
+  }
+
+  if (uspConsent) {
+    params.push(`us_privacy=${encodeURIComponent(uspConsent)}`);
+  }
+
+  if (gppConsent) {
+    if (gppConsent.gppString) {
+      params.push(`gpp=${encodeURIComponent(gppConsent.gppString)}`);
+    }
+    if (Array.isArray(gppConsent.applicableSections) && gppConsent.applicableSections.length > 0) {
+      params.push(`gpp_sid=${encodeURIComponent(gppConsent.applicableSections.join(','))}`);
+    }
+  }
+
+  return [{ type: 'iframe', url: `${USER_SYNC_LOADER}?${params.join('&')}` }];
+}
+
+/**
+ * Determines whether a bid request is an outstream video placement. Only outstream needs a
+ * client-side renderer: instream video is played by the publisher's own video player / ad server,
+ * while banner and native are rendered by Prebid core.
+ * @param {BidRequest} bidRequest - The originating bid request
+ * @returns {boolean} True if mediaTypes.video.context === 'outstream'
+ */
+function isOutstreamVideo(bidRequest) {
+  return deepAccess(bidRequest, 'mediaTypes.video.context') === 'outstream';
+}
+
+/**
+ * Determines whether the OCM renderer should be installed on a bid. It is skipped when the publisher
+ * supplied their own renderer (at the ad unit or mediaTypes.video level) that is not flagged
+ * backupOnly, so the publisher's renderer wins. Prebid core enforces the same precedence at render
+ * time (isRendererPreferredFromAdUnit in src/Renderer.js); this just avoids installing a redundant one.
+ * @param {BidRequest} bidRequest - The originating bid request
+ * @returns {boolean} True if the OCM renderer should be installed
+ */
+function shouldAttachRenderer(bidRequest) {
+  const publisherRenderer = bidRequest?.renderer || deepAccess(bidRequest, 'mediaTypes.video.renderer');
+  return !publisherRenderer || publisherRenderer.backupOnly === true;
+}
+
+/**
+ * Attaches the OCM outstream video renderer to a bid response when applicable, mutating it in place.
+ * No-op for non-video bids, instream video, or when a publisher renderer takes precedence.
+ * @param {Object} bidResponse - The bid response built by the ORTB converter
+ * @param {BidRequest} [bidRequest] - The originating bid request (context.bidRequest)
+ * @returns {void}
+ */
+function maybeAttachOutstreamRenderer(bidResponse, bidRequest) {
+  if (!bidResponse || bidResponse.mediaType !== VIDEO || !bidRequest) {
+    return;
+  }
+  if (isOutstreamVideo(bidRequest) && shouldAttachRenderer(bidRequest)) {
+    bidResponse.renderer = createRenderer(bidRequest);
+  }
+}
+
+/**
+ * Builds a (not-yet-loaded) Prebid Renderer for an outstream video bid. The Renderer lazily loads
+ * RENDERER_URL via loadExternalScript on first render, then calls ocmOutstreamRender. Publisher
+ * overrides from mediaTypes.video.renderer.options (or params.rendererConfig) are stored on the
+ * renderer config and deep-merged into the player config at render time.
+ * @param {BidRequest} bidRequest - The originating bid request
+ * @returns {Renderer} The configured renderer
+ */
+function createRenderer(bidRequest) {
+  const config = deepAccess(bidRequest, 'mediaTypes.video.renderer.options') ||
+    deepAccess(bidRequest, 'params.rendererConfig') || {};
+
+  const renderer = Renderer.install({
+    id: bidRequest.adUnitCode,
+    url: RENDERER_URL,
+    config,
+    adUnitCode: bidRequest.adUnitCode,
+    loaded: false
+  });
+
+  try {
+    renderer.setRender(ocmOutstreamRender);
+  } catch (e) {
+    logError(`${BIDDER_CODE}: error calling setRender on outstream renderer`, e);
+  }
+
+  return renderer;
+}
+
+/**
+ * Renderer entry point Prebid invokes when an outstream bid wins and must be displayed. Rendering is
+ * deferred via renderer.push so the player call only runs once RENDERER_URL has loaded and
+ * window.OcmPlayer is defined (push buffers the call until then; see src/Renderer.js).
+ * @param {Object} bid - The winning bid (vastUrl/vastXml, playerWidth/playerHeight, adUnitCode, renderer)
+ * @param {Document} [doc] - Document Prebid wants the ad rendered into (defaults to window.document)
+ * @returns {void}
+ */
+function ocmOutstreamRender(bid, doc) {
+  bid.renderer.push(() => renderOcmPlayer(bid, doc));
+}
+
+/**
+ * Instantiates the OCM Video Player for an outstream bid. Locates the ad slot by adUnitCode, injects
+ * a dedicated wrapper element (so the player cannot clobber sibling slot content), builds the player
+ * config from the bid, and calls the global window.OcmPlayer(containerId, config, callback).
+ * @param {Object} bid - The winning bid
+ * @param {Document} [doc] - Target document (defaults to window.document)
+ * @returns {void}
+ */
+function renderOcmPlayer(bid, doc) {
+  const ownerDocument = doc || document;
+
+  if (typeof window.OcmPlayer !== 'function') {
+    logError(`${BIDDER_CODE}: window.OcmPlayer unavailable; cannot render outstream bid for ${bid?.adUnitCode}`);
+    return;
+  }
+
+  const slot = ownerDocument.getElementById(bid.adUnitCode);
+  if (!slot) {
+    logError(`${BIDDER_CODE}: outstream container '${bid.adUnitCode}' not found`);
+    return;
+  }
+
+  // Render into a dedicated child element so repeat renders / multiple slots cannot collide.
+  const wrapper = ownerDocument.createElement('div');
+  wrapper.id = `ocm-player-wrapper-${bid.adId || getUniqueIdentifierStr()}`;
+  slot.appendChild(wrapper);
+
+  try {
+    window.OcmPlayer(wrapper.id, buildOcmPlayerConfig(bid), () => {
+      logMessage(`${BIDDER_CODE}: OCM player ready for ad unit ${bid.adUnitCode}`);
+    });
+  } catch (e) {
+    logError(`${BIDDER_CODE}: OCM player failed to render for ${bid.adUnitCode}`, e);
+  }
+}
+
+/**
+ * Builds the OCM Video Player config for an outstream bid, mirroring the defaults used by OCM's
+ * prebid wrapper (in-article outstream, muted autoplay, collapse on completion). The VAST source —
+ * preferring the hosted bid.vastUrl and falling back to inline bid.vastXml — is injected as the
+ * preroll, and the player is sized from the bid's player/creative dimensions. Publisher overrides
+ * stored on the renderer config are deep-merged last so they take precedence.
+ * @param {Object} bid - The winning bid
+ * @returns {Object} The config object passed to window.OcmPlayer
+ */
+function buildOcmPlayerConfig(bid) {
+  const overrides = (typeof bid.renderer?.getConfig === 'function' && bid.renderer.getConfig()) || {};
+
+  const width = bid.playerWidth || bid.width;
+  const height = bid.playerHeight || bid.height;
+  const vast = bid.vastUrl || bid.vastXml;
+
+  const config = {
+    player: {
+      outstream: { type: 'in-article' },
+      titleBar: false,
+      playAds: true,
+      autoplay: true,
+      autoplayInview: true,
+      autoplayInviewPct: 50,
+      pauseWhenOutOfViewport: false,
+      volume: true,
+      fullscreen: false,
+      controls: true,
+      controlsTimeout: 500,
+      autohideAdControls: true,
+      startVolume: 0,
+      muted: true,
+      onVideoEnd: 'collapse'
+    },
+    playlist: [],
+    ads: {
+      data: {},
+      preroll: [{ waterfall: [{ vast: { url: vast } }] }],
+      prebid: { enabled: false }
+    }
+  };
+
+  if (width != null) {
+    config.player.width = typeof width === 'number' ? `${width}px` : width;
+  }
+  if (height != null) {
+    config.player.height = typeof height === 'number' ? `${height}px` : height;
+  }
+
+  return mergeDeep(config, overrides);
+}
+
+/**
+ * Registers the impression event URL PBS returns on a bid at `bid.ext.prebid.events.imp` as an ORTB
+ * event tracker on the bid response, so Prebid core fires it at the protocol-defined time instead of
+ * this adapter pinging it directly. It is added as an EVENT_TYPE_IMPRESSION image pixel, which core
+ * fires when the bid is billed — on render for a normal ad unit, or on `pbjs.triggerBilling()` for a
+ * unit that defers billing (adapterManager.triggerBilling, invoked from auction addWinningBid).
+ *
+ * The win URL (`bid.ext.prebid.events.win`) is intentionally not handled here: the shared pbsExtensions
+ * processor (addEventTrackers in libraries/pbsExtensions/processors/eventTrackers.js) already maps it
+ * to an EVENT_TYPE_WIN tracker, which core fires the moment the bid wins (markWinningBid in
+ * src/adRendering). That processor does not map `events.imp` — the impression URL this fills in.
+ *
+ * The dedup guard is still needed on the impression path: that same shared processor maps a legacy
+ * `bid.burl` to an EVENT_TYPE_IMPRESSION tracker, so when PBS sets `burl` to the same `/event` URL it
+ * puts in `events.imp`, skipping the duplicate avoids firing the impression twice. For video, PBS
+ * injects the impression tracker into the VAST server-side, so `events.imp` is normally absent on
+ * video bids and nothing is added for them.
+ * @param {Object} bidResponse - The bid response built by the ORTB converter (mutated in place)
+ * @param {Object} bid - The raw ORTB bid, source of ext.prebid.events.imp
+ * @returns {void}
+ */
+function addPbsEventTrackers(bidResponse, bid) {
+  const impUrl = bid?.ext?.prebid?.events?.imp;
+  if (!bidResponse || !impUrl) {
+    return;
+  }
+
+  bidResponse.eventtrackers = bidResponse.eventtrackers || [];
+  const alreadyTracked = bidResponse.eventtrackers.some(
+    (tracker) => tracker.event === EVENT_TYPE_IMPRESSION && tracker.method === TRACKER_METHOD_IMG && tracker.url === impUrl
+  );
+  if (!alreadyTracked) {
+    bidResponse.eventtrackers.push({ method: TRACKER_METHOD_IMG, event: EVENT_TYPE_IMPRESSION, url: impUrl });
+  }
+}
+
+// No onBidWon handler is registered. OCM's billing URL (bid.burl) is turned into an ORTB
+// EVENT_TYPE_IMPRESSION tracker by the shared pbsExtensions processor (see addPbsEventTrackers), and
+// Prebid core fires that tracker exactly once at billing time (adapterManager.triggerBilling). Firing
+// burl again from onBidWon would double-count the billing event. The win-notice URL (bid.nurl) is
+// likewise consumed by the ORTB converter per media type (a render pixel for banner, the creative URL
+// for video/audio), so the adapter never pings it directly either.
+
+/**
+ * Logs a warning when OCM bid request(s) time out. Auction analytics are reported separately by
+ * the OCM analytics adapter (ocmPbaAdapter), so this handler is log-only to aid debugging and
+ * deliberately performs no network calls (avoiding duplicate event reporting).
+ * @param {Array<Object>} timeoutData - Array of timeout information objects
+ * @returns {void}
+ */
+function onTimeout(timeoutData) {
+  logWarn(`${BIDDER_CODE}: bid request(s) timed out`, timeoutData);
+}
+
+/**
+ * Logs an error when the OCM server responds with an error. Log-only for debugging; no network
+ * calls are made because analytics are handled by the OCM analytics adapter (ocmPbaAdapter).
+ * @param {Object} args - Error context
+ * @param {Object} args.error - The error/XHR object
+ * @param {Object} args.bidderRequest - The originating bidder request
+ * @returns {void}
+ */
+function onBidderError({ error, bidderRequest }) {
+  logError(`${BIDDER_CODE}: server responded with an error`, error, bidderRequest);
+}
+
+/**
+ * Bidder adapter specification object for OCM
+ * @type {Object}
+ */
+export const spec = {
+  code: BIDDER_CODE,
+  gvlid: GVLID,
+  supportedMediaTypes: [BANNER, VIDEO, NATIVE],
+  isBidRequestValid: isBidRequestValid,
+  buildRequests: buildRequests,
+  interpretResponse: interpretResponse,
+  getUserSyncs: getUserSyncs,
+  onTimeout: onTimeout,
+  onBidderError: onBidderError,
+};
+
+registerBidder(spec);

--- a/modules/ocmBidAdapter.md
+++ b/modules/ocmBidAdapter.md
@@ -27,8 +27,8 @@ var adUnits = [
         bids: [{
             bidder: 'ocm',
             params: {
-                publisherId: 'your_publisher_id',
-                placementId: 'your_placement_id'
+                publisherId: 'orangeclickmedia.com',
+                placementId: '65b49bb0cc723602'
             }
         }]
     }

--- a/modules/ocmBidAdapter.md
+++ b/modules/ocmBidAdapter.md
@@ -1,0 +1,277 @@
+# Overview
+
+```
+Module Name: OCM Bid Adapter
+Module Type: Bidder Adapter
+Maintainer: support@orangeclickmedia.com
+```
+
+# Description
+
+OCM Bid Adapter supports Banner, Video, and Native media types.
+
+The adapter uses OpenRTB format and connects to Orange Click Media's prebid server.
+
+# Test Parameters
+
+## Banner Ad Unit
+```javascript
+var adUnits = [
+    {
+        code: 'banner-ad-unit',
+        mediaTypes: {
+            banner: {
+                sizes: [[300, 250], [728, 90]]
+            }
+        },
+        bids: [{
+            bidder: 'ocm',
+            params: {
+                publisherId: 'your_publisher_id',
+                placementId: 'your_placement_id'
+            }
+        }]
+    }
+];
+```
+
+## Video Ad Unit: Instream
+```javascript
+var adUnits = [
+    {
+        code: 'video-instream-ad-unit',
+        mediaTypes: {
+            video: {
+                context: 'instream',
+                playerSize: [640, 480],
+                mimes: ['video/mp4', 'video/webm'],
+                protocols: [2, 3, 5, 6],
+                maxduration: 30,
+                minduration: 5
+            }
+        },
+        bids: [{
+            bidder: 'ocm',
+            params: {
+                publisherId: 'your_publisher_id',
+                placementId: 'your_placement_id'
+            }
+        }]
+    }
+];
+```
+
+## Video Ad Unit: Outstream
+```javascript
+var adUnits = [
+    {
+        code: 'video-outstream-ad-unit',
+        mediaTypes: {
+            video: {
+                context: 'outstream',
+                playerSize: [640, 480],
+                mimes: ['video/mp4'],
+                protocols: [2, 3, 5, 6]
+            }
+        },
+        bids: [{
+            bidder: 'ocm',
+            params: {
+                publisherId: 'your_publisher_id',
+                placementId: 'your_placement_id'
+            }
+        }]
+    }
+];
+```
+
+## Native Ad Unit
+```javascript
+var adUnits = [
+    {
+        code: 'native-ad-unit',
+        mediaTypes: {
+            native: {
+                ortb: {
+                    assets: [
+                        {
+                            id: 1,
+                            required: 1,
+                            title: {
+                                len: 80
+                            }
+                        },
+                        {
+                            id: 2,
+                            required: 1,
+                            img: {
+                                type: 3,
+                                w: 150,
+                                h: 150
+                            }
+                        },
+                        {
+                            id: 3,
+                            required: 0,
+                            data: {
+                                type: 1
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        bids: [{
+            bidder: 'ocm',
+            params: {
+                publisherId: 'your_publisher_id',
+                placementId: 'your_placement_id'
+            }
+        }]
+    }
+];
+```
+
+## Multi-Format Ad Unit
+```javascript
+var adUnits = [
+    {
+        code: 'multi-format-ad-unit',
+        mediaTypes: {
+            banner: {
+                sizes: [[300, 250], [728, 90]]
+            },
+            video: {
+                context: 'outstream',
+                playerSize: [640, 480],
+                mimes: ['video/mp4']
+            },
+            native: {
+                ortb: {
+                    assets: [
+                        {
+                            id: 1,
+                            required: 1,
+                            title: {
+                                len: 80
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        bids: [{
+            bidder: 'ocm',
+            params: {
+                publisherId: 'your_publisher_id',
+                placementId: 'your_placement_id'
+            }
+        }]
+    }
+];
+```
+
+# Outstream Video Rendering
+
+Outstream video bids are rendered automatically by the adapter using the **OCM Video Player**. When
+an outstream video bid is built, the adapter attaches a Prebid `Renderer` to it; Prebid lazily loads
+the player script (`https://cdn.orangeclickmedia.com/tech/libs/ocm-player.js`) the first time the bid
+renders, then calls the global `window.OcmPlayer(containerId, config, callback)`. The player is
+mounted into a child element of the ad unit's slot (`document.getElementById(adUnitCode)`), sized from
+the bid's player size, and fed the bid's VAST (`vastUrl`, falling back to inline `vastXml`).
+
+No extra configuration is required — defining an outstream video ad unit (see the example above) is
+enough. Notes:
+
+- **Instream** video is left untouched; it is expected to be rendered by the publisher's own video
+  player / ad server.
+- **Publisher renderers win.** If you define your own renderer on the ad unit (`adUnit.renderer`) or
+  on `mediaTypes.video.renderer` and it is not flagged `backupOnly: true`, the OCM renderer is not
+  installed and your renderer is used instead.
+- **Player overrides.** Options set on `mediaTypes.video.renderer.options` (or `params.rendererConfig`)
+  are deep-merged into the OCM player config at render time, so you can tweak player behaviour while
+  still using the OCM player.
+
+```javascript
+var adUnits = [
+    {
+        code: 'video-outstream-ad-unit',
+        mediaTypes: {
+            video: {
+                context: 'outstream',
+                playerSize: [640, 480],
+                mimes: ['video/mp4'],
+                protocols: [2, 3, 5, 6],
+                // optional: override OCM player defaults
+                renderer: {
+                    options: { player: { muted: false, autoplay: false } }
+                }
+            }
+        },
+        bids: [{
+            bidder: 'ocm',
+            params: { publisherId: 'your_publisher_id', placementId: 'your_placement_id' }
+        }]
+    }
+];
+```
+
+# Configuration
+
+## Required Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `publisherId` | String | Your publisher ID provided by Orange Click Media |
+| `placementId` | String | The placement ID for the ad unit |
+
+# User Syncing
+
+OCM's Prebid Server `cookie_sync` endpoint is POST-only, so it cannot be loaded directly from an
+iframe/pixel. Syncing is therefore routed through a small GET-renderable **loader page** that the
+adapter renders in a hidden iframe; the loader POSTs to `cookie_sync` (with credentials) and drops
+the per-bidder sync pixels it returns.
+
+Flow:
+1. `getUserSyncs` reads the bidders PBS actually invoked from the auction response
+   (`ext.responsetimemillis` keys, plus any `seatbid[].seat`).
+2. It renders an iframe to the loader page with those bidders, the publisher `account`
+   (the `publisherId`), the sync `limit`, and all consent signals
+   (`gdpr`, `gdpr_consent`, `us_privacy`, `gpp`, `gpp_sid`).
+3. The loader POSTs `{ bidders, account, limit, gdpr, ... }` to
+   `https://pbam.orangeclickmedia.com/cookie_sync` and drops each returned `usersync` (an `iframe`
+   type becomes a hidden iframe; a `redirect` type becomes an image pixel).
+
+**Deployment requirement:** the loader page must be reachable at
+`https://pbam.orangeclickmedia.com/static/cookie_sync.html`. On PBS-Go, drop the file into the
+server's `./static/` directory (served via `ServeFiles("/static/*filepath", http.Dir("static"))`),
+which keeps it same-origin with `/cookie_sync` (no CORS) and with the PBS `uids` cookie
+(first-party). A reference implementation is provided in `tasks/cookie_sync.html`.
+
+User syncing only runs if the publisher enables iframe syncing and allows the `ocm` bidder
+(the adapter returns an iframe sync only — the loader handles the per-bidder image/iframe pixels
+itself). For example:
+
+```javascript
+pbjs.setConfig({
+    userSync: {
+        filterSettings: {
+            iframe: {
+                bidders: ['ocm'],   // or '*'
+                filter: 'include'
+            }
+        }
+    }
+});
+```
+
+Without iframe syncing enabled for `ocm`, `getUserSyncs` returns no syncs (it is a no-op).
+
+# Notes
+
+- Both `publisherId` and `placementId` are required parameters for all ad units
+- The adapter supports all three media types: Banner, Video, and Native
+- Video ads support both instream and outstream contexts; outstream bids are rendered client-side by the OCM Video Player (see *Outstream Video Rendering* above)
+- Native ads should use the ORTB format (ortb.assets)
+- The bid's billing URL (`burl`) is registered as an ORTB impression event tracker (via the shared PBS extensions), so Prebid core fires it once at billing time — the adapter does not fire it on win. The win-notice URL (`nurl`) is handled by Prebid's ORTB conversion per media type and is not fired separately
+- When the Prebid Server account has event tracking enabled, PBS returns event URLs on each bid at `bid.ext.prebid.events` (`win` and `imp`). The adapter registers these as ORTB event trackers on the bid response, so Prebid core fires them at the standard times: the `win` URL when the bid wins and the `imp` URL when the bid is billed (on render, or on `pbjs.triggerBilling()` for ad units that defer billing). For video, PBS injects the impression tracker into the VAST server-side, so `imp` is normally absent on video bids

--- a/modules/ocmBidAdapter.md
+++ b/modules/ocmBidAdapter.md
@@ -236,11 +236,18 @@ Flow:
 1. `getUserSyncs` reads the bidders PBS actually invoked from the auction response
    (`ext.responsetimemillis` keys, plus any `seatbid[].seat`).
 2. It renders an iframe to the loader page with those bidders, the publisher `account`
-   (the `publisherId`), the sync `limit`, and all consent signals
+   (the `ext.account` PBS echoes on the auction response), the sync `limit`, the sync policy
+   (`filter` — the allowed sync types, and `coopSync=0`), and all consent signals
    (`gdpr`, `gdpr_consent`, `us_privacy`, `gpp`, `gpp_sid`).
-3. The loader POSTs `{ bidders, account, limit, gdpr, ... }` to
+3. The loader POSTs `{ bidders, account, limit, filterSettings, coopSync, gdpr, ... }` to
    `https://pbam.orangeclickmedia.com/cookie_sync` and drops each returned `usersync` (an `iframe`
-   type becomes a hidden iframe; a `redirect` type becomes an image pixel).
+   type becomes a hidden iframe; a `redirect` type becomes an image pixel). The loader **must** honour
+   the forwarded `filter`/`coopSync`: it only requests/drops the sync types the publisher enabled
+   (`iframe` always; `image`/`redirect` only when pixel syncing is enabled) and disables PBS
+   cooperative syncing, so a disabled sync type or an unrequested bidder never fires from inside the
+   loader iframe. The `account` is taken solely from the current auction's echoed `ext.account`, so
+   overlapping OCM auctions cannot leak one publisher's account into another's sync — PBS must echo
+   `ext.account` for the account to be forwarded.
 
 **Deployment requirement:** the loader page must be reachable at
 `https://pbam.orangeclickmedia.com/static/cookie_sync.html`. On PBS-Go, drop the file into the
@@ -250,7 +257,7 @@ which keeps it same-origin with `/cookie_sync` (no CORS) and with the PBS `uids`
 
 User syncing only runs if the publisher enables iframe syncing and allows the `ocm` bidder
 (the adapter returns an iframe sync only — the loader handles the per-bidder image/iframe pixels
-itself). For example:
+itself, constrained to the sync types the publisher enabled). For example:
 
 ```javascript
 pbjs.setConfig({

--- a/modules/ocmBidAdapter.md
+++ b/modules/ocmBidAdapter.md
@@ -1,20 +1,21 @@
 # Overview
 
-```
+```text
 Module Name: OCM Bid Adapter
 Module Type: Bidder Adapter
 Maintainer: support@orangeclickmedia.com
 ```
 
-# Description
+## Description
 
 OCM Bid Adapter supports Banner, Video, and Native media types.
 
 The adapter uses OpenRTB format and connects to Orange Click Media's prebid server.
 
-# Test Parameters
+## Test Parameters
 
 ## Banner Ad Unit
+
 ```javascript
 var adUnits = [
     {
@@ -27,8 +28,8 @@ var adUnits = [
         bids: [{
             bidder: 'ocm',
             params: {
-                publisherId: 'orangeclickmedia.com',
-                placementId: '65b49bb0cc723602'
+                publisherId: 'your_publisher_id',
+                placementId: 'your_placement_id'
             }
         }]
     }
@@ -36,6 +37,7 @@ var adUnits = [
 ```
 
 ## Video Ad Unit: Instream
+
 ```javascript
 var adUnits = [
     {
@@ -62,6 +64,7 @@ var adUnits = [
 ```
 
 ## Video Ad Unit: Outstream
+
 ```javascript
 var adUnits = [
     {
@@ -86,6 +89,7 @@ var adUnits = [
 ```
 
 ## Native Ad Unit
+
 ```javascript
 var adUnits = [
     {
@@ -133,6 +137,7 @@ var adUnits = [
 ```
 
 ## Multi-Format Ad Unit
+
 ```javascript
 var adUnits = [
     {
@@ -171,7 +176,7 @@ var adUnits = [
 ];
 ```
 
-# Outstream Video Rendering
+## Outstream Video Rendering
 
 Outstream video bids are rendered automatically by the adapter using the **OCM Video Player**. When
 an outstream video bid is built, the adapter attaches a Prebid `Renderer` to it; Prebid lazily loads
@@ -216,7 +221,7 @@ var adUnits = [
 ];
 ```
 
-# Configuration
+## Configuration
 
 ## Required Parameters
 
@@ -225,7 +230,7 @@ var adUnits = [
 | `publisherId` | String | Your publisher ID provided by Orange Click Media |
 | `placementId` | String | The placement ID for the ad unit |
 
-# User Syncing
+## User Syncing
 
 OCM's Prebid Server `cookie_sync` endpoint is POST-only, so it cannot be loaded directly from an
 iframe/pixel. Syncing is therefore routed through a small GET-renderable **loader page** that the
@@ -233,31 +238,25 @@ adapter renders in a hidden iframe; the loader POSTs to `cookie_sync` (with cred
 the per-bidder sync pixels it returns.
 
 Flow:
+
 1. `getUserSyncs` reads the bidders PBS actually invoked from the auction response
    (`ext.responsetimemillis` keys, plus any `seatbid[].seat`).
 2. It renders an iframe to the loader page with those bidders, the publisher `account`
-   (the `ext.account` PBS echoes on the auction response), the sync `limit`, the sync policy
-   (`filter` — the allowed sync types, and `coopSync=0`), and all consent signals
+   (the `publisherId`), the sync `limit`, and all consent signals
    (`gdpr`, `gdpr_consent`, `us_privacy`, `gpp`, `gpp_sid`).
-3. The loader POSTs `{ bidders, account, limit, filterSettings, coopSync, gdpr, ... }` to
+3. The loader POSTs `{ bidders, account, limit, gdpr, ... }` to
    `https://pbam.orangeclickmedia.com/cookie_sync` and drops each returned `usersync` (an `iframe`
-   type becomes a hidden iframe; a `redirect` type becomes an image pixel). The loader **must** honour
-   the forwarded `filter`/`coopSync`: it only requests/drops the sync types the publisher enabled
-   (`iframe` always; `image`/`redirect` only when pixel syncing is enabled) and disables PBS
-   cooperative syncing, so a disabled sync type or an unrequested bidder never fires from inside the
-   loader iframe. The `account` is taken solely from the current auction's echoed `ext.account`, so
-   overlapping OCM auctions cannot leak one publisher's account into another's sync — PBS must echo
-   `ext.account` for the account to be forwarded.
+   type becomes a hidden iframe; a `redirect` type becomes an image pixel).
 
 **Deployment requirement:** the loader page must be reachable at
 `https://pbam.orangeclickmedia.com/static/cookie_sync.html`. On PBS-Go, drop the file into the
 server's `./static/` directory (served via `ServeFiles("/static/*filepath", http.Dir("static"))`),
 which keeps it same-origin with `/cookie_sync` (no CORS) and with the PBS `uids` cookie
-(first-party). A reference implementation is provided in `tasks/cookie_sync.html`.
+(first-party).
 
 User syncing only runs if the publisher enables iframe syncing and allows the `ocm` bidder
 (the adapter returns an iframe sync only — the loader handles the per-bidder image/iframe pixels
-itself, constrained to the sync types the publisher enabled). For example:
+itself). For example:
 
 ```javascript
 pbjs.setConfig({
@@ -274,7 +273,7 @@ pbjs.setConfig({
 
 Without iframe syncing enabled for `ocm`, `getUserSyncs` returns no syncs (it is a no-op).
 
-# Notes
+## Notes
 
 - Both `publisherId` and `placementId` are required parameters for all ad units
 - The adapter supports all three media types: Banner, Video, and Native

--- a/test/spec/modules/ocmBidAdapter_spec.js
+++ b/test/spec/modules/ocmBidAdapter_spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { spec } from 'modules/ocmBidAdapter.js';
 import * as utils from 'src/utils.js';
+import { Renderer } from 'src/Renderer.js';
 import { EVENT_TYPE_IMPRESSION, EVENT_TYPE_WIN, TRACKER_METHOD_IMG } from 'src/eventTrackers.js';
 // Side-effect import: registers the price-floors ORTB processors the adapter relies on through
 // pbsExtensions, so the floor pass-through test below exercises the real conversion path.
@@ -703,6 +704,75 @@ describe('ocmBidAdapter', function () {
       expect(() => bid.renderer._render(bid)).to.not.throw();
       expect(stub.called).to.equal(true);
       stub.restore();
+    });
+
+    it('logs an error without throwing when setRender fails while installing the renderer', function () {
+      // Force the installed renderer's setRender to throw so createRenderer's defensive catch runs.
+      const logErr = sinon.stub(utils, 'logError');
+      const installStub = sinon.stub(Renderer, 'install').returns({
+        setRender() { throw new Error('setRender failed'); }
+      });
+      try {
+        const request = spec.buildRequests([outstreamVideoBid], outstreamBidderRequest);
+        expect(() => spec.interpretResponse(videoResponse('bid-video-outstream-1'), request)).to.not.throw();
+        expect(logErr.called).to.equal(true);
+      } finally {
+        installStub.restore();
+        logErr.restore();
+      }
+    });
+
+    it('logs an error when the outstream container element cannot be found', function () {
+      const request = spec.buildRequests([outstreamVideoBid], outstreamBidderRequest);
+      const bid = spec.interpretResponse(videoResponse('bid-video-outstream-1'), request)[0];
+      // Point the bid at an ad-slot id that is not present in the DOM.
+      bid.adUnitCode = 'ocm-missing-slot';
+      window.OcmPlayer = sinon.spy();
+      const logErr = sinon.stub(utils, 'logError');
+
+      bid.renderer.loaded = true;
+      expect(() => bid.renderer._render(bid)).to.not.throw();
+      // The player is never instantiated when its container is missing.
+      expect(window.OcmPlayer.called).to.equal(false);
+      expect(logErr.called).to.equal(true);
+      logErr.restore();
+    });
+
+    it('logs a ready message when the OCM player invokes its ready callback', function () {
+      const request = spec.buildRequests([outstreamVideoBid], outstreamBidderRequest);
+      const bid = spec.interpretResponse(videoResponse('bid-video-outstream-1'), request)[0];
+      bid.adUnitCode = outstreamVideoBid.adUnitCode;
+      bid.adId = 'ad-id-ready';
+
+      const slot = document.createElement('div');
+      slot.id = outstreamVideoBid.adUnitCode;
+      document.body.appendChild(slot);
+      const logMsg = sinon.stub(utils, 'logMessage');
+      // Invoke the ready callback the adapter passes as the player's third argument.
+      window.OcmPlayer = (containerId, config, cb) => cb();
+
+      bid.renderer.loaded = true;
+      bid.renderer._render(bid);
+
+      expect(logMsg.called).to.equal(true);
+      logMsg.restore();
+    });
+
+    it('logs an error without throwing when the OCM player throws while rendering', function () {
+      const request = spec.buildRequests([outstreamVideoBid], outstreamBidderRequest);
+      const bid = spec.interpretResponse(videoResponse('bid-video-outstream-1'), request)[0];
+      bid.adUnitCode = outstreamVideoBid.adUnitCode;
+
+      const slot = document.createElement('div');
+      slot.id = outstreamVideoBid.adUnitCode;
+      document.body.appendChild(slot);
+      const logErr = sinon.stub(utils, 'logError');
+      window.OcmPlayer = () => { throw new Error('player boom'); };
+
+      bid.renderer.loaded = true;
+      expect(() => bid.renderer._render(bid)).to.not.throw();
+      expect(logErr.called).to.equal(true);
+      logErr.restore();
     });
   });
 

--- a/test/spec/modules/ocmBidAdapter_spec.js
+++ b/test/spec/modules/ocmBidAdapter_spec.js
@@ -569,6 +569,44 @@ describe('ocmBidAdapter', function () {
       expect(bid.renderer).to.equal(undefined);
     });
 
+    // Regression: the documented override shape (mediaTypes.video.renderer.options, an options-only
+    // holder with no url/render) must NOT be mistaken for a publisher renderer. Otherwise the OCM
+    // renderer is skipped and the outstream bid is left with no renderer at all. Core only prefers
+    // an ad-unit renderer that defines both url and render (isRendererPreferredFromAdUnit).
+    it('installs the OCM renderer when the ad unit only supplies renderer.options (documented override)', function () {
+      const optionsBid = {
+        ...outstreamVideoBid,
+        mediaTypes: {
+          video: {
+            ...outstreamVideoBid.mediaTypes.video,
+            renderer: { options: { player: { muted: false, autoplay: false } } }
+          }
+        }
+      };
+      const request = spec.buildRequests([optionsBid], { bidderCode: 'ocm', bids: [optionsBid] });
+      const bid = spec.interpretResponse(videoResponse('bid-video-outstream-1'), request)[0];
+      expect(bid.renderer).to.exist;
+      expect(bid.renderer.url).to.equal(RENDERER_URL);
+      // The publisher's options ride along on the OCM renderer config (merged into the player at render time).
+      expect(bid.renderer.getConfig()).to.deep.equal({ player: { muted: false, autoplay: false } });
+    });
+
+    it('installs the OCM renderer over a publisher renderer flagged backupOnly', function () {
+      const backupBid = {
+        ...outstreamVideoBid,
+        mediaTypes: {
+          video: {
+            ...outstreamVideoBid.mediaTypes.video,
+            renderer: { url: 'https://pub.example/r.js', render: () => {}, backupOnly: true }
+          }
+        }
+      };
+      const request = spec.buildRequests([backupBid], { bidderCode: 'ocm', bids: [backupBid] });
+      const bid = spec.interpretResponse(videoResponse('bid-video-outstream-1'), request)[0];
+      expect(bid.renderer).to.exist;
+      expect(bid.renderer.url).to.equal(RENDERER_URL);
+    });
+
     it('renders an outstream bid through window.OcmPlayer with the bid VAST and player size', function () {
       const request = spec.buildRequests([outstreamVideoBid], outstreamBidderRequest);
       const bid = spec.interpretResponse(videoResponse('bid-video-outstream-1'), request)[0];

--- a/test/spec/modules/ocmBidAdapter_spec.js
+++ b/test/spec/modules/ocmBidAdapter_spec.js
@@ -1,0 +1,719 @@
+import { expect } from 'chai';
+import { spec } from 'modules/ocmBidAdapter.js';
+import * as utils from 'src/utils.js';
+import { EVENT_TYPE_IMPRESSION, EVENT_TYPE_WIN, TRACKER_METHOD_IMG } from 'src/eventTrackers.js';
+// Side-effect import: registers the price-floors ORTB processors the adapter relies on through
+// pbsExtensions, so the floor pass-through test below exercises the real conversion path.
+import 'modules/priceFloors.js';
+
+const AUCTION_ENDPOINT = 'https://pbam.orangeclickmedia.com/openrtb2/auction';
+const USER_SYNC_LOADER = 'https://pbam.orangeclickmedia.com/static/cookie_sync.html';
+
+describe('ocmBidAdapter', function () {
+  const baseParams = { publisherId: 'pub-123', placementId: 'plc-456' };
+
+  const bannerBid = {
+    bidder: 'ocm',
+    adUnitCode: 'div-banner',
+    bidId: 'bid-banner-1',
+    params: { ...baseParams },
+    mediaTypes: { banner: { sizes: [[300, 250], [728, 90]] } }
+  };
+
+  const bannerBidderRequest = {
+    bidderCode: 'ocm',
+    bids: [bannerBid]
+  };
+
+  const videoBid = {
+    bidder: 'ocm',
+    adUnitCode: 'div-video',
+    bidId: 'bid-video-1',
+    params: { ...baseParams },
+    mediaTypes: {
+      video: {
+        context: 'instream',
+        playerSize: [[640, 480]],
+        mimes: ['video/mp4'],
+        protocols: [2, 3],
+        maxduration: 30,
+        minduration: 5
+      }
+    }
+  };
+
+  const nativeBid = {
+    bidder: 'ocm',
+    adUnitCode: 'div-native',
+    bidId: 'bid-native-1',
+    params: { ...baseParams },
+    mediaTypes: {
+      native: {
+        ortb: {
+          assets: [
+            { id: 1, required: 1, title: { len: 80 } },
+            { id: 2, required: 0, data: { type: 1 } }
+          ]
+        }
+      }
+    }
+  };
+
+  describe('isBidRequestValid', function () {
+    it('returns true for a valid banner bid', function () {
+      expect(spec.isBidRequestValid(bannerBid)).to.equal(true);
+    });
+
+    it('returns true for a valid instream video bid', function () {
+      expect(spec.isBidRequestValid(videoBid)).to.equal(true);
+    });
+
+    it('returns true for a valid ORTB native bid', function () {
+      expect(spec.isBidRequestValid(nativeBid)).to.equal(true);
+    });
+
+    it('returns false when publisherId is missing', function () {
+      const bid = { ...bannerBid, params: { placementId: 'plc-456' } };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('returns false when placementId is missing', function () {
+      const bid = { ...bannerBid, params: { publisherId: 'pub-123' } };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('returns false when publisherId is not a string', function () {
+      const bid = { ...bannerBid, params: { publisherId: 123, placementId: 'plc-456' } };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('returns false for a banner bid without sizes', function () {
+      const bid = { ...bannerBid, mediaTypes: { banner: { sizes: [] } } };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('returns false for a video bid without a valid context', function () {
+      const bid = {
+        ...videoBid,
+        mediaTypes: { video: { context: 'invalid', playerSize: [[640, 480]] } }
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    // isValid(NATIVE, ...) runs for every bid, so the native branch must tolerate a bid with no
+    // mediaTypes at all rather than throwing while dereferencing mediaTypes.native.
+    it('returns false (without throwing) for a bid that declares no mediaTypes', function () {
+      const bid = { bidder: 'ocm', params: { ...baseParams } };
+      expect(() => spec.isBidRequestValid(bid)).to.not.throw();
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    // Regression: a native video asset with minduration:0 must be accepted.
+    // Before the fix the falsy `!asset.video.minduration` check rejected a legitimate 0.
+    it('accepts a native video asset with minduration of 0', function () {
+      const bid = {
+        ...nativeBid,
+        mediaTypes: {
+          native: {
+            ortb: {
+              assets: [{
+                id: 1,
+                required: 1,
+                video: { mimes: ['video/mp4'], minduration: 0, maxduration: 30, protocols: [2, 3] }
+              }]
+            }
+          }
+        }
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('rejects a native video asset that is missing minduration', function () {
+      const bid = {
+        ...nativeBid,
+        mediaTypes: {
+          native: {
+            ortb: {
+              assets: [{
+                id: 1,
+                required: 1,
+                video: { mimes: ['video/mp4'], maxduration: 30, protocols: [2, 3] }
+              }]
+            }
+          }
+        }
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('rejects an ORTB native bid whose event tracker has no methods', function () {
+      const bid = {
+        ...nativeBid,
+        mediaTypes: {
+          native: {
+            ortb: {
+              assets: [{ id: 1, required: 1, title: { len: 80 } }],
+              eventtrackers: [{ event: 1, methods: [] }]
+            }
+          }
+        }
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('accepts an ORTB native bid with a valid event tracker', function () {
+      const bid = {
+        ...nativeBid,
+        mediaTypes: {
+          native: {
+            ortb: {
+              assets: [{ id: 1, required: 1, title: { len: 80 } }],
+              eventtrackers: [{ event: 1, methods: [1, 2] }]
+            }
+          }
+        }
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+  });
+
+  describe('buildRequests', function () {
+    it('builds a single POST request to the OCM auction endpoint', function () {
+      const request = spec.buildRequests([bannerBid], bannerBidderRequest);
+      expect(request).to.be.an('object');
+      expect(request.method).to.equal('POST');
+      expect(request.url).to.equal(AUCTION_ENDPOINT);
+      expect(request.data).to.be.an('object');
+    });
+
+    it('maps placementId into imp.ext.prebid.storedrequest.id', function () {
+      const request = spec.buildRequests([bannerBid], bannerBidderRequest);
+      const imp = request.data.imp[0];
+      expect(imp.ext.prebid.storedrequest.id).to.equal('plc-456');
+    });
+
+    it('removes imp.ext.prebid.bidder so PBS resolves demand from the stored request', function () {
+      const request = spec.buildRequests([bannerBid], bannerBidderRequest);
+      const imp = request.data.imp[0];
+      // The injected bidder.ocm params are what broke the stored-request setup; they must be gone.
+      expect(imp.ext.prebid.bidder).to.equal(undefined);
+      // storedrequest is preserved, and other PBS fields (e.g. adunitcode) are no longer whitelisted
+      // away — the same mechanism that now lets price-floor data through.
+      expect(imp.ext.prebid.storedrequest.id).to.equal('plc-456');
+      expect(imp.ext.prebid.adunitcode).to.equal('div-banner');
+    });
+
+    it('passes price-floor data through to the OCM request', function () {
+      // The price-floors module attaches getFloor to each bid during the auction; simulate that so
+      // the pbsExtensions floor processors populate the imp during conversion.
+      const flooredBid = { ...bannerBid, getFloor: () => ({ currency: 'USD', floor: 1.25 }) };
+      const request = spec.buildRequests([flooredBid], { bidderCode: 'ocm', bids: [flooredBid] });
+      const imp = request.data.imp[0];
+
+      // Top-level OpenRTB floor (what PBS and downstream bidders read).
+      expect(imp.bidfloor).to.equal(1.25);
+      expect(imp.bidfloorcur).to.equal('USD');
+      // PBS floorMin under ext.prebid.floors must survive the imp cleanup (previously stripped).
+      expect(imp.ext.prebid.floors.floorMin).to.equal(1.25);
+      // ...without losing the stored request.
+      expect(imp.ext.prebid.storedrequest.id).to.equal('plc-456');
+    });
+
+    // Regression: publisherId must attach even when the converter did not pre-seed a publisher object.
+    it('attaches publisherId to the site publisher object', function () {
+      const request = spec.buildRequests([bannerBid], bannerBidderRequest);
+      expect(request.data.site.publisher.id).to.equal('pub-123');
+    });
+  });
+
+  describe('interpretResponse', function () {
+    const sampleResponse = {
+      body: {
+        id: 'auction-1',
+        cur: 'USD',
+        seatbid: [{
+          seat: 'ocm',
+          bid: [{
+            id: 'bid-1',
+            impid: 'bid-banner-1',
+            price: 1.5,
+            adm: '<div>OCM Ad</div>',
+            adomain: ['example.com'],
+            crid: 'creative-1',
+            w: 300,
+            h: 250,
+            mtype: 1
+          }]
+        }]
+      }
+    };
+
+    it('maps the ORTB response to Prebid bids with the OCM bidderCode', function () {
+      const request = spec.buildRequests([bannerBid], bannerBidderRequest);
+      const result = spec.interpretResponse(sampleResponse, request);
+      expect(result).to.be.an('array').with.lengthOf(1);
+      const bid = result[0];
+      expect(bid.cpm).to.equal(1.5);
+      expect(bid.currency).to.equal('USD');
+      expect(bid.width).to.equal(300);
+      expect(bid.height).to.equal(250);
+      expect(bid.creativeId).to.equal('creative-1');
+      expect(bid.bidderCode).to.equal('ocm');
+      expect(bid.meta.advertiserDomains).to.deep.equal(['example.com']);
+    });
+
+    it('returns an array of bids (not the converter wrapper object)', function () {
+      const request = spec.buildRequests([bannerBid], bannerBidderRequest);
+      const result = spec.interpretResponse(sampleResponse, request);
+      expect(result).to.be.an('array');
+      expect(result.bids).to.equal(undefined);
+    });
+
+    it('returns no bids for an empty seatbid', function () {
+      const request = spec.buildRequests([bannerBid], bannerBidderRequest);
+      const result = spec.interpretResponse({ body: { id: 'auction-1', cur: 'USD', seatbid: [] } }, request);
+      expect(result).to.be.an('array').that.is.empty;
+    });
+  });
+
+  describe('native', function () {
+    // Prebid core decorates each native bid request with `nativeOrtbRequest` (derived from
+    // mediaTypes.native.ortb) before calling buildRequests; the ORTB converter reads that field to
+    // populate imp.native. Replicate that decoration here so the native request path is exercised
+    // exactly as it is in production.
+    const nativeOrtbRequest = {
+      ver: '1.2',
+      assets: [
+        { id: 1, required: 1, title: { len: 80 } },
+        { id: 2, required: 1, img: { type: 3, w: 150, h: 150 } },
+        { id: 3, required: 0, data: { type: 1 } }
+      ]
+    };
+    const nativeRequestBid = { ...nativeBid, nativeOrtbRequest };
+    const nativeBidderRequest = { bidderCode: 'ocm', bids: [nativeRequestBid] };
+
+    // A native ORTB response: the creative markup (adm) is the JSON-serialised native object PBS
+    // returns, and mtype 4 marks the bid as native (see ORTB_MTYPES in the mediaType processor).
+    const nativeAdm = {
+      ver: '1.2',
+      link: { url: 'https://example.com/click' },
+      assets: [
+        { id: 1, title: { text: 'OCM Native Ad' } },
+        { id: 2, img: { url: 'https://cdn.example.com/i.png', w: 150, h: 150 } }
+      ]
+    };
+    function nativeResponse(impid) {
+      return {
+        body: {
+          id: 'auction-native',
+          cur: 'USD',
+          seatbid: [{
+            seat: 'ocm',
+            bid: [{
+              id: 'nbid-1',
+              impid,
+              price: 2.1,
+              adm: JSON.stringify(nativeAdm),
+              adomain: ['example.com'],
+              crid: 'creative-native',
+              mtype: 4
+            }]
+          }]
+        }
+      };
+    }
+
+    it('builds imp.native.request from the ad unit native ORTB request', function () {
+      const request = spec.buildRequests([nativeRequestBid], nativeBidderRequest);
+      const imp = request.data.imp[0];
+      // imp.native is populated by the converter's native processor, which is compiled out when
+      // FEATURES.NATIVE is disabled (e.g. the all-features-disabled test build); guard accordingly.
+      if (FEATURES.NATIVE) {
+        expect(imp.native).to.be.an('object');
+        const parsed = JSON.parse(imp.native.request);
+        expect(parsed.assets).to.have.lengthOf(3);
+        expect(parsed.ver).to.equal('1.2');
+      }
+      // The stored-request wiring and PBS bidder-params cleanup apply to native imps as well.
+      expect(imp.ext.prebid.storedrequest.id).to.equal('plc-456');
+      expect(imp.ext.prebid.bidder).to.equal(undefined);
+    });
+
+    it('interprets a native ORTB response into bidResponse.native.ortb', function () {
+      const request = spec.buildRequests([nativeRequestBid], nativeBidderRequest);
+      const bid = spec.interpretResponse(nativeResponse('bid-native-1'), request)[0];
+      expect(bid).to.exist;
+      expect(bid.cpm).to.equal(2.1);
+      expect(bid.bidderCode).to.equal('ocm');
+      // mtype 4 maps to the native mediaType regardless of the native feature flag.
+      expect(bid.mediaType).to.equal('native');
+      // The native creative is parsed by the converter's native response processor (FEATURES.NATIVE).
+      if (FEATURES.NATIVE) {
+        expect(bid.native).to.be.an('object');
+        expect(bid.native.ortb.assets).to.have.lengthOf(2);
+        expect(bid.native.ortb.link.url).to.equal('https://example.com/click');
+      }
+      // Native bids never receive the outstream video renderer.
+      expect(bid.renderer).to.equal(undefined);
+    });
+
+    it('validates and builds a multi-format (banner + video + native) ad unit', function () {
+      const multiBid = {
+        bidder: 'ocm',
+        adUnitCode: 'div-multi',
+        bidId: 'bid-multi-1',
+        params: { ...baseParams },
+        mediaTypes: {
+          banner: { sizes: [[300, 250]] },
+          video: { context: 'outstream', playerSize: [[640, 480]], mimes: ['video/mp4'], protocols: [2, 3] },
+          native: { ortb: { assets: [{ id: 1, required: 1, title: { len: 80 } }] } }
+        },
+        nativeOrtbRequest: { assets: [{ id: 1, required: 1, title: { len: 80 } }] }
+      };
+      expect(spec.isBidRequestValid(multiBid)).to.equal(true);
+
+      const request = spec.buildRequests([multiBid], { bidderCode: 'ocm', bids: [multiBid] });
+      const imp = request.data.imp[0];
+      expect(imp.banner).to.be.an('object');
+      if (FEATURES.NATIVE) {
+        expect(imp.native).to.be.an('object');
+      }
+      if (FEATURES.VIDEO) {
+        expect(imp.video).to.be.an('object');
+      }
+    });
+  });
+
+  describe('PBS event trackers', function () {
+    const IMP_URL = 'https://pbam.orangeclickmedia.com/event?t=imp&b=evt-bid-1&a=pub-123';
+    const WIN_URL = 'https://pbam.orangeclickmedia.com/event?t=win&b=evt-bid-1&a=pub-123';
+
+    // Builds a banner ORTB response for div-banner whose bid carries the PBS-generated win/impression
+    // event URLs at bid.ext.prebid.events, mirroring an events-enabled Prebid Server response.
+    function responseWithEvents(events) {
+      return {
+        body: {
+          id: 'auction-evt',
+          cur: 'USD',
+          seatbid: [{
+            seat: 'ocm',
+            bid: [{
+              id: 'evt-bid-1',
+              impid: 'bid-banner-1',
+              price: 1.5,
+              adm: '<div>OCM Ad</div>',
+              crid: 'creative-1',
+              w: 300,
+              h: 250,
+              mtype: 1,
+              ext: { prebid: { events } }
+            }]
+          }]
+        }
+      };
+    }
+
+    function trackersFor(bid, event) {
+      return (bid.eventtrackers || []).filter((t) => t.event === event && t.method === TRACKER_METHOD_IMG);
+    }
+
+    it('registers the impression event URL as an image impression tracker so core fires it on billing', function () {
+      const request = spec.buildRequests([bannerBid], bannerBidderRequest);
+      const bid = spec.interpretResponse(responseWithEvents({ imp: IMP_URL }), request)[0];
+      const impTrackers = trackersFor(bid, EVENT_TYPE_IMPRESSION);
+      expect(impTrackers).to.have.lengthOf(1);
+      expect(impTrackers[0].url).to.equal(IMP_URL);
+    });
+
+    // The win tracker itself is registered by the shared pbsExtensions processor (addEventTrackers),
+    // not by the adapter's addPbsEventTrackers; this asserts the end-to-end result: an interpreted OCM
+    // bid carries the win URL as a WIN image tracker so core fires it on win.
+    it('registers the win event URL as an image win tracker so core fires it when the bid wins', function () {
+      const request = spec.buildRequests([bannerBid], bannerBidderRequest);
+      const bid = spec.interpretResponse(responseWithEvents({ win: WIN_URL }), request)[0];
+      const winTrackers = trackersFor(bid, EVENT_TYPE_WIN);
+      expect(winTrackers).to.have.lengthOf(1);
+      expect(winTrackers[0].url).to.equal(WIN_URL);
+    });
+
+    it('registers both the win and impression trackers when PBS supplies both', function () {
+      const request = spec.buildRequests([bannerBid], bannerBidderRequest);
+      const bid = spec.interpretResponse(responseWithEvents({ imp: IMP_URL, win: WIN_URL }), request)[0];
+      expect(trackersFor(bid, EVENT_TYPE_IMPRESSION)).to.have.lengthOf(1);
+      expect(trackersFor(bid, EVENT_TYPE_WIN)).to.have.lengthOf(1);
+    });
+
+    it('does not duplicate the win tracker already added by the shared pbsExtensions processor', function () {
+      const request = spec.buildRequests([bannerBid], bannerBidderRequest);
+      const bid = spec.interpretResponse(responseWithEvents({ win: WIN_URL }), request)[0];
+      expect(trackersFor(bid, EVENT_TYPE_WIN)).to.have.lengthOf(1);
+    });
+
+    // The shared pbsExtensions processor maps a legacy bid.burl to an impression tracker; when PBS sets
+    // burl to the same /event URL as events.imp, the adapter's dedup guard must keep a single tracker.
+    it('does not duplicate the impression tracker when burl matches the impression event URL', function () {
+      const request = spec.buildRequests([bannerBid], bannerBidderRequest);
+      const response = responseWithEvents({ imp: IMP_URL });
+      response.body.seatbid[0].bid[0].burl = IMP_URL;
+      const bid = spec.interpretResponse(response, request)[0];
+      const impTrackers = trackersFor(bid, EVENT_TYPE_IMPRESSION);
+      expect(impTrackers).to.have.lengthOf(1);
+      expect(impTrackers[0].url).to.equal(IMP_URL);
+    });
+
+    it('adds no win/impression trackers when the bid carries no ext.prebid.events', function () {
+      const request = spec.buildRequests([bannerBid], bannerBidderRequest);
+      const bareResponse = {
+        body: {
+          id: 'auction-bare',
+          cur: 'USD',
+          seatbid: [{ seat: 'ocm', bid: [{ id: 'bare-1', impid: 'bid-banner-1', price: 1, adm: '<div></div>', crid: 'c', w: 300, h: 250, mtype: 1 }] }]
+        }
+      };
+      const bid = spec.interpretResponse(bareResponse, request)[0];
+      expect(trackersFor(bid, EVENT_TYPE_IMPRESSION)).to.have.lengthOf(0);
+      expect(trackersFor(bid, EVENT_TYPE_WIN)).to.have.lengthOf(0);
+    });
+  });
+
+  describe('outstream renderer', function () {
+    const RENDERER_URL = 'https://cdn.orangeclickmedia.com/tech/libs/ocm-player.js';
+
+    const outstreamVideoBid = {
+      bidder: 'ocm',
+      adUnitCode: 'div-video-outstream',
+      bidId: 'bid-video-outstream-1',
+      params: { ...baseParams },
+      mediaTypes: {
+        video: {
+          context: 'outstream',
+          playerSize: [[640, 480]],
+          mimes: ['video/mp4'],
+          protocols: [2, 3]
+        }
+      }
+    };
+    const outstreamBidderRequest = { bidderCode: 'ocm', bids: [outstreamVideoBid] };
+
+    // Builds an ORTB video response (mtype 2) whose bid maps to `impid`; carries both an inline VAST
+    // document (adm -> vastXml) and a hosted VAST URL (nurl -> vastUrl).
+    function videoResponse(impid) {
+      return {
+        body: {
+          id: 'auction-v',
+          cur: 'USD',
+          seatbid: [{
+            seat: 'ocm',
+            bid: [{
+              id: 'vbid-1',
+              impid,
+              price: 3.2,
+              adm: '<VAST version="4.0"></VAST>',
+              nurl: 'https://vast.orangeclickmedia.com/v.xml',
+              adomain: ['example.com'],
+              crid: 'creative-v',
+              w: 640,
+              h: 480,
+              mtype: 2
+            }]
+          }]
+        }
+      };
+    }
+
+    afterEach(function () {
+      delete window.OcmPlayer;
+      const node = document.getElementById('div-video-outstream');
+      if (node) node.remove();
+    });
+
+    it('attaches the OCM renderer to outstream video bids', function () {
+      const request = spec.buildRequests([outstreamVideoBid], outstreamBidderRequest);
+      const bid = spec.interpretResponse(videoResponse('bid-video-outstream-1'), request)[0];
+      expect(bid.mediaType).to.equal('video');
+      expect(bid.renderer).to.exist;
+      expect(bid.renderer.url).to.equal(RENDERER_URL);
+    });
+
+    it('does not attach a renderer to instream video bids', function () {
+      const request = spec.buildRequests([videoBid], { bidderCode: 'ocm', bids: [videoBid] });
+      const bid = spec.interpretResponse(videoResponse('bid-video-1'), request)[0];
+      expect(bid.mediaType).to.equal('video');
+      expect(bid.renderer).to.equal(undefined);
+    });
+
+    it('does not attach a renderer to banner bids', function () {
+      const request = spec.buildRequests([bannerBid], bannerBidderRequest);
+      const bid = spec.interpretResponse({
+        body: {
+          id: 'auction-b',
+          cur: 'USD',
+          seatbid: [{ seat: 'ocm', bid: [{ id: 'b1', impid: 'bid-banner-1', price: 1, adm: '<div></div>', crid: 'c', w: 300, h: 250, mtype: 1 }] }]
+        }
+      }, request)[0];
+      expect(bid.renderer).to.equal(undefined);
+    });
+
+    it('does not override a publisher-defined (non-backupOnly) renderer', function () {
+      const pubBid = {
+        ...outstreamVideoBid,
+        mediaTypes: {
+          video: {
+            ...outstreamVideoBid.mediaTypes.video,
+            renderer: { url: 'https://pub.example/r.js', render: () => {}, backupOnly: false }
+          }
+        }
+      };
+      const request = spec.buildRequests([pubBid], { bidderCode: 'ocm', bids: [pubBid] });
+      const bid = spec.interpretResponse(videoResponse('bid-video-outstream-1'), request)[0];
+      expect(bid.renderer).to.equal(undefined);
+    });
+
+    it('renders an outstream bid through window.OcmPlayer with the bid VAST and player size', function () {
+      const request = spec.buildRequests([outstreamVideoBid], outstreamBidderRequest);
+      const bid = spec.interpretResponse(videoResponse('bid-video-outstream-1'), request)[0];
+      // Prebid core populates adUnitCode/adId on the bid before invoking the renderer; replicate that.
+      bid.adUnitCode = outstreamVideoBid.adUnitCode;
+      bid.adId = 'ad-id-1';
+
+      const slot = document.createElement('div');
+      slot.id = outstreamVideoBid.adUnitCode;
+      document.body.appendChild(slot);
+      window.OcmPlayer = sinon.spy();
+
+      // loaded=true makes renderer.push() run synchronously; invoking the render fn directly avoids
+      // depending on loadExternalScript fetching the player script over the network.
+      bid.renderer.loaded = true;
+      bid.renderer._render(bid);
+
+      expect(window.OcmPlayer.calledOnce).to.equal(true);
+      const [containerId, config] = window.OcmPlayer.firstCall.args;
+      expect(containerId).to.match(/^ocm-player-wrapper-/);
+      expect(document.getElementById(containerId)).to.exist;
+      // vastUrl is populated by the ORTB converter's video response processor, which is compiled out
+      // when FEATURES.VIDEO is disabled (e.g. the all-features-disabled test build), so guard this
+      // assertion; the player dimensions below derive from bid.w/bid.h and hold either way.
+      if (FEATURES.VIDEO) {
+        expect(config.ads.preroll[0].waterfall[0].vast.url).to.equal('https://vast.orangeclickmedia.com/v.xml');
+      }
+      expect(config.player.width).to.equal('640px');
+      expect(config.player.height).to.equal('480px');
+      expect(config.player.outstream.type).to.equal('in-article');
+    });
+
+    it('logs an error without throwing when window.OcmPlayer is unavailable', function () {
+      const request = spec.buildRequests([outstreamVideoBid], outstreamBidderRequest);
+      const bid = spec.interpretResponse(videoResponse('bid-video-outstream-1'), request)[0];
+      bid.adUnitCode = outstreamVideoBid.adUnitCode;
+      delete window.OcmPlayer;
+      const stub = sinon.stub(utils, 'logError');
+
+      bid.renderer.loaded = true;
+      expect(() => bid.renderer._render(bid)).to.not.throw();
+      expect(stub.called).to.equal(true);
+      stub.restore();
+    });
+  });
+
+  describe('getUserSyncs', function () {
+    const syncResponses = [{ body: { ext: { responsetimemillis: { appnexus: 80, rubicon: 120 } } } }];
+
+    it('returns no syncs when iframe syncing is disabled', function () {
+      expect(spec.getUserSyncs({ iframeEnabled: false, pixelEnabled: true }, syncResponses)).to.deep.equal([]);
+    });
+
+    it('returns no syncs when the auction response lists no bidders', function () {
+      expect(spec.getUserSyncs({ iframeEnabled: true }, [{ body: {} }])).to.deep.equal([]);
+    });
+
+    it('returns an iframe sync to the loader page with the bidders from the response', function () {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, syncResponses);
+      expect(syncs).to.have.lengthOf(1);
+      expect(syncs[0].type).to.equal('iframe');
+      expect(syncs[0].url.indexOf(USER_SYNC_LOADER)).to.equal(0);
+      expect(decodeURIComponent(syncs[0].url)).to.contain('bidders=appnexus,rubicon');
+      expect(syncs[0].url).to.contain('limit=10');
+    });
+
+    it('derives bidders from seatbid seats when responsetimemillis is absent', function () {
+      const responses = [{ body: { seatbid: [{ seat: 'pubmatic' }, { seat: 'ix' }] } }];
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, responses);
+      expect(decodeURIComponent(syncs[0].url)).to.contain('bidders=pubmatic,ix');
+    });
+
+    it('includes the account captured from publisherId during buildRequests', function () {
+      spec.buildRequests([bannerBid], bannerBidderRequest); // sets the module-level sync account
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, syncResponses);
+      expect(syncs[0].url).to.contain('account=pub-123');
+    });
+
+    it('prefers an account echoed in the auction response over the captured publisherId', function () {
+      spec.buildRequests([bannerBid], bannerBidderRequest); // captures account=pub-123
+      const responses = [{ body: { ext: { account: 'echoed-789', responsetimemillis: { appnexus: 80 } } } }];
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, responses);
+      expect(syncs[0].url).to.contain('account=echoed-789');
+      expect(syncs[0].url).to.not.contain('account=pub-123');
+    });
+
+    it('forwards GDPR, USP and GPP consent', function () {
+      const syncs = spec.getUserSyncs(
+        { iframeEnabled: true },
+        syncResponses,
+        { gdprApplies: true, consentString: 'consent-xyz' },
+        '1YNN',
+        { gppString: 'DBACNYA', applicableSections: [7, 8] }
+      );
+      const url = syncs[0].url;
+      expect(url).to.contain('gdpr=1');
+      expect(url).to.contain('gdpr_consent=consent-xyz');
+      expect(url).to.contain('us_privacy=1YNN');
+      expect(url).to.contain('gpp=DBACNYA');
+      expect(decodeURIComponent(url)).to.contain('gpp_sid=7,8');
+    });
+  });
+
+  describe('billing (burl)', function () {
+    // burl is fired by Prebid core via the impression event tracker that the shared pbsExtensions
+    // processor registers (see the PBS event trackers suite), not by the adapter — so there is no
+    // onBidWon handler that would double-fire it on win.
+    it('registers no onBidWon handler (core fires burl at billing time)', function () {
+      expect(spec.onBidWon).to.equal(undefined);
+    });
+
+    it('exposes a PBS burl as an image impression tracker so core fires it at billing', function () {
+      const request = spec.buildRequests([bannerBid], bannerBidderRequest);
+      const BURL = 'https://pbam.orangeclickmedia.com/event?t=imp&b=burl-1&a=pub-123';
+      const response = {
+        body: {
+          id: 'auction-burl',
+          cur: 'USD',
+          seatbid: [{
+            seat: 'ocm',
+            bid: [{ id: 'burl-1', impid: 'bid-banner-1', price: 1.5, adm: '<div></div>', crid: 'c', w: 300, h: 250, mtype: 1, burl: BURL }]
+          }]
+        }
+      };
+      const bid = spec.interpretResponse(response, request)[0];
+      const impTrackers = (bid.eventtrackers || []).filter((t) => t.event === EVENT_TYPE_IMPRESSION && t.method === TRACKER_METHOD_IMG);
+      expect(impTrackers.map((t) => t.url)).to.include(BURL);
+    });
+  });
+
+  describe('onTimeout', function () {
+    it('logs a warning without throwing', function () {
+      const stub = sinon.stub(utils, 'logWarn');
+      expect(() => spec.onTimeout([{ bidder: 'ocm', timeout: 3000 }])).to.not.throw();
+      expect(stub.calledOnce).to.equal(true);
+      stub.restore();
+    });
+  });
+
+  describe('onBidderError', function () {
+    it('logs an error without throwing', function () {
+      const stub = sinon.stub(utils, 'logError');
+      expect(() => spec.onBidderError({ error: { status: 500 }, bidderRequest: {} })).to.not.throw();
+      expect(stub.calledOnce).to.equal(true);
+      stub.restore();
+    });
+  });
+});

--- a/test/spec/modules/ocmBidAdapter_spec.js
+++ b/test/spec/modules/ocmBidAdapter_spec.js
@@ -175,6 +175,59 @@ describe('ocmBidAdapter', function () {
       };
       expect(spec.isBidRequestValid(bid)).to.equal(true);
     });
+
+    it('returns false for a bid with no params object', function () {
+      expect(spec.isBidRequestValid({ bidder: 'ocm' })).to.equal(false);
+    });
+
+    // isValidAsset rejection paths, reached through the ORTB native validation branch.
+    it('rejects an ORTB native asset that has no valid integer id', function () {
+      const bid = {
+        ...nativeBid,
+        mediaTypes: { native: { ortb: { assets: [{ required: 1, title: { len: 80 } }] } } }
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('rejects an ORTB native asset with no content (title/img/data/video)', function () {
+      const bid = {
+        ...nativeBid,
+        mediaTypes: { native: { ortb: { assets: [{ id: 1, required: 1 }] } } }
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('rejects an ORTB native title asset that is missing a valid len', function () {
+      const bid = {
+        ...nativeBid,
+        mediaTypes: { native: { ortb: { assets: [{ id: 1, required: 1, title: {} }] } } }
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('rejects an ORTB native data asset that is missing a valid type', function () {
+      const bid = {
+        ...nativeBid,
+        mediaTypes: { native: { ortb: { assets: [{ id: 1, required: 1, data: {} }] } } }
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    // Legacy (non-ORTB) native path: mediaTypes.native carries no `ortb`, so the adapter converts
+    // bid.nativeParams via toOrtbNativeRequest and validates the resulting assets.
+    it('returns false for a legacy native bid with no nativeParams', function () {
+      const bid = { ...nativeBid, mediaTypes: { native: {} } };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('returns true for a legacy native bid whose nativeParams convert to a valid asset', function () {
+      const bid = {
+        ...nativeBid,
+        mediaTypes: { native: {} },
+        nativeParams: { title: { required: true, len: 80 } }
+      };
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
   });
 
   describe('buildRequests', function () {

--- a/test/spec/modules/ocmBidAdapter_spec.js
+++ b/test/spec/modules/ocmBidAdapter_spec.js
@@ -679,18 +679,35 @@ describe('ocmBidAdapter', function () {
       expect(decodeURIComponent(syncs[0].url)).to.contain('bidders=pubmatic,ix');
     });
 
-    it('includes the account captured from publisherId during buildRequests', function () {
-      spec.buildRequests([bannerBid], bannerBidderRequest); // sets the module-level sync account
+    it('constrains the loader to iframe syncs and disables cooperative syncing by default', function () {
+      // When only iframe syncing is enabled, the loader must be told not to drop image/redirect syncs
+      // and not to co-operatively sync bidders the publisher never requested.
       const syncs = spec.getUserSyncs({ iframeEnabled: true }, syncResponses);
-      expect(syncs[0].url).to.contain('account=pub-123');
+      const url = decodeURIComponent(syncs[0].url);
+      expect(url).to.contain('filter=iframe');
+      expect(url).to.not.contain('image');
+      expect(syncs[0].url).to.contain('coopSync=0');
     });
 
-    it('prefers an account echoed in the auction response over the captured publisherId', function () {
-      spec.buildRequests([bannerBid], bannerBidderRequest); // captures account=pub-123
+    it('allows image syncs in the loader filter when pixel syncing is enabled', function () {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true, pixelEnabled: true }, syncResponses);
+      expect(decodeURIComponent(syncs[0].url)).to.contain('filter=iframe,image');
+    });
+
+    it('includes the account echoed by PBS in the auction response', function () {
       const responses = [{ body: { ext: { account: 'echoed-789', responsetimemillis: { appnexus: 80 } } } }];
       const syncs = spec.getUserSyncs({ iframeEnabled: true }, responses);
       expect(syncs[0].url).to.contain('account=echoed-789');
-      expect(syncs[0].url).to.not.contain('account=pub-123');
+    });
+
+    it('scopes the sync account to the auction response and never a captured fallback', function () {
+      // Regression: the cookie_sync account must come only from THIS auction's response (ext.account),
+      // not from a module-level value captured during buildRequests — otherwise an overlapping auction
+      // could leak its publisher account into this sync. buildRequests runs first (it used to capture
+      // account=pub-123) but the response below echoes no account, so no account must be emitted.
+      spec.buildRequests([bannerBid], bannerBidderRequest);
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, syncResponses);
+      expect(syncs[0].url).to.not.contain('account=');
     });
 
     it('forwards GDPR, USP and GPP consent', function () {


### PR DESCRIPTION
Add the OCM (Orange Click Media) bid adapter for Prebid.js submission, ported from the OCM prebid fork. The adapter supports Banner, Video (outstream) and Native media types via the ORTB converter, resolves demand from an OCM Prebid Server stored request, attaches an outstream video renderer (OCM Video Player) loaded through Prebid's Renderer, registers PBS win/impression event trackers, and performs iframe-based user syncing through a POST-capable cookie_sync loader.

Includes:
- modules/ocmBidAdapter.js      the adapter (spec + registerBidder)
- modules/ocmBidAdapter.md      module docs, params and test parameters
- test/spec/modules/ocmBidAdapter_spec.js  unit tests (47 tests)

Prepared for upstream submission: dropped a dead variable initializer that tripped the stricter no-useless-assignment lint rule. gulp lint is clean and gulp test passes in both the default and all-features-disabled build variants.

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This is an update of the old aliased OCM bid adapter (prev. aliased against adtelligent).
We're moving to an in-house bid adapter and prebid server.

Peter Lazaridis <peter@orangeclickmedia.com>
- Test parameters for validating bids:
```
{
  bidder: 'ocm',
  params: {
    'publisherId': 'orangeclickmedia.com',
    'placementId': '65b49bb0cc723602'
  }
}
```

## Other information
The bid adapter has already been tested and running on several sites of our network.