### PR TITLE
Adverxo and ConnectAd Bid Adapters: use COPPA sync argument

### DIFF
--- a/modules/adverxoBidAdapter.js
+++ b/modules/adverxoBidAdapter.js
@@ -4,7 +4,6 @@ import { BANNER, VIDEO, NATIVE } from '../src/mediaTypes.js';
 import { ortbConverter as OrtbConverter } from '../libraries/ortbConverter/converter.js';
 import { Renderer } from '../src/Renderer.js';
 import { deepAccess, deepSetValue } from '../src/utils.js';
-import { config } from '../src/config.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').Bid} Bid
@@ -112,7 +111,7 @@ const ortbConverter = OrtbConverter({
 });
 
 const userSyncUtils = {
-  buildUsyncParams: function (gdprConsent, uspConsent, gppConsent) {
+  buildUsyncParams: function (gdprConsent, uspConsent, gppConsent, coppa) {
     const params = [];
 
     if (gdprConsent) {
@@ -120,7 +119,7 @@ const userSyncUtils = {
       params.push('gdpr_consent=' + encodeURIComponent(gdprConsent.consentString || ''));
     }
 
-    if (config.getConfig('coppa') === true) {
+    if (coppa) {
       params.push('coppa=1');
     }
 
@@ -310,14 +309,15 @@ export const spec = {
    * @param {*} gdprConsent
    * @param {*} uspConsent
    * @param {*} gppConsent
+   * @param {boolean} coppa
    * @return {UserSync[]} The user syncs which should be dropped.
    */
-  getUserSyncs: (syncOptions, responses, gdprConsent, uspConsent, gppConsent) => {
+  getUserSyncs: (syncOptions, responses, gdprConsent, uspConsent, gppConsent, coppa) => {
     if (!responses || responses.length === 0 || (!syncOptions.pixelEnabled && !syncOptions.iframeEnabled)) {
       return [];
     }
 
-    const privacyParams = userSyncUtils.buildUsyncParams(gdprConsent, uspConsent, gppConsent);
+    const privacyParams = userSyncUtils.buildUsyncParams(gdprConsent, uspConsent, gppConsent, coppa);
     const syncType = syncOptions.iframeEnabled ? USYNC_TYPES.IFRAME : USYNC_TYPES.REDIRECT;
 
     const result = [];

--- a/modules/connectadBidAdapter.js
+++ b/modules/connectadBidAdapter.js
@@ -2,7 +2,6 @@ import { logWarn, getWindowTop } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { Renderer } from '../src/Renderer.js';
 import { BANNER, VIDEO, NATIVE, AUDIO } from '../src/mediaTypes.js';
-import { config } from '../src/config.js';
 import { tryAppendQueryString } from '../libraries/urlUtils/urlUtils.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { isViewabilityMeasurable, getViewability } from '../libraries/percentInView/percentInView.js';
@@ -248,7 +247,7 @@ export const spec = {
     return converter.fromORTB({ response, request }).bids || [];
   },
 
-  getUserSyncs: (syncOptions, responses, gdprConsent, uspConsent, gppConsent) => {
+  getUserSyncs: (syncOptions, responses, gdprConsent, uspConsent, gppConsent, coppa) => {
     const pixelType = syncOptions.iframeEnabled ? 'iframe' : 'image';
     let syncEndpoint;
 
@@ -275,7 +274,7 @@ export const spec = {
       syncEndpoint = tryAppendQueryString(syncEndpoint, 'gpp_sid', gppConsent?.applicableSections?.join(','));
     }
 
-    if (config.getConfig('coppa') === true) {
+    if (coppa) {
       syncEndpoint = tryAppendQueryString(syncEndpoint, 'coppa', 1);
     }
 

--- a/test/spec/modules/adverxoBidAdapter_spec.js
+++ b/test/spec/modules/adverxoBidAdapter_spec.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { spec } from 'modules/adverxoBidAdapter.js';
-import { config } from 'src/config';
 
 describe('Adverxo Bid Adapter', () => {
   function makeBidRequestWithParams(params) {
@@ -150,10 +149,6 @@ describe('Adverxo Bid Adapter', () => {
     bids: videoOutstreamBidRequests,
     auctionId: 'new-auction-id'
   };
-
-  afterEach(function () {
-    config.resetConfig();
-  });
 
   describe('isBidRequestValid', function () {
     it('should validate bid request with valid params (adUnit as number)', () => {
@@ -743,6 +738,13 @@ describe('Adverxo Bid Adapter', () => {
       const result = spec.getUserSyncs(iframeConfig, responses, undefined, undefined, gppConsent);
       expect(result).to.deep.equal([{
         type: 'iframe', url: `${exampleUrl}&type=iframe&gpp=foo&gpp_sid=123%2C456`
+      }]);
+    });
+
+    it('should add COPPA when enabled', function () {
+      const result = spec.getUserSyncs(iframeConfig, responses, undefined, undefined, undefined, true);
+      expect(result).to.deep.equal([{
+        type: 'iframe', url: `${exampleUrl}&type=iframe&coppa=1`
       }]);
     });
   });

--- a/test/spec/modules/connectadBidAdapter_spec.js
+++ b/test/spec/modules/connectadBidAdapter_spec.js
@@ -1077,9 +1077,8 @@ describe('ConnectAd Adapter', function () {
       });
     }
 
-    it('should append coppa flag when coppa config is enabled', function () {
-      config.setConfig({ coppa: true });
-      const result = spec.getUserSyncs({ iframeEnabled: true, pixelEnabled: false }, {}, null);
+    it('should append coppa flag when coppa is enabled', function () {
+      const result = spec.getUserSyncs({ iframeEnabled: true, pixelEnabled: false }, {}, null, null, null, true);
       expect(result[0].url).to.equal('https://sync.connectad.io/iFrameSyncer?coppa=1&');
     });
 


### PR DESCRIPTION
### Motivation

- Stop importing core `config` in adapters to read COPPA and instead consume the COPPA boolean passed into `getUserSyncs`, aligning adapters with the core change that exposes COPPA via the usersync callback. 
- Reduce adapter-side coupling to core configuration and ensure consistent COPPA handling across bidders following the approach in the core change that passes `coppa` to `getUserSyncs`.

### Description

- Update `modules/adverxoBidAdapter.js` to accept a `coppa` parameter in `getUserSyncs`, forward it into the user-sync parameter builder, and remove the `config` import used only for COPPA. 
- Update `modules/connectadBidAdapter.js` to accept the `coppa` argument in `getUserSyncs` and append `coppa` to sync URLs from that argument instead of calling `config.getConfig('coppa')`. 
- Update focused unit tests in `test/spec/modules/adverxoBidAdapter_spec.js` and `test/spec/modules/connectadBidAdapter_spec.js` to pass the `coppa` argument to `getUserSyncs` and to assert that `coppa=1` is included when enabled. 
- Add a JSDoc `coppa` parameter note for clarity in the affected adapter `getUserSyncs` signatures.

### Testing

- Ran lint on the changed files with `npx eslint 'modules/adverxoBidAdapter.js' 'modules/connectadBidAdapter.js' 'test/spec/modules/adverxoBidAdapter_spec.js' 'test/spec/modules/connectadBidAdapter_spec.js' --cache --cache-strategy content` and it passed. 
- Executed the focused spec bundles with `npx gulp test --nolint --file test/spec/modules/adverxoBidAdapter_spec.js` and `npx gulp test --nolint --file test/spec/modules/connectadBidAdapter_spec.js`, and both completed successfully (Adverxo spec completed and ConnectAd spec completed). 
- Performed `git diff --check` and repository checks to ensure no whitespace or diff issues were introduced and the working tree is clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a720396c084832b8bd26f4a8ab72d7c)