### PR TITLE
Freedom Ad Network Bid Adapter: guard optional ext.libertas access

### DIFF
--- a/modules/fanBidAdapter.js
+++ b/modules/fanBidAdapter.js
@@ -119,7 +119,7 @@ const converter = ortbConverter({
     }
 
     // Add renderer if needed for outstream video
-    if (bidResponse.mediaType === VIDEO && bid.ext.libertas.ovp) {
+    if (bidResponse.mediaType === VIDEO && bid.ext?.libertas?.ovp) {
       bidResponse.width = bid.w;
       bidResponse.height = bid.h;
       bidResponse.renderer = createRenderer(bidRequest, bid.ext.libertas.vp);
@@ -295,10 +295,11 @@ export const spec = {
       triggerPixel(bid.nurl);
     }
 
-    if (bid.meta.libertas.pxl && bid.meta.libertas.pxl.length > 0) {
-      for (var i = 0; i < bid.meta.libertas.pxl.length; i++) {
-        if (Number(bid.meta.libertas.pxl[i].type) === 0) {
-          triggerPixel(bid.meta.libertas.pxl[i].url);
+    const pxl = bid.meta?.libertas?.pxl;
+    if (pxl && pxl.length > 0) {
+      for (var i = 0; i < pxl.length; i++) {
+        if (Number(pxl[i].type) === 0) {
+          triggerPixel(pxl[i].url);
         }
       }
     }

--- a/test/spec/modules/fanBidAdapter_spec.js
+++ b/test/spec/modules/fanBidAdapter_spec.js
@@ -251,6 +251,45 @@ describe('freedomadnetworkAdapter', function() {
       expect(bid.currency).to.equal('USD');
       expect(bid.ttl).to.equal(300);
     });
+
+    it('should not throw and should skip the renderer when a VIDEO bid has no ext.libertas', function() {
+      const builtRequests = spec.buildRequests([validBidRequestVideo], bidderRequest);
+      const fakeRequest = builtRequests[0];
+
+      const ortbResponse = {
+        id: fakeRequest.data.id,
+        cur: 'USD',
+        seatbid: [
+          {
+            bid: [
+              {
+                id: '456',
+                impid: fakeRequest.data.imp[0].id,
+                price: 3.5,
+                adm: '<VAST></VAST>',
+                w: 640,
+                h: 480,
+                crid: 'cr456',
+                mtype: 2, // video, no `ext` at all
+              }
+            ]
+          }
+        ],
+      };
+
+      const serverResponse = { body: ortbResponse };
+
+      let bidResponses;
+      expect(() => {
+        bidResponses = spec.interpretResponse(serverResponse, fakeRequest);
+      }).to.not.throw();
+
+      expect(bidResponses).to.be.an('array').with.lengthOf(1);
+      const bid = bidResponses[0];
+      expect(bid.mediaType).to.equal('video');
+      expect(bid.vastXml).to.equal('<VAST></VAST>');
+      expect(bid.renderer).to.not.exist;
+    });
   });
 
   describe('getUserSyncs', function() {
@@ -343,6 +382,25 @@ describe('freedomadnetworkAdapter', function() {
       // Second call: win tracking URL must start with base
       const winCallArgs = triggerPixelStub.getCall(1).args[0];
       expect(winCallArgs).to.match(/^https:\/\/pxl\.nurl\/track\?bid=req456/);
+    });
+
+    it('onBidWon should not throw when the winning bid has no meta.libertas', function() {
+      const fakeBid = {
+        requestId: 'req789',
+        auctionId: 'auc789',
+        cpm: 2.0,
+        currency: 'USD',
+        creativeId: 'creative789',
+        nurl: 'https://win.nurl/track?bid=req789',
+        meta: {
+          networkName: 'freedomadnetwork',
+          advertiserDomains: []
+        },
+      };
+
+      expect(() => spec.onBidWon(fakeBid)).to.not.throw();
+      expect(triggerPixelStub.calledWith('https://win.nurl/track?bid=req789')).to.be.true;
+      expect(triggerPixelStub.calledOnce).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## Summary

`modules/fanBidAdapter.js`'s `bidResponse()` customizer treats `bid.ext.libertas` as an optional OpenRTB `Bid.ext` extension when first reading it:

https://github.com/prebid/Prebid.js/blob/master/modules/fanBidAdapter.js#L101-L103
```js
if (bid.ext && bid.ext.libertas) {
  bidResponse.meta.libertas = bid.ext.libertas;
}
```

but three lines later, when adding an outstream renderer for VIDEO bids, it dereferences `bid.ext.libertas.ovp` unconditionally:

https://github.com/prebid/Prebid.js/blob/master/modules/fanBidAdapter.js#L122-L126
```js
if (bidResponse.mediaType === VIDEO && bid.ext.libertas.ovp) {
  bidResponse.width = bid.w;
  bidResponse.height = bid.h;
  bidResponse.renderer = createRenderer(bidRequest, bid.ext.libertas.vp);
}
```

`Bid.ext` is optional per the OpenRTB spec, and the adapter's own code three lines earlier already acknowledges `ext.libertas` may be absent — so any VIDEO seatbid response that omits the vendor-specific `ext.libertas` extension (e.g. a plain VAST bid with no `ext`, or `ext` without a `libertas` key) throws a `TypeError` inside `ortbConverter`'s `bidResponse` builder. That's caught by the converter (`libraries/ortbConverter/converter.ts`, "Error while converting ORTB seatbid.bid to bidResponse; bid skipped."), so the whole bid is **silently dropped from the auction** rather than just missing a renderer.

`onBidWon()` has the same class of bug:

https://github.com/prebid/Prebid.js/blob/master/modules/fanBidAdapter.js#L298
```js
if (bid.meta.libertas.pxl && bid.meta.libertas.pxl.length > 0) {
```

`bid.meta.libertas` is only set when `ext.libertas` was present at bid-response-build time (see the guarded block above), so it's `undefined` on any BANNER win, or a VIDEO win without the extension — throwing whenever such a bid wins (caught by `adapterManager`'s `invokeBidderMethod`, so it doesn't crash the page, but the error is logged and no legitimate nurl/pixel logic before it in this branch runs correctly for those cases).

**Why the existing tests didn't catch this:** the adapter's only `interpretResponse` test uses a BANNER response (`mtype: 1`), so `bidResponse.mediaType === VIDEO` is never true and line 122 is never exercised. The `onBidWon` test always supplies a bid with a fully-populated `meta.libertas.pxl` fixture, so line 298 is never exercised without it.

## Fix

Guard both accesses with optional chaining (`bid.ext?.libertas?.ovp`, `bid.meta?.libertas?.pxl`), matching the guard style the adapter itself already uses when first reading `bid.ext.libertas`.

## Verification

Added two regression tests to `test/spec/modules/fanBidAdapter_spec.js`:
- A VIDEO `interpretResponse` case with no `ext.libertas` on the bid — against the unmodified adapter this fails with `AssertionError: expected [] to have a length of 1 but got +0` (the bid is silently dropped).
- An `onBidWon` case with no `meta.libertas` on the winning bid — against the unmodified adapter this fails with `TypeError: Cannot read properties of undefined (reading 'pxl')`.

Both tests pass with the fix. Confirmed by reverting only `modules/fanBidAdapter.js` (keeping the new tests) and re-running — both new tests fail as described above; restoring the fix makes them pass.

- `npx gulp lint --files modules/fanBidAdapter.js,test/spec/modules/fanBidAdapter_spec.js`: clean, no changes needed.
- `npx gulp test-only --file test/spec/modules/fanBidAdapter_spec.js`: 18/18 passing.
- `npx gulp test-only` (full suite, all 8 chunks): all passing (no new failures).

## Scope

Single, narrowly-scoped bugfix to one adapter file plus its test spec. No behavior change for any bid that already carries `ext.libertas` — `bid.ext?.libertas?.ovp` is equivalent to `bid.ext.libertas.ovp` whenever `bid.ext.libertas` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)