### PR TITLE
New bid adapter: advertronic

### DIFF
--- a/modules/advertronic.md
+++ b/modules/advertronic.md
@@ -1,0 +1,58 @@
+# Overview
+
+```
+Module Name: Advertronic Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: info@advertronic.io
+```
+
+# Description
+
+Module that connects to Advertronic SSP for bids. Supports banner and video
+(outstream with an own renderer, instream returns VAST XML). Prices are
+returned net to the publisher in RUB — use the currency module (or set
+`adServerCurrency: "RUB"`) if your ad server currency differs.
+
+Both `publisherId` and `placementId` are issued during onboarding
+(info@advertronic.io).
+
+# Test Parameters
+
+```
+var adUnits = [
+  // Banner
+  {
+    code: 'test-banner-div',
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]]
+      }
+    },
+    bids: [{
+      bidder: 'advertronic',
+      params: {
+        publisherId: '1',
+        placementId: 'prebidtest0001'
+      }
+    }]
+  },
+  // Video (outstream)
+  {
+    code: 'test-video-div',
+    mediaTypes: {
+      video: {
+        context: 'outstream',
+        playerSize: [640, 360],
+        mimes: ['video/mp4']
+      }
+    },
+    bids: [{
+      bidder: 'advertronic',
+      params: {
+        publisherId: '1',
+        placementId: 'prebidtest0001'
+      }
+    }]
+  }
+];
+```

--- a/modules/advertronicBidAdapter.d.ts
+++ b/modules/advertronicBidAdapter.d.ts
@@ -1,0 +1,16 @@
+export interface AdvertronicBidderParams {
+  /**
+   * Publisher ID issued during onboarding.
+   */
+  publisherId: string;
+  /**
+   * Placement token issued during onboarding.
+   */
+  placementId: string;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    advertronic: AdvertronicBidderParams;
+  }
+}

--- a/modules/advertronicBidAdapter.js
+++ b/modules/advertronicBidAdapter.js
@@ -4,6 +4,12 @@ import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { Renderer } from '../src/Renderer.js';
 import { deepAccess, deepSetValue, logWarn } from '../src/utils.js';
 
+/**
+ * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
+ * @typedef {import('./advertronicBidAdapter.d.ts').AdvertronicBidderParams} AdvertronicBidderParams
+ * @typedef {BidRequest & { params: AdvertronicBidderParams }} AdvertronicBidRequest
+ */
+
 const BIDDER_CODE = 'advertronic';
 const ENDPOINT_URL = 'https://ssp.advertronic.io/prebid/v1/auction';
 const SYNC_URL = 'https://ssp.advertronic.io/prebid/v1/sync';
