### PR TITLE
Sparteo Bid Adapter: outstream iframe rendering and vastUrl/nurl correctness

### DIFF
--- a/modules/sparteoBidAdapter.js
+++ b/modules/sparteoBidAdapter.js
@@ -3,6 +3,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { Renderer } from '../src/Renderer.js';
+import { getAdUnitElement } from '../src/utils/adUnits.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -57,11 +58,13 @@ const converter = ortbConverter({
     const response = buildBidResponse(bid, context);
 
     if (context.mediaType === 'video') {
+      // nurl is a win-notification tracker (fired by onBidWon), not a VAST URL. ortbConverter's
+      // video processor defaults bidResponse.vastUrl to seatbid.nurl, so override that mapping:
+      // vastUrl holds the Prebid Cache URL when present, otherwise null. Left pointing at nurl,
+      // a VAST consumer (a GAM VAST-tag-URL line item, IMA SDK, ...) would fetch the tracker as
+      // if it were VAST — firing the win notification without a real render.
       response.nurl = bid.nurl;
-      const cacheUrl = deepAccess(bid, 'ext.prebid.cache.vastXml.url');
-      if (cacheUrl) {
-        response.vastUrl = cacheUrl;
-      }
+      response.vastUrl = deepAccess(bid, 'ext.prebid.cache.vastXml.url') ?? null;
     }
 
     // extract renderer config, if present, and create Prebid renderer
