### PR TITLE
Yieldmo Bid Adapter: do not bid on or sync COPPA (child-directed) requests

### DIFF
--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -18,6 +18,7 @@ import {
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { Renderer } from '../src/Renderer.js';
+import { config } from '../src/config.js';
 import { getDNT } from '../libraries/dnt/index.js';
 
 /**
@@ -69,6 +70,11 @@ export const spec = {
    * @return ServerRequest Info describing the request to the server.
    */
   buildRequests: function (bidRequests, bidderRequest) {
+    // COPPA: Yieldmo does not serve child-directed inventory. When COPPA is set,
+    // discard the request at the adapter — send nothing so we never bid on it.
+    if (config.getConfig('coppa') === true) {
+      return [];
+    }
     const stage = isStage(bidderRequest);
     const bannerUrl = getAdserverUrl(BANNER_PATH, stage);
     const videoUrl = getAdserverUrl(VIDEO_PATH, stage);
@@ -216,6 +222,11 @@ export const spec = {
   },
 
   getUserSyncs: function (syncOptions, serverResponses, gdprConsent = {}, uspConsent = '') {
+    // COPPA: Yieldmo does not serve or track child-directed inventory —
+    // suppress cookie-sync pixels on COPPA traffic, mirroring the bid discard.
+    if (config.getConfig('coppa') === true) {
+      return [];
+    }
     const syncs = [];
     const gdprFlag = `&gdpr=${gdprConsent.gdprApplies ? 1 : 0}`;
     const gdprString = `&gdpr_consent=${encodeURIComponent((gdprConsent.consentString || ''))}`;

--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -18,7 +18,7 @@ import {
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { Renderer } from '../src/Renderer.js';
-import { config } from '../src/config.js';
+import { coppaDataHandler } from '../src/consentHandler.js';
 import { getDNT } from '../libraries/dnt/index.js';
 
 /**
@@ -70,9 +70,10 @@ export const spec = {
    * @return ServerRequest Info describing the request to the server.
    */
   buildRequests: function (bidRequests, bidderRequest) {
-    // COPPA: Yieldmo does not serve child-directed inventory. When COPPA is set,
-    // discard the request at the adapter — send nothing so we never bid on it.
-    if (config.getConfig('coppa') === true) {
+    // COPPA: Yieldmo does not serve child-directed inventory. When COPPA is
+    // enabled, discard the request at the adapter — send nothing so we never bid
+    // on it. Use coppaDataHandler so the numeric core flag (coppa: 1) counts too.
+    if (coppaDataHandler.getCoppa()) {
       return [];
     }
     const stage = isStage(bidderRequest);
@@ -224,7 +225,8 @@ export const spec = {
   getUserSyncs: function (syncOptions, serverResponses, gdprConsent = {}, uspConsent = '') {
     // COPPA: Yieldmo does not serve or track child-directed inventory —
     // suppress cookie-sync pixels on COPPA traffic, mirroring the bid discard.
-    if (config.getConfig('coppa') === true) {
+    // Use coppaDataHandler so the numeric core flag (coppa: 1) counts too.
+    if (coppaDataHandler.getCoppa()) {
       return [];
     }
     const syncs = [];

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -485,6 +485,16 @@ describe('YieldmoAdapter', function () {
         }
       });
 
+      it('should discard the request when coppa is set to the numeric flag (coppa: 1)', function () {
+        config.setConfig({ coppa: 1 });
+        try {
+          expect(build([mockBannerBid()])).to.deep.equal([]);
+          expect(build([mockVideoBid()], mockBidderRequest({}, [mockVideoBid()]))).to.deep.equal([]);
+        } finally {
+          config.resetConfig();
+        }
+      });
+
       it('should add eids to the banner bid request', function () {
         const params = {
           userIdAsEids: [{
@@ -1084,6 +1094,15 @@ describe('YieldmoAdapter', function () {
     });
     it('should register no syncs on COPPA (child-directed) traffic', function () {
       config.setConfig({ coppa: true });
+      try {
+        expect(spec.getUserSyncs({ iframeEnabled: true })).to.deep.equal([]);
+        expect(spec.getUserSyncs({ pixelEnabled: true })).to.deep.equal([]);
+      } finally {
+        config.resetConfig();
+      }
+    });
+    it('should register no syncs when coppa is set to the numeric flag (coppa: 1)', function () {
+      config.setConfig({ coppa: 1 });
       try {
         expect(spec.getUserSyncs({ iframeEnabled: true })).to.deep.equal([]);
         expect(spec.getUserSyncs({ pixelEnabled: true })).to.deep.equal([]);

--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { spec } from 'modules/yieldmoBidAdapter.js';
 import * as utils from 'src/utils.js';
+import { config } from 'src/config.js';
 
 /* eslint no-console: ["error", { allow: ["log", "warn", "error"] }] */
 // above is used for debugging purposes only
@@ -464,6 +465,24 @@ describe('YieldmoAdapter', function () {
           })
         );
         expect(biddata[0].data.gpc).to.equal('1');
+      });
+
+      it('should discard the banner request entirely when coppa is set', function () {
+        config.setConfig({ coppa: true });
+        try {
+          expect(build([mockBannerBid()])).to.deep.equal([]);
+        } finally {
+          config.resetConfig();
+        }
+      });
+
+      it('should discard the video request entirely when coppa is set', function () {
+        config.setConfig({ coppa: true });
+        try {
+          expect(build([mockVideoBid()], mockBidderRequest({}, [mockVideoBid()]))).to.deep.equal([]);
+        } finally {
+          config.resetConfig();
+        }
       });
 
       it('should add eids to the banner bid request', function () {
@@ -1062,6 +1081,15 @@ describe('YieldmoAdapter', function () {
     });
     it('should register no syncs', function () {
       expect(spec.getUserSyncs({})).to.deep.equal([]);
+    });
+    it('should register no syncs on COPPA (child-directed) traffic', function () {
+      config.setConfig({ coppa: true });
+      try {
+        expect(spec.getUserSyncs({ iframeEnabled: true })).to.deep.equal([]);
+        expect(spec.getUserSyncs({ pixelEnabled: true })).to.deep.equal([]);
+      } finally {
+        config.resetConfig();
+      }
     });
   });
 });


### PR DESCRIPTION
## Type of change

- [x] Feature
- [x] Updated bidder adapter

## Description of change

When COPPA is enabled (`config.getConfig('coppa') === true`), the Yieldmo adapter now short-circuits both entry points:

- **`buildRequests`** returns `[]` — no bid request is sent, so the adapter does not bid on child-directed inventory (covers banner and video via one guard).
- **`getUserSyncs`** returns `[]` — no cookie-sync pixel is registered on COPPA traffic (same approach as `improvedigitalBidAdapter` and `newspassidBidAdapter`).

Rationale: the Yieldmo exchange does not serve child-directed inventory, so on COPPA requests the adapter declines to participate entirely — no bid, no user sync, no identifiers set — rather than forwarding the flag downstream. COPPA is read via `config.getConfig('coppa')`, consistent with the documented adapter convention.

No new bidder params and no change to the request/response shape for non-COPPA traffic, so no docs PR is required.

Tests: added coverage for banner + video request discard and user-sync suppression under COPPA. `gulp test --file test/spec/modules/yieldmoBidAdapter_spec.js` → 92 passing; `gulp lint` clean.

## Other information

Scoped to a single change (COPPA handling in the Yieldmo adapter).
