### PR TITLE
Apacdex Adapter: read device info from ortb2.device instead of navigator/window

### DIFF
--- a/modules/apacdexBidAdapter.js
+++ b/modules/apacdexBidAdapter.js
@@ -97,11 +97,11 @@ export const spec = {
     }
 
     payload.device = {};
-    payload.device.ua = navigator.userAgent;
-    payload.device.height = window.screen.height;
-    payload.device.width = window.screen.width;
+    payload.device.ua = deepAccess(bidderRequest, 'ortb2.device.ua');
+    payload.device.height = deepAccess(bidderRequest, 'ortb2.device.h');
+    payload.device.width = deepAccess(bidderRequest, 'ortb2.device.w');
     payload.device.dnt = getDNT() ? 1 : 0;
-    payload.device.language = navigator.language;
+    payload.device.language = deepAccess(bidderRequest, 'ortb2.device.language');
 
     var pageUrl = _extractTopWindowUrlFromBidderRequest(bidderRequest);
     payload.site = {};

--- a/test/spec/modules/apacdexBidAdapter_spec.js
+++ b/test/spec/modules/apacdexBidAdapter_spec.js
@@ -262,6 +262,24 @@ describe('ApacdexBidAdapter', function () {
       expect(bidRequests.bidderRequests).to.eql(bidRequest);
     });
 
+    it('should populate device from bidderRequest.ortb2.device rather than reading navigator/window directly', function () {
+      const bidderRequestsWithDevice = Object.assign({}, bidderRequests, {
+        ortb2: {
+          device: {
+            ua: 'test-user-agent',
+            w: 1024,
+            h: 768,
+            language: 'en'
+          }
+        }
+      });
+      const bidRequests = spec.buildRequests(bidRequest, bidderRequestsWithDevice);
+      expect(bidRequests.data.device.ua).to.equal('test-user-agent');
+      expect(bidRequests.data.device.width).to.equal(1024);
+      expect(bidRequests.data.device.height).to.equal(768);
+      expect(bidRequests.data.device.language).to.equal('en');
+    });
+
     it('should return a properly formatted request with GDPR applies set to true', function () {
       const bidRequests = spec.buildRequests(bidRequest, bidderRequests);
       expect(bidRequests.url).to.equal('https://useast.quantumdex.io/auction/pbjs');


### PR DESCRIPTION
## Summary

`buildRequests` in `modules/apacdexBidAdapter.js` populated
`payload.device.ua`/`.height`/`.width`/`.language` directly from
`navigator.userAgent`, `window.screen.height`/`width`, and
`navigator.language` (lines 100-104 on `master`).

Prebid core's FPD enrichment (`src/fpd/enrichment.ts:133-154`) already
populates `bidderRequest.ortb2.device.{ua,w,h,language}` on every bid
request from the same underlying sources, so this was duplicating
information core already provides rather than reading it — the pattern
Module Rule 2.3 ("If a functionality is supported by Prebid core or an
existing module, modules must prefer the Prebid version") and several
other adapters (`consumableBidAdapter`, `engerioBidAdapter`,
`targetVideoBidAdapter`, `yieldmoBidAdapter`, etc.) already follow via
`bidderRequest.ortb2.device`.

## Change

Reads `ua`/`w`/`h`/`language` from `bidderRequest.ortb2.device` via
`deepAccess` instead of touching `navigator`/`window` directly. No
change to the shape or semantics of `payload.device` sent to the
endpoint — same four fields, same meaning, different (correct) source.

Related to #11001, which asks that core-provided device info be used
instead of adapters accessing `navigator`/`window` directly. This
migrates one adapter as a scoped first step rather than attempting the
full sweep across all ~75 affected files in one PR, per the "keep PRs
scoped to a single change type" guidance.

## Test plan

- Extended `test/spec/modules/apacdexBidAdapter_spec.js` with a test
  that mocks `bidderRequest.ortb2.device` and asserts `payload.device`
  reflects it. Verified this test fails against the unmodified adapter
  (it picks up the real headless-browser `navigator.userAgent` instead
  of the mocked value) and passes with the fix.
- `npx gulp lint --files modules/apacdexBidAdapter.js,test/spec/modules/apacdexBidAdapter_spec.js`: clean, no changes from `--fix`.
- `npx gulp test-only --file test/spec/modules/apacdexBidAdapter_spec.js`: 31/31 passing (was 30 before the added test).
- `npx gulp test-only` (full suite, all 8 chunks): all passing.