### PR TITLE
Yieldmo Bid Adapter: guard getFloor, unmatched video imps, empty response body

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -192,7 +192,10 @@ export const spec = {
    */
   interpretResponse: function (serverResponse, bidRequest) {
     const bids = [];
-    const data = serverResponse.body;
+    const data = serverResponse && serverResponse.body;
+    if (!data) {
+      return bids;
+    }
     if (data.length > 0) {
       data.forEach(response => {
         if (response.cpm > 0) {
@@ -202,7 +205,12 @@ export const spec = {
     }
     if (data.seatbid) {
       const seatbids = data.seatbid.reduce((acc, seatBid) => acc.concat(seatBid.bid), []);
-      seatbids.forEach(bid => bids.push(createNewVideoBid(bid, bidRequest)));
+      seatbids.forEach(bid => {
+        const videoBid = createNewVideoBid(bid, bidRequest);
+        if (videoBid) {
+          bids.push(videoBid);
+        }
+      });
     }
     return bids;
   },
@@ -323,6 +331,14 @@ function createNewBannerBid(response) {
  */
 function createNewVideoBid(response, bidRequest) {
   const imp = (deepAccess(bidRequest, 'data.imp') || []).find(imp => imp.id === response.impid);
+
+  // A response bid whose impid doesn't match a requested imp can't be built
+  // (imp.id / imp.video.* would throw). Skip it so one malformed bid doesn't
+  // abort interpretResponse and drop every other bid in the response; the
+  // caller filters out this null.
+  if (!imp) {
+    return null;
+  }
 
   const result = {
     dealId: response.dealid,
@@ -527,7 +543,13 @@ function getBidFloor(bidRequest, mediaType) {
   let floorInfo = {};
 
   if (typeof bidRequest.getFloor === 'function') {
-    floorInfo = bidRequest.getFloor({ currency: CURRENCY, mediaType, size: '*' });
+    // getFloor can throw or return undefined/null (e.g. no matching floor rule);
+    // guard both so a floors misconfig can't drop the bid.
+    try {
+      floorInfo = bidRequest.getFloor({ currency: CURRENCY, mediaType, size: '*' }) || {};
+    } catch (e) {
+      logError('yieldmo: getFloor threw; falling back to params bidfloor', e);
+    }
   }
 
   return floorInfo.floor || bidRequest.params.bidfloor || bidRequest.params.bidFloor || 0;

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -362,6 +362,16 @@ describe('YieldmoAdapter', function () {
         expect(placementsData[1].bidFloor).to.equal(1.23);
       });
 
+      it('should fall back to params bidFloor when getFloor throws or returns undefined (no throw)', function () {
+        const throwing = mockBannerBid({ getFloor: () => { throw new Error('boom'); } }, { bidFloor: 0.42 });
+        expect(() => build([throwing])).to.not.throw();
+        expect(JSON.parse(buildAndGetPlacementInfo([throwing]))[0].bidFloor).to.equal(0.42);
+
+        const undef = mockBannerBid({ getFloor: () => undefined }, { bidFloor: 0.42 });
+        expect(() => build([undef])).to.not.throw();
+        expect(JSON.parse(buildAndGetPlacementInfo([undef]))[0].bidFloor).to.equal(0.42);
+      });
+
       it('should use bidFloor if no floors module is available', function() {
         const placementsData = JSON.parse(buildAndGetPlacementInfo([
           mockBannerBid({}, { bidFloor: 1.2 }),
@@ -980,6 +990,46 @@ describe('YieldmoAdapter', function () {
       });
     });
 
+    it('should skip a video bid whose impid does not match a requested imp, keeping the rest', function () {
+      const response = mockServerResponse();
+      const seatbid = [
+        {
+          bid: {
+            adm: '<?xml version="1.0" encoding="UTF-8"?>',
+            adomain: ['www.example.com'],
+            crid: 'unmatched-crid',
+            impid: 'no-such-imp',
+            price: 1.5,
+            dealid: 'YMO_456'
+          },
+        },
+        {
+          bid: {
+            adm: '<?xml version="1.0" encoding="UTF-8"?>',
+            adomain: ['www.example.com'],
+            crid: 'matched-crid',
+            impid: '91ea8bba1',
+            price: 2.0,
+            dealid: 'YMO_789'
+          },
+        },
+      ];
+      const bidRequest = {
+        data: { imp: [{ id: '91ea8bba1', video: { h: 250, w: 300 } }] },
+      };
+      // Only the seatbid (video) response; no banner entries, so the result
+      // contains just the video bids that were built.
+      response.body = [];
+      response.body.seatbid = seatbid;
+
+      // The unmatched bid must be skipped (not throw), and must not drop the
+      // matching video bid.
+      const newResponse = spec.interpretResponse(response, bidRequest);
+      expect(newResponse.length).to.equal(1);
+      expect(newResponse[0].requestId).to.equal('91ea8bba1');
+      expect(newResponse[0].creativeId).to.equal('matched-crid');
+    });
+
     it('should not add responses if the cpm is 0 or null', function () {
       const response = mockServerResponse();
       response.body[0].cpm = 0;
@@ -987,6 +1037,13 @@ describe('YieldmoAdapter', function () {
 
       response.body[0].cpm = null;
       expect(spec.interpretResponse(response)).to.deep.equal([]);
+    });
+
+    it('should return [] (not throw) when the response body is missing or null', function () {
+      expect(spec.interpretResponse({ body: null })).to.deep.equal([]);
+      expect(spec.interpretResponse({ body: undefined })).to.deep.equal([]);
+      expect(spec.interpretResponse({})).to.deep.equal([]);
+      expect(() => spec.interpretResponse(undefined)).to.not.throw();
     });
   });
 


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description of change

Three small, defensive fixes to the Yieldmo bid adapter. Each hardens a path where a single edge case currently throws and, because the throw propagates out of `buildRequests`/`interpretResponse`, drops **every** bid for that auction rather than just the problematic one. All three only change behavior in cases that previously threw — normal responses/bid-requests are unaffected.

**1. `getBidFloor` — handle `getFloor()` throwing or returning `null`/`undefined`**

`bidRequest.getFloor()` can legitimately return `null` (a floors rule whose value is `null` is a valid "no floor for this combination" signal — `priceFloors` returns `null` in that case) or throw on malformed floor data. The result was dereferenced directly:

```js
floorInfo = bidRequest.getFloor({ currency: CURRENCY, mediaType, size: '*' });
// ...
return floorInfo.floor || ...;   // floorInfo === null -> TypeError
```

Because `getBidFloor` runs during `buildRequests`, that `TypeError` fails the entire request and the adapter bids on nothing for the auction. Any publisher using a `null` floor rule hits this. Fix: default to `{}` and wrap in try/catch, then fall back to `params.bidfloor`/`bidFloor` exactly as before.

**2. `createNewVideoBid` — skip a bid whose `impid` matches no requested imp**

If a response bid's `impid` doesn't match any requested imp, `imp` is `undefined` and `imp.id` / `imp.video.*` throw, aborting `interpretResponse` and dropping every other (valid) bid in the response. Now returns `null` for that bid; the caller filters it out, so only the unmatched bid is skipped.

**3. `interpretResponse` — tolerate a missing/null response body**

`const data = serverResponse.body` followed by `data.length` throws when the body is null/missing. Now guards and returns `[]`.

## Other information

Unit tests added for all three cases (getFloor throw/undefined fallback, unmatched-impid skip preserving other bids, missing/null body). `gulp lint` clean; the `yieldmoBidAdapter` spec passes.
