### PR TITLE
Adferry Bid Adapter: new bid adapter

### DIFF
--- a/modules/adferryBidAdapter.md
+++ b/modules/adferryBidAdapter.md
@@ -1,0 +1,78 @@
+# Overview
+
+```
+Module Name: Adferry Bid Adapter
+Module Type: Bidder Adapter
+Maintainer: admin@adferry.co
+```
+
+# Description
+
+Connects to Adferry for instream / outstream video, banner (display) and
+audio demand over OpenRTB 2.6. Native is not supported.
+
+# Bid Parameters
+
+| Name          | Scope    | Description                                        | Example        | Type     |
+|---------------|----------|----------------------------------------------------|----------------|----------|
+| `placementId` | required | Tag ID, from Adferry portal → Integrations → Prebid | `'adferryprebidtest1'` | `string` |
+| `bidFloor`    | optional | Floor CPM for this placement                       | `2.50`         | `number` |
+| `currency`    | optional | Floor currency. Defaults to `USD`                  | `'USD'`        | `string` |
+
+# Test Parameters
+
+The `placementId` below is a live test tag that reliably returns a test VAST
+creative from the endpoint, for validating the integration. Banner and audio
+demand are also supported in production; this test tag is video.
+
+```javascript
+var adUnits = [
+  {
+    code: 'video-1',
+    mediaTypes: {
+      video: {
+        context: 'instream',
+        playerSize: [640, 480],
+        mimes: ['video/mp4'],
+        protocols: [2, 3, 5, 6, 7, 8]
+      }
+    },
+    bids: [
+      {
+        bidder: 'adferry',
+        params: {
+          placementId: 'adferryprebidtest1'
+        }
+      }
+    ]
+  }
+];
+```
+
+# Notes
+
+**One HTTP request per ad unit.** The server limits concurrency per tag, so
+batching several placements into one call would queue them behind each other.
+Separate requests keep each placement in its own lane.
+
+**US privacy signals are forwarded.** The US privacy (CCPA) string, GPP
+(the full string plus every applicable section id, national and state-level
+alike), and the COPPA flag are all passed through - both in the oRTB 2.6
+core `regs` fields and wherever the consent modules put them on `ortb2`.
+Without them the server treats the request as having no consent, which is
+the correct default and also the one that fills worst. The adapter is
+US-only: it carries no GVL ID and does no TCF handling.
+
+**First-party data is forwarded.** The `ortb2` object travels to the exchange
+as-is; `ortb2Imp` is merged into each impression.
+
+**`schain` is forwarded** on the oRTB 2.6 core `source.schain`, whether it
+arrives through `ortb2.source.ext.schain` or pinned per-bid (the `ext` copy
+travels too).
+
+**No user syncs.** There is no sync pixel or iframe; the demand path is
+server-side and CTV-first.
+
+**`creativeId` is a stable opaque id**, not a demand partner name. It groups
+consistently across auctions so it can be used for reporting, and it does not
+disclose which partner filled the impression.

