### PR TITLE
Build system: reject failed CDN chunk loads

### DIFF
--- a/test/spec/web-bundler/load_spec.js
+++ b/test/spec/web-bundler/load_spec.js
@@ -76,6 +76,29 @@ describe('web bundler load utils', () => {
         sinon.assert.match(e.message, /someModule/);
       }
     });
+    it('should reject after all chunk loads settle if one fails', async () => {
+      const failure = new Error('chunk failed');
+      let finishPendingLoad;
+      loader.onFirstCall().returns(Promise.reject(failure));
+      loader.onSecondCall().returns(new Promise(resolve => {
+        finishPendingLoad = resolve;
+      }));
+      resolveDeps.returns(['failed', 'pending']);
+
+      const load = doLoad([]);
+      let settled = false;
+      load.then(() => { settled = true; }, () => { settled = true; });
+      await Promise.resolve();
+      expect(settled).to.be.false;
+
+      finishPendingLoad();
+      try {
+        await load;
+        sinon.assert.fail('did not reject');
+      } catch (e) {
+        expect(e).to.equal(failure);
+      }
+    });
   });
 
   describe('checkAdnRun', () => {

--- a/web-bundler/load.mjs
+++ b/web-bundler/load.mjs
@@ -39,9 +39,19 @@ export async function loadModules(loader, manifest, modules, resolveDeps = resol
     throw new Error(`Cannot find modules: ${missing.join(', ')}`);
   }
   const chunks = resolveDeps(modules, manifest.dependencies, (module) => manifest.checksums.hasOwnProperty(module + METADATA_SUFFIX));
-  return Promise.allSettled(
-    chunks.map(chunk => loader(chunk, manifest.checksums[chunk]))
+  return loadChunks(loader, chunks, manifest.checksums);
+}
+
+export async function loadChunks(loader, chunks, checksums) {
+  // Codex bot: wait for every load before surfacing a failure so late scripts cannot race a retry.
+  const results = await Promise.allSettled(
+    chunks.map(chunk => loader(chunk, checksums[chunk]))
   );
+  const failure = results.find(result => result.status === 'rejected');
+  if (failure) {
+    throw failure.reason;
+  }
+  return results;
 }
 
 /**
@@ -72,4 +82,3 @@ export function checkAndRun(globalVarName, load) {
       });
   }
 }
-

--- a/web-bundler/out/webbundle.js
+++ b/web-bundler/out/webbundle.js
@@ -1,6 +1,4 @@
-import { scriptLoader } from '../load.mjs';
-
-import { checkAndRun } from '../load.mjs'
+import { checkAndRun, loadChunks, scriptLoader } from '../load.mjs';
 import options from 'buildOptions.mjs';
 import checksums from 'checksums.json';
 import {injectBuildOptions} from 'injectBuildOptions';
@@ -13,8 +11,6 @@ if (!options.defineGlobal) {
   checkAndRun(options.pbGlobal, () => {
     injectBuildOptions(options);
     const loader = scriptLoader(options.distUrlBase, scope);
-    return Promise.allSettled(
-      Object.entries(checksums).map(([file, checksum]) => loader(file, checksum))
-    );
+    return loadChunks(loader, Object.keys(checksums), checksums);
   });
 }


### PR DESCRIPTION
### Motivation
- Prevent incomplete CDN/SRI chunk loads from being masked by `Promise.allSettled` so an incomplete bundle cannot proceed to initialization. 【F:web-bundler/load.mjs†L36-L55】
- Ensure both module-level loading and the full web-bundle loader behave consistently when any chunk fails. 【F:web-bundler/out/webbundle.js†L11-L15】
- Add regression coverage to guard against a late-settling chunk hiding earlier failures. 【F:test/spec/web-bundler/load_spec.js†L79-L101]

### Description
- Add `loadChunks(loader, chunks, checksums)` to `web-bundler/load.mjs` which awaits `Promise.allSettled`, throws the first rejection, and returns settled results on success. 【F:web-bundler/load.mjs†L36-L55】
- Replace the previous direct `Promise.allSettled` usage in `loadModules` and in the web-bundle entry with `loadChunks` so failures are surfaced only after every in-flight load settles. 【F:web-bundler/load.mjs†L36-L55】【F:web-bundler/out/webbundle.js†L11-L15】
- Add a unit test `should reject after all chunk loads settle if one fails` to `test/spec/web-bundler/load_spec.js` that simulates a rejected chunk plus a pending load and verifies the aggregate load only rejects after all loads have settled. 【F:test/spec/web-bundler/load_spec.js†L79-L101] 

### Testing
- `npm ci --ignore-scripts` completed successfully to install dependencies. 
- `npx gulp lint --files web-bundler/load.mjs,web-bundler/out/webbundle.js,test/spec/web-bundler/load_spec.js` passed (with expected ignored-file warnings for the two `web-bundler` files). 
- `CHROME_BIN=/tmp/chrome-nosandbox npx gulp test-only-nobuild --file test/spec/web-bundler/load_spec.js` passed (the spec ran and reported 17 tests passing). 
- `CHROME_BIN=/tmp/chrome-nosandbox npx gulp test-only` (full test suite) completed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6aa40b4cb6a8832b97dedcdebd8971ee)