### PR TITLE
Oncore Digital: Remove GVLIDs

### DIFF
--- a/modules/mediafuseBidAdapter.js
+++ b/modules/mediafuseBidAdapter.js
@@ -31,7 +31,6 @@ import { chunk } from '../libraries/chunk/chunk.js';
 import { getAdUnitElement } from '../src/utils/adUnits.js';
 
 const BIDDER_CODE = 'mediafuse';
-const GVLID = 32;
 const ENDPOINT_URL_NORMAL = 'https://ib.adnxs.com/openrtb2/prebidjs';
 const ENDPOINT_URL_SIMPLE = 'https://ib.adnxs-simple.com/openrtb2/prebidjs';
 const SOURCE = 'pbjs';
@@ -788,7 +787,6 @@ function hasOmidSupport(bid) {
 
 export const spec = {
   code: BIDDER_CODE,
-  gvlid: GVLID,
   maintainer: { email: 'indrajit@oncoredigital.com' },
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
   isBidRequestValid: function (bid) {

--- a/modules/revnewBidAdapter.ts
+++ b/modules/revnewBidAdapter.ts
@@ -12,7 +12,6 @@ const BIDDER_CODE = 'revnew';
 const REQUEST_URL = 'https://fast.nexx360.io/revnew';
 const PAGE_VIEW_ID = generateUUID();
 const BIDDER_VERSION = '1.0';
-const GVLID = 1468;
 const REVNEW_KEY = 'revnew_storage';
 
 type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
@@ -89,7 +88,6 @@ const buildRequests = (
 
 export const spec:BidderSpec<typeof BIDDER_CODE> = {
   code: BIDDER_CODE,
-  gvlid: GVLID,
   supportedMediaTypes: [BANNER, VIDEO, NATIVE],
   isBidRequestValid,
   buildRequests,


### PR DESCRIPTION
 Removed GVLID constant from mediafuseBidAdapter and the revnew adapter as IABE revoked their gvlid https://vendor-list.consensu.org/v3/vendor-list.json#:~:text=OnCore%20Digital%20Media

fixes #15510 
