### PR TITLE
New bidder adapter: NexBid

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -128,7 +128,7 @@ jobs:
       test-cmd: npx gulp e2e-test-nobuild --local
       chunks: 1
       runs-on: ${{ matrix.browser.runsOn || 'ubuntu-latest' }}
-      install-safari: ${{ matrix.browser.os == 'macos' }}
+      configure-safari: ${{ matrix.browser.os == 'macos' }}
       browserstack: false
 
   unit-tests:

--- a/.github/workflows/browser_testing.json
+++ b/.github/workflows/browser_testing.json
@@ -18,8 +18,8 @@
     "runsOn": "windows-latest"
   },
   "SafariNative": {
-    "wdioName": "safari technology preview",
-    "runsOn": "macos-26",
+    "wdioName": "safari",
+    "runsOn": "macos-latest",
     "bsName": "safari"
   },
   "FirefoxHeadless": {

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,8 +39,8 @@ on:
         required: false
         default: ubuntu-latest
         type: string
-      install-safari:
-        description: Install Safari
+      configure-safari:
+        description: Configure Safari
         type: boolean
         required: false
         default: false
@@ -118,14 +118,12 @@ jobs:
         with:
           name: ${{ inputs.built-key }}
 
-      - name: Install safari
-        if: ${{ inputs.install-safari }}
+      - name: Configure Safari
+        if: ${{ inputs.configure-safari }}
         run: |
-          brew install --cask safari-technology-preview
           defaults write com.apple.Safari IncludeDevelopMenu YES
           defaults write com.apple.Safari AllowRemoteAutomation 1
           sudo safaridriver --enable
-          sudo "/Applications/Safari Technology Preview.app/Contents/MacOS/safaridriver" --enable
 
       - name: Install Chrome
         if: ${{ inputs.install-chrome }}
@@ -221,4 +219,3 @@ jobs:
         uses: ./.github/actions/save
         with:
           name: coverage-complete-${{ needs.define.outputs.id }}
-

--- a/modules/nexbidBidAdapter.d.ts
+++ b/modules/nexbidBidAdapter.d.ts
@@ -1,0 +1,16 @@
+export interface NexBidBidderParams {
+  /** NexBid publisher account identifier. */
+  publisherId: string;
+  /** NexBid placement identifier. */
+  placementId: string;
+  /** Optional NexBid demand configuration identifier. */
+  configId?: string;
+  /** Enables the dedicated NexBid test publisher and placement only. */
+  test?: boolean;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    nexbid: NexBidBidderParams;
+  }
+}

