### PR TITLE
Core: escape values interpolated into generated VAST XML

### DIFF
--- a/libraries/video/shared/vastXmlBuilder.js
+++ b/libraries/video/shared/vastXmlBuilder.js
@@ -1,4 +1,5 @@
 import { getGlobal } from '../../../src/prebidGlobal.js';
+import { attributeValue, cdata } from '../../../src/utils/xml.js';
 
 export function buildVastWrapper(adId, adTagUrl, impressionUrl, impressionId, errorUrl) {
   let wrapperBody = getAdSystemNode('Prebid org', getGlobal().version);
@@ -49,7 +50,7 @@ export function getErrorNode(pingUrl) {
 // Helpers
 
 function getUrlNode(labelName, url, attributes) {
-  const body = `<![CDATA[${url}]]>`;
+  const body = cdata(url);
   return getNode(labelName, body, attributes);
 }
 
@@ -59,7 +60,9 @@ function getNode(labelName, body, attributes) {
 }
 
 /*
-attributes is a KVP Object.
+attributes is a KVP Object. Keys become attribute names verbatim, so they must be literals: a
+name taken from untrusted input would need validating against the XML Name grammar, which escaping
+cannot do. Only the values are escaped.
  */
 function getOpeningLabel(name, attributes) {
   if (!attributes) {
@@ -72,6 +75,6 @@ function getOpeningLabel(name, attributes) {
       return label;
     }
 
-    return label + ` ${key}="${value}"`;
+    return label + ` ${key}="${attributeValue(value)}"`;
   }, name);
 }

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -1,3 +1,6 @@
+// This module, and the calls to it in videoCache and vastXmlBuilder, were written by a bot
+// (Claude Code).
+
 /**
  * Helpers for placing untrusted text into XML that is built by string concatenation.
  *

--- a/src/utils/xml.ts
+++ b/src/utils/xml.ts
@@ -1,0 +1,29 @@
+/**
+ * Helpers for placing untrusted text into XML that is built by string concatenation.
+ *
+ * Element and attribute names in the documents Prebid generates are literals, so the values
+ * interpolated between them are the only place a document's structure can be altered.
+ */
+
+/**
+ * Wraps text in a CDATA section.
+ *
+ * A CDATA section ends at the first ']]>', so text containing that sequence is split across two
+ * sections. A parser reading the result back sees the original text, including the ']]>'.
+ */
+export function cdata(text: string): string {
+  return `<![CDATA[${String(text).replace(/]]>/g, ']]]]><![CDATA[>')}]]>`;
+}
+
+/**
+ * Escapes text for use as a double-quoted XML attribute value.
+ *
+ * Expects raw text: this replaces '&' with an entity reference, so applying it to its own output
+ * would escape the ampersands it just produced.
+ */
+export function attributeValue(text: string): string {
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/"/g, '&quot;');
+}

--- a/src/videoCache.ts
+++ b/src/videoCache.ts
@@ -13,6 +13,7 @@ import { qualifiedAjaxBuilder } from './ajax.js';
 import { config } from './config.js';
 import { auctionManager } from './auctionManager.js';
 import { generateUUID, logError, logWarn } from './utils.js';
+import { attributeValue, cdata } from './utils/xml.js';
 import { addBidToAuction } from './auction.js';
 import { hook } from './hook.js';
 import { OUTSTREAM } from './video.js';
@@ -45,25 +46,21 @@ export interface VastTrackers {
  * @return A VAST URL which loads XML from the given URI.
  */
 function wrapURI(uri: string, trackers?: VastTrackers) {
-  // Technically, this is vulnerable to cross-script injection by sketchy vastUrl bids.
-  // We could make sure it's a valid URI... but since we're loading VAST XML from the
-  // URL they provide anyway, that's probably not a big deal.
-
   // Build Impression tags
   const impressions = trackers?.impression?.length
-    ? trackers.impression.map(trk => `<Impression><![CDATA[${trk}]]></Impression>`).join('')
+    ? trackers.impression.map(trk => `<Impression>${cdata(trk)}</Impression>`).join('')
     : '';
 
   // Build Error tags
   const errors = trackers?.error?.length
-    ? trackers.error.map(trk => `<Error><![CDATA[${trk}]]></Error>`).join('')
+    ? trackers.error.map(trk => `<Error>${cdata(trk)}</Error>`).join('')
     : '';
 
   // Build TrackingEvents for Linear creative
   let trackingEventsXml = '';
   if (trackers?.trackingEvents?.length) {
     const trackingTags = trackers.trackingEvents
-      .map(({ event, url }) => `<Tracking event="${event}"><![CDATA[${url}]]></Tracking>`)
+      .map(({ event, url }) => `<Tracking event="${attributeValue(event)}">${cdata(url)}</Tracking>`)
       .join('');
     trackingEventsXml = `<Creative><Linear><TrackingEvents>${trackingTags}</TrackingEvents></Linear></Creative>`;
   }
@@ -72,7 +69,7 @@ function wrapURI(uri: string, trackers?: VastTrackers) {
     '<Ad>' +
     '<Wrapper>' +
     '<AdSystem>prebid.org wrapper</AdSystem>' +
-    '<VASTAdTagURI><![CDATA[' + uri + ']]></VASTAdTagURI>' +
+    '<VASTAdTagURI>' + cdata(uri) + '</VASTAdTagURI>' +
     impressions +
     errors +
     '<Creatives>' + trackingEventsXml + '</Creatives>' +

--- a/test/spec/libraries/vastTrackers_spec.js
+++ b/test/spec/libraries/vastTrackers_spec.js
@@ -393,4 +393,64 @@ describe('vast trackers', () => {
       expect(trackers.trackingEvents).to.be.an('array').that.is.empty;
     });
   });
+
+  // insertVastTrackers builds nodes with DOM APIs rather than by string concatenation, which is
+  // what stops a tracker value from altering the structure of the document it is placed in. These
+  // assert the resulting structure, so they hold for any implementation that keeps that property.
+  describe('tracker values containing XML syntax', () => {
+    const WRAPPER = '<VAST><Ad><Wrapper></Wrapper></Ad></VAST>';
+    // ']]>' ends a CDATA section; the text after it would otherwise be parsed as markup.
+    const BREAKOUT = 'https://tracking.mydomain.com/a]]></Impression><Impression><![CDATA[https://evil.example/pwn';
+
+    function insert(trackers, vastXml = WRAPPER) {
+      const doc = new DOMParser().parseFromString(
+        insertVastTrackers({ impression: [], error: [], trackingEvents: [], ...trackers }, vastXml),
+        'text/xml'
+      );
+      expect(doc.getElementsByTagName('parsererror')).to.have.lengthOf(0);
+      return doc;
+    }
+
+    // A value that cannot be represented is allowed to be left out, but must never appear as
+    // extra structure - hence `at.most` rather than an exact count.
+    function expectNoExtra(doc, tagName, value) {
+      const elements = Array.from(doc.getElementsByTagName(tagName));
+      expect(elements).to.have.lengthOf.at.most(1);
+      elements.forEach(el => expect(el.textContent).to.equal(value));
+    }
+
+    it('does not let an impression url add an Impression element', () => {
+      expectNoExtra(insert({ impression: [BREAKOUT] }), 'Impression', BREAKOUT);
+    });
+
+    it('does not let an error url add an Error element', () => {
+      expectNoExtra(insert({ error: [BREAKOUT] }), 'Error', BREAKOUT);
+    });
+
+    it('does not let a tracking event url add a Tracking element', () => {
+      const doc = insert({ trackingEvents: [{ event: 'start', url: BREAKOUT }] });
+      expectNoExtra(doc, 'Tracking', BREAKOUT);
+    });
+
+    it('does not let a tracking event name add attributes to Tracking', () => {
+      const event = 'complete" onload="x';
+      const doc = insert({ trackingEvents: [{ event, url: 'https://tracking.mydomain.com/c' }] });
+      const tracking = doc.getElementsByTagName('Tracking');
+      expect(tracking).to.have.lengthOf(1);
+      expect(tracking[0].getAttributeNames()).to.eql(['event']);
+      expect(tracking[0].getAttribute('event')).to.equal(event);
+    });
+
+    it('returns the vastXml unchanged when it has no Wrapper or InLine element', () => {
+      const noWrapper = '<VAST><Ad></Ad></VAST>';
+      const trackers = { impression: ['https://tracking.mydomain.com/i'], error: [], trackingEvents: [] };
+      expect(insertVastTrackers(trackers, noWrapper)).to.equal(noWrapper);
+    });
+
+    it('returns the vastXml unchanged when it cannot be parsed', () => {
+      const malformed = 'not xml at all <<<';
+      const trackers = { impression: ['https://tracking.mydomain.com/i'], error: [], trackingEvents: [] };
+      expect(insertVastTrackers(trackers, malformed)).to.equal(malformed);
+    });
+  });
 });

