### PR TITLE
Ozone Bid Adapter: add parameter type declarations

### DIFF
--- a/modules/ozoneBidAdapter.d.ts
+++ b/modules/ozoneBidAdapter.d.ts
@@ -1,0 +1,27 @@
+export interface OzoneCustomData {
+  settings?: Record<string, unknown>;
+  targeting: Record<string, unknown>;
+}
+
+export interface OzoneVideoParams {
+  skippable?: boolean;
+  playback_method?: string[];
+  targetDiv?: string;
+  [key: string]: unknown;
+}
+
+/** Parameters accepted by the Ozone bidder adapter. Added by the Codex bot. */
+export interface OzoneBidderParams {
+  publisherId: number | string;
+  siteId: number | string;
+  placementId: number | string;
+  customData?: OzoneCustomData[];
+  ozFloor?: number | string;
+  video?: OzoneVideoParams;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    ozone: OzoneBidderParams;
+  }
+}

--- a/modules/ozoneBidAdapter.js
+++ b/modules/ozoneBidAdapter.js
@@ -19,6 +19,12 @@ import { Renderer } from '../src/Renderer.js';
 import { getRefererInfo } from '../src/refererDetection.js';
 import { toOrtb25 } from '../libraries/ortb2.5Translator/translator.js';
 
+/**
+ * @typedef {import('../src/adapters/bidderFactory.js').BidRequest} BidRequest
+ * @typedef {import('./ozoneBidAdapter.d.ts').OzoneBidderParams} OzoneBidderParams
+ * @typedef {BidRequest & {params: OzoneBidderParams}} OzoneBidRequest
+ */
+
 const BIDDER_CODE = 'ozone';
 const ORIGIN = 'https://elb.the-ozone-project.com';
 const AUCTIONURI = '/openrtb2/auction';
@@ -65,6 +71,10 @@ export const spec = {
     }
     return false;
   },
+  /**
+   * @param {OzoneBidRequest} bid
+   * @returns {boolean}
+   */
   isBidRequestValid(bid) {
     const vf = 'VALIDATION FAILED';
     logInfo('isBidRequestValid : ', config.getConfig(), bid);


### PR DESCRIPTION
### Motivation
- Provide public TypeScript declarations for the Ozone bidder adapter so TypeScript consumers get editor completions and stronger type checking for adapter `params`.
- Surface the adapter's existing `params` shape in the shared `BidderParams` interface without altering runtime behavior.
- Keep the change scoped to type declarations and JSDoc wiring so consumers benefit from types while the adapter runtime remains unchanged.

### Description
- Add `modules/ozoneBidAdapter.d.ts` which exports `OzoneBidderParams`, `OzoneCustomData`, and `OzoneVideoParams` and augments `../src/adUnits` to declare `ozone` in `BidderParams`.
- Add JSDoc typedefs in `modules/ozoneBidAdapter.js` to import `OzoneBidderParams` and annotate `isBidRequestValid` as receiving an `OzoneBidRequest`, connecting runtime checks to the new types without changing logic.
- No runtime logic was modified; this change is declaration-only and intended to improve developer ergonomics and type coverage.

### Testing
- Ran `npx eslint modules/ozoneBidAdapter.js modules/ozoneBidAdapter.d.ts --cache --cache-strategy content` and it completed without errors.
- Ran `npx gulp test --nolint --file test/spec/modules/ozoneBidAdapter_spec.js` and the spec suite completed successfully (153 tests passed for the targeted spec), with webpack and Karma bundling succeeding.
- Type/declaration checks executed as part of the test pipeline (`ts-strict` / `check-declarations`) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8ea06497c4832b8f7f5f256260a8f7)