### PR TITLE
CI: don't lint the whole repo when the changed-file list is empty

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -39,7 +39,10 @@ jobs:
         run: git diff --name-only --diff-filter=A origin/${{ github.event.pull_request.base.ref }}...refs/remotes/pull/${{ github.event.pull_request.number }}/merge | grep '^\(modules\|src\|libraries\)/.*\.js$' > __new_js_files.txt || true
 
       - name: Run linter on base branch
-        run: npx eslint --no-inline-config --format json $(cat __changed_files.txt | xargs stat --printf '%n\n' 2> /dev/null) > __base.json || true
+        run: |
+          files=$(cat __changed_files.txt | xargs stat --printf '%n\n' 2> /dev/null) || true
+          # eslint with no file arguments would lint the whole repo; report nothing instead
+          if [ -z "$files" ]; then echo '[]' > __base.json; else npx eslint --no-inline-config --format json $files > __base.json || true; fi
 
       - name: Check out PR
         run: git checkout ${{ github.event.pull_request.head.sha }}
@@ -48,7 +51,10 @@ jobs:
         run: npm ci
 
       - name: Run linter on PR
-        run: npx eslint --no-inline-config --format json $(cat __changed_files.txt | xargs stat --printf '%n\n' 2> /dev/null) > __pr.json || true
+        run: |
+          files=$(cat __changed_files.txt | xargs stat --printf '%n\n' 2> /dev/null) || true
+          # eslint with no file arguments would lint the whole repo; report nothing instead
+          if [ -z "$files" ]; then echo '[]' > __pr.json; else npx eslint --no-inline-config --format json $files > __pr.json || true; fi
 
       - name: Compare them and post comment if necessary
         uses: actions/github-script@v9


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [x] CI related changes

## Description of change

`linter.yml` compares linter output between the base branch and the PR, to report how many errors a
PR adds. Both lint steps filter their changed-file list through `xargs stat`, which drops paths that
do not exist at the checked-out commit. When *every* path is dropped, the command substitution
expands to nothing, and `npx eslint` with no file arguments lints the whole repository - so the
comparison attributes every pre-existing error to the PR.

This hits any PR whose only changed `.js` files under `modules/`, `src/`, `libraries/` or
`creative/` were renamed or deleted, TypeScript migrations in particular. On #15395 the workflow
reported 117 added errors across ~60 files; a repo-wide `npx eslint --no-inline-config` reports
exactly 117 errors across 74 files. (`--no-inline-config` is why they count as errors at all: it
ignores every `eslint-disable` comment in the tree.)

Both steps now write `[]` when none of the listed files exist, leaving the comparison nothing to
report. Behaviour is unchanged whenever at least one file exists.

The `|| true` on the assignment is not cosmetic: `run:` blocks execute under `bash -e`, and `xargs`
exits 123 when `stat` fails on any of its input paths, so without it the step would abort whenever a
single listed file had been renamed - turning a wrong comment into a failing check.

### Verification

Run under `bash -e`, matching the Actions shell:

| changed-file list | result |
| ----------------- | ------ |
| one existing file plus one missing | exit 0, normal report for the existing file |
| all paths missing | exit 0, `[]`, without invoking eslint |
| empty list | exit 0, `[]` |

The same cases exit 123 without the `|| true`. The `github-script` comparison step was exercised
against empty reports in both directions - empty base, empty PR - and behaves: `mkDiff` iterates the
PR report, so an empty one is silent, and an empty base correctly attributes errors in newly added
files. `__new_js_files.txt` has no equivalent problem, as it comes from `git diff` rather than the
filesystem and its consumer guards with `existsSync`.

## Other information

Found while working on #15395, which is what the workflow mis-reported.
