### PR TITLE
Bid Espresso Bid Adapter: new bid adapter

### DIFF
--- a/modules/bidespressoBidAdapter.md
+++ b/modules/bidespressoBidAdapter.md
@@ -1,0 +1,114 @@
+# Overview
+
+```
+Module Name: Bid Espresso Bid Adapter
+Module Type: Bidder Adapter
+Maintainer: prebid@bidespresso.com
+```
+
+# Description
+
+Bid Espresso is a supply-side auction gateway. The adapter sends a single
+OpenRTB request per auction to the Bid Espresso gateway, which enriches it and
+fans out to demand server-side. Bids are returned net of the Bid Espresso
+margin (`netRevenue: true`).
+
+Banner and video are supported (outstream video requires a publisher-supplied
+renderer). Mixed banner+video ad units send both media objects on a single
+imp — the gateway auctions each media class separately server-side, stamps
+oRTB `mtype` on every bid, and either class can win. The adapter forwards
+GDPR, US Privacy (CCPA) and GPP consent, first-party data (`ortb2`),
+extended IDs (`userId`/`eids`), and floors via the floors module.
+
+Note: the auction request is credentialed (`withCredentials: true`) so the
+Bid Espresso user-match cookie can attach. The match id is carried only by
+that cookie, which is set server-side during sync — the adapter itself uses
+no storage manager and writes nothing to cookies or localStorage.
+
+Bid Espresso does not currently declare an IAB TCF Global Vendor List ID.
+Publishers enforcing vendor-level TCF consent should list `bidespresso`
+under `vendorExceptions` (or supply a `gvlMapping` entry) to include the
+adapter for EEA traffic; GDPR, US Privacy and GPP consent signals are always
+forwarded on both auction requests and user syncs regardless.
+
+Price floors are read from the floors module (`getFloor`) and requested in
+USD — floors configured in another currency are converted automatically when
+the currency module is present. Only floors that cannot be resolved to USD
+are withheld: the Bid Espresso gateway prices floors in USD, and forwarding
+an unconverted floor would silently misprice it. Banner bids carry
+a 300s TTL and video bids 900s; a per-bid `exp` from the gateway takes
+precedence.
+
+# Bid Parameters
+
+| Name          | Scope    | Description                                                                              | Example      | Type     |
+|---------------|----------|------------------------------------------------------------------------------------------|--------------|----------|
+| `publisherId` | required | Publisher ID on the Bid Espresso gateway. Provided by Bid Espresso during onboarding.     | `'k8xw2r4p'` | `string` |
+| `inventoryId` | required | Inventory segment ID. Always assigned by Bid Espresso during onboarding — single-placement integrations receive their default segment ID. | `'n7c3tkqe'` | `string` |
+
+# Example Ad Unit
+
+```js
+var adUnits = [
+  {
+    code: 'div-ad-leaderboard',
+    mediaTypes: {
+      banner: {
+        sizes: [
+          [728, 90],
+          [970, 90]
+        ]
+      }
+    },
+    bids: [{
+      bidder: 'bidespresso',
+      params: {
+        publisherId: 'k8xw2r4p', // Required — provided by Bid Espresso during onboarding
+        inventoryId: 'n7c3tkqe'  // Required — assigned by Bid Espresso during onboarding
+      }
+    }]
+  }
+];
+```
+
+# Configuration
+
+User syncing requires iframe syncs to be enabled for this bidder — Prebid
+does not enable them by default, and without this the adapter registers no
+syncs and user matching silently never happens (the sync chain must execute
+as a document, so it registers nothing in pixel-only mode):
+
+```js
+pbjs.setConfig({
+  userSync: {
+    filterSettings: {
+      iframe: {
+        bidders: ['bidespresso'],
+        filter: 'include'
+      }
+    }
+  }
+});
+```
+
+# Test Parameters
+
+```js
+var adUnits = [
+  {
+    code: 'test-div',
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]]
+      }
+    },
+    bids: [{
+      bidder: 'bidespresso',
+      params: {
+        publisherId: 'prebidtest',
+        inventoryId: 'ron'
+      }
+    }]
+  }
+];
+```

