### PR TITLE
TeqBlaze Bidder Utils: Fix for the undefined bidfloor

### DIFF
--- a/libraries/teqblazeUtils/bidderUtils.ts
+++ b/libraries/teqblazeUtils/bidderUtils.ts
@@ -56,7 +56,8 @@ interface Placement {
   bidId: string;
   schain: unknown;
   bidfloor: number | undefined;
-  adFormat?: string;
+  floors?: Record<string, number>;
+  adFormat?: typeof BANNER | typeof VIDEO | typeof NATIVE;
   sizes?: Size | Size[];
   playerSize?: Size | Size[];
   minduration?: number;
@@ -115,29 +116,55 @@ const isBidResponseValid = (bid: any): boolean => {
   }
 };
 
-const getBidFloor = (bid: BidRequest<BidderCode>): number => {
-  try {
-    const bidFloor = bid.getFloor({
-      currency: 'USD',
-      mediaType: '*',
-      size: '*',
-    });
+const toArray = (sizes: Size | Size[]): Size[] => {
+  if (Array.isArray(sizes[0])) {
+    return sizes as Size[];
+  }
 
-    return bidFloor?.floor;
-  } catch (err) {
-    return 0;
+  return [sizes as Size];
+};
+
+const getFloors = (bid: BidRequest<BidderCode>, placement: Placement): { bidFloor: number; floors?: Record<string, number> } => {
+  const floors: Record<string, number> = {};
+
+  if (!bid.getFloor) {
+    return { bidFloor: 0 };
+  }
+
+  try {
+    if (placement.adFormat === NATIVE) {
+      const bidFloor = bid.getFloor({ currency: 'USD', mediaType: NATIVE, size: '*' }).floor;
+      return { bidFloor: bidFloor ?? 0 };
+    }
+
+    const sizes: Size[] = toArray(placement.sizes || placement.playerSize);
+
+    for (let i = 0; i < sizes.length; i++) {
+      const size = sizes[i];
+      const floor = bid.getFloor({ currency: 'USD', mediaType: placement.adFormat, size }).floor;
+
+      if (floor) floors[`${size[0]}x${size[1]}`] = floor;
+    }
+
+    const keys = Object.keys(floors);
+
+    return {
+      bidFloor: keys.length ? floors[keys[0]] : 0,
+      floors: keys.length ? floors : undefined
+    };
+  } catch {
+    return { bidFloor: 0 };
   }
 };
 
 const createBasePlacement = (bid: BidRequest<BidderCode>, bidderRequest: BaseBidderRequest<BidderCode>): Placement => {
   const { bidId, mediaTypes, transactionId, userIdAsEids, ortb2Imp } = bid;
   const schain = bidderRequest?.ortb2?.source?.ext?.schain || {};
-  const bidfloor = getBidFloor(bid);
 
   const placement: Placement = {
     bidId,
     schain,
-    bidfloor
+    bidfloor: 0
   };
 
   if (mediaTypes && mediaTypes[BANNER]) {
@@ -166,6 +193,13 @@ const createBasePlacement = (bid: BidRequest<BidderCode>, bidderRequest: BaseBid
   } else if (mediaTypes && mediaTypes[NATIVE]) {
     placement.native = mediaTypes[NATIVE];
     placement.adFormat = NATIVE;
+  }
+
+  const { bidFloor, floors } = getFloors(bid, placement);
+  placement.bidfloor = bidFloor;
+
+  if (floors) {
+    placement.floors = floors;
   }
 
   if (transactionId) {

--- a/modules/colossussspBidAdapter.js
+++ b/modules/colossussspBidAdapter.js
@@ -71,6 +71,7 @@ const addCustomFieldsToPlacement = (bid, bidderRequest, placement) => {
   }
 
   delete placement.bidfloor;
+  delete placement.floors;
   delete placement.plcmt;
   delete placement.ext;
 };

--- a/test/spec/libraries/teqblazeUtils/bidderUtils_spec.js
+++ b/test/spec/libraries/teqblazeUtils/bidderUtils_spec.js
@@ -302,6 +302,98 @@ describe('TeqBlazeBidderUtils', function () {
     });
   });
 
+  describe('floor logic', function () {
+    const buildBidWithFloor = (mediaType, mediaTypeData, getFloor) => ({
+      bidId: getUniqueIdentifierStr(),
+      bidder,
+      mediaTypes: { [mediaType]: mediaTypeData },
+      params: { placementId: 'test' },
+      getFloor
+    });
+
+    it('returns bidfloor 0 and no floors map when getFloor is not defined', function () {
+      const bid = {
+        bidId: getUniqueIdentifierStr(),
+        bidder,
+        mediaTypes: { [BANNER]: { sizes: [[300, 250]] } },
+        params: { placementId: 'test' }
+      };
+      const req = spec.buildRequests([bid], bidderRequest);
+      const placement = req.data.placements[0];
+      expect(placement.bidfloor).to.equal(0);
+      expect(placement.floors).to.be.undefined;
+    });
+
+    it('returns correct bidfloor and floors map for banner with single size', function () {
+      const bid = buildBidWithFloor(BANNER, { sizes: [[300, 250]] }, () => ({ currency: 'USD', floor: 1.5 }));
+      const req = spec.buildRequests([bid], bidderRequest);
+      const placement = req.data.placements[0];
+      expect(placement.bidfloor).to.equal(1.5);
+      expect(placement.floors).to.deep.equal({ '300x250': 1.5 });
+    });
+
+    it('returns floors map for all sizes and bidfloor from first size for banner with multiple sizes', function () {
+      const floorMap = { '300x250': 1.5, '728x90': 2.0 };
+      const bid = buildBidWithFloor(
+        BANNER,
+        { sizes: [[300, 250], [728, 90]] },
+        ({ size }) => ({ currency: 'USD', floor: floorMap[`${size[0]}x${size[1]}`] })
+      );
+      const req = spec.buildRequests([bid], bidderRequest);
+      const placement = req.data.placements[0];
+      expect(placement.floors).to.deep.equal({ '300x250': 1.5, '728x90': 2.0 });
+      expect(placement.bidfloor).to.equal(1.5);
+    });
+
+    it('picks first size with a valid floor when earlier sizes return no floor', function () {
+      const bid = buildBidWithFloor(
+        BANNER,
+        { sizes: [[300, 250], [728, 90]] },
+        ({ size }) => size[0] === 300 ? { currency: 'USD', floor: 0 } : { currency: 'USD', floor: 2.0 }
+      );
+      const req = spec.buildRequests([bid], bidderRequest);
+      const placement = req.data.placements[0];
+      expect(placement.floors).to.deep.equal({ '728x90': 2.0 });
+      expect(placement.bidfloor).to.equal(2.0);
+    });
+
+    it('returns bidfloor 0 and no floors map when all sizes return no floor', function () {
+      const bid = buildBidWithFloor(BANNER, { sizes: [[300, 250], [728, 90]] }, () => ({ currency: 'USD', floor: 0 }));
+      const req = spec.buildRequests([bid], bidderRequest);
+      const placement = req.data.placements[0];
+      expect(placement.bidfloor).to.equal(0);
+      expect(placement.floors).to.be.undefined;
+    });
+
+    it('returns correct bidfloor and floors map for video', function () {
+      const bid = buildBidWithFloor(VIDEO, { playerSize: [[640, 480]] }, () => ({ currency: 'USD', floor: 3.0 }));
+      const req = spec.buildRequests([bid], bidderRequest);
+      const placement = req.data.placements[0];
+      expect(placement.bidfloor).to.equal(3.0);
+      expect(placement.floors).to.deep.equal({ '640x480': 3.0 });
+    });
+
+    it('returns correct bidfloor and no floors map for native', function () {
+      const bid = buildBidWithFloor(
+        NATIVE,
+        { native: { title: { required: true } } },
+        () => ({ currency: 'USD', floor: 0.5 })
+      );
+      const req = spec.buildRequests([bid], bidderRequest);
+      const placement = req.data.placements[0];
+      expect(placement.bidfloor).to.equal(0.5);
+      expect(placement.floors).to.be.undefined;
+    });
+
+    it('returns bidfloor 0 and no floors map when getFloor throws', function () {
+      const bid = buildBidWithFloor(BANNER, { sizes: [[300, 250]] }, () => { throw new Error('floor error'); });
+      const req = spec.buildRequests([bid], bidderRequest);
+      const placement = req.data.placements[0];
+      expect(placement.bidfloor).to.equal(0);
+      expect(placement.floors).to.be.undefined;
+    });
+  });
+
   describe('gpp consent', function () {
     it('bidderRequest.gppConsent', () => {
       bidderRequest.gppConsent = {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
If multiple floors were configured for a given size, the function would return undefined.
<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->
