### PR TITLE
Richaudience Bid Adapter: fix floor currency and referer state, add ORTB signals

### DIFF
--- a/modules/richaudienceBidAdapter.js
+++ b/modules/richaudienceBidAdapter.js
@@ -48,11 +48,13 @@ export const spec = {
         eids: deepAccess(bid, 'userIdAsEids') ? bid.userIdAsEids : [],
         videoData: raiGetVideoInfo(bid),
         scr_rsl: raiGetResolution(),
+        device: { ext: { visibility: { hidden: raiIsPageHidden() } } },
         kws: bid.params.keywords,
         schain: bid?.ortb2?.source?.ext?.schain,
         gpid: raiSetPbAdSlot(bid),
         dsa: setDSA(bid),
-        userData: deepAccess(bid, 'ortb2.user.data')
+        userData: deepAccess(bid, 'ortb2.user.data'),
+        ext: { prebid: { channel: { name: 'pbjs', version: '$prebid.version$' } } }
       };
 
       payload.gdpr_consent = '';
@@ -237,10 +239,14 @@ function raiGetSizes(bid) {
 function raiGetVideoInfo(bid) {
   let videoData;
   if (bid.mediaTypes?.video) {
+    const video = bid.mediaTypes.video;
+
     videoData = {
-      format: bid.mediaTypes.video.context,
-      playerSize: bid.mediaTypes.video.playerSize,
-      mimes: bid.mediaTypes.video.mimes
+      format: video.context,
+      playerSize: video.playerSize,
+      mimes: video.mimes,
+      plcmt: video.plcmt,
+      playbackmethod: video.playbackmethod
     };
   } else {
     videoData = {
@@ -271,6 +277,10 @@ function raiGetResolution() {
     resolution = window.screen.width + 'x' + window.screen.height;
   }
   return resolution;
+}
+
+function raiIsPageHidden() {
+  return typeof document !== 'undefined' && document.hidden === true;
 }
 
 function raiSetPbAdSlot(bid) {

--- a/modules/richaudienceBidAdapter.js
+++ b/modules/richaudienceBidAdapter.js
@@ -4,9 +4,9 @@ import { config } from '../src/config.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { Renderer } from '../src/Renderer.js';
 import { getCurrencyFromBidderRequest } from '../libraries/ortb2Utils/currency.js';
+import { getRefererInfo } from '../src/refererDetection.js';
 
 const BIDDER_CODE = 'richaudience';
-let REFERER = '';
 
 export const spec = {
   code: BIDDER_CODE,
@@ -30,6 +30,8 @@ export const spec = {
    * @returns {ServerRequest} Info describing the request to the server
    */
   buildRequests: function (validBidRequests, bidderRequest) {
+    const referer = raiGetReferer(bidderRequest.refererInfo);
+
     return validBidRequests.map(bid => {
       const floor = raiGetFloor(bid, bidderRequest);
       var payload = {
@@ -40,7 +42,7 @@ export const spec = {
         auctionId: bid.auctionId,
         tagId: bid.adUnitCode,
         sizes: raiGetSizes(bid),
-        referer: (typeof bidderRequest.refererInfo.page !== 'undefined' ? encodeURIComponent(bidderRequest.refererInfo.page) : null),
+        referer: referer,
         transactionId: bid.ortb2Imp?.ext?.tid,
         timeout: bidderRequest.timeout || 600,
         eids: deepAccess(bid, 'userIdAsEids') ? bid.userIdAsEids : [],
@@ -52,8 +54,6 @@ export const spec = {
         dsa: setDSA(bid),
         userData: deepAccess(bid, 'ortb2.user.data')
       };
-
-      REFERER = (typeof bidderRequest.refererInfo.page !== 'undefined' ? encodeURIComponent(bidderRequest.refererInfo.page) : null);
 
       payload.gdpr_consent = '';
       payload.gdpr = false;
@@ -189,8 +189,10 @@ export const spec = {
       });
     }
 
-    if (syncOptions.pixelEnabled && REFERER != null && syncs.length === 0 && raiSync.raiImage !== 'exclude') {
-      let syncUrl = `https://sync.richaudience.com/bf7c142f4339da0278e83698a02b0854/?referrer=${REFERER}`;
+    const referer = raiGetReferer(getRefererInfo());
+
+    if (syncOptions.pixelEnabled && referer != null && syncs.length === 0 && raiSync.raiImage !== 'exclude') {
+      let syncUrl = `https://sync.richaudience.com/bf7c142f4339da0278e83698a02b0854/?referrer=${referer}`;
       if (consent !== '') {
         syncUrl += `&${consent}`;
       }
@@ -214,6 +216,10 @@ export const spec = {
 };
 
 registerBidder(spec);
+
+function raiGetReferer(refererInfo) {
+  return refererInfo?.page != null ? encodeURIComponent(refererInfo.page) : null;
+}
 
 function raiGetSizes(bid) {
   let raiNewSizes;

--- a/modules/richaudienceBidAdapter.js
+++ b/modules/richaudienceBidAdapter.js
@@ -1,4 +1,4 @@
-import { deepAccess, triggerPixel } from '../src/utils.js';
+import { deepAccess, isFn, logWarn, triggerPixel } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
@@ -31,11 +31,12 @@ export const spec = {
    */
   buildRequests: function (validBidRequests, bidderRequest) {
     return validBidRequests.map(bid => {
+      const floor = raiGetFloor(bid, bidderRequest);
       var payload = {
-        bidfloor: raiGetFloor(bid, config),
+        bidfloor: floor?.value,
         ifa: bid.params.ifa,
         pid: bid.params.pid,
-        currencyCode: getCurrencyFromBidderRequest(bidderRequest),
+        currencyCode: floor?.currency,
         auctionId: bid.auctionId,
         tagId: bid.adUnitCode,
         sizes: raiGetSizes(bid),
@@ -295,24 +296,28 @@ function raiGetSyncInclude(config) {
   }
 }
 
-function raiGetFloor(bid, config) {
-  try {
-    let raiFloor;
-    if (bid.params.bidfloor != null) {
-      raiFloor = bid.params.bidfloor;
-    } else if (typeof bid.getFloor === 'function') {
-      const floorSpec = bid.getFloor({
-        currency: config.getConfig('floors.data.currency') != null ? config.getConfig('floors.data.currency') : 'USD',
-        mediaType: typeof bid.mediaTypes['banner'] === 'object' ? 'banner' : 'video',
-        size: '*'
-      });
+function raiGetFloor(bid, bidderRequest) {
+  const currency = getCurrencyFromBidderRequest(bidderRequest) || 'USD';
+  const paramFloor = parseFloat(bid.params.bidfloor);
 
-      raiFloor = floorSpec.floor;
+  if (isFn(bid.getFloor)) {
+    let floorInfo;
+    try {
+      floorInfo = bid.getFloor({ currency, mediaType: '*', size: '*' });
+    } catch (e) {
+      logWarn(`${BIDDER_CODE}: cannot compute floor for bid`, bid, e);
     }
-    return raiFloor;
-  } catch (e) {
-    return 0;
+    const moduleFloor = parseFloat(floorInfo?.floor);
+    if (moduleFloor && !isNaN(moduleFloor)) {
+      if (floorInfo.currency !== currency) {
+        logWarn(`${BIDDER_CODE}: announcing a ${floorInfo.currency} floor, ${currency} could not be delivered`);
+        return { value: moduleFloor, currency: floorInfo.currency };
+      }
+      return { value: isNaN(paramFloor) ? moduleFloor : Math.max(paramFloor, moduleFloor), currency };
+    }
   }
+
+  return isNaN(paramFloor) ? undefined : { value: paramFloor, currency };
 }
 
 function raiGetTimeoutURL(data) {

--- a/modules/richaudienceBidAdapter.js
+++ b/modules/richaudienceBidAdapter.js
@@ -100,49 +100,51 @@ export const spec = {
    */
   interpretResponse: function (serverResponse, bidRequest) {
     const bidResponses = [];
-    // try catch
     const response = serverResponse.body;
-    if (response) {
-      const bidResponse = {
-        requestId: bidRequest.bidId,
-        cpm: response.cpm,
-        width: response.width,
-        height: response.height,
-        creativeId: response.creative_id,
-        mediaType: response.media_type,
-        netRevenue: response.netRevenue,
-        currency: response.currency,
-        ttl: response.ttl,
-        meta: {
-          advertiserDomains: response.adomain?.length ? [response.adomain[0]] : []
-        },
-        dealId: response.dealId
-      };
 
-      if (response.media_type === 'video') {
-        bidResponse.vastXml = response.vastXML;
-        try {
-          if (bidResponse.vastXml != null) {
-            if (bidRequest.videoData.format === 'outstream' || bidRequest.videoData.format === 'banner') {
-              bidResponse.renderer = Renderer.install({
-                id: bidRequest.bidId,
-                adUnitCode: bidRequest.adUnitCode,
-                loaded: false,
-                config: response.media_type,
-                url: 'https://cdn3.richaudience.com/prebidVideo/player.js'
-              });
-              bidResponse.renderer.setRender(renderer);
-            }
-          }
-        } catch (e) {
-          bidResponse.ad = response.adm;
-        }
-      } else {
-        bidResponse.ad = response.adm;
-      }
-
-      bidResponses.push(bidResponse);
+    if (!response) {
+      return bidResponses;
     }
+
+    const isVideo = response.media_type === 'video';
+    const creative = isVideo ? response.vastXML : response.adm;
+    if (!(response.cpm > 0) || !creative) {
+      return bidResponses;
+    }
+
+    const bidResponse = {
+      requestId: bidRequest.bidId,
+      cpm: response.cpm,
+      width: response.width,
+      height: response.height,
+      creativeId: response.creative_id,
+      mediaType: response.media_type,
+      netRevenue: response.netRevenue,
+      currency: response.currency,
+      ttl: response.ttl,
+      meta: {
+        advertiserDomains: response.adomain?.length ? [response.adomain[0]] : []
+      },
+      dealId: response.dealId
+    };
+
+    if (isVideo) {
+      bidResponse.vastXml = response.vastXML;
+      if (bidRequest.videoData?.format === 'outstream' || bidRequest.videoData?.format === 'banner') {
+        bidResponse.renderer = Renderer.install({
+          id: bidRequest.bidId,
+          adUnitCode: bidRequest.adUnitCode,
+          loaded: false,
+          config: response.media_type,
+          url: 'https://cdn3.richaudience.com/prebidVideo/player.js'
+        });
+        bidResponse.renderer.setRender(renderer);
+      }
+    } else {
+      bidResponse.ad = response.adm;
+    }
+
+    bidResponses.push(bidResponse);
     return bidResponses;
   },
   /***

--- a/modules/richaudienceBidAdapter.js
+++ b/modules/richaudienceBidAdapter.js
@@ -54,6 +54,8 @@ export const spec = {
         gpid: raiSetPbAdSlot(bid),
         dsa: setDSA(bid),
         userData: deepAccess(bid, 'ortb2.user.data'),
+        displaymanager: bid.ortb2Imp?.displaymanager || 'Prebid.js',
+        displaymanagerver: bid.ortb2Imp?.displaymanagerver || '$prebid.version$',
         ext: { prebid: { channel: { name: 'pbjs', version: '$prebid.version$' } } }
       };
 

--- a/test/spec/modules/richaudienceBidAdapter_spec.js
+++ b/test/spec/modules/richaudienceBidAdapter_spec.js
@@ -474,6 +474,145 @@ describe('Richaudience adapter tests', function () {
     expect(request[0].adUnitCode).to.equal('test-div');
   });
 
+  describe('floors', function () {
+    const bidderRequestEUR = {
+      gdprConsent: {
+        consentString: 'BOZcQl_ObPFjWAeABAESCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NohBgA',
+        gdprApplies: true
+      },
+      refererInfo: { page: 'https://domain.com', numIframes: 0 },
+      ortb2: { ext: { prebid: { adServerCurrency: 'EUR' } } }
+    };
+
+    function bannerBid(overrides) {
+      return Object.assign({
+        adUnitCode: 'test-div',
+        bidId: '2c7c8e9c900244',
+        mediaTypes: { banner: { sizes: [[300, 250]] } },
+        bidder: 'richaudience',
+        params: { pid: 'ADb1f40rmi', supplyType: 'site' },
+        auctionId: '0cb3144c-d084-4686-b0d6-f5dbe917c563'
+      }, overrides);
+    }
+
+    it('falls back to params.bidfloor when the floors module is absent', function () {
+      const bid = bannerBid({ params: { pid: 'ADb1f40rmi', supplyType: 'site', bidfloor: 0.5 } });
+      const request = spec.buildRequests([bid], bidderRequestEUR);
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent.bidfloor).to.equal(0.5);
+      expect(requestContent.currencyCode).to.equal('EUR');
+    });
+
+    it('queries getFloor() in the currency announced in currencyCode', function () {
+      const calls = [];
+      const bid = bannerBid({
+        getFloor: (args) => {
+          calls.push(args);
+          return { currency: args.currency, floor: 1.2 };
+        }
+      });
+      const request = spec.buildRequests([bid], bidderRequestEUR);
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent.bidfloor).to.equal(1.2);
+      expect(requestContent.currencyCode).to.equal('EUR');
+      expect(calls).to.have.lengthOf(1);
+      expect(calls[0]).to.deep.equal({ currency: 'EUR', mediaType: '*', size: '*' });
+    });
+
+    it('lets the core resolve the media type instead of picking one', function () {
+      const calls = [];
+      const bid = bannerBid({
+        mediaTypes: { video: { context: 'outstream', playerSize: [640, 480], mimes: ['video/mp4'] } },
+        getFloor: (args) => {
+          calls.push(args);
+          return { currency: args.currency, floor: 0.8 };
+        }
+      });
+      const request = spec.buildRequests([bid], bidderRequestEUR);
+      expect(JSON.parse(request[0].data).bidfloor).to.equal(0.8);
+      expect(calls.map(c => c.mediaType)).to.deep.equal(['*']);
+    });
+
+    it('sends the higher of params.bidfloor and the floors module value', function () {
+      const bid = bannerBid({
+        params: { pid: 'ADb1f40rmi', supplyType: 'site', bidfloor: 0.5 },
+        getFloor: ({ currency }) => ({ currency, floor: 1.2 })
+      });
+      const request = spec.buildRequests([bid], bidderRequestEUR);
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent.bidfloor).to.equal(1.2);
+      expect(requestContent.currencyCode).to.equal('EUR');
+    });
+
+    it('keeps params.bidfloor when it is the higher of the two', function () {
+      const bid = bannerBid({
+        params: { pid: 'ADb1f40rmi', supplyType: 'site', bidfloor: 2.5 },
+        getFloor: ({ currency }) => ({ currency, floor: 1.2 })
+      });
+      const requestContent = JSON.parse(spec.buildRequests([bid], bidderRequestEUR)[0].data);
+      expect(requestContent.bidfloor).to.equal(2.5);
+      expect(requestContent.currencyCode).to.equal('EUR');
+    });
+
+    it('omits bidfloor and currencyCode when getFloor() yields no usable floor and there is no param', function () {
+      const bid = bannerBid({ getFloor: () => null });
+      const request = spec.buildRequests([bid], bidderRequestEUR);
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent).to.not.have.property('bidfloor');
+      expect(requestContent).to.not.have.property('currencyCode');
+    });
+
+    it('announces a floor the module could not convert in its own currency', function () {
+      const bid = bannerBid({
+        mediaTypes: { banner: { sizes: [[300, 250]] } },
+        getFloor: () => ({ currency: 'USD', floor: 0.9 })
+      });
+      const request = spec.buildRequests([bid], bidderRequestEUR);
+      expect(request).to.have.lengthOf(1);
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent.bidfloor).to.equal(0.9);
+      expect(requestContent.currencyCode).to.equal('USD');
+    });
+
+    it('leaves params.bidfloor out when it cannot be compared with the module floor', function () {
+      const bid = bannerBid({
+        params: { pid: 'ADb1f40rmi', supplyType: 'site', bidfloor: 2.5 },
+        getFloor: () => ({ currency: 'USD', floor: 0.9 })
+      });
+      const requestContent = JSON.parse(spec.buildRequests([bid], bidderRequestEUR)[0].data);
+      expect(requestContent.bidfloor).to.equal(0.9);
+      expect(requestContent.currencyCode).to.equal('USD');
+    });
+
+    it('falls back to params.bidfloor when getFloor() throws', function () {
+      const bid = bannerBid({
+        params: { pid: 'ADb1f40rmi', supplyType: 'site', bidfloor: 0.33 },
+        getFloor: () => { throw new Error('no floor'); }
+      });
+      const request = spec.buildRequests([bid], bidderRequestEUR);
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent.bidfloor).to.equal(0.33);
+      expect(requestContent.currencyCode).to.equal('EUR');
+    });
+
+    it('omits bidfloor when getFloor() throws and there is no param', function () {
+      const bid = bannerBid({ getFloor: () => { throw new Error('no floor'); } });
+      const request = spec.buildRequests([bid], bidderRequestEUR);
+      expect(JSON.parse(request[0].data)).to.not.have.property('bidfloor');
+    });
+
+    it('defaults the announced currency to USD when no ad server currency is set', function () {
+      const bid = bannerBid({ params: { pid: 'ADb1f40rmi', supplyType: 'site', bidfloor: 0.5 } });
+      const request = spec.buildRequests([bid], {
+        gdprConsent: { consentString: '', gdprApplies: false },
+        refererInfo: { page: 'https://domain.com', numIframes: 0 }
+      });
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent.bidfloor).to.equal(0.5);
+      expect(requestContent.currencyCode).to.equal('USD');
+    });
+  });
+
   describe('gdpr test', function () {
     it('Verify build request with GDPR', function () {
       config.setConfig({

--- a/test/spec/modules/richaudienceBidAdapter_spec.js
+++ b/test/spec/modules/richaudienceBidAdapter_spec.js
@@ -475,6 +475,96 @@ describe('Richaudience adapter tests', function () {
     expect(request[0].adUnitCode).to.equal('test-div');
   });
 
+  describe('video ORTB fields', function () {
+    const bidderRequest = {
+      refererInfo: {
+        page: 'https://domain.com',
+        numIframes: 0
+      }
+    };
+
+    function bidFor(mediaTypes) {
+      return [{
+        adUnitCode: 'test-div',
+        bidId: '2c7c8e9c900244',
+        mediaTypes: mediaTypes,
+        bidder: 'richaudience',
+        params: { pid: 'ADb1f40rmi', supplyType: 'site' },
+        auctionId: '0cb3144c-d084-4686-b0d6-f5dbe917c563'
+      }];
+    }
+
+    function videoDataFor(video) {
+      const request = spec.buildRequests(bidFor({
+        video: Object.assign({ playerSize: [640, 480], mimes: ['video/mp4'] }, video)
+      }), bidderRequest);
+      return JSON.parse(request[0].data).videoData;
+    }
+
+    it('forwards the plcmt and playbackmethod declared on the ad unit', function () {
+      const videoData = videoDataFor({ context: 'instream', plcmt: 2, playbackmethod: [2, 6] });
+      expect(videoData).to.have.property('plcmt').and.to.equal(2);
+      expect(videoData).to.have.property('playbackmethod').and.to.deep.equal([2, 6]);
+    });
+
+    it('forwards the plcmt the core derives for outstream ad units', function () {
+      expect(videoDataFor({ context: 'outstream', plcmt: 4 })).to.have.property('plcmt').and.to.equal(4);
+    });
+
+    it('omits plcmt and playbackmethod when the ad unit declares neither', function () {
+      const videoData = videoDataFor({ context: 'instream' });
+      expect(videoData).to.not.have.property('plcmt');
+      expect(videoData).to.not.have.property('playbackmethod');
+    });
+
+    it('does not send video fields on banner requests', function () {
+      const request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL, bidderRequest);
+      expect(JSON.parse(request[0].data).videoData).to.deep.equal({ format: 'banner' });
+    });
+
+    it('marks a banner-only ad unit as banner', function () {
+      const request = spec.buildRequests(bidFor({ banner: { sizes: [[300, 250]] } }), bidderRequest);
+      expect(JSON.parse(request[0].data).videoData).to.deep.equal({ format: 'banner' });
+    });
+
+    it('sends both the banner sizes and the video data on multiformat ad units', function () {
+      const request = spec.buildRequests(bidFor({
+        banner: { sizes: [[300, 250]] },
+        video: { context: 'outstream', playerSize: [640, 480], mimes: ['video/mp4'], plcmt: 4 }
+      }), bidderRequest);
+      const requestContent = JSON.parse(request[0].data);
+      expect(requestContent.sizes).to.deep.equal([{ w: 300, h: 250 }]);
+      expect(requestContent.videoData.format).to.equal('outstream');
+      expect(requestContent.videoData.plcmt).to.equal(4);
+    });
+  });
+
+  it('announces the prebid channel and version', function () {
+    const request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL, {
+      refererInfo: {
+        page: 'https://domain.com',
+        numIframes: 0
+      }
+    });
+
+    const channel = JSON.parse(request[0].data).ext.prebid.channel;
+    expect(channel).to.have.property('name').and.to.equal('pbjs');
+    expect(channel.version).to.be.a('string').and.to.match(/^\d+\.\d+\.\d+/);
+  });
+
+  it('announces the prebid channel on video requests too', function () {
+    const request = spec.buildRequests(DEFAULT_PARAMS_VIDEO_OUT, {
+      refererInfo: {
+        page: 'https://domain.com',
+        numIframes: 0
+      }
+    });
+
+    const requestContent = JSON.parse(request[0].data);
+    expect(requestContent.ext.prebid.channel.name).to.equal('pbjs');
+    expect(requestContent.device.ext.visibility).to.have.property('hidden').and.to.be.a('boolean');
+  });
+
   describe('floors', function () {
     const bidderRequestEUR = {
       gdprConsent: {
@@ -679,6 +769,36 @@ describe('Richaudience adapter tests', function () {
       });
       const requestContent = JSON.parse(request[0].data);
       expect(requestContent).to.have.property('gdpr_consent').and.to.equal('BOZcQl_ObPFjWAeABAESCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NohBgA');
+    });
+  });
+
+  describe('page visibility test', function () {
+    function setPageHidden(hidden) {
+      Object.defineProperty(document, 'hidden', { value: hidden, configurable: true });
+    }
+
+    afterEach(function () {
+      delete document.hidden;
+    });
+
+    function buildAndParse() {
+      const request = spec.buildRequests(DEFAULT_PARAMS_WO_OPTIONAL, {
+        refererInfo: {
+          page: 'https://domain.com',
+          numIframes: 0
+        }
+      });
+      return JSON.parse(request[0].data);
+    }
+
+    it('reports the page as not hidden when the tab is active', function () {
+      setPageHidden(false);
+      expect(buildAndParse().device.ext.visibility.hidden).to.equal(false);
+    });
+
+    it('reports the page as hidden when the tab is in the background', function () {
+      setPageHidden(true);
+      expect(buildAndParse().device.ext.visibility.hidden).to.equal(true);
     });
   });
 

--- a/test/spec/modules/richaudienceBidAdapter_spec.js
+++ b/test/spec/modules/richaudienceBidAdapter_spec.js
@@ -666,6 +666,72 @@ describe('Richaudience adapter tests', function () {
     expect(bids[0].meta.advertiserDomains).to.deep.equal([]);
   });
 
+  it('returns [] when cpm is 0 or undefined', function () {
+    const request = spec.buildRequests(DEFAULT_PARAMS_NEW_SIZES, {
+      gdprConsent: {
+        consentString: 'BOZcQl_ObPFjWAeABAESCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NohBgA',
+        gdprApplies: true
+      },
+      refererInfo: {
+        page: 'https://domain.com',
+        numIframes: 0
+      }
+    });
+
+    const zeroCpm = { body: { ...BID_RESPONSE.body, cpm: 0 } };
+    expect(spec.interpretResponse(zeroCpm, request[0])).to.deep.equal([]);
+
+    const noCpm = { body: { ...BID_RESPONSE.body } };
+    delete noCpm.body.cpm;
+    expect(spec.interpretResponse(noCpm, request[0])).to.deep.equal([]);
+  });
+
+  it('returns [] when the creative for the media type is missing', function () {
+    const request = spec.buildRequests(DEFAULT_PARAMS_NEW_SIZES, {
+      gdprConsent: {
+        consentString: 'BOZcQl_ObPFjWAeABAESCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NohBgA',
+        gdprApplies: true
+      },
+      refererInfo: {
+        page: 'https://domain.com',
+        numIframes: 0
+      }
+    });
+
+    const noAdm = { body: { ...BID_RESPONSE.body } };
+    delete noAdm.body.adm;
+    expect(spec.interpretResponse(noAdm, request[0])).to.deep.equal([]);
+
+    const noVast = { body: { ...BID_RESPONSE_VIDEO.body } };
+    delete noVast.body.vastXML;
+    expect(spec.interpretResponse(noVast, request[0])).to.deep.equal([]);
+  });
+
+  it('returns [] on an empty no-bid body without throwing', function () {
+    const request = spec.buildRequests(DEFAULT_PARAMS_NEW_SIZES, {
+      gdprConsent: {
+        consentString: 'BOZcQl_ObPFjWAeABAESCD-AAAAjx7_______9______9uz_Ov_v_f__33e8__9v_l_7_-___u_-33d4-_1vf99yfm1-7ftr3tp_87ues2_Xur__59__3z3_NohBgA',
+        gdprApplies: true
+      },
+      refererInfo: {
+        page: 'https://domain.com',
+        numIframes: 0
+      }
+    });
+
+    expect(spec.interpretResponse({ body: {} }, request[0])).to.deep.equal([]);
+    expect(spec.interpretResponse({ body: null }, request[0])).to.deep.equal([]);
+    expect(spec.interpretResponse({}, request[0])).to.deep.equal([]);
+  });
+
+  it('builds a video bid without a renderer when the request carries no videoData', function () {
+    const bidRequest = { bidId: 'req-1', tagId: 'test-div', data: JSON.stringify({ bidId: 'req-1' }) };
+    const bids = spec.interpretResponse(BID_RESPONSE_VIDEO, bidRequest);
+    expect(bids).to.have.lengthOf(1);
+    expect(bids[0].vastXml).to.equal('<VAST></VAST>');
+    expect(bids[0].renderer).to.equal(undefined);
+  });
+
   it('no banner media response inestream', function () {
     const request = spec.buildRequests(DEFAULT_PARAMS_VIDEO_IN, {
       gdprConsent: {

--- a/test/spec/modules/richaudienceBidAdapter_spec.js
+++ b/test/spec/modules/richaudienceBidAdapter_spec.js
@@ -5,6 +5,7 @@ import {
 } from 'modules/richaudienceBidAdapter.js';
 import { config } from 'src/config.js';
 import * as utils from 'src/utils.js';
+import * as refererDetection from 'src/refererDetection.js';
 import sinon from 'sinon';
 
 describe('Richaudience adapter tests', function () {
@@ -1576,15 +1577,31 @@ describe('Richaudience adapter tests', function () {
     });
 
     it('Verifies user syncs URL image include with GPP', function () {
+      const refererStub = sinon.stub(refererDetection, 'getRefererInfo').returns({ page: 'http://domain.com' });
       const gppConsent = {
         gppString: 'DBACMYA~CP5P4cAP5P4cAPoABAESAlEAAAAAAAAAAAAAA2QAQA2ADZABADYAAAAA.QA2QAQA2AAAA.IA2QAQA2AAAA~BP5P4cAP5P4cAPoABABGBACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA',
         applicableSections: [0]
       };
       const result = spec.getUserSyncs({ pixelEnabled: true }, undefined, undefined, undefined, gppConsent);
+      refererStub.restore();
       expect(result).to.deep.equal([{
         type: 'image',
         url: `https://sync.richaudience.com/bf7c142f4339da0278e83698a02b0854/?referrer=http%3A%2F%2Fdomain.com&gpp=DBACMYA~CP5P4cAP5P4cAPoABAESAlEAAAAAAAAAAAAAA2QAQA2ADZABADYAAAAA.QA2QAQA2AAAA.IA2QAQA2AAAA~BP5P4cAP5P4cAPoABABGBACAAAAAAAAAAAAAAAAAAA.YAAAAAAAAAA&gpp_sid=0`
       }]);
+    });
+
+    it('Verifies image sync is skipped when the page referer is unavailable', function () {
+      config.setConfig({
+        'userSync': { filterSettings: { image: { bidders: '*', filter: 'include' } } }
+      });
+
+      const refererStub = sinon.stub(refererDetection, 'getRefererInfo').returns({ page: null });
+      const syncs = spec.getUserSyncs({ iframeEnabled: false, pixelEnabled: true }, [BID_RESPONSE], {
+        consentString: '',
+        gdprApplies: false
+      });
+      refererStub.restore();
+      expect(syncs).to.have.lengthOf(0);
     });
   });
 });

--- a/test/spec/modules/richaudienceBidAdapter_spec.js
+++ b/test/spec/modules/richaudienceBidAdapter_spec.js
@@ -565,6 +565,38 @@ describe('Richaudience adapter tests', function () {
     expect(requestContent.device.ext.visibility).to.have.property('hidden').and.to.be.a('boolean');
   });
 
+  describe('displaymanager', function () {
+    const bidderRequest = {
+      refererInfo: {
+        page: 'https://domain.com',
+        numIframes: 0
+      }
+    };
+
+    function payloadFor(ortb2Imp, bids) {
+      const bid = Object.assign({}, (bids || DEFAULT_PARAMS_WO_OPTIONAL)[0], ortb2Imp ? { ortb2Imp } : {});
+      return JSON.parse(spec.buildRequests([bid], bidderRequest)[0].data);
+    }
+
+    it('announces Prebid.js and its version when the publisher declares nothing', function () {
+      const requestContent = payloadFor();
+      expect(requestContent).to.have.property('displaymanager').and.to.equal('Prebid.js');
+      expect(requestContent.displaymanagerver).to.be.a('string').and.to.match(/^\d+\.\d+\.\d+/);
+    });
+
+    it('lets the publisher override both fields through ortb2Imp', function () {
+      const requestContent = payloadFor({ displaymanager: 'PublisherPlayer', displaymanagerver: '4.2.0' });
+      expect(requestContent).to.have.property('displaymanager').and.to.equal('PublisherPlayer');
+      expect(requestContent).to.have.property('displaymanagerver').and.to.equal('4.2.0');
+    });
+
+    it('only defaults the field the publisher left out', function () {
+      const requestContent = payloadFor({ displaymanager: 'PublisherPlayer' });
+      expect(requestContent).to.have.property('displaymanager').and.to.equal('PublisherPlayer');
+      expect(requestContent.displaymanagerver).to.be.a('string').and.to.match(/^\d+\.\d+\.\d+/);
+    });
+  });
+
   describe('floors', function () {
     const bidderRequestEUR = {
       gdprConsent: {


### PR DESCRIPTION
## Type of change

- [x] Bugfix
- [x] Feature
- [ ] New bidder adapter
- [x] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented
- [ ] Other

## Description of change

Bugfixes + new request signals for the Richaudience bid adapter

**Fixes**
- Ask `getFloor()` for the same currency announced in `currencyCode`.
- Drop the module-level `REFERER` variable, written in `buildRequests` and read in `getUserSyncs`. The state leaked across auctions and made syncs depend on a previous `buildRequests` call; `getUserSyncs` now resolves it with `getRefererInfo()`.
- Return `[]` from `interpretResponse` when there is no body, when `cpm` is not `> 0`, or when the creative for the media type is missing (`vastXML` for video, `adm` for banner), instead of building an invalid bid.

**Cleanup / refactor**
- Remove the internal `try/catch` in `interpretResponse`. It is redundant
- `raiGetFloor()` now mirrors the core's own ORTB floor processor (`setOrtbImpBidFloor` / `tryGetFloor` in `modules/priceFloors`) 

**New request signals**
- `videoData.plcmt` and `videoData.playbackmethod`, forwarded verbatim from `mediaTypes.video`.
- `device.ext.visibility.hidden`.
- `ext.prebid.channel` (`{ name: 'pbjs', version }`).
- `displaymanager

### Testing
- ESLint over the changed adapter + spec: clean, no errors.
- `gulp test --file test/spec/modules/richaudienceBidAdapter_spec.js`: **67 tests passing**.