### PR TITLE
humansecurity RTD: park auctions that start before the script has loaded

### DIFF
--- a/modules/humansecurityRtdProvider.ts
+++ b/modules/humansecurityRtdProvider.ts
@@ -62,6 +62,16 @@ let implRef: HumanSecurityImpl | null = null;
 let clientId: string = '';
 let verbose: boolean = false;
 let sessionId: string = '';
+let pending: ((impl?: HumanSecurityImpl | null) => void)[] = [];
+
+/**
+ * Hands every auction waiting on the implementation script back to the caller, either to be
+ * enriched by the now available implementation or to be released unenriched
+ */
+
+const flushPending = (impl?: HumanSecurityImpl | null) => {
+  pending.splice(0).forEach((resume) => resume(impl));
+};
 
 /**
  * Injects HUMAN Security script on the page to facilitate pre-bid signal collection.
@@ -74,10 +84,12 @@ const load = (config: RTDProviderConfig<'humansecurity'>) => {
     throw new Error(`The 'clientId' parameter must be a short alphanumeric string`);
   }
 
-  // Load/reset the state
+  // Load/reset the state. Anything parked on the previous session is released rather than
+  // carried over, since the script this reload injects will publish under a new session ID
   verbose = !!config?.params?.verbose;
   implRef = null;
   sessionId = generateUUID();
+  flushPending(null);
 
   // Get the best domain possible here, it still might be null
   const refDomain = getRefererInfo().domain || '';
@@ -118,10 +130,13 @@ const getImpl = () => {
 
 const onImplLoaded = (config: RTDProviderConfig<'humansecurity'>) => {
   const impl = getImpl();
-  if (!impl) return;
 
   // And set up a bridge between the RTD submodule and the implementation.
-  impl.connect(getGlobal(), null, config);
+  if (impl) impl.connect(getGlobal(), null, config);
+
+  // Runs even when the implementation could not be resolved, so that a script which loads but
+  // fails to publish its API releases the auctions waiting on it instead of stranding them
+  flushPending(impl);
 };
 
 /**
@@ -141,8 +156,16 @@ const getBidRequestData = (
 ) => {
   const impl = getImpl();
   if (!impl || typeof impl.getBidRequestData !== 'function') {
-    // Implementation not available; continue auction by invoking the callback.
-    callback();
+    // The script is injected asynchronously, so an auction started in the same task as
+    // setConfig arrives before it lands. Park it for onImplLoaded instead of giving up on
+    // enriching it; the RTD module still releases the auction at auctionDelay either way
+    pending.push((readyImpl) => {
+      if (readyImpl && typeof readyImpl.getBidRequestData === 'function') {
+        readyImpl.getBidRequestData(reqBidsConfigObj, callback, config, userConsent);
+      } else {
+        callback();
+      }
+    });
     return;
   }
 

--- a/test/spec/modules/humansecurityRtdProvider_spec.js
+++ b/test/spec/modules/humansecurityRtdProvider_spec.js
@@ -10,7 +10,9 @@ const {
   SUBMODULE_NAME,
   SCRIPT_URL,
   main,
-  load
+  load,
+  onImplLoaded,
+  getBidRequestData
 } = __TEST__;
 
 describe('humansecurity RTD module', function () {
@@ -94,6 +96,87 @@ describe('humansecurity RTD module', function () {
 
       const args = loadExternalScriptStub.getCall(0).args;
       expect(args[0]).to.include(`${SCRIPT_URL}?r=example.com&c=customer123`);
+    });
+  });
+
+  describe('Auctions started before the implementation script loads', function () {
+    let sandbox2;
+    let impl;
+
+    beforeEach(function () {
+      sandbox2 = sinon.createSandbox();
+      impl = { connect: sandbox2.spy(), getBidRequestData: sandbox2.spy() };
+    });
+    afterEach(function () {
+      sandbox2.restore();
+    });
+
+    const publishImpl = () => sandbox2.stub(stubWindow, sonarStubId).value(impl);
+
+    it('should hold on to the auction instead of releasing it unenriched', function () {
+      load({});
+
+      const callback = sandbox2.spy();
+      getBidRequestData({ adUnits: [] }, callback, {}, {});
+
+      expect(callback.called).to.equal(false);
+    });
+
+    it('should hand the auction to the implementation once it loads', function () {
+      load({});
+
+      const reqBidsConfigObj = { adUnits: [] };
+      const callback = sandbox2.spy();
+      const config = { params: {} };
+      const userConsent = { gdpr: null };
+      getBidRequestData(reqBidsConfigObj, callback, config, userConsent);
+
+      publishImpl();
+      onImplLoaded({});
+
+      expect(impl.getBidRequestData.calledOnce).to.equal(true);
+      const args = impl.getBidRequestData.getCall(0).args;
+      expect(args[0]).to.equal(reqBidsConfigObj);
+      expect(args[1]).to.equal(callback);
+      expect(args[2]).to.equal(config);
+      expect(args[3]).to.equal(userConsent);
+      // The implementation owns the callback from here on
+      expect(callback.called).to.equal(false);
+    });
+
+    it('should release the auction if the script loads without publishing its API', function () {
+      load({});
+
+      const callback = sandbox2.spy();
+      getBidRequestData({ adUnits: [] }, callback, {}, {});
+      expect(callback.called).to.equal(false);
+
+      onImplLoaded({});
+
+      expect(callback.calledOnce).to.equal(true);
+    });
+
+    it('should release the auction if the module is initialized again', function () {
+      load({});
+
+      const callback = sandbox2.spy();
+      getBidRequestData({ adUnits: [] }, callback, {}, {});
+      expect(callback.called).to.equal(false);
+
+      load({});
+
+      expect(callback.calledOnce).to.equal(true);
+    });
+
+    it('should go straight to the implementation once it is available', function () {
+      publishImpl();
+      load({});
+      onImplLoaded({});
+
+      const callback = sandbox2.spy();
+      getBidRequestData({ adUnits: [] }, callback, {}, {});
+
+      expect(impl.getBidRequestData.calledOnce).to.equal(true);
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Auctions that start before our script lands are now queued and handed to the implementation once it loads.

## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
