### PR TITLE
Nexx360 Adapters: use shared RequireAtLeastOne type

### DIFF
--- a/modules/adgridBidAdapter.ts
+++ b/modules/adgridBidAdapter.ts
@@ -6,18 +6,13 @@ import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { BidRequest, ClientBidderRequest } from '../src/adapterManager.js';
 import { interpretResponse, enrichImp, enrichRequest, getAmxId, getGzipSetting, getLocalStorageFunctionGenerator, getUserSyncs } from '../libraries/nexx360Utils/index.js';
 import { ORTBRequest } from '../src/prebid.public.js';
+import type { RequireAtLeastOne } from '../src/types/objects.d.ts';
 
 const BIDDER_CODE = 'adgrid';
 const REQUEST_URL = 'https://fast.nexx360.io/adgrid';
 const PAGE_VIEW_ID = generateUUID();
 const BIDDER_VERSION = '2.0';
 const ADGRID_KEY = 'adgrid';
-
-type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
-  Omit<T, Keys> & {
-    [K in Keys]-?: Required<Pick<T, K>> &
-      Partial<Pick<T, Exclude<Keys, K>>>
-  }[Keys];
 
 type AdgridBidParams = RequireAtLeastOne<{
   domainId?: string;

--- a/modules/insuradsBidAdapter.ts
+++ b/modules/insuradsBidAdapter.ts
@@ -8,6 +8,7 @@ import { interpretResponse as nexxInterpretResponse, enrichImp, enrichRequest, g
 import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
 import { BidRequest, ClientBidderRequest } from '../src/adapterManager.js';
 import { ORTBImp, ORTBRequest } from '../src/prebid.public.js';
+import type { RequireAtLeastOne } from '../src/types/objects.d.ts';
 
 const BIDDER_CODE = 'insurads';
 const REQUEST_URL = 'https://fast.nexx360.io/booster';
@@ -15,12 +16,6 @@ const PAGE_VIEW_ID = generateUUID();
 const BIDDER_VERSION = '7.1';
 const GVLID = 596;
 const ALT_KEY = 'nexx360_storage';
-
-type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
-  Omit<T, Keys> & {
-    [K in Keys]-?: Required<Pick<T, K>> &
-    Partial<Pick<T, Exclude<Keys, K>>>
-  }[Keys];
 
 type InsurAdsBidParams = RequireAtLeastOne<{
   tagId?: string;

--- a/modules/movingupBidAdapter.ts
+++ b/modules/movingupBidAdapter.ts
@@ -7,18 +7,13 @@ import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { interpretResponse, enrichImp, enrichRequest, getGzipSetting, getLocalStorageFunctionGenerator, getUserSyncs } from '../libraries/nexx360Utils/index.js';
 import { BidRequest, ClientBidderRequest } from '../src/adapterManager.js';
 import { ORTBImp, ORTBRequest } from '../src/prebid.public.js';
+import type { RequireAtLeastOne } from '../src/types/objects.d.ts';
 
 const BIDDER_CODE = 'movingup';
 const REQUEST_URL = 'https://fast.nexx360.io/movingup';
 const PAGE_VIEW_ID = generateUUID();
 const BIDDER_VERSION = '1.0';
 const MOVINGUP_KEY = 'movingup_storage';
-
-type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
-  Omit<T, Keys> & {
-    [K in Keys]-?: Required<Pick<T, K>> &
-      Partial<Pick<T, Exclude<Keys, K>>>
-  }[Keys];
 
 type MovingupBidParams = RequireAtLeastOne<{
   tagId?: string;

--- a/modules/mtcBidAdapter.ts
+++ b/modules/mtcBidAdapter.ts
@@ -7,18 +7,13 @@ import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { interpretResponse, enrichImp, enrichRequest, getGzipSetting, getLocalStorageFunctionGenerator, getUserSyncs } from '../libraries/nexx360Utils/index.js';
 import { BidRequest, ClientBidderRequest } from '../src/adapterManager.js';
 import { ORTBImp, ORTBRequest } from '../src/prebid.public.js';
+import type { RequireAtLeastOne } from '../src/types/objects.d.ts';
 
 const BIDDER_CODE = 'mtc';
 const REQUEST_URL = 'https://fast.nexx360.io/mtc';
 const PAGE_VIEW_ID = generateUUID();
 const BIDDER_VERSION = '1.0';
 const MTC_KEY = 'mtc_storage';
-
-type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
-  Omit<T, Keys> & {
-    [K in Keys]-?: Required<Pick<T, K>> &
-      Partial<Pick<T, Exclude<Keys, K>>>
-  }[Keys];
 
 type MtcBidParams = RequireAtLeastOne<{
   tagId?: string;

--- a/modules/nexx360BidAdapter.ts
+++ b/modules/nexx360BidAdapter.ts
@@ -8,6 +8,7 @@ import { interpretResponse, enrichImp, enrichRequest, getAmxId, getGzipSetting a
 import { getBoundingClientRect } from '../libraries/boundingClientRect/boundingClientRect.js';
 import { BidRequest, ClientBidderRequest } from '../src/adapterManager.js';
 import { ORTBImp, ORTBRequest } from '../src/prebid.public.js';
+import type { RequireAtLeastOne } from '../src/types/objects.d.ts';
 
 const BIDDER_CODE = 'nexx360';
 const REQUEST_URL = 'https://fast.nexx360.io/booster';
@@ -15,12 +16,6 @@ const PAGE_VIEW_ID = generateUUID();
 const BIDDER_VERSION = '8.0';
 const GVLID = 965;
 const NEXXID_KEY = 'nexx360_storage';
-
-type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
-  Omit<T, Keys> & {
-    [K in Keys]-?: Required<Pick<T, K>> &
-      Partial<Pick<T, Exclude<Keys, K>>>
-  }[Keys];
 
 type Nexx360BidParams = RequireAtLeastOne<{
   tagId?: string;

--- a/modules/revnewBidAdapter.ts
+++ b/modules/revnewBidAdapter.ts
@@ -7,18 +7,13 @@ import { ortbConverter } from '../libraries/ortbConverter/converter.js';
 import { interpretResponse, enrichImp, enrichRequest, getAmxId, getGzipSetting, getLocalStorageFunctionGenerator, getUserSyncs } from '../libraries/nexx360Utils/index.js';
 import { BidRequest, ClientBidderRequest } from '../src/adapterManager.js';
 import { ORTBImp, ORTBRequest } from '../src/prebid.public.js';
+import type { RequireAtLeastOne } from '../src/types/objects.d.ts';
 
 const BIDDER_CODE = 'revnew';
 const REQUEST_URL = 'https://fast.nexx360.io/revnew';
 const PAGE_VIEW_ID = generateUUID();
 const BIDDER_VERSION = '1.0';
 const REVNEW_KEY = 'revnew_storage';
-
-type RequireAtLeastOne<T, Keys extends keyof T = keyof T> =
-  Omit<T, Keys> & {
-    [K in Keys]-?: Required<Pick<T, K>> &
-      Partial<Pick<T, Exclude<Keys, K>>>
-  }[Keys];
 
 type RevnewBidParams = RequireAtLeastOne<{
   tagId?: string;


### PR DESCRIPTION
### Motivation
- Remove duplicated `RequireAtLeastOne` type declarations that were repeated inside multiple adapter modules. 
- Centralize on the existing utility type in `src/types/objects.d.ts` to keep typings consistent and reduce maintenance overhead.

### Description
- Replaced local `type RequireAtLeastOne<...>` declarations with a type-only import `import type { RequireAtLeastOne } from '../src/types/objects.d.ts'` in six adapter files. 
- Updated the following modules to use the shared type: `modules/adgridBidAdapter.ts`, `modules/insuradsBidAdapter.ts`, `modules/movingupBidAdapter.ts`, `modules/mtcBidAdapter.ts`, `modules/nexx360BidAdapter.ts`, and `modules/revnewBidAdapter.ts`.
- No functional code changes were made; only type declarations were removed and imports added.
- Changes were committed with message `Use shared RequireAtLeastOne type in adapters`.

### Testing
- Ran `git diff --check` with no reported issues, and committed the changes successfully. 
- Ran `npx gulp lint --files <modified files>` and `npx gulp ts`, both completed successfully. 
- `npx gulp ts-strict` initially reported no inputs when run standalone, but the full precompile invoked by `npx gulp test-only` completed `ts-strict` and declaration checks successfully during the full suite run. 
- Ran unit tests for the affected adapters using `npx gulp test-only-nobuild --file` for each adapter spec and `npx gulp test-only --file` for `nexx360`; all targeted specs passed. 
- Ran the full test suite via `npx gulp test-only`, which completed successfully (precompile, declaration checks, and tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a959d30bc80832ba6141380c5adee09)