### PR TITLE
Clarify requirements for hashed email in Acxiom Real ID

### DIFF
--- a/modules/acxiomRealIdSystem.md
+++ b/modules/acxiomRealIdSystem.md
@@ -2,6 +2,8 @@
 
 Acxiom Real ID module surfaces an Acxiom Real ID in the bid request via the Prebid User ID system. The module sends a POST request to the lookup API with the partner ID, source ID, and user agent, and stores the returned token for use in bid requests.
 
+> **Important — a hashed email (`hem`) is required to resolve an ID.** The lookup API resolves the Acxiom Real ID **solely** by matching the supplied hashed email (HEM). If `params.hem` is not provided, the API has nothing to match against and returns an empty result, so no ID is stored and none is added to the bid request. Configuring only `partnerId` will therefore never resolve an ID on its own — you must also pass `params.hem` for any user you want to resolve (typically a logged-in / known user whose email you can hash). See [Passing the hashed email (`hem`)](#passing-the-hashed-email-hem) for how to produce it.
+
 ## Building Prebid with Acxiom Real ID Support
 
 Add the Acxiom Real ID submodule to your Prebid.js package:
@@ -19,7 +21,7 @@ The following configuration parameters are available:
 | name | Required | String | Module identifier | `'acxiomRealId'` |
 | params | Required | Object | Module configuration | |
 | params.partnerId | Required | String | Partner ID issued by GrowthCode on behalf of Acxiom | `'ABC123'` |
-| params.hem | Optional | String | SHA-256 hashed email for improved match rate | `'a1b2c3...'` |
+| params.hem | Required to resolve | String | SHA-256 hashed email of the user. This is the **only** signal the API matches on — without it the API returns an empty result and no ID is set. Technically optional (the module will still fire a request without it), but resolution is impossible unless it is supplied. The module forwards this value to the API **exactly as provided** — no hashing or transformation is applied. See [Passing the hashed email](#passing-the-hashed-email-hem). | `'a1b2c3...'` |
 | params.sourceId | Optional | String | EID source to request from the lookup API. Defaults to `'acxiom.id'` | `'acxiom.id'` |
 | params.apiUrl | Optional | String | Override the full API endpoint URL | `'https://ids.api.gcprivacy.id/v1/eid/l'` |
 | storage | Required | Object | Storage configuration | |
@@ -29,13 +31,16 @@ The following configuration parameters are available:
 
 ### Example Configuration
 
+Both `partnerId` and `hem` are required. `partnerId` alone will not resolve — with no `params.hem` the API has nothing to match on and always returns an empty result, so **no ID is resolved or stored**.
+
 ```javascript
 pbjs.setConfig({
   userSync: {
     userIds: [{
       name: 'acxiomRealId',
       params: {
-        partnerId: 'YOUR_PARTNER_ID'
+        partnerId: 'YOUR_PARTNER_ID',
+        hem: 'a1b2c3...' // required — SHA-256 or MD5 hashed email
       },
       storage: {
         type: 'html5',
@@ -47,7 +52,40 @@ pbjs.setConfig({
 });
 ```
 
-### Configuration with Custom API URL and Hashed Email
+### Passing the hashed email (`hem`)
+
+The `hem` value is a **hashed email (HEM)** — a hash of the user's email address. The module sends this value to the API **unchanged**, and the lookup is an **exact match** against the ID graph — so the value you send must be produced the same way the graph was keyed (same hash algorithm and the same email form). Use the exact hashing convention agreed with your GrowthCode contact.
+
+If the hashed email is available at page-configuration time, set it directly in `params.hem` (see [Example Configuration](#example-configuration)).
+
+Because the email is often only known after the user logs in (i.e. after the initial Prebid config), you can supply the `hem` later by re-setting the User ID configuration and refreshing:
+
+```javascript
+pbjs.setConfig({
+  userSync: {
+    // setConfig REPLACES userSync.userIds, so re-list all of your userId configs here.
+    userIds: [
+      {
+        name: 'acxiomRealId',
+        params: { partnerId: 'YOUR_PARTNER_ID', hem: hashedEmail },
+        storage: { type: 'html5', name: 'acxiomRealId', expires: 7 }
+      }
+      // ...your other userId submodule configs
+    ]
+  }
+});
+pbjs.refreshUserIds(); // re-run resolution now that a hem is available
+```
+
+> Use `setConfig` (which replaces `userSync.userIds`) and re-list all of your userId configs. Do **not** use `mergeConfig` to add the `hem` — it appends to the array and would create a duplicate `acxiomRealId` entry instead of updating the existing one.
+
+**Notes:**
+- The lookup is an exact match on the hashed email, so it must be produced the same way the ID graph was built (same hash algorithm — e.g. SHA-256 or MD5 — and the same email form).
+- Only supply a `hem` for users whose email you legitimately hold and for whom you have the appropriate consent.
+- `refreshUserIds()` re-queries only when no ID is already stored for this module. If a previous lookup already stored an ID (in `storage.name`), that stored value is returned as-is; clear it first if you need to force a fresh lookup with a newly available `hem`.
+- If no `hem` is available for a given user (e.g. anonymous / logged-out), it is expected that no ID resolves — Prebid will log an informational `request id responded with an empty value` message, which is normal and not an error.
+
+### Configuration with Custom API URL
 
 ```javascript
 pbjs.setConfig({


### PR DESCRIPTION
 Type of change
  
  - [ ] Bugfix
  - [ ] Feature
  - [ ] New bidder adapter
  - [ ] Updated bidder adapter
  - [ ] Code style update (formatting, local variables)
  - [ ] Refactoring (no functional changes, no api changes)
  - [ ] Build related changes
  - [ ] CI related changes
  - [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
  - [x] Other — Documentation only (module .md)

  Description of change

  Documentation-only update to modules/acxiomRealIdSystem.md. No source, test, or metadata files are changed; the module's runtime behavior is unchanged.

  The existing docs marked params.hem as "Optional — for improved match rate" and led with a partnerId-only example. In practice the lookup API resolves the Acxiom Real ID solely by matching the supplied hashed email, so a partnerId-only configuration never
  resolves an ID and only logs request id responded with an empty value. This misled integrators into shipping a config that can't resolve. This PR corrects the documentation to make the hem requirement explicit and to show integrators how to supply it.

  Changes:
  - Clarified that hem is required to resolve. Added an upfront note and updated the params.hem row: it is the only signal the API matches on, is forwarded to the API exactly as provided (no hashing/normalization in the module), and without it no ID is resolved or stored.
  - Documented how to pass hem, both statically (params.hem at page-config time) and dynamically after login via pbjs.setConfig(...) + pbjs.refreshUserIds().
  - Added a warning against mergeConfig for supplying hem — mergeConfig deep-merges and appends to userSync.userIds, creating a duplicate acxiomRealId entry instead of updating the existing one; setConfig (which replaces the array) is the correct approach.
  - Kept the hashing convention algorithm-agnostic (SHA-256 or MD5) and deferred the exact convention to the GrowthCode contact, since the value must exactly match how the ID graph was keyed (the module does not normalize).
  - Consolidated two near-identical config examples into a single "Example Configuration" section and fixed the affected cross-references/anchors.
  - Added notes on exact-match/consent expectations, refreshUserIds() behavior when an ID is already stored, and that an empty result for anonymous/no-hem users is expected (informational log, not an error).

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](https://github.com/prebid/Prebid.js/blob/master/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
