### PR TITLE
Unicorn Bid Adapter: forward GPID; rename imp.ext.unicorn to imp.ext.…

### DIFF
--- a/modules/unicornBidAdapter.js
+++ b/modules/unicornBidAdapter.js
@@ -16,7 +16,7 @@ const UNICORN_ENDPOINT = 'https://ds.uncn.jp/pb/0/bid.json';
 const UNICORN_DEFAULT_CURRENCY = 'JPY';
 const UNICORN_PB_COOKIE_KEY = '__pb_unicorn_aud';
 const UNICORN_PB_VERSION = '1.1';
-const ADSLOT_SIGNAL_VERSION = 1; // imp.ext.unicorn schema version
+const ADSLOT_SIGNAL_VERSION = 1; // imp.ext.adslot schema version
 const storage = getStorageManager({ bidderCode: BIDDER_CODE });
 
 /**
@@ -172,10 +172,21 @@ function buildOpenRtbBidRequestPayload(validBidRequests, bidderRequest) {
       secure: 1,
       bidfloor: parseFloat(0)
     };
+    const ext = {};
     if (adslot) {
       // Slot geometry/viewability, sent only in this adapter's own OpenRTB
       // payload — not shared FPD, so no other bidder or PBS ever sees it.
-      impObj.ext = { unicorn: adslot.signal };
+      ext.adslot = adslot.signal;
+    }
+    // GPID (Global Placement ID) — set by the gpid / gptPreAuction module on
+    // ortb2Imp.ext.gpid. Forwarded so the exchange can key on a stable slot id
+    // that is independent of the ad unit code.
+    const gpid = deepAccess(br, 'ortb2Imp.ext.gpid');
+    if (gpid) {
+      ext.gpid = gpid;
+    }
+    if (Object.keys(ext).length > 0) {
+      impObj.ext = ext;
     }
     return impObj;
   });

--- a/modules/unicornBidAdapter.md
+++ b/modules/unicornBidAdapter.md
@@ -16,10 +16,12 @@ written back to shared First Party Data:
 - `imp.banner.pos` — OpenRTB AdPosition (1 = above the fold, 3 = below the
   fold). A publisher-declared `ortb2Imp.banner.pos`, if present, is used
   instead of the measured value.
-- `imp.ext.unicorn` — `{ ver, ratio, fixed, sticky, w, h, x, y }`, where
+- `imp.ext.adslot` — `{ ver, ratio, fixed, sticky, w, h, x, y }`, where
   `ratio` is the visible-area ratio (0–1), `fixed`/`sticky` report a
   fixed/sticky ancestor, and `x`/`y`/`w`/`h` are the slot's document-relative
   position and rendered size in CSS pixels.
+- `imp.ext.gpid` — the Global Placement ID, forwarded from
+  `ortb2Imp.ext.gpid` (set by the `gpid` / `gptPreAuction` module) when present.
 
 Slot element resolution order: `ortb2Imp.ext.data.divId` → GPT
 `getSlotElementId()` → the ad unit code.

--- a/test/spec/modules/unicornBidAdapter_spec.js
+++ b/test/spec/modules/unicornBidAdapter_spec.js
@@ -646,12 +646,12 @@ describe('unicornBidAdapterTest', () => {
       createdEls.splice(0).forEach(el => el.remove());
     });
 
-    it('adds imp.ext.unicorn and imp.banner.pos for a resolvable, above-the-fold slot', () => {
+    it('adds imp.ext.adslot and imp.banner.pos for a resolvable, above-the-fold slot', () => {
       sandbox.stub(percentInViewLib, 'getViewability').returns(75);
       makeSlotEl('adslot-1', { top: 100, left: 10, width: 300, height: 250 });
       const imp = buildImp(bidReq('adslot-1'));
 
-      expect(imp.ext.unicorn).to.deep.equal({
+      expect(imp.ext.adslot).to.deep.equal({
         ver: 1, ratio: 0.75, fixed: false, sticky: false, w: 300, h: 250, x: 10, y: 100
       });
       expect(imp.banner.pos).to.equal(1);
@@ -670,7 +670,7 @@ describe('unicornBidAdapterTest', () => {
       makeSlotEl('adslot-2', { top: 50, left: 0, width: 300, height: 250 });
       const imp = buildImp(bidReq('adslot-2'));
 
-      expect(imp.ext.unicorn.y).to.equal(5050);
+      expect(imp.ext.adslot.y).to.equal(5050);
       expect(imp.banner.pos).to.equal(3);
     });
 
@@ -679,9 +679,9 @@ describe('unicornBidAdapterTest', () => {
       makeSlotEl('adslot-3', { top: 0, left: 0, width: 0, height: 0 });
       const imp = buildImp(bidReq('adslot-3'));
 
-      expect(imp.ext.unicorn.w).to.equal(300);
-      expect(imp.ext.unicorn.h).to.equal(250);
-      expect(imp.ext.unicorn.ratio).to.equal(0.4);
+      expect(imp.ext.adslot.w).to.equal(300);
+      expect(imp.ext.adslot.h).to.equal(250);
+      expect(imp.ext.adslot.ratio).to.equal(0.4);
     });
 
     it('detects a fixed ancestor wrapper, not only the slot element itself', () => {
@@ -693,8 +693,8 @@ describe('unicornBidAdapterTest', () => {
       makeSlotEl('adslot-4', { top: 0, left: 0, width: 300, height: 250 }, { parent: wrapper });
       const imp = buildImp(bidReq('adslot-4'));
 
-      expect(imp.ext.unicorn.fixed).to.equal(true);
-      expect(imp.ext.unicorn.sticky).to.equal(false);
+      expect(imp.ext.adslot.fixed).to.equal(true);
+      expect(imp.ext.adslot.sticky).to.equal(false);
     });
 
     it('keeps fixed and sticky as distinct flags', () => {
@@ -706,8 +706,8 @@ describe('unicornBidAdapterTest', () => {
       makeSlotEl('adslot-5', { top: 0, left: 0, width: 300, height: 250 }, { parent: wrapper });
       const imp = buildImp(bidReq('adslot-5'));
 
-      expect(imp.ext.unicorn.sticky).to.equal(true);
-      expect(imp.ext.unicorn.fixed).to.equal(false);
+      expect(imp.ext.adslot.sticky).to.equal(true);
+      expect(imp.ext.adslot.fixed).to.equal(false);
     });
 
     it('prefers a publisher-declared ortb2Imp.banner.pos over the measured value', () => {
@@ -732,15 +732,71 @@ describe('unicornBidAdapterTest', () => {
       };
       const imp = buildImp(bidReq('/1234/gpt-ad-unit-code'));
 
-      expect(imp.ext.unicorn).to.not.equal(undefined);
-      expect(imp.ext.unicorn.w).to.equal(300);
+      expect(imp.ext.adslot).to.not.equal(undefined);
+      expect(imp.ext.adslot.w).to.equal(300);
     });
 
-    it('omits ext.unicorn and banner.pos when the slot element cannot be resolved', () => {
+    it('omits ext.adslot and banner.pos when the slot element cannot be resolved', () => {
       const imp = buildImp(bidReq('adslot-does-not-exist'));
 
       expect(imp.ext).to.equal(undefined);
       expect(imp.banner.pos).to.equal(undefined);
+    });
+
+    it('sends both imp.ext.adslot and imp.ext.gpid when a slot resolves and gpid is set', () => {
+      sandbox.stub(percentInViewLib, 'getViewability').returns(60);
+      makeSlotEl('adslot-7', { top: 0, left: 0, width: 300, height: 250 });
+      const imp = buildImp(bidReq('adslot-7', { ortb2Imp: { ext: { gpid: '/1234/home#slot-7' } } }));
+
+      expect(imp.ext.adslot).to.not.equal(undefined);
+      expect(imp.ext.gpid).to.equal('/1234/home#slot-7');
+    });
+  });
+
+  describe('imp.ext.gpid', () => {
+    const bReq = {
+      bidderCode: 'unicorn',
+      auctionId: 'auction-gpid',
+      bidderRequestId: 'bidder-req-gpid',
+      refererInfo: {
+        ref: 'https://uni-corn.net/',
+        reachedTop: true,
+        numIframes: 0,
+        stack: ['https://uni-corn.net/']
+      }
+    };
+
+    // No matching DOM element for adUnitCode, so measureAdslot resolves nothing
+    // and imp.ext carries gpid only — isolating the gpid behavior.
+    function bidReq(overrides = {}) {
+      return Object.assign({
+        bidder: 'unicorn',
+        params: { accountId: 12345 },
+        mediaTypes: { banner: { sizes: [[300, 250]] } },
+        adUnitCode: 'gpid-adunit-no-dom',
+        sizes: [[300, 250]],
+        bidId: 'bid-gpid',
+        bidderRequestId: 'bidder-req-gpid',
+        transactionId: 'tx-gpid',
+        auctionId: 'auction-gpid',
+        src: 'client'
+      }, overrides);
+    }
+
+    function buildImp(br) {
+      return JSON.parse(spec.buildRequests([br], bReq).data).imp[0];
+    }
+
+    it('forwards ortb2Imp.ext.gpid to imp.ext.gpid', () => {
+      const imp = buildImp(bidReq({ ortb2Imp: { ext: { gpid: '/1234/home#slot-1' } } }));
+
+      expect(imp.ext.gpid).to.equal('/1234/home#slot-1');
+    });
+
+    it('omits imp.ext when neither gpid nor a resolvable slot is present', () => {
+      const imp = buildImp(bidReq());
+
+      expect(imp.ext).to.equal(undefined);
     });
   });
 });


### PR DESCRIPTION
## Type of change

- [x]  Updated bidder adapter

## Description of change

Follow-up to #15379, which added client-side ad slot
position/geometry/viewability signals to the UNICORN bid adapter. Two changes,
both on `imp.ext`:

1. **Forward GPID.** When the `gpid` / `gptPreAuction` module has set
`ortb2Imp.ext.gpid`, the adapter now sends it on the wire as `imp.ext.gpid`.
2. **Rename `imp.ext.unicorn` → `imp.ext.adslot`.** The signal added in #15379
was namespaced `unicorn`. It lives only in this adapter's own OpenRTB
payload (not shared FPD / `ortb2Imp`), so the collision concern with the
established `ext.data.adslot` key does not apply here, and `adslot` is the
more descriptive name for slot position/geometry — as noted in the #15379
review.

Both keys touch `imp.ext`, so the rename and the gpid addition are combined to
keep `imp.ext = { adslot, gpid }` a single change. The signal is only ever read
by the UNICORN exchange.

Resulting payload (per imp):

```json
"ext": {
  "adslot": { "ver": 1, "ratio": 0.75, "fixed": false, "sticky": false, "w": 300, "h": 250, "x": 10, "y": 100 },
  "gpid": "/1234/home#slot-1"
}
```

The adapter spec covers gpid forwarding, gpid omitted when absent, and adslot +
gpid coexisting under imp.ext.