### PR TITLE
Ms Clarity RTD Provider: add behavioral signals module

### DIFF
--- a/integrationExamples/gpt/msclarity_rtd_example.html
+++ b/integrationExamples/gpt/msclarity_rtd_example.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <title>MS Clarity RTD — Integration Example</title>
+
+  <!--
+    The RTD module auto-injects the Clarity JS tag by default.
+    To disable auto-injection, set params.injectClarity = false and
+    include the Clarity snippet manually. Replace YOUR_PROJECT_ID below.
+  -->
+  <!--
+  <script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+      c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+      t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+      y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", "YOUR_PROJECT_ID");
+  </script>
+  -->
+
+  <!-- Prebid.js (built with msClarityRtdProvider + appnexusBidAdapter + msftBidAdapter) -->
+  <script src="../../build/dev/prebid.js"></script>
+
+  <!-- GPT -->
+  <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
+</head>
+<body>
+<h1>MS Clarity RTD — Integration Test</h1>
+<p>Open the browser console to see bucketed Clarity signals flowing into bid requests.</p>
+<p>Scroll down, click around, and watch feature values change between auctions.</p>
+<p><strong>Signals are written to global ORTB2 — all bidders receive them.</strong></p>
+
+<div id="ad-div-1" style="width:300px;height:250px;border:1px solid #ccc;margin:20px 0;"></div>
+
+<!-- filler content for scroll-depth testing -->
+<div style="height:2000px;background:linear-gradient(to bottom,#f0f0f0,#d0d0d0);padding:20px;">
+  <p>Scroll down to increase the <code>scroll</code> feature...</p>
+  <div style="margin-top:800px;">
+    <p>You've scrolled past 40% of the page.</p>
+  </div>
+  <div style="margin-top:400px;">
+    <p>You've scrolled past 60% of the page.</p>
+  </div>
+</div>
+
+<div id="ad-div-2" style="width:728px;height:90px;border:1px solid #ccc;margin:20px 0;"></div>
+
+<script>
+  window.pbjs = window.pbjs || { que: [] };
+
+  pbjs.que.push(function() {
+    console.log('=== PREBID + MS CLARITY RTD INITIALIZATION ===');
+    console.log('Installed Modules:', pbjs.installedModules);
+
+    // Enable debug logging
+    pbjs.setConfig({ debug: true });
+
+    // Configure RTD + Clarity
+    // Signals are written to global ORTB2 — available to all bidders.
+    // The Clarity JS tag is auto-injected by default (set injectClarity: false to disable).
+    pbjs.setConfig({
+      realTimeData: {
+        auctionDelay: 200,
+        dataProviders: [{
+          name: 'msClarity',
+          waitForIt: true,
+          params: {
+            projectId: 'YOUR_PROJECT_ID',   // Replace with your Clarity project ID
+            // injectClarity: false,          // Uncomment to disable auto-injection of Clarity tag
+            targetingPrefix: 'msc'
+          }
+        }]
+      }
+    });
+
+    // Ad units — all bidders receive Clarity signals via global ORTB2
+    pbjs.addAdUnits([
+      {
+        code: 'ad-div-1',
+        mediaTypes: { banner: { sizes: [[300, 250]] } },
+        bids: [
+          { bidder: 'appnexus', params: { placementId: 13144370 } },
+          { bidder: 'msft', params: { placement_id: '13144370' } }
+        ]
+      },
+      {
+        code: 'ad-div-2',
+        mediaTypes: { banner: { sizes: [[728, 90]] } },
+        bids: [
+          { bidder: 'appnexus', params: { placementId: 13144370 } },
+          { bidder: 'msft', params: { placement_id: '13144370' } }
+        ]
+      }
+    ]);
+
+    console.log('=== REQUESTING BIDS ===');
+    pbjs.requestBids({
+      bidsBackHandler: function (bidResponses) {
+        console.log('=== BID RESPONSES ===', bidResponses);
+
+        // Log bidder requests to inspect the per-auction ORTB2 fragments
+        // produced by RTD enrichment.
+        var bidderRequests = pbjs.getBidderRequests();
+        console.log('=== BIDDER REQUEST ORTB2 ===', bidderRequests.map(function (request) {
+          return { bidderCode: request.bidderCode, ortb2: request.ortb2 };
+        }));
+
+        // Render via GPT
+        window.googletag = window.googletag || { cmd: [] };
+        googletag.cmd.push(function () {
+          googletag.pubads().disableInitialLoad();
+          googletag.pubads().enableSingleRequest();
+
+          var slot1 = googletag.defineSlot('/19968336/header-bid-tag-0', [300, 250], 'ad-div-1').addService(googletag.pubads());
+          var slot2 = googletag.defineSlot('/19968336/header-bid-tag-1', [728, 90], 'ad-div-2').addService(googletag.pubads());
+          googletag.enableServices();
+
+          pbjs.setTargetingForGPTAsync();
+
+          console.log('=== GPT SLOTS RENDERED ===');
+          console.log('Clarity signals are in bidder request ORTB2 (site.ext.data.msclarity, user.data, site.keywords)');
+
+          googletag.pubads().refresh();
+        });
+      }
+    });
+  });
+</script>
+</body>
+</html>

--- a/integrationExamples/gpt/msclarity_rtd_example.html
+++ b/integrationExamples/gpt/msclarity_rtd_example.html
@@ -112,8 +112,8 @@
           googletag.pubads().disableInitialLoad();
           googletag.pubads().enableSingleRequest();
 
-          var slot1 = googletag.defineSlot('/19968336/header-bid-tag-0', [300, 250], 'ad-div-1').addService(googletag.pubads());
-          var slot2 = googletag.defineSlot('/19968336/header-bid-tag-1', [728, 90], 'ad-div-2').addService(googletag.pubads());
+          googletag.defineSlot('/19968336/header-bid-tag-0', [300, 250], 'ad-div-1').addService(googletag.pubads());
+          googletag.defineSlot('/19968336/header-bid-tag-1', [728, 90], 'ad-div-2').addService(googletag.pubads());
           googletag.enableServices();
 
           pbjs.setTargetingForGPTAsync();

--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -112,6 +112,7 @@
       "mgidRtdProvider",
       "mileRtdProvider",
       "mobianRtdProvider",
+      "msClarityRtdProvider",
       "neuwoRtdProvider",
       "nodalsAiRtdProvider",
       "oftmediaRtdProvider",

--- a/modules/msClarityRtdProvider.d.ts
+++ b/modules/msClarityRtdProvider.d.ts
@@ -1,0 +1,36 @@
+/**
+ * Microsoft Clarity RTD provider parameters.
+ */
+export interface MsClarityRtdProviderParams {
+  /**
+   * Microsoft Clarity project ID. Find this in Clarity project settings.
+   */
+  projectId: string;
+  /**
+   * When `true`, load the Microsoft Clarity JavaScript tag through Prebid's
+   * external-script loader. Defaults to `true`.
+   */
+  injectClarity?: boolean;
+  /**
+   * Prefix used for generated `site.keywords` entries. Defaults to `msc`.
+   */
+  targetingPrefix?: string;
+}
+
+export interface MsClarityRtdProviderConfig {
+  /**
+   * If true, delay the auction up to `auctionDelay` milliseconds to wait for
+   * this provider.
+   */
+  waitForIt?: boolean;
+  /**
+   * Module-specific parameters.
+   */
+  params: MsClarityRtdProviderParams;
+}
+
+declare module './rtdModule/spec' {
+  interface ProviderConfig {
+    msClarity: MsClarityRtdProviderConfig;
+  }
+}

--- a/modules/msClarityRtdProvider.js
+++ b/modules/msClarityRtdProvider.js
@@ -44,6 +44,7 @@ import { MODULE_TYPE_RTD } from '../src/activities/modules.js';
  */
 
 const MODULE_NAME = 'msClarity';
+const APPNEXUS_GVLID = 32;
 const LOG_PREFIX = '[MsClarity RTD]';
 
 /**
@@ -871,6 +872,7 @@ function getBidRequestData(reqBidsConfigObj, callback, config) {
 /** @type {RtdSubmodule} */
 export const msClaritySubmodule = {
   name: MODULE_NAME,
+  gvlid: APPNEXUS_GVLID,
   init,
   getBidRequestData,
 };

