### PR TITLE
Core: honor null price-floor rule values against floorMin in bid response enforcement

### DIFF
--- a/modules/priceFloors.ts
+++ b/modules/priceFloors.ts
@@ -1015,6 +1015,11 @@ export const addBidResponseHook = timedBidResponseHook('priceFloors', function a
   // get the matching rule
   const floorInfo = getFirstMatchingFloor(floorData.data, matchingBidRequest, { ...bid, size: [bid.width, bid.height] });
 
+  // a rule value of `null` means the publisher explicitly wants no floor for this match, same as getFloor() honors below
+  if (floorInfo.floorRuleValue === null) {
+    return fn.call(this, adUnitCode, bid, reject);
+  }
+
   if (!floorInfo.matchingFloor) {
     if (floorInfo.matchingFloor !== 0) logWarn(`${MODULE_NAME}: unable to determine a matching price floor for bidResponse`, bid);
     return fn.call(this, adUnitCode, bid, reject);

--- a/test/spec/modules/priceFloors_spec.js
+++ b/test/spec/modules/priceFloors_spec.js
@@ -2288,6 +2288,17 @@ describe('the price floors module', function () {
       expect(reject.calledOnce).to.be.true;
       expect(returnedBidResponse).to.not.exist;
     });
+    it('does not enforce floorMin against a bid when the matching rule explicitly sets a null floor', function () {
+      _floorDataForAuction[AUCTION_ID] = utils.deepClone(basicFloorConfig);
+      // floorMin is a safety-net minimum; a null rule value means "no floor for this match" and should
+      // take precedence, exactly as it already does for getFloor() (see 'setting null as rule value' tests)
+      _floorDataForAuction[AUCTION_ID].data.floorMin = 5;
+      _floorDataForAuction[AUCTION_ID].data.values = { 'banner': null };
+      runBidResponse();
+      expect(reject.called).to.be.false;
+      expect(returnedBidResponse).to.exist;
+      expect(returnedBidResponse).to.not.haveOwnProperty('floorData');
+    });
     it('enforces floors for all bidders by default', function () {
       _floorDataForAuction[AUCTION_ID] = utils.deepClone(basicFloorConfig);
       _floorDataForAuction[AUCTION_ID].data.values = { 'banner': 1.0 };


### PR DESCRIPTION
## Problem

`addBidResponseHook()` in `modules/priceFloors.ts` (the module's bid-response-side floor enforcement path) does not check `floorInfo.floorRuleValue` for `null` before enforcing a floor against a bid.

A floor rule value of `null` is a documented, tested feature meaning "no floor for this match" — see the `describe('setting null as rule value', ...)` block in `test/spec/modules/priceFloors_spec.js`, and `getFloor()`'s own check:

```js
if (floorInfo.floorRuleValue === null) {
  return null;
}
```

`getFirstMatchingFloor()` computes the effective floor as:

```js
matchingData.matchingFloor = Math.max(matchingData.floorMin, matchingData.floorRuleValue);
```

Since `Math.max` coerces `null` to `0`, a configured `floorMin` (the publisher's global safety-net minimum, `floorData.floorMin` or the adUnit-level `ortb2Imp.ext.prebid.floors.floorMin` override) silently overrides the rule's explicit `null` and becomes the enforced floor for that bid.

This makes `addBidResponseHook()` inconsistent with `getFloor()` (the client-facing floor exposed to bidder adapters via `bidRequest.getFloor()`), which already short-circuits on a `null` rule value *regardless* of `floorMin`. Concretely: a bid can be told via `getFloor()` that it has no floor for a given media type/size match, yet still be silently rejected post-response by `addBidResponseHook()` for being below `floorMin` — because the enforcement path never applies the same `null` exemption.

## Fix

Added the same `floorRuleValue === null` check already used by `getFloor()` to `addBidResponseHook()`, immediately after computing `floorInfo` and before any currency/adjustment work, so a bid matching an explicit `null` rule is never floored — consistent with `getFloor()`'s existing, tested behavior:

```js
// a rule value of `null` means the publisher explicitly wants no floor for this match, same as getFloor() honors below
if (floorInfo.floorRuleValue === null) {
  return fn.call(this, adUnitCode, bid, reject);
}
```

## Verification

Added a regression test in the `bidResponseHook tests` describe block asserting that a bid below a configured `floorMin` (5) is **not** rejected when the matching rule's value is `null`.

- Reverted just the source fix (kept the test): the new test fails —
  `AssertionError: expected true to be false` (`reject.called` was `true`).
- Restored the fix: `npx gulp test-only --file test/spec/modules/priceFloors_spec.js` passes 97/97 (96 pre-existing + 1 new).
- `npx gulp lint --files modules/priceFloors.ts,test/spec/modules/priceFloors_spec.js`: clean, no auto-fix changes needed.
- Full suite `npx gulp test-only` (all 8 chunks): all green, both before this change (baseline) and after (97 tests in the affected chunk, +1 over baseline for the new test).

## Scope

Narrowly scoped to the one missing check in the bid-response enforcement path; no behavior change to `getFloor()`, which already handled this correctly.