### PR TITLE
Consent management: optionally wait for late CMP APIs

### DIFF
--- a/libraries/cmp/cmpClient.js
+++ b/libraries/cmp/cmpClient.js
@@ -13,6 +13,29 @@ import { PbPromise } from '../../src/utils/promise.js';
 export const MODE_MIXED = 0;
 export const MODE_RETURN = 1;
 export const MODE_CALLBACK = 2;
+export const CMP_POLL_INTERVAL = 100;
+
+/**
+ * Wait for a CMP API to become available.
+ *
+ * @param {object} apiConfig arguments passed to {@link cmpClient}
+ * @param {number} timeout maximum time to wait, in milliseconds
+ * @returns {Promise<CMPClient|undefined>}
+ */
+export function pollForCmp(apiConfig, timeout) {
+  const deadline = Date.now() + timeout;
+  return new PbPromise(resolve => {
+    function check() {
+      const cmp = cmpClient(apiConfig);
+      if (cmp || Date.now() >= deadline) {
+        resolve(cmp);
+      } else {
+        setTimeout(check, Math.min(CMP_POLL_INTERVAL, deadline - Date.now()));
+      }
+    }
+    check();
+  });
+}
 
 /**
  * Returns a client function that can interface with a CMP regardless of where it's located.

--- a/libraries/consentManagement/cmUtils.ts
+++ b/libraries/consentManagement/cmUtils.ts
@@ -49,6 +49,7 @@ export function consentManagementHook(name, loadConsentData) {
  * @param {Number?} options.cmpTimeout timeout (in ms) after which the auction should continue without consent data.
  * @param {Number?} options.actionTimeout timeout (in ms) from when provisional consent is available to when the auction should continue with it
  * @param {() => {}} options.getNullConsent consent data to use on timeout
+ * @param {boolean} options.waitForCmp whether to wait for a CMP API that is loaded late
  * @returns {Promise<{error: Error, consentData: {}}>}
  */
 export function lookupConsentData(
@@ -58,7 +59,8 @@ export function lookupConsentData(
     setupCmp,
     cmpTimeout,
     actionTimeout,
-    getNullConsent
+    getNullConsent,
+    waitForCmp
   }
 ) {
   consentDataHandler.enable();
@@ -89,7 +91,7 @@ export function lookupConsentData(
         timeoutHandle = null;
       }
     }
