### PR TITLE
Teads Bid Adapter: forward the COPPA flag

### DIFF
--- a/modules/teadsBidAdapter.js
+++ b/modules/teadsBidAdapter.js
@@ -126,6 +126,11 @@ export const spec = {
       payload.us_privacy = bidderRequest.uspConsent;
     }
 
+    // `regs.coppa` is set to 1 by the core enrichment when the publisher sets the `coppa` config.
+    if (bidderRequest?.ortb2?.regs?.coppa) {
+      payload.coppa = 1;
+    }
+
     const userAgentClientHints = firstBidRequest?.ortb2?.device?.sua;
     if (userAgentClientHints) {
       payload.userAgentClientHints = userAgentClientHints;

--- a/test/spec/modules/teadsBidAdapter_spec.js
+++ b/test/spec/modules/teadsBidAdapter_spec.js
@@ -1205,6 +1205,36 @@ describe('teadsBidAdapter', () => {
       expect(JSON.parse(defaultRequest.data).dsa).to.not.exist;
     });
 
+    it('should add coppa to payload when coppa applies', function () {
+      const bidRequestWithCoppa = Object.assign({}, bidderRequestDefault, {
+        ortb2: {
+          regs: {
+            coppa: 1
+          }
+        }
+      });
+
+      const requestWithCoppa = spec.buildRequests(bidRequests, bidRequestWithCoppa);
+
+      expect(JSON.parse(requestWithCoppa.data).coppa).to.equal(1);
+    });
+
+    it('should not add coppa to payload when coppa does not apply or is not set', function () {
+      const bidRequestWithoutCoppa = Object.assign({}, bidderRequestDefault, {
+        ortb2: {
+          regs: {
+            coppa: 0
+          }
+        }
+      });
+
+      const requestWithoutCoppa = spec.buildRequests(bidRequests, bidRequestWithoutCoppa);
+      expect(JSON.parse(requestWithoutCoppa.data).coppa).to.not.exist;
+
+      const defaultRequest = spec.buildRequests(bidRequests, bidderRequestDefault);
+      expect(JSON.parse(defaultRequest.data).coppa).to.not.exist;
+    });
+
     it('should include timeout in the payload when provided', function() {
       const bidderRequest = {
         timeout: 3000


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [X] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Add `coppa: 1` to the payload when COPPA applies, so that it can be taken into account when the bid request is processed.

The value is read from `ortb2.regs.coppa`, which Prebid core sets to 1/0 from the publisher's `coppa` config, in the same way the adapter already reads DSA from `ortb2.regs.ext.dsa`. The field is only added when COPPA applies.

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
