### PR TITLE
CI: correct coverage instrumentation scope and reporting gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -215,7 +215,12 @@ jobs:
           github-token: ${{ github.token }}
           lcov-file: "coverage.info"
           base-lcov-file: "base-coverage.info"
-          minimum-ratio: 0
+          # Barecheck rounds each total to two decimals before subtracting them, so a reported diff of
+          # -0.01 can come entirely from the two totals falling on opposite sides of a rounding
+          # boundary. That artifact is bounded at one step, so tolerating -0.01 absorbs it while
+          # anything at -0.02 or beyond still implies a real drop. Note a negative value here would
+          # disable the check altogether rather than widen the tolerance.
+          minimum-ratio: 0.01
           send-summary-comment: false
           show-annotations: "warning"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -189,7 +189,11 @@ jobs:
   coverage:
     name: Coverage
     needs: [checkout, test, base-coverage-combine]
-    if: always() && needs.test.result == 'success' && (needs.base-coverage-combine.result == 'success' || needs.base-coverage-combine.result == 'skipped')
+    # Gate on the coverage artifact rather than on the result of the whole browser-tests call, which
+    # also covers e2e, browserstack and the browsers that run without instrumentation. The output is
+    # only set by a matrix leg that both succeeded and produced coverage, so a non-empty value is
+    # exactly the condition under which there is something to report.
+    if: always() && needs.test.outputs.coverage && (needs.base-coverage-combine.result == 'success' || needs.base-coverage-combine.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -31,6 +31,7 @@ function newWebpackConfig(codeCoverage, disableFeatures) {
     options: {
       cacheDirectory: cacheDir, cacheCompression: false,
       presets: [['@babel/preset-env', {modules: 'commonjs'}]],
+      // The coverage instrumentation options below were written by a bot (Claude Code).
       // Keep the specs out of coverage: they run start to finish by definition, so counting them
       // swamps the totals for the code they exercise. `exclude` is anchored to `cwd`, which has to be
       // the precompiled tree because that's where the files being instrumented live. Both options are

--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -31,7 +31,15 @@ function newWebpackConfig(codeCoverage, disableFeatures) {
     options: {
       cacheDirectory: cacheDir, cacheCompression: false,
       presets: [['@babel/preset-env', {modules: 'commonjs'}]],
-      plugins: codeCoverage ? ['babel-plugin-istanbul'] : []
+      // Keep the specs out of coverage: they run start to finish by definition, so counting them
+      // swamps the totals for the code they exercise. `exclude` is anchored to `cwd`, which has to be
+      // the precompiled tree because that's where the files being instrumented live. Both options are
+      // needed - `cwd` on its own is overridden by the nyc config lookup, which walks up to the
+      // nearest package.json and resets `cwd` to the repo root.
+      plugins: codeCoverage ? [['babel-plugin-istanbul', {
+        cwd: helpers.getPrecompiledPath(),
+        exclude: ['test/**']
+      }]] : []
     }
   })
   return webpackConfig;


### PR DESCRIPTION
## Type of change

- [x] Build related changes
- [x] CI related changes

## Description of change

Barecheck correctly identifies uncovered lines but reports a coverage diff of 0.00% on nearly every PR, its summary comment goes missing entirely on a significant share of runs, and the `Coverage` job fails intermittently on diffs that do not correspond to any real regression. Three separate causes, one per commit.

### Specs were being instrumented, and dominated the totals

`karma.conf.maker.js` applied `babel-plugin-istanbul` to every `.js` outside `node_modules` with no options. Istanbul's default excludes do cover `test{,s}/**`, but they are anchored to a `cwd` that resolves to the repo root, and sources are precompiled into `dist/src` before Karma sees them — so the paths being instrumented are `dist/src/test/spec/...` and the anchored pattern never matches.

The result, measured from the lcov artifacts of run 31010108350:

| | files | lines | covered | share of reported total |
| --- | --- | --- | --- | --- |
| `test/spec` | 895 | 165,384 | 99.41% | 67.1% |
| `modules` | 758 | 69,093 | 90.72% | 28.0% |
| `libraries` | 175 | 6,391 | 92.22% | 2.6% |
| `src` | 76 | 5,058 | 94.72% | 2.1% |

Two thirds of the headline number was measuring how much of the test suite executed. Reported total 96.67%; actual source coverage 91.09%.

The fix points istanbul's `cwd` at the precompiled tree and excludes `test/**` relative to it. Both options are required — `cwd` on its own is silently overwritten by `@istanbuljs/load-nyc-config`, which walks up to the nearest `package.json` and resets `cwd` to the repo root.

### Coverage was dropped whenever any unrelated test job failed

The `coverage` job required the entire `browser-tests.yml` call to succeed. That call also covers e2e, BrowserStack, and the browsers that run without instrumentation, so a single Safari Technology Preview e2e failure was enough to skip it — no `coverage.info` artifact, and `barecheck.yml` then skipped its report step with nothing to comment on. Run 31012356718 is an example: the only failure in the whole run was Safari TP e2e.

Across the last 100 pull-request runs of this workflow, roughly a third of the failures were of this kind — the coverage-producing leg had succeeded and its data was discarded anyway. (The remainder had the ChromeHeadless leg itself fail, so there was genuinely nothing to report, or were cancelled by concurrency, or were fork PRs awaiting approval.)

The fix gates on `needs.test.outputs.coverage` instead of on the aggregate result. Per the matrix-output semantics for reusable workflows, that output is only set by a leg that both succeeded and produced coverage, so a non-empty value is exactly the condition under which there is something to report. I confirmed by experiment that a caller can still read `needs.<call>.outputs.*` after the called workflow concludes as `failure`, and that legs publishing an empty value do not clobber a real one.

Note that this does not make the summary comment land any sooner — `barecheck.yml` is triggered by `workflow_run` on the whole **Run tests** workflow, so its latency floor is unchanged. It only stops the report from being lost.

### The ratio check was failing on rounding artifacts

`minimum-ratio: 0` fails the job on any negative diff. But Barecheck rounds each total to two decimals *before* subtracting them (`calculatePercentage` returns `parseFloat(((hit / found) * 100).toFixed(2))`), so the reported diff is a difference of quantized values rather than a quantized difference.

With a denominator of ~246k lines, one line of coverage is 0.00041% — 4% of a 0.01 step — and a full step is about 25 lines. The measured head-vs-base difference for PR #15356 was 0.00049%, roughly one line. So the true signal is a twentieth of the step size, and what survives rounding is decided by where each total happens to sit inside its bucket. The totals also sit right beside a boundary: the base total measures 96.6703%, only 0.0047% below the 96.675 cutoff.

The observable consequence, sampling recent `Coverage` jobs:

```
31025201048  head=96.68 base=96.68 diff= 0.00
31024884308  head=96.68 base=96.67 diff=+0.01
31024851219  head=96.68 base=96.68 diff= 0.00
31010108350  head=96.67 base=96.67 diff= 0.00
31008936133  head=96.67 base=96.67 diff= 0.00
31002469978  head=96.68 base=96.67 diff=+0.01
31001869842  head=96.68 base=96.68 diff= 0.00
30999337410  head=96.67 base=96.67 diff= 0.00
30994692444  head=96.67 base=96.67 diff= 0.00
30984345903  head=96.66 base=96.67 diff=-0.01  <- failed the job
```

Every diff is 0.00 or ±0.01, never more than a single step, and the sign is effectively a coin flip on bucket placement. A larger denominator makes this *more* likely rather than less, because it shrinks the true signal relative to the fixed 0.01 step.

Raising the tolerance to `0.01` absorbs exactly that artifact. It is bounded at one step — writing the reported value as `d + e` where each rounding error is at most 0.005, reaching -0.02 requires a true diff of at least -0.01 — so a genuine drop is still caught. Worth noting that a negative value here would not widen the tolerance; the guard is `if (minCoverageRatio >= 0)`, so anything negative disables the check entirely.

This matters more after the first commit, not less: dropping the specs shrinks the denominator to ~81k lines and a step to about 8 lines, so bucket crossings become roughly three times more frequent and `minimum-ratio: 0` would have failed considerably more often than it already did.

## Expected: this PR and the ones after it will report a large negative coverage diff

Until this change is on master, Barecheck compares a head measured source-only (~91.09%) against a base measured source-plus-specs (~96.67%), and will report a diff of about **-5.58%**. That includes this PR.

Nothing became less tested. The denominator shrank by 165k lines of spec code that never belonged in it.

This cannot be avoided by clearing the coverage cache. Base coverage is always derived from the base commit's own checkout — either from the cache entry that commit's own push run wrote, or by recomputing from that checkout on a miss — so any pre-fix base commit keeps producing the old number regardless. It self-corrects on the first master push after merge, and PRs whose merge base includes this change compare like for like.

The `minimum-ratio: 0.01` tolerance in the third commit does not rescue this — -5.58% fails under any tolerance — so expect a red `Coverage` check on this PR and on any PR that runs before master's post-merge push completes. If that is not acceptable, the gate can be disabled for the merge by setting `minimum-ratio` to any negative value and restored afterwards.

## Testing

`npx eslint` over the repository sources: clean, no output.

`npx gulp test`: green, 47,557 tests completed across all 8 chunks of both the default and all-features-disabled passes, no failures.

Verified the instrumentation change directly by running `npx gulp test-coverage --file <spec>` before and after and diffing the `SF:` entries in the generated lcov. For `test/spec/unit/core/events_spec.js` the instrumented file count goes from 116 to 103 and the `test/`-prefixed entries from 13 to 0, with the same 10 tests passing.

## Other information

No associated issue, so per the repo guidelines the issue template is filled in below.

### Type of issue

Bug — code coverage reporting.

### Description

Barecheck reports a coverage diff of 0.00% on nearly every PR, its summary comment is absent on many runs, and the `Coverage` job fails intermittently on a -0.01% diff that reflects no real regression.

### Steps to reproduce

1. Open any PR and wait for **Run tests** to complete.
2. Read the `Coverage` job log: `Current code coverage` and `Base branch code coverage` agree to two decimal places, and `Code coverage diff` is `0.00%`.
3. Download the `coverage.info` artifact and note that `SF:` entries include `test/spec/**`.
4. For the missing-comment case, find a run whose only failure is outside the ChromeHeadless unit job and observe that `Coverage` was skipped and no `coverage.info` was uploaded.
5. For the spurious failure case, compare the `Code coverage diff` across several runs and note that it only ever takes the values 0.00 or ±0.01, and that the -0.01 runs fail.

### Test page

Not applicable; this is build and CI tooling.

### Expected results

The reported total reflects coverage of the source under test, and a report is produced whenever coverage data exists.

### Actual results

The total is dominated by spec files at 99.41% coverage, the report is dropped whenever any job in the browser-tests call fails, and the ratio check fails on quantization artifacts.

### Platform details

Node 20, Ubuntu, GitHub Actions runners. Affects `karma.conf.maker.js` and `.github/workflows/test.yml` only; no shipped code changes.

### Other information

Suggested labels: `maintenance`, `patch`. No documentation PR needed — nothing user-facing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