--- a/modules/bidespressoBidAdapter.ts
+++ b/modules/bidespressoBidAdapter.ts
@@ -1,0 +1,245 @@
+import { ortbConverter } from '../libraries/ortbConverter/converter.js';
+import { getUserSyncParams } from '../libraries/userSyncUtils/userSyncUtils.js';
+import { type BidderSpec, registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import { deepSetValue, formatQS, logWarn } from '../src/utils.js';
+
+export interface BidEspressoBidParams {
+  /**
+   * Bid Espresso publisher ID, assigned during onboarding. Routes the auction
+   * to the publisher's configuration on the Bid Espresso gateway (`?pub=`).
+   */
+  publisherId: string;
+  /**
+   * Inventory segment ID, always assigned by Bid Espresso during onboarding —
+   * single-placement integrations receive their default segment ID (`?inv=`).
+   */
+  inventoryId: string;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    [BIDDER_CODE]: BidEspressoBidParams;
+  }
+}
+
+const BIDDER_CODE = 'bidespresso';
+const ENDPOINT_URL = 'https://auction.bidespresso.com/openrtb2/auction';
+const SYNC_URL = 'https://auction.bidespresso.com/usync';
+const DEFAULT_TTL = 300;
+// Video creatives sit in caches (Prebid Cache / the ad server) far longer than
+// banners; a per-bid `exp` from the gateway still takes precedence.
+const VIDEO_TTL = 900;
+const DEFAULT_CURRENCY = 'USD';
+
+export const converter = ortbConverter<typeof BIDDER_CODE>({
+  context: {
+    netRevenue: true, // the gateway's margin is already applied; bids are net to the publisher
+    ttl: DEFAULT_TTL,
+    // The gateway's upstream partners answer in an oRTB 2.4-era dialect with no
+    // response `cur`, so the currency is pinned here.
+    currency: DEFAULT_CURRENCY,
+  },
+  imp(buildImp, bidRequest, context) {
+    const imp = buildImp(bidRequest, context);
+    // A mixed ad unit sends BOTH media objects on one imp — the gateway
+    // auctions each media class separately server-side and stamps `mtype` on
+    // every bid. Only a malformed video half is dropped (the banner side can
+    // still bid), and the drop is never silent.
+    if (imp.banner && imp.video) {
+      const video = (bidRequest.mediaTypes as Record<string, unknown> | undefined)?.video as Record<string, unknown> | undefined;
+      // ortb2Imp can inject imp.video with no mediaTypes declaration to
+      // validate against — treat that like a malformed half and keep banner.
+      if (!video || !isValidVideoDeclaration(video, bidRequest.bidId)) {
+        logWarn(`bidespresso: ad unit "${bidRequest.adUnitCode}" has a malformed video declaration; sending banner only`);
+        delete imp.video;
+      }
+    }
+    // The gateway's zone map and per-imp analytics key on tagid.
+    imp.tagid ||= bidRequest.adUnitCode;
+    // The segment id rides on every imp so imps stay self-describing when
+    // requests are split per segment, logged, or debugged individually.
+    deepSetValue(imp, 'ext.inventoryId', bidRequest.params.inventoryId);
+    // Provenance fields some DSPs read; `||=` so publisher ortb2Imp wins.
+    imp.displaymanager ||= 'Prebid.js';
+    imp.displaymanagerver ||= '$prebid.version$';
+    return imp;
+  },
+  request(buildRequest, imps, bidderRequest, context) {
+    const request = buildRequest(imps, bidderRequest, context);
+    // The gateway reads consent at its OpenRTB 2.5 locations (regs.ext.*).
+    // Prebid core deliberately consolidates gpp/gpp_sid at their 2.6 root
+    // locations (src/fpd/normalize.js), so they are relocated here. Never
+    // dual-populate: a request carrying both locations gets one of them
+    // silently dropped downstream. (eids need no such move — core already
+    // consolidates them at user.ext.eids before adapters run.)
+    const regs = request.regs as Record<string, unknown> | undefined;
+    if (regs) {
+      if (regs.gpp != null && (regs.ext as Record<string, unknown>)?.gpp == null) {
+        deepSetValue(request, 'regs.ext.gpp', regs.gpp);
+        if (regs.gpp_sid != null) {
+          deepSetValue(request, 'regs.ext.gpp_sid', regs.gpp_sid);
+        }
+      }
+      delete regs.gpp;
+      delete regs.gpp_sid;
+      if (Object.keys(regs).length === 0) {
+        delete request.regs;
+      }
+    }
+    // The Bid Espresso match id travels ONLY as the credentialed cookie. A
+    // buyeruid inside the page payload is by definition not ours and is never
+    // forwarded — the same "ours or nothing" rule the gateway enforces
+    // server-side.
+    const user = request.user as Record<string, unknown> | undefined;
+    if (user) {
+      delete user.buyeruid;
+      if (Object.keys(user).length === 0) {
+        delete request.user;
+      }
+    }
+    return request;
+  },
+  bidResponse(buildBidResponse, bid, context) {
+    // The gateway stamps oRTB `mtype` on every bid (1 banner, 2 video) and
+    // the converter core honors it natively, so it is deliberately not
+    // re-derived here. The context fallback covers legacy/no-mtype responses
+    // only: unambiguous for single-media imps; a dual-media imp defaults to
+    // banner (the gateway's historical banner-preferred behavior).
+    const isVideo = bid.mtype != null
+      ? bid.mtype === 2
+      : Boolean(context.imp?.video && !context.imp?.banner);
+    if (bid.mtype == null) {
+      context.mediaType = isVideo ? VIDEO : BANNER;
+    }
+    if (isVideo) {
+      context.ttl = VIDEO_TTL;
+    }
+    return buildBidResponse(bid, context);
+  },
+  overrides: {
+    imp: {
+      bidfloor(applyDefaultBidFloor, imp, bidRequest, context) {
+        // The gateway prices floors in USD. Ask the floors module for USD and
+        // attach the result only when it actually is USD — a floor in any
+        // other currency would be silently misread downstream. (This override
+        // only runs when the publisher has compiled the priceFloors module.)
+        const floor = {};
+        applyDefaultBidFloor(floor, bidRequest, { ...context, currency: DEFAULT_CURRENCY });
+        if ((floor as Record<string, unknown>).bidfloorcur === DEFAULT_CURRENCY) {
+          Object.assign(imp, floor);
+        }
+      },
+    },
+  },
+});
+
+function hasResolvableSize(video: Record<string, unknown>): boolean {
+  const ps = video.playerSize;
+  if (Array.isArray(ps)) {
+    const flat = Array.isArray(ps[0]) ? ps[0] : ps;
+    if (flat.length === 2 && flat.every((n) => Number.isFinite(n))) {
+      return true;
+    }
+  }
+  return Number.isFinite(video.w) && Number.isFinite(video.h);
+}
+
+function isValidVideoDeclaration(video: Record<string, unknown>, bidId: string): boolean {
+  if (!Array.isArray(video.mimes) || video.mimes.length === 0) {
+    logWarn(`bidespresso: invalid mediaTypes.video on bid "${bidId}" — mimes must be a non-empty array`);
+    return false;
+  }
+  if (!hasResolvableSize(video)) {
+    logWarn(`bidespresso: invalid mediaTypes.video on bid "${bidId}" — needs playerSize ([[w,h]] or [w,h]) or numeric w/h`);
+    return false;
+  }
+  return true;
+}
+
+const isBidRequestValid: BidderSpec<typeof BIDDER_CODE>['isBidRequestValid'] = (bid) => {
+  const params = bid?.params;
+  if (typeof params?.publisherId !== 'string' || params.publisherId.length === 0) {
+    return false;
+  }
+  if (typeof params.inventoryId !== 'string' || params.inventoryId.length === 0) {
+    return false;
+  }
+  const mediaTypes = bid?.mediaTypes as Record<string, unknown> | undefined;
+  const video = mediaTypes?.video as Record<string, unknown> | undefined;
+  // A video-only ad unit must be answerable: hard-require what the gateway's
+  // video path cannot synthesize. Mixed units stay valid — their banner side
+  // can still bid.
+  if (video && !mediaTypes?.banner && !isValidVideoDeclaration(video, bid.bidId)) {
+    return false;
+  }
+  return true;
+};
+
+const buildRequests: BidderSpec<typeof BIDDER_CODE>['buildRequests'] = (validBidRequests, bidderRequest) => {
+  // One POST per (publisherId, inventoryId) pair: a page may carry ad units
+  // from different inventory segments, and every imp must ride under its own
+  // routing ids — never the first bid's.
+  const groups: Record<string, typeof validBidRequests> = {};
+  for (const bid of validBidRequests) {
+    // Encoded parts so an id containing the delimiter can never merge groups.
+    const key = `${encodeURIComponent(bid.params.publisherId)}|${encodeURIComponent(bid.params.inventoryId)}`;
+    (groups[key] ??= []).push(bid);
+  }
+  return Object.values(groups).map((groupBids) => {
+    const data = converter.toORTB({ bidRequests: groupBids, bidderRequest });
+    const { publisherId, inventoryId } = groupBids[0].params;
+    const url = `${ENDPOINT_URL}?pub=${encodeURIComponent(publisherId)}&inv=${encodeURIComponent(inventoryId)}`;
+    return {
+      method: 'POST' as const,
+      url,
+      data,
+      options: {
+        // Both options match today's core defaults for adapter POSTs
+        // (src/adapters/bidderFactory applies withCredentials:true +
+        // text/plain). They are pinned deliberately: the user-match cookie
+        // only attaches on a credentialed request, and matching would fail
+        // silently if a future core default change or a stray override ever
+        // flipped it. text/plain additionally keeps the POST preflight-free.
+        withCredentials: true,
+        contentType: 'text/plain',
+      },
+    };
+  });
+};
+
+const interpretResponse: BidderSpec<typeof BIDDER_CODE>['interpretResponse'] = (serverResponse, request) => {
+  const body = serverResponse.body as { id?: string } | string | null | undefined;
+  const requestId = (request.data as { id?: string })?.id;
+  const bodyId = typeof body === 'object' && body != null ? body.id : undefined;
+  // Cross-talk guard: a response that answers some other request must not be
+  // parsed as ours (fromORTB matches on impids, which can collide across
+  // auctions).
+  if (bodyId != null && requestId != null && bodyId !== requestId) {
+    logWarn(`bidespresso: dropping response "${bodyId}" that does not answer request "${requestId}"`);
+    return { bids: [] };
+  }
+  return converter.fromORTB({ response: serverResponse.body, request: request.data });
+};
+
+const getUserSyncs: BidderSpec<typeof BIDDER_CODE>['getUserSyncs'] = (syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) => {
+  // The sync endpoint redirects into a multi-partner sync page whose logic must
+  // execute as a document — loaded as an image it dies silently. Iframe or nothing.
+  if (!syncOptions.iframeEnabled) {
+    return [];
+  }
+  const params = getUserSyncParams(gdprConsent, uspConsent, gppConsent);
+  const qs = formatQS(params);
+  return [{ type: 'iframe', url: qs ? `${SYNC_URL}?${qs}` : SYNC_URL }];
+};
+
+export const spec: BidderSpec<typeof BIDDER_CODE> = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [BANNER, VIDEO],
+  isBidRequestValid,
+  buildRequests,
+  interpretResponse,
+  getUserSyncs,
+};
+
+registerBidder(spec);

--- a/modules/bidespressoBidAdapter.ts
+++ b/modules/bidespressoBidAdapter.ts
@@ -252,6 +252,10 @@ const getUserSyncs: BidderSpec<typeof BIDDER_CODE>['getUserSyncs'] = (syncOption
 
 export const spec: BidderSpec<typeof BIDDER_CODE> = {
   code: BIDDER_CODE,
+  // Device-storage disclosure for the server-set match cookie (the adapter
+  // itself uses no storage APIs; the cookie attaches via the credentialed
+  // request and is set during the iframe sync).
+  disclosureURL: 'https://auction.bidespresso.com/device-storage-disclosure.json',
   supportedMediaTypes: [BANNER, VIDEO],
   isBidRequestValid,
   buildRequests,

--- a/modules/bidespressoBidAdapter.ts
+++ b/modules/bidespressoBidAdapter.ts
@@ -130,6 +130,23 @@ export const converter = ortbConverter<typeof BIDDER_CODE>({
           Object.assign(imp, floor);
         }
       },
+      extBidfloor(setGranularBidfloors, imp, bidRequest, context) {
+        // Same USD rule for the granular floors the module writes under
+        // banner/video `ext` and `banner.format[].ext`: run the default
+        // processor, then withhold any floor it wrote that did not resolve
+        // in USD.
+        setGranularBidfloors(imp, bidRequest, { ...context, currency: DEFAULT_CURRENCY });
+        const scrub = (obj: unknown) => {
+          const ext = (obj as { ext?: Record<string, unknown> } | undefined)?.ext;
+          if (ext && 'bidfloor' in ext && ext.bidfloorcur !== DEFAULT_CURRENCY) {
+            delete ext.bidfloor;
+            delete ext.bidfloorcur;
+          }
+        };
+        scrub(imp.banner);
+        scrub(imp.video);
+        ((imp.banner as { format?: unknown[] } | undefined)?.format ?? []).forEach(scrub);
+      },
     },
   },
 });

