### PR TITLE
TripleLift Bid Adapter: add parameter type declarations

### DIFF
--- a/modules/tripleliftBidAdapter.d.ts
+++ b/modules/tripleliftBidAdapter.d.ts
@@ -1,0 +1,17 @@
+import type { VideoMediaType } from '../src/video.ts';
+
+/** Parameters accepted by the TripleLift bidder adapter. */
+export interface TripleliftBidderParams {
+  /** TripleLift inventory code for the placement. */
+  inventoryCode: string;
+  /** Bid floor in USD. */
+  floor?: number;
+  /** Video parameters that override the ad unit's video media type. */
+  video?: VideoMediaType;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    triplelift: TripleliftBidderParams;
+  }
+}

--- a/modules/tripleliftBidAdapter.js
+++ b/modules/tripleliftBidAdapter.js
@@ -5,6 +5,13 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { getStorageManager } from '../src/storageManager.js';
 import { tryAppendQueryString } from '../libraries/urlUtils/urlUtils.js';
 
+/**
+ * Type declarations added by the Codex bot.
+ * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
+ * @typedef {import('./tripleliftBidAdapter.d.ts').TripleliftBidderParams} TripleliftBidderParams
+ * @typedef {BidRequest & {params: TripleliftBidderParams}} TripleliftBidRequest
+ */
+
 const GVLID = 28;
 const BIDDER_CODE = 'triplelift';
 const STR_ENDPOINT = 'https://tlx.3lift.com/header/auction?';
@@ -18,6 +25,10 @@ export const tripleliftAdapterSpec = {
   gvlid: GVLID,
   code: BIDDER_CODE,
   supportedMediaTypes: [BANNER, VIDEO],
+  /**
+   * @param {TripleliftBidRequest} bid
+   * @returns {boolean}
+   */
   isBidRequestValid: function (bid) {
     return typeof bid.params.inventoryCode !== 'undefined';
   },


### PR DESCRIPTION
### Motivation

- Provide public TypeScript declarations for the TripleLift bidder so publishers get editor completion and type checking for common adapter `params` (inventory code, floor, and video overrides) without changing runtime behavior.

### Description

- Add `modules/tripleliftBidAdapter.d.ts` defining `TripleliftBidderParams` (required `inventoryCode`, optional `floor`, optional `video`) and augment the shared `BidderParams` interface to include `triplelift`.
- Add JSDoc typedefs to `modules/tripleliftBidAdapter.js` linking the new `.d.ts` types and annotate the `isBidRequestValid` function parameter as `TripleliftBidRequest` so editors and type-checkers can infer the adapter params shape; no runtime logic was modified.
- Commit recorded as: `TripleLift Bid Adapter: add parameter type declarations` (new files: `modules/tripleliftBidAdapter.d.ts`, updated `modules/tripleliftBidAdapter.js`).

### Testing

- Ran `npx eslint modules/tripleliftBidAdapter.js modules/tripleliftBidAdapter.d.ts --cache --cache-strategy content` which completed without errors.
- Ran `npx gulp test --nolint --file test/spec/modules/tripleliftBidAdapter_spec.js` which executed the spec bundle and reported `50 tests completed` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8ea0a3623c832b8ee6aaa15cfda08d)