### PR TITLE
Seedtag Bidder - add correct mediaType when calling bidRequest.getFloor

### DIFF
--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -43,9 +43,11 @@ function getBidFloor(bidRequest) {
   let floorInfo = {};
 
   let mediaType = '*';
-  if (bidRequest.mediaTypes?.banner) {
+  const hasBanner = hasBannerMediaType(bidRequest);
+  const hasVideo = hasVideoMediaType(bidRequest);
+  if (hasBanner && !hasVideo) {
     mediaType = BANNER;
-  } else if (bidRequest.mediaTypes?.video) {
+  } else if (hasVideo && !hasBanner) {
     mediaType = VIDEO;
   }
 

--- a/modules/seedtagBidAdapter.js
+++ b/modules/seedtagBidAdapter.js
@@ -42,10 +42,17 @@ export const BIDFLOOR_CURRENCY = 'USD';
 function getBidFloor(bidRequest) {
   let floorInfo = {};
 
+  let mediaType = '*';
+  if (bidRequest.mediaTypes?.banner) {
+    mediaType = BANNER;
+  } else if (bidRequest.mediaTypes?.video) {
+    mediaType = VIDEO;
+  }
+
   if (typeof bidRequest.getFloor === 'function') {
     floorInfo = bidRequest.getFloor({
       currency: BIDFLOOR_CURRENCY,
-      mediaType: '*',
+      mediaType: mediaType,
       size: '*'
     });
   }

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -423,7 +423,7 @@ describe('Seedtag Adapter', function () {
           expect(data.bidRequests[0].bidFloor).to.equal(bidFloor);
         });
 
-        it('should request banner floor when bid has banner and video mediaTypes', function () {
+        it('should request wildcard floor when bid has banner and video mediaTypes', function () {
           const { getFloor } = buildRequestWithFloor({
             banner: {},
             video: {
@@ -434,7 +434,7 @@ describe('Seedtag Adapter', function () {
 
           expect(getFloor.calledWith({
             currency: BIDFLOOR_CURRENCY,
-            mediaType: 'banner',
+            mediaType: '*',
             size: '*'
           })).to.equal(true);
         });

--- a/test/spec/modules/seedtagBidAdapter_spec.js
+++ b/test/spec/modules/seedtagBidAdapter_spec.js
@@ -400,6 +400,71 @@ describe('Seedtag Adapter', function () {
         expect(bidRequests[1]).not.to.have.property('bidFloor');
       });
 
+      describe('getFloor mediaType', function () {
+        function buildRequestWithFloor(mediaTypes) {
+          const getFloor = sinon.stub().returns({
+            currency: BIDFLOOR_CURRENCY,
+            floor: bidFloor
+          });
+          const bidRequest = getSlotConfigs(mediaTypes, mandatoryDisplayParams);
+          bidRequest.getFloor = getFloor;
+          const request = spec.buildRequests([bidRequest], bidderRequest);
+          return { getFloor, data: JSON.parse(request.data) };
+        }
+
+        it('should request banner floor when bid has only banner mediaType', function () {
+          const { getFloor, data } = buildRequestWithFloor({ banner: {} });
+
+          expect(getFloor.calledWith({
+            currency: BIDFLOOR_CURRENCY,
+            mediaType: 'banner',
+            size: '*'
+          })).to.equal(true);
+          expect(data.bidRequests[0].bidFloor).to.equal(bidFloor);
+        });
+
+        it('should request banner floor when bid has banner and video mediaTypes', function () {
+          const { getFloor } = buildRequestWithFloor({
+            banner: {},
+            video: {
+              context: 'outstream',
+              playerSize: [[600, 200]],
+            },
+          });
+
+          expect(getFloor.calledWith({
+            currency: BIDFLOOR_CURRENCY,
+            mediaType: 'banner',
+            size: '*'
+          })).to.equal(true);
+        });
+
+        it('should request video floor when bid has only video mediaType', function () {
+          const { getFloor } = buildRequestWithFloor({
+            video: {
+              context: 'instream',
+              playerSize: [[300, 200]],
+            },
+          });
+
+          expect(getFloor.calledWith({
+            currency: BIDFLOOR_CURRENCY,
+            mediaType: 'video',
+            size: '*'
+          })).to.equal(true);
+        });
+
+        it('should request wildcard floor when bid has neither banner nor video mediaType', function () {
+          const { getFloor } = buildRequestWithFloor({ native: {} });
+
+          expect(getFloor.calledWith({
+            currency: BIDFLOOR_CURRENCY,
+            mediaType: '*',
+            size: '*'
+          })).to.equal(true);
+        });
+      });
+
       it('should not launch an exception when request a video with no playerSize', function () {
         const validBidRequests = [
           getSlotConfigs(


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
Pass the correct mediaType when calling bidRequest.getFloor() instead of a wildcard.

The logic is : 
- when banner only we use banner
- when video only we use video
- in all others cases we uses wildcard *
