### PR TITLE
Epom Ad Server Bid Adapter: new adapter

### DIFF
--- a/modules/epom_asBidAdapter.md
+++ b/modules/epom_asBidAdapter.md
@@ -31,27 +31,12 @@ Supported media types: `banner`.
 
 # Test Parameters
 
+A live placement that always fills, for verifying the adapter end to end:
+
 ```js
 const adUnits = [
   {
-    code: "leaderboard",
-    mediaTypes: {
-      banner: {
-        sizes: [[728, 90], [970, 250]]
-      }
-    },
-    bids: [
-      {
-        bidder: "epom_as",
-        params: {
-          host: "ads.example.com",
-          placementKey: "a4f21c9e7b"
-        }
-      }
-    ]
-  },
-  {
-    code: "sidebar",
+    code: "test-div",
     mediaTypes: {
       banner: {
         sizes: [[300, 250]]
@@ -61,12 +46,46 @@ const adUnits = [
       {
         bidder: "epom_as",
         params: {
-          host: "ads.example.com",
-          placementKey: "6d0e83b415",
-          bidFloor: 0.50
+          host: "aj2494.online",
+          placementKey: "63bad7a99f270394e7b4b370952cbff2"
         }
       }
     ]
+  }
+];
+```
+
+The optional parameters, on a deployment of your own. `host` is a bare hostname —
+the adapter posts to `https://{host}/hb/bid` — and every ad unit naming the same
+host travels in one request:
+
+```js
+const adUnits = [
+  {
+    code: "leaderboard",
+    mediaTypes: { banner: { sizes: [[728, 90], [970, 250]] } },
+    bids: [{
+      bidder: "epom_as",
+      params: {
+        host: "ads.example.com",
+        placementKey: "a4f21c9e7b",
+        channel: "sports-uk",
+        customParams: { section: "sport" }
+      }
+    }]
+  },
+  {
+    code: "sidebar",
+    mediaTypes: { banner: { sizes: [[300, 250]] } },
+    bids: [{
+      bidder: "epom_as",
+      params: {
+        host: "ads.example.com",
+        placementKey: "6d0e83b415",
+        bidFloor: 0.50,
+        bidFloorCur: "EUR"
+      }
+    }]
   }
 ];
 ```

--- a/modules/epom_asBidAdapter.md
+++ b/modules/epom_asBidAdapter.md
@@ -24,6 +24,8 @@ Supported media types: `banner`.
 |----------------|----------|-------------------------------------------------------------------------------------------------------------------------------|------------------------|----------|
 | `host`         | required | Serving host of the publisher's Epom deployment, as a bare hostname. The adapter POSTs to `https://{host}/hb/bid`.             | `"ads.example.com"`    | `string` |
 | `placementKey` | required | Placement identifier, copied from the placement's invocation-code tab in the Epom UI. Sent as `imp.tagid`.                     | `"a4f21c9e7b"`         | `string` |
+| `channel`      | optional | Epom channel — a publisher traffic-slice label used for channel targeting and reporting. Sent as `imp.ext.epom_as.channel`. | `"sports-uk"`        | `string` |
+| `customParams` | optional | Epom custom parameters, for custom targeting and creative macros. Merged into `imp.ext.data`. Scalar values only; at most 32 keys, keys up to 128 and values up to 512 characters. | `{section: 'sport'}` | `object` |
 | `bidFloor`     | optional | CPM floor for this impression. Applied only when the Price Floors module has not already resolved `imp.bidfloor`.              | `0.50`                 | `number` |
 | `bidFloorCur`  | optional | Currency of `bidFloor`. Defaults to `USD`.                                                                                    | `"EUR"`                | `string` |
 

--- a/modules/epom_asBidAdapter.md
+++ b/modules/epom_asBidAdapter.md
@@ -26,6 +26,22 @@ Which slot a placement can fill is decided on the ad server, by the placement's 
 Placement answers video impressions, a Native Placement native ones. A slot whose placement is of a
 different type than the ad unit declares is simply not filled.
 
+## Instream video needs a cache setting
+
+Prebid refuses an instream bid that carries only `vastXml` with no `cache` configured, and it does
+so before the bid reaches `bidsBackHandler` — so the ad server answers correctly and the slot still
+reports no bid, with the reason only in the console. Set one of:
+
+```js
+pbjs.setConfig({ cache: { allowVastXmlOnly: true } });  // player takes VAST as a string
+pbjs.setConfig({ cache: { useLocal: true } });          // player wants a URL, cached in the browser
+pbjs.setConfig({ cache: { url: '…' } });                // Prebid Cache — required for Google Ad Manager
+```
+
+`allowVastXmlOnly` is enough for a player that accepts a VAST document directly, which IMA and JW
+both do. A hosted Prebid Cache is only required when the ad server is rendered through Google Ad
+Manager, which builds its VAST tag around `hb_uuid`.
+
 The same parameters are accepted by the Prebid Server adapter, which posts to `https://{{.Host}}/hb/bid` on the host the PBS host company configures.
 
 ## Bid TTL

--- a/modules/epom_asBidAdapter.md
+++ b/modules/epom_asBidAdapter.md
@@ -16,7 +16,15 @@ Epom Ad Server is white-label: each network runs its own deployment on its own d
 
 All ad units on the page are auctioned in a **single request** with one `imp` per ad unit. The ad server resolves the page as a unit, so its roadblock and one-campaign-per-page rules require every slot to be decided together.
 
-Supported media types: `banner`.
+Supported media types: `banner`, `video`, `native`.
+
+The ad server names the format it filled on each bid's `mtype`, so a mixed ad unit is offered whole
+and answered with whichever the ad server had demand for. Video comes back as VAST in `adm`; native
+as an OpenRTB native response, with each asset carried under the id the page asked it under.
+
+Which slot a placement can fill is decided on the ad server, by the placement's own type — a Video
+Placement answers video impressions, a Native Placement native ones. A slot whose placement is of a
+different type than the ad unit declares is simply not filled.
 
 The same parameters are accepted by the Prebid Server adapter, which posts to `https://{{.Host}}/hb/bid` on the host the PBS host company configures.
 

--- a/modules/epom_asBidAdapter.md
+++ b/modules/epom_asBidAdapter.md
@@ -100,4 +100,4 @@ pbjs.addAdUnits([
 
 The adapter registers IAB TCF Global Vendor List ID **849** and relies on Prebid.js's standard consent plumbing via `ortbConverter`: GDPR (`regs.ext.gdpr`, `user.ext.consent`), US Privacy (`regs.ext.us_privacy`), GPP (`regs.gpp`, `regs.gpp_sid`) and COPPA (`regs.coppa`) are forwarded without bidder-specific configuration.
 
-The adapter sets `withCredentials: false`, so no cookies are sent to the ad server and no user syncs are performed.
+The adapter sets `withCredentials: true`, so an existing Epom identity on the ad-server domain reaches the auction. The ad server answers with the request origin rather than a wildcard.

--- a/modules/epom_asBidAdapter.md
+++ b/modules/epom_asBidAdapter.md
@@ -18,20 +18,40 @@ All ad units on the page are auctioned in a **single request** with one `imp` pe
 
 Supported media types: `banner`.
 
+The same parameters are accepted by the Prebid Server adapter, which posts to `https://{{.Host}}/hb/bid` on the host the PBS host company configures.
+
+## Bid TTL
+
+Bids default to a **25-second** TTL — short, because the ad server stops accepting a bid's impression beacon after that window, and a creative rendered from cache past it would serve without being counted. It is a default, not a ceiling: a deployment configured with a wider window says so per bid in `bid.exp`, which takes precedence.
+
+## Deals
+
+The ad server stamps `dealid` on the bids it returns for a deal-backed line item; the adapter surfaces it as `bid.dealId`, which Prebid exposes as the `hb_deal_epom_as` targeting key. A Google Ad Manager Sponsorship line item keyed on that value is the supported way to have an Epom direct bid outrank the rest of the stack rather than compete with it on price alone.
+
+## Advertiser domains
+
+Epom Ad Server does not currently populate `seatbid[].bid[].adomain`, so `bid.meta.advertiserDomains` is left unset rather than filled with a placeholder. Brand-safety line items and analytics that key on advertiser domain will not match Epom bids until the ad server starts sending it; the adapter forwards the field unchanged as soon as it does.
+
+## Device storage
+
+The adapter uses no storage manager and writes nothing to cookies or `localStorage`. It does send the request with credentials, so an Epom identity cookie previously set by the ad server on its own domain reaches the auction — the ad server answers with the request's own `Origin` rather than a wildcard. That cookie is disclosed in the device-storage disclosure published for IAB TCF Global Vendor List ID **849**, declared on the adapter as `disclosureURL`. There is no cross-domain user sync: `getUserSyncs` deliberately registers nothing.
+
 # Bid Parameters
 
 | Name           | Scope    | Description                                                                                                                   | Example                | Type     |
 |----------------|----------|-------------------------------------------------------------------------------------------------------------------------------|------------------------|----------|
-| `host`         | required | Serving host of the publisher's Epom deployment, as a bare hostname. The adapter POSTs to `https://{host}/hb/bid`.             | `"ads.example.com"`    | `string` |
-| `placementKey` | required | Placement identifier, copied from the placement's invocation-code tab in the Epom UI. Sent as `imp.tagid`.                     | `"a4f21c9e7b"`         | `string` |
-| `channel`      | optional | Epom channel — a publisher traffic-slice label used for channel targeting and reporting. Sent as `imp.ext.epom_as.channel`. | `"sports-uk"`        | `string` |
-| `customParams` | optional | Epom custom parameters, for custom targeting and creative macros. Merged into `imp.ext.data`. Scalar values only; at most 32 keys, keys up to 128 and values up to 512 characters. | `{section: 'sport'}` | `object` |
-| `bidFloor`     | optional | CPM floor for this impression. Applied only when the Price Floors module has not already resolved `imp.bidfloor`.              | `0.50`                 | `number` |
-| `bidFloorCur`  | optional | Currency of `bidFloor`. Defaults to `USD`.                                                                                    | `"EUR"`                | `string` |
+| `host`         | required | Serving host of the publisher's Epom Ad Server deployment, as a bare hostname with an optional port — no scheme, path or query. The adapter POSTs to `https://{host}/hb/bid`. | `'ads.example.com'`    | `string` |
+| `placementKey` | required | Placement identifier, copied from the placement's invocation-code tab in the Epom UI. Sent as `imp.tagid`.                     | `'a4f21c9e7b'`         | `string` |
+| `channel`      | optional | Epom channel — a publisher traffic-slice label used for channel targeting and reporting. Sent as `imp.ext.epom_as.channel`. An empty value is ignored. | `'sports-uk'`        | `string` |
+| `customParams` | optional | Epom custom parameters, for custom targeting and creative macros. Values must be strings, numbers or booleans; they are stringified and merged into `imp.ext.data`, where keys already on the impression win. The ad server applies its own ingest limits on top (at most 32 keys, keys to 128 and values to 512 characters) and ignores anything beyond them. | `{section: 'sport'}` | `object` |
+| `bidFloor`     | optional | CPM floor for this impression, applied only when no floor has already been resolved — a value from the Price Floors module always wins. `0` means no floor. | `0.50`                 | `number` |
+| `bidFloorCur`  | optional | Currency of `bidFloor`, as an ISO-4217 code. Defaults to `USD`.                                                                | `'EUR'`                | `string` |
+
+A bid whose parameters violate the table above is rejected by `isBidRequestValid` and never leaves the page — the same input the Prebid Server params schema rejects.
 
 # Test Parameters
 
-A live placement that always fills, for verifying the adapter end to end:
+A live placement on an Epom Ad Server demo deployment that always fills, for verifying the adapter end to end:
 
 ```js
 const adUnits = [
@@ -117,6 +137,6 @@ pbjs.addAdUnits([
 
 # Consent and Privacy
 
-The adapter registers IAB TCF Global Vendor List ID **849** and relies on Prebid.js's standard consent plumbing via `ortbConverter`: GDPR (`regs.ext.gdpr`, `user.ext.consent`), US Privacy (`regs.ext.us_privacy`), GPP (`regs.gpp`, `regs.gpp_sid`) and COPPA (`regs.coppa`) are forwarded without bidder-specific configuration.
+The adapter registers IAB TCF Global Vendor List ID **849** and relies on Prebid.js's standard consent plumbing via `ortbConverter`: GDPR (`regs.ext.gdpr`, `user.ext.consent`), US Privacy (`regs.ext.us_privacy`), GPP (`regs.gpp`, `regs.gpp_sid`) and COPPA (`regs.coppa`) are forwarded to the ad server unchanged, without bidder-specific configuration.
 
-The adapter sets `withCredentials: true`, so an existing Epom identity on the ad-server domain reaches the auction. The ad server answers with the request origin rather than a wildcard.
+First-party data set through `pbjs.setConfig({ortb2})`, `pbjs.setBidderConfig` and an ad unit's `ortb2Imp` is forwarded as-is, as are the EIDs written by the User ID modules (`user.ext.eids`).

--- a/modules/epom_asBidAdapter.md
+++ b/modules/epom_asBidAdapter.md
@@ -1,0 +1,101 @@
+# Overview
+
+```
+Module Name: Epom Ad Server Bidder Adapter
+Module Type: Bidder Adapter
+Maintainer: support@epom.com
+```
+
+# Description
+
+Prebid.js adapter for the **Epom Ad Server** — the sell-side product of the Epom platform, where a publisher's own direct-sold campaigns are booked and served.
+
+This is a different product from `epom_dsp`, which is the buy side. `epom_dsp` buys impressions on the open market; `epom_as` sells a publisher's own inventory.
+
+Epom Ad Server is white-label: each network runs its own deployment on its own domain, so the serving host is supplied per ad unit via `params.host`. Only the host is configurable — the request path is fixed by the adapter, so a page configuration cannot redirect the auction payload to an arbitrary URL. A page may mix several deployments; the adapter groups impressions by host and sends one request to each.
+
+All ad units on the page are auctioned in a **single request** with one `imp` per ad unit. The ad server resolves the page as a unit, so its roadblock and one-campaign-per-page rules require every slot to be decided together.
+
+Supported media types: `banner`.
+
+# Bid Parameters
+
+| Name           | Scope    | Description                                                                                                                   | Example                | Type     |
+|----------------|----------|-------------------------------------------------------------------------------------------------------------------------------|------------------------|----------|
+| `host`         | required | Serving host of the publisher's Epom deployment, as a bare hostname. The adapter POSTs to `https://{host}/hb/bid`.             | `"ads.example.com"`    | `string` |
+| `placementKey` | required | Placement identifier, copied from the placement's invocation-code tab in the Epom UI. Sent as `imp.tagid`.                     | `"a4f21c9e7b"`         | `string` |
+| `bidFloor`     | optional | CPM floor for this impression. Applied only when the Price Floors module has not already resolved `imp.bidfloor`.              | `0.50`                 | `number` |
+| `bidFloorCur`  | optional | Currency of `bidFloor`. Defaults to `USD`.                                                                                    | `"EUR"`                | `string` |
+
+# Test Parameters
+
+```js
+const adUnits = [
+  {
+    code: "leaderboard",
+    mediaTypes: {
+      banner: {
+        sizes: [[728, 90], [970, 250]]
+      }
+    },
+    bids: [
+      {
+        bidder: "epom_as",
+        params: {
+          host: "ads.example.com",
+          placementKey: "a4f21c9e7b"
+        }
+      }
+    ]
+  },
+  {
+    code: "sidebar",
+    mediaTypes: {
+      banner: {
+        sizes: [[300, 250]]
+      }
+    },
+    bids: [
+      {
+        bidder: "epom_as",
+        params: {
+          host: "ads.example.com",
+          placementKey: "6d0e83b415",
+          bidFloor: 0.50
+        }
+      }
+    ]
+  }
+];
+```
+
+# Multiple Deployments
+
+A publisher whose inventory is sold by two Epom networks can run both in the same auction. Each host receives its own request containing only the impressions addressed to it.
+
+```js
+pbjs.addAdUnits([
+  {
+    code: "slot-a",
+    mediaTypes: { banner: { sizes: [[300, 250]] } },
+    bids: [{
+      bidder: "epom_as",
+      params: { host: "ads.network-one.com", placementKey: "a4f21c9e7b" }
+    }]
+  },
+  {
+    code: "slot-b",
+    mediaTypes: { banner: { sizes: [[728, 90]] } },
+    bids: [{
+      bidder: "epom_as",
+      params: { host: "ads.network-two.com", placementKey: "6d0e83b415" }
+    }]
+  }
+]);
+```
+
+# Consent and Privacy
+
+The adapter registers IAB TCF Global Vendor List ID **849** and relies on Prebid.js's standard consent plumbing via `ortbConverter`: GDPR (`regs.ext.gdpr`, `user.ext.consent`), US Privacy (`regs.ext.us_privacy`), GPP (`regs.gpp`, `regs.gpp_sid`) and COPPA (`regs.coppa`) are forwarded without bidder-specific configuration.
+
+The adapter sets `withCredentials: false`, so no cookies are sent to the ad server and no user syncs are performed.

--- a/modules/epom_asBidAdapter.md
+++ b/modules/epom_asBidAdapter.md
@@ -75,7 +75,9 @@ A bid whose parameters violate the table above is rejected by `isBidRequestValid
 
 # Test Parameters
 
-A live placement on an Epom Ad Server demo deployment that always fills, for verifying the adapter end to end:
+Live placements on an Epom Ad Server demo deployment that always fill, one per media type, for
+verifying the adapter end to end. Each key is a placement of that type on the same host, since the ad
+server decides what a placement may answer from its own type.
 
 ```js
 const adUnits = [
@@ -95,9 +97,56 @@ const adUnits = [
         }
       }
     ]
+  },
+  {
+    code: "test-video",
+    mediaTypes: {
+      video: {
+        context: "instream",
+        playerSize: [[640, 480]],
+        mimes: ["video/mp4"],
+        protocols: [2, 3, 5, 6]
+      }
+    },
+    bids: [
+      {
+        bidder: "epom_as",
+        params: {
+          host: "aj2494.online",
+          placementKey: "7659fd47e17263ba6ae1de3c9e137c74"
+        }
+      }
+    ]
+  },
+  {
+    code: "test-native",
+    mediaTypes: {
+      native: {
+        ortb: {
+          assets: [
+            { id: 1, required: 1, title: { len: 90 } },
+            { id: 2, required: 1, img: { type: 3, w: 1200, h: 627 } },
+            { id: 3, required: 0, img: { type: 1, w: 128, h: 128 } },
+            { id: 4, required: 0, data: { type: 1, len: 50 } }
+          ]
+        }
+      }
+    },
+    bids: [
+      {
+        bidder: "epom_as",
+        params: {
+          host: "aj2494.online",
+          placementKey: "f4dd0f413d5c4f8d8c515f8a999e038f"
+        }
+      }
+    ]
   }
 ];
 ```
+
+The video unit needs one of the cache settings above, or Prebid discards the bid before it reaches
+`bidsBackHandler`.
 
 The optional parameters, on a deployment of your own. `host` is a bare hostname —
 the adapter posts to `https://{host}/hb/bid` — and every ad unit naming the same

