### PR TITLE
Adkernel Bid Adapter: fix banner nurl pixel test

### DIFF
--- a/test/spec/modules/adkernelBidAdapter_spec.js
+++ b/test/spec/modules/adkernelBidAdapter_spec.js
@@ -690,8 +690,8 @@ describe('Adkernel adapter', function () {
     it('should add nurl as pixel for banner response', function () {
       const [pbRequests] = buildRequest([bid1_zone1]);
       const resp = spec.interpretResponse({ body: bannerBidResponse }, pbRequests[0])[0];
-      const expectedNurl = bannerBidResponse.seatbid[0].bid[0].nurl + '&px=1';
-      expect(resp.ad).to.have.string(expectedNurl);
+      const expectedPixel = utils.createTrackPixelHtml(`${bannerBidResponse.seatbid[0].bid[0].nurl}&px=1`);
+      expect(resp.ad).to.have.string(expectedPixel);
     });
 
     it('should handle bidresponse with user-sync only', function () {


### PR DESCRIPTION
### Motivation
- The banner nurl unit test failed because it compared the raw nurl string instead of the HTML-escaped tracking pixel markup produced by `createTrackPixelHtml`.

### Description
- Updated `test/spec/modules/adkernelBidAdapter_spec.js` to generate the expected value with `utils.createTrackPixelHtml(`${bannerBidResponse.seatbid[0].bid[0].nurl}&px=1`)` and assert `resp.ad` contains that pixel.
- No production code changes were made; only the test assertion was corrected.

### Testing
- `npx eslint test/spec/modules/adkernelBidAdapter_spec.js --cache --cache-strategy content` was run and passed.
- `npx gulp test --nolint --file test/spec/modules/adkernelBidAdapter_spec.js` was run and passed, with 45 tests completing successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4fc0637af4832b9f5d9c12173e013a)