### PR TITLE
Remove gvlid from revantageBidAdapter

### DIFF
--- a/modules/revantageBidAdapter.js
+++ b/modules/revantageBidAdapter.js
@@ -8,7 +8,6 @@ const SYNC_URL = 'https://sync.revantage.io/sync';
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: 1588,
   aliases: ['revbidortb'],
   supportedMediaTypes: [BANNER, VIDEO],
 


### PR DESCRIPTION
this was deleted from the gvl 

https://vendor-list.consensu.org/v3/vendor-list.json#:~:text=%221588%22%3A%20%7B%22id%22%3A%201588%2C%20%22name%22%3A%20%22ReVantage%20GmbH%22%2C%20%22purposes%22%3A%20%5B%5D%2C%20%22legIntPurposes%22%3A%20%5B2%2C%207%2C%209%2C%2010%5D%2C%20%22flexiblePurposes%22%3A%20%5B%5D%2C%20%22specialPurposes%22%3A%20%5B1%2C%202%2C%203%5D%2C%20%22features%22%3A%20%5B1%2C%203%5D%2C%20%22specialFeatures%22%3A%20%5B%5D%2C%20%22deletedDate%22%3A%20%222026%2D08%2D05T10%3A31%3A54.431Z%22%2C