### PR TITLE
Core: remove three page-lifetime retainers of per-auction data

### DIFF
--- a/src/adapters/bidderFactory.ts
+++ b/src/adapters/bidderFactory.ts
@@ -240,15 +240,15 @@ function makeTidGuard({ bidderCode }) {
 // the same guard: stable proxy identity, and one transmitTid activity check
 // per bidder request. The cache is keyed weakly, so an entry cannot outlive
 // the bidderRequest it guards.
-const tidGuards = new WeakMap();
-export const guardTids: any = (bidderRequest) => {
+const tidGuards = new WeakMap<object, ReturnType<typeof makeTidGuard>>();
+export function guardTids<B extends BidderCode>(bidderRequest: ClientBidderRequest<B>) {
   let guard = tidGuards.get(bidderRequest);
   if (guard == null) {
     guard = makeTidGuard(bidderRequest);
     tidGuards.set(bidderRequest, guard);
   }
   return guard;
-};
+}
 
 declare module '../events' {
   interface Events {

--- a/src/adapters/bidderFactory.ts
+++ b/src/adapters/bidderFactory.ts
@@ -199,7 +199,7 @@ export function registerBidder<B extends BidderCode>(spec: BidderSpec<B>) {
   }
 }
 
-export const guardTids: any = memoize(({ bidderCode }) => {
+function makeTidGuard({ bidderCode }) {
   const tidsAllowed = isActivityAllowed(ACTIVITY_TRANSMIT_TID, activityParams(MODULE_TYPE_BIDDER, bidderCode));
   function get(target, prop, receiver) {
     if (TIDS.hasOwnProperty(prop)) {
@@ -234,7 +234,23 @@ export const guardTids: any = memoize(({ bidderCode }) => {
       }
     })
   };
-});
+}
+
+// Guards are cached in a WeakMap keyed by the bidderRequest, so that the two
+// uses within one bid cycle (request validation and buildRequests) share one
+// guard — stable proxy identity, one tidsAllowed activity check per bidder
+// request — while the cache entry lives no longer than the bidderRequest
+// itself. A strong (Map-based) cache here would retain every bidderRequest,
+// its bids, and the per-auction ortb2 for the page lifetime.
+const tidGuards = new WeakMap();
+export const guardTids: any = (bidderRequest) => {
+  let guard = tidGuards.get(bidderRequest);
+  if (guard == null) {
+    guard = makeTidGuard(bidderRequest);
+    tidGuards.set(bidderRequest, guard);
+  }
+  return guard;
+};
 
 declare module '../events' {
   interface Events {

--- a/src/adapters/bidderFactory.ts
+++ b/src/adapters/bidderFactory.ts
@@ -236,12 +236,10 @@ function makeTidGuard({ bidderCode }) {
   };
 }
 
-// Guards are cached in a WeakMap keyed by the bidderRequest, so that the two
-// uses within one bid cycle (request validation and buildRequests) share one
-// guard — stable proxy identity, one tidsAllowed activity check per bidder
-// request — while the cache entry lives no longer than the bidderRequest
-// itself. A strong (Map-based) cache here would retain every bidderRequest,
-// its bids, and the per-auction ortb2 for the page lifetime.
+// Guards are cached per bidderRequest, so every use of the same request sees
+// the same guard: stable proxy identity, and one transmitTid activity check
+// per bidder request. The cache is keyed weakly, so an entry cannot outlive
+// the bidderRequest it guards.
 const tidGuards = new WeakMap();
 export const guardTids: any = (bidderRequest) => {
   let guard = tidGuards.get(bidderRequest);

--- a/src/auction.ts
+++ b/src/auction.ts
@@ -28,7 +28,7 @@ import { type Metrics, useMetrics } from './utils/perfMetrics.js';
 import { adjustCpm } from './utils/cpm.js';
 import { getGlobal } from './prebidGlobal.js';
 import { ttlCollection } from './utils/ttlCollection.js';
-import { getEffectiveMinBidCacheTTL, onMinBidCacheTTLChange } from './bidTTL.js';
+import { getEffectiveMinBidCacheTTL } from './bidTTL.js';
 import type { Bid, BidResponse } from "./bidfactory.ts";
 import type { AdUnitCode, BidderCode, Identifier, ORTBFragments } from './types/common.d.ts';
 import type { TargetingMap } from "./targeting.ts";
@@ -215,8 +215,6 @@ export function newAuction({ adUnits, adUnitCodes, callback, cbTimeout, labels, 
   let _timeoutTimer;
   let _auctionStatus: AuctionStatus;
   let _nonBids = [];
-
-  onMinBidCacheTTLChange(() => _bidsReceived.refresh());
 
   function addBidRequests(bidderRequests) { _bidderRequests = _bidderRequests.concat(bidderRequests); }
   function addBidReceived(bid) { _bidsReceived.add(bid); }
@@ -446,16 +444,11 @@ export function newAuction({ adUnits, adUnitCodes, callback, cbTimeout, labels, 
     _bidsReceived.refresh();
   }
 
-  events.on(EVENTS.PBS_ANALYTICS, (event) => {
-    if (event.auctionId === _auctionId && event.seatnonbid != null) {
-      addNonBids(event.seatnonbid);
-    }
-  });
-
   return {
     addBidReceived,
     addBidRejected,
     addNoBid,
+    addNonBids,
     callBids,
     addWinningBid,
     setBidTargeting,
@@ -473,6 +466,7 @@ export function newAuction({ adUnits, adUnitCodes, callback, cbTimeout, labels, 
     getNonBids: () => _nonBids,
     getFPD: () => ortb2Fragments,
     getMetrics: () => metrics,
+    refreshBidTTLs: () => _bidsReceived.refresh(),
     end: done.promise,
     requestsDone: requestsDone.promise,
     getProperties

--- a/src/auction.ts
+++ b/src/auction.ts
@@ -220,7 +220,7 @@ export function newAuction({ adUnits, adUnitCodes, callback, cbTimeout, labels, 
   function addBidReceived(bid) { _bidsReceived.add(bid); }
   function addBidRejected(bidsRejected) { _bidsRejected = _bidsRejected.concat(bidsRejected); }
   function addNoBid(noBid) { _noBids = _noBids.concat(noBid); }
-  function addNonBids(seatnonbids) { _nonBids = _nonBids.concat(seatnonbids); }
+  function addSeatNonBids(seatnonbids) { _nonBids = _nonBids.concat(seatnonbids); }
 
   function getProperties() {
     return {
@@ -448,7 +448,7 @@ export function newAuction({ adUnits, adUnitCodes, callback, cbTimeout, labels, 
     addBidReceived,
     addBidRejected,
     addNoBid,
-    addNonBids,
+    addSeatNonBids,
     callBids,
     addWinningBid,
     setBidTargeting,

--- a/src/auctionManager.js
+++ b/src/auctionManager.js
@@ -77,13 +77,20 @@ export function newAuctionManager() {
     }
   }
 
-  // Route PBS analytics nonbids to the auction they belong to.
-  // Registered once per manager rather than once per auction: a per-auction
-  // listener stays in the global event registry for the page lifetime and
-  // keeps the entire auction closure reachable.
+  // Auctions that have not yet ended, keyed by auctionId. The auctionId can be
+  // supplied by the publisher, so concurrent auctions may share one: each key
+  // holds the set of live auctions using it. Auctions are added on creation
+  // and removed when their `end` promise resolves, so the map holds no
+  // reference to an auction past its end.
+  const _inFlightAuctions = new Map();
+
+  // Single listener routing PBS analytics nonbids to the auction(s) they
+  // belong to. Routing goes through the in-flight map, not the TTL'd auction
+  // cache, so nonbids reach their auction while it is in flight even if the
+  // cache is cleared (e.g. clearAllAuctions) before the PBS response arrives.
   events.on(EVENTS.PBS_ANALYTICS, (event) => {
     if (event.seatnonbid != null) {
-      getAuction(event.auctionId)?.addNonBids(event.seatnonbid);
+      _inFlightAuctions.get(event.auctionId)?.forEach((auction) => auction.addNonBids(event.seatnonbid));
     }
   });
 
@@ -141,6 +148,20 @@ export function newAuctionManager() {
   auctionManager.createAuction = function(opts) {
     const auction = newAuction(opts);
     _addAuction(auction);
+    const auctionId = auction.getAuctionId();
+    if (!_inFlightAuctions.has(auctionId)) {
+      _inFlightAuctions.set(auctionId, new Set());
+    }
+    _inFlightAuctions.get(auctionId).add(auction);
+    auction.end.then(() => {
+      const auctions = _inFlightAuctions.get(auctionId);
+      if (auctions != null) {
+        auctions.delete(auction);
+        if (auctions.size === 0) {
+          _inFlightAuctions.delete(auctionId);
+        }
+      }
+    });
     return auction;
   };
 

--- a/src/auctionManager.js
+++ b/src/auctionManager.js
@@ -29,7 +29,8 @@
 import { uniques, logWarn } from './utils.js';
 import { newAuction, getStandardBidderSettings, AUCTION_COMPLETED } from './auction.js';
 import { AuctionIndex } from './auctionIndex.js';
-import { BID_STATUS, JSON_MAPPING } from './constants.js';
+import { BID_STATUS, EVENTS, JSON_MAPPING } from './constants.js';
+import * as events from './events.js';
 import { useMetrics } from './utils/perfMetrics.js';
 import { ttlCollection } from './utils/ttlCollection.js';
 import { getEffectiveMinBidCacheTTL, getMinBidCacheTTL, onMinBidCacheTTLChange } from './bidTTL.js';
@@ -59,7 +60,12 @@ export function newAuctionManager() {
     }),
   });
 
-  onMinBidCacheTTLChange(() => _auctions.refresh());
+  onMinBidCacheTTLChange(() => {
+    for (const auction of _auctions) {
+      auction.refreshBidTTLs();
+    }
+    _auctions.refresh();
+  });
 
   const auctionManager = {
     onExpiry: _auctions.onExpiry
@@ -70,6 +76,16 @@ export function newAuctionManager() {
       if (auction.getAuctionId() === auctionId) return auction;
     }
   }
+
+  // Route PBS analytics nonbids to the auction they belong to.
+  // Registered once per manager rather than once per auction: a per-auction
+  // listener stays in the global event registry for the page lifetime and
+  // keeps the entire auction closure reachable.
+  events.on(EVENTS.PBS_ANALYTICS, (event) => {
+    if (event.seatnonbid != null) {
+      getAuction(event.auctionId)?.addNonBids(event.seatnonbid);
+    }
+  });
 
   auctionManager.addWinningBid = function(bid) {
     const metrics = useMetrics(bid.metrics);

--- a/src/auctionManager.js
+++ b/src/auctionManager.js
@@ -85,21 +85,24 @@ export function newAuctionManager() {
   // the timeout timer is armed, or a request queued on origin capacity that
   // never frees — stays in this map for the page lifetime; clearAllAuctions
   // does not clear it, because mid-flight routing (below) depends on entries
-  // surviving that call. This residual is bounded by those error paths and is
-  // the same class of retention that existed before per-auction routing.
+  // surviving that call. This is bounded to those error paths: entries are not
+  // retained per normal auction, and do not accumulate with auction count.
   const _inFlightAuctions = new Map();
 
   // Single listener routing PBS analytics nonbids to the auction(s) they
   // belong to. Delivery targets the union of the in-flight set for the
-  // auctionId and the auction found in the TTL'd cache, deduplicated: the
-  // in-flight set covers auctions that ended or were removed from the cache
-  // (e.g. clearAllAuctions) while the PBS response was outstanding, and the
-  // cache covers auctions that have ended but not yet been evicted by TTL.
+  // auctionId and every auction in the TTL'd cache with a matching id,
+  // deduplicated: the in-flight set covers auctions that ended or were removed
+  // from the cache (e.g. clearAllAuctions) while the PBS response was
+  // outstanding, and the cache covers auctions that have ended but not yet
+  // been evicted by TTL. auctionId can be publisher-supplied, so more than one
+  // auction may match on either side.
   events.on(EVENTS.PBS_ANALYTICS, (event) => {
     if (event.seatnonbid != null) {
       const targets = new Set(_inFlightAuctions.get(event.auctionId));
-      const cached = getAuction(event.auctionId);
-      if (cached != null) targets.add(cached);
+      for (const auction of _auctions) {
+        if (auction.getAuctionId() === event.auctionId) targets.add(auction);
+      }
       targets.forEach((auction) => auction.addSeatNonBids(event.seatnonbid));
     }
   });

--- a/src/auctionManager.js
+++ b/src/auctionManager.js
@@ -79,18 +79,28 @@ export function newAuctionManager() {
 
   // Auctions that have not yet ended, keyed by auctionId. The auctionId can be
   // supplied by the publisher, so concurrent auctions may share one: each key
-  // holds the set of live auctions using it. Auctions are added on creation
-  // and removed when their `end` promise resolves, so the map holds no
-  // reference to an auction past its end.
+  // holds the set of live auctions using it. An entry is added on creation and
+  // removed when the auction's `end` promise resolves. An auction whose `end`
+  // never resolves — e.g. callBids() throwing out of makeBidRequests before
+  // the timeout timer is armed, or a request queued on origin capacity that
+  // never frees — stays in this map for the page lifetime; clearAllAuctions
+  // does not clear it, because mid-flight routing (below) depends on entries
+  // surviving that call. This residual is bounded by those error paths and is
+  // the same class of retention that existed before per-auction routing.
   const _inFlightAuctions = new Map();
 
   // Single listener routing PBS analytics nonbids to the auction(s) they
-  // belong to. Routing goes through the in-flight map, not the TTL'd auction
-  // cache, so nonbids reach their auction while it is in flight even if the
-  // cache is cleared (e.g. clearAllAuctions) before the PBS response arrives.
+  // belong to. Delivery targets the union of the in-flight set for the
+  // auctionId and the auction found in the TTL'd cache, deduplicated: the
+  // in-flight set covers auctions that ended or were removed from the cache
+  // (e.g. clearAllAuctions) while the PBS response was outstanding, and the
+  // cache covers auctions that have ended but not yet been evicted by TTL.
   events.on(EVENTS.PBS_ANALYTICS, (event) => {
     if (event.seatnonbid != null) {
-      _inFlightAuctions.get(event.auctionId)?.forEach((auction) => auction.addNonBids(event.seatnonbid));
+      const targets = new Set(_inFlightAuctions.get(event.auctionId));
+      const cached = getAuction(event.auctionId);
+      if (cached != null) targets.add(cached);
+      targets.forEach((auction) => auction.addSeatNonBids(event.seatnonbid));
     }
   });
 

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -846,6 +846,40 @@ describe('auctionmanager.js', function () {
       expect(auction.getNonBids()[0]).to.equal('test');
     });
 
+    it('does not choke on PBS_ANALYTICS events for unknown auctions', () => {
+      const auction = auctionManager.createAuction({ adUnits });
+      expect(() => {
+        events.emit(EVENTS.PBS_ANALYTICS, {
+          auctionId: 'no-such-auction',
+          seatnonbid: ['test']
+        });
+      }).to.not.throw();
+      expect(auction.getNonBids()).to.eql([]);
+    });
+
+    it('does not add nonbids when seatnonbid is null or absent', () => {
+      const auction = auctionManager.createAuction({ adUnits });
+      events.emit(EVENTS.PBS_ANALYTICS, {
+        auctionId: auction.getAuctionId()
+      });
+      events.emit(EVENTS.PBS_ANALYTICS, {
+        auctionId: auction.getAuctionId(),
+        seatnonbid: null
+      });
+      expect(auction.getNonBids()).to.eql([]);
+    });
+
+    it('routes nonbids to the auction they belong to when multiple auctions are live', () => {
+      const auction1 = auctionManager.createAuction({ adUnits });
+      const auction2 = auctionManager.createAuction({ adUnits });
+      events.emit(EVENTS.PBS_ANALYTICS, {
+        auctionId: auction2.getAuctionId(),
+        seatnonbid: ['nonbid2']
+      });
+      expect(auction1.getNonBids()).to.eql([]);
+      expect(auction2.getNonBids()).to.eql(['nonbid2']);
+    });
+
     it('resolves .requestsDone', async () => {
       const auction = auctionManager.createAuction({ adUnits });
       stubCallAdapters.resetHistory();
@@ -940,6 +974,24 @@ describe('auctionmanager.js', function () {
           await clock.tick(0);
           await clock.tick(20 * 1000);
           expect(auctionManager.getBidsReceived().length).to.equal(1);
+        });
+
+        it('pick up updates to minBidCacheTTL on every live auction', async () => {
+          const auction2 = auctionManager.createAuction({ adUnits });
+          indexAuctions.push(auction2);
+          auction.callBids();
+          auction2.callBids();
+          await auction.end;
+          await auction2.end;
+          clock.tick(10 * 1000);
+          expect(auctionManager.getBidsReceived().length).to.equal(4);
+          config.setConfig({
+            minBidCacheTTL: 20
+          });
+          await clock.tick(0);
+          await clock.tick(20 * 1000);
+          // each auction had one ttl=10 bid (now stale) and one ttl=100 bid
+          expect(auctionManager.getBidsReceived().length).to.equal(2);
         });
 
         it('do not expire targeted bids when minTargetedBidCacheTTL is set', async () => {

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -920,6 +920,21 @@ describe('auctionmanager.js', function () {
       expect(auction2.getNonBids()).to.eql(['nonbid']);
     });
 
+    it('routes nonbids to every ended-but-retained auction sharing an auctionId', async () => {
+      const auction1 = auctionManager.createAuction({ adUnits, auctionId: 'shared-auction-id' });
+      const auction2 = auctionManager.createAuction({ adUnits, auctionId: 'shared-auction-id' });
+      auction1.callBids();
+      auction2.callBids();
+      await auction1.end;
+      await auction2.end;
+      events.emit(EVENTS.PBS_ANALYTICS, {
+        auctionId: 'shared-auction-id',
+        seatnonbid: ['late']
+      });
+      expect(auction1.getNonBids()).to.eql(['late']);
+      expect(auction2.getNonBids()).to.eql(['late']);
+    });
+
     it('resolves .requestsDone', async () => {
       const auction = auctionManager.createAuction({ adUnits });
       stubCallAdapters.resetHistory();

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -864,6 +864,17 @@ describe('auctionmanager.js', function () {
       expect(auction.getNonBids()).to.eql(['test']);
     });
 
+    it('adds nonbids emitted after the auction ends while it is still retained', async () => {
+      const auction = auctionManager.createAuction({ adUnits });
+      auction.callBids();
+      await auction.end;
+      events.emit(EVENTS.PBS_ANALYTICS, {
+        auctionId: auction.getAuctionId(),
+        seatnonbid: ['late']
+      });
+      expect(auction.getNonBids()).to.eql(['late']);
+    });
+
     it('ignores PBS_ANALYTICS events naming an unknown auction, without throwing', () => {
       const auction = auctionManager.createAuction({ adUnits });
       expect(() => {

--- a/test/spec/auctionmanager_spec.js
+++ b/test/spec/auctionmanager_spec.js
@@ -846,7 +846,25 @@ describe('auctionmanager.js', function () {
       expect(auction.getNonBids()[0]).to.equal('test');
     });
 
-    it('does not choke on PBS_ANALYTICS events for unknown auctions', () => {
+    it('does not register a listener per auction', () => {
+      const q = () => (events.get()[EVENTS.PBS_ANALYTICS]?.que ?? []).length;
+      const before = q();
+      auctionManager.createAuction({ adUnits });
+      auctionManager.createAuction({ adUnits });
+      expect(q()).to.equal(before);
+    });
+
+    it('adds nonbids emitted after the auction cache is cleared mid-flight', () => {
+      const auction = auctionManager.createAuction({ adUnits });
+      auctionManager.clearAllAuctions();
+      events.emit(EVENTS.PBS_ANALYTICS, {
+        auctionId: auction.getAuctionId(),
+        seatnonbid: ['test']
+      });
+      expect(auction.getNonBids()).to.eql(['test']);
+    });
+
+    it('ignores PBS_ANALYTICS events naming an unknown auction, without throwing', () => {
       const auction = auctionManager.createAuction({ adUnits });
       expect(() => {
         events.emit(EVENTS.PBS_ANALYTICS, {
@@ -878,6 +896,17 @@ describe('auctionmanager.js', function () {
       });
       expect(auction1.getNonBids()).to.eql([]);
       expect(auction2.getNonBids()).to.eql(['nonbid2']);
+    });
+
+    it('routes nonbids to every live auction sharing the same auctionId', () => {
+      const auction1 = auctionManager.createAuction({ adUnits, auctionId: 'shared-auction-id' });
+      const auction2 = auctionManager.createAuction({ adUnits, auctionId: 'shared-auction-id' });
+      events.emit(EVENTS.PBS_ANALYTICS, {
+        auctionId: 'shared-auction-id',
+        seatnonbid: ['nonbid']
+      });
+      expect(auction1.getNonBids()).to.eql(['nonbid']);
+      expect(auction2.getNonBids()).to.eql(['nonbid']);
     });
 
     it('resolves .requestsDone', async () => {
@@ -991,6 +1020,19 @@ describe('auctionmanager.js', function () {
           await clock.tick(0);
           await clock.tick(20 * 1000);
           // each auction had one ttl=10 bid (now stale) and one ttl=100 bid
+          expect(auctionManager.getBidsReceived().length).to.equal(2);
+        });
+
+        it('exposes refreshBidTTLs on the auction, and repeated calls retain the same bids as one', async () => {
+          config.setConfig({
+            minBidCacheTTL: 30
+          });
+          auction.callBids();
+          await auction.end;
+          expect(auction.refreshBidTTLs).to.be.a('function');
+          auction.refreshBidTTLs();
+          expect(auctionManager.getBidsReceived().length).to.equal(2);
+          auction.refreshBidTTLs();
           expect(auctionManager.getBidsReceived().length).to.equal(2);
         });
 

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -1831,7 +1831,11 @@ describe('bidderFactory', () => {
       const guard1 = guardTids(request1);
       const guard2 = guardTids(request2);
       expect(guard1).to.not.equal(guard2);
-      expect(guard1.bidderRequest(request1)).to.not.equal(guard2.bidderRequest(request2));
+      // bidRequest is memoized per guard (keyed by bidId): the same guard
+      // returns the same proxy for the same bid, different guards do not.
+      const bid = { bidId: 'bid-1' };
+      expect(guard1.bidRequest(bid)).to.equal(guard1.bidRequest(bid));
+      expect(guard1.bidRequest(bid)).to.not.equal(guard2.bidRequest(bid));
     });
   });
 });

--- a/test/spec/unit/core/bidderFactory_spec.js
+++ b/test/spec/unit/core/bidderFactory_spec.js
@@ -1,4 +1,4 @@
-import { isValid, newBidder, registerBidder } from 'src/adapters/bidderFactory.js';
+import { guardTids, isValid, newBidder, registerBidder } from 'src/adapters/bidderFactory.js';
 import adapterManager from 'src/adapterManager.js';
 import * as ajax from 'src/ajax.js';
 import { expect } from 'chai';
@@ -1816,6 +1816,22 @@ describe('bidderFactory', () => {
       expect(recorded['adapter.client.net']).to.eql([0]);
       // `total` spans compression, so it is the timer that should account for the delay.
       expect(recorded['adapter.client.total']).to.equal(COMPRESSION_MS);
+    });
+  });
+
+  describe('guardTids', () => {
+    it('returns the same guard for the same bidderRequest across calls', () => {
+      const bidderRequest = { bidderCode: 'mockBidder', bids: [] };
+      expect(guardTids(bidderRequest)).to.equal(guardTids(bidderRequest));
+    });
+
+    it('returns independent guards for different bidderRequests', () => {
+      const request1 = { bidderCode: 'mockBidder', bids: [] };
+      const request2 = { bidderCode: 'mockBidder', bids: [] };
+      const guard1 = guardTids(request1);
+      const guard2 = guardTids(request2);
+      expect(guard1).to.not.equal(guard2);
+      expect(guard1.bidderRequest(request1)).to.not.equal(guard2.bidderRequest(request2));
     });
   });
 });


### PR DESCRIPTION
# Core: remove three page-lifetime retainers of per-auction data

## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] New bidder adapter
- [ ] Updated bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change

Setting `minBidCacheTTL` and `eventHistoryTTL` is meant to bound how much per-auction history a long-lived page retains. Measured on a page that runs many auctions in sequence, both set still left the settled heap growing about 14 KB per auction (measured at `minBidCacheTTL: 5`, `eventHistoryTTL: 5`; about 47 KB/auction with neither set). The remainder traced to three registrations made once per auction, each holding a page-lifetime reference to that auction's request-side graph — ad-unit copies, bidder requests with their per-auction ortb2, bid requests, metrics — independent of any TTL:

- an `EVENTS.PBS_ANALYTICS` listener registered per auction inside `newAuction()`;
- an `onMinBidCacheTTLChange` callback registered per auction inside `newAuction()`;
- `guardTids`, memoized per bidder request with no eviction.

None of the three scaled down when a TTL config made an auction itself eligible for collection: every new auction added one more permanent listener or cache entry, so the auction it closed over never became unreachable.

This moves all three off per-auction, page-lifetime registration:

- PBS analytics routing and the minBidCacheTTL-triggered bid-TTL refresh are each a single registration owned by the auction manager, instead of every auction subscribing for itself. The `PBS_ANALYTICS` listener delivers a seatnonbid to every auction still retained under the event's auction id: those in flight — tracked from creation until they end, so delivery survives `clearAllAuctions()` — and those that have ended but are still held in the manager's cache, so a late seatnonbid still reaches a live reader of the auction until it is evicted. Where a publisher reuses one auction id across concurrent auctions, each matching auction receives the seatnonbid exactly once. The TTL-change callback re-evaluates bid retention on every live auction the manager holds. `Auction.addSeatNonBids` and `Auction.refreshBidTTLs` are the delegation points this needs; they are new members on the object `newAuction()` returns, additive only — no existing member changed shape.
- `guardTids` keys its per-bidder-request guard in a `WeakMap` on the bidder request object instead of an unbounded memoization cache, so the entry is collected with the bidder request rather than with the page. Its runtime call and return shape are unchanged (the parameter type tightens from `any` to the bidder request it requires), and within one `callBids` pass the validate and buildRequests paths still share the same guard (same proxy identity, same `tidsAllowed` computation, still re-evaluated against runtime consent rather than frozen at first use). The `clear` method that `memoize` attached to `guardTids` is gone; nothing in the tree called it.

Behaviour with no TTLs configured is unchanged: page-lifetime retention stays the default. This does not address other page-lifetime stores outside these three (analytics-adapter queues and similar). A seatnonbid reaches its auction for as long as the auction is retained by the manager, and a config change re-evaluates the bid retention of every auction the manager still holds; once an auction is evicted its data is gone, which is the retention this change bounds.

An acceptance run (two phases of 150 sequential auctions returning fresh bids with unique creative markup, `{minBidCacheTTL: 0, eventHistoryTTL: 0}`, heap sampled after TTL settle plus two forced GCs) shows phase-two growth of 1.66 MB (±0.04 MB across three runs) on a bundle built from master `77c421ad9` and 0.15 MB on one built from this branch's tip `d0f5a35c2`, against a 0.8 MB threshold. A WeakRef census over the same configuration against the `d0f5a35c2` build found none of the tracked per-auction objects still reachable across 150 auctions after settle — ad-unit copies, bidder requests with their ortb2, bid requests, received bids, the per-request, per-bid and per-auction metrics, and the auction-end event payloads, all at zero across the nine tracked categories. That harness is not part of this PR — it lives outside the repository by design — so this branch adds unit test coverage only.

## Other information

**Lint / type-check / tests**, on tip `d0f5a35c2` (four commits from master `77c421ad9`; commits 2–4 are review iterations that resolve findings against the earlier commits):
- `gulp lint` on the changed files: pass, no rewrites needed.
- `gulp ts` and `gulp ts-strict`: pass.
- `gulp test-only` (full suite, all chunks): 24,463 tests completed, 5 skipped, 0 failures.

**Docs:** no publisher-facing config or API changed — `Auction.addSeatNonBids` and `Auction.refreshBidTTLs` are additive members of an internal factory's return object — so no companion docs-repo PR.

**Overlap with #15474:** this branch and PR #15474 both change `guardTids` in `bidderFactory.ts`. If both proceed, the second to merge needs a small manual conflict resolution there; this PR makes no other change relative to #15474.

### No associated issue — issue template

**Type of issue:** Bug — unbounded memory growth in a long-lived, single-page application, present even when `minBidCacheTTL` and `eventHistoryTTL` are configured to bound retained history.

**Description:** Per-auction registrations that were meant to be transient (an analytics-event listener, a config-change callback, a per-bidder-request guard cache) were instead created once per auction and never released for the life of the page, so each auction's request-side graph stayed reachable regardless of TTL configuration.

**Steps to reproduce:**
1. `pbjs.setConfig({minBidCacheTTL: 0, eventHistoryTTL: 0})`.
2. On a long-lived page, call `requestBids` repeatedly (e.g. an SPA re-running auctions on navigation).
3. After each auction settles, force a GC and sample JS heap usage.

**Test page:** none public; reproduced with an out-of-repo harness driving headless Chrome, not committed to this repository.

**Expected results:** heap usage stops growing once earlier auctions are no longer live, since the TTL configuration exists to bound retained per-auction history.

**Actual results (master `77c421ad9`, pre-fix):** heap kept growing per auction because the three registrations above retained per-auction structure independent of TTL: about 14 KB/auction measured at `minBidCacheTTL: 5` + `eventHistoryTTL: 5`, and 1.66 MB (±0.04 MB) over a 150-auction phase under the 0/0 configuration of the steps above.

**Platform details:** reproduced against master `77c421ad9` in headless Chrome 138; the retaining registrations were the two per-auction listeners in `src/auction.ts` and the `guardTids` cache in `src/adapters/bidderFactory.ts`.

**Other information:** fixing analytics-adapter or other module-level stores is out of scope; default (no-TTL) retention behaviour is unchanged by design.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
