### PR TITLE
Geoedge RTD Provider: display opt-out

### DIFF
--- a/modules/geoedgeRtdProvider.d.ts
+++ b/modules/geoedgeRtdProvider.d.ts
@@ -1,0 +1,44 @@
+// the augmentation in this file only applies where the spec is part of the program
+import type {} from './rtdModule/spec.js';
+
+export interface GeoedgeRtdProviderParams {
+  /**
+   * Geoedge customer key. Contact Geoedge to obtain one.
+   */
+  key: string;
+  /**
+   * Bidders to monitor, keyed by bidder code. Set a bidder to `true` to monitor it.
+   * When omitted, bids from all bidders are monitored.
+   */
+  bidders?: Record<string, boolean>;
+  /**
+   * When `true`, wrap bid responses only after the monitoring client has loaded.
+   * Defaults to `false`.
+   */
+  wap?: boolean;
+  /**
+   * When `true`, monitor every Google Publisher Tag ad slot through the in-page
+   * script rather than wrapping Prebid bid responses. Defaults to `false`.
+   */
+  gpt?: boolean;
+  /**
+   * When `true`, extend monitoring to outstream video bids by gating the bid's own
+   * renderer until the monitoring client clears the creative. Defaults to `false`.
+   */
+  outstream?: boolean;
+  /**
+   * When `false`, opt out of display monitoring and leave display bids unwrapped.
+   * Defaults to `true`.
+   */
+  display?: boolean;
+}
+
+declare module './rtdModule/spec' {
+  interface ProviderConfig {
+    geoedge: {
+      params: GeoedgeRtdProviderParams;
+    };
+  }
+}
+
+export {};

--- a/modules/geoedgeRtdProvider.js
+++ b/modules/geoedgeRtdProvider.js
@@ -15,6 +15,7 @@
  * @property {?boolean} wap
  * @property {?boolean} gpt
  * @property {?boolean} outstream publisher opt-in to outstream video monitoring
+ * @property {?boolean} display publisher opt-out of display monitoring, defaults to true
  * @property {?string} keyName
  */
 
