### PR TITLE
Various Bid Adapters: explicitly inherit GVL IDs for short aliases

### DIFF
--- a/modules/mediasquareBidAdapter.js
+++ b/modules/mediasquareBidAdapter.js
@@ -26,7 +26,7 @@ const OUTSTREAM_RENDERER_URL = 'https://acdn.adnxs.com/video/outstream/ANOutstre
 export const spec = {
   code: BIDDER_CODE,
   gvlid: 791,
-  aliases: ['msq'], // short code
+  aliases: [{ code: 'msq', gvlid: 791 }], // short code
   supportedMediaTypes: [BANNER, NATIVE, VIDEO],
   /**
    * Determines whether or not the given bid request is valid.

--- a/modules/nativeryBidAdapter.js
+++ b/modules/nativeryBidAdapter.js
@@ -18,7 +18,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
  */
 
 const BIDDER_CODE = 'nativery';
-const BIDDER_ALIAS = ['nat'];
+const BIDDER_ALIAS = [{ code: 'nat', gvlid: 1133 }];
 const ENDPOINT = 'https://hb.nativery.com/openrtb2/auction';
 const EVENT_TRACKER_URL = 'https://hb.nativery.com/openrtb2/track-event';
 // Currently we log every event

--- a/modules/performaxBidAdapter.js
+++ b/modules/performaxBidAdapter.js
@@ -116,7 +116,7 @@ export const converter = ortbConverter({
 
 export const spec = {
   code: BIDDER_CODE,
-  aliases: [BIDDER_SHORT_CODE],
+  aliases: [{ code: BIDDER_SHORT_CODE, gvlid: GVLID }],
   gvlid: GVLID,
   supportedMediaTypes: [BANNER],
 

--- a/modules/prismaBidAdapter.js
+++ b/modules/prismaBidAdapter.js
@@ -24,7 +24,7 @@ const GVLID = 965;
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
-  aliases: ['prismadirect'], // short code
+  aliases: [{ code: 'prismadirect', gvlid: GVLID }], // short code
   supportedMediaTypes: [BANNER, VIDEO],
   /**
    * Determines whether or not the given bid request is valid.

--- a/modules/prismaBidAdapter.js
+++ b/modules/prismaBidAdapter.js
@@ -24,7 +24,7 @@ const GVLID = 965;
 export const spec = {
   code: BIDDER_CODE,
   gvlid: GVLID,
-  aliases: [{ code: 'prismadirect', gvlid: GVLID }], // short code
+  aliases: [{ code: 'prismadirect', gvlid: GVLID }],
   supportedMediaTypes: [BANNER, VIDEO],
   /**
    * Determines whether or not the given bid request is valid.

--- a/test/spec/modules/mediasquareBidAdapter_spec.js
+++ b/test/spec/modules/mediasquareBidAdapter_spec.js
@@ -239,7 +239,7 @@ describe('MediaSquare bid adapter tests', function () {
 
   it('Verifies bidder aliases', function () {
     expect(spec.aliases).to.have.lengthOf(1);
-    expect(spec.aliases[0]).to.equal('msq');
+    expect(spec.aliases[0]).to.eql({ code: 'msq', gvlid: 791 });
   });
   it('Verifies if bid request valid', function () {
     expect(spec.isBidRequestValid(DEFAULT_PARAMS[0])).to.equal(true);

--- a/test/spec/modules/nativeryBidAdapter_spec.js
+++ b/test/spec/modules/nativeryBidAdapter_spec.js
@@ -43,6 +43,10 @@ describe('NativeryAdapter', function () {
 
   afterEach(() => sandBox.restore());
 
+  it('declares the nat alias with Nativery\'s GVL ID', function () {
+    expect(spec.aliases).to.deep.equal([{ code: 'nat', gvlid: 1133 }]);
+  });
+
   describe('inherited functions', function () {
     it('exists and is a function', function () {
       expect(adapter.callBids).to.exist.and.to.be.a('function');

--- a/test/spec/modules/performaxBidAdapter_spec.js
+++ b/test/spec/modules/performaxBidAdapter_spec.js
@@ -4,6 +4,10 @@ import * as utils from '../../../src/utils.js';
 import sinon from 'sinon';
 
 describe('Performax adapter', function () {
+  it('declares the px alias with Performax\'s GVL ID', function () {
+    expect(spec.aliases).to.deep.equal([{ code: 'px', gvlid: 732 }]);
+  });
+
   const bids = [{
     bidder: 'performax',
     params: {

--- a/test/spec/modules/prismaBidAdapter_spec.js
+++ b/test/spec/modules/prismaBidAdapter_spec.js
@@ -229,7 +229,7 @@ describe('Prisma bid adapter tests', function () {
 
   it('Verifies bidder aliases', function () {
     expect(spec.aliases).to.have.lengthOf(1);
-    expect(spec.aliases[0]).to.eql('prismadirect');
+    expect(spec.aliases[0]).to.eql({ code: 'prismadirect', gvlid: 965 });
   });
   it('Verifies if bid request valid', function () {
     expect(spec.isBidRequestValid(DISPLAY_BID_REQUEST[0])).to.equal(true);


### PR DESCRIPTION
### Motivation
- Ensure short-code aliases declare the correct GVL vendor mapping so TCF consent and activity-control checks evaluate the intended vendor.
- Prevent implicit inheritance mistakes by making alias→GVL relationships explicit in the adapter metadata.

### Description
- Replace string alias declarations with alias descriptor objects including `code` and `gvlid` in four adapters: `prismadirect` for Prisma (`965`), `msq` for MediaSquare (`791`), `nat` for Nativery (`1133`), and `px` for Performax (`732`).
- Update unit assertions to expect the alias objects instead of plain strings for the affected specs: `test/spec/modules/prismaBidAdapter_spec.js`, `test/spec/modules/mediasquareBidAdapter_spec.js`, `test/spec/modules/nativeryBidAdapter_spec.js`, and `test/spec/modules/performaxBidAdapter_spec.js`.
- Files changed: `modules/prismaBidAdapter.js`, `modules/mediasquareBidAdapter.js`, `modules/nativeryBidAdapter.js`, `modules/performaxBidAdapter.js`, and the four corresponding spec files.

### Testing
- Ran lint for the changed files with `npx gulp lint --files <files>` and it completed successfully.
- Ran the targeted specs with `npx gulp test-only-nobuild --file` for each of the four adapter specs and each spec completed successfully.
- Ran the full unit suite with `npx gulp test-only` and the build+tests completed; the test run finished without failing tests for the modified specs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6aa04bdb0d24832bbb71f9893e4df861)