### PR TITLE
51D Docs: Fix for Call to eval-like DOM function

### DIFF
--- a/integrationExamples/gpt/51DegreesRtdProvider_pageIntegration_example.html
+++ b/integrationExamples/gpt/51DegreesRtdProvider_pageIntegration_example.html
@@ -68,7 +68,10 @@
             if (ID_USAGE) {
                 scriptURL += '?id.usage=' + encodeURIComponent(ID_USAGE);
             }
-            document.write('<script src="' + scriptURL + '"><\/script>');
+            var externalScript = document.createElement('script');
+            externalScript.src = scriptURL;
+            externalScript.async = false;
+            (document.head || document.getElementsByTagName('head')[0]).appendChild(externalScript);
         }
 
         // A reload alone answers to the new preference only if the script is


### PR DESCRIPTION
Replace the `document.write(...)` script injection with explicit DOM script element creation and insertion.

Best fix in this file:
- In `integrationExamples/gpt/51DegreesRtdProvider_pageIntegration_example.html`, inside the `if (RESOURCE_KEY) { ... }` block, remove `document.write('<script src="' + scriptURL + '"><\/script>');`.
- Create a `<script>` element via `document.createElement('script')`.
- Set `src` to `scriptURL`.
- Set `async = false` to preserve ordered execution semantics as closely as possible for parser-adjacent loading.
- Append it to `document.head` (or fallback to first `<head>` element).

This preserves functionality (loading the same remote JS URL built from the same inputs) while avoiding string-to-code HTML parsing.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._