### PR TITLE
Pinelake Bid Adapter: fix lint errors

### DIFF
--- a/modules/pinelakeBidAdapter.js
+++ b/modules/pinelakeBidAdapter.js
@@ -36,6 +36,6 @@ export const spec = {
     }
     return Response;
   }
-}
+};
 
 registerBidder(spec);

--- a/test/spec/modules/pinelakeBidAdapter_spec.js
+++ b/test/spec/modules/pinelakeBidAdapter_spec.js
@@ -4,7 +4,7 @@ import * as utils from '../../../src/utils.js';
 
 describe('pinelake adapter', function () {
   let bannerRequest, nativeRequest;
-  let bannerResponse, nativeResponse, invalidBannerResponse, invalidNativeResponse;
+  let bannerResponse, nativeResponse, invalidBannerResponse;
 
   beforeEach(function () {
     bannerRequest = [
@@ -114,29 +114,6 @@ describe('pinelake adapter', function () {
         'bidid': 'BIDDER_-1'
       }
     };
-    invalidNativeResponse = {
-      'body': {
-        'id': '453ade66-9113-4944-a674-5bbdcb9808ac',
-        'seatbid': [{
-          'bid': [{
-            'id': '652c9a4c-66ea-4579-998b-cefe7b4cfecd',
-            'impid': '2c3875bdbb1893',
-            'price': 1.1,
-            'adid': '368852',
-            'adm': 'invalid response',
-            'adomain': ['www.diabetesincontrol.com'],
-            'iurl': 'https://cdn.pinelake.com/1_368852_0.png',
-            'cid': '468132/368852',
-            'crid': '368852',
-            'cat': ['IAB7']
-          }],
-          'seat': 'pinelake',
-          'group': 0
-        }],
-        'cur': 'USD',
-        'bidid': 'BIDDER_-1'
-      }
-    };
   });
 
   describe('validations', function () {
@@ -167,7 +144,7 @@ describe('pinelake adapter', function () {
   describe('Validate Banner Request', function () {
     it('Immutable bid request validate', function () {
       const _Request = utils.deepClone(bannerRequest);
-      const bidRequest = spec.buildRequests(bannerRequest);
+      spec.buildRequests(bannerRequest);
       expect(bannerRequest).to.deep.equal(_Request);
     });
     it('Validate bidder connection', function () {
@@ -234,7 +211,7 @@ describe('pinelake adapter', function () {
   describe('Validate Native Request', function () {
     it('Immutable bid request validate', function () {
       const _Request = utils.deepClone(nativeRequest);
-      const bidRequest = spec.buildRequests(nativeRequest);
+      spec.buildRequests(nativeRequest);
       expect(nativeRequest).to.deep.equal(_Request);
     });
     it('Validate bidder connection', function () {


### PR DESCRIPTION
### Motivation
- Fix lint failures in the Pinelake adapter source and spec that caused stylistic and unused-variable errors during automated checks.

### Description
- Add a missing semicolon after the exported `spec` object in `modules/pinelakeBidAdapter.js` to satisfy `@stylistic/semi`.
- Remove the unused `invalidNativeResponse` fixture from `test/spec/modules/pinelakeBidAdapter_spec.js` to eliminate `no-unused-vars` warnings.
- Remove unused `bidRequest` variable assignments in immutable-request tests while retaining the `spec.buildRequests(...)` invocation to preserve test behavior.

### Testing
- Ran `npx eslint modules/pinelakeBidAdapter.js test/spec/modules/pinelakeBidAdapter_spec.js --cache --cache-strategy content`, which completed with no errors.
- Ran `npx gulp test --nolint --file test/spec/modules/pinelakeBidAdapter_spec.js`, which passed with 19 tests completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5c265e58b0832b8bb33f851c60354d)