### PR TITLE
Blue Bid Adapter: remove GVL ID

### DIFF
--- a/libraries/blueUtils/bidderUtils.js
+++ b/libraries/blueUtils/bidderUtils.js
@@ -21,7 +21,9 @@ export function getBidFloor(bid, mediaType, defaultCurrency) {
 export function buildOrtbRequest(bidRequests, bidderRequest, context, gvlid, ortbConverterInstance) {
   const ortbRequest = ortbConverterInstance.toORTB({ bidRequests, bidderRequest, context });
   ortbRequest.ext = ortbRequest.ext || {};
-  deepSetValue(ortbRequest, 'ext.gvlid', gvlid);
+  if (gvlid != null) {
+    deepSetValue(ortbRequest, 'ext.gvlid', gvlid);
+  }
   return ortbRequest;
 }
 

--- a/modules/blueBidAdapter.js
+++ b/modules/blueBidAdapter.js
@@ -19,7 +19,6 @@ import {
 } from '../src/utils.js';
 const BIDDER_CODE = 'blue';
 const ENDPOINT_URL = 'https://bidder-us-east-1.getblue.io/engine/?src=prebid';
-const GVLID = 620;
 const DEFAULT_CURRENCY = 'USD';
 
 export const storage = getStorageManager({ bidderCode: BIDDER_CODE });
@@ -28,7 +27,6 @@ const converter = createOrtbConverter(ortbConverter, BANNER, DEFAULT_CURRENCY, o
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: GVLID,
   supportedMediaTypes: [BANNER],
 
   // Validate bid request
@@ -39,7 +37,7 @@ export const spec = {
     const context = {
       publisherId: getPublisherIdFromBids(validBidRequests),
     };
-    const ortbRequestData = buildOrtbRequest(validBidRequests, bidderRequest, context, GVLID, converter);
+    const ortbRequestData = buildOrtbRequest(validBidRequests, bidderRequest, context, null, converter);
 
     const blueDataProcessor = (data) => data;
     const blueOptions = { contentType: 'application/json' };

--- a/test/spec/modules/blueBidAdapter_spec.js
+++ b/test/spec/modules/blueBidAdapter_spec.js
@@ -4,7 +4,6 @@ import { spec, storage } from 'modules/blueBidAdapter.js';
 
 const BIDDER_CODE = 'blue';
 const ENDPOINT_URL = 'https://bidder-us-east-1.getblue.io/engine/?src=prebid';
-const GVLID = 620;
 const CURRENCY = 'USD';
 
 describe('blueBidAdapter:', function () {
@@ -71,7 +70,7 @@ describe('blueBidAdapter:', function () {
       expect(request.options.contentType).to.equal('application/json');
 
       const ortbRequest = request.data;
-      expect(ortbRequest.ext.gvlid).to.equal(GVLID);
+      expect(ortbRequest.ext).not.to.have.property('gvlid');
       expect(ortbRequest.imp[0].bidfloor).to.equal(1.5);
       expect(ortbRequest.imp[0].bidfloorcur).to.equal(CURRENCY);
     });


### PR DESCRIPTION
### Motivation
- Blue no longer has an IAB GVL ID and should not advertise or attach the obsolete ID in OpenRTB requests.
- Prevent shared request-building helper from emitting `ext.gvlid` when an adapter does not supply one.

### Description
- Make `buildOrtbRequest` in `libraries/blueUtils/bidderUtils.js` set `ext.gvlid` only when the provided `gvlid` is non-null so adapters can omit the field.
- Remove the hard-coded `GVLID` constant and `gvlid` property from `modules/blueBidAdapter.js` and pass `null` into `buildOrtbRequest` so Blue no longer exposes a GVL ID.
- Update `test/spec/modules/blueBidAdapter_spec.js` to assert that generated OpenRTB requests do not include `ext.gvlid` for the Blue adapter.
- Preserves existing behavior for adapters that continue to provide a GVL ID (the helper still injects `ext.gvlid` when a valid ID is passed).

### Testing
- Ran lint: `npx eslint modules/blueBidAdapter.js libraries/blueUtils/bidderUtils.js test/spec/modules/blueBidAdapter_spec.js --cache --cache-strategy content` (succeeded with no reported errors).
- Ran adapter unit tests: `npx gulp test --nolint --file test/spec/modules/blueBidAdapter_spec.js` (tests passed; 5 tests completed).
- Verified related adapter tests: `npx gulp test --nolint --file test/spec/modules/bmsBidAdapter_spec.js` (tests passed; 5 tests completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a64c51b7f1c832ba8df527bbbe4437b)