### PR TITLE
CORE: when the BIDDER_INVALID_REQUEST event is emitted pass the original bid instance when available

### DIFF
--- a/src/adapters/bidderFactory.ts
+++ b/src/adapters/bidderFactory.ts
@@ -303,7 +303,7 @@ export function newBidder<B extends BidderCode>(spec: BidderSpec<B>) {
       }
 
       const validBidRequests = adapterMetrics(bidderRequest)
-        .measureTime('validate', () => bidderRequest.bids.filter((br) => filterAndWarn(tidGuard.bidRequest(br))));
+        .measureTime('validate', () => bidderRequest.bids.filter((br) => filterAndWarn(tidGuard.bidRequest(br), br)));
 
       if (validBidRequests.length === 0) {
         afterAllResponses();
@@ -377,9 +377,10 @@ export function newBidder<B extends BidderCode>(spec: BidderSpec<B>) {
     registerSyncInner(spec, responses, gdprConsent, uspConsent, gppConsent);
   }
 
-  function filterAndWarn(bid) {
+  function filterAndWarn(bid, originalBid?) {
     if (!spec.isBidRequestValid(bid)) {
       logWarn(`Invalid bid sent to bidder ${spec.code}: ${JSON.stringify(bid)}`);
+      events.emit(EVENTS.BIDDER_INVALID_REQUEST, originalBid ?? bid);
       return false;
     }
     return true;


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description of change
Currently all emitted events except the BIDDER_INVALID_REQUEST return the original instances. I think every consumer of these events is expecting the original object it (indirectly) created as well rather than the proxied ones, as certain things like auctionId can be different in the tidGuarded/Proxied instances or even just the reference. I believe the tidGuard is mainly in place for bidders to get their own view of the bid objects. But for consumers of prebid events these aren't relevant and expect the configured bid objects.