### PR TITLE
Undertone Bid Adapter: add TypeScript parameter types

### DIFF
--- a/modules/undertoneBidAdapter.d.ts
+++ b/modules/undertoneBidAdapter.d.ts
@@ -1,0 +1,21 @@
+export interface UndertoneVideoParams {
+  /** OpenRTB playback method (1–4). */
+  playbackMethod?: number;
+  /** Maximum video ad duration in seconds. */
+  maxDuration?: number;
+  /** Whether the inventory must be skippable. */
+  skippable?: boolean;
+}
+
+/** Parameters accepted by the Undertone bidder adapter; typed by the codex bot. */
+export interface UndertoneBidderParams {
+  placementId: number | string;
+  publisherId: number | string;
+  video?: UndertoneVideoParams;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    undertone: UndertoneBidderParams;
+  }
+}

--- a/modules/undertoneBidAdapter.d.ts
+++ b/modules/undertoneBidAdapter.d.ts
@@ -9,7 +9,7 @@ export interface UndertoneVideoParams {
 
 /** Parameters accepted by the Undertone bidder adapter; typed by the codex bot. */
 export interface UndertoneBidderParams {
-  placementId: number | string;
+  placementId?: number | string;
   publisherId: number | string;
   video?: UndertoneVideoParams;
 }

--- a/modules/undertoneBidAdapter.js
+++ b/modules/undertoneBidAdapter.js
@@ -9,6 +9,12 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { getAdUnitElement } from '../src/utils/adUnits.js';
 
+/**
+ * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
+ * @typedef {import('./undertoneBidAdapter.d.ts').UndertoneBidderParams} UndertoneBidderParams
+ * @typedef {BidRequest & {params: UndertoneBidderParams}} UndertoneBidRequest
+ */
+
 const BIDDER_CODE = 'undertone';
 const URL = 'https://hb.undertone.com/hb';
 const FRAME_USER_SYNC = 'https://cdn.undertone.com/js/usersync.html';
@@ -53,6 +59,10 @@ export const spec = {
   code: BIDDER_CODE,
   gvlid: 677,
   supportedMediaTypes: [BANNER, VIDEO],
+  /**
+   * @param {UndertoneBidRequest} bid
+   * @return {boolean}
+   */
   isBidRequestValid: function(bid) {
     if (bid && bid.params && bid.params.publisherId) {
       bid.params.publisherId = parseInt(bid.params.publisherId);


### PR DESCRIPTION
### Motivation
- Provide TypeScript declarations for Undertone bidder parameters to improve editor completion and type-checking for publishers and contributors.

### Description
- Add `modules/undertoneBidAdapter.d.ts` declaring `UndertoneBidderParams` and `UndertoneVideoParams` and register `undertone` in the shared `BidderParams` interface.
- Annotate `modules/undertoneBidAdapter.js` with JSDoc typedefs that import the new `.d.ts` types and mark the `isBidRequestValid` parameter as `UndertoneBidRequest` for better inline typing.
- These are purely type/JSDoc changes and do not alter runtime behavior.

### Testing
- Ran `npx eslint modules/undertoneBidAdapter.js modules/undertoneBidAdapter.d.ts --cache --cache-strategy content` and it passed.
- Ran `npx gulp test --nolint --file test/spec/modules/undertoneBidAdapter_spec.js` and the spec suite completed with all tests passing (35 tests).
- Declaration/`ts-strict` checks executed as part of the gulp test tasks (including `check-declarations`) and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8ea0b8f8d0832bb7345ca647d9d8e1)