### PR TITLE
RTD: isolate submodules from each other's callbacks and exceptions

### DIFF
--- a/modules/rtdModule/index.ts
+++ b/modules/rtdModule/index.ts
@@ -164,7 +164,14 @@ function initSubModules(logNewlyEnabled = true) {
       return;
     }
     if (!initializedSubModules.has(sm)) {
-      const enabled = !!(sm.init && sm.init(provider, _userConsent));
+      let enabled = false;
+      try {
+        enabled = !!(sm.init && sm.init(provider, _userConsent));
+      } catch (e) {
+        // A provider that throws on init is treated as one that returned false, so that the
+        // providers configured after it are still given their turn
+        logError(`Error executing ${sm.name}.init`, e);
+      }
       initializedSubModules.set(sm, enabled);
       if (enabled && logNewlyEnabled) {
         logInfo(`Real time data module: enabling submodule ${sm.name}`);
@@ -201,7 +208,10 @@ export const setBidRequestsData = timedAuctionHook('rtd', function setBidRequest
   });
 
   const shouldDelayAuction = prioritySubModules.length && _moduleConfig?.auctionDelay > 0;
-  let callbacksExpected = prioritySubModules.length;
+  // Tracked by submodule identity rather than as a bare counter, so that a submodule which calls
+  // its own callback more than once can only ever clear its own slot, and can never affect -
+  // accidentally or otherwise - how long the auction waits for any other submodule.
+  const pendingPrioritySubModules = new Set(prioritySubModules);
   let isDone = false;
   let waitTimeout;
 
@@ -235,17 +245,31 @@ export const setBidRequestsData = timedAuctionHook('rtd', function setBidRequest
         return Reflect.deleteProperty(target, prop);
       }
     });
-    sm.getBidRequestData(request, onGetBidRequestDataCallback.bind(sm), sm.config, _userConsent, timeout);
+    try {
+      sm.getBidRequestData(request, onGetBidRequestDataCallback.bind(sm), sm.config, _userConsent, timeout);
+    } catch (e) {
+      // Without this, one throwing provider would take the whole loop down with it and every
+      // provider behind it would lose its chance to enrich the auction. A provider that threw
+      // will also never call its callback, so it stops being something to wait for
+      logError(`Error executing ${sm.name}.getBidRequestData`, e);
+      pendingPrioritySubModules.delete(sm);
+    }
   });
