### PR TITLE
Multiple Adapters: use COPPA user sync argument

### DIFF
--- a/libraries/teqblazeUtils/bidderUtils.ts
+++ b/libraries/teqblazeUtils/bidderUtils.ts
@@ -2,7 +2,6 @@ import type { CreativeAttribute } from 'iab-adcom';
 import type { Device } from 'iab-openrtb/v25';
 
 import { BANNER, NATIVE, VIDEO } from '../../src/mediaTypes.js';
-import { config } from '../../src/config.js';
 import type {
   BaseBidderRequest,
   BidRequest
@@ -353,7 +352,8 @@ export const getUserSyncs = (syncUrl: string) => (
   _serverResponses: ServerResponse[],
   gdprConsent: null | ConsentData[typeof CONSENT_GDPR],
   uspConsent: null | ConsentData[typeof CONSENT_USP],
-  gppConsent: null | ConsentData[typeof CONSENT_GPP]
+  gppConsent: null | ConsentData[typeof CONSENT_GPP],
+  coppa: boolean
 ): { type: SyncType; url: string }[] => {
   if (!syncOptions.iframeEnabled && !syncOptions.pixelEnabled) {
     return [];
@@ -379,8 +379,7 @@ export const getUserSyncs = (syncUrl: string) => (
     url += '&gpp_sid=' + gppConsent.applicableSections.join(',');
   }
 
-  const coppa = config.getConfig('coppa') ? 1 : 0;
-  url += `&coppa=${coppa}`;
+  url += `&coppa=${coppa ? 1 : 0}`;
 
   return [{
     type,

--- a/test/spec/libraries/teqblazeUtils/bidderUtils_spec.js
+++ b/test/spec/libraries/teqblazeUtils/bidderUtils_spec.js
@@ -645,5 +645,11 @@ describe('TeqBlazeBidderUtils', function () {
       expect(syncData[0].url).to.be.a('string');
       expect(syncData[0].url).to.equal(`https://${DOMAIN}/image?pbjs=1&gpp=abc123&gpp_sid=8&coppa=0`);
     });
+
+    it('Should include COPPA in the sync URL', function () {
+      const syncData = spec.getUserSyncs({ pixelEnabled: true }, {}, {}, undefined, undefined, true);
+
+      expect(syncData[0].url).to.equal(`https://${DOMAIN}/image?pbjs=1&coppa=1`);
+    });
   });
 });


### PR DESCRIPTION
### Motivation
- Align TeqBlaze-based bidders with core's new COPPA plumbing so adapters stop importing `config` and instead consume the COPPA value provided by the consent handler as introduced in #15431. 
- Prevent duplicated COPPA checks and ensure `getUserSyncs` consistently reflects the COPPA flag supplied by core rather than reading global configuration.

### Description
- Remove direct `config` usage from the TeqBlaze shared helper and add a `coppa` boolean parameter to `getUserSyncs` (`libraries/teqblazeUtils/bidderUtils.ts`).
- Serialize COPPA in user-sync URLs as `coppa=1` or `coppa=0` using the new `coppa` argument instead of calling `config.getConfig('coppa')`.
- Add a unit test that calls `spec.getUserSyncs(..., true)` and asserts the generated sync URL contains `coppa=1` (`test/spec/libraries/teqblazeUtils/bidderUtils_spec.js`).
- Keep existing GDPR/USP/GPP handling unchanged and only change how COPPA is obtained and appended to the sync URL.

### Testing
- Ran `npx eslint 'libraries/teqblazeUtils/bidderUtils.ts' 'test/spec/libraries/teqblazeUtils/bidderUtils_spec.js' --cache --cache-strategy content` and it completed without errors.
- Ran the focused test spec with `npx gulp test --nolint --file test/spec/libraries/teqblazeUtils/bidderUtils_spec.js` and the suite completed successfully (32 tests passed).
- Verified diffs include the two files changed: `libraries/teqblazeUtils/bidderUtils.ts` and `test/spec/libraries/teqblazeUtils/bidderUtils_spec.js` and no lint/test failures were produced during the runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a72039b4740832bb4e96ede7da33af3)