--- a/test/spec/modules/bidespressoBidAdapter_spec.js
+++ b/test/spec/modules/bidespressoBidAdapter_spec.js
@@ -294,6 +294,34 @@ describe('Bid Espresso bid adapter', () => {
       expect(request.data.imp[0].bidfloorcur).to.be.undefined;
     });
 
+    it('attaches per-size granular floors when they resolve in USD', () => {
+      bid.mediaTypes = { banner: { sizes: [[300, 250], [728, 90]] } };
+      bid.getFloor = ({ currency, size }) => ({
+        currency,
+        floor: Array.isArray(size) && size[0] === 728 ? 2.5 : 1.25,
+      });
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      const formats = request.data.imp[0].banner.format;
+      const leaderboard = formats.find((f) => f.w === 728);
+      expect(leaderboard.ext.bidfloor).to.equal(2.5);
+      expect(leaderboard.ext.bidfloorcur).to.equal('USD');
+    });
+
+    it('withholds granular floors that cannot resolve in USD', () => {
+      bid.mediaTypes = { banner: { sizes: [[300, 250], [728, 90]] } };
+      bid.getFloor = ({ size }) => ({
+        currency: 'EUR',
+        floor: Array.isArray(size) && size[0] === 728 ? 2.5 : 0.8,
+      });
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.imp[0].bidfloor).to.be.undefined;
+      const banner = request.data.imp[0].banner;
+      expect(banner.ext?.bidfloor).to.be.undefined;
+      (banner.format ?? []).forEach((f) => {
+        expect(f.ext?.bidfloor, `format ${f.w}x${f.h}`).to.be.undefined;
+      });
+    });
+
     it('forwards the COPPA flag from config', () => {
       bidderRequest.ortb2.regs = { coppa: 1 };
       const [request] = spec.buildRequests([bid], bidderRequest);

--- a/test/spec/modules/bidespressoBidAdapter_spec.js
+++ b/test/spec/modules/bidespressoBidAdapter_spec.js
@@ -328,30 +328,34 @@ describe('Bid Espresso bid adapter', () => {
       expect(request.data.regs.coppa).to.equal(1);
     });
 
-    it('builds a video imp for a video-only ad unit', () => {
-      bid.mediaTypes = {
-        video: { context: 'instream', playerSize: [[640, 480]], mimes: ['video/mp4'], protocols: [2, 3] },
-      };
-      const [request] = spec.buildRequests([bid], bidderRequest);
-      expect(request.data.imp).to.have.lengthOf(1);
-      expect(request.data.imp[0].video).to.exist;
-      expect(request.data.imp[0].video.w).to.equal(640);
-      expect(request.data.imp[0].video.h).to.equal(480);
-      expect(request.data.imp[0].video.mimes).to.deep.equal(['video/mp4']);
-      expect(request.data.imp[0].banner).to.not.exist;
-    });
+    if (FEATURES.VIDEO) {
+      it('builds a video imp for a video-only ad unit', () => {
+        bid.mediaTypes = {
+          video: { context: 'instream', playerSize: [[640, 480]], mimes: ['video/mp4'], protocols: [2, 3] },
+        };
+        const [request] = spec.buildRequests([bid], bidderRequest);
+        expect(request.data.imp).to.have.lengthOf(1);
+        expect(request.data.imp[0].video).to.exist;
+        expect(request.data.imp[0].video.w).to.equal(640);
+        expect(request.data.imp[0].video.h).to.equal(480);
+        expect(request.data.imp[0].video.mimes).to.deep.equal(['video/mp4']);
+        expect(request.data.imp[0].banner).to.not.exist;
+      });
+    }
 
-    it('sends both media objects for a mixed banner+video ad unit', () => {
-      bid.mediaTypes = {
-        banner: { sizes: [[300, 250]] },
-        video: { context: 'instream', playerSize: [[640, 480]], mimes: ['video/mp4'] },
-      };
-      const [request] = spec.buildRequests([bid], bidderRequest);
-      expect(request.data.imp).to.have.lengthOf(1);
-      expect(request.data.imp[0].banner).to.exist;
-      expect(request.data.imp[0].video).to.exist;
-      expect(request.data.imp[0].video.mimes).to.deep.equal(['video/mp4']);
-    });
+    if (FEATURES.VIDEO) {
+      it('sends both media objects for a mixed banner+video ad unit', () => {
+        bid.mediaTypes = {
+          banner: { sizes: [[300, 250]] },
+          video: { context: 'instream', playerSize: [[640, 480]], mimes: ['video/mp4'] },
+        };
+        const [request] = spec.buildRequests([bid], bidderRequest);
+        expect(request.data.imp).to.have.lengthOf(1);
+        expect(request.data.imp[0].banner).to.exist;
+        expect(request.data.imp[0].video).to.exist;
+        expect(request.data.imp[0].video.mimes).to.deep.equal(['video/mp4']);
+      });
+    }
 
     it('drops only a malformed video half from a mixed ad unit', () => {
       bid.mediaTypes = {
@@ -520,50 +524,52 @@ describe('Bid Espresso bid adapter', () => {
     });
   });
 
-  describe('interpretResponse for a mixed banner+video response', () => {
-    // Two ad units (one banner, one video) answered in ONE response. Pins the
-    // converter's per-imp context isolation: the video bid's mediaType/ttl
-    // treatment must never leak onto the banner bid.
-    it('types and ttls each bid by its own imp', () => {
-      const bannerBid = deepClone(bidRequestBase);
-      const videoBid = deepClone(bidRequestBase);
-      videoBid.bidId = 'video-bid-1';
-      videoBid.adUnitCode = 'video-ad-unit-code';
-      videoBid.mediaTypes = { video: { context: 'instream', playerSize: [[640, 480]], mimes: ['video/mp4'] } };
-      const bidderRequest = {
-        bidderCode: 'bidespresso',
-        auctionId: bannerBid.auctionId,
-        bidderRequestId: bannerBid.bidderRequestId,
-        bids: [bannerBid, videoBid],
-        ortb2: {},
-      };
-      const [request] = spec.buildRequests([bannerBid, videoBid], bidderRequest);
-      const response = {
-        body: {
-          id: request.data.id,
-          seatbid: [
-            {
-              seat: '2307',
-              bid: [
-                { id: 'v', impid: 'video-bid-1', price: 0.35, adm: '<VAST version="3.0"></VAST>', crid: 'vid' },
-                { id: 'b', impid: 'bid-id-1', price: 0.09, adm: '<div>ad</div>', w: 300, h: 250, crid: 'ban' },
-              ],
-            },
-          ],
-        },
-      };
-      const result = spec.interpretResponse(response, request);
-      const bids = result.bids;
-      expect(bids).to.have.lengthOf(2);
-      const video = bids.find((b) => b.requestId === 'video-bid-1');
-      const banner = bids.find((b) => b.requestId === 'bid-id-1');
-      expect(video.mediaType).to.equal('video');
-      expect(video.ttl).to.equal(900);
-      expect(banner.mediaType).to.equal('banner');
-      expect(banner.ttl).to.equal(300);
-      expect(banner.ad).to.equal('<div>ad</div>');
+  if (FEATURES.VIDEO) {
+    describe('interpretResponse for a mixed banner+video response', () => {
+      // Two ad units (one banner, one video) answered in ONE response. Pins the
+      // converter's per-imp context isolation: the video bid's mediaType/ttl
+      // treatment must never leak onto the banner bid.
+      it('types and ttls each bid by its own imp', () => {
+        const bannerBid = deepClone(bidRequestBase);
+        const videoBid = deepClone(bidRequestBase);
+        videoBid.bidId = 'video-bid-1';
+        videoBid.adUnitCode = 'video-ad-unit-code';
+        videoBid.mediaTypes = { video: { context: 'instream', playerSize: [[640, 480]], mimes: ['video/mp4'] } };
+        const bidderRequest = {
+          bidderCode: 'bidespresso',
+          auctionId: bannerBid.auctionId,
+          bidderRequestId: bannerBid.bidderRequestId,
+          bids: [bannerBid, videoBid],
+          ortb2: {},
+        };
+        const [request] = spec.buildRequests([bannerBid, videoBid], bidderRequest);
+        const response = {
+          body: {
+            id: request.data.id,
+            seatbid: [
+              {
+                seat: '2307',
+                bid: [
+                  { id: 'v', impid: 'video-bid-1', price: 0.35, adm: '<VAST version="3.0"></VAST>', crid: 'vid' },
+                  { id: 'b', impid: 'bid-id-1', price: 0.09, adm: '<div>ad</div>', w: 300, h: 250, crid: 'ban' },
+                ],
+              },
+            ],
+          },
+        };
+        const result = spec.interpretResponse(response, request);
+        const bids = result.bids;
+        expect(bids).to.have.lengthOf(2);
+        const video = bids.find((b) => b.requestId === 'video-bid-1');
+        const banner = bids.find((b) => b.requestId === 'bid-id-1');
+        expect(video.mediaType).to.equal('video');
+        expect(video.ttl).to.equal(900);
+        expect(banner.mediaType).to.equal('banner');
+        expect(banner.ttl).to.equal(300);
+        expect(banner.ad).to.equal('<div>ad</div>');
+      });
     });
-  });
+  }
 
   describe('interpretResponse with gateway-stamped mtype (dual-media imps)', () => {
     // The gateway stamps `mtype` on every bid; on a dual-media imp it is the
@@ -615,13 +621,15 @@ describe('Bid Espresso bid adapter', () => {
       expect(result.bids[0].ttl).to.equal(300);
     });
 
-    it('classifies an mtype 2 bid on a dual-media imp as video with the video ttl', () => {
-      const result = spec.interpretResponse(dualResponse({ adm: vast, mtype: 2 }), request);
-      expect(result.bids).to.have.lengthOf(1);
-      expect(result.bids[0].mediaType).to.equal('video');
-      expect(result.bids[0].vastXml).to.equal(vast);
-      expect(result.bids[0].ttl).to.equal(900);
-    });
+    if (FEATURES.VIDEO) {
+      it('classifies an mtype 2 bid on a dual-media imp as video with the video ttl', () => {
+        const result = spec.interpretResponse(dualResponse({ adm: vast, mtype: 2 }), request);
+        expect(result.bids).to.have.lengthOf(1);
+        expect(result.bids[0].mediaType).to.equal('video');
+        expect(result.bids[0].vastXml).to.equal(vast);
+        expect(result.bids[0].ttl).to.equal(900);
+      });
+    }
 
     it('defaults a no-mtype bid on a dual-media imp to banner', () => {
       const result = spec.interpretResponse(
@@ -632,63 +640,65 @@ describe('Bid Espresso bid adapter', () => {
     });
   });
 
-  describe('interpretResponse for video', () => {
-    // Gateway bids carry no mtype; the adapter must infer VIDEO from the imp
-    // the bid answers, and video bids get the longer video ttl.
-    const videoBid = {
-      adUnitCode: 'video-ad-unit-code',
-      auctionId: 'auction-id',
-      bidId: 'video-bid-1',
-      bidder: 'bidespresso',
-      bidderRequestId: 'bidder-request-id',
-      mediaTypes: { video: { context: 'instream', playerSize: [[640, 480]], mimes: ['video/mp4'] } },
-      params: { publisherId: 'k8xw2r4p', inventoryId: 'n7c3tkqe' },
-    };
-
-    const vast = '<VAST version="3.0"><Ad><InLine></InLine></Ad></VAST>';
-
-    it('maps a no-mtype video bid to a Prebid video bid with vastXml and the video ttl', () => {
-      const bid = deepClone(videoBid);
-      const bidderRequest = {
-        bidderCode: 'bidespresso',
-        auctionId: bid.auctionId,
-        bidderRequestId: bid.bidderRequestId,
-        bids: [bid],
-        ortb2: {},
+  if (FEATURES.VIDEO) {
+    describe('interpretResponse for video', () => {
+      // Gateway bids carry no mtype; the adapter must infer VIDEO from the imp
+      // the bid answers, and video bids get the longer video ttl.
+      const videoBid = {
+        adUnitCode: 'video-ad-unit-code',
+        auctionId: 'auction-id',
+        bidId: 'video-bid-1',
+        bidder: 'bidespresso',
+        bidderRequestId: 'bidder-request-id',
+        mediaTypes: { video: { context: 'instream', playerSize: [[640, 480]], mimes: ['video/mp4'] } },
+        params: { publisherId: 'k8xw2r4p', inventoryId: 'n7c3tkqe' },
       };
-      const [request] = spec.buildRequests([bid], bidderRequest);
-      const videoServerResponse = {
-        body: {
-          id: request.data.id,
-          seatbid: [
-            {
-              seat: '2307',
-              bid: [
-                {
-                  id: '1',
-                  impid: 'video-bid-1',
-                  price: 0.35,
-                  adm: vast,
-                  adomain: ['advertiser.example'],
-                  crid: '2307:vid123',
-                },
-              ],
-            },
-          ],
-        },
-      };
-      const result = spec.interpretResponse(videoServerResponse, request);
-      const bids = result.bids;
-      expect(bids).to.have.lengthOf(1);
-      expect(bids[0].requestId).to.equal('video-bid-1');
-      expect(bids[0].mediaType).to.equal('video');
-      expect(bids[0].cpm).to.equal(0.35);
-      expect(bids[0].vastXml).to.equal(vast);
-      expect(bids[0].currency).to.equal('USD');
-      expect(bids[0].netRevenue).to.equal(true);
-      expect(bids[0].ttl).to.equal(900);
+
+      const vast = '<VAST version="3.0"><Ad><InLine></InLine></Ad></VAST>';
+
+      it('maps a no-mtype video bid to a Prebid video bid with vastXml and the video ttl', () => {
+        const bid = deepClone(videoBid);
+        const bidderRequest = {
+          bidderCode: 'bidespresso',
+          auctionId: bid.auctionId,
+          bidderRequestId: bid.bidderRequestId,
+          bids: [bid],
+          ortb2: {},
+        };
+        const [request] = spec.buildRequests([bid], bidderRequest);
+        const videoServerResponse = {
+          body: {
+            id: request.data.id,
+            seatbid: [
+              {
+                seat: '2307',
+                bid: [
+                  {
+                    id: '1',
+                    impid: 'video-bid-1',
+                    price: 0.35,
+                    adm: vast,
+                    adomain: ['advertiser.example'],
+                    crid: '2307:vid123',
+                  },
+                ],
+              },
+            ],
+          },
+        };
+        const result = spec.interpretResponse(videoServerResponse, request);
+        const bids = result.bids;
+        expect(bids).to.have.lengthOf(1);
+        expect(bids[0].requestId).to.equal('video-bid-1');
+        expect(bids[0].mediaType).to.equal('video');
+        expect(bids[0].cpm).to.equal(0.35);
+        expect(bids[0].vastXml).to.equal(vast);
+        expect(bids[0].currency).to.equal('USD');
+        expect(bids[0].netRevenue).to.equal(true);
+        expect(bids[0].ttl).to.equal(900);
+      });
     });
-  });
+  }
 
   describe('getUserSyncs', () => {
     it('registers nothing in pixel-only mode: the sync chain must run as a document', () => {

--- a/test/spec/modules/bidespressoBidAdapter_spec.js
+++ b/test/spec/modules/bidespressoBidAdapter_spec.js
@@ -1,0 +1,701 @@
+import { expect } from 'chai';
+import { spec } from '../../../modules/bidespressoBidAdapter.ts';
+import { deepClone } from '../../../src/utils.js';
+import { hook } from '../../../src/hook.js';
+// Load core plus the modules that register the converter's real ORTB
+// processors — without these, floors/currency/consent conversion logic is a
+// no-op in tests and assertions against it would pass vacuously.
+import 'src/prebid.js';
+import 'modules/currency.js';
+import 'modules/priceFloors.js';
+import 'modules/consentManagementTcf.js';
+import 'modules/consentManagementUsp.js';
+
+const ENDPOINT_URL = 'https://auction.bidespresso.com/openrtb2/auction';
+const SYNC_URL = 'https://auction.bidespresso.com/usync';
+
+const bidRequestBase = {
+  adUnitCode: 'banner-ad-unit-code',
+  auctionId: 'auction-id',
+  bidId: 'bid-id-1',
+  bidder: 'bidespresso',
+  bidderRequestId: 'bidder-request-id',
+  mediaTypes: { banner: { sizes: [[300, 250]] } },
+  params: { publisherId: 'k8xw2r4p', inventoryId: 'n7c3tkqe' },
+};
+
+describe('Bid Espresso bid adapter', () => {
+  before(() => {
+    hook.ready();
+  });
+
+  describe('spec', () => {
+    it('has the required properties', () => {
+      expect(spec).to.have.property('code', 'bidespresso');
+      expect(spec).to.have.property('supportedMediaTypes').that.includes('banner');
+      expect(spec).to.have.property('supportedMediaTypes').that.includes('video');
+      expect(spec).to.have.property('isBidRequestValid').that.is.a('function');
+      expect(spec).to.have.property('buildRequests').that.is.a('function');
+      expect(spec).to.have.property('interpretResponse').that.is.a('function');
+      expect(spec).to.have.property('getUserSyncs').that.is.a('function');
+    });
+  });
+
+  describe('isBidRequestValid', () => {
+    let bid;
+
+    beforeEach(() => {
+      bid = deepClone(bidRequestBase);
+    });
+
+    it('returns true when both publisherId and inventoryId are non-empty strings', () => {
+      expect(spec.isBidRequestValid(bid)).to.be.true;
+    });
+
+    it('returns false when inventoryId is missing', () => {
+      delete bid.params.inventoryId;
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+    });
+
+    it('returns false when params is missing', () => {
+      delete bid.params;
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+    });
+
+    it('returns false when publisherId is missing', () => {
+      bid.params = { inventoryId: 'n7c3tkqe' };
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+    });
+
+    it('returns false when publisherId is an empty string', () => {
+      bid.params = { publisherId: '', inventoryId: 'n7c3tkqe' };
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+    });
+
+    it('returns false when publisherId is a number', () => {
+      bid.params = { publisherId: 12345, inventoryId: 'n7c3tkqe' };
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+    });
+
+    it('returns false when inventoryId is present but empty', () => {
+      bid.params.inventoryId = '';
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+    });
+
+    it('returns false when inventoryId is present but not a string', () => {
+      bid.params.inventoryId = 42;
+      expect(spec.isBidRequestValid(bid)).to.be.false;
+    });
+
+    describe('video-only ad units', () => {
+      beforeEach(() => {
+        bid.mediaTypes = {
+          video: { context: 'instream', playerSize: [[640, 480]], mimes: ['video/mp4'] },
+        };
+      });
+
+      it('returns true for a well-formed video declaration', () => {
+        expect(spec.isBidRequestValid(bid)).to.be.true;
+      });
+
+      it('returns false when mimes is missing', () => {
+        delete bid.mediaTypes.video.mimes;
+        expect(spec.isBidRequestValid(bid)).to.be.false;
+      });
+
+      it('returns false when mimes is an empty array', () => {
+        bid.mediaTypes.video.mimes = [];
+        expect(spec.isBidRequestValid(bid)).to.be.false;
+      });
+
+      it('accepts a flat playerSize ([w, h])', () => {
+        bid.mediaTypes.video.playerSize = [640, 480];
+        expect(spec.isBidRequestValid(bid)).to.be.true;
+      });
+
+      it('accepts numeric w/h in place of playerSize', () => {
+        delete bid.mediaTypes.video.playerSize;
+        bid.mediaTypes.video.w = 640;
+        bid.mediaTypes.video.h = 480;
+        expect(spec.isBidRequestValid(bid)).to.be.true;
+      });
+
+      it('returns false when no player size is resolvable', () => {
+        delete bid.mediaTypes.video.playerSize;
+        expect(spec.isBidRequestValid(bid)).to.be.false;
+      });
+    });
+
+    it('keeps a mixed banner+video ad unit valid even when the video half is malformed', () => {
+      bid.mediaTypes = {
+        banner: { sizes: [[300, 250]] },
+        video: { context: 'instream' }, // no mimes, no size — banner can still bid
+      };
+      expect(spec.isBidRequestValid(bid)).to.be.true;
+    });
+  });
+
+  describe('buildRequests', () => {
+    let bid;
+    let bidderRequest;
+
+    beforeEach(() => {
+      bid = deepClone(bidRequestBase);
+      bidderRequest = {
+        bidderCode: 'bidespresso',
+        auctionId: bid.auctionId,
+        bidderRequestId: bid.bidderRequestId,
+        bids: [bid],
+        ortb2: {
+          site: { page: 'https://example.com/article' },
+        },
+      };
+    });
+
+    it('sends one POST per segment group with both routing params on the URL', () => {
+      const requests = spec.buildRequests([bid], bidderRequest);
+      expect(requests).to.have.lengthOf(1);
+      expect(requests[0].method).to.equal('POST');
+      expect(requests[0].url).to.equal(`${ENDPOINT_URL}?pub=k8xw2r4p&inv=n7c3tkqe`);
+    });
+
+    it('splits a mixed-segment page into one request per publisherId|inventoryId group', () => {
+      const secondBid = deepClone(bidRequestBase);
+      secondBid.bidId = 'bid-id-2';
+      secondBid.adUnitCode = 'second-ad-unit';
+      secondBid.params = { publisherId: 'k8xw2r4p', inventoryId: 'zz99tt11' };
+      bidderRequest.bids = [bid, secondBid];
+
+      const requests = spec.buildRequests([bid, secondBid], bidderRequest);
+      expect(requests).to.have.lengthOf(2);
+      const first = requests.find((r) => r.url === `${ENDPOINT_URL}?pub=k8xw2r4p&inv=n7c3tkqe`);
+      const second = requests.find((r) => r.url === `${ENDPOINT_URL}?pub=k8xw2r4p&inv=zz99tt11`);
+      expect(first, 'request for segment n7c3tkqe').to.exist;
+      expect(second, 'request for segment zz99tt11').to.exist;
+      expect(first.data.imp).to.have.lengthOf(1);
+      expect(first.data.imp[0].id).to.equal('bid-id-1');
+      expect(first.data.imp[0].ext.inventoryId).to.equal('n7c3tkqe');
+      expect(second.data.imp).to.have.lengthOf(1);
+      expect(second.data.imp[0].id).to.equal('bid-id-2');
+      expect(second.data.imp[0].ext.inventoryId).to.equal('zz99tt11');
+      expect(first.data.id).to.not.equal(second.data.id);
+    });
+
+    it('never merges segments whose ids contain the group delimiter', () => {
+      bid.params = { publisherId: 'a|b', inventoryId: 'c' };
+      const secondBid = deepClone(bidRequestBase);
+      secondBid.bidId = 'bid-id-2';
+      secondBid.params = { publisherId: 'a', inventoryId: 'b|c' };
+      bidderRequest.bids = [bid, secondBid];
+
+      const requests = spec.buildRequests([bid, secondBid], bidderRequest);
+      expect(requests).to.have.lengthOf(2);
+    });
+
+    it('drops an empty user object after stripping a lone buyeruid', () => {
+      bidderRequest.ortb2.user = { buyeruid: 'page-injected-id' };
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.user).to.be.undefined;
+    });
+
+    it('drops an empty regs object (gpp_sid without gpp is meaningless)', () => {
+      bidderRequest.ortb2.regs = { gpp_sid: [7] };
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.regs).to.be.undefined;
+    });
+
+    it('URL-encodes both param values', () => {
+      bid.params.publisherId = 'a b&c';
+      bid.params.inventoryId = 'x/y';
+      const requests = spec.buildRequests([bid], bidderRequest);
+      expect(requests[0].url).to.equal(`${ENDPOINT_URL}?pub=a%20b%26c&inv=x%2Fy`);
+    });
+
+    it('sends a credentialed request so the user-match cookie can attach', () => {
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.options.withCredentials).to.equal(true);
+    });
+
+    it('uses a simple content type to avoid a CORS preflight', () => {
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.options.contentType).to.equal('text/plain');
+    });
+
+    it('builds an ORTB request with one banner imp per bid', () => {
+      const secondBid = deepClone(bidRequestBase);
+      secondBid.bidId = 'bid-id-2';
+      secondBid.adUnitCode = 'banner-ad-unit-code-2';
+      bidderRequest.bids = [bid, secondBid];
+
+      const [request] = spec.buildRequests([bid, secondBid], bidderRequest);
+      expect(request.data.imp).to.have.lengthOf(2);
+      expect(request.data.imp[0].id).to.equal('bid-id-1');
+      expect(request.data.imp[0].banner.format).to.deep.equal([{ w: 300, h: 250 }]);
+      expect(request.data.imp[1].id).to.equal('bid-id-2');
+      expect(request.data.site.page).to.equal('https://example.com/article');
+    });
+
+    it('stamps imp.tagid from the ad unit code and respects a publisher preset', () => {
+      const presetBid = deepClone(bidRequestBase);
+      presetBid.bidId = 'bid-id-2';
+      presetBid.adUnitCode = 'preset-ad-unit';
+      presetBid.ortb2Imp = { tagid: 'publisher-tag' };
+      bidderRequest.bids = [bid, presetBid];
+
+      const [request] = spec.buildRequests([bid, presetBid], bidderRequest);
+      expect(request.data.imp[0].tagid).to.equal('banner-ad-unit-code');
+      expect(request.data.imp[1].tagid).to.equal('publisher-tag');
+    });
+
+    it('stamps imp.ext.inventoryId on every imp', () => {
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.imp[0].ext.inventoryId).to.equal('n7c3tkqe');
+    });
+
+    it('sets displaymanager defaults and lets publisher ortb2Imp win', () => {
+      const presetBid = deepClone(bidRequestBase);
+      presetBid.bidId = 'bid-id-2';
+      presetBid.adUnitCode = 'preset-ad-unit';
+      presetBid.ortb2Imp = { displaymanager: 'PubPlayer', displaymanagerver: '9.9' };
+      bidderRequest.bids = [bid, presetBid];
+
+      const [request] = spec.buildRequests([bid, presetBid], bidderRequest);
+      expect(request.data.imp[0].displaymanager).to.equal('Prebid.js');
+      expect(request.data.imp[0].displaymanagerver).to.be.a('string').with.length.greaterThan(0);
+      expect(request.data.imp[1].displaymanager).to.equal('PubPlayer');
+      expect(request.data.imp[1].displaymanagerver).to.equal('9.9');
+    });
+
+    it('strips a page-injected user.buyeruid but keeps the rest of user', () => {
+      bidderRequest.ortb2.user = { buyeruid: 'page-injected-id', id: 'keep-me' };
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.user.buyeruid).to.be.undefined;
+      expect(request.data.user.id).to.equal('keep-me');
+    });
+
+    it('carries ortb2Imp.ext.gpid through untouched', () => {
+      bid.ortb2Imp = { ext: { gpid: '/1234/homepage#top' } };
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.imp[0].ext.gpid).to.equal('/1234/homepage#top');
+      expect(request.data.imp[0].ext.inventoryId).to.equal('n7c3tkqe');
+    });
+
+    it('attaches a USD floor from the floors module', () => {
+      bid.getFloor = ({ currency }) => ({ currency, floor: 1.25 });
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.imp[0].bidfloor).to.equal(1.25);
+      expect(request.data.imp[0].bidfloorcur).to.equal('USD');
+    });
+
+    it('refuses a floor the module cannot quote in USD', () => {
+      bid.getFloor = () => ({ currency: 'EUR', floor: 0.8 });
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.imp[0].bidfloor).to.be.undefined;
+      expect(request.data.imp[0].bidfloorcur).to.be.undefined;
+    });
+
+    it('forwards the COPPA flag from config', () => {
+      bidderRequest.ortb2.regs = { coppa: 1 };
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.regs.coppa).to.equal(1);
+    });
+
+    it('builds a video imp for a video-only ad unit', () => {
+      bid.mediaTypes = {
+        video: { context: 'instream', playerSize: [[640, 480]], mimes: ['video/mp4'], protocols: [2, 3] },
+      };
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.imp).to.have.lengthOf(1);
+      expect(request.data.imp[0].video).to.exist;
+      expect(request.data.imp[0].video.w).to.equal(640);
+      expect(request.data.imp[0].video.h).to.equal(480);
+      expect(request.data.imp[0].video.mimes).to.deep.equal(['video/mp4']);
+      expect(request.data.imp[0].banner).to.not.exist;
+    });
+
+    it('sends both media objects for a mixed banner+video ad unit', () => {
+      bid.mediaTypes = {
+        banner: { sizes: [[300, 250]] },
+        video: { context: 'instream', playerSize: [[640, 480]], mimes: ['video/mp4'] },
+      };
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.imp).to.have.lengthOf(1);
+      expect(request.data.imp[0].banner).to.exist;
+      expect(request.data.imp[0].video).to.exist;
+      expect(request.data.imp[0].video.mimes).to.deep.equal(['video/mp4']);
+    });
+
+    it('drops only a malformed video half from a mixed ad unit', () => {
+      bid.mediaTypes = {
+        banner: { sizes: [[300, 250]] },
+        video: { context: 'instream' }, // no mimes, no size — banner still bids
+      };
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.imp).to.have.lengthOf(1);
+      expect(request.data.imp[0].banner).to.exist;
+      expect(request.data.imp[0].video).to.not.exist;
+    });
+
+    it('drops an ortb2Imp-injected video that has no mediaTypes declaration to validate', () => {
+      bid.ortb2Imp = { video: { mimes: ['video/mp4'], w: 640, h: 480 } };
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.imp[0].banner).to.exist;
+      expect(request.data.imp[0].video).to.not.exist;
+    });
+
+    it('carries page-level deals (ortb2Imp.pmp) into the imp', () => {
+      bid.ortb2Imp = {
+        pmp: {
+          private_auction: 0,
+          deals: [{ id: 'MAGNITE-DEAL-1', bidfloor: 2.5, bidfloorcur: 'USD' }],
+        },
+      };
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.imp[0].pmp).to.deep.equal({
+        private_auction: 0,
+        deals: [{ id: 'MAGNITE-DEAL-1', bidfloor: 2.5, bidfloorcur: 'USD' }],
+      });
+    });
+
+    it('forwards 2.5-located consent untouched', () => {
+      bidderRequest.ortb2.regs = { ext: { gdpr: 0, us_privacy: '1YNN' } };
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.regs.ext.gdpr).to.equal(0);
+      expect(request.data.regs.ext.us_privacy).to.equal('1YNN');
+    });
+
+    it('relocates root-level gpp/gpp_sid to regs.ext', () => {
+      bidderRequest.ortb2.regs = { gpp: 'DBACOe~SOMETHING', gpp_sid: [7] };
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.regs.ext.gpp).to.equal('DBACOe~SOMETHING');
+      expect(request.data.regs.ext.gpp_sid).to.deep.equal([7]);
+      expect(request.data.regs.gpp).to.be.undefined;
+      expect(request.data.regs.gpp_sid).to.be.undefined;
+    });
+
+    it('keeps the ext copy and drops the root copy when gpp is in both locations', () => {
+      bidderRequest.ortb2.regs = { gpp: 'ROOT-COPY', gpp_sid: [7], ext: { gpp: 'EXT-COPY', gpp_sid: [6] } };
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.regs.ext.gpp).to.equal('EXT-COPY');
+      expect(request.data.regs.ext.gpp_sid).to.deep.equal([6]);
+      expect(request.data.regs.gpp).to.be.undefined;
+      expect(request.data.regs.gpp_sid).to.be.undefined;
+    });
+
+    it('passes user.ext.eids through untouched (core normalizes eids before adapters run)', () => {
+      const eids = [{ source: 'pubcid.org', uids: [{ id: 'abc-123', atype: 1 }] }];
+      bidderRequest.ortb2.user = { ext: { eids } };
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      expect(request.data.user.ext.eids).to.deep.equal(eids);
+      expect(request.data.user.eids).to.be.undefined;
+    });
+  });
+
+  describe('interpretResponse', () => {
+    let bid;
+    let bidderRequest;
+    let request;
+    let serverResponse;
+
+    // Shaped like a REAL gateway response: upstream answers in an oRTB 2.4-era
+    // dialect, so bids carry no `mtype` and the response no `cur`. The adapter
+    // pins both via converter context. The response id echoes the request id.
+    const gatewayResponseBody = {
+      seatbid: [
+        {
+          seat: '2307',
+          bid: [
+            {
+              id: '1',
+              impid: 'bid-id-1',
+              price: 0.09,
+              adm: '<div>bidespresso-ad</div>',
+              adomain: ['advertiser.example'],
+              crid: '2307:abc123',
+              w: 300,
+              h: 250,
+            },
+          ],
+        },
+      ],
+      ext: { optimera: { bids: 1, ms: 200, note: 'ok', synced: false, variant: 'go-v2' } },
+    };
+
+    beforeEach(() => {
+      bid = deepClone(bidRequestBase);
+      bidderRequest = {
+        bidderCode: 'bidespresso',
+        auctionId: bid.auctionId,
+        bidderRequestId: bid.bidderRequestId,
+        bids: [bid],
+        ortb2: {},
+      };
+      [request] = spec.buildRequests([bid], bidderRequest);
+      serverResponse = { body: deepClone(gatewayResponseBody) };
+      serverResponse.body.id = request.data.id;
+    });
+
+    it('maps a gateway banner bid without mtype or cur to a Prebid bid', () => {
+      const result = spec.interpretResponse(serverResponse, request);
+      const bids = result.bids;
+      expect(bids).to.have.lengthOf(1);
+      expect(bids[0].requestId).to.equal('bid-id-1');
+      expect(bids[0].cpm).to.equal(0.09);
+      expect(bids[0].width).to.equal(300);
+      expect(bids[0].height).to.equal(250);
+      expect(bids[0].ad).to.equal('<div>bidespresso-ad</div>');
+      expect(bids[0].creativeId).to.equal('2307:abc123');
+      expect(bids[0].currency).to.equal('USD');
+      expect(bids[0].netRevenue).to.equal(true);
+      expect(bids[0].ttl).to.equal(300);
+      expect(bids[0].mediaType).to.equal('banner');
+      expect(bids[0].meta.advertiserDomains).to.deep.equal(['advertiser.example']);
+    });
+
+    it('surfaces a deal ID when the gateway returns one', () => {
+      serverResponse.body.seatbid[0].bid[0].dealid = 'MAGNITE-DEAL-1';
+      const result = spec.interpretResponse(serverResponse, request);
+      expect(result.bids).to.have.lengthOf(1);
+      expect(result.bids[0].dealId).to.equal('MAGNITE-DEAL-1');
+    });
+
+    it('honors a per-bid exp for ttl', () => {
+      serverResponse.body.seatbid[0].bid[0].exp = 42;
+      const result = spec.interpretResponse(serverResponse, request);
+      expect(result.bids[0].ttl).to.equal(42);
+    });
+
+    it('drops a response that does not answer this request', () => {
+      serverResponse.body.id = 'some-other-auction';
+      const result = spec.interpretResponse(serverResponse, request);
+      expect(result.bids).to.deep.equal([]);
+    });
+
+    it('returns no bids for an empty response body', () => {
+      const result = spec.interpretResponse({ body: null }, request);
+      expect(result.bids).to.have.lengthOf(0);
+    });
+
+    it('returns no bids for a literal empty-string body (a raw 204)', () => {
+      const result = spec.interpretResponse({ body: '' }, request);
+      expect(result.bids).to.have.lengthOf(0);
+    });
+
+    it('returns no bids for the gateway no-bid shape', () => {
+      const result = spec.interpretResponse({ body: { id: request.data.id } }, request);
+      expect(result.bids).to.have.lengthOf(0);
+    });
+
+    it('returns no bids when seatbid is an empty array', () => {
+      const result = spec.interpretResponse({ body: { id: request.data.id, seatbid: [] } }, request);
+      expect(result.bids).to.have.lengthOf(0);
+    });
+  });
+
+  describe('interpretResponse for a mixed banner+video response', () => {
+    // Two ad units (one banner, one video) answered in ONE response. Pins the
+    // converter's per-imp context isolation: the video bid's mediaType/ttl
+    // treatment must never leak onto the banner bid.
+    it('types and ttls each bid by its own imp', () => {
+      const bannerBid = deepClone(bidRequestBase);
+      const videoBid = deepClone(bidRequestBase);
+      videoBid.bidId = 'video-bid-1';
+      videoBid.adUnitCode = 'video-ad-unit-code';
+      videoBid.mediaTypes = { video: { context: 'instream', playerSize: [[640, 480]], mimes: ['video/mp4'] } };
+      const bidderRequest = {
+        bidderCode: 'bidespresso',
+        auctionId: bannerBid.auctionId,
+        bidderRequestId: bannerBid.bidderRequestId,
+        bids: [bannerBid, videoBid],
+        ortb2: {},
+      };
+      const [request] = spec.buildRequests([bannerBid, videoBid], bidderRequest);
+      const response = {
+        body: {
+          id: request.data.id,
+          seatbid: [
+            {
+              seat: '2307',
+              bid: [
+                { id: 'v', impid: 'video-bid-1', price: 0.35, adm: '<VAST version="3.0"></VAST>', crid: 'vid' },
+                { id: 'b', impid: 'bid-id-1', price: 0.09, adm: '<div>ad</div>', w: 300, h: 250, crid: 'ban' },
+              ],
+            },
+          ],
+        },
+      };
+      const result = spec.interpretResponse(response, request);
+      const bids = result.bids;
+      expect(bids).to.have.lengthOf(2);
+      const video = bids.find((b) => b.requestId === 'video-bid-1');
+      const banner = bids.find((b) => b.requestId === 'bid-id-1');
+      expect(video.mediaType).to.equal('video');
+      expect(video.ttl).to.equal(900);
+      expect(banner.mediaType).to.equal('banner');
+      expect(banner.ttl).to.equal(300);
+      expect(banner.ad).to.equal('<div>ad</div>');
+    });
+  });
+
+  describe('interpretResponse with gateway-stamped mtype (dual-media imps)', () => {
+    // The gateway stamps `mtype` on every bid; on a dual-media imp it is the
+    // ONLY way to classify a bid, since the imp carries both media objects.
+    // The literals 1/2 are the wire contract.
+    const mixedBid = {
+      adUnitCode: 'mixed-ad-unit-code',
+      auctionId: 'auction-id',
+      bidId: 'mixed-bid-1',
+      bidder: 'bidespresso',
+      bidderRequestId: 'bidder-request-id',
+      mediaTypes: {
+        banner: { sizes: [[300, 250]] },
+        video: { context: 'instream', playerSize: [[640, 480]], mimes: ['video/mp4'] },
+      },
+      params: { publisherId: 'k8xw2r4p', inventoryId: 'n7c3tkqe' },
+    };
+    const vast = '<VAST version="3.0"><Ad><InLine></InLine></Ad></VAST>';
+
+    let request;
+
+    beforeEach(() => {
+      const bid = deepClone(mixedBid);
+      const bidderRequest = {
+        bidderCode: 'bidespresso',
+        auctionId: bid.auctionId,
+        bidderRequestId: bid.bidderRequestId,
+        bids: [bid],
+        ortb2: {},
+      };
+      [request] = spec.buildRequests([bid], bidderRequest);
+    });
+
+    function dualResponse(bidFields) {
+      return {
+        body: {
+          id: request.data.id,
+          seatbid: [{ seat: '2307', bid: [{ id: '1', impid: 'mixed-bid-1', price: 0.2, ...bidFields }] }],
+        },
+      };
+    }
+
+    it('classifies an mtype 1 bid on a dual-media imp as banner', () => {
+      const result = spec.interpretResponse(
+        dualResponse({ adm: '<div>banner-ad</div>', mtype: 1, w: 300, h: 250 }), request);
+      expect(result.bids).to.have.lengthOf(1);
+      expect(result.bids[0].mediaType).to.equal('banner');
+      expect(result.bids[0].ad).to.equal('<div>banner-ad</div>');
+      expect(result.bids[0].ttl).to.equal(300);
+    });
+
+    it('classifies an mtype 2 bid on a dual-media imp as video with the video ttl', () => {
+      const result = spec.interpretResponse(dualResponse({ adm: vast, mtype: 2 }), request);
+      expect(result.bids).to.have.lengthOf(1);
+      expect(result.bids[0].mediaType).to.equal('video');
+      expect(result.bids[0].vastXml).to.equal(vast);
+      expect(result.bids[0].ttl).to.equal(900);
+    });
+
+    it('defaults a no-mtype bid on a dual-media imp to banner', () => {
+      const result = spec.interpretResponse(
+        dualResponse({ adm: '<div>legacy-ad</div>', w: 300, h: 250 }), request);
+      expect(result.bids).to.have.lengthOf(1);
+      expect(result.bids[0].mediaType).to.equal('banner');
+      expect(result.bids[0].ttl).to.equal(300);
+    });
+  });
+
+  describe('interpretResponse for video', () => {
+    // Gateway bids carry no mtype; the adapter must infer VIDEO from the imp
+    // the bid answers, and video bids get the longer video ttl.
+    const videoBid = {
+      adUnitCode: 'video-ad-unit-code',
+      auctionId: 'auction-id',
+      bidId: 'video-bid-1',
+      bidder: 'bidespresso',
+      bidderRequestId: 'bidder-request-id',
+      mediaTypes: { video: { context: 'instream', playerSize: [[640, 480]], mimes: ['video/mp4'] } },
+      params: { publisherId: 'k8xw2r4p', inventoryId: 'n7c3tkqe' },
+    };
+
+    const vast = '<VAST version="3.0"><Ad><InLine></InLine></Ad></VAST>';
+
+    it('maps a no-mtype video bid to a Prebid video bid with vastXml and the video ttl', () => {
+      const bid = deepClone(videoBid);
+      const bidderRequest = {
+        bidderCode: 'bidespresso',
+        auctionId: bid.auctionId,
+        bidderRequestId: bid.bidderRequestId,
+        bids: [bid],
+        ortb2: {},
+      };
+      const [request] = spec.buildRequests([bid], bidderRequest);
+      const videoServerResponse = {
+        body: {
+          id: request.data.id,
+          seatbid: [
+            {
+              seat: '2307',
+              bid: [
+                {
+                  id: '1',
+                  impid: 'video-bid-1',
+                  price: 0.35,
+                  adm: vast,
+                  adomain: ['advertiser.example'],
+                  crid: '2307:vid123',
+                },
+              ],
+            },
+          ],
+        },
+      };
+      const result = spec.interpretResponse(videoServerResponse, request);
+      const bids = result.bids;
+      expect(bids).to.have.lengthOf(1);
+      expect(bids[0].requestId).to.equal('video-bid-1');
+      expect(bids[0].mediaType).to.equal('video');
+      expect(bids[0].cpm).to.equal(0.35);
+      expect(bids[0].vastXml).to.equal(vast);
+      expect(bids[0].currency).to.equal('USD');
+      expect(bids[0].netRevenue).to.equal(true);
+      expect(bids[0].ttl).to.equal(900);
+    });
+  });
+
+  describe('getUserSyncs', () => {
+    it('registers nothing in pixel-only mode: the sync chain must run as a document', () => {
+      expect(spec.getUserSyncs({ iframeEnabled: false, pixelEnabled: true }, [])).to.deep.equal([]);
+    });
+
+    it('registers an iframe sync when enabled', () => {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, []);
+      expect(syncs).to.have.lengthOf(1);
+      expect(syncs[0].type).to.equal('iframe');
+      expect(syncs[0].url).to.equal(SYNC_URL);
+    });
+
+    it('appends consent params for GDPR, US Privacy and GPP', () => {
+      const syncs = spec.getUserSyncs(
+        { iframeEnabled: true },
+        [],
+        { gdprApplies: true, consentString: 'CONSENT-STRING' },
+        '1YNY',
+        { gppString: 'DBACOe~SOMETHING', applicableSections: [7] }
+      );
+      expect(syncs).to.have.lengthOf(1);
+      const url = new URL(syncs[0].url);
+      expect(`${url.origin}${url.pathname}`).to.equal(SYNC_URL);
+      expect(url.searchParams.get('gdpr')).to.equal('1');
+      expect(url.searchParams.get('gdpr_consent')).to.equal('CONSENT-STRING');
+      expect(url.searchParams.get('gpp')).to.equal('DBACOe~SOMETHING');
+      expect(url.searchParams.get('gpp_sid')).to.equal('7');
+      expect(syncs[0].url).to.contain('us_privacy=');
+    });
+
+    it('appends no query string when no consent is available', () => {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, [], undefined, undefined, undefined);
+      expect(syncs[0].url).to.equal(SYNC_URL);
+      expect(syncs[0].url).to.not.contain('?');
+    });
+  });
+});


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter

## Description of change
New client adapter for Bid Espresso, a supply-side auction gateway. The
adapter sends one credentialed OpenRTB POST per inventory segment to
`https://auction.bidespresso.com/openrtb2/auction`; the gateway enriches the
request and fans out to demand server-side. Bids are returned net of the Bid
Espresso margin (`netRevenue: true`). Banner and video are supported; mixed
banner+video ad units send both media objects on one impression and the
gateway answers per media class with oRTB `mtype` stamped on every bid.

- Bidder code: `bidespresso`
- Maintainer: prebid@bidespresso.com
- Official adapter submitted by the bidder
- Docs PR: prebid/prebid.github.io#6693

### Test parameters
Working test parameters are in the module .md (`publisherId: 'prebidtest'`,
`inventoryId: 'ron'`). They serve a rendered $0.10 test creative from
production at any time — no account or staging setup needed to verify.

### Verification (run against current master)
- `npx eslint modules/bidespressoBidAdapter.ts test/spec/modules/bidespressoBidAdapter_spec.js` — clean (no output)
- `npx gulp test-coverage --nolint --file test/spec/modules/bidespressoBidAdapter_spec.js` — 59 tests, 0 failures
- Coverage on the module: 100% — 96/96 lines, 56/56 branches (>80% required)
- Full production bundle build with the module included — clean
- `gulp update-metadata` — clean generation (component: `{aliasOf: null, gvlid: null}`; no storage disclosures — the adapter uses no storage)
- `gulp validate-names` — no conflict on `bidespresso`; bidder-code collision sweep across `modules/` and `metadata/` including alias arrays and the 6-character prefix rule — only our own files match
- Mutation-tested: removing any single behavior fails at least one named test
- Neighbor suites green: bidderFactory, priceFloors, currency