@@ -28,21 +34,23 @@ const converter = ortbConverter({
   },
   bidResponse(buildBidResponse, bid, context) {
     const bidResponse = buildBidResponse(bid, context);
-    // bid.api (OpenRTB 2.6) marks executable (VPAID) creatives; the renderer
-    // enables its VPAID runtime only when this flag is present.
-    if (bid.api === 1 || bid.api === 2) {
-      bidResponse.advtVpaid = true;
-    }
-    if (bidResponse.mediaType === VIDEO) {
-      const { bidRequest } = context;
-      // Attach our renderer for outstream unless the publisher supplied one.
-      if (
-        bidRequest &&
-        deepAccess(bidRequest, 'mediaTypes.video.context') === 'outstream' &&
-        !bidRequest.renderer &&
-        !deepAccess(bidRequest, 'mediaTypes.video.renderer')
-      ) {
-        bidResponse.renderer = createRenderer(bidResponse, bidRequest.adUnitCode);
+    if (FEATURES.VIDEO) {
+      // bid.api (OpenRTB 2.6) marks executable (VPAID) creatives; the renderer
+      // enables its VPAID runtime only when this flag is present.
+      if (bid.api === 1 || bid.api === 2) {
+        bidResponse.advtVpaid = true;
+      }
+      if (bidResponse.mediaType === VIDEO) {
+        const { bidRequest } = context;
+        // Attach our renderer for outstream unless the publisher supplied one.
+        if (
+          bidRequest &&
+          deepAccess(bidRequest, 'mediaTypes.video.context') === 'outstream' &&
+          !bidRequest.renderer &&
+          !deepAccess(bidRequest, 'mediaTypes.video.renderer')
+        ) {
+          bidResponse.renderer = createRenderer(bidResponse, bidRequest.adUnitCode);
+        }
       }
     }
     return bidResponse;
@@ -74,6 +82,10 @@ export const spec = {
   code: BIDDER_CODE,
   supportedMediaTypes: [BANNER, VIDEO],
 
+  /**
+   * @param {AdvertronicBidRequest} bid
+   * @returns {boolean}
+   */
   isBidRequestValid(bid) {
     return !!(
       bid &&

--- a/modules/advertronicBidAdapter.js
+++ b/modules/advertronicBidAdapter.js
@@ -100,8 +100,10 @@ export const spec = {
         url: ENDPOINT_URL,
         data,
         // withCredentials carries the first-party user id cookie used for
-        // user matching; without it all requests are anonymous.
-        options: { withCredentials: true, contentType: 'application/json' },
+        // user matching; without it all requests are anonymous. Content type
+        // is left at the ajax default (text/plain) so the cross-origin POST
+        // stays a simple request and needs no CORS preflight.
+        options: { withCredentials: true },
       },
     ];
   },

--- a/modules/advertronicBidAdapter.js
+++ b/modules/advertronicBidAdapter.js
@@ -1,0 +1,124 @@
+import { ortbConverter } from '../libraries/ortbConverter/converter.js';
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER, VIDEO } from '../src/mediaTypes.js';
+import { Renderer } from '../src/Renderer.js';
+import { deepAccess, deepSetValue, logWarn } from '../src/utils.js';
+
+const BIDDER_CODE = 'advertronic';
+const ENDPOINT_URL = 'https://ssp.advertronic.io/prebid/v1/auction';
+const SYNC_URL = 'https://ssp.advertronic.io/prebid/v1/sync';
+const RENDERER_URL = 'https://ssp.advertronic.io/tag/prebid-renderer-v1.js';
+const DEFAULT_TTL = 300;
+
+const converter = ortbConverter({
+  context: {
+    // Prices returned by the endpoint are net to the publisher.
+    netRevenue: true,
+    ttl: DEFAULT_TTL,
+  },
+  imp(buildImp, bidRequest, context) {
+    const imp = buildImp(bidRequest, context);
+    imp.tagid = String(bidRequest.params.placementId);
+    return imp;
+  },
+  request(buildRequest, imps, bidderRequest, context) {
+    const request = buildRequest(imps, bidderRequest, context);
+    deepSetValue(request, 'site.publisher.id', String(context.publisherId));
+    return request;
+  },
+  bidResponse(buildBidResponse, bid, context) {
+    const bidResponse = buildBidResponse(bid, context);
+    // bid.api (OpenRTB 2.6) marks executable (VPAID) creatives; the renderer
+    // enables its VPAID runtime only when this flag is present.
+    if (bid.api === 1 || bid.api === 2) {
+      bidResponse.advtVpaid = true;
+    }
+    if (bidResponse.mediaType === VIDEO) {
+      const { bidRequest } = context;
+      // Attach our renderer for outstream unless the publisher supplied one.
+      if (
+        bidRequest &&
+        deepAccess(bidRequest, 'mediaTypes.video.context') === 'outstream' &&
+        !bidRequest.renderer &&
+        !deepAccess(bidRequest, 'mediaTypes.video.renderer')
+      ) {
+        bidResponse.renderer = createRenderer(bidResponse, bidRequest.adUnitCode);
+      }
+    }
+    return bidResponse;
+  },
+});
+
+function createRenderer(bidResponse, adUnitCode) {
+  const renderer = Renderer.install({
+    id: bidResponse.requestId,
+    url: RENDERER_URL,
+    adUnitCode,
+    loaded: false,
+  });
+  try {
+    renderer.setRender(outstreamRender);
+  } catch (e) {
+    logWarn('advertronic: renderer.setRender failed', e);
+  }
+  return renderer;
+}
+
+function outstreamRender(bid) {
+  bid.renderer.push(() => {
+    window.advertronicPrebidRenderer.render(bid);
+  });
+}
+
+export const spec = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [BANNER, VIDEO],
+
+  isBidRequestValid(bid) {
+    return !!(
+      bid &&
+      bid.params &&
+      bid.params.placementId &&
+      typeof bid.params.placementId === 'string' &&
+      bid.params.publisherId &&
+      /^\d+$/.test(String(bid.params.publisherId))
+    );
+  },
+
+  buildRequests(validBidRequests, bidderRequest) {
+    if (!validBidRequests.length) {
+      return [];
+    }
+    const data = converter.toORTB({
+      bidRequests: validBidRequests,
+      bidderRequest,
+      context: { publisherId: validBidRequests[0].params.publisherId },
+    });
+    return [
+      {
+        method: 'POST',
+        url: ENDPOINT_URL,
+        data,
+        // withCredentials carries the first-party user id cookie used for
+        // user matching; without it all requests are anonymous.
+        options: { withCredentials: true, contentType: 'application/json' },
+      },
+    ];
+  },
+
+  interpretResponse(serverResponse, request) {
+    if (!serverResponse || !serverResponse.body) {
+      return [];
+    }
+    return converter.fromORTB({ response: serverResponse.body, request: request.data }).bids;
+  },
+
+  getUserSyncs(syncOptions) {
+    if (syncOptions.iframeEnabled) {
+      return [{ type: 'iframe', url: SYNC_URL }];
+    }
+    return [];
+  },
+};
+
+registerBidder(spec);

--- a/test/spec/modules/advertronicBidAdapter_spec.js
+++ b/test/spec/modules/advertronicBidAdapter_spec.js
@@ -1,0 +1,161 @@
+import { expect } from 'chai';
+import { spec } from 'modules/advertronicBidAdapter.js';
+
+describe('advertronicBidAdapter', function () {
+  const bannerBidRequest = {
+    bidder: 'advertronic',
+    bidId: 'bid-1',
+    adUnitCode: 'div-banner',
+    transactionId: 'txn-1',
+    params: { publisherId: '7', placementId: 'tok123abc456' },
+    mediaTypes: { banner: { sizes: [[300, 250], [300, 600]] } },
+  };
+
+  const videoBidRequest = {
+    bidder: 'advertronic',
+    bidId: 'bid-2',
+    adUnitCode: 'div-video',
+    transactionId: 'txn-2',
+    params: { publisherId: '7', placementId: 'tokvideo0001' },
+    mediaTypes: {
+      video: { context: 'outstream', playerSize: [[640, 360]], mimes: ['video/mp4'] },
+    },
+  };
+
+  const bidderRequest = {
+    bidderCode: 'advertronic',
+    auctionId: 'auc-1',
+    bidderRequestId: 'br-1',
+    timeout: 1000,
+    bids: [bannerBidRequest, videoBidRequest],
+    refererInfo: { page: 'https://pub.example/article' },
+  };
+
+  describe('isBidRequestValid', function () {
+    it('accepts valid params', function () {
+      expect(spec.isBidRequestValid(bannerBidRequest)).to.equal(true);
+    });
+    it('rejects missing placementId', function () {
+      expect(spec.isBidRequestValid({ params: { publisherId: '7' } })).to.equal(false);
+    });
+    it('rejects missing publisherId', function () {
+      expect(spec.isBidRequestValid({ params: { placementId: 'tok' } })).to.equal(false);
+    });
+    it('rejects non-numeric publisherId', function () {
+      expect(spec.isBidRequestValid({ params: { placementId: 'tok', publisherId: 'oops' } })).to.equal(false);
+    });
+    it('rejects numeric placementId (string token expected)', function () {
+      expect(spec.isBidRequestValid({ params: { placementId: 123, publisherId: '7' } })).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', function () {
+    it('sends a single POST with ORTB payload and credentials', function () {
+      const reqs = spec.buildRequests([bannerBidRequest, videoBidRequest], bidderRequest);
+      expect(reqs).to.have.lengthOf(1);
+      const req = reqs[0];
+      expect(req.method).to.equal('POST');
+      expect(req.url).to.equal('https://ssp.advertronic.io/prebid/v1/auction');
+      expect(req.options.withCredentials).to.equal(true);
+
+      const data = req.data;
+      expect(data.imp).to.have.lengthOf(2);
+      expect(data.imp[0].tagid).to.equal('tok123abc456');
+      expect(data.imp[0].banner.format[0]).to.deep.include({ w: 300, h: 250 });
+      expect(data.imp[1].tagid).to.equal('tokvideo0001');
+      expect(data.imp[1].video).to.be.an('object');
+      expect(data.site.publisher.id).to.equal('7');
+      expect(data.tmax).to.equal(1000);
+    });
+  });
+
+  describe('interpretResponse', function () {
+    function ortbResponse() {
+      const reqs = spec.buildRequests([bannerBidRequest, videoBidRequest], bidderRequest);
+      const request = reqs[0];
+      const impidBanner = request.data.imp[0].id;
+      const impidVideo = request.data.imp[1].id;
+      const body = {
+        id: request.data.id,
+        cur: 'RUB',
+        seatbid: [
+          {
+            seat: 'advertronic',
+            bid: [
+              {
+                id: 'a-1',
+                impid: impidBanner,
+                price: 40,
+                adm: '<div>ad</div>',
+                crid: 'cr1',
+                adomain: ['adv.ru'],
+                w: 300,
+                h: 250,
+                mtype: 1,
+              },
+              {
+                id: 'a-2',
+                impid: impidVideo,
+                price: 55,
+                adm: '<VAST version="3.0"></VAST>',
+                crid: 'cr2',
+                adomain: ['video-adv.ru'],
+                w: 640,
+                h: 360,
+                mtype: 2,
+                api: 2,
+              },
+            ],
+          },
+        ],
+      };
+      return { request, body };
+    }
+
+    it('maps a banner bid', function () {
+      const { request, body } = ortbResponse();
+      const bids = spec.interpretResponse({ body }, request);
+      expect(bids).to.have.lengthOf(2);
+      const b = bids.find((x) => x.requestId === 'bid-1');
+      expect(b.cpm).to.equal(40);
+      expect(b.currency).to.equal('RUB');
+      expect(b.netRevenue).to.equal(true);
+      expect(b.ttl).to.equal(300);
+      expect(b.mediaType).to.equal('banner');
+      expect(b.ad).to.equal('<div>ad</div>');
+      expect(b.creativeId).to.equal('cr1');
+      expect(b.width).to.equal(300);
+      expect(b.height).to.equal(250);
+      expect(b.meta.advertiserDomains).to.deep.equal(['adv.ru']);
+    });
+
+    it('maps a video bid: vastXml, VPAID flag, outstream renderer', function () {
+      const { request, body } = ortbResponse();
+      const bids = spec.interpretResponse({ body }, request);
+      const v = bids.find((x) => x.requestId === 'bid-2');
+      expect(v.mediaType).to.equal('video');
+      expect(v.vastXml).to.contain('<VAST');
+      expect(v.advtVpaid).to.equal(true);
+      expect(v.renderer).to.be.an('object');
+      expect(v.renderer.url).to.equal('https://ssp.advertronic.io/tag/prebid-renderer-v1.js');
+    });
+
+    it('returns no bids on empty body (204)', function () {
+      const reqs = spec.buildRequests([bannerBidRequest], bidderRequest);
+      expect(spec.interpretResponse({ body: null }, reqs[0])).to.deep.equal([]);
+      expect(spec.interpretResponse(undefined, reqs[0])).to.deep.equal([]);
+    });
+  });
+
+  describe('getUserSyncs', function () {
+    it('returns the iframe sync when iframeEnabled', function () {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true });
+      expect(syncs).to.deep.equal([
+        { type: 'iframe', url: 'https://ssp.advertronic.io/prebid/v1/sync' },
+      ]);
+    });
+    it('returns nothing otherwise (no pixel sync)', function () {
+      expect(spec.getUserSyncs({ pixelEnabled: true })).to.deep.equal([]);
+    });
+  });
+});

--- a/test/spec/modules/advertronicBidAdapter_spec.js
+++ b/test/spec/modules/advertronicBidAdapter_spec.js
@@ -63,7 +63,9 @@ describe('advertronicBidAdapter', function () {
       expect(data.imp[0].tagid).to.equal('tok123abc456');
       expect(data.imp[0].banner.format[0]).to.deep.include({ w: 300, h: 250 });
       expect(data.imp[1].tagid).to.equal('tokvideo0001');
-      expect(data.imp[1].video).to.be.an('object');
+      if (FEATURES.VIDEO) {
+        expect(data.imp[1].video).to.be.an('object');
+      }
       expect(data.site.publisher.id).to.equal('7');
       expect(data.tmax).to.equal(1000);
     });
@@ -129,16 +131,18 @@ describe('advertronicBidAdapter', function () {
       expect(b.meta.advertiserDomains).to.deep.equal(['adv.ru']);
     });
 
-    it('maps a video bid: vastXml, VPAID flag, outstream renderer', function () {
-      const { request, body } = ortbResponse();
-      const bids = spec.interpretResponse({ body }, request);
-      const v = bids.find((x) => x.requestId === 'bid-2');
-      expect(v.mediaType).to.equal('video');
-      expect(v.vastXml).to.contain('<VAST');
-      expect(v.advtVpaid).to.equal(true);
-      expect(v.renderer).to.be.an('object');
-      expect(v.renderer.url).to.equal('https://ssp.advertronic.io/tag/prebid-renderer-v1.js');
-    });
+    if (FEATURES.VIDEO) {
+      it('maps a video bid: vastXml, VPAID flag, outstream renderer', function () {
+        const { request, body } = ortbResponse();
+        const bids = spec.interpretResponse({ body }, request);
+        const v = bids.find((x) => x.requestId === 'bid-2');
+        expect(v.mediaType).to.equal('video');
+        expect(v.vastXml).to.contain('<VAST');
+        expect(v.advtVpaid).to.equal(true);
+        expect(v.renderer).to.be.an('object');
+        expect(v.renderer.url).to.equal('https://ssp.advertronic.io/tag/prebid-renderer-v1.js');
+      });
+    }
 
     it('returns no bids on empty body (204)', function () {
       const reqs = spec.buildRequests([bannerBidRequest], bidderRequest);


### PR DESCRIPTION
## Type of change

- [x] New bidder adapter

## Description of change

New bid adapter for Advertronic SSP (banner and video).

- Thin adapter built on the ortbConverter library; the endpoint speaks plain OpenRTB 2.x.
- Outstream video is rendered by our own renderer (loaded from Advertronic servers) unless the publisher supplies one on the ad unit.
- Bid prices are net to the publisher, currency is RUB (documented on the bidder page).
- Single iframe user sync; the partner list and frequency capping are handled server-side.
- Test parameters in `modules/advertronic.md` consistently return a static test creative from any location.

- contact email of the adapter maintainer: info@advertronic.io
- [x] official adapter submission
- [x] unit tests added (`test/spec/modules/advertronicBidAdapter_spec.js`)

Docs PR: (link will be added right after it is opened)
