### PR TITLE
 AppNexus, Rubicon, and Index Exchange Bid Adapters: add parameter type declarations

### DIFF
--- a/modules/appnexusBidAdapter.d.ts
+++ b/modules/appnexusBidAdapter.d.ts
@@ -23,13 +23,13 @@ export interface AppnexusUserParams {
 
 /** Parameters accepted by the AppNexus bidder adapter. */
 export interface AppnexusBidderParams {
-  placementId?: number | string;
-  /** @deprecated Use `placementId`. */
   placement_id?: number | string;
+  /** @deprecated Use `placement_id`. */
+  placementId?: number | string;
   member?: number | string;
-  invCode?: string;
-  /** @deprecated Use `invCode`. */
   inv_code?: string;
+  /** @deprecated Use `inv_code`. */
+  invCode?: string;
   allowSmallerSizes?: boolean;
   allow_smaller_sizes?: boolean;
   usePaymentRule?: boolean;

--- a/modules/appnexusBidAdapter.d.ts
+++ b/modules/appnexusBidAdapter.d.ts
@@ -62,5 +62,17 @@ export interface AppnexusBidderParams {
 declare module '../src/adUnits' {
   interface BidderParams {
     appnexus: AppnexusBidderParams;
+    appnexusAst: AppnexusBidderParams;
+    pagescience: AppnexusBidderParams;
+    gourmetads: AppnexusBidderParams;
+    newdream: AppnexusBidderParams;
+    matomy: AppnexusBidderParams;
+    featureforward: AppnexusBidderParams;
+    adasta: AppnexusBidderParams;
+    beintoo: AppnexusBidderParams;
+    projectagora: AppnexusBidderParams;
+    stailamedia: AppnexusBidderParams;
+    uol: AppnexusBidderParams;
+    adzymic: AppnexusBidderParams;
   }
 }

--- a/modules/appnexusBidAdapter.d.ts
+++ b/modules/appnexusBidAdapter.d.ts
@@ -1,0 +1,55 @@
+import type { Size } from '../src/types/common.d.ts';
+
+export interface AppnexusVideoParams {
+  id?: number | string;
+  minduration?: number;
+  maxduration?: number;
+  skippable?: boolean;
+  playback_method?: string;
+  frameworks?: number[];
+  context?: string;
+  skipoffset?: number;
+}
+
+export interface AppnexusUserParams {
+  age?: number;
+  externalUid?: string;
+  external_uid?: string;
+  segments?: Array<number | Record<string, unknown>>;
+  gender?: string;
+  dnt?: boolean | number;
+  language?: string;
+}
+
+/** Parameters accepted by the AppNexus bidder adapter. */
+export interface AppnexusBidderParams {
+  placementId?: number | string;
+  /** @deprecated Use `placementId`. */
+  placement_id?: number | string;
+  member?: number | string;
+  invCode?: string;
+  /** @deprecated Use `invCode`. */
+  inv_code?: string;
+  allow_smaller_sizes?: boolean;
+  use_payment_rule?: boolean;
+  use_pmt_rule?: boolean;
+  position?: 'above' | 'below' | string;
+  traffic_source_code?: string;
+  private_sizes?: Size[];
+  supply_type?: string;
+  pub_click?: string;
+  ext_inv_code?: string;
+  publisher_id?: number | string;
+  external_imp_id?: string;
+  reserve?: number;
+  frameworks?: number[];
+  video?: AppnexusVideoParams;
+  user?: AppnexusUserParams;
+  app?: Record<string, unknown> & { id?: string };
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    appnexus: AppnexusBidderParams;
+  }
+}

--- a/modules/appnexusBidAdapter.d.ts
+++ b/modules/appnexusBidAdapter.d.ts
@@ -5,7 +5,7 @@ export interface AppnexusVideoParams {
   minduration?: number;
   maxduration?: number;
   skippable?: boolean;
-  playback_method?: string;
+  playback_method?: string | number | Array<string | number>;
   frameworks?: number[];
   context?: string;
   skipoffset?: number;
@@ -30,22 +30,33 @@ export interface AppnexusBidderParams {
   invCode?: string;
   /** @deprecated Use `invCode`. */
   inv_code?: string;
+  allowSmallerSizes?: boolean;
   allow_smaller_sizes?: boolean;
+  usePaymentRule?: boolean;
   use_payment_rule?: boolean;
+  usePmtRule?: boolean;
   use_pmt_rule?: boolean;
   position?: 'above' | 'below' | string;
+  trafficSourceCode?: string;
   traffic_source_code?: string;
-  private_sizes?: Size[];
+  privateSizes?: Size | Size[];
+  private_sizes?: Size | Size[];
+  supplyType?: string;
   supply_type?: string;
+  pubClick?: string;
   pub_click?: string;
+  extInvCode?: string;
   ext_inv_code?: string;
+  publisherId?: number | string;
   publisher_id?: number | string;
+  externalImpId?: string;
   external_imp_id?: string;
   reserve?: number;
   frameworks?: number[];
   video?: AppnexusVideoParams;
   user?: AppnexusUserParams;
   app?: Record<string, unknown> & { id?: string };
+  keywords?: Record<string, string | number | Array<string | number>>;
 }
 
 declare module '../src/adUnits' {

--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -40,6 +40,8 @@ import { getAdUnitElement } from '../src/utils/adUnits.js';
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
  * @typedef {import('../src/adapters/bidderFactory.js').Bid} Bid
+ * @typedef {import('./appnexusBidAdapter.d.ts').AppnexusBidderParams} AppnexusBidderParams
+ * @typedef {BidRequest & {params: AppnexusBidderParams}} AppnexusBidRequest
  */
 
 const BIDDER_CODE = 'appnexus';
@@ -132,7 +134,7 @@ export const spec = {
   /**
    * Determines whether or not the given bid request is valid.
    *
-   * @param {object} bid The bid to validate.
+   * @param {AppnexusBidRequest} bid The bid to validate.
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: function (bid) {

--- a/modules/ixBidAdapter.d.ts
+++ b/modules/ixBidAdapter.d.ts
@@ -1,0 +1,31 @@
+import type { Size } from '../src/types/common.d.ts';
+
+export interface IxMediaParams {
+  siteId?: number | string;
+  [key: string]: unknown;
+}
+
+export interface IxVideoParams extends IxMediaParams {
+  playerSize?: Size | Size[];
+}
+
+/** Parameters accepted by the Index Exchange bidder adapter. */
+export interface IxBidderParams {
+  /** Required unless `exchangeId` is configured globally. */
+  siteId?: number | string;
+  size?: Size;
+  id?: number | string;
+  tagId?: string;
+  bidFloor?: number;
+  bidFloorCur?: string;
+  externalId?: string;
+  banner?: IxMediaParams;
+  video?: IxVideoParams;
+  native?: IxMediaParams;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    ix: IxBidderParams;
+  }
+}

--- a/modules/ixBidAdapter.js
+++ b/modules/ixBidAdapter.js
@@ -25,6 +25,12 @@ import { Renderer } from '../src/Renderer.js';
 import { getGptSlotInfoForAdUnitCode } from '../libraries/gptUtils/gptUtils.js';
 import { getAdUnitElement } from '../src/utils/adUnits.js';
 
+/**
+ * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
+ * @typedef {import('./ixBidAdapter.d.ts').IxBidderParams} IxBidderParams
+ * @typedef {BidRequest & {params: IxBidderParams}} IxBidRequest
+ */
+
 const divIdCache = {};
 
 export function getDivIdFromAdUnit(adUnitCode, target) {
@@ -1575,7 +1581,7 @@ export const spec = {
   /**
    * Determines whether or not the given bid request is valid.
    *
-   * @param  {object}  bid The bid to validate.
+   * @param  {IxBidRequest}  bid The bid to validate.
    * @return {boolean}     True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: function (bid) {

--- a/modules/rubiconBidAdapter.d.ts
+++ b/modules/rubiconBidAdapter.d.ts
@@ -1,0 +1,36 @@
+import type { Size } from '../src/types/common.d.ts';
+
+export interface RubiconVideoParams {
+  playerWidth?: number;
+  playerHeight?: number;
+  size_id?: number;
+  language?: string;
+  [key: string]: unknown;
+}
+
+/** Parameters accepted by the Rubicon bidder adapter. */
+export interface RubiconBidderParams {
+  accountId: number | string;
+  siteId: number | string;
+  zoneId: number | string;
+  floor?: number | string;
+  userId?: string;
+  latLong?: [number, number];
+  position?: 'atf' | 'btf';
+  keywords?: string | string[];
+  visitor?: Record<string, unknown>;
+  inventory?: Record<string, unknown>;
+  video?: RubiconVideoParams;
+  sizes?: Size[];
+  playerWidth?: number;
+  playerHeight?: number;
+  bidonmultiformat?: boolean;
+  referrer?: string;
+  secure?: boolean;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    rubicon: RubiconBidderParams;
+  }
+}

--- a/modules/rubiconBidAdapter.d.ts
+++ b/modules/rubiconBidAdapter.d.ts
@@ -13,7 +13,7 @@ export interface RubiconBidderParams {
   zoneId: number | string;
   floor?: number | string;
   userId?: string;
-  latLong?: [number, number];
+  latLong?: [number | string, number | string];
   position?: 'atf' | 'btf';
   keywords?: string | string[];
   visitor?: Record<string, unknown>;

--- a/modules/rubiconBidAdapter.d.ts
+++ b/modules/rubiconBidAdapter.d.ts
@@ -1,5 +1,3 @@
-import type { Size } from '../src/types/common.d.ts';
-
 export interface RubiconVideoParams {
   playerWidth?: number;
   playerHeight?: number;
@@ -21,7 +19,8 @@ export interface RubiconBidderParams {
   visitor?: Record<string, unknown>;
   inventory?: Record<string, unknown>;
   video?: RubiconVideoParams;
-  sizes?: Size[];
+  /** Rubicon size IDs, such as 15 for 300x250 or 57 for 970x250. */
+  sizes?: number[];
   playerWidth?: number;
   playerHeight?: number;
   bidonmultiformat?: boolean;

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -26,6 +26,8 @@ import { outstreamRenderer } from '../libraries/magniteUtils/outstream.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
+ * @typedef {import('./rubiconBidAdapter.d.ts').RubiconBidderParams} RubiconBidderParams
+ * @typedef {BidRequest & {params: RubiconBidderParams}} RubiconBidRequest
  */
 
 const DEFAULT_INTEGRATION = 'pbjs_lite';
@@ -259,7 +261,7 @@ export const spec = {
   gvlid: GVLID,
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
   /**
-   * @param {object} bid
+   * @param {RubiconBidRequest} bid
    * @return boolean
    */
   isBidRequestValid: function (bid) {


### PR DESCRIPTION
All three of these adapters are being replaced but are quite popular. Adding the maintainers as reviewers. who will hopefully pr the newer companion module if necessary.
### Motivation

- Provide public TypeScript declarations for common bidder parameters to improve editor completion and type checking for publishers using AppNexus, Rubicon, and Index Exchange.
- Surface existing adapter `params` shapes in the shared `BidderParams` interface without changing runtime behavior.

