### PR TITLE
Core: start net timer at request dispatch

### DIFF
--- a/src/adapters/bidderFactory.ts
+++ b/src/adapters/bidderFactory.ts
@@ -454,7 +454,7 @@ export const processBidderRequests = hook('async', function<B extends BidderCode
     // If the adapter code fails, no bids should be added. After all the bids have been added,
     // make sure to call the `requestDone` function so that we're one step closer to calling onCompletion().
     const onSuccess = wrapCallback(function(response, responseObj) {
-      networkDone();
+      networkDone?.();
       try {
         response = JSON.parse(response);
       } catch (e) { /* response might not be JSON... that's ok. */ }
@@ -502,14 +502,14 @@ export const processBidderRequests = hook('async', function<B extends BidderCode
     });
 
     const onFailure = wrapCallback(function (errorMessage, error) {
-      networkDone();
+      networkDone?.();
       onError(errorMessage, error);
       requestDone();
     });
 
     onRequest(request);
 
-    const networkDone = requestMetrics.startTiming('net');
+    let networkDone;
 
     const debugMode = getParameterByName(DEBUG_MODE).toUpperCase() === 'TRUE' || debugTurnedOn();
 
@@ -517,14 +517,24 @@ export const processBidderRequests = hook('async', function<B extends BidderCode
       return Object.assign(defaults, request.options);
     }
 
+    // start network timer here so we do not include the compression time in `net` metric
+    const doAjax = (url: string, payload: string | undefined, options: AjaxOptions) => {
+      networkDone = requestMetrics.startTiming('net');
+      ajax(
+        url,
+        {
+          success: onSuccess,
+          error: onFailure
+        },
+        payload,
+        options
+      );
+    };
+
     switch (request.method) {
       case 'GET':
-        ajax(
+        doAjax(
           `${request.url}${formatGetParameters(request.data)}`,
-          {
-            success: onSuccess,
-            error: onFailure
-          },
           undefined,
           getOptions({
             method: 'GET',
@@ -535,12 +545,8 @@ export const processBidderRequests = hook('async', function<B extends BidderCode
       case 'POST':
         const enableGZipCompression = request.options?.endpointCompression;
         const callAjax = ({ url, payload }) => {
-          ajax(
+          doAjax(
             url,
-            {
-              success: onSuccess,
-              error: onFailure
-            },
             payload,
             getOptions({
               method: 'POST',

--- a/src/adapters/bidderFactory.ts
+++ b/src/adapters/bidderFactory.ts
@@ -518,7 +518,7 @@ export const processBidderRequests = hook('async', function<B extends BidderCode
     }
 
     // start network timer here so we do not include the compression time in `net` metric
-    const doAjax = (url: string, payload: string | undefined, options: AjaxOptions) => {
+    const doAjax = (url: string, payload: unknown, options: AjaxOptions) => {
       networkDone = requestMetrics.startTiming('net');
       ajax(
         url,

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -16,6 +16,7 @@ import * as activityRules from 'src/activities/rules.js';
 import { MODULE_TYPE_BIDDER } from '../../../../src/activities/modules.js';
 import { ACTIVITY_TRANSMIT_TID } from '../../../../src/activities/activities.js';
 import { getGlobal } from '../../../../src/prebidGlobal.js';
+import { metricsFactory } from '../../../../src/utils/perfMetrics.js';
 
 const CODE = 'sampleBidder';
 const MOCK_BIDS_REQUEST = {
@@ -1739,7 +1740,7 @@ describe('bidderFactory', () => {
       getGlobal().bidderSettings = origBS;
     });
 
-    function runRequest() {
+    function runRequest(bidderRequest = MOCK_BIDS_REQUEST) {
       return new Promise((resolve, reject) => {
         spec.isBidRequestValid.returns(true);
         spec.buildRequests.returns({
@@ -1750,7 +1751,7 @@ describe('bidderFactory', () => {
             endpointCompression
           }
         });
-        bidder.callBids(MOCK_BIDS_REQUEST, addBidResponseStub, () => {
+        bidder.callBids(bidderRequest, addBidResponseStub, () => {
           resolve();
         }, ajaxStub, onTimelyResponseStub, wrappedCallback);
       });
@@ -1804,6 +1805,32 @@ describe('bidderFactory', () => {
       expect(ajaxStub.calledOnce).to.be.true;
       expect(ajaxStub.firstCall.args[0]).to.not.include('gzip=1');
       expect(ajaxStub.firstCall.args[2]).to.equal(JSON.stringify(data));
+    });
+
+    it('should not count compression time as network time', async () => {
+      const COMPRESSION_MS = 100;
+      isGzipSupportedStub.returns(true);
+      getParameterByNameStub.withArgs(DEBUG_MODE).returns('false');
+      debugTurnedOnStub.returns(false);
+
+      // Drive the metrics clock manually so the timings are exact rather than wall-clock dependent.
+      let clock = 0;
+      const metrics = metricsFactory({ now: () => clock })();
+      // Charge all of the elapsed time to compression: the clock only moves while gzip is pending.
+      gzipStub.returns(Promise.resolve().then(() => {
+        clock += COMPRESSION_MS;
+        return 'compressedData';
+      }));
+
+      await runRequest(Object.assign({ metrics }, MOCK_BIDS_REQUEST));
+
+      expect(gzipStub.calledOnce).to.be.true;
+      const recorded = metrics.getMetrics();
+      // `net` is recorded on a forked metrics node, so it propagates up as a group (array).
+      // It starts at dispatch, after the clock has already advanced, so it sees none of the delay.
+      expect(recorded['adapter.client.net']).to.eql([0]);
+      // `total` spans compression, so it is the timer that should account for the delay.
+      expect(recorded['adapter.client.total']).to.equal(COMPRESSION_MS);
     });
   });
 });


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description

The `adapter.<code>.net` timer is started synchronously in `processBidderRequests`, before the `switch (request.method)` that dispatches the request. On the `endpointCompression` path, dispatch is deferred into a `.then()`, so everything between those two points is charged to `net`:

- `JSON.stringify` of the request payload
- `TextEncoder.encode`
- the `CompressionStream('gzip')` work (Blob → stream → Response → arrayBuffer)
- at least one microtask turn of event-loop deferral, plus however long that continuation waits behind already-queued work on a contended main thread

Since `adapter.<code>.total` also spans compression, `total − net` — the natural way to isolate non-network cost — cannot see it either:

| Timer | Includes compression? |
|---|---|
| `adapter.<code>.total` | yes |
| `adapter.<code>.net` | yes |
| `total − net` | cannot see it |

Two consequences:

1. The cost of `endpointCompression` is not measurable from Prebid's own metrics.
2. The uncompressed path dispatches synchronously, so `net` is an honest network measurement there. Enabling `endpointCompression` silently changes what `net` means, which breaks comparability between the two paths — that makes A/B measurement of the feature invalid regardless of compression's absolute cost.

This moves `startTiming('net')` into a small `doAjax` helper that both the GET and POST paths route through, so the timer starts at actual dispatch and `net` means the same thing everywhere. `networkDone` becomes `let` and is called as `networkDone?.()`, since it is now assigned at dispatch rather than before the switch.

No behavior change other than the timing boundary. `getOptions()` is still evaluated at the same point in program order, and `networkDone` remains per-request scoped inside `requests.forEach`.

### Note for anyone trending this metric

This changes the value reported as network latency for gzip-enabled bidders — e.g. `magniteAnalyticsAdapter` sets `httpLatencyMillis` from `adapter.<code>.net`. That is the point of the fix, but it is a discontinuity in reported numbers worth knowing about before/after upgrade.

## Other information

Added a regression test that fails without the source change. It injects a fake clock into `metricsFactory` and advances it only while `compressDataWithGZip` is pending, so the assertions are exact rather than wall-clock dependent. On unpatched code `net` measures the full injected compression span (`[100]`); with the fix it is `[0]` while `total` correctly reports `100`.

- `npx eslint src/adapters/bidderFactory.ts test/spec/unit/core/bidderFactory_spec.js` — clean.
- `npx gulp test --file test/spec/unit/core/bidderFactory_spec.js` — 81 passing.
- `npx gulp test --file test/spec/modules/magniteAnalyticsAdapter_spec.js` — 99 passing (consumes `net`).
