### PR TITLE
DSPx Bid Adapter: do not execute response scripts in the page

### DIFF
--- a/modules/dspxBidAdapter.js
+++ b/modules/dspxBidAdapter.js
@@ -1,4 +1,4 @@
-import { deepAccess, logMessage, getBidIdParameter, logError, logWarn } from '../src/utils.js';
+import { createIframe, deepAccess, logMessage, getBidIdParameter, logError, logWarn } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 
@@ -185,31 +185,19 @@ export const spec = {
  */
 function outstreamRender(bid) {
   logMessage('[DSPx][outstreamRender] bid:', bid);
-  const embedCode = createOutstreamEmbedCode(bid);
   try {
-    const inIframe = getBidIdParameter('iframe', bid.renderer.config);
-    if (inIframe && window.document.getElementById(inIframe).nodeName === 'IFRAME') {
-      const iframe = window.document.getElementById(inIframe);
-      const framedoc = iframe.contentDocument || (iframe.contentWindow && iframe.contentWindow.document);
-      framedoc.body.appendChild(embedCode);
-      if (typeof window.dspxRender === 'function') {
-        window.dspxRender(bid);
-      } else {
-        logError('[DSPx][outstreamRender] Error: dspxRender function is not found');
-      }
+    const rendererConfig = (bid.renderer && bid.renderer.config) || {};
+    const slot = getBidIdParameter('slot', rendererConfig) || bid.adUnitCode;
+    const slotEl = slot && window.document.getElementById(slot);
+    if (!slotEl) {
+      logError('[DSPx][outstreamRender] Error: slot not found');
       return;
     }
-
-    const slot = getBidIdParameter('slot', bid.renderer.config) || bid.adUnitCode;
-    if (slot && window.document.getElementById(slot)) {
-      window.document.getElementById(slot).appendChild(embedCode);
-      if (typeof window.dspxRender === 'function') {
-        window.dspxRender(bid);
-      } else {
-        logError('[DSPx][outstreamRender] Error: dspxRender function is not found');
-      }
-    } else if (slot) {
-      logError('[DSPx][outstreamRender] Error: slot not found');
+    slotEl.appendChild(createOutstreamEmbedCode(bid));
+    if (typeof window.dspxRender === 'function') {
+      window.dspxRender(bid);
+    } else {
+      logError('[DSPx][outstreamRender] Error: dspxRender function is not found');
     }
   } catch (err) {
     logError('[DSPx][outstreamRender] Error:' + err.message);
@@ -217,34 +205,44 @@ function outstreamRender(bid) {
 }
 
 /**
- * create Outstream Embed Code Node
+ * Strip executable markup from a response-supplied HTML string.
+ * Parse in an inert document so handler attributes never compile against the page.
+ */
+export function sanitizeOutstreamMarkup(html) {
+  const inert = window.document.implementation.createHTMLDocument('');
+  inert.body.innerHTML = html || '';
+  Array.from(inert.querySelectorAll('script')).forEach((script) => script.remove());
+  Array.from(inert.body.querySelectorAll('*')).forEach((el) => {
+    Array.from(el.attributes).forEach((attr) => {
+      if (/^on/i.test(attr.name)) {
+        el.removeAttribute(attr.name);
+      }
+    });
+  });
+  return inert.body.innerHTML;
+}
+
+/**
+ * Create outstream embed code. Markup from the bid response is placed in a
+ * renderer iframe and is never reconstituted as page-level script.
  *
  * @param bid
  * @returns {DocumentFragment}
  */
-function createOutstreamEmbedCode(bid) {
+export function createOutstreamEmbedCode(bid) {
   const fragment = window.document.createDocumentFragment();
-  const div = window.document.createElement('div');
-  div.innerHTML = deepAccess(bid, 'renderer.config.code', '');
-  fragment.appendChild(div);
-
-  // run scripts
-  var scripts = div.getElementsByTagName('script');
-  var scriptsClone = [];
-  for (var idx = 0; idx < scripts.length; idx++) {
-    scriptsClone.push(scripts[idx]);
-  }
-  for (var i = 0; i < scriptsClone.length; i++) {
-    var currentScript = scriptsClone[i];
-    var s = document.createElement('script');
-    for (var j = 0; j < currentScript.attributes.length; j++) {
-      var a = currentScript.attributes[j];
-      s.setAttribute(a.name, a.value);
-    }
-    s.appendChild(document.createTextNode(currentScript.innerHTML));
-    currentScript.parentNode.replaceChild(s, currentScript);
-  }
-
+  const width = bid.width || '100%';
+  const height = bid.height || '100%';
+  const iframe = createIframe(window.document, {
+    width,
+    height
+  }, {
+    width: typeof width === 'number' ? `${width}px` : width,
+    height: typeof height === 'number' ? `${height}px` : height,
+    border: '0px'
+  });
+  iframe.srcdoc = sanitizeOutstreamMarkup(deepAccess(bid, 'renderer.config.code', '') || '');
+  fragment.appendChild(iframe);
   return fragment;
 }
 

--- a/test/spec/modules/dspxBidAdapter_spec.js
+++ b/test/spec/modules/dspxBidAdapter_spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { config } from 'src/config.js';
-import { spec } from 'modules/dspxBidAdapter.js';
+import { spec, createOutstreamEmbedCode, sanitizeOutstreamMarkup } from 'modules/dspxBidAdapter.js';
 
 import { deepClone } from '../../../src/utils.js';
 import { BANNER } from '../../../src/mediaTypes.js';
@@ -801,6 +801,106 @@ describe('dspxAdapter', function () {
     it(`check for zero array when iframeEnabled`, function () {
       expect(spec.getUserSyncs({ pixelEnabled: true })).to.be.an('array');
       expect(spec.getUserSyncs({ pixelEnabled: true }, serverResponses).length).to.be.equal(0);
+    });
+  });
+
+  describe('outstream renderer markup', function () {
+    const SLOT_ID = 'dspx-outstream-test-slot';
+    const FLAG = '__dspxRendererCodeRan';
+
+    const bidRequest = {
+      method: 'GET',
+      url: ENDPOINT_URL,
+      mediaTypes: {
+        video: {
+          playerSize: [640, 480],
+          context: 'outstream'
+        }
+      },
+      data: {
+        bid_id: '30b31c1838de1e'
+      }
+    };
+
+    function responseWithRendererCode(code) {
+      return {
+        body: {
+          cpm: 5000000,
+          crid: 100500,
+          width: '300',
+          height: '250',
+          vastXml: '<VAST version="3.0"></VAST>',
+          requestId: '220ed41385952a',
+          type: 'vast2',
+          currency: 'EUR',
+          ttl: 60,
+          netRevenue: true,
+          zone: '6682',
+          renderer: {
+            id: 1,
+            url: '//player.example.com',
+            options: {
+              slot: SLOT_ID,
+              code: code
+            }
+          }
+        }
+      };
+    }
+
+    let slot;
+
+    beforeEach(function () {
+      slot = document.createElement('div');
+      slot.id = SLOT_ID;
+      document.body.appendChild(slot);
+      delete window[FLAG];
+    });
+
+    afterEach(function () {
+      if (slot && slot.parentNode) {
+        slot.parentNode.removeChild(slot);
+      }
+      delete window[FLAG];
+    });
+
+    it('strips script tags and event handler attributes from response markup', function () {
+      const cleaned = sanitizeOutstreamMarkup(
+        '<div id="ok">ad</div><script src="https://example.invalid/renderer.js"></script><img src="https://example.invalid/pixel.gif" onerror="void(0)">'
+      );
+      expect(cleaned).to.include('id="ok"');
+      expect(cleaned.toLowerCase()).to.not.include('<script');
+      expect(cleaned.toLowerCase()).to.not.include('onerror');
+    });
+
+    it('places sanitized markup in an iframe instead of reconstituting script tags', function () {
+      const fragment = createOutstreamEmbedCode({
+        width: 300,
+        height: 250,
+        renderer: {
+          config: {
+            code: '<div id="creative">ad</div><script>window["' + FLAG + '"] = true;</script>'
+          }
+        }
+      });
+      const iframe = fragment.querySelector('iframe');
+      expect(iframe).to.exist;
+      expect(iframe.srcdoc.toLowerCase()).to.not.include('<script');
+      slot.appendChild(fragment);
+      expect(window[FLAG]).to.equal(undefined);
+      expect(slot.querySelectorAll('script').length).to.equal(0);
+    });
+
+    it('should not run a script supplied by the bid response in the page', function () {
+      const code = '<script>window[\'' + FLAG + '\'] = true;</' + 'script>';
+      const bids = spec.interpretResponse(responseWithRendererCode(code), bidRequest);
+      bids[0].adUnitCode = SLOT_ID;
+
+      expect(bids[0].renderer).to.exist;
+      bids[0].renderer._render(bids[0]);
+
+      expect(window[FLAG]).to.equal(undefined);
+      expect(slot.querySelector('iframe')).to.exist;
     });
   });
 });


### PR DESCRIPTION
## Type of change
- [x] Bugfix

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change

Fixes #15547.

`createOutstreamEmbedCode` rebuilt every `<script>` from `renderer.config.code` (including `src`) and ran it in the page. That breaks [module rule 2](https://docs.prebid.org/dev-docs/module-rules.html).

Markup is now parsed in an inert document, scripts and `on*` attributes are stripped, and the remainder is placed in a renderer iframe. `dspxRender` still comes from the Renderer URL. Response-chosen publisher iframe targeting is gone.

## Other information

`npx gulp test-only --file test/spec/modules/dspxBidAdapter_spec.js` (58 passing). The new specs assert response scripts do not run in the page; they are not a repro that executes bidder JS.

@dgirardi