### PR TITLE
CI: fix e2e tests on older Chrome versions

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -124,7 +124,6 @@ jobs:
       ./.github/workflows/run-tests.yml
     with:
       browser: ${{ matrix.browser.wdioName }}
-      browser-version: ${{ matrix.browser.version }}
       built-key: ${{ needs.build.outputs[matrix.browser.os] }}
       test-cmd: npx gulp e2e-test-nobuild --local
       chunks: 1

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -115,7 +115,7 @@ jobs:
   e2e-tests:
     needs: [setup, build]
     if: ${{ !inputs.coverage-only }}
-    name: "E2E (browser: ${{ matrix.browser.wdioName }})"
+    name: "E2E (browser: ${{ matrix.browser.wdioName }} ${{ matrix.browser.version }})"
     strategy:
       fail-fast: false
       matrix:
@@ -129,6 +129,7 @@ jobs:
       chunks: 1
       runs-on: ${{ matrix.browser.runsOn || 'ubuntu-latest' }}
       install-safari: ${{ matrix.browser.os == 'macos' }}
+      install-chrome: ${{ matrix.browser.chrome }}
       browserstack: false
 
   unit-tests:

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -124,12 +124,12 @@ jobs:
       ./.github/workflows/run-tests.yml
     with:
       browser: ${{ matrix.browser.wdioName }}
+      browser-version: ${{ matrix.browser.version }}
       built-key: ${{ needs.build.outputs[matrix.browser.os] }}
       test-cmd: npx gulp e2e-test-nobuild --local
       chunks: 1
       runs-on: ${{ matrix.browser.runsOn || 'ubuntu-latest' }}
       install-safari: ${{ matrix.browser.os == 'macos' }}
-      install-chrome: ${{ matrix.browser.chrome }}
       browserstack: false
 
   unit-tests:

--- a/.github/workflows/browser_testing.json
+++ b/.github/workflows/browser_testing.json
@@ -7,7 +7,8 @@
       "113.0": {
         "coverage": false,
         "chrome": "113.0.5672.0",
-        "name": "ChromeNoSandbox"
+        "name": "ChromeNoSandbox",
+        "wdioName": null
       }
     }
   },

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,10 +6,6 @@ on:
         description: value to set as the BROWSER env variable
         required: false
         type: string
-      browser-version:
-        description: value to set as the BROWSER_VERSION env variable
-        required: false
-        type: string
       chunks:
         description: Number of chunks to split tests into
         required: false

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,7 +3,11 @@ on:
   workflow_call:
     inputs:
       browser:
-        description: values to set as the BROWSER env variable
+        description: value to set as the BROWSER env variable
+        required: false
+        type: string
+      browser-version:
+        description: value to set as the BROWSER_VERSION env variable
         required: false
         type: string
       chunks:
@@ -97,6 +101,7 @@ jobs:
       TEST_CHUNKS: ${{ inputs.chunks }}
       TEST_CHUNK: ${{ matrix.chunk-no }}
       BROWSER: ${{ inputs.browser }}
+      BROWSER_VERSION: ${{ inputs.browser-version }}
     outputs:
       coverage: ${{ steps.coverage.outputs.coverage }}
     concurrency:

--- a/wdio.local.conf.js
+++ b/wdio.local.conf.js
@@ -6,7 +6,6 @@ exports.config = {
   capabilities: [
     {
       browserName: 'chrome',
-      browserVersion: process.env.BROWSER_VERSION !== 'latest' ? process.env.BROWSER_VERSION : undefined,
       'goog:chromeOptions': {
         args: ['headless', 'disable-gpu'],
       },

--- a/wdio.local.conf.js
+++ b/wdio.local.conf.js
@@ -6,9 +6,9 @@ exports.config = {
   capabilities: [
     {
       browserName: 'chrome',
+      browserVersion: process.env.BROWSER_VERSION !== 'latest' ? process.env.BROWSER_VERSION : undefined,
       'goog:chromeOptions': {
         args: ['headless', 'disable-gpu'],
-        binary: process.env.CHROME_BIN
       },
     },
     {

--- a/wdio.local.conf.js
+++ b/wdio.local.conf.js
@@ -8,6 +8,7 @@ exports.config = {
       browserName: 'chrome',
       'goog:chromeOptions': {
         args: ['headless', 'disable-gpu'],
+        binary: process.env.CHROME_BIN
       },
     },
     {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] CI related changes

## Description of change

E2E tests run twice on chrome latest instead of once on latest and once on 113. Unfortunately wdio is not able to run chrome 113.
