### PR TITLE
Nexx360 Analytics Adapter: declare GVL ID

### DIFF
--- a/modules/nexx360AnalyticsAdapter.ts
+++ b/modules/nexx360AnalyticsAdapter.ts
@@ -8,6 +8,7 @@ import { Nexx360ImpressionAuction, Nexx360ServerAuction } from '../libraries/nex
 
 const analyticsType = 'endpoint';
 const ANALYTICS_CODE = 'nexx360';
+const GVLID = 965;
 const DEFAULT_ENDPOINT = 'https://monitoring.nexx360.io';
 
 const {
@@ -782,6 +783,7 @@ nexx360AnalyticsAdapter.enableAnalytics = function(config: { options?: Partial<N
 adapterManager.registerAnalyticsAdapter({
   adapter: nexx360AnalyticsAdapter,
   code: ANALYTICS_CODE,
+  gvlid: GVLID,
 });
 
 export default nexx360AnalyticsAdapter;


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter

## Description of change
Declares the IAB GVL ID (965) on the Nexx360 analytics adapter's `registerAnalyticsAdapter` call, so TCF enforcement (`tcfControl`) can apply the correct purpose and vendor checks for this module. The adapter was added in #15388 without a `gvlid`.

Maintainer: gabriel@nexx360.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)