### PR TITLE
Anonymised id system module

### DIFF
--- a/modules/.submodules.json
+++ b/modules/.submodules.json
@@ -10,6 +10,7 @@
       "adriverIdSystem",
       "adtelligentIdSystem",
       "amxIdSystem",
+      "anonymisedIdSystem",
       "ceeIdSystem",
       "connectIdSystem",
       "criteoIdSystem",

--- a/modules/anonymisedIdSystem.d.ts
+++ b/modules/anonymisedIdSystem.d.ts
@@ -1,0 +1,20 @@
+// the augmentation in this file only applies where the spec is part of the program
+import type {} from './userId/spec.js';
+
+export type AnonymisedIdSystemModuleName = 'anonymisedId';
+
+declare module './userId/spec' {
+  interface UserId {
+    anonymisedId: string;
+  }
+
+  interface ProvidersToId {
+    anonymisedId: 'anonymisedId';
+  }
+
+  interface ProviderParams {
+    anonymisedId: never;
+  }
+}
+
+export {};

--- a/modules/anonymisedIdSystem.js
+++ b/modules/anonymisedIdSystem.js
@@ -29,10 +29,17 @@ export const MAX_ID_LENGTH = 100;
 export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME });
 
 /**
+ * Characters that cannot occur in a raw identifier, and whose presence means the value was
+ * serialised rather than written as-is - a JSON object, array, or quoted scalar. Passing such a
+ * value on would send bidders an ID that matches nothing.
+ */
+const ENCODED_VALUE_CHARS = /[\s{}[\]"']/;
+
+/**
  * The Marketing Tag writes the CUID as a plain string. Validation is deliberately loose - it
- * rejects the values that would be harmful to pass on (empty, a JSON blob left by another writer,
- * or an implausibly long one) without pinning the identifier's format, which is owned by the tag
- * and can change on a much faster release cycle than this module.
+ * rejects the values that would be harmful to pass on (empty, serialised, or implausibly long)
+ * without pinning the identifier's format, which is owned by the tag and can change on a much
+ * faster release cycle than this module.
  * @param {*} value
  * @returns {boolean}
  */
@@ -40,7 +47,7 @@ export function isValidId(value) {
   return typeof value === 'string' &&
     value.length > 0 &&
     value.length <= MAX_ID_LENGTH &&
-    !/[\s{]/.test(value);
+    !ENCODED_VALUE_CHARS.test(value);
 }
 
 export const anonymisedIdSubmodule = {
@@ -61,14 +68,21 @@ export const anonymisedIdSubmodule = {
    * read with no network call: when the tag has not written an ID yet - because it is not installed,
    * or the user is not signed in - there is simply no ID for this page view.
    * @function
+   * @param {Object} [config] this submodule's publisher configuration
    * @returns {{id: string} | undefined}
    */
-  getId() {
+  getId(config) {
+    if (config?.storage) {
+      logWarn(`${LOG_PREFIX}this module must be configured without "storage". The Anonymised Marketing Tag owns this ID and removes it on sign-out; a copy kept by Prebid.js would outlive that removal and keep sending the ID of a signed-out user.`);
+    }
+
     const stored = storage.getDataFromLocalStorage(STORAGE_KEY);
     const cuid = typeof stored === 'string' ? stored.trim() : null;
 
     if (!cuid) {
-      logWarn(`${LOG_PREFIX}no ID in localStorage["${STORAGE_KEY}"] - the Anonymised Marketing Tag must be installed on this page and the user signed in`);
+      // No ID is the expected state for a signed-out user, so this is not a warning: it is also
+      // what a reader sees when device access is denied, and it is most of the traffic.
+      logInfo(`${LOG_PREFIX}no ID in localStorage["${STORAGE_KEY}"] - the user is signed out, the Anonymised Marketing Tag is not installed on this page, or device access is not permitted`);
       return undefined;
     }
 

--- a/modules/anonymisedIdSystem.js
+++ b/modules/anonymisedIdSystem.js
@@ -28,6 +28,26 @@ export const MAX_ID_LENGTH = 100;
 
 export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME });
 
+const STORAGE_CONFIG_WARNING = `${LOG_PREFIX}no ID will be provided: this module must be configured without "storage". ` +
+  'The Anonymised Marketing Tag owns this ID and removes it on sign-out and on consent withdrawal; ' +
+  'a copy cached by Prebid.js would outlive that removal and keep sending the ID of a signed-out user.';
+
+/**
+ * A publisher who configures `storage` gets no ID at all, rather than one that Prebid.js may cache
+ * past the point where the Marketing Tag has removed it. Both entry points have to refuse:
+ * `getId` so nothing is ever written to the publisher's store, and `decode` because the User ID
+ * module skips `getId` entirely while a cached value is still fresh, decoding that copy instead.
+ * @param {Object} [config] this submodule's publisher configuration
+ * @returns {boolean}
+ */
+function usesUnsupportedStorage(config) {
+  if (!config?.storage) {
+    return false;
+  }
+  logWarn(STORAGE_CONFIG_WARNING);
+  return true;
+}
+
 /**
  * Characters that cannot occur in a raw identifier, and whose presence means the value was
  * serialised rather than written as-is - a JSON object, array, or quoted scalar. Passing such a
@@ -72,8 +92,8 @@ export const anonymisedIdSubmodule = {
    * @returns {{id: string} | undefined}
    */
   getId(config) {
-    if (config?.storage) {
-      logWarn(`${LOG_PREFIX}this module must be configured without "storage". The Anonymised Marketing Tag owns this ID and removes it on sign-out; a copy kept by Prebid.js would outlive that removal and keep sending the ID of a signed-out user.`);
+    if (usesUnsupportedStorage(config)) {
+      return undefined;
     }
 
     const stored = storage.getDataFromLocalStorage(STORAGE_KEY);
@@ -99,9 +119,14 @@ export const anonymisedIdSubmodule = {
    * decode the stored id value for passing to bid requests
    * @function
    * @param {string} value
+   * @param {Object} [config] this submodule's publisher configuration
    * @returns {{anonymisedId: string} | undefined}
    */
-  decode(value) {
+  decode(value, config) {
+    if (usesUnsupportedStorage(config)) {
+      return undefined;
+    }
+
     return isValidId(value) ? { [MODULE_NAME]: value } : undefined;
   },
 

--- a/modules/anonymisedIdSystem.js
+++ b/modules/anonymisedIdSystem.js
@@ -1,0 +1,102 @@
+/**
+ * This module adds the Anonymised ID to the User ID module
+ * The {@link module:modules/userId} module is required
+ * @module modules/anonymisedIdSystem
+ * @requires module:modules/userId
+ */
+import { submodule } from '../src/hook.js';
+import { getStorageManager } from '../src/storageManager.js';
+import { MODULE_TYPE_UID } from '../src/activities/modules.js';
+import { logInfo, logWarn } from '../src/utils.js';
+
+const MODULE_NAME = 'anonymisedId';
+const GVLID = 1116;
+const EID_SOURCE = 'anonymised.io';
+const LOG_PREFIX = 'User ID - anonymisedId submodule: ';
+
+/**
+ * Local storage key holding the CUID. It is written by the Anonymised Marketing Tag when the user
+ * signs in, and removed by it on sign-out or when consent is withdrawn. This module only reads it.
+ */
+export const STORAGE_KEY = 'anon-cuid';
+
+/**
+ * Generous upper bound on the identifier length, to keep a corrupted value from bloating every
+ * bid request.
+ */
+export const MAX_ID_LENGTH = 100;
+
+export const storage = getStorageManager({ moduleType: MODULE_TYPE_UID, moduleName: MODULE_NAME });
+
+/**
+ * The Marketing Tag writes the CUID as a plain string. Validation is deliberately loose - it
+ * rejects the values that would be harmful to pass on (empty, a JSON blob left by another writer,
+ * or an implausibly long one) without pinning the identifier's format, which is owned by the tag
+ * and can change on a much faster release cycle than this module.
+ * @param {*} value
+ * @returns {boolean}
+ */
+export function isValidId(value) {
+  return typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= MAX_ID_LENGTH &&
+    !/[\s{]/.test(value);
+}
+
+export const anonymisedIdSubmodule = {
+  /**
+   * used to link submodule with config
+   * @type {string}
+   */
+  name: MODULE_NAME,
+
+  /**
+   * IAB Global Vendor List ID
+   * @type {number}
+   */
+  gvlid: GVLID,
+
+  /**
+   * Read the CUID that the Anonymised Marketing Tag stored on this domain. This is a synchronous
+   * read with no network call: when the tag has not written an ID yet - because it is not installed,
+   * or the user is not signed in - there is simply no ID for this page view.
+   * @function
+   * @returns {{id: string} | undefined}
+   */
+  getId() {
+    const stored = storage.getDataFromLocalStorage(STORAGE_KEY);
+    const cuid = typeof stored === 'string' ? stored.trim() : null;
+
+    if (!cuid) {
+      logWarn(`${LOG_PREFIX}no ID in localStorage["${STORAGE_KEY}"] - the Anonymised Marketing Tag must be installed on this page and the user signed in`);
+      return undefined;
+    }
+
+    if (!isValidId(cuid)) {
+      logWarn(`${LOG_PREFIX}ignoring malformed value in localStorage["${STORAGE_KEY}"]`);
+      return undefined;
+    }
+
+    logInfo(`${LOG_PREFIX}ID found`);
+    return { id: cuid };
+  },
+
+  /**
+   * decode the stored id value for passing to bid requests
+   * @function
+   * @param {string} value
+   * @returns {{anonymisedId: string} | undefined}
+   */
+  decode(value) {
+    return isValidId(value) ? { [MODULE_NAME]: value } : undefined;
+  },
+
+  eids: {
+    [MODULE_NAME]: {
+      source: EID_SOURCE,
+      atype: 1
+    }
+  }
+};
+
+submodule('userId', anonymisedIdSubmodule);

--- a/modules/anonymisedIdSystem.md
+++ b/modules/anonymisedIdSystem.md
@@ -58,6 +58,9 @@ copy would outlive the removal and the submodule would keep sending a stale iden
 until Prebid's own expiry elapsed. Reading the value fresh on every initialization makes removal take
 effect immediately.
 
+If a `storage` object is configured, the submodule logs a warning and provides **no** ID at all,
+rather than one Prebid.js may cache beyond the Marketing Tag's removal of it.
+
 ### Do not set `userSync.ppid` to `anonymised.io`
 
 The Marketing Tag sets the Google Ad Manager Publisher Provided ID itself, as part of its SignalLift

--- a/modules/anonymisedIdSystem.md
+++ b/modules/anonymisedIdSystem.md
@@ -1,0 +1,101 @@
+# Overview
+
+Module Name: anonymisedIdSystem
+Module Type: UserID Module
+Maintainer: support@anonymised.io
+
+# Description
+
+Anonymised is a data anonymization technology for privacy-preserving advertising.
+
+The Anonymised User ID submodule exposes the CUID - the identifier that the
+[Anonymised Marketing Tag](https://support.anonymised.io/integrate/marketing-tag?t=LPukVCXzSIcRoal5jggyeg)
+assigns when a user signs in - to bid adapters as an OpenRTB Extended ID under the source
+`anonymised.io`.
+
+The submodule performs no network calls. It reads the identifier that the Marketing Tag has already
+stored on the publisher's own domain, in `localStorage` under the key `anon-cuid`, and passes it to
+the bid stream. When the Marketing Tag is not installed, or the user is not signed in, no ID is read
+and no EID is added.
+
+### Prerequisite
+
+The Anonymised Marketing Tag must be installed on the page. This submodule does not load it. The tag
+can be installed [natively](https://support.anonymised.io/integrate/install-the-anonymised-tag-natively?t=LPukVCXzSIcRoal5jggyeg)
+or through the [`anonymisedRtdProvider`](anonymisedRtdProvider.md) module's `tagConfig` parameter.
+
+# Building Prebid with Anonymised ID support
+
+```bash
+gulp build --modules=userId,anonymisedIdSystem
+```
+
+# Configuration
+
+```javascript
+pbjs.setConfig({
+    userSync: {
+        userIds: [{
+            name: 'anonymisedId'
+        }]
+    }
+});
+```
+
+| Param under userSync.userIds[] | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| name | Required | String | The name of this module. | `'anonymisedId'` |
+
+The submodule takes no `params`.
+
+### Do not configure `storage`
+
+This submodule manages the identifier itself and must be configured **without** a `storage` object.
+
+The Marketing Tag is the single source of truth for the CUID: it writes the identifier on sign-in and
+removes it on sign-out and on consent withdrawal. If Prebid.js were allowed to keep its own copy, that
+copy would outlive the removal and the submodule would keep sending a stale identifier to bidders
+until Prebid's own expiry elapsed. Reading the value fresh on every initialization makes removal take
+effect immediately.
+
+### Do not set `userSync.ppid` to `anonymised.io`
+
+The Marketing Tag sets the Google Ad Manager Publisher Provided ID itself, as part of its SignalLift
+feature. Pointing `userSync.ppid` at `anonymised.io` makes Prebid.js set the PPID as well, which
+produces two problems:
+
+- Prebid.js strips non-alphanumeric characters from an ID before setting it as the PPID, while the
+  Marketing Tag sends the identifier unmodified. The same user would be represented by two different
+  PPIDs depending on which code path ran, splitting Google Ad Manager audiences and reporting.
+- The Marketing Tag applies its own logic when deciding whether a PPID should be set at all. Prebid.js
+  is not aware of that logic and would bypass it.
+
+The division is: the Marketing Tag owns the identifier sent to **Google Ad Manager**; this submodule
+owns the identifier sent to **bidders**.
+
+### Single-page applications
+
+`getId` is called when the User ID module initializes and is not re-run for subsequent auctions. If a
+user signs in after that point, call `pbjs.refreshUserIds({ submoduleNames: ['anonymisedId'] })` to
+pick up the new identifier. Always pass `submoduleNames` - an unscoped refresh re-initializes every
+configured ID submodule, including those that make network requests.
+
+### Subdomains
+
+The identifier is read from `localStorage`, which is scoped to a single origin. A publisher serving
+the same user from more than one subdomain will have an identifier available on each subdomain only
+after the Marketing Tag has run there.
+
+### Data deletion
+
+Deletion requests are handled by the Marketing Tag, which owns the user's session and every
+identifier derived from it. This submodule stores nothing of its own and therefore implements no
+`onDataDeletionRequest` callback.
+
+### Vendor and storage disclosure
+
+The submodule declares GVL ID `1116`. Its first-party storage use is disclosed at
+[https://cdn1.anonymised.io/deviceStorage.json](https://cdn1.anonymised.io/deviceStorage.json).
+
+For any questions or assistance with integrating Prebid, `anonymisedIdSystem`, or the Anonymised
+Marketing Tag, please contact an [Anonymised representative](mailto:support@anonymised.io).

--- a/modules/userId/eids.md
+++ b/modules/userId/eids.md
@@ -27,6 +27,13 @@ userIdAsEids = [
         }]
     },
     {
+        source: 'anonymised.io',
+        uids: [{
+            id: 'some-random-id-value',
+            atype: 1
+        }]
+    },
+    {
         source: 'utiq.com',
         uids: [{
             id: 'some-random-id-value',

--- a/modules/userId/userId.md
+++ b/modules/userId/userId.md
@@ -41,6 +41,9 @@ pbjs.setConfig({
                 refreshInSeconds: 86400
             }
         }, {
+            // the Anonymised Marketing Tag owns this ID; it must be configured without `storage`
+            name: "anonymisedId"
+        }, {
             name: "pubCommonId",
             storage: {
                 type: "cookie",

--- a/test/spec/modules/anonymisedIdSystem_spec.js
+++ b/test/spec/modules/anonymisedIdSystem_spec.js
@@ -1,0 +1,101 @@
+import { anonymisedIdSubmodule, storage, STORAGE_KEY, MAX_ID_LENGTH } from 'modules/anonymisedIdSystem.js';
+import { createEidsArray } from 'modules/userId/eids.js';
+
+const CUID = '01f6a483-86fa-406b-a7c2-45f6d4a89469';
+
+describe('anonymisedId submodule', function () {
+  let getDataFromLocalStorageStub;
+
+  beforeEach(function () {
+    getDataFromLocalStorageStub = sinon.stub(storage, 'getDataFromLocalStorage');
+  });
+
+  afterEach(function () {
+    getDataFromLocalStorageStub.restore();
+  });
+
+  it('is registered with the expected name and GVL ID', function () {
+    expect(anonymisedIdSubmodule.name).to.equal('anonymisedId');
+    expect(anonymisedIdSubmodule.gvlid).to.equal(1116);
+  });
+
+  describe('getId()', function () {
+    it('returns the CUID stored by the Marketing Tag', function () {
+      getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns(CUID);
+      expect(anonymisedIdSubmodule.getId()).to.deep.equal({ id: CUID });
+    });
+
+    it('trims surrounding whitespace', function () {
+      getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns(`  ${CUID}\n`);
+      expect(anonymisedIdSubmodule.getId()).to.deep.equal({ id: CUID });
+    });
+
+    it('does not read any key other than anon-cuid', function () {
+      getDataFromLocalStorageStub.returns(CUID);
+      anonymisedIdSubmodule.getId();
+      expect(getDataFromLocalStorageStub.calledOnceWith(STORAGE_KEY)).to.equal(true);
+    });
+
+    [undefined, null, '', '   ', 0, {}].forEach(function (stored) {
+      it(`returns undefined when localStorage holds ${JSON.stringify(stored)}`, function () {
+        getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns(stored);
+        expect(anonymisedIdSubmodule.getId()).to.equal(undefined);
+      });
+    });
+
+    it('rejects a JSON blob left by another writer', function () {
+      getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns(`{"cuid":"${CUID}"}`);
+      expect(anonymisedIdSubmodule.getId()).to.equal(undefined);
+    });
+
+    it('rejects a value containing whitespace', function () {
+      getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns('not an id');
+      expect(anonymisedIdSubmodule.getId()).to.equal(undefined);
+    });
+
+    it('rejects a value longer than the maximum length', function () {
+      getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns('a'.repeat(MAX_ID_LENGTH + 1));
+      expect(anonymisedIdSubmodule.getId()).to.equal(undefined);
+    });
+
+    it('accepts a value at the maximum length', function () {
+      const id = 'a'.repeat(MAX_ID_LENGTH);
+      getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns(id);
+      expect(anonymisedIdSubmodule.getId()).to.deep.equal({ id });
+    });
+
+    it('does not pin the identifier to a UUID format', function () {
+      getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns('AbC_123.456');
+      expect(anonymisedIdSubmodule.getId()).to.deep.equal({ id: 'AbC_123.456' });
+    });
+  });
+
+  describe('decode()', function () {
+    it('decodes a stored CUID', function () {
+      expect(anonymisedIdSubmodule.decode(CUID)).to.deep.equal({ anonymisedId: CUID });
+    });
+
+    [undefined, null, '', ' ', 42, {}, { anonymisedId: CUID }].forEach(function (value) {
+      it(`returns undefined for ${JSON.stringify(value)}`, function () {
+        expect(anonymisedIdSubmodule.decode(value)).to.equal(undefined);
+      });
+    });
+  });
+
+  describe('eids', function () {
+    it('produces an anonymised.io EID with atype 1', function () {
+      const eids = createEidsArray(
+        { anonymisedId: CUID },
+        new Map([['anonymisedId', anonymisedIdSubmodule.eids.anonymisedId]])
+      );
+      expect(eids).to.deep.equal([{
+        source: 'anonymised.io',
+        uids: [{ id: CUID, atype: 1 }]
+      }]);
+    });
+
+    it('declares atype as a number, as OpenRTB requires', function () {
+      expect(anonymisedIdSubmodule.eids.anonymisedId.atype).to.be.a('number');
+    });
+  });
+});

--- a/test/spec/modules/anonymisedIdSystem_spec.js
+++ b/test/spec/modules/anonymisedIdSystem_spec.js
@@ -59,6 +59,11 @@ describe('anonymisedId submodule', function () {
       expect(anonymisedIdSubmodule.getId()).to.equal(undefined);
     });
 
+    it('rejects either bracket on its own, not just a well-formed array', function () {
+      getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns(`${CUID}]`);
+      expect(anonymisedIdSubmodule.getId()).to.equal(undefined);
+    });
+
     it('rejects a value containing whitespace', function () {
       getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns('not an id');
       expect(anonymisedIdSubmodule.getId()).to.equal(undefined);

--- a/test/spec/modules/anonymisedIdSystem_spec.js
+++ b/test/spec/modules/anonymisedIdSystem_spec.js
@@ -80,14 +80,29 @@ describe('anonymisedId submodule', function () {
       expect(anonymisedIdSubmodule.getId()).to.deep.equal({ id: 'AbC_123.456' });
     });
 
-    it('warns when the publisher configured storage, which this module must not use', function () {
+    // Prebid.js caches whatever `getId` returns when `storage` is configured, and that copy would
+    // outlive the Marketing Tag's removal of the key. Refusing to return an ID is what keeps a
+    // signed-out user's CUID out of the bid stream; a warning alone would not.
+    it('provides no ID at all when the publisher configured storage', function () {
       const logWarnStub = sinon.stub(utils, 'logWarn');
       getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns(CUID);
 
       try {
         const id = anonymisedIdSubmodule.getId({ storage: { type: 'html5', name: 'anonymisedId', expires: 30 } });
-        expect(id).to.deep.equal({ id: CUID });
+        expect(id).to.equal(undefined);
         expect(logWarnStub.calledWithMatch(/must be configured without "storage"/)).to.equal(true);
+      } finally {
+        logWarnStub.restore();
+      }
+    });
+
+    it('does not read storage at all when the publisher configured storage', function () {
+      const logWarnStub = sinon.stub(utils, 'logWarn');
+      getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns(CUID);
+
+      try {
+        anonymisedIdSubmodule.getId({ storage: { type: 'html5', name: 'anonymisedId' } });
+        expect(getDataFromLocalStorageStub.called).to.equal(false);
       } finally {
         logWarnStub.restore();
       }
@@ -139,6 +154,24 @@ describe('anonymisedId submodule', function () {
       it(`returns undefined for ${JSON.stringify(value)}`, function () {
         expect(anonymisedIdSubmodule.decode(value)).to.equal(undefined);
       });
+    });
+
+    // The User ID module skips getId entirely while a cached value is still fresh, and decodes
+    // that copy instead - so refusing in getId alone would still let a stale cached ID through.
+    it('refuses a value cached by Prebid.js when storage is configured', function () {
+      const logWarnStub = sinon.stub(utils, 'logWarn');
+
+      try {
+        const decoded = anonymisedIdSubmodule.decode(CUID, { storage: { type: 'html5', name: 'anonymisedId', expires: 30 } });
+        expect(decoded).to.equal(undefined);
+        expect(logWarnStub.calledWithMatch(/must be configured without "storage"/)).to.equal(true);
+      } finally {
+        logWarnStub.restore();
+      }
+    });
+
+    it('decodes normally when no storage is configured', function () {
+      expect(anonymisedIdSubmodule.decode(CUID, {})).to.deep.equal({ anonymisedId: CUID });
     });
   });
 

--- a/test/spec/modules/anonymisedIdSystem_spec.js
+++ b/test/spec/modules/anonymisedIdSystem_spec.js
@@ -1,5 +1,6 @@
 import { anonymisedIdSubmodule, storage, STORAGE_KEY, MAX_ID_LENGTH } from 'modules/anonymisedIdSystem.js';
 import { createEidsArray } from 'modules/userId/eids.js';
+import * as utils from 'src/utils.js';
 
 const CUID = '01f6a483-86fa-406b-a7c2-45f6d4a89469';
 
@@ -48,6 +49,16 @@ describe('anonymisedId submodule', function () {
       expect(anonymisedIdSubmodule.getId()).to.equal(undefined);
     });
 
+    it('rejects a JSON-stringified CUID rather than passing on its quotes', function () {
+      getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns(JSON.stringify(CUID));
+      expect(anonymisedIdSubmodule.getId()).to.equal(undefined);
+    });
+
+    it('rejects a JSON array', function () {
+      getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns(`["${CUID}"]`);
+      expect(anonymisedIdSubmodule.getId()).to.equal(undefined);
+    });
+
     it('rejects a value containing whitespace', function () {
       getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns('not an id');
       expect(anonymisedIdSubmodule.getId()).to.equal(undefined);
@@ -67,6 +78,55 @@ describe('anonymisedId submodule', function () {
     it('does not pin the identifier to a UUID format', function () {
       getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns('AbC_123.456');
       expect(anonymisedIdSubmodule.getId()).to.deep.equal({ id: 'AbC_123.456' });
+    });
+
+    it('warns when the publisher configured storage, which this module must not use', function () {
+      const logWarnStub = sinon.stub(utils, 'logWarn');
+      getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns(CUID);
+
+      try {
+        const id = anonymisedIdSubmodule.getId({ storage: { type: 'html5', name: 'anonymisedId', expires: 30 } });
+        expect(id).to.deep.equal({ id: CUID });
+        expect(logWarnStub.calledWithMatch(/must be configured without "storage"/)).to.equal(true);
+      } finally {
+        logWarnStub.restore();
+      }
+    });
+
+    it('does not warn about storage when none is configured', function () {
+      const logWarnStub = sinon.stub(utils, 'logWarn');
+      getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns(CUID);
+
+      try {
+        anonymisedIdSubmodule.getId({});
+        expect(logWarnStub.called).to.equal(false);
+      } finally {
+        logWarnStub.restore();
+      }
+    });
+
+    it('does not warn when the user is simply signed out', function () {
+      const logWarnStub = sinon.stub(utils, 'logWarn');
+      getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns(null);
+
+      try {
+        expect(anonymisedIdSubmodule.getId()).to.equal(undefined);
+        expect(logWarnStub.called).to.equal(false);
+      } finally {
+        logWarnStub.restore();
+      }
+    });
+
+    it('warns when the stored value is malformed', function () {
+      const logWarnStub = sinon.stub(utils, 'logWarn');
+      getDataFromLocalStorageStub.withArgs(STORAGE_KEY).returns('{"cuid":"x"}');
+
+      try {
+        expect(anonymisedIdSubmodule.getId()).to.equal(undefined);
+        expect(logWarnStub.calledWithMatch(/malformed/)).to.equal(true);
+      } finally {
+        logWarnStub.restore();
+      }
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Adds anonymisedIdSystem, a User ID submodule that exposes the Anonymised user identifier to bid adapters as an OpenRTB Extended ID under the source anonymised.io.

The submodule makes no network request and loads no script. The Anonymised Marketing Tag, which the publisher already runs on the page, stores the identifier in localStorage under the key anon-cuid; getId reads that key through getStorageManager, validates it, and returns it. When the tag is absent or the user is not signed in there is no key, and no EID is added.

Anonymised already maintains anonymisedRtdProvider (same vendor, GVL ID 1116), which carries contextual segments. This submodule handles user identity only, in line with the separation the User ID and RTD frameworks draw.

**Testing**
`npx gulp test --file test/spec/modules/anonymisedIdSystem_spec.js   # 31 tests passing`
`npx eslint modules/anonymisedIdSystem.js modules/anonymisedIdSystem.d.ts`
`test/spec/modules/anonymisedIdSystem_spec.js   # clean`

Coverage spans every branch of getId and decode, the EID output shape via createEidsArray, and the warning behaviour.

Verified end-to-end on integrationExamples/gpt/hello_world.html with a build of userId,anonymisedIdSystem, and separately against a live auction, where the identifier appears in the outgoing bid request:

`
{
  "eids": [
    {
      "source": "anonymised.io",
      "uids": [{ "id": "01f6a483-86fa-406b-a7c2-45f6d4a89469", "atype": 1 }]
    }
  ]
}
`

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
Documentation [PR](https://github.com/prebid/prebid.github.io/pull/6705)
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
