### PR TITLE
Guard access to isSecureContext and add unit test for unavailable API

### DIFF
--- a/src/ajax.ts
+++ b/src/ajax.ts
@@ -83,7 +83,7 @@ export function toFetchRequest(url, data, options: AjaxOptions = {}) {
   if (options.withCredentials) {
     rqOpts.credentials = 'include';
   }
-  if (isSecureContext) {
+  if (typeof isSecureContext !== 'undefined' && isSecureContext) {
     ['browsingTopics'].forEach(opt => {
       // the Request constructor will throw an exception if the browser supports topics
       // but we're not in a secure context

--- a/test/spec/unit/core/ajax_spec.js
+++ b/test/spec/unit/core/ajax_spec.js
@@ -255,6 +255,11 @@ describe('ajax', () => {
               toFetchRequest(EXAMPLE_URL, null, opts);
               sinon.assert.calledWithMatch(dep.makeRequest, sinon.match.any, { [option]: undefined });
             });
+            it('should not be set when secure context API is unavailable', () => {
+              sandbox.stub(window, 'isSecureContext').get(() => undefined);
+              toFetchRequest(EXAMPLE_URL, null, opts);
+              sinon.assert.calledWithMatch(dep.makeRequest, sinon.match.any, { [option]: undefined });
+            });
           });
         });
       });


### PR DESCRIPTION
### Motivation
- Prevent a runtime error and incorrect request option setting when the global `isSecureContext` symbol is not present, and ensure chrome-specific fetch options are only applied in supported secure contexts.

### Description
- Replace `if (isSecureContext)` with `if (typeof isSecureContext !== 'undefined' && isSecureContext)` in `src/ajax.ts` to avoid referencing an undefined global.
- Add a unit test in `test/spec/unit/core/ajax_spec.js` that stubs `window.isSecureContext` to `undefined` and asserts chrome options like `browsingTopics` are not set on the request.

### Testing
- Ran the ajax unit tests (`test/spec/unit/core/ajax_spec.js`) including the new `isSecureContext` unavailable case, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5651392f5c832bbd0adef3884ed4c4)