### PR TITLE
Pubmatic , newspass, pixfuture, nexverse Adapters: use user sync COPPA argument

### DIFF
--- a/modules/newspassidBidAdapter.js
+++ b/modules/newspassidBidAdapter.js
@@ -129,10 +129,10 @@ export const spec = {
     return bidResponses;
   },
 
-  getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) {
+  getUserSyncs: function(syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent, coppa) {
     if (!syncOptions.iframeEnabled) return []; // disable if iframe sync is disabled
     if (!hasPurpose1Consent(gdprConsent)) return []; // disable if no purpose1 consent
-    if (config.getConfig('coppa') === true) return []; // disable syncs for coppa
+    if (coppa) return []; // disable syncs for coppa
 
     const params = {
       gdpr: gdprConsent?.gdprApplies ? 1 : 0,

--- a/modules/nexverseBidAdapter.js
+++ b/modules/nexverseBidAdapter.js
@@ -139,7 +139,7 @@ export const spec = {
    * @param {Object} gppConsent - GPP consent details.
    * @returns {Array} List of user sync URLs.
    */
-  getUserSyncs: (syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) => {
+  getUserSyncs: (syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent, coppa) => {
     const type = syncOptions.iframeEnabled ? "iframe" : "image";
     let url = BIDDER_ENDPOINT + `/${type}?pbjs=1`;
 
@@ -162,8 +162,7 @@ export const spec = {
       url += "&gpp_sid=" + gppConsent.applicableSections.join(",");
     }
 
-    const coppa = config.getConfig("coppa") ? 1 : 0;
-    url += `&coppa=${coppa}`;
+    url += `&coppa=${coppa ? 1 : 0}`;
 
     url += `&uid=${getUid(storage)}`;
 

--- a/modules/pixfutureBidAdapter.js
+++ b/modules/pixfutureBidAdapter.js
@@ -179,7 +179,7 @@ export const spec = {
 
     return bids;
   },
-  getUserSyncs: function (syncOptions, bid, gdprConsent, uspConsent) {
+  getUserSyncs: function (syncOptions, bid, gdprConsent, uspConsent, gppConsent, coppa) {
     const syncs = [];
 
     let syncurl = 'pixid=' + pixID;
@@ -192,7 +192,7 @@ export const spec = {
       syncurl += '&us_privacy=' + encodeURIComponent(uspConsent);
     }
 
-    if (config.getConfig('coppa') === true) {
+    if (coppa) {
       syncurl += '&coppa=1';
     }
 

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -845,7 +845,7 @@ export const spec = {
   /**
    * Register User Sync.
    */
-  getUserSyncs: (syncOptions, responses, gdprConsent, uspConsent, gppConsent) => {
+  getUserSyncs: (syncOptions, responses, gdprConsent, uspConsent, gppConsent, coppa) => {
     let syncurl = pubId;
 
     // Attaching GDPR Consent Params in UserSync url
@@ -864,7 +864,7 @@ export const spec = {
     }
 
     // coppa compliance
-    if (config.getConfig('coppa') === true) {
+    if (coppa) {
       syncurl += '&coppa=1';
     }
 

--- a/test/spec/modules/newspassidBidAdapter_spec.js
+++ b/test/spec/modules/newspassidBidAdapter_spec.js
@@ -301,8 +301,7 @@ describe('newspassidBidAdapter', function () {
     });
 
     it('should have zero user syncs if coppa is true', function() {
-      config.setConfig({ coppa: true });
-      const syncs = spec.getUserSyncs({ iframeEnabled: true });
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, [], null, null, null, true);
       expect(syncs).to.be.empty;
     });
 

--- a/test/spec/modules/nexverseBidAdapter_spec.js
+++ b/test/spec/modules/nexverseBidAdapter_spec.js
@@ -6,6 +6,18 @@ import { getOsVersion } from '../../../libraries/advangUtils/index.js';
 const BIDDER_ENDPOINT = 'https://rtb.nexverse.ai';
 
 describe('nexverseBidAdapterTests', () => {
+  describe('getUserSyncs', () => {
+    it('includes configured COPPA in the sync URL', () => {
+      const [sync] = spec.getUserSyncs({ pixelEnabled: true }, [], null, null, null, true);
+      expect(sync.url).to.include('&coppa=1');
+    });
+
+    it('reports COPPA as disabled in the sync URL', () => {
+      const [sync] = spec.getUserSyncs({ pixelEnabled: true }, [], null, null, null, false);
+      expect(sync.url).to.include('&coppa=0');
+    });
+  });
+
   describe('isBidRequestValid', function () {
     const sbid = {
       'adUnitCode': 'div',

--- a/test/spec/modules/pixfutureBidAdapter_spec.js
+++ b/test/spec/modules/pixfutureBidAdapter_spec.js
@@ -3,6 +3,18 @@ import { spec } from 'modules/pixfutureBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
 
 describe('PixFutureAdapter', function () {
+  describe('getUserSyncs', function () {
+    it('includes COPPA in the sync URL when enabled', function () {
+      const [sync] = spec.getUserSyncs({ iframeEnabled: true }, [], null, null, null, true);
+      expect(sync.url).to.include('&coppa=1');
+    });
+
+    it('does not include COPPA in the sync URL when disabled', function () {
+      const [sync] = spec.getUserSyncs({ iframeEnabled: true }, [], null, null, null, false);
+      expect(sync.url).to.not.include('&coppa=1');
+    });
+  });
+
   it('<description of unit or feature being tested>', function () {
     const adapter = newBidder(spec);
     describe('inherited functions', function () {

--- a/test/spec/modules/pubmaticBidAdapter_spec.js
+++ b/test/spec/modules/pubmaticBidAdapter_spec.js
@@ -1621,11 +1621,10 @@ describe('PubMatic adapter', () => {
       });
 
       it('returns iframe sync url with consent parameters and COPPA', () => {
-        config.setConfig({ coppa: true });
         const gdprConsent = { gdprApplies: true, consentString: 'CONSENT' };
         const uspConsent = '1YNN';
         const gppConsent = { gppString: 'GPP', applicableSections: [2, 4] };
-        const [sync] = spec.getUserSyncs({ iframeEnabled: true }, [], gdprConsent, uspConsent, gppConsent);
+        const [sync] = spec.getUserSyncs({ iframeEnabled: true }, [], gdprConsent, uspConsent, gppConsent, true);
         expect(sync).to.deep.equal({
           type: 'iframe',
           url: 'https://ads.pubmatic.com/AdServer/js/user_sync.html?kdntuid=1&p=5670&gdpr=1&gdpr_consent=CONSENT&us_privacy=1YNN&gpp=GPP&gpp_sid=2%2C4&coppa=1'


### PR DESCRIPTION
### Motivation
- Follow up on the core change that exposes COPPA to bidder user syncs so adapters stop importing core `config` for COPPA decisions.
- Ensure bidder `getUserSyncs` implementations receive the COPPA state from `bidderFactory` so sync logic is consistent with site settings.
- Reduce direct `config.getConfig('coppa')` usage in adapter modules and make adapter behavior testable via the COPPA argument.

### Description
- Updated `getUserSyncs` signatures to accept a `coppa` boolean for Newspassid, Nexverse, Pixfuture, and PubMatic adapters and removed direct `config.getConfig('coppa')` checks in those modules (`modules/newspassidBidAdapter.js`, `modules/nexverseBidAdapter.js`, `modules/pixfutureBidAdapter.js`, `modules/pubmaticBidAdapter.js`).
- Replaced COPPA checks/URL construction to use the `coppa` argument (e.g. `&coppa=${coppa ? 1 : 0}`) and to block syncs when `coppa` is true where appropriate.
- Added and adjusted unit tests to pass the `coppa` argument and assert both enabled and disabled COPPA behaviors in `test/spec/modules/newspassidBidAdapter_spec.js`, `test/spec/modules/nexverseBidAdapter_spec.js`, `test/spec/modules/pixfutureBidAdapter_spec.js`, and `test/spec/modules/pubmaticBidAdapter_spec.js`.
- Committed the changes under the message "M-Q Bid Adapters: use user sync COPPA argument" and updated the test coverage for the affected adapters.

### Testing
- Ran ESLint on the changed files with `npx eslint 'modules/newspassidBidAdapter.js' 'modules/pubmaticBidAdapter.js' 'modules/pixfutureBidAdapter.js' 'modules/nexverseBidAdapter.js' 'test/spec/modules/newspassidBidAdapter_spec.js' 'test/spec/modules/pubmaticBidAdapter_spec.js' 'test/spec/modules/pixfutureBidAdapter_spec.js' 'test/spec/modules/nexverseBidAdapter_spec.js' --cache --cache-strategy content` and it completed successfully.
- Executed the affected unit specs with `npx gulp test --nolint --file <spec_file>` for each modified spec and all runs completed successfully (each spec bundle passed).
- Performed repository checks with `git diff --check` and `git status --short --branch` which reported a clean diff and no lint errors.
- All automated tests invoked for these changes passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7203b03258832b85da0d09a3116402)