--- a/modules/adferryBidAdapter.ts
+++ b/modules/adferryBidAdapter.ts
@@ -1,0 +1,186 @@
+import { type BidderSpec, registerBidder } from '../src/adapters/bidderFactory.js';
+import { ortbConverter } from '../libraries/ortbConverter/converter.js';
+import { AUDIO, BANNER, VIDEO } from '../src/mediaTypes.js';
+import { deepAccess, deepSetValue, logWarn } from '../src/utils.js';
+
+/**
+ * Adferry bid adapter.
+ *
+ * Thin on purpose. The endpoint already speaks OpenRTB 2.6 and already returns
+ * everything Prebid needs on the bid object - price, currency, adm, crid,
+ * w/h, mtype - so the shape translation is delegated to Prebid's own
+ * ortbConverter and the only code here is what is Adferry-specific: the
+ * placementId -> imp.tagid join, mirroring consent into the oRTB 2.6 core
+ * regs fields the endpoint binds, and the one-request-per-placement fan-out.
+ * Any logic that looks like it belongs here almost certainly belongs on the
+ * server, where it is tested and where it applies to every integration
+ * rather than only to Prebid.js.
+ *
+ * Submitted to prebid/Prebid.js. Until it is merged, publishers cannot write
+ * `bidder: 'adferry'` at all, which is the whole reason this file exists.
+ */
+
+const BIDDER_CODE = 'adferry';
+const ENDPOINT = 'https://rtb.adferry.co/api/ortb/prebid';
+const DEFAULT_TTL = 300;
+const DEFAULT_CURRENCY = 'USD';
+
+// US-only on purpose: no gvlid and no TCF handling. If Adferry ever serves
+// EU traffic this needs an IAB Europe registration first, not a code patch.
+
+type AdferryBidParams = {
+  placementId: string;
+  bidFloor?: number;
+  currency?: string;
+};
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    [BIDDER_CODE]: AdferryBidParams;
+  }
+}
+
+const converter = ortbConverter({
+  context: {
+    netRevenue: true,
+    ttl: DEFAULT_TTL,
+  },
+
+  imp(buildImp: any, bidRequest: any, context: any) {
+    const imp = buildImp(bidRequest, context);
+    // The join to the portal. Everything else in the imp is standard oRTB the
+    // converter assembles from mediaTypes - video params come from
+    // AdUnit.mediaTypes.video per the module rules, never from bidder params.
+    imp.tagid = String(bidRequest.params.placementId);
+    // The floors module wins when installed; the param is only the fallback.
+    if (imp.bidfloor == null && bidRequest.params.bidFloor != null) {
+      imp.bidfloor = bidRequest.params.bidFloor;
+      imp.bidfloorcur = bidRequest.params.currency || DEFAULT_CURRENCY;
+    }
+    return imp;
+  },
+
+  request(buildRequest: any, imps: any, bidderRequest: any, context: any) {
+    const request = buildRequest(imps, bidderRequest, context);
+
+    // Privacy signals travel or the server cannot make a lawful decision.
+    // Passing them is not optional politeness: without them the request is
+    // treated as having no consent at all, which is the correct default and
+    // also the one that fills worst. The converter already merges ortb2
+    // (covering consent modules that write there, including regs.coppa);
+    // this mirrors the bidderRequest consent objects into the oRTB 2.6 core
+    // fields the endpoint binds, without clobbering anything a module set.
+    const usp = deepAccess(bidderRequest, 'uspConsent');
+    if (usp && !deepAccess(request, 'regs.us_privacy')) {
+      deepSetValue(request, 'regs.us_privacy', usp);
+    }
+    const gpp = deepAccess(bidderRequest, 'gppConsent.gppString');
+    if (gpp && !deepAccess(request, 'regs.gpp')) {
+      deepSetValue(request, 'regs.gpp', gpp);
+      deepSetValue(request, 'regs.gpp_sid',
+        deepAccess(bidderRequest, 'gppConsent.applicableSections') || []);
+    }
+
+    // schain: Prebid hands it through ortb2.source.ext.schain (the 2.5-era
+    // location, already merged into the request above); very old setups pin
+    // it per-bid. The endpoint binds the oRTB 2.6 core location,
+    // source.schain, so mirror it there.
+    const schain = deepAccess(request, 'source.ext.schain') ||
+      deepAccess(context, 'bidRequests.0.ortb2.source.ext.schain') ||
+      deepAccess(context, 'bidRequests.0.schain');
+    if (schain && !deepAccess(request, 'source.schain')) {
+      deepSetValue(request, 'source.schain', schain);
+    }
+
+    if (!request.cur) {
+      request.cur = [DEFAULT_CURRENCY];
+    }
+    return request;
+  },
+
+  bidResponse(buildBidResponse: any, bid: any, context: any) {
+    // oRTB 2.6 mtype says what the markup is (1 banner, 2 video, 3 audio);
+    // older responses say it through the markup itself. Prebid's core
+    // converter maps 1/2/4 only - audio (3) is absent from its table - so
+    // that one has to be named here or buildBidResponse throws
+    // "Cannot determine mediaType".
+    if (bid.mtype === 3) {
+      context.mediaType = AUDIO;
+    } else if (bid.mtype == null) {
+      context.mediaType = /<VAST/i.test(bid.adm || '') ? VIDEO : BANNER;
+    }
+    const bidResponse = buildBidResponse(bid, context);
+    // Required on every bid response - Prebid reviews for it and publisher
+    // brand-safety tooling blocks on it.
+    bidResponse.meta = Object.assign({}, bidResponse.meta, {
+      advertiserDomains: bid.adomain || [],
+    });
+    return bidResponse;
+  },
+});
+
+export const spec: BidderSpec<typeof BIDDER_CODE> = {
+  code: BIDDER_CODE,
+  supportedMediaTypes: [BANNER, VIDEO, AUDIO],
+
+  /**
+   * A placementId is the tag id issued in the portal. The server resolves it
+   * from imp[].tagid, so the name a publisher types here has to survive
+   * unchanged all the way to that field.
+   */
+  isBidRequestValid(bid: any): boolean {
+    const placementId = deepAccess(bid, 'params.placementId');
+    if (!placementId) {
+      logWarn(`${BIDDER_CODE}: params.placementId is required.`);
+      return false;
+    }
+    if (!deepAccess(bid, 'mediaTypes.video') &&
+        !deepAccess(bid, 'mediaTypes.banner') &&
+        !deepAccess(bid, 'mediaTypes.audio')) {
+      logWarn(`${BIDDER_CODE}: video, banner or audio mediaTypes are required.`);
+      return false;
+    }
+    return true;
+  },
+
+  /**
+   * One HTTP call per placement rather than one per bidder.
+   *
+   * The server enforces a concurrency limit PER TAG, so collapsing several
+   * placements into a single call would put them behind one another in the
+   * same queue. Separate requests keep each placement in its own lane, which
+   * is how the limit was designed to be used.
+   */
+  buildRequests(validBidRequests: any[], bidderRequest: any) {
+    return validBidRequests.map((bid: any) => ({
+      method: 'POST',
+      url: ENDPOINT,
+      // contentType is application/json on purpose, even though it makes the
+      // POST a non-simple CORS request that triggers a preflight: the endpoint
+      // is declared `[Consumes("application/json")]` and answers text/plain
+      // with 415. The preflight is answered at the edge and cached for 24h
+      // (Access-Control-Max-Age), so it costs one OPTIONS per origin per day,
+      // not one per auction. withCredentials is false - no cookies, no sync.
+      data: converter.toORTB({ bidRequests: [bid], bidderRequest }),
+      options: { contentType: 'application/json', withCredentials: false },
+    }));
+  },
+
+  interpretResponse(serverResponse: any, request: any) {
+    // A no-bid is the common case (204 / empty seatbid), not an error.
+    // Returning [] keeps one empty answer from taking down the whole auction.
+    const body = serverResponse && serverResponse.body;
+    if (!body || !body.seatbid || !body.seatbid.length) {
+      return [];
+    }
+    const result = converter.fromORTB({ response: body, request: request.data });
+    return (result as { bids: any[] }).bids;
+  },
+
+  // No getUserSyncs on purpose: there is no sync endpoint to register, and the
+  // demand path is server-side and CTV-first, where cookie syncing buys
+  // nothing. If a sync endpoint ever exists it registers here and nowhere
+  // else - the module rules forbid pixels outside this hook.
+};
+
+registerBidder(spec);

