### PR TITLE
Core: preserve tracking pixel URL behavior

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -453,10 +453,6 @@ export function insertUserSyncIframe(url, done, timeout) {
   internal.insertElement(iframe, document, 'html', true);
 }
 
-function decodeAmpersandEntities(url) {
-  return url.replace(/&(amp|#38|#x26);/gi, '&');
-}
-
 /**
  * Creates a snippet of HTML that retrieves the specified `url`
  * @param  {string} url URL to be requested
@@ -468,20 +464,7 @@ export function createTrackPixelHtml(url, encode = encodeURI) {
     return '';
   }
 
-  const escapedUrl = encode(decodeAmpersandEntities(url)).replace(/["'&<>]/g, (char) => {
-    switch (char) {
-      case '"':
-        return '&quot;';
-      case '\'':
-        return '&#x27;';
-      case '&':
-        return '&amp;';
-      case '<':
-        return '&lt;';
-      case '>':
-        return '&gt;';
-    }
-  });
+  const escapedUrl = encode(url);
   let img = '<div style="position:absolute;left:0px;top:0px;visibility:hidden;">';
   img += '<img src="' + escapedUrl + '"></div>';
   return img;

--- a/test/spec/modules/trustxBidAdapter_spec.js
+++ b/test/spec/modules/trustxBidAdapter_spec.js
@@ -843,9 +843,9 @@ describe('trustxBidAdapter', function() {
         expect(bids).to.be.an('array').that.is.not.empty;
         // burl is directly mapped to bidResponse.burl by ortbConverter
         expect(bids[0].burl).to.equal(burl);
-        // nurl is processed by banner processor: if adm exists, nurl is embedded as an escaped tracking pixel in ad
+        // nurl is processed by banner processor: if adm exists, nurl is embedded as tracking pixel in ad
         // if no adm, nurl becomes adUrl. In this case, we have adm, so nurl is in ad as tracking pixel
-        expect(bids[0].ad).to.include('https://trackers.trustx.org/event?brid=xxx&amp;e=nurl&amp;cpm=${AUCTION_PRICE}');
+        expect(bids[0].ad).to.include(nurl); // nurl should be embedded in ad as tracking pixel
         expect(bids[0].ad).to.include('<div>Test Ad</div>'); // original adm should still be there
       });
 

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -844,10 +844,15 @@ describe('Utils', function () {
     });
 
     describe('createTrackPixelHtml', () => {
-      it('escapes url entities that can break the src attribute', () => {
+      it('keeps an encoded quote inside the src attribute', () => {
         const url = 'https://www.example.com/?x=&quot;onerror=alert(1)//';
+        const container = document.createElement('div');
 
-        expect(utils.createTrackPixelHtml(url)).to.contain('src="https://www.example.com/?x=&amp;quot;onerror=alert(1)//"');
+        // This browser-level assertion, added by a bot, documents that character references do not create attributes.
+        container.innerHTML = utils.createTrackPixelHtml(url);
+        const pixel = container.querySelector('img');
+        expect(pixel.getAttribute('src')).to.equal('https://www.example.com/?x="onerror=alert(1)//');
+        expect(pixel.hasAttribute('onerror')).to.be.false;
       });
 
       it('escapes encoded quotes in the url', () => {
@@ -856,15 +861,22 @@ describe('Utils', function () {
         expect(utils.createTrackPixelHtml(url)).to.contain('src="https://www.example.com/?x=%22test%22"');
       });
 
-      it('does not double-escape html-encoded query separators', () => {
+      it('lets the browser decode character references in tracker URLs', () => {
         const cases = [
-          ['https://www.example.com/?a=1&amp;b=2&amp;c=3', 'https://www.example.com/?a=1&amp;b=2&amp;c=3'],
-          ['https://www.example.com/?a=1&#38;b=2', 'https://www.example.com/?a=1&amp;b=2'],
-          ['https://www.example.com/?a=1&#x26;b=2', 'https://www.example.com/?a=1&amp;b=2']
+          ['&', '&'],
+          ['&amp;', '&'],
+          ['&#38;', '&'],
+          ['&#038;', '&'],
+          ['&#x26;', '&'],
+          ['&#x026;', '&'],
+          ['&quot;', '"'],
+          ['&#34;', '"']
         ];
 
-        cases.forEach(([url, expected]) => {
-          expect(utils.createTrackPixelHtml(url)).to.contain(`src="${expected}"`);
+        cases.forEach(([entity, expected]) => {
+          const container = document.createElement('div');
+          container.innerHTML = utils.createTrackPixelHtml(`https://www.example.com/?x=${entity}`);
+          expect(container.querySelector('img').getAttribute('src')).to.equal(`https://www.example.com/?x=${expected}`);
         });
       });
     });


### PR DESCRIPTION
### Motivation
- A recent change rewrote HTML character references in tracker URLs and added partial ampersand normalization, which can alter long-tail tracking requests. 
- The motivating XSS scenario is not reproduced by normal browser parsing, so the rewrite provides doubtful security benefit while changing behavior used across banner processing and adapters. 

### Description
- Restore legacy behavior in `createTrackPixelHtml` by removing entity rewriting and ampersand-normalization so the URL is encoded with `encodeURI` only (`src/utils.js`).
- Add browser-level unit tests that parse the generated HTML into a DOM and assert the `img` `src` contains decoded character references (e.g. `&amp;`, `&#38;`, `&#x26;`, `&quot;`) and that no `onerror` attribute is created (`test/spec/utils_spec.js`).
- Update an adapter test to assert the original `nurl` remains embedded in banner markup rather than matching a rewritten escaped entity form (`test/spec/modules/trustxBidAdapter_spec.js`).

### Testing
- Ran lint with `npx eslint src/utils.js test/spec/utils_spec.js test/spec/modules/trustxBidAdapter_spec.js --cache --cache-strategy content` and it passed. 
- Ran targeted unit tests with `npx gulp test --nolint --file test/spec/utils_spec.js` which completed successfully (185 tests passed). 
- Ran adapter unit test chunks with `npx gulp test --nolint --file` for `adkernel`, `kimberlite`, and `trustx` specs and they all passed (45, 12, and 38/41 tests respectively across feature configurations). 
- Ran `git diff --check` as a final safety check and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a64b35d1e8c832bad3b08b567ddf0b6)