### PR TITLE
Gulp: Fix for Semicolon insertion

### DIFF
--- a/gulpHelpers.js
+++ b/gulpHelpers.js
@@ -86,7 +86,7 @@ const SOURCE_FOLDERS = [
   'modules',
   'test',
   'public'
-]
+];
 
 // get only subdirectories that contain package.json with 'main' property
 function isModuleDirectory(filePath) {

--- a/gulpHelpers.js
+++ b/gulpHelpers.js
@@ -74,7 +74,7 @@ tokens.forEach((token) => {
   }
 });
 
-const PRECOMPILED_PATH = './dist/src'
+const PRECOMPILED_PATH = './dist/src';
 const MODULE_PATH = './modules';
 const BUILD_PATH = './build/dist';
 const DEV_PATH = './build/dev';


### PR DESCRIPTION
The fix is to make semicolon usage consistent by explicitly terminating the `SOURCE_FOLDERS` array declaration with a semicolon.

Best fix (no functional change):
- In `gulpHelpers.js`, update the declaration ending on line 89 from `]` to `];`.
- This is a minimal style-only change that preserves behavior and resolves the CodeQL finding.
- No imports, new methods, or variable definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._