--- a/modules/epom_asBidAdapter.ts
+++ b/modules/epom_asBidAdapter.ts
@@ -21,7 +21,12 @@ const BIDDER_CODE = 'epom_as';
 const GVLID = 849;
 const BID_PATH = '/hb/bid';
 const DEFAULT_CURRENCY = 'USD';
-const DEFAULT_TTL = 300;
+/**
+ * The ad server's impression beacon is only accepted within 30 s of the bid, so a bid cached
+ * longer than that renders without being counted. Five seconds are left for the beacon itself.
+ * A server that widens its window says so per bid in `bid.exp`, which overrides this.
+ */
+const DEFAULT_TTL = 25;
 
 /**
  * Hostname with an optional port — no scheme, no path, no query, no credentials, so a page

--- a/modules/epom_asBidAdapter.ts
+++ b/modules/epom_asBidAdapter.ts
@@ -186,10 +186,12 @@ export const spec: BidderSpec<typeof BIDDER_CODE> = {
       method: 'POST',
       url: `https://${host}${BID_PATH}`,
       data: converter.toORTB({ bidRequests: group, bidderRequest }),
-      // `text/plain` keeps this a simple cross-origin request, so the
-      // browser skips the CORS preflight — one round-trip inside the
-      // auction timeout instead of two. The body is still JSON.
-      options: { contentType: 'text/plain', withCredentials: false },
+      // `text/plain` keeps this a simple cross-origin request, so the browser
+      // skips the CORS preflight — one round-trip inside the auction timeout
+      // instead of two. The body is still JSON. Credentials are sent because
+      // the ad server answers with the request's own Origin, which is what
+      // lets an existing Epom identity reach the auction.
+      options: { contentType: 'text/plain', withCredentials: true },
     }));
   },
 

--- a/modules/epom_asBidAdapter.ts
+++ b/modules/epom_asBidAdapter.ts
@@ -1,7 +1,7 @@
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { type BidderSpec, registerBidder } from '../src/adapters/bidderFactory.js';
 import { type Bid } from '../src/bidfactory.js';
-import { BANNER } from '../src/mediaTypes.js';
+import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { deepSetValue, isPlainObject } from '../src/utils.js';
 
 /**
@@ -117,7 +117,10 @@ const converter = ortbConverter<typeof BIDDER_CODE>({
     netRevenue: true,
     ttl: DEFAULT_TTL,
     currency: DEFAULT_CURRENCY,
-    mediaType: BANNER,
+    // No mediaType here on purpose: pinning one makes the converter believe every
+    // response whatever the ad server sent. Left off, it reads `mtype` off the bid,
+    // which is the field the ad server sets per creative — and a bid that names no
+    // media type is discarded rather than rendered as the wrong one.
   },
 
   imp(buildImp, bidRequest, context) {
@@ -171,7 +174,7 @@ export const spec: BidderSpec<typeof BIDDER_CODE> = {
   // server on its own domain and only reaches the auction because the POST is
   // credentialed (see buildRequests).
   disclosureURL: 'https://epom.com/deviceStorage.json',
-  supportedMediaTypes: [BANNER],
+  supportedMediaTypes: [BANNER, VIDEO, NATIVE],
 
   /**
    * Only the bidder's own parameters are checked, and each check is the client-side

--- a/modules/epom_asBidAdapter.ts
+++ b/modules/epom_asBidAdapter.ts
@@ -23,8 +23,11 @@ const BID_PATH = '/hb/bid';
 const DEFAULT_CURRENCY = 'USD';
 const DEFAULT_TTL = 300;
 
-/** Hostnames only — no scheme, no path, no port, no credentials. */
-const HOST_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
+/**
+ * Hostname with an optional port — no scheme, no path, no query, no credentials, so a page
+ * configuration cannot redirect the payload. Matches the Prebid Server params schema exactly.
+ */
+const HOST_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+(:\d{1,5})?$/i;
 
 export type EpomAsBidParams = {
   /** Serving host of the publisher's Epom deployment, e.g. `ads.example.com`. */

--- a/modules/epom_asBidAdapter.ts
+++ b/modules/epom_asBidAdapter.ts
@@ -2,7 +2,7 @@ import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { type BidderSpec, registerBidder } from '../src/adapters/bidderFactory.js';
 import { type Bid } from '../src/bidfactory.js';
 import { BANNER } from '../src/mediaTypes.js';
-import { logWarn } from '../src/utils.js';
+import { deepSetValue, logWarn } from '../src/utils.js';
 
 /**
  * Prebid.js adapter for the Epom Ad Server — the supply side of the Epom
@@ -31,16 +31,56 @@ export type EpomAsBidParams = {
   host: string;
   /** Opaque placement identifier from the Epom invocation-code tab. */
   placementKey: string;
+  /** Epom channel — a traffic-slice label used for targeting and reporting. */
+  channel?: string;
+  /** Epom custom parameters, for custom targeting and creative macros. */
+  customParams?: Record<string, string | number | boolean>;
   /** Optional CPM floor, used only when the Price Floors module supplies none. */
   bidFloor?: number;
   /** Currency of `bidFloor`. Defaults to USD. */
   bidFloorCur?: string;
 };
 
