### PR TITLE
Core: run post-auction tracking pixels as background tasks

### DIFF
--- a/src/adRendering.ts
+++ b/src/adRendering.ts
@@ -5,9 +5,8 @@ import {
   insertElement,
   logError,
   logWarn,
+  politeTriggerPixel,
   replaceMacros,
-  runBackgroundTask,
-  triggerPixel
 } from './utils.js';
 import * as events from './events.js';
 import { AD_RENDER_FAILED_REASON, BID_STATUS, EVENTS, MESSAGES, PB_LOCATOR } from './constants.js';
@@ -60,7 +59,7 @@ declare module './events' {
 
 export const markWinningBid = hook('sync', function (bid) {
   (parseEventTrackers(bid.eventtrackers)[EVENT_TYPE_WIN]?.[TRACKER_METHOD_IMG] || [])
-    .forEach(url => runBackgroundTask(() => triggerPixel(url)));
+    .forEach(url => politeTriggerPixel(url));
   events.emit(BID_WON, bid);
   auctionManager.addWinningBid(bid);
 });

--- a/src/adRendering.ts
+++ b/src/adRendering.ts
@@ -6,6 +6,7 @@ import {
   logError,
   logWarn,
   replaceMacros,
+  runBackgroundTask,
   triggerPixel
 } from './utils.js';
 import * as events from './events.js';
@@ -59,7 +60,7 @@ declare module './events' {
 
 export const markWinningBid = hook('sync', function (bid) {
   (parseEventTrackers(bid.eventtrackers)[EVENT_TYPE_WIN]?.[TRACKER_METHOD_IMG] || [])
-    .forEach(url => triggerPixel(url));
+    .forEach(url => runBackgroundTask(() => triggerPixel(url)));
   events.emit(BID_WON, bid);
   auctionManager.addWinningBid(bid);
 });

--- a/src/adapterManager.ts
+++ b/src/adapterManager.ts
@@ -18,6 +18,7 @@ import {
   logMessage,
   logWarn,
   mergeDeep,
+  runBackgroundTask,
   shuffle,
   timestamp,
   uniques,
@@ -1005,7 +1006,7 @@ const adapterManager = {
       if (!BILLED.has(bid)) {
         BILLED.add(bid);
         (parseEventTrackers(bid.eventtrackers)[EVENT_TYPE_IMPRESSION]?.[TRACKER_METHOD_IMG] || [])
-          .forEach((url) => internal.triggerPixel(url));
+          .forEach((url) => runBackgroundTask(() => internal.triggerPixel(url)));
         tryCallBidderMethod(bid.bidder, 'onBidBillable', bid);
       }
     };

--- a/src/adapterManager.ts
+++ b/src/adapterManager.ts
@@ -9,7 +9,6 @@ import {
   getUniqueIdentifierStr,
   getUserConfiguredParams,
   groupBy,
-  internal,
   isArray,
   isPlainObject,
   isValidMediaTypes,
@@ -18,7 +17,7 @@ import {
   logMessage,
   logWarn,
   mergeDeep,
-  runBackgroundTask,
+  politeTriggerPixel,
   shuffle,
   timestamp,
   uniques,
@@ -1006,7 +1005,7 @@ const adapterManager = {
       if (!BILLED.has(bid)) {
         BILLED.add(bid);
         (parseEventTrackers(bid.eventtrackers)[EVENT_TYPE_IMPRESSION]?.[TRACKER_METHOD_IMG] || [])
-          .forEach((url) => runBackgroundTask(() => internal.triggerPixel(url)));
+          .forEach((url) => politeTriggerPixel(url));
         tryCallBidderMethod(bid.bidder, 'onBidBillable', bid);
       }
     };

--- a/src/native.ts
+++ b/src/native.ts
@@ -9,6 +9,7 @@ import {
   isPlainObject,
   logError,
   pick,
+  runBackgroundTask,
   triggerPixel
 } from './utils.js';
 
@@ -355,7 +356,7 @@ export function fireNativeTrackers(message, bidResponse) {
   return message.action;
 }
 
-export function fireImpressionTrackers(nativeResponse, bidResponse, { runMarkup = (mkup) => insertHtmlIntoIframe(mkup), fetchURL = triggerPixel } = {}) {
+export function fireImpressionTrackers(nativeResponse, bidResponse, { runMarkup = (mkup) => insertHtmlIntoIframe(mkup), fetchURL = (url) => runBackgroundTask(() => triggerPixel(url)) } = {}) {
   const filteredEventTrackers = filterEventTrackers(nativeResponse, bidResponse);
   let { [TRACKER_METHOD_IMG]: img = [], [TRACKER_METHOD_JS]: js = [] } = parseEventTrackers(
     filteredEventTrackers || []

--- a/src/native.ts
+++ b/src/native.ts
@@ -9,7 +9,7 @@ import {
   isPlainObject,
   logError,
   pick,
-  runBackgroundTask,
+  politeTriggerPixel,
   triggerPixel
 } from './utils.js';
 
@@ -356,7 +356,7 @@ export function fireNativeTrackers(message, bidResponse) {
   return message.action;
 }
 
-export function fireImpressionTrackers(nativeResponse, bidResponse, { runMarkup = (mkup) => insertHtmlIntoIframe(mkup), fetchURL = (url) => runBackgroundTask(() => triggerPixel(url)) } = {}) {
+export function fireImpressionTrackers(nativeResponse, bidResponse, { runMarkup = (mkup) => insertHtmlIntoIframe(mkup), fetchURL = politeTriggerPixel } = {}) {
   const filteredEventTrackers = filterEventTrackers(nativeResponse, bidResponse);
   let { [TRACKER_METHOD_IMG]: img = [], [TRACKER_METHOD_JS]: js = [] } = parseEventTrackers(
     filteredEventTrackers || []

--- a/src/utils.js
+++ b/src/utils.js
@@ -1228,7 +1228,7 @@ export function triggerNurlWithCpm(bid, cpm) {
       /\${AUCTION_PRICE}/,
       cpm
     );
-    triggerPixel(bid.nurl);
+    runBackgroundTask(() => triggerPixel(bid.nurl));
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1228,7 +1228,7 @@ export function triggerNurlWithCpm(bid, cpm) {
       /\${AUCTION_PRICE}/,
       cpm
     );
-    runBackgroundTask(() => triggerPixel(bid.nurl));
+    politeTriggerPixel(bid.nurl);
   }
 }
 

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -3861,6 +3861,8 @@ describe('S2S Adapter', function () {
   describe('bid won events', function () {
     let uniqueIdCount = 0;
     let triggerPixelStub;
+    let originalScheduler;
+    let originalRequestIdleCallback;
     const staticUniqueIds = ['1000', '1001', '1002', '1003'];
 
     before(function () {
@@ -3875,6 +3877,14 @@ describe('S2S Adapter', function () {
         return staticUniqueIds[uniqueIdCount - 1];
       });
       triggerPixelStub.resetHistory();
+      originalScheduler = window.scheduler;
+      originalRequestIdleCallback = window.requestIdleCallback;
+      window.scheduler = {
+        postTask(task) {
+          setTimeout(task, 0);
+          return Promise.resolve();
+        }
+      };
 
       config.setConfig({
         s2sConfig: Object.assign({}, CONFIG, {
@@ -3886,6 +3896,8 @@ describe('S2S Adapter', function () {
     });
 
     afterEach(function () {
+      window.scheduler = originalScheduler;
+      window.requestIdleCallback = originalRequestIdleCallback;
       utils.triggerPixel.resetHistory();
       utils.insertUserSyncIframe.restore();
       utils.logError.restore();
@@ -3918,7 +3930,7 @@ describe('S2S Adapter', function () {
       ]);
     });
 
-    it('should call triggerPixel if wurl is defined', function () {
+    it('should call triggerPixel if wurl is defined', function (doneCb) {
       const clonedResponse = utils.deepClone(RESPONSE_OPENRTB);
       clonedResponse.seatbid[0].bid[0].ext.prebid.events = {
         win: 'https://wurl.org'
@@ -3930,8 +3942,11 @@ describe('S2S Adapter', function () {
       sinon.assert.calledOnce(addBidResponse);
       markWinningBid(addBidResponse.getCall(0).args[1]);
 
-      expect(utils.triggerPixel.called).to.be.true;
-      expect(utils.triggerPixel.getCall(0).args[0]).to.include('https://wurl.org');
+      setTimeout(() => {
+        expect(utils.triggerPixel.called).to.be.true;
+        expect(utils.triggerPixel.getCall(0).args[0]).to.include('https://wurl.org');
+        doneCb();
+      }, 0);
     });
 
     it('should not call triggerPixel if wurl is undefined', function () {

--- a/test/spec/modules/prebidServerBidAdapter_spec.js
+++ b/test/spec/modules/prebidServerBidAdapter_spec.js
@@ -3861,12 +3861,10 @@ describe('S2S Adapter', function () {
   describe('bid won events', function () {
     let uniqueIdCount = 0;
     let triggerPixelStub;
-    let originalScheduler;
-    let originalRequestIdleCallback;
     const staticUniqueIds = ['1000', '1001', '1002', '1003'];
 
     before(function () {
-      triggerPixelStub = sinon.stub(utils, 'triggerPixel');
+      triggerPixelStub = sinon.stub(utils, 'politeTriggerPixel');
     });
 
     beforeEach(function () {
@@ -3877,14 +3875,6 @@ describe('S2S Adapter', function () {
         return staticUniqueIds[uniqueIdCount - 1];
       });
       triggerPixelStub.resetHistory();
-      originalScheduler = window.scheduler;
-      originalRequestIdleCallback = window.requestIdleCallback;
-      window.scheduler = {
-        postTask(task) {
-          setTimeout(task, 0);
-          return Promise.resolve();
-        }
-      };
 
       config.setConfig({
         s2sConfig: Object.assign({}, CONFIG, {
@@ -3896,9 +3886,7 @@ describe('S2S Adapter', function () {
     });
 
     afterEach(function () {
-      window.scheduler = originalScheduler;
-      window.requestIdleCallback = originalRequestIdleCallback;
-      utils.triggerPixel.resetHistory();
+      utils.politeTriggerPixel.resetHistory();
       utils.insertUserSyncIframe.restore();
       utils.logError.restore();
       utils.getUniqueIdentifierStr.restore();
@@ -3906,7 +3894,7 @@ describe('S2S Adapter', function () {
     });
 
     after(function () {
-      triggerPixelStub.restore();
+      utils.politeTriggerPixel.restore();
     });
 
     it('should translate wurl and burl into eventtrackers', () => {
@@ -3930,7 +3918,7 @@ describe('S2S Adapter', function () {
       ]);
     });
 
-    it('should call triggerPixel if wurl is defined', function (doneCb) {
+    it('should call politeTriggerPixel if wurl is defined', function () {
       const clonedResponse = utils.deepClone(RESPONSE_OPENRTB);
       clonedResponse.seatbid[0].bid[0].ext.prebid.events = {
         win: 'https://wurl.org'
@@ -3942,14 +3930,11 @@ describe('S2S Adapter', function () {
       sinon.assert.calledOnce(addBidResponse);
       markWinningBid(addBidResponse.getCall(0).args[1]);
 
-      setTimeout(() => {
-        expect(utils.triggerPixel.called).to.be.true;
-        expect(utils.triggerPixel.getCall(0).args[0]).to.include('https://wurl.org');
-        doneCb();
-      }, 0);
+      expect(utils.politeTriggerPixel.called).to.be.true;
+      expect(utils.politeTriggerPixel.getCall(0).args[0]).to.include('https://wurl.org');
     });
 
-    it('should not call triggerPixel if wurl is undefined', function () {
+    it('should not call politeTriggerPixel if wurl is undefined', function () {
       const clonedResponse = utils.deepClone(RESPONSE_OPENRTB);
       clonedResponse.seatbid[0].bid[0].ext.prebid.events = {};
 
@@ -3958,7 +3943,7 @@ describe('S2S Adapter', function () {
 
       sinon.assert.calledOnce(addBidResponse);
       markWinningBid(addBidResponse.getCall(0).args[1]);
-      expect(utils.triggerPixel.called).to.be.false;
+      expect(utils.politeTriggerPixel.called).to.be.false;
     });
   });
 

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -185,41 +185,28 @@ const bidWithUndefinedFields = {
 describe('native.js', function () {
   let sandbox;
   let triggerPixelStub;
+  let politeTriggerPixelStub;
   let insertHtmlIntoIframeStub;
-  let originalScheduler;
-  let originalRequestIdleCallback;
 
   beforeEach(function () {
     sandbox = sinon.createSandbox();
     triggerPixelStub = sandbox.stub(utils, 'triggerPixel');
+    politeTriggerPixelStub = sandbox.stub(utils, 'politeTriggerPixel');
     insertHtmlIntoIframeStub = sandbox.stub(utils, 'insertHtmlIntoIframe');
-    originalScheduler = window.scheduler;
-    originalRequestIdleCallback = window.requestIdleCallback;
-    window.scheduler = {
-      postTask(task) {
-        setTimeout(task, 0);
-        return Promise.resolve();
-      }
-    };
   });
 
   afterEach(function () {
-    window.scheduler = originalScheduler;
-    window.requestIdleCallback = originalRequestIdleCallback;
     sandbox.restore();
   });
 
-  it('fires impression trackers', function (done) {
+  it('fires impression trackers', function () {
     fireNativeTrackers({}, bid);
-    setTimeout(() => {
-      sinon.assert.calledOnce(triggerPixelStub);
-      sinon.assert.calledWith(triggerPixelStub, bid.native.impressionTrackers[0]);
-      sinon.assert.calledWith(
-        insertHtmlIntoIframeStub,
-        bid.native.javascriptTrackers
-      );
-      done();
-    }, 0);
+    sinon.assert.calledOnce(politeTriggerPixelStub);
+    sinon.assert.calledWith(politeTriggerPixelStub, bid.native.impressionTrackers[0]);
+    sinon.assert.calledWith(
+      insertHtmlIntoIframeStub,
+      bid.native.javascriptTrackers
+    );
   });
 
   it('fires click trackers', function () {

--- a/test/spec/native_spec.js
+++ b/test/spec/native_spec.js
@@ -186,25 +186,40 @@ describe('native.js', function () {
   let sandbox;
   let triggerPixelStub;
   let insertHtmlIntoIframeStub;
+  let originalScheduler;
+  let originalRequestIdleCallback;
 
   beforeEach(function () {
     sandbox = sinon.createSandbox();
     triggerPixelStub = sandbox.stub(utils, 'triggerPixel');
     insertHtmlIntoIframeStub = sandbox.stub(utils, 'insertHtmlIntoIframe');
+    originalScheduler = window.scheduler;
+    originalRequestIdleCallback = window.requestIdleCallback;
+    window.scheduler = {
+      postTask(task) {
+        setTimeout(task, 0);
+        return Promise.resolve();
+      }
+    };
   });
 
   afterEach(function () {
+    window.scheduler = originalScheduler;
+    window.requestIdleCallback = originalRequestIdleCallback;
     sandbox.restore();
   });
 
-  it('fires impression trackers', function () {
+  it('fires impression trackers', function (done) {
     fireNativeTrackers({}, bid);
-    sinon.assert.calledOnce(triggerPixelStub);
-    sinon.assert.calledWith(triggerPixelStub, bid.native.impressionTrackers[0]);
-    sinon.assert.calledWith(
-      insertHtmlIntoIframeStub,
-      bid.native.javascriptTrackers
-    );
+    setTimeout(() => {
+      sinon.assert.calledOnce(triggerPixelStub);
+      sinon.assert.calledWith(triggerPixelStub, bid.native.impressionTrackers[0]);
+      sinon.assert.calledWith(
+        insertHtmlIntoIframeStub,
+        bid.native.javascriptTrackers
+      );
+      done();
+    }, 0);
   });
 
   it('fires click trackers', function () {

--- a/test/spec/unit/adRendering_spec.js
+++ b/test/spec/unit/adRendering_spec.js
@@ -205,34 +205,19 @@ describe('adRendering', () => {
     });
 
     describe('markWinningBid', () => {
-      let bid, originalScheduler, originalRequestIdleCallback;
+      let bid;
       beforeEach(() => {
         bid = { adId: '123' };
-        sandbox.stub(utils, 'triggerPixel');
-        originalScheduler = window.scheduler;
-        originalRequestIdleCallback = window.requestIdleCallback;
-        window.scheduler = {
-          postTask(task) {
-            setTimeout(task, 0);
-            return Promise.resolve();
-          }
-        };
-      });
-      afterEach(() => {
-        window.scheduler = originalScheduler;
-        window.requestIdleCallback = originalRequestIdleCallback;
+        sandbox.stub(utils, 'politeTriggerPixel');
       });
       it('should fire BID_WON', () => {
         markWinningBid(bid);
         sinon.assert.calledWith(events.emit, EVENTS.BID_WON, bid);
       });
-      it('should fire win tracking pixels', (done) => {
+      it('should fire win tracking pixels', () => {
         bid.eventtrackers = [{ event: EVENT_TYPE_WIN, method: TRACKER_METHOD_IMG, url: 'tracker' }];
         markWinningBid(bid);
-        setTimeout(() => {
-          sinon.assert.calledWith(utils.triggerPixel, 'tracker');
-          done();
-        }, 0);
+        sinon.assert.calledWith(utils.politeTriggerPixel, 'tracker');
       });
       it('should NOT fire non-win or non-pixel trackers', () => {
         bid.eventtrackers = [
@@ -240,7 +225,7 @@ describe('adRendering', () => {
           { event: EVENT_TYPE_IMPRESSION, method: TRACKER_METHOD_IMG, url: 'ignored' }
         ];
         markWinningBid(bid);
-        sinon.assert.notCalled(utils.triggerPixel);
+        sinon.assert.notCalled(utils.politeTriggerPixel);
       });
     });
 

--- a/test/spec/unit/adRendering_spec.js
+++ b/test/spec/unit/adRendering_spec.js
@@ -205,19 +205,34 @@ describe('adRendering', () => {
     });
 
     describe('markWinningBid', () => {
-      let bid;
+      let bid, originalScheduler, originalRequestIdleCallback;
       beforeEach(() => {
         bid = { adId: '123' };
         sandbox.stub(utils, 'triggerPixel');
+        originalScheduler = window.scheduler;
+        originalRequestIdleCallback = window.requestIdleCallback;
+        window.scheduler = {
+          postTask(task) {
+            setTimeout(task, 0);
+            return Promise.resolve();
+          }
+        };
+      });
+      afterEach(() => {
+        window.scheduler = originalScheduler;
+        window.requestIdleCallback = originalRequestIdleCallback;
       });
       it('should fire BID_WON', () => {
         markWinningBid(bid);
         sinon.assert.calledWith(events.emit, EVENTS.BID_WON, bid);
       });
-      it('should fire win tracking pixels', () => {
+      it('should fire win tracking pixels', (done) => {
         bid.eventtrackers = [{ event: EVENT_TYPE_WIN, method: TRACKER_METHOD_IMG, url: 'tracker' }];
         markWinningBid(bid);
-        sinon.assert.calledWith(utils.triggerPixel, 'tracker');
+        setTimeout(() => {
+          sinon.assert.calledWith(utils.triggerPixel, 'tracker');
+          done();
+        }, 0);
       });
       it('should NOT fire non-win or non-pixel trackers', () => {
         bid.eventtrackers = [

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -450,16 +450,32 @@ describe('adapterManager tests', function () {
     });
 
     describe('triggerBilling', () => {
+      let originalScheduler, originalRequestIdleCallback;
       beforeEach(() => {
         criteoSpec.onBidBillable = sinon.spy();
         sandbox.stub(utils.internal, 'triggerPixel');
+        originalScheduler = window.scheduler;
+        originalRequestIdleCallback = window.requestIdleCallback;
+        window.scheduler = {
+          postTask(task) {
+            setTimeout(task, 0);
+            return Promise.resolve();
+          }
+        };
       });
-      it('should fire impression pixels from eventtrackers', () => {
+      afterEach(() => {
+        window.scheduler = originalScheduler;
+        window.requestIdleCallback = originalRequestIdleCallback;
+      });
+      it('should fire impression pixels from eventtrackers', (done) => {
         bids[0].eventtrackers = [
           { event: EVENT_TYPE_IMPRESSION, method: TRACKER_METHOD_IMG, url: 'tracker' },
         ];
         adapterManager.triggerBilling(bids[0]);
-        sinon.assert.calledWith(utils.internal.triggerPixel, 'tracker');
+        setTimeout(() => {
+          sinon.assert.calledWith(utils.internal.triggerPixel, 'tracker');
+          done();
+        }, 0);
       });
 
       it('should NOT fire non-impression or non-pixel trackers', () => {

--- a/test/spec/unit/core/adapterManager_spec.js
+++ b/test/spec/unit/core/adapterManager_spec.js
@@ -450,32 +450,16 @@ describe('adapterManager tests', function () {
     });
 
     describe('triggerBilling', () => {
-      let originalScheduler, originalRequestIdleCallback;
       beforeEach(() => {
         criteoSpec.onBidBillable = sinon.spy();
-        sandbox.stub(utils.internal, 'triggerPixel');
-        originalScheduler = window.scheduler;
-        originalRequestIdleCallback = window.requestIdleCallback;
-        window.scheduler = {
-          postTask(task) {
-            setTimeout(task, 0);
-            return Promise.resolve();
-          }
-        };
+        sandbox.stub(utils, 'politeTriggerPixel');
       });
-      afterEach(() => {
-        window.scheduler = originalScheduler;
-        window.requestIdleCallback = originalRequestIdleCallback;
-      });
-      it('should fire impression pixels from eventtrackers', (done) => {
+      it('should fire impression pixels from eventtrackers', () => {
         bids[0].eventtrackers = [
           { event: EVENT_TYPE_IMPRESSION, method: TRACKER_METHOD_IMG, url: 'tracker' },
         ];
         adapterManager.triggerBilling(bids[0]);
-        setTimeout(() => {
-          sinon.assert.calledWith(utils.internal.triggerPixel, 'tracker');
-          done();
-        }, 0);
+        sinon.assert.calledWith(utils.politeTriggerPixel, 'tracker');
       });
 
       it('should NOT fire non-impression or non-pixel trackers', () => {
@@ -484,7 +468,7 @@ describe('adapterManager tests', function () {
           { event: EVENT_TYPE_IMPRESSION, method: TRACKER_METHOD_JS, url: 'ignored' },
         ];
         adapterManager.triggerBilling(bids[0]);
-        sinon.assert.notCalled(utils.internal.triggerPixel);
+        sinon.assert.notCalled(utils.politeTriggerPixel);
       });
       describe('on client bids', () => {
         it('should call bidder\'s onBidBillable', () => {

--- a/test/spec/unit/pbjs_api_spec.js
+++ b/test/spec/unit/pbjs_api_spec.js
@@ -1265,7 +1265,7 @@ describe('Unit: Prebid Module', function () {
 
       inIframe = true;
       sinon.stub(utils, 'inIframe').callsFake(() => inIframe);
-      triggerPixelStub = sinon.stub(utils.internal, 'triggerPixel');
+      triggerPixelStub = sinon.stub(utils, 'politeTriggerPixel');
     });
 
     afterEach(function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

[#12584](https://github.com/prebid/Prebid.js/issues/12584) asks that known background work (analytics, timeouts/errors, other post-auction network traffic) be labeled as low priority via scheduler.postTask / keepalive / similar. Core already has `runBackgroundTask()` from [#13174](https://github.com/prebid/Prebid.js/pull/13174) (postTask → requestIdleCallback → sync fallback).

This PR applies that helper to remaining post-auction tracking pixels that still fire synchronously on the critical path:

win pixels in `markWinningBid` (src/adRendering.ts)
impression pixels in `triggerBilling` (src/adapterManager.ts)
native impression pixels in `fireImpressionTrackers` (src/native.ts)
nurl pixels in `triggerNurlWithCpm` (src/utils.js)

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
Closes #12584 