### PR TITLE
Build system: exclude dead browsers from browserslist

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ For instructions on writing tests for Prebid.js, see [Testing Prebid.js](https:/
 
 ### Supported Browsers
 
-Prebid.js is supported on IE11 and modern browsers until 5.x. 6.x+ transpiles to target >0.25%; not dead. 11.21+ removes not dead and adds not ios_saf 11.
+Prebid.js is supported on IE11 and modern browsers until 5.x. 6.x+ transpiles to target >0.25%; not dead. 11.22+ adds not ios_saf 11.
 
 ### Governance
 Review our governance model [here](https://github.com/prebid/Prebid.js/tree/master/governance.md).

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "@babel/plugin-transform-runtime": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
         "@babel/preset-typescript": "^7.29.7",
-        "@babel/register": "^7.29.7",
         "@babel/runtime-corejs3": "^7.29.7",
         "@chiragrupani/karma-chromium-edge-launcher": "^2.4.1",
         "@eslint/compat": "^1.4.1",
@@ -1729,119 +1728,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/register": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.29.7.tgz",
-      "integrity": "sha512-AMGJoWuES861riy6pcB0fphE1YXybtQnBYQMuIyPv6mKLiosfa79BKTnAOyx215c/3RJPJpdQwoHZ3earVH7AA==",
-      "dev": true,
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "find-cache-dir": "^2.0.0",
-        "make-dir": "^2.1.0",
-        "pirates": "^4.0.6",
-        "source-map-support": "^0.5.16"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/register/node_modules/find-cache-dir": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@babel/register/node_modules/find-up": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@babel/register/node_modules/locate-path": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@babel/register/node_modules/make-dir": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@babel/register/node_modules/p-locate": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@babel/register/node_modules/path-exists": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/register/node_modules/pify": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@babel/register/node_modules/pkg-dir": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@babel/register/node_modules/semver": {
-      "version": "5.7.2",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/@babel/runtime": {
@@ -7997,30 +7883,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/clone-deep": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4",
-        "kind-of": "^6.0.2",
-        "shallow-clone": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/clone-deep/node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/clone-stats": {
@@ -14904,14 +14766,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/klona": {
       "version": "2.0.6",
       "license": "MIT",
@@ -16910,14 +16764,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pirates": {
-      "version": "4.0.6",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/pkcs7": {
       "version": "1.0.4",
       "dev": true,
@@ -18337,17 +18183,6 @@
       "version": "1.2.0",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/shallow-clone": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -22580,79 +22415,6 @@
         "@babel/plugin-transform-typescript": "^7.29.7"
       }
     },
-    "@babel/register": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.29.7.tgz",
-      "integrity": "sha512-AMGJoWuES861riy6pcB0fphE1YXybtQnBYQMuIyPv6mKLiosfa79BKTnAOyx215c/3RJPJpdQwoHZ3earVH7AA==",
-      "dev": true,
-      "requires": {
-        "clone-deep": "^4.0.1",
-        "find-cache-dir": "^2.0.0",
-        "make-dir": "^2.1.0",
-        "pirates": "^4.0.6",
-        "source-map-support": "^0.5.16"
-      },
-      "dependencies": {
-        "find-cache-dir": {
-          "version": "2.1.0",
-          "dev": true,
-          "requires": {
-            "commondir": "^1.0.1",
-            "make-dir": "^2.0.0",
-            "pkg-dir": "^3.0.0"
-          }
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "make-dir": {
-          "version": "2.1.0",
-          "dev": true,
-          "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "dev": true
-        },
-        "pify": {
-          "version": "4.0.1",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "3.0.0",
-          "dev": true,
-          "requires": {
-            "find-up": "^3.0.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.2",
-          "dev": true
-        }
-      }
-    },
     "@babel/runtime": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
@@ -26610,24 +26372,6 @@
     "clone-buffer": {
       "version": "1.0.0",
       "dev": true
-    },
-    "clone-deep": {
-      "version": "4.0.1",
-      "dev": true,
-      "requires": {
-        "is-plain-object": "^2.0.4",
-        "kind-of": "^6.0.2",
-        "shallow-clone": "^3.0.0"
-      },
-      "dependencies": {
-        "is-plain-object": {
-          "version": "2.0.4",
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          }
-        }
-      }
     },
     "clone-stats": {
       "version": "1.0.0",
@@ -31146,10 +30890,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "kind-of": {
-      "version": "6.0.3",
-      "dev": true
-    },
     "klona": {
       "version": "2.0.6"
     },
@@ -32395,10 +32135,6 @@
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true
     },
