### PR TITLE
Microsoft Bid Adapter: move Project Agora alias from AppNexus

### DIFF
--- a/libraries/appnexusUtils/anUtils.js
+++ b/libraries/appnexusUtils/anUtils.js
@@ -19,7 +19,6 @@ export const appnexusAliases = [
   { code: 'featureforward', gvlid: 32 },
   { code: 'adasta', gvlid: 32 },
   { code: 'beintoo', gvlid: 618 },
-  { code: 'projectagora', gvlid: 1032 },
   { code: 'stailamedia', gvlid: 32 },
   { code: 'uol', gvlid: 32 },
   { code: 'adzymic', gvlid: 723 },

--- a/modules/msftBidAdapter.js
+++ b/modules/msftBidAdapter.js
@@ -319,7 +319,7 @@ export const spec = {
     { code: 'oftmedia', gvlid: 32 },
     { code: 'msftstaila', gvlid: 32 },
     { code: 'projectagora', gvlid: 1032 }
-  ], // TODO fill in after full transition or as seperately requested
+  ], // TODO fill in after full transition or as separately requested
   supportedMediaTypes: [BANNER, NATIVE, VIDEO],
 
   isBidRequestValid: (bid) => {

--- a/modules/msftBidAdapter.js
+++ b/modules/msftBidAdapter.js
@@ -317,7 +317,8 @@ export const spec = {
   gvlid: GVLID,
   aliases: [
     { code: 'oftmedia', gvlid: 32 },
-    { code: 'msftstaila', gvlid: 32 }
+    { code: 'msftstaila', gvlid: 32 },
+    { code: 'projectagora', gvlid: 1032 }
   ], // TODO fill in after full transition or as seperately requested
   supportedMediaTypes: [BANNER, NATIVE, VIDEO],
 

--- a/test/spec/modules/msftBidAdapter_spec.js
+++ b/test/spec/modules/msftBidAdapter_spec.js
@@ -12,10 +12,22 @@ import {
 import {
   deepClone
 } from '../../../src/utils.js';
+import {
+  appnexusAliases
+} from '../../../libraries/appnexusUtils/anUtils.js';
 
 const ENDPOINT_URL_NORMAL = 'https://ib.adnxs.com/openrtb2/prebidjs';
 
 describe('msftBidAdapter', function () {
+  describe('aliases', function () {
+    it('should register Project Agora with Microsoft only', function () {
+      const projectAgoraAlias = { code: 'projectagora', gvlid: 1032 };
+
+      expect(spec.aliases).to.deep.include(projectAgoraAlias);
+      expect(appnexusAliases).to.not.deep.include(projectAgoraAlias);
+    });
+  });
+
   const baseBidRequests = {
     bidder: 'msft',
     adUnitCode: 'adunit-code',


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [x] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Move the existing `projectagora` alias from the deprecated AppNexus bidder adapter to the Microsoft bidder adapter.

- Remove `{ code: 'projectagora', gvlid: 1032 }` from the AppNexus aliases.
- Add `{ code: 'projectagora', gvlid: 1032 }` to the Microsoft aliases.
- Preserve the public bidder code and Project Agora GVL ID.
- Adopt the Microsoft bid parameter contract. Project Agora integrations must use numeric `placement_id`; legacy `placementId` is not supported.

Maintainer contact: [pub_growth@projectagora.com](mailto:pub_growth@projectagora.com)

## Validation

- `npx eslint modules/msftBidAdapter.js libraries/appnexusUtils/anUtils.js --cache --cache-strategy content`
- `npx gulp test --nolint --file test/spec/modules/msftBidAdapter_spec.js`
- `npx gulp test --nolint --file test/spec/modules/appnexusBidAdapter_spec.js`
- `npx gulp build --modules=msftBidAdapter`

All commands passed locally. The focused build contains the `projectagora` alias with GVL ID `1032` in `msftBidAdapter`.

A live bid-response test was not performed because no current test placement was supplied. The documentation value `11111` is an example only.

## Other information

- Documentation PR: https://github.com/prebid/prebid.github.io/pull/6691
- This change is required because the AppNexus bidder adapter is being deprecated in favor of Microsoft.
- Project Agora can coordinate confirmation of the Microsoft alias relationship if requested during review.

<details>
<summary>Associated issue context</summary>

## Type of issue

Updated bidder adapter / maintenance.

## Description

Project Agora currently aliases AppNexus. Move the unchanged `projectagora` bidder code to Microsoft before AppNexus deprecation.

## Steps to reproduce

Not a bug reproduction. Inspect the current adapter alias lists.

## Test page

No live test page or verified test placement is currently available.

### Expected results

`projectagora` is registered by `msftBidAdapter` with GVL ID `1032` and accepts the Microsoft `placement_id` parameter.

### Actual results

`projectagora` is currently registered by `appnexusBidAdapter` and documented with the legacy `placementId` parameter.

## Platform details

- Prebid.js `master`
- Node.js 22.23.1
- npm 10.9.8
- Chrome Headless 151 on Fedora Linux 44

## Other information

Related documentation PR: https://github.com/prebid/prebid.github.io/pull/6691

</details>
