### PR TITLE
Core: avoid double-escaping tracker query separators

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -453,6 +453,10 @@ export function insertUserSyncIframe(url, done, timeout) {
   internal.insertElement(iframe, document, 'html', true);
 }
 
+function decodeAmpersandEntities(url) {
+  return url.replace(/&amp;/gi, '&');
+}
+
 /**
  * Creates a snippet of HTML that retrieves the specified `url`
  * @param  {string} url URL to be requested
@@ -464,7 +468,7 @@ export function createTrackPixelHtml(url, encode = encodeURI) {
     return '';
   }
 
-  const escapedUrl = encode(url).replace(/["'&<>]/g, (char) => {
+  const escapedUrl = encode(decodeAmpersandEntities(url)).replace(/["'&<>]/g, (char) => {
     switch (char) {
       case '"':
         return '&quot;';

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -839,8 +839,8 @@ describe('Utils', function () {
       ].forEach(([input, expected]) => {
         it(`can encode ${input} -> ${expected}`, () => {
           expect(encodeMacroURI(input)).to.eql(expected);
-        })
-      })
+        });
+      });
     });
 
     describe('createTrackPixelHtml', () => {
@@ -854,6 +854,12 @@ describe('Utils', function () {
         const url = 'https://www.example.com/?x="test"';
 
         expect(utils.createTrackPixelHtml(url)).to.contain('src="https://www.example.com/?x=%22test%22"');
+      });
+
+      it('does not double-escape html-encoded query separators', () => {
+        const url = 'https://www.example.com/?a=1&amp;b=2&amp;c=3';
+
+        expect(utils.createTrackPixelHtml(url)).to.contain('src="https://www.example.com/?a=1&amp;b=2&amp;c=3"');
       });
     });
   });


### PR DESCRIPTION
### Motivation
- Tracker image URLs coming from ad markup or XML can already contain HTML-entity encoded separators like `&amp;`, and passing them through the existing encode+escape path produced `&amp;amp;` in emitted HTML which breaks server-side parameter parsing.

### Description
- Add a small helper `decodeAmpersandEntities(url)` that converts existing `&amp;` back to `&` before encoding.
- Normalize URLs by calling `encode(decodeAmpersandEntities(url))` inside `createTrackPixelHtml` so already-encoded query separators are not double-escaped.
- Add a unit test in `test/spec/utils_spec.js` that asserts `createTrackPixelHtml` preserves `&amp;` separators in emitted `src` for an input URL containing `&amp;`.
- Fix nearby missing semicolons in `test/spec/utils_spec.js` to satisfy linting for the changed file.

### Testing
- Ran lint on the changed files with `npx eslint src/utils.js test/spec/utils_spec.js --cache --cache-strategy content` and it passed for the final change set.
- Ran the targeted unit tests with `npx gulp test --nolint --file test/spec/utils_spec.js` and the test chunk completed successfully (`185 tests completed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e23c4c698832b9c864f118f50caf1)