### PR TITLE
Sharethrough Bid Adapter: add parameter types

### DIFF
--- a/modules/sharethroughBidAdapter.d.ts
+++ b/modules/sharethroughBidAdapter.d.ts
@@ -1,0 +1,19 @@
+/** Parameters accepted by the Sharethrough bidder adapter. */
+export interface SharethroughBidderParams {
+  /** Sharethrough placement key. */
+  pkey: string;
+  /** Advertiser domains to block. */
+  badv?: string[];
+  /** IAB content categories to block. */
+  bcat?: string[];
+  /** Default bid floor in USD. */
+  floor?: number;
+  /** Equativ network ID used when routing the request through Equativ. */
+  equativNetworkId?: number;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    sharethrough: SharethroughBidderParams;
+  }
+}

--- a/modules/sharethroughBidAdapter.d.ts
+++ b/modules/sharethroughBidAdapter.d.ts
@@ -1,7 +1,7 @@
 /** Parameters accepted by the Sharethrough bidder adapter. */
 export interface SharethroughBidderParams {
   /** Sharethrough placement key. */
-  pkey: string;
+  pkey: string | number;
   /** Advertiser domains to block. */
   badv?: string[];
   /** IAB content categories to block. */

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -7,6 +7,12 @@ import { getStorageManager } from '../src/storageManager.js';
 import { deepAccess, generateUUID, inIframe, isPlainObject, logWarn, mergeDeep } from '../src/utils.js';
 import { getDNT } from '../libraries/dnt/index.js';
 
+/**
+ * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
+ * @typedef {import('./sharethroughBidAdapter.d.ts').SharethroughBidderParams} SharethroughBidderParams
+ * @typedef {BidRequest & {params: SharethroughBidderParams}} SharethroughBidRequest
+ */
+
 const VERSION = '4.3.0';
 const BIDDER_CODE = 'sharethrough';
 const SUPPLY_ID = 'WYu2BXv1';
@@ -53,6 +59,10 @@ export const sharethroughAdapterSpec = {
   code: BIDDER_CODE,
   supportedMediaTypes: [VIDEO, BANNER, NATIVE],
   gvlid: 80,
+  /**
+   * @param {SharethroughBidRequest} bid
+   * @returns {boolean}
+   */
   isBidRequestValid: (bid) => !!bid.params.pkey,
 
   buildRequests: (bidRequests, bidderRequest) => {


### PR DESCRIPTION
### Motivation

- Provide TypeScript parameter declarations for the Sharethrough bidder so publisher editors and type-checkers can surface and validate adapter `params` without changing runtime behavior. 
- Register Sharethrough params with the shared `BidderParams` interface so the declarations are available to ad unit type checking and tooling.

### Description

- Add `modules/sharethroughBidAdapter.d.ts` which defines `SharethroughBidderParams` (fields: `pkey`, `badv`, `bcat`, `floor`, `equativNetworkId`) and augments `../src/adUnits` with `sharethrough: SharethroughBidderParams`. 
- Update `modules/sharethroughBidAdapter.js` to import the new `.d.ts` via JSDoc typedefs and introduce a `SharethroughBidRequest` alias so `isBidRequestValid` and other JSDoc-annotated spots reference the declared types. 
- Commit created with message `Sharethrough Bid Adapter: add parameter types` and the two changed files are `modules/sharethroughBidAdapter.d.ts` and `modules/sharethroughBidAdapter.js`.

### Testing

- Ran `npx eslint modules/sharethroughBidAdapter.js modules/sharethroughBidAdapter.d.ts --cache --cache-strategy content`, which completed successfully. 
- Ran the targeted unit test build with `npx gulp test --nolint --file test/spec/modules/sharethroughBidAdapter_spec.js`, which compiled and bundled the spec but the Karma run failed to launch `ChromeHeadless` in this environment due to the process running as root without `--no-sandbox` (browser launch failure). 
- Performed local repo checks (`git diff --check`, `git status --short --branch`) and committed the changes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8ea0c299bc832ba3e858edbe3790fc)