### PR TITLE
Yieldmo Bid Adapter: remove dead Topics handling

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -76,7 +76,6 @@ export const spec = {
     const videoBidRequests = bidRequests.filter(request => hasVideoMediaType(request));
     const serverRequests = [];
     const eids = getEids(bidRequests[0]) || [];
-    const topicsData = getTopics(bidderRequest);
     if (bannerBidRequests.length > 0) {
       const serverRequest = {
         pbav: '$prebid.version$',
@@ -98,9 +97,6 @@ export const spec = {
         }),
         us_privacy: deepAccess(bidderRequest, 'uspConsent') || '',
       };
-      if (topicsData) {
-        serverRequest.topics = JSON.stringify(topicsData);
-      }
       const gpc = getGPCSignal(bidderRequest);
       if (gpc) {
         serverRequest.gpc = gpc;
@@ -176,9 +172,6 @@ export const spec = {
 
     if (videoBidRequests.length > 0) {
       const serverRequest = openRtbRequest(videoBidRequests, bidderRequest);
-      if (topicsData) {
-        serverRequest.topics = topicsData;
-      }
       if (eids.length) {
         deepSetValue(serverRequest, 'user.ext.eids', eids);
       };
@@ -474,25 +467,6 @@ function openRtbRequest(bidRequests, bidderRequest) {
 function getGPCSignal(bidderRequest) {
   const gpc = deepAccess(bidderRequest, 'ortb2.regs.ext.gpc');
   return gpc;
-}
-
-function getTopics(bidderRequest) {
-  const userData = deepAccess(bidderRequest, 'ortb2.user.data') || [];
-  const topicsData = userData.filter((dataObj) => {
-    const segtax = dataObj.ext?.segtax;
-    return segtax >= 600 && segtax <= 609;
-  })[0];
-
-  if (topicsData) {
-    const topicsObject = {
-      taxonomy: topicsData.ext.segtax,
-      classifier: topicsData.ext.segclass,
-      // topics needs to be array of numbers
-      topics: Object.values(topicsData.segment).map(i => Number(i)),
-    };
-    return topicsObject;
-  }
-  return null;
 }
 
 /**

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -440,30 +440,6 @@ describe('YieldmoAdapter', function () {
         expect(placementInfo).to.include('"gpid":"/6355419/Travel/Europe/France/Paris"');
       });
 
-      it('should add topics to the banner bid request', function () {
-        const biddata = build([mockBannerBid()], mockBidderRequest({
-          ortb2: {
-            user: {
-              data: [
-                {
-                  ext: {
-                    segtax: 600,
-                    segclass: '2206021246',
-                  },
-                  segment: ['7', '8', '9'],
-                },
-              ],
-            }
-          }
-        }));
-
-        expect(biddata[0].data.topics).to.equal(JSON.stringify({
-          taxonomy: 600,
-          classifier: '2206021246',
-          topics: [7, 8, 9],
-        }));
-      });
-
       it('should send gpc in the banner bid request', function () {
         const biddata = build(
           [mockBannerBid()],
@@ -725,33 +701,6 @@ describe('YieldmoAdapter', function () {
           }]
         };
         expect(buildAndGetData([mockVideoBid({ ...params })]).user.ext.eids).to.eql(params.fakeUserIdAsEids);
-      });
-
-      it('should add topics to the bid request', function () {
-        const videoBidder = mockBidderRequest(
-          {
-            ortb2: {
-              user: {
-                data: [
-                  {
-                    ext: {
-                      segtax: 600,
-                      segclass: '2206021246',
-                    },
-                    segment: ['7', '8', '9'],
-                  },
-                ],
-              },
-            },
-          },
-          [mockVideoBid()]
-        );
-        const payload = buildAndGetData([mockVideoBid()], 0, videoBidder);
-        expect(payload.topics).to.deep.equal({
-          taxonomy: 600,
-          classifier: '2206021246',
-          topics: [7, 8, 9],
-        });
       });
 
       it('should send gpc in the bid request', function () {


### PR DESCRIPTION
## Type of change

- [x] Refactoring (no functional changes, no api changes)
- [x] Bugfix

## Description of change

The Topics API was removed from Chrome and `topicsFpdModule` was made a no-op in **11.26** (#15369) — `processFpd` no longer writes anything to `ortb2.user.data`. The Yieldmo adapter's `getTopics` reads `ortb2.user.data` for `segtax` 600–609, so it now reads a signal that no longer exists.

This removes the dead topics handling from the adapter:
- `getTopics()` and its call site
- the banner (`serverRequest.topics = JSON.stringify(...)`) and video (`serverRequest.topics = ...`) send-sites
- the two topics unit tests

It also removes a latent bug in that path: `getTopics` built the array with `Object.values(topicsData.segment).map(i => Number(i))`, but ORTB `user.data[].segment` is an array of `{ id }` objects, so `Number({id})` was `NaN` (serialized to `null`).

No behavior change on 11.26+ (topics data no longer flows); on the code paths that remain, `gulp test` and `gulp lint` pass.

## Other information

- `gulp lint`: clean
- `gulp test --file test/spec/modules/yieldmoBidAdapter_spec.js`: passing
- Suggested labels: `maintenance`, `patch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
