### PR TITLE
Build system: fix missing GVL ID in analytics module metadata; remove missing GVL ID from pubwise analytics

### DIFF
--- a/modules/_moduleMetadata.js
+++ b/modules/_moduleMetadata.js
@@ -89,7 +89,7 @@ function analyticsMetadata() {
         return [
           provider,
           {
-            gvlid: formatGvlid(GDPR_GVLIDS.get(name).modules?.[MODULE_TYPE_ANALYTICS] ?? null),
+            gvlid: formatGvlid(GDPR_GVLIDS.get(provider).modules?.[MODULE_TYPE_ANALYTICS] ?? null),
             disclosureURL: adapter.disclosureURL
           }
         ];

--- a/modules/pubwiseAnalyticsAdapter.js
+++ b/modules/pubwiseAnalyticsAdapter.js
@@ -332,7 +332,6 @@ pubwiseAnalytics.enableAnalytics = function (config) {
 adapterManager.registerAnalyticsAdapter({
   adapter: pubwiseAnalytics,
   code: MODULE_CODE,
-  gvlid: 842
 });
 
 export default pubwiseAnalytics;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix
- [x] Build related changes

## Description of change

- fix a bug in the metadata extraction logic that lost GVL IDs for all analytics adapters;
- remove pubwise's GVL ID - 842 deleted or missing

## Impact

[storageControl](https://docs.prebid.org/dev-docs/modules/storageControl.html) would not pick up disclosures from the GVL ID (and potentially block or warn incorrectly);
[tcfControl](https://docs.prebid.org/dev-docs/modules/tcfControl.html#full-enforcement-since-prebidjs-1115) "full enforcement" would incorrectly miss analytics modules' GVL purpose declarations


