### PR TITLE
adstir Bid Adapter: add priceFloors module support

### DIFF
--- a/modules/adstirBidAdapter.js
+++ b/modules/adstirBidAdapter.js
@@ -41,6 +41,7 @@ export const spec = {
           usp: (bidderRequest.uspConsent || '1---') !== '1---',
           eids: utils.deepAccess(r, 'userIdAsEids', []),
           schain: serializeSchain(utils.deepAccess(r, 'ortb2.source.ext.schain', null)),
+          floors: getBidFloor(r),
           pbVersion: '$prebid.version$',
         }),
       };
@@ -87,6 +88,29 @@ function serializeSchain(schain) {
 
 function encodeURIComponentForRFC3986(str) {
   return encodeURIComponent(str).replace(/[!'()*]/g, c => `%${c.charCodeAt(0).toString(16)}`);
+}
+
+function getBidFloor(bidRequest) {
+  if (!utils.isFn(bidRequest.getFloor)) {
+    return;
+  }
+  const floor = bidRequest.getFloor(
+    {
+      currency: 'JPY',
+      mediaType: BANNER,
+      size: '*',
+    }
+  );
+  if (utils.isPlainObject(floor) && !isNaN(floor.floor) && floor.currency === 'JPY') {
+    return {
+      [BANNER]: {
+        '*': {
+          cur: floor.currency,
+          floor: Math.ceil(floor.floor * 1000),
+        },
+      },
+    };
+  }
 }
 
 registerBidder(spec);

--- a/test/spec/modules/adstirBidAdapter_spec.js
+++ b/test/spec/modules/adstirBidAdapter_spec.js
@@ -366,6 +366,31 @@ describe('AdstirAdapter', function () {
         expect(d.sua).to.deep.equal(sua);
       });
     });
+
+    it('should add floors param if available', function () {
+      const bidRequest = utils.deepClone(validBidRequests[0]);
+
+      let [request] = spec.buildRequests([bidRequest], bidderRequest);
+      expect(JSON.parse(request.data).floors).to.not.exist;
+
+      bidRequest.getFloor = () => null;
+      [request] = spec.buildRequests([bidRequest], bidderRequest);
+      expect(JSON.parse(request.data).floors).to.not.exist;
+
+      bidRequest.getFloor = () => ({});
+      [request] = spec.buildRequests([bidRequest], bidderRequest);
+      expect(JSON.parse(request.data).floors).to.not.exist;
+
+      bidRequest.getFloor = () => ({ currency: 'USD', floor: 0.01 });
+      [request] = spec.buildRequests([bidRequest], bidderRequest);
+      expect(JSON.parse(request.data).floors).to.not.exist;
+
+      bidRequest.getFloor = () => ({ currency: 'JPY', floor: 7.5 });
+      [request] = spec.buildRequests([bidRequest], bidderRequest);
+      expect(JSON.parse(request.data).floors).to.deep.equal(
+        { 'banner': { '*': { cur: 'JPY', floor: 7500 } } }
+      );
+    });
   });
 
   describe('interpretResponse', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
- [x] Updated bidder adapter
## Description of change
Add priceFloors module support (JPY banner floors only) to the adstir bid adapter.


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
