### PR TITLE
Core: fix remaining COPPA test failures

### DIFF
--- a/modules/livewrappedBidAdapter.js
+++ b/modules/livewrappedBidAdapter.js
@@ -342,6 +342,6 @@ function getDeviceHeight() {
 }
 
 function getCoppa(bidderRequest) {
-  return (bidderRequest?.ortb2?.regs?.coppa === 1 || coppaDataHandler.getCoppa());
+  return bidderRequest?.ortb2?.regs?.coppa === 1 || (coppaDataHandler.getCoppa() ? true : undefined);
 }
 registerBidder(spec);

--- a/test/spec/modules/adyoulikeBidAdapter_spec.js
+++ b/test/spec/modules/adyoulikeBidAdapter_spec.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 
 import { spec } from 'modules/adyoulikeBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
-import { config } from 'src/config.js';
 
 describe('Adyoulike Adapter', function () {
   const canonicalUrl = 'https://canonical.url/?t=%26';
@@ -862,25 +861,8 @@ describe('Adyoulike Adapter', function () {
       });
 
       describe('COPPA', function() {
-        let sandbox;
-
-        this.beforeEach(function() {
-          sandbox = sinon.createSandbox();
-        });
-
-        this.afterEach(function() {
-          sandbox.restore();
-        });
-
         it('should add coppa parameters if provided', function() {
-          sandbox.stub(config, 'getConfig').callsFake(key => {
-            const config = {
-              'coppa': true
-            };
-            return config[key];
-          });
-
-          expect(spec.getUserSyncs(userSyncConfig, {}, undefined, undefined)).to.deep.equal([{
+          expect(spec.getUserSyncs(userSyncConfig, {}, undefined, undefined, undefined, true)).to.deep.equal([{
             type: 'iframe', url: `${syncurl_iframe}&coppa=1`
           }]);
         });

--- a/test/spec/modules/connatixBidAdapter_spec.js
+++ b/test/spec/modules/connatixBidAdapter_spec.js
@@ -769,15 +769,13 @@ describe('connatixBidAdapter', function () {
       expect(url).to.equal(`${UserSyncEndpointWithParams}&gdpr=1&gdpr_consent=test%262&us_privacy=1YYYN&gpp=GPP&gpp_sid=2,4`);
     });
     it('Should append coppa to the url if coppa is true', function () {
-      config.setConfig({
-        coppa: true
-      });
       const userSyncList = spec.getUserSyncs(
         { iframeEnabled: true, pixelEnabled: true },
         [serverResponse],
         { gdprApplies: true, consentString: 'test&2' },
         '1YYYN',
-        { gppString: 'GPP', applicableSections: [2, 4] }
+        { gppString: 'GPP', applicableSections: [2, 4] },
+        true
       );
       const { url } = userSyncList[0];
       expect(url).to.equal(`${UserSyncEndpoint}?gdpr=1&gdpr_consent=test%262&us_privacy=1YYYN&gpp=GPP&gpp_sid=2,4&coppa=1`);

--- a/test/spec/modules/livewrappedBidAdapter_spec.js
+++ b/test/spec/modules/livewrappedBidAdapter_spec.js
@@ -784,16 +784,10 @@ describe('Livewrapped adapter tests', function () {
     it('should pass coppa parameter', function() {
       sandbox.stub(utils, 'isSafariBrowser').callsFake(() => false);
       sandbox.stub(storage, 'cookiesAreEnabled').callsFake(() => true);
-
-      const origGetConfig = config.getConfig;
-      sandbox.stub(config, 'getConfig').callsFake(function (key) {
-        if (key === 'coppa') {
-          return true;
-        }
-        return origGetConfig.apply(config, arguments);
+      const result = spec.buildRequests(bidderRequest.bids, {
+        ...bidderRequest,
+        ortb2: { regs: { coppa: 1 } }
       });
-
-      const result = spec.buildRequests(bidderRequest.bids, bidderRequest);
       const data = JSON.parse(result.data);
 
       expect(result.url).to.equal('https://lwadm.com/ad');
@@ -809,6 +803,7 @@ describe('Livewrapped adapter tests', function () {
         height: 100,
         cookieSupport: true,
         coppa: true,
+        rtbData: { regs: { coppa: 1 } },
         adRequests: [{
           adUnitId: '9E153CED-61BC-479E-98DF-24DC0D01BA37',
           callerAdUnitId: 'panorama_d_1',

--- a/test/spec/modules/mediafuseBidAdapter_spec.js
+++ b/test/spec/modules/mediafuseBidAdapter_spec.js
@@ -162,12 +162,10 @@ describe('mediafuseBidAdapter', function () {
       expect(req.data.user?.ext?.addtl_consent).to.be.undefined;
     });
 
-    it('should set regs.coppa=1 when coppa config is true', function () {
-      sandbox.stub(config, 'getConfig').callsFake((key) => {
-        if (key === 'coppa') return true;
-        return undefined;
-      });
-      const [req] = spec.buildRequests([deepClone(BASE_BID)], deepClone(BASE_BIDDER_REQUEST));
+    it('should set regs.coppa=1 when ortb2 regs coppa is 1', function () {
+      const bidderRequest = deepClone(BASE_BIDDER_REQUEST);
+      bidderRequest.ortb2 = { regs: { coppa: 1 } };
+      const [req] = spec.buildRequests([deepClone(BASE_BID)], bidderRequest);
       expect(req.data.regs.coppa).to.equal(1);
     });
   });

--- a/test/spec/modules/medianetBidAdapter_spec.js
+++ b/test/spec/modules/medianetBidAdapter_spec.js
@@ -4,7 +4,7 @@ import { POST_ENDPOINT } from '../../../libraries/medianetUtils/constants.js';
 import { makeSlot } from '../integration/faker/googletag.js';
 import { config } from '../../../src/config.js';
 import { server } from '../../mocks/xhr.js';
-import { resetWinDimensions } from '../../../src/utils.js';
+import { deepClone, resetWinDimensions } from '../../../src/utils.js';
 import { getGlobal } from '../../../src/prebidGlobal.js';
 import * as adUnits from 'src/utils/adUnits';
 
@@ -1799,14 +1799,13 @@ describe('Media.net bid adapter', function () {
     });
 
     it('should have valid crid present in bid request', function() {
-      sandbox.stub(config, 'getConfig').callsFake((key) => {
-        const config = {
-          'coppa': true
-        };
-        return config[key];
+      const bidreq = spec.buildRequests(VALID_BID_REQUEST_WITH_CRID, {
+        ...VALID_AUCTIONDATA,
+        ortb2: { regs: { coppa: 1 } }
       });
-      const bidreq = spec.buildRequests(VALID_BID_REQUEST_WITH_CRID, VALID_AUCTIONDATA);
-      expect(JSON.parse(bidreq.data)).to.deep.equal(VALID_PAYLOAD_WITH_CRID);
+      const expectedPayload = deepClone(VALID_PAYLOAD_WITH_CRID);
+      expectedPayload.ortb2.regs = { coppa: 1 };
+      expect(JSON.parse(bidreq.data)).to.deep.equal(expectedPayload);
     });
 
     it('should have valid ortb2Imp param present in bid request', function() {

--- a/test/spec/modules/ocmBidAdapter_spec.js
+++ b/test/spec/modules/ocmBidAdapter_spec.js
@@ -1180,10 +1180,9 @@ describe('ocmBidAdapter', function () {
 
     describe('privacy gates', function () {
       it('registers no syncs when COPPA is enabled', function () {
-        config.setConfig({ coppa: true });
         const warn = sinon.stub(utils, 'logWarn');
         try {
-          expect(spec.getUserSyncs({ iframeEnabled: true }, syncResponses)).to.deep.equal([]);
+          expect(spec.getUserSyncs({ iframeEnabled: true }, syncResponses, undefined, undefined, undefined, true)).to.deep.equal([]);
           expect(warn.called).to.equal(true);
         } finally {
           warn.restore();


### PR DESCRIPTION
### Motivation

- Tests were failing after refactoring bidders to remove `getConfig` for COPPA because many adapters and tests still relied on global `config.getConfig('coppa')` behavior or implicitly expected COPPA to be present in `ortb2`/request payloads.
- The intent is to stop relying on global `getConfig('coppa')` in tests and adapters and ensure COPPA is sourced from the bid/bidderRequest `ortb2.regs.coppa` or the legacy `coppaDataHandler` without introducing `coppa: false` into requests.

### Description

- Updated `modules/livewrappedBidAdapter.js` to avoid emitting an explicit `coppa: false` and to normalize the adapter's `getCoppa` to return `true` only when `ortb2.regs.coppa === 1` or legacy handler indicates COPPA; otherwise return `undefined` so it does not inject a false value into payloads (`getCoppa` adjusted). (modules/livewrappedBidAdapter.js)
- Changed user-sync tests (Adyoulike, Connatix, OCM) to pass COPPA via the `getUserSyncs` `coppa` argument instead of stubbing global config, and updated expectations to assert the URL includes `coppa=1` when appropriate. (test/spec/modules/adyoulikeBidAdapter_spec.js, test/spec/modules/connatixBidAdapter_spec.js, test/spec/modules/ocmBidAdapter_spec.js)
- Updated request-level tests (Livewrapped, Mediafuse, Media.net) to provide COPPA through `bidderRequest.ortb2.regs.coppa` and to assert the resulting OpenRTB/adapter payload contains the expected COPPA values (including adding `rtbData` expectations where adapters place `coppa` in nested request data). (test/spec/modules/livewrappedBidAdapter_spec.js, test/spec/modules/mediafuseBidAdapter_spec.js, test/spec/modules/medianetBidAdapter_spec.js)
- Removed now-unused `config` stubbing in tests and added `deepClone` import where needed to prepare modified bidder request fixtures for tests. (multiple test spec updates)

### Testing

- Ran lint for the affected files with `npx eslint modules/livewrappedBidAdapter.js test/spec/modules/{adyoulike,connatix,livewrapped,mediafuse,medianet,ocm}BidAdapter_spec.js --cache --cache-strategy content` and fixed the reported issue; lint passed for the adjusted files.
- Ran the affected unit specs with `npx gulp test --nolint --file 'test/spec/modules/{adyoulike,connatix,livewrapped,mediafuse,medianet,ocm}BidAdapter_spec.js'` and verified the suite completed (all tests in those specs passed).
- Exercised test chunk runs used by CI: `TEST_CHUNKS=8 TEST_CHUNK=2/3/5 npx gulp test-only-nobuild --no-coverage`, and confirmed the chunks completed successfully in this environment (the previously failing tests for chunks 2, 3 and 5 are now passing for the runs executed).
- Verified no leftover diff-check issues with `git diff --check` and recorded that the repository tests for the impacted spec files passed locally.

If you want, I can open a follow-up PR to update any adapter docs that mention COPPA behavior, or run additional adapter-specific tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a75fa361938832bb517c25335612a07)