### PR TITLE
Ampliffy Bid Adapter: parse response markup in an inert document

### DIFF
--- a/modules/ampliffyBidAdapter.js
+++ b/modules/ampliffyBidAdapter.js
@@ -332,6 +332,13 @@ export function isAllowedToBidUp(html, currentURL) {
     if (allowedToPush) {
       const excludedURL = html.querySelectorAll('[excludedURLs]')[0];
       if (excludedURL) {
+        // TODO: pre-existing bug, not fixed here to keep this change to one concern.
+        // This reads the attribute off `domainsMap` rather than off `excludedURL`,
+        // the element just selected for it. It only works when both attributes sit
+        // on the same element, which is the only shape the tests cover. Otherwise
+        // the value is null, or `domainsMap` is undefined and this throws; either
+        // way the catch below swallows it and `allowedToPush` stays true, so the
+        // exclusion list is silently ignored and an excluded URL is bid on.
         const excludedURLsString = domainsMap.getAttribute('excludedURLs');
         if (excludedURLsString !== '') {
           const excluded = JSON.parse(excludedURLsString);

--- a/modules/ampliffyBidAdapter.js
+++ b/modules/ampliffyBidAdapter.js
@@ -293,9 +293,10 @@ export function parseXML(xml, bid) {
     if (ct) {
       const companion = xml.getElementsByTagName('Companion')[0];
       const htmlResource = companion.getElementsByTagName('HTMLResource')[0];
-      // Parse in an inert document: the response markup is bidder-controlled, and
-      // assigning it to an element owned by the live document compiles event-handler
-      // attributes and starts image loads. Only attributes are read back from it.
+      // Parse in an inert document. The markup below is bidder-controlled and only
+      // ever read for attribute values, so it must not be activated: parsing it into
+      // any node owned by the live document (as `createElement('html')` + `innerHTML`
+      // did) compiles event-handler attributes and starts image loads.
       const htmlContent = new window.DOMParser().parseFromString(htmlResource.textContent, 'text/html');
 
       ret.cpm = extractCPM(htmlContent, ct, ret.cpm);

--- a/modules/ampliffyBidAdapter.js
+++ b/modules/ampliffyBidAdapter.js
@@ -295,9 +295,8 @@ export function parseXML(xml, bid) {
       const htmlResource = companion.getElementsByTagName('HTMLResource')[0];
       // Parse in an inert document. `htmlResource.textContent` is bidder-controlled
       // and only ever read for attribute values, so it must not be activated:
-      // parsing it into any node owned by the live document (as
-      // `createElement('html')` + `innerHTML` did) compiles event-handler
-      // attributes and starts image loads.
+      // parsing it into any node owned by the live document compiles its
+      // event-handler attributes into live handlers and starts its image loads.
       const htmlContent = new window.DOMParser().parseFromString(htmlResource.textContent, 'text/html');
 
       ret.cpm = extractCPM(htmlContent, ct, ret.cpm);
@@ -334,12 +333,15 @@ export function isAllowedToBidUp(html, currentURL) {
       const excludedURL = html.querySelectorAll('[excludedURLs]')[0];
       if (excludedURL) {
         // TODO: this reads the attribute off `domainsMap`, not off `excludedURL`,
-        // the element just selected for it. It works only when `domainMap` and
-        // `excludedURLs` are on the same element. Otherwise it throws: `domainsMap`
-        // is undefined when the payload carries no `domainMap` at all, and
-        // otherwise `getAttribute` returns null, which `JSON.parse` turns into null
-        // and the `forEach` below rejects. The catch then leaves `allowedToPush`
-        // true, so the exclusion list is ignored and an excluded URL is bid on.
+        // the element just selected for it. It gives the right answer only when the
+        // first `[domainMap]` element is also the first `[excludedURLs]` element.
+        // When it is not, either the read throws - `domainsMap` is undefined if
+        // nothing carries `domainMap`, and otherwise `getAttribute` returns null,
+        // which `JSON.parse` turns into null for the `forEach` below to reject - or,
+        // if `domainsMap` happens to carry its own `excludedURLs`, it silently
+        // consults that list instead of the selected one and does not throw at all.
+        // Every path ends with `allowedToPush` still true, so an excluded URL is bid
+        // on, and only the throwing ones leave anything in the log.
         const excludedURLsString = domainsMap.getAttribute('excludedURLs');
         if (excludedURLsString !== '') {
           const excluded = JSON.parse(excludedURLsString);

--- a/modules/ampliffyBidAdapter.js
+++ b/modules/ampliffyBidAdapter.js
@@ -297,7 +297,14 @@ export function parseXML(xml, bid) {
       // and only ever read for attribute values, so it must not be activated:
       // parsing it into any node owned by the live document compiles its
       // event-handler attributes into live handlers and starts its image loads.
-      const htmlContent = new window.DOMParser().parseFromString(htmlResource.textContent, 'text/html');
+      //
+      // `createHTMLDocument` rather than `DOMParser` because this keeps the same
+      // parse algorithm - a fragment parse with `<html>` as context - and so keeps
+      // the same document order. The extractors below all take
+      // `querySelectorAll(...)[0]`, so a parse that surfaces earlier matches
+      // changes which element they read, not just whether they find one.
+      const htmlContent = document.implementation.createHTMLDocument('');
+      htmlContent.documentElement.innerHTML = htmlResource.textContent;
 
       ret.cpm = extractCPM(htmlContent, ct, ret.cpm);
       ret.currency = extractCurrency(htmlContent, ret.currency);
@@ -332,16 +339,13 @@ export function isAllowedToBidUp(html, currentURL) {
     if (allowedToPush) {
       const excludedURL = html.querySelectorAll('[excludedURLs]')[0];
       if (excludedURL) {
-        // TODO: this reads the attribute off `domainsMap`, not off `excludedURL`,
-        // the element just selected for it. It gives the right answer only when the
-        // first `[domainMap]` element is also the first `[excludedURLs]` element.
-        // When it is not, either the read throws - `domainsMap` is undefined if
-        // nothing carries `domainMap`, and otherwise `getAttribute` returns null,
-        // which `JSON.parse` turns into null for the `forEach` below to reject - or,
-        // if `domainsMap` happens to carry its own `excludedURLs`, it silently
-        // consults that list instead of the selected one and does not throw at all.
-        // Every path ends with `allowedToPush` still true, so an excluded URL is bid
-        // on, and only the throwing ones leave anything in the log.
+        // TODO: this reads the attribute off `domainsMap`, not off `excludedURL` -
+        // the element `querySelectorAll` just selected for exactly this purpose.
+        // The two are the same element only when the first `[domainMap]` match is
+        // also the first `[excludedURLs]` match, and when they are not, the wrong
+        // exclusion list is applied or the read throws into the catch below. Bids
+        // are both wrongly allowed and wrongly dropped as a result, and the paths
+        // that do not throw leave nothing behind to notice them by.
         const excludedURLsString = domainsMap.getAttribute('excludedURLs');
         if (excludedURLsString !== '') {
           const excluded = JSON.parse(excludedURLsString);

--- a/modules/ampliffyBidAdapter.js
+++ b/modules/ampliffyBidAdapter.js
@@ -332,13 +332,12 @@ export function isAllowedToBidUp(html, currentURL) {
     if (allowedToPush) {
       const excludedURL = html.querySelectorAll('[excludedURLs]')[0];
       if (excludedURL) {
-        // TODO: pre-existing bug, not fixed here to keep this change to one concern.
-        // This reads the attribute off `domainsMap` rather than off `excludedURL`,
-        // the element just selected for it. It only works when both attributes sit
-        // on the same element, which is the only shape the tests cover. Otherwise
-        // the value is null, or `domainsMap` is undefined and this throws; either
-        // way the catch below swallows it and `allowedToPush` stays true, so the
-        // exclusion list is silently ignored and an excluded URL is bid on.
+        // TODO: this reads the attribute off `domainsMap`, not off `excludedURL`,
+        // the element just selected for it. It works only when `domainMap` and
+        // `excludedURLs` are on the same element. Otherwise `getAttribute` returns
+        // null, or `domainsMap` is undefined and this throws; either way the catch
+        // below leaves `allowedToPush` true, so the exclusion list is ignored and
+        // an excluded URL is bid on.
         const excludedURLsString = domainsMap.getAttribute('excludedURLs');
         if (excludedURLsString !== '') {
           const excluded = JSON.parse(excludedURLsString);

--- a/modules/ampliffyBidAdapter.js
+++ b/modules/ampliffyBidAdapter.js
@@ -293,8 +293,10 @@ export function parseXML(xml, bid) {
     if (ct) {
       const companion = xml.getElementsByTagName('Companion')[0];
       const htmlResource = companion.getElementsByTagName('HTMLResource')[0];
-      const htmlContent = document.createElement('html');
-      htmlContent.innerHTML = htmlResource.textContent;
+      // Parse in an inert document: the response markup is bidder-controlled, and
+      // assigning it to an element owned by the live document compiles event-handler
+      // attributes and starts image loads. Only attributes are read back from it.
+      const htmlContent = new window.DOMParser().parseFromString(htmlResource.textContent, 'text/html');
 
       ret.cpm = extractCPM(htmlContent, ct, ret.cpm);
       ret.currency = extractCurrency(htmlContent, ret.currency);

--- a/modules/ampliffyBidAdapter.js
+++ b/modules/ampliffyBidAdapter.js
@@ -293,10 +293,11 @@ export function parseXML(xml, bid) {
     if (ct) {
       const companion = xml.getElementsByTagName('Companion')[0];
       const htmlResource = companion.getElementsByTagName('HTMLResource')[0];
-      // Parse in an inert document. The markup below is bidder-controlled and only
-      // ever read for attribute values, so it must not be activated: parsing it into
-      // any node owned by the live document (as `createElement('html')` + `innerHTML`
-      // did) compiles event-handler attributes and starts image loads.
+      // Parse in an inert document. `htmlResource.textContent` is bidder-controlled
+      // and only ever read for attribute values, so it must not be activated:
+      // parsing it into any node owned by the live document (as
+      // `createElement('html')` + `innerHTML` did) compiles event-handler
+      // attributes and starts image loads.
       const htmlContent = new window.DOMParser().parseFromString(htmlResource.textContent, 'text/html');
 
       ret.cpm = extractCPM(htmlContent, ct, ret.cpm);
@@ -334,10 +335,11 @@ export function isAllowedToBidUp(html, currentURL) {
       if (excludedURL) {
         // TODO: this reads the attribute off `domainsMap`, not off `excludedURL`,
         // the element just selected for it. It works only when `domainMap` and
-        // `excludedURLs` are on the same element. Otherwise `getAttribute` returns
-        // null, or `domainsMap` is undefined and this throws; either way the catch
-        // below leaves `allowedToPush` true, so the exclusion list is ignored and
-        // an excluded URL is bid on.
+        // `excludedURLs` are on the same element. Otherwise it throws: `domainsMap`
+        // is undefined when the payload carries no `domainMap` at all, and
+        // otherwise `getAttribute` returns null, which `JSON.parse` turns into null
+        // and the `forEach` below rejects. The catch then leaves `allowedToPush`
+        // true, so the exclusion list is ignored and an excluded URL is bid on.
         const excludedURLsString = domainsMap.getAttribute('excludedURLs');
         if (excludedURLsString !== '') {
           const excluded = JSON.parse(excludedURLsString);

--- a/test/spec/modules/ampliffyBidAdapter_spec.js
+++ b/test/spec/modules/ampliffyBidAdapter_spec.js
@@ -356,11 +356,12 @@ describe('Ampliffy bid adapter Test', function () {
     });
 
     it('Should extract from a payload wrapped in html/head/body', () => {
-      // The parse this adapter now uses is a full document parse, where it was a
-      // fragment parse with <html> as context. That distinction only shows up on
-      // payloads carrying their own <html>/<head>/<body>, which HTMLResource
-      // payloads generally do. The unclosed <div> is deliberate: it is legal HTML
-      // and a fatal XML error, so this also pins that the parse stays lenient.
+      // HTMLResource payloads generally carry their own document wrapper, and the
+      // parse behind this is a full document parse where it was a fragment parse
+      // with <html> as context. Extraction is unaffected either way - this is a
+      // characterization test, and it passes against both - but nothing else
+      // covers the wrapped shape at all. The unclosed <div> is deliberate: legal
+      // HTML and a fatal XML error, so this also pins that the parse stays lenient.
       const xmlStrWrapped = `<?xml version="1.0" encoding="UTF-8"?>
                   <Ads type="video">
                     <Companion id="138316138683">
@@ -414,17 +415,26 @@ describe('Ampliffy bid adapter Test', function () {
         expect(cpmData.cpm).to.equal('.77');
         expect(cpmData.currency).to.equal('CHF');
 
-        // A handler compiled during that parse would fire from an error task
-        // queued before this image's, so once this one reports, it has had its
-        // turn. Waiting on it rather than on a timer keeps the test off the clock
-        // and turns a missing signal into a timeout instead of a silent pass.
-        const control = new Image();
-        control.onerror = () => {
+        // A compiled handler fires from the image's error task, which lands well
+        // under a millisecond after the parse. Poll to a deadline orders of
+        // magnitude beyond that: fail the moment the marker flips, pass only once
+        // the deadline has gone by without it flipping.
+        //
+        // Waiting on a second image's error event instead does not work, however
+        // much tidier it looks. The two error tasks are queued sub-millisecond
+        // apart and nothing orders them, so that version passes against a module
+        // that does run the handler about half the time.
+        const deadlineMs = 500;
+        const intervalMs = 10;
+        let waitedMs = 0;
+        const poll = setInterval(() => {
+          waitedMs += intervalMs;
           const fired = window[marker];
+          if (!fired && waitedMs < deadlineMs) return;
+          clearInterval(poll);
           cleanUp();
           done(fired ? new Error('an onerror handler from the response markup ran during parsing') : undefined);
-        };
-        control.src = undecodableImage;
+        }, intervalMs);
       } catch (e) {
         cleanUp();
         throw e;

--- a/test/spec/modules/ampliffyBidAdapter_spec.js
+++ b/test/spec/modules/ampliffyBidAdapter_spec.js
@@ -355,6 +355,35 @@ describe('Ampliffy bid adapter Test', function () {
       expect(cpmData.currency).to.equal('USD');
     });
 
+    it('Should extract from a payload wrapped in html/head/body', () => {
+      // The parse this adapter now uses is a full document parse, where it was a
+      // fragment parse with <html> as context. That distinction only shows up on
+      // payloads carrying their own <html>/<head>/<body>, which HTMLResource
+      // payloads generally do. The unclosed <div> is deliberate: it is legal HTML
+      // and a fatal XML error, so this also pins that the parse stays lenient.
+      const xmlStrWrapped = `<?xml version="1.0" encoding="UTF-8"?>
+                  <Ads type="video">
+                    <Companion id="138316138683">
+                      <HTMLResource><![CDATA[<!doctype html>
+                              <html><head></head>
+                                <body>
+                                  <div class="GoogleActiveViewInnerContainer"></div>
+                                  <div cpmMap=\'{"ES":".42"}\' cpmCurrency=\'GBP\'
+                                       creativeMap=\'{"https://bidder.ampliffy.com/gampad/ads?adName=wrapped.xml":["ES"]}\'>
+                                </body>
+                              </html>]]>
+                      </HTMLResource>
+                    </Companion>
+                    <Extensions><Extension type="geo"><Country>ES</Country></Extension></Extensions>
+                  </Ads>`;
+      const xmlWrapped = new window.DOMParser().parseFromString(xmlStrWrapped, 'text/xml');
+      const cpmData = parseXML(xmlWrapped, { width: 300, height: 250 });
+
+      expect(cpmData.cpm).to.equal('.42');
+      expect(cpmData.currency).to.equal('GBP');
+      expect(cpmData.creativeURL).to.equal('https://bidder.ampliffy.com/gampad/ads?adName=wrapped.xml');
+    });
+
     it('Should not run event handlers declared in the response markup', (done) => {
       // The markup below is parsed, not rendered. Parsed into a document with
       // scripting enabled, the onerror content attribute becomes a live handler
@@ -368,8 +397,8 @@ describe('Ampliffy bid adapter Test', function () {
                   <Ads type="video">
                     <Companion id="138316138683">
                       <HTMLResource><![CDATA[
-                              <img src="${undecodableImage}" onerror="window.${marker} = true">
-                              <ad cpmMap=\'{"ES":".77"}\' cpmCurrency=\'CHF\' />
+                              <img src="${undecodableImage}" onerror="window.${marker} = true"
+                                   cpmMap=\'{"ES":".77"}\' cpmCurrency=\'CHF\'>
                               ]]>
                       </HTMLResource>
                     </Companion>
@@ -378,7 +407,10 @@ describe('Ampliffy bid adapter Test', function () {
         const xmlHandler = new window.DOMParser().parseFromString(xmlStrHandler, 'text/xml');
         const cpmData = parseXML(xmlHandler);
 
-        // Guards against passing vacuously: the payload really was parsed and read.
+        // Guards against passing vacuously. These attributes sit on the same
+        // element as the handler, so reading them back proves that this element
+        // survived the parse - a strategy that dropped or stripped it could not
+        // reach here and then claim inertness.
         expect(cpmData.cpm).to.equal('.77');
         expect(cpmData.currency).to.equal('CHF');
 

--- a/test/spec/modules/ampliffyBidAdapter_spec.js
+++ b/test/spec/modules/ampliffyBidAdapter_spec.js
@@ -37,8 +37,7 @@ describe('Ampliffy bid adapter Test', function () {
   const xml = new window.DOMParser().parseFromString(xmlStr, 'text/xml');
   const companion = xml.getElementsByTagName('Companion')[0];
   const htmlResource = companion.getElementsByTagName('HTMLResource')[0];
-  const htmlContent = document.createElement('html');
-  htmlContent.innerHTML = htmlResource.textContent;
+  const htmlContent = new window.DOMParser().parseFromString(htmlResource.textContent, 'text/html');
 
   describe('Is allowed to bid up', function () {
     it('Should return true using a URL that is in domainMap', () => {
@@ -354,6 +353,50 @@ describe('Ampliffy bid adapter Test', function () {
       expect(cpmData).to.not.be.a('null');
       expect(cpmData.cpm).to.equal('.23');
       expect(cpmData.currency).to.equal('USD');
+    });
+
+    it('Should not run event handlers declared in the response markup', (done) => {
+      // The markup below is parsed, not rendered. Parsed into a document with
+      // scripting enabled, the onerror content attribute becomes a live handler
+      // and runs when the deliberately undecodable image fails.
+      const marker = '__ampliffyInertParseProbe';
+      const undecodableImage = 'data:image/png;base64,not-a-png';
+      const cleanUp = () => { delete window[marker]; };
+      window[marker] = false;
+      try {
+        const xmlStrHandler = `<?xml version="1.0" encoding="UTF-8"?>
+                  <Ads type="video">
+                    <Companion id="138316138683">
+                      <HTMLResource><![CDATA[
+                              <img src="${undecodableImage}" onerror="window.${marker} = true">
+                              <ad cpmMap=\'{"ES":".77"}\' cpmCurrency=\'CHF\' />
+                              ]]>
+                      </HTMLResource>
+                    </Companion>
+                    <Extensions><Extension type="geo"><Country>ES</Country></Extension></Extensions>
+                  </Ads>`;
+        const xmlHandler = new window.DOMParser().parseFromString(xmlStrHandler, 'text/xml');
+        const cpmData = parseXML(xmlHandler);
+
+        // Guards against passing vacuously: the payload really was parsed and read.
+        expect(cpmData.cpm).to.equal('.77');
+        expect(cpmData.currency).to.equal('CHF');
+
+        // A handler compiled during that parse would fire from an error task
+        // queued before this image's, so once this one reports, it has had its
+        // turn. Waiting on it rather than on a timer keeps the test off the clock
+        // and turns a missing signal into a timeout instead of a silent pass.
+        const control = new Image();
+        control.onerror = () => {
+          const fired = window[marker];
+          cleanUp();
+          done(fired ? new Error('an onerror handler from the response markup ran during parsing') : undefined);
+        };
+        control.src = undecodableImage;
+      } catch (e) {
+        cleanUp();
+        throw e;
+      }
     });
 
     it('It should return no ads when the CPM is less than zero.', () => {

--- a/test/spec/modules/ampliffyBidAdapter_spec.js
+++ b/test/spec/modules/ampliffyBidAdapter_spec.js
@@ -313,6 +313,12 @@ describe('Ampliffy bid adapter Test', function () {
     });
   });
   describe('Interpret response', function () {
+    // Set by markup under test, below, and read back from the global scope an
+    // inline handler would run in. Cleared here so it cannot outlive its test
+    // even on a path that never reaches the test's own cleanup.
+    const INERT_MARKER = '__ampliffyInertParseProbe';
+    afterEach(() => { delete window[INERT_MARKER]; });
+
     const bidRequest = {
       bidRequest: {
         adUnitCode: 'div-gpt-ad-1460505748561-0',
@@ -389,7 +395,7 @@ describe('Ampliffy bid adapter Test', function () {
       // The markup below is parsed, not rendered. Parsed into a document with
       // scripting enabled, the onerror content attribute becomes a live handler
       // and runs when the deliberately undecodable image fails.
-      const marker = '__ampliffyInertParseProbe';
+      const marker = INERT_MARKER;
       const undecodableImage = 'data:image/png;base64,not-a-png';
       const cleanUp = () => { delete window[marker]; };
       window[marker] = false;
@@ -420,21 +426,24 @@ describe('Ampliffy bid adapter Test', function () {
         // magnitude beyond that: fail the moment the marker flips, pass only once
         // the deadline has gone by without it flipping.
         //
+        // The deadline is elapsed time, not a tick count. Timer delivery is not
+        // guaranteed to keep to the interval - a browser throttles timers hard in
+        // a backgrounded page - and counting ticks would turn that into a mocha
+        // timeout on a correct module.
+        //
         // Waiting on a second image's error event instead does not work, however
         // much tidier it looks. The two error tasks are queued sub-millisecond
         // apart and nothing orders them, so that version passes against a module
         // that does run the handler about half the time.
         const deadlineMs = 500;
-        const intervalMs = 10;
-        let waitedMs = 0;
+        const startedAt = Date.now();
         const poll = setInterval(() => {
-          waitedMs += intervalMs;
           const fired = window[marker];
-          if (!fired && waitedMs < deadlineMs) return;
+          if (!fired && Date.now() - startedAt < deadlineMs) return;
           clearInterval(poll);
           cleanUp();
           done(fired ? new Error('an onerror handler from the response markup ran during parsing') : undefined);
-        }, intervalMs);
+        }, 10);
       } catch (e) {
         cleanUp();
         throw e;

--- a/test/spec/modules/ampliffyBidAdapter_spec.js
+++ b/test/spec/modules/ampliffyBidAdapter_spec.js
@@ -37,7 +37,8 @@ describe('Ampliffy bid adapter Test', function () {
   const xml = new window.DOMParser().parseFromString(xmlStr, 'text/xml');
   const companion = xml.getElementsByTagName('Companion')[0];
   const htmlResource = companion.getElementsByTagName('HTMLResource')[0];
-  const htmlContent = new window.DOMParser().parseFromString(htmlResource.textContent, 'text/html');
+  const htmlContent = document.implementation.createHTMLDocument('');
+  htmlContent.documentElement.innerHTML = htmlResource.textContent;
 
   describe('Is allowed to bid up', function () {
     it('Should return true using a URL that is in domainMap', () => {
@@ -362,12 +363,11 @@ describe('Ampliffy bid adapter Test', function () {
     });
 
     it('Should extract from a payload wrapped in html/head/body', () => {
-      // HTMLResource payloads generally carry their own document wrapper, and the
-      // parse behind this is a full document parse where it was a fragment parse
-      // with <html> as context. Extraction is unaffected either way - this is a
-      // characterization test, and it passes against both - but nothing else
-      // covers the wrapped shape at all. The unclosed <div> is deliberate: legal
-      // HTML and a fatal XML error, so this also pins that the parse stays lenient.
+      // HTMLResource payloads generally carry their own document wrapper, so the
+      // parse has to handle one. This is a characterization test: extraction is
+      // unaffected by the wrapper and it passes against the pre-change module too.
+      // The unclosed <div> is deliberate - legal HTML and a fatal XML error - so
+      // this also pins that the parse stays lenient.
       const xmlStrWrapped = `<?xml version="1.0" encoding="UTF-8"?>
                   <Ads type="video">
                     <Companion id="138316138683">
@@ -389,6 +389,31 @@ describe('Ampliffy bid adapter Test', function () {
       expect(cpmData.cpm).to.equal('.42');
       expect(cpmData.currency).to.equal('GBP');
       expect(cpmData.creativeURL).to.equal('https://bidder.ampliffy.com/gampad/ads?adName=wrapped.xml');
+    });
+
+    it('Should read the first attribute in document order, not one the parse invented', () => {
+      // Every extractor takes querySelectorAll('[attr]')[0], so a parse that
+      // surfaces an earlier match changes which element is read. An attribute on
+      // the payload's own <html> tag is the case that separates the inert parsers:
+      // a full document parse exposes it and it wins, ahead of the real values.
+      const xmlStrDecoy = `<?xml version="1.0" encoding="UTF-8"?>
+                  <Ads type="video">
+                    <Companion id="138316138683">
+                      <HTMLResource><![CDATA[<!doctype html>
+                              <html cpmMap=\'{"ES":"9.99"}\' cpmCurrency=\'USD\'>
+                                <body>
+                                  <div cpmMap=\'{"ES":".42"}\' cpmCurrency=\'GBP\'></div>
+                                </body>
+                              </html>]]>
+                      </HTMLResource>
+                    </Companion>
+                    <Extensions><Extension type="geo"><Country>ES</Country></Extension></Extensions>
+                  </Ads>`;
+      const xmlDecoy = new window.DOMParser().parseFromString(xmlStrDecoy, 'text/xml');
+      const cpmData = parseXML(xmlDecoy, { width: 300, height: 250 });
+
+      expect(cpmData.cpm).to.equal('.42');
+      expect(cpmData.currency).to.equal('GBP');
     });
 
     it('Should not run event handlers declared in the response markup', (done) => {


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [x] Updated bidder adapter

## For the ampliffy maintainer (@vicenteampliffy)

**1. This PR assumes your `HTMLResource` creatives never carry `cpmMap`, `cpmCurrency`, `creativeMap`, `userSyncs`, `domainMap`, `excludedURLs` or `bidder-tracking-url` inside a `<noscript>` block.** `implementation.createHTMLDocument('')` treats `<noscript>` differently compared to `createElement('html')`; if these properties _can_ appear within `<noscript>`, bids may be incorrect or lost.

**2. Parsing no longer fires the payload's resource loads.** Removed on purpose — that is the defect being fixed — but if any of that markup doubles as an impression or measurement beacon, it stops firing. See "What stops happening".

**3. A `TODO` is added over an unrelated pre-existing bug** in `isAllowedToBidUp`, which is left unfixed on purpose. See "A bug flagged, not fixed".

## Description of change

`parseXML` reads seven attribute values out of the VAST `<Companion><HTMLResource>` payload. To do that it was building a parse buffer with `document.createElement('html')` and assigning the payload to its `innerHTML` (`modules/ampliffyBidAdapter.js#L296-L297` before this change).

`document.createElement('html')` does not create a document — it creates an element whose `ownerDocument` is the live page document, which is fully active with scripting enabled. Assigning `innerHTML` there does not run `<script>` (nothing revives it), but it does compile event-handler content attributes such as `onerror` into live handlers, and it does start `<img>` loads. Detaching the element changes neither; only an inert document does.

The payload is bidder response content. `parseXML` runs on every parsed response — from `interpretResponse` (`modules/ampliffyBidAdapter.js#L135`) and again from `getUserSyncs` (`modules/ampliffyBidAdapter.js#L368`; all line numbers here are against master @ 52be0c58d, before this change) — before any rendering and whether or not the bid wins.

This parses it with `document.implementation.createHTMLDocument('')` and an `innerHTML` assignment on its `documentElement` instead. That is the *same* parse algorithm — a fragment parse with `<html>` as context — run in a document with no browsing context, so it is inert while keeping the same document order. `DOMParser.parseFromString(..., 'text/html')` is also inert but runs a full document parse, which surfaces attributes on the payload's own `<html>` tag ahead of the real ones; see below for why that matters.

### What stops happening — the point of the change

The payload's `onerror`/`onload` attributes are no longer compiled into live handlers, and it no longer issues the resource fetches the markup asks for. That is the defect being fixed, but if any of that markup is being relied on as a beacon it is also the one thing here that could be missed: **if ampliffy's `HTMLResource` carries an impression or measurement pixel, this stops firing it** — at response-parse time, for every response, and twice per response because `getUserSyncs` re-parses. Measured on one payload, the old parse issued four fetches — `<img>`, `<svg><image>`, `<video poster>` and `<input type="image">` — and the new parse issued none. (`<link>`, `<script>`, `<iframe>`, `<embed>` and `<object>` did not fetch under either.) Nothing in the adapter reads those loads back, so nothing here depends on them, but please confirm nothing on your side does. Beacons belong on a deliberate path (`triggerPixel`, which this adapter already imports, or `vastTrackers`), not on a side effect of inspecting markup.

### A bug flagged, not fixed

The other half of the module diff is a `TODO` over an unrelated defect noticed while working on this one. `isAllowedToBidUp` selects the element carrying `[excludedURLs]` and then reads the attribute off `domainsMap` instead. It gives the right answer only when the first `[domainMap]` element is also the first `[excludedURLs]` element. Otherwise it fails one of two ways:

- **Loudly.** `domainsMap` is `undefined` when nothing carries `domainMap`, so the read throws; and when `domainsMap` carries no `excludedURLs`, `getAttribute` returns `null`, `JSON.parse` turns that into `null`, and the `forEach` throws. Both land in the surrounding `catch`, which logs.
- **Silently.** If `domainsMap` happens to carry its own `excludedURLs`, that list is consulted instead of the selected element's. Nothing throws and nothing is logged. Note this happens even with `domainMap` and `excludedURLs` on one element, as long as some earlier element also carries `excludedURLs`.

## Other information

Module rule conformance — Global Module Rules 2.3 (https://docs.prebid.org/dev-docs/module-rules.html). No publisher action is required and no configuration changes.

### Steps to reproduce

1. Serve an ampliffy bid response whose `<Companion><HTMLResource>` payload contains `<img src="data:image/png;base64,not-a-png" onerror="/* anything */">` alongside the usual `cpmMap` / `cpmCurrency` attributes.
2. Run an auction including the `ampliffy` bidder.

**Expected results:** the payload is inspected for its attribute values and nothing in it is activated.

**Actual results (before this change):** the `onerror` handler is compiled and runs, and an `<img>` fetch is issued, at response-parse time — before rendering, and whether or not the bid wins.

### Platform details

Prebid.js `master` @ 52be0c58d (`11.32.0-pre`); Node 22.23.2; verified in Chrome Headless 138.0.7204.92 (Linux x86_64).

### Verification

- `npx gulp lint --nolintfix --files modules/ampliffyBidAdapter.js,test/spec/modules/ampliffyBidAdapter_spec.js` — clean.
- `npx gulp test-only` — full suite green, 8 chunks, exit 0.
- Coverage for the changed line, from `npx gulp test-only-nobuild --file test/spec/modules/ampliffyBidAdapter_spec.js` and `build/coverage/chunks/1/lcov.info`: the modified statement is executed 8 times by this spec.
- The added inertness test was run 10 times against the pre-change module and failed 10 times, and 10 times against this branch and passed 10 times.

The branch's commits are review iterations rather than a curated history — please squash-merge.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
