### PR TITLE
docs: fix typo recomended -> recommended

### DIFF
--- a/modules/copper6sspBidAdapter.md
+++ b/modules/copper6sspBidAdapter.md
@@ -25,7 +25,7 @@ var adUnits = [
                     pId: '59ac17c192832d0016683fe3',
                     bidFloor: 0.0001,
                     ext: {
-                        // custom params that were recomended to add by a partner
+                        // custom params that were recommended to add by a partner
                     }
                 }
             }


### PR DESCRIPTION
Corrects the misspelling `recomended` -> `recommended` in `modules/copper6sspBidAdapter.md`.

Documentation only, no behaviour change.