### PR TITLE
Bid Adapters: read COPPA from request context

### DIFF
--- a/modules/adtrueBidAdapter.js
+++ b/modules/adtrueBidAdapter.js
@@ -530,7 +530,7 @@ export const spec = {
       deepSetValue(payload, 'regs.ext.us_privacy', bidderRequest.uspConsent);
     }
     // coppa compliance
-    if (config.getConfig('coppa') === true) {
+    if (bidderRequest?.ortb2?.regs?.coppa === 1) {
       deepSetValue(payload, 'regs.coppa', 1);
     }
 
@@ -610,7 +610,7 @@ export const spec = {
     }
     return bidResponses;
   },
-  getUserSyncs: function (syncOptions, responses, gdprConsent, uspConsent) {
+  getUserSyncs: function (syncOptions, responses, gdprConsent, uspConsent, gppConsent, coppa) {
     if (!responses || responses.length === 0 || (!syncOptions.iframeEnabled && !syncOptions.pixelEnabled)) {
       return [];
     }
@@ -626,7 +626,7 @@ export const spec = {
               '&gdpr=' + (gdprConsent && gdprConsent.gdprApplies ? 1 : 0) +
               '&gdpr_consent=' + encodeURIComponent((gdprConsent ? gdprConsent.consentString : '')) +
               '&us_privacy=' + encodeURIComponent((uspConsent || '')) +
-              '&coppa=' + (config.getConfig('coppa') === true ? 1 : 0)
+              '&coppa=' + (coppa === true ? 1 : 0)
           };
         });
         return accum.concat(cookieSyncObjects);

--- a/modules/lassoBidAdapter.js
+++ b/modules/lassoBidAdapter.js
@@ -2,7 +2,6 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER } from '../src/mediaTypes.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { ajax } from '../src/ajax.js';
-import { config } from '../src/config.js';
 import { getWinDimensions } from '../src/utils.js';
 
 const BIDDER_CODE = 'lasso';
