### PR TITLE
adQuery ID System: resolve qid synchronously without backend round-trip

### DIFF
--- a/modules/adqueryIdSystem.js
+++ b/modules/adqueryIdSystem.js
@@ -54,6 +54,12 @@ export const adqueryIdSubmodule = {
 
     let qid = storage.getDataFromLocalStorage('qid');
 
+    if (qid && qid.length > 36) {
+      logInfo('adqueryIdSubmodule ID QID invalid length, removing:', qid.length);
+      storage.removeDataFromLocalStorage('qid');
+      qid = null;
+    }
+
     if (!qid) {
       if (window.crypto && window.crypto.getRandomValues) {
         const randomValues = Array.from(window.crypto.getRandomValues(new Uint32Array(4)));

--- a/modules/adqueryIdSystem.js
+++ b/modules/adqueryIdSystem.js
@@ -7,7 +7,7 @@
 
 import { getStorageManager } from '../src/storageManager.js';
 import { submodule } from '../src/hook.js';
-import { logInfo, logMessage } from '../src/utils.js';
+import { generateUUID, logInfo, logMessage } from '../src/utils.js';
 import { MODULE_TYPE_UID } from '../src/activities/modules.js';
 
 /**
@@ -55,8 +55,12 @@ export const adqueryIdSubmodule = {
     let qid = storage.getDataFromLocalStorage('qid');
 
     if (!qid) {
-      const randomValues = Array.from(window.crypto.getRandomValues(new Uint32Array(4)));
-      qid = randomValues.map(val => val.toString(36)).join('').substring(0, 20);
+      if (window.crypto && window.crypto.getRandomValues) {
+        const randomValues = Array.from(window.crypto.getRandomValues(new Uint32Array(4)));
+        qid = randomValues.map(val => val.toString(36)).join('').substring(0, 20);
+      } else {
+        qid = generateUUID();
+      }
       storage.setDataInLocalStorage('qid', qid);
 
       logInfo('adqueryIdSubmodule ID QID GENERATED:', qid);

--- a/modules/adqueryIdSystem.js
+++ b/modules/adqueryIdSystem.js
@@ -5,10 +5,9 @@
  * @requires module:modules/userId
  */
 
-import { ajax } from '../src/ajax.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { submodule } from '../src/hook.js';
-import { isFn, isPlainObject, isStr, logError, logInfo, logMessage } from '../src/utils.js';
+import { logInfo, logMessage } from '../src/utils.js';
 import { MODULE_TYPE_UID } from '../src/activities/modules.js';
 
 /**
@@ -21,20 +20,6 @@ const MODULE_NAME = 'qid';
 const AU_GVLID = 902;
 
 export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: 'qid' });
-
-/**
- * Param or default.
- * @param {String} param
- * @param {String} defaultVal
- */
-function paramOrDefault(param, defaultVal, arg) {
-  if (isFn(param)) {
-    return param(arg);
-  } else if (isStr(param)) {
-    return param;
-  }
-  return defaultVal;
-}
 
 /** @type {Submodule} */
 export const adqueryIdSubmodule = {
@@ -60,70 +45,26 @@ export const adqueryIdSubmodule = {
     return { qid: value };
   },
   /**
-   * performs action to obtain id and return a value in the callback's response argument
+   * performs action to obtain id and return a value synchronously
    * @function
-   * @param {SubmoduleConfig} [config]
    * @returns {IdResponse|undefined}
    */
-  getId(config) {
+  getId() {
     logMessage('adqueryIdSubmodule getId');
 
-    const qid = storage.getDataFromLocalStorage('qid');
+    let qid = storage.getDataFromLocalStorage('qid');
 
-    if (qid) {
-      return {
-        callback: function (callback) {
-          callback(qid);
-        }
-      };
+    if (!qid) {
+      const randomValues = Array.from(window.crypto.getRandomValues(new Uint32Array(4)));
+      qid = randomValues.map(val => val.toString(36)).join('').substring(0, 20);
+      storage.setDataInLocalStorage('qid', qid);
+
+      logInfo('adqueryIdSubmodule ID QID GENERATED:', qid);
     }
 
-    if (!isPlainObject(config.params)) {
-      config.params = {};
-    }
+    logInfo('adqueryIdSubmodule ID QID:', qid);
 
-    const url = paramOrDefault(
-      config.params.url,
-      `https://bidder.adquery.io/prebid/qid`,
-      config.params.urlArg
-    );
-
-    const resp = function (callback) {
-      let qid = window.qid;
-
-      if (!qid) {
-        const ramdomValues = Array.from(window.crypto.getRandomValues(new Uint32Array(4)));
-        qid = ramdomValues.map(val => val.toString(36)).join('').substring(0, 20);
-
-        logInfo('adqueryIdSubmodule ID QID GENERTAED:', qid);
-      }
-      logInfo('adqueryIdSubmodule ID QID:', qid);
-
-      const callbacks = {
-        success: response => {
-          let responseObj;
-          if (response) {
-            try {
-              responseObj = JSON.parse(response);
-            } catch (error) {
-              logError(error);
-            }
-          }
-          if (responseObj.qid) {
-            const myQid = responseObj.qid;
-            storage.setDataInLocalStorage('qid', myQid);
-            return callback(myQid);
-          }
-          callback();
-        },
-        error: error => {
-          logError(`${MODULE_NAME}: ID fetch encountered an error`, error);
-          callback();
-        }
-      };
-      ajax(url + '?qid=' + qid, callbacks, undefined, { method: 'GET' });
-    };
-    return { callback: resp };
+    return { id: qid };
   },
   eids: {
     'qid': {

--- a/modules/adqueryIdSystem.md
+++ b/modules/adqueryIdSystem.md
@@ -29,7 +29,4 @@ The below parameters apply only to the Adquery User ID Module integration.
 | storage.type | Required | String | This is where the results of the user ID will be stored. The recommended method is `localStorage` by specifying `html5`. | `"html5"` |
 | storage.name | Required | String | The name of the html5 local storage where the user ID will be stored. | `"qid"` |
 | storage.expires | Optional | Integer | How long (in days) the user ID information will be stored. | `365` |
-| value | Optional | Object | Used only if the page has a separate mechanism for storing the Adquery ID. The value is an object containing the values to be sent to the adapters. In this scenario, no URL is called and nothing is added to local storage | `{"qid": "2abf9f001fcd81241b67"}` |
-| params | Optional | Object | Used to store params for the id system |
-| params.url | Optional | String | Set an alternate GET url for qid with this parameter |
-| params.urlArg | Optional | Object | Optional url parameter for params.url |
+| value | Optional | Object | Used only if the page has a separate mechanism for storing the Adquery ID. The value is an object containing the values to be sent to the adapters. In this scenario, nothing is added to local storage | `{"qid": "2abf9f001fcd81241b67"}` |

--- a/test/spec/modules/adqueryIdSystem_spec.js
+++ b/test/spec/modules/adqueryIdSystem_spec.js
@@ -56,6 +56,23 @@ describe('AdqueryIdSystem', function () {
 
       expect(second.id).to.equal(first.id);
     });
+
+    it('falls back to Math.random when window.crypto.getRandomValues is unavailable', function () {
+      getDataFromLocalStorageStub.withArgs('qid').returns(null);
+
+      const cryptoTmp = window.crypto;
+      delete window.crypto;
+
+      let result;
+      try {
+        result = adqueryIdSubmodule.getId();
+      } finally {
+        window.crypto = cryptoTmp;
+      }
+
+      expect(result.id).to.be.a('string').that.is.not.empty;
+      expect(setDataInLocalStorageStub.calledWith('qid', result.id)).to.be.true;
+    });
   });
   describe('eid', () => {
     before(() => {

--- a/test/spec/modules/adqueryIdSystem_spec.js
+++ b/test/spec/modules/adqueryIdSystem_spec.js
@@ -18,15 +18,18 @@ describe('AdqueryIdSystem', function () {
   describe('getId', function () {
     let getDataFromLocalStorageStub;
     let setDataInLocalStorageStub;
+    let removeDataFromLocalStorageStub;
 
     beforeEach(function () {
       getDataFromLocalStorageStub = sinon.stub(storage, 'getDataFromLocalStorage');
       setDataInLocalStorageStub = sinon.stub(storage, 'setDataInLocalStorage');
+      removeDataFromLocalStorageStub = sinon.stub(storage, 'removeDataFromLocalStorage');
     });
 
     afterEach(function () {
       getDataFromLocalStorageStub.restore();
       setDataInLocalStorageStub.restore();
+      removeDataFromLocalStorageStub.restore();
     });
 
     it('returns the persisted qid synchronously when one already exists', function () {
@@ -71,6 +74,18 @@ describe('AdqueryIdSystem', function () {
       }
 
       expect(result.id).to.be.a('string').that.is.not.empty;
+      expect(setDataInLocalStorageStub.calledWith('qid', result.id)).to.be.true;
+    });
+
+    it('discards a stored qid longer than 36 characters and generates a fresh one', function () {
+      const oversizedQid = 'a'.repeat(37);
+      getDataFromLocalStorageStub.withArgs('qid').returns(oversizedQid);
+
+      const result = adqueryIdSubmodule.getId();
+
+      expect(removeDataFromLocalStorageStub.calledWith('qid')).to.be.true;
+      expect(result.id).to.not.equal(oversizedQid);
+      expect(result.id.length).to.be.at.most(36);
       expect(setDataInLocalStorageStub.calledWith('qid', result.id)).to.be.true;
     });
   });

--- a/test/spec/modules/adqueryIdSystem_spec.js
+++ b/test/spec/modules/adqueryIdSystem_spec.js
@@ -1,5 +1,4 @@
 import { adqueryIdSubmodule, storage } from 'modules/adqueryIdSystem.js';
-import { server } from 'test/mocks/xhr.js';
 import sinon from 'sinon';
 import { attachIdSystem } from '../../../modules/userId/index.js';
 import { createEidsArray } from '../../../modules/userId/eids.js';
@@ -18,41 +17,44 @@ describe('AdqueryIdSystem', function () {
 
   describe('getId', function () {
     let getDataFromLocalStorageStub;
+    let setDataInLocalStorageStub;
 
     beforeEach(function () {
       getDataFromLocalStorageStub = sinon.stub(storage, 'getDataFromLocalStorage');
+      setDataInLocalStorageStub = sinon.stub(storage, 'setDataInLocalStorage');
     });
 
     afterEach(function () {
       getDataFromLocalStorageStub.restore();
+      setDataInLocalStorageStub.restore();
     });
 
-    it('gets a adqueryId', function () {
-      const config = {
-        params: {}
-      };
-      const callbackSpy = sinon.spy();
-      const callback = adqueryIdSubmodule.getId(config).callback;
-      callback(callbackSpy);
-      const request = server.requests[0];
-      expect(request.url).to.contain(`https://bidder.adquery.io/prebid/qid`);
-      request.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify({ qid: 'qid_string' }));
-      expect(callbackSpy.lastCall.lastArg).to.deep.equal('qid_string');
+    it('returns the persisted qid synchronously when one already exists', function () {
+      getDataFromLocalStorageStub.withArgs('qid').returns('existing-qid');
+
+      const result = adqueryIdSubmodule.getId();
+
+      expect(result).to.deep.equal({ id: 'existing-qid' });
+      expect(setDataInLocalStorageStub.called).to.be.false;
     });
 
-    it('allows configurable id url', function () {
-      const config = {
-        params: {
-          url: 'https://bidder2.adquery.io'
-        }
-      };
-      const callbackSpy = sinon.spy();
-      const callback = adqueryIdSubmodule.getId(config).callback;
-      callback(callbackSpy);
-      const request = server.requests[0];
-      expect(request.url).to.contains('https://bidder2.adquery.io');
-      request.respond(200, { 'Content-Type': 'application/json' }, JSON.stringify({ qid: 'testqid' }));
-      expect(callbackSpy.lastCall.lastArg).to.deep.equal('testqid');
+    it('generates and persists a new qid when none is stored yet', function () {
+      getDataFromLocalStorageStub.withArgs('qid').returns(null);
+
+      const result = adqueryIdSubmodule.getId();
+
+      expect(result.id).to.be.a('string').that.is.not.empty;
+      expect(setDataInLocalStorageStub.calledWith('qid', result.id)).to.be.true;
+    });
+
+    it('reuses the same qid across multiple getId calls once persisted', function () {
+      getDataFromLocalStorageStub.withArgs('qid').returns(null);
+      const first = adqueryIdSubmodule.getId();
+
+      getDataFromLocalStorageStub.withArgs('qid').returns(first.id);
+      const second = adqueryIdSubmodule.getId();
+
+      expect(second.id).to.equal(first.id);
     });
   });
   describe('eid', () => {


### PR DESCRIPTION
Type of change

  - [x] Updated bidder adapter

  Description of change

Previously, adqueryIdSubmodule.getId() made an async ajax call to https://bidder.adquery.io/prebid/qid to fetch the qid. The client-side fallback id was only persisted to localStorage after the backend responded — if the
request failed or returned no qid, nothing was saved and the id could be regenerated on every call.

  getId() is now fully synchronous, with no backend round-trip:
  - Checks localStorage for an existing qid first.
  - If none exists, generates one and persists it immediately.
  - Uses window.crypto.getRandomValues as before, falling back to generateUUID() from src/utils.js when WebCrypto isn't available, instead of throwing.
  - Discards any stored qid longer than 36 characters and generates a new one.