### PR TITLE
Build system: disable Chrome sandbox for root tests

### DIFF
--- a/karma.conf.maker.js
+++ b/karma.conf.maker.js
@@ -124,6 +124,11 @@ function setReporters(karmaConf, codeCoverage, browserstack, chunkNo) {
   }
 }
 
+function chromeNeedsNoSandbox(isDocker = require('is-docker')(), getuid = process.getuid) {
+  // Codex added the uid check because container detection is not reliable in every agent runtime.
+  return isDocker || (typeof getuid === 'function' && getuid() === 0);
+}
+
 function setBrowsers(karmaConf, browserstack) {
   karmaConf.customLaunchers = karmaConf.customLaunchers || {};
   karmaConf.customLaunchers.ChromeNoSandbox = {
@@ -144,8 +149,7 @@ function setBrowsers(karmaConf, browserstack) {
     karmaConf.customLaunchers = require('./browsers.json');
     karmaConf.browsers = Object.keys(karmaConf.customLaunchers);
   } else {
-    var isDocker = require('is-docker')();
-    if (isDocker) {
+    if (chromeNeedsNoSandbox()) {
       karmaConf.browsers = ['ChromeNoSandbox'];
     } else {
       karmaConf.browsers = ['ChromeHeadless'];
@@ -227,3 +231,5 @@ module.exports = function(codeCoverage, browserstack, watchMode, file, disableFe
   setBrowsers(config, browserstack);
   return config;
 }
+
+module.exports.chromeNeedsNoSandbox = chromeNeedsNoSandbox;

--- a/test/build-logic/karmaConfig_spec.mjs
+++ b/test/build-logic/karmaConfig_spec.mjs
@@ -1,0 +1,25 @@
+import { createRequire } from 'node:module';
+import { expect } from 'chai';
+
+const require = createRequire(import.meta.url);
+const { chromeNeedsNoSandbox } = require('../../karma.conf.maker.js');
+
+describe('Karma configuration', function () {
+  describe('chromeNeedsNoSandbox', function () {
+    it('disables the Chrome sandbox in Docker', function () {
+      expect(chromeNeedsNoSandbox(true, () => 1000)).to.be.true;
+    });
+
+    it('disables the Chrome sandbox when running as root outside Docker', function () {
+      expect(chromeNeedsNoSandbox(false, () => 0)).to.be.true;
+    });
+
+    it('keeps the Chrome sandbox for non-root hosts', function () {
+      expect(chromeNeedsNoSandbox(false, () => 1000)).to.be.false;
+    });
+
+    it('keeps the Chrome sandbox where user IDs are unavailable', function () {
+      expect(chromeNeedsNoSandbox(false, null)).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent Chrome from repeatedly failing to start in root-based agent environments by selecting the existing `ChromeNoSandbox` launcher whenever tests run inside Docker or as UID 0.

### Description
- Add a `chromeNeedsNoSandbox(isDocker = require('is-docker')(), getuid = process.getuid)` helper to `karma.conf.maker.js` and export it for testing.
- Use `chromeNeedsNoSandbox()` in `setBrowsers` to choose `ChromeNoSandbox` instead of relying solely on `is-docker`.
- Add unit tests in `test/build-logic/karmaConfig_spec.mjs` that exercise Docker, root, non-root, and environments without `getuid`.

### Testing
- Ran `npx mocha test/build-logic/karmaConfig_spec.mjs` and verified the new spec passed after a small adjustment to the test input.
- Ran `npx gulp lint --files karma.conf.maker.js,test/build-logic/karmaConfig_spec.mjs` which completed successfully.
- Ran `npx gulp test-build-logic` (72 tests passed), `npx gulp test-only --file test/spec/utils_spec.js --no-coverage` (233 tests passed and Karma launched `ChromeNoSandbox`), and `npx gulp test-only --no-coverage` (full multi-chunk suite completed); all succeeded.
- Ran `git diff --check` with no whitespace errors found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6aa049dc6568832ba119841d807fffa8)