### PR TITLE
TrustX Bid Adapter: fix tracking URL test assertion

### DIFF
--- a/test/spec/modules/trustxBidAdapter_spec.js
+++ b/test/spec/modules/trustxBidAdapter_spec.js
@@ -843,9 +843,9 @@ describe('trustxBidAdapter', function() {
         expect(bids).to.be.an('array').that.is.not.empty;
         // burl is directly mapped to bidResponse.burl by ortbConverter
         expect(bids[0].burl).to.equal(burl);
-        // nurl is processed by banner processor: if adm exists, nurl is embedded as tracking pixel in ad
+        // nurl is processed by banner processor: if adm exists, nurl is embedded as an escaped tracking pixel in ad
         // if no adm, nurl becomes adUrl. In this case, we have adm, so nurl is in ad as tracking pixel
-        expect(bids[0].ad).to.include(nurl); // nurl should be embedded in ad as tracking pixel
+        expect(bids[0].ad).to.include('https://trackers.trustx.org/event?brid=xxx&amp;e=nurl&amp;cpm=${AUCTION_PRICE}');
         expect(bids[0].ad).to.include('<div>Test Ad</div>'); // original adm should still be there
       });
 


### PR DESCRIPTION
### Motivation
- A unit test for TrustX was failing because the banner response embeds `nurl` into `ad` markup via `createTrackPixelHtml`, which escapes HTML characters such as `&`, so the test should assert the escaped form instead of the raw URL.

### Description
- Updated the assertion in `test/spec/modules/trustxBidAdapter_spec.js` to expect the HTML-escaped tracking-pixel URL (`https://trackers.trustx.org/event?brid=xxx&amp;e=nurl&amp;cpm=${AUCTION_PRICE}`) while still asserting the original `adm` markup is present.

### Testing
- Ran `npx eslint test/spec/modules/trustxBidAdapter_spec.js --cache --cache-strategy content` which passed.
- Ran `npx gulp test --nolint --file test/spec/modules/trustxBidAdapter_spec.js` which passed (the previously failing test now succeeds).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4fc0a36848832b92261f4397ee781e)