@@ -84,10 +85,12 @@ export function setWrapper(responseText) {
 /**
  * builds the params object handed to the client inside the frame
  * @param {string} key
+ * @param {?boolean} display publisher opt-out of display monitoring
  * @param {?boolean} outstream publisher opt-in to outstream video monitoring
+ * @param {?Object} bidders
  * @return {Object}
  */
-export function getInitialParams(key, outstream, bidders) {
+export function getInitialParams(key, display, outstream, bidders) {
   const params = {
     wver: '1.1.2',
     wtype: 'pbjs-module',
@@ -97,7 +100,8 @@ export function getInitialParams(key, outstream, bidders) {
     pimp: PV_ID,
     fsRan: true,
     frameApi: true,
-    outstream
+    outstream,
+    display
   };
 
   if (outstream) {
@@ -161,15 +165,17 @@ function stopClientLoadTimer() {
 /**
  * loads the monitoring client in an invisible iframe
  * @param {string} key
+ * @param {?boolean} display publisher opt-out of display monitoring
  * @param {?boolean} outstream publisher opt-in to outstream video monitoring
+ * @param {?Object} bidders
  */
-export function loadClientInIframe(key, outstream, bidders) {
+export function loadClientInIframe(key, display, outstream, bidders) {
   const iframe = createInvisibleIframe();
   const url = getClientUrl(key);
 
   iframe.id = 'grumiFrame';
   insertElement(iframe);
-  iframe.contentWindow.grumi = getInitialParams(key, outstream, bidders);
+  iframe.contentWindow.grumi = getInitialParams(key, display, outstream, bidders);
   clientFrame = iframe;
 
   loadExternalScript(url, MODULE_TYPE_RTD, SUBMODULE_NAME, markClientAsLoaded, iframe.contentDocument);
@@ -260,8 +266,9 @@ function shouldWrap(bid, params) {
   const supportedBidder = isSupportedBidder(bid.bidderCode, params.bidders);
   const clientReady = params.wap ? clientLoaded : true;
   const isGPT = params.gpt;
+  const displayEnabled = params.display !== false;
 
-  return wrapperReady && supportedBidder && clientReady && !isGPT;
+  return displayEnabled && wrapperReady && supportedBidder && clientReady && !isGPT;
 }
 
 function conditionallyWrap(bidResponse, config, userConsent) {
@@ -445,21 +452,25 @@ function fireBillableEventsForApplicableBids(params) {
 function setupInPage(params) {
   window.grumi = params;
   window.grumi.fromPrebid = true;
+
   loadExternalScript(getInPageUrl(params.key), MODULE_TYPE_RTD, SUBMODULE_NAME);
 }
 
 function init(config, userConsent) {
   const params = config.params;
+
   if (!params || !params.key) {
     logError('missing key for geoedge RTD module provider');
     return false;
   }
+
   if (params.gpt) {
     setupInPage(params);
   } else {
     fetchWrapper(setWrapper);
-    loadClientInIframe(params.key, params.outstream, params.bidders);
+    loadClientInIframe(params.key, params.display, params.outstream, params.bidders);
   }
+
   fireBillableEventsForApplicableBids(params);
 
   return true;

--- a/test/spec/modules/geoedgeRtdProvider_spec.js
+++ b/test/spec/modules/geoedgeRtdProvider_spec.js
@@ -136,13 +136,13 @@ describe('Geoedge RTD module', function () {
         expect(loadExternalScriptCall.calledWithMatch(isClientUrl)).to.equal(true);
       });
       it('should carry the publisher outstream opt-in into the frame', function () {
-        loadClientInIframe(key, true);
+        loadClientInIframe(key, undefined, true);
         // insertElement prepends into <head>, so the newest frame is the FIRST match, not the last
         const grumi = document.querySelector('#grumiFrame').contentWindow.grumi;
         expect(grumi.outstream).to.equal(true);
       });
       it('should hand the frame a reference to this prebid instance when outstream is on', function () {
-        loadClientInIframe(key, true);
+        loadClientInIframe(key, undefined, true);
         const grumi = document.querySelector('#grumiFrame').contentWindow.grumi;
         expect(grumi.pbjs).to.equal(getGlobal());
       });
@@ -150,6 +150,11 @@ describe('Geoedge RTD module', function () {
         loadClientInIframe(key);
         const grumi = document.querySelector('#grumiFrame').contentWindow.grumi;
         expect(grumi.pbjs).to.equal(undefined);
+      });
+      it('should carry the publisher display opt-out into the frame', function () {
+        loadClientInIframe(key, false);
+        const grumi = document.querySelector('#grumiFrame').contentWindow.grumi;
+        expect(grumi.display).to.equal(false);
       });
     });
     describe('setWrapper', function () {
@@ -185,6 +190,16 @@ describe('Geoedge RTD module', function () {
         const bidFromB = mockBid('bidderB');
         geoedgeSubmodule.onBidResponseEvent(bidFromB, makeConfig(false));
         expect(bidFromB.ad.indexOf('<wrapper>')).to.equal(-1);
+      });
+      it('should not wrap a display bid when the publisher opted out of display', function () {
+        const bid = mockBid('bidderA');
+        geoedgeSubmodule.onBidResponseEvent(bid, { name: 'geoedge', params: { key, display: false } });
+        expect(bid.ad.indexOf('<wrapper>')).to.equal(-1);
+      });
+      it('should wrap a display bid when display is not configured, since the opt-out defaults to off', function () {
+        const bid = mockBid('bidderA');
+        geoedgeSubmodule.onBidResponseEvent(bid, { name: 'geoedge', params: { key } });
+        expect(bid.ad.indexOf('<wrapper>')).to.equal(0);
       });
       it('should only muatate the bid ad porperty', function () {
         const copy = Object.assign({}, bidFromA);
@@ -264,7 +279,7 @@ describe('Geoedge RTD module', function () {
       beforeEach(function () {
         document.querySelectorAll('#grumiFrame').forEach(el => el.remove());
         // establishes clientFrame; the adloader stub fires the load callback synchronously
-        loadClientInIframe(key, true);
+        loadClientInIframe(key, undefined, true);
         frame = document.querySelector('#grumiFrame');
         delete frame.contentWindow[OUTSTREAM_API];
         resetOutstreamGateStateForTesting();
@@ -488,7 +503,7 @@ describe('Geoedge RTD module', function () {
         beforeEach(function () {
           clock = sinon.useFakeTimers();
           // re-arm the deadline against the fake clock
-          loadClientInIframe(key, true);
+          loadClientInIframe(key, undefined, true);
           frame = document.querySelector('#grumiFrame');
           delete frame.contentWindow[OUTSTREAM_API];
           resetOutstreamGateStateForTesting();


### PR DESCRIPTION
## Type of change

- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change

Adds an optional `params.display` to the Geoedge RTD module, letting a publisher turn off display monitoring while leaving the outstream video gate active. This is for video-only publishers who do not want their display bids wrapped.

It is an opt-out rather than an opt-in: only an explicit `display: false` disables wrapping, so omitting the param keeps current behavior for every existing publisher.

```javascript
pbjs.setConfig({
  realTimeData: {
    dataProviders: [{
      name: 'geoedge',
      params: {
        key: '123123123',
        display: false,
        outstream: true
      }
    }]
  }
});
```

`display` is also passed into the monitoring client's frame, alongside the existing `outstream` flag, so the client can distinguish display monitoring from outstream monitoring.

Note on the spec diff: `display` sits second in the `getInitialParams` and `loadClientInIframe` signatures, so the existing spec calls that passed `outstream` positionally were updated to `loadClientInIframe(key, undefined, true)`.

Tests cover both sides of the gate (opted out, and the default when the param is omitted) plus the frame plumbing. Module coverage is 97% lines / 92% branches.

## Other information

Docs PR: prebid/prebid.github.io#6731

Also adds `modules/geoedgeRtdProvider.d.ts`, typing and exporting the module's params per AGENTS.md so publishers importing prebid's types via npm can type-check the geoedge config. `keyName` is omitted from the type: it appears in the JSDoc typedef but the module never reads it.