### PR TITLE
OneTag Bid Adapter: send the auction timeout as ortb2.tmax

### DIFF
--- a/modules/onetagBidAdapter.js
+++ b/modules/onetagBidAdapter.js
@@ -134,6 +134,12 @@ function buildRequests(validBidRequests, bidderRequest) {
   if (bidderRequest && bidderRequest.ortb2) {
     payload.ortb2 = bidderRequest.ortb2;
   }
+  const tmax = parseInt(bidderRequest && bidderRequest.timeout, 10);
+  if (!isNaN(tmax)) {
+    // Mirror core's ORTB converter: the auction timeout wins over any publisher-set
+    // `ortb2.tmax`. Shallow-copy first, `bidderRequest.ortb2` is shared with every bid.
+    payload.ortb2 = { ...payload.ortb2, tmax };
+  }
   if (validBidRequests && validBidRequests.length !== 0 && validBidRequests[0].userIdAsEids) {
     payload.userId = validBidRequests[0].userIdAsEids;
   }
@@ -296,7 +302,7 @@ function getPageInfo(bidderRequest) {
     timing: getTiming(),
     version: {
       prebid: '$prebid.version$',
-      adapter: '1.1.8'
+      adapter: '1.1.9'
     }
   };
 }

--- a/test/spec/modules/onetagBidAdapter_spec.js
+++ b/test/spec/modules/onetagBidAdapter_spec.js
@@ -737,7 +737,7 @@ describe('onetag', function () {
       const serverRequest = spec.buildRequests([bannerBid], bidderRequest);
       const payload = JSON.parse(serverRequest.data);
       expect(payload.ortb2).to.exist;
-      expect(payload.ortb2).to.exist.and.to.deep.equal(firtPartyData);
+      expect(payload.ortb2).to.exist.and.to.deep.equal({ ...firtPartyData, tmax: 3000 });
     });
     it('Should send DSA (ortb2 field)', function () {
       const dsa = {
@@ -765,7 +765,53 @@ describe('onetag', function () {
       const serverRequest = spec.buildRequests([bannerBid], bidderRequest);
       const payload = JSON.parse(serverRequest.data);
       expect(payload.ortb2).to.exist;
-      expect(payload.ortb2).to.exist.and.to.deep.equal(dsa);
+      expect(payload.ortb2).to.exist.and.to.deep.equal({ ...dsa, tmax: 3000 });
+    });
+    it('Should send the auction timeout as ortb2.tmax', function () {
+      const bidderRequest = {
+        'bidderCode': 'onetag',
+        'auctionId': '1d1a030790a475',
+        'bidderRequestId': '22edbae2733bf6',
+        'timeout': 1200
+      };
+      const serverRequest = spec.buildRequests([bannerBid], bidderRequest);
+      const payload = JSON.parse(serverRequest.data);
+      expect(payload.ortb2.tmax).to.equal(1200);
+    });
+    it('Should let the auction timeout win over a publisher-set ortb2.tmax', function () {
+      const bidderRequest = {
+        'bidderCode': 'onetag',
+        'auctionId': '1d1a030790a475',
+        'bidderRequestId': '22edbae2733bf6',
+        'timeout': 1200,
+        'ortb2': { tmax: 500, site: { domain: 'page.example.com' } }
+      };
+      const serverRequest = spec.buildRequests([bannerBid], bidderRequest);
+      const payload = JSON.parse(serverRequest.data);
+      expect(payload.ortb2.tmax).to.equal(1200);
+      expect(payload.ortb2.site.domain).to.equal('page.example.com');
+    });
+    it('Should not set ortb2.tmax when the auction timeout is not a number', function () {
+      const bidderRequest = {
+        'bidderCode': 'onetag',
+        'auctionId': '1d1a030790a475',
+        'bidderRequestId': '22edbae2733bf6'
+      };
+      const serverRequest = spec.buildRequests([bannerBid], bidderRequest);
+      const payload = JSON.parse(serverRequest.data);
+      expect(payload.ortb2).to.be.undefined;
+    });
+    it('Should not mutate the shared ortb2 object of the bidder request', function () {
+      const ortb2 = { site: { domain: 'page.example.com' } };
+      const bidderRequest = {
+        'bidderCode': 'onetag',
+        'auctionId': '1d1a030790a475',
+        'bidderRequestId': '22edbae2733bf6',
+        'timeout': 1200,
+        ortb2
+      };
+      spec.buildRequests([bannerBid], bidderRequest);
+      expect(ortb2).to.deep.equal({ site: { domain: 'page.example.com' } });
     });
     it('Should send FLEDGE eligibility flag set to false when fledgeEnabled is not defined', function () {
       const bidderRequest = {


### PR DESCRIPTION
## Type of change

- [x] Updated bidder adapter

## Description of change

`buildRequests` copied `bidderRequest.ortb2` verbatim into the payload and
never set `tmax`, so our endpoint received no indication of the auction
timeout it was being held to. This sets `ortb2.tmax` from
`bidderRequest.timeout`.

The behaviour mirrors core's ORTB converter
(`libraries/ortbConverter/processors/default.js`), which sets
`ortbRequest.tmax = parseInt(bidderRequest.timeout, 10)` after the FPD merge:
the auction timeout takes precedence over a publisher-set `ortb2.tmax`. This
adapter builds its request by hand, so it never inherited that behaviour.

`bidderRequest.ortb2` is shared by reference with every bid request and with
the already-emitted `bidRequested` event, so the object is shallow-copied
before the field is added rather than mutated in place. A test covers this.

Tests added for: the timeout being sent as `ortb2.tmax`, the auction value
winning over a publisher-set `ortb2.tmax`, the field being omitted when the
timeout is not a number, and the bidder request's `ortb2` not being mutated.
Two existing assertions that deep-compared the whole `ortb2` object were
updated accordingly.

Adapter version bumped to 1.1.9.

## Other information

No bidder parameters change, so no docs PR is needed.
