### PR TITLE
Utiq ID module: Uprgade utiq modules to pass the category ('mobile' | 'fixed' ) in the `ext` response

### DIFF
--- a/modules/utiqIdSystem.js
+++ b/modules/utiqIdSystem.js
@@ -67,9 +67,14 @@ function getUtiqFromStorage() {
 
   return {
     utiq:
-      utiqPass && utiqPass.atid
-        ? utiqPass.atid
-        : null,
+      {
+        id: utiqPass && utiqPass.atid
+          ? utiqPass.atid
+          : null,
+        category: utiqPass && utiqPass.category
+          ? utiqPass.category
+          : null,
+      }
   };
 }
 
@@ -148,8 +153,16 @@ export const utiqIdSubmodule = {
       source: 'utiq.com',
       atype: 1,
       getValue: function (data) {
-        return data;
+        return data.id;
       },
+      getUidExt: function (data) {
+        const category = (data && data.category) || false;
+        return {
+          utiq: {
+            category
+          }
+        };
+      }
     },
   }
 };

--- a/modules/utiqIdSystem.js
+++ b/modules/utiqIdSystem.js
@@ -66,15 +66,12 @@ function getUtiqFromStorage() {
   }
 
   return {
-    utiq:
-      {
-        id: utiqPass && utiqPass.atid
-          ? utiqPass.atid
-          : null,
-        category: utiqPass && utiqPass.category
-          ? utiqPass.category
-          : null,
-      }
+    utiq: utiqPass && utiqPass.atid
+      ? {
+          id: utiqPass.atid,
+          category: utiqPass.category,
+        }
+      : null
   };
 }
 

