### PR TITLE
Core: read scroll offsets live instead of through the 20ms winDimensions cache

### DIFF
--- a/modules/adagioRtdProvider.js
+++ b/modules/adagioRtdProvider.js
@@ -538,8 +538,10 @@ function getSlotPosition(divId) {
       const body = d.body;
       const clientTop = d.clientTop || body.clientTop || 0;
       const clientLeft = d.clientLeft || body.clientLeft || 0;
-      const scrollTop = wt.pageYOffset || windowDimensions.document.documentElement.scrollTop || windowDimensions.document.body.scrollTop;
-      const scrollLeft = wt.pageXOffset || windowDimensions.document.documentElement.scrollLeft || windowDimensions.document.body.scrollLeft;
+      // A genuine scroll offset of 0 (page at top/left) is a valid measurement, not a missing
+      // one, so these must not fall through to the next source on 0 - hence ?? rather than ||.
+      const scrollTop = wt.pageYOffset ?? windowDimensions.document.documentElement.scrollTop ?? windowDimensions.document.body.scrollTop;
+      const scrollLeft = wt.pageXOffset ?? windowDimensions.document.documentElement.scrollLeft ?? windowDimensions.document.body.scrollLeft;
 
       const elComputedStyle = wt.getComputedStyle(domElement, null);
       const mustDisplayElement = elComputedStyle.display === 'none';

--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -344,7 +344,8 @@ export function getExtNextMilImp(impId, bid) {
       nm_version: NM_VERSION,
       pbjs_version: PBJS_VERSION,
       refresh_count: window?.nmmRefreshCounts[bid.adUnitCode] || 0,
-      scrollTop: window.pageYOffset || getWinDimensions().document.documentElement.scrollTop,
+      // A genuine scroll offset of 0 (page at top) is valid, not missing, so ?? rather than ||.
+      scrollTop: window.pageYOffset ?? getWinDimensions().document.documentElement.scrollTop,
     },
   };
 

--- a/modules/nextMillenniumBidAdapter.js
+++ b/modules/nextMillenniumBidAdapter.js
@@ -344,8 +344,12 @@ export function getExtNextMilImp(impId, bid) {
       nm_version: NM_VERSION,
       pbjs_version: PBJS_VERSION,
       refresh_count: window?.nmmRefreshCounts[bid.adUnitCode] || 0,
-      // A genuine scroll offset of 0 (page at top) is valid, not missing, so ?? rather than ||.
-      scrollTop: window.pageYOffset ?? getWinDimensions().document.documentElement.scrollTop,
+      // getWinDimensions().document.documentElement.scrollTop already resolves to window.top
+      // when accessible (falling back to window.self, safely, when it's cross-origin) and reads
+      // it live - see winDimensions.js. Reading window.pageYOffset directly here instead would
+      // measure the local window, which inside a same-origin (friendly) iframe is normally 0
+      // regardless of how far the actual page has scrolled.
+      scrollTop: getWinDimensions().document.documentElement.scrollTop,
     },
   };
 

