### PR TITLE
OpenX Bid Adapter: add parameter type declarations

### DIFF
--- a/modules/openxBidAdapter.d.ts
+++ b/modules/openxBidAdapter.d.ts
@@ -1,3 +1,5 @@
+import type { VideoMediaType } from '../src/video.ts';
+
 /** Parameters accepted by the OpenX bidder adapter. Added by a Codex bot. */
 export interface OpenxBidderParams {
   /** OpenX ad unit identifier. Required for video and native requests. */
@@ -8,11 +10,13 @@ export interface OpenxBidderParams {
   platform?: string;
   customParams?: Record<string, string | string[]>;
   customFloor?: number;
+  /** Prevent advertisers from using data for this user. */
+  doNotTrack?: boolean;
   coppa?: boolean;
   test?: boolean;
   response_template_name?: string;
   /** Overrides corresponding fields from `mediaTypes.video`. */
-  video?: Record<string, unknown>;
+  video?: Partial<VideoMediaType>;
 }
 
 declare module '../src/adUnits' {

--- a/modules/openxBidAdapter.d.ts
+++ b/modules/openxBidAdapter.d.ts
@@ -1,0 +1,22 @@
+/** Parameters accepted by the OpenX bidder adapter. Added by a Codex bot. */
+export interface OpenxBidderParams {
+  /** OpenX ad unit identifier. Required for video and native requests. */
+  unit?: string;
+  /** OpenX delivery domain. Required unless `platform` is provided. */
+  delDomain?: string;
+  /** OpenX platform hash. Required unless `delDomain` is provided. */
+  platform?: string;
+  customParams?: Record<string, string | string[]>;
+  customFloor?: number;
+  coppa?: boolean;
+  test?: boolean;
+  response_template_name?: string;
+  /** Overrides corresponding fields from `mediaTypes.video`. */
+  video?: Record<string, unknown>;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    openx: OpenxBidderParams;
+  }
+}

--- a/modules/openxBidAdapter.js
+++ b/modules/openxBidAdapter.js
@@ -5,6 +5,12 @@ import { mergeDeep } from '../src/utils.js';
 import { BANNER, NATIVE, VIDEO } from '../src/mediaTypes.js';
 import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 
+/**
+ * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
+ * @typedef {import('./openxBidAdapter.d.ts').OpenxBidderParams} OpenxBidderParams
+ * @typedef {BidRequest & {params: OpenxBidderParams}} OpenxBidRequest
+ */
+
 const bidderConfig = 'hb_pb_ortb';
 const bidderVersion = '2.0';
 export const REQUEST_URL = 'https://rtb.openx.net/openrtbb/prebidjs';
@@ -126,6 +132,10 @@ const converter = ortbConverter({
   }
 });
 
+/**
+ * @param {OpenxBidRequest} bidRequest
+ * @returns {boolean}
+ */
 function isBidRequestValid(bidRequest) {
   const hasDelDomainOrPlatform = bidRequest.params.delDomain ||
     bidRequest.params.platform;


### PR DESCRIPTION
### Motivation
- Provide TypeScript declarations for the OpenX bidder params so publishers get editor completion and static type checking for `openx` ad unit configuration.
- Annotate the adapter’s JS with JSDoc typedefs that reference the new declarations so tooling can surface the types without changing runtime behavior.

### Description
- Add `modules/openxBidAdapter.d.ts` which declares `OpenxBidderParams` (fields such as `unit`, `delDomain`, `platform`, `customParams`, `customFloor`, `coppa`, `test`, `response_template_name`, and `video`) and augments the shared `BidderParams` with `openx`.
- Add JSDoc typedefs to `modules/openxBidAdapter.js` importing `OpenxBidderParams` from the new `.d.ts` and annotate the `isBidRequestValid` signature as `OpenxBidRequest`.
- No runtime logic was changed; this PR only adds types and in-file JSDoc annotations to improve dev DX and type checking.

### Testing
- `npx eslint modules/openxBidAdapter.js modules/openxBidAdapter.d.ts --cache --cache-strategy content` completed with no errors.
- `npx gulp test --nolint --file test/spec/modules/openxBidAdapter_spec.js` was executed and the adapter tests completed successfully (feature-disabled chunk and full chunk passed; the run showed tests passing and `check-declarations`/build checks completed).
- `git diff --check` produced no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8ea0409a38832b9a9039922f26f5e8)