--- a/modules/utiqIdSystem.js
+++ b/modules/utiqIdSystem.js
@@ -48,7 +48,18 @@ function getUtiqFromStorage() {
   ) {
     const idGraph = utiqPassStorage.connectId.idGraph;
 
-    utiqPass = CATEGORY_PRIORITIES.reduce((acc, cat) => acc || idGraph.find(g => g.category === cat), null) || idGraph[0];
+    for (let i = 0; i < CATEGORY_PRIORITIES.length; i++) {
+      const found = idGraph.find(g => g.category === CATEGORY_PRIORITIES[i]);
+      if (found) {
+        utiqPass = found;
+        break; // Stop immediately once the highest priority is found
+      }
+    }
+
+    // Fallback to the first item if no prioritized category matched
+    if (!utiqPass) {
+      utiqPass = idGraph[0];
+    }
 
     logInfo(
       `${LOG_PREFIX}: Graph of utiqPass: ${JSON.stringify(

--- a/modules/utiqIdSystem.js
+++ b/modules/utiqIdSystem.js
@@ -103,7 +103,7 @@ export const utiqIdSubmodule = {
   /**
    * Decodes the stored id value for passing to bid requests.
    * @function
-   * @returns {{utiq: {atid:string,category:string}} | null}
+   * @returns {{utiq: {atid: string, category: string} | string } | null}
    */
   decode(bidId) {
     logInfo(`${LOG_PREFIX}: Decoded ID value ${JSON.stringify(bidId)}`);

--- a/modules/utiqIdSystem.js
+++ b/modules/utiqIdSystem.js
@@ -25,7 +25,7 @@ export const storage = getStorageManager({
 
 /**
  * Get the "atid" from html5 local storage to make it available to the UserId module.
- * @returns {{utiq: (*|string)}}
+ * @returns {{utiq: (*|{atid:string,category:string})}}
  */
 function getUtiqFromStorage() {
   let utiqPass;
@@ -68,7 +68,7 @@ function getUtiqFromStorage() {
   return {
     utiq: utiqPass && utiqPass.atid
       ? {
-          id: utiqPass.atid,
+          atid: utiqPass.atid,
           category: utiqPass.category,
         }
       : null
@@ -150,7 +150,7 @@ export const utiqIdSubmodule = {
       source: 'utiq.com',
       atype: 1,
       getValue: function (data) {
-        return data.id;
+        return data.atid;
       },
       getUidExt: function (data) {
         const category = (data && data.category) || false;

--- a/modules/utiqIdSystem.js
+++ b/modules/utiqIdSystem.js
@@ -86,7 +86,7 @@ export const utiqIdSubmodule = {
   /**
    * Decodes the stored id value for passing to bid requests.
    * @function
-   * @returns {{utiq: string} | null}
+   * @returns {{utiq: {atid:string,category:string}} | null}
    */
   decode(bidId) {
     logInfo(`${LOG_PREFIX}: Decoded ID value ${JSON.stringify(bidId)}`);
@@ -95,7 +95,7 @@ export const utiqIdSubmodule = {
   /**
    * Get the id from helper function and initiate a new user sync.
    * @param config
-   * @returns {{callback: Function}|{id: {utiq: string}}}
+   * @returns {{callback: Function}|{id: {utiq: {atid:string,category:string}}}}
    */
   getId: function (config) {
     const data = getUtiqFromStorage();

--- a/modules/utiqIdSystem.js
+++ b/modules/utiqIdSystem.js
@@ -17,6 +17,7 @@ import { getGlobal } from '../src/prebidGlobal.js';
 
 const MODULE_NAME = 'utiqId';
 const LOG_PREFIX = 'Utiq module';
+const CATEGORY_PRIORITIES = ['mobile', 'netid', 'fixed'];
 
 export const storage = getStorageManager({
   moduleType: MODULE_TYPE_UID,
@@ -33,16 +34,11 @@ function getUtiqFromStorage() {
     storage.getDataFromLocalStorage('utiqPass')
   );
 
-  const netIdAdtechpass = storage.getDataFromLocalStorage('netid_utiq_adtechpass');
-
-  if (netIdAdtechpass) {
-    logInfo(
-      `${LOG_PREFIX}: Local storage netid_utiq_adtechpass: ${netIdAdtechpass}`
-    );
-    return {
-      utiq: netIdAdtechpass,
-    };
-  }
+  logInfo(
+    `${LOG_PREFIX}: Local storage utiqPass: ${JSON.stringify(
+      utiqPassStorage
+    )}`
+  );
 
   if (
     utiqPassStorage &&
@@ -50,19 +46,29 @@ function getUtiqFromStorage() {
     Array.isArray(utiqPassStorage.connectId.idGraph) &&
     utiqPassStorage.connectId.idGraph.length > 0
   ) {
-    utiqPass = utiqPassStorage.connectId.idGraph[0];
+    const idGraph = utiqPassStorage.connectId.idGraph;
 
-    logInfo(
-      `${LOG_PREFIX}: Local storage utiqPass: ${JSON.stringify(
-        utiqPassStorage
-      )}`
-    );
+    utiqPass = CATEGORY_PRIORITIES.reduce((acc, cat) => acc || idGraph.find(g => g.category === cat), null) || idGraph[0];
 
     logInfo(
       `${LOG_PREFIX}: Graph of utiqPass: ${JSON.stringify(
         utiqPass
       )}`
     );
+  }
+
+  const netIdAdtechpass = storage.getDataFromLocalStorage('netid_utiq_adtechpass');
+
+  if (netIdAdtechpass) {
+    const atidPriority = CATEGORY_PRIORITIES.findIndex(el => utiqPass && el === utiqPass.category);
+    const netIdPriority = CATEGORY_PRIORITIES.findIndex(el => el === 'netid');
+
+    if (atidPriority >= 0 && netIdPriority < atidPriority) {
+      logInfo(
+        `${LOG_PREFIX}: Local storage netid_utiq_adtechpass: ${netIdAdtechpass}`
+      );
+      return { utiq: { atid: netIdAdtechpass, category: 'netid' } };
+    }
   }
 
   return {

--- a/modules/utiqMtpIdSystem.js
+++ b/modules/utiqMtpIdSystem.js
@@ -88,7 +88,7 @@ export const utiqMtpIdSubmodule = {
   /**
    * Decodes the stored id value for passing to bid requests.
    * @function
-   * @returns {{utiqMtp: {mtid:string,category:string}} | null}
+   * @returns {{utiqMtp: {mtid: string, category: string} | string} | null}
    */
   decode(bidId) {
     logInfo(`${LOG_PREFIX}: Decoded ID value ${JSON.stringify(bidId)}`);

--- a/modules/utiqMtpIdSystem.js
+++ b/modules/utiqMtpIdSystem.js
@@ -73,7 +73,7 @@ export const utiqMtpIdSubmodule = {
   /**
    * Decodes the stored id value for passing to bid requests.
    * @function
-   * @returns {{utiqMtp: string} | null}
+   * @returns {{utiqMtp: {mtid:string,category:string}} | null}
    */
   decode(bidId) {
     logInfo(`${LOG_PREFIX}: Decoded ID value ${JSON.stringify(bidId)}`);
@@ -82,7 +82,7 @@ export const utiqMtpIdSubmodule = {
   /**
    * Get the id from helper function and initiate a new user sync.
    * @param config
-   * @returns {{callback: Function}|{id: {utiqMtp: string}}}
+   * @returns {{callback: Function}|{id: {utiqMtp: {mtid:string,category:string}}}}
    */
   getId: function (config) {
     const data = getUtiqFromStorage();

--- a/modules/utiqMtpIdSystem.js
+++ b/modules/utiqMtpIdSystem.js
@@ -25,7 +25,7 @@ export const storage = getStorageManager({
 
 /**
  * Get the "mtid" from html5 local storage to make it available to the UserId module.
- * @returns {{utiqMtp: (*|string)}}
+ * @returns {{utiqMtp: (*|{mtid:string,category:string})}}
  */
 function getUtiqFromStorage() {
   let utiqPass;
@@ -55,7 +55,7 @@ function getUtiqFromStorage() {
   return {
     utiqMtp: utiqPass && utiqPass.mtid
       ? {
-          id: utiqPass.mtid,
+          mtid: utiqPass.mtid,
           category: utiqPass.category,
         }
       : null
@@ -137,7 +137,7 @@ export const utiqMtpIdSubmodule = {
       source: 'utiq-mtp.com',
       atype: 1,
       getValue: function (data) {
-        return data.id;
+        return data.mtid;
       },
       getUidExt: function (data) {
         const category = (data && data.category) || false;

--- a/modules/utiqMtpIdSystem.js
+++ b/modules/utiqMtpIdSystem.js
@@ -17,6 +17,7 @@ import { getGlobal } from '../src/prebidGlobal.js';
 
 const MODULE_NAME = 'utiqMtpId';
 const LOG_PREFIX = 'Utiq MTP module';
+const CATEGORY_PRIORITIES = ['mobile', 'fixed'];
 
 export const storage = getStorageManager({
   moduleType: MODULE_TYPE_UID,
@@ -44,13 +45,16 @@ function getUtiqFromStorage() {
     Array.isArray(utiqPassStorage.connectId.idGraph) &&
     utiqPassStorage.connectId.idGraph.length > 0
   ) {
-    utiqPass = utiqPassStorage.connectId.idGraph[0];
+    const idGraph = utiqPassStorage.connectId.idGraph;
+
+    utiqPass = CATEGORY_PRIORITIES.reduce((acc, cat) => acc || idGraph.find(g => g.category === cat), null) || idGraph[0];
+
+    logInfo(
+      `${LOG_PREFIX}: Graph of utiqPass: ${JSON.stringify(
+        utiqPass
+      )}`
+    );
   }
-  logInfo(
-    `${LOG_PREFIX}: Graph of utiqPass: ${JSON.stringify(
-      utiqPass
-    )}`
-  );
 
   return {
     utiqMtp: utiqPass && utiqPass.mtid

--- a/modules/utiqMtpIdSystem.js
+++ b/modules/utiqMtpIdSystem.js
@@ -54,9 +54,14 @@ function getUtiqFromStorage() {
 
   return {
     utiqMtp:
-      utiqPass && utiqPass.mtid
-        ? utiqPass.mtid
-        : null,
+      {
+        id: utiqPass && utiqPass.mtid
+          ? utiqPass.mtid
+          : null,
+        category: utiqPass && utiqPass.category
+          ? utiqPass.category
+          : null,
+      }
   };
 }
 
@@ -135,8 +140,16 @@ export const utiqMtpIdSubmodule = {
       source: 'utiq-mtp.com',
       atype: 1,
       getValue: function (data) {
-        return data;
+        return data.id;
       },
+      getUidExt: function (data) {
+        const category = (data && data.category) || false;
+        return {
+          utiq: {
+            category
+          }
+        };
+      }
     },
   }
 };

--- a/modules/utiqMtpIdSystem.js
+++ b/modules/utiqMtpIdSystem.js
@@ -53,15 +53,12 @@ function getUtiqFromStorage() {
   );
 
   return {
-    utiqMtp:
-      {
-        id: utiqPass && utiqPass.mtid
-          ? utiqPass.mtid
-          : null,
-        category: utiqPass && utiqPass.category
-          ? utiqPass.category
-          : null,
-      }
+    utiqMtp: utiqPass && utiqPass.mtid
+      ? {
+          id: utiqPass.mtid,
+          category: utiqPass.category,
+        }
+      : null
   };
 }
 

--- a/modules/utiqMtpIdSystem.js
+++ b/modules/utiqMtpIdSystem.js
@@ -29,38 +29,49 @@ export const storage = getStorageManager({
  * @returns {{utiqMtp: (*|{mtid:string,category:string})}}
  */
 function getUtiqFromStorage() {
-  let utiqPass;
-  const utiqPassStorage = JSON.parse(
+  let utiqMtpPass;
+  const utiqMtpPassStorage = JSON.parse(
     storage.getDataFromLocalStorage('utiqPass')
   );
   logInfo(
     `${LOG_PREFIX}: Local storage utiqPass: ${JSON.stringify(
-      utiqPassStorage
+      utiqMtpPassStorage
     )}`
   );
 
   if (
-    utiqPassStorage &&
-    utiqPassStorage.connectId &&
-    Array.isArray(utiqPassStorage.connectId.idGraph) &&
-    utiqPassStorage.connectId.idGraph.length > 0
+    utiqMtpPassStorage &&
+    utiqMtpPassStorage.connectId &&
+    Array.isArray(utiqMtpPassStorage.connectId.idGraph) &&
+    utiqMtpPassStorage.connectId.idGraph.length > 0
   ) {
-    const idGraph = utiqPassStorage.connectId.idGraph;
+    const idGraph = utiqMtpPassStorage.connectId.idGraph;
 
-    utiqPass = CATEGORY_PRIORITIES.reduce((acc, cat) => acc || idGraph.find(g => g.category === cat), null) || idGraph[0];
+    for (let i = 0; i < CATEGORY_PRIORITIES.length; i++) {
+      const found = idGraph.find(g => g.category === CATEGORY_PRIORITIES[i]);
+      if (found) {
+        utiqMtpPass = found;
+        break; // Stop immediately once the highest priority is found
+      }
+    }
+
+    // Fallback to the first item if no prioritized category matched
+    if (!utiqMtpPass) {
+      utiqMtpPass = idGraph[0];
+    }
 
     logInfo(
       `${LOG_PREFIX}: Graph of utiqPass: ${JSON.stringify(
-        utiqPass
+        utiqMtpPass
       )}`
     );
   }
 
   return {
-    utiqMtp: utiqPass && utiqPass.mtid
+    utiqMtp: utiqMtpPass && utiqMtpPass.mtid
       ? {
-          mtid: utiqPass.mtid,
-          category: utiqPass.category,
+          mtid: utiqMtpPass.mtid,
+          category: utiqMtpPass.category,
         }
       : null
   };

--- a/test/spec/modules/utiqIdSystem_spec.js
+++ b/test/spec/modules/utiqIdSystem_spec.js
@@ -48,18 +48,21 @@ describe('utiqIdSystem', () => {
       const idGraph = {
         'domain': 'test.domain',
         'atid': 'atidValue',
+        'category': 'categoryValue',
       };
       storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData(idGraph)));
       const response = utiqIdSubmodule.getId();
       expect(response).to.have.property('id');
       expect(response.id).to.have.property('utiq');
-      expect(response.id.utiq).to.be.equal('atidValue');
+      expect(response.id.utiq.id).to.be.equal('atidValue');
+      expect(response.id.utiq.category).to.be.equal('categoryValue');
     });
 
     it('returns {utiq: data.utiq} if we have the right data stored in the localstorage right after the callback is called', (done) => {
       const idGraph = {
         'domain': 'test.domain',
         'atid': 'atidValue',
+        'category': 'categoryValue',
       };
       const response = utiqIdSubmodule.getId();
       expect(response).to.have.property('callback');
@@ -70,7 +73,8 @@ describe('utiqIdSystem', () => {
         response.callback(function (result) {
           expect(result).to.not.be.null;
           expect(result).to.have.property('utiq');
-          expect(result.utiq).to.be.equal('atidValue');
+          expect(result.utiq.id).to.be.equal('atidValue');
+          expect(result.utiq.category).to.be.equal('categoryValue');
           done();
         });
       }
@@ -80,6 +84,7 @@ describe('utiqIdSystem', () => {
       const idGraph = {
         'domain': 'test.domain',
         'atid': 'atidValue',
+        'category': 'categoryValue',
       };
 
       const response = utiqIdSubmodule.getId();
@@ -93,7 +98,8 @@ describe('utiqIdSystem', () => {
         response.callback(function (result) {
           expect(result).to.not.be.null;
           expect(result).to.have.property('utiq');
-          expect(result.utiq).to.be.equal('atidValue');
+          expect(result.utiq.id).to.be.equal('atidValue');
+          expect(result.utiq.category).to.be.equal('categoryValue');
           done();
         });
       }
@@ -167,6 +173,7 @@ describe('utiqIdSystem', () => {
         const idGraph = {
           'domain': domain,
           'atid': 'atidValue',
+          'category': 'categoryValue',
         };
 
         storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData(idGraph)));
@@ -180,7 +187,8 @@ describe('utiqIdSystem', () => {
         const response = utiqIdSubmodule.getId();
         expect(response).to.have.property('id');
         expect(response.id).to.have.property('utiq');
-        expect(response.id.utiq).to.be.equal('atidValue');
+        expect(response.id.utiq.id).to.be.equal('atidValue');
+        expect(response.id.utiq.category).to.be.equal('categoryValue');
         done();
       });
     });
@@ -196,6 +204,7 @@ describe('utiqIdSystem', () => {
       storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData({
         'domain': 'TEST DOMAIN',
         'atid': 'TEST ATID',
+        'category': 'categoryValue',
       }))); // setting idGraph
       storage.setDataInLocalStorage(netIdKey, ''); // setting an empty value
 
@@ -203,7 +212,8 @@ describe('utiqIdSystem', () => {
       const response = utiqIdSubmodule.getId();
 
       // then
-      expect(response.id.utiq).to.be.equal('TEST ATID');
+      expect(response.id.utiq.id).to.be.equal('TEST ATID');
+      expect(response.id.utiq.category).to.be.equal('categoryValue');
       done();
     });
 

--- a/test/spec/modules/utiqIdSystem_spec.js
+++ b/test/spec/modules/utiqIdSystem_spec.js
@@ -7,11 +7,11 @@ describe('utiqIdSystem', () => {
 
   const getStorageData = (idGraph) => {
     if (!idGraph) {
-      idGraph = { id: 501, domain: '' };
+      idGraph = [{ id: 501, domain: '' }];
     }
     return {
       'connectId': {
-        'idGraph': [idGraph],
+        'idGraph': idGraph,
       }
     };
   };
@@ -36,20 +36,20 @@ describe('utiqIdSystem', () => {
     });
 
     it('tests if localstorage & JSON works properly ', () => {
-      const idGraph = {
+      const idGraph = [{
         'domain': 'domainValue',
         'atid': 'atidValue',
-      };
+      }];
       storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData(idGraph)));
       expect(JSON.parse(storage.getDataFromLocalStorage(utiqPassKey))).to.have.property('connectId');
     });
 
     it('returns {id: {utiq: data.utiq}} if we have the right data stored in the localstorage ', () => {
-      const idGraph = {
+      const idGraph = [{
         'domain': 'test.domain',
         'atid': 'atidValue',
         'category': 'categoryValue',
-      };
+      }];
       storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData(idGraph)));
       const response = utiqIdSubmodule.getId();
       expect(response).to.have.property('id');
@@ -59,11 +59,11 @@ describe('utiqIdSystem', () => {
     });
 
     it('returns {utiq: data.utiq} if we have the right data stored in the localstorage right after the callback is called', (done) => {
-      const idGraph = {
+      const idGraph = [{
         'domain': 'test.domain',
         'atid': 'atidValue',
         'category': 'categoryValue',
-      };
+      }];
       const response = utiqIdSubmodule.getId();
       expect(response).to.have.property('callback');
       expect(response.callback.toString()).contain('result(callback)');
@@ -81,11 +81,11 @@ describe('utiqIdSystem', () => {
     });
 
     it('returns {utiq: data.utiq} if we have the right data stored in the localstorage right after 500ms delay', (done) => {
-      const idGraph = {
+      const idGraph = [{
         'domain': 'test.domain',
         'atid': 'atidValue',
         'category': 'categoryValue',
-      };
+      }];
 
       const response = utiqIdSubmodule.getId();
       expect(response).to.have.property('callback');
@@ -106,10 +106,10 @@ describe('utiqIdSystem', () => {
     });
 
     it('returns null if we have the data stored in the localstorage after 500ms delay and the max (waiting) delay is only 200ms ', (done) => {
-      const idGraph = {
+      const idGraph = [{
         'domain': 'test.domain',
         'atid': 'atidValue',
-      };
+      }];
 
       const response = utiqIdSubmodule.getId({ params: { maxDelayTime: 200 } });
       expect(response).to.have.property('callback');
@@ -170,11 +170,11 @@ describe('utiqIdSystem', () => {
 
     domains.forEach(domain => {
       it(`correctly sets utiq value for domain name ${domain}`, (done) => {
-        const idGraph = {
+        const idGraph = [{
           'domain': domain,
           'atid': 'atidValue',
           'category': 'categoryValue',
-        };
+        }];
 
         storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData(idGraph)));
 
@@ -201,11 +201,11 @@ describe('utiqIdSystem', () => {
 
     it(`correctly set utiqPassKey as adtechpass utiq value for ${netIdKey} empty`, (done) => {
       // given
-      storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData({
+      storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData([{
         'domain': 'TEST DOMAIN',
         'atid': 'TEST ATID',
         'category': 'categoryValue',
-      }))); // setting idGraph
+      }]))); // setting idGraph
       storage.setDataInLocalStorage(netIdKey, ''); // setting an empty value
 
       // when
@@ -217,19 +217,61 @@ describe('utiqIdSystem', () => {
       done();
     });
 
-    it(`correctly set netIdAdtechpass as adtechpass utiq value for ${netIdKey} settled`, (done) => {
+    it(`correctly set utiqPassKey as adtechpass utiq value for ${netIdKey} settled on mobile connection`, (done) => {
       // given
-      storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData({
+      storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData([{
         'domain': 'TEST DOMAIN',
         'atid': 'TEST ATID',
-      }))); // setting idGraph
+        'category': 'mobile',
+      }]))); // setting idGraph
       storage.setDataInLocalStorage(netIdKey, 'testNetIdValue'); // setting a correct value
 
       // when
       const response = utiqIdSubmodule.getId();
 
       // then
-      expect(response.id.utiq).to.be.equal('testNetIdValue');
+      expect(response.id.utiq.atid).to.be.equal('TEST ATID');
+      expect(response.id.utiq.category).to.be.equal('mobile');
+      done();
+    });
+
+    it(`correctly set utiqPassKey as adtechpass utiq value for ${netIdKey} settled on mobile connection found in the idGraph`, (done) => {
+      // given
+      storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData([{
+        'domain': 'TEST DOMAIN',
+        'atid': 'TEST FIXED ATID',
+        'category': 'fixed',
+      }, {
+        'domain': 'TEST DOMAIN',
+        'atid': 'TEST MOBILE ATID',
+        'category': 'mobile',
+      }]))); // setting idGraph
+      storage.setDataInLocalStorage(netIdKey, 'testNetIdValue'); // setting a correct value
+
+      // when
+      const response = utiqIdSubmodule.getId();
+
+      // then
+      expect(response.id.utiq.atid).to.be.equal('TEST MOBILE ATID');
+      expect(response.id.utiq.category).to.be.equal('mobile');
+      done();
+    });
+
+    it(`correctly set netIdAdtechpass as adtechpass utiq value for ${netIdKey} settled on fixed connection`, (done) => {
+      // given
+      storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData([{
+        'domain': 'TEST DOMAIN',
+        'atid': 'TEST ATID',
+        'category': 'fixed',
+      }]))); // setting idGraph
+      storage.setDataInLocalStorage(netIdKey, 'testNetIdValue'); // setting a correct value
+
+      // when
+      const response = utiqIdSubmodule.getId();
+
+      // then
+      expect(response.id.utiq.atid).to.be.equal('testNetIdValue');
+      expect(response.id.utiq.category).to.be.equal('netid');
       done();
     });
   });

--- a/test/spec/modules/utiqIdSystem_spec.js
+++ b/test/spec/modules/utiqIdSystem_spec.js
@@ -54,7 +54,7 @@ describe('utiqIdSystem', () => {
       const response = utiqIdSubmodule.getId();
       expect(response).to.have.property('id');
       expect(response.id).to.have.property('utiq');
-      expect(response.id.utiq.id).to.be.equal('atidValue');
+      expect(response.id.utiq.atid).to.be.equal('atidValue');
       expect(response.id.utiq.category).to.be.equal('categoryValue');
     });
 
@@ -73,7 +73,7 @@ describe('utiqIdSystem', () => {
         response.callback(function (result) {
           expect(result).to.not.be.null;
           expect(result).to.have.property('utiq');
-          expect(result.utiq.id).to.be.equal('atidValue');
+          expect(result.utiq.atid).to.be.equal('atidValue');
           expect(result.utiq.category).to.be.equal('categoryValue');
           done();
         });
@@ -98,7 +98,7 @@ describe('utiqIdSystem', () => {
         response.callback(function (result) {
           expect(result).to.not.be.null;
           expect(result).to.have.property('utiq');
-          expect(result.utiq.id).to.be.equal('atidValue');
+          expect(result.utiq.atid).to.be.equal('atidValue');
           expect(result.utiq.category).to.be.equal('categoryValue');
           done();
         });
@@ -187,7 +187,7 @@ describe('utiqIdSystem', () => {
         const response = utiqIdSubmodule.getId();
         expect(response).to.have.property('id');
         expect(response.id).to.have.property('utiq');
-        expect(response.id.utiq.id).to.be.equal('atidValue');
+        expect(response.id.utiq.atid).to.be.equal('atidValue');
         expect(response.id.utiq.category).to.be.equal('categoryValue');
         done();
       });
@@ -212,7 +212,7 @@ describe('utiqIdSystem', () => {
       const response = utiqIdSubmodule.getId();
 
       // then
-      expect(response.id.utiq.id).to.be.equal('TEST ATID');
+      expect(response.id.utiq.atid).to.be.equal('TEST ATID');
       expect(response.id.utiq.category).to.be.equal('categoryValue');
       done();
     });

--- a/test/spec/modules/utiqMtpIdSystem_spec.js
+++ b/test/spec/modules/utiqMtpIdSystem_spec.js
@@ -6,11 +6,11 @@ describe('utiqMtpIdSystem', () => {
 
   const getStorageData = (idGraph) => {
     if (!idGraph) {
-      idGraph = { id: 501, domain: '' };
+      idGraph = [{ id: 501, domain: '' }];
     }
     return {
       'connectId': {
-        'idGraph': [idGraph],
+        'idGraph': idGraph,
       }
     };
   };
@@ -35,20 +35,20 @@ describe('utiqMtpIdSystem', () => {
     });
 
     it('tests if localstorage & JSON works properly ', () => {
-      const idGraph = {
+      const idGraph = [{
         'domain': 'domainValue',
         'mtid': 'mtidValue',
-      };
+      }];
       storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData(idGraph)));
       expect(JSON.parse(storage.getDataFromLocalStorage(utiqPassKey))).to.have.property('connectId');
     });
 
     it('returns {id: {utiq: data.utiq}} if we have the right data stored in the localstorage ', () => {
-      const idGraph = {
+      const idGraph = [{
         'domain': 'test.domain',
         'mtid': 'mtidValue',
         'category': 'categoryValue',
-      };
+      }];
       storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData(idGraph)));
       const response = utiqMtpIdSubmodule.getId();
       expect(response).to.have.property('id');
@@ -58,11 +58,11 @@ describe('utiqMtpIdSystem', () => {
     });
 
     it('returns {utiqMtp: data.utiqMtp} if we have the right data stored in the localstorage right after the callback is called', (done) => {
-      const idGraph = {
+      const idGraph = [{
         'domain': 'test.domain',
         'mtid': 'mtidValue',
         'category': 'categoryValue',
-      };
+      }];
       const response = utiqMtpIdSubmodule.getId();
       expect(response).to.have.property('callback');
       expect(response.callback.toString()).contain('result(callback)');
@@ -80,11 +80,11 @@ describe('utiqMtpIdSystem', () => {
     });
 
     it('returns {utiqMtp: data.utiqMtp} if we have the right data stored in the localstorage right after 500ms delay', (done) => {
-      const idGraph = {
+      const idGraph = [{
         'domain': 'test.domain',
         'mtid': 'mtidValue',
         'category': 'categoryValue',
-      };
+      }];
 
       const response = utiqMtpIdSubmodule.getId();
       expect(response).to.have.property('callback');
@@ -105,10 +105,10 @@ describe('utiqMtpIdSystem', () => {
     });
 
     it('returns null if we have the data stored in the localstorage after 500ms delay and the max (waiting) delay is only 200ms ', (done) => {
-      const idGraph = {
+      const idGraph = [{
         'domain': 'test.domain',
         'mtid': 'mtidValue',
-      };
+      }];
 
       const response = utiqMtpIdSubmodule.getId({ params: { maxDelayTime: 200 } });
       expect(response).to.have.property('callback');
@@ -169,11 +169,11 @@ describe('utiqMtpIdSystem', () => {
 
     domains.forEach(domain => {
       it(`correctly sets utiq value for domain name ${domain}`, (done) => {
-        const idGraph = {
+        const idGraph = [{
           'domain': domain,
           'mtid': 'mtidValue',
           'category': 'categoryValue',
-        };
+        }];
 
         storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData(idGraph)));
 
@@ -190,6 +190,33 @@ describe('utiqMtpIdSystem', () => {
         expect(response.id.utiqMtp.category).to.be.equal('categoryValue');
         done();
       });
+    });
+  });
+
+  describe('utiq getUtiqFromStorage', () => {
+    afterEach(() => {
+      storage.removeDataFromLocalStorage(utiqPassKey);
+    });
+
+    it(`correctly set mobilePassKey as martechpass utiq value on mobile connection found in the idGraph`, (done) => {
+      // given
+      storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData([{
+        'domain': 'TEST DOMAIN',
+        'mtid': 'TEST FIXED MTID',
+        'category': 'fixed',
+      }, {
+        'domain': 'TEST DOMAIN',
+        'mtid': 'TEST MOBILE MTID',
+        'category': 'mobile',
+      }]))); // setting idGraph
+
+      // when
+      const response = utiqMtpIdSubmodule.getId();
+
+      // then
+      expect(response.id.utiqMtp.mtid).to.be.equal('TEST MOBILE MTID');
+      expect(response.id.utiqMtp.category).to.be.equal('mobile');
+      done();
     });
   });
 });

--- a/test/spec/modules/utiqMtpIdSystem_spec.js
+++ b/test/spec/modules/utiqMtpIdSystem_spec.js
@@ -47,18 +47,21 @@ describe('utiqMtpIdSystem', () => {
       const idGraph = {
         'domain': 'test.domain',
         'mtid': 'mtidValue',
+        'category': 'categoryValue',
       };
       storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData(idGraph)));
       const response = utiqMtpIdSubmodule.getId();
       expect(response).to.have.property('id');
       expect(response.id).to.have.property('utiqMtp');
-      expect(response.id.utiqMtp).to.be.equal('mtidValue');
+      expect(response.id.utiqMtp.id).to.be.equal('mtidValue');
+      expect(response.id.utiqMtp.category).to.be.equal('categoryValue');
     });
 
     it('returns {utiqMtp: data.utiqMtp} if we have the right data stored in the localstorage right after the callback is called', (done) => {
       const idGraph = {
         'domain': 'test.domain',
         'mtid': 'mtidValue',
+        'category': 'categoryValue',
       };
       const response = utiqMtpIdSubmodule.getId();
       expect(response).to.have.property('callback');
@@ -69,7 +72,8 @@ describe('utiqMtpIdSystem', () => {
         response.callback(function (result) {
           expect(result).to.not.be.null;
           expect(result).to.have.property('utiqMtp');
-          expect(result.utiqMtp).to.be.equal('mtidValue');
+          expect(result.utiqMtp.id).to.be.equal('mtidValue');
+          expect(result.utiqMtp.category).to.be.equal('categoryValue');
           done();
         });
       }
@@ -79,6 +83,7 @@ describe('utiqMtpIdSystem', () => {
       const idGraph = {
         'domain': 'test.domain',
         'mtid': 'mtidValue',
+        'category': 'categoryValue',
       };
 
       const response = utiqMtpIdSubmodule.getId();
@@ -92,7 +97,8 @@ describe('utiqMtpIdSystem', () => {
         response.callback(function (result) {
           expect(result).to.not.be.null;
           expect(result).to.have.property('utiqMtp');
-          expect(result.utiqMtp).to.be.equal('mtidValue');
+          expect(result.utiqMtp.id).to.be.equal('mtidValue');
+          expect(result.utiqMtp.category).to.be.equal('categoryValue');
           done();
         });
       }
@@ -166,6 +172,7 @@ describe('utiqMtpIdSystem', () => {
         const idGraph = {
           'domain': domain,
           'mtid': 'mtidValue',
+          'category': 'categoryValue',
         };
 
         storage.setDataInLocalStorage(utiqPassKey, JSON.stringify(getStorageData(idGraph)));
@@ -179,7 +186,8 @@ describe('utiqMtpIdSystem', () => {
         const response = utiqMtpIdSubmodule.getId();
         expect(response).to.have.property('id');
         expect(response.id).to.have.property('utiqMtp');
-        expect(response.id.utiqMtp).to.be.equal('mtidValue');
+        expect(response.id.utiqMtp.id).to.be.equal('mtidValue');
+        expect(response.id.utiqMtp.category).to.be.equal('categoryValue');
         done();
       });
     });

--- a/test/spec/modules/utiqMtpIdSystem_spec.js
+++ b/test/spec/modules/utiqMtpIdSystem_spec.js
@@ -53,7 +53,7 @@ describe('utiqMtpIdSystem', () => {
       const response = utiqMtpIdSubmodule.getId();
       expect(response).to.have.property('id');
       expect(response.id).to.have.property('utiqMtp');
-      expect(response.id.utiqMtp.id).to.be.equal('mtidValue');
+      expect(response.id.utiqMtp.mtid).to.be.equal('mtidValue');
       expect(response.id.utiqMtp.category).to.be.equal('categoryValue');
     });
 
@@ -72,7 +72,7 @@ describe('utiqMtpIdSystem', () => {
         response.callback(function (result) {
           expect(result).to.not.be.null;
           expect(result).to.have.property('utiqMtp');
-          expect(result.utiqMtp.id).to.be.equal('mtidValue');
+          expect(result.utiqMtp.mtid).to.be.equal('mtidValue');
           expect(result.utiqMtp.category).to.be.equal('categoryValue');
           done();
         });
@@ -97,7 +97,7 @@ describe('utiqMtpIdSystem', () => {
         response.callback(function (result) {
           expect(result).to.not.be.null;
           expect(result).to.have.property('utiqMtp');
-          expect(result.utiqMtp.id).to.be.equal('mtidValue');
+          expect(result.utiqMtp.mtid).to.be.equal('mtidValue');
           expect(result.utiqMtp.category).to.be.equal('categoryValue');
           done();
         });
@@ -186,7 +186,7 @@ describe('utiqMtpIdSystem', () => {
         const response = utiqMtpIdSubmodule.getId();
         expect(response).to.have.property('id');
         expect(response.id).to.have.property('utiqMtp');
-        expect(response.id.utiqMtp.id).to.be.equal('mtidValue');
+        expect(response.id.utiqMtp.mtid).to.be.equal('mtidValue');
         expect(response.id.utiqMtp.category).to.be.equal('categoryValue');
         done();
       });


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
Upgraded utiq modules to pass the category ('mobile' | 'fixed' ) in the `ext` response for `pbjs.getUserIdsAsEids()`


## Other information
