### PR TITLE
Ogury Bid Adapter: fix SecurityError in cross-origin iframes

### DIFF
--- a/modules/oguryBidAdapter.js
+++ b/modules/oguryBidAdapter.js
@@ -5,6 +5,7 @@ import { getWindowSelf, getWindowTop, isFn, deepAccess, isPlainObject, deepSetVa
 import { getDevicePixelRatio } from '../libraries/devicePixelRatio/devicePixelRatio.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { ajax } from '../src/ajax.js';
+import { getRefererInfo } from '../src/refererDetection.js';
 import { getAdUnitSizes } from '../libraries/sizeUtils/sizeUtils.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 
@@ -14,7 +15,7 @@ const DEFAULT_TIMEOUT = 1000;
 const BID_HOST = 'https://mweb-hb.presage.io/api/header-bidding-request';
 const TIMEOUT_MONITORING_HOST = 'https://ms-ads-monitoring-events.presage.io';
 const MS_COOKIE_SYNC_DOMAIN = 'https://ms-cookie-sync.presage.io';
-const ADAPTER_VERSION = '2.1.0';
+const ADAPTER_VERSION = '2.1.1';
 
 export const ortbConverterProps = {
   context: {
@@ -26,7 +27,6 @@ export const ortbConverterProps = {
     const req = buildRequest(imps, bidderRequest, context);
     req.tmax = DEFAULT_TIMEOUT;
     deepSetValue(req, 'device.pxratio', getDevicePixelRatio(getWindowContext()));
-    deepSetValue(req, 'site.page', getWindowContext().location.href);
 
     req.ext = mergeDeep({}, req.ext, {
       adapterversion: ADAPTER_VERSION,
@@ -160,15 +160,23 @@ function getWindowContext() {
 }
 
 function onBidWon(bid) {
-  const w = getWindowContext();
-  w.OG_PREBID_BID_OBJECT = {
-    ...(bid && { ...bid }),
-  };
   if (bid && bid.nurl) ajax(bid.nurl, null);
+  try {
+    const w = getWindowContext();
+    w.OG_PREBID_BID_OBJECT = {
+      ...(bid && { ...bid }),
+    };
+  } catch (e) {
+    // top window is not writable from a cross-origin frame; the win ping already fired above
+  }
 }
 
 function onTimeout(timeoutData) {
-  ajax(`${TIMEOUT_MONITORING_HOST}/bid_timeout`, null, JSON.stringify({ ...timeoutData[0], location: window.location.href }), {
+  // report the same page as the bid request: site.page comes from the bid's ortb2, which the
+  // core already enriched with refererInfo and let the publisher override. Fall back to
+  // refererInfo when a timeout event carries no ortb2 (bids dropped before FPD is attached).
+  const page = deepAccess(timeoutData[0], 'ortb2.site.page') || getRefererInfo().page || window.location.href;
+  ajax(`${TIMEOUT_MONITORING_HOST}/bid_timeout`, null, JSON.stringify({ ...timeoutData[0], location: page }), {
     method: 'POST',
     contentType: 'application/json'
   });

--- a/test/spec/modules/oguryBidAdapter_spec.js
+++ b/test/spec/modules/oguryBidAdapter_spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { ortbConverterProps, spec } from 'modules/oguryBidAdapter';
 import * as utils from 'src/utils.js';
+import { getRefererInfo } from 'src/refererDetection.js';
 import { server } from '../../mocks/xhr.js';
 
 const BID_URL = 'https://mweb-hb.presage.io/api/header-bidding-request';
@@ -116,6 +117,7 @@ describe('OguryBidAdapter', () => {
     gdprConsent: { consentString: 'myConsentString', vendorData: {}, gdprApplies: true },
     gppConsent: { gppString: 'myGppString', gppData: {}, applicableSections: [7], parsedSections: {} },
     timeout: 1000,
+    refererInfo: { page: currentLocation },
     ortb2
   };
 
@@ -676,7 +678,7 @@ describe('OguryBidAdapter', () => {
 
       expect(dataRequest.ext).to.deep.equal({
         prebidversion: '$prebid.version$',
-        adapterversion: '2.1.0'
+        adapterversion: '2.1.1'
       });
 
       expect(dataRequest.device).to.deep.equal({
@@ -797,12 +799,29 @@ describe('OguryBidAdapter', () => {
       expect(request.data.imp[0].ext.gpid).to.equal(bidRequests[0].adUnitCode);
     });
 
-    it('should set the actual site location in site.page when the ORTB object contains the referrer instead of the current location', () => {
+    it('should keep the publisher provided site.page instead of overriding it with the current location', () => {
       const bidderRequest = utils.deepClone(bidderRequestBase);
-      bidderRequest.ortb2.site.page = 'https://google.com';
+      bidderRequest.ortb2.site.page = 'https://publisher.com/custom-page-url';
 
       const request = spec.buildRequests(bidRequests, bidderRequest);
-      expect(request.data.site.page).to.equal(currentLocation);
+      expect(request.data.site.page).to.equal('https://publisher.com/custom-page-url');
+    });
+
+    it('should not throw and should keep site.page when the top window location is not readable (cross-origin iframe)', () => {
+      const bidderRequest = utils.deepClone(bidderRequestBase);
+      bidderRequest.ortb2.site.page = 'https://publisher-page.example/article';
+
+      windowTopStub.returns({
+        get location() {
+          throw new DOMException('Blocked a frame with origin "https://frame.publisher-page.example" from accessing a cross-origin frame.', 'SecurityError');
+        },
+        devicePixelRatio: stubbedDevicePixelRatio
+      });
+
+      expect(() => spec.buildRequests(bidRequests, bidderRequest)).to.not.throw();
+
+      const request = spec.buildRequests(bidRequests, bidderRequest);
+      expect(request.data.site.page).to.equal('https://publisher-page.example/article');
     });
   });
 
@@ -929,6 +948,21 @@ describe('OguryBidAdapter', () => {
       expect(requests[0].method).to.equal('GET');
     });
 
+    it('Should still send the nurl ping when writing OG_PREBID_BID_OBJECT on the top window throws (cross-origin iframe)', function() {
+      const frozenTopWindow = Object.freeze({});
+      const windowTopStub = sinon.stub(utils, 'getWindowTop');
+      windowTopStub.returns(frozenTopWindow);
+
+      try {
+        spec.onBidWon({ nurl });
+      } finally {
+        windowTopStub.restore();
+      }
+
+      expect(requests.length).to.equal(1);
+      expect(requests[0].url).to.equal(nurl);
+    });
+
     it('Should trigger getWindowContext method', function() {
       const bidSample = {
         id: 'advertId',
@@ -991,7 +1025,22 @@ describe('OguryBidAdapter', () => {
       expect(requests.length).to.equal(1);
       expect(requests[0].url).to.equal(TIMEOUT_URL);
       expect(requests[0].method).to.equal('POST');
-      expect(JSON.parse(requests[0].requestBody).location).to.equal(window.location.href);
+      expect(JSON.parse(requests[0].requestBody).location).to.equal(getRefererInfo().page);
+    });
+
+    it('should report the same page URL as buildRequests when ortb2.site.page diverges from refererInfo', function() {
+      const bid = {
+        ad: '<img style="width: 300px; height: 250px;" src="https://assets.afcdn.com/recipe/20190529/93153_w1024h768c1cx2220cy1728cxt0cyt0cxb4441cyb3456.jpg" alt="cookies" />',
+        cpm: 3,
+        ortb2: { site: { page: 'https://publisher.com/custom-page-url' } }
+      };
+
+      spec.onTimeout([bid]);
+
+      expect(requests.length).to.equal(1);
+      // request() sends ortb2.site.page, so timeout monitoring must report the same URL
+      expect(JSON.parse(requests[0].requestBody).location).to.equal('https://publisher.com/custom-page-url');
+      expect(JSON.parse(requests[0].requestBody).location).to.not.equal(getRefererInfo().page);
     });
   });
 


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [x] Updated bidder adapter

## Description of change

The Ogury bid adapter throws a `SecurityError` and returns `noBid` when it runs inside a cross-origin iframe, because of unguarded `window.top` access in three places.

**1. `site.page` derivation** — `ortbConverterProps.request()` no longer does `deepSetValue(req, 'site.page', getWindowContext().location.href)`. The core already sets it: `enrichFPD` populates `ortb2.site.page` from `refererInfo` before every auction and merges it *under* the publisher's own `ortb2`, so a publisher-configured `pageUrl` already takes precedence, and the ORTB converter seeds the request from `bidderRequest.ortb2`. Overriding it here discarded publisher-configured URLs (custom `pageUrl` for SPAs, SafeFrames) and, when the top window was not readable, fell back to the iframe's own location instead of the real page.

**2. `onBidWon()`** — the `nurl` win ping now fires *before* the `OG_PREBID_BID_OBJECT` write, and the write is wrapped in `try/catch`. Previously a cross-origin write threw and prevented the win notification from being sent at all, losing billing/reporting.

**3. `onTimeout()`** — reports `timeoutData[0].ortb2.site.page` instead of the local frame's `window.location.href`, so timeout monitoring matches the URL actually sent in the bid request. Falls back to `getRefererInfo().page`, then `window.location.href`, for timeout events that carry no FPD.

`ADAPTER_VERSION` bumped `2.1.0` → `2.1.1`.

No bidder parameters were added or changed, so no documentation PR is required.

## Other information

Tests added to `test/spec/modules/oguryBidAdapter_spec.js`:

- the shared `bidderRequestBase` fixture now carries `refererInfo`;
- `buildRequests` — asserts no throw and the correct `site.page` when `window.top.location` throws a `SecurityError`;
- `buildRequests` — asserts a publisher-provided `ortb2.site.page` is preserved rather than overridden;
- `onBidWon` — asserts the `nurl` ping still fires when the top window is not writable (simulated with a frozen object, same failure shape as a cross-origin `SecurityError`);
- `onTimeout` — asserts the reported `location` is the top-level page URL from `ortb2.site.page`.

Each test was confirmed to fail against the pre-fix code for the expected reason before the fix was applied.

Results:

- `npx eslint modules/oguryBidAdapter.js test/spec/modules/oguryBidAdapter_spec.js` — clean, no issues found.
- `npx gulp test --nolint --file test/spec/modules/oguryBidAdapter_spec.js` — 92 tests completed, 0 failures.