+
+  // The callback is what normally notices that the last priority submodule is done. If that
+  // submodule threw instead, there is nobody left to notice it
+  if (prioritySubModules.length && pendingPrioritySubModules.size === 0) {
+    setTimeout(exitHook, 0);
+  }
 
   function onGetBidRequestDataCallback() {
     if (isDone) {
       return;
     }
     if (this.config && this.config.waitForIt) {
-      callbacksExpected--;
+      pendingPrioritySubModules.delete(this);
     }
-    if (callbacksExpected === 0) {
+    if (pendingPrioritySubModules.size === 0) {
       setTimeout(exitHook, 0);
     }
   }
@@ -280,7 +304,15 @@ export function getAdUnitTargeting(auction) {
   }
   const targeting = [];
   for (let i = relevantSubModules.length - 1; i >= 0; i--) {
-    const smTargeting = relevantSubModules[i].getTargetingData(adUnitCodes, relevantSubModules[i].config, _userConsent, auction);
+    let smTargeting;
+    try {
+      smTargeting = relevantSubModules[i].getTargetingData(adUnitCodes, relevantSubModules[i].config, _userConsent, auction);
+    } catch (e) {
+      // This runs as the AUCTION_END preprocess, outside the try/catch that guards the event
+      // handlers, so a throw here would also cost every provider its onAuctionEndEvent
+      logError(`Error executing ${relevantSubModules[i].name}.getTargetingData`, e);
+      continue;
+    }
     if (smTargeting && typeof smTargeting === 'object') {
       targeting.push(smTargeting);
     } else {

--- a/test/spec/modules/realTimeDataModule_spec.js
+++ b/test/spec/modules/realTimeDataModule_spec.js
@@ -251,6 +251,26 @@ describe('Real time module', function () {
       });
     });
 
+    it('should still place targeting from the other submodules when one throws', () => {
+      const auction = {
+        adUnitCodes: ['ad1', 'ad2'],
+        adUnits: [
+          {
+            code: 'ad1'
+          },
+          {
+            code: 'ad2',
+          }
+        ]
+      };
+      validSMWait.getTargetingData = () => {
+        throw new Error('this provider is broken');
+      };
+
+      expect(() => rtdModule.getAdUnitTargeting(auction)).to.not.throw();
+      expect(auction.adUnits[1].adserverTargeting).to.eql({ key: 'validSM' });
+    });
+
     describe('setBidRequestData', () => {
       let withWait, withoutWait;
 
@@ -296,6 +316,58 @@ describe('Real time module', function () {
         return runSetBidRequestData().then(() => {
           expect(withWait.cbRan).to.be.true;
           expect(withoutWait.cbRan).to.be.false;
+        });
+      });
+
+      it('should not let a priority submodule release the auction early by invoking its own callback more than once', () => {
+        const doubleCalling = {
+          name: 'doubleCallingSM',
+          config: { waitForIt: true },
+          getBidRequestData: sinon.stub().callsFake((_, cb) => {
+            cb();
+            cb(); // buggy (or adversarial) submodule invoking its own callback twice
+          })
+        };
+        withWait.cbTime = 20;
+        rtdModule.subModules.push(doubleCalling);
+
+        return runSetBidRequestData().then(() => {
+          // the second callback must only ever clear doubleCallingSM's own slot; it must not
+          // also release the auction on validSMWait's behalf
+          expect(withWait.cbRan).to.be.true;
+        });
+      });
+
+      it('should run the submodules that follow one that throws', () => {
+        const throwing = {
+          name: 'throwingSM',
+          config: { waitForIt: false },
+          getBidRequestData: sinon.stub().throws(new Error('this provider is broken'))
+        };
+        rtdModule.subModules.unshift(throwing);
+
+        return runSetBidRequestData().then(() => {
+          expect(withWait.cbRan).to.be.true;
+          expect(withoutWait.cbRan).to.be.true;
+        });
+      });
+
+      it('should not hold the auction for a priority submodule that throws', () => {
+        const throwing = {
+          name: 'throwingPrioritySM',
+          config: { waitForIt: true },
+          getBidRequestData: sinon.stub().throws(new Error('this provider is broken'))
+        };
+        // the only submodule left, so nothing else can release the auction on its behalf
+        rtdModule.subModules.splice(0, rtdModule.subModules.length, throwing);
+
+        // a provider that threw will never call its callback, so the auction has to be released
+        // without waiting out the whole 100ms auctionDelay
+        const released = runSetBidRequestData().then(() => 'released');
+        const waitedOut = new Promise((resolve) => setTimeout(() => resolve('waited out'), 90));
+
+        return Promise.race([released, waitedOut]).then((outcome) => {
+          expect(outcome).to.equal('released');
         });
       });
     });
@@ -531,6 +603,15 @@ describe('Real time module', function () {
       sinon.assert.calledOnce(failing.init);
       attach(mockProvider('other'));
       sinon.assert.calledOnce(failing.init);
+    });
+
+    it('does not let a provider that throws in init keep the others from initializing', () => {
+      const throwing = attach(mockProvider('throwing'));
+      throwing.init.throws(new Error('this provider is broken'));
+      const other = attach(mockProvider('other'));
+      configure('throwing', 'other');
+      expect(rtdModule.subModules).to.not.include(throwing);
+      expect(rtdModule.subModules).to.include(other);
     });
 
     it('does not activate a provider that is registered but not configured', () => {


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Every call into provider code ran unguarded, so a provider that threw in `init`, `getBidRequestData` or `getTargetingData` took down every provider behind it in the loop. `getTargetingData` is also wired in as the AUCTION_END preprocess, outside the guard around the event handlers, so a throw there cost those providers their onAuctionEndEvent too. All three are now wrapped the way `onDataDeletionRequest` already was.

Waiting is tracked by submodule identity rather than by a bare counter, so a provider that invokes its own callback twice can only clear its own slot instead of releasing the auction on another provider's behalf. That is also what lets the `getBidRequestData` catch drop a provider that threw: it will never call back, and the auction should not wait out auctionDelay for it.


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
