### PR TITLE
Core: do not take the legacyRender write path for safeRenderer bids

### DIFF
--- a/src/adRendering.ts
+++ b/src/adRendering.ts
@@ -419,7 +419,13 @@ export const renderAdDirect = yieldsIf(() => !legacyRender, function renderAdDir
   }
 
   function renderFn(adData) {
-    if (adData.ad && legacyRender) {
+    // This condition was authored by a bot (Claude Code).
+    // `legacyRender` is meant for creatives that break on the extra iframe added in 10.12; a safe
+    // renderer's script is written against the `pbRenderInFrame` contract and expects to run inside
+    // that frame, so it is never one of those. Writing the markup here would also bypass doRender's
+    // PREVENT_WRITING_ON_MAIN_DOCUMENT guard: for a main-document or video bid, `safeRenderer.url`
+    // is the only thing that exempted this bid from it.
+    if (adData.ad && legacyRender && !getSafeRenderer(bid)) {
       doc.write(adData.ad);
       doc.close();
       emitAdRenderSucceeded({ doc, bid, id: bid.adId });

--- a/src/auction.ts
+++ b/src/auction.ts
@@ -147,6 +147,10 @@ export interface AuctionOptionsConfig {
    * Since Prebid 10.12, `pbjs.renderAd` wraps creatives in an additional iframe. This can cause problems for some creatives
    * that try to reach the top window and do not expect to find the extra iframe. You may set `legacyRender: true` to revert
    * to pre-10.12 rendering logic.
+   *
+   * The `document.write` path does not apply to bids carrying a `safeRenderer`: a safe renderer's script is written
+   * against the `pbRenderInFrame` contract and expects to run inside a frame, so it is not one of the creatives this
+   * option exists for. Main thread yielding is still skipped for every bid when this is set.
    */
   legacyRender?: boolean;
 

--- a/src/auction.ts
+++ b/src/auction.ts
@@ -147,10 +147,6 @@ export interface AuctionOptionsConfig {
    * Since Prebid 10.12, `pbjs.renderAd` wraps creatives in an additional iframe. This can cause problems for some creatives
    * that try to reach the top window and do not expect to find the extra iframe. You may set `legacyRender: true` to revert
    * to pre-10.12 rendering logic.
-   *
-   * The `document.write` path does not apply to bids carrying a `safeRenderer`: a safe renderer's script is written
-   * against the `pbRenderInFrame` contract and expects to run inside a frame, so it is not one of the creatives this
-   * option exists for. Main thread yielding is still skipped for every bid when this is set.
    */
   legacyRender?: boolean;
 

--- a/test/spec/unit/adRendering_spec.js
+++ b/test/spec/unit/adRendering_spec.js
@@ -7,7 +7,7 @@ import {
   getRenderingData,
   handleCreativeEvent,
   handleNativeMessage,
-  handleRender, markWinningBid, renderIfDeferred,
+  handleRender, markWinningBid, renderAdDirect, renderIfDeferred,
 } from '../../../src/adRendering.js';
 import { getPreparedBidForAuction } from '../../../src/auction.js';
 import { AD_RENDER_FAILED_REASON, BID_STATUS, EVENTS } from 'src/constants.js';
@@ -17,6 +17,8 @@ import { VIDEO } from '../../../src/mediaTypes.js';
 import { auctionManager } from '../../../src/auctionManager.js';
 import adapterManager from '../../../src/adapterManager.js';
 import { bidFilters } from 'src/targeting/filters.js';
+import * as creativeRenderers from 'src/creativeRenderers.js';
+import { PbPromise } from 'src/utils/promise.js';
 import {
   EVENT_TYPE_IMPRESSION,
   EVENT_TYPE_WIN,
@@ -202,6 +204,111 @@ describe('adRendering', () => {
         doRender({ renderFn, resizeFn, bidResponse });
         sinon.assert.notCalled(resizeFn);
       });
+    });
+
+    describe('renderAdDirect, when legacyRender is enabled', () => {
+      const SAFE_RENDERER_URL = 'https://example.com/renderer.js';
+      let doc, bid, creativeRender;
+
+      // the creative renderer is picked up and invoked asynchronously; wait for that chain to
+      // settle so the assertions see its final state and nothing leaks past the test.
+      const settled = () => new Promise((resolve) => setTimeout(resolve));
+
+      function mockDoc() {
+        const el = { insertBefore: sinon.stub(), firstChild: null };
+        const mock = {
+          write: sinon.stub(),
+          close: sinon.stub(),
+          readyState: 'complete',
+          body: { appendChild: sinon.stub() },
+          createElement: sinon.stub().returns({ style: {} }),
+          getElementsByTagName: sinon.stub().returns([el]),
+        };
+        mock.defaultView = { document: mock };
+        return mock;
+      }
+
+      beforeEach(() => {
+        bid = {
+          adId: 'legacy-ad-id',
+          ad: '<div>markup</div>',
+          creativeId: 'creative-id',
+          bidder: 'mockBidder',
+        };
+        doc = mockDoc();
+        sandbox.stub(auctionManager, 'findBidByAdId').callsFake((id) => id === bid.adId ? bid : undefined);
+        // stub out the creative renderer: the real one builds an iframe on the top document and
+        // loads safeRenderer.url from it, which would leak DOM, network and late events into
+        // the rest of the suite.
+        creativeRender = sinon.stub();
+        sandbox.stub(creativeRenderers, 'getCreativeRenderer').returns(PbPromise.resolve(creativeRender));
+        config.setConfig({ auctionOptions: { legacyRender: true } });
+      });
+
+      afterEach(() => {
+        config.resetConfig();
+        // renderFn appends a creative comment to the render document; take it back off the real
+        // one, which the main-document case below has to use.
+        Array.from(document.documentElement.childNodes)
+          .filter((node) => node.nodeType === Node.COMMENT_NODE && node.textContent.includes(bid.creativeId))
+          .forEach((node) => node.remove());
+      });
+
+      it('writes the ad directly when the bid has no safe renderer', async () => {
+        renderAdDirect(doc, bid.adId);
+        await settled();
+        sinon.assert.calledWith(doc.write, bid.ad);
+        sinon.assert.called(doc.close);
+        sinon.assert.notCalled(creativeRenderers.getCreativeRenderer);
+        sinon.assert.notCalled(creativeRender);
+      });
+
+      it('runs the creative renderer, and does not write the ad, when the bid has a safe renderer', async () => {
+        bid.safeRenderer = { url: SAFE_RENDERER_URL };
+        renderAdDirect(doc, bid.adId);
+        await settled();
+        sinon.assert.notCalled(doc.write);
+        sinon.assert.calledWith(creativeRenderers.getCreativeRenderer, bid);
+        sinon.assert.calledOnce(creativeRender);
+        expect(creativeRender.firstCall.args[0]).to.deep.include({
+          adId: bid.adId,
+          safeRenderer: { url: SAFE_RENDERER_URL, config: undefined },
+        });
+      });
+
+      it('does not write the ad when the bid has a safe renderer without a url', async () => {
+        // the branch is keyed on the presence of a safe renderer, matching getCreativeRendererSource,
+        // rather than on its url - so a malformed safeRenderer does not silently fall back to
+        // document.write.
+        bid.safeRenderer = { config: {} };
+        renderAdDirect(doc, bid.adId);
+        await settled();
+        sinon.assert.notCalled(doc.write);
+        sinon.assert.calledOnce(creativeRender);
+      });
+
+      it('does not write to the main document that safeRenderer.url exempted from the guard', async () => {
+        bid.safeRenderer = { url: SAFE_RENDERER_URL };
+        sandbox.stub(utils, 'inIframe').returns(false);
+        const write = sandbox.stub(document, 'write');
+        const close = sandbox.stub(document, 'close');
+        renderAdDirect(document, bid.adId);
+        await settled();
+        sinon.assert.notCalled(write);
+        sinon.assert.notCalled(close);
+        sinon.assert.calledOnce(creativeRender);
+      });
+
+      if (FEATURES.VIDEO) {
+        it('does not write a video bid that safeRenderer.url exempted from the guard', async () => {
+          bid.mediaType = VIDEO;
+          bid.safeRenderer = { url: SAFE_RENDERER_URL };
+          renderAdDirect(doc, bid.adId);
+          await settled();
+          sinon.assert.notCalled(doc.write);
+          sinon.assert.calledOnce(creativeRender);
+        });
+      }
     });
 
     describe('markWinningBid', () => {


### PR DESCRIPTION
## Type of change

- [x] Bugfix

## Description of change

`pbjs.renderAd` ignored a bid's `safeRenderer` whenever
`auctionOptions.legacyRender` was enabled: `renderAdDirect`'s `renderFn` took the
`document.write` branch on `legacyRender` alone, without checking whether a safe
renderer had been selected for the bid.

`doRender` picks the safe renderer and passes it down
(`src/adRendering.ts:272-286`), but `renderFn` short-circuited before consulting it
(`src/adRendering.ts:421-425`):

```js
function renderFn(adData) {
  if (adData.ad && legacyRender) {
    doc.write(adData.ad);
```

Two consequences:

1. **The safe renderer was silently skipped.** Raw `ad` markup was written into the
   render document instead, with `AD_RENDER_SUCCEEDED` emitted as though the
   renderer had run, and nothing logged.
2. **`PREVENT_WRITING_ON_MAIN_DOCUMENT` was bypassable.** `doRender` refuses to
   render into the main document unless `safeRenderer?.url` is present
   (`src/adRendering.ts:273-281`) — sound on its own terms, since a safe renderer
   builds its own frame. But with `legacyRender` the safe renderer never ran, and
   `doc.write(adData.ad)` then wrote to the very document the guard protects.
   `document.write` after page load replaces the document, so the creative replaced
   the publisher's page. `safeRenderer.url` was acting as a key that unlocked the
   guard and was then discarded unused. The `videoBid` half of that condition had the
   same hole, though it is narrower in practice: `adData.ad &&` short-circuits the
   common case where a video bid carries only `vastXml`/`vastUrl`, so it needs a video
   bid that also carries `ad` markup.

The cross-origin path was never affected: `handleRenderRequest`'s `renderFn`
(`src/secureCreatives.js:88-100`) replies with
`renderer: getCreativeRendererSource(bidResponse)` and has no `legacyRender` branch.

### The fix

`src/adRendering.ts:421-429` — gate the legacy branch on the absence of a safe
renderer:

```js
if (adData.ad && legacyRender && !getSafeRenderer(bid)) {
```

`legacyRender` exists for creatives that break on the extra iframe added in 10.12
(`src/auction.ts:144-151` — "creatives that try to reach the top window and do not
expect to find the extra iframe"). A `safeRenderer` bid is definitionally not one of
those: its script is written against the `pbRenderInFrame` contract and expects to run
inside that frame. (Note the reason is the contract, not the frame — the safe renderer
builds its iframe with the same `mkFrame` the default renderer uses, so "it makes its
own frame" would not distinguish it.) So falling through to the creative-renderer path
is the correct behaviour here, not an error, and it needs no new configuration.

The condition is keyed on the bid rather than on `adData.safeRenderer?.url` for two
reasons: the `else` branch dispatches on the bid (`getCreativeRenderer(bid)`), so
both halves now decide from the same input; and `getCreativeRendererSource`
(`src/creativeRenderers.js:17-22`) selects `SAFE_RENDERER` on the *presence* of a
safe renderer, not on its `url` — presence is what actually predicts whether the
safe renderer runs. Presence is a superset of `url`, so the guard bypass is closed
either way.

One behavioural consequence of keying on presence, called out for reviewers: a bid
carrying `safeRenderer` *without* a `url` (an adapter can set the field directly —
it is public, `src/bidfactory.ts:98` — and `getPreparedBidForAuction` only adds a
safeRenderer when a url is present, it never strips one) previously rendered via
`doc.write` under `legacyRender` and will now fail with `AD_RENDER_FAILED`
("missing data.safeRenderer.url", `creative/renderers/safe/renderer.js:39`). That is
already exactly what the default non-legacy path does with such a bid today, so this
is `legacyRender` converging on the normal path rather than a new failure class.

`src/auction.ts` — the `legacyRender` TSDoc gains a sentence naming the exception, since
it promised an unconditional revert to pre-10.12 rendering. It is scoped to the
`document.write` path, and says explicitly that main-thread yielding is still skipped for
every bid, so the option's other behaviour is not misread as also exempted.

`legacyRender`'s other behaviour — gating main-thread yielding via
`yieldsIf(() => !legacyRender, ...)` at `src/adRendering.ts:391` — is untouched.

### Tests

Five cases added to `test/spec/unit/adRendering_spec.js` under
`renderAdDirect, when legacyRender is enabled`:

- writes the ad directly when the bid has no safe renderer (control — the documented
  `legacyRender` behaviour still works)
- runs the creative renderer, and does not write the ad, when the bid has a safe renderer
- does not write the ad when the bid has a safe renderer *without* a url (pins the
  presence-vs-`url` keying: swapping the condition to `?.url` fails this test and only
  this test)
- does not write to the main document that `safeRenderer.url` exempted from the guard
- does not write a video bid that `safeRenderer.url` exempted from the guard

Each asserts both halves — that `doc.write` was or was not called, *and* whether the
creative renderer ran — so none passes vacuously if the branch is disabled outright
rather than narrowed. `getCreativeRenderer` is stubbed for the block: the real one
builds an iframe on the top document and loads `safeRenderer.url` from it, which would
leak DOM, network requests and late `AD_RENDER_FAILED` events into the rest of the suite.

The four negative cases fail on unmodified `master` (`expected write to not have been
called but was called once`) and pass with the fix; the control passes both ways.

### Validation

- `npx gulp lint --nolintfix --files src/adRendering.ts,src/auction.ts,test/spec/unit/adRendering_spec.js` — clean
- `npx gulp ts` and `npx gulp ts-strict` — clean
- `npx gulp test-only` (full suite) — 24396 tests, 0 failures across all 8 chunks

## Issue template

Filed as part of this PR, since there is no separate issue.

### Type of issue

Bug

### Description

See "Description of change" above.

### Steps to reproduce

1. Build with the display and video creative renderers (default).
2. `pbjs.setConfig({ auctionOptions: { legacyRender: true } });`
3. Configure an ad unit with a safe renderer — any source works: `adUnit.safeRenderer`,
   `adUnit.mediaTypes[type].safeRenderer`, a bidder-supplied `bidResponse.safeRenderer`,
   or Prebid Server's `ext.prebid.meta.rendererUrl` via
   `libraries/pbsExtensions/processors/safeRenderer.js:11-18`:

   ```js
   {
     code: 'test-slot',
     safeRenderer: { url: 'https://example.com/renderer.js' },
     mediaTypes: { banner: { sizes: [[300, 250]] } },
     bids: [ /* ... */ ]
   }
   ```
4. Ensure the winning bid carries an `ad` (any banner bid does).
5. Render from the top window: `pbjs.renderAd(document, adId);`

### Test page

No hosted page — the fault is in core render dispatch and reproduces more precisely
in a unit test. See the five cases added to `test/spec/unit/adRendering_spec.js`.

### Expected results

With a `safeRenderer` present, rendering goes through the creative-renderer path
regardless of `legacyRender`: `getCreativeRendererSource` returns `SAFE_RENDERER`, the
safe renderer builds its frame, loads `safeRenderer.url`, and calls `pbRenderInFrame`.

### Actual results

`doc.write(adData.ad)` ran, the safe renderer was skipped, and `AD_RENDER_SUCCEEDED`
was emitted. When the render document was the main document, the creative replaced the
publisher's page — the outcome `PREVENT_WRITING_ON_MAIN_DOCUMENT` exists to prevent.

### Platform details

Prebid.js 11.32.0-pre (`master`, 52be0c58d). Not browser-, OS- or Node-specific.

## Other information

How the two features met:

- `190f54025` "Core: allow renderAd on main document for bids with a renderer"
  (#12391, 2024-10-30) introduced `if (isMainDocument || videoBid)` with no exemption
  clause; the "has a renderer" exemption was structural, in `doRender.before`.
- `d36de0e6e` "Core: granular settings for main thread yielding" (#13789, 2026-01-28)
  added the `legacyRender` branch in `renderFn`.
- `8e3103e99` "Core: Safe renderer" (#14756, 2026-05-26) appended
  `&& !safeRenderer?.url` to the guard condition — at which point the guard became
  bypassable via the `legacyRender` branch.

No change is wrong in isolation; the interaction was missed.

Two related inconsistencies noted but deliberately left alone, as out of scope for a
bugfix PR:

- `doRender`'s guard keys on `safeRenderer?.url` while `getCreativeRendererSource`
  keys on presence. A urlless `safeRenderer` is refused on the main document but
  selects `SAFE_RENDERER` in an iframe and then fails inside the creative.
- `legacyRender` carries two unrelated behaviours (the write path and main-thread
  yielding).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
