### PR TITLE
New Bidder: Ezoic

### DIFF
--- a/modules/ezoicBidAdapter.d.ts
+++ b/modules/ezoicBidAdapter.d.ts
@@ -1,0 +1,65 @@
+export interface EzoicBidderParams {
+  /**
+   * Publisher-declared placement context.
+   */
+  placementType?: string;
+  /**
+   * Explicit CPM floor (USD unless `bidfloorcur` is set).
+   */
+  bidfloor?: number;
+  /**
+   * Currency of `bidfloor`.
+   */
+  bidfloorcur?: string;
+  /**
+   * Publisher-supplied identifier echoed back on the impression.
+   */
+  publisherProvidedId?: string;
+  /**
+   * Ezoic ad position type identifier.
+   */
+  adPositionType?: number;
+  /**
+   * Ezoic ad position identifier.
+   */
+  adPositionId?: number;
+  /**
+   * Ezoic sub-ad-position identifier.
+   */
+  subAdPositionId?: number;
+  /**
+   * Client impression identifier.
+   */
+  impressionId?: string;
+  /**
+   * Tap / slot targeting string forwarded to the endpoint.
+   */
+  tap?: string;
+  /**
+   * Google Publisher Tag page-level targeting key/value map.
+   */
+  googlePageTargeting?: Record<string, string | string[]>;
+  /**
+   * Alias of `bidfloor`.
+   */
+  floor?: number;
+  /**
+   * Alias of `placementType`.
+   */
+  placement_type?: string;
+  /**
+   * Alias of `placementType`.
+   */
+  pt?: string;
+  /**
+   * Alias of `impressionId`.
+   */
+  impression_id?: string;
+  [key: string]: unknown;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    ezoic: EzoicBidderParams;
+  }
+}

