### PR TITLE
R–U Adapters: use ORTB2 `regs.coppa` (stop importing `config`)

### DIFF
--- a/libraries/teqblazeUtils/bidderUtils.ts
+++ b/libraries/teqblazeUtils/bidderUtils.ts
@@ -2,7 +2,6 @@ import type { CreativeAttribute } from 'iab-adcom';
 import type { Device } from 'iab-openrtb/v25';
 
 import { BANNER, NATIVE, VIDEO } from '../../src/mediaTypes.js';
-import { config } from '../../src/config.js';
 import type {
   BaseBidderRequest,
   BidRequest
@@ -353,7 +352,8 @@ export const getUserSyncs = (syncUrl: string) => (
   _serverResponses: ServerResponse[],
   gdprConsent: null | ConsentData[typeof CONSENT_GDPR],
   uspConsent: null | ConsentData[typeof CONSENT_USP],
-  gppConsent: null | ConsentData[typeof CONSENT_GPP]
+  gppConsent: null | ConsentData[typeof CONSENT_GPP],
+  coppa: boolean
 ): { type: SyncType; url: string }[] => {
   if (!syncOptions.iframeEnabled && !syncOptions.pixelEnabled) {
     return [];
@@ -379,8 +379,7 @@ export const getUserSyncs = (syncUrl: string) => (
     url += '&gpp_sid=' + gppConsent.applicableSections.join(',');
   }
 
-  const coppa = config.getConfig('coppa') ? 1 : 0;
-  url += `&coppa=${coppa}`;
+  url += `&coppa=${coppa ? 1 : 0}`;
 
   return [{
     type,

--- a/modules/resetdigitalBidAdapter.js
+++ b/modules/resetdigitalBidAdapter.js
@@ -168,7 +168,7 @@ export const spec = {
         imp_id: req.bidId,
         sizes: req.sizes,
         force_bid: req.params.forceBid,
-        coppa: config.getConfig('coppa') === true ? 1 : 0,
+        coppa: bidderRequest.ortb2?.regs?.coppa === 1 ? 1 : 0,
         media_types: deepAccess(req, 'mediaTypes'),
       });
     }

--- a/modules/rubiconBidAdapter.js
+++ b/modules/rubiconBidAdapter.js
@@ -604,7 +604,7 @@ export const spec = {
 
     applyFPD(bidRequest, BANNER, data);
 
-    if (config.getConfig('coppa') === true) {
+    if (bidderRequest.ortb2?.regs?.coppa === 1) {
       data['coppa'] = 1;
     }
 

--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -1,6 +1,5 @@
 import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import { config } from '../src/config.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { _map, getWinDimensions, isArray, triggerPixel } from '../src/utils.js';
 import { getViewportCoordinates } from '../libraries/viewport/viewport.js';
@@ -327,7 +326,7 @@ export const spec = {
       payload.schain = schain;
     }
 
-    const coppa = config.getConfig('coppa');
+    const coppa = bidderRequest.ortb2?.regs?.coppa;
     if (coppa) {
       payload.coppa = coppa;
     }

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -83,7 +83,7 @@ export const sharethroughAdapterSpec = {
         ext: {},
       },
       regs: {
-        coppa: config.getConfig('coppa') === true ? 1 : 0,
+        coppa: bidderRequest.ortb2?.regs?.coppa === 1 ? 1 : 0,
         ext: {},
       },
       source: {

--- a/modules/smaatoBidAdapter.js
+++ b/modules/smaatoBidAdapter.js
@@ -263,7 +263,7 @@ const converter = ortbConverter({
       }
     } else {
       request.regs = {
-        coppa: config.getConfig('coppa') === true ? 1 : 0,
+        coppa: bidderRequest.ortb2?.regs?.coppa === 1 ? 1 : 0,
         ext: {
           gdpr: isGdprApplicable() ? bidderRequest.gdprConsent.gdprApplies ? 1 : 0 : null,
           us_privacy: bidderRequest.uspConsent

--- a/modules/smartyadsBidAdapter.js
+++ b/modules/smartyadsBidAdapter.js
@@ -1,6 +1,5 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
-import { config } from '../src/config.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import { getAdUrlByRegion } from '../libraries/smartyadsUtils/getAdUrlByRegion.js';
 import { interpretResponse, getUserSyncs } from '../libraries/teqblazeUtils/bidderUtils.js';
@@ -32,7 +31,7 @@ export const spec = {
       'deviceHeight': winTop.screen.height,
       'host': location?.domain ?? '',
       'page': location?.page ?? '',
-      'coppa': config.getConfig('coppa') === true ? 1 : 0,
+      'coppa': bidderRequest?.ortb2?.regs?.coppa === 1 ? 1 : 0,
       'placements': placements,
       'eeid': validBidRequests[0]?.userIdAsEids,
       'ifa': bidderRequest?.ortb2?.device?.ifa,

--- a/modules/smartytechBidAdapter.js
+++ b/modules/smartytechBidAdapter.js
@@ -152,7 +152,7 @@ export const spec = {
       }
 
       // Add COPPA flag if configured
-      const coppa = config.getConfig('coppa');
+      const coppa = bidderRequest.ortb2?.regs?.coppa;
       if (coppa) {
         oneRequest.coppa = coppa;
       }

--- a/modules/snigelBidAdapter.js
+++ b/modules/snigelBidAdapter.js
@@ -56,7 +56,7 @@ export const spec = {
         gdprConsentString: gdprApplies === true ? deepAccess(bidderRequest, 'gdprConsent.consentString') : undefined,
         gdprConsentProv: gdprApplies === true ? deepAccess(bidderRequest, 'gdprConsent.addtlConsent') : undefined,
         uspConsent: deepAccess(bidderRequest, 'uspConsent'),
-        coppa: getConfig('coppa'),
+        coppa: bidderRequest.ortb2?.regs?.coppa,
         eids: deepAccess(bidRequests, '0.userIdAsEids'),
         schain: deepAccess(bidRequests, '0.ortb2.source.ext.schain'),
         page: getPage(bidderRequest),

--- a/modules/sonobiBidAdapter.js
+++ b/modules/sonobiBidAdapter.js
@@ -154,7 +154,7 @@ export const spec = {
       payload.us_privacy = bidderRequest.uspConsent;
     }
 
-    if (config.getConfig('coppa') === true) {
+    if (bidderRequest.ortb2?.regs?.coppa === 1) {
       payload.coppa = 1;
     } else {
       payload.coppa = 0;

--- a/modules/ssmasBidAdapter.js
+++ b/modules/ssmasBidAdapter.js
@@ -2,7 +2,6 @@ import { BANNER } from '../src/mediaTypes.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { triggerPixel, deepSetValue } from '../src/utils.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
-import { config } from '../src/config.js';
 
 export const SSMAS_CODE = 'ssmas';
 const SSMAS_SERVER = 'ads.ssmas.com';
@@ -58,7 +57,7 @@ export const spec = {
       data.regs.ext.consent = bidderRequest.uspConsent.consentString;
       data.regs.ext.ccpa = 1;
     }
-    if (config.getConfig('coppa') === true) {
+    if (bidderRequest.ortb2?.regs?.coppa === 1) {
       data.regs.coppa = 1;
     }
 

--- a/modules/taboolaBidAdapter.js
+++ b/modules/taboolaBidAdapter.js
@@ -2,7 +2,6 @@
 
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, NATIVE } from '../src/mediaTypes.js';
-import { config } from '../src/config.js';
 import {
   deepSetValue,
   getWinDimensions,
@@ -399,7 +398,7 @@ function fillTaboolaReqData(bidderRequest, bidRequest, data, context) {
     deepSetValue(data, 'regs.ext.gpp_sid', bidderRequest.ortb2.regs.gpp_sid);
   }
 
-  if (config.getConfig('coppa')) {
+  if (bidderRequest.ortb2?.regs?.coppa) {
     deepSetValue(data, 'regs.coppa', 1);
   }
 

--- a/modules/tappxBidAdapter.js
+++ b/modules/tappxBidAdapter.js
@@ -3,7 +3,6 @@
 import { logWarn, deepAccess, isFn, isPlainObject, isBoolean, isNumber, isStr, isArray } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
-import { config } from '../src/config.js';
 import { Renderer } from '../src/Renderer.js';
 import { parseDomain } from '../src/refererDetection.js';
 import { getDNT } from '../libraries/dnt/index.js';
@@ -476,8 +475,8 @@ function buildOneRequest(validBidRequests, bidderRequest) {
   }
 
   // COPPA compliance
-  if (config.getConfig('coppa') === true) {
-    regs.coppa = config.getConfig('coppa') === true ? 1 : 0;
+  if (bidderRequest.ortb2?.regs?.coppa === 1) {
+    regs.coppa = 1;
   }
   // < GDPR
 

--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -2,7 +2,6 @@ import * as utils from '../src/utils.js';
 import { logMessage, logError, isEmpty, logWarn } from '../src/utils.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
-import { config } from '../src/config.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { tryAppendQueryString } from '../libraries/urlUtils/urlUtils.js';
 
@@ -58,7 +57,7 @@ export const tripleliftAdapterSpec = {
       tlCall = tryAppendQueryString(tlCall, 'us_privacy', bidderRequest.uspConsent);
     }
 
-    if (config.getConfig('coppa') === true) {
+    if (bidderRequest?.ortb2?.regs?.coppa === 1) {
       tlCall = tryAppendQueryString(tlCall, 'coppa', true);
     }
 

--- a/modules/trustxBidAdapter.js
+++ b/modules/trustxBidAdapter.js
@@ -10,7 +10,6 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { Renderer } from '../src/Renderer.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
-import { config } from '../src/config.js';
 
 /**
  * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
@@ -142,7 +141,7 @@ const ortbAdapterConverter = ortbConverter({
     }
 
     // COPPA
-    if (config.getConfig('coppa') === true) {
+    if (bidderRequest.ortb2?.regs?.coppa === 1) {
       deepSetValue(requestObj, 'regs.coppa', 1);
     }
 

--- a/modules/ttdBidAdapter.js
+++ b/modules/ttdBidAdapter.js
@@ -1,5 +1,4 @@
 import * as utils from '../src/utils.js';
-import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { isNumber } from '../src/utils.js';
@@ -47,7 +46,7 @@ function getRegs(bidderRequest) {
   if (bidderRequest.uspConsent) {
     utils.deepSetValue(regs, 'ext.us_privacy', bidderRequest.uspConsent);
   }
-  if (config.getConfig('coppa') === true) {
+  if (bidderRequest.ortb2?.regs?.coppa === 1) {
     regs.coppa = 1;
   }
   if (bidderRequest.ortb2?.regs) {

--- a/modules/ucfunnelBidAdapter.js
+++ b/modules/ucfunnelBidAdapter.js
@@ -2,7 +2,6 @@ import { generateUUID, _each, deepAccess } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO, NATIVE } from '../src/mediaTypes.js';
 import { getStorageManager } from '../src/storageManager.js';
-import { config } from '../src/config.js';
 import { convertOrtbRequestToProprietaryNative } from '../src/native.js';
 import { getDNT } from '../libraries/dnt/index.js';
 
@@ -331,7 +330,7 @@ function getRequestData(bid, bidderRequest) {
     });
   }
 
-  if (config.getConfig('coppa')) {
+  if (bidderRequest?.ortb2?.regs?.coppa) {
     bidData.coppa = true;
   }
 

--- a/test/spec/libraries/teqblazeUtils/bidderUtils_spec.js
+++ b/test/spec/libraries/teqblazeUtils/bidderUtils_spec.js
@@ -645,5 +645,9 @@ describe('TeqBlazeBidderUtils', function () {
       expect(syncData[0].url).to.be.a('string');
       expect(syncData[0].url).to.equal(`https://${DOMAIN}/image?pbjs=1&gpp=abc123&gpp_sid=8&coppa=0`);
     });
+    it('Should include configured COPPA in the sync URL', function () {
+      const syncData = spec.getUserSyncs({ pixelEnabled: true }, {}, {}, undefined, undefined, true);
+      expect(syncData[0].url).to.equal(`https://${DOMAIN}/image?pbjs=1&coppa=1`);
+    });
   });
 });

--- a/test/spec/modules/bidfuseBidAdapter_spec.js
+++ b/test/spec/modules/bidfuseBidAdapter_spec.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import { spec } from '../../../modules/bidfuseBidAdapter.js';
 import { BANNER, VIDEO, NATIVE } from '../../../src/mediaTypes.js';
 import { getUniqueIdentifierStr } from '../../../src/utils.js';
-import { config } from "../../../src/config.ts";
 
 const bidder = 'bidfuse';
 
@@ -310,10 +309,7 @@ describe('BidfuseBidAdapter', function () {
     });
 
     it('should have valid user sync with coppa 1 on response', function () {
-      config.setConfig({
-        coppa: 1
-      });
-      const result = spec.getUserSyncs({ iframeEnabled: true }, [serverResponse]);
+      const result = spec.getUserSyncs({ iframeEnabled: true }, [serverResponse], undefined, undefined, undefined, true);
       expect(result).to.deep.equal([{
         type: 'iframe',
         url: 'https://syncbf.bidfuse.com/iframe?pbjs=1&coppa=1'
@@ -331,7 +327,7 @@ describe('BidfuseBidAdapter', function () {
         applicableSections: [7]
       };
 
-      const result = spec.getUserSyncs({ pixelEnabled: true }, [serverResponse], gdprConsent, uspConsent, gppConsent);
+      const result = spec.getUserSyncs({ pixelEnabled: true }, [serverResponse], gdprConsent, uspConsent, gppConsent, true);
 
       expect(result).to.deep.equal([{
         'url': 'https://syncbf.bidfuse.com/image?pbjs=1&gdpr=1&gdpr_consent=consent_string&ccpa_consent=usp_string&gpp=gpp_string&gpp_sid=7&coppa=1',

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import { getTimeoutUrl, spec, BIDFLOOR_CURRENCY } from 'modules/seedtagBidAdapter.js';
 import * as utils from 'src/utils.js';
 import * as mockGpt from 'test/spec/integration/faker/googletag.js';
-import { config } from '../../../src/config.js';
 import * as adUnits from 'src/utils/adUnits';
 
 const PUBLISHER_ID = '0000-0000-01';
@@ -427,23 +426,22 @@ describe('Seedtag Adapter', function () {
     });
 
     describe('COPPA param', function () {
-      it('should add COPPA param to payload when prebid config has parameter COPPA equal to true', function () {
-        config.setConfig({ coppa: true });
-
-        const request = spec.buildRequests(validBidRequests, bidderRequest);
+      it('should add COPPA param to payload when present in the bidder request', function () {
+        const request = spec.buildRequests(validBidRequests, {
+          ...bidderRequest,
+          ortb2: { regs: { coppa: 1 } }
+        });
         const data = JSON.parse(request.data);
-        expect(data.coppa).to.equal(true);
+        expect(data.coppa).to.equal(1);
       });
 
-      it('should not add COPPA param to payload when prebid config has parameter COPPA equal to false', function () {
-        config.setConfig({ coppa: false });
-
+      it('should not add COPPA param to payload when the bidder request has no COPPA flag', function () {
         const request = spec.buildRequests(validBidRequests, bidderRequest);
         const data = JSON.parse(request.data);
         expect(data.coppa).to.be.undefined;
       });
 
-      it('should not add COPPA param to payload when prebid config has not parameter COPPA', function () {
+      it('should not add COPPA param to payload when the bidder request has no ORTB2 data', function () {
         const request = spec.buildRequests(validBidRequests, bidderRequest);
         const data = JSON.parse(request.data);
         expect(data.coppa).to.be.undefined;

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -417,6 +417,7 @@ describe('sharethrough adapter spec', function () {
           ref: 'https://referer.com',
         },
         ortb2: {
+          regs: { coppa: 1 },
           source: {
             tid: 'auction-id',
           },
@@ -602,9 +603,11 @@ describe('sharethrough adapter spec', function () {
 
         describe('coppa', () => {
           it('should populate request accordingly when coppa does not apply', () => {
-            config.setConfig({ coppa: false });
-
-            const openRtbReq = spec.buildRequests(bidRequests, bidderRequest)[0].data;
+            const request = {
+              ...bidderRequest,
+              ortb2: { ...bidderRequest.ortb2, regs: { coppa: 0 } }
+            };
+            const openRtbReq = spec.buildRequests(bidRequests, request)[0].data;
 
             expect(openRtbReq.regs.coppa).to.equal(0);
           });

--- a/test/spec/modules/smartyadsBidAdapter_spec.js
+++ b/test/spec/modules/smartyadsBidAdapter_spec.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { spec } from '../../../modules/smartyadsBidAdapter.js';
-import { config } from '../../../src/config.js';
 
 describe('SmartyadsAdapter', function () {
   const bid = {
@@ -65,17 +64,8 @@ describe('SmartyadsAdapter', function () {
   });
 
   describe('with COPPA', function() {
-    beforeEach(function() {
-      sinon.stub(config, 'getConfig')
-        .withArgs('coppa')
-        .returns(true);
-    });
-    afterEach(function() {
-      config.getConfig.restore();
-    });
-
     it('should send the Coppa "required" flag set to "1" in the request', function () {
-      const serverRequest = spec.buildRequests([bid]);
+      const serverRequest = spec.buildRequests([bid], { ortb2: { regs: { coppa: 1 } } });
       expect(serverRequest.data.coppa).to.equal(1);
     });
   });

--- a/test/spec/modules/snigelBidAdapter_spec.js
+++ b/test/spec/modules/snigelBidAdapter_spec.js
@@ -123,14 +123,13 @@ describe('snigelBidAdapter', function () {
     });
 
     it('should forward whether or not COPPA applies', function () {
-      config.setConfig({
-        'coppa': true,
+      const request = spec.buildRequests([], {
+        ...BASE_BIDDER_REQUEST,
+        ortb2: { regs: { coppa: 1 } }
       });
-
-      const request = spec.buildRequests([], BASE_BIDDER_REQUEST);
       expect(request).to.have.property('data');
       const data = JSON.parse(request.data);
-      expect(data).to.have.property('coppa').and.to.equal(true);
+      expect(data).to.have.property('coppa').and.to.equal(1);
     });
 
     it('should forward refresh information', function () {

--- a/test/spec/modules/sonobiBidAdapter_spec.js
+++ b/test/spec/modules/sonobiBidAdapter_spec.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import { _getPlatform, spec } from 'modules/sonobiBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
 import { userSync } from '../../../src/userSync.js';
-import { config } from 'src/config.js';
 import * as gptUtils from '../../../libraries/gptUtils/gptUtils.js';
 import { parseQS } from '../../../src/utils.js';
 import { getGlobal } from '../../../src/prebidGlobal.js';
@@ -438,15 +437,16 @@ describe('SonobiBidAdapter', function () {
       expect(bidRequests.data.fpd).to.equal(encodeURIComponent(JSON.stringify(ortb2)));
     });
 
-    it('should populate coppa as 1 if set in config', function () {
-      config.setConfig({ coppa: true });
-      const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
+    it('should populate coppa as 1 if set in the bidder request', function () {
+      const bidRequests = spec.buildRequests(bidRequest, {
+        ...bidderRequests,
+        ortb2: { ...bidderRequests.ortb2, regs: { coppa: 1 } }
+      });
 
       expect(bidRequests.data.coppa).to.equal(encodeURIComponent(1));
     });
 
-    it('should populate coppa as 0 if set in config', function () {
-      config.setConfig({ coppa: false });
+    it('should populate coppa as 0 if absent from the bidder request', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
 
       expect(bidRequests.data.coppa).to.equal(encodeURIComponent(0));

--- a/test/spec/modules/ssmasBidAdapter_spec.js
+++ b/test/spec/modules/ssmasBidAdapter_spec.js
@@ -52,6 +52,14 @@ describe('ssmasBidAdapter', function () {
       expect(request[0].method).to.equal(SSMAS_REQUEST_METHOD);
       expect(request[0].url).to.equal(SSMAS_ENDPOINT);
     });
+
+    it('passes COPPA from the bidder request', function () {
+      const request = spec.buildRequests([bid], {
+        ...bidderRequest,
+        ortb2: { ...bidderRequest.ortb2, regs: { coppa: 1 } }
+      });
+      expect(request[0].data.regs.coppa).to.equal(1);
+    });
   });
 
   describe('register adapter functions', () => {

--- a/test/spec/modules/taboolaBidAdapter_spec.js
+++ b/test/spec/modules/taboolaBidAdapter_spec.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { spec, internal, BANNER_ENDPOINT_URL, NATIVE_ENDPOINT_URL, userData, EVENT_ENDPOINT, detectBot, getPageVisibility } from 'modules/taboolaBidAdapter.js';
-import { config } from '../../../src/config.js';
 import * as utils from '../../../src/utils.js';
 import { server } from '../../mocks/xhr.js';
 import { getGlobal } from '../../../src/prebidGlobal.js';
@@ -601,12 +600,12 @@ describe('Taboola Adapter', function () {
       });
 
       it('should pass coppa consent', function () {
-        config.setConfig({ coppa: true });
-
-        const [res] = spec.buildRequests([defaultBidRequest], commonBidderRequest);
+        const bidderRequest = {
+          ...commonBidderRequest,
+          ortb2: { regs: { coppa: 1 } }
+        };
+        const [res] = spec.buildRequests([defaultBidRequest], bidderRequest);
         expect(res.data.regs.coppa).to.equal(1);
-
-        config.resetConfig();
       });
     });
 

--- a/test/spec/modules/tappxBidAdapter_spec.js
+++ b/test/spec/modules/tappxBidAdapter_spec.js
@@ -202,6 +202,14 @@ describe('Tappx bid adapter', function () {
       expect(payload.regs.ext.us_privacy).to.exist;
     });
 
+    it('should add COPPA from the bidder request', function () {
+      const request = spec.buildRequests(validBidRequests, {
+        ...bidderRequest,
+        ortb2: { ...bidderRequest.ortb2, regs: { coppa: 1 } }
+      });
+      expect(JSON.parse(request[0].data).regs.coppa).to.equal(1);
+    });
+
     it('should properly build a banner request', function () {
       const request = spec.buildRequests(validBidRequests, bidderRequest);
       expect(request[0].url).to.match(/^(http|https):\/\/(.*)\.tappx\.com\/.+/);

--- a/test/spec/modules/tripleliftBidAdapter_spec.js
+++ b/test/spec/modules/tripleliftBidAdapter_spec.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import { tripleliftAdapterSpec, storage } from 'modules/tripleliftBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
 
-import { config } from 'src/config.js';
 import prebid from 'package.json';
 import * as utils from 'src/utils.js';
 import { getGlobal } from '../../../src/prebidGlobal.js';
@@ -891,17 +890,16 @@ describe('triplelift adapter', function () {
       const url = request.url;
       expect(url).to.match(/(\?|&)us_privacy=1YYY/);
     });
-    it('should return coppa param when COPPA config is set to true', function() {
-      sinon.stub(config, 'getConfig').withArgs('coppa').returns(true);
-      const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
-      config.getConfig.restore();
+    it('should return coppa param when COPPA is set in the bidder request', function() {
+      const request = tripleliftAdapterSpec.buildRequests(bidRequests, {
+        ...bidderRequest,
+        ortb2: { regs: { coppa: 1 } }
+      });
       const url = request.url;
       expect(url).to.match(/(\?|&)coppa=true/);
     });
-    it('should not return coppa param when COPPA config is set to false', function() {
-      sinon.stub(config, 'getConfig').withArgs('coppa').returns(false);
+    it('should not return coppa param when COPPA is absent from the bidder request', function() {
       const request = tripleliftAdapterSpec.buildRequests(bidRequests, bidderRequest);
-      config.getConfig.restore();
       const url = request.url;
       expect(url).not.to.match(/(\?|&)coppa=/);
     });

--- a/test/spec/modules/trustxBidAdapter_spec.js
+++ b/test/spec/modules/trustxBidAdapter_spec.js
@@ -1,9 +1,6 @@
 import { expect } from 'chai';
 import { spec } from 'modules/trustxBidAdapter.js';
 
-import sinon from 'sinon';
-import { config } from 'src/config.js';
-
 const getBannerRequest = () => {
   return {
     bidderCode: 'trustx',
@@ -659,16 +656,14 @@ describe('trustxBidAdapter', function() {
       });
 
       it('should include COPPA flag in request when set to true', function() {
-        // Mock the config.getConfig function to return true for coppa
-        sinon.stub(config, 'getConfig').withArgs('coppa').returns(true);
-
-        const requests = spec.buildRequests(bidRequestsWithMediaTypes, mockBidderRequest);
+        const bidderRequest = {
+          ...mockBidderRequest,
+          ortb2: { regs: { coppa: 1 } }
+        };
+        const requests = spec.buildRequests(bidRequestsWithMediaTypes, bidderRequest);
         const data = requests.data;
 
         expect(data.regs).to.have.property('coppa', 1);
-
-        // Restore the stub
-        config.getConfig.restore();
       });
     });
   });

--- a/test/spec/modules/ttdBidAdapter_spec.js
+++ b/test/spec/modules/ttdBidAdapter_spec.js
@@ -535,10 +535,8 @@ describe('ttdBidAdapter', function () {
 
     it('adds coppa consent info to the request', function () {
       const clonedBidderRequest = deepClone(baseBidderRequest);
-
-      config.setConfig({ coppa: true });
+      clonedBidderRequest.ortb2 = { regs: { coppa: 1 } };
       const requestBody = testBuildRequests(baseBannerBidRequests, clonedBidderRequest).data;
-      config.resetConfig();
       expect(requestBody.regs.coppa).to.equal(1);
     });
 

--- a/test/spec/modules/ucfunnelBidAdapter_spec.js
+++ b/test/spec/modules/ucfunnelBidAdapter_spec.js
@@ -186,6 +186,14 @@ describe('ucfunnel Adapter', function () {
       expect(data.schain).to.equal('1.0,1!exchange1.com,1234,1,bid-request-1,publisher,publisher.com');
     });
 
+    it('should attach COPPA from the bidder request', function () {
+      const requests = spec.buildRequests([validBannerBidReq], {
+        ...bidderRequest,
+        ortb2: { ...bidderRequest.ortb2, regs: { coppa: 1 } }
+      });
+      expect(requests[0].data.coppa).to.equal(true);
+    });
+
     it('should support multiple size', function () {
       const sizes = [[300, 250], [336, 280]];
       const format = '300,250;336,280';


### PR DESCRIPTION
### Motivation

- Prevent individual bidders from importing core `config` just to read COPPA and instead rely on the enriched OpenRTB request data so COPPA decisions follow publisher-supplied `ortb2.regs.coppa` semantics. 
- Ensure user-sync logic receives COPPA state from caller code (via bidder factory / userSync flow) rather than adapters querying core config. 
- Reduce coupling between adapters and core configuration and make COPPA usage consistent across adapters starting with R–U.

### Description

- Updated R–U adapters to read COPPA from the bidder request (using `bidderRequest.ortb2?.regs?.coppa`) and removed direct uses/imports of `config.getConfig('coppa')` where applicable. 
- Modified the TeqBlaze user-sync helper `libraries/teqblazeUtils/bidderUtils.ts` to accept a `coppa` boolean parameter and append `&coppa=` to sync URLs (no `config` import). 
- Adjusted and added unit tests to pass COPPA via the bidder request `ortb2.regs.coppa` and to assert correct behavior for sync URLs and request payloads; test files updated include many affected adapters' specs and the TeqBlaze spec. 
- Changes touch multiple files under `modules/` and `test/spec/modules/` and the TeqBlaze library, and the patch removes several `config` imports replaced by request-driven COPPA checks.

### Testing

- Ran lint on the changed files with `npx eslint $CHANGED --cache --cache-strategy content` and it passed. 
- Executed targeted unit tests with `npx gulp test --nolint --file 'test/spec/{libraries/teqblazeUtils/bidderUtils_spec.js,modules/{resetdigital,rubicon,seedtag,sharethrough,smaato,smartyads,smartytech,snigel,sonobi,ssmas,taboola,tappx,triplelift,trustx,ttd,ucfunnel}BidAdapter_spec.js}'` and the bundle run completed successfully (tests passed in the run used during development). 
- Ran the full test bundle used in CI locally and observed success (`npx gulp test` completed with the test chunks exercised in this change passing), and `git diff --check` produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7203b97cdc832b9bf2d2dbb113d7d2)