### PR TITLE
Yieldmo Bid Adapter: fix bidfloor test setup

### DIFF
--- a/test/spec/modules/yieldmoBidAdapter_spec.js
+++ b/test/spec/modules/yieldmoBidAdapter_spec.js
@@ -383,7 +383,7 @@ describe('YieldmoAdapter', function () {
       });
 
       it('should not write 0 bidfloor value by default', function() {
-        const placementsData = JSON.parse(buildAndGetPlacementInfo([mockBannerBid()]));
+        const placementsData = JSON.parse(buildAndGetPlacementInfo([mockBannerBid({}, { bidFloor: undefined })]));
         expect(placementsData[0].bidFloor).to.be.undefined;
       });
 


### PR DESCRIPTION
### Motivation
- The unit test asserting that no default "0" bid floor is written used the banner mock which provided a default `bidFloor` value, causing the test to not exercise the no-floor case.

### Description
- Update `test/spec/modules/yieldmoBidAdapter_spec.js` to call `mockBannerBid({}, { bidFloor: undefined })` for the "should not write 0 bidfloor value by default" test so the test verifies the adapter behavior when the bidFloor is explicitly unset.

### Testing
- Ran linter on the spec with `npx eslint test/spec/modules/yieldmoBidAdapter_spec.js --cache --cache-strategy content` which succeeded with no errors.
- Ran the spec with `npx gulp test --nolint --file test/spec/modules/yieldmoBidAdapter_spec.js` and the test chunk completed successfully (`✔ 93 tests completed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a73765b343c832bb5a369b1b48aaafa)