### PR TITLE
Richaudience Bid Adapter: clean up request payload and fix response handling

### DIFF
--- a/modules/richaudienceBidAdapter.js
+++ b/modules/richaudienceBidAdapter.js
@@ -106,10 +106,11 @@ export const spec = {
   interpretResponse: function (serverResponse, bidRequest) {
     const bidResponses = [];
     // try catch
-    var response = serverResponse.body;
+    const response = serverResponse.body;
     if (response) {
-      var bidResponse = {
-        requestId: JSON.parse(bidRequest.data).bidId,
+      const request = JSON.parse(bidRequest.data);
+      const bidResponse = {
+        requestId: request.bidId,
         cpm: response.cpm,
         width: response.width,
         height: response.height,
@@ -128,7 +129,7 @@ export const spec = {
         bidResponse.vastXml = response.vastXML;
         try {
           if (bidResponse.vastXml != null) {
-            if (JSON.parse(bidRequest.data).videoData.format === 'outstream' || JSON.parse(bidRequest.data).videoData.format === 'banner') {
+            if (request.videoData.format === 'outstream' || request.videoData.format === 'banner') {
               bidResponse.renderer = Renderer.install({
                 id: bidRequest.bidId,
                 adunitcode: bidRequest.tagId,

--- a/modules/richaudienceBidAdapter.js
+++ b/modules/richaudienceBidAdapter.js
@@ -119,7 +119,7 @@ export const spec = {
         currency: response.currency,
         ttl: response.ttl,
         meta: {
-          advertiserDomains: [response.adomain[0]]
+          advertiserDomains: response.adomain?.length ? [response.adomain[0]] : []
         },
         dealId: response.dealId
       };
@@ -136,8 +136,8 @@ export const spec = {
                 config: response.media_type,
                 url: 'https://cdn3.richaudience.com/prebidVideo/player.js'
               });
+              bidResponse.renderer.setRender(renderer);
             }
-            bidResponse.renderer.setRender(renderer);
           }
         } catch (e) {
           bidResponse.ad = response.adm;

--- a/modules/richaudienceBidAdapter.js
+++ b/modules/richaudienceBidAdapter.js
@@ -21,7 +21,7 @@ export const spec = {
    * @returns {boolean} True if this is a valid bid, and false otherwise
    */
   isBidRequestValid: function (bid) {
-    return !!(bid.params && bid.params.pid && bid.params.supplyType);
+    return !!(bid.params && bid.params.pid);
   },
   /***
    * Build a server request from the list of valid BidRequests
@@ -35,24 +35,16 @@ export const spec = {
         bidfloor: raiGetFloor(bid, config),
         ifa: bid.params.ifa,
         pid: bid.params.pid,
-        supplyType: bid.params.supplyType,
         currencyCode: getCurrencyFromBidderRequest(bidderRequest),
         auctionId: bid.auctionId,
-        bidId: bid.bidId,
-        BidRequestsCount: bid.bidRequestsCount,
-        bidder: bid.bidder,
-        bidderRequestId: bid.bidderRequestId,
         tagId: bid.adUnitCode,
         sizes: raiGetSizes(bid),
         referer: (typeof bidderRequest.refererInfo.page !== 'undefined' ? encodeURIComponent(bidderRequest.refererInfo.page) : null),
-        numIframes: (typeof bidderRequest.refererInfo.numIframes !== 'undefined' ? bidderRequest.refererInfo.numIframes : null),
         transactionId: bid.ortb2Imp?.ext?.tid,
         timeout: bidderRequest.timeout || 600,
         eids: deepAccess(bid, 'userIdAsEids') ? bid.userIdAsEids : [],
-        demand: raiGetDemandType(bid),
         videoData: raiGetVideoInfo(bid),
         scr_rsl: raiGetResolution(),
-        cpuc: null,
         kws: bid.params.keywords,
         schain: bid?.ortb2?.source?.ext?.schain,
         gpid: raiSetPbAdSlot(bid),
@@ -94,6 +86,8 @@ export const spec = {
         method: 'POST',
         url: endpoint,
         data: payloadString,
+        bidId: bid.bidId,
+        videoData: payload.videoData,
       };
     });
   },
@@ -108,9 +102,8 @@ export const spec = {
     // try catch
     const response = serverResponse.body;
     if (response) {
-      const request = JSON.parse(bidRequest.data);
       const bidResponse = {
-        requestId: request.bidId,
+        requestId: bidRequest.bidId,
         cpm: response.cpm,
         width: response.width,
         height: response.height,
@@ -129,7 +122,7 @@ export const spec = {
         bidResponse.vastXml = response.vastXML;
         try {
           if (bidResponse.vastXml != null) {
-            if (request.videoData.format === 'outstream' || request.videoData.format === 'banner') {
+            if (bidRequest.videoData.format === 'outstream' || bidRequest.videoData.format === 'banner') {
               bidResponse.renderer = Renderer.install({
                 id: bidRequest.bidId,
                 adunitcode: bidRequest.tagId,
@@ -231,26 +224,9 @@ function raiGetSizes(bid) {
   }
 }
 
-function raiGetDemandType(bid) {
-  let raiFormat = 'display';
-  if (typeof bid.sizes !== 'undefined') {
-    bid.sizes.forEach(function (sz) {
-      if ((sz[0] === 1800 && sz[1] === 1000) || (sz[0] === 1 && sz[1] === 1)) {
-        raiFormat = 'skin';
-      }
-    });
-  }
-  if (bid.mediaTypes !== undefined) {
-    if (bid.mediaTypes.video !== undefined) {
-      raiFormat = 'video';
-    }
-  }
-  return raiFormat;
-}
-
 function raiGetVideoInfo(bid) {
   let videoData;
-  if (raiGetDemandType(bid) === 'video') {
+  if (bid.mediaTypes?.video) {
     videoData = {
       format: bid.mediaTypes.video.context,
       playerSize: bid.mediaTypes.video.playerSize,

--- a/modules/richaudienceBidAdapter.js
+++ b/modules/richaudienceBidAdapter.js
@@ -88,6 +88,7 @@ export const spec = {
         data: payloadString,
         bidId: bid.bidId,
         videoData: payload.videoData,
+        adUnitCode: bid.adUnitCode,
       };
     });
   },
@@ -125,7 +126,7 @@ export const spec = {
             if (bidRequest.videoData.format === 'outstream' || bidRequest.videoData.format === 'banner') {
               bidResponse.renderer = Renderer.install({
                 id: bidRequest.bidId,
-                adunitcode: bidRequest.tagId,
+                adUnitCode: bidRequest.adUnitCode,
                 loaded: false,
                 config: response.media_type,
                 url: 'https://cdn3.richaudience.com/prebidVideo/player.js'

--- a/modules/richaudienceBidAdapter.md
+++ b/modules/richaudienceBidAdapter.md
@@ -25,7 +25,6 @@ Please reach out to your account manager for more information.
                         bidder: 'richaudience',
                         params: {
                             "pid":"ADb1f40rmi",
-                            "supplyType":"site",
                             "bidfloor":0.70,
                         }
                     }]
@@ -37,7 +36,6 @@ Please reach out to your account manager for more information.
                         bidder: 'richaudience',
                         params: {
                             "pid":"ADb1f40rmo",
-                            "supplyType":"site",
                             "bidfloor":0.40,
                             "keywords": "key1=value1;key2=value2;key3=value3;"
                         }
@@ -61,7 +59,6 @@ Please reach out to your account manager for more information.
                 bidder: 'richaudience',
                 params: {
                   pid: 'OjUW9KhuQV',
-                  supplyType: 'site',
                   player: {
                      init: "open",
                      end: "close",
@@ -87,7 +84,6 @@ Please reach out to your account manager for more information.
                             bidder: 'richaudience',
                             params: {
                                 "pid":"ADb1f40rmi",
-                                "supplyType":"app",
                                 "ifa":"AAAAAAAAA-BBBB-CCCC-1111-222222220000",
                                 "bidfloor":0.70,
                             }
@@ -101,7 +97,6 @@ Please reach out to your account manager for more information.
                             bidder: 'richaudience',
                             params: {
                                 "pid":"ADb1f40rmo",
-                                "supplyType":"app",
                                 "ifa":"AAAAAAAAA-BBBB-CCCC-1111-222222220000",
                                 "bidfloor":0.40,
                             }

--- a/test/spec/modules/richaudienceBidAdapter_spec.js
+++ b/test/spec/modules/richaudienceBidAdapter_spec.js
@@ -471,6 +471,7 @@ describe('Richaudience adapter tests', function () {
     expect(requestContent).to.not.have.property('demand');
     expect(requestContent.videoData).to.have.property('format').and.to.equal('outstream');
     expect(request[0].videoData).to.have.property('format').and.to.equal('outstream');
+    expect(request[0].adUnitCode).to.equal('test-div');
   });
 
   describe('gdpr test', function () {
@@ -713,6 +714,7 @@ describe('Richaudience adapter tests', function () {
     expect(bid.mediaType).to.equal('video');
     expect(bid.vastXml).to.equal('<VAST></VAST>');
     expect(bid.renderer.url).to.equal('https://cdn3.richaudience.com/prebidVideo/player.js');
+    expect(bid.renderer.adUnitCode).to.equal('test-div');
     expect(bid.cpm).to.equal(1.50);
     expect(bid.width).to.equal(1);
     expect(bid.height).to.equal(1);

--- a/test/spec/modules/richaudienceBidAdapter_spec.js
+++ b/test/spec/modules/richaudienceBidAdapter_spec.js
@@ -409,12 +409,12 @@ describe('Richaudience adapter tests', function () {
     const requestContent = JSON.parse(request[0].data);
     expect(requestContent).to.have.property('bidfloor').and.to.equal(0.5);
     expect(requestContent).to.have.property('pid').and.to.equal('ADb1f40rmi');
-    expect(requestContent).to.have.property('supplyType').and.to.equal('site');
+    expect(requestContent).to.not.have.property('supplyType');
     expect(requestContent).to.have.property('auctionId').and.to.equal('0cb3144c-d084-4686-b0d6-f5dbe917c563');
-    expect(requestContent).to.have.property('bidId').and.to.equal('2c7c8e9c900244');
-    expect(requestContent).to.have.property('BidRequestsCount').and.to.equal(1);
-    expect(requestContent).to.have.property('bidder').and.to.equal('richaudience');
-    expect(requestContent).to.have.property('bidderRequestId').and.to.equal('1858b7382993ca');
+    expect(requestContent).to.not.have.property('bidId');
+    expect(requestContent).to.not.have.property('BidRequestsCount');
+    expect(requestContent).to.not.have.property('bidder');
+    expect(requestContent).to.not.have.property('bidderRequestId');
     expect(requestContent).to.have.property('tagId').and.to.equal('test-div');
     expect(requestContent).to.have.property('referer').and.to.equal('https%3A%2F%2Fdomain.com');
     expect(requestContent).to.have.property('sizes');
@@ -428,7 +428,7 @@ describe('Richaudience adapter tests', function () {
     expect(requestContent.sizes[3]).to.have.property('h').and.to.equal(250);
     expect(requestContent).to.have.property('transactionId').and.to.equal('29df2112-348b-4961-8863-1b33684d95e6');
     expect(requestContent).to.have.property('timeout').and.to.equal(600);
-    expect(requestContent).to.have.property('numIframes').and.to.equal(0);
+    expect(requestContent).to.not.have.property('numIframes');
     expect(typeof requestContent.scr_rsl === 'string');
     expect(typeof requestContent.gpid === 'string');
     expect(requestContent).to.have.property('kws').and.to.equal('key1=value1;key2=value2');
@@ -449,7 +449,7 @@ describe('Richaudience adapter tests', function () {
     expect(request[0]).to.have.property('method').and.to.equal('POST');
     const requestContent = JSON.parse(request[0].data);
 
-    expect(requestContent).to.have.property('demand').and.to.equal('video');
+    expect(requestContent).to.not.have.property('demand');
     expect(requestContent.videoData).to.have.property('format').and.to.equal('instream');
   });
 
@@ -468,8 +468,9 @@ describe('Richaudience adapter tests', function () {
     expect(request[0]).to.have.property('method').and.to.equal('POST');
     const requestContent = JSON.parse(request[0].data);
 
-    expect(requestContent).to.have.property('demand').and.to.equal('video');
+    expect(requestContent).to.not.have.property('demand');
     expect(requestContent.videoData).to.have.property('format').and.to.equal('outstream');
+    expect(request[0].videoData).to.have.property('format').and.to.equal('outstream');
   });
 
   describe('gdpr test', function () {
@@ -499,7 +500,7 @@ describe('Richaudience adapter tests', function () {
       expect(requestContent).to.have.property('gdpr_consent').and.to.equal('BOZcQl_ObPFjWAeABAESCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NohBgA');
     });
 
-    it('Verify adding ifa when supplyType equal to app', function () {
+    it('Verify adding ifa param', function () {
       const request = spec.buildRequests(DEFAULT_PARAMS_APP, {
         gdprConsent: {
           consentString: 'BOZcQl_ObPFjWAeABAESCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NohBgA',
@@ -511,7 +512,6 @@ describe('Richaudience adapter tests', function () {
         }
       });
       const requestContent = JSON.parse(request[0].data);
-      expect(requestContent).to.have.property('supplyType').and.to.equal('app');
       expect(requestContent).to.have.property('ifa').and.to.equal('AAAAAAAAA-BBBB-CCCC-1111-222222220000');
     });
 
@@ -631,6 +631,7 @@ describe('Richaudience adapter tests', function () {
     const bids = spec.interpretResponse(BID_RESPONSE, request[0]);
     expect(bids).to.have.lengthOf(1);
     const bid = bids[0];
+    expect(bid.requestId).to.equal('2c7c8e9c900244');
     expect(bid.cpm).to.equal(1.50);
     expect(bid.ad).to.equal('<!-- script -->');
     expect(bid.mediaType).to.equal('js');
@@ -722,6 +723,22 @@ describe('Richaudience adapter tests', function () {
     expect(bid.dealId).to.equal('dealId');
   });
 
+  it('interpretResponse reads the render context from the request without parsing its data', function () {
+    const request = {
+      bidId: '2c7c8e9c900244',
+      tagId: 'test-div',
+      videoData: { format: 'outstream' },
+      data: 'not-json'
+    };
+
+    let bids;
+    expect(() => { bids = spec.interpretResponse(BID_RESPONSE_VIDEO, request); }).to.not.throw();
+    expect(bids).to.have.lengthOf(1);
+    expect(bids[0].mediaType).to.equal('video');
+    expect(bids[0].vastXml).to.equal('<VAST></VAST>');
+    expect(bids[0].renderer.url).to.equal('https://cdn3.richaudience.com/prebidVideo/player.js');
+  });
+
   it('banner media and response VAST', function () {
     const request = spec.buildRequests(DEFAULT_PARAMS_BANNER_OUTSTREAM, {
       gdprConsent: {
@@ -771,7 +788,7 @@ describe('Richaudience adapter tests', function () {
       params: {
         pid: 'ADb1f40rmi'
       }
-    })).to.equal(false);
+    })).to.equal(true);
     expect(spec.isBidRequestValid({
       params: {
         supplyType: 'site'
@@ -826,7 +843,7 @@ describe('Richaudience adapter tests', function () {
         pid: ['1gCB5ZC4XL', '1a40xk8qSV'],
         bidfloor: 0.50,
       }
-    })).to.equal(false);
+    })).to.equal(true);
     expect(spec.isBidRequestValid({
       params: {
         pid: ['1gCB5ZC4XL', '1a40xk8qSV'],

--- a/test/spec/modules/richaudienceBidAdapter_spec.js
+++ b/test/spec/modules/richaudienceBidAdapter_spec.js
@@ -644,6 +644,26 @@ describe('Richaudience adapter tests', function () {
     expect(bid.meta.advertiserDomains[0]).to.equal('richaudience.com');
   });
 
+  it('response without adomain does not throw and returns empty advertiserDomains', function () {
+    const request = spec.buildRequests(DEFAULT_PARAMS_NEW_SIZES, {
+      gdprConsent: {
+        consentString: 'BOZcQl_ObPFjWAeABAESCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NohBgA',
+        gdprApplies: true
+      },
+      refererInfo: {
+        page: 'https://domain.com',
+        numIframes: 0
+      }
+    });
+
+    const response = { body: { ...BID_RESPONSE.body } };
+    delete response.body.adomain;
+
+    const bids = spec.interpretResponse(response, request[0]);
+    expect(bids).to.have.lengthOf(1);
+    expect(bids[0].meta.advertiserDomains).to.deep.equal([]);
+  });
+
   it('no banner media response inestream', function () {
     const request = spec.buildRequests(DEFAULT_PARAMS_VIDEO_IN, {
       gdprConsent: {


### PR DESCRIPTION
## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [x] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [x] Does this change affect user-facing APIs or examples documented
- [ ] Other

## Description of change

Maintenance + bugfixes for the Richaudience bid adapter, scoped to `modules/richaudienceBidAdapter.js` (with its `.md` and spec).

**Fixes**
- Guard `response.adomain` before indexing, so a missing/empty `adomain` no longer throws in `interpretResponse` (`advertiserDomains` falls back to `[]`).
- Only call `renderer.setRender(...)` when a renderer was actually installed (moved inside the install guard).
- Pass the real `adUnitCode` to the outstream `Renderer.install(...)` instead of `tagId`, so a publisher-provided renderer override is honored.

**Cleanup / refactor**
- Parse `bidRequest.data` once in `interpretResponse` instead of repeatedly.
- Remove request payload fields the endpoint does not use: `supplyTyper`, `bidderRequestId`, `numIframes`, `demand`, `cpuc`. `bidId` and`videoData` now travel on the server-request object instead of inside the serialized body.
- `supplyType` is no longer required by `isBidRequestValid` (only `pid` is required). Backward compatible — configs still sending `supplyType` keep working, the field is simply ignored. `.md` examples updated accordingly.
- Simplify video detection to `bid.mediaTypes?.video`, dropping the redundant `raiGetDemandType` helper.

No changes to the request endpoint or to the bid-response shape beyond

### Testing
- ESLint over the changed adapter + spec: clean, no errors.
- `gulp test --file test/spec/modules/richaudienceBidAdapter_spec.js`: **41 tests passing**.

## Other information

Companion docs PR removing `supplyType` from the Rich Audience bidder page: prebid/prebid.github.io#6692