-    "pirates": {
-      "version": "4.0.6",
-      "dev": true
-    },
     "pkcs7": {
       "version": "1.0.4",
       "dev": true,
@@ -33380,13 +33116,6 @@
     "setprototypeof": {
       "version": "1.2.0",
       "dev": true
-    },
-    "shallow-clone": {
-      "version": "3.0.1",
-      "dev": true,
-      "requires": {
-        "kind-of": "^6.0.2"
-      }
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   ],
   "browserslist": [
     "> 0.25%",
-    "not ios_saf 11"
+    "not ios_saf 11",
+    "not dead"
   ],
   "keywords": [
     "advertising",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@babel/plugin-transform-runtime": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
     "@babel/preset-typescript": "^7.29.7",
-    "@babel/register": "^7.29.7",
     "@babel/runtime-corejs3": "^7.29.7",
     "@chiragrupani/karma-chromium-edge-launcher": "^2.4.1",
     "@eslint/compat": "^1.4.1",

--- a/wdio.shared.conf.js
+++ b/wdio.shared.conf.js
@@ -1,12 +1,3 @@
-const path = require('path');
-const fs = require('fs');
-
-if (!process.env.BABEL_CACHE_PATH) {
-  const cacheFile = path.resolve(__dirname, '.cache', 'babel-register.json');
-  fs.mkdirSync(path.dirname(cacheFile), {recursive: true});
-  process.env.BABEL_CACHE_PATH = cacheFile;
-}
-
 // Collected per worker and printed by `after` below. The run log is long - a failing
 // browserstack run is easily ten thousand lines, of which fewer than a hundred say
 // anything about the tests - and webdriverio reports each spec as its worker finishes,
@@ -27,7 +18,6 @@ exports.config = {
   mochaOpts: {
     ui: 'bdd',
     timeout: 60000,
-    compilers: ['js:@babel/register'],
   },
   // if you see error, update this to spec reporter and logLevel above to get detailed report.
   reporters: ['spec'],


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [x] Build related changes
- [x] CI related changes

## Description of change

#15227 dropped `not IE 11`, `not dead` and `not op_mini all` from the browserslist, leaving `> 0.25%` to decide. IE 11 sits at 0.266% global usage, so it re-entered the resolved `preset-env` targets as soon as the 11.30.0 release refreshed caniuse-lite (1.0.30001807 → 1.0.30001810) via `gulp update-browserslist`. Everything babel touches is now downleveled to ES5, and in the e2e specs `@babel/plugin-transform-runtime` injects ESM helper imports into CommonJS files, so node loads them as ES modules and every e2e job on master dies before the first test with `require is not defined in ES module scope`.

- `Build system: exclude dead browsers from browserslist` — puts `not dead` back, which drops IE 11 from the targets; ES5 output is the job of the separate `--ES5` build, which forces syntax down independently of this list.
- `Test suite: stop running babel over the e2e specs` — removes `mochaOpts.compilers: ['js:@babel/register']` (and the `BABEL_CACHE_PATH` bootstrap it needed) from the wdio config, so a future targets change can't corrupt spec loading again; nothing in `test/spec/e2e` needs transpiling.
- `Test suite: drop the @babel/register dependency` — `npm uninstall @babel/register`, now that `mochaOpts.compilers` was its only consumer.
- `update README` — the supported-browsers line no longer says `not dead` was removed.

Either of the first two commits fixes CI on its own; the second is there so this can't recur.

## Tests

Ran the e2e suite against the failing job's own build artifact (chrome, `gulp e2e-test-nobuild --local`): fails as on master unpatched, and 8 passed / 1 skipped with each fix applied alone and with all three applied. `gulp test-build-logic` passes (32 tests) — it is the other mocha entry point that could have relied on the register hook. `npx eslint` clean; `gulp test` not run, as no unit-tested code changed.

No docs PR needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