+/** Mirrors the server-side ingest cap; oversized input is dropped rather than truncated. */
+const CUSTOM_PARAMS_MAX_KEYS = 32;
+const CUSTOM_PARAMS_MAX_KEY_LENGTH = 128;
+const CUSTOM_PARAMS_MAX_VALUE_LENGTH = 512;
+
 declare module '../src/adUnits' {
   interface BidderParams {
     [BIDDER_CODE]: EpomAsBidParams;
   }
+}
+
+/**
+ * Keep only scalar entries within the limits the ad server enforces on ingest, so a
+ * publisher sees the same set of parameters accepted here and applied there.
+ */
+function sanitiseCustomParams(
+  raw: EpomAsBidParams['customParams']
+): Record<string, string> | null {
+  if (!raw || typeof raw !== 'object') {
+    return null;
+  }
+  const out: Record<string, string> = {};
+  let kept = 0;
+  Object.keys(raw).forEach((key) => {
+    if (kept >= CUSTOM_PARAMS_MAX_KEYS || key.length > CUSTOM_PARAMS_MAX_KEY_LENGTH) {
+      return;
+    }
+    const value = raw[key];
+    const type = typeof value;
+    if (type !== 'string' && type !== 'number' && type !== 'boolean') {
+      return;
+    }
+    const asString = String(value);
+    if (asString.length > CUSTOM_PARAMS_MAX_VALUE_LENGTH) {
+      return;
+    }
+    out[key] = asString;
+    kept++;
+  });
+  return kept > 0 ? out : null;
 }
 
 const converter = ortbConverter<typeof BIDDER_CODE>({
@@ -65,6 +105,19 @@ const converter = ortbConverter<typeof BIDDER_CODE>({
     if (imp.bidfloor == null && params.bidFloor != null) {
       imp.bidfloor = Number(params.bidFloor);
       imp.bidfloorcur = params.bidFloorCur || DEFAULT_CURRENCY;
+    }
+
+    if (params.channel) {
+      deepSetValue(imp, `ext.${BIDDER_CODE}.channel`, String(params.channel));
+    }
+
+    // Custom parameters go to imp.ext.data, the standard first-party-data home, so
+    // that RTD modules and gptPreAuction contribute to the same object rather than
+    // to a private one the ad server would have to read twice.
+    const custom = sanitiseCustomParams(params.customParams);
+    if (custom) {
+      imp.ext = imp.ext || {};
+      imp.ext.data = { ...custom, ...(imp.ext.data as object) };
     }
 
     return imp;

--- a/modules/epom_asBidAdapter.ts
+++ b/modules/epom_asBidAdapter.ts
@@ -116,31 +116,25 @@ export const spec: BidderSpec<typeof BIDDER_CODE> = {
       return [];
     }
 
-    const byHost = new Map<string, typeof validBidRequests>();
+    const byHost = new Map<string, (typeof validBidRequests)[number][]>();
     validBidRequests.forEach((bid) => {
-      const host = bid.params.host;
-      let group = byHost.get(host);
-      if (!group) {
-        group = [] as unknown as typeof validBidRequests;
-        byHost.set(host, group);
+      const group = byHost.get(bid.params.host);
+      if (group) {
+        group.push(bid);
+      } else {
+        byHost.set(bid.params.host, [bid]);
       }
-      group.push(bid);
     });
 
-    const requests = [];
-    byHost.forEach((group, host) => {
-      requests.push({
-        method: 'POST',
-        url: `https://${host}${BID_PATH}`,
-        data: converter.toORTB({ bidRequests: group, bidderRequest }),
-        // `text/plain` keeps this a simple cross-origin request, so the
-        // browser skips the CORS preflight — one round-trip inside the
-        // auction timeout instead of two. The body is still JSON.
-        options: { contentType: 'text/plain', withCredentials: false },
-      });
-    });
-
-    return requests;
+    return Array.from(byHost, ([host, group]) => ({
+      method: 'POST',
+      url: `https://${host}${BID_PATH}`,
+      data: converter.toORTB({ bidRequests: group, bidderRequest }),
+      // `text/plain` keeps this a simple cross-origin request, so the
+      // browser skips the CORS preflight — one round-trip inside the
+      // auction timeout instead of two. The body is still JSON.
+      options: { contentType: 'text/plain', withCredentials: false },
+    }));
   },
 
   interpretResponse(serverResponse, request) {

--- a/modules/epom_asBidAdapter.ts
+++ b/modules/epom_asBidAdapter.ts
@@ -2,7 +2,7 @@ import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { type BidderSpec, registerBidder } from '../src/adapters/bidderFactory.js';
 import { type Bid } from '../src/bidfactory.js';
 import { BANNER } from '../src/mediaTypes.js';
-import { deepSetValue, logWarn } from '../src/utils.js';
+import { deepSetValue, isPlainObject } from '../src/utils.js';
 
 /**
  * Prebid.js adapter for the Epom Ad Server — the supply side of the Epom
@@ -29,10 +29,14 @@ const DEFAULT_CURRENCY = 'USD';
 const DEFAULT_TTL = 25;
 
 /**
- * Hostname with an optional port — no scheme, no path, no query, no credentials, so a page
- * configuration cannot redirect the payload. Matches the Prebid Server params schema exactly.
+ * Hostname with an optional port — no scheme, path, query, fragment or userinfo, so a page
+ * configuration cannot redirect the payload. Byte-identical to the expression Prebid Server
+ * validates the same parameter with (`util/urlutil/security.go`, and the `host` property of
+ * the epom_as params schema), so a bid this adapter accepts is one that server also accepts.
+ * Single-label hosts are deliberately allowed: an internal deployment reachable as `api-us`
+ * is a legitimate configuration on both transports.
  */
-const HOST_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+(:\d{1,5})?$/i;
+const HOST_PATTERN = /^[a-zA-Z0-9.-]+(:[0-9]+)?$/;
 
 export type EpomAsBidParams = {
   /** Serving host of the publisher's Epom deployment, e.g. `ads.example.com`. */
@@ -49,11 +53,6 @@ export type EpomAsBidParams = {
   bidFloorCur?: string;
 };
 
-/** Mirrors the server-side ingest cap; oversized input is dropped rather than truncated. */
-const CUSTOM_PARAMS_MAX_KEYS = 32;
-const CUSTOM_PARAMS_MAX_KEY_LENGTH = 128;
-const CUSTOM_PARAMS_MAX_VALUE_LENGTH = 512;
-
 declare module '../src/adUnits' {
   interface BidderParams {
     [BIDDER_CODE]: EpomAsBidParams;
@@ -61,34 +60,38 @@ declare module '../src/adUnits' {
 }
 
 /**
- * Keep only scalar entries within the limits the ad server enforces on ingest, so a
- * publisher sees the same set of parameters accepted here and applied there.
+ * The values the ad server can key targeting on. A nested object or an array stringifies to
+ * something no campaign can ever match, so it is rejected as a misconfiguration in
+ * `isBidRequestValid` rather than quietly sent — which is also what the Prebid Server params
+ * schema does with the same input.
+ */
+function isTargetableScalar(value: unknown): boolean {
+  const type = typeof value;
+  return type === 'string' || type === 'number' || type === 'boolean';
+}
+
+/**
+ * Stringify every entry — the ad server compares custom parameters as strings, so sending
+ * `2` and `"2"` differently would make an otherwise identical campaign match one and not
+ * the other. Nothing is dropped: the caps the ad server applies on ingest are its own, and
+ * silently discarding keys here would leave a publisher with no signal that half their
+ * targeting never arrived.
  */
 function sanitiseCustomParams(
   raw: EpomAsBidParams['customParams']
 ): Record<string, string> | null {
-  if (!raw || typeof raw !== 'object') {
+  if (!isPlainObject(raw)) {
+    return null;
+  }
+  const keys = Object.keys(raw);
+  if (keys.length === 0) {
     return null;
   }
   const out: Record<string, string> = {};
-  let kept = 0;
-  Object.keys(raw).forEach((key) => {
-    if (kept >= CUSTOM_PARAMS_MAX_KEYS || key.length > CUSTOM_PARAMS_MAX_KEY_LENGTH) {
-      return;
-    }
-    const value = raw[key];
-    const type = typeof value;
-    if (type !== 'string' && type !== 'number' && type !== 'boolean') {
-      return;
-    }
-    const asString = String(value);
-    if (asString.length > CUSTOM_PARAMS_MAX_VALUE_LENGTH) {
-      return;
-    }
-    out[key] = asString;
-    kept++;
+  keys.forEach((key) => {
+    out[key] = String(raw[key]);
   });
-  return kept > 0 ? out : null;
+  return out;
 }
 
 const converter = ortbConverter<typeof BIDDER_CODE>({
@@ -110,8 +113,9 @@ const converter = ortbConverter<typeof BIDDER_CODE>({
 
     // Honour a manual floor only when the Price Floors module has not already
     // resolved one; the module's value is always the more informed of the two.
-    if (imp.bidfloor == null && params.bidFloor != null) {
-      imp.bidfloor = Number(params.bidFloor);
+    // A floor of 0 is "no floor" and is left off the wire entirely.
+    if (imp.bidfloor == null && typeof params.bidFloor === 'number' && params.bidFloor > 0) {
+      imp.bidfloor = params.bidFloor;
       imp.bidfloorcur = params.bidFloorCur || DEFAULT_CURRENCY;
     }
 
@@ -121,7 +125,8 @@ const converter = ortbConverter<typeof BIDDER_CODE>({
 
     // Custom parameters go to imp.ext.data, the standard first-party-data home, so
     // that RTD modules and gptPreAuction contribute to the same object rather than
-    // to a private one the ad server would have to read twice.
+    // to a private one the ad server would have to read twice. Anything already on
+    // the impression wins — first-party data is the more authoritative source.
     const custom = sanitiseCustomParams(params.customParams);
     if (custom) {
       imp.ext = imp.ext || {};
@@ -143,16 +148,32 @@ const converter = ortbConverter<typeof BIDDER_CODE>({
 export const spec: BidderSpec<typeof BIDDER_CODE> = {
   code: BIDDER_CODE,
   gvlid: GVLID,
+  // Device-storage disclosure for the Epom identity cookie. The adapter itself
+  // uses no storage manager and writes nothing — the cookie is set by the ad
+  // server on its own domain and only reaches the auction because the POST is
+  // credentialed (see buildRequests).
+  disclosureURL: 'https://epom.com/deviceStorage.json',
   supportedMediaTypes: [BANNER],
 
+  /**
+   * Only the bidder's own parameters are checked, and each check is the client-side
+   * twin of the Prebid Server params schema — a bid rejected here is an imp that
+   * server would reject too. Core already logs the rejection, so nothing is logged.
+   */
   isBidRequestValid(bid) {
     const params = bid?.params;
-    if (!params?.host || typeof params.host !== 'string' || !HOST_PATTERN.test(params.host)) {
-      logWarn(`${BIDDER_CODE}: params.host must be a bare hostname, e.g. "ads.example.com".`);
+    if (typeof params?.host !== 'string' || !HOST_PATTERN.test(params.host)) {
       return false;
     }
-    if (!params?.placementKey || typeof params.placementKey !== 'string') {
-      logWarn(`${BIDDER_CODE}: params.placementKey is required.`);
+    if (typeof params.placementKey !== 'string' || params.placementKey.length === 0) {
+      return false;
+    }
+    if (params.customParams !== undefined &&
+      (!isPlainObject(params.customParams) || !Object.values(params.customParams).every(isTargetableScalar))) {
+      return false;
+    }
+    if (params.bidFloor !== undefined &&
+      (typeof params.bidFloor !== 'number' || !isFinite(params.bidFloor) || params.bidFloor < 0)) {
       return false;
     }
     return true;
@@ -188,14 +209,17 @@ export const spec: BidderSpec<typeof BIDDER_CODE> = {
     });
 
     return Array.from(byHost, ([host, group]) => ({
-      method: 'POST',
+      method: 'POST' as const,
       url: `https://${host}${BID_PATH}`,
       data: converter.toORTB({ bidRequests: group, bidderRequest }),
-      // `text/plain` keeps this a simple cross-origin request, so the browser
-      // skips the CORS preflight — one round-trip inside the auction timeout
-      // instead of two. The body is still JSON. Credentials are sent because
-      // the ad server answers with the request's own Origin, which is what
-      // lets an existing Epom identity reach the auction.
+      // Both options are already core's defaults for an adapter POST
+      // (src/adapters/bidderFactory), and are pinned here so a change to those
+      // defaults cannot break either one silently. `text/plain` keeps this a
+      // simple cross-origin request, so the browser skips the CORS preflight —
+      // one round-trip inside the auction timeout instead of two; the body is
+      // still JSON. Credentials are sent because the ad server answers with the
+      // request's own Origin, which is what lets an existing Epom identity
+      // reach the auction.
       options: { contentType: 'text/plain', withCredentials: true },
     }));
   },
@@ -209,6 +233,10 @@ export const spec: BidderSpec<typeof BIDDER_CODE> = {
       request: request.data,
     }) as { bids: Bid[] }).bids;
   },
+
+  // The ad server matches on its own first-party cookie and offers no
+  // cross-domain sync endpoint, so there is deliberately nothing to register.
+  getUserSyncs: () => [],
 };
 
 registerBidder(spec);

--- a/modules/epom_asBidAdapter.ts
+++ b/modules/epom_asBidAdapter.ts
@@ -30,13 +30,31 @@ const DEFAULT_TTL = 25;
 
 /**
  * Hostname with an optional port — no scheme, path, query, fragment or userinfo, so a page
- * configuration cannot redirect the payload. Byte-identical to the expression Prebid Server
- * validates the same parameter with (`util/urlutil/security.go`, and the `host` property of
- * the epom_as params schema), so a bid this adapter accepts is one that server also accepts.
- * Single-label hosts are deliberately allowed: an internal deployment reachable as `api-us`
- * is a legitimate configuration on both transports.
+ * configuration cannot redirect the payload. The shape is the expression Prebid Server validates
+ * the same parameter with (`util/urlutil/security.go`, and the `host` property of the epom_as
+ * params schema), so a bid this adapter accepts is one that server also accepts. Single-label
+ * hosts are deliberately allowed: an internal deployment reachable as `api-us` is a legitimate
+ * configuration on both transports.
  */
-const HOST_PATTERN = /^[a-zA-Z0-9.-]+(:[0-9]+)?$/;
+const HOST_PATTERN = /^[a-zA-Z0-9.-]+(?::(\d{1,5}))?$/;
+const MAX_PORT = 65535;
+
+/**
+ * The port is range-checked on top of the shape. Out of range, `new URL()` throws rather than
+ * returning something unusable, and buildRequests is not called inside a try — one mistyped port
+ * in a page's configuration would take the whole request down instead of costing one bid.
+ */
+function isUsableHost(host: unknown): boolean {
+  if (typeof host !== 'string') {
+    return false;
+  }
+  const match = HOST_PATTERN.exec(host);
+  if (match == null) {
+    return false;
+  }
+  const port = match[1];
+  return port === undefined || (Number(port) >= 1 && Number(port) <= MAX_PORT);
+}
 
 export type EpomAsBidParams = {
   /** Serving host of the publisher's Epom deployment, e.g. `ads.example.com`. */
@@ -162,7 +180,7 @@ export const spec: BidderSpec<typeof BIDDER_CODE> = {
    */
   isBidRequestValid(bid) {
     const params = bid?.params;
-    if (typeof params?.host !== 'string' || !HOST_PATTERN.test(params.host)) {
+    if (!isUsableHost(params?.host)) {
       return false;
     }
     if (typeof params.placementKey !== 'string' || params.placementKey.length === 0) {

--- a/modules/epom_asBidAdapter.ts
+++ b/modules/epom_asBidAdapter.ts
@@ -22,9 +22,9 @@ const GVLID = 849;
 const BID_PATH = '/hb/bid';
 const DEFAULT_CURRENCY = 'USD';
 /**
- * The ad server's impression beacon is only accepted within 30 s of the bid, so a bid cached
- * longer than that renders without being counted. Five seconds are left for the beacon itself.
- * A server that widens its window says so per bid in `bid.exp`, which overrides this.
+ * A bid cached longer than the ad server accepts its impression beacon renders without being
+ * counted, so this is deliberately short. It is only the floor: a deployment configured with a
+ * wider window says so per bid in `bid.exp`, which overrides this.
  */
 const DEFAULT_TTL = 25;
 

--- a/modules/epom_asBidAdapter.ts
+++ b/modules/epom_asBidAdapter.ts
@@ -1,0 +1,157 @@
+import { ortbConverter } from '../libraries/ortbConverter/converter.js';
+import { type BidderSpec, registerBidder } from '../src/adapters/bidderFactory.js';
+import { type Bid } from '../src/bidfactory.js';
+import { BANNER } from '../src/mediaTypes.js';
+import { logWarn } from '../src/utils.js';
+
+/**
+ * Prebid.js adapter for the Epom Ad Server — the supply side of the Epom
+ * platform, where a publisher's own direct campaigns live.
+ *
+ * Epom is white-label: every network runs its own deployment under its own
+ * domain, so the serving host is a per-bid parameter (`params.host`) rather
+ * than a module constant. Only the host varies — the path is fixed, so a
+ * page config can never redirect the auction payload to an arbitrary URL.
+ *
+ * Not to be confused with `epom_dsp`, which is the demand side: it buys
+ * impressions. This adapter sells a publisher's inventory.
+ */
+
+const BIDDER_CODE = 'epom_as';
+const GVLID = 849;
+const BID_PATH = '/hb/bid';
+const DEFAULT_CURRENCY = 'USD';
+const DEFAULT_TTL = 300;
+
+/** Hostnames only — no scheme, no path, no port, no credentials. */
+const HOST_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
+
+export type EpomAsBidParams = {
+  /** Serving host of the publisher's Epom deployment, e.g. `ads.example.com`. */
+  host: string;
+  /** Opaque placement identifier from the Epom invocation-code tab. */
+  placementKey: string;
+  /** Optional CPM floor, used only when the Price Floors module supplies none. */
+  bidFloor?: number;
+  /** Currency of `bidFloor`. Defaults to USD. */
+  bidFloorCur?: string;
+};
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    [BIDDER_CODE]: EpomAsBidParams;
+  }
+}
+
+const converter = ortbConverter<typeof BIDDER_CODE>({
+  context: {
+    netRevenue: true,
+    ttl: DEFAULT_TTL,
+    currency: DEFAULT_CURRENCY,
+    mediaType: BANNER,
+  },
+
+  imp(buildImp, bidRequest, context) {
+    const imp = buildImp(bidRequest, context);
+    const params = bidRequest.params;
+
+    // The placement travels as `imp.tagid` rather than in an ext object so a
+    // single request can carry a different placement per impression. It is
+    // per-imp data and therefore cannot live in the URL — see buildRequests.
+    imp.tagid = params.placementKey;
+
+    // Honour a manual floor only when the Price Floors module has not already
+    // resolved one; the module's value is always the more informed of the two.
+    if (imp.bidfloor == null && params.bidFloor != null) {
+      imp.bidfloor = Number(params.bidFloor);
+      imp.bidfloorcur = params.bidFloorCur || DEFAULT_CURRENCY;
+    }
+
+    return imp;
+  },
+
+  request(buildRequest, imps, bidderRequest, context) {
+    const request = buildRequest(imps, bidderRequest, context);
+    if (!request.cur || request.cur.length === 0) {
+      request.cur = [DEFAULT_CURRENCY];
+    }
+    return request;
+  },
+});
+
+export const spec: BidderSpec<typeof BIDDER_CODE> = {
+  code: BIDDER_CODE,
+  gvlid: GVLID,
+  supportedMediaTypes: [BANNER],
+
+  isBidRequestValid(bid) {
+    const params = bid?.params;
+    if (!params?.host || typeof params.host !== 'string' || !HOST_PATTERN.test(params.host)) {
+      logWarn(`${BIDDER_CODE}: params.host must be a bare hostname, e.g. "ads.example.com".`);
+      return false;
+    }
+    if (!params?.placementKey || typeof params.placementKey !== 'string') {
+      logWarn(`${BIDDER_CODE}: params.placementKey is required.`);
+      return false;
+    }
+    return true;
+  },
+
+  /**
+   * One request per host, carrying every impression that belongs to it.
+   *
+   * Prebid runs a single auction for the whole page, so `validBidRequests`
+   * arrives with one entry per ad unit. Batching them into one OpenRTB
+   * request with N `imp` objects is what lets the ad server resolve the page
+   * as a unit — its roadblock and one-campaign-per-page rules only hold when
+   * every slot is decided together. Emitting one request per ad unit would
+   * make those rules race each other.
+   *
+   * Grouping is by host because a page may legitimately mix two Epom
+   * deployments. Taking the host from the first bid instead would silently
+   * route the remaining impressions to the wrong network.
+   */
+  buildRequests(validBidRequests, bidderRequest) {
+    if (!validBidRequests?.length) {
+      return [];
+    }
+
+    const byHost = new Map<string, typeof validBidRequests>();
+    validBidRequests.forEach((bid) => {
+      const host = bid.params.host;
+      let group = byHost.get(host);
+      if (!group) {
+        group = [] as unknown as typeof validBidRequests;
+        byHost.set(host, group);
+      }
+      group.push(bid);
+    });
+
+    const requests = [];
+    byHost.forEach((group, host) => {
+      requests.push({
+        method: 'POST',
+        url: `https://${host}${BID_PATH}`,
+        data: converter.toORTB({ bidRequests: group, bidderRequest }),
+        // `text/plain` keeps this a simple cross-origin request, so the
+        // browser skips the CORS preflight — one round-trip inside the
+        // auction timeout instead of two. The body is still JSON.
+        options: { contentType: 'text/plain', withCredentials: false },
+      });
+    });
+
+    return requests;
+  },
+
+  interpretResponse(serverResponse, request) {
+    if (!serverResponse?.body) {
+      return [];
+    }
+    return (converter.fromORTB({
+      response: serverResponse.body,
+      request: request.data,
+    }) as { bids: Bid[] }).bids;
+  },
+};
+
+registerBidder(spec);

--- a/test/spec/modules/epom_asBidAdapter_spec.js
+++ b/test/spec/modules/epom_asBidAdapter_spec.js
@@ -77,11 +77,14 @@ describe('Epom Ad Server adapter', function () {
     // The host is the only publisher-controlled part of the URL, so it must be a
     // bare hostname — anything that could carry a scheme, path, port, credentials
     // or a query string would let a page config redirect the payload elsewhere.
+    it('accepts a host with a port, as the Prebid Server schema does', function () {
+      expect(spec.isBidRequestValid(bannerBid({ params: { host: 'ads.example.com:8443', placementKey: PLACEMENT } }))).to.equal(true);
+    });
+
     it('rejects a host that is not a bare hostname', function () {
       const bad = [
         'https://ads.example.com',
         'ads.example.com/collect',
-        'ads.example.com:8080',
         'user@ads.example.com',
         'ads.example.com?x=1',
         'ads.example.com#f',

--- a/test/spec/modules/epom_asBidAdapter_spec.js
+++ b/test/spec/modules/epom_asBidAdapter_spec.js
@@ -1,0 +1,333 @@
+import { expect } from 'chai';
+import { spec } from 'modules/epom_asBidAdapter';
+import { newBidder } from 'src/adapters/bidderFactory';
+import { addFPDToBidderRequest } from '../../helpers/fpd.js';
+
+// Prebid core + the ORTB processors the converter relies on.
+import 'src/prebid.js';
+import 'modules/currency.js';
+import 'modules/priceFloors.js';
+import 'modules/consentManagementTcf.js';
+
+const HOST = 'ads.example.com';
+const OTHER_HOST = 'ads.other-network.com';
+const PLACEMENT = 'a4f21c9e7b';
+const ENDPOINT = `https://${HOST}/hb/bid`;
+
+function bannerBid(overrides = {}) {
+  return {
+    bidder: 'epom_as',
+    params: { host: HOST, placementKey: PLACEMENT },
+    mediaTypes: { banner: { sizes: [[300, 250], [728, 90]] } },
+    adUnitCode: 'div-leaderboard',
+    transactionId: 'txn-1',
+    bidId: 'bid-1',
+    bidderRequestId: 'req-1',
+    auctionId: 'auction-1',
+    sizes: [[300, 250], [728, 90]],
+    ...overrides,
+  };
+}
+
+function bidderRequestFor(bids) {
+  return {
+    bidderCode: 'epom_as',
+    auctionId: 'auction-1',
+    bidderRequestId: 'req-1',
+    timeout: 1000,
+    refererInfo: { page: 'https://publisher.example.com/article', domain: 'publisher.example.com' },
+    bids,
+  };
+}
+
+describe('Epom Ad Server adapter', function () {
+  describe('inherited functions', function () {
+    it('exists and is a function', function () {
+      expect(newBidder(spec).callBids).to.be.a('function');
+    });
+  });
+
+  describe('spec metadata', function () {
+    it('declares the bidder code, GVL ID and banner support', function () {
+      expect(spec.code).to.equal('epom_as');
+      expect(spec.gvlid).to.equal(849);
+      expect(spec.supportedMediaTypes).to.deep.equal(['banner']);
+    });
+  });
+
+  describe('isBidRequestValid', function () {
+    it('accepts a bid carrying host and placementKey', function () {
+      expect(spec.isBidRequestValid(bannerBid())).to.equal(true);
+    });
+
+    it('rejects a bid with no params at all', function () {
+      expect(spec.isBidRequestValid({ bidder: 'epom_as' })).to.equal(false);
+    });
+
+    it('rejects a missing or non-string host', function () {
+      expect(spec.isBidRequestValid(bannerBid({ params: { placementKey: PLACEMENT } }))).to.equal(false);
+      expect(spec.isBidRequestValid(bannerBid({ params: { host: 42, placementKey: PLACEMENT } }))).to.equal(false);
+    });
+
+    it('rejects a missing or non-string placementKey', function () {
+      expect(spec.isBidRequestValid(bannerBid({ params: { host: HOST } }))).to.equal(false);
+      expect(spec.isBidRequestValid(bannerBid({ params: { host: HOST, placementKey: 7 } }))).to.equal(false);
+    });
+
+    // The host is the only publisher-controlled part of the URL, so it must be a
+    // bare hostname — anything that could carry a scheme, path, port, credentials
+    // or a query string would let a page config redirect the payload elsewhere.
+    it('rejects a host that is not a bare hostname', function () {
+      const bad = [
+        'https://ads.example.com',
+        'ads.example.com/collect',
+        'ads.example.com:8080',
+        'user@ads.example.com',
+        'ads.example.com?x=1',
+        'ads.example.com#f',
+        'localhost',
+        '',
+        ' ads.example.com',
+        'ads.example.com/../evil.com',
+      ];
+      bad.forEach((host) => {
+        expect(spec.isBidRequestValid(bannerBid({ params: { host, placementKey: PLACEMENT } })), host).to.equal(false);
+      });
+    });
+  });
+
+  describe('buildRequests', function () {
+    it('returns nothing when there are no bids', function () {
+      expect(spec.buildRequests([], bidderRequestFor([]))).to.deep.equal([]);
+    });
+
+    it('POSTs to https://{host}/hb/bid as text/plain without credentials', async function () {
+      const bids = [bannerBid()];
+      const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+
+      expect(requests).to.have.lengthOf(1);
+      expect(requests[0].method).to.equal('POST');
+      expect(requests[0].url).to.equal(ENDPOINT);
+      // text/plain keeps the POST a simple request, so the browser skips the
+      // CORS preflight; withCredentials false means no cookies leave the page.
+      expect(requests[0].options.contentType).to.equal('text/plain');
+      expect(requests[0].options.withCredentials).to.equal(false);
+    });
+
+    it('packs every ad unit of one host into a single request, one imp each', async function () {
+      const bids = [
+        bannerBid(),
+        bannerBid({ bidId: 'bid-2', adUnitCode: 'div-sidebar', params: { host: HOST, placementKey: '6d0e83b415' } }),
+        bannerBid({ bidId: 'bid-3', adUnitCode: 'div-footer', params: { host: HOST, placementKey: 'ff0011aa22' } }),
+      ];
+      const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+
+      expect(requests).to.have.lengthOf(1);
+      const { imp } = requests[0].data;
+      expect(imp).to.have.lengthOf(3);
+      expect(imp.map((i) => i.id)).to.deep.equal(['bid-1', 'bid-2', 'bid-3']);
+      expect(imp.map((i) => i.tagid)).to.deep.equal([PLACEMENT, '6d0e83b415', 'ff0011aa22']);
+    });
+
+    it('splits by host so impressions never reach the wrong deployment', async function () {
+      const bids = [
+        bannerBid(),
+        bannerBid({ bidId: 'bid-2', params: { host: OTHER_HOST, placementKey: '6d0e83b415' } }),
+        bannerBid({ bidId: 'bid-3', params: { host: HOST, placementKey: 'ff0011aa22' } }),
+      ];
+      const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+
+      expect(requests).to.have.lengthOf(2);
+      const byUrl = Object.fromEntries(requests.map((r) => [r.url, r.data.imp.map((i) => i.id)]));
+      expect(byUrl[ENDPOINT]).to.deep.equal(['bid-1', 'bid-3']);
+      expect(byUrl[`https://${OTHER_HOST}/hb/bid`]).to.deep.equal(['bid-2']);
+    });
+
+    it('carries banner sizes through to imp.banner.format', async function () {
+      const bids = [bannerBid()];
+      const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+
+      expect(requests[0].data.imp[0].banner.format).to.deep.equal([
+        { w: 300, h: 250 },
+        { w: 728, h: 90 },
+      ]);
+    });
+
+    it('defaults the request currency to USD', async function () {
+      const bids = [bannerBid()];
+      const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+
+      expect(requests[0].data.cur).to.deep.equal(['USD']);
+    });
+
+    it('forwards the page URL from refererInfo', async function () {
+      const bids = [bannerBid()];
+      const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+
+      expect(requests[0].data.site.page).to.equal('https://publisher.example.com/article');
+    });
+
+    describe('floors', function () {
+      it('applies params.bidFloor when no floors module value is present', async function () {
+        const bids = [bannerBid({ params: { host: HOST, placementKey: PLACEMENT, bidFloor: 1.25 } })];
+        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+
+        expect(requests[0].data.imp[0].bidfloor).to.equal(1.25);
+        expect(requests[0].data.imp[0].bidfloorcur).to.equal('USD');
+      });
+
+      it('honours params.bidFloorCur', async function () {
+        const bids = [bannerBid({ params: { host: HOST, placementKey: PLACEMENT, bidFloor: 2, bidFloorCur: 'EUR' } })];
+        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+
+        expect(requests[0].data.imp[0].bidfloorcur).to.equal('EUR');
+      });
+
+      it('lets the Price Floors module win over params.bidFloor', async function () {
+        const bids = [bannerBid({
+          params: { host: HOST, placementKey: PLACEMENT, bidFloor: 1.25 },
+          getFloor: () => ({ currency: 'USD', floor: 3.5 }),
+        })];
+        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+
+        expect(requests[0].data.imp[0].bidfloor).to.equal(3.5);
+      });
+    });
+
+    describe('consent', function () {
+      it('forwards TCF consent and the GDPR flag', async function () {
+        const bids = [bannerBid()];
+        const bidderRequest = bidderRequestFor(bids);
+        bidderRequest.gdprConsent = {
+          gdprApplies: true,
+          consentString: 'CONSENT-STRING',
+        };
+        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequest));
+
+        expect(requests[0].data.regs.ext.gdpr).to.equal(1);
+        expect(requests[0].data.user.ext.consent).to.equal('CONSENT-STRING');
+      });
+
+      // US privacy, GPP and COPPA are resolved into ortb2.regs by core, so what
+      // the adapter owes is simply not to drop them on the way out.
+      it('forwards the regs object untouched', async function () {
+        const bids = [bannerBid()];
+        const bidderRequest = bidderRequestFor(bids);
+        bidderRequest.ortb2 = {
+          regs: { coppa: 1, gpp: 'GPP-STRING', gpp_sid: [7], ext: { us_privacy: '1YNN' } },
+        };
+        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequest));
+
+        expect(requests[0].data.regs.ext.us_privacy).to.equal('1YNN');
+        expect(requests[0].data.regs.gpp).to.equal('GPP-STRING');
+        expect(requests[0].data.regs.gpp_sid).to.deep.equal([7]);
+        expect(requests[0].data.regs.coppa).to.equal(1);
+      });
+    });
+  });
+
+  describe('interpretResponse', function () {
+    let request;
+
+    beforeEach(async function () {
+      const bids = [bannerBid()];
+      request = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)))[0];
+    });
+
+    it('returns nothing for an empty response', function () {
+      expect(spec.interpretResponse({}, request)).to.deep.equal([]);
+      expect(spec.interpretResponse({ body: null }, request)).to.deep.equal([]);
+    });
+
+    it('returns nothing when the ad server has no bid', function () {
+      const response = { body: { id: request.data.id, seatbid: [], cur: 'USD' } };
+      expect(spec.interpretResponse(response, request)).to.deep.equal([]);
+    });
+
+    it('maps a seatbid into a Prebid bid', function () {
+      const response = {
+        body: {
+          id: request.data.id,
+          cur: 'USD',
+          seatbid: [{
+            seat: 'epom',
+            bid: [{
+              id: 'server-bid-1',
+              impid: 'bid-1',
+              price: 2.75,
+              adm: '<div>creative</div>',
+              crid: 'creative-99',
+              w: 300,
+              h: 250,
+              adomain: ['advertiser.example.com'],
+            }],
+          }],
+        },
+      };
+
+      const bids = spec.interpretResponse(response, request);
+      expect(bids).to.have.lengthOf(1);
+      expect(bids[0].requestId).to.equal('bid-1');
+      expect(bids[0].cpm).to.equal(2.75);
+      expect(bids[0].currency).to.equal('USD');
+      expect(bids[0].width).to.equal(300);
+      expect(bids[0].height).to.equal(250);
+      expect(bids[0].ad).to.equal('<div>creative</div>');
+      expect(bids[0].creativeId).to.equal('creative-99');
+      expect(bids[0].mediaType).to.equal('banner');
+      expect(bids[0].netRevenue).to.equal(true);
+      expect(bids[0].ttl).to.equal(300);
+      expect(bids[0].meta.advertiserDomains).to.deep.equal(['advertiser.example.com']);
+    });
+
+    // The whole Google Ad Manager integration hangs off hb_deal_epom_as: a
+    // Sponsorship line item keyed on the deal id is what makes an Epom bid
+    // outrank AdX rather than compete with it on price.
+    it('surfaces the deal id the ad server stamps on every bid', function () {
+      const response = {
+        body: {
+          id: request.data.id,
+          cur: 'USD',
+          seatbid: [{
+            bid: [{
+              id: 'server-bid-1',
+              impid: 'bid-1',
+              price: 2.75,
+              adm: '<div>creative</div>',
+              crid: 'creative-99',
+              dealid: 'epom-direct',
+              w: 300,
+              h: 250,
+            }],
+          }],
+        },
+      };
+
+      expect(spec.interpretResponse(response, request)[0].dealId).to.equal('epom-direct');
+    });
+
+    it('maps one bid per impression back to its own ad unit', async function () {
+      const bids = [
+        bannerBid(),
+        bannerBid({ bidId: 'bid-2', adUnitCode: 'div-sidebar', params: { host: HOST, placementKey: '6d0e83b415' } }),
+      ];
+      const multiRequest = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)))[0];
+      const response = {
+        body: {
+          id: multiRequest.data.id,
+          cur: 'USD',
+          seatbid: [{
+            bid: [
+              { id: 's1', impid: 'bid-1', price: 1.5, adm: '<div>a</div>', crid: 'c1', w: 300, h: 250 },
+              { id: 's2', impid: 'bid-2', price: 4.0, adm: '<div>b</div>', crid: 'c2', w: 728, h: 90 },
+            ],
+          }],
+        },
+      };
+
+      const interpreted = spec.interpretResponse(response, multiRequest);
+      expect(interpreted.map((b) => b.requestId)).to.deep.equal(['bid-1', 'bid-2']);
+      expect(interpreted.map((b) => b.cpm)).to.deep.equal([1.5, 4.0]);
+    });
+  });
+});

--- a/test/spec/modules/epom_asBidAdapter_spec.js
+++ b/test/spec/modules/epom_asBidAdapter_spec.js
@@ -95,6 +95,20 @@ describe('Epom Ad Server adapter', function () {
       expect(spec.isBidRequestValid(bannerBid({ params: { host: null, placementKey: PLACEMENT } }))).to.equal(false);
     });
 
+    it('rejects a port outside the range a URL can carry', function () {
+      // The shape alone would accept it, and `new URL()` then throws rather than returning
+      // something unusable — buildRequests is not called inside a try, so one mistyped port in a
+      // page's configuration would take the whole request down instead of costing a single bid.
+      ['ads.example.com:0', 'ads.example.com:65536', 'ads.example.com:99999'].forEach((host) => {
+        expect(spec.isBidRequestValid(bannerBid({
+          params: { host, placementKey: PLACEMENT },
+        })), host).to.equal(false);
+      });
+      expect(spec.isBidRequestValid(bannerBid({
+        params: { host: 'ads.example.com:65535', placementKey: PLACEMENT },
+      }))).to.equal(true);
+    });
+
     it('rejects a missing, empty or non-string placementKey', function () {
       expect(spec.isBidRequestValid(bannerBid({ params: { host: HOST } }))).to.equal(false);
       expect(spec.isBidRequestValid(bannerBid({ params: { host: HOST, placementKey: '' } }))).to.equal(false);

--- a/test/spec/modules/epom_asBidAdapter_spec.js
+++ b/test/spec/modules/epom_asBidAdapter_spec.js
@@ -1,9 +1,13 @@
 import { expect } from 'chai';
 import { spec } from 'modules/epom_asBidAdapter';
 import { newBidder } from 'src/adapters/bidderFactory';
+import { config } from 'src/config.js';
+import { hook } from 'src/hook.js';
 import { addFPDToBidderRequest } from '../../helpers/fpd.js';
 
-// Prebid core + the ORTB processors the converter relies on.
+// Prebid core plus the modules that register the ORTB processors the converter
+// relies on — without them the floors, currency and consent assertions below
+// would pass vacuously against processors that were never installed.
 import 'src/prebid.js';
 import 'modules/currency.js';
 import 'modules/priceFloors.js';
@@ -40,7 +44,15 @@ function bidderRequestFor(bids) {
   };
 }
 
+async function buildOne(bids) {
+  return spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+}
+
 describe('Epom Ad Server adapter', function () {
+  before(function () {
+    hook.ready();
+  });
+
   describe('inherited functions', function () {
     it('exists and is a function', function () {
       expect(newBidder(spec).callBids).to.be.a('function');
@@ -52,6 +64,19 @@ describe('Epom Ad Server adapter', function () {
       expect(spec.code).to.equal('epom_as');
       expect(spec.gvlid).to.equal(849);
       expect(spec.supportedMediaTypes).to.deep.equal(['banner']);
+    });
+
+    // The POST is credentialed, so the ad server's identity cookie reaches the
+    // auction; the disclosure is what a TCF vendor-849 check resolves to.
+    it('discloses the device storage the credentialed request relies on', function () {
+      expect(spec.disclosureURL).to.be.a('string').that.is.not.empty;
+    });
+
+    it('exposes the whole bidder surface', function () {
+      expect(spec).to.have.property('isBidRequestValid').that.is.a('function');
+      expect(spec).to.have.property('buildRequests').that.is.a('function');
+      expect(spec).to.have.property('interpretResponse').that.is.a('function');
+      expect(spec).to.have.property('getUserSyncs').that.is.a('function');
     });
   });
 
@@ -67,20 +92,31 @@ describe('Epom Ad Server adapter', function () {
     it('rejects a missing or non-string host', function () {
       expect(spec.isBidRequestValid(bannerBid({ params: { placementKey: PLACEMENT } }))).to.equal(false);
       expect(spec.isBidRequestValid(bannerBid({ params: { host: 42, placementKey: PLACEMENT } }))).to.equal(false);
+      expect(spec.isBidRequestValid(bannerBid({ params: { host: null, placementKey: PLACEMENT } }))).to.equal(false);
     });
 
-    it('rejects a missing or non-string placementKey', function () {
+    it('rejects a missing, empty or non-string placementKey', function () {
       expect(spec.isBidRequestValid(bannerBid({ params: { host: HOST } }))).to.equal(false);
+      expect(spec.isBidRequestValid(bannerBid({ params: { host: HOST, placementKey: '' } }))).to.equal(false);
       expect(spec.isBidRequestValid(bannerBid({ params: { host: HOST, placementKey: 7 } }))).to.equal(false);
     });
 
-    // The host is the only publisher-controlled part of the URL, so it must be a
-    // bare hostname — anything that could carry a scheme, path, port, credentials
-    // or a query string would let a page config redirect the payload elsewhere.
     it('accepts a host with a port, as the Prebid Server schema does', function () {
       expect(spec.isBidRequestValid(bannerBid({ params: { host: 'ads.example.com:8443', placementKey: PLACEMENT } }))).to.equal(true);
     });
 
+    // The host pattern is byte-identical to the one Prebid Server validates the
+    // same parameter with, and that one accepts a single label — an internal
+    // deployment reachable as `api-us` is a legitimate configuration.
+    it('accepts a single-label host, as the Prebid Server schema does', function () {
+      ['localhost', 'api-us'].forEach((host) => {
+        expect(spec.isBidRequestValid(bannerBid({ params: { host, placementKey: PLACEMENT } })), host).to.equal(true);
+      });
+    });
+
+    // The host is the only publisher-controlled part of the URL, so anything
+    // that could carry a scheme, path, credentials or a query string would let
+    // a page config redirect the payload elsewhere.
     it('rejects a host that is not a bare hostname', function () {
       const bad = [
         'https://ads.example.com',
@@ -88,13 +124,98 @@ describe('Epom Ad Server adapter', function () {
         'user@ads.example.com',
         'ads.example.com?x=1',
         'ads.example.com#f',
-        'localhost',
         '',
         ' ads.example.com',
         'ads.example.com/../evil.com',
+        'ads.example.com:80x',
       ];
       bad.forEach((host) => {
         expect(spec.isBidRequestValid(bannerBid({ params: { host, placementKey: PLACEMENT } })), host).to.equal(false);
+      });
+    });
+
+    describe('customParams', function () {
+      it('accepts scalar values of every allowed type', function () {
+        expect(spec.isBidRequestValid(bannerBid({
+          params: { host: HOST, placementKey: PLACEMENT, customParams: { section: 'sport', tier: 2, premium: true } },
+        }))).to.equal(true);
+      });
+
+      it('accepts an empty object and an absent value', function () {
+        expect(spec.isBidRequestValid(bannerBid({
+          params: { host: HOST, placementKey: PLACEMENT, customParams: {} },
+        }))).to.equal(true);
+        expect(spec.isBidRequestValid(bannerBid({
+          params: { host: HOST, placementKey: PLACEMENT, customParams: undefined },
+        }))).to.equal(true);
+      });
+
+      // No cap lives in the adapter, so a large-but-well-formed set is valid
+      // here; the ad server applies its own ingest limits.
+      it('accepts far more keys than the ad server will ingest', function () {
+        const many = {};
+        for (let i = 0; i < 40; i++) {
+          many['k' + i] = 'v' + i;
+        }
+        expect(spec.isBidRequestValid(bannerBid({
+          params: { host: HOST, placementKey: PLACEMENT, customParams: many },
+        }))).to.equal(true);
+      });
+
+      it('rejects a customParams that is not an object', function () {
+        ['section=sport', 42, null, true].forEach((customParams) => {
+          expect(spec.isBidRequestValid(bannerBid({
+            params: { host: HOST, placementKey: PLACEMENT, customParams },
+          })), String(customParams)).to.equal(false);
+        });
+      });
+
+      it('rejects an array, which stringifies to something no campaign matches', function () {
+        expect(spec.isBidRequestValid(bannerBid({
+          params: { host: HOST, placementKey: PLACEMENT, customParams: [['section', 'sport']] },
+        }))).to.equal(false);
+      });
+
+      it('rejects a non-scalar value', function () {
+        expect(spec.isBidRequestValid(bannerBid({
+          params: { host: HOST, placementKey: PLACEMENT, customParams: { nested: { a: 1 } } },
+        }))).to.equal(false);
+        expect(spec.isBidRequestValid(bannerBid({
+          params: { host: HOST, placementKey: PLACEMENT, customParams: { list: [1, 2] } },
+        }))).to.equal(false);
+      });
+    });
+
+    describe('bidFloor', function () {
+      it('accepts a positive floor and an explicit zero', function () {
+        expect(spec.isBidRequestValid(bannerBid({
+          params: { host: HOST, placementKey: PLACEMENT, bidFloor: 1.25 },
+        }))).to.equal(true);
+        expect(spec.isBidRequestValid(bannerBid({
+          params: { host: HOST, placementKey: PLACEMENT, bidFloor: 0 },
+        }))).to.equal(true);
+      });
+
+      it('rejects a negative floor, matching the schema minimum of 0', function () {
+        expect(spec.isBidRequestValid(bannerBid({
+          params: { host: HOST, placementKey: PLACEMENT, bidFloor: -1 },
+        }))).to.equal(false);
+      });
+
+      it('rejects a floor that is not a number', function () {
+        ['1.25', null, NaN].forEach((bidFloor) => {
+          expect(spec.isBidRequestValid(bannerBid({
+            params: { host: HOST, placementKey: PLACEMENT, bidFloor },
+          })), String(bidFloor)).to.equal(false);
+        });
+      });
+
+      // The params schema declares no format for bidFloorCur, so the adapter
+      // must not invent one and reject a bid the server would have accepted.
+      it('does not police the shape of bidFloorCur', function () {
+        expect(spec.isBidRequestValid(bannerBid({
+          params: { host: HOST, placementKey: PLACEMENT, bidFloor: 1, bidFloorCur: 'eur' },
+        }))).to.equal(true);
       });
     });
   });
@@ -105,8 +226,7 @@ describe('Epom Ad Server adapter', function () {
     });
 
     it('POSTs to https://{host}/hb/bid as text/plain with credentials', async function () {
-      const bids = [bannerBid()];
-      const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+      const requests = await buildOne([bannerBid()]);
 
       expect(requests).to.have.lengthOf(1);
       expect(requests[0].method).to.equal('POST');
@@ -118,12 +238,11 @@ describe('Epom Ad Server adapter', function () {
     });
 
     it('packs every ad unit of one host into a single request, one imp each', async function () {
-      const bids = [
+      const requests = await buildOne([
         bannerBid(),
         bannerBid({ bidId: 'bid-2', adUnitCode: 'div-sidebar', params: { host: HOST, placementKey: '6d0e83b415' } }),
         bannerBid({ bidId: 'bid-3', adUnitCode: 'div-footer', params: { host: HOST, placementKey: 'ff0011aa22' } }),
-      ];
-      const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+      ]);
 
       expect(requests).to.have.lengthOf(1);
       const { imp } = requests[0].data;
@@ -133,12 +252,11 @@ describe('Epom Ad Server adapter', function () {
     });
 
     it('splits by host so impressions never reach the wrong deployment', async function () {
-      const bids = [
+      const requests = await buildOne([
         bannerBid(),
         bannerBid({ bidId: 'bid-2', params: { host: OTHER_HOST, placementKey: '6d0e83b415' } }),
         bannerBid({ bidId: 'bid-3', params: { host: HOST, placementKey: 'ff0011aa22' } }),
-      ];
-      const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+      ]);
 
       expect(requests).to.have.lengthOf(2);
       const byUrl = Object.fromEntries(requests.map((r) => [r.url, r.data.imp.map((i) => i.id)]));
@@ -147,8 +265,7 @@ describe('Epom Ad Server adapter', function () {
     });
 
     it('carries banner sizes through to imp.banner.format', async function () {
-      const bids = [bannerBid()];
-      const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+      const requests = await buildOne([bannerBid()]);
 
       expect(requests[0].data.imp[0].banner.format).to.deep.equal([
         { w: 300, h: 250 },
@@ -156,101 +273,152 @@ describe('Epom Ad Server adapter', function () {
       ]);
     });
 
+    // The converter pins context.mediaType to banner; without it the default
+    // ORTB processors would populate imp.video for a mixed ad unit and the ad
+    // server would be asked for a format it does not sell.
+    it('sends only a banner imp for a mixed banner+video ad unit', async function () {
+      const requests = await buildOne([bannerBid({
+        mediaTypes: {
+          banner: { sizes: [[300, 250]] },
+          video: { context: 'outstream', playerSize: [[640, 480]], mimes: ['video/mp4'] },
+        },
+      })]);
+
+      expect(requests[0].data.imp[0].banner).to.exist;
+      expect(requests[0].data.imp[0].video).to.not.exist;
+    });
+
     it('defaults the request currency to USD', async function () {
-      const bids = [bannerBid()];
-      const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+      const requests = await buildOne([bannerBid()]);
 
       expect(requests[0].data.cur).to.deep.equal(['USD']);
     });
 
+    // USD is a default, not an override: once the currency module is active it
+    // owns request.cur, and the adapter must leave what it set alone.
+    it('leaves a request currency set by the currency module alone', async function () {
+      config.setConfig({ currency: { adServerCurrency: 'USD' } });
+      try {
+        const requests = await buildOne([bannerBid()]);
+
+        expect(requests[0].data.cur).to.deep.equal(['USD']);
+      } finally {
+        config.resetConfig();
+      }
+    });
+
     it('forwards the page URL from refererInfo', async function () {
-      const bids = [bannerBid()];
-      const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+      const requests = await buildOne([bannerBid()]);
 
       expect(requests[0].data.site.page).to.equal('https://publisher.example.com/article');
     });
 
     describe('floors', function () {
       it('applies params.bidFloor when no floors module value is present', async function () {
-        const bids = [bannerBid({ params: { host: HOST, placementKey: PLACEMENT, bidFloor: 1.25 } })];
-        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+        const requests = await buildOne([bannerBid({ params: { host: HOST, placementKey: PLACEMENT, bidFloor: 1.25 } })]);
 
         expect(requests[0].data.imp[0].bidfloor).to.equal(1.25);
         expect(requests[0].data.imp[0].bidfloorcur).to.equal('USD');
       });
 
       it('honours params.bidFloorCur', async function () {
-        const bids = [bannerBid({ params: { host: HOST, placementKey: PLACEMENT, bidFloor: 2, bidFloorCur: 'EUR' } })];
-        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+        const requests = await buildOne([bannerBid({ params: { host: HOST, placementKey: PLACEMENT, bidFloor: 2, bidFloorCur: 'EUR' } })]);
 
         expect(requests[0].data.imp[0].bidfloorcur).to.equal('EUR');
       });
 
+      // 0 is the schema's way of saying "no floor", so nothing goes on the wire
+      // and the ad server is left to apply its own.
+      it('treats a bidFloor of 0 as no floor', async function () {
+        const requests = await buildOne([bannerBid({ params: { host: HOST, placementKey: PLACEMENT, bidFloor: 0 } })]);
+
+        expect(requests[0].data.imp[0].bidfloor).to.equal(undefined);
+        expect(requests[0].data.imp[0].bidfloorcur).to.equal(undefined);
+      });
+
       it('lets the Price Floors module win over params.bidFloor', async function () {
-        const bids = [bannerBid({
+        const requests = await buildOne([bannerBid({
           params: { host: HOST, placementKey: PLACEMENT, bidFloor: 1.25 },
           getFloor: () => ({ currency: 'USD', floor: 3.5 }),
-        })];
-        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+        })]);
 
         expect(requests[0].data.imp[0].bidfloor).to.equal(3.5);
+      });
+
+      // The adapter pins only the request currency, never the floor's: a module
+      // floor quoted in another currency travels verbatim, with its own
+      // bidfloorcur, rather than being reinterpreted as USD.
+      it('passes a non-USD floors module value through with its own currency', async function () {
+        const requests = await buildOne([bannerBid({
+          params: { host: HOST, placementKey: PLACEMENT, bidFloor: 1.25, bidFloorCur: 'USD' },
+          getFloor: () => ({ currency: 'EUR', floor: 2.2 }),
+        })]);
+
+        expect(requests[0].data.imp[0].bidfloor).to.equal(2.2);
+        expect(requests[0].data.imp[0].bidfloorcur).to.equal('EUR');
       });
     });
 
     describe('channel and custom params', function () {
       it('sends the channel under our own namespace', async function () {
-        const bids = [bannerBid({ params: { host: HOST, placementKey: PLACEMENT, channel: 'sports-uk' } })];
-        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+        const requests = await buildOne([bannerBid({ params: { host: HOST, placementKey: PLACEMENT, channel: 'sports-uk' } })]);
 
         expect(requests[0].data.imp[0].ext.epom_as.channel).to.equal('sports-uk');
+      });
+
+      it('omits an empty channel rather than sending a blank one', async function () {
+        const requests = await buildOne([bannerBid({ params: { host: HOST, placementKey: PLACEMENT, channel: '' } })]);
+
+        expect(requests[0].data.imp[0].ext?.epom_as).to.equal(undefined);
       });
 
       // Custom params share imp.ext.data with first-party data and RTD modules, so the
       // ad server has one place to read targetable key-values from.
       it('merges custom params into imp.ext.data as strings', async function () {
-        const bids = [bannerBid({
+        const requests = await buildOne([bannerBid({
           params: { host: HOST, placementKey: PLACEMENT, customParams: { section: 'sport', tier: 2, premium: true } },
-        })];
-        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+        })]);
 
         expect(requests[0].data.imp[0].ext.data).to.deep.equal({
           section: 'sport', tier: '2', premium: 'true',
         });
       });
 
-      it('drops non-scalar values and oversized entries', async function () {
-        const bids = [bannerBid({
-          params: {
-            host: HOST,
-            placementKey: PLACEMENT,
-            customParams: {
-              ok: 'yes',
-              nested: { a: 1 },
-              list: [1, 2],
-              ['k'.repeat(129)]: 'long-key',
-              tooLong: 'v'.repeat(513),
-            },
-          },
-        })];
-        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+      // Nothing is capped or dropped in the adapter — a publisher who configures
+      // more keys than the ad server ingests sees them all leave the page, and
+      // which ones survive is the ad server's documented decision, not a
+      // nondeterministic one taken here.
+      it('keeps every scalar entry, well past the ad server ingest limit', async function () {
+        const many = {};
+        for (let i = 0; i < 40; i++) {
+          many['k' + i] = 'v' + i;
+        }
+        const requests = await buildOne([bannerBid({ params: { host: HOST, placementKey: PLACEMENT, customParams: many } })]);
 
-        expect(requests[0].data.imp[0].ext.data).to.deep.equal({ ok: 'yes' });
+        const sent = requests[0].data.imp[0].ext.data;
+        expect(Object.keys(sent)).to.have.lengthOf(40);
+        expect(sent.k0).to.equal('v0');
+        expect(sent.k39).to.equal('v39');
       });
 
-      it('caps the number of custom params', async function () {
-        const many = {};
-        for (let i = 0; i < 50; i++) {
-          many['k' + i] = 'v';
-        }
-        const bids = [bannerBid({ params: { host: HOST, placementKey: PLACEMENT, customParams: many } })];
-        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+      it('lets first-party data on the impression win over a custom param of the same name', async function () {
+        const requests = await buildOne([bannerBid({
+          params: { host: HOST, placementKey: PLACEMENT, customParams: { section: 'sport', tier: '2' } },
+          ortb2Imp: { ext: { data: { section: 'news' } } },
+        })]);
 
-        expect(Object.keys(requests[0].data.imp[0].ext.data)).to.have.lengthOf(32);
+        expect(requests[0].data.imp[0].ext.data.section).to.equal('news');
+        expect(requests[0].data.imp[0].ext.data.tier).to.equal('2');
+      });
+
+      it('sends no imp.ext.data for an empty customParams object', async function () {
+        const requests = await buildOne([bannerBid({ params: { host: HOST, placementKey: PLACEMENT, customParams: {} } })]);
+
+        expect(requests[0].data.imp[0].ext?.data).to.equal(undefined);
       });
 
       it('adds nothing when neither is configured', async function () {
-        const bids = [bannerBid()];
-        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+        const requests = await buildOne([bannerBid()]);
 
         expect(requests[0].data.imp[0].ext?.epom_as).to.equal(undefined);
         expect(requests[0].data.imp[0].ext?.data).to.equal(undefined);
@@ -293,17 +461,52 @@ describe('Epom Ad Server adapter', function () {
     let request;
 
     beforeEach(async function () {
-      const bids = [bannerBid()];
-      request = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)))[0];
+      request = (await buildOne([bannerBid()]))[0];
     });
 
     it('returns nothing for an empty response', function () {
       expect(spec.interpretResponse({}, request)).to.deep.equal([]);
       expect(spec.interpretResponse({ body: null }, request)).to.deep.equal([]);
+      expect(spec.interpretResponse({ body: '' }, request)).to.deep.equal([]);
+      expect(spec.interpretResponse(undefined, request)).to.deep.equal([]);
+    });
+
+    // A misconfigured host or a proxy in front of the ad server answers with
+    // something that is not OpenRTB at all. That must cost the auction one
+    // bidder, not throw out of the whole response handler.
+    it('returns nothing for a non-ORTB body', function () {
+      const htmlErrorPage = '<!doctype html><html><body><h1>502 Bad Gateway</h1></body></html>';
+      expect(spec.interpretResponse({ body: htmlErrorPage }, request)).to.deep.equal([]);
+      expect(spec.interpretResponse({ body: 'no bid' }, request)).to.deep.equal([]);
+      expect(spec.interpretResponse({ body: 42 }, request)).to.deep.equal([]);
+      expect(spec.interpretResponse({ body: [] }, request)).to.deep.equal([]);
+    });
+
+    it('returns nothing when the body carries no seatbid at all', function () {
+      expect(spec.interpretResponse({ body: { id: request.data.id } }, request)).to.deep.equal([]);
     });
 
     it('returns nothing when the ad server has no bid', function () {
       const response = { body: { id: request.data.id, seatbid: [], cur: 'USD' } };
+      expect(spec.interpretResponse(response, request)).to.deep.equal([]);
+    });
+
+    it('returns nothing for a seatbid entry with no bids', function () {
+      const response = { body: { id: request.data.id, seatbid: [{ seat: 'epom' }], cur: 'USD' } };
+      expect(spec.interpretResponse(response, request)).to.deep.equal([]);
+    });
+
+    // fromORTB matches bids to impressions by impid; a bid naming an impression
+    // that is not in this request belongs to some other auction.
+    it('drops a bid whose impid matches no impression in the request', function () {
+      const response = {
+        body: {
+          id: request.data.id,
+          cur: 'USD',
+          seatbid: [{ bid: [{ id: 's1', impid: 'not-our-imp', price: 3, adm: '<div>x</div>', crid: 'c1', w: 300, h: 250 }] }],
+        },
+      };
+
       expect(spec.interpretResponse(response, request)).to.deep.equal([]);
     });
 
@@ -340,7 +543,52 @@ describe('Epom Ad Server adapter', function () {
       expect(bids[0].mediaType).to.equal('banner');
       expect(bids[0].netRevenue).to.equal(true);
       expect(bids[0].ttl).to.equal(25);
+      // Derived from bid.adomain by the converter — Epom Ad Server does not
+      // populate it today, so this pins the wiring rather than the ad server.
       expect(bids[0].meta.advertiserDomains).to.deep.equal(['advertiser.example.com']);
+    });
+
+    // Today's ad server sends no adomain, so nothing is fabricated in its place —
+    // the field is simply absent, and a brand-safety line item keyed on it will
+    // not match an Epom bid until the ad server starts populating it.
+    it('leaves advertiserDomains unset when the ad server sends no adomain', function () {
+      const response = {
+        body: {
+          id: request.data.id,
+          cur: 'USD',
+          seatbid: [{ bid: [{ id: 's1', impid: 'bid-1', price: 1, adm: '<div>a</div>', crid: 'c1', w: 300, h: 250 }] }],
+        },
+      };
+
+      const bid = spec.interpretResponse(response, request)[0];
+      expect(bid.meta).to.be.an('object');
+      expect(bid.meta.advertiserDomains).to.equal(undefined);
+    });
+
+    // The 25s default is the impression beacon's window, not a ceiling: a
+    // deployment configured wider says so per bid.
+    it('honours a per-bid exp over the default ttl', function () {
+      const response = {
+        body: {
+          id: request.data.id,
+          cur: 'USD',
+          seatbid: [{ bid: [{ id: 's1', impid: 'bid-1', price: 1, adm: '<div>a</div>', crid: 'c1', w: 300, h: 250, exp: 120 }] }],
+        },
+      };
+
+      expect(spec.interpretResponse(response, request)[0].ttl).to.equal(120);
+    });
+
+    it('honours a response currency other than the requested one', function () {
+      const response = {
+        body: {
+          id: request.data.id,
+          cur: 'EUR',
+          seatbid: [{ bid: [{ id: 's1', impid: 'bid-1', price: 1.8, adm: '<div>a</div>', crid: 'c1', w: 300, h: 250 }] }],
+        },
+      };
+
+      expect(spec.interpretResponse(response, request)[0].currency).to.equal('EUR');
     });
 
     // The whole Google Ad Manager integration hangs off hb_deal_epom_as: a
@@ -370,11 +618,10 @@ describe('Epom Ad Server adapter', function () {
     });
 
     it('maps one bid per impression back to its own ad unit', async function () {
-      const bids = [
+      const multiRequest = (await buildOne([
         bannerBid(),
         bannerBid({ bidId: 'bid-2', adUnitCode: 'div-sidebar', params: { host: HOST, placementKey: '6d0e83b415' } }),
-      ];
-      const multiRequest = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)))[0];
+      ]))[0];
       const response = {
         body: {
           id: multiRequest.data.id,
@@ -391,6 +638,12 @@ describe('Epom Ad Server adapter', function () {
       const interpreted = spec.interpretResponse(response, multiRequest);
       expect(interpreted.map((b) => b.requestId)).to.deep.equal(['bid-1', 'bid-2']);
       expect(interpreted.map((b) => b.cpm)).to.deep.equal([1.5, 4.0]);
+    });
+  });
+
+  describe('getUserSyncs', function () {
+    it('registers no user syncs', function () {
+      expect(spec.getUserSyncs({ iframeEnabled: true, pixelEnabled: true }, [])).to.deep.equal([]);
     });
   });
 });

--- a/test/spec/modules/epom_asBidAdapter_spec.js
+++ b/test/spec/modules/epom_asBidAdapter_spec.js
@@ -33,6 +33,31 @@ function bannerBid(overrides = {}) {
   };
 }
 
+function videoBid(overrides = {}) {
+  return bannerBid({
+    mediaTypes: { video: { context: 'instream', playerSize: [[640, 480]], mimes: ['video/mp4'] } },
+    sizes: [[640, 480]],
+    ...overrides,
+  });
+}
+
+function nativeBid(overrides = {}) {
+  return bannerBid({
+    mediaTypes: {
+      native: {
+        ortb: {
+          ver: '1.2',
+          assets: [
+            { id: 1, required: 1, title: { len: 90 } },
+            { id: 2, required: 1, img: { type: 3, w: 1200, h: 627 } },
+          ],
+        },
+      },
+    },
+    ...overrides,
+  });
+}
+
 function bidderRequestFor(bids) {
   return {
     bidderCode: 'epom_as',
@@ -60,10 +85,12 @@ describe('Epom Ad Server adapter', function () {
   });
 
   describe('spec metadata', function () {
-    it('declares the bidder code, GVL ID and banner support', function () {
+    it('declares the bidder code, GVL ID and the media types the ad server serves', function () {
       expect(spec.code).to.equal('epom_as');
       expect(spec.gvlid).to.equal(849);
-      expect(spec.supportedMediaTypes).to.deep.equal(['banner']);
+      // Prebid will not offer a slot to a bidder that has not declared its media type, so
+      // this list is what decides which auctions ever reach us — not the ad server.
+      expect(spec.supportedMediaTypes).to.deep.equal(['banner', 'video', 'native']);
     });
 
     // The POST is credentialed, so the ad server's identity cookie reaches the
@@ -287,10 +314,10 @@ describe('Epom Ad Server adapter', function () {
       ]);
     });
 
-    // The converter pins context.mediaType to banner; without it the default
-    // ORTB processors would populate imp.video for a mixed ad unit and the ad
-    // server would be asked for a format it does not sell.
-    it('sends only a banner imp for a mixed banner+video ad unit', async function () {
+    // A mixed ad unit now offers both, and the ad server answers with whichever it
+    // filled — the bid's mtype says which. Stripping video here, as this adapter did
+    // while it sold banner only, would decide the auction on the page's behalf.
+    it('offers both formats for a mixed banner+video ad unit', async function () {
       const requests = await buildOne([bannerBid({
         mediaTypes: {
           banner: { sizes: [[300, 250]] },
@@ -299,7 +326,10 @@ describe('Epom Ad Server adapter', function () {
       })]);
 
       expect(requests[0].data.imp[0].banner).to.exist;
-      expect(requests[0].data.imp[0].video).to.not.exist;
+      if (FEATURES.VIDEO) {
+        expect(requests[0].data.imp[0].video).to.exist;
+        expect(requests[0].data.imp[0].video.mimes).to.deep.equal(['video/mp4']);
+      }
     });
 
     it('defaults the request currency to USD', async function () {
@@ -505,6 +535,66 @@ describe('Epom Ad Server adapter', function () {
       expect(spec.interpretResponse(response, request)).to.deep.equal([]);
     });
 
+    // mtype is what tells the converter which kind of creative came back. The ad server
+    // stamps it per creative; without it a bid is discarded rather than guessed at, which
+    // is why every fixture here carries one.
+    it('reads a video bid back as video, with the VAST document as its markup', async function () {
+      const videoRequest = (await buildOne([videoBid()]))[0];
+      const vast = '<VAST version="4.0"><Ad><InLine/></Ad></VAST>';
+      const response = {
+        body: {
+          id: videoRequest.data.id,
+          cur: 'USD',
+          seatbid: [{ bid: [{ id: 's1', impid: 'bid-1', price: 12, adm: vast, crid: 'c1', w: 640, h: 480, mtype: 2 }] }],
+        },
+      };
+      const bids = spec.interpretResponse(response, videoRequest);
+      expect(bids).to.have.lengthOf(1);
+      expect(bids[0].mediaType).to.equal('video');
+      // The VAST itself is only unpacked when the build carries video support; the media
+      // type is decided above it either way.
+      if (FEATURES.VIDEO) {
+        expect(bids[0].vastXml).to.equal(vast);
+      }
+    });
+
+    it('reads a native bid back as native, with the assets the page asked for', async function () {
+      const nativeRequest = (await buildOne([nativeBid()]))[0];
+      const adm = JSON.stringify({
+        assets: [
+          { id: 1, required: 1, title: { text: 'Northwind Autumn Sale' } },
+          { id: 2, required: 1, img: { url: 'https://cdn.test/main.jpg', w: 1200, h: 627 } },
+        ],
+        link: { url: 'https://ads.test/click' },
+        imptrackers: ['https://ads.test/imp'],
+      });
+      const response = {
+        body: {
+          id: nativeRequest.data.id,
+          cur: 'USD',
+          seatbid: [{ bid: [{ id: 's1', impid: 'bid-1', price: 4, adm, crid: 'c1', mtype: 4 }] }],
+        },
+      };
+      const bids = spec.interpretResponse(response, nativeRequest);
+      expect(bids).to.have.lengthOf(1);
+      expect(bids[0].mediaType).to.equal('native');
+      if (FEATURES.NATIVE) {
+        // The renderer matches a response asset to a requested one by id alone.
+        expect(bids[0].native.ortb.assets.map((a) => a.id)).to.deep.equal([1, 2]);
+      }
+    });
+
+    it('discards a bid that names no media type rather than rendering it as the wrong one', function () {
+      const response = {
+        body: {
+          id: request.data.id,
+          cur: 'USD',
+          seatbid: [{ bid: [{ id: 's1', impid: 'bid-1', price: 1, adm: '<div>a</div>', crid: 'c1', w: 300, h: 250 }] }],
+        },
+      };
+      expect(spec.interpretResponse(response, request)).to.deep.equal([]);
+    });
+
     it('returns nothing for a seatbid entry with no bids', function () {
       const response = { body: { id: request.data.id, seatbid: [{ seat: 'epom' }], cur: 'USD' } };
       expect(spec.interpretResponse(response, request)).to.deep.equal([]);
@@ -517,7 +607,7 @@ describe('Epom Ad Server adapter', function () {
         body: {
           id: request.data.id,
           cur: 'USD',
-          seatbid: [{ bid: [{ id: 's1', impid: 'not-our-imp', price: 3, adm: '<div>x</div>', crid: 'c1', w: 300, h: 250 }] }],
+          seatbid: [{ bid: [{ id: 's1', impid: 'not-our-imp', price: 3, adm: '<div>x</div>', crid: 'c1', w: 300, h: 250, mtype: 1 }] }],
         },
       };
 
@@ -536,6 +626,7 @@ describe('Epom Ad Server adapter', function () {
               impid: 'bid-1',
               price: 2.75,
               adm: '<div>creative</div>',
+              mtype: 1,
               crid: 'creative-99',
               w: 300,
               h: 250,
@@ -570,7 +661,7 @@ describe('Epom Ad Server adapter', function () {
         body: {
           id: request.data.id,
           cur: 'USD',
-          seatbid: [{ bid: [{ id: 's1', impid: 'bid-1', price: 1, adm: '<div>a</div>', crid: 'c1', w: 300, h: 250 }] }],
+          seatbid: [{ bid: [{ id: 's1', impid: 'bid-1', price: 1, adm: '<div>a</div>', crid: 'c1', w: 300, h: 250, mtype: 1 }] }],
         },
       };
 
@@ -586,7 +677,7 @@ describe('Epom Ad Server adapter', function () {
         body: {
           id: request.data.id,
           cur: 'USD',
-          seatbid: [{ bid: [{ id: 's1', impid: 'bid-1', price: 1, adm: '<div>a</div>', crid: 'c1', w: 300, h: 250, exp: 120 }] }],
+          seatbid: [{ bid: [{ id: 's1', impid: 'bid-1', price: 1, adm: '<div>a</div>', crid: 'c1', w: 300, h: 250, mtype: 1, exp: 120 }] }],
         },
       };
 
@@ -598,7 +689,7 @@ describe('Epom Ad Server adapter', function () {
         body: {
           id: request.data.id,
           cur: 'EUR',
-          seatbid: [{ bid: [{ id: 's1', impid: 'bid-1', price: 1.8, adm: '<div>a</div>', crid: 'c1', w: 300, h: 250 }] }],
+          seatbid: [{ bid: [{ id: 's1', impid: 'bid-1', price: 1.8, adm: '<div>a</div>', crid: 'c1', w: 300, h: 250, mtype: 1 }] }],
         },
       };
 
@@ -619,6 +710,7 @@ describe('Epom Ad Server adapter', function () {
               impid: 'bid-1',
               price: 2.75,
               adm: '<div>creative</div>',
+              mtype: 1,
               crid: 'creative-99',
               dealid: 'epom-direct',
               w: 300,
@@ -642,8 +734,8 @@ describe('Epom Ad Server adapter', function () {
           cur: 'USD',
           seatbid: [{
             bid: [
-              { id: 's1', impid: 'bid-1', price: 1.5, adm: '<div>a</div>', crid: 'c1', w: 300, h: 250 },
-              { id: 's2', impid: 'bid-2', price: 4.0, adm: '<div>b</div>', crid: 'c2', w: 728, h: 90 },
+              { id: 's1', impid: 'bid-1', price: 1.5, adm: '<div>a</div>', crid: 'c1', w: 300, h: 250, mtype: 1 },
+              { id: 's2', impid: 'bid-2', price: 4.0, adm: '<div>b</div>', crid: 'c2', w: 728, h: 90, mtype: 1 },
             ],
           }],
         },

--- a/test/spec/modules/epom_asBidAdapter_spec.js
+++ b/test/spec/modules/epom_asBidAdapter_spec.js
@@ -104,7 +104,7 @@ describe('Epom Ad Server adapter', function () {
       expect(spec.buildRequests([], bidderRequestFor([]))).to.deep.equal([]);
     });
 
-    it('POSTs to https://{host}/hb/bid as text/plain without credentials', async function () {
+    it('POSTs to https://{host}/hb/bid as text/plain with credentials', async function () {
       const bids = [bannerBid()];
       const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
 
@@ -339,7 +339,7 @@ describe('Epom Ad Server adapter', function () {
       expect(bids[0].creativeId).to.equal('creative-99');
       expect(bids[0].mediaType).to.equal('banner');
       expect(bids[0].netRevenue).to.equal(true);
-      expect(bids[0].ttl).to.equal(300);
+      expect(bids[0].ttl).to.equal(25);
       expect(bids[0].meta.advertiserDomains).to.deep.equal(['advertiser.example.com']);
     });
 

--- a/test/spec/modules/epom_asBidAdapter_spec.js
+++ b/test/spec/modules/epom_asBidAdapter_spec.js
@@ -194,6 +194,66 @@ describe('Epom Ad Server adapter', function () {
       });
     });
 
+    describe('channel and custom params', function () {
+      it('sends the channel under our own namespace', async function () {
+        const bids = [bannerBid({ params: { host: HOST, placementKey: PLACEMENT, channel: 'sports-uk' } })];
+        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+
+        expect(requests[0].data.imp[0].ext.epom_as.channel).to.equal('sports-uk');
+      });
+
+      // Custom params share imp.ext.data with first-party data and RTD modules, so the
+      // ad server has one place to read targetable key-values from.
+      it('merges custom params into imp.ext.data as strings', async function () {
+        const bids = [bannerBid({
+          params: { host: HOST, placementKey: PLACEMENT, customParams: { section: 'sport', tier: 2, premium: true } },
+        })];
+        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+
+        expect(requests[0].data.imp[0].ext.data).to.deep.equal({
+          section: 'sport', tier: '2', premium: 'true',
+        });
+      });
+
+      it('drops non-scalar values and oversized entries', async function () {
+        const bids = [bannerBid({
+          params: {
+            host: HOST,
+            placementKey: PLACEMENT,
+            customParams: {
+              ok: 'yes',
+              nested: { a: 1 },
+              list: [1, 2],
+              ['k'.repeat(129)]: 'long-key',
+              tooLong: 'v'.repeat(513),
+            },
+          },
+        })];
+        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+
+        expect(requests[0].data.imp[0].ext.data).to.deep.equal({ ok: 'yes' });
+      });
+
+      it('caps the number of custom params', async function () {
+        const many = {};
+        for (let i = 0; i < 50; i++) {
+          many['k' + i] = 'v';
+        }
+        const bids = [bannerBid({ params: { host: HOST, placementKey: PLACEMENT, customParams: many } })];
+        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+
+        expect(Object.keys(requests[0].data.imp[0].ext.data)).to.have.lengthOf(32);
+      });
+
+      it('adds nothing when neither is configured', async function () {
+        const bids = [bannerBid()];
+        const requests = spec.buildRequests(bids, await addFPDToBidderRequest(bidderRequestFor(bids)));
+
+        expect(requests[0].data.imp[0].ext?.epom_as).to.equal(undefined);
+        expect(requests[0].data.imp[0].ext?.data).to.equal(undefined);
+      });
+    });
+
     describe('consent', function () {
       it('forwards TCF consent and the GDPR flag', async function () {
         const bids = [bannerBid()];

--- a/test/spec/modules/epom_asBidAdapter_spec.js
+++ b/test/spec/modules/epom_asBidAdapter_spec.js
@@ -112,9 +112,9 @@ describe('Epom Ad Server adapter', function () {
       expect(requests[0].method).to.equal('POST');
       expect(requests[0].url).to.equal(ENDPOINT);
       // text/plain keeps the POST a simple request, so the browser skips the
-      // CORS preflight; withCredentials false means no cookies leave the page.
+      // CORS preflight; credentials carry an existing Epom identity.
       expect(requests[0].options.contentType).to.equal('text/plain');
-      expect(requests[0].options.withCredentials).to.equal(false);
+      expect(requests[0].options.withCredentials).to.equal(true);
     });
 
     it('packs every ad unit of one host into a single request, one imp each', async function () {


### PR DESCRIPTION
## Type of change
- [x] New bidder adapter

## Description of change

New bid adapter for **Epom Ad Server** (`epom_as`), built on `ortbConverter`, for banner, video and native.

Epom Ad Server is the sell side of the Epom platform, where a publisher's own direct-sold campaigns
are booked and served. It is a different product from the existing `epom_dsp` adapter, which is the
buy side.

Epom Ad Server is white-label: each network runs its own deployment on its own domain, so the
serving host is supplied per ad unit via `params.host` and the adapter posts to
`https://{host}/hb/bid`. Only the host is configurable — the request path is fixed by the adapter,
so a page configuration cannot redirect the auction payload to an arbitrary URL. A page may mix
several deployments; the adapter groups impressions by host and sends one request to each. The host
pattern is byte-identical to the expression Prebid Server validates the same parameter with.

The ad server names the format it filled on each bid's `mtype`: video comes back as VAST in `adm`,
native as an OpenRTB native response. An instream video unit needs a `cache` setting, or Prebid
discards the VAST-only bid before `bidsBackHandler`; `modules/epom_asBidAdapter.md` lists the options.

GVL vendor id 849, with the device-storage disclosure published on that vendor list entry. The
adapter itself uses no storage manager and writes nothing; the identity cookie is set by the ad
server on its own domain and reaches the auction only because the POST is credentialed.

Maintainer: support@epom.com

Test parameters for validating bids, one live placement per media type on the same host (full ad
units in `modules/epom_asBidAdapter.md`):

```js
// banner
{ bidder: 'epom_as', params: { host: 'aj2494.online', placementKey: '63bad7a99f270394e7b4b370952cbff2' } }
// video (instream)
{ bidder: 'epom_as', params: { host: 'aj2494.online', placementKey: '7659fd47e17263ba6ae1de3c9e137c74' } }
// native
{ bidder: 'epom_as', params: { host: 'aj2494.online', placementKey: 'f4dd0f413d5c4f8d8c515f8a999e038f' } }
```

Verified against the Hello World sample page: the banner placement bids 1.23 USD on a 300x250 slot
and renders. A request carrying several impressions is answered with a bid per impression; an unknown
placement key and a size the placement does not carry both return a no-fill.

Tests: 61, covering parameter validation, request building and response parsing, video and native
bids included.

## Other information

Documentation PR: https://github.com/prebid/prebid.github.io/pull/6714
Prebid Server adapter for the same bidder: https://github.com/prebid/prebid-server/pull/4916

`bid.meta.advertiserDomains` is filled from `bid.adomain` whenever the ad server sends it, and is
left unset otherwise.