--- a/modules/adferryBidAdapter.ts
+++ b/modules/adferryBidAdapter.ts
@@ -28,7 +28,7 @@ const DEFAULT_CURRENCY = 'USD';
 // US-only on purpose: no gvlid and no TCF handling. If Adferry ever serves
 // EU traffic this needs an IAB Europe registration first, not a code patch.
 
-type AdferryBidParams = {
+export type AdferryBidParams = {
   placementId: string;
   bidFloor?: number;
   currency?: string;
@@ -44,6 +44,10 @@ const converter = ortbConverter({
   context: {
     netRevenue: true,
     ttl: DEFAULT_TTL,
+    // The endpoint answers in USD; state it so a response with no `cur`
+    // (oRTB's USD default) still yields a bid with a currency rather than
+    // one bidderFactory rejects for the missing field.
+    currency: DEFAULT_CURRENCY,
   },
 
   imp(buildImp: any, bidRequest: any, context: any) {
@@ -99,17 +103,16 @@ const converter = ortbConverter({
   },
 
   bidResponse(buildBidResponse: any, bid: any, context: any) {
-    // oRTB 2.6 mtype says what the markup is (1 banner, 2 video, 3 audio);
-    // older responses say it through the markup itself. Prebid's core
-    // converter maps 1/2/4 only - audio (3) is absent from its table - so
-    // that one has to be named here or buildBidResponse throws
-    // "Cannot determine mediaType".
-    if (bid.mtype === 3) {
-      context.mediaType = AUDIO;
-    } else if (bid.mtype == null) {
-      context.mediaType = /<VAST/i.test(bid.adm || '') ? VIDEO : BANNER;
-    }
-    const bidResponse = buildBidResponse(bid, context);
+    // The endpoint always sets oRTB 2.6 mtype. The core converter maps
+    // 1/2/4 but not audio (3), so name that one - on a per-bid COPY of the
+    // context, never the shared one. ortbConverter reuses a single
+    // per-impression context across every bid for that imp, so mutating
+    // context.mediaType would push a later banner/video bid for the same
+    // imp through the audio type. A missing mtype is left to the core
+    // converter rather than guessed from the markup (audio adm is VAST
+    // too, and a video guess is rejected on an audio-only ad unit).
+    const bidContext = bid.mtype === 3 ? { ...context, mediaType: AUDIO } : context;
+    const bidResponse = buildBidResponse(bid, bidContext);
     // Required on every bid response - Prebid reviews for it and publisher
     // brand-safety tooling blocks on it.
     bidResponse.meta = Object.assign({}, bidResponse.meta, {

--- a/modules/adferryBidAdapter.ts
+++ b/modules/adferryBidAdapter.ts
@@ -158,14 +158,12 @@ export const spec: BidderSpec<typeof BIDDER_CODE> = {
     return validBidRequests.map((bid: any) => ({
       method: 'POST',
       url: ENDPOINT,
-      // contentType is application/json on purpose, even though it makes the
-      // POST a non-simple CORS request that triggers a preflight: the endpoint
-      // is declared `[Consumes("application/json")]` and answers text/plain
-      // with 415. The preflight is answered at the edge and cached for 24h
-      // (Access-Control-Max-Age), so it costs one OPTIONS per origin per day,
-      // not one per auction. withCredentials is false - no cookies, no sync.
+      // No contentType: bidderFactory serialises the object and the default
+      // text/plain keeps the auction a "simple" cross-origin POST with no
+      // preflight round-trip. The endpoint parses the JSON body under
+      // text/plain. withCredentials is false - no cookies, no sync.
       data: converter.toORTB({ bidRequests: [bid], bidderRequest }),
-      options: { contentType: 'application/json', withCredentials: false },
+      options: { withCredentials: false },
     }));
   },
 

--- a/test/spec/modules/adferryBidAdapter_spec.js
+++ b/test/spec/modules/adferryBidAdapter_spec.js
@@ -1,0 +1,231 @@
+import { expect } from 'chai';
+// The module is TypeScript (adferryBidAdapter.ts); Prebid's build resolves
+// the .js specifier to it, same as every core import.
+import { spec } from 'modules/adferryBidAdapter.js';
+
+describe('adferryBidAdapter', function () {
+  const validBid = {
+    bidder: 'adferry',
+    bidId: 'bid123',
+    adUnitCode: 'video-1',
+    params: { placementId: 'adferryprebidtest1' },
+    mediaTypes: {
+      video: {
+        context: 'instream',
+        playerSize: [[640, 480]],
+        mimes: ['video/mp4'],
+        protocols: [2, 3, 5, 6, 7, 8],
+      },
+    },
+  };
+
+  const bidderRequest = {
+    bidderCode: 'adferry',
+    auctionId: 'auction-1',
+    timeout: 1000,
+    refererInfo: { page: 'https://example.com/watch', domain: 'example.com' },
+    uspConsent: '1YNN',
+    gppConsent: { gppString: 'GPP_STRING', applicableSections: [7] },
+  };
+
+  describe('isBidRequestValid', function () {
+    it('accepts a video bid with a placementId', function () {
+      expect(spec.isBidRequestValid(validBid)).to.equal(true);
+    });
+
+    it('rejects a bid with no placementId', function () {
+      // The placementId is the only thing tying the request to a tag. Without
+      // it the server answers 400, so failing here saves a round trip and
+      // gives the publisher an error they can act on.
+      const bid = { ...validBid, params: {} };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+
+    it('accepts a banner bid', function () {
+      const bid = { ...validBid, mediaTypes: { banner: { sizes: [[300, 250]] } } };
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('accepts an audio bid', function () {
+      const bid = { ...validBid, mediaTypes: { audio: { mimes: ['audio/mp4'] } } };
+      expect(spec.isBidRequestValid(bid)).to.equal(true);
+    });
+
+    it('rejects a bid with none of video, banner or audio', function () {
+      const bid = { ...validBid, mediaTypes: { native: {} } };
+      expect(spec.isBidRequestValid(bid)).to.equal(false);
+    });
+  });
+
+  describe('buildRequests', function () {
+    it('sends one request per bid', function () {
+      // Not a style choice. The server caps concurrency per tag, so batching
+      // would put placements in the same queue behind one another.
+      const reqs = spec.buildRequests([validBid, { ...validBid, bidId: 'bid456' }], bidderRequest);
+      expect(reqs).to.have.lengthOf(2);
+    });
+
+    it('puts placementId on imp[].tagid', function () {
+      // This is the single field that joins Prebid to the portal. If it moves,
+      // every integration silently 400s.
+      const [req] = spec.buildRequests([validBid], bidderRequest);
+      expect(req.data.imp[0].tagid).to.equal('adferryprebidtest1');
+    });
+
+    it('reads video params from mediaTypes.video', function () {
+      const [req] = spec.buildRequests([validBid], bidderRequest);
+      expect(req.data.imp[0].video.w).to.equal(640);
+      expect(req.data.imp[0].video.h).to.equal(480);
+      expect(req.data.imp[0].video.mimes).to.deep.equal(['video/mp4']);
+    });
+
+    it('builds a banner imp with every size in format', function () {
+      const bid = { ...validBid, mediaTypes: { banner: { sizes: [[300, 250], [728, 90]] } } };
+      const [req] = spec.buildRequests([bid], bidderRequest);
+      expect(req.data.imp[0].banner.format).to.deep.equal([{ w: 300, h: 250 }, { w: 728, h: 90 }]);
+      expect(req.data.imp[0].video).to.equal(undefined);
+    });
+
+    it('builds an audio imp from mediaTypes.audio', function () {
+      const bid = { ...validBid, mediaTypes: { audio: { mimes: ['audio/mp4'], protocols: [9, 10] } } };
+      const [req] = spec.buildRequests([bid], bidderRequest);
+      expect(req.data.imp[0].audio.mimes).to.deep.equal(['audio/mp4']);
+      expect(req.data.imp[0].video).to.equal(undefined);
+      expect(req.data.imp[0].banner).to.equal(undefined);
+    });
+
+    it('falls back to the bidFloor param when the floors module is absent', function () {
+      const bid = { ...validBid, params: { placementId: 'adferryprebidtest1', bidFloor: 2.5 } };
+      const [req] = spec.buildRequests([bid], bidderRequest);
+      expect(req.data.imp[0].bidfloor).to.equal(2.5);
+      expect(req.data.imp[0].bidfloorcur).to.equal('USD');
+    });
+
+    it('mirrors US privacy signals into the oRTB 2.6 core regs fields', function () {
+      // The server binds regs.us_privacy / regs.gpp / regs.gpp_sid (2.6
+      // core), not only the 2.5-era regs.ext.* the consent modules write.
+      const [req] = spec.buildRequests([validBid], bidderRequest);
+      expect(req.data.regs.us_privacy).to.equal('1YNN');
+      expect(req.data.regs.gpp).to.equal('GPP_STRING');
+      expect(req.data.regs.gpp_sid).to.deep.equal([7]);
+    });
+
+    it('forwards first-party data and coppa through ortb2', function () {
+      const withOrtb2 = {
+        ...bidderRequest,
+        ortb2: { site: { cat: ['IAB1'] }, regs: { coppa: 1 } },
+      };
+      const [req] = spec.buildRequests([validBid], withOrtb2);
+      expect(req.data.site.cat).to.deep.equal(['IAB1']);
+      expect(req.data.regs.coppa).to.equal(1);
+    });
+
+    it('mirrors the ortb2 schain to the oRTB 2.6 core source.schain', function () {
+      const schain = {
+        ver: '1.0',
+        complete: 1,
+        nodes: [{ asi: 'example.com', sid: 'pub-1', hp: 1 }],
+      };
+      const withSchain = {
+        ...bidderRequest,
+        ortb2: { source: { ext: { schain } } },
+      };
+      const [req] = spec.buildRequests([validBid], withSchain);
+      expect(req.data.source.schain).to.deep.equal(schain);
+    });
+
+    it('mirrors a legacy per-bid schain too', function () {
+      const schain = { ver: '1.0', complete: 1, nodes: [] };
+      const [req] = spec.buildRequests([{ ...validBid, schain }], bidderRequest);
+      expect(req.data.source.schain).to.deep.equal(schain);
+    });
+  });
+
+  describe('interpretResponse', function () {
+    function respond(request, bid) {
+      return {
+        body: {
+          id: request.data.id,
+          cur: 'USD',
+          seatbid: [{
+            seat: 'af_1a2b3c4d',
+            bid: [{ impid: request.data.imp[0].id, ...bid }],
+          }],
+        },
+      };
+    }
+
+    it('maps a video bid', function () {
+      const [req] = spec.buildRequests([validBid], bidderRequest);
+      const [bid] = spec.interpretResponse(respond(req, {
+        price: 4.5,
+        adm: '<VAST version="4.2"></VAST>',
+        crid: 'af_1a2b3c4d',
+        w: 640,
+        h: 480,
+        mtype: 2,
+        adomain: ['brand.com'],
+      }), req);
+      expect(bid.cpm).to.equal(4.5);
+      expect(bid.currency).to.equal('USD');
+      expect(bid.vastXml).to.contain('VAST');
+      expect(bid.mediaType).to.equal('video');
+      expect(bid.creativeId).to.equal('af_1a2b3c4d');
+      expect(bid.meta.advertiserDomains).to.deep.equal(['brand.com']);
+    });
+
+    it('maps a banner bid', function () {
+      const bannerBid = { ...validBid, mediaTypes: { banner: { sizes: [[300, 250]] } } };
+      const [req] = spec.buildRequests([bannerBid], bidderRequest);
+      const [bid] = spec.interpretResponse(respond(req, {
+        price: 1.2,
+        adm: '<div>ad</div>',
+        crid: 'af_1a2b3c4d',
+        w: 300,
+        h: 250,
+        mtype: 1,
+        adomain: ['brand.com'],
+      }), req);
+      expect(bid.mediaType).to.equal('banner');
+      expect(bid.ad).to.contain('<div>');
+      expect(bid.width).to.equal(300);
+      expect(bid.height).to.equal(250);
+    });
+
+    it('maps an audio bid', function () {
+      const audioBid = { ...validBid, mediaTypes: { audio: { mimes: ['audio/mp4'] } } };
+      const [req] = spec.buildRequests([audioBid], bidderRequest);
+      const [bid] = spec.interpretResponse(respond(req, {
+        price: 2.2,
+        adm: '<VAST version="4.2"></VAST>',
+        crid: 'af_1a2b3c4d',
+        mtype: 3,
+        adomain: ['brand.com'],
+      }), req);
+      expect(bid.mediaType).to.equal('audio');
+      expect(bid.vastXml).to.contain('VAST');
+      expect(bid.meta.advertiserDomains).to.deep.equal(['brand.com']);
+    });
+
+    it('sniffs VAST markup when mtype is missing', function () {
+      // Pre-2.6 responses say what they are through the markup itself.
+      const [req] = spec.buildRequests([validBid], bidderRequest);
+      const [bid] = spec.interpretResponse(respond(req, {
+        price: 3.0,
+        adm: '<VAST version="3.0"></VAST>',
+        crid: 'af_1a2b3c4d',
+      }), req);
+      expect(bid.mediaType).to.equal('video');
+      expect(bid.vastXml).to.contain('VAST');
+    });
+
+    it('returns nothing on a no-bid', function () {
+      // A no-bid is the common case, not an error. Returning [] rather than
+      // throwing keeps one empty seatbid from taking down the whole auction.
+      const [req] = spec.buildRequests([validBid], bidderRequest);
+      expect(spec.interpretResponse({ body: { seatbid: [] } }, req)).to.deep.equal([]);
+      expect(spec.interpretResponse({ body: {} }, req)).to.deep.equal([]);
+      expect(spec.interpretResponse({}, req)).to.deep.equal([]);
+    });
+  });
+});

--- a/test/spec/modules/adferryBidAdapter_spec.js
+++ b/test/spec/modules/adferryBidAdapter_spec.js
@@ -207,16 +207,40 @@ describe('adferryBidAdapter', function () {
       expect(bid.meta.advertiserDomains).to.deep.equal(['brand.com']);
     });
 
-    it('sniffs VAST markup when mtype is missing', function () {
-      // Pre-2.6 responses say what they are through the markup itself.
+    it('defaults the currency to USD when the response omits cur', function () {
+      // oRTB's protocol default is USD; without a context currency the bid
+      // would have none and bidderFactory would reject it.
       const [req] = spec.buildRequests([validBid], bidderRequest);
-      const [bid] = spec.interpretResponse(respond(req, {
-        price: 3.0,
-        adm: '<VAST version="3.0"></VAST>',
-        crid: 'af_1a2b3c4d',
-      }), req);
-      expect(bid.mediaType).to.equal('video');
-      expect(bid.vastXml).to.contain('VAST');
+      const [bid] = spec.interpretResponse({
+        body: {
+          id: req.data.id,
+          seatbid: [{ bid: [{ impid: req.data.imp[0].id, price: 4.5, adm: '<VAST/>', crid: 'c', mtype: 2 }] }],
+        },
+      }, req);
+      expect(bid.currency).to.equal('USD');
+    });
+
+    it('keeps each bid\'s media type independent for a multiformat imp', function () {
+      // ortbConverter reuses one per-impression context across bids; an audio
+      // bid must not drag a sibling video bid for the same imp into audio.
+      const mfBid = { ...validBid, mediaTypes: { video: { context: 'instream', playerSize: [[640, 480]] }, audio: { mimes: ['audio/mp4'] } } };
+      const [req] = spec.buildRequests([mfBid], bidderRequest);
+      const impid = req.data.imp[0].id;
+      const bids = spec.interpretResponse({
+        body: {
+          id: req.data.id,
+          cur: 'USD',
+          seatbid: [{
+            bid: [
+              { id: 'a', impid, price: 2.2, adm: '<VAST/>', crid: 'ca', mtype: 3 },
+              { id: 'v', impid, price: 3.3, adm: '<VAST/>', crid: 'cv', mtype: 2 },
+            ]
+          }],
+        },
+      }, req);
+      const byId = Object.fromEntries(bids.map((b) => [b.creativeId, b.mediaType]));
+      expect(byId.ca).to.equal('audio');
+      expect(byId.cv).to.equal('video');
     });
 
     it('returns nothing on a no-bid', function () {


### PR DESCRIPTION
## Type of change

- [x] New bidder adapter

## Description of change

New oRTB 2.6 bid adapter for **Adferry**, built on the `ortbConverter` library.

- **Maintainer:** admin@adferry.co
- **Endpoint:** `https://rtb.adferry.co/api/ortb/prebid` (live, public, CORS `*`)
- **Media types:** banner, video, audio
- **Privacy (US-only):** forwards `uspConsent`, `gppConsent` (string + section ids) and `ortb2.regs.coppa`. No GVL ID / TCF handling by design.
- `schain` forwarded on `source.schain`; `meta.advertiserDomains` populated on every bid response.
- One request per placement (the server caps concurrency per tag).

### Test parameters

Also in `modules/adferryBidAdapter.md`. This placement returns a live test VAST creative:

```js
var adUnits = [{
  code: 'video-1',
  mediaTypes: { video: { context: 'instream', playerSize: [640, 480], mimes: ['video/mp4'], protocols: [2, 3, 5, 6, 7, 8] } },
  bids: [{ bidder: 'adferry', params: { placementId: 'adferryprebidtest1' } }]
}];
```

Unit tests: `test/spec/modules/adferryBidAdapter_spec.js` (20 cases). Lint and tests pass locally.