### PR TITLE
Yieldmo Bid Adapter: add parameter type declarations

### DIFF
--- a/modules/yieldmoBidAdapter.d.ts
+++ b/modules/yieldmoBidAdapter.d.ts
@@ -1,0 +1,45 @@
+/** Type declarations added by the Codex agent as a follow-up to Prebid.js #15428. */
+export interface YieldmoVideoParams {
+  mimes?: string[];
+  startdelay?: number;
+  placement?: number;
+  plcmt?: number;
+  skipafter?: number;
+  protocols?: number[];
+  api?: number[];
+  playbackmethod?: number[];
+  maxduration?: number;
+  minduration?: number;
+  pos?: number;
+  skip?: number;
+  skippable?: boolean;
+}
+
+export interface YieldmoSiteParams {
+  name?: string;
+  domain?: string;
+  cat?: string[];
+  keywords?: string;
+}
+
+/** Parameters accepted by the Yieldmo bidder adapter. */
+export interface YieldmoBidderParams {
+  /** Required for video bids. */
+  placementId?: string;
+  bidFloor?: number;
+  bidfloor?: number;
+  /** LiveRamp ATS envelope. */
+  lr_env?: string;
+  /** Blocked IAB content categories. */
+  bcat?: string[];
+  /** Blocked advertiser domains (video only). */
+  badv?: string[];
+  video?: YieldmoVideoParams;
+  site?: YieldmoSiteParams;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    yieldmo: YieldmoBidderParams;
+  }
+}

--- a/modules/yieldmoBidAdapter.js
+++ b/modules/yieldmoBidAdapter.js
@@ -27,6 +27,8 @@ import { getDNT } from '../libraries/dnt/index.js';
  * @typedef {import('../src/adapters/bidderFactory.js').BidderRequest} BidderRequest
  * @typedef {import('../src/adapters/bidderFactory.js').ServerResponse} ServerResponse
  * @typedef {import('../src/adapters/bidderFactory.js').ServerRequest} ServerRequest
+ * @typedef {import('./yieldmoBidAdapter.d.ts').YieldmoBidderParams} YieldmoBidderParams
+ * @typedef {BidRequest & {params: YieldmoBidderParams}} YieldmoBidRequest
  */
 
 const BIDDER_CODE = 'yieldmo';
@@ -54,7 +56,7 @@ export const spec = {
   gvlid: GVLID,
   /**
    * Determines whether or not the given bid request is valid.
-   * @param {object} bid bid to validate
+   * @param {YieldmoBidRequest} bid bid to validate
    * @return {boolean} true if valid, otherwise false
    */
   isBidRequestValid: function (bid) {


### PR DESCRIPTION
### Motivation

- Provide public TypeScript declarations for the Yieldmo adapter's common bidder parameters to improve editor completion and type-checking.
- Make the adapter's JSDoc typedefs reference the declared types so validation and tooling see the real `params` shape.

### Description

- Add `modules/yieldmoBidAdapter.d.ts` exporting `YieldmoBidderParams`, `YieldmoVideoParams`, and `YieldmoSiteParams`, and augment the shared `BidderParams` with `yieldmo`.
- Update `modules/yieldmoBidAdapter.js` JSDoc to import `YieldmoBidderParams` and declare `YieldmoBidRequest` for use in `isBidRequestValid` and related validators.
- These changes are declaration-only and do not alter runtime behavior or request payloads.

### Testing

- Ran `npx eslint modules/yieldmoBidAdapter.js modules/yieldmoBidAdapter.d.ts` which completed without errors.
- Ran the targeted unit tests with `npx gulp test --nolint --file test/spec/modules/yieldmoBidAdapter_spec.js` and observed the spec bundle complete with `92 tests completed` for the Yieldmo spec.
- The repository's stricter TypeScript declaration checks (`ts-strict` / `check-declarations`) completed successfully, but a full `gulp test` run later failed due to an unrelated build-logic test timeout, causing the overall test task to error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8ea0ea1740832bb33a055993732592)