@@ -78,7 +81,10 @@ function createRenderer(rendererConfig) {
   const renderer = Renderer.install({
     url: rendererConfig.url,
     loaded: false,
-    config: rendererConfig
+    config: {
+      ...rendererConfig,
+      documentResolver: (_bid, _sourceDocument, renderDocument) => renderDocument
+    }
   });
   try {
     renderer.setRender(outstreamRender);
@@ -88,30 +94,41 @@ function createRenderer(rendererConfig) {
   return renderer;
 }
 
-function outstreamRender(bid) {
-  // TODO this should use getAdUnitElement
-  if (!document.getElementById(bid.adUnitCode)) {
-    logError(`Sparteo Bid Adapter: Video renderer did not started. bidResponse.adUnitCode is probably not a DOM element : ${bid.adUnitCode}`);
+function outstreamRender(bid, doc) {
+  const renderDoc = doc || document;
+  const slot = renderDoc.getElementById(bid.adUnitCode) || getAdUnitElement(bid);
+
+  if (!slot) {
+    logError(`Sparteo Bid Adapter: outstream renderer could not find the ad slot for adUnitCode '${bid.adUnitCode}'.`);
     return;
   }
 
   const config = bid.renderer.getConfig() ?? {};
+  const win = renderDoc.defaultView || window;
 
   bid.renderer.push(() => {
-    window.ANOutstreamVideo.renderAd({
-      targetId: bid.adUnitCode, // target div id to render video
-      adResponse: {
-        ad: {
-          video: {
-            content: bid.vastXml,
-            player_width: bid.width,
-            player_height: bid.height
+    if (!win.ANOutstreamVideo || typeof win.ANOutstreamVideo.renderAd !== 'function') {
+      logError('Sparteo Bid Adapter: ANOutstreamVideo is not available on the render window.');
+      return;
+    }
+    try {
+      win.ANOutstreamVideo.renderAd({
+        targetId: slot.id || bid.adUnitCode, // target div id to render video
+        adResponse: {
+          ad: {
+            video: {
+              content: bid.vastXml,
+              player_width: bid.width,
+              player_height: bid.height
+            }
           }
-        }
-      },
-      sizes: [bid.width, bid.height],
-      rendererOptions: config.options ?? {}
-    });
+        },
+        sizes: [bid.width, bid.height],
+        rendererOptions: config.options ?? {}
+      });
+    } catch (err) {
+      logError('Sparteo Bid Adapter: ANOutstreamVideo.renderAd threw an error', err);
+    }
   });
 }
 

--- a/modules/sparteoBidAdapter.js
+++ b/modules/sparteoBidAdapter.js
@@ -3,7 +3,6 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { Renderer } from '../src/Renderer.js';
-import { getAdUnitElement } from '../src/utils/adUnits.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -83,7 +82,12 @@ function createRenderer(rendererConfig) {
     loaded: false,
     config: {
       ...rendererConfig,
-      documentResolver: (_bid, _sourceDocument, renderDocument) => renderDocument
+      // Prebid loads the renderer script (ANOutstreamVideo) into the document this callback
+      // returns, and the player can only resolve a targetId that exists in that same document.
+      // Prefer the render document (e.g. a GAM friendly iframe whose slot only lives inside it),
+      // and fall back to the source (parent) document when the slot is not in the render document.
+      documentResolver: (bid, sourceDocument, renderDocument) =>
+        (renderDocument?.getElementById(bid.adUnitCode) ? renderDocument : sourceDocument) || renderDocument
     }
   });
   try {
@@ -95,8 +99,10 @@ function createRenderer(rendererConfig) {
 }
 
 function outstreamRender(bid, doc) {
+  // `doc` is the document Prebid loaded the renderer script into (see documentResolver above),
+  // so ANOutstreamVideo lives on its defaultView and can only resolve a slot that exists in it.
   const renderDoc = doc || document;
-  const slot = renderDoc.getElementById(bid.adUnitCode) || getAdUnitElement(bid);
+  const slot = renderDoc.getElementById(bid.adUnitCode);
 
   if (!slot) {
     logError(`Sparteo Bid Adapter: outstream renderer could not find the ad slot for adUnitCode '${bid.adUnitCode}'.`);

--- a/test/spec/modules/sparteoBidAdapter_spec.js
+++ b/test/spec/modules/sparteoBidAdapter_spec.js
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import { deepClone } from 'src/utils';
+import * as utils from 'src/utils';
 import { spec as adapter } from 'modules/sparteoBidAdapter';
+import { Renderer } from 'src/Renderer.js';
 
 const CURRENCY = 'EUR';
 const TTL = 60;
@@ -257,6 +259,17 @@ describe('SparteoAdapter', function () {
         delete wrongBid.mediaTypes.video.playerSize;
         expect(adapter.isBidRequestValid(wrongBid)).to.equal(false);
       });
+
+      it('should return false because the bid params are missing', function () {
+        expect(adapter.isBidRequestValid({})).to.equal(false);
+      });
+
+      it('should return false because the placement is neither banner nor video', function () {
+        const wrongBid = deepClone(VALID_BID_BANNER);
+        delete wrongBid.mediaTypes.banner;
+
+        expect(adapter.isBidRequestValid(wrongBid)).to.equal(false);
+      });
     });
   });
 
@@ -299,6 +312,16 @@ describe('SparteoAdapter', function () {
           expect(request).to.deep.equal(expectedRequest);
         });
       }
+
+      it('sets publisher.ext.params.publisherId under site root when params.publisherId is provided', function () {
+        const bid = deepClone(VALID_BID_BANNER);
+        bid.params.publisherId = 'pub-123';
+
+        const request = adapter.buildRequests([bid], { bids: [bid], ortb2: ORTB2_GLOBAL });
+        delete request.data.id;
+
+        expect(request.data.site.publisher.ext.params.publisherId).to.equal('pub-123');
+      });
     });
   });
 
@@ -507,6 +530,196 @@ describe('SparteoAdapter', function () {
     });
   });
 
