### PR TITLE
TRUSTX Bid Adapter: include params.video in OpenRTB requests

### DIFF
--- a/modules/trustxBidAdapter.js
+++ b/modules/trustxBidAdapter.js
@@ -35,10 +35,12 @@ const ortbAdapterConverter = ortbConverter({
     imp: {
       video(fillVideoImp, impression, bidRequest, context) {
         if (containsVideoRequest(bidRequest)) {
+          const bidderVideoParams = Object.assign({}, bidRequest.params?.video);
+          delete bidderVideoParams.pos;
           const videoParams = Object.assign(
             {},
             bidRequest.mediaTypes[VIDEO],
-            bidRequest.params?.video
+            bidderVideoParams
           );
           bidRequest = {
             ...bidRequest,

--- a/modules/trustxBidAdapter.js
+++ b/modules/trustxBidAdapter.js
@@ -31,6 +31,27 @@ const ortbAdapterConverter = ortbConverter({
     netRevenue: NET_REVENUE,
     ttl: BID_TTL
   },
+  overrides: {
+    imp: {
+      video(fillVideoImp, impression, bidRequest, context) {
+        if (containsVideoRequest(bidRequest)) {
+          const videoParams = Object.assign(
+            {},
+            bidRequest.mediaTypes[VIDEO],
+            bidRequest.params?.video
+          );
+          bidRequest = {
+            ...bidRequest,
+            mediaTypes: {
+              ...bidRequest.mediaTypes,
+              [VIDEO]: videoParams
+            }
+          };
+        }
+        fillVideoImp(impression, bidRequest, context);
+      }
+    }
+  },
   imp(buildImp, bidRequest, context) {
     const impression = buildImp(bidRequest, context);
     const params = bidRequest.params || {};

--- a/modules/trustxBidAdapter.md
+++ b/modules/trustxBidAdapter.md
@@ -23,8 +23,8 @@ TRUSTX bid adapter supports Banner and Video ad formats with advanced targeting 
 - `uid` or `secid` (required) - Placement ID / Tag ID
 - `mediaTypes.video.context` (required) - Must be 'instream' or 'outstream'
 - `mediaTypes.video.playerSize` (required) - Array format [[w, h]]
-- `mediaTypes.video.mimes` (required) - Array of MIME types
-- `mediaTypes.video.protocols` (required) - Array of protocol numbers
+- `mediaTypes.video.mimes` or `params.video.mimes` (required) - Array of MIME types
+- `mediaTypes.video.protocols` or `params.video.protocols` (required) - Array of protocol numbers
 
 # Test Parameters
 
@@ -70,7 +70,7 @@ We support the following OpenRTB params that can be specified in `mediaTypes.vid
 
 ## Instream Video adUnit using mediaTypes.video
 
-*Note:* By default, the adapter will read the mandatory parameters from mediaTypes.video.
+*Note:* By default, the adapter will read the mandatory parameters from mediaTypes.video. Values in `params.video` override matching values from `mediaTypes.video`.
 *Note:* The TRUSTX ad server will respond with a VAST XML to load into your defined player.
 
 ```

--- a/modules/trustxBidAdapter.md
+++ b/modules/trustxBidAdapter.md
@@ -70,7 +70,7 @@ We support the following OpenRTB params that can be specified in `mediaTypes.vid
 
 ## Instream Video adUnit using mediaTypes.video
 
-*Note:* By default, the adapter will read the mandatory parameters from mediaTypes.video. Values in `params.video` override matching values from `mediaTypes.video`.
+*Note:* By default, the adapter will read the mandatory parameters from mediaTypes.video. Values in `params.video` override matching values from `mediaTypes.video`, except `pos`, which is always sourced from `mediaTypes.video.pos`.
 *Note:* The TRUSTX ad server will respond with a VAST XML to load into your defined player.
 
 ```

--- a/test/spec/modules/trustxBidAdapter_spec.js
+++ b/test/spec/modules/trustxBidAdapter_spec.js
@@ -575,6 +575,17 @@ describe('trustxBidAdapter', function() {
           });
         });
 
+        it('should source video pos from mediaTypes when bidder-specific params also set pos', function () {
+          const bidderRequest = getVideoRequest();
+          const videoBid = bidderRequest.bids[0];
+          videoBid.params.uid = 'trustx-placement-1';
+          videoBid.mediaTypes.video.pos = 1;
+          videoBid.params.video.pos = 3;
+
+          const request = spec.buildRequests([videoBid], { ...bidderRequest, bids: [videoBid] });
+          expect(request.data.imp[0].video.pos).to.equal(videoBid.mediaTypes.video.pos);
+        });
+
         it('should attach End 2 End test data', function () {
           bidRequestsWithMediaTypes[1].params.test = true;
           const requests = spec.buildRequests(bidRequestsWithMediaTypes, mockBidderRequest);

--- a/test/spec/modules/trustxBidAdapter_spec.js
+++ b/test/spec/modules/trustxBidAdapter_spec.js
@@ -557,6 +557,24 @@ describe('trustxBidAdapter', function() {
           expect(data.ext.adapterver).to.equal(spec.VERSION);
         });
 
+        it('should include bidder-specific video params in request data', function () {
+          const bidderRequest = getVideoRequest();
+          const videoBid = bidderRequest.bids[0];
+          videoBid.params.uid = 'trustx-placement-1';
+
+          expect(spec.isBidRequestValid(videoBid)).to.be.true;
+
+          const request = spec.buildRequests([videoBid], { ...bidderRequest, bids: [videoBid] });
+          expect(request.data.imp[0].video).to.deep.include({
+            mimes: videoBid.params.video.mimes,
+            protocols: videoBid.params.video.protocols,
+            api: videoBid.params.video.api,
+            delivery: videoBid.params.video.delivery,
+            placement: videoBid.params.video.placement,
+            plcmt: videoBid.params.video.plcmt
+          });
+        });
+
         it('should attach End 2 End test data', function () {
           bidRequestsWithMediaTypes[1].params.test = true;
           const requests = spec.buildRequests(bidRequestsWithMediaTypes, mockBidderRequest);


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [x] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

The TRUSTX adapter validates video properties from both `mediaTypes.video` and `bids[].params.video`. However, the OpenRTB request builder previously only read `mediaTypes.video`, causing values supplied exclusively through `params.video` to be omitted from the outgoing `imp.video` object.

This change:

- Merges `bids[].params.video` over `mediaTypes.video` before standard OpenRTB conversion.
- Preserves existing validation and backwards compatibility.
- Adds regression coverage for bidder-specific video parameters.
- Updates the adapter documentation to describe the supported configuration and precedence.