### PR TITLE
Core: fix userId refresh never triggering when no _last timestamp is stored

### DIFF
--- a/modules/userId/index.ts
+++ b/modules/userId/index.ts
@@ -856,8 +856,10 @@ function populateSubmoduleId(submodule: SubmoduleContainer<UserIdProvider>, forc
 
     let refreshNeeded = false;
     if (typeof submodule.config.storage.refreshInSeconds === 'number') {
-      const storedDate = new Date(getStoredValue(submodule, 'last'));
-      refreshNeeded = storedDate && (Date.now() - storedDate.getTime() > submodule.config.storage.refreshInSeconds * 1000);
+      const lastUpdated = new Date(getStoredValue(submodule, 'last')).getTime();
+      // if we have no record of when this ID was last refreshed (e.g. it predates `refreshInSeconds`
+      // being configured), treat it the same as an overdue refresh rather than silently skipping it forever
+      refreshNeeded = isNaN(lastUpdated) || (Date.now() - lastUpdated > submodule.config.storage.refreshInSeconds * 1000);
     }
 
     if (!storedId || refreshNeeded || forceRefresh || consentChanged(submodule)) {

--- a/test/spec/modules/userId_spec.js
+++ b/test/spec/modules/userId_spec.js
@@ -2499,6 +2499,67 @@ describe('User ID', function () {
       });
     });
 
+    describe('refreshInSeconds with html5 storage and no previously stored "last" timestamp', function () {
+      let mockGetId;
+      let mockDecode;
+      let mockIdSystem;
+      const mockIdKey = 'MOCKID_HTML5';
+
+      beforeEach(function () {
+        mockGetId = sinon.stub();
+        mockDecode = sinon.stub();
+        mockIdSystem = {
+          name: 'mockIdHtml5',
+          getId: mockGetId,
+          decode: mockDecode
+        };
+
+        coreStorage.removeDataFromLocalStorage(mockIdKey);
+        coreStorage.removeDataFromLocalStorage(`${mockIdKey}_exp`);
+        coreStorage.removeDataFromLocalStorage(`${mockIdKey}_last`);
+        coreStorage.removeDataFromLocalStorage(`${mockIdKey}_cst`);
+        allConsent.reset();
+
+        init(config);
+        attachIdSystem(mockIdSystem);
+      });
+
+      afterEach(function () {
+        config.resetConfig();
+        coreStorage.removeDataFromLocalStorage(mockIdKey);
+        coreStorage.removeDataFromLocalStorage(`${mockIdKey}_exp`);
+        coreStorage.removeDataFromLocalStorage(`${mockIdKey}_last`);
+        coreStorage.removeDataFromLocalStorage(`${mockIdKey}_cst`);
+      });
+
+      it('treats a stored id with no "_last" entry as due for refresh, not as never-refreshable', function () {
+        // simulates an id that was stored before `refreshInSeconds` was configured (or otherwise
+        // never recorded a last-refresh time): the id and its expiry exist, but "_last" does not.
+        coreStorage.setDataInLocalStorage(mockIdKey, JSON.stringify({ id: '1234' }));
+        coreStorage.setDataInLocalStorage(`${mockIdKey}_exp`, new Date(Date.now() + 60000).toUTCString());
+        coreStorage.setDataInLocalStorage(`${mockIdKey}_cst`, getConsentHash());
+
+        config.setConfig({
+          userSync: {
+            userIds: [{
+              name: 'mockIdHtml5',
+              storage: {
+                name: mockIdKey,
+                type: 'html5',
+                refreshInSeconds: 30
+              }
+            }],
+            auctionDelay: 5
+          }
+        });
+
+        return runBidsHook((config) => {
+        }, { adUnits }).then(() => {
+          sinon.assert.calledOnce(mockGetId);
+        });
+      });
+    });
+
     describe('requestDataDeletion', () => {
       function idMod(name, value) {
         return {


### PR DESCRIPTION
## Problem

`populateSubmoduleId()` in `modules/userId/index.ts` computes whether a stored ID is due for refresh as:

```js
const storedDate = new Date(getStoredValue(submodule, 'last'));
refreshNeeded = storedDate && (Date.now() - storedDate.getTime() > submodule.config.storage.refreshInSeconds * 1000);
```

When no `_last` value has ever been stored for an ID, `getStoredValue(submodule, 'last')` returns `undefined` (cookie storage) or the literal string `"null"` (html5/localStorage storage, since `getValueFromLocalStorage()` falls through to `decodeURIComponent(mgr.getDataFromLocalStorage(storedKey))`, and `decodeURIComponent(null)` coerces to the string `"null"` when the key is absent from `localStorage`). Either way, `new Date(...)` produces an `Invalid Date`.

**A JavaScript `Date` object is truthy even when invalid.** So `storedDate && (...)` evaluates the right-hand side, which computes `Date.now() - NaN = NaN`, and `NaN > threshold` is always `false`. `refreshNeeded` silently and permanently stays `false` for that ID — the periodic refresh a publisher explicitly configured via `refreshInSeconds` never fires, until the stored value's own `storage.expires` TTL lapses entirely (which can be a much longer window, or may never happen if the ID keeps getting freshly re-read/extended).

This reproduces whenever an ID predates `refreshInSeconds` being configured — e.g. a publisher adds `refreshInSeconds` to an already-live `userSync.userIds` config, or an ID was stored under an older config — since `setValueInCookie`/`setValueInLocalStorage` only ever write the `_last` suffix key when `storage.refreshInSeconds` was *already* a number at save time:

```js
if (typeof storage.refreshInSeconds === 'number') {
  mgr.setDataInLocalStorage(`${storage.name}_last`, new Date().toUTCString());
}
```

Note the two storage backends silently diverge here: for **cookie** storage, a missing `_last` cookie reads back as `null` → `new Date(null)` is the Unix epoch (1970), which is far enough in the past that `refreshNeeded` correctly evaluates `true` — the cookie path incidentally self-heals. It's specifically **html5/localStorage** storage (via the `decodeURIComponent(null)` → `"null"` → `Invalid Date` path) that stays silently broken.

## Fix

Compute `lastUpdated` once as a timestamp and treat `isNaN(lastUpdated)` as "refresh needed" explicitly, matching the cookie path's existing fail-safe behavior instead of relying on `Date` object truthiness:

```js
const lastUpdated = new Date(getStoredValue(submodule, 'last')).getTime();
// if we have no record of when this ID was last refreshed (e.g. it predates `refreshInSeconds`
// being configured), treat it the same as an overdue refresh rather than silently skipping it forever
refreshNeeded = isNaN(lastUpdated) || (Date.now() - lastUpdated > submodule.config.storage.refreshInSeconds * 1000);
```

## Verification

Added a regression test (`describe('refreshInSeconds with html5 storage and no previously stored "last" timestamp', ...)`) that stores an id + a valid (unexpired) `_exp`, but no `_last`, configures `refreshInSeconds: 30`, and asserts the submodule's `getId` is invoked.

- Reverted just the source fix (kept the test): the new test fails — `AssertError: expected stub to be called once but was called 0 times` (refresh never triggered).
- Restored the fix: `npx gulp test-only --file test/spec/modules/userId_spec.js` passes 139/139 (138 pre-existing + 1 new).
- `npx gulp lint --files modules/userId/index.ts,test/spec/modules/userId_spec.js`: clean, no auto-fix changes needed.
- Full suite `npx gulp test-only` (all 8 chunks): all green, both before this change (baseline) and after (one extra passing test in the affected chunk, matching the new test).

## Scope

Narrowly scoped to the one refresh-eligibility check; no other behavior in `populateSubmoduleId()` is touched.