### PR TITLE
Yaleo Bid Adapter: support configurable endpoint via config

### DIFF
--- a/modules/yaleoBidAdapter.ts
+++ b/modules/yaleoBidAdapter.ts
@@ -1,7 +1,9 @@
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { pbsExtensions } from '../libraries/pbsExtensions/pbsExtensions.js';
 import { BidderSpec, registerBidder } from '../src/adapters/bidderFactory.js';
+import { config } from '../src/config.js';
 import { BANNER } from '../src/mediaTypes.js';
+import { logWarn } from '../src/utils.js';
 
 interface YaleoBidParams {
   /**
@@ -19,15 +21,30 @@ interface YaleoBidParams {
   maxCpm?: number;
 }
 
+interface YaleoConfig {
+  /**
+   * Overrides the bidder endpoint URL. Must be one of the approved HTTPS Yaleo
+   * endpoints; any other value is ignored. Defaults to the production endpoint.
+   */
+  endpoint?: string;
+}
+
 declare module '../src/adUnits' {
   interface BidderParams {
     [BIDDER_CODE]: YaleoBidParams;
   }
 }
 
+declare module '../src/config' {
+  interface Config {
+    [BIDDER_CODE]?: YaleoConfig;
+  }
+}
+
 const BIDDER_CODE = 'yaleo';
 const AUDIENZZ_VENDOR_ID = 783;
-const PREBID_URL = 'https://bidder.yaleo.com/prebid';
+const DEFAULT_ENDPOINT = 'https://bidder.yaleo.com/prebid';
+const ALLOWED_ENDPOINTS = new Set([DEFAULT_ENDPOINT, 'https://dev-bidder.yaleo.com/prebid']);
 const DEFAULT_TTL = 300;
 
 const converter = ortbConverter<typeof BIDDER_CODE>({
@@ -37,6 +54,18 @@ const converter = ortbConverter<typeof BIDDER_CODE>({
   },
   processors: pbsExtensions,
 });
+
+const resolveEndpoint = (): string => {
+  const customEndpoint = config.getConfig(BIDDER_CODE)?.endpoint;
+  if (!customEndpoint) {
+    return DEFAULT_ENDPOINT;
+  }
+  if (!ALLOWED_ENDPOINTS.has(customEndpoint)) {
+    logWarn(`${BIDDER_CODE}: ignoring unapproved endpoint override "${customEndpoint}"`);
+    return DEFAULT_ENDPOINT;
+  }
+  return customEndpoint;
+};
 
 const isBidRequestValid: BidderSpec<typeof BIDDER_CODE>['isBidRequestValid'] = (request) => {
   if (!request.params || typeof request.params.placementId !== 'string') {
@@ -53,7 +82,7 @@ const buildRequests: BidderSpec<typeof BIDDER_CODE>['buildRequests'] = (validBid
   });
 
   return {
-    url: PREBID_URL,
+    url: resolveEndpoint(),
     method: 'POST',
     data: ortbRequest,
   };

--- a/test/spec/modules/yaleoBidAdapter_spec.js
+++ b/test/spec/modules/yaleoBidAdapter_spec.js
@@ -1,4 +1,5 @@
 import { cloneDeep } from "lodash";
+import { config } from "src/config.js";
 import { spec } from "../../../modules/yaleoBidAdapter.ts";
 
 const bannerBidRequestBase = {
@@ -120,6 +121,10 @@ describe('Yaleo bid adapter', () => {
   });
 
   describe('buildRequests', () => {
+    afterEach(() => {
+      config.resetConfig();
+    });
+
     it('creates a valid banner bid request', () => {
       const bidderRequest = {
         bids: [bannerBidRequest],
@@ -139,6 +144,70 @@ describe('Yaleo bid adapter', () => {
       expect(request.data.imp.length).to.equal(1);
       expect(request.data.imp[0]).to.have.property('banner');
       expect(request.data.site.page).to.be.equal('http://example.com');
+    });
+
+    it('uses the production endpoint by default', () => {
+      const bidderRequest = {
+        bids: [bannerBidRequest],
+        auctionId: bannerBidRequest.auctionId,
+        bidderRequestId: bannerBidRequest.bidderRequestId,
+      };
+
+      const request = spec.buildRequests([bannerBidRequest], bidderRequest);
+
+      expect(request.url).to.equal('https://bidder.yaleo.com/prebid');
+    });
+
+    it('overrides the endpoint via yaleo.endpoint config for an approved Yaleo host', () => {
+      config.setConfig({ yaleo: { endpoint: 'https://dev-bidder.yaleo.com/prebid' } });
+      const bidderRequest = {
+        bids: [bannerBidRequest],
+        auctionId: bannerBidRequest.auctionId,
+        bidderRequestId: bannerBidRequest.bidderRequestId,
+      };
+
+      const request = spec.buildRequests([bannerBidRequest], bidderRequest);
+
+      expect(request.url).to.equal('https://dev-bidder.yaleo.com/prebid');
+    });
+
+    it('ignores an endpoint override that is not a Yaleo host', () => {
+      config.setConfig({ yaleo: { endpoint: 'https://bidder.example.com/prebid' } });
+      const bidderRequest = {
+        bids: [bannerBidRequest],
+        auctionId: bannerBidRequest.auctionId,
+        bidderRequestId: bannerBidRequest.bidderRequestId,
+      };
+
+      const request = spec.buildRequests([bannerBidRequest], bidderRequest);
+
+      expect(request.url).to.equal('https://bidder.yaleo.com/prebid');
+    });
+
+    it('ignores a non-HTTPS endpoint override', () => {
+      config.setConfig({ yaleo: { endpoint: 'http://bidder.yaleo.com/prebid' } });
+      const bidderRequest = {
+        bids: [bannerBidRequest],
+        auctionId: bannerBidRequest.auctionId,
+        bidderRequestId: bannerBidRequest.bidderRequestId,
+      };
+
+      const request = spec.buildRequests([bannerBidRequest], bidderRequest);
+
+      expect(request.url).to.equal('https://bidder.yaleo.com/prebid');
+    });
+
+    it('ignores an unapproved Yaleo subdomain override', () => {
+      config.setConfig({ yaleo: { endpoint: 'https://anything.yaleo.com/prebid' } });
+      const bidderRequest = {
+        bids: [bannerBidRequest],
+        auctionId: bannerBidRequest.auctionId,
+        bidderRequestId: bannerBidRequest.bidderRequestId,
+      };
+
+      const request = spec.buildRequests([bannerBidRequest], bidderRequest);
+
+      expect(request.url).to.equal('https://bidder.yaleo.com/prebid');
     });
 
     it('checks that all params are passed to the request', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change

Makes the bidder endpoint configurable via `pbjs.setConfig({ yaleo: { endpoint } })`, defaulting to the production URL when unset.

## Other information

Docs PR: https://github.com/prebid/prebid.github.io/pull/6683
