### PR TITLE
Ms Clarity RTD Provider: add AppNexus GVL ID

### DIFF
--- a/modules/msClarityRtdProvider.js
+++ b/modules/msClarityRtdProvider.js
@@ -44,6 +44,7 @@ import { MODULE_TYPE_RTD } from '../src/activities/modules.js';
  */
 
 const MODULE_NAME = 'msClarity';
+const APPNEXUS_GVLID = 32;
 const LOG_PREFIX = '[MsClarity RTD]';
 
 /**
@@ -871,6 +872,7 @@ function getBidRequestData(reqBidsConfigObj, callback, config) {
 /** @type {RtdSubmodule} */
 export const msClaritySubmodule = {
   name: MODULE_NAME,
+  gvlid: APPNEXUS_GVLID,
   init,
   getBidRequestData,
 };

--- a/test/spec/modules/msClarityRtdProvider_spec.js
+++ b/test/spec/modules/msClarityRtdProvider_spec.js
@@ -1235,6 +1235,10 @@ describe('msClarityRtdProvider', function () {
       expect(msClaritySubmodule.name).to.equal('msClarity');
     });
 
+    it('should use the AppNexus GVL ID', function () {
+      expect(msClaritySubmodule.gvlid).to.equal(32);
+    });
+
     it('should expose init and getBidRequestData only', function () {
       expect(msClaritySubmodule.init).to.be.a('function');
       expect(msClaritySubmodule.getBidRequestData).to.be.a('function');


### PR DESCRIPTION
### Motivation
- Expose the AppNexus Global Vendor List ID so the msClarity RTD provider can be associated with the correct vendor for consent/vendor-aware logic (AppNexus GVL ID = 32).

### Description
- Add `const APPNEXUS_GVLID = 32` and set `gvlid: APPNEXUS_GVLID` on `msClaritySubmodule` in `modules/msClarityRtdProvider.js`, and add a unit test in `test/spec/modules/msClarityRtdProvider_spec.js` that asserts `msClaritySubmodule.gvlid === 32`.

### Testing
- `npx eslint modules/msClarityRtdProvider.js test/spec/modules/msClarityRtdProvider_spec.js --cache --cache-strategy content` — passed.
- `npx gulp test --nolint --file test/spec/modules/msClarityRtdProvider_spec.js` — passed (124 tests completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4fd37c4e54832ba252e072bd328185)