### PR TITLE
Core: fix analytics provider configuration types

### DIFF
--- a/libraries/analyticsAdapter/AnalyticsAdapter.ts
+++ b/libraries/analyticsAdapter/AnalyticsAdapter.ts
@@ -74,13 +74,13 @@ export type AnalyticsConfig<P extends AnalyticsProvider> = (
        */
       excludeEvents?: (keyof events.Events)[];
       /**
-       * Adapter specific options.
+       * Adapter specific options, on top of the ones every adapter takes.
        *
        * Providers that declare `options` in AnalyticsProviderConfig use the type they declared
        * there; anything else takes an open bag.
        */
       options?: P extends keyof AnalyticsProviderConfig
-        ? (AnalyticsProviderConfig[P] extends { options: infer O } ? O : Record<string, unknown>)
+        ? (AnalyticsProviderConfig[P] extends { options: infer O } ? O & DefaultOptions : Record<string, unknown>)
         : Record<string, unknown>
     };
 

--- a/libraries/analyticsAdapter/AnalyticsAdapter.ts
+++ b/libraries/analyticsAdapter/AnalyticsAdapter.ts
@@ -74,9 +74,14 @@ export type AnalyticsConfig<P extends AnalyticsProvider> = (
        */
       excludeEvents?: (keyof events.Events)[];
       /**
-       * Adapter specific options
+       * Adapter specific options.
+       *
+       * Providers that declare `options` in AnalyticsProviderConfig use the type they declared
+       * there; anything else takes an open bag.
        */
-      options?: P extends keyof AnalyticsProviderConfig ? AnalyticsProviderConfig[P] : Record<string, unknown>
+      options?: P extends keyof AnalyticsProviderConfig
+        ? (AnalyticsProviderConfig[P] extends { options: infer O } ? O : Record<string, unknown>)
+        : Record<string, unknown>
     };
 
 type AnalyticsAdapterOptions = {

--- a/libraries/analyticsAdapter/AnalyticsAdapter.ts
+++ b/libraries/analyticsAdapter/AnalyticsAdapter.ts
@@ -84,6 +84,16 @@ export type AnalyticsConfig<P extends AnalyticsProvider> = (
         : Record<string, unknown>
     };
 
+/**
+ * Configuration for any one provider - the type it declared, or the open-ended shape for providers
+ * that declared none. Mapping over the declared providers keeps each one's options to itself;
+ * naming them as a type argument (`AnalyticsConfig<keyof AnalyticsProviderConfig>`) instantiates
+ * with a union, and intersects every provider's options with every other provider's.
+ */
+export type SomeAnalyticsConfig =
+  { [P in keyof AnalyticsProviderConfig]: AnalyticsConfig<P> }[keyof AnalyticsProviderConfig]
+  | AnalyticsConfig<AnalyticsProvider>;
+
 type AnalyticsAdapterOptions = {
   analyticsType?: AnalyticsType;
   url?: string;

--- a/modules/intentIqAnalyticsAdapter.ts
+++ b/modules/intentIqAnalyticsAdapter.ts
@@ -170,6 +170,14 @@ export interface IntentIqAnalyticsAdapterOptions {
   gamObjectReference?: Record<string, unknown>;
 }
 
+declare module '../libraries/analyticsAdapter/AnalyticsAdapter' {
+  interface AnalyticsProviderConfig {
+    iiqAnalytics: {
+      options: IntentIqAnalyticsAdapterOptions
+    }
+  }
+}
+
 const MODULE_NAME = 'iiqAnalytics' as const;
 const analyticsType = 'endpoint' as const;
 const prebidVersion = '$prebid.version$';

--- a/modules/intentIqAnalyticsAdapter.ts
+++ b/modules/intentIqAnalyticsAdapter.ts
@@ -154,9 +154,24 @@ export interface IntentIqAnalyticsAdapterOptions {
   domainName?: string;
 
   /**
-   * Freeform key-value pairs appended to every report URL.
+   * Custom parameters appended to report URLs, each routed to the requests named by its
+   * `destination`.
    */
-  additionalParams?: Record<string, string | number | boolean>;
+  additionalParams?: {
+    /**
+     * Name of the parameter, sent prefixed with `agp_`.
+     */
+    parameterName: string;
+    /**
+     * Value to assign to the parameter.
+     */
+    parameterValue: string | number;
+    /**
+     * Whether to send the parameter with, in order, the sync request, the VR request and the win
+     * report. Each entry is 1 to send and 0 to omit.
+     */
+    destination: (0 | 1)[];
+  }[];
 
   /**
    * When `true`, first-party data is stored under a partner-specific key.

--- a/modules/pgamdirectAnalyticsAdapter.ts
+++ b/modules/pgamdirectAnalyticsAdapter.ts
@@ -62,9 +62,9 @@ const FORWARDED_EVENTS: readonly string[] = [
 
 interface PgamAnalyticsOptions {
   /**
-   * PGAM organisation ID. Required; without it the adapter forwards nothing.
+   * PGAM organisation ID. The adapter forwards nothing without it.
    */
-  orgId?: string;
+  orgId: string;
   /**
    * Override for the event collection endpoint.
    */
@@ -344,8 +344,10 @@ export function normalise(eventType: string, rawArgs: unknown): NormalisedEvent 
 // modules/AsteriobidPbmAnalyticsAdapter.js and other TS adapters.
 (pgamdirectAnalytics as unknown as Record<string, unknown>)
   .originEnableAnalytics = pgamdirectAnalytics.enableAnalytics;
+// Partial, because this validates what the publisher actually passed rather than what the
+// configuration type asks for.
 pgamdirectAnalytics.enableAnalytics = function (config: {
-  options?: PgamAnalyticsOptions;
+  options?: Partial<PgamAnalyticsOptions>;
 }) {
   const opts = config?.options ?? {};
   if (!opts.orgId || typeof opts.orgId !== 'string') {

--- a/modules/pgamdirectAnalyticsAdapter.ts
+++ b/modules/pgamdirectAnalyticsAdapter.ts
@@ -61,8 +61,22 @@ const FORWARDED_EVENTS: readonly string[] = [
 ];
 
 interface PgamAnalyticsOptions {
+  /**
+   * PGAM organisation ID. Required; without it the adapter forwards nothing.
+   */
   orgId?: string;
+  /**
+   * Override for the event collection endpoint.
+   */
   endpoint?: string;
+}
+
+declare module '../libraries/analyticsAdapter/AnalyticsAdapter' {
+  interface AnalyticsProviderConfig {
+    pgamdirect: {
+      options: PgamAnalyticsOptions
+    }
+  }
 }
 
 let orgId: string | null = null;

--- a/modules/terceptAnalyticsAdapter.d.ts
+++ b/modules/terceptAnalyticsAdapter.d.ts
@@ -25,3 +25,11 @@ export interface TerceptAnalyticsAdapterOptions {
    */
   analyticsBatchTimeout?: number;
 }
+
+declare module '../libraries/analyticsAdapter/AnalyticsAdapter' {
+  interface AnalyticsProviderConfig {
+    tercept: {
+      options: TerceptAnalyticsAdapterOptions
+    }
+  }
+}

--- a/src/adapterManager.ts
+++ b/src/adapterManager.ts
@@ -932,13 +932,8 @@ const adapterManager = {
     config: AnalyticsConfig<keyof AnalyticsProviderConfig>
             | AnalyticsConfig<AnalyticsProvider>
             | AnalyticsConfig<AnalyticsProvider>[]
-            | any
   ) {
-    if (!isArray(config)) {
-      config = [config];
-    }
-
-    config.forEach(adapterConfig => {
+    (Array.isArray(config) ? config : [config]).forEach(adapterConfig => {
       const entry = _analyticsRegistry[adapterConfig.provider];
       if (entry && entry.adapter) {
         entry.config = adapterConfig;

--- a/src/adapterManager.ts
+++ b/src/adapterManager.ts
@@ -65,7 +65,8 @@ import type { DeepPartial } from "./types/objects.d.ts";
 import type { ORTBRequest } from "./types/ortb/request.d.ts";
 import type {
   AnalyticsConfig,
-  AnalyticsProvider, AnalyticsProviderConfig,
+  AnalyticsProvider,
+  SomeAnalyticsConfig,
 } from "../libraries/analyticsAdapter/AnalyticsAdapter.ts";
 import { getGlobal } from "./prebidGlobal.ts";
 
@@ -84,7 +85,7 @@ export const dep = {
 
 const _bidderRegistry = {};
 const _aliasRegistry: { [aliasCode: BidderCode]: BidderCode } = {};
-const _analyticsRegistry: { [P in AnalyticsProvider]?: { adapter: AnalyticsAdapter<P>, gvlid?: number, enabled?: boolean, config?: AnalyticsConfig<P> } } = {};
+const _analyticsRegistry: { [P in AnalyticsProvider]?: { adapter: AnalyticsAdapter<P>, gvlid?: number, enabled?: boolean, config?: SomeAnalyticsConfig } } = {};
 
 let _s2sConfigs : any[] | any = [];
 config.getConfig('s2sConfig', config => {
@@ -928,18 +929,16 @@ const adapterManager = {
       logError('Prebid Error: analyticsAdapter or analyticsCode not specified');
     }
   },
-  enableAnalytics(
-    config: AnalyticsConfig<keyof AnalyticsProviderConfig>
-            | AnalyticsConfig<AnalyticsProvider>
-            | AnalyticsConfig<AnalyticsProvider>[]
-  ) {
+  enableAnalytics(config: SomeAnalyticsConfig | SomeAnalyticsConfig[]) {
     (Array.isArray(config) ? config : [config]).forEach(adapterConfig => {
       const entry = _analyticsRegistry[adapterConfig.provider];
       if (entry && entry.adapter) {
         entry.config = adapterConfig;
         if (isAnalyticsAllowed(adapterConfig)) {
           try {
-            entry.adapter.enableAnalytics(adapterConfig);
+            // the registry is keyed by provider name, which loses the tie between an adapter and
+            // the configuration type it declared; the two do match, having been registered together
+            entry.adapter.enableAnalytics(adapterConfig as AnalyticsConfig<AnalyticsProvider>);
             entry.enabled = true;
           } catch (e) {
             logError(`Could not enable '${adapterConfig.provider}' analytics`, e);

--- a/test/types/analyticsConfig.ts
+++ b/test/types/analyticsConfig.ts
@@ -1,0 +1,78 @@
+/**
+ * Compile-time expectations for `AnalyticsConfig`.
+ *
+ * Not a unit test - `tsc` (`gulp ts`) compiles this along with the rest of the project, and fails
+ * the build if any expectation below stops holding. The `@ts-expect-error` directives assert in
+ * both directions: tsc reports an unused directive if the line under it stops being an error.
+ */
+import type { AnalyticsConfig, AnalyticsProviderConfig } from '../../libraries/analyticsAdapter/AnalyticsAdapter.ts';
+
+type Assert<T extends true> = T;
+
+/**
+ * Guards everything below: the `generic` expectations only mean something while
+ * genericAnalyticsAdapter declares that provider. Without it they would be checked against the
+ * open-ended shape that providers with no declared types get, and would all pass regardless.
+ */
+export type GenericIsTyped = Assert<'generic' extends keyof AnalyticsProviderConfig ? true : false>;
+
+/**
+ * A provider's declared `options` type is applied once, as `options`. Applying it at the top level
+ * and again underneath itself would demand `options.options`, leaving the type unsatisfiable.
+ */
+export type OptionsNotNestedUnderThemselves = Assert<
+  'options' extends keyof NonNullable<AnalyticsConfig<'generic'>['options']> ? false : true
+>;
+
+export const urlOptions: AnalyticsConfig<'generic'> = {
+  provider: 'generic',
+  options: { url: 'https://example.com', batchSize: 5 }
+};
+
+export const handlerOptions: AnalyticsConfig<'generic'> = {
+  provider: 'generic',
+  options: { handler: () => {} }
+};
+
+export const eventFilters: AnalyticsConfig<'generic'> = {
+  provider: 'generic',
+  options: { url: 'https://example.com' },
+  includeEvents: ['auctionEnd'],
+  excludeEvents: ['bidWon']
+};
+
+/** Providers with no declared types take arbitrary options and top-level keys. */
+export const untypedProvider: AnalyticsConfig<'someUntypedAdapter'> = {
+  provider: 'someUntypedAdapter',
+  options: { anything: 1 },
+  topLevelKey: 2
+};
+
+// @ts-expect-error - `options` is required, because the generic adapter declares it that way
+export const missingOptions: AnalyticsConfig<'generic'> = { provider: 'generic' };
+
+export const wrongOptionType: AnalyticsConfig<'generic'> = {
+  provider: 'generic',
+  // @ts-expect-error - `url` is a string
+  options: { url: 42 }
+};
+
+export const unknownOption: AnalyticsConfig<'generic'> = {
+  provider: 'generic',
+  // @ts-expect-error - `bogus` is not one of the generic adapter's options
+  options: { url: 'https://example.com', bogus: true }
+};
+
+export const unknownTopLevelKey: AnalyticsConfig<'generic'> = {
+  provider: 'generic',
+  options: { url: 'https://example.com' },
+  // @ts-expect-error - not part of an analytics config, and not declared by the generic adapter
+  bogus: true
+};
+
+export const badEventName: AnalyticsConfig<'generic'> = {
+  provider: 'generic',
+  options: { url: 'https://example.com' },
+  // @ts-expect-error - not a Prebid event
+  includeEvents: ['notAnEvent']
+};

--- a/test/types/analyticsConfig.ts
+++ b/test/types/analyticsConfig.ts
@@ -34,6 +34,21 @@ export const handlerOptions: AnalyticsConfig<'generic'> = {
   options: { handler: () => {} }
 };
 
+/**
+ * Guards the expectation below. It is stated against tercept rather than generic because generic
+ * declares `DefaultOptions` in its own entry, so generic would hold either way.
+ */
+export type TerceptIsTyped = Assert<'tercept' extends keyof AnalyticsProviderConfig ? true : false>;
+
+/**
+ * `sampling` is read by the base adapter for every provider, so it belongs to the options of a
+ * provider that declares its own just as much as to one that declares none.
+ */
+export const sharedOptions: AnalyticsConfig<'tercept'> = {
+  provider: 'tercept',
+  options: { pubId: 1, pubKey: 2, sampling: 0.5 }
+};
+
 export const eventFilters: AnalyticsConfig<'generic'> = {
   provider: 'generic',
   options: { url: 'https://example.com' },


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [x] Updated bidder adapter <!-- three analytics adapters, types only -->
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

`AnalyticsConfig` applied `AnalyticsProviderConfig[P]` twice — spread at the top level, and again under `options` (`libraries/analyticsAdapter/AnalyticsAdapter.ts:61-85`). Providers declare `options` inside their own entry, so the two applications nested the declared type under itself: `AnalyticsConfig<'generic'>` demanded `options.options`, and no natural configuration satisfied it. The `options` clause now uses the option type the provider declared, so both applications agree.

Nothing caught that because `adapterManager.enableAnalytics` accepted `| any` (added in #14599, while working towards a build that does not need `skipLibCheck`). That is dropped. The parameter is no longer reassigned, so the one-or-many normalisation is now an expression; it uses `Array.isArray` rather than the imported `isArray`, which arrives untyped from `src/utils.js` and so loses its type predicate. **This is the only line in the PR with any runtime effect** — everything else is types, comments, or erased at emit.

`intentIqAnalyticsAdapter`, `pgamdirectAnalyticsAdapter` and `terceptAnalyticsAdapter` each describe the options they accept in their own types, but never declared them in `AnalyticsProviderConfig`, so nothing that reads a publisher's configuration knew about them. All three now augment it.

That made `AnalyticsConfig<keyof AnalyticsProviderConfig>` instantiate with a union of four providers rather than one, and because the mapping appeared twice each application distributed over that union independently — so the two cross-multiplied and `options` became one provider's options intersected with another's. Completions already showed this before it was an error, listing every provider's option keys whichever provider was named. `SomeAnalyticsConfig` maps over the declared providers instead, which builds the same union without instantiating with one. Measured with tsserver, `options: { … }` now completes with the named provider's own keys (8 for `generic`, 5 for `tercept`) instead of a merged list of 30.

Where the registry hands a configuration back to its adapter (`src/adapterManager.ts:939`), the provider name it is keyed by has erased the tie between the two, hence the assertion there.

Finally, `IntentIqAnalyticsAdapterOptions.additionalParams` was declared as a map of names to values, while the adapter reads it as an array of parameters (`libraries/intentIqUtils/handleAdditionalParams.ts:20-38`) — which is also how `modules/intentIqAnalyticsAdapter.md` documents it. Harmless while nothing consumed the type; now that the options are declared, the two have to agree.

### Not a breaking change for publishers

The union at the call site still collapses to its permissive `AnalyticsConfig<AnalyticsProvider>` arm — its `{[key: string]: unknown}` spread and `options?: Record<string, unknown>` accept anything — so a publisher writing a wrong option type, an unknown option, an excess top-level key, or omitting a required `options` gets no new error. This is the same limitation as #14895 and is unchanged here. The only new call-site errors are an object literal with no `provider` at all, and a value that is not a configuration (a number, a string), both of which were already broken at runtime.

What does become strict is an explicit `AnalyticsConfig<'someProvider'>` annotation. For the three newly-declared providers such an annotation previously resolved to the untyped branch and accepted anything, so it could not have been relied on.

### Compile-time check

`test/types/analyticsConfig.ts` records the expectations for `tsc` to enforce; `gulp ts` compiles it with the rest of the project. It is not a unit test — karma's entry only collects `/_spec$/`, so it is invisible there — and it deliberately asserts against the provider-specific instantiation rather than the permissive union, which would accept anything and prove nothing.

The `@ts-expect-error` directives hold in both directions, since an unused directive is itself an error: reverting the `AnalyticsConfig` fix produces 7 errors including unused directives, and widening `options` to `any` produces 4. A guard asserts that `generic` really is a key of the mapping, without which every other expectation would fall through to the untyped branch and pass regardless — renaming the key in `genericAnalyticsAdapter` makes it fire.

## Verification

- `npx eslint src libraries modules test creative --cache --cache-strategy content` — clean, exit 0. Note this is `gulp lint` scoped to the source folders: bare `gulp lint` passes no paths and runs with `--fix`, and on a checkout with a git worktree under `.claude/` it will traverse and rewrite files there.
- `npx gulp test --nolint` — full suite, exit 0. All 8 chunks pass, no failures.
- `npx tsc --noEmit -p tsconfig.json` (`gulp ts`) — 0 errors.
- `npx tsc --noEmit -p tsconfig-strict.json` (`gulp ts-strict`) — 0 errors.
- Checked against the build-time checks in #15395: `gulp precompile` (which there includes `ts-strict` and `check-declarations`) produces output identical to that branch without this change, and all three new augmentations survive declaration emit and satisfy `prebid/augmentation-reachable`. `terceptAnalyticsAdapter.d.ts` imports nothing, so it qualifies via the other route the rule allows: the augmentation target — the `libraries/analyticsAdapter/AnalyticsAdapter` module that the `declare module` names — is in core's program. `src/adapterManager.ts` and `src/types/summary/exports.d.ts` both `import type` from it, and type-only imports still place a file in the program.

No documentation PR is needed; no documented option changes, and the `additionalParams` correction brings the type into line with the documentation that already exists.

## Other information

Scope spans `src`/`libraries` and three modules because the pieces are interdependent: without the first fix the three newly-declared providers' configurations would be unsatisfiable, since each entry declares `options`, and it was declaring them that exposed the cross-product.

There is no associated issue, so per the contributing notes the issue template is filled in below.

<details>
<summary>Issue template</summary>

**Type of issue** — bug.

**Description** — `AnalyticsConfig<P>` applies a provider's declared configuration twice, so for any provider that declares `options` the resulting type requires `options.options` and no natural configuration satisfies it. Three analytics adapters describe their options but never declare them in `AnalyticsProviderConfig`, so those types reach no consumer.

**Steps to reproduce** — with `genericAnalyticsAdapter` in the build, annotate a configuration with the declared type:

```ts
import type { AnalyticsConfig } from 'prebid.js/libraries/analyticsAdapter/AnalyticsAdapter';

const config: AnalyticsConfig<'generic'> = {
  provider: 'generic',
  options: { url: 'https://example.com' }
};
```

**Test page** — not applicable; this reproduces under `tsc`, with no runtime component.

**Expected results** — compiles.

**Actual results** — `Property 'options' is missing in type '{ url: string; }' but required in type '{ options: … }'`. The only assignable form is a doubly-nested `options: { url: '…', options: { url: '…' } }`.

**Platform details** — Prebid.js `master`, TypeScript 5.8.2, node 20.

</details>

This pull request was generated by Claude.

