### PR TITLE
CI: classify PR files as core by component ownership

### DIFF
--- a/.github/workflows/scripts/coreFiles.js
+++ b/.github/workflows/scripts/coreFiles.js
@@ -217,10 +217,17 @@ function coreFileMatcher({
   }
 
   function isCoreLibrary(library) {
+    const users = usersOf(library);
     // a library a core module depends on is core whatever its name suggests - `timeoutQueue` reads as
     // an extension of the `timeout` rtd component, but core modules use it
-    if (usersOf(library).some(isCoreModule)) {
+    if (users.some(isCoreModule)) {
       return true;
+    }
+    // a single consumer owns the library outright; this is how a vendor library added together with
+    // its adapter is recognized, before any component of that vendor is registered. It becomes core
+    // as soon as a second module picks it up.
+    if (users.length === 1) {
+      return false;
     }
     return !vendorLibraries.includes(library) && !belongsToVendor(library);
   }

--- a/.github/workflows/scripts/coreFiles.js
+++ b/.github/workflows/scripts/coreFiles.js
@@ -8,6 +8,8 @@
  *
  * This file doubles as a CLI - see `usage` at the bottom - so that the classification can be run over
  * an arbitrary list of files.
+ *
+ * This file was written by a bot (Claude Code).
  */
 
 const fs = require('fs');
@@ -51,6 +53,24 @@ const MIN_VENDOR_NAME_LENGTH = 3;
 // Giving them metadata is the way to take them off this list.
 const VENDOR_MODULES = [
   'seenthisBrandStories'
+];
+
+// Libraries that belong to a vendor - typically a white label serving several brands - but whose name
+// does not begin with any registered component name, either because the vendor's own brand is not a
+// component (`teqblaze`, `vizionik`) or because its components are registered under a longer name
+// (`intentIqId`, `advangelists`). Everything else under libraries/ is taken to be shared code.
+const VENDOR_LIBRARIES = [
+  'advangUtils',
+  'agenticxUtils',
+  'audUtils',
+  'dxUtils',
+  'intentIqConstants',
+  'intentIqUtils',
+  'pageInfosUtils',
+  'teqblazeUtils',
+  'utiqUtils',
+  'vizionikUtils',
+  'xeUtils'
 ];
 
 /**
@@ -139,7 +159,10 @@ function vendorNamePrefix({components} = {}) {
 /**
  * Core is what is not owned by an outside component: a module is core if it declares no component
  * (or has no metadata at all), or if every component it declares is a `prebid` one; a library is core
- * if it's pulled in by a core module - which includes prebid-core itself.
+ * if a core module pulls it in - prebid-core included - or, failing that, if it does not belong to a
+ * vendor. Libraries default to core because most of them are shared code that happens to be used only
+ * by vendor modules, and because a library extracted tomorrow should be reviewed until someone says
+ * otherwise; the vendor ones are recognizable by name.
  *
  * @param {object} [options]
  * @param {object} [options.dependencies] dependency graph, as loaded from dependencies.json.
@@ -147,8 +170,7 @@ function vendorNamePrefix({components} = {}) {
  * @param {Array<object>} [options.components] the component registry, as found in metadata/modules.json.
  * @param {Array<string>} [options.vendorModules] modules known to belong to a vendor, for the ones no
  * naming convention can pick out.
- * @param {boolean} [options.unknownLibrariesAreCore] how to classify a library that no entry point
- * pulls in - it has no known owner, so by default it's assumed to be core.
+ * @param {Array<string>} [options.vendorLibraries] libraries known to belong to a vendor, likewise.
  * @param {string} [options.missingMetadata] how to classify a module that has no metadata file at all.
  * Metadata is generated separately from the module it describes, so a newly added module does not have
  * any yet; `by-name` (the default) falls back to the naming conventions - a module named `<vendor>BidAdapter`
@@ -161,7 +183,7 @@ function coreFileMatcher({
   metadataDir,
   components,
   vendorModules = VENDOR_MODULES,
-  unknownLibrariesAreCore = true,
+  vendorLibraries = VENDOR_LIBRARIES,
   missingMetadata = 'by-name'
 } = {}) {
   const componentsOf = moduleComponents({metadataDir});
@@ -194,6 +216,15 @@ function coreFileMatcher({
     return libraryUsers[library];
   }
 
+  function isCoreLibrary(library) {
+    // a library a core module depends on is core whatever its name suggests - `timeoutQueue` reads as
+    // an extension of the `timeout` rtd component, but core modules use it
+    if (usersOf(library).some(isCoreModule)) {
+      return true;
+    }
+    return !vendorLibraries.includes(library) && !belongsToVendor(library);
+  }
+
   return function isCoreFile(path) {
     if (EXCLUDE_PATTERNS.find(pat => pat.test(path))) {
       return false;
@@ -204,8 +235,7 @@ function coreFileMatcher({
     }
     const lib = LIBRARY_PATTERN.exec(path);
     if (lib != null) {
-      const users = usersOf(lib[1]);
-      return users.length === 0 ? unknownLibrariesAreCore : users.some(isCoreModule);
+      return isCoreLibrary(lib[1]);
     }
     return true;
   };
@@ -217,6 +247,7 @@ module.exports = {
   EXCLUDE_PATTERNS,
   LIBRARY_PATTERN,
   VENDOR_MODULES,
+  VENDOR_LIBRARIES,
   loadDependencies,
   moduleName,
   entryModule,

--- a/.github/workflows/scripts/coreFiles.js
+++ b/.github/workflows/scripts/coreFiles.js
@@ -1,0 +1,316 @@
+/**
+ * Decides whether a given repository file counts as a "core" change.
+ *
+ * A "core" PR needs more scrutiny than a module PR (see `reviewRequirements` in getPRProperties.js),
+ * so the goal is to classify as core only the files that are not owned by an outside vendor: a module
+ * is core when it declares no component of its own (or only `prebid` ones), and a library is core when
+ * a core module pulls it in.
+ *
+ * This file doubles as a CLI - see `usage` at the bottom - so that the classification can be run over
+ * an arbitrary list of files.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const MODULE_PATTERNS = [
+  /^modules\/([^\/]+)BidAdapter(\.(\w+)|\/)/,
+  /^modules\/([^\/]+)AnalyticsAdapter(\.(\w+)|\/)/,
+  /^modules\/([^\/]+)RtdProvider(\.(\w+)|\/)/,
+  /^modules\/([^\/]+)IdSystem(\.(\w+)|\/)/,
+  // a video provider is an integration with a particular player, so it always belongs to its vendor
+  /^modules\/([^\/]+)VideoProvider(\.(\w+)|\/)/
+];
+
+const EXCLUDE_PATTERNS = [
+  /^test\//,
+  /^integrationExamples\//,
+  /^[^\/]+$/,
+  /^.github\//,
+  // registries and per-module data that every new module has to touch; a change here is about the
+  // module being registered, not about the file itself
+  /^metadata\/modules\.json$/,
+  /^metadata\/disclosures\/modules\//,
+  /^modules\/\.submodules\.json$/,
+];
+
+const LIBRARY_PATTERN = /^libraries\/([^\/]+)\//;
+const MODULE_FILE_PATTERN = /^modules\/([^\/.]+)/;
+const MODULE_METADATA_PATTERN = /^metadata\/modules\/([^\/.]+)\.json$/;
+
+const REPO_ROOT = path.join(__dirname, '..', '..', '..');
+const DEFAULT_DEPENDENCIES_JSON = path.join(REPO_ROOT, 'build', 'dist', 'dependencies.json');
+const DEFAULT_METADATA_DIR = path.join(REPO_ROOT, 'metadata', 'modules');
+const DEFAULT_COMPONENTS_JSON = path.join(REPO_ROOT, 'metadata', 'modules.json');
+
+// shortest name that is distinctive enough to identify a vendor by itself
+const MIN_VENDOR_NAME_LENGTH = 3;
+
+// Modules that belong to a vendor but carry no sign of it: they declare no component, their name follows
+// none of the module naming conventions, and no component is registered under their vendor's name.
+// Giving them metadata is the way to take them off this list.
+const VENDOR_MODULES = [
+  'seenthisBrandStories'
+];
+
+/**
+ * Loads the dependency graph (entry point -> chunk files) built by webpack's manifest plugin.
+ *
+ * @param {string} [file] path to dependencies.json; defaults to $DEPENDENCIES_JSON, then to the local build output.
+ */
+function loadDependencies(file = process.env.DEPENDENCIES_JSON || DEFAULT_DEPENDENCIES_JSON) {
+  if (!fs.existsSync(file)) {
+    throw new Error(`Cannot find dependency graph '${file}'; run 'gulp build' or set DEPENDENCIES_JSON`);
+  }
+  return JSON.parse(fs.readFileSync(file).toString());
+}
+
+/**
+ * The name of the module a repository file belongs to - the first path element under `modules/`,
+ * without its extension (`modules/foo.js` and `modules/foo/bar/baz.js` both belong to module `foo`),
+ * or the module a metadata file describes (`metadata/modules/foo.json` -> `foo`).
+ *
+ * @returns {string|null} module name, or null if the file does not belong to a module.
+ */
+function moduleName(path) {
+  for (const pat of [MODULE_FILE_PATTERN, MODULE_METADATA_PATTERN]) {
+    const match = pat.exec(path);
+    if (match != null) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
+/**
+ * @param {string} entry name of a dependencies.json entry point (e.g. `appnexusBidAdapter.js` or
+ * `appnexusBidAdapter.metadata.js`)
+ * @returns {string} the module it builds (e.g. `appnexusBidAdapter`).
+ */
+function entryModule(entry) {
+  return entry.replace(/\.js$/, '').replace(/\.metadata$/, '');
+}
+
+/**
+ * Reads the components a module declares in its metadata.
+ *
+ * @param {object} [options]
+ * @param {string} [options.metadataDir] directory containing the per-module metadata JSON.
+ * @returns {function(string): Array<object>|null} module name -> its components, or null if it has no metadata.
+ */
+function moduleComponents({metadataDir = DEFAULT_METADATA_DIR} = {}) {
+  const cache = {};
+  return function (module) {
+    if (!cache.hasOwnProperty(module)) {
+      const file = path.join(metadataDir, `${module}.json`);
+      cache[module] = fs.existsSync(file) ? (JSON.parse(fs.readFileSync(file).toString()).components || []) : null;
+    }
+    return cache[module];
+  };
+}
+
+/**
+ * Tells whether a module name begins with the name of a component registered anywhere in the repo -
+ * `adlooxAdServerVideo` starts with `adloox`, which is registered as an rtd and an analytics component,
+ * so the module belongs to that vendor. The remainder has to start on a camelCase boundary, so that a
+ * component named e.g. `currency` does not make `modules/currency.js` look vendor-owned.
+ *
+ * @param {object} [options]
+ * @param {Array<object>} [options.components] the component registry, as found in metadata/modules.json.
+ * @returns {function(string): boolean} module name -> whether a registered vendor owns it.
+ */
+function vendorNamePrefix({components} = {}) {
+  let names;
+  return function (module) {
+    if (names == null) {
+      const registry = components ?? JSON.parse(fs.readFileSync(DEFAULT_COMPONENTS_JSON).toString()).components;
+      names = Array.from(new Set(
+        registry
+          .filter(component => component.componentType !== 'prebid')
+          .flatMap(component => [component.componentName, component.aliasOf])
+          .filter(name => name != null && name.length >= MIN_VENDOR_NAME_LENGTH)
+          .map(name => name.toLowerCase())
+      ));
+    }
+    return names.some(name => module.toLowerCase().startsWith(name) && /^[A-Z]/.test(module.charAt(name.length)));
+  };
+}
+
+/**
+ * Core is what is not owned by an outside component: a module is core if it declares no component
+ * (or has no metadata at all), or if every component it declares is a `prebid` one; a library is core
+ * if it's pulled in by a core module - which includes prebid-core itself.
+ *
+ * @param {object} [options]
+ * @param {object} [options.dependencies] dependency graph, as loaded from dependencies.json.
+ * @param {string} [options.metadataDir] directory containing the per-module metadata JSON.
+ * @param {Array<object>} [options.components] the component registry, as found in metadata/modules.json.
+ * @param {Array<string>} [options.vendorModules] modules known to belong to a vendor, for the ones no
+ * naming convention can pick out.
+ * @param {boolean} [options.unknownLibrariesAreCore] how to classify a library that no entry point
+ * pulls in - it has no known owner, so by default it's assumed to be core.
+ * @param {string} [options.missingMetadata] how to classify a module that has no metadata file at all.
+ * Metadata is generated separately from the module it describes, so a newly added module does not have
+ * any yet; `by-name` (the default) falls back to the naming conventions - a module named `<vendor>BidAdapter`
+ * & co, or one whose name starts with a registered component name, belongs to a vendor, anything else is
+ * core - while `core` treats them all like a module with no components, and `not-core` keeps them all out.
+ * @returns {function(string): boolean} true if the given path should count as a core change.
+ */
+function coreFileMatcher({
+  dependencies,
+  metadataDir,
+  components,
+  vendorModules = VENDOR_MODULES,
+  unknownLibrariesAreCore = true,
+  missingMetadata = 'by-name'
+} = {}) {
+  const componentsOf = moduleComponents({metadataDir});
+  const belongsToVendor = vendorNamePrefix({components});
+  let deps = dependencies;
+  const libraryUsers = {};
+
+  function isCoreModule(module) {
+    const declared = componentsOf(module);
+    if (declared == null) {
+      switch (missingMetadata) {
+        case 'core': return true;
+        case 'not-core': return false;
+        default: return !vendorModules.includes(module) &&
+          !MODULE_PATTERNS.find(pat => pat.test(`modules/${module}.js`)) &&
+          !belongsToVendor(module);
+      }
+    }
+    return declared.length === 0 ||
+      declared.every(component => component.componentType === 'prebid');
+  }
+
+  function usersOf(library) {
+    if (!libraryUsers.hasOwnProperty(library)) {
+      if (deps == null) deps = loadDependencies();
+      libraryUsers[library] = Object.entries(deps)
+        .filter(([entry, chunks]) => chunks.includes(`${library}.js`))
+        .map(([entry]) => entryModule(entry));
+    }
+    return libraryUsers[library];
+  }
+
+  return function isCoreFile(path) {
+    if (EXCLUDE_PATTERNS.find(pat => pat.test(path))) {
+      return false;
+    }
+    const module = moduleName(path);
+    if (module != null) {
+      return isCoreModule(module);
+    }
+    const lib = LIBRARY_PATTERN.exec(path);
+    if (lib != null) {
+      const users = usersOf(lib[1]);
+      return users.length === 0 ? unknownLibrariesAreCore : users.some(isCoreModule);
+    }
+    return true;
+  };
+}
+
+module.exports = {
+  coreFileMatcher,
+  MODULE_PATTERNS,
+  EXCLUDE_PATTERNS,
+  LIBRARY_PATTERN,
+  VENDOR_MODULES,
+  loadDependencies,
+  moduleName,
+  entryModule,
+  moduleComponents,
+  vendorNamePrefix,
+};
+
+function usage() {
+  return [
+    'Classify repository files as "core" or not, the way PR assignment does.',
+    '',
+    'Usage: node .github/workflows/scripts/coreFiles.js [options] [file...]',
+    '',
+    'Files may also be piped in, one per line, e.g.:',
+    '  gh pr diff --name-only 1234 | node .github/workflows/scripts/coreFiles.js',
+    '',
+    'Options:',
+    '  -d, --deps <file>   path to dependencies.json (default: $DEPENDENCIES_JSON, then build/dist)',
+    '  -o, --option <k=v>  pass an option to the matcher (repeatable; values are JSON when parseable)',
+    '  -c, --core-only     print only the files classified as core',
+    '  -j, --json          print results as JSON',
+    '  -h, --help          show this message',
+    '',
+    'Exit code is 0 if any file is core, 1 otherwise - matching `isCoreChange` in getPRProperties.js.',
+  ].join('\n');
+}
+
+function parseArgs(argv) {
+  const opts = {files: [], options: {}};
+  while (argv.length) {
+    const arg = argv.shift();
+    switch (arg) {
+      case '-d': case '--deps': opts.deps = argv.shift(); break;
+      case '-c': case '--core-only': opts.coreOnly = true; break;
+      case '-j': case '--json': opts.json = true; break;
+      case '-h': case '--help': opts.help = true; break;
+      case '-o': case '--option': {
+        const [key, ...rest] = argv.shift().split('=');
+        const value = rest.join('=');
+        try {
+          opts.options[key] = JSON.parse(value);
+        } catch (e) {
+          opts.options[key] = value;
+        }
+        break;
+      }
+      default: opts.files.push(arg);
+    }
+  }
+  return opts;
+}
+
+function readStdin() {
+  try {
+    return fs.readFileSync(0).toString();
+  } catch (e) {
+    return '';
+  }
+}
+
+function main(argv) {
+  const opts = parseArgs(argv);
+  if (opts.help) {
+    console.log(usage());
+    return 0;
+  }
+  let files = opts.files;
+  if (!files.length && !process.stdin.isTTY) {
+    files = readStdin().split('\n').map(line => line.trim()).filter(Boolean);
+  }
+  if (!files.length) {
+    console.error(usage());
+    return 2;
+  }
+  const isCore = coreFileMatcher(Object.assign(
+    opts.deps ? {dependencies: loadDependencies(opts.deps)} : {},
+    opts.options
+  ));
+  const results = files.map(file => ({file, core: isCore(file)}));
+  if (opts.json) {
+    console.log(JSON.stringify(opts.coreOnly ? results.filter(({core}) => core) : results, null, 2));
+  } else {
+    results
+      .filter(({core}) => core || !opts.coreOnly)
+      .forEach(({file, core}) => console.log(opts.coreOnly ? file : `${core ? 'CORE' : '    '} ${file}`));
+  }
+  return results.some(({core}) => core) ? 0 : 1;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = main(process.argv.slice(2));
+  } catch (e) {
+    console.error(e.message);
+    process.exitCode = 2;
+  }
+}

--- a/.github/workflows/scripts/getPRProperties.js
+++ b/.github/workflows/scripts/getPRProperties.js
@@ -1,61 +1,8 @@
 const ghRequester = require('./ghRequest.js');
 const AWS = require("@aws-sdk/client-s3");
-const fs = require('fs');
+const { coreFileMatcher } = require('./coreFiles.js');
 
-const MODULE_PATTERNS = [
-  /^modules\/([^\/]+)BidAdapter(\.(\w+)|\/)/,
-  /^modules\/([^\/]+)AnalyticsAdapter(\.(\w+)|\/)/,
-  /^modules\/([^\/]+)RtdProvider(\.(\w+)|\/)/,
-  /^modules\/([^\/]+)IdSystem(\.(\w+)|\/)/
-]
-
-const EXCLUDE_PATTERNS = [
-  /^test\//,
-  /^integrationExamples\//,
-  /^[^\/]+$/,
-  /^.github\//,
-]
-
-const LIBRARY_PATTERN = /^libraries\/([^\/]+)\//;
-
-function extractVendor(chunkName) {
-  for (const pat of MODULE_PATTERNS) {
-    const match = pat.exec(`modules/${chunkName}`);
-    if (match != null) {
-      return match[1];
-    }
-  }
-  return chunkName;
-}
-
-const getLibraryRefs = (() => {
-  const deps = JSON.parse(fs.readFileSync(process.env.DEPENDENCIES_JSON).toString());
-  const refs = {};
-  return function (libraryName) {
-    if (!refs.hasOwnProperty(libraryName)) {
-      refs[libraryName] = new Set();
-      Object.entries(deps)
-        .filter(([name, deps]) => deps.includes(`${libraryName}.js`))
-        .forEach(([name]) => refs[libraryName].add(extractVendor(name)))
-    }
-    return refs[libraryName];
-  }
-})();
-
-function isCoreFile(path) {
-  if (EXCLUDE_PATTERNS.find(pat => pat.test(path))) {
-    return false;
-  }
-  if (MODULE_PATTERNS.find(pat => pat.test(path)) ) {
-    return false;
-  }
-  const lib = LIBRARY_PATTERN.exec(path);
-  if (lib != null) {
-    // a library is "core" if it's used by more than one vendor
-    return getLibraryRefs(lib[1]).size > 1;
-  }
-  return true;
-}
+const isCoreFile = coreFileMatcher();
 
 async function isPrebidMember(ghHandle) {
   const client = new AWS.S3({region: 'us-east-2'});


### PR DESCRIPTION
## Type of change

- [x] CI related changes
- [x] Refactoring (no functional changes, no api changes)

## Description of change

`PR-assignment.yml` labels a PR `core` and requires a second Prebid reviewer when any changed file looks like a core file. The rule that decided this lived inline in `getPRProperties.js`: everything counts as core except test/example/top-level/workflow files, modules matching an adapter naming convention, and libraries referenced by a single vendor.

That produces a lot of false positives. It flags the autogenerated per-module metadata under `metadata/modules/`, the vendor-specific `libraries/*Utils` shared between an adapter and its aliases, and the registries (`metadata/modules.json`, `modules/.submodules.json`) that every new module has to touch.

This PR moves the logic into `.github/workflows/scripts/coreFiles.js` and replaces the heuristic with one based on component ownership:

- a **module** is core when its metadata declares no component, or only `prebid` components. Modules with no metadata at all — a newly added module, since metadata is generated separately from the module it describes — fall back to the naming conventions: `<vendor>BidAdapter`, `AnalyticsAdapter`, `RtdProvider`, `IdSystem`, `VideoProvider`, or a name that begins with a component name already registered in `metadata/modules.json` (`adlooxAdServerVideo` → `adloox`). The prefix has to end on a camelCase boundary, so a component named `currency` would not make `modules/currency.js` look vendor-owned.
- a **library** is core when a core module pulls it in, according to the chunk graph in `dependencies.json` — `prebid-core` falls out of this naturally, since its metadata declares only `prebid` components. Failing that, a library with a single consumer is that consumer's own code; otherwise it is core unless it belongs to a vendor. Libraries default to core: most of them are shared code that happens to have only vendor modules as consumers (`ortbConverter`, `dnt`, `sizeUtils`), and a library extracted tomorrow should be reviewed until someone says otherwise. Vendor libraries are recognized by name, the same way metadata-less modules are.
- `metadata/modules.json`, `metadata/disclosures/modules/`, and `modules/.submodules.json` are excluded: a change there is about the module being registered, not about the file itself.

Two constants hold what no convention can pick out. `VENDOR_MODULES` has one entry, `seenthisBrandStories`: vendor-owned, but with no metadata, no conventional name, and no component registered under its vendor's name. `VENDOR_LIBRARIES` has eleven, mostly white labels whose own brand is not a component (`teqblazeUtils`, `vizionikUtils`) or whose components are registered under a longer name than the library (`intentIqUtils` → `intentIqId`, `advangUtils` → `advangelists`). Both lists shrink as the modules involved gain metadata.

`coreFiles.js` also runs as a CLI, so the classification can be checked against any set of files:

```
gh pr diff --name-only 1234 | node .github/workflows/scripts/coreFiles.js
node .github/workflows/scripts/coreFiles.js -c $(git diff --name-only master)
```

## Effect on recent PRs

Measured against the 112 PRs opened or updated in the two weeks to 2026-08-04, using each PR's file list from the GitHub API and a locally built `dependencies.json`.

|                                    | current | this PR |
|------------------------------------|---------|---------|
| PRs flagged core                    | 41      | **25**  |
| distinct files flagged core (of 492)| 150     | **79**  |

No PR is newly flagged as core. 16 stop being flagged:

| PR | title | flagged by |
|----|-------|------------|
| #15441 | Microsoft Bid Adapter: move Project Agora alias from AppNexus | `libraries/appnexusUtils/anUtils.js` |
| #15427 | Copper6SSP Adapter Update: temporary override until GVL 1356 deviceStorageDisclosureUrl is updated | `metadata/modules.json`, `metadata/modules/copper6sspBidAdapter.json` |
| #15400 | Revert "Vidazoo utils: add event callbacks" | `libraries/vidazooUtils/bidderUtils.js` |
| #15392 | Blue Bid Adapter: remove GVL ID | `libraries/blueUtils/bidderUtils.js` |
| #15388 | Nexx360 Analytics Adapter: add analytics adapter | `libraries/nexx360Utils/index.ts` (+3) |
| #15379 | Unicorn RTD Provider: add slot position & viewability module | `modules/.submodules.json` |
| #15374 | New Bid Adapter: Adbix | `metadata/modules/adbixBidAdapter.json` |
| #15360 | Gopl adapter | `metadata/modules.json`, `metadata/modules/goplBidAdapter.json` (+1) |
| #15335 | Vidazoo utils: add event callbacks | `libraries/vidazooUtils/bidderUtils.js` |
| #15319 | Stackup RTD Module: disclose sessionStorage cache keys and fix ortb2 data block merge collapse | `metadata/disclosures/modules/stackupRtdProvider.json` |
| #15315 | Mantis RTD: New RTD Module Added | `modules/.submodules.json` |
| #15297 | precisoBidAdapter-updated | `libraries/precisoUtils/bidUtils.js`, `libraries/precisoUtils/bidUtilsCommon.js` |
| #15296 | AdSmartx Adapter: Rebranded to Agenticx & Added support for audio ads | `libraries/agenticxUtils/bidderUtils.js` |
| #15082 | New Bid Adapter: BidFabrik | `metadata/modules.json`, `metadata/modules/bidfabrikBidAdapter.json` |
| #15006 | MGID Bid Adapter: populate bid request with MGID session props | `libraries/mgidUtils/mgidSessionStorage.ts` |
| #14991 | Copper6 adapter: change utility suite | `libraries/vidazooUtils/bidderUtils.js`, `libraries/vidazooUtils/vidazooTypes.ts` |

The 25 that remain core are the `src/` changes, the build/metadata tooling (`metadata/compileMetadata.mjs`, `customize/`), the prebid-owned modules (`userId`, `rtdModule`, `consentManagement*`, `topicsFpdModule`, `adChoices`, `devtoolsMcp`, `gamAdServerVideo`) and the libraries they use.

## What is flagged core repo-wide

314 of 3772 tracked files, down from 1076. Modules go from 44 to 38; libraries from 76 to 52, but not the same 52 — the ones dropped are vendor-owned, and shared code that no core module happens to use is now kept.

### Modules (38 of 753)

Declaring only `prebid` components (4):

`debugging`, `topicsFpdModule`, `userId`, `validationFpdModule`

<details>
<summary>With no metadata and no vendor name (34)</summary>

`_moduleMetadata`, `adChoices`, `allowActivities`, `bidResponseFilter`, `bidViewability`, `bidViewabilityIO`, `consentManagementGpp`, `consentManagementTcf`, `consentManagementUsp`, `currency`, `dataControllerModule`, `dchain`, `dsaControl`, `enrichmentLiftMeasurement`, `fpdModule`, `gamAdServerVideo`, `gppControl_usnat`, `gppControl_usstates`, `gptPreAuction`, `idImportLibrary`, `instreamTracking`, `multibid`, `nativeRendering`, `previousAuctionInfo`, `priceFloors`, `rtdModule`, `rules`, `s2sTesting`, `schain`, `sizeMapping`, `sizeMappingV2`, `storageControl`, `tcfControl`, `videoModule`

</details>

### Libraries (52 of 103)

Consumer counts in parentheses. 21 of these are core because a core module pulls them in; the other 31 because they have several consumers and nothing marks them as a vendor's.

`analyticsAdapter` (70), `autoplayDetection` (4), `bidViewabilityPixels` (2), `bidderTimeoutUtils` (2), `boundingClientRect` (37), `chunk` (21), `cmp` (3), `connectionInfo` (18), `consentManagement` (4), `cookieSync` (2), `currencyUtils` (8), `dealUtils` (2), `devicePixelRatio` (10), `dfpUtils` (1), `dnt` (47), `domainOverrideToRootDomain` (4), `fingerprinting` (26), `fpdUtils` (7), `gamUtils` (0), `getOrigin` (3), `gptUtils` (29), `greedy` (0), `keywords` (14), `metadata` (714), `mspa` (2), `navigatorData` (4), `objectGuard` (1), `ortb2.5StrictTranslator` (0), `ortb2.5Translator` (5), `ortb2Utils` (31), `ortbConverter` (135), `pbsExtensions` (13), `percentInView` (17), `placementPositionInfo` (4), `processResponse` (2), `purposeDeclarations` (1), `schainSerializer` (2), `sizeUtils` (33), `storageDisclosure` (1), `timeToFirstBytesUtils` (2), `timeoutQueue` (5), `timezone` (14), `transformParamsUtils` (2), `uid1Eids` (2), `urlUtils` (20), `userAgentUtils` (9), `userSyncUtils` (7), `video` (4), `viewport` (1), `weakStore` (0), `webdriver` (3), `xmlUtils` (2)

<details>
<summary>The 51 that are not core, all owned by a single vendor</summary>

`adagioUtils`, `adkernelUtils`, `adrelevantisUtils`, `adtelligentUtils`, `advangUtils`, `agenticxUtils`, `alliance_gravityUtils`, `appnexusUtils`, `asteriobidUtils`, `audUtils`, `biddoInvamiaUtils`, `blueUtils`, `braveUtils`, `browsiUtils`, `cryptoUtils`, `deepintentUtils`, `dspxUtils`, `dxUtils`, `encypherUtils`, `equativUtils`, `ferioUtils`, `htmlEscape`, `hybridVoxUtils`, `hypelabUtils`, `intentIqConstants`, `intentIqUtils`, `interpretResponseUtils`, `liveIntentId`, `magniteUtils`, `mediaImpactUtils`, `medianetUtils`, `mgidUtils`, `nexverseUtils`, `nexx360Utils`, `omsUtils`, `pageInfosUtils`, `permutiveUtils`, `precisoUtils`, `pubmaticUtils`, `riseUtils`, `smartyadsUtils`, `targetVideoUtils`, `teqblazeUtils`, `uid2Eids`, `uid2IdSystemShared`, `uniquestUtils`, `utiqUtils`, `vastTrackers`, `vidazooUtils`, `vizionikUtils`, `xeUtils`

</details>

Beyond the single-consumer case, the consumer count is deliberately not part of the rule. The previous heuristic counted consuming vendors, which flagged as core every white-label library shared between a vendor's brands; `teqblazeUtils` has 55 consumers, more than `pbsExtensions` (13) or `devicePixelRatio` (10), so no threshold separates shared infrastructure from a white label.

Everything under `src/`, `creative/`, `plugins/`, `customize/` and the build tooling stays core, as before — the rule only changes how `modules/` and `libraries/` are judged.

## Known limitations

- Four libraries have no recorded user at all — `gamUtils`, `greedy`, `weakStore` and `ortb2.5StrictTranslator` — so they fall into the "unknown owner" branch and stay core by assumption rather than by lookup.

  `webpack.conf.js` gives every directory under `libraries/` its own `splitChunks` cacheGroup, so a library gets a `<lib>.js` chunk — and therefore an entry in `dependencies.json` — whenever its code survives into a build. No chunk means the code is not in the bundle, and each of the four is absent for its own reason:

  | library | why it has no chunk | is core right? |
  |---------|---------------------|----------------|
  | `gamUtils` | one line, re-exporting four symbols from `dfpUtils`; webpack elides the intermediate module, so `gamAdServerVideo` records a dependency on `dfpUtils` instead | yes — `gamAdServerVideo` is core, so correct attribution would reach the same answer |
  | `greedy` | imported by `src/utils/promise.ts` behind `FEATURES.GREEDY`, which `gulpHelpers.js` disables by default; tree-shaken out of `chunk-core.js` | yes — `src/` is core |
  | `weakStore` | no importer outside `test/` | no — nothing ships it, so nothing owns it |
  | `ortb2.5StrictTranslator` | no importer outside `test/` | no — same |

  All four end up core anyway, since none of them is vendor-named, so the blind spot costs nothing today. It would matter for a vendor library that fell out of the chunk graph the way `gamUtils` does. `gamUtils` is worth removing on its own merits regardless — it is a one-line re-export with a single consumer, which could import `dfpUtils` directly.
- `PR-assignment.yml` checks out `master`, so metadata lookups always reflect `master` while `dependencies.json` comes from the PR build. A module added in the PR is therefore judged by name, which is what the naming fallback is for.
- Library classification leans on names, and names collide. `timeoutQueue` begins with `timeout`, which is a registered rtd component, so the name test calls it vendor-owned; it stays core only because `currency`, `priceFloors` and `rules` use it. That ordering — usage first, name second — is deliberate, but a shared library with a colliding name and no core consumer would be missed. Conversely `uid1Eids` is core while `uid2Eids` is not, purely because `uid2` is a registered component name and `uid1` is not, though the two are the same kind of file.
- A library extracted with only one consumer is treated as that consumer's, so genuinely shared code starts out non-core until a second module adopts it. This is what keeps a new adapter's own library from being flagged: on `master` the vendor is not registered yet, so no name test can recognize it. Four existing libraries are classified this way — `cryptoUtils` (`sevioBidAdapter`), `htmlEscape` (`adgenerationBidAdapter`), `interpretResponseUtils` (`craftBidAdapter`) and `vastTrackers` (`medianetAnalyticsAdapter`) — each a single vendor's helper with a generic name.
- `VENDOR_LIBRARIES` is maintained by hand and will drift as white labels are added. It is the smaller of the two possible lists — white-label platforms appear rarely, while shared libraries are extracted constantly — and the failure mode of forgetting an entry is a PR flagged core that need not have been, not a core change slipping through.
- The general fix for both the `VENDOR_MODULES` exception and the metadata-less modules is for those modules to declare a component, the way `metadata/core.json` already does for `debugging`, `topicsFpdModule`, `userId` and `validationFpdModule`. That would turn a 34-module guess into a lookup.

## Testing

`.github/` is excluded from eslint and there is no unit test harness for the workflow scripts, so this was verified by running the classifier over the repository and over the recent PR set, as reported above. The extraction step was checked separately: before the heuristic was changed, the extracted code agreed with the previous inline implementation on all 3771 tracked files.

## Other information

No documentation PR is needed; this does not change anything user-facing.

---

## Issue template

**Type of issue** — CI / tooling improvement. No associated issue.

**Description** — the `core` label and the two-reviewer requirement it triggers are applied to PRs that only touch vendor-owned files, because the file classification treats per-module metadata, single-vendor libraries and module registries as core.

**Steps to reproduce** — open a PR that changes only `libraries/vidazooUtils/bidderUtils.js` (e.g. #15335) or only adds a new adapter and its metadata (e.g. #15374); the `core` label is applied and two Prebid reviewers are required.

**Expected results** — a PR touching only files owned by one vendor is not flagged as core.

**Actual results** — it is flagged as core. Of the 112 PRs from the last two weeks, 41 are flagged; 16 of those touch nothing but vendor-owned files.

**Platform details** — GitHub Actions, `actions/github-script@v9`, Node 20+.

---

*This PR was generated by Claude Code.*