### Design notes
- **Credentialed request:** the auction POST pins `withCredentials: true` +
  `contentType: 'text/plain'` (identical to core's defaults for adapter
  POSTs). The Bid Espresso user-match id travels ONLY as a server-set cookie
  on that credentialed request — the adapter registers no storage manager and
  writes nothing to cookies or localStorage. Any `user.buyeruid` found in the
  page payload is stripped rather than forwarded.
- **OpenRTB 2.5 relocations:** the gateway reads consent at 2.5 locations, so
  root `regs.gpp`/`regs.gpp_sid` (which core deliberately consolidates at the
  2.6 root) are relocated to `regs.ext`, never dual-populated. eids need no
  such move — core already consolidates them at `user.ext.eids`.
- **Multiformat:** mixed banner+video ad units send both media objects on one
  imp; the gateway auctions each media class separately server-side and
  stamps oRTB `mtype` on every bid — either class can win. A malformed video
  half is dropped with a console warning so the banner side can still bid.
- **Both params are required:** `publisherId` and `inventoryId` are
  Bid-Espresso-assigned routing keys issued during onboarding, not data
  derivable from the request — `publisherId` routes to the publisher's
  configuration on the gateway, `inventoryId` to the inventory segment
  (single-placement integrations receive a default segment ID). Requests are
  grouped per `publisherId`+`inventoryId`, one POST per segment.
- **Endpoint domain:** `auction.bidespresso.com` is Bid Espresso's own
  bidding/sync infrastructure; the maintainer address is on the same
  organization's domain. The endpoint is a fixed constant — no param or
  config can redirect it.
- **No GVL ID (yet):** Bid Espresso is not currently IAB TCF-registered, so
  no `gvlid` is declared (deliberately omitted rather than set undefined).
  The .md documents `vendorExceptions`/`gvlMapping` guidance for publishers
  enforcing vendor-level TCF. A GVL ID will be added in a standalone PR with
  verification once registration completes.

This adapter was developed with AI assistance under human direction and
review at Bid Espresso, Inc. Per this repository's conventions, the branch
name carries the `agent` marker.
