### PR TITLE
Prevent double-escaping of HTML-encoded ampersands in createTrackPixelHtml and add tests

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -453,6 +453,10 @@ export function insertUserSyncIframe(url, done, timeout) {
   internal.insertElement(iframe, document, 'html', true);
 }
 
+function decodeAmpersandEntities(url) {
+  return url.replace(/&(amp|#38|#x26);/gi, '&');
+}
+
 /**
  * Creates a snippet of HTML that retrieves the specified `url`
  * @param  {string} url URL to be requested
@@ -464,7 +468,7 @@ export function createTrackPixelHtml(url, encode = encodeURI) {
     return '';
   }
 
-  const escapedUrl = encode(url).replace(/["'&<>]/g, (char) => {
+  const escapedUrl = encode(decodeAmpersandEntities(url)).replace(/["'&<>]/g, (char) => {
     switch (char) {
       case '"':
         return '&quot;';

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -839,8 +839,8 @@ describe('Utils', function () {
       ].forEach(([input, expected]) => {
         it(`can encode ${input} -> ${expected}`, () => {
           expect(encodeMacroURI(input)).to.eql(expected);
-        })
-      })
+        });
+      });
     });
 
     describe('createTrackPixelHtml', () => {
@@ -854,6 +854,18 @@ describe('Utils', function () {
         const url = 'https://www.example.com/?x="test"';
 
         expect(utils.createTrackPixelHtml(url)).to.contain('src="https://www.example.com/?x=%22test%22"');
+      });
+
+      it('does not double-escape html-encoded query separators', () => {
+        const cases = [
+          ['https://www.example.com/?a=1&amp;b=2&amp;c=3', 'https://www.example.com/?a=1&amp;b=2&amp;c=3'],
+          ['https://www.example.com/?a=1&#38;b=2', 'https://www.example.com/?a=1&amp;b=2'],
+          ['https://www.example.com/?a=1&#x26;b=2', 'https://www.example.com/?a=1&amp;b=2']
+        ];
+
+        cases.forEach(([url, expected]) => {
+          expect(utils.createTrackPixelHtml(url)).to.contain(`src="${expected}"`);
+        });
       });
     });
   });


### PR DESCRIPTION
### Motivation

- Ensure query separators that are already HTML-encoded (like `&amp;`, `&#38;`, `&#x26;`) are not double-escaped when building a tracking pixel `img` `src` attribute, which can produce incorrect URLs or broken attributes.
- Add unit tests to assert the correct handling of various encoded ampersand forms.

### Description

- Add a helper `decodeAmpersandEntities` that converts `&amp;`, `&#38;`, and `&#x26;` to the literal `&` before further processing. 
- Update `createTrackPixelHtml` to call `decodeAmpersandEntities(url)` before applying the provided `encode` function and HTML-escaping, preventing double-encoding of already-encoded separators. 
- Extend `test/spec/utils_spec.js` with cases verifying that `createTrackPixelHtml` preserves or normalizes encoded query separators and does not double-escape them. 
- Minor test formatting adjustments in the `encodeMacroURI` test block for consistency.

### Testing

- Ran the unit test suite which includes the updated `test/spec/utils_spec.js` specs; the tests covering `createTrackPixelHtml` and `encodeMacroURI` passed. 
- The new cases asserting handling of `&amp;`, `&#38;`, and `&#x26;` were executed as part of the automated tests and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4e23c4c698832b9c864f118f50caf1)