### PR TITLE
Consumable Bid Adapter: source COPPA from request

### DIFF
--- a/modules/consumableBidAdapter.js
+++ b/modules/consumableBidAdapter.js
@@ -1,5 +1,4 @@
 import { logWarn, deepAccess, isArray, deepSetValue, isFn, isPlainObject } from '../src/utils.js';
-import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 
@@ -87,7 +86,7 @@ export const spec = {
       data.schain = schain;
     }
 
-    if (config.getConfig('coppa')) {
+    if (bidderRequest?.ortb2?.regs?.coppa === 1) {
       data.coppa = true;
     }
 

--- a/test/spec/modules/consumableBidAdapter_spec.js
+++ b/test/spec/modules/consumableBidAdapter_spec.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { spec } from 'modules/consumableBidAdapter.js';
 import { createBid } from 'src/bidfactory.js';
-import { config } from 'src/config.js';
 import { deepClone } from 'src/utils.js';
 
 const BIDDER_REQUEST_1 = {
@@ -496,16 +495,20 @@ describe('Consumable BidAdapter', function () {
       expect(data.schain).to.be.undefined;
     });
 
-    it('should contain coppa if configured', function () {
-      config.setConfig({ coppa: true });
-      const request = spec.buildRequests(BIDDER_REQUEST_1.bidRequest, BIDDER_REQUEST_1);
+    it('should contain coppa if present in the request regs', function () {
+      const request = spec.buildRequests(BIDDER_REQUEST_1.bidRequest, {
+        ...BIDDER_REQUEST_1,
+        ortb2: {
+          ...BIDDER_REQUEST_1.ortb2,
+          regs: { coppa: 1 }
+        }
+      });
       const data = JSON.parse(request.data);
 
       expect(data.coppa).to.be.true;
     });
 
-    it('should not contain coppa if not configured', function () {
-      config.setConfig({ coppa: false });
+    it('should not contain coppa if not present in the request regs', function () {
       const request = spec.buildRequests(BIDDER_REQUEST_1.bidRequest, BIDDER_REQUEST_1);
       const data = JSON.parse(request.data);
 


### PR DESCRIPTION
### Motivation
- Avoid importing `config` into the adapter and prefer sourcing COPPA from the bid request (OTRB2 `regs.coppa`) so adapters rely on request-scoped privacy signals instead of global config.

### Description
- Removed the `config` import and changed COPPA handling in `modules/consumableBidAdapter.js` to set `data.coppa` when `bidderRequest?.ortb2?.regs?.coppa === 1`, and updated `test/spec/modules/consumableBidAdapter_spec.js` to assert COPPA is only present when supplied on the request.

### Testing
- Ran lint and the adapter unit tests with `npx eslint modules/consumableBidAdapter.js test/spec/modules/consumableBidAdapter_spec.js --cache --cache-strategy content` and `npx gulp test --nolint --file test/spec/modules/consumableBidAdapter_spec.js`, and the test run completed successfully (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a731d256250832b99b7f1dfec19cef7)