### PR TITLE
51Degrees RTD Module: name the Model Terms for Marketing on every 51Did eids entry

### DIFF
--- a/modules/51DegreesRtdProvider.js
+++ b/modules/51DegreesRtdProvider.js
@@ -16,6 +16,16 @@ const MODULE_NAME = '51Degrees';
 export const LOG_PREFIX = `[${MODULE_NAME} RTD Submodule]:`;
 const { logMessage, logWarn, logError } = prefixLog(LOG_PREFIX);
 
+// The Model Terms for Marketing, published by the Movement for an Open
+// Web, which every party sending or receiving a 51Did is bound by. They
+// are the legal basis a receiver acts under, so they are named on every
+// 51d.es eids entry rather than left for the receiver to find. The
+// document is versioned and cannot be changed once published, which is
+// what the Terms Document Locator specification asks of a terms
+// document. A publisher's own TDL is listed after this one, being the
+// more specific statement, and never in place of it.
+export const MODEL_TERMS_URL = 'https://m4ow.uk/mtm/2.txt';
+
 // ORTB device types
 const ORTB_DEVICE_TYPE = {
   UNKNOWN: 0,
@@ -416,8 +426,9 @@ const FODID_EID = {
  * atype 1, and Hashed Email is mm 3 (authenticated) atype 3. The type
  * comes from which type-specific property the cloud populated (see
  * FODID_EID). A type's license and global values share its entry,
- * license value first. ext.tdl is populated from the supplied URL on
- * every entry when present, and omitted otherwise.
+ * license value first. ext.tdl names the Model Terms for Marketing on
+ * every entry, followed by the publisher's own TDL when one is
+ * configured.
  *
  * @param {Object} fodid 51Degrees fodid object
  * @param {string} [fodid.idproblic] License-tier Probabilistic 51DiD
@@ -457,15 +468,14 @@ export const convert51DegreesFoDiDToOrtb2 = (fodid, tdlUrl) => {
 
   const eids = [];
   byMm.forEach((uids, mm) => {
-    const entry = { inserter: '51degrees.com', source: '51d.es', mm, uids };
-    if (tdlUrl) {
-      entry.ext = { tdl: [tdlUrl] };
-    }
-    eids.push(entry);
+    // A fresh array per entry, so a consumer that edits one entry's
+    // terms does not edit every other entry's at the same time.
+    const tdl = tdlUrl ? [MODEL_TERMS_URL, tdlUrl] : [MODEL_TERMS_URL];
+    eids.push({ inserter: '51degrees.com', source: '51d.es', mm, uids, ext: { tdl } });
   });
 
   if (!tdlUrl) {
-    logWarn('tdlUrl is not configured; emitting eids entries without ext.tdl');
+    logWarn('tdlUrl is not configured; eids entries name the Model Terms alone in ext.tdl');
   }
 
   return { user: { eids } };

--- a/test/spec/modules/51DegreesRtdProvider_spec.js
+++ b/test/spec/modules/51DegreesRtdProvider_spec.js
@@ -15,6 +15,7 @@ import {
   getPageFodErrors,
   storageManager,
   fiftyOneDegreesSubmodule,
+  MODEL_TERMS_URL,
 } from 'modules/51DegreesRtdProvider';
 import { mergeDeep } from '../../../src/utils.js';
 import { loadExternalScriptStub } from 'test/mocks/adloaderStub.js';
@@ -484,7 +485,7 @@ describe('51DegreesRtdProvider', function() {
       const result = convert51DegreesDataToOrtb2(data51, { tdlUrl: 'https://tdl.example/x' });
       expect(result.user.eids).to.have.lengthOf(1);
       expect(result.user.eids[0].uids).to.deep.equal([{ id: 'lic-uid', atype: 1 }, { id: 'global-uid', atype: 1 }]);
-      expect(result.user.eids[0].ext.tdl).to.deep.equal(['https://tdl.example/x']);
+      expect(result.user.eids[0].ext.tdl).to.deep.equal([MODEL_TERMS_URL, 'https://tdl.example/x']);
     });
 
     it('returns only device mapping when ip and fodid are absent', function () {
@@ -782,16 +783,32 @@ describe('51DegreesRtdProvider', function() {
             source: '51d.es',
             mm: 5,
             uids: [{ id: 'lic-uid-base64', atype: 1 }, { id: 'global-uid-base64', atype: 1 }],
-            ext: { tdl: [TDL_URL] },
+            ext: { tdl: [MODEL_TERMS_URL, TDL_URL] },
           }],
         },
       });
     });
 
