### PR TITLE
Build system: update artifact downloads to v8

### DIFF
--- a/.github/actions/load/action.yml
+++ b/.github/actions/load/action.yml
@@ -25,7 +25,6 @@ runs:
     - name: Download artifact
       id: download
       continue-on-error: true
-      # Automated fix prepared by a Codex bot.
       uses: actions/download-artifact@v8
       with:
         path: '${{ runner.temp }}'

--- a/.github/actions/load/action.yml
+++ b/.github/actions/load/action.yml
@@ -25,7 +25,8 @@ runs:
     - name: Download artifact
       id: download
       continue-on-error: true
-      uses: actions/download-artifact@v7
+      # Automated fix prepared by a Codex bot.
+      uses: actions/download-artifact@v8
       with:
         path: '${{ runner.temp }}'
         name: '${{ inputs.name }}'
@@ -35,7 +36,7 @@ runs:
       run: sleep 10
     - name: Retry downloading artifact
       if: steps.download.outcome != 'success'
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v8
       with:
         path: '${{ runner.temp }}'
         name: '${{ inputs.name }}'


### PR DESCRIPTION
### Motivation
- Fix intermittent `Restore source` failures in GitHub Actions runs where the shared composite `load` action was still using `actions/download-artifact@v7`, preventing matrix jobs from restoring uploaded artifacts (affecting runs such as `34247688999` and `34246629255`).

### Description
- Update the shared artifact loader at `/.github/actions/load/action.yml` to use `actions/download-artifact@v8` for both the initial download and the delayed retry while preserving the existing 10s retry delay. 【F:.github/actions/load/action.yml†L25-L42】

### Testing
- Ran `npx gulp test-build-logic` (68 passing), ran `git diff --check` (no problems), and ran a workflow lint (`actionlint`) which produced two pre-existing findings in unrelated workflow files that were not modified by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6aa0433ef39c832b8688f6334e206aea)