### PR TITLE
Floxis Bid Adapter: set imp.tagid from adUnitCode when absent

### DIFF
--- a/modules/floxisBidAdapter.js
+++ b/modules/floxisBidAdapter.js
@@ -167,6 +167,11 @@ const CONVERTER = ortbConverter({
     const imp = buildImp(bidRequest, context);
     imp.secure = bidRequest.ortb2Imp?.secure ?? 1;
 
+    // Placement identity for SSP-side reporting; ortb2Imp.tagid (already merged in by buildImp) wins.
+    if (!imp.tagid && bidRequest.adUnitCode) {
+      imp.tagid = bidRequest.adUnitCode;
+    }
+
     // The priceFloors processor already sets imp.bidfloor when the module is active; only fill a
     // floor here when it left none — from getFloor (ignoring 0, which would clobber an FPD floor)
     // or a static params.bidFloor fallback for bundles without the floors module.

--- a/modules/floxisBidAdapter.md
+++ b/modules/floxisBidAdapter.md
@@ -16,6 +16,7 @@ The Floxis Bid Adapter enables integration with the Floxis programmatic advertis
 - Privacy signal forwarding (GDPR/TCF, USP, GPP, COPPA) via Prebid.js core
 - User identity (User ID / `eids`) and supply chain (`schain`) passthrough
 - First-party fallback id for cookieless browsers (`user.ext.floxisId`)
+- Placement identity: `imp.tagid` is set from the ad unit code unless the publisher supplies `ortb2Imp.tagid`
 - Prebid.js Floors Module support (plus a static `bidFloor` param fallback)
 - User sync (iframe and pixel cookie matching)
 
@@ -126,4 +127,4 @@ pbjs.setConfig({
 The adapter reports client-observed auction timeouts and bidder transport errors to Floxis as cookieless operational telemetry. Each beacon is a `keepalive` fetch sent with credentials omitted (no cookies) and scheduled off the auction's critical path, so it carries only the seat, region, event type, and relevant operational dimensions (HTTP status, timeout flag, duration, auction ID, publisher domain) — no user or device identifier is included. Consent signals are forwarded as opaque pass-through parameters where available. Each beacon fires at most once per distinct seat+region pair per event, and telemetry failures are silently suppressed so they never affect the auction lifecycle.
 
 ## Testing
-Unit tests are provided in `test/spec/modules/floxisBidAdapter_spec.js` and cover validation, request building (params, host-label safety, floors, FPD/consent passthrough, first-party fallback id), response interpretation and meta mapping, user syncs, billing notifications, and error/timeout telemetry callbacks.
+Unit tests are provided in `test/spec/modules/floxisBidAdapter_spec.js` and cover validation, request building (params, host-label safety, floors, placement `tagid`, FPD/consent passthrough, first-party fallback id), response interpretation and meta mapping, user syncs, billing notifications, and error/timeout telemetry callbacks.

--- a/test/spec/modules/floxisBidAdapter_spec.js
+++ b/test/spec/modules/floxisBidAdapter_spec.js
@@ -212,6 +212,23 @@ describe('floxisBidAdapter', function () {
       expect(imp.secure).to.equal(1);
     });
 
+    it('should set imp.tagid from adUnitCode', function () {
+      const requests = spec.buildRequests([validBannerBid], bidderRequest);
+      expect(requests[0].data.imp[0].tagid).to.equal('adunit-banner');
+    });
+
+    it('should keep a publisher-supplied ortb2Imp.tagid', function () {
+      const bidWithTagid = { ...validBannerBid, ortb2Imp: { tagid: 'publisher-placement-1' } };
+      const requests = spec.buildRequests([bidWithTagid], bidderRequest);
+      expect(requests[0].data.imp[0].tagid).to.equal('publisher-placement-1');
+    });
+
+    it('should fall back to adUnitCode when ortb2Imp.tagid is empty', function () {
+      const bidWithEmptyTagid = { ...validBannerBid, ortb2Imp: { tagid: '' } };
+      const requests = spec.buildRequests([bidWithEmptyTagid], bidderRequest);
+      expect(requests[0].data.imp[0].tagid).to.equal('adunit-banner');
+    });
+
     if (FEATURES.VIDEO) {
       it('should build video imp correctly', function () {
         const requests = spec.buildRequests([validVideoBid], bidderRequest);


### PR DESCRIPTION
## Type of change

- [x] Updated bidder adapter

## Description of change

The Floxis adapter's ortbConverter `imp` processor never set `imp.tagid`, so bid requests from
Prebid.js publishers carried no placement identifier. Placement-level reporting and per-placement
optimisation on the exchange side need an identifier the publisher owns and recognises, and the ad
unit code is the one that is always available.

`imp.tagid` is now set from `bidRequest.adUnitCode` when it is absent or empty. A publisher-supplied
`ortb2Imp.tagid` is merged onto the imp by `buildImp` before this runs and is left untouched, so this
is a default, not an override.

Unit tests added to `test/spec/modules/floxisBidAdapter_spec.js`:

- `imp.tagid` defaults to the ad unit code
- a publisher `ortb2Imp.tagid` is preserved
- an empty `ortb2Imp.tagid` falls back to the ad unit code

No bidder parameter changed, so no prebid.github.io PR is required; `modules/floxisBidAdapter.md`
notes the behaviour.

Checks run on the changed files:

- `gulp test --nolint --nointegration --file test/spec/modules/floxisBidAdapter_spec.js` — 126 tests completed, 0 failed
- `eslint modules/floxisBidAdapter.js test/spec/modules/floxisBidAdapter_spec.js` — no output, exit 0

Reverting the adapter change with the new tests in place fails exactly the two behaviour tests, so
they cover the change rather than passing incidentally.

## Other information

Adapter maintainer: prebid@floxis.tech