-    it('omits ext.tdl when tdlUrl is falsy', function() {
+    it('names the Model Terms alone when tdlUrl is falsy', function() {
       const result = convert51DegreesFoDiDToOrtb2(fullFodid, undefined);
-      expect(result.user.eids[0].ext).to.be.undefined;
+      expect(result.user.eids[0].ext.tdl).to.deep.equal([MODEL_TERMS_URL]);
       expect(result.user.eids[0].uids).to.deep.equal([{ id: 'lic-uid-base64', atype: 1 }, { id: 'global-uid-base64', atype: 1 }]);
+    });
+
+    it('names the Model Terms first and the publisher TDL second', function() {
+      const result = convert51DegreesFoDiDToOrtb2(fullFodid, TDL_URL);
+      expect(result.user.eids[0].ext.tdl).to.deep.equal([MODEL_TERMS_URL, TDL_URL]);
+    });
+
+    it('gives every entry its own terms array', function() {
+      const result = convert51DegreesFoDiDToOrtb2({
+        idproblic: 'p-lic',
+        idrandlic: 'r-lic',
+      }, TDL_URL);
+      expect(result.user.eids).to.have.lengthOf(2);
+      expect(result.user.eids[0].ext.tdl).to.not.equal(result.user.eids[1].ext.tdl);
+      result.user.eids[0].ext.tdl.push('https://elsewhere.example/y');
+      expect(result.user.eids[1].ext.tdl).to.deep.equal([MODEL_TERMS_URL, TDL_URL]);
     });
 
     it('emits entry with only idproblic when idprobglobal is absent', function() {
@@ -846,7 +863,8 @@ describe('51DegreesRtdProvider', function() {
       expect(result.user.eids).to.have.lengthOf(3);
       expect(result.user.eids.map((e) => e.mm)).to.deep.equal([5, 0, 3]);
       expect(result.user.eids.every((e) => e.source === '51d.es')).to.equal(true);
-      expect(result.user.eids.every((e) => e.ext.tdl[0] === TDL_URL)).to.equal(true);
+      expect(result.user.eids.every((e) => e.ext.tdl[0] === MODEL_TERMS_URL)).to.equal(true);
+      expect(result.user.eids.every((e) => e.ext.tdl[1] === TDL_URL)).to.equal(true);
       expect(result.user.eids[2].uids).to.deep.equal(
         [{ id: 'h-lic', atype: 3 }, { id: 'h-global', atype: 3 }]);
     });
@@ -1102,7 +1120,7 @@ describe('51DegreesRtdProvider', function() {
       expect(reqBidsConfigObj.ortb2Fragments.global.user.eids[0].uids)
         .to.deep.equal([{ id: 'lic-uid', atype: 1 }, { id: 'global-uid', atype: 1 }]);
       expect(reqBidsConfigObj.ortb2Fragments.global.user.eids[0].ext.tdl)
-        .to.deep.equal(['https://tdl.example/x']);
+        .to.deep.equal([MODEL_TERMS_URL, 'https://tdl.example/x']);
     });
 
     it('does not overwrite a publisher-set device.ip / device.ipv6', async function() {


### PR DESCRIPTION
## Type of change

- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change

Every party sending or receiving a 51Did is bound by the [Model Terms for Marketing](https://m4ow.uk/mtm), published by the Movement for an Open Web. They are the legal basis a receiver acts under, so `ext.tdl` now names them on every `51d.es` eids entry rather than leaving a receiver to find them.

```js
export const MODEL_TERMS_URL = 'https://m4ow.uk/mtm/2.txt';
...
const tdl = tdlUrl ? [MODEL_TERMS_URL, tdlUrl] : [MODEL_TERMS_URL];
eids.push({ inserter: '51degrees.com', source: '51d.es', mm, uids, ext: { tdl } });
```

The versioned text is used rather than the explainer page, because the [Terms Document Locator specification](https://github.com/jwrosewell/data-labels/blob/main/OpenRTB.md) asks that a terms document be human readable, immutable and never change once published, with versioning recommended. Version 2 meets that, and its own copyright statement forbids changing it.

A publisher's own TDL, from `params.tdlUrl`, is listed after the Model Terms rather than in place of them, being the more specific statement of the same kind. The specification allows several documents in one array.

Three consequences worth calling out for review.

1. An entry is no longer emitted without `ext.tdl`, because the Model Terms always apply. Previously `ext` was absent when `params.tdlUrl` was not configured.
2. The warning for a missing publisher TDL still fires, and now says what the entry carries instead.
3. Each entry gets its own array, so a consumer that edits one entry's terms does not edit every other entry's at the same time. The previous code created one array per entry as well, but the new form makes that explicit because the array is now always present.

## Tests

Added to `test/spec/modules/51DegreesRtdProvider_spec.js`:

- the Model Terms come first and the publisher TDL second
- the Model Terms are named on their own when `tdlUrl` is falsy, replacing the test that asserted `ext` was absent
- every entry names the terms, across all three identifier types
- every entry has its own terms array, and editing one does not change another

The existing assertions that named `TDL_URL` alone are updated to the new order.

## Documentation

Companion pull request on the docs repository: https://github.com/prebid/prebid.github.io/pull/6730 It documents this change and corrects two claims on the same page, being a description of 51Did as "privacy-safe" and a description of `device.ext.fod.deviceId` as "a permanent device ID".

## Notes

Written with AI assistance and reviewed by 51Degrees before submission.