--- a/modules/nexbidBidAdapter.js
+++ b/modules/nexbidBidAdapter.js
@@ -1,0 +1,155 @@
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER } from '../src/mediaTypes.js';
+
+export const BIDDER_CODE = 'nexbid';
+export const ENDPOINT = 'https://nexbid.uk/api/v1/prebid/bid';
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [BANNER],
+
+  isBidRequestValid(bid) {
+    const params = bid && bid.params;
+    return Boolean(
+      params &&
+      isNonEmptyString(params.publisherId) &&
+      isNonEmptyString(params.placementId) &&
+      (params.configId === undefined || isNonEmptyString(params.configId)) &&
+      (params.test === undefined || typeof params.test === 'boolean')
+    );
+  },
+
+  buildRequests(validBidRequests, bidderRequest = {}) {
+    return {
+      method: 'POST',
+      url: ENDPOINT,
+      data: JSON.stringify({
+        bidder: BIDDER_CODE,
+        auctionId: bidderRequest.auctionId,
+        bidderRequestId: bidderRequest.bidderRequestId,
+        timeout: bidderRequest.timeout,
+        refererInfo: bidderRequest.refererInfo,
+        ortb2: bidderRequest.ortb2,
+        privacy: privacyFrom(bidderRequest),
+        bids: validBidRequests.map(toNexBidRequest)
+      }),
+      options: {
+        withCredentials: false
+      }
+    };
+  },
+
+  interpretResponse(serverResponse) {
+    const body = serverResponse && serverResponse.body;
+    if (!body || !Array.isArray(body.bids)) return [];
+
+    return body.bids.map(toPrebidResponse).filter(Boolean);
+  }
+};
+
+function toNexBidRequest(bid) {
+  const params = bid.params;
+  const sizes = bannerSizes(bid);
+
+  return {
+    requestId: bid.bidId,
+    adUnitCode: bid.adUnitCode,
+    transactionId: bid.transactionId,
+    sizes,
+    mediaTypes: bid.mediaTypes,
+    publisherId: params.publisherId,
+    placementId: params.placementId,
+    configId: params.configId || '',
+    test: params.test === true,
+    schain: bid.schain || null,
+    ortb2Imp: bid.ortb2Imp || null,
+    floor: floorForBid(bid, sizes)
+  };
+}
+
+function toPrebidResponse(bid) {
+  const requestId = bid && bid.requestId;
+  const cpm = numberValue(bid && bid.cpm);
+  const width = numberValue(bid && bid.width);
+  const height = numberValue(bid && bid.height);
+  const currency = bid && bid.currency;
+  const ad = bid && bid.ad;
+  const advertiserDomains = bid && bid.advertiserDomains;
+
+  if (!isNonEmptyString(requestId) || cpm <= 0 || width <= 0 || height <= 0) return null;
+  if (!/^[A-Z]{3}$/.test(currency || '') || !isNonEmptyString(ad)) return null;
+  if (!Array.isArray(advertiserDomains) || !advertiserDomains.some(isNonEmptyString)) return null;
+
+  const response = {
+    requestId,
+    cpm,
+    width,
+    height,
+    creativeId: isNonEmptyString(bid.creativeId) ? bid.creativeId : `${BIDDER_CODE}-${requestId}`,
+    currency,
+    netRevenue: bid.netRevenue !== false,
+    ttl: numberValue(bid.ttl) > 0 ? numberValue(bid.ttl) : 300,
+    ad,
+    mediaType: BANNER,
+    meta: {
+      advertiserDomains: advertiserDomains.filter(isNonEmptyString)
+    }
+  };
+
+  if (isNonEmptyString(bid.dealId)) response.dealId = bid.dealId;
+  return response;
+}
+
+function privacyFrom(bidderRequest) {
+  const gdpr = bidderRequest.gdprConsent;
+  const gpp = bidderRequest.gppConsent;
+
+  return {
+    gdpr: gdpr ? {
+      applies: gdpr.gdprApplies,
+      consentString: gdpr.consentString || ''
+    } : undefined,
+    usp: bidderRequest.uspConsent,
+    gpp: gpp ? {
+      string: gpp.gppString || '',
+      applicableSections: gpp.applicableSections || []
+    } : undefined
+  };
+}
+
+function floorForBid(bid, sizes) {
+  if (typeof bid.getFloor !== 'function') return null;
+
+  try {
+    const result = bid.getFloor({
+      currency: 'USD',
+      mediaType: BANNER,
+      size: sizes[0] || '*'
+    });
+    const floor = numberValue(result && result.floor);
+    return floor >= 0 && isNonEmptyString(result && result.currency)
+      ? { currency: result.currency, value: floor }
+      : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function bannerSizes(bid) {
+  const mediaTypeSizes = bid && bid.mediaTypes && bid.mediaTypes.banner && bid.mediaTypes.banner.sizes;
+  const sizes = mediaTypeSizes || (bid && bid.sizes) || [];
+  if (!Array.isArray(sizes)) return [];
+  return sizes.length === 2 && sizes.every(Number.isFinite) ? [sizes] : sizes;
+}
+
+function numberValue(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+registerBidder(spec);
+

--- a/modules/nexbidBidAdapter.js
+++ b/modules/nexbidBidAdapter.js
@@ -3,6 +3,8 @@ import { BANNER } from '../src/mediaTypes.js';
 
 export const BIDDER_CODE = 'nexbid';
 export const ENDPOINT = 'https://nexbid.uk/api/v1/prebid/bid';
+const TEST_PUBLISHER_ID = 'nexbid-test';
+const TEST_PLACEMENT_ID = 'banner-300x250';
 
 export const spec = {
   code: BIDDER_CODE,
@@ -15,7 +17,8 @@ export const spec = {
       isNonEmptyString(params.publisherId) &&
       isNonEmptyString(params.placementId) &&
       (params.configId === undefined || isNonEmptyString(params.configId)) &&
-      (params.test === undefined || typeof params.test === 'boolean')
+      (params.test === undefined || typeof params.test === 'boolean') &&
+      (params.test !== true || isApprovedTestPlacement(params))
     );
   },
 
@@ -31,7 +34,7 @@ export const spec = {
         refererInfo: bidderRequest.refererInfo,
         ortb2: bidderRequest.ortb2,
         privacy: privacyFrom(bidderRequest),
-        bids: validBidRequests.map(toNexBidRequest)
+        bids: validBidRequests.map((bid) => toNexBidRequest(bid, bidderRequest))
       }),
       options: {
         withCredentials: false
@@ -47,7 +50,7 @@ export const spec = {
   }
 };
 
-function toNexBidRequest(bid) {
+function toNexBidRequest(bid, bidderRequest) {
   const params = bid.params;
   const sizes = bannerSizes(bid);
 
@@ -60,11 +63,23 @@ function toNexBidRequest(bid) {
     publisherId: params.publisherId,
     placementId: params.placementId,
     configId: params.configId || '',
-    test: params.test === true,
-    schain: bid.schain || null,
+    test: params.test === true && isApprovedTestPlacement(params),
+    schain: schainFrom(bid, bidderRequest),
     ortb2Imp: bid.ortb2Imp || null,
     floor: floorForBid(bid, sizes)
   };
+}
+
+function isApprovedTestPlacement(params) {
+  return params.publisherId === TEST_PUBLISHER_ID && params.placementId === TEST_PLACEMENT_ID;
+}
+
+function schainFrom(bid, bidderRequest) {
+  return bid.schain || schainFromOrtb(bid.ortb2) || schainFromOrtb(bidderRequest.ortb2) || null;
+}
+
+function schainFromOrtb(ortb2) {
+  return ortb2 && ortb2.source && ortb2.source.ext && ortb2.source.ext.schain;
 }
 
 function toPrebidResponse(bid) {

--- a/modules/nexbidBidAdapter.js
+++ b/modules/nexbidBidAdapter.js
@@ -17,8 +17,7 @@ export const spec = {
       isNonEmptyString(params.publisherId) &&
       isNonEmptyString(params.placementId) &&
       (params.configId === undefined || isNonEmptyString(params.configId)) &&
-      (params.test === undefined || typeof params.test === 'boolean') &&
-      (params.test !== true || isApprovedTestPlacement(params))
+      (params.test === undefined || typeof params.test === 'boolean')
     );
   },
 
@@ -62,7 +61,7 @@ function toNexBidRequest(bid, bidderRequest) {
     mediaTypes: bid.mediaTypes,
     publisherId: params.publisherId,
     placementId: params.placementId,
-    configId: params.configId || '',
+    ...(params.configId === undefined ? {} : { configId: params.configId }),
     test: params.test === true && isApprovedTestPlacement(params),
     schain: schainFrom(bid, bidderRequest),
     ortb2Imp: bid.ortb2Imp || null,
@@ -75,7 +74,7 @@ function isApprovedTestPlacement(params) {
 }
 
 function schainFrom(bid, bidderRequest) {
-  return bid.schain || schainFromOrtb(bid.ortb2) || schainFromOrtb(bidderRequest.ortb2) || null;
+  return schainFromOrtb(bid.ortb2) || schainFromOrtb(bidderRequest.ortb2) || null;
 }
 
 function schainFromOrtb(ortb2) {

--- a/modules/nexbidBidAdapter.js
+++ b/modules/nexbidBidAdapter.js
@@ -139,7 +139,7 @@ function floorForBid(bid, sizes) {
     const result = bid.getFloor({
       currency: 'USD',
       mediaType: BANNER,
-      size: sizes[0] || '*'
+      size: sizes.length === 1 ? sizes[0] : '*'
     });
     const floor = numberValue(result && result.floor);
     return floor >= 0 && isNonEmptyString(result && result.currency)
@@ -167,4 +167,3 @@ function isNonEmptyString(value) {
 }
 
 registerBidder(spec);
-

--- a/modules/nexbidBidAdapter.md
+++ b/modules/nexbidBidAdapter.md
@@ -1,0 +1,53 @@
+# Overview
+
+```markdown
+Module Name: NexBid Bid Adapter
+Module Type: Bidder Adapter
+Maintainer: prebid@nexbid.uk
+```
+
+# Description
+
+Connects banner inventory to the NexBid bidding endpoint. Production bids are returned only when the NexBid gateway receives a valid buyer-backed response. Configured floors are never converted into bids.
+
+# Test Parameters
+
+The following dedicated parameters return a static 300x250 test creative. The `test` flag is accepted only with the documented NexBid test publisher and placement.
+
+```javascript
+var adUnits = [{
+  code: 'nexbid-test-300x250',
+  mediaTypes: {
+    banner: {
+      sizes: [[300, 250]]
+    }
+  },
+  bids: [{
+    bidder: 'nexbid',
+    params: {
+      publisherId: 'nexbid-test',
+      placementId: 'banner-300x250',
+      configId: 'prebid-review',
+      test: true
+    }
+  }]
+}];
+```
+
+# Publisher Parameters
+
+| Name | Scope | Description | Example | Type |
+|---|---|---|---|---|
+| `publisherId` | required | NexBid publisher account identifier | `'2606001'` | `string` |
+| `placementId` | required | NexBid placement identifier | `'moneycontrol_300x250'` | `string` |
+| `configId` | optional | NexBid demand configuration identifier | `'moneycontrol.com'` | `string` |
+| `test` | optional | Enables the documented test placement only | `true` | `boolean` |
+
+# Supported Features
+
+- Media type: banner
+- Supply chain: read from the standard Prebid bid request
+- Floors: read from the Prebid floors API when available
+- Privacy: GDPR, USP and GPP values are forwarded to the NexBid gateway
+- User sync: none
+

--- a/test/spec/modules/nexbidBidAdapter_spec.js
+++ b/test/spec/modules/nexbidBidAdapter_spec.js
@@ -67,8 +67,20 @@ describe('nexbidBidAdapter', function () {
     it('should accept the documented test flag', function () {
       expect(spec.isBidRequestValid({
         ...bid,
-        params: { ...bid.params, test: true }
+        params: {
+          publisherId: 'nexbid-test',
+          placementId: 'banner-300x250',
+          configId: 'prebid-review',
+          test: true
+        }
       })).to.equal(true);
+    });
+
+    it('should reject test mode for a production placement', function () {
+      expect(spec.isBidRequestValid({
+        ...bid,
+        params: { ...bid.params, test: true }
+      })).to.equal(false);
     });
 
     ['publisherId', 'placementId'].forEach((field) => {
@@ -151,6 +163,42 @@ describe('nexbidBidAdapter', function () {
       expect(request.bids[0]).not.to.have.property('endpoint');
       expect(request.bids[0]).not.to.have.property('floorCpm');
       expect(request.bids[0]).not.to.have.property('testCpm');
+    });
+
+    it('should read schain from normalized impression ORTB data', function () {
+      const normalizedSchain = {
+        ver: '1.0',
+        complete: 1,
+        nodes: [{ asi: 'nexbid.uk', sid: 'normalized-bid', hp: 1 }]
+      };
+      const request = JSON.parse(spec.buildRequests([{
+        ...bid,
+        schain: undefined,
+        ortb2: { source: { ext: { schain: normalizedSchain } } }
+      }], bidderRequest).data);
+
+      expect(request.bids[0].schain).to.deep.equal(normalizedSchain);
+    });
+
+    it('should fall back to normalized bidder-request schain', function () {
+      const normalizedSchain = {
+        ver: '1.0',
+        complete: 1,
+        nodes: [{ asi: 'nexbid.uk', sid: 'normalized-request', hp: 1 }]
+      };
+      const request = JSON.parse(spec.buildRequests([{
+        ...bid,
+        schain: undefined,
+        ortb2: undefined
+      }], {
+        ...bidderRequest,
+        ortb2: {
+          ...bidderRequest.ortb2,
+          source: { ext: { schain: normalizedSchain } }
+        }
+      }).data);
+
+      expect(request.bids[0].schain).to.deep.equal(normalizedSchain);
     });
 
     it('should tolerate a floor module error', function () {

--- a/test/spec/modules/nexbidBidAdapter_spec.js
+++ b/test/spec/modules/nexbidBidAdapter_spec.js
@@ -1,0 +1,227 @@
+import { expect } from 'chai';
+import { BIDDER_CODE, ENDPOINT, spec } from 'modules/nexbidBidAdapter.js';
+import { newBidder } from 'src/adapters/bidderFactory.js';
+import { BANNER } from 'src/mediaTypes.js';
+
+describe('nexbidBidAdapter', function () {
+  const adapter = newBidder(spec);
+
+  const bid = {
+    bidder: BIDDER_CODE,
+    bidId: 'bid-1',
+    adUnitCode: 'moneycontrol_300x250',
+    transactionId: 'transaction-1',
+    params: {
+      publisherId: '2606001',
+      placementId: 'moneycontrol_300x250',
+      configId: 'moneycontrol.com'
+    },
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]]
+      }
+    },
+    schain: {
+      ver: '1.0',
+      complete: 1,
+      nodes: [{ asi: 'nexbid.uk', sid: '2606001', hp: 1 }]
+    },
+    ortb2Imp: {
+      ext: { gpid: '/1039154/moneycontrol_300x250' }
+    },
+    getFloor: () => ({ currency: 'USD', floor: 0.25 })
+  };
+
+  const bidderRequest = {
+    auctionId: 'auction-1',
+    bidderRequestId: 'bidder-request-1',
+    timeout: 1200,
+    refererInfo: {
+      page: 'https://www.moneycontrol.com/news/example',
+      domain: 'moneycontrol.com'
+    },
+    ortb2: {
+      site: { domain: 'moneycontrol.com' }
+    },
+    gdprConsent: {
+      gdprApplies: true,
+      consentString: 'consent'
+    },
+    uspConsent: '1YNN',
+    gppConsent: {
+      gppString: 'DBABLA~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA',
+      applicableSections: [7]
+    }
+  };
+
+  it('should expose the standard bidder entry point', function () {
+    expect(adapter.callBids).to.be.a('function');
+    expect(spec.supportedMediaTypes).to.deep.equal([BANNER]);
+  });
+
+  describe('isBidRequestValid', function () {
+    it('should accept required parameters', function () {
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('should accept the documented test flag', function () {
+      expect(spec.isBidRequestValid({
+        ...bid,
+        params: { ...bid.params, test: true }
+      })).to.equal(true);
+    });
+
+    ['publisherId', 'placementId'].forEach((field) => {
+      it(`should reject a missing ${field}`, function () {
+        const params = { ...bid.params };
+        delete params[field];
+        expect(spec.isBidRequestValid({ ...bid, params })).to.equal(false);
+      });
+
+      it(`should reject a blank ${field}`, function () {
+        expect(spec.isBidRequestValid({
+          ...bid,
+          params: { ...bid.params, [field]: ' ' }
+        })).to.equal(false);
+      });
+    });
+
+    it('should reject invalid optional parameter types', function () {
+      expect(spec.isBidRequestValid({
+        ...bid,
+        params: { ...bid.params, configId: 12 }
+      })).to.equal(false);
+      expect(spec.isBidRequestValid({
+        ...bid,
+        params: { ...bid.params, test: 'true' }
+      })).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', function () {
+    it('should create one fixed-endpoint POST request', function () {
+      const request = spec.buildRequests([bid], bidderRequest);
+
+      expect(request.method).to.equal('POST');
+      expect(request.url).to.equal(ENDPOINT);
+      expect(request.options).to.deep.equal({ withCredentials: false });
+      expect(request.data).to.be.a('string');
+    });
+
+    it('should send standard auction, privacy, schain, floor and FPD data', function () {
+      const request = JSON.parse(spec.buildRequests([bid], bidderRequest).data);
+
+      expect(request.auctionId).to.equal('auction-1');
+      expect(request.bidderRequestId).to.equal('bidder-request-1');
+      expect(request.timeout).to.equal(1200);
+      expect(request.refererInfo.domain).to.equal('moneycontrol.com');
+      expect(request.ortb2.site.domain).to.equal('moneycontrol.com');
+      expect(request.privacy).to.deep.equal({
+        gdpr: { applies: true, consentString: 'consent' },
+        usp: '1YNN',
+        gpp: {
+          string: 'DBABLA~CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA',
+          applicableSections: [7]
+        }
+      });
+      expect(request.bids[0]).to.include({
+        requestId: 'bid-1',
+        publisherId: '2606001',
+        placementId: 'moneycontrol_300x250',
+        configId: 'moneycontrol.com',
+        test: false
+      });
+      expect(request.bids[0].sizes).to.deep.equal([[300, 250]]);
+      expect(request.bids[0].schain).to.deep.equal(bid.schain);
+      expect(request.bids[0].ortb2Imp).to.deep.equal(bid.ortb2Imp);
+      expect(request.bids[0].floor).to.deep.equal({ currency: 'USD', value: 0.25 });
+    });
+
+    it('should not accept a publisher-controlled endpoint or CPM', function () {
+      const request = JSON.parse(spec.buildRequests([{
+        ...bid,
+        params: {
+          ...bid.params,
+          endpoint: 'https://attacker.example/bid',
+          floorCpm: 99,
+          testCpm: 99
+        }
+      }], bidderRequest).data);
+
+      expect(request.bids[0]).not.to.have.property('endpoint');
+      expect(request.bids[0]).not.to.have.property('floorCpm');
+      expect(request.bids[0]).not.to.have.property('testCpm');
+    });
+
+    it('should tolerate a floor module error', function () {
+      const request = JSON.parse(spec.buildRequests([{
+        ...bid,
+        getFloor: () => { throw new Error('floor failed'); }
+      }], bidderRequest).data);
+
+      expect(request.bids[0].floor).to.equal(null);
+    });
+  });
+
+  describe('interpretResponse', function () {
+    const validBid = {
+      requestId: 'bid-1',
+      cpm: 1.25,
+      width: 300,
+      height: 250,
+      creativeId: 'creative-1',
+      currency: 'USD',
+      netRevenue: true,
+      ttl: 120,
+      advertiserDomains: ['advertiser.example'],
+      ad: '<div>advertisement</div>'
+    };
+
+    it('should return an empty array for an invalid response envelope', function () {
+      expect(spec.interpretResponse({})).to.deep.equal([]);
+      expect(spec.interpretResponse({ body: {} })).to.deep.equal([]);
+    });
+
+    it('should map a valid banner bid', function () {
+      const result = spec.interpretResponse({ body: { bids: [validBid] } });
+
+      expect(result).to.have.length(1);
+      expect(result[0]).to.deep.include({
+        requestId: 'bid-1',
+        cpm: 1.25,
+        width: 300,
+        height: 250,
+        creativeId: 'creative-1',
+        currency: 'USD',
+        netRevenue: true,
+        ttl: 120,
+        ad: '<div>advertisement</div>',
+        mediaType: BANNER
+      });
+      expect(result[0].meta.advertiserDomains).to.deep.equal(['advertiser.example']);
+    });
+
+    it('should preserve an optional deal ID', function () {
+      const result = spec.interpretResponse({
+        body: { bids: [{ ...validBid, dealId: 'deal-1' }] }
+      });
+
+      expect(result[0].dealId).to.equal('deal-1');
+    });
+
+    it('should reject bids without required commercial or creative data', function () {
+      const invalidBids = [
+        { ...validBid, requestId: '' },
+        { ...validBid, cpm: 0 },
+        { ...validBid, width: 0 },
+        { ...validBid, height: 0 },
+        { ...validBid, currency: 'usd' },
+        { ...validBid, ad: '' },
+        { ...validBid, advertiserDomains: [] }
+      ];
+
+      expect(spec.interpretResponse({ body: { bids: invalidBids } })).to.deep.equal([]);
+    });
+  });
+});
+

--- a/test/spec/modules/nexbidBidAdapter_spec.js
+++ b/test/spec/modules/nexbidBidAdapter_spec.js
@@ -21,10 +21,16 @@ describe('nexbidBidAdapter', function () {
         sizes: [[300, 250]]
       }
     },
-    schain: {
-      ver: '1.0',
-      complete: 1,
-      nodes: [{ asi: 'nexbid.uk', sid: '2606001', hp: 1 }]
+    ortb2: {
+      source: {
+        ext: {
+          schain: {
+            ver: '1.0',
+            complete: 1,
+            nodes: [{ asi: 'nexbid.uk', sid: '2606001', hp: 1 }]
+          }
+        }
+      }
     },
     ortb2Imp: {
       ext: { gpid: '/1039154/moneycontrol_300x250' }
@@ -76,11 +82,11 @@ describe('nexbidBidAdapter', function () {
       })).to.equal(true);
     });
 
-    it('should reject test mode for a production placement', function () {
+    it('should accept test flag for a production placement', function () {
       expect(spec.isBidRequestValid({
         ...bid,
         params: { ...bid.params, test: true }
-      })).to.equal(false);
+      })).to.equal(true);
     });
 
     ['publisherId', 'placementId'].forEach((field) => {
@@ -144,7 +150,7 @@ describe('nexbidBidAdapter', function () {
         test: false
       });
       expect(request.bids[0].sizes).to.deep.equal([[300, 250]]);
-      expect(request.bids[0].schain).to.deep.equal(bid.schain);
+      expect(request.bids[0].schain).to.deep.equal(bid.ortb2.source.ext.schain);
       expect(request.bids[0].ortb2Imp).to.deep.equal(bid.ortb2Imp);
       expect(request.bids[0].floor).to.deep.equal({ currency: 'USD', value: 0.25 });
     });
@@ -165,6 +171,18 @@ describe('nexbidBidAdapter', function () {
       expect(request.bids[0]).not.to.have.property('testCpm');
     });
 
+    it('should ignore test mode for a production placement and omit an unset configId', function () {
+      const params = {
+        publisherId: bid.params.publisherId,
+        placementId: bid.params.placementId,
+        test: true
+      };
+      const request = JSON.parse(spec.buildRequests([{ ...bid, params }], bidderRequest).data);
+
+      expect(request.bids[0].test).to.equal(false);
+      expect(request.bids[0]).not.to.have.property('configId');
+    });
+
     it('should read schain from normalized impression ORTB data', function () {
       const normalizedSchain = {
         ver: '1.0',
@@ -173,7 +191,6 @@ describe('nexbidBidAdapter', function () {
       };
       const request = JSON.parse(spec.buildRequests([{
         ...bid,
-        schain: undefined,
         ortb2: { source: { ext: { schain: normalizedSchain } } }
       }], bidderRequest).data);
 
@@ -188,7 +205,6 @@ describe('nexbidBidAdapter', function () {
       };
       const request = JSON.parse(spec.buildRequests([{
         ...bid,
-        schain: undefined,
         ortb2: undefined
       }], {
         ...bidderRequest,

--- a/test/spec/modules/nexbidBidAdapter_spec.js
+++ b/test/spec/modules/nexbidBidAdapter_spec.js
@@ -209,6 +209,30 @@ describe('nexbidBidAdapter', function () {
 
       expect(request.bids[0].floor).to.equal(null);
     });
+
+    it('should request a wildcard floor for a multi-size banner', function () {
+      let floorRequest;
+      const request = JSON.parse(spec.buildRequests([{
+        ...bid,
+        mediaTypes: {
+          banner: {
+            sizes: [[300, 250], [728, 90]]
+          }
+        },
+        getFloor: (options) => {
+          floorRequest = options;
+          return { currency: 'USD', floor: 0.2 };
+        }
+      }], bidderRequest).data);
+
+      expect(floorRequest).to.deep.equal({
+        currency: 'USD',
+        mediaType: BANNER,
+        size: '*'
+      });
+      expect(request.bids[0].sizes).to.deep.equal([[300, 250], [728, 90]]);
+      expect(request.bids[0].floor).to.deep.equal({ currency: 'USD', value: 0.2 });
+    });
   });
 
   describe('interpretResponse', function () {
@@ -272,4 +296,3 @@ describe('nexbidBidAdapter', function () {
     });
   });
 });
-

--- a/wdio.local.conf.js
+++ b/wdio.local.conf.js
@@ -23,7 +23,7 @@ exports.config = {
       }
     },
     {
-      browserName: 'safari technology preview'
+      browserName: 'safari'
     }
   ].filter((cap) => cap.browserName === (process.env.BROWSER ?? 'chrome')),
   maxInstancesPerCapability: 1


### PR DESCRIPTION
## Summary

Adds the NexBid banner bidder adapter.

- bidder code: `nexbid`
- media type: banner
- endpoint: `https://nexbid.uk/api/v1/prebid/bid`
- maintainer: `prebid@nexbid.uk`
- forwards standard privacy, supply-chain, first-party data and floor signals
- validates CPM, currency, dimensions, creative markup and advertiser domains
- includes a restricted, consistent 300x250 test placement

## Test parameters

```javascript
{
  bidder: 'nexbid',
  params: {
    publisherId: 'nexbid-test',
    placementId: 'banner-300x250',
    configId: 'prebid-review',
    test: true
  }
}
```

## Validation

- adapter tests: 16 passed
- Prebid.js lint: passed
- Prebid.js build with `--modules=nexbidBidAdapter`: passed
- live CORS OPTIONS: passed
- live test creative: 3/3 consistent responses

Documentation PR: https://github.com/prebid/prebid.github.io/pull/6661