-    setupCmp(setProvisionalConsent)
+    setupCmp(setProvisionalConsent, { waitForCmp, timeout: cmpTimeout })
       .then(() => resolve({ consentData: consentDataHandler.getConsentData() }), reject);
     cmpTimeout != null && resetTimeout(cmpTimeout);
   }).finally(() => {
@@ -101,6 +103,11 @@ export function lookupConsentData(
 }
 
 export interface BaseCMConfig {
+  /**
+   * Wait for a CMP API that is not present when consent lookup begins.
+   * This supports non-compliant integrations that load the CMP stub late and defaults to false.
+   */
+  waitForCmp?: boolean;
   /**
    * Length of time (in milliseconds) to delay auctions while waiting for consent data from the CMP.
    * Default is 10,000.
@@ -244,6 +251,7 @@ export function configParser(
       cmpTimeout,
       actionTimeout,
       getNullConsent,
+      waitForCmp: cmConfig.waitForCmp === true,
     });
 
     cdLoader = (() => {

--- a/modules/consentManagementGpp.ts
+++ b/modules/consentManagementGpp.ts
@@ -8,7 +8,7 @@ import { deepSetValue, isEmpty, isPlainObject, isStr, logInfo, logWarn } from '.
 import { config } from '../src/config.js';
 import { gppDataHandler } from '../src/adapterManager.js';
 import { enrichFPD } from '../src/fpd/enrichment.js';
-import { cmpClient, MODE_CALLBACK } from '../libraries/cmp/cmpClient.js';
+import { cmpClient, MODE_CALLBACK, pollForCmp } from '../libraries/cmp/cmpClient.js';
 import { PbPromise, defer } from '../src/utils/promise.js';
 import { type CMConfig, configParser } from '../libraries/consentManagement/cmUtils.js';
 import { createCmpEventManager, type CmpEventManager } from '../libraries/cmp/cmpEventUtils.js';
@@ -190,8 +190,15 @@ export class GPPClient {
   }
 }
 
-function lookupIabConsent() {
-  return new PbPromise((resolve) => resolve(GPPClient.get().refresh()));
+function lookupIabConsent(_setProvisionalConsent, { waitForCmp = false, timeout = 0 }: { waitForCmp?: boolean; timeout?: number } = {}) {
+  if (!waitForCmp) {
+    return new PbPromise((resolve) => resolve(GPPClient.get().refresh()));
+  }
+  const apiConfig = { apiName: '__gpp', apiArgs: ['command', 'callback', 'parameter'], mode: MODE_CALLBACK };
+  return pollForCmp(apiConfig, timeout).then(cmp => {
+    if (!cmp) throw new GPPError('GPP CMP not found');
+    return GPPClient.get(() => cmp).refresh();
+  });
 }
 
 // add new CMPs here, with their dedicated lookup function

--- a/modules/consentManagementTcf.ts
+++ b/modules/consentManagementTcf.ts
@@ -9,7 +9,7 @@ import { config } from '../src/config.js';
 import { gdprDataHandler } from '../src/adapterManager.js';
 import { registerOrtbProcessor, REQUEST } from '../src/pbjsORTB.js';
 import { enrichFPD } from '../src/fpd/enrichment.js';
-import { cmpClient } from '../libraries/cmp/cmpClient.js';
+import { cmpClient, pollForCmp } from '../libraries/cmp/cmpClient.js';
 import { configParser } from '../libraries/consentManagement/cmUtils.js';
 import { createCmpEventManager, type CmpEventManager } from '../libraries/cmp/cmpEventUtils.js';
 import { CONSENT_GDPR } from "../src/consentHandler.ts";
@@ -57,7 +57,7 @@ declare module '../src/consentHandler' {
 /**
  * This function handles interacting with an IAB compliant CMP to obtain the consent information of the user.
  */
-function lookupIabConsent(setProvisionalConsent) {
+function lookupIabConsent(setProvisionalConsent, { waitForCmp = false, timeout = 0 }: { waitForCmp?: boolean; timeout?: number } = {}) {
   return new Promise<void>((resolve, reject) => {
     function cmpResponseCallback(tcfData, success) {
       logInfo('Received a response from CMP', tcfData);
@@ -83,31 +83,37 @@ function lookupIabConsent(setProvisionalConsent) {
       }
     }
 
-    const cmp = cmpClient({
+    const apiConfig = {
       apiName: '__tcfapi',
       apiVersion: CMP_VERSION,
       apiArgs: ['command', 'version', 'callback', 'parameter'],
-    });
+    };
+
+    function subscribe(cmp) {
+      if ((cmp as any).isDirect) {
+        logInfo('Detected CMP API is directly accessible, calling it now...');
+      } else {
+        logInfo('Detected CMP is outside the current iframe where Prebid.js is located, calling it now...');
+      }
+
+      if (!tcfCmpEventManager) {
+        tcfCmpEventManager = createCmpEventManager('tcf', () => gdprDataHandler.getConsentData());
+      }
+      tcfCmpEventManager.setCmpApi(cmp);
+      cmp({ command: 'addEventListener', callback: cmpResponseCallback });
+    }
+
+    const cmp = cmpClient(apiConfig);
 
     if (!cmp) {
-      reject(new Error('TCF2 CMP not found.'));
+      if (!waitForCmp) {
+        reject(new Error('TCF2 CMP not found.'));
+      } else {
+        pollForCmp(apiConfig, timeout).then(cmp => cmp ? subscribe(cmp) : reject(new Error('TCF2 CMP not found.')));
+      }
+      return;
     }
-    if ((cmp as any).isDirect) {
-      logInfo('Detected CMP API is directly accessible, calling it now...');
-    } else {
-      logInfo('Detected CMP is outside the current iframe where Prebid.js is located, calling it now...');
-    }
-
-    // Initialize CMP event manager and set CMP API
-    if (!tcfCmpEventManager) {
-      tcfCmpEventManager = createCmpEventManager('tcf', () => gdprDataHandler.getConsentData());
-    }
-    tcfCmpEventManager.setCmpApi(cmp);
-
-    cmp({
-      command: 'addEventListener',
-      callback: cmpResponseCallback
-    });
+    subscribe(cmp);
   });
 }
 

--- a/modules/consentManagementUsp.ts
+++ b/modules/consentManagementUsp.ts
@@ -10,7 +10,7 @@ import adapterManager, { uspDataHandler } from '../src/adapterManager.js';
 import { timedAuctionHook } from '../src/utils/perfMetrics.js';
 import { getHook } from '../src/hook.js';
 import { enrichFPD } from '../src/fpd/enrichment.js';
-import { cmpClient } from '../libraries/cmp/cmpClient.js';
+import { cmpClient, pollForCmp } from '../libraries/cmp/cmpClient.js';
 import type { IABCMConfig, StaticCMConfig } from "../libraries/consentManagement/cmUtils.ts";
 import type { CONSENT_USP } from "../src/consentHandler.ts";
 
@@ -21,6 +21,7 @@ const USPAPI_VERSION = 1;
 export let consentAPI = DEFAULT_CONSENT_API;
 export let consentTimeout = DEFAULT_CONSENT_TIMEOUT;
 export let staticConsentData;
+let waitForCmp = false;
 
 type USPConsentData = string;
 type BaseUSPConfig = {
@@ -29,6 +30,8 @@ type BaseUSPConfig = {
    * Default is 50.
    */
   timeout?: number;
+  /** Wait for a CMP API that is loaded after Prebid. Defaults to false. */
+  waitForCmp?: boolean;
 };
 
 type StaticUSPData = {
@@ -90,37 +93,36 @@ function lookupUspConsent({ onSuccess, onError }) {
     };
   }
 
-  const callbackHandler = handleUspApiResponseCallbacks();
-
-  const cmp = cmpClient({
+  const apiConfig = {
     apiName: '__uspapi',
     apiVersion: USPAPI_VERSION,
     apiArgs: ['command', 'version', 'callback'],
-  }) as any;
+  };
+
+  function subscribe(cmp) {
+    const callbackHandler = handleUspApiResponseCallbacks();
+    if (cmp.isDirect) {
+      logInfo('Detected USP CMP is directly accessible, calling it now...');
+    } else {
+      logInfo('Detected USP CMP is outside the current iframe where Prebid.js is located, calling it now...');
+    }
+    cmp({ command: 'getUSPData', callback: callbackHandler.consentDataCallback });
+    cmp({
+      command: 'registerDeletion',
+      callback: (res, success) => (success == null || success) && adapterManager.callDataDeletionRequest(res)
+    }).catch(e => logError('Error invoking CMP `registerDeletion`:', e));
+  }
+
+  const cmp = cmpClient(apiConfig) as any;
 
   if (!cmp) {
+    if (waitForCmp) {
+      pollForCmp(apiConfig, consentTimeout).then(cmp => cmp && subscribe(cmp));
+      return;
+    }
     return onError('USP CMP not found.');
   }
-
-  if (cmp.isDirect) {
-    logInfo('Detected USP CMP is directly accessible, calling it now...');
-  } else {
-    logInfo(
-      'Detected USP CMP is outside the current iframe where Prebid.js is located, calling it now...'
-    );
-  }
-
-  cmp({
-    command: 'getUSPData',
-    callback: callbackHandler.consentDataCallback
-  });
-
-  cmp({
-    command: 'registerDeletion',
-    callback: (res, success) => (success == null || success) && adapterManager.callDataDeletionRequest(res)
-  }).catch(e => {
-    logError('Error invoking CMP `registerDeletion`:', e);
-  });
+  subscribe(cmp);
 }
 
 /**
@@ -227,6 +229,7 @@ export function resetConsentData() {
   consentTimeout = undefined;
   uspDataHandler.reset();
   enabled = false;
+  waitForCmp = false;
 }
 
 /**
@@ -251,6 +254,7 @@ export function setConsentConfig(config) {
     consentTimeout = DEFAULT_CONSENT_TIMEOUT;
     logInfo(`consentManagement.usp config did not specify timeout. Using system default setting (${DEFAULT_CONSENT_TIMEOUT}).`);
   }
+  waitForCmp = config?.waitForCmp === true;
   if (consentAPI === 'static') {
     if (isPlainObject(config.consentData) && isPlainObject(config.consentData.getUSPData)) {
       if (config.consentData.getUSPData.uspString) staticConsentData = { usPrivacy: config.consentData.getUSPData.uspString };

--- a/test/spec/libraries/cmp/cmpClient_spec.js
+++ b/test/spec/libraries/cmp/cmpClient_spec.js
@@ -1,6 +1,20 @@
-import { cmpClient, MODE_CALLBACK, MODE_RETURN } from '../../../../libraries/cmp/cmpClient.js';
+import { cmpClient, MODE_CALLBACK, MODE_RETURN, pollForCmp } from '../../../../libraries/cmp/cmpClient.js';
 
 describe('cmpClient', () => {
+  describe('pollForCmp', () => {
+    afterEach(() => delete window.__pollCmp);
+
+    it('resolves when a CMP appears during the polling window', async () => {
+      const result = pollForCmp({ apiName: '__pollCmp' }, 200);
+      setTimeout(() => { window.__pollCmp = sinon.stub(); }, 10);
+      expect(await result).to.have.property('isDirect', true);
+    });
+
+    it('resolves undefined after the polling window', async () => {
+      expect(await pollForCmp({ apiName: '__pollCmp' }, 0)).to.be.undefined;
+    });
+  });
+
   function mockWindow(props = {}) {
     let listeners = [];
     const win = {

--- a/test/spec/modules/consentManagement_spec.js
+++ b/test/spec/modules/consentManagement_spec.js
@@ -382,6 +382,24 @@ describe('consentManagement', function () {
         expect(gdprDataHandler.ready).to.be.true;
       });
 
+      it('should wait for a late CMP only when configured', async function () {
+        const configPromise = setConsentConfig({
+          cmpApi: 'iab',
+          timeout: 500,
+          waitForCmp: true,
+        });
+        setTimeout(() => {
+          window.__tcfapi = mockCMP({ gdprApplies: true, tcString: 'late-consent' });
+        }, 10);
+        try {
+          await configPromise;
+          expect(await runHook()).to.be.true;
+          expect(gdprDataHandler.getConsentData().consentString).to.eql('late-consent');
+        } finally {
+          delete window.__tcfapi;
+        }
+      });
+
       it('should poll again to check if it appears later', async () => {
         await setConsentConfig({
           cmpApi: 'iab',


### PR DESCRIPTION
### Motivation
- Fix a real-world race where CMP stubs load after Prebid and publishers see cancelled/failed auctions or ID submodules run without consent; make waiting for a late CMP opt-in and bounded by the publisher-configured timeout. 

### Description
- Add a bounded polling helper `pollForCmp` in `libraries/cmp/cmpClient.js` that checks immediately and then polls at 100ms intervals until a deadline. 
- Add a typed `waitForCmp` option to the shared consent-management config in `libraries/consentManagement/cmUtils.ts` and pass it into CMP setup. 
- Gate late-CMP polling behind `waitForCmp: true` for TCF, GPP, and USP integrations by updating `modules/consentManagementTcf.ts`, `modules/consentManagementGpp.ts`, and `modules/consentManagementUsp.ts`, preserving the existing immediate-missing-CMP behavior by default. 
- Add unit tests for polling and the opt-in TCF flow in `test/spec/libraries/cmp/cmpClient_spec.js` and `test/spec/modules/consentManagement_spec.js`.

### Testing
- Ran `npx eslint` against the modified files and fixed JSDoc warnings, with the lint command completing successfully. 
- Ran focused unit tests with gulp: `npx gulp test --nolint --file test/spec/libraries/cmp/cmpClient_spec.js` (114 tests passed), `npx gulp test --nolint --file test/spec/modules/consentManagement_spec.js` (45 tests passed), `npx gulp test --nolint --file test/spec/modules/consentManagementGpp_spec.js` (41 tests passed), and `npx gulp test --nolint --file test/spec/modules/consentManagementUsp_spec.js` (26 tests passed), all successful.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a643a6b33e4832bb4534fae0f3e3b50)