--- a/modules/msClarityRtdProvider.js
+++ b/modules/msClarityRtdProvider.js
@@ -1,0 +1,877 @@
+/**
+ * Microsoft Clarity RTD Module
+ *
+ * Collects behavioral signals from a self-contained DOM tracker and writes
+ * bucketed features into global ORTB2 fragments, making them available to
+ * all bidders.  Signals are also published as ORTB2 user.data segments for
+ * native consumption by ORTB-compatible adapters and DSP platforms like
+ * Microsoft Curate.
+ *
+ * Features are organized into three tiers:
+ *   1. Cumulative (durable) — scroll, dwell, interaction, frustration,
+ *      engagement, reading mode, view quality.
+ *   2. Recency / momentum — activity recency, recent engagement.
+ *   3. Auction-time snapshots — attention and page-momentum at the moment
+ *      the bid request is built.
+ *
+ * The Clarity JS tag is injected by default for analytics /
+ * session-recording functionality (set params.injectClarity = false to
+ * opt out).  Bid-enrichment signals are computed independently from DOM
+ * events (scroll, click, keydown, visibility changes).
+ *
+ * Warm-start: the module persists the latest durable signal snapshot to
+ * localStorage so the first auction of a new page load can use stale
+ * (≤ 30 min) signals instead of sending empty defaults.  Transient
+ * auction-time snapshots are always computed fresh.
+ *
+ * See: https://clarity.microsoft.com
+ *
+ * @module modules/msClarityRtdProvider
+ * @requires module:modules/realTimeData
+ */
+
+import { submodule } from '../src/hook.js';
+import { logInfo, logWarn, logError, deepSetValue, deepAccess, getWinDimensions } from '../src/utils.js';
+import { getStorageManager } from '../src/storageManager.js';
+// Required to route optional Clarity tag loading through Prebid activity controls.
+// eslint-disable-next-line no-restricted-imports
+import { loadExternalScript } from '../src/adloader.js';
+import { MODULE_TYPE_RTD } from '../src/activities/modules.js';
+
+/**
+ * @typedef {import('../modules/rtdModule/index.js').RtdSubmodule} RtdSubmodule
+ */
+
+const MODULE_NAME = 'msClarity';
+const LOG_PREFIX = '[MsClarity RTD]';
+
+/**
+ * Default configuration values.
+ */
+const DEFAULTS = Object.freeze({
+  targetingPrefix: 'msc',
+});
+
+/** Idle threshold — stop counting active time after this gap. */
+const IDLE_MS = 10000;
+
+/** localStorage key for warm-start signal persistence. */
+const STORAGE_KEY = 'msc_rtd_signals';
+
+/** Warm-start TTL — signals older than 30 minutes are discarded. */
+const STORAGE_TTL_MS = 30 * 60 * 1000;
+
+/** Storage manager — consent-aware localStorage access. */
+export const storage = getStorageManager({ moduleType: MODULE_TYPE_RTD, moduleName: MODULE_NAME });
+
+/** CSS selector for interactive elements (unresponsive-click detection). */
+const INTERACTIVE_SELECTOR =
+  'a, button, input, select, textarea, label, summary, video, audio, ' +
+  '[role="button"], [role="link"], [role="tab"], [role="menuitem"], ' +
+  '[tabindex], [data-click], [data-action], [onclick], ' +
+  '[class*="btn"], [class*="click"], [class*="card"]';
+
+/** Regex to detect framework event binding attributes (Angular, Vue, etc.). */
+const FRAMEWORK_CLICK_RE = /^(ng-|v-|@|data-ng-)click/;
+
+/** Debounce window for mousemove interaction counting. */
+const MOUSEMOVE_DEBOUNCE_MS = 5000;
+
+/** Timestamp of last mousemove-triggered interaction increment. */
+let _lastMouseMoveInteraction = 0;
+
+/** Duration of the recent-window for recency/momentum signals. */
+const RECENT_WINDOW_MS = 10000;
+
+/** Scroll must be still for this long to count as "reading" vs "scanning". */
+const SCROLL_STABLE_MS = 2000;
+
+/**
+ * Default values for all durable features.
+ * Used for warm-start baseline detection and backward-compat cache loading.
+ */
+const DURABLE_DEFAULTS = Object.freeze({
+  engagement: 'low',
+  dwell: 'bounce',
+  scroll: 'none',
+  frustration: 'none',
+  interaction: 'passive',
+  readingMode: 'skim',
+  viewQuality: 'low',
+});
+
+// ─── Bucket Functions (exported for testability) ─────────────────────────────
+
+/**
+ * Bucket raw scroll depth (0–1) into a categorical label.
+ *
+ * @param {number} depth - 0 to 1
+ * @returns {string}
+ */
+export function scrollBucket(depth) {
+  if (depth <= 0) return 'none';
+  if (depth < 0.25) return 'shallow';
+  if (depth < 0.50) return 'mid';
+  if (depth < 0.75) return 'deep';
+  return 'complete';
+}
+
+/**
+ * Bucket active dwell time into a categorical label.
+ *
+ * @param {number} ms - active time in milliseconds
+ * @returns {string}
+ */
+export function dwellBucket(ms) {
+  if (ms < 5000) return 'bounce';
+  if (ms < 15000) return 'brief';
+  if (ms < 30000) return 'moderate';
+  if (ms < 60000) return 'long';
+  return 'extended';
+}
+
+/**
+ * Bucket frustration signals (rage + exploratory clicks + scroll reversals)
+ * into a categorical label.  Exploratory clicks (on non-interactive elements)
+ * are weighted at 0.5× — they indicate exploration, not necessarily frustration.
+ *
+ * @param {number} rageClicks
+ * @param {number} exploratoryClicks - clicks on non-interactive elements
+ * @param {number} [scrollReversals=0] - every 5 reversals counts as 1 frustration point
+ * @returns {string}
+ */
+export function frustrationBucket(rageClicks, exploratoryClicks, scrollReversals = 0) {
+  const total = rageClicks + Math.floor(exploratoryClicks * 0.5) + Math.floor(scrollReversals / 5);
+  if (total === 0) return 'none';
+  if (total <= 2) return 'mild';
+  if (total <= 5) return 'moderate';
+  return 'severe';
+}
+
+/**
+ * Bucket interaction rate (deliberate events per second of active time).
+ *
+ * @param {number} count  - deliberate interaction events (click, keydown, touch)
+ * @param {number} activeMs - active time in ms
+ * @returns {string}
+ */
+export function interactionBucket(count, activeMs) {
+  if (activeMs <= 0 || count <= 0) return 'passive';
+  const perSec = count / (activeMs / 1000);
+  if (perSec < 0.2) return 'light';
+  if (perSec < 0.5) return 'moderate';
+  if (perSec < 1.0) return 'active';
+  return 'intense';
+}
+
+/**
+ * Composite engagement bucket.  Weighted blend of scroll, time, interaction,
+ * minus a frustration penalty.
+ *
+ * @param {number} scrollDepth  - 0 to 1
+ * @param {number} activeMs
+ * @param {number} interactions
+ * @param {number} rageClicks
+ * @param {number} exploratoryClicks
+ * @returns {string}
+ */
+export function engagementBucket(scrollDepth, activeMs, interactions, rageClicks, exploratoryClicks) {
+  const scrollW = Math.min(1, scrollDepth) * 0.30;
+  const timeW = Math.min(1, activeMs / 60000) * 0.35;
+  const interW = Math.min(1, interactions / 20) * 0.20;
+  // frustPenalty is capped at 0.15 — rage clicks count fully, exploratory at half.
+  const frustPenalty = Math.min(0.15, rageClicks * 0.03 + exploratoryClicks * 0.015);
+  // The + 0.15 is an intentional baseline warmth term: even a completely idle
+  // page starts with a small positive score, acknowledging that the user has
+  // at least loaded the page.  This keeps 'low' from being the *only* outcome
+  // when all weighted signals are zero.
+  const score = Math.max(0, Math.min(1, scrollW + timeW + interW + 0.15 - frustPenalty));
+
+  if (score < 0.25) return 'low';
+  if (score < 0.50) return 'medium';
+  if (score < 0.75) return 'high';
+  return 'very_high';
+}
+
+// ─── Recency / Momentum Buckets ──────────────────────────────────────────────
+
+/**
+ * Bucket seconds since last activity into a recency label.
+ * Reflects how "present" the user currently is.
+ *
+ * @param {number} ms - milliseconds since last activity
+ * @returns {string}
+ */
+export function activityRecencyBucket(ms) {
+  if (ms < 2000) return 'live';
+  if (ms < 10000) return 'recent';
+  return 'stale';
+}
+
+/**
+ * Bucket the count of deliberate interactions in the recent window (10 s).
+ * Captures short-term engagement momentum.
+ *
+ * @param {number} count - deliberate interactions in the last 10 s
+ * @returns {string}
+ */
+export function recentEngagementBucket(count) {
+  if (count === 0) return 'cold';
+  if (count <= 3) return 'warming';
+  return 'hot';
+}
+
+// ─── Visibility / Read-Quality Buckets ───────────────────────────────────────
+
+/**
+ * Bucket the read-vs-scan ratio.  "Reading" is when the tab is visible,
+ * the user is active, and scroll position has been stable for ≥ SCROLL_STABLE_MS.
+ * "Scanning" is active time spent while scroll is in motion.
+ *
+ * @param {number} readTimeMs  - cumulative "reading" time (stable scroll)
+ * @param {number} scanTimeMs  - cumulative "scanning" time (active scroll)
+ * @returns {string}
+ */
+export function readingModeBucket(readTimeMs, scanTimeMs) {
+  const total = readTimeMs + scanTimeMs;
+  if (total < 2000) return 'skim';
+  const readRatio = readTimeMs / total;
+  if (readRatio >= 0.6) return 'read';
+  if (readRatio >= 0.3) return 'scan';
+  return 'skim';
+}
+
+/**
+ * Composite view-quality signal.  Combines reading time, active time,
+ * and scroll depth to judge the overall quality of the page view.
+ *
+ * @param {number} readTimeMs
+ * @param {number} activeTimeMs
+ * @param {number} scrollDepth - 0 to 1
+ * @returns {string}
+ */
+export function viewQualityBucket(readTimeMs, activeTimeMs, scrollDepth) {
+  if (readTimeMs >= 5000 && activeTimeMs >= 10000 && scrollDepth >= 0.25) return 'high';
+  if (readTimeMs >= 2000 && activeTimeMs >= 5000) return 'medium';
+  return 'low';
+}
+
+// ─── Auction-Time Snapshot Buckets ───────────────────────────────────────────
+
+/**
+ * Auction-time attention snapshot.  Computed fresh at bid-request time to
+ * reflect the user's current attentiveness.
+ *
+ * @param {boolean} tabHidden
+ * @param {number}  msSinceLastActivity
+ * @param {number}  readTimeMs
+ * @param {number}  scanTimeMs
+ * @returns {string}
+ */
+export function auctionAttentionBucket(tabHidden, msSinceLastActivity, readTimeMs, scanTimeMs) {
+  if (tabHidden || msSinceLastActivity >= 10000) return 'low';
+  const isReading = readTimeMs > scanTimeMs && readTimeMs >= 2000;
+  if (msSinceLastActivity < 2000 && isReading) return 'high';
+  return 'medium';
+}
+
+/**
+ * Page-momentum snapshot — what phase of the page visit the user is in
+ * at auction time.
+ *
+ * @param {number} activeTimeMs
+ * @param {number} readTimeMs
+ * @param {number} scrollDepth  - 0 to 1
+ * @param {number} msSinceLastActivity
+ * @param {number} recentInteractionCount
+ * @param {number} msSinceLastScroll
+ * @returns {string}
+ */
+export function pageMomentumBucket(activeTimeMs, readTimeMs, scrollDepth, msSinceLastActivity, recentInteractionCount, msSinceLastScroll) {
+  // Just arrived — not enough time for meaningful signals
+  if (activeTimeMs < 5000) return 'arrival';
+  // Fatigued — long session with declining engagement
+  if (activeTimeMs > 30000 && (msSinceLastActivity >= 10000 || recentInteractionCount === 0)) return 'fatigued';
+  // In reading flow — actively reading content (stable scroll, recent activity)
+  if (readTimeMs >= 2000 && msSinceLastActivity < 10000 && msSinceLastScroll >= SCROLL_STABLE_MS) return 'in_reading_flow';
+  // Post scroll — scrolled deep, now settled
+  if (scrollDepth > 0.5 && msSinceLastScroll >= 5000) return 'post_scroll';
+  // Default: active mid-session
+  return 'in_reading_flow';
+}
+
+// ─── Self-Contained Behavioral Tracker ───────────────────────────────────────
+
+const _tracker = {
+  scrollDepth: 0,
+  activeTimeMs: 0,
+  rageClickCount: 0,
+  exploratoryClickCount: 0,
+  totalClicks: 0,
+  activityCount: 0,
+  interactionCount: 0,
+  scrollReversals: 0,
+  readTimeMs: 0,
+  scanTimeMs: 0,
+  _lastActivity: 0,
+  _lastScrollY: 0,
+  _lastScrollDirection: 0,
+  _lastScrollChangeTime: 0,
+  _lastRageBurstTime: 0,
+  _recentInteractions: [],
+  _clickHistory: [],
+  _activeTimer: null,
+  _tabHidden: false,
+  _listeners: [],
+  _initialized: false,
+};
+
+/**
+ * Helper — register a listener and remember it for cleanup.
+ */
+function _addListener(target, event, handler, options) {
+  target.addEventListener(event, handler, options);
+  _tracker._listeners.push({ target, event, handler });
+}
+
+/**
+ * Reset tracker to initial state, remove event listeners and intervals.
+ * Exported for test isolation (called automatically by init()).
+ */
+export function resetTracker() {
+  if (_tracker._activeTimer) {
+    clearInterval(_tracker._activeTimer);
+  }
+  _tracker._listeners.forEach(({ target, event, handler }) => {
+    target.removeEventListener(event, handler);
+  });
+  _tracker.scrollDepth = 0;
+  _tracker.activeTimeMs = 0;
+  _tracker.rageClickCount = 0;
+  _tracker.exploratoryClickCount = 0;
+  _tracker.totalClicks = 0;
+  _tracker.activityCount = 0;
+  _tracker.interactionCount = 0;
+  _tracker.scrollReversals = 0;
+  _tracker.readTimeMs = 0;
+  _tracker.scanTimeMs = 0;
+  _tracker._lastActivity = 0;
+  _tracker._lastScrollY = 0;
+  _tracker._lastScrollDirection = 0;
+  _tracker._lastScrollChangeTime = 0;
+  _tracker._lastRageBurstTime = 0;
+  _tracker._recentInteractions = [];
+  _tracker._clickHistory = [];
+  _tracker._activeTimer = null;
+  _tracker._tabHidden = false;
+  _tracker._listeners = [];
+  _tracker._initialized = false;
+  _lastMouseMoveInteraction = 0;
+}
+
+/**
+ * Bootstrap active time from Navigation Timing API heuristics.
+ * Called once during tracker initialization to pre-seed reasonable
+ * active-time values for returning users and same-site navigations.
+ *
+ * - back_forward: returning visitor heuristic → 5 000 ms
+ * - same-origin referrer: session continuity   → 3 000 ms
+ *
+ * Gracefully no-ops if the Performance API is unavailable.
+ */
+function bootstrapFromNavTiming() {
+  try {
+    if (typeof performance === 'undefined' || typeof performance.getEntriesByType !== 'function') return;
+    const entries = performance.getEntriesByType('navigation');
+    if (!entries || entries.length === 0) return;
+
+    const nav = entries[0];
+
+    if (nav.type === 'back_forward') {
+      _tracker.activeTimeMs = Math.max(_tracker.activeTimeMs, 5000);
+      logInfo(`${LOG_PREFIX} Nav Timing: back_forward detected — seeded activeTimeMs to ${_tracker.activeTimeMs}.`);
+      return;
+    }
+
+    const referrer = getDocumentReferrer();
+    if (referrer) {
+      try {
+        const referrerHost = new URL(referrer).hostname;
+        if (referrerHost === location.hostname) {
+          _tracker.activeTimeMs = Math.max(_tracker.activeTimeMs, 3000);
+          logInfo(`${LOG_PREFIX} Nav Timing: same-origin referrer — seeded activeTimeMs to ${_tracker.activeTimeMs}.`);
+        }
+      } catch (e) { /* malformed referrer — ignore */ }
+    }
+  } catch (e) { /* Performance API error — ignore */ }
+}
+
+/**
+ * Thin getter for document.referrer — extracted for testability in
+ * environments where the native property cannot be overridden.
+ * @returns {string}
+ */
+export function getDocumentReferrer() {
+  return document.referrer;
+}
+
+/**
+ * Check whether an element is likely interactive — accounts for standard
+ * HTML interactive elements, ARIA roles, tabindex, and framework-specific
+ * event binding attributes (Angular ng-click, Vue v-click / @click, etc.).
+ *
+ * @param {Element} el
+ * @returns {boolean}
+ */
+export function isLikelyInteractive(el) {
+  if (!el || typeof el.closest !== 'function') return false;
+
+  // Standard selector check
+  if (el.closest(INTERACTIVE_SELECTOR)) return true;
+
+  // Framework event-binding attribute check (walk up from target)
+  let node = el;
+  while (node && node !== document.body) {
+    if (node.attributes) {
+      for (let i = 0; i < node.attributes.length; i++) {
+        if (FRAMEWORK_CLICK_RE.test(node.attributes[i].name)) return true;
+      }
+    }
+    node = node.parentElement;
+  }
+
+  return false;
+}
+
+/**
+ * Start the behavioral tracker.  Attaches scroll, click, keydown,
+ * touchstart, pointerdown, mousemove, and visibilitychange listeners.
+ * Safe to call after resetTracker() to re-initialise.
+ */
+function initTracker() {
+  if (_tracker._initialized) return;
+  _tracker._initialized = true;
+  _tracker._lastActivity = Date.now();
+  _tracker._lastScrollY = window.scrollY || 0;
+  _tracker._lastScrollChangeTime = Date.now();
+
+  // Bootstrap active time from Navigation Timing API heuristics
+  bootstrapFromNavTiming();
+
+  /** Increment activity counter (all DOM events). */
+  function markActivity(now) {
+    _tracker._lastActivity = now || Date.now();
+    _tracker.activityCount++;
+  }
+
+  /** Increment deliberate interaction counter (click, keydown, touch + recent tracking). */
+  function markInteraction(now) {
+    now = now || Date.now();
+    markActivity(now);
+    _tracker.interactionCount++;
+    _tracker._recentInteractions.push(now);
+  }
+
+  // ── Visibility tracking ─────────────────────────────────────────────────
+  _addListener(document, 'visibilitychange', () => {
+    _tracker._tabHidden = document.hidden;
+  });
+
+  // ── Scroll tracking (depth + reversal detection) ───────────────────────
+  const onScroll = () => {
+    const now = Date.now();
+    markActivity(now);
+
+    const scrollTop = window.scrollY || window.pageYOffset || 0;
+    const winDim = getWinDimensions();
+    const docHeight = Math.max(
+      document.body.scrollHeight || 0,
+      document.documentElement.scrollHeight || 0
+    ) - (winDim.innerHeight || 0);
+
+    if (docHeight > 0) {
+      _tracker.scrollDepth = Math.max(
+        _tracker.scrollDepth,
+        Math.min(1, scrollTop / docHeight)
+      );
+    }
+
+    // Scroll reversal detection
+    const delta = scrollTop - _tracker._lastScrollY;
+    if (delta !== 0) {
+      const direction = delta > 0 ? 1 : -1;
+      if (_tracker._lastScrollDirection !== 0 && direction !== _tracker._lastScrollDirection) {
+        _tracker.scrollReversals++;
+      }
+      _tracker._lastScrollDirection = direction;
+    }
+
+    _tracker._lastScrollChangeTime = now;
+    _tracker._lastScrollY = scrollTop;
+  };
+  _addListener(window, 'scroll', onScroll, { passive: true });
+
+  // ── Active time — 1 s tick, visibility-aware, idle-gated ───────────────
+  // Deliberate interactions: keydown, touchstart, pointerdown.
+  ['keydown', 'touchstart', 'pointerdown'].forEach(evt => {
+    _addListener(window, evt, () => markInteraction(), { passive: true });
+  });
+
+  // Debounced mousemove: prevents read-heavy pages from showing 'passive'
+  // interaction.  Only increments interactionCount once per 5-second window,
+  // but keeps the idle timer alive on every move.
+  _addListener(window, 'mousemove', () => {
+    const now = Date.now();
+    _tracker._lastActivity = now;
+    if (now - _lastMouseMoveInteraction > MOUSEMOVE_DEBOUNCE_MS) {
+      _tracker.interactionCount++;
+      _lastMouseMoveInteraction = now;
+    }
+  }, { passive: true });
+
+  _tracker._activeTimer = setInterval(() => {
+    const now = Date.now();
+    if (!_tracker._tabHidden && now - _tracker._lastActivity < IDLE_MS) {
+      _tracker.activeTimeMs += 1000;
+      // Read vs scan: stable scroll = reading, recent scroll = scanning
+      if (now - _tracker._lastScrollChangeTime >= SCROLL_STABLE_MS) {
+        _tracker.readTimeMs += 1000;
+      } else {
+        _tracker.scanTimeMs += 1000;
+      }
+    }
+  }, 1000);
+
+  // ── Click tracking — rage-clicks (deduplicated) & exploratory clicks ───
+  _addListener(window, 'click', (e) => {
+    const now = Date.now();
+    markInteraction(now);
+    _tracker.totalClicks++;
+
+    const x = e.clientX;
+    const y = e.clientY;
+    _tracker._clickHistory.push({ time: now, x, y });
+
+    // Prune to last 2 seconds
+    _tracker._clickHistory = _tracker._clickHistory.filter(c => now - c.time < 2000);
+
+    // Rage click: ≥ 3 clicks in 500 ms within 30 px — deduplicated per burst
+    const recent = _tracker._clickHistory.filter(c =>
+      now - c.time < 500 &&
+      Math.abs(c.x - x) < 30 &&
+      Math.abs(c.y - y) < 30
+    );
+    if (recent.length >= 3 && (now - _tracker._lastRageBurstTime > 500)) {
+      _tracker.rageClickCount++;
+      _tracker._lastRageBurstTime = now;
+    }
+
+    // Exploratory click: target not inside any interactive element
+    if (e.target && !isLikelyInteractive(e.target)) {
+      _tracker.exploratoryClickCount++;
+    }
+  });
+
+  logInfo(`${LOG_PREFIX} Behavioral tracker started.`);
+}
+
+// ─── Feature Builders ─────────────────────────────────────────────────────────
+
+/**
+ * Count recent deliberate interactions within the RECENT_WINDOW_MS window,
+ * pruning stale entries.  Used by snapshot features.
+ *
+ * @param {number} now - current timestamp
+ * @returns {number}
+ */
+function getRecentInteractionCount(now) {
+  const cutoff = now - RECENT_WINDOW_MS;
+  while (_tracker._recentInteractions.length > 0 && _tracker._recentInteractions[0] < cutoff) {
+    _tracker._recentInteractions.shift();
+  }
+  return _tracker._recentInteractions.length;
+}
+
+/**
+ * Build the 7 durable bucketed features from current tracker state.
+ * These features are persisted to localStorage for warm-start.
+ * Exported for testability.
+ *
+ * @returns {Object} features
+ */
+export function buildFeatures() {
+  return {
+    engagement: engagementBucket(
+      _tracker.scrollDepth,
+      _tracker.activeTimeMs,
+      _tracker.interactionCount,
+      _tracker.rageClickCount,
+      _tracker.exploratoryClickCount
+    ),
+    dwell: dwellBucket(_tracker.activeTimeMs),
+    scroll: scrollBucket(_tracker.scrollDepth),
+    frustration: frustrationBucket(_tracker.rageClickCount, _tracker.exploratoryClickCount, _tracker.scrollReversals),
+    interaction: interactionBucket(_tracker.interactionCount, _tracker.activeTimeMs),
+    readingMode: readingModeBucket(_tracker.readTimeMs, _tracker.scanTimeMs),
+    viewQuality: viewQualityBucket(_tracker.readTimeMs, _tracker.activeTimeMs, _tracker.scrollDepth),
+  };
+}
+
+/**
+ * Build 4 transient auction-time snapshot features.
+ * These reflect the user's current state at the moment of bid request
+ * and are NOT persisted to localStorage.
+ * Exported for testability.
+ *
+ * @returns {Object} snapshot features
+ */
+export function buildSnapshotFeatures() {
+  const now = Date.now();
+  const msSinceLastActivity = _tracker._lastActivity > 0
+    ? (now - _tracker._lastActivity) : IDLE_MS + 1;
+  const recentCount = getRecentInteractionCount(now);
+  const msSinceLastScroll = _tracker._lastScrollChangeTime > 0
+    ? (now - _tracker._lastScrollChangeTime) : IDLE_MS + 1;
+
+  return {
+    activityRecency: activityRecencyBucket(msSinceLastActivity),
+    recentEngagement: recentEngagementBucket(recentCount),
+    auctionAttention: auctionAttentionBucket(
+      _tracker._tabHidden,
+      msSinceLastActivity,
+      _tracker.readTimeMs,
+      _tracker.scanTimeMs
+    ),
+    pageMomentum: pageMomentumBucket(
+      _tracker.activeTimeMs,
+      _tracker.readTimeMs,
+      _tracker.scrollDepth,
+      msSinceLastActivity,
+      recentCount,
+      msSinceLastScroll
+    ),
+  };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Check whether the Clarity JS tag is present on the page.
+ * @returns {boolean}
+ */
+function isClarityPresent() {
+  return typeof window.clarity === 'function';
+}
+
+/**
+ * Queue Clarity API calls until the Clarity tag finishes loading.
+ */
+function installClarityStub() {
+  window.clarity = window.clarity || function () {
+    (window.clarity.q = window.clarity.q || []).push(arguments);
+  };
+}
+
+/**
+ * Inject the Microsoft Clarity tag through Prebid's external-script loader so
+ * activity controls and request de-duplication are applied consistently.
+ *
+ * @param {string} projectId
+ */
+function injectClarityScript(projectId) {
+  try {
+    installClarityStub();
+    loadExternalScript(`https://www.clarity.ms/tag/${projectId}`, MODULE_TYPE_RTD, MODULE_NAME, {
+      success: () => logInfo(`${LOG_PREFIX} Injected Clarity tag for project ${projectId}.`),
+      error: (e) => logError(`${LOG_PREFIX} Failed to inject Clarity tag:`, e)
+    });
+  } catch (e) {
+    logError(`${LOG_PREFIX} Failed to inject Clarity tag:`, e);
+  }
+}
+
+/**
+ * Build keyword string from features for site.keywords.
+ * Iterates over all features dynamically.  Omits frustration='none'
+ * to reduce noise.
+ *
+ * @param {Object} features - all features (durable + snapshot)
+ * @param {string} prefix
+ * @returns {string} comma-separated keywords
+ */
+function buildKeywords(features, prefix) {
+  return Object.entries(features)
+    .filter(([key, value]) => !(key === 'frustration' && value === 'none'))
+    .map(([key, value]) => `${prefix}_${key}=${value}`)
+    .join(',');
+}
+
+/**
+ * Build ORTB2 user.data segment array from bucketed features.
+ * Each feature becomes a segment with id = "feature_value".
+ *
+ * @param {Object} features
+ * @returns {Object} user.data entry
+ */
+export function buildSegments(features) {
+  const segments = Object.entries(features).map(([key, value]) => ({
+    id: `${key}_${value}`
+  }));
+
+  return {
+    name: 'msclarity',
+    segment: segments
+  };
+}
+
+/**
+ * Save features to localStorage with a timestamp for warm-start.
+ *
+ * @param {Object} features
+ */
+function saveToStorage(features) {
+  try {
+    const payload = JSON.stringify({
+      ts: Date.now(),
+      features
+    });
+    storage.setDataInLocalStorage(STORAGE_KEY, payload);
+  } catch (e) {
+    logWarn(`${LOG_PREFIX} Could not persist signals to localStorage.`);
+  }
+}
+
+/**
+ * Load features from localStorage if they are within the TTL window.
+ *
+ * @returns {Object|null} features or null if expired/missing
+ */
+export function loadFromStorage() {
+  try {
+    const raw = storage.getDataFromLocalStorage(STORAGE_KEY);
+    if (!raw) return null;
+
+    const { ts, features } = JSON.parse(raw);
+    if (Date.now() - ts > STORAGE_TTL_MS) return null;
+    // Merge with defaults for backward compatibility with older cached data
+    return { ...DURABLE_DEFAULTS, ...features };
+  } catch (e) {
+    return null;
+  }
+}
+
+// ─── RTD Submodule Interface ─────────────────────────────────────────────────
+
+/**
+ * Module init — validates config, optionally injects Clarity, starts tracker.
+ *
+ * @param {Object} config
+ * @returns {boolean}
+ */
+function init(config) {
+  resetTracker();
+
+  const projectId = deepAccess(config, 'params.projectId');
+  if (!projectId) {
+    logWarn(`${LOG_PREFIX} params.projectId is required. Get your project ID from https://clarity.microsoft.com`);
+    return false;
+  }
+
+  // Clarity script injection — on by default, opt out with injectClarity: false
+  const injectClarity = deepAccess(config, 'params.injectClarity') !== false;
+  if (injectClarity && !isClarityPresent()) {
+    logInfo(`${LOG_PREFIX} Injecting Clarity tag for project ${projectId}.`);
+    injectClarityScript(projectId);
+  }
+
+  initTracker();
+
+  logInfo(`${LOG_PREFIX} Initialized for project ${projectId}.`);
+  return true;
+}
+
+/**
+ * Pre-auction enrichment — builds bucketed features and writes them into
+ * global ORTB2 fragments (available to all bidders).  Also publishes
+ * user.data segments and persists to localStorage for warm-start.
+ *
+ * @param {Object}   reqBidsConfigObj
+ * @param {function} callback
+ * @param {Object}   config
+ */
+function getBidRequestData(reqBidsConfigObj, callback, config) {
+  try {
+    const prefix = deepAccess(config, 'params.targetingPrefix') || DEFAULTS.targetingPrefix;
+    let durableFeatures = buildFeatures();
+    const snapshotFeatures = buildSnapshotFeatures();
+
+    // Warm-start: if all durable features are at baseline defaults, try localStorage
+    const isBaseline = Object.entries(DURABLE_DEFAULTS).every(
+      ([key, defaultVal]) => durableFeatures[key] === defaultVal
+    );
+
+    if (isBaseline) {
+      const cached = loadFromStorage();
+      if (cached) {
+        durableFeatures = cached;
+        logInfo(`${LOG_PREFIX} Using warm-start signals from localStorage.`);
+      }
+    }
+
+    // Merge durable + transient snapshot for output
+    const features = { ...durableFeatures, ...snapshotFeatures };
+
+    const keywords = buildKeywords(features, prefix);
+    const segmentData = buildSegments(features);
+
+    reqBidsConfigObj.ortb2Fragments = reqBidsConfigObj.ortb2Fragments || {};
+    reqBidsConfigObj.ortb2Fragments.global = reqBidsConfigObj.ortb2Fragments.global || {};
+
+    // Site-level: all bucketed features (durable + snapshot)
+    deepSetValue(
+      reqBidsConfigObj,
+      'ortb2Fragments.global.site.ext.data.msclarity',
+      { ...features }
+    );
+
+    // User-level: segments for ORTB2-native consumption (Curate, DSPs)
+    const existingUserData = deepAccess(reqBidsConfigObj, 'ortb2Fragments.global.user.data') || [];
+    deepSetValue(
+      reqBidsConfigObj,
+      'ortb2Fragments.global.user.data',
+      [...existingUserData, segmentData]
+    );
+
+    // Keywords for adapters that consume site.keywords (e.g., AppNexus)
+    if (keywords) {
+      const existing = deepAccess(
+        reqBidsConfigObj,
+        'ortb2Fragments.global.site.keywords'
+      ) || '';
+      const merged = existing ? `${existing},${keywords}` : keywords;
+      deepSetValue(
+        reqBidsConfigObj,
+        'ortb2Fragments.global.site.keywords',
+        merged
+      );
+    }
+
+    // Persist only durable features for warm-start on next page load
+    saveToStorage(durableFeatures);
+
+    logInfo(`${LOG_PREFIX} Enriched global ORTB2 with ${Object.keys(features).length} features + segments.`);
+  } catch (e) {
+    logError(`${LOG_PREFIX} Error enriching bid requests:`, e);
+  }
+
+  callback();
+}
+
+/** @type {RtdSubmodule} */
+export const msClaritySubmodule = {
+  name: MODULE_NAME,
+  init,
+  getBidRequestData,
+};
+
+submodule('realTimeData', msClaritySubmodule);

--- a/modules/msClarityRtdProvider.js
+++ b/modules/msClarityRtdProvider.js
@@ -40,6 +40,7 @@ import { MODULE_TYPE_RTD } from '../src/activities/modules.js';
 
 /**
  * @typedef {import('../modules/rtdModule/index.js').RtdSubmodule} RtdSubmodule
+ * @typedef {import('./msClarityRtdProvider.d.ts').MsClarityRtdProviderConfig} MsClarityRtdProviderConfig
  */
 
 const MODULE_NAME = 'msClarity';
@@ -765,7 +766,7 @@ export function loadFromStorage() {
 /**
  * Module init — validates config, optionally injects Clarity, starts tracker.
  *
- * @param {Object} config
+ * @param {MsClarityRtdProviderConfig} config
  * @returns {boolean}
  */
 function init(config) {
@@ -797,7 +798,7 @@ function init(config) {
  *
  * @param {Object}   reqBidsConfigObj
  * @param {function} callback
- * @param {Object}   config
+ * @param {MsClarityRtdProviderConfig} config
  */
 function getBidRequestData(reqBidsConfigObj, callback, config) {
   try {

--- a/modules/msClarityRtdProvider.md
+++ b/modules/msClarityRtdProvider.md
@@ -1,0 +1,156 @@
+# Microsoft Clarity RTD Provider
+
+## Overview
+
+The Microsoft Clarity RTD module collects behavioral signals from a self-contained DOM tracker and enriches bid requests with **bucketed categorical features**. Signals are compact string labels (e.g. `"deep"`, `"moderate"`, `"high"`) — not raw numerics — making them directly usable in DSP targeting rules without additional processing.
+
+Signals are written into **global ORTB2 fragments**, making them available to **all bidders**. Data is published through three complementary paths:
+
+1. **`site.ext.data.msclarity`** — structured key-value features for general consumption
+2. **`user.data` segments** — ORTB2-native segments for DSPs and platforms like Microsoft Curate
+3. **`site.keywords`** — keyword strings for adapters that consume keywords (e.g., AppNexus)
+
+The module also persists signals to **localStorage** for warm-start support — the first auction of a new page load can use recent (≤ 30 min) signals instead of empty defaults.
+
+The Clarity JS tag is **injected by default** for analytics / session-recording functionality. Set `params.injectClarity: false` to opt out of automatic injection. Bid-enrichment signals are computed independently from DOM events regardless of whether the Clarity tag is present.
+
+## Prerequisites
+
+1. A Microsoft Clarity account and project — sign up at https://clarity.microsoft.com
+2. Your Clarity **Project ID** (found in Project Settings)
+
+> **Note:** The module automatically injects the Clarity JS tag unless
+> `params.injectClarity` is explicitly set to `false`. To manage the Clarity tag
+> yourself, set `injectClarity: false` and add the tag to your page before Prebid loads.
+
+## Integration
+
+### Build
+
+```bash
+gulp build --modules=rtdModule,msClarityRtdProvider,appnexusBidAdapter,msftBidAdapter
+```
+
+### Configuration
+
+```javascript
+pbjs.setConfig({
+  realTimeData: {
+    auctionDelay: 200,
+    dataProviders: [{
+      name: 'msClarity',
+      waitForIt: true,
+      params: {
+        projectId: 'abc123xyz',               // Required: Clarity project ID
+        // injectClarity: false,               // Optional: set false to disable auto-injection (default: true)
+        targetingPrefix: 'msc'                 // Optional: prefix for site.keywords
+      }
+    }]
+  }
+});
+```
+
+### Parameters
+
+| Param | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `projectId` | string | yes | — | Microsoft Clarity project ID |
+| `injectClarity` | boolean | no | `true` | When `true` (the default), automatically injects the Clarity JS tag if not already present. Set to `false` to disable auto-injection. |
+| `targetingPrefix` | string | no | `'msc'` | Prefix for keyword key-values in `site.keywords`. |
+
+## Feature Reference
+
+The module computes **11 features** in two tiers:
+
+### Durable Features (7) — persisted to localStorage for warm-start
+
+These accumulate over the page session and are saved to `localStorage` for use in the first auction of subsequent page loads.
+
+| Feature | Key | Values | Description |
+|---------|-----|--------|-------------|
+| Engagement | `engagement` | `low`, `medium`, `high`, `very_high` | Composite: scroll + dwell + interaction − frustration |
+| Dwell Time | `dwell` | `bounce`, `brief`, `moderate`, `long`, `extended` | Visibility-aware active dwell time |
+| Scroll Depth | `scroll` | `none`, `shallow`, `mid`, `deep`, `complete` | High-water-mark page scroll depth |
+| Frustration | `frustration` | `none`, `mild`, `moderate`, `severe` | Deduplicated rage clicks + exploratory clicks (0.5× weight) + scroll reversals |
+| Interaction | `interaction` | `passive`, `light`, `moderate`, `active`, `intense` | Deliberate events per second of active time (click, keydown, touch, debounced mousemove — no scroll) |
+| Reading Mode | `readingMode` | `skim`, `scan`, `read` | Whether the user is reading steadily (scroll stable ≥ 2 s), scanning, or skimming |
+| View Quality | `viewQuality` | `low`, `medium`, `high` | Composite of reading time, active time, and scroll depth |
+
+### Transient Snapshot Features (4) — computed fresh at auction time
+
+These reflect the user's instantaneous state when a bid request fires. They are **not** persisted.
+
+| Feature | Key | Values | Description |
+|---------|-----|--------|-------------|
+| Activity Recency | `activityRecency` | `live`, `recent`, `stale` | Time since last deliberate interaction (< 2 s / < 10 s / ≥ 10 s) |
+| Recent Engagement | `recentEngagement` | `cold`, `warming`, `hot` | Count of deliberate interactions in the last 10 seconds |
+| Auction Attention | `auctionAttention` | `low`, `medium`, `high` | Whether the user is attentive right now (tab visible, activity recency, reading vs scanning) |
+| Page Momentum | `pageMomentum` | `arrival`, `in_reading_flow`, `post_scroll`, `fatigued` | Phase of the page visit lifecycle |
+
+## Where Data Is Written
+
+### Global ORTB2 (All Bidders)
+
+```
+ortb2Fragments.global.site.ext.data.msclarity = {
+  engagement: "high",
+  dwell: "moderate",
+  scroll: "deep",
+  frustration: "none",
+  interaction: "active",
+  readingMode: "read",
+  viewQuality: "high",
+  activityRecency: "live",
+  recentEngagement: "hot",
+  auctionAttention: "high",
+  pageMomentum: "in_reading_flow"
+}
+
+ortb2Fragments.global.site.keywords =
+  "msc_engagement=high,msc_dwell=moderate,msc_scroll=deep,msc_interaction=active,msc_readingMode=read,msc_viewQuality=high,msc_activityRecency=live,msc_recentEngagement=hot,msc_auctionAttention=high,msc_pageMomentum=in_reading_flow"
+
+ortb2Fragments.global.user.data = [
+  {
+    name: "msclarity",
+    segment: [
+      { id: "engagement_high" },
+      { id: "dwell_moderate" },
+      { id: "scroll_deep" },
+      { id: "frustration_none" },
+      { id: "interaction_active" },
+      { id: "readingMode_read" },
+      { id: "viewQuality_high" },
+      { id: "activityRecency_live" },
+      { id: "recentEngagement_hot" },
+      { id: "auctionAttention_high" },
+      { id: "pageMomentum_in_reading_flow" }
+    ]
+  }
+]
+```
+
+> **Note:** The `msft` adapter uses the standard `ortbConverter`, so all global ORTB2
+> data passes through directly to the OpenRTB2 request. The `appnexus` adapter
+> transforms `site.keywords` into its UT payload format via `getANKeywordParam()`.
+> The `user.data` segments are available to ORTB2-compatible DSPs and platforms
+> like Microsoft Curate.
+
+> `frustration` keyword is omitted when its value is `"none"`.
+
+### Warm-Start (localStorage)
+
+The module persists the **7 durable features** to `localStorage` (key: `msc_rtd_signals`) with a 30-minute TTL. On the first auction of a new page load, if all durable features are at baseline defaults, the module falls back to the cached snapshot. Transient snapshot features (activityRecency, recentEngagement, auctionAttention, pageMomentum) are always computed fresh and are never persisted.
+
+The storage manager respects consent — if localStorage access is blocked by consent management, warm-start is silently skipped.
+
+## Privacy
+
+- The Clarity JS tag is injected by default. Set `params.injectClarity: false` to disable auto-injection and manage the tag yourself.
+- All signals are page-level behavioral data (scroll, clicks, timing) — **no PII** is collected or transmitted.
+- Signal values are bucketed categorical strings, not raw measurements, providing an additional privacy layer.
+- localStorage persistence uses the consent-aware `storageManager` and respects TCF/GPP consent signals.
+- If `projectId` is not configured, the module silently disables itself.
+
+## Example
+
+See [integrationExamples/gpt/msclarity_rtd_example.html](../../integrationExamples/gpt/msclarity_rtd_example.html) for a working integration test page.

--- a/modules/msClarityRtdProvider.md
+++ b/modules/msClarityRtdProvider.md
@@ -31,6 +31,22 @@ The Clarity JS tag is **injected by default** for analytics / session-recording 
 gulp build --modules=rtdModule,msClarityRtdProvider,appnexusBidAdapter,msftBidAdapter
 ```
 
+
+### TypeScript definitions
+
+The RTD provider parameters are typed in `modules/msClarityRtdProvider.d.ts` and exported as `MsClarityRtdProviderParams` for publisher integrations that import Prebid types:
+
+```typescript
+export interface MsClarityRtdProviderParams {
+  /** Microsoft Clarity project ID. */
+  projectId: string;
+  /** Load the Clarity JavaScript tag through Prebid's external-script loader. Defaults to true. */
+  injectClarity?: boolean;
+  /** Prefix for generated site.keywords entries. Defaults to "msc". */
+  targetingPrefix?: string;
+}
+```
+
 ### Configuration
 
 ```javascript

--- a/test/spec/modules/msClarityRtdProvider_spec.js
+++ b/test/spec/modules/msClarityRtdProvider_spec.js
@@ -1235,6 +1235,10 @@ describe('msClarityRtdProvider', function () {
       expect(msClaritySubmodule.name).to.equal('msClarity');
     });
 
+    it('should use the AppNexus GVL ID', function () {
+      expect(msClaritySubmodule.gvlid).to.equal(32);
+    });
+
     it('should expose init and getBidRequestData only', function () {
       expect(msClaritySubmodule.init).to.be.a('function');
       expect(msClaritySubmodule.getBidRequestData).to.be.a('function');

--- a/test/spec/modules/msClarityRtdProvider_spec.js
+++ b/test/spec/modules/msClarityRtdProvider_spec.js
@@ -1,0 +1,1244 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import {
+  msClaritySubmodule,
+  scrollBucket,
+  dwellBucket,
+  frustrationBucket,
+  interactionBucket,
+  engagementBucket,
+  activityRecencyBucket,
+  recentEngagementBucket,
+  readingModeBucket,
+  viewQualityBucket,
+  auctionAttentionBucket,
+  pageMomentumBucket,
+  buildFeatures,
+  buildSnapshotFeatures,
+  buildSegments,
+  loadFromStorage,
+  storage,
+  resetTracker,
+  isLikelyInteractive,
+} from 'modules/msClarityRtdProvider.js';
+import { deepAccess } from 'src/utils.js';
+
+describe('msClarityRtdProvider', function () {
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+    resetTracker();
+    delete window.clarity;
+    document.querySelectorAll('script[src*="clarity.ms/tag"]').forEach(el => el.remove());
+  });
+
+  // ─── Helpers ──────────────────────────────────────────────────────────────
+
+  function makeConfig(overrides) {
+    return {
+      params: Object.assign({
+        projectId: 'test-project-123',
+      }, overrides || {})
+    };
+  }
+
+  function makeReqBidsConfigObj(adUnits) {
+    return {
+      adUnits: adUnits || [],
+      ortb2Fragments: { global: {}, bidder: {} }
+    };
+  }
+
+  // ─── Bucket Functions ─────────────────────────────────────────────────────
+
+  describe('scrollBucket()', function () {
+    it('should return none for 0', function () {
+      expect(scrollBucket(0)).to.equal('none');
+    });
+
+    it('should return shallow for 0.1', function () {
+      expect(scrollBucket(0.1)).to.equal('shallow');
+    });
+
+    it('should return mid for 0.3', function () {
+      expect(scrollBucket(0.3)).to.equal('mid');
+    });
+
+    it('should return deep for 0.6', function () {
+      expect(scrollBucket(0.6)).to.equal('deep');
+    });
+
+    it('should return complete for 0.9', function () {
+      expect(scrollBucket(0.9)).to.equal('complete');
+    });
+
+    it('should return complete for 1.0', function () {
+      expect(scrollBucket(1.0)).to.equal('complete');
+    });
+
+    it('should return none for negative values', function () {
+      expect(scrollBucket(-0.1)).to.equal('none');
+    });
+  });
+
+  describe('dwellBucket()', function () {
+    it('should return bounce for < 5s', function () {
+      expect(dwellBucket(2000)).to.equal('bounce');
+    });
+
+    it('should return brief for 5–15s', function () {
+      expect(dwellBucket(10000)).to.equal('brief');
+    });
+
+    it('should return moderate for 15–30s', function () {
+      expect(dwellBucket(20000)).to.equal('moderate');
+    });
+
+    it('should return long for 30–60s', function () {
+      expect(dwellBucket(45000)).to.equal('long');
+    });
+
+    it('should return extended for >= 60s', function () {
+      expect(dwellBucket(90000)).to.equal('extended');
+    });
+
+    it('should return bounce for 0', function () {
+      expect(dwellBucket(0)).to.equal('bounce');
+    });
+  });
+
+  describe('frustrationBucket()', function () {
+    it('should return none for 0 rage + 0 exploratory', function () {
+      expect(frustrationBucket(0, 0)).to.equal('none');
+    });
+
+    it('should return mild for 1 rage + 0 exploratory', function () {
+      expect(frustrationBucket(1, 0)).to.equal('mild');
+    });
+
+    it('should return mild for 0 rage + 2 exploratory', function () {
+      expect(frustrationBucket(0, 2)).to.equal('mild');
+    });
+
+    it('should return moderate for 3 rage + 2 exploratory', function () {
+      expect(frustrationBucket(3, 2)).to.equal('moderate');
+    });
+
+    it('should return severe for 6 rage + 5 exploratory', function () {
+      expect(frustrationBucket(6, 5)).to.equal('severe');
+    });
+
+    it('should return none for 0 rage + 0 dead + 4 reversals (below threshold)', function () {
+      // Math.floor(4 / 5) = 0, total = 0
+      expect(frustrationBucket(0, 0, 4)).to.equal('none');
+    });
+
+    it('should return severe for 0 rage + 0 dead + 25 reversals', function () {
+      // Math.floor(25 / 5) = 5 → total = 5 → moderate boundary, but 5 ≤ 5 → moderate
+      // Actually 25/5 = 5, total = 5, ≤ 5 → moderate. Let's use 26.
+      // Math.floor(26 / 5) = 5, total = 5 ≤ 5 → moderate. Need > 5 for severe.
+      // 30 reversals: Math.floor(30 / 5) = 6 → total = 6 > 5 → severe
+      expect(frustrationBucket(0, 0, 30)).to.equal('severe');
+    });
+
+    it('should return none for 0 rage + 0 dead + 0 reversals (backward compat)', function () {
+      expect(frustrationBucket(0, 0, 0)).to.equal('none');
+    });
+
+    it('should return mild when reversals just reach threshold', function () {
+      // Math.floor(5 / 5) = 1, total = 1 → mild
+      expect(frustrationBucket(0, 0, 5)).to.equal('mild');
+    });
+
+    it('should combine reversals with clicks', function () {
+      // 1 rage + 0 dead + 10 reversals: Math.floor(10/5)=2, total=3 → moderate
+      expect(frustrationBucket(1, 0, 10)).to.equal('moderate');
+    });
+  });
+
+  describe('interactionBucket()', function () {
+    it('should return passive for 0 interactions', function () {
+      expect(interactionBucket(0, 10000)).to.equal('passive');
+    });
+
+    it('should return light for low rate', function () {
+      // 1 event in 10s = 0.1/s
+      expect(interactionBucket(1, 10000)).to.equal('light');
+    });
+
+    it('should return moderate for medium rate', function () {
+      // 4 events in 10s = 0.4/s
+      expect(interactionBucket(4, 10000)).to.equal('moderate');
+    });
+
+    it('should return active for high rate', function () {
+      // 8 events in 10s = 0.8/s
+      expect(interactionBucket(8, 10000)).to.equal('active');
+    });
+
+    it('should return intense for very high rate', function () {
+      // 20 events in 10s = 2.0/s
+      expect(interactionBucket(20, 10000)).to.equal('intense');
+    });
+
+    it('should return passive when activeMs is 0', function () {
+      expect(interactionBucket(5, 0)).to.equal('passive');
+    });
+  });
+
+  describe('engagementBucket()', function () {
+    it('should return low for minimal engagement', function () {
+      expect(engagementBucket(0, 0, 0, 0, 0)).to.equal('low');
+    });
+
+    it('should return medium for some engagement', function () {
+      expect(engagementBucket(0.3, 15000, 5, 0, 0)).to.equal('medium');
+    });
+
+    it('should return high for good engagement', function () {
+      expect(engagementBucket(0.6, 30000, 10, 0, 0)).to.equal('high');
+    });
+
+    it('should return very_high for maximum engagement', function () {
+      expect(engagementBucket(1.0, 60000, 20, 0, 0)).to.equal('very_high');
+    });
+
+    it('should penalize frustration signals', function () {
+      const withFrust = engagementBucket(0.5, 30000, 10, 5, 5);
+      const withoutFrust = engagementBucket(0.5, 30000, 10, 0, 0);
+      const order = ['low', 'medium', 'high', 'very_high'];
+      expect(order.indexOf(withFrust)).to.be.at.most(order.indexOf(withoutFrust));
+    });
+  });
+
+  // ─── activityRecencyBucket() ─────────────────────────────────────────────
+
+  describe('activityRecencyBucket()', function () {
+    it('should return live for < 2s', function () {
+      expect(activityRecencyBucket(0)).to.equal('live');
+      expect(activityRecencyBucket(1000)).to.equal('live');
+      expect(activityRecencyBucket(1999)).to.equal('live');
+    });
+
+    it('should return recent for 2s–10s', function () {
+      expect(activityRecencyBucket(2000)).to.equal('recent');
+      expect(activityRecencyBucket(5000)).to.equal('recent');
+      expect(activityRecencyBucket(9999)).to.equal('recent');
+    });
+
+    it('should return stale for >= 10s', function () {
+      expect(activityRecencyBucket(10000)).to.equal('stale');
+      expect(activityRecencyBucket(60000)).to.equal('stale');
+    });
+  });
+
+  // ─── recentEngagementBucket() ───────────────────────────────────────────
+
+  describe('recentEngagementBucket()', function () {
+    it('should return cold for 0 interactions', function () {
+      expect(recentEngagementBucket(0)).to.equal('cold');
+    });
+
+    it('should return warming for 1–3 interactions', function () {
+      expect(recentEngagementBucket(1)).to.equal('warming');
+      expect(recentEngagementBucket(3)).to.equal('warming');
+    });
+
+    it('should return hot for >= 4 interactions', function () {
+      expect(recentEngagementBucket(4)).to.equal('hot');
+      expect(recentEngagementBucket(10)).to.equal('hot');
+    });
+  });
+
+  // ─── readingModeBucket() ───────────────────────────────────────────────
+
+  describe('readingModeBucket()', function () {
+    it('should return skim when total time < 2s', function () {
+      expect(readingModeBucket(0, 0)).to.equal('skim');
+      expect(readingModeBucket(500, 500)).to.equal('skim');
+    });
+
+    it('should return read when read ratio >= 0.6', function () {
+      expect(readingModeBucket(5000, 1000)).to.equal('read');
+    });
+
+    it('should return scan when read ratio 0.3–0.6', function () {
+      expect(readingModeBucket(3000, 4000)).to.equal('scan');
+    });
+
+    it('should return skim when read ratio < 0.3', function () {
+      expect(readingModeBucket(1000, 5000)).to.equal('skim');
+    });
+  });
+
+  // ─── viewQualityBucket() ───────────────────────────────────────────────
+
+  describe('viewQualityBucket()', function () {
+    it('should return low for short sessions', function () {
+      expect(viewQualityBucket(1000, 3000, 0.1)).to.equal('low');
+    });
+
+    it('should return medium for moderate reading', function () {
+      expect(viewQualityBucket(3000, 8000, 0.1)).to.equal('medium');
+    });
+
+    it('should return high for quality sessions', function () {
+      expect(viewQualityBucket(6000, 15000, 0.5)).to.equal('high');
+    });
+
+    it('should return medium when scrollDepth < 0.25 even with long read', function () {
+      expect(viewQualityBucket(6000, 15000, 0.1)).to.equal('medium');
+    });
+  });
+
+  // ─── auctionAttentionBucket() ──────────────────────────────────────────
+
+  describe('auctionAttentionBucket()', function () {
+    it('should return low when tab is hidden', function () {
+      expect(auctionAttentionBucket(true, 1000, 5000, 1000)).to.equal('low');
+    });
+
+    it('should return low when activity is stale', function () {
+      expect(auctionAttentionBucket(false, 15000, 5000, 1000)).to.equal('low');
+    });
+
+    it('should return high when live + reading', function () {
+      expect(auctionAttentionBucket(false, 1000, 5000, 1000)).to.equal('high');
+    });
+
+    it('should return medium for recent but not strongly reading', function () {
+      expect(auctionAttentionBucket(false, 5000, 1000, 2000)).to.equal('medium');
+    });
+  });
+
+  // ─── pageMomentumBucket() ─────────────────────────────────────────────
+
+  describe('pageMomentumBucket()', function () {
+    it('should return arrival for short sessions', function () {
+      expect(pageMomentumBucket(3000, 0, 0, 1000, 1, 1000)).to.equal('arrival');
+    });
+
+    it('should return fatigued for long stale sessions', function () {
+      expect(pageMomentumBucket(60000, 5000, 0.8, 15000, 0, 10000)).to.equal('fatigued');
+    });
+
+    it('should return in_reading_flow for active reading', function () {
+      expect(pageMomentumBucket(10000, 5000, 0.3, 2000, 2, 5000)).to.equal('in_reading_flow');
+    });
+
+    it('should return post_scroll for deep scroll that settled', function () {
+      expect(pageMomentumBucket(20000, 1000, 0.7, 2000, 1, 10000)).to.equal('post_scroll');
+    });
+
+    it('should default to in_reading_flow for mid-session', function () {
+      expect(pageMomentumBucket(10000, 0, 0.3, 5000, 2, 500)).to.equal('in_reading_flow');
+    });
+
+    it('should return fatigued via recentInteractionCount === 0 path', function () {
+      // msSinceLastActivity 5000 < 10000 (first OR branch false),
+      // but recentInteractionCount === 0 (second OR branch true)
+      expect(pageMomentumBucket(60000, 5000, 0.5, 5000, 0, 2000)).to.equal('fatigued');
+    });
+
+    it('should return in_reading_flow when reading with stable scroll', function () {
+      // readTimeMs >= 2000, msSinceLastActivity < 10000, msSinceLastScroll >= SCROLL_STABLE_MS (2000)
+      expect(pageMomentumBucket(10000, 3000, 0.3, 1000, 2, 3000)).to.equal('in_reading_flow');
+    });
+  });
+
+  // ─── init() ───────────────────────────────────────────────────────────────
+
+  describe('init()', function () {
+    it('should return false when projectId is missing', function () {
+      const result = msClaritySubmodule.init(makeConfig({ projectId: undefined }));
+      expect(result).to.be.false;
+    });
+
+    it('should return false when projectId is empty string', function () {
+      const result = msClaritySubmodule.init(makeConfig({ projectId: '' }));
+      expect(result).to.be.false;
+    });
+
+    it('should inject Clarity by default when injectClarity is not set', function () {
+      const result = msClaritySubmodule.init(makeConfig());
+      expect(result).to.be.true;
+      // The queuing stub is installed synchronously; Prebid's external-script
+      // loader controls whether the tag is allowed in the current test build.
+      expect(typeof window.clarity).to.equal('function');
+    });
+
+    it('should inject Clarity when injectClarity is true', function () {
+      const result = msClaritySubmodule.init(makeConfig({ injectClarity: true }));
+      expect(result).to.be.true;
+      expect(typeof window.clarity).to.equal('function');
+    });
+
+    it('should return true when Clarity is already present', function () {
+      window.clarity = function () {};
+      const result = msClaritySubmodule.init(makeConfig());
+      expect(result).to.be.true;
+    });
+
+    it('should return true without bidders param', function () {
+      window.clarity = function () {};
+      const result = msClaritySubmodule.init(makeConfig());
+      expect(result).to.be.true;
+    });
+
+    it('should not inject when injectClarity is true but Clarity is already present', function () {
+      window.clarity = function () {};
+      const result = msClaritySubmodule.init(makeConfig({ injectClarity: true }));
+      expect(result).to.be.true;
+      // Only the pre-existing Clarity function, no script tag injected
+      const tag = document.querySelector('script[src*="clarity.ms/tag/test-project-123"]');
+      expect(tag).to.not.exist;
+    });
+
+    it('should NOT inject Clarity when injectClarity is explicitly false', function () {
+      const result = msClaritySubmodule.init(makeConfig({ injectClarity: false }));
+      expect(result).to.be.true;
+      const tag = document.querySelector('script[src*="clarity.ms/tag/test-project-123"]');
+      expect(tag).to.not.exist;
+    });
+  });
+
+  // ─── getBidRequestData() ──────────────────────────────────────────────────
+
+  describe('getBidRequestData()', function () {
+    let storageGetStub;
+    let storageSetStub;
+
+    beforeEach(function () {
+      window.clarity = function () {};
+      msClaritySubmodule.init(makeConfig());
+      storageGetStub = sandbox.stub(storage, 'getDataFromLocalStorage');
+      storageSetStub = sandbox.stub(storage, 'setDataInLocalStorage');
+    });
+
+    it('should always call the callback', function (done) {
+      const reqBids = makeReqBidsConfigObj();
+      msClaritySubmodule.getBidRequestData(reqBids, done, makeConfig());
+    });
+
+    it('should write all 11 features to global site.ext.data.msclarity', function (done) {
+      const reqBids = makeReqBidsConfigObj();
+      msClaritySubmodule.getBidRequestData(reqBids, function () {
+        const site = deepAccess(reqBids, 'ortb2Fragments.global.site.ext.data.msclarity');
+        expect(site).to.exist;
+        expect(site).to.have.all.keys(
+          'engagement', 'dwell', 'scroll', 'frustration', 'interaction',
+          'readingMode', 'viewQuality',
+          'activityRecency', 'recentEngagement', 'auctionAttention', 'pageMomentum'
+        );
+        Object.values(site).forEach(v => expect(v).to.be.a('string'));
+        done();
+      }, makeConfig());
+    });
+
+    it('should NOT write to ortb2Fragments.bidder', function (done) {
+      const reqBids = makeReqBidsConfigObj();
+      msClaritySubmodule.getBidRequestData(reqBids, function () {
+        expect(reqBids.ortb2Fragments.bidder).to.deep.equal({});
+        done();
+      }, makeConfig());
+    });
+
+    it('should write user.data segments to global', function (done) {
+      const reqBids = makeReqBidsConfigObj();
+      msClaritySubmodule.getBidRequestData(reqBids, function () {
+        const userData = deepAccess(reqBids, 'ortb2Fragments.global.user.data');
+        expect(userData).to.be.an('array').with.lengthOf(1);
+        expect(userData[0].name).to.equal('msclarity');
+        expect(userData[0].segment).to.be.an('array').with.lengthOf(11);
+        userData[0].segment.forEach(seg => {
+          expect(seg.id).to.be.a('string');
+          expect(seg.id).to.match(/^(engagement|dwell|scroll|frustration|interaction|readingMode|viewQuality|activityRecency|recentEngagement|auctionAttention|pageMomentum)_/);
+        });
+        done();
+      }, makeConfig());
+    });
+
+    it('should append to existing user.data', function (done) {
+      const reqBids = makeReqBidsConfigObj();
+      reqBids.ortb2Fragments.global = {
+        user: { data: [{ name: 'existing', segment: [{ id: '123' }] }] }
+      };
+      msClaritySubmodule.getBidRequestData(reqBids, function () {
+        const userData = deepAccess(reqBids, 'ortb2Fragments.global.user.data');
+        expect(userData).to.be.an('array').with.lengthOf(2);
+        expect(userData[0].name).to.equal('existing');
+        expect(userData[1].name).to.equal('msclarity');
+        done();
+      }, makeConfig());
+    });
+
+    it('should build keywords with bucketed values', function (done) {
+      const reqBids = makeReqBidsConfigObj();
+      msClaritySubmodule.getBidRequestData(reqBids, function () {
+        const kw = deepAccess(reqBids, 'ortb2Fragments.global.site.keywords');
+        expect(kw).to.be.a('string');
+        expect(kw).to.include('msc_engagement=');
+        expect(kw).to.include('msc_dwell=');
+        expect(kw).to.include('msc_scroll=');
+        expect(kw).to.include('msc_interaction=');
+        // stage and scroll_pattern should NOT appear
+        expect(kw).to.not.include('msc_stage=');
+        expect(kw).to.not.include('msc_scroll_pattern=');
+        done();
+      }, makeConfig());
+    });
+
+    it('should use custom targetingPrefix', function (done) {
+      const reqBids = makeReqBidsConfigObj();
+      msClaritySubmodule.getBidRequestData(reqBids, function () {
+        const kw = deepAccess(reqBids, 'ortb2Fragments.global.site.keywords');
+        expect(kw).to.include('cl_scroll=');
+        expect(kw).to.include('cl_engagement=');
+        done();
+      }, makeConfig({ targetingPrefix: 'cl' }));
+    });
+
+    it('should append to existing keywords', function (done) {
+      const reqBids = makeReqBidsConfigObj();
+      reqBids.ortb2Fragments.global = {
+        site: { keywords: 'existing_kw=value' }
+      };
+      msClaritySubmodule.getBidRequestData(reqBids, function () {
+        const kw = deepAccess(reqBids, 'ortb2Fragments.global.site.keywords');
+        expect(kw).to.include('existing_kw=value');
+        expect(kw).to.include('msc_scroll=');
+        done();
+      }, makeConfig());
+    });
+
+    it('should not include frustration keyword when frustration is none', function (done) {
+      const reqBids = makeReqBidsConfigObj();
+      msClaritySubmodule.getBidRequestData(reqBids, function () {
+        const kw = deepAccess(reqBids, 'ortb2Fragments.global.site.keywords');
+        // Fresh tracker has 0 rage + 0 unresponsive = 'none', so no frustration keyword
+        expect(kw).to.not.include('msc_frustration=');
+        done();
+      }, makeConfig());
+    });
+
+    it('should persist only durable features to localStorage', function (done) {
+      const reqBids = makeReqBidsConfigObj();
+      msClaritySubmodule.getBidRequestData(reqBids, function () {
+        expect(storageSetStub.calledOnce).to.be.true;
+        const [key, value] = storageSetStub.firstCall.args;
+        expect(key).to.equal('msc_rtd_signals');
+        const parsed = JSON.parse(value);
+        expect(parsed.ts).to.be.a('number');
+        expect(parsed.features).to.have.all.keys(
+          'engagement', 'dwell', 'scroll', 'frustration', 'interaction',
+          'readingMode', 'viewQuality'
+        );
+        // Transient features should NOT be persisted
+        expect(parsed.features).to.not.have.property('activityRecency');
+        expect(parsed.features).to.not.have.property('recentEngagement');
+        expect(parsed.features).to.not.have.property('auctionAttention');
+        expect(parsed.features).to.not.have.property('pageMomentum');
+        done();
+      }, makeConfig());
+    });
+
+    it('should use warm-start from localStorage when features are baseline', function (done) {
+      const cachedFeatures = {
+        engagement: 'high',
+        dwell: 'moderate',
+        scroll: 'deep',
+        frustration: 'none',
+        interaction: 'active',
+        readingMode: 'read',
+        viewQuality: 'high',
+      };
+      storageGetStub.returns(JSON.stringify({
+        ts: Date.now() - 60000, // 1 minute ago — within TTL
+        features: cachedFeatures
+      }));
+
+      const reqBids = makeReqBidsConfigObj();
+      msClaritySubmodule.getBidRequestData(reqBids, function () {
+        const site = deepAccess(reqBids, 'ortb2Fragments.global.site.ext.data.msclarity');
+        // Durable features from cache
+        expect(site.engagement).to.equal('high');
+        expect(site.dwell).to.equal('moderate');
+        expect(site.scroll).to.equal('deep');
+        expect(site.readingMode).to.equal('read');
+        expect(site.viewQuality).to.equal('high');
+        // Transient features are still computed fresh
+        expect(site).to.have.property('activityRecency');
+        expect(site).to.have.property('pageMomentum');
+        done();
+      }, makeConfig());
+    });
+
+    it('should NOT use warm-start when localStorage data is expired', function (done) {
+      const cachedFeatures = {
+        engagement: 'high',
+        dwell: 'moderate',
+        scroll: 'deep',
+        frustration: 'none',
+        interaction: 'active',
+        readingMode: 'read',
+        viewQuality: 'high',
+      };
+      storageGetStub.returns(JSON.stringify({
+        ts: Date.now() - (31 * 60 * 1000), // 31 minutes ago — expired
+        features: cachedFeatures
+      }));
+
+      const reqBids = makeReqBidsConfigObj();
+      msClaritySubmodule.getBidRequestData(reqBids, function () {
+        const site = deepAccess(reqBids, 'ortb2Fragments.global.site.ext.data.msclarity');
+        // Should be baseline since cached data expired
+        expect(site.engagement).to.equal('low');
+        expect(site.dwell).to.equal('bounce');
+        expect(site.scroll).to.equal('none');
+        expect(site.readingMode).to.equal('skim');
+        expect(site.viewQuality).to.equal('low');
+        done();
+      }, makeConfig());
+    });
+
+    it('should handle errors gracefully and still call callback', function (done) {
+      // Passing null will cause an error inside the try block
+      msClaritySubmodule.getBidRequestData(null, function () {
+        done();
+      }, makeConfig());
+    });
+
+    it('should create ortb2Fragments when missing from reqBidsConfigObj', function (done) {
+      const reqBids = { adUnits: [] };
+      msClaritySubmodule.getBidRequestData(reqBids, function () {
+        expect(reqBids.ortb2Fragments).to.exist;
+        expect(reqBids.ortb2Fragments.global).to.exist;
+        const site = deepAccess(reqBids, 'ortb2Fragments.global.site.ext.data.msclarity');
+        expect(site).to.exist;
+        expect(site).to.have.all.keys(
+          'engagement', 'dwell', 'scroll', 'frustration', 'interaction',
+          'readingMode', 'viewQuality',
+          'activityRecency', 'recentEngagement', 'auctionAttention', 'pageMomentum'
+        );
+        done();
+      }, makeConfig());
+    });
+
+    it('should create global when ortb2Fragments exists but global is missing', function (done) {
+      const reqBids = { adUnits: [], ortb2Fragments: { bidder: {} } };
+      msClaritySubmodule.getBidRequestData(reqBids, function () {
+        expect(reqBids.ortb2Fragments.global).to.exist;
+        const site = deepAccess(reqBids, 'ortb2Fragments.global.site.ext.data.msclarity');
+        expect(site).to.exist;
+        done();
+      }, makeConfig());
+    });
+  });
+
+  // ─── buildFeatures() ─────────────────────────────────────────────────────
+
+  describe('buildFeatures()', function () {
+    beforeEach(function () {
+      window.clarity = function () {};
+      msClaritySubmodule.init(makeConfig());
+    });
+
+    it('should return all 7 durable features', function () {
+      const features = buildFeatures();
+      expect(features).to.have.all.keys(
+        'engagement', 'dwell', 'scroll', 'frustration', 'interaction',
+        'readingMode', 'viewQuality'
+      );
+    });
+
+    it('should NOT include removed features', function () {
+      const features = buildFeatures();
+      expect(features).to.not.have.property('scroll_pattern');
+      expect(features).to.not.have.property('stage');
+    });
+
+    it('should return string values for all features', function () {
+      const features = buildFeatures();
+      Object.values(features).forEach(v => {
+        expect(v).to.be.a('string');
+      });
+    });
+
+    it('should return baseline values for fresh tracker', function () {
+      const features = buildFeatures();
+      expect(features.scroll).to.equal('none');
+      expect(features.dwell).to.equal('bounce');
+      expect(features.frustration).to.equal('none');
+      expect(features.interaction).to.equal('passive');
+      expect(features.readingMode).to.equal('skim');
+      expect(features.viewQuality).to.equal('low');
+    });
+  });
+
+  // ─── buildSnapshotFeatures() ────────────────────────────────────────────
+
+  describe('buildSnapshotFeatures()', function () {
+    beforeEach(function () {
+      window.clarity = function () {};
+      msClaritySubmodule.init(makeConfig());
+    });
+
+    it('should return all 4 transient features', function () {
+      const snapshot = buildSnapshotFeatures();
+      expect(snapshot).to.have.all.keys(
+        'activityRecency', 'recentEngagement', 'auctionAttention', 'pageMomentum'
+      );
+    });
+
+    it('should return string values for all features', function () {
+      const snapshot = buildSnapshotFeatures();
+      Object.values(snapshot).forEach(v => {
+        expect(v).to.be.a('string');
+      });
+    });
+
+    it('should return baseline snapshot for fresh tracker', function () {
+      const snapshot = buildSnapshotFeatures();
+      // Fresh tracker: just initialized, so _lastActivity is now → live
+      expect(snapshot.activityRecency).to.equal('live');
+      // No deliberate interactions yet → cold
+      expect(snapshot.recentEngagement).to.equal('cold');
+    });
+
+    it('should NOT include any durable features', function () {
+      const snapshot = buildSnapshotFeatures();
+      expect(snapshot).to.not.have.property('engagement');
+      expect(snapshot).to.not.have.property('dwell');
+      expect(snapshot).to.not.have.property('scroll');
+      expect(snapshot).to.not.have.property('frustration');
+      expect(snapshot).to.not.have.property('interaction');
+      expect(snapshot).to.not.have.property('readingMode');
+      expect(snapshot).to.not.have.property('viewQuality');
+    });
+
+    it('should use IDLE_MS fallback when tracker was never initialized', function () {
+      // resetTracker sets _lastActivity and _lastScrollChangeTime to 0
+      // Don't call init — exercises both ternary else branches
+      resetTracker();
+      const snapshot = buildSnapshotFeatures();
+      // _lastActivity === 0 → msSinceLastActivity = IDLE_MS + 1 → stale
+      expect(snapshot.activityRecency).to.equal('stale');
+      // activeTimeMs is 0 → arrival
+      expect(snapshot.pageMomentum).to.equal('arrival');
+      // No interactions → cold
+      expect(snapshot.recentEngagement).to.equal('cold');
+      // Tab hidden false, stale activity → low attention
+      expect(snapshot.auctionAttention).to.equal('low');
+    });
+  });
+
+  // ─── buildSegments() ─────────────────────────────────────────────────────
+
+  describe('buildSegments()', function () {
+    it('should return an object with name and segment array', function () {
+      const features = {
+        engagement: 'high',
+        dwell: 'moderate',
+        scroll: 'deep',
+        frustration: 'none',
+        interaction: 'active',
+      };
+      const result = buildSegments(features);
+      expect(result.name).to.equal('msclarity');
+      expect(result.segment).to.be.an('array').with.lengthOf(5);
+    });
+
+    it('should format segment IDs as feature_value', function () {
+      const features = {
+        engagement: 'high',
+        dwell: 'moderate',
+        scroll: 'deep',
+        frustration: 'none',
+        interaction: 'active',
+      };
+      const result = buildSegments(features);
+      const ids = result.segment.map(s => s.id);
+      expect(ids).to.include('engagement_high');
+      expect(ids).to.include('dwell_moderate');
+      expect(ids).to.include('scroll_deep');
+      expect(ids).to.include('frustration_none');
+      expect(ids).to.include('interaction_active');
+    });
+  });
+
+  // ─── loadFromStorage() ────────────────────────────────────────────────────
+
+  describe('loadFromStorage()', function () {
+    let storageGetStub;
+
+    beforeEach(function () {
+      storageGetStub = sandbox.stub(storage, 'getDataFromLocalStorage');
+    });
+
+    it('should return null when no data in localStorage', function () {
+      storageGetStub.returns(null);
+      expect(loadFromStorage()).to.be.null;
+    });
+
+    it('should return features merged with defaults when data is within TTL', function () {
+      const features = { engagement: 'high', dwell: 'moderate', scroll: 'deep', frustration: 'none', interaction: 'active' };
+      storageGetStub.returns(JSON.stringify({ ts: Date.now() - 60000, features }));
+      const result = loadFromStorage();
+      // Merges with DURABLE_DEFAULTS so new keys get default values
+      expect(result.engagement).to.equal('high');
+      expect(result.dwell).to.equal('moderate');
+      expect(result.scroll).to.equal('deep');
+      expect(result.readingMode).to.equal('skim');
+      expect(result.viewQuality).to.equal('low');
+    });
+
+    it('should return null when data is expired', function () {
+      const features = { engagement: 'high', dwell: 'moderate', scroll: 'deep', frustration: 'none', interaction: 'active' };
+      storageGetStub.returns(JSON.stringify({ ts: Date.now() - (31 * 60 * 1000), features }));
+      expect(loadFromStorage()).to.be.null;
+    });
+
+    it('should return null for malformed JSON', function () {
+      storageGetStub.returns('not-valid-json');
+      expect(loadFromStorage()).to.be.null;
+    });
+  });
+
+  // ─── isLikelyInteractive() ──────────────────────────────────────────────
+
+  describe('isLikelyInteractive()', function () {
+    it('should return true for a standard button', function () {
+      const btn = document.createElement('button');
+      document.body.appendChild(btn);
+      expect(isLikelyInteractive(btn)).to.be.true;
+      btn.remove();
+    });
+
+    it('should return true for a link', function () {
+      const a = document.createElement('a');
+      a.href = '#';
+      document.body.appendChild(a);
+      expect(isLikelyInteractive(a)).to.be.true;
+      a.remove();
+    });
+
+    it('should return true for [role="tab"]', function () {
+      const div = document.createElement('div');
+      div.setAttribute('role', 'tab');
+      document.body.appendChild(div);
+      expect(isLikelyInteractive(div)).to.be.true;
+      div.remove();
+    });
+
+    it('should return true for [role="menuitem"]', function () {
+      const div = document.createElement('div');
+      div.setAttribute('role', 'menuitem');
+      document.body.appendChild(div);
+      expect(isLikelyInteractive(div)).to.be.true;
+      div.remove();
+    });
+
+    it('should return true for element with [tabindex]', function () {
+      const span = document.createElement('span');
+      span.setAttribute('tabindex', '0');
+      document.body.appendChild(span);
+      expect(isLikelyInteractive(span)).to.be.true;
+      span.remove();
+    });
+
+    it('should return true for element with Angular ng-click attribute', function () {
+      const div = document.createElement('div');
+      div.setAttribute('ng-click', 'doSomething()');
+      document.body.appendChild(div);
+      expect(isLikelyInteractive(div)).to.be.true;
+      div.remove();
+    });
+
+    it('should return true for element with Vue @click attribute', function () {
+      const div = document.createElement('div');
+      div.setAttribute('@click', 'handler');
+      document.body.appendChild(div);
+      expect(isLikelyInteractive(div)).to.be.true;
+      div.remove();
+    });
+
+    it('should return true for child of element with v-click', function () {
+      const parent = document.createElement('div');
+      parent.setAttribute('v-click', 'handler');
+      const child = document.createElement('span');
+      parent.appendChild(child);
+      document.body.appendChild(parent);
+      expect(isLikelyInteractive(child)).to.be.true;
+      parent.remove();
+    });
+
+    it('should return false for a plain <div> with no interactive traits', function () {
+      const div = document.createElement('div');
+      div.textContent = 'plain text';
+      document.body.appendChild(div);
+      expect(isLikelyInteractive(div)).to.be.false;
+      div.remove();
+    });
+
+    it('should return false for null or undefined', function () {
+      expect(isLikelyInteractive(null)).to.be.false;
+      expect(isLikelyInteractive(undefined)).to.be.false;
+    });
+  });
+
+  // ─── bootstrapFromNavTiming() ─────────────────────────────────────────────
+
+  describe('bootstrapFromNavTiming()', function () {
+    it('should seed activeTimeMs on back_forward navigation so dwell >= brief', function () {
+      // Stub Performance API to report back_forward
+      const perfStub = sandbox.stub(performance, 'getEntriesByType');
+      perfStub.withArgs('navigation').returns([{ type: 'back_forward' }]);
+
+      window.clarity = function () {};
+      resetTracker();
+      msClaritySubmodule.init(makeConfig());
+
+      const features = buildFeatures();
+      // back_forward seeds 5000 ms → dwellBucket should be at least 'brief' (>=3000)
+      expect(['brief', 'moderate', 'extended']).to.include(features.dwell);
+    });
+
+    it('should seed activeTimeMs on same-origin referrer so dwell >= brief', function () {
+      const perfStub = sandbox.stub(performance, 'getEntriesByType');
+      perfStub.withArgs('navigation').returns([{ type: 'navigate' }]);
+
+      window.clarity = function () {};
+      resetTracker();
+      msClaritySubmodule.init(makeConfig());
+
+      const features = buildFeatures();
+      // same-origin referrer seeds 3000 ms → dwellBucket should be at least 'brief'
+      // Note: this test verifies the code path exists; the actual referrer
+      // in the test environment may be empty, so dwell may still be 'bounce'.
+      // The back_forward test above validates the seeding mechanism itself.
+      expect(features.dwell).to.be.a('string');
+    });
+
+    it('should handle empty navigation entries gracefully', function () {
+      const perfStub = sandbox.stub(performance, 'getEntriesByType');
+      perfStub.withArgs('navigation').returns([]);
+
+      window.clarity = function () {};
+      resetTracker();
+      msClaritySubmodule.init(makeConfig());
+
+      const features = buildFeatures();
+      // Empty entries → no seeding → dwell stays at bounce
+      expect(features.dwell).to.equal('bounce');
+    });
+  });
+
+  // ─── Debounced mousemove ──────────────────────────────────────────────────
+
+  describe('debounced mousemove counting', function () {
+    let clock;
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers({ now: Date.now(), shouldAdvanceTime: false });
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('should count only one interaction per 5-second window for rapid mousemoves', function () {
+      window.clarity = function () {};
+      msClaritySubmodule.init(makeConfig());
+
+      // Fire several rapid mousemove events
+      for (let i = 0; i < 20; i++) {
+        window.dispatchEvent(new Event('mousemove'));
+      }
+
+      const features1 = buildFeatures();
+      // All 20 moves within same tick — only 1 interaction increment from mousemove
+      // (plus the initial state), so interaction should stay low
+      expect(features1.interaction).to.be.a('string');
+
+      // Advance clock past debounce window
+      clock.tick(5100);
+      window.dispatchEvent(new Event('mousemove'));
+
+      // Now another batch — should allow one more increment
+      for (let i = 0; i < 10; i++) {
+        window.dispatchEvent(new Event('mousemove'));
+      }
+
+      // We can't directly inspect interactionCount, but the debounce
+      // logic means we should have at most 2 mousemove-based increments
+      // across the two windows. The feature should reflect limited interaction.
+      const features2 = buildFeatures();
+      expect(features2.interaction).to.be.a('string');
+    });
+  });
+
+  // ─── Scroll tracking (depth + reversals) ─────────────────────────────────
+
+  describe('scroll tracking', function () {
+    let mockScrollY;
+    let origScrollYDesc;
+
+    beforeEach(function () {
+      mockScrollY = 0;
+      origScrollYDesc = Object.getOwnPropertyDescriptor(window, 'scrollY');
+      try {
+        Object.defineProperty(window, 'scrollY', {
+          get: () => mockScrollY,
+          configurable: true
+        });
+      } catch (e) { /* browser may not allow override */ }
+
+      // Add a tall element so docHeight > 0
+      const spacer = document.createElement('div');
+      spacer.id = 'scroll-test-spacer';
+      spacer.style.height = '10000px';
+      document.body.appendChild(spacer);
+
+      window.clarity = function () {};
+      msClaritySubmodule.init(makeConfig());
+    });
+
+    afterEach(function () {
+      const spacer = document.getElementById('scroll-test-spacer');
+      if (spacer) spacer.remove();
+      try {
+        if (origScrollYDesc) {
+          Object.defineProperty(window, 'scrollY', origScrollYDesc);
+        } else {
+          delete window.scrollY;
+        }
+      } catch (e) { /* restore best effort */ }
+    });
+
+    it('should track scroll depth from scroll events', function () {
+      mockScrollY = 500;
+      window.dispatchEvent(new Event('scroll'));
+
+      mockScrollY = 1500;
+      window.dispatchEvent(new Event('scroll'));
+
+      const features = buildFeatures();
+      // scrollY advanced, so scroll should be > none
+      expect(features.scroll).to.be.a('string');
+    });
+
+    it('should detect scroll direction reversals', function () {
+      // Scroll down
+      mockScrollY = 200;
+      window.dispatchEvent(new Event('scroll'));
+
+      mockScrollY = 600;
+      window.dispatchEvent(new Event('scroll'));
+
+      // Reverse — scroll up
+      mockScrollY = 300;
+      window.dispatchEvent(new Event('scroll'));
+
+      // Reverse again — scroll down
+      mockScrollY = 800;
+      window.dispatchEvent(new Event('scroll'));
+
+      const features = buildFeatures();
+      // 2 reversals → frustration may register
+      expect(features).to.have.property('frustration');
+      expect(features.frustration).to.be.a('string');
+    });
+  });
+
+  // ─── Click tracking (rage + exploratory) ───────────────────────────────────
+
+  describe('click tracking', function () {
+    beforeEach(function () {
+      window.clarity = function () {};
+      msClaritySubmodule.init(makeConfig());
+    });
+
+    it('should count exploratory clicks on non-interactive elements', function () {
+      const div = document.createElement('div');
+      div.textContent = 'plain text';
+      document.body.appendChild(div);
+
+      // Click the non-interactive element — event bubbles to window
+      div.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        clientX: 50,
+        clientY: 50
+      }));
+
+      const features = buildFeatures();
+      // Exploratory click should register — frustration may be mild
+      expect(['none', 'mild']).to.include(features.frustration);
+      div.remove();
+    });
+
+    it('should detect rage clicks from rapid repeated clicks', function () {
+      const div = document.createElement('div');
+      document.body.appendChild(div);
+
+      // Dispatch 4 clicks in rapid succession at the same location
+      for (let i = 0; i < 4; i++) {
+        div.dispatchEvent(new MouseEvent('click', {
+          bubbles: true,
+          clientX: 100,
+          clientY: 100
+        }));
+      }
+
+      const features = buildFeatures();
+      // Should have detected a rage click burst
+      expect(['mild', 'moderate', 'severe']).to.include(features.frustration);
+      div.remove();
+    });
+  });
+
+  // ─── Active timer (visibility-aware) ───────────────────────────────────────
+
+  describe('active timer behavior', function () {
+    let clock;
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers({ now: Date.now(), shouldAdvanceTime: false });
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('should not accumulate active time when tab is hidden', function () {
+      window.clarity = function () {};
+      msClaritySubmodule.init(makeConfig());
+
+      // Simulate tab hidden
+      const origHidden = Object.getOwnPropertyDescriptor(document, 'hidden') ||
+        Object.getOwnPropertyDescriptor(Document.prototype, 'hidden');
+      Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+      document.dispatchEvent(new Event('visibilitychange'));
+
+      // Tick 5 seconds — timer fires 5 times but tab is hidden
+      clock.tick(5000);
+
+      const features = buildFeatures();
+      // Active time should be minimal → bounce
+      expect(features.dwell).to.equal('bounce');
+
+      // Restore
+      if (origHidden) {
+        Object.defineProperty(document, 'hidden', origHidden);
+      } else {
+        Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+      }
+    });
+
+    it('should accumulate read time when scroll is stable', function () {
+      window.clarity = function () {};
+      msClaritySubmodule.init(makeConfig());
+
+      // Keep activity alive
+      window.dispatchEvent(new Event('mousemove'));
+
+      // Advance past SCROLL_STABLE_MS (2s) + extra ticks
+      // First 2 ticks: scan (scroll just happened at init).
+      // Ticks 3+: read (scroll stable).
+      clock.tick(6000);
+
+      const features = buildFeatures();
+      // After 6 seconds, some read time accumulated
+      expect(features.readingMode).to.be.a('string');
+      expect(features.dwell).to.not.equal('bounce');
+    });
+  });
+
+  // ─── Recent interaction pruning ───────────────────────────────────────────
+
+  describe('recent interaction pruning', function () {
+    let clock;
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers({ now: Date.now(), shouldAdvanceTime: false });
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('should prune stale interactions so recentEngagement drops to cold', function () {
+      window.clarity = function () {};
+      msClaritySubmodule.init(makeConfig());
+
+      // Generate deliberate interactions
+      for (let i = 0; i < 5; i++) {
+        window.dispatchEvent(new Event('keydown'));
+      }
+
+      const snap1 = buildSnapshotFeatures();
+      expect(['warming', 'hot']).to.include(snap1.recentEngagement);
+
+      // Advance past RECENT_WINDOW_MS (10s)
+      clock.tick(11000);
+
+      // Interactions are now stale — pruning loop exercises
+      const snap2 = buildSnapshotFeatures();
+      expect(snap2.recentEngagement).to.equal('cold');
+    });
+  });
+
+  // ─── resetTracker() ──────────────────────────────────────────────────────
+
+  describe('resetTracker()', function () {
+    it('should reset all tracker state to baseline', function () {
+      window.clarity = function () {};
+      msClaritySubmodule.init(makeConfig());
+
+      resetTracker();
+      const features = buildFeatures();
+      expect(features.scroll).to.equal('none');
+      expect(features.dwell).to.equal('bounce');
+      expect(features.frustration).to.equal('none');
+      expect(features.interaction).to.equal('passive');
+    });
+
+    it('should reset scrollReversals so frustration returns to none', function () {
+      window.clarity = function () {};
+      msClaritySubmodule.init(makeConfig());
+
+      // Simulate some scroll reversals by dispatching scroll events
+      // Then reset and verify frustration is 'none'
+      resetTracker();
+      const features = buildFeatures();
+      expect(features.frustration).to.equal('none');
+    });
+
+    it('should allow re-initialization after reset', function () {
+      window.clarity = function () {};
+      msClaritySubmodule.init(makeConfig());
+      resetTracker();
+      // Re-init should succeed
+      const result = msClaritySubmodule.init(makeConfig());
+      expect(result).to.be.true;
+    });
+  });
+
+  // ─── Module metadata ──────────────────────────────────────────────────────
+
+  describe('module metadata', function () {
+    it('should have the correct module name', function () {
+      expect(msClaritySubmodule.name).to.equal('msClarity');
+    });
+
+    it('should expose init and getBidRequestData only', function () {
+      expect(msClaritySubmodule.init).to.be.a('function');
+      expect(msClaritySubmodule.getBidRequestData).to.be.a('function');
+      expect(msClaritySubmodule.getTargetingData).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Add the Microsoft Clarity RTD submodule (extracted from prebid/Prebid.js#14564) to provide bucketed, privacy-preserving page-behavior signals to bidders without including the analytics adapter.
- Address review feedback about external script loading, testability, and the integration example so the RTD provider follows Prebid activity controls and is easy to validate.


cc @drpaulfarrow 

goal here was to help move along 14564, wait for ms feedback before considering