@@ -75,7 +74,7 @@ export const spec = {
         crumbs: JSON.stringify(bidRequest.crumbs),
         prebidVersion: '$prebid.version$',
         version: 4,
-        coppa: config.getConfig('coppa') === true ? 1 : 0,
+        coppa: bidderRequest?.ortb2?.regs?.coppa === 1 ? 1 : 0,
         ccpa: bidderRequest.uspConsent || undefined,
         test,
         testDk,

--- a/modules/winrBidAdapter.js
+++ b/modules/winrBidAdapter.js
@@ -146,7 +146,7 @@ export const spec = {
     const tags = bidRequests.map(bidToTag);
     const userObjBid = ((bidRequests) || []).find(hasUserInfo);
     let userObj = {};
-    if (config.getConfig('coppa') === true) {
+    if (bidderRequest?.ortb2?.regs?.coppa === 1) {
       userObj = { 'coppa': true };
     }
 

--- a/test/spec/modules/adtrueBidAdapter_spec.js
+++ b/test/spec/modules/adtrueBidAdapter_spec.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { spec } from 'modules/adtrueBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
-import { config } from 'src/config.js';
 
 describe('AdTrueBidAdapter', function () {
   const adapter = newBidder(spec);
@@ -344,7 +343,7 @@ describe('AdTrueBidAdapter', function () {
         expect(data.source.ext.schain).to.deep.equal(bidRequests[0].ortb2.source.ext.schain);
       });
 
-      it('should NOT include coppa flag in bid request if coppa config is not present', () => {
+      it('should NOT include coppa flag in bid request if coppa is not present', () => {
         const request = spec.buildRequests(bidRequests, {});
         const data = JSON.parse(request.data);
         if (data.regs) {
@@ -354,28 +353,13 @@ describe('AdTrueBidAdapter', function () {
           expect(data.regs).to.equal(undefined);
         }
       });
-      it('should include coppa flag in bid request if coppa is set to true', () => {
-        const sandbox = sinon.createSandbox();
-        sandbox.stub(config, 'getConfig').callsFake(key => {
-          const config = {
-            'coppa': true
-          };
-          return config[key];
-        });
-        const request = spec.buildRequests(bidRequests, {});
+      it('should include coppa flag in bid request if coppa is set in ortb2 regs', () => {
+        const request = spec.buildRequests(bidRequests, { ortb2: { regs: { coppa: 1 } } });
         const data = JSON.parse(request.data);
         expect(data.regs.coppa).to.equal(1);
-        sandbox.restore();
       });
-      it('should NOT include coppa flag in bid request if coppa is set to false', () => {
-        const sandbox = sinon.createSandbox();
-        sandbox.stub(config, 'getConfig').callsFake(key => {
-          const config = {
-            'coppa': false
-          };
-          return config[key];
-        });
-        const request = spec.buildRequests(bidRequests, {});
+      it('should NOT include coppa flag in bid request if coppa is set to 0', () => {
+        const request = spec.buildRequests(bidRequests, { ortb2: { regs: { coppa: 0 } } });
         const data = JSON.parse(request.data);
         if (data.regs) {
           // in case GDPR is set then data.regs will exist
@@ -383,7 +367,6 @@ describe('AdTrueBidAdapter', function () {
         } else {
           expect(data.regs).to.equal(undefined);
         }
-        sandbox.restore();
       });
     });
   });
@@ -489,14 +472,14 @@ describe('AdTrueBidAdapter', function () {
     afterEach(function () {
       sandbox.restore();
     });
-    it('execute as per config', function () {
+    it('returns iframe syncs', function () {
       expect(spec.getUserSyncs({ iframeEnabled: true }, [bidResponses], undefined, undefined)).to.deep.equal([{
         type: 'iframe',
         url: 'https://hb.adtrue.com/prebid/usersync?bidder=adtrue&publisherId=1212&zoneId=21423&gdpr=0&gdpr_consent=&us_privacy=&coppa=0'
       }]);
     });
     // Multiple user sync output
-    it('execute as per config', function () {
+    it('returns multiple user syncs', function () {
       expect(spec.getUserSyncs({ iframeEnabled: true }, [bidResponses2], undefined, undefined)).to.deep.equal([
         {
           type: 'image',
@@ -516,11 +499,14 @@ describe('AdTrueBidAdapter', function () {
         { pixelEnabled: true },
         [bidResponses],
         { gdprApplies: true, consentString: 'consentData' },
-        '1YNN'
+        '1YNN',
+        undefined,
+        true
       );
       expect(syncs[0].url).to.contain('gdpr=1');
       expect(syncs[0].url).to.contain('gdpr_consent=consentData');
       expect(syncs[0].url).to.contain('us_privacy=1YNN');
+      expect(syncs[0].url).to.contain('coppa=1');
     });
   });
 });

--- a/test/spec/modules/lassoBidAdapter_spec.js
+++ b/test/spec/modules/lassoBidAdapter_spec.js
@@ -104,6 +104,15 @@ describe('lassoBidAdapter', function () {
       expect(bidRequest.method).to.equal('GET');
       expect(bidRequest.url).to.equal(GET_IUD_URL + ENDPOINT_URL + '/request');
     });
+
+    it('uses coppa from bidderRequest ortb2 regs', () => {
+      const [request] = spec.buildRequests([bid], {
+        ...bidderRequest,
+        ortb2: { regs: { coppa: 1 } }
+      });
+
+      expect(request.data.coppa).to.equal(1);
+    });
   });
 
   describe('buildRequests with dgid', function () {

--- a/test/spec/modules/winrBidAdapter_spec.js
+++ b/test/spec/modules/winrBidAdapter_spec.js
@@ -503,18 +503,13 @@ describe('WinrAdapter', function () {
       });
     });
 
-    it('should populate coppa if set in config', function () {
+    it('should populate coppa if set in ortb2 regs', function () {
       const bidRequest = Object.assign({}, bidRequests[0]);
-      sinon.stub(config, 'getConfig')
-        .withArgs('coppa')
-        .returns(true);
 
-      const request = spec.buildRequests([bidRequest]);
+      const request = spec.buildRequests([bidRequest], { ortb2: { regs: { coppa: 1 } } });
       const payload = JSON.parse(request.data);
 
       expect(payload.user.coppa).to.equal(true);
-
-      config.getConfig.restore();
     });
 
     it('should set the X-Is-Test customHeader if test flag is enabled', function () {


### PR DESCRIPTION
### Motivation
- Adapters were reading COPPA from global config (`config.getConfig('coppa')`) which can be inaccurate for request-scoped COPPA signals.
- COPPA is provided in the OpenRTB request (`bidderRequest.ortb2.regs.coppa`) or via the usersync flow, so adapters should prefer those sources.
- Align adapters to use request/user-sync COPPA to ensure correct compliance signaling per-auction.

### Description
- AdTrue: stop using global config for COPPA and set `regs.coppa` when `bidderRequest?.ortb2?.regs?.coppa === 1`, and accept a `coppa` argument into `getUserSyncs` to append the flag to user-sync URLs.
- Lasso: populate the outgoing `payload.coppa` from `bidderRequest?.ortb2?.regs?.coppa === 1` instead of `config.getConfig('coppa')` and remove the unused config import.
- Winr: populate `user.coppa` from `bidderRequest?.ortb2?.regs?.coppa === 1` instead of reading global config.
- Tests: update/replace adapter specs to assert COPPA is read from `bidderRequest.ortb2.regs.coppa` (AdTrue, Lasso, Winr) and adjust AdTrue user-sync spec to pass the `coppa` argument and validate sync URLs include `coppa`.

### Testing
- Linted the modified files with `npx eslint modules/lassoBidAdapter.js modules/adtrueBidAdapter.js modules/winrBidAdapter.js test/spec/modules/lassoBidAdapter_spec.js test/spec/modules/adtrueBidAdapter_spec.js test/spec/modules/winrBidAdapter_spec.js --cache --cache-strategy content` and the linter completed without error messages.
- Ran the affected unit tests with `npx gulp test --nolint --file test/spec/modules/lassoBidAdapter_spec.js --file test/spec/modules/adtrueBidAdapter_spec.js --file test/spec/modules/winrBidAdapter_spec.js` and the test chunk completed successfully (all tests in the chunk passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7321b7f910832b97a0be9f4ae259c5)