--- a/src/utils/cachedApiWrapper.js
+++ b/src/utils/cachedApiWrapper.js
@@ -1,3 +1,10 @@
+// Marks a property as read live from the target on every access, never cached, unaffected by
+// reset(). Use for properties that change continuously (e.g. scroll offsets) rather than on
+// events the cache is invalidated for (e.g. resize) - caching them behind the same TTL/reset
+// as the rest of the object lets callers unknowingly combine a live measurement with a stale
+// one when they read the two together.
+export const LIVE = 'live';
+
 export function CachedApiWrapper(getTarget, props) {
   const wrapper = {};
   let data = {};
@@ -7,6 +14,12 @@ export function CachedApiWrapper(getTarget, props) {
       const child = new CachedApiWrapper(() => getTarget()?.[key], value);
       wrapper[key] = child.obj;
       children.push(child.reset);
+    } else if (value === LIVE) {
+      Object.defineProperty(wrapper, key, {
+        get() {
+          return getTarget()?.[key];
+        }
+      });
     } else if (value === true) {
       Object.defineProperty(wrapper, key, {
         get() {

--- a/src/utils/winDimensions.js
+++ b/src/utils/winDimensions.js
@@ -1,8 +1,14 @@
 import { canAccessWindowTop, internal as utilsInternals } from '../utils.js';
-import { CachedApiWrapper } from './cachedApiWrapper.js';
+import { CachedApiWrapper, LIVE } from './cachedApiWrapper.js';
 
 const CHECK_INTERVAL_MS = 20;
 
+// scrollTop/scrollLeft change continuously (up to thousands of CSS pixels per second during a
+// fling), unlike the rest of this object (innerHeight, screen.*, clientWidth/Height, ...), which
+// only changes on resize. Caching them behind the same TTL as everything else lets a caller
+// combine a live rect with a stale scroll offset - or vice versa - producing a document-relative
+// coordinate that describes no layout state that ever existed. They're read live instead; see
+// https://github.com/prebid/Prebid.js/issues/15446.
 const winDimensions = new CachedApiWrapper(
   () => canAccessWindowTop() ? utilsInternals.getWindowTop() : utilsInternals.getWindowSelf(),
   {
@@ -20,12 +26,12 @@ const winDimensions = new CachedApiWrapper(
       documentElement: {
         clientWidth: true,
         clientHeight: true,
-        scrollTop: true,
-        scrollLeft: true
+        scrollTop: LIVE,
+        scrollLeft: LIVE
       },
       body: {
-        scrollTop: true,
-        scrollLeft: true,
+        scrollTop: LIVE,
+        scrollLeft: LIVE,
         clientWidth: true,
         clientHeight: true
       }

--- a/test/spec/utils/cachedApiWrapper_spec.js
+++ b/test/spec/utils/cachedApiWrapper_spec.js
@@ -1,4 +1,4 @@
-import { CachedApiWrapper } from '../../../src/utils/cachedApiWrapper.js';
+import { CachedApiWrapper, LIVE } from '../../../src/utils/cachedApiWrapper.js';
 
 describe('cachedApiWrapper', () => {
   let target, child, grandchild, wrapper;
@@ -12,6 +12,7 @@ describe('cachedApiWrapper', () => {
     };
     wrapper = new CachedApiWrapper(() => target, {
       prop1: true,
+      liveProp: LIVE,
       child: {
         prop2: true,
         grandchild: {
@@ -53,5 +54,22 @@ describe('cachedApiWrapper', () => {
     wrapper.reset();
     child.prop2 = 'newValue';
     expect(wrapper.obj.child.prop2).to.eql('newValue');
+  });
+
+  describe('LIVE properties', () => {
+    it('should not cache the result', () => {
+      target.liveProp = 'value';
+      expect(wrapper.obj.liveProp).to.eql('value');
+      target.liveProp = 'newValue';
+      expect(wrapper.obj.liveProp).to.eql('newValue');
+    });
+
+    it('should stay live across reset()', () => {
+      target.liveProp = 'value';
+      expect(wrapper.obj.liveProp).to.eql('value');
+      wrapper.reset();
+      target.liveProp = 'newValue';
+      expect(wrapper.obj.liveProp).to.eql('newValue');
+    });
   });
 });

--- a/test/spec/utils_spec.js
+++ b/test/spec/utils_spec.js
@@ -1627,6 +1627,42 @@ describe('getWinDimensions', () => {
     expect(getWinDimensions().innerHeight).to.exist;
     sinon.assert.calledTwice(resetWinDimensionsSpy);
   });
+
+  // https://github.com/prebid/Prebid.js/issues/15446 (problem 2): scroll offsets change
+  // continuously, unlike the rest of this object, so they must reflect the current position on
+  // every read rather than being memoized behind the same TTL as properties that only change on
+  // resize - otherwise a caller combining a scroll offset with a freshly-measured rect can get
+  // values sampled at two different instants.
+  it('should read scrollTop/scrollLeft live, even within the 20ms cache window', () => {
+    // winDimensions reads from window.top (canAccessWindowTop() ? getWindowTop() :
+    // getWindowSelf()), which under Karma is not the same document as the bare `document`
+    // reference in this spec file - Karma runs specs inside an iframe.
+    const topDocumentElement = window.top.document.documentElement;
+    let scrollTop = 100;
+    let scrollLeft = 50;
+    Object.defineProperty(topDocumentElement, 'scrollTop', { configurable: true, get: () => scrollTop });
+    Object.defineProperty(topDocumentElement, 'scrollLeft', { configurable: true, get: () => scrollLeft });
+
+    try {
+      const before = getWinDimensions();
+      expect(before.document.documentElement.scrollTop).to.equal(100);
+      expect(before.document.documentElement.scrollLeft).to.equal(50);
+      const cachedInnerHeightBefore = before.innerHeight;
+
+      // still inside the 20ms cache window: a cached property must not change...
+      clock.tick(1);
+      scrollTop = 900;
+      scrollLeft = 450;
+      const during = getWinDimensions();
+      expect(during.innerHeight).to.equal(cachedInnerHeightBefore);
+      // ...but the live scroll offsets must reflect the new position immediately.
+      expect(during.document.documentElement.scrollTop).to.equal(900);
+      expect(during.document.documentElement.scrollLeft).to.equal(450);
+    } finally {
+      delete topDocumentElement.scrollTop;
+      delete topDocumentElement.scrollLeft;
+    }
+  });
 });
 
 describe('polite sync helpers', () => {


### PR DESCRIPTION
Fixes #15446 (problem 2 only — see note below).

## Summary

`getWinDimensions()` (`src/utils/winDimensions.js`) memoizes
`document.documentElement`/`body` `scrollTop`/`scrollLeft` behind the
same 20ms TTL as properties that only change on resize (`innerHeight`,
`screen.*`, `clientWidth`/`Height`, ...). Scroll offsets are different in
kind: they change continuously, at up to thousands of CSS pixels per
second during a fling. A caller computing a document-relative coordinate
from a freshly-measured rect plus a scroll offset pulled from this cache
can combine two different sampling instants, producing coordinates that
describe no layout state that ever existed — worst exactly while the
user is scrolling, which is when the computation must not drift.

## Change

- Adds a `LIVE` mode to `CachedApiWrapper` (`src/utils/cachedApiWrapper.js`,
  the shared primitive `winDimensions.js` is built on) for properties
  that must always read the current value, never memoized and
  unaffected by `reset()`.
- Applies `LIVE` to `scrollTop`/`scrollLeft` on both
  `document.documentElement` and `document.body` in `winDimensions.js`.
- Fixes the two current in-tree readers of these values
  (`adagioRtdProvider.js:541-542`, `nextMillenniumBidAdapter.js:347`) to
  use `??` instead of `||`: a genuine scroll offset of `0` (page at
  top/left) is a valid measurement and must not fall through to the next
  source in the fallback chain.

## Note on scope

The issue describes two independent problems. This addresses problem 2
only (the one it calls "the smallest correct fix," explicitly
independent of problem 1). Problem 1 — the `boundingClientRect` cache
being cleared *after* RTD modules run due to hook-priority ordering — is
a separate, larger change (moving the rect cache to a
`requestAnimationFrame`-based epoch, plus rewriting a timing-sensitive
existing test) that needs its own design discussion; not attempted here.

## Test plan

- Added a `LIVE` mode test case to `cachedApiWrapper_spec.js` (not
  cached, unaffected by `reset()`).
- Added a test to `utils_spec.js`'s existing `getWinDimensions` suite
  (reusing its `sinon.useFakeTimers` harness) proving `scrollTop`/`scrollLeft`
  reflect a changed position *within* the 20ms cache window, while
  `innerHeight` stays cached in the same window. Verified this test
  fails against the unmodified code (returns the stale cached value)
  and passes with the fix.
- `npx gulp lint --files ...`: clean, no changes from `--fix`.
- `npx gulp test-only --file test/spec/modules/adagioRtdProvider_spec.js`
  and `nextMillenniumBidAdapter_spec.js`: pass unmodified (27 and 61
  tests respectively).
- `npx gulp test-only` (full suite, all 8 chunks): all passing.