--- a/test/spec/modules/gamAdServerVideo_spec.js
+++ b/test/spec/modules/gamAdServerVideo_spec.js
@@ -17,6 +17,29 @@ import { AuctionIndex } from '../../../src/auctionIndex.js';
 import { server } from '../../mocks/xhr.js';
 import { uspDataHandler, gppDataHandler } from '../../../src/consentHandler.js';
 
+/**
+ * Responds to the two requests getVastXml makes for a locally cached bid: first to the ad server for
+ * the GAM wrapper, then to fetch the blob that wrapper points at. The mock server responds to one
+ * request per `respond()` call, and the second request is only issued once the first has resolved,
+ * so the second response has to wait for it to arrive.
+ */
+function respondToAdServerThenBlob() {
+  server.respond();
+
+  let timeout;
+
+  const respondWhenBlobRequested = () => {
+    if (server.requests.length >= 2) {
+      server.respond();
+      clearTimeout(timeout);
+    } else {
+      timeout = setTimeout(respondWhenBlobRequested, 50);
+    }
+  };
+
+  respondWhenBlobRequested();
+}
+
 describe('The DFP video support module', function () {
   before(() => {
     hook.ready();
@@ -781,20 +804,7 @@ describe('The DFP video support module', function () {
       })
       .finally(config.resetConfig);
 
-    server.respond();
-
-    let timeout;
-
-    const waitForSecondRequest = () => {
-      if (server.requests.length >= 2) {
-        server.respond();
-        clearTimeout(timeout);
-      } else {
-        timeout = setTimeout(waitForSecondRequest, 50);
-      }
-    };
-
-    waitForSecondRequest();
+    respondToAdServerThenBlob();
   });
 
   it('should return unmodified gam vast wrapper if it doesn\'nt contain locally cached uuid', (done) => {
@@ -854,6 +864,46 @@ describe('The DFP video support module', function () {
       .finally(config.resetConfig);
 
     server.respond();
+  });
+
+  // The cached bid's own vastXml reaches this path as a blob (see vastLocalCache in videoCache) and
+  // is placed in a CDATA section, so it must not be able to close that section and add structure.
+  it('should not let locally cached blob content alter the wrapper structure', (done) => {
+    config.setConfig({ cache: { useLocal: true } });
+    const url = 'https://pubads.g.doubleclick.net/gampad/ads';
+    // ']]>' ends a CDATA section; what follows would otherwise be parsed as markup.
+    const blobContent = '<VAST version="3.0"></VAST>]]></VASTAdTagURI><Impression><![CDATA[https://evil.example/pwn';
+    const blobUrl = URL.createObjectURL(new Blob([blobContent], { type: 'text/xml' }));
+    const uuid = generateUUID();
+    const localMap = new Map([[uuid, blobUrl]]);
+
+    const bidCacheUrl = 'https://prebid-test-cache-server.org/cache?uuid=' + uuid;
+    const gamWrapper = (
+      `<VAST version="3.0">` +
+        `<Ad>` +
+          `<Wrapper>` +
+           `<AdSystem>prebid.org wrapper</AdSystem>` +
+            `<VASTAdTagURI><![CDATA[${bidCacheUrl}]]></VASTAdTagURI>` +
+          `</Wrapper>` +
+       `</Ad>` +
+      `</VAST>`
+    );
+
+    server.respondWith(/^https:\/\/pubads.*/, gamWrapper);
+    server.respondWith(/^blob:http:*/, blobContent);
+
+    getVastXml({ url, adUnit: {}, bid: {} }, localMap)
+      .then((vastXml) => {
+        const doc = new DOMParser().parseFromString(vastXml, 'application/xml');
+        expect(doc.getElementsByTagName('parsererror')).to.have.lengthOf(0);
+        expect(doc.getElementsByTagName('VASTAdTagURI')).to.have.lengthOf(1);
+        expect(doc.getElementsByTagName('Impression')).to.have.lengthOf(0);
+        done();
+      })
+      .catch(done)
+      .finally(config.resetConfig);
+
+    respondToAdServerThenBlob();
   });
 
   it('should return returned unmodified gam vast wrapper if exception has been thrown', (done) => {

--- a/test/spec/modules/videoModule/shared/vastXmlBuilder_spec.js
+++ b/test/spec/modules/videoModule/shared/vastXmlBuilder_spec.js
@@ -104,3 +104,51 @@ describe('getErrorNode', function () {
     expect(errorNode).to.be.equal('<Error><![CDATA[http://wwww.testUrl.com/adError.jpg]]></Error>');
   });
 });
+
+// Nodes are built by string concatenation, so values placed in them must not be able to close the
+// element or attribute they sit in.
+describe('values containing XML syntax', function () {
+  function parse(xml) {
+    const doc = new DOMParser().parseFromString(`<Root>${xml}</Root>`, 'application/xml');
+    expect(doc.getElementsByTagName('parsererror')).to.have.lengthOf(0);
+    return doc;
+  }
+
+  // ']]>' closes a CDATA section; the text after it would otherwise be parsed as markup.
+  const BREAKOUT = 'http://wwww.testUrl.com/i]]></Impression><Impression><![CDATA[http://evil.example/pwn';
+
+  it('keeps a url containing ]]> in a single element', function () {
+    const impressions = parse(getImpressionNode(BREAKOUT)).getElementsByTagName('Impression');
+    expect(impressions).to.have.lengthOf(1);
+    expect(impressions[0].textContent).to.equal(BREAKOUT);
+  });
+
+  it('keeps an error url containing ]]> in a single element', function () {
+    const errors = parse(getErrorNode(BREAKOUT)).getElementsByTagName('Error');
+    expect(errors).to.have.lengthOf(1);
+    expect(errors[0].textContent).to.equal(BREAKOUT);
+  });
+
+  it('does not let an id attribute add attributes to the node', function () {
+    const id = 'a" foo="bar';
+    const impression = parse(getImpressionNode('http://wwww.testUrl.com/i.jpg', id)).getElementsByTagName('Impression')[0];
+    expect(impression.getAttributeNames()).to.eql(['id']);
+    expect(impression.getAttribute('id')).to.equal(id);
+  });
+
+  it('does not let an ad id add attributes to the Ad node', function () {
+    const adId = 'a" foo="bar';
+    const ad = parse(buildVastWrapper(adId, 'http://wwww.testUrl.com/redirectUrl.xml')).getElementsByTagName('Ad')[0];
+    expect(ad.getAttributeNames()).to.eql(['id']);
+    expect(ad.getAttribute('id')).to.equal(adId);
+  });
+
+  it('keeps the ad tag uri in a single VASTAdTagURI element', function () {
+    const uri = 'http://wwww.testUrl.com/r.xml]]></VASTAdTagURI><Impression><![CDATA[http://evil.example/x';
+    const doc = parse(buildVastWrapper('adId123', uri));
+    const uris = doc.getElementsByTagName('VASTAdTagURI');
+    expect(uris).to.have.lengthOf(1);
+    expect(uris[0].textContent).to.equal(uri);
+    expect(doc.getElementsByTagName('Impression')).to.have.lengthOf(0);
+  });
+});

--- a/test/spec/videoCache_spec.js
+++ b/test/spec/videoCache_spec.js
@@ -456,6 +456,58 @@ describe('The video cache', function () {
       updateVast(bidResponse);
       expect(bidResponse.vastXml).to.eql('<VAST version="3.0"><Ad><Wrapper><AdSystem>prebid.org wrapper</AdSystem><VASTAdTagURI><![CDATA[my-mock-url.com]]></VASTAdTagURI><Impression><![CDATA[imptracker.com]]></Impression><Error><![CDATA[https://error.mydomain.com/error]]></Error><Creatives><Creative><Linear><TrackingEvents><Tracking event="start"><![CDATA[https://tracking.mydomain.com/start]]></Tracking></TrackingEvents></Linear></Creative></Creatives></Wrapper></Ad></VAST>');
     });
+
+    // The wrapper is built by string interpolation, so tracker values that contain XML syntax must
+    // not be able to close the element they are placed in.
+    describe('tracker values containing XML syntax', () => {
+      // ']]>' closes a CDATA section; the text after it would otherwise be parsed as markup.
+      const BREAKOUT = 'https://tracker.example/a]]></Impression><Impression><![CDATA[https://evil.example/pwn';
+
+      function parsed() {
+        updateVast(bidResponse);
+        const doc = new DOMParser().parseFromString(bidResponse.vastXml, 'text/xml');
+        expect(doc.getElementsByTagName('parsererror')).to.have.lengthOf(0);
+        return doc;
+      }
+
+      it('keeps an impression tracker in a single Impression element', () => {
+        bidResponse.vastTrackers = { impression: [BREAKOUT] };
+        const impressions = parsed().getElementsByTagName('Impression');
+        expect(impressions).to.have.lengthOf(1);
+        expect(impressions[0].textContent).to.equal(BREAKOUT);
+      });
+
+      it('keeps an error tracker in a single Error element', () => {
+        bidResponse.vastTrackers = { error: [BREAKOUT] };
+        const errors = parsed().getElementsByTagName('Error');
+        expect(errors).to.have.lengthOf(1);
+        expect(errors[0].textContent).to.equal(BREAKOUT);
+      });
+
+      it('keeps a tracking event url in a single Tracking element', () => {
+        bidResponse.vastTrackers = { trackingEvents: [{ event: 'start', url: BREAKOUT }] };
+        const tracking = parsed().getElementsByTagName('Tracking');
+        expect(tracking).to.have.lengthOf(1);
+        expect(tracking[0].textContent).to.equal(BREAKOUT);
+      });
+
+      it('does not let a tracking event name add attributes to Tracking', () => {
+        const event = 'start" foo="bar';
+        bidResponse.vastTrackers = { trackingEvents: [{ event, url: 'https://tracker.example/s' }] };
+        const tracking = parsed().getElementsByTagName('Tracking')[0];
+        expect(tracking.getAttributeNames()).to.eql(['event']);
+        expect(tracking.getAttribute('event')).to.equal(event);
+      });
+
+      it('keeps the vast url in a single VASTAdTagURI element', () => {
+        bidResponse.vastUrl = 'https://bidder.example/v.xml]]></VASTAdTagURI><Impression><![CDATA[https://evil.example/x';
+        const doc = parsed();
+        const uris = doc.getElementsByTagName('VASTAdTagURI');
+        expect(uris).to.have.lengthOf(1);
+        expect(uris[0].textContent).to.equal(bidResponse.vastUrl);
+        expect(doc.getElementsByTagName('Impression')).to.have.lengthOf(0);
+      });
+    });
   });
 
   describe('local video cache', function() {


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

No docs PR required — no documented API or example changes.

## Description of change

Prebid constructs or mutates VAST XML in five places. Three build it by string concatenation, two by DOM APIs:

| site | construction |
|---|---|
| `src/videoCache.ts` `wrapURI` | string template |
| `libraries/video/shared/vastXmlBuilder.js` | string template |
| `libraries/video/shared/vastXmlEditor.js` | string-builds a node, re-parses it, grafts it in |
| `libraries/vastTrackers/vastTrackers.js` `insertVastTrackers` | DOM APIs |
| `modules/adlooxAdServerVideo.js:133` | `textContent =` |

The string-built sites placed untrusted values into the document without escaping them.

### The defects

**CDATA.** `wrapURI` and `getUrlNode` wrapped tracker and ad tag URLs in `<![CDATA[...]]>`. A CDATA section ends at the first `]]>`, so a URL containing that sequence closed the section early and everything after it was parsed as markup. A tracker URL of the form

```
https://tracker.example/a]]></Impression><Impression><![CDATA[https://elsewhere.example/x
```

produced two `<Impression>` elements, the second pointing wherever the value said. The result is well-formed XML, so no parser rejects it.

**Attribute values.** `getOpeningLabel` in `vastXmlBuilder.js` interpolated attribute values with no escaping at all, so a value containing a double quote closed the attribute and could open another. This affected `Ad id`, `Impression id`, `VAST version` and `AdSystem version` — including the `id` of the `<Ad>` in Prebid's own wrapper. `wrapURI` had the same problem for the `event` attribute of `<Tracking>`.

**`vastXmlEditor`.** It parses the real VAST with `xmlUtil.parse` and appends via DOM, which is safe, but it builds the impression and error nodes with the string builder above and then re-parses them. With `]]>` in the URL the re-parse failed, and because nothing checks for it, `appendChild(doc.documentElement)` grafted an XHTML-namespaced `<parsererror>` element — inline styles and all — into the `<Impression>` inside the VAST. Fixed as a consequence of fixing the builder.

### The change

Add `cdata` and `attributeValue` to a new `src/utils/xml.ts` and use them at both string-built sites (`videoCache.ts:51,56,63,72`; `vastXmlBuilder.js:53,78`).

`cdata` splits `]]>` across two adjacent sections, which a parser reads back as the original text — so nothing is dropped or altered, only relocated across a section boundary.

**Attribute names are deliberately not escaped.** Every name in these builders is a literal (`{ id: adId }`, `{ version }`), and `getNode`/`getOpeningLabel` are not exported, so no caller can supply one. More importantly, escaping is the wrong tool for a name: XML Names have a restricted grammar, and a space or quote cannot be escaped into a valid one — the correct treatment would be rejection. A guard would also be unreachable with the current callers and therefore untestable, so the constraint is documented where the names are assembled instead.

### Compatibility

Output is unchanged for any value that does not contain `]]>`, `"`, `<` or `>`. Values containing those are percent-encoded or entity-escaped; all four characters are excluded from the RFC 3986 URI grammar anyway, so encoding them is more correct than emitting them raw. No existing assertion needed updating, including the exact-string wrapper assertions in `videoCache_spec.js` and `gamAdServerVideo_spec.js`.

Also drops the comment in `wrapURI` that discounted this ("*we're loading VAST XML from the URL they provide anyway, that's probably not a big deal*"). That reasoning covers the ad tag URL it was written for, but not the tracker values, which can come from analytics modules through `registerVastTrackers`.

### Severity

Values reaching these paths come from the bid response (`vastTrackers`, `vastImpUrl`, `vastUrl`) and from first-party modules that call `registerVastTrackers`.

The defect is **XML injection**: anyone who can set one of these values could place arbitrary XML in the generated document, not just the tracker element the value was meant to become. A namespaced element such as an XHTML or SVG `<script>` survives the breakout as well-formed XML.

The actors who can set these values are:

- **Bidders**, through the bid response — `vastTrackers.impression`, `vastTrackers.error`, `vastTrackers.trackingEvents` (both the url and the event name), the deprecated `vastImpUrl`, and `vastUrl` itself, which becomes the `<VASTAdTagURI>`. In tree, `ttdBidAdapter`, `prismaBidAdapter`, `waardexBidAdapter`, `appnexusBidAdapter`, `adrelevantisBidAdapter`, `mediafuseBidAdapter`, `ampliffyBidAdapter` and `libraries/targetVideoUtils` all populate these fields.
- **Modules that call `registerVastTrackers`**, whose returned trackers are merged into every video bid's document — `medianetAnalyticsAdapter` in tree. These are first-party code in the publisher's build, gated on the `ACTIVITY_REPORT_ANALYTICS` activity.
- **The publisher**, through the video module's `video.adServer.tracking` config, whose `getUrl` callback and `id` reach `vastXmlBuilder` via `videoImpressionVerifier`. A publisher injecting into its own page is not a threat, but it means malformed config produces malformed VAST rather than an error.

**What can actually be achieved with the injected XML is unclear**, and depends entirely on the security of whatever consumes the VAST. Prebid uploads the document to a cache and hands a URL to a player; that player may be a browser-based library, a native SDK, a CTV application or a server-side stitcher, and Prebid cannot determine which. An XML document containing namespaced script executes if it is loaded as a document rather than fetched as data — but whether any given consumer does that, and with what privileges, is outside what this PR can establish. It is not offered as a demonstrated exploit.

One scope limit, so the above is not over-read: the `wrapURI`-path blob does not reach a player as a `blob:` URL. `bid.vastUrl` is already set in that path — it is the precondition `updateVast` tests — so `assignVastUrlAndCacheId` leaves it alone (`videoCache.ts:299-301`), and the blob is instead re-encoded by `gamAdServerVideo` as an opaque-origin `data:` URL.

## Tests

Two commits: the fix, then guard tests for the DOM-built sites.

**For the fix.** 5 tests in `videoCache_spec.js` and 5 in `vastXmlBuilder_spec.js`, asserting on the parsed document — element counts, `textContent`, `getAttributeNames()`, and absence of `parsererror`. Each set was confirmed to fail with its own source change reverted and the tests held constant.

**For the sites this PR does not change.** The DOM-built builders cannot have their structure altered by the values they place, but nothing asserted it, so rewriting one with string templates would have passed every existing test. `insertVastTrackers` gets six: four placing `]]>` or a quote in an impression url, an error url, a tracking event url and a tracking event name; two covering the fallback, where `vastXml` with no `Wrapper`/`InLine` and `vastXml` that cannot be parsed are both returned unchanged. Element counts are asserted as *at most* one rather than exactly one, so they hold for any implementation that keeps the property — including one that inserts `]]>`-bearing values losslessly instead of bailing out. Verified by replacing `insertVastTrackers` with a string-template implementation, which failed all four injection tests.

`gamAdServerVideo` gets one test for the locally cached branch, where a bid's own `vastXml` arrives through `vastLocalCache` as a blob and is placed in a CDATA section. Noting its limit: it does **not** fail if only the base64 encoding is dropped from `getBase64BlobContent`, because `createCDATASection` then rejects the sequence on its own — it covers the two steps together, not either alone.

| spec | result |
|---|---|
| `test/spec/videoCache_spec.js` | 33 |
| `test/spec/modules/videoModule/shared/vastXmlBuilder_spec.js` | 19 |
| `test/spec/modules/videoModule/shared/vastXmlEditor_spec.js` | 11 |
| `test/spec/modules/videoModule/videoImpressionVerifier_spec.js` | 3 |
| `test/spec/libraries/vastTrackers_spec.js` | 28 |
| `test/spec/modules/gamAdServerVideo_spec.js` | 95 |

`npx eslint` clean on all changed files. `npx tsc --noEmit --strict src/utils/xml.ts` clean.

## Other information

**Prompted by #15391**, which reports that VAST tracker URLs are inserted into CDATA sections without being validated, and flags `libraries/vastTrackers/vastTrackers.js`. The path it points at builds its nodes with DOM APIs, so a tracker value cannot alter the document there — `createCDATASection` rejects `]]>` and the insertion falls back to returning the original XML untouched. That was not asserted anywhere, and the six tests added here pin it.

Checking it did turn up two other sites that assemble the same elements by string concatenation, and those were injectable; they are what this PR fixes. The two changes are not alternatives. The http(s) scheme validation #15391 proposes would not have prevented these injections, since `https://tracker.example/a]]></Impression>…` is a perfectly valid https URL; conversely, escaping does not restrict which schemes a tracker may use. Whether tracker URLs should additionally be limited to http(s) is a separate question this PR does not settle.

**Suggested labels:** `fix`, `patch`.

**Noticed while testing, unrelated to this change.** With `cache.useLocal`, `storeLocally` blobs the bid's `vastXml` as `text/xml` and — when the bid carried no `vastUrl` of its own — that `blob:` URL becomes `bid.vastUrl` and is handed to the player. A `blob:` URL inherits the creating origin, and an XML document containing XHTML- or SVG-namespaced script executes when loaded as a document, so a bidder's own VAST could run script in the publisher's origin without any injection being involved. Whether a given player navigates to the URL or fetches it decides whether that happens. Worth its own issue; nothing here changes it.

**Noticed while testing, not addressed here.** `insertVastTrackers` inserts only where the selector `VAST Ad Wrapper, VAST Ad InLine` matches, and returns the document untouched otherwise, with no warning. A bid whose VAST does not match that shape therefore loses every registered module's trackers silently. Two of the tests added here pin the current return-unchanged behaviour, but whether silence is the right response is a separate question.

**Possible follow-up: construct these documents with the DOM.** That would make the string-built sites safe by construction and remove the need for either helper. It is not done here because `XMLSerializer` changes the serialised form — `<Creatives></Creatives>` becomes `<Creatives/>`, which `wrapURI` emits whenever a bid has no tracking events — and whether that matters to the players, SDKs and stitchers that consume the document seems worth settling on its own rather than as a side effect of a fix. Escaping keeps output byte-identical for ordinary input, so it closes the defect without deciding that question.

**Possible follow-up: a shared builder.** `libraries/xmlUtils/xmlUtils.js` offers `parse` and `serialize` but no construction helpers, which is why each builder rolls its own. Unifying the five sites behind one element builder does not fit all of them cleanly, though: two hold a `Document` and want nodes in it, two hold nothing and must return a string, so either return type forces one group into a conversion.