+  if (FEATURES.VIDEO) {
+    describe('outstream renderer', function () {
+      const AD_UNIT_CODE = 'id-5678';
+      const RENDERER_RESPONSE = {
+        body: {
+          id: '63f4d300-6896-4bdc-8561-0932f73148b1',
+          cur: 'EUR',
+          seatbid: [{
+            seat: 'sparteo',
+            group: 0,
+            bid: [{
+              id: 'cdbb6982-a269-40c7-84e5-04797f11d87b',
+              impid: '5e6f7g8h',
+              price: 5,
+              ext: { prebid: { type: 'video', renderer: { url: 'testVideoPlayer.js', options: { showVolume: false } } } },
+              adm: 'tag',
+              crid: 'crid',
+              w: 640,
+              h: 480
+            }]
+          }]
+        }
+      };
+
+      function freshRenderer() {
+        const request = adapter.buildRequests([VALID_BID_VIDEO], BIDDER_REQUEST_VIDEO);
+        return adapter.interpretResponse(RENDERER_RESPONSE, request)[0].renderer;
+      }
+
+      function renderBid(renderer) {
+        return { adUnitCode: AD_UNIT_CODE, renderer, vastXml: '<VAST/>', width: 640, height: 480 };
+      }
+
+      // Minimal Document stand-in: getElementById resolves the slot only when hasSlot is true,
+      // and defaultView is the window ANOutstreamVideo is looked up on.
+      function fakeDoc(hasSlot, win, slotId = AD_UNIT_CODE) {
+        return {
+          getElementById: (id) => (hasSlot && id === AD_UNIT_CODE ? { id: slotId } : null),
+          defaultView: win
+        };
+      }
+
+      describe('documentResolver', function () {
+        it('returns the render document when it holds the slot', function () {
+          const resolver = freshRenderer().getConfig().documentResolver;
+          const renderDoc = fakeDoc(true, {});
+          const sourceDoc = fakeDoc(false, {});
+          expect(resolver({ adUnitCode: AD_UNIT_CODE }, sourceDoc, renderDoc)).to.equal(renderDoc);
+        });
+
+        it('falls back to the source document when the render document lacks the slot', function () {
+          const resolver = freshRenderer().getConfig().documentResolver;
+          const renderDoc = fakeDoc(false, {});
+          const sourceDoc = fakeDoc(true, {});
+          expect(resolver({ adUnitCode: AD_UNIT_CODE }, sourceDoc, renderDoc)).to.equal(sourceDoc);
+        });
+
+        it('defaults to the render document when there is no source document', function () {
+          const resolver = freshRenderer().getConfig().documentResolver;
+          const renderDoc = fakeDoc(false, {});
+          expect(resolver({ adUnitCode: AD_UNIT_CODE }, null, renderDoc)).to.equal(renderDoc);
+        });
+      });
+
+      describe('render', function () {
+        afterEach(function () {
+          delete window.ANOutstreamVideo;
+        });
+
+        it('renders the outstream ad into the render document via ANOutstreamVideo', function () {
+          const renderAd = sinon.stub();
+          const doc = fakeDoc(true, { ANOutstreamVideo: { renderAd } });
+          const renderer = freshRenderer();
+          renderer.loaded = true;
+          renderer._render(renderBid(renderer), doc);
+
+          sinon.assert.calledOnce(renderAd);
+          const args = renderAd.getCall(0).args[0];
+          expect(args.targetId).to.equal(AD_UNIT_CODE);
+          expect(args.sizes).to.deep.equal([640, 480]);
+          expect(args.adResponse.ad.video.content).to.equal('<VAST/>');
+        });
+
+        it('does not render when the slot is absent from the render document', function () {
+          const renderAd = sinon.stub();
+          const doc = fakeDoc(false, { ANOutstreamVideo: { renderAd } });
+          const renderer = freshRenderer();
+          renderer.loaded = true;
+          renderer._render(renderBid(renderer), doc);
+          sinon.assert.notCalled(renderAd);
+        });
+
+        it('does not throw when ANOutstreamVideo is unavailable on the render window', function () {
+          const doc = fakeDoc(true, {});
+          const renderer = freshRenderer();
+          renderer.loaded = true;
+          expect(() => renderer._render(renderBid(renderer), doc)).to.not.throw();
+        });
+
+        it('swallows errors thrown by ANOutstreamVideo.renderAd', function () {
+          const renderAd = sinon.stub().throws(new Error('boom'));
+          const doc = fakeDoc(true, { ANOutstreamVideo: { renderAd } });
+          const renderer = freshRenderer();
+          renderer.loaded = true;
+          expect(() => renderer._render(renderBid(renderer), doc)).to.not.throw();
+          sinon.assert.calledOnce(renderAd);
+        });
+
+        it('falls back to the global document when no doc argument is provided', function () {
+          const renderer = freshRenderer();
+          renderer.loaded = true;
+
+          // No `doc` passed: outstreamRender must fall back to the global `document`. The slot
+          // won't be found there, so it just logs and returns - the point here is the fallback
+          // itself doesn't throw.
+          expect(() => renderer._render(renderBid(renderer))).to.not.throw();
+        });
+
+        it('falls back to window when the render document has no defaultView', function () {
+          const renderAd = sinon.stub();
+          window.ANOutstreamVideo = { renderAd };
+          const doc = fakeDoc(true, undefined);
+          const renderer = freshRenderer();
+          renderer.loaded = true;
+
+          renderer._render(renderBid(renderer), doc);
+
+          sinon.assert.calledOnce(renderAd);
+        });
+
+        it('defaults rendererOptions to {} when the server config has no options', function () {
+          const renderAd = sinon.stub();
+          const doc = fakeDoc(true, { ANOutstreamVideo: { renderAd } });
+          const renderer = freshRenderer();
+          renderer.loaded = true;
+          delete renderer.config.options;
+
+          renderer._render(renderBid(renderer), doc);
+
+          sinon.assert.calledOnce(renderAd);
+          expect(renderAd.getCall(0).args[0].rendererOptions).to.deep.equal({});
+        });
+
+        it('defaults options when the renderer has no config', function () {
+          const renderAd = sinon.stub();
+          const doc = fakeDoc(true, { ANOutstreamVideo: { renderAd } });
+          const renderer = freshRenderer();
+          renderer.loaded = true;
+          renderer.config = null;
+
+          expect(() => renderer._render(renderBid(renderer), doc)).to.not.throw();
+
+          sinon.assert.calledOnce(renderAd);
+          expect(renderAd.getCall(0).args[0].rendererOptions).to.deep.equal({});
+        });
+
+        it('falls back to adUnitCode when the slot element has no id', function () {
+          const renderAd = sinon.stub();
+          const doc = fakeDoc(true, { ANOutstreamVideo: { renderAd } }, '');
+          const renderer = freshRenderer();
+          renderer.loaded = true;
+
+          renderer._render(renderBid(renderer), doc);
+
+          sinon.assert.calledOnce(renderAd);
+          expect(renderAd.getCall(0).args[0].targetId).to.equal(AD_UNIT_CODE);
+        });
+      });
+
+      describe('createRenderer error handling', function () {
+        let setRenderStub;
+        let logWarnStub;
+
+        afterEach(function () {
+          if (setRenderStub) { setRenderStub.restore(); setRenderStub = null; }
+          if (logWarnStub) { logWarnStub.restore(); logWarnStub = null; }
+        });
+
+        it('logs a warning and does not throw when Renderer.prototype.setRender throws', function () {
+          setRenderStub = sinon.stub(Renderer.prototype, 'setRender').throws(new Error('boom'));
+          logWarnStub = sinon.stub(utils, 'logWarn');
+
+          expect(() => freshRenderer()).to.not.throw();
+
+          sinon.assert.calledOnce(logWarnStub);
+        });
+      });
+    });
+  }
+
   describe('onBidWon', function () {
     describe('Check methods succeed', function () {
       it('should not throw error', function () {
@@ -556,12 +769,39 @@ describe('SparteoAdapter', function () {
     });
   });
 
+  describe('onTimeout', function () {
+    it('should not throw', function () {
+      expect(() => adapter.onTimeout({})).to.not.throw();
+    });
+  });
+
+  describe('onSetTargeting', function () {
+    it('should not throw', function () {
+      expect(() => adapter.onSetTargeting({})).to.not.throw();
+    });
+  });
+
   describe('getUserSyncs', function () {
     beforeEach(function () {
       delete window.sparteoCrossfire;
     });
 
     describe('Check methods succeed', function () {
+      // `isSynced` is a module-level flag that only ever flips false -> true, never back (it is
+      // never reset between tests since the module is loaded once for the whole spec run). This
+      // test must therefore run BEFORE the "fires" test below: it keeps iframeEnabled false so it
+      // never trips the flag, leaving the gate open for the next test to exercise the full path.
+      it('falls back to default empty values when GDPR/GPP consent sub-fields are missing', function () {
+        const syncOptions = { iframeEnabled: false };
+        const gdprConsent = { gdprApplies: false };
+        const gppConsent = {};
+
+        const result = adapter.getUserSyncs(syncOptions, null, gdprConsent, undefined, gppConsent);
+
+        expect(result).to.be.undefined;
+        expect(window.sparteoCrossfire).to.be.undefined;
+      });
+
       it('should return the sync url with GDPR, USP and GPP consent params', function () {
         const syncOptions = {
           'iframeEnabled': true,
@@ -799,6 +1039,24 @@ describe('SparteoAdapter', function () {
           'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&app_domain=dev.sparteo.com&bundle=unknown'
         );
       });
+    });
+
+    it('produces &bundle=unknown when the app.bundle field is entirely absent', function () {
+      const ENDPOINT = 'https://bid.sparteo.com/auction?network_id=${NETWORK_ID}${APP_DOMAIN_QUERY}${BUNDLE_QUERY}';
+      const bid = deepClone(VALID_BID_BANNER);
+      bid.params.endpoint = ENDPOINT;
+
+      const bidderReq = {
+        bids: [bid],
+        ortb2: { app: { domain: 'dev.sparteo.com' } }
+      };
+
+      const req = adapter.buildRequests([bid], bidderReq);
+      delete req.data.id;
+
+      expect(req.url).to.equal(
+        'https://bid.sparteo.com/auction?network_id=1234567a-eb1b-1fae-1d23-e1fbaef234cf&app_domain=dev.sparteo.com&bundle=unknown'
+      );
     });
 
     it('app domain missing becomes app_domain=unknown while keeping bundle', function () {

--- a/test/spec/modules/sparteoBidAdapter_spec.js
+++ b/test/spec/modules/sparteoBidAdapter_spec.js
@@ -408,7 +408,7 @@ describe('SparteoAdapter', function () {
       });
 
       if (FEATURES.VIDEO) {
-        it('should fallback to nurl as vastUrl when no cache URL is present', function () {
+        it('should not use nurl as vastUrl when no cache URL is present', function () {
           const response = {
             body: {
               'id': '63f4d300-6896-4bdc-8561-0932f73148b1',
@@ -442,7 +442,7 @@ describe('SparteoAdapter', function () {
           const request = adapter.buildRequests([VALID_BID_VIDEO], BIDDER_REQUEST_VIDEO);
           const bids = adapter.interpretResponse(response, request);
 
-          expect(bids[0].vastUrl).to.equal('https://t.bidder.sparteo.com/vast');
+          expect(bids[0].vastUrl).to.equal(null);
           expect(bids[0].nurl).to.equal('https://t.bidder.sparteo.com/vast');
         });
 
@@ -497,7 +497,11 @@ describe('SparteoAdapter', function () {
           let formattedReponse = adapter.interpretResponse(response, request);
 
           expect(formattedReponse[0].renderer.url).to.equal(response.body.seatbid[0].bid[0].ext.prebid.renderer.url);
-          expect(formattedReponse[0].renderer.config).to.deep.equal(response.body.seatbid[0].bid[0].ext.prebid.renderer);
+          // config now carries a documentResolver callback (for iframe render support) in addition
+          // to the server-provided renderer config, so assert the server config is included rather
+          // than an exact match.
+          expect(formattedReponse[0].renderer.config).to.deep.include(response.body.seatbid[0].bid[0].ext.prebid.renderer);
+          expect(formattedReponse[0].renderer.config.documentResolver).to.be.a('function');
         });
       }
     });


### PR DESCRIPTION
Hi Team :-)

Please, we would like to submit this update to our Bid Adapter.

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [X] Bugfix

## Description of change
**1. Outstream renderer follows the render document (iframe support)**
- `createRenderer` now injects a `documentResolver` into the renderer config, so `ANOutstreamVideo`
  renders inside the document it is invoked with (e.g. a GAM friendly iframe) instead of always the
  top-level `document`.
- `outstreamRender` resolves the ad slot from the render document, falling back to `getAdUnitElement(bid)`,
  and renders against that document's window (`renderDoc.defaultView`).
- Hardened: guard on `ANOutstreamVideo` availability on the render window and wrap `renderAd` in a
  try/catch, so a missing player or a render error is logged instead of throwing.

**2. Do not default video `vastUrl` to `nurl`**
- `nurl` is a win-notification tracker (fired on `onBidWon`), not a VAST document. Previously, when a bid
  had no Prebid Cache URL (`ext.prebid.cache.vastXml.url`), `vastUrl` was left defaulted to `nurl` by the
  ORTB video processor.
- A VAST consumer (GAM VAST-tag-URL line item, IMA SDK, …) would then fetch the win tracker as if it were
  VAST — firing the win notification without a real render.
- `vastUrl` now resolves to the Prebid Cache URL when present, otherwise `null`; `nurl` is kept separately.

Unit spec updated for both changes.