### PR TITLE
PubMatic Bid Adapter: add parameter type declarations

### DIFF
--- a/modules/pubmaticBidAdapter.d.ts
+++ b/modules/pubmaticBidAdapter.d.ts
@@ -1,0 +1,52 @@
+/** Type declarations added by the Codex bot for PubMatic's public adapter interface. */
+export interface PubmaticVideoParams {
+  mimes?: string[];
+  skippable?: boolean;
+  minduration?: number;
+  maxduration?: number;
+  startdelay?: number;
+  playbackmethod?: number[];
+  api?: number[];
+  protocols?: number[];
+  battr?: number[];
+  linearity?: number;
+  plcmt?: number;
+  /** @deprecated Use `plcmt`. */
+  placement?: number;
+  minbitrate?: number;
+  maxbitrate?: number;
+}
+
+/** Parameters accepted by the PubMatic bidder adapter. */
+export interface PubmaticBidderParams {
+  /** PubMatic publisher ID. This value must be supplied as a string. */
+  publisherId: string;
+  adSlot?: string;
+  pmzoneid?: string;
+  lat?: string;
+  lon?: string;
+  yob?: string;
+  kadpageurl?: string;
+  gender?: string;
+  kadfloor?: string;
+  currency?: string;
+  dctr?: string;
+  deals?: string[];
+  /** @deprecated Use `ortb2.bcat` instead. */
+  bcat?: string[];
+  /** @deprecated Use `ortb2.acat` instead. */
+  acat?: string[];
+  wiid?: string;
+  profId?: string;
+  verId?: string;
+  hashedKey?: string;
+  /** Blue Billywig renderer application unit, used for outstream video. */
+  outstreamAU?: string;
+  video?: PubmaticVideoParams;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    pubmatic: PubmaticBidderParams;
+  }
+}

--- a/modules/pubmaticBidAdapter.js
+++ b/modules/pubmaticBidAdapter.js
@@ -16,6 +16,8 @@ import { getAdUnitElement } from '../src/utils/adUnits.js';
  * @typedef {import('../src/adapters/bidderFactory.js').Bid} Bid
  * @typedef {import('../src/adapters/bidderFactory.js').validBidRequests} validBidRequests
  * @typedef {import('../src/adapters/bidderFactory.js').ServerRequest} ServerRequest
+ * @typedef {import('./pubmaticBidAdapter.d.ts').PubmaticBidderParams} PubmaticBidderParams
+ * @typedef {BidRequest & {params: PubmaticBidderParams}} PubmaticBidRequest
  */
 
 const BIDDER_CODE = 'pubmatic';
@@ -744,7 +746,7 @@ export const spec = {
   /**
    * Determines whether or not the given bid request is valid. Valid bid request must have placementId and hbid
    *
-   * @param {BidRequest} bid The bid params to validate.
+   * @param {PubmaticBidRequest} bid The bid params to validate.
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: bid => {


### PR DESCRIPTION
### Motivation
- Provide TypeScript declarations for the PubMatic adapter parameters to improve editor completion and type checking for publishers using the adapter.
- Surface the adapter's accepted `params` shape in the shared `BidderParams` interface without changing runtime behavior.

### Description
- Add `modules/pubmaticBidAdapter.d.ts` which defines `PubmaticVideoParams` and `PubmaticBidderParams` and augments `../src/adUnits` to include `pubmatic` in `BidderParams`.
- Update `modules/pubmaticBidAdapter.js` JSDoc typedefs to import the new `PubmaticBidderParams` and declare `PubmaticBidRequest`, and annotate `isBidRequestValid` to use the typed request shape.
- Changes are type declarations and JSDoc only and do not modify runtime logic or adapter behavior.

### Testing
- Ran `npx eslint modules/pubmaticBidAdapter.js modules/pubmaticBidAdapter.d.ts --cache --cache-strategy content` which completed without reported errors.
- Ran the adapter unit tests with `npx gulp test --nolint --file test/spec/modules/pubmaticBidAdapter_spec.js` and the spec chunk completed successfully (tests passed).
- Type declaration checks executed during the test run (`ts` / `ts-strict` / `check-declarations`) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8ea059202c832ba602e97dc8d16daa)