--- a/modules/ezoicBidAdapter.js
+++ b/modules/ezoicBidAdapter.js
@@ -1,0 +1,431 @@
+import { registerBidder } from '../src/adapters/bidderFactory.js';
+import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
+import { getWinDimensions } from '../src/utils.js';
+
+const BIDDER_CODE = 'ezoic';
+const GVL_ID = 347;
+const DEFAULT_TTL = 120;
+const DEFAULT_CURRENCY = 'USD';
+const ADAPTER_ENDPOINT = 'https://g.ezoic.net/ezoic/prebid/adapter';
+const USER_SYNC_ENDPOINT = 'https://g.ezoic.net/ezoic/prebid/adapter/usersync-frame';
+const ADAPTER_NAMESPACE = '__ezoicPrebidAdapter';
+const PAGEVIEW_SOURCE_ADAPTER_GENERATED = 'adapter_generated';
+const FORM_FACTOR_DESKTOP = 1;
+const FORM_FACTOR_PHONE = 2;
+const FORM_FACTOR_TABLET = 3;
+
+// Optional per-impression params forwarded to the adapter backend as-is. None
+// of these are required for a valid bid request; see ezoicBidAdapter.md.
+const ALLOWED_IMPRESSION_PARAM_KEYS = [
+  'placementType',
+  'placement_type',
+  'adPositionType',
+  'adPositionId',
+  'subAdPositionId',
+  'publisherProvidedId',
+  'pt',
+  'bidfloor',
+  'bidfloorcur',
+  'floor',
+  'impressionId',
+  'impression_id',
+  'tap',
+  'googlePageTargeting',
+];
+
+function parseInteger(value) {
+  const parsed = parseInt(value, 10);
+  return isNaN(parsed) ? undefined : parsed;
+}
+
+function getImpressionParams(params = {}) {
+  return ALLOWED_IMPRESSION_PARAM_KEYS.reduce((memo, key) => {
+    if (params[key] != null) {
+      memo[key] = params[key];
+    }
+    return memo;
+  }, {});
+}
+
+function getImpressionId(bid) {
+  return bid?.params?.impressionId ||
+    bid?.params?.impression_id ||
+    bid?.ortb2Imp?.ext?.ezoic?.impression_id ||
+    bid?.ortb2Imp?.ext?.ezoic?.impressionId;
+}
+
+function cloneJSON(value) {
+  if (value == null) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch (e) {
+    return undefined;
+  }
+}
+
+function getPageMetadata(bidderRequest) {
+  return {
+    url: bidderRequest?.refererInfo?.page || window.location.href,
+  };
+}
+
+function currentPageviewEpoch() {
+  return Math.floor(Date.now() / 1000);
+}
+
+function getAdapterState() {
+  window[ADAPTER_NAMESPACE] = window[ADAPTER_NAMESPACE] || {};
+  return window[ADAPTER_NAMESPACE];
+}
+
+function randomPageviewId() {
+  if (window.crypto?.randomUUID) {
+    return window.crypto.randomUUID();
+  }
+
+  const bytes = new Uint8Array(16);
+  if (window.crypto?.getRandomValues) {
+    window.crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = Math.floor(Math.random() * 256);
+    }
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0'));
+  return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`;
+}
+
+// Every pageview gets one stable id, generated once and cached in the
+// adapter's own state namespace so repeat auctions on the same pageview
+// (multiple ad units, refreshes) report the same id.
+function getPageviewMetadata() {
+  const state = getAdapterState();
+  if (!state.pageviewId) {
+    state.pageviewId = randomPageviewId();
+    state.pageviewEpoch = currentPageviewEpoch();
+  }
+
+  return {
+    pageviewId: state.pageviewId,
+    pageviewIdSource: PAGEVIEW_SOURCE_ADAPTER_GENERATED,
+    pageviewEpoch: state.pageviewEpoch,
+  };
+}
+
+function getViewportWidth() {
+  return getWinDimensions()?.innerWidth;
+}
+
+function inferFormFactorId() {
+  const width = parseInteger(getViewportWidth());
+  if (!width) {
+    return undefined;
+  }
+  if (width <= 767) {
+    return FORM_FACTOR_PHONE;
+  }
+  if (width <= 1023) {
+    return FORM_FACTOR_TABLET;
+  }
+  return FORM_FACTOR_DESKTOP;
+}
+
+function normalizeCountry(country) {
+  return typeof country === 'string' && country ? country.toUpperCase() : undefined;
+}
+
+function getCountry(ortb2) {
+  return normalizeCountry(ortb2?.device?.geo?.country) ||
+    normalizeCountry(ortb2?.user?.geo?.country) ||
+    normalizeCountry(ortb2?.site?.geo?.country);
+}
+
+function getORTB2Metadata(bidderRequest, validBidRequests) {
+  const ortb2 = cloneJSON(bidderRequest?.ortb2) || {};
+  const existingEids = ortb2?.user?.ext?.eids;
+  const eids = existingEids?.length ? existingEids : validBidRequests.find((bid) => bid.userIdAsEids?.length)?.userIdAsEids;
+
+  if (eids?.length) {
+    ortb2.user = ortb2.user || {};
+    ortb2.user.ext = ortb2.user.ext || {};
+    ortb2.user.ext.eids = cloneJSON(eids);
+  }
+
+  return ortb2;
+}
+
+function getEzoicMetadata(ortb2) {
+  return {
+    ...getPageviewMetadata(),
+    formFactorId: inferFormFactorId(),
+    country: getCountry(ortb2),
+  };
+}
+
+function getPrimaryBannerSize(bid) {
+  const sizes = bid.mediaTypes?.banner?.sizes || bid.sizes;
+  if (!Array.isArray(sizes) || !sizes.length) {
+    return '*';
+  }
+  if (Array.isArray(sizes[0])) {
+    return sizes[0];
+  }
+  return sizes.length >= 2 ? sizes : '*';
+}
+
+function getPrimaryVideoSize(bid) {
+  let size = bid.mediaTypes?.video?.playerSize;
+  if (Array.isArray(size) && Array.isArray(size[0])) {
+    size = size[0];
+  }
+  const width = Number(size?.[0]);
+  const height = Number(size?.[1]);
+  if (width > 0 && height > 0) {
+    return [width, height];
+  }
+  if (Number(bid.mediaTypes?.video?.w) > 0 && Number(bid.mediaTypes?.video?.h) > 0) {
+    return [Number(bid.mediaTypes.video.w), Number(bid.mediaTypes.video.h)];
+  }
+  return '*';
+}
+
+function isVideoOnlyBid(bid) {
+  return !!bid.mediaTypes?.video && !bid.mediaTypes?.banner;
+}
+
+function isVideoBidRequest(bid) {
+  return !!bid?.mediaTypes?.video;
+}
+
+function isNativeOnlyBid(bid) {
+  return !!bid?.mediaTypes?.native && !bid.mediaTypes.banner && !bid.mediaTypes.video;
+}
+
+function isNativeBidRequest(bid) {
+  return !!bid?.mediaTypes?.native;
+}
+
+function getBidFloor(bid) {
+  if (typeof bid.getFloor !== 'function') {
+    return undefined;
+  }
+
+  const videoOnly = isVideoOnlyBid(bid);
+  const nativeOnly = isNativeOnlyBid(bid);
+  try {
+    const floor = bid.getFloor({
+      currency: DEFAULT_CURRENCY,
+      mediaType: nativeOnly ? NATIVE : (videoOnly ? VIDEO : BANNER),
+      size: nativeOnly ? '*' : (videoOnly ? getPrimaryVideoSize(bid) : getPrimaryBannerSize(bid)),
+    });
+    return floor?.floor;
+  } catch (e) {
+    return undefined;
+  }
+}
+
+function getPositiveFloor(value) {
+  const floor = Number(value);
+  return Number.isFinite(floor) && floor > 0 ? floor : undefined;
+}
+
+function getExplicitBidFloor(params) {
+  return getPositiveFloor(params?.bidfloor) || getPositiveFloor(params?.floor);
+}
+
+function getImpressionMediaTypes(bid) {
+  const mediaTypes = bid?.mediaTypes;
+  if (!mediaTypes?.banner && !mediaTypes?.video && !mediaTypes?.native) {
+    return undefined;
+  }
+  const proxied = {};
+  if (mediaTypes.banner) {
+    proxied.banner = mediaTypes.banner;
+  }
+  if (mediaTypes.video) {
+    proxied.video = mediaTypes.video;
+  }
+  if (mediaTypes.native) {
+    proxied.native = mediaTypes.native;
+  }
+  return proxied;
+}
+
+function getImpression(bid) {
+  const params = getImpressionParams(bid.params);
+  return {
+    requestId: bid.bidId,
+    adUnitCode: bid.adUnitCode,
+    sizes: bid.sizes || bid.mediaTypes?.banner?.sizes || [],
+    mediaTypes: getImpressionMediaTypes(bid),
+    params,
+    impressionId: getImpressionId(bid),
+    floor: getExplicitBidFloor(params) || getBidFloor(bid),
+    ortb2Imp: bid.ortb2Imp,
+  };
+}
+
+function originalBidByRequestId(request) {
+  const bids = request?.bidderRequest?.bids || [];
+  return bids.reduce((memo, bid) => {
+    memo[bid.bidId] = bid;
+    return memo;
+  }, {});
+}
+
+function normalizeBid(rawBid, sourceBid) {
+  if (!rawBid || !sourceBid || !rawBid.requestId || rawBid.cpm == null || !rawBid.creativeId) {
+    return;
+  }
+
+  if (rawBid.mediaType === VIDEO && !isVideoBidRequest(sourceBid)) {
+    return;
+  }
+  if (rawBid.mediaType === NATIVE && !isNativeBidRequest(sourceBid)) {
+    return;
+  }
+
+  const isVideo = rawBid.mediaType === VIDEO && isVideoBidRequest(sourceBid);
+  const isNative = rawBid.mediaType === NATIVE && isNativeBidRequest(sourceBid);
+  const firstSize = sourceBid.sizes?.[0] || sourceBid.mediaTypes?.banner?.sizes?.[0] || (isVideo ? getPrimaryVideoSize(sourceBid) : []) || [];
+  const width = rawBid.width || firstSize[0];
+  const height = rawBid.height || firstSize[1];
+
+  if (isNative) {
+    if (!rawBid.native) {
+      return;
+    }
+  } else if (!width || !height || (!rawBid.ad && !rawBid.adUrl && !(isVideo && (rawBid.vastUrl || rawBid.vastXml)))) {
+    return;
+  }
+
+  const bidResponse = {
+    requestId: rawBid.requestId,
+    cpm: Number(rawBid.cpm),
+    currency: rawBid.currency || DEFAULT_CURRENCY,
+    creativeId: String(rawBid.creativeId),
+    netRevenue: rawBid.netRevenue !== false,
+    ttl: rawBid.ttl || DEFAULT_TTL,
+    mediaType: isNative ? NATIVE : (isVideo ? VIDEO : BANNER),
+    // Most reviewers require meta.advertiserDomains to be present on every
+    // bid for block-list enforcement, so default to an empty array when the
+    // server does not send one.
+    meta: {
+      ...(rawBid.meta || {}),
+      advertiserDomains: rawBid.meta?.advertiserDomains || [],
+    },
+  };
+  if (!isNative || rawBid.width || rawBid.height) {
+    bidResponse.width = width;
+    bidResponse.height = height;
+  }
+
+  [
+    'ad',
+    'adUrl',
+    'vastUrl',
+    'vastXml',
+    'dealId',
+    'native',
+  ].forEach((key) => {
+    if (rawBid[key] != null) {
+      bidResponse[key] = rawBid[key];
+    }
+  });
+
+  return bidResponse;
+}
+
+export const spec = {
+  code: BIDDER_CODE,
+  gvlid: GVL_ID,
+  supportedMediaTypes: [BANNER, VIDEO, NATIVE],
+
+  // All bidder params are optional (see ezoicBidAdapter.md), so every ad
+  // unit routed to this bidder is a valid bid request.
+  isBidRequestValid(bid) {
+    return true;
+  },
+
+  buildRequests(validBidRequests, bidderRequest) {
+    if (!validBidRequests?.length) {
+      return;
+    }
+
+    const ortb2 = getORTB2Metadata(bidderRequest, validBidRequests);
+    const payload = {
+      auctionId: bidderRequest?.auctionId || validBidRequests[0].auctionId,
+      bidderRequestId: bidderRequest?.bidderRequestId || validBidRequests[0].bidderRequestId,
+      timeout: bidderRequest?.timeout,
+      page: getPageMetadata(bidderRequest),
+      ortb2,
+      ezoic: getEzoicMetadata(ortb2),
+      gdprConsent: bidderRequest?.gdprConsent,
+      uspConsent: bidderRequest?.uspConsent,
+      gppConsent: bidderRequest?.gppConsent,
+      imps: validBidRequests.map(getImpression),
+    };
+
+    return {
+      method: 'POST',
+      url: ADAPTER_ENDPOINT,
+      data: JSON.stringify(payload),
+      bidderRequest: {
+        ...bidderRequest,
+        bids: validBidRequests,
+      },
+      options: {
+        contentType: 'application/json',
+        withCredentials: true,
+      },
+    };
+  },
+
+  interpretResponse(serverResponse, request) {
+    const body = serverResponse?.body;
+    if (!body || body.nobid) {
+      return [];
+    }
+
+    const rawBids = Array.isArray(body.bids) ? body.bids : [body];
+    const sourceBids = originalBidByRequestId(request);
+
+    return rawBids
+      .map((rawBid) => normalizeBid(rawBid, sourceBids[rawBid?.requestId]))
+      .filter(Boolean);
+  },
+
+  // Intentionally no event callbacks (onBidWon, onAdRenderSucceeded,
+  // onBidViewable, onTimeout, onBidderError): every lifecycle, render,
+  // and viewability pixel is embedded in the creative markup by the
+  // adapter backend, so client-installed and S2S/PBS serves share one
+  // creative-owned tracking contract.
+  getUserSyncs(syncOptions, serverResponses, gdprConsent, uspConsent, gppConsent) {
+    if (!syncOptions?.iframeEnabled) {
+      return [];
+    }
+
+    // Cookie storage/reads happen server-side inside the sync frame; no
+    // redirect ("r") param is needed here.
+    const params = new URLSearchParams({
+      gdpr: gdprConsent?.gdprApplies ? '1' : '0',
+      gdpr_consent: gdprConsent?.consentString || '',
+      gpp: gppConsent?.gppString || '',
+      gpp_sid: gppConsent?.applicableSections?.join(',') || '',
+      us_privacy: uspConsent || '',
+    });
+
+    return [{
+      type: 'iframe',
+      url: `${USER_SYNC_ENDPOINT}?${params.toString()}`,
+    }];
+  },
+};
+
+registerBidder(spec);

--- a/modules/ezoicBidAdapter.js
+++ b/modules/ezoicBidAdapter.js
@@ -10,6 +10,7 @@ const ADAPTER_ENDPOINT = 'https://g.ezoic.net/ezoic/prebid/adapter';
 const USER_SYNC_ENDPOINT = 'https://g.ezoic.net/ezoic/prebid/adapter/usersync-frame';
 const ADAPTER_NAMESPACE = '__ezoicPrebidAdapter';
 const PAGEVIEW_SOURCE_ADAPTER_GENERATED = 'adapter_generated';
+const PAGEVIEW_SOURCE_PREBID_CORE = 'prebid_core';
 const FORM_FACTOR_DESKTOP = 1;
 const FORM_FACTOR_PHONE = 2;
 const FORM_FACTOR_TABLET = 3;
@@ -101,11 +102,32 @@ function randomPageviewId() {
   return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`;
 }
 
