### PR TITLE
CI: name the modules that cannot be mapped to metadata

### DIFF
--- a/.github/workflows/adapter-naming.yml
+++ b/.github/workflows/adapter-naming.yml
@@ -18,12 +18,40 @@ jobs:
       - name: Update metadata
         id: update
         continue-on-error: true
+        env:
+          METADATA_ERROR_REPORT: ${{ runner.temp }}/metadata-errors.md
         run: |
           npx gulp update-metadata --no-fetch
       - name: Adapter code does not match file name
         if: ${{ steps.update.outcome != 'success' }}
-        run: |
-          echo '{"issue_number": ${{ github.event.pull_request.number }}, "body": "This PR includes an adapter whose code does not match its file name. Bid adapter modules should be named `<bidderCode>BidAdapter`, userId `<userIdCode>IdSystem`, RTD `<rtdCode>RtdProvider`, and analytics `<analyticsCode>AnalyticsAdapter`."}' > ${{ runner.temp }}/comment.json
+        uses: actions/github-script@v9
+        id: naming
+        env:
+          METADATA_ERROR_REPORT: ${{ runner.temp }}/metadata-errors.md
+        with:
+          result-encoding: string
+          script: |
+            const fs = require('fs');
+            // the report exists only when metadata compilation failed on module <-> component mapping;
+            // any other failure (build, GVL IDs, purpose declarations) is not a naming problem
+            let details;
+            try {
+              details = fs.readFileSync(process.env.METADATA_ERROR_REPORT).toString().trim();
+            } catch (e) {
+              details = null;
+            }
+            if (!details) {
+              return 'false';
+            }
+            fs.writeFileSync('${{ runner.temp }}/comment.json', JSON.stringify({
+              issue_number: ${{ github.event.pull_request.number }},
+              body: [
+                'This PR includes an adapter whose code does not match its file name. Bid adapter modules should be named `<bidderCode>BidAdapter`, userId `<userIdCode>IdSystem`, RTD `<rtdCode>RtdProvider`, and analytics `<analyticsCode>AnalyticsAdapter`.',
+                '',
+                details
+              ].join('\n')
+            }));
+            return 'true';
       - name: Calculate diff
         if: ${{ steps.update.outcome == 'success' }}
         run: |
@@ -53,7 +81,7 @@ jobs:
             return 'false';
 
       - name: Upload comment data
-        if: ${{ steps.update.outcome != 'success' || steps.check.outputs.result == 'true' }}
+        if: ${{ steps.naming.outputs.result == 'true' || steps.check.outputs.result == 'true' }}
         uses: actions/upload-artifact@v7
         with:
           name: comment

--- a/metadata/compileMetadata.mjs
+++ b/metadata/compileMetadata.mjs
@@ -178,14 +178,66 @@ async function validateGvlIds() {
   }
 }
 
