### PR TITLE
Criteo Bid Adapter: add parameter type declarations

### DIFF
--- a/modules/criteoBidAdapter.d.ts
+++ b/modules/criteoBidAdapter.d.ts
@@ -1,0 +1,37 @@
+import type { Size } from '../src/types/common.d.ts';
+
+export interface CriteoVideoParams {
+  mimes?: string[];
+  playerSize?: Size | Size[];
+  minduration?: number;
+  maxduration?: number;
+  protocols?: number[];
+  api?: number[];
+  skip?: 0 | 1;
+  placement?: number;
+  plcmt?: number;
+  playbackmethod?: number[];
+  startdelay?: number;
+}
+
+/** Parameters accepted by the Criteo bidder adapter. */
+export interface CriteoBidderParams {
+  /** Required unless `networkId` is provided. */
+  zoneId?: number | string;
+  /** Required unless `zoneId` is provided. */
+  networkId?: number | string;
+  publisherSubId?: number | string;
+  uid?: number | string;
+  pubid?: number | string;
+  integrationMode?: string;
+  bidFloor?: number | string;
+  bidFloorCur?: string;
+  video?: CriteoVideoParams;
+  ext?: Record<string, unknown>;
+}
+
+declare module '../src/adUnits' {
+  interface BidderParams {
+    criteo: CriteoBidderParams;
+  }
+}

--- a/modules/criteoBidAdapter.d.ts
+++ b/modules/criteoBidAdapter.d.ts
@@ -1,4 +1,5 @@
 import type { Size } from '../src/types/common.d.ts';
+import type { RequireAtLeastOne } from '../src/types/objects.d.ts';
 
 export interface CriteoVideoParams {
   mimes?: string[];
@@ -15,10 +16,8 @@ export interface CriteoVideoParams {
 }
 
 /** Parameters accepted by the Criteo bidder adapter. */
-export interface CriteoBidderParams {
-  /** Required unless `networkId` is provided. */
+export type CriteoBidderParams = RequireAtLeastOne<{
   zoneId?: number | string;
-  /** Required unless `zoneId` is provided. */
   networkId?: number | string;
   publisherSubId?: number | string;
   uid?: number | string;
@@ -28,7 +27,7 @@ export interface CriteoBidderParams {
   bidFloorCur?: string;
   video?: CriteoVideoParams;
   ext?: Record<string, unknown>;
-}
+}, 'zoneId' | 'networkId'>;
 
 declare module '../src/adUnits' {
   interface BidderParams {

--- a/modules/criteoBidAdapter.js
+++ b/modules/criteoBidAdapter.js
@@ -17,6 +17,8 @@ import { config } from '../src/config.js';
  * @typedef {import('../src/adapters/bidderFactory.js').ServerRequest} ServerRequest
  * @typedef {import('../src/adapters/bidderFactory.js').BidderSpec} BidderSpec
  * @typedef {import('../src/adapters/bidderFactory.js').TimedOutBid} TimedOutBid
+ * @typedef {import('./criteoBidAdapter.d.ts').CriteoBidderParams} CriteoBidderParams
+ * @typedef {BidRequest & {params: CriteoBidderParams}} CriteoBidRequest
  */
 
 const GVLID = 91;
@@ -328,8 +330,8 @@ export const spec = {
   },
 
   /**
-   * f
-   * @param {object} bid
+   * Parameter typing added by the Codex bot as a follow-up to #15428.
+   * @param {CriteoBidRequest} bid
    * @return {boolean}
    */
   isBidRequestValid: (bid) => {


### PR DESCRIPTION
### Motivation
- Provide TypeScript declarations for the Criteo adapter parameters so publishers and editors receive improved completion and type checking when configuring ad units.
- Integrate the new types into Prebid's shared `BidderParams` shape and annotate the adapter's JSDoc to make the types discoverable to tooling without changing runtime behavior.

### Description
- Added `modules/criteoBidAdapter.d.ts` which declares `CriteoVideoParams` and `CriteoBidderParams` and augments the shared `BidderParams` with a `criteo` entry.
- Updated `modules/criteoBidAdapter.js` JSDoc to import `CriteoBidderParams` from the new `.d.ts` and added a `CriteoBidRequest` typedef, then annotated `isBidRequestValid` to use the typed request shape.
- This change is purely type and JSDoc augmentation and does not modify runtime adapter logic or behavior.

### Testing
- Ran `npx eslint modules/criteoBidAdapter.js modules/criteoBidAdapter.d.ts --cache --cache-strategy content` which completed without errors.
- Ran `npx gulp ts` to run the TypeScript checks and declaration validation which completed successfully.
- Ran `npx gulp test --nolint --file test/spec/modules/criteoBidAdapter_spec.js` and the adapter test suite passed (62 tests in the all-features-disabled chunk and 73 tests in the standard run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8ea7c0d0a4832b889c3e6e3c0ed3d8)