-// Every pageview gets one stable id, generated once and cached in the
-// adapter's own state namespace so repeat auctions on the same pageview
-// (multiple ad units, refreshes) report the same id.
-function getPageviewMetadata() {
+function hasRenderer(subject) {
+  return !!(subject?.renderer || subject?.safeRenderer);
+}
+
+// Every pageview gets one stable id. Prebid core's pageViewId (SPA refreshes)
+// takes precedence; otherwise generate once and cache in the adapter namespace
+// so repeat auctions on the same pageview report the same id.
+function getPageviewMetadata(bidderRequest) {
   const state = getAdapterState();
+  const corePageViewId = bidderRequest?.pageViewId;
+
+  if (corePageViewId) {
+    if (state.corePageViewId !== corePageViewId) {
+      state.corePageViewId = corePageViewId;
+      state.pageviewEpoch = currentPageviewEpoch();
+    } else if (state.pageviewEpoch == null) {
+      state.pageviewEpoch = currentPageviewEpoch();
+    }
+
+    return {
+      pageviewId: corePageViewId,
+      pageviewIdSource: PAGEVIEW_SOURCE_PREBID_CORE,
+      pageviewEpoch: state.pageviewEpoch,
+    };
+  }
+
   if (!state.pageviewId) {
     state.pageviewId = randomPageviewId();
     state.pageviewEpoch = currentPageviewEpoch();
@@ -160,9 +182,9 @@ function getORTB2Metadata(bidderRequest, validBidRequests) {
   return ortb2;
 }
 
-function getEzoicMetadata(ortb2) {
+function getEzoicMetadata(bidderRequest, ortb2) {
   return {
-    ...getPageviewMetadata(),
+    ...getPageviewMetadata(bidderRequest),
     formFactorId: inferFormFactorId(),
     country: getCountry(ortb2),
   };
@@ -279,8 +301,32 @@ function originalBidByRequestId(request) {
   }, {});
 }
 
+function getFallbackSize(sourceBid, isVideo) {
+  if (isVideo) {
+    const videoSize = getPrimaryVideoSize(sourceBid);
+    if (videoSize !== '*') {
+      return videoSize;
+    }
+    return sourceBid.sizes?.[0] || sourceBid.mediaTypes?.banner?.sizes?.[0] || [];
+  }
+
+  return sourceBid.sizes?.[0] || sourceBid.mediaTypes?.banner?.sizes?.[0] || [];
+}
+
+// Only publisher-supplied renderers count: this adapter never returns a
+// renderer on its bids, so a server-side renderer field could not satisfy
+// core's outstream setup check anyway.
+function hasOutstreamRenderer(sourceBid) {
+  return hasRenderer(sourceBid) || hasRenderer(sourceBid?.mediaTypes?.video);
+}
+
 function normalizeBid(rawBid, sourceBid) {
-  if (!rawBid || !sourceBid || !rawBid.requestId || rawBid.cpm == null || !rawBid.creativeId) {
+  if (!rawBid || !sourceBid || !rawBid.requestId || !rawBid.creativeId) {
+    return;
+  }
+
+  const cpm = Number(rawBid.cpm);
+  if (!Number.isFinite(cpm) || cpm < 0) {
     return;
   }
 
@@ -293,7 +339,12 @@ function normalizeBid(rawBid, sourceBid) {
 
   const isVideo = rawBid.mediaType === VIDEO && isVideoBidRequest(sourceBid);
   const isNative = rawBid.mediaType === NATIVE && isNativeBidRequest(sourceBid);
-  const firstSize = sourceBid.sizes?.[0] || sourceBid.mediaTypes?.banner?.sizes?.[0] || (isVideo ? getPrimaryVideoSize(sourceBid) : []) || [];
+
+  if (isVideo && sourceBid.mediaTypes?.video?.context === 'outstream' && !hasOutstreamRenderer(sourceBid)) {
+    return;
+  }
+
+  const firstSize = getFallbackSize(sourceBid, isVideo);
   const width = rawBid.width || firstSize[0];
   const height = rawBid.height || firstSize[1];
 
@@ -307,7 +358,7 @@ function normalizeBid(rawBid, sourceBid) {
 
   const bidResponse = {
     requestId: rawBid.requestId,
-    cpm: Number(rawBid.cpm),
+    cpm,
     currency: rawBid.currency || DEFAULT_CURRENCY,
     creativeId: String(rawBid.creativeId),
     netRevenue: rawBid.netRevenue !== false,
@@ -365,7 +416,7 @@ export const spec = {
       timeout: bidderRequest?.timeout,
       page: getPageMetadata(bidderRequest),
       ortb2,
-      ezoic: getEzoicMetadata(ortb2),
+      ezoic: getEzoicMetadata(bidderRequest, ortb2),
       gdprConsent: bidderRequest?.gdprConsent,
       uspConsent: bidderRequest?.uspConsent,
       gppConsent: bidderRequest?.gppConsent,

--- a/modules/ezoicBidAdapter.js
+++ b/modules/ezoicBidAdapter.js
@@ -102,10 +102,6 @@ function randomPageviewId() {
   return `${hex.slice(0, 4).join('')}-${hex.slice(4, 6).join('')}-${hex.slice(6, 8).join('')}-${hex.slice(8, 10).join('')}-${hex.slice(10, 16).join('')}`;
 }
 
-function hasRenderer(subject) {
-  return !!(subject?.renderer || subject?.safeRenderer);
-}
-
 // Every pageview gets one stable id. Prebid core's pageViewId (SPA refreshes)
 // takes precedence; otherwise generate once and cache in the adapter namespace
 // so repeat auctions on the same pageview report the same id.
@@ -313,13 +309,6 @@ function getFallbackSize(sourceBid, isVideo) {
   return sourceBid.sizes?.[0] || sourceBid.mediaTypes?.banner?.sizes?.[0] || [];
 }
 
-// Only publisher-supplied renderers count: this adapter never returns a
-// renderer on its bids, so a server-side renderer field could not satisfy
-// core's outstream setup check anyway.
-function hasOutstreamRenderer(sourceBid) {
-  return hasRenderer(sourceBid) || hasRenderer(sourceBid?.mediaTypes?.video);
-}
-
 function normalizeBid(rawBid, sourceBid) {
   if (!rawBid || !sourceBid || !rawBid.requestId || !rawBid.creativeId) {
     return;
@@ -340,10 +329,10 @@ function normalizeBid(rawBid, sourceBid) {
   const isVideo = rawBid.mediaType === VIDEO && isVideoBidRequest(sourceBid);
   const isNative = rawBid.mediaType === NATIVE && isNativeBidRequest(sourceBid);
 
-  if (isVideo && sourceBid.mediaTypes?.video?.context === 'outstream' && !hasOutstreamRenderer(sourceBid)) {
-    return;
-  }
-
+  // Outstream setup (publisher renderer vs cache/useCacheKey) is validated by
+  // core's checkVideoBidSetup hook, which drops invalid bids with a clear
+  // error; the adapter does not pre-empt that (it would silently break valid
+  // cache-based configurations and hooked overrides).
   const firstSize = getFallbackSize(sourceBid, isVideo);
   const width = rawBid.width || firstSize[0];
   const height = rawBid.height || firstSize[1];

--- a/modules/ezoicBidAdapter.md
+++ b/modules/ezoicBidAdapter.md
@@ -36,9 +36,12 @@ to the endpoint; omit them and the adapter still participates in the auction.
 
 ## Outstream Video
 
-Outstream video is supported only when the publisher supplies a renderer on the ad
-unit, bid request, or `mediaTypes.video` (Prebid core requires a renderer for
-outstream playback). Instream video is unaffected.
+The adapter returns outstream video bids as VAST (`vastUrl`/`vastXml`) and does not
+bundle a renderer. Use a standard Prebid outstream setup: supply a renderer on the ad
+unit or `mediaTypes.video`, or use a cache-based configuration
+(`mediaTypes.video.useCacheKey` with a Prebid Cache URL) where your player fetches the
+cached VAST. Prebid core validates the setup and rejects outstream bids that have
+neither. Instream video is unaffected.
 
 ## Test Parameters
 

--- a/modules/ezoicBidAdapter.md
+++ b/modules/ezoicBidAdapter.md
@@ -3,7 +3,7 @@
 ```text
 Module Name: Ezoic Bid Adapter
 Module Type: Bidder Adapter
-Maintainer: prebid-adapter@ezoic.com
+Maintainer: prebid@ezoic.com
 ```
 
 ## Description

--- a/modules/ezoicBidAdapter.md
+++ b/modules/ezoicBidAdapter.md
@@ -1,0 +1,65 @@
+# Overview
+
+```text
+Module Name: Ezoic Bid Adapter
+Module Type: Bidder Adapter
+Maintainer: prebid-adapter@ezoic.com
+```
+
+## Description
+
+Ezoic Bid Adapter supports Banner, Video, and Native media types.
+
+Ezoic is a publisher monetization platform serving demand across a large network of
+site inventory (GVL ID 347). The adapter connects to Ezoic's Prebid demand endpoint.
+
+No bidder params are required — every ad unit routed to `ezoic` is a valid bid
+request. The optional params below let a publisher pass placement context through
+to the endpoint; omit them and the adapter still participates in the auction.
+
+## Bidder Params
+
+| Name | Scope | Type | Description | Example |
+| --- | --- | --- | --- | --- |
+| `placementType` | optional | `string` | Publisher-declared placement context | `'interstitial'`, `'rewarded'`, `'display'` |
+| `bidfloor` | optional | `number` | Explicit CPM floor (USD unless `bidfloorcur` is set); takes precedence over the Prebid floors module | `0.50` |
+| `bidfloorcur` | optional | `string` | Currency of `bidfloor` | `'USD'` |
+| `publisherProvidedId` | optional | `string` | Publisher-supplied identifier echoed back on the impression | `'ppid-123'` |
+
+## Test Parameters
+
+```javascript
+var adUnits = [
+    {
+        code: 'banner-ad-unit',
+        mediaTypes: {
+            banner: {
+                sizes: [[300, 250]]
+            }
+        },
+        bids: [{
+            bidder: 'ezoic',
+            params: {}
+        }]
+    }
+];
+```
+
+## User Syncing
+
+The adapter registers an iframe user sync (`https://g.ezoic.net/ezoic/prebid/adapter/usersync-frame`)
+that carries GDPR, GPP, and CCPA/USP consent as query parameters. Cookie storage and reads happen
+server-side inside the sync frame. Enable iframe syncing to allow it to run:
+
+```javascript
+pbjs.setConfig({
+    userSync: {
+        filterSettings: {
+            iframe: {
+                bidders: ['ezoic'],
+                filter: 'include'
+            }
+        }
+    }
+});
+```

--- a/modules/ezoicBidAdapter.md
+++ b/modules/ezoicBidAdapter.md
@@ -25,6 +25,20 @@ to the endpoint; omit them and the adapter still participates in the auction.
 | `bidfloor` | optional | `number` | Explicit CPM floor (USD unless `bidfloorcur` is set); takes precedence over the Prebid floors module | `0.50` |
 | `bidfloorcur` | optional | `string` | Currency of `bidfloor` | `'USD'` |
 | `publisherProvidedId` | optional | `string` | Publisher-supplied identifier echoed back on the impression | `'ppid-123'` |
+| `adPositionType` | optional | `number` | Ezoic ad position type; optional placement context for Ezoic-managed integrations | `5` |
+| `adPositionId` | optional | `number` | Ezoic ad position identifier | `1100` |
+| `subAdPositionId` | optional | `number` | Ezoic sub-ad-position identifier | `42` |
+| `impressionId` | optional | `string` | Client impression identifier echoed on the request | `'client-impression-1'` |
+| `tap` | optional | `string` | Tap / slot targeting string for placement reporting | `'content-slot-1'` |
+| `googlePageTargeting` | optional | `object` | GPT page-level targeting key/value map forwarded as placement context | `{ AU_SEG: ['test'] }` |
+| `floor` | optional | `number` | Alias of `bidfloor` | `0.50` |
+| Aliases | optional | various | `placement_type` / `pt` alias `placementType`; `impression_id` aliases `impressionId` | `pt: 'display'` |
+
+## Outstream Video
+
+Outstream video is supported only when the publisher supplies a renderer on the ad
+unit, bid request, or `mediaTypes.video` (Prebid core requires a renderer for
+outstream playback). Instream video is unaffected.
 
 ## Test Parameters
 

--- a/test/spec/modules/ezoicBidAdapter_spec.js
+++ b/test/spec/modules/ezoicBidAdapter_spec.js
@@ -111,6 +111,56 @@ function getNativeBidRequest(overrides = {}) {
   });
 }
 
+function getMultiformatBidRequest(overrides = {}) {
+  return getBidRequest({
+    sizes: [[300, 250]],
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]]
+      },
+      video: {
+        context: 'instream',
+        playerSize: [[640, 360]],
+        mimes: ['video/mp4'],
+        protocols: [2, 3],
+      }
+    },
+    ...overrides
+  });
+}
+
+function getOutstreamBidRequest(overrides = {}) {
+  return getVideoBidRequest({
+    mediaTypes: {
+      video: {
+        context: 'outstream',
+        playerSize: [[640, 360]],
+        plcmt: 3
+      }
+    },
+    ortb2Imp: {
+      video: {
+        plcmt: 3,
+        w: 640,
+        h: 360
+      }
+    },
+    ...overrides
+  });
+}
+
+function getOutstreamVastResponse(overrides = {}) {
+  return {
+    requestId: BID_ID,
+    cpm: 3.21,
+    currency: 'USD',
+    creativeId: 'creative-video',
+    mediaType: 'video',
+    vastUrl: 'https://vastproxy.ezoic.net/vastadapter/signed-video-token',
+    ...overrides
+  };
+}
+
 function getBidderRequest(overrides = {}) {
   return {
     auctionId: 'auction-1',
@@ -261,6 +311,48 @@ describe('Ezoic adapter', function () {
       expect(firstPayload.ezoic.pageviewIdSource).to.equal('adapter_generated');
       expect(firstPayload.ezoic.pageviewEpoch).to.equal(1714752000);
       expect(secondPayload.ezoic.pageviewEpoch).to.equal(1714752000);
+    });
+
+    it('prefers core pageViewId and refreshes epoch when it changes', function () {
+      sinon.stub(Date, 'now').returns(1714752000000);
+
+      const firstRequest = spec.buildRequests([getBidRequest()], getBidderRequest({
+        pageViewId: 'core-pageview-1'
+      }));
+      const secondRequest = spec.buildRequests([getBidRequest({ bidId: 'ezoic-bid-2' })], getBidderRequest({
+        pageViewId: 'core-pageview-1'
+      }));
+      const firstPayload = JSON.parse(firstRequest.data);
+      const secondPayload = JSON.parse(secondRequest.data);
+
+      expect(firstPayload.ezoic.pageviewId).to.equal('core-pageview-1');
+      expect(firstPayload.ezoic.pageviewIdSource).to.equal('prebid_core');
+      expect(firstPayload.ezoic.pageviewEpoch).to.equal(1714752000);
+      expect(secondPayload.ezoic.pageviewId).to.equal('core-pageview-1');
+      expect(secondPayload.ezoic.pageviewEpoch).to.equal(1714752000);
+
+      sinon.restore();
+      sinon.stub(Date, 'now').returns(1714752600000);
+
+      const thirdRequest = spec.buildRequests([getBidRequest({ bidId: 'ezoic-bid-3' })], getBidderRequest({
+        pageViewId: 'core-pageview-2'
+      }));
+      const thirdPayload = JSON.parse(thirdRequest.data);
+
+      expect(thirdPayload.ezoic.pageviewId).to.equal('core-pageview-2');
+      expect(thirdPayload.ezoic.pageviewIdSource).to.equal('prebid_core');
+      expect(thirdPayload.ezoic.pageviewEpoch).to.equal(1714752600);
+    });
+
+    it('falls back to adapter-generated pageview metadata when core omits pageViewId', function () {
+      sinon.stub(Date, 'now').returns(1714752000000);
+
+      const request = spec.buildRequests([getBidRequest()], getBidderRequest());
+      const payload = JSON.parse(request.data);
+
+      expect(payload.ezoic.pageviewId).to.match(UUID_V4_REGEX);
+      expect(payload.ezoic.pageviewIdSource).to.equal('adapter_generated');
+      expect(payload.ezoic.pageviewEpoch).to.equal(1714752000);
     });
 
     it('passes a single banner size to getFloor', function () {
@@ -526,36 +618,20 @@ describe('Ezoic adapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('normalizes outstream VAST URL responses into Prebid video bids', function () {
+    it('normalizes outstream VAST URL responses when a publisher renderer is present', function () {
       const result = spec.interpretResponse({
         body: {
-          bids: [{
-            requestId: BID_ID,
-            cpm: 3.21,
-            currency: 'USD',
+          bids: [getOutstreamVastResponse({
             width: 640,
             height: 360,
-            creativeId: 'creative-video',
-            mediaType: 'video',
-            vastUrl: 'https://vastproxy.ezoic.net/vastadapter/signed-video-token'
-          }]
+          })]
         }
       }, {
         bidderRequest: {
-          bids: [getVideoBidRequest({
-            mediaTypes: {
-              video: {
-                context: 'outstream',
-                playerSize: [[640, 360]],
-                plcmt: 3
-              }
-            },
-            ortb2Imp: {
-              video: {
-                plcmt: 3,
-                w: 640,
-                h: 360
-              }
+          bids: [getOutstreamBidRequest({
+            renderer: {
+              url: 'https://example.com/outstream.js',
+              render: () => {},
             }
           })]
         }
@@ -573,6 +649,127 @@ describe('Ezoic adapter', function () {
         vastUrl: 'https://vastproxy.ezoic.net/vastadapter/signed-video-token'
       });
       expect(result[0].ad).to.equal(undefined);
+    });
+
+    it('drops outstream video bids when no publisher renderer is present', function () {
+      const result = spec.interpretResponse({
+        body: {
+          bids: [getOutstreamVastResponse({
+            width: 640,
+            height: 360,
+          })]
+        }
+      }, {
+        bidderRequest: {
+          bids: [getOutstreamBidRequest()]
+        }
+      });
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('keeps outstream video bids when mediaTypes.video defines a renderer', function () {
+      const result = spec.interpretResponse({
+        body: {
+          bids: [getOutstreamVastResponse({
+            width: 640,
+            height: 360,
+          })]
+        }
+      }, {
+        bidderRequest: {
+          bids: [getOutstreamBidRequest({
+            mediaTypes: {
+              video: {
+                context: 'outstream',
+                playerSize: [[640, 360]],
+                plcmt: 3,
+                renderer: {
+                  url: 'https://example.com/outstream.js',
+                  render: () => {},
+                }
+              }
+            }
+          })]
+        }
+      });
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].mediaType).to.equal('video');
+    });
+
+    it('drops bids with non-numeric or negative cpm values', function () {
+      const request = {
+        bidderRequest: {
+          bids: [getBidRequest()]
+        }
+      };
+      const baseBid = {
+        requestId: BID_ID,
+        currency: 'USD',
+        width: 300,
+        height: 250,
+        creativeId: 'creative-1',
+        ad: '<div>ad</div>',
+      };
+
+      expect(spec.interpretResponse({
+        body: { bids: [{ ...baseBid, cpm: 'not-a-number' }] }
+      }, request)).to.deep.equal([]);
+
+      expect(spec.interpretResponse({
+        body: { bids: [{ ...baseBid, cpm: -0.01 }] }
+      }, request)).to.deep.equal([]);
+
+      expect(spec.interpretResponse({
+        body: { bids: [{ ...baseBid, cpm: 0 }] }
+      }, request)).to.have.lengthOf(1);
+    });
+
+    it('uses video playerSize for multiformat video bids missing width and height', function () {
+      const result = spec.interpretResponse({
+        body: {
+          bids: [{
+            requestId: BID_ID,
+            cpm: 2.5,
+            currency: 'USD',
+            creativeId: 'creative-video',
+            mediaType: 'video',
+            vastUrl: 'https://vastproxy.ezoic.net/vastadapter/signed-video-token'
+          }]
+        }
+      }, {
+        bidderRequest: {
+          bids: [getMultiformatBidRequest()]
+        }
+      });
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].width).to.equal(640);
+      expect(result[0].height).to.equal(360);
+    });
+
+    it('uses banner size for multiformat banner bids missing width and height', function () {
+      const result = spec.interpretResponse({
+        body: {
+          bids: [{
+            requestId: BID_ID,
+            cpm: 1.5,
+            currency: 'USD',
+            creativeId: 'creative-banner',
+            ad: '<div>ad</div>'
+          }]
+        }
+      }, {
+        bidderRequest: {
+          bids: [getMultiformatBidRequest()]
+        }
+      });
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].width).to.equal(300);
+      expect(result[0].height).to.equal(250);
+      expect(result[0].mediaType).to.equal('banner');
     });
 
     it('normalizes native ORTB responses into Prebid native bids', function () {

--- a/test/spec/modules/ezoicBidAdapter_spec.js
+++ b/test/spec/modules/ezoicBidAdapter_spec.js
@@ -618,7 +618,10 @@ describe('Ezoic adapter', function () {
       expect(result).to.deep.equal([]);
     });
 
-    it('normalizes outstream VAST URL responses when a publisher renderer is present', function () {
+    it('normalizes outstream VAST URL responses (setup validation is left to core)', function () {
+      // No renderer here on purpose: core's checkVideoBidSetup owns
+      // outstream setup validation (renderer vs useCacheKey/cache config),
+      // so the adapter returns the bid regardless.
       const result = spec.interpretResponse({
         body: {
           bids: [getOutstreamVastResponse({
@@ -628,12 +631,7 @@ describe('Ezoic adapter', function () {
         }
       }, {
         bidderRequest: {
-          bids: [getOutstreamBidRequest({
-            renderer: {
-              url: 'https://example.com/outstream.js',
-              render: () => {},
-            }
-          })]
+          bids: [getOutstreamBidRequest()]
         }
       });
 
@@ -649,53 +647,6 @@ describe('Ezoic adapter', function () {
         vastUrl: 'https://vastproxy.ezoic.net/vastadapter/signed-video-token'
       });
       expect(result[0].ad).to.equal(undefined);
-    });
-
-    it('drops outstream video bids when no publisher renderer is present', function () {
-      const result = spec.interpretResponse({
-        body: {
-          bids: [getOutstreamVastResponse({
-            width: 640,
-            height: 360,
-          })]
-        }
-      }, {
-        bidderRequest: {
-          bids: [getOutstreamBidRequest()]
-        }
-      });
-
-      expect(result).to.deep.equal([]);
-    });
-
-    it('keeps outstream video bids when mediaTypes.video defines a renderer', function () {
-      const result = spec.interpretResponse({
-        body: {
-          bids: [getOutstreamVastResponse({
-            width: 640,
-            height: 360,
-          })]
-        }
-      }, {
-        bidderRequest: {
-          bids: [getOutstreamBidRequest({
-            mediaTypes: {
-              video: {
-                context: 'outstream',
-                playerSize: [[640, 360]],
-                plcmt: 3,
-                renderer: {
-                  url: 'https://example.com/outstream.js',
-                  render: () => {},
-                }
-              }
-            }
-          })]
-        }
-      });
-
-      expect(result).to.have.lengthOf(1);
-      expect(result[0].mediaType).to.equal('video');
     });
 
     it('drops bids with non-numeric or negative cpm values', function () {

--- a/test/spec/modules/ezoicBidAdapter_spec.js
+++ b/test/spec/modules/ezoicBidAdapter_spec.js
@@ -1,0 +1,795 @@
+import { expect } from 'chai';
+import { spec } from 'modules/ezoicBidAdapter.js';
+import { resetWinDimensions } from 'src/utils.js';
+
+const ENDPOINT = 'https://g.ezoic.net/ezoic/prebid/adapter';
+const SYNC_URL = 'https://g.ezoic.net/ezoic/prebid/adapter/usersync-frame';
+const BID_ID = 'ezoic-bid-1';
+const AD_UNIT_CODE = 'div-gpt-ad-content-1';
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+function getBidRequest(overrides = {}) {
+  return {
+    bidder: 'ezoic',
+    params: {
+      domainId: 123,
+      placementType: 'display',
+      adPositionType: 5,
+      placementId: 987,
+      renderUrl: 'https://g.ezoic.net/render',
+    },
+    adUnitCode: AD_UNIT_CODE,
+    sizes: [[300, 250]],
+    bidId: BID_ID,
+    bidderRequestId: 'bidder-request-1',
+    auctionId: 'auction-1',
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]]
+      }
+    },
+    ...overrides
+  };
+}
+
+function getVideoBidRequest(overrides = {}) {
+  return getBidRequest({
+    params: {
+      placementType: 'video',
+      adPositionType: 15,
+      adPositionId: 2200,
+    },
+    sizes: undefined,
+    mediaTypes: {
+      video: {
+        context: 'instream',
+        playerSize: [[640, 360]],
+        plcmt: 1,
+        mimes: ['video/mp4'],
+        protocols: [2, 3],
+        api: [7],
+        playbackmethod: [1],
+        minduration: 5,
+        maxduration: 30
+      }
+    },
+    ortb2Imp: {
+      video: {
+        plcmt: 1,
+        w: 640,
+        h: 360
+      },
+      ext: {
+        data: {
+          pos: 'preroll'
+        }
+      }
+    },
+    ...overrides
+  });
+}
+
+function getNativeBidRequest(overrides = {}) {
+  return getBidRequest({
+    params: {
+      placementType: 'native',
+      adPositionType: 5,
+      adPositionId: 3300,
+    },
+    sizes: undefined,
+    mediaTypes: {
+      native: {
+        ortb: {
+          ver: '1.2',
+          assets: [{
+            id: 1,
+            required: 1,
+            title: { len: 90 }
+          }, {
+            id: 2,
+            required: 1,
+            img: { type: 3, wmin: 300, hmin: 250 }
+          }],
+          eventtrackers: [{ event: 1, methods: [1, 2] }]
+        }
+      }
+    },
+    ortb2Imp: {
+      native: {
+        request: JSON.stringify({
+          ver: '1.2',
+          assets: [{ id: 1, required: 1, title: { len: 90 } }]
+        })
+      },
+      ext: {
+        data: {
+          pos: 'native-feed'
+        }
+      }
+    },
+    ...overrides
+  });
+}
+
+function getBidderRequest(overrides = {}) {
+  return {
+    auctionId: 'auction-1',
+    bidderRequestId: 'bidder-request-1',
+    timeout: 750,
+    refererInfo: {
+      page: 'https://example.com/article'
+    },
+    gdprConsent: {
+      gdprApplies: false
+    },
+    uspConsent: '1---',
+    gppConsent: {
+      gppString: 'GPP_STRING',
+      applicableSections: [7]
+    },
+    ortb2: {
+      site: {
+        domain: 'example.com',
+        page: 'https://example.com/article'
+      }
+    },
+    ...overrides
+  };
+}
+
+describe('Ezoic adapter', function () {
+  afterEach(function () {
+    // The adapter caches a generated pageview id/epoch on window for the
+    // life of the page; reset it between tests so each test starts fresh.
+    delete window.__ezoicPrebidAdapter;
+    sinon.restore();
+    resetWinDimensions();
+  });
+
+  it('declares Ezoic Inc GVL vendor id for Prebid TCF enforcement', function () {
+    expect(spec.gvlid).to.equal(347);
+  });
+
+  it('declares banner, video, and native support', function () {
+    expect(spec.supportedMediaTypes).to.include('banner');
+    expect(spec.supportedMediaTypes).to.include('video');
+    expect(spec.supportedMediaTypes).to.include('native');
+  });
+
+  describe('isBidRequestValid', function () {
+    it('returns true for a bid request with no params', function () {
+      expect(spec.isBidRequestValid(getBidRequest({ params: {} }))).to.equal(true);
+    });
+
+    it('returns true for a banner request with params', function () {
+      expect(spec.isBidRequestValid(getBidRequest())).to.equal(true);
+    });
+
+    it('returns true regardless of bid shape', function () {
+      expect(spec.isBidRequestValid({})).to.equal(true);
+    });
+  });
+
+  describe('buildRequests', function () {
+    it('posts Prebid and ORTB metadata to the fixed adapter endpoint', function () {
+      // Karma runs specs inside an iframe, so `window.top` (what
+      // getWinDimensions actually reads via canAccessWindowTop) is the outer
+      // browser window, not the local `window` binding.
+      sinon.stub(window.top, 'innerWidth').value(1280);
+      resetWinDimensions();
+      const bidderRequest = getBidderRequest({
+        ortb2: {
+          site: {
+            domain: 'example.com',
+            page: 'https://example.com/article',
+            cat: ['IAB13']
+          },
+          device: {
+            geo: {
+              country: 'CA'
+            }
+          },
+          user: {
+            ext: {
+              eids: [{ source: 'pubcid.org', uids: [{ id: 'pubcid-1', atype: 1 }] }]
+            }
+          }
+        }
+      });
+      const request = spec.buildRequests([getBidRequest({
+        params: {
+          ...getBidRequest().params,
+          impressionId: 'client-impression-1',
+          tap: 'content-slot-client-impression-1',
+          adPositionId: 1100,
+          publisherProvidedId: 'ppid-from-client',
+          googlePageTargeting: {
+            AU_SEG: ['AU_SEG_TEST'],
+            'li-module-enabled': 't1-e1'
+          }
+        }
+      })], bidderRequest);
+
+      expect(request.method).to.equal('POST');
+      expect(request.url).to.equal(ENDPOINT);
+      expect(request.options.contentType).to.equal('application/json');
+      expect(request.options.withCredentials).to.equal(true);
+
+      const payload = JSON.parse(request.data);
+      expect(payload.auctionId).to.equal('auction-1');
+      expect(payload.timeout).to.equal(750);
+      expect(payload.page.url).to.equal('https://example.com/article');
+      expect(payload.ortb2.site.cat).to.deep.equal(['IAB13']);
+      expect(payload.ortb2.device.geo.country).to.equal('CA');
+      expect(payload.ortb2.user.ext.eids[0].source).to.equal('pubcid.org');
+      expect(payload.gdprConsent).to.deep.equal(bidderRequest.gdprConsent);
+      expect(payload.uspConsent).to.equal(bidderRequest.uspConsent);
+      expect(payload.gppConsent).to.deep.equal(bidderRequest.gppConsent);
+      expect(payload.ezoic.formFactorId).to.equal(1);
+      expect(payload.ezoic.country).to.equal('CA');
+      expect(payload).to.not.have.property('buyeruids');
+      expect(payload.imps).to.have.lengthOf(1);
+      expect(payload.imps[0].requestId).to.equal(BID_ID);
+      expect(payload.imps[0].adUnitCode).to.equal(AD_UNIT_CODE);
+      expect(payload.imps[0].sizes[0]).to.deep.equal([300, 250]);
+      expect(payload.imps[0].params).to.deep.equal({
+        placementType: 'display',
+        adPositionType: 5,
+        impressionId: 'client-impression-1',
+        tap: 'content-slot-client-impression-1',
+        adPositionId: 1100,
+        publisherProvidedId: 'ppid-from-client',
+        googlePageTargeting: {
+          AU_SEG: ['AU_SEG_TEST'],
+          'li-module-enabled': 't1-e1'
+        }
+      });
+      expect(payload.imps[0].impressionId).to.equal('client-impression-1');
+    });
+
+    it('generates and reuses adapter pageview metadata across auctions', function () {
+      sinon.stub(Date, 'now').returns(1714752000000);
+
+      const firstRequest = spec.buildRequests([getBidRequest()], getBidderRequest());
+      const secondRequest = spec.buildRequests([getBidRequest({ bidId: 'ezoic-bid-2' })], getBidderRequest());
+      const firstPayload = JSON.parse(firstRequest.data);
+      const secondPayload = JSON.parse(secondRequest.data);
+
+      expect(firstPayload.ezoic.pageviewId).to.be.a('string').and.not.equal('');
+      expect(firstPayload.ezoic.pageviewId).to.match(UUID_V4_REGEX);
+      expect(firstPayload.ezoic.pageviewId).to.equal(secondPayload.ezoic.pageviewId);
+      expect(firstPayload.ezoic.pageviewIdSource).to.equal('adapter_generated');
+      expect(firstPayload.ezoic.pageviewEpoch).to.equal(1714752000);
+      expect(secondPayload.ezoic.pageviewEpoch).to.equal(1714752000);
+    });
+
+    it('passes a single banner size to getFloor', function () {
+      const getFloor = sinon.stub().returns({ currency: 'USD', floor: 0.75 });
+      const request = spec.buildRequests([getBidRequest({ getFloor })], getBidderRequest());
+      const payload = JSON.parse(request.data);
+
+      expect(getFloor.calledOnce).to.equal(true);
+      expect(getFloor.firstCall.args[0]).to.deep.equal({
+        currency: 'USD',
+        mediaType: 'banner',
+        size: [300, 250]
+      });
+      expect(payload.imps[0].floor).to.equal(0.75);
+    });
+
+    it('posts video media type details and asks Prebid floors for video size', function () {
+      const getFloor = sinon.stub().returns({ currency: 'USD', floor: 1.25 });
+      const bid = getVideoBidRequest({ getFloor });
+
+      const request = spec.buildRequests([bid], getBidderRequest());
+      const payload = JSON.parse(request.data);
+
+      expect(getFloor.calledOnce).to.equal(true);
+      expect(getFloor.firstCall.args[0]).to.deep.equal({
+        currency: 'USD',
+        mediaType: 'video',
+        size: [640, 360]
+      });
+      expect(payload.imps[0].sizes).to.deep.equal([]);
+      expect(payload.imps[0].mediaTypes).to.deep.equal({
+        video: bid.mediaTypes.video
+      });
+      expect(payload.imps[0].floor).to.equal(1.25);
+      expect(payload.imps[0].ortb2Imp.video.plcmt).to.equal(1);
+    });
+
+    it('posts native media type details and asks Prebid floors for native', function () {
+      const getFloor = sinon.stub().returns({ currency: 'USD', floor: 0.95 });
+      const bid = getNativeBidRequest({ getFloor });
+
+      const request = spec.buildRequests([bid], getBidderRequest());
+      const payload = JSON.parse(request.data);
+
+      expect(getFloor.calledOnce).to.equal(true);
+      expect(getFloor.firstCall.args[0]).to.deep.equal({
+        currency: 'USD',
+        mediaType: 'native',
+        size: '*'
+      });
+      expect(payload.imps[0].sizes).to.deep.equal([]);
+      expect(payload.imps[0].mediaTypes).to.deep.equal({
+        native: bid.mediaTypes.native
+      });
+      expect(payload.imps[0].floor).to.equal(0.95);
+      expect(payload.imps[0].ortb2Imp.native.request).to.be.a('string');
+    });
+
+    it('prefers explicit adapter floor params over Prebid floor module output', function () {
+      const getFloor = sinon.stub().returns({ currency: 'USD', floor: 5.15 });
+      const request = spec.buildRequests([getBidRequest({
+        getFloor,
+        params: {
+          ...getBidRequest().params,
+          floor: 0.4,
+          bidfloor: 0.4,
+          bidfloorcur: 'USD'
+        }
+      })], getBidderRequest());
+      const payload = JSON.parse(request.data);
+
+      expect(payload.imps[0].params.floor).to.equal(0.4);
+      expect(payload.imps[0].params.bidfloor).to.equal(0.4);
+      expect(payload.imps[0].floor).to.equal(0.4);
+      expect(getFloor.called).to.equal(false);
+    });
+
+    it('returns undefined when there are no valid bid requests', function () {
+      expect(spec.buildRequests([], getBidderRequest())).to.equal(undefined);
+    });
+
+    it('attaches the validBidRequests as bidderRequest.bids on the built request', function () {
+      const bid = getBidRequest();
+      const request = spec.buildRequests([bid], getBidderRequest());
+
+      expect(request.bidderRequest.bids).to.deep.equal([bid]);
+    });
+  });
+
+  describe('interpretResponse', function () {
+    it('returns no bids for an explicit no-bid response', function () {
+      const result = spec.interpretResponse({ body: { nobid: true } }, {
+        bidderRequest: {
+          bids: [getBidRequest()]
+        }
+      });
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('returns no bids when the response body is empty', function () {
+      const result = spec.interpretResponse({}, {
+        bidderRequest: {
+          bids: [getBidRequest()]
+        }
+      });
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('normalizes a bid into a Prebid banner bid response', function () {
+      const result = spec.interpretResponse({
+        body: {
+          bids: [{
+            requestId: BID_ID,
+            cpm: 1.23,
+            currency: 'USD',
+            width: 300,
+            height: 250,
+            creativeId: 'creative-1',
+            ad: '<div>ad</div>',
+            dealId: 'deal-1',
+            meta: {
+              advertiserDomains: ['advertiser.example']
+            },
+            ttl: 120,
+            netRevenue: true,
+            nurl: 'https://g.ezoic.net/win',
+          }]
+        }
+      }, {
+        bidderRequest: {
+          bids: [getBidRequest()]
+        }
+      });
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0]).to.include({
+        requestId: BID_ID,
+        cpm: 1.23,
+        currency: 'USD',
+        width: 300,
+        height: 250,
+        creativeId: 'creative-1',
+        ad: '<div>ad</div>',
+        dealId: 'deal-1',
+        ttl: 120,
+        netRevenue: true,
+        mediaType: 'banner',
+      });
+      expect(result[0].nurl).to.be.undefined;
+      expect(result[0].meta.advertiserDomains).to.deep.equal(['advertiser.example']);
+    });
+
+    it('defaults meta.advertiserDomains to an empty array when the server omits meta', function () {
+      const result = spec.interpretResponse({
+        body: {
+          bids: [{
+            requestId: BID_ID,
+            cpm: 1.23,
+            currency: 'USD',
+            width: 300,
+            height: 250,
+            creativeId: 'creative-1',
+            ad: '<div>ad</div>',
+          }]
+        }
+      }, {
+        bidderRequest: {
+          bids: [getBidRequest()]
+        }
+      });
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].meta).to.deep.equal({ advertiserDomains: [] });
+    });
+
+    it('defaults meta.advertiserDomains to an empty array when the server sends meta without it', function () {
+      const result = spec.interpretResponse({
+        body: {
+          bids: [{
+            requestId: BID_ID,
+            cpm: 1.23,
+            currency: 'USD',
+            width: 300,
+            height: 250,
+            creativeId: 'creative-1',
+            ad: '<div>ad</div>',
+            meta: {
+              mediaType: 'banner'
+            },
+          }]
+        }
+      }, {
+        bidderRequest: {
+          bids: [getBidRequest()]
+        }
+      });
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].meta).to.deep.equal({ mediaType: 'banner', advertiserDomains: [] });
+    });
+
+    it('normalizes explicit video VAST responses into Prebid video bids', function () {
+      const result = spec.interpretResponse({
+        body: {
+          bids: [{
+            requestId: BID_ID,
+            cpm: 3.21,
+            currency: 'USD',
+            width: 640,
+            height: 360,
+            creativeId: 'creative-video',
+            mediaType: 'video',
+            vastUrl: 'https://vastproxy.ezoic.net/vastadapter/signed-video-token',
+            ttl: 120,
+            netRevenue: true,
+          }]
+        }
+      }, {
+        bidderRequest: {
+          bids: [getVideoBidRequest()]
+        }
+      });
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0]).to.include({
+        requestId: BID_ID,
+        cpm: 3.21,
+        currency: 'USD',
+        width: 640,
+        height: 360,
+        creativeId: 'creative-video',
+        mediaType: 'video',
+        vastUrl: 'https://vastproxy.ezoic.net/vastadapter/signed-video-token',
+        ttl: 120,
+        netRevenue: true,
+      });
+      expect(result[0].ad).to.equal(undefined);
+    });
+
+    it('drops explicit video responses for banner-only requests', function () {
+      const result = spec.interpretResponse({
+        body: {
+          bids: [{
+            requestId: BID_ID,
+            cpm: 3.21,
+            currency: 'USD',
+            width: 640,
+            height: 360,
+            creativeId: 'creative-video',
+            mediaType: 'video',
+            vastUrl: 'https://vastproxy.ezoic.net/vastadapter/signed-video-token',
+            ad: '<div>video fallback markup</div>'
+          }]
+        }
+      }, {
+        bidderRequest: {
+          bids: [getBidRequest()]
+        }
+      });
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('normalizes outstream VAST URL responses into Prebid video bids', function () {
+      const result = spec.interpretResponse({
+        body: {
+          bids: [{
+            requestId: BID_ID,
+            cpm: 3.21,
+            currency: 'USD',
+            width: 640,
+            height: 360,
+            creativeId: 'creative-video',
+            mediaType: 'video',
+            vastUrl: 'https://vastproxy.ezoic.net/vastadapter/signed-video-token'
+          }]
+        }
+      }, {
+        bidderRequest: {
+          bids: [getVideoBidRequest({
+            mediaTypes: {
+              video: {
+                context: 'outstream',
+                playerSize: [[640, 360]],
+                plcmt: 3
+              }
+            },
+            ortb2Imp: {
+              video: {
+                plcmt: 3,
+                w: 640,
+                h: 360
+              }
+            }
+          })]
+        }
+      });
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0]).to.include({
+        requestId: BID_ID,
+        cpm: 3.21,
+        currency: 'USD',
+        width: 640,
+        height: 360,
+        creativeId: 'creative-video',
+        mediaType: 'video',
+        vastUrl: 'https://vastproxy.ezoic.net/vastadapter/signed-video-token'
+      });
+      expect(result[0].ad).to.equal(undefined);
+    });
+
+    it('normalizes native ORTB responses into Prebid native bids', function () {
+      const nativeResponse = {
+        ortb: {
+          link: {
+            url: 'https://advertiser.example/landing',
+            clicktrackers: ['https://tracker.example/click']
+          },
+          assets: [{
+            id: 1,
+            title: { text: 'Native title' }
+          }, {
+            id: 2,
+            img: { url: 'https://cdn.example/image.jpg', w: 300, h: 250 }
+          }],
+          eventtrackers: [{ event: 1, method: 1, url: 'https://tracker.example/imp' }]
+        }
+      };
+      const result = spec.interpretResponse({
+        body: {
+          bids: [{
+            requestId: BID_ID,
+            cpm: 2.34,
+            currency: 'USD',
+            creativeId: 'creative-native',
+            mediaType: 'native',
+            native: nativeResponse,
+            ttl: 120,
+            netRevenue: true,
+          }]
+        }
+      }, {
+        bidderRequest: {
+          bids: [getNativeBidRequest()]
+        }
+      });
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0]).to.include({
+        requestId: BID_ID,
+        cpm: 2.34,
+        currency: 'USD',
+        creativeId: 'creative-native',
+        mediaType: 'native',
+        ttl: 120,
+        netRevenue: true,
+      });
+      expect(result[0].native).to.deep.equal(nativeResponse);
+      expect(result[0].ad).to.equal(undefined);
+      expect(result[0].width).to.equal(undefined);
+      expect(result[0].height).to.equal(undefined);
+    });
+
+    it('drops native responses for banner-only requests', function () {
+      const result = spec.interpretResponse({
+        body: {
+          bids: [{
+            requestId: BID_ID,
+            cpm: 2.34,
+            currency: 'USD',
+            creativeId: 'creative-native',
+            mediaType: 'native',
+            native: {
+              ortb: {
+                link: { url: 'https://advertiser.example/landing' },
+                assets: [{ id: 1, title: { text: 'Native title' } }]
+              }
+            }
+          }]
+        }
+      }, {
+        bidderRequest: {
+          bids: [getBidRequest()]
+        }
+      });
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('drops bids that cannot be matched to an original request', function () {
+      const result = spec.interpretResponse({
+        body: {
+          bids: [{
+            requestId: 'unknown',
+            cpm: 1.23,
+            currency: 'USD',
+            width: 300,
+            height: 250,
+            creativeId: 'creative-1',
+            ad: '<div>ad</div>'
+          }]
+        }
+      }, {
+        bidderRequest: {
+          bids: [getBidRequest()]
+        }
+      });
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('drops bids missing required fields (cpm, creativeId)', function () {
+      const result = spec.interpretResponse({
+        body: {
+          bids: [{
+            requestId: BID_ID,
+            width: 300,
+            height: 250,
+            ad: '<div>ad</div>'
+          }]
+        }
+      }, {
+        bidderRequest: {
+          bids: [getBidRequest()]
+        }
+      });
+
+      expect(result).to.deep.equal([]);
+    });
+  });
+
+  describe('getUserSyncs', function () {
+    it('returns no syncs when iframe syncing is disabled', function () {
+      expect(spec.getUserSyncs({ iframeEnabled: false }, [])).to.deep.equal([]);
+    });
+
+    it('returns no syncs when syncOptions is missing', function () {
+      expect(spec.getUserSyncs(undefined, [])).to.deep.equal([]);
+    });
+
+    it('returns a single iframe sync at the fixed usersync-frame URL when iframe syncing is enabled', function () {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, []);
+
+      expect(syncs).to.have.lengthOf(1);
+      expect(syncs[0].type).to.equal('iframe');
+      expect(syncs[0].url.indexOf(SYNC_URL)).to.equal(0);
+    });
+
+    it('propagates GDPR consent onto the sync URL', function () {
+      const syncs = spec.getUserSyncs(
+        { iframeEnabled: true },
+        [],
+        { gdprApplies: true, consentString: 'CONSENT_STRING' }
+      );
+
+      const url = new URL(syncs[0].url);
+      expect(url.searchParams.get('gdpr')).to.equal('1');
+      expect(url.searchParams.get('gdpr_consent')).to.equal('CONSENT_STRING');
+    });
+
+    it('sends gdpr=0 and an empty gdpr_consent when GDPR does not apply or consent is missing', function () {
+      const syncs = spec.getUserSyncs(
+        { iframeEnabled: true },
+        [],
+        { gdprApplies: false }
+      );
+
+      const url = new URL(syncs[0].url);
+      expect(url.searchParams.get('gdpr')).to.equal('0');
+      expect(url.searchParams.get('gdpr_consent')).to.equal('');
+    });
+
+    it('sends gdpr=0 and empty consent when gdprConsent is not provided at all', function () {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, []);
+
+      const url = new URL(syncs[0].url);
+      expect(url.searchParams.get('gdpr')).to.equal('0');
+      expect(url.searchParams.get('gdpr_consent')).to.equal('');
+    });
+
+    it('propagates GPP consent onto the sync URL', function () {
+      const syncs = spec.getUserSyncs(
+        { iframeEnabled: true },
+        [],
+        undefined,
+        undefined,
+        { gppString: 'GPP_STRING', applicableSections: [7, 8] }
+      );
+
+      const url = new URL(syncs[0].url);
+      expect(url.searchParams.get('gpp')).to.equal('GPP_STRING');
+      expect(url.searchParams.get('gpp_sid')).to.equal('7,8');
+    });
+
+    it('sends empty gpp/gpp_sid when gppConsent is not provided', function () {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, []);
+
+      const url = new URL(syncs[0].url);
+      expect(url.searchParams.get('gpp')).to.equal('');
+      expect(url.searchParams.get('gpp_sid')).to.equal('');
+    });
+
+    it('propagates USP (CCPA) consent onto the sync URL', function () {
+      const syncs = spec.getUserSyncs(
+        { iframeEnabled: true },
+        [],
+        undefined,
+        '1YNN'
+      );
+
+      const url = new URL(syncs[0].url);
+      expect(url.searchParams.get('us_privacy')).to.equal('1YNN');
+    });
+
+    it('sends an empty us_privacy when uspConsent is not provided', function () {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, []);
+
+      const url = new URL(syncs[0].url);
+      expect(url.searchParams.get('us_privacy')).to.equal('');
+    });
+
+    it('does not include a redirect ("r") param', function () {
+      const syncs = spec.getUserSyncs({ iframeEnabled: true }, []);
+
+      const url = new URL(syncs[0].url);
+      expect(url.searchParams.has('r')).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
## Type of change

- [x] New bidder adapter

## Description of change

Adds the Ezoic bid adapter.

- Bidder code: `ezoic`, GVL ID 347
- Media types: banner, video, native
- No required bidder params — every ad unit routed to `ezoic` is a valid bid request; optional params pass placement context (see `modules/ezoicBidAdapter.md`)
- Iframe user sync carrying GDPR, GPP, and CCPA/USP consent as query parameters
- Unit tests: 36 specs covering request building (consent, floors, eids, media types), response interpretation (banner/video/native validation, advertiserDomains defaulting), and user syncs

Docs PR: https://github.com/prebid/prebid.github.io/pull/6614

- contact email of the adapter's maintainer: prebid@ezoic.com
- [x] official adapter submission