+// The mapping error reporting below was written by Claude, an AI bot.
+
+/**
+ * Describes, in markdown, the modules and components that could not be matched to each other.
+ */
+export function formatMappingErrors({unmatched, ambiguous, orphaned}) {
+  const sections = [];
+
+  function declaration({componentType, componentName, aliasOf}) {
+    return `${componentType} ${aliasOf ? 'alias' : 'code'} \`${componentName}\``;
+  }
+
+  if (unmatched.length > 0) {
+    sections.push(
+      ['The following modules do not define a component that matches their file name:']
+        .concat(unmatched.map(({moduleName, componentType, expectedName}) =>
+          ` * \`${moduleName}\` should define ${componentType} code \`${expectedName}\``))
+        .join('\n')
+    );
+  }
+  if (ambiguous.length > 0) {
+    sections.push(
+      ['The following modules match more than one component:']
+        .concat(ambiguous.map(({moduleName, names}) =>
+          ` * \`${moduleName}\` matches ${names.map(name => `\`${name}\``).join(', ')}`))
+        .join('\n')
+    );
+  }
+  if (orphaned.length > 0) {
+    sections.push(
+      ['The following components are not defined by any module file:']
+        .concat(orphaned.map(component => ` * ${declaration(component)}`))
+        .join('\n')
+    );
+  }
+  return sections.join('\n\n');
+}
+
+/**
+ * When `METADATA_ERROR_REPORT` is set (as it is in CI), save the report there so that it can be
+ * quoted back to the contributor.
+ */
+function saveErrorReport(report) {
+  const dest = process.env.METADATA_ERROR_REPORT;
+  if (dest) {
+    fs.writeFileSync(dest, report);
+  }
+}
+
 async function compileModuleMetadata(fetch = true) {
   const processed = [];
   const found = new WeakSet();
-  let err = false;
+  const unmatched = [];
+  const ambiguous = [];
   for (const moduleName of helpers.getModuleNames()) {
-    let predicate;
+    let predicate, componentType, expectedName;
     for (const [suffix, moduleType] of Object.entries(modules)) {
       if (moduleName.endsWith(suffix)) {
+        componentType = moduleType;
+        expectedName = overrides[moduleName] ?? moduleName.slice(0, -suffix.length);
         predicate = overrides.hasOwnProperty(moduleName)
           ? ({componentName, aliasOf}) => componentName === overrides[moduleName] || aliasOf === overrides[moduleName]
           : matches(moduleName, suffix);
@@ -198,11 +250,9 @@ async function compileModuleMetadata(fetch = true) {
       meta.forEach((entry) => found.add(entry));
       const names = new Set(meta.map(({componentName, aliasOf}) => aliasOf ?? componentName));
       if (names.size === 0) {
-        console.error('Cannot determine module name for module file: ', moduleName);
-        err = true;
+        unmatched.push({moduleName, componentType, expectedName});
       } else if (names.size > 1) {
-        console.error('More than one module name matches module file:', moduleName, names);
-        err = true;
+        ambiguous.push({moduleName, names: Array.from(names)});
       } else {
         await updateModuleMetadata(moduleName, meta, fetch);
         processed.push(moduleName);
@@ -210,13 +260,12 @@ async function compileModuleMetadata(fetch = true) {
     }
   }
 
-  const notFound = moduleMetadata.components.filter(entry => !found.has(entry));
-  if (notFound.length > 0) {
-    console.error('Could not find module name for metadata', notFound);
-    err = true;
-  }
+  const orphaned = moduleMetadata.components.filter(entry => !found.has(entry));
 
-  if (err) {
+  if (unmatched.length + ambiguous.length + orphaned.length > 0) {
+    const report = formatMappingErrors({unmatched, ambiguous, orphaned});
+    console.error(report);
+    saveErrorReport(report);
     throw new Error('Could not compile module metadata');
   }
   return processed;


### PR DESCRIPTION
## Type of change

- [x] CI related changes
- [x] Refactoring (no functional changes, no api changes)

## Description of change

When `gulp update-metadata` cannot map a module file to the components it defines, the `adapter-naming.yml` workflow posts [a comment like this one](https://github.com/prebid/Prebid.js/pull/15137#issuecomment-5011109635). The comment cannot say *which* file is at fault: the failure was reported by three separate `console.error` calls buried in several hundred lines of `update-metadata` output, and the workflow had nothing structured to quote back.

`compileModuleMetadata` now collects the three mapping failures instead of logging them ad hoc — a module that matches no component, a module that matches more than one, and a component that belongs to no module file (`metadata/compileMetadata.mjs:265`). They are rendered into a single markdown report by `formatMappingErrors` (`metadata/compileMetadata.mjs:186`), printed as before, and additionally written to the path in `METADATA_ERROR_REPORT` when that variable is set (`metadata/compileMetadata.mjs:223`).

The workflow sets that variable (`.github/workflows/adapter-naming.yml:22`) and appends the report to the comment body. Example of the resulting comment:

> This PR includes an adapter whose code does not match its file name. Bid adapter modules should be named `<bidderCode>BidAdapter`, userId `<userIdCode>IdSystem`, RTD `<rtdCode>RtdProvider`, and analytics `<analyticsCode>AnalyticsAdapter`.
>
> The following modules do not define a component that matches their file name:
> * `zzzunmatchedBidAdapter` should define bidder code `zzzunmatched`
>
> The following modules match more than one component:
> * `zzzambigBidAdapter` matches `zzzambig`, `zzzambigbid`
>
> The following components are not defined by any module file:
> * bidder code `zzzorphan`
> * bidder alias `zzzorphanalias`

The comment is also gated on the report being present (`.github/workflows/adapter-naming.yml:84`), so an `update-metadata` failure that has nothing to do with naming — a broken build, an invalid GVL ID, an out-of-spec purpose declaration — no longer produces a misleading complaint about adapter file names. Such a failure now leaves no comment at all; `continue-on-error: true` was already keeping it from failing the check.

Building the comment JSON moved from a shell `echo` of a JSON literal to `actions/github-script`, since the multi-line report cannot be interpolated safely into the former.

## Testing

No automated tests: `metadata/` has no existing spec coverage and is excluded from eslint, so the change was verified by hand.

All three failure modes were reproduced in one `npx gulp compile-metadata --no-fetch` run, with temporary fixtures for each: a module file defining no matching component, a module file matching two component names, and two components (one code, one alias) with no module file. Each produced the corresponding section shown above, both on stderr and in the report file, and the task still errored with `Could not compile module metadata`.

The workflow's comment script was then run against that report file with the `${{ }}` expressions substituted: with the report present it returns `true` and writes the comment shown above; with the report absent it returns `false` and writes no `comment.json`, so the upload step is skipped.

`gulp lint` passes.

## Platform details

node v20, Linux. No runtime code is affected — the change is limited to the metadata build script and the CI workflow.

## Other information

Related: the comment format this improves on was introduced alongside `metadata/validateNaming.mjs`, whose `formatViolationsSummary` handles the other (non-fatal) half of the naming check. No documentation PR is needed.

---

This PR description was generated by Claude.
