### PR TITLE
Unruly Bid Adapter: add parameter type declarations

### DIFF
--- a/modules/unrulyBidAdapter.d.ts
+++ b/modules/unrulyBidAdapter.d.ts
@@ -1,0 +1,18 @@
+export interface UnrulyFeatureOverrides {
+  canRunUnmissable?: boolean;
+  [key: string]: unknown;
+}
+
+/** Parameters accepted by the Unruly bidder adapter. */
+export interface UnrulyBidderParams {
+  siteId: number;
+  featureOverrides?: UnrulyFeatureOverrides;
+  floor?: number;
+  endpoint?: string;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    unruly: UnrulyBidderParams;
+  }
+}

--- a/modules/unrulyBidAdapter.js
+++ b/modules/unrulyBidAdapter.js
@@ -3,6 +3,12 @@ import { Renderer } from '../src/Renderer.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { VIDEO, BANNER } from '../src/mediaTypes.js';
 
+/**
+ * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
+ * @typedef {import('./unrulyBidAdapter.d.ts').UnrulyBidderParams} UnrulyBidderParams
+ * @typedef {BidRequest & {params: UnrulyBidderParams}} UnrulyBidRequest
+ */
+
 function configureUniversalTag(exchangeRenderer, requestId) {
   if (!exchangeRenderer.config) throw new Error('UnrulyBidAdapter: Missing renderer config.');
   if (!exchangeRenderer.config.siteId) throw new Error('UnrulyBidAdapter: Missing renderer siteId.');
@@ -216,6 +222,10 @@ export const adapter = {
   code: 'unruly',
   supportedMediaTypes: [VIDEO, BANNER],
   gvlid: 36,
+  /**
+   * @param {UnrulyBidRequest} bid
+   * @return {boolean}
+   */
   isBidRequestValid: function (bid) {
     const siteId = deepAccess(bid, 'params.siteId');
     const isBidValid = siteId && isMediaTypesValid(bid);


### PR DESCRIPTION
### Motivation

- Provide public TypeScript declarations for the Unruly bidder adapter so publisher editors and typecheckers can surface `params` shapes (e.g. `siteId`, `featureOverrides`, `floor`, `endpoint`).
- Make the adapter's runtime validation and JSDoc typedefs align with the emitted `.d.ts` types for better IDE completion and safer integration with consumer TypeScript builds.

### Description

- Add a new declaration file `modules/unrulyBidAdapter.d.ts` that defines `UnrulyFeatureOverrides`, `UnrulyBidderParams`, and augments the shared `BidderParams` interface with `unruly`.
- Add JSDoc typedefs to `modules/unrulyBidAdapter.js` that import `UnrulyBidderParams` and define `UnrulyBidRequest` so existing validation (e.g. `isBidRequestValid`) is typed for editors and tooling.
- No runtime behavior was changed; the update is strictly type/annotation additions and module augmentation to expose param shapes to TypeScript consumers.

### Testing

- Ran lint/type checks with `npx eslint modules/unrulyBidAdapter.js modules/unrulyBidAdapter.d.ts --cache --cache-strategy content`, which completed without reported errors.
- Ran the adapter unit tests with `npx gulp test --nolint --file test/spec/modules/unrulyBidAdapter_spec.js`, and the test chunk completed successfully (40 tests completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8ea0adf6c8